### PR TITLE
Fix for qwen model prompt (#514)

### DIFF
--- a/src/gaia/agents/Chaty/prompts.py
+++ b/src/gaia/agents/Chaty/prompts.py
@@ -64,6 +64,7 @@ class Prompts:
         "chatglm": "You are ChatGLM3, a large language model trained by Zhipu.AI. Follow the user's instructions carefully. Respond using markdown.",
         "gemma": "You are Gemma, a helpful AI assistant. You provide clear, accurate, and technically-sound responses while maintaining a friendly demeanor.",
         "deepseek": "You are DeepSeek R1, a large language model trained by DeepSeek. You provide clear, accurate, and technically-sound responses while maintaining a friendly demeanor.",
+        "qwen": "You are Qwen, a helpful AI assistant. You provide clear, accurate, and technically-sound responses while maintaining a friendly demeanor.",
         "default": "You are a helpful AI assistant. You provide clear, accurate, and technically-sound responses while maintaining a friendly demeanor.",
         # Add other system messages here...
     }
@@ -259,23 +260,7 @@ class Prompts:
     @classmethod
     def get_system_prompt(cls, model: str, chat_history: list[str]) -> str:
         """Get the formatted system prompt for the given model and chat history."""
-        model_type = cls._match_model_name(model)
-        format_template = cls.prompt_formats[model_type]
-        system_message = cls.system_messages[model_type]
-
-        # Format system message
-        prompt = format_template["system"].format(system_message=system_message)
-
-        # Format chat history
-        for message in chat_history:
-            if message.startswith("user: "):
-                content = message[6:]  # Remove "user: " prefix
-                prompt += format_template["user"].format(content=content)
-            elif message.startswith("assistant: "):
-                content = message[11:]  # Remove "assistant: " prefix
-                prompt += format_template["assistant"].format(content=content)
-
-        return prompt
+        return cls.format_chat_history(model, chat_history)
 
 
 def main():


### PR DESCRIPTION
Fix Qwen model prompt formatting:

- Add Qwen system message to system_messages dictionary
- Refactor get_system_prompt to use format_chat_history for consistent formatting
- Fix empty assistant responses and extra newlines in Qwen chat format
- Fix following error message
```
[2025-03-24 14:30:04] | ERROR | aiohttp.server.log_exception | web_protocol.py:451 | Error handling request from 127.0.0.1
Traceback (most recent call last):
  File "C:\Users\kalin\miniconda3\envs\gaiaenv3\lib\site-packages\aiohttp\web_protocol.py", line 480, in _handle_request
    resp = await request_handler(request)
  File "C:\Users\kalin\miniconda3\envs\gaiaenv3\lib\site-packages\aiohttp\web_app.py", line 569, in _handle
    return await handler(request)
  File "C:\Users\kalin\Work\gaia3\src\gaia\agents\agent.py", line 204, in _on_prompt_received
    response = self.prompt_received(data["prompt"])
  File "C:\Users\kalin\Work\gaia3\src\gaia\agents\Chaty\app.py", line 41, in prompt_received
    response = self.prompt_llm(prompt)
  File "C:\Users\kalin\Work\gaia3\src\gaia\agents\Chaty\app.py", line 31, in prompt_llm
    prompt = Prompts.get_system_prompt(
  File "C:\Users\kalin\Work\gaia3\src\gaia\agents\Chaty\prompts.py", line 264, in get_system_prompt
    system_message = cls.system_messages[model_type]
KeyError: 'qwen'
```

closes #24 