### PR TITLE
Fix OpenAI client initialization by adding missing api_key parameter

### DIFF
--- a/workshop/blender.ipynb
+++ b/workshop/blender.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "from openai import OpenAI\n",
     "\n",
-    "llm = OpenAI(base_url=\"http://localhost:8000/api/v0\")\n",
+    "llm = OpenAI(base_url=\"http://localhost:8000/api/v0\", api_key=\"none\")\n",
     "\n",
     "response = llm.completions.create(\n",
     "    model=\"Llama-3.2-3B-Instruct-Hybrid\",\n",


### PR DESCRIPTION
## Changes
- Fixed missing `api_key` parameter for Blender notebook