### PR TITLE
Upgrade GAIA BETA to v0.65+raux.0.2.1

### DIFF
--- a/installer/Installer.nsi
+++ b/installer/Installer.nsi
@@ -10,7 +10,7 @@
 !define /ifndef NPU_DRIVER_ZIP "NPU_RAI1.3.zip"
 !define /ifndef NPU_DRIVER_VERSION "32.0.203.251"
 !define /ifndef LEMONADE_VERSION "v7.0.4"
-!define /ifndef RAUX_VERSION "v0.6.5+raux.0.2.0"
+!define /ifndef RAUX_VERSION "v0.6.5+raux.0.2.1"
 !define /ifndef RAUX_PRODUCT_NAME "GAIA BETA"
 !define /ifndef RAUX_PRODUCT_SQUIRREL_NAME "GaiaBeta"
 !define /ifndef RAUX_PRODUCT_SQUIRREL_PATH "$LOCALAPPDATA\GaiaBeta"

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 import os
 
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 
 
 def get_package_version() -> str:


### PR DESCRIPTION
## Changes

<!-- Briefly describe your changes in bulleted form -->
- Update RAUX to `v0.6.5+raux.0.2.1`
- RAUX introduced internal updates and Lemonade indictor