### PR TITLE
Fix Lemonade version comparison

### DIFF
--- a/installer/Installer.nsi
+++ b/installer/Installer.nsi
@@ -9,7 +9,7 @@
 !define /ifndef RYZENAI_FOLDER "ryzen_ai_13_ga"
 !define /ifndef NPU_DRIVER_ZIP "NPU_RAI1.3.zip"
 !define /ifndef NPU_DRIVER_VERSION "32.0.203.251"
-!define /ifndef LEMONADE_VERSION "v7.0.4"
+!define /ifndef LEMONADE_VERSION "8.0.1"
 !define /ifndef RAUX_VERSION "v0.6.5+raux.0.2.1"
 !define /ifndef RAUX_PRODUCT_NAME "GAIA BETA"
 !define /ifndef RAUX_PRODUCT_SQUIRREL_NAME "GaiaBeta"
@@ -596,6 +596,7 @@ Section "-Install Main Components" SEC01
 
         ; Call installer_utils.py to check version compatibility
         DetailPrint "- Running version check command..."
+        DetailPrint "- Command: python installer_utils.py ${LEMONADE_VERSION} '$3'"
         nsExec::ExecToStack 'cmd /c ""$INSTDIR\python\python.exe" "$INSTDIR\installer_utils.py" "${LEMONADE_VERSION}" "$3""'
         Pop $4  ; Return value
         Pop $5  ; Command output
@@ -610,7 +611,7 @@ Section "-Install Main Components" SEC01
         ${Else}
           DetailPrint "- Lemonade version is not compatible"
           ${IfNot} ${Silent}
-            MessageBox MB_YESNO "Your $3 and is not compatible with the required version ${LEMONADE_VERSION}.$\n$\nWould you like to update Lemonade now?" IDYES install_lemonade IDNO skip_lemonade
+            MessageBox MB_YESNO "Your 'Running: lemonade-server --version' $3 is not compatible with the required version ${LEMONADE_VERSION}.$\n$\nWould you like to update Lemonade now?" IDYES install_lemonade IDNO skip_lemonade
           ${Else}
             GoTo skip_lemonade
           ${EndIf}
@@ -625,7 +626,7 @@ Section "-Install Main Components" SEC01
       download_lemonade:
         DetailPrint "- Downloading Lemonade installer..."
         ; Use nsExec::ExecToStack to capture the output and error code
-        nsExec::ExecToStack 'curl -L -f -v --retry 3 --retry-delay 2 -o "$TEMP\Lemonade_Server_Installer.exe" "https://github.com/lemonade-sdk/lemonade/releases/download/${LEMONADE_VERSION}/Lemonade_Server_Installer.exe"'
+        nsExec::ExecToStack 'curl -L -f -v --retry 3 --retry-delay 2 -o "$TEMP\Lemonade_Server_Installer.exe" "https://github.com/lemonade-sdk/lemonade/releases/download/v${LEMONADE_VERSION}/Lemonade_Server_Installer.exe"'
         Pop $0  ; Return value
         Pop $1  ; Command output
         DetailPrint "- Curl return code: $0"

--- a/installer/install.bat
+++ b/installer/install.bat
@@ -8,107 +8,112 @@ setlocal EnableDelayedExpansion
 set PYTHON_EXE=%1
 set INSTALL_DIR=%2
 set MODE=%3
-set LOG_FILE=%INSTALL_DIR%\gaia_install.log
+:: Remove quotes from INSTALL_DIR for LOG_FILE construction
+set INSTALL_DIR_UNQUOTED=%INSTALL_DIR:"=%
+set LOG_FILE="%INSTALL_DIR_UNQUOTED%\gaia_install.log"
+
+echo Install directory: %INSTALL_DIR%
+echo Log file: %LOG_FILE%
 
 :: Set GAIA_INSTALL_DIR environment variable
-setx GAIA_INSTALL_DIR "%INSTALL_DIR%"
+setx GAIA_INSTALL_DIR %INSTALL_DIR%
 set GAIA_INSTALL_DIR=%INSTALL_DIR%
 
 :: Create installation directory if it doesn't exist
-if not exist "%INSTALL_DIR%" mkdir "%INSTALL_DIR%"
+if not exist %INSTALL_DIR% mkdir %INSTALL_DIR%
 
 :: Create log header
-echo GAIA Installation Log > "%LOG_FILE%"
-echo Timestamp: %date% %time% >> "%LOG_FILE%"
-echo Python: %PYTHON_EXE% >> "%LOG_FILE%"
-echo Install Dir: %INSTALL_DIR% >> "%LOG_FILE%"
-echo Mode: %MODE% >> "%LOG_FILE%"
-echo. >> "%LOG_FILE%"
+echo GAIA Installation Log > %LOG_FILE%
+echo Timestamp: %date% %time% >> %LOG_FILE%
+echo Python: %PYTHON_EXE% >> %LOG_FILE%
+echo Install Dir: %INSTALL_DIR% >> %LOG_FILE%
+echo Mode: %MODE% >> %LOG_FILE%
+echo. >> %LOG_FILE%
 
 :: Validate installation mode
 if "%MODE%"=="" (
-    echo ERROR: Installation mode not specified >> "%LOG_FILE%"
-    echo ERROR: Mode must be one of: NPU, HYBRID, or GENERIC >> "%LOG_FILE%"
+    echo ERROR: Installation mode not specified >> %LOG_FILE%
+    echo ERROR: Mode must be one of: NPU, HYBRID, or GENERIC >> %LOG_FILE%
     exit /b 1
 )
 
 if not "%MODE%"=="NPU" if not "%MODE%"=="HYBRID" if not "%MODE%"=="GENERIC" (
-    echo ERROR: Invalid installation mode: %MODE% >> "%LOG_FILE%"
-    echo ERROR: Mode must be one of: NPU, HYBRID, or GENERIC >> "%LOG_FILE%"
+    echo ERROR: Invalid installation mode: %MODE% >> %LOG_FILE%
+    echo ERROR: Mode must be one of: NPU, HYBRID, or GENERIC >> %LOG_FILE%
     exit /b 1
 )
 
 :: Set GAIA_MODE using the appropriate mode-setting script
 if "%MODE%"=="NPU" (
-    call set_npu_mode.bat "%INSTALL_DIR%" >> "%LOG_FILE%" 2>&1
+    call "%INSTALL_DIR_UNQUOTED%\set_npu_mode.bat" %INSTALL_DIR% >> %LOG_FILE% 2>&1
 ) else if "%MODE%"=="HYBRID" (
-    call set_hybrid_mode.bat "%INSTALL_DIR%" >> "%LOG_FILE%" 2>&1
+    call "%INSTALL_DIR_UNQUOTED%\set_hybrid_mode.bat" %INSTALL_DIR% >> %LOG_FILE% 2>&1
 ) else (
-    call set_generic_mode.bat "%INSTALL_DIR%" >> "%LOG_FILE%" 2>&1
+    call "%INSTALL_DIR_UNQUOTED%\set_generic_mode.bat" %INSTALL_DIR% >> %LOG_FILE% 2>&1
 )
 
 echo Installing GAIA. Please be patient, this can take 5-10 minutes...
-echo Installing GAIA. Please be patient, this can take 5-10 minutes... >> "%LOG_FILE%"
+echo Installing GAIA. Please be patient, this can take 5-10 minutes... >> %LOG_FILE%
 
 :: Update pip and dependencies
-echo Updating pip, setuptools, and wheel... >> "%LOG_FILE%"
-"%PYTHON_EXE%" -m pip install --upgrade pip setuptools wheel >> "%LOG_FILE%" 2>&1
+echo Updating pip, setuptools, and wheel... >> %LOG_FILE%
+%PYTHON_EXE% -m pip install --upgrade pip setuptools wheel >> %LOG_FILE% 2>&1
 if %ERRORLEVEL% neq 0 (
-    echo ERROR: Failed to update pip and dependencies >> "%LOG_FILE%"
+    echo ERROR: Failed to update pip and dependencies >> %LOG_FILE%
     echo Check %LOG_FILE% for detailed error information
     exit /b 1
 )
 
 :: Install GAIA based on mode using direct installation (not editable mode)
 if "%MODE%"=="NPU" (
-    echo Installing GAIA NPU... >> "%LOG_FILE%"
-    "%PYTHON_EXE%" -m pip install --no-warn-script-location "%INSTALL_DIR%"[npu,clip,joker,rag,talk] >> "%LOG_FILE%" 2>&1
+    echo Installing GAIA NPU... >> %LOG_FILE%
+    %PYTHON_EXE% -m pip install --no-warn-script-location %INSTALL_DIR%[npu,clip,joker,rag,talk] >> %LOG_FILE% 2>&1
 ) else if "%MODE%"=="HYBRID" (
-    echo Installing GAIA Hybrid... >> "%LOG_FILE%"
-    "%PYTHON_EXE%" -m pip install --no-warn-script-location "%INSTALL_DIR%"[hybrid,clip,joker,rag,talk] >> "%LOG_FILE%" 2>&1
+    echo Installing GAIA Hybrid... >> %LOG_FILE%
+    %PYTHON_EXE% -m pip install --no-warn-script-location %INSTALL_DIR%[hybrid,clip,joker,rag,talk] >> %LOG_FILE% 2>&1
 ) else (
-    echo Installing GAIA Generic... >> "%LOG_FILE%"
-    "%PYTHON_EXE%" -m pip install --no-warn-script-location "%INSTALL_DIR%"[clip,joker,rag,talk] >> "%LOG_FILE%" 2>&1
+    echo Installing GAIA Generic... >> %LOG_FILE%
+    %PYTHON_EXE% -m pip install --no-warn-script-location %INSTALL_DIR%[clip,joker,rag,talk] >> %LOG_FILE% 2>&1
 )
 
 :: Check final error level
 if %ERRORLEVEL% neq 0 (
-    echo ERROR: Installation failed >> "%LOG_FILE%"
+    echo ERROR: Installation failed >> %LOG_FILE%
     echo Check %LOG_FILE% for detailed error information
     exit /b 1
 )
 
 :: Verify that required settings files exist
-echo Verifying settings files... >> "%LOG_FILE%"
-set INTERFACE_DIR=%INSTALL_DIR%\src\gaia\interface
+echo Verifying settings files... >> %LOG_FILE%
+set "INTERFACE_DIR=%INSTALL_DIR%\src\gaia\interface"
 set SETTINGS_FOUND=0
 
 :: Check for mode-specific settings file
 if "%MODE%"=="NPU" (
     if exist "%INTERFACE_DIR%\npu_settings.json" (
-        echo Found NPU settings file >> "%LOG_FILE%"
+        echo Found NPU settings file >> %LOG_FILE%
         set SETTINGS_FOUND=1
     )
 ) else if "%MODE%"=="HYBRID" (
     if exist "%INTERFACE_DIR%\hybrid_settings.json" (
-        echo Found HYBRID settings file >> "%LOG_FILE%"
+        echo Found HYBRID settings file >> %LOG_FILE%
         set SETTINGS_FOUND=1
     )
 ) else (
     if exist "%INTERFACE_DIR%\generic_settings.json" (
-        echo Found GENERIC settings file >> "%LOG_FILE%"
+        echo Found GENERIC settings file >> %LOG_FILE%
         set SETTINGS_FOUND=1
     )
 )
 
 :: Error if no settings file found
 if %SETTINGS_FOUND%==0 (
-    echo ERROR: Required settings file not found in %INTERFACE_DIR% >> "%LOG_FILE%"
-    echo ERROR: Installation cannot continue without proper settings file >> "%LOG_FILE%"
+    echo ERROR: Required settings file not found in "%INTERFACE_DIR%" >> %LOG_FILE%
+    echo ERROR: Installation cannot continue without proper settings file >> %LOG_FILE%
     echo Check %LOG_FILE% for detailed error information
     exit /b 1
 )
 
 :: This message is used in RunInstaller.ps1 to check if the installation was successful
-echo GAIA package installation successful >> "%LOG_FILE%"
+echo GAIA package installation successful >> %LOG_FILE%
 exit /b 0

--- a/installer/installer_utils.py
+++ b/installer/installer_utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import re
 from packaging import version
 
 
@@ -7,58 +8,50 @@ def check_version_compatibility(expected_version, actual_version):
     """
     Compare two version strings, checking if they are compatible.
     Compatible means they have the same major and minor version numbers.
-    Patch version differences are ignored.
 
     Args:
-        expected_version (str): The expected version string (e.g. "v6.2.0")
-        actual_version (str): The actual version string to check (e.g. "Lemonade Server version is 6.2.0")
+        expected_version (str): Expected version (e.g. "8.0.1", "v8.0.1")
+        actual_version (str): Actual version output (may contain extra text)
 
     Returns:
         bool: True if versions are compatible, False otherwise
     """
     try:
-        # Remove 'v' prefix from expected version if present
+        # Clean expected version (remove 'v' prefix)
         expected = expected_version.lstrip("v")
-        print(f"- Cleaned expected version: {expected}")
 
-        # Find first digit in actual_version
-        for i, char in enumerate(actual_version):
-            if char.isdigit():
-                actual = actual_version[i:]
-                break
-        else:
-            print(f"- ERROR: No version number found in: {actual_version}")
+        # Extract version number from actual output using regex
+        # Look for pattern like "8.0.1" in the string
+        version_match = re.search(r"\d+\.\d+(?:\.\d+)?", actual_version)
+        if not version_match:
+            print(f"ERROR: No version number found in: {actual_version}")
             return False
 
-        print(f"- Cleaned actual version: {actual}")
+        actual = version_match.group()
 
-        # Parse versions
+        # Parse and compare major.minor versions
         expected_ver = version.parse(expected)
         actual_ver = version.parse(actual)
 
-        print(f"- Parsed expected version: {expected_ver}")
-        print(f"- Parsed actual version: {actual_ver}")
-
-        # Compare major and minor versions
         is_compatible = (
             expected_ver.major == actual_ver.major
             and expected_ver.minor == actual_ver.minor
         )
 
-        print(f"- Version compatibility check result: {is_compatible}")
+        print(
+            f"Expected: {expected} (major.minor: {expected_ver.major}.{expected_ver.minor})"
+        )
+        print(f"Actual: {actual} (major.minor: {actual_ver.major}.{actual_ver.minor})")
+        print(f"Compatible: {is_compatible}")
+
         return is_compatible
 
     except Exception as e:
-        print(f"- ERROR: Error comparing versions: {str(e)}")
+        print(f"ERROR: {e}")
         return False
 
 
 def main():
-    """
-    Main function to handle command line arguments.
-    Takes two arguments: expected_version and actual_version.
-    Returns 0 if versions are compatible, 1 otherwise.
-    """
     if len(sys.argv) != 3:
         print("Usage: python installer_utils.py <expected_version> <actual_version>")
         sys.exit(1)
@@ -66,12 +59,7 @@ def main():
     expected = sys.argv[1]
     actual = sys.argv[2]
 
-    print(f"- Starting version compatibility check")
-    print(f"- Expected version: {expected}")
-    print(f"- Actual version: {actual}")
-
     is_compatible = check_version_compatibility(expected, actual)
-    # Return 0 for success (compatible), 1 for failure (incompatible)
     sys.exit(0 if is_compatible else 1)
 
 

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 import os
 
-__version__ = "0.8.6"
+__version__ = "0.8.8"
 
 
 def get_package_version() -> str:


### PR DESCRIPTION
Modified the version parsing logic to handle additional text, e.g.:
```bash
(gaiaenv2) C:\Users\kalin\Work\gaia>lemonade-server --version
"Running: lemonade-server-dev  --version"
8.0.0
```

##  Changes

**System Integration**
- Upgraded to Lemonade v8.0.1
- Enhanced version compatibility checking
- Improved version parsing for development builds

**Core Engine**
- Llama.cpp non-streaming mode support
- Usage statistics in `completions` and `chat/completions` endpoints
- Performance optimizations for faster response times

## 📦 What's New
- **System Tray** - Native desktop integration
- **HuggingFace Models** - Direct GGUF model access