### PR TITLE
Loosen the python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
             "gaia-cli = gaia.cli:main",
         ]
     },
-    python_requires=">=3.8, <3.13",
+    python_requires=">=3.8",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     include_package_data=True,


### PR DESCRIPTION
I have no problem running on Python 3.13.7

Closes: https://github.com/amd/gaia/issues/91
