### PR TITLE
Fix Blender MCP 'Namespace' object has no attribute 'stats'

### DIFF
--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -4996,7 +4996,7 @@ def handle_blender_command(args):
             max_steps=args.steps,
             output_dir=output_dir,
             streaming=args.stream,
-            show_stats=args.stats,
+            show_stats=args.show_stats,
             debug_prompts=args.debug_prompts,
         )
 


### PR DESCRIPTION
This fixes
```gaia.cli.handle_blender_command | cli.py:5019 | Error running Blender agent:
:x: Error: 'Namespace' object has no attribute 'stats'
```


