### PR TITLE
Add GitHub Automation: CODEOWNERS and Auto-Labeling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# CODEOWNERS file for GAIA repository
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default reviewer for all files
+* @kovtcharov-amd
+
+# Core agent system
+src/gaia/agents/ @kovtcharov-amd
+
+# MCP integration
+src/gaia/mcp/ @kovtcharov-amd
+
+# Documentation
+docs/ @kovtcharov-amd
+*.md @kovtcharov-amd
+CLAUDE.md @kovtcharov-amd
+
+# CI/CD workflows
+.github/workflows/ @kovtcharov-amd
+
+# Installer & packaging
+installer/ @kovtcharov-amd
+docs/deployment/ @kovtcharov-amd
+
+# Security-sensitive files
+src/gaia/llm/ @kovtcharov-amd
+docs/sdk/security.md @kovtcharov-amd
+.github/workflows/test_security.yml @kovtcharov-amd

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,105 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Auto-labeling configuration for pull requests
+# See: https://github.com/actions/labeler
+
+# Documentation changes (user-facing docs only)
+documentation:
+  - changed-files:
+    - any-glob-to-any-file: ['docs/**/*', 'README.md', 'CONTRIBUTING.md']
+
+# Workflow/config changes (not user docs)
+workflow-config:
+  - changed-files:
+    - any-glob-to-any-file: ['.github/**/*', 'CLAUDE.md', '.gitignore', '.editorconfig']
+
+# Agent system changes (base agent or multiple agents)
+agents:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/agents/**/*']
+
+# Chat SDK changes
+chat:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/chat/**/*', 'docs/guides/chat.md', 'docs/sdk/sdks/chat.md']
+
+# Code agent specific (use "agents" for general agent changes)
+code-agent:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/agents/code_agent.py', 'docs/guides/code.md', 'docs/spec/code-*']
+
+# MCP changes
+mcp:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/mcp/**/*', 'docs/guides/mcp.md', 'docs/spec/mcp-*']
+
+# RAG changes
+rag:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/rag/**/*', 'docs/sdk/sdks/rag.md', 'docs/spec/rag-*']
+
+# LLM backend changes
+llm:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/llm/**/*', 'docs/sdk/sdks/llm.md', 'docs/spec/llm-*']
+
+# Audio changes (ASR/TTS)
+audio:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/audio/**/*', 'docs/sdk/sdks/audio.md']
+
+# Talk agent changes
+talk:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/talk/**/*', 'docs/guides/talk.md', 'docs/sdk/agents/talk.md']
+
+# Blender agent changes
+blender:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/agents/blender_agent.py', 'docs/guides/blender.md', 'docs/spec/blender-agent.md']
+
+# Jira agent changes
+jira:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/agents/jira_agent.py', 'src/gaia/apps/jira/**/*', 'docs/guides/jira.md', 'docs/spec/jira-agent.md']
+
+# Evaluation framework changes
+eval:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/eval/**/*', 'docs/reference/eval.md']
+
+# Test changes
+tests:
+  - changed-files:
+    - any-glob-to-any-file: ['tests/**/*']
+
+# CI/CD workflow changes
+ci-cd:
+  - changed-files:
+    - any-glob-to-any-file: ['.github/workflows/**/*']
+
+# Installer changes
+installer:
+  - changed-files:
+    - any-glob-to-any-file: ['installer/**/*', 'docs/deployment/installer.md']
+
+# Electron app changes
+electron:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/apps/**/*.html', 'src/gaia/apps/**/*.js', 'src/gaia/apps/**/*.css']
+
+# Dependencies
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file: ['setup.py', 'pyproject.toml', 'requirements*.txt', 'uv.lock', 'package.json', 'package-lock.json']
+
+# Security-sensitive changes
+security:
+  - changed-files:
+    - any-glob-to-any-file: ['docs/sdk/security.md', 'src/gaia/**/security.py', '.github/workflows/test_security.yml']
+
+# Performance-critical changes
+performance:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/llm/**/*', 'src/gaia/rag/**/*', 'src/gaia/eval/**/*']

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,20 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+name: Auto Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary
Adds code ownership and automatic PR labeling to streamline PR management and review workflows.

## Changes

### 1. CODEOWNERS (`.github/CODEOWNERS`)
- Auto-assigns @kovtcharov-amd as default reviewer on all PRs
- Defines code ownership for critical areas:
  - Core agent system (`src/gaia/agents/`)
  - MCP integration (`src/gaia/mcp/`)
  - Documentation (`docs/`, `*.md`)
  - CI/CD workflows (`.github/workflows/`)
  - Security-sensitive files (`src/gaia/llm/`, security docs)
- Ensures maintainer review on critical changes

### 2. Auto-Labeling (`.github/labeler.yml` + `.github/workflows/auto-label.yml`)
- Automatically labels PRs based on changed files
- **Labels include**: `documentation`, `agents`, `mcp`, `rag`, `llm`, `audio`, `chat`, `tests`, `ci-cd`, `security`, `performance`, etc.
- Workflow triggers on PR open and synchronize events
- Runs on all PRs including forks (minimal compute cost)

## Benefits
- **Faster PR triage**: Labels help identify PR scope immediately
- **Clearer ownership**: CODEOWNERS ensures right people review critical changes
- **Better organization**: Categorized PRs are easier to filter and prioritize
- **Scalability**: Automated processes reduce manual overhead as project grows

## Testing
- Auto-labeling workflow runs on every PR
- CODEOWNERS assignments verified with GitHub's team features
- Both features work on fork PRs