### PR TITLE
Skip copyright header check for outside contributors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,8 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Check copyright headers
+        # Skip for outside contributors (PRs from forks) - they can't add AMD headers
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           python util/header.py --check
 


### PR DESCRIPTION
External contributors submitting PRs from forks cannot add AMD copyright headers. This skips the header check for fork PRs while keeping it enabled for internal contributors and other CI events.