### PR TITLE
[Fix]: Add missing `requests` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         "python-dotenv",
         "aiohttp",
         "rich",
+        "requests",
         "watchdog>=2.1.0",
         "pillow>=9.0.0",
     ],


### PR DESCRIPTION
Adds `requests` to base dependencies. It was only in `extras_require["dev"]` but is imported at runtime, causing CI lint failures.

## Changes

- Added `requests` to `install_requires` in `setup.py`

## Files Using `requests`

- `src/gaia/llm/lemonade_client.py:29`
- `src/gaia/installer/init_command.py:22`