### PR TITLE
Add Computer Use Agent (CUA) to Q1 2026 roadmap

### DIFF
--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -107,7 +107,32 @@ Key capabilities:
 - Auto-registration of MCP tools as agent tools
 - Multi-server orchestration
 
-→ [View detailed plan](/plans/mcp-client) • [Vote with 👍 on GitHub](https://github.com/amd/gaia/issues/203)
+→ [View detailed plan](/plans/mcp-client) • [Vote with 👍 on GitHub](https://github.com/amd/gaia/issues/203) • See [CUA](#q1-2026-computer-use-agent-cua) for the first production implementation
+
+### Q1 2026: Computer Use Agent (CUA)
+
+**AI-powered desktop automation through natural language**
+
+The first production agent built on GAIA's MCP Client infrastructure. CUA lets you control your desktop through natural language commands:
+
+```bash
+gaia cua "turn on dark mode"
+gaia cua "check my battery status"
+gaia cua "prepare my laptop for a meeting"
+```
+
+Built as a reference design, CUA demonstrates how to create computer-use agents that connect to MCP servers (like Windows MCP) for desktop automation.
+
+**Key capabilities:**
+- Natural language desktop control
+- Battery conservation workflows
+- System health monitoring
+- Meeting preparation automation
+- Windows settings management
+
+CUA validates the MCP Client Mixin framework and serves as a template for building other computer-use agents.
+
+→ [View detailed plan](/plans/cua) • [Vote with 👍 on GitHub](https://github.com/amd/gaia/issues/224)
 
 ### Q2 2026: MCP Docs Server
 
@@ -181,4 +206,4 @@ The more votes an issue gets, the higher priority it becomes. Your input directl
 
 ---
 
-*Updated: January 19, 2026*
+*Updated: January 26, 2026*


### PR DESCRIPTION
## Summary

- Add CUA section to roadmap after MCP Client Mixin with description, CLI examples, and key capabilities
- Add cross-reference from MCP Client Mixin section to CUA section
- Update roadmap date to January 26, 2026

Closes #247

## Test plan

- [ ] Verify CUA section appears in Q1 2026 roadmap
- [ ] Verify cross-reference link from MCP Client Mixin works
- [ ] Verify all links (`/plans/cua`, GitHub issue #224) are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)