### PR TITLE
Fix: Add missing gaia.agents.tools package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "gaia.mcp.servers",
         "gaia.agents",
         "gaia.agents.base",
+        "gaia.agents.tools",
         "gaia.agents.blender",
         "gaia.agents.blender.core",
         "gaia.agents.chat",


### PR DESCRIPTION
The `gaia.agents.tools` package directory exists with `FileSearchToolsMixin` but was never registered in setup.py, causing `ModuleNotFoundError` when importing.