### PR TITLE
Standardize playbook installation instructions with folder creation guidance

### DIFF
--- a/docs/playbooks/chat-agent/part-1-getting-started.mdx
+++ b/docs/playbooks/chat-agent/part-1-getting-started.mdx
@@ -87,10 +87,42 @@ graph TD
 Get a working agent running to understand the basic flow.
 
 <Steps>
-  <Step title="Install dependencies">
-    ```bash
-    uv pip install -e ".[rag]"
-    ```
+  <Step title="Set up your project">
+    Choose your installation path:
+
+    <Tabs>
+      <Tab title="PyPI (Recommended)">
+        Create a new project folder and install from PyPI:
+
+        ```bash
+        mkdir my-chat-agent
+        cd my-chat-agent
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install "amd-gaia[rag]"
+        ```
+
+        <Info>
+        This is the recommended path for most users. You'll create your agent scripts in this folder.
+        </Info>
+      </Tab>
+
+      <Tab title="Developer (Editable Install)">
+        Clone the repository for development or to access examples:
+
+        ```bash
+        git clone https://github.com/amd/gaia.git
+        cd gaia
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install -e ".[rag]"
+        ```
+
+        <Info>
+        Use this path if you want to modify GAIA source code or contribute to the project.
+        </Info>
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step title="Start Lemonade Server">
@@ -105,7 +137,7 @@ Get a working agent running to understand the basic flow.
   </Step>
 
   <Step title="Create your first agent">
-    Create `my_chat_agent.py`:
+    Create `my_chat_agent.py` in your project folder:
 
     ```python title="my_chat_agent.py"
     import json
@@ -119,8 +151,6 @@ Get a working agent running to understand the basic flow.
 
     # Ask a question
     result = agent.process_query("What does the manual say about installation?")
-    import json
-
     print(json.dumps(result, indent=2))
     ```
   </Step>

--- a/docs/playbooks/code-agent/part-1-introduction.mdx
+++ b/docs/playbooks/code-agent/part-1-introduction.mdx
@@ -293,12 +293,42 @@ Everything is connected:
 Let's see GAIA Code in action:
 
 <Steps>
-  <Step title="Prerequisites">
-    ```bash
-    git clone https://github.com/amd/gaia.git
-    cd gaia
-    uv pip install -e ".[dev]"
-    ```
+  <Step title="Set up your project">
+    Choose your installation path:
+
+    <Tabs>
+      <Tab title="PyPI (Recommended)">
+        Create a new project folder and install from PyPI:
+
+        ```bash
+        mkdir my-code-agent
+        cd my-code-agent
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install "amd-gaia[dev]"
+        ```
+
+        <Info>
+        This is the recommended path for most users. The `gaia-code` command will be available after installation.
+        </Info>
+      </Tab>
+
+      <Tab title="Developer (Editable Install)">
+        Clone the repository for development or to access examples:
+
+        ```bash
+        git clone https://github.com/amd/gaia.git
+        cd gaia
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install -e ".[dev]"
+        ```
+
+        <Info>
+        Use this path if you want to modify GAIA source code or contribute to the project.
+        </Info>
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step title="Start Lemonade Server">

--- a/docs/playbooks/emr-agent/part-1-getting-started.mdx
+++ b/docs/playbooks/emr-agent/part-1-getting-started.mdx
@@ -73,18 +73,44 @@ graph TD
 Get a working intake agent running to understand the basic flow.
 
 <Steps>
-  <Step title="Clone and install">
-    <Warning>
-      **Developer Preview:** The Medical Intake Agent requires cloning the repository. PyPI package coming soon.
-    </Warning>
+  <Step title="Set up your project">
+    Choose your installation path:
 
-    ```bash
-    git clone https://github.com/amd/gaia.git
-    cd gaia
-    uv pip install -e ".[api,rag]"
-    ```
+    <Tabs>
+      <Tab title="PyPI (Recommended)">
+        Create a new project folder and install from PyPI:
 
-    The `api` extra provides FastAPI/uvicorn for the web dashboard. The `rag` extra provides PyMuPDF for PDF processing.
+        ```bash
+        mkdir my-emr-agent
+        cd my-emr-agent
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install "amd-gaia[api,rag]"
+        ```
+
+        The `api` extra provides FastAPI/uvicorn for the web dashboard. The `rag` extra provides PyMuPDF for PDF processing.
+
+        <Info>
+        This is the recommended path for most users. You'll create your agent scripts in this folder.
+        </Info>
+      </Tab>
+
+      <Tab title="Developer (Editable Install)">
+        Clone the repository for development or to access examples:
+
+        ```bash
+        git clone https://github.com/amd/gaia.git
+        cd gaia
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install -e ".[api,rag]"
+        ```
+
+        <Info>
+        Use this path if you want to modify GAIA source code or contribute to the project.
+        </Info>
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step title="Start Lemonade Server">
@@ -99,7 +125,7 @@ Get a working intake agent running to understand the basic flow.
   </Step>
 
   <Step title="Create your first intake agent">
-    Create `intake_agent.py`:
+    Create `intake_agent.py` in your project folder:
 
     ```python title="intake_agent.py"
     from gaia.agents.emr import MedicalIntakeAgent

--- a/docs/playbooks/emr-agent/part-2-dashboard.mdx
+++ b/docs/playbooks/emr-agent/part-2-dashboard.mdx
@@ -69,9 +69,9 @@ flowchart TB
 
 ## Quick Start
 
-<Note>
-  This assumes you've already cloned the repository and installed dependencies from [Part 1](./part-1-getting-started).
-</Note>
+<Warning>
+**Developer Installation Required:** The dashboard feature requires the Developer (Editable Install) path from [Part 1](./part-1-getting-started), as it uses source files from the cloned repository. If you used the PyPI installation, clone the repository to access the dashboard.
+</Warning>
 
 ### Launch the Dashboard
 

--- a/docs/playbooks/hardware-advisor/index.mdx
+++ b/docs/playbooks/hardware-advisor/index.mdx
@@ -84,10 +84,42 @@ graph TD
 Get a working agent running to understand the basic flow.
 
 <Steps>
-  <Step title="Install GAIA">
-    ```bash
-    uv pip install amd-gaia
-    ```
+  <Step title="Set up your project">
+    Choose your installation path:
+
+    <Tabs>
+      <Tab title="PyPI (Recommended)">
+        Create a new project folder and install from PyPI:
+
+        ```bash
+        mkdir my-hardware-advisor
+        cd my-hardware-advisor
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install amd-gaia
+        ```
+
+        <Info>
+        This is the recommended path for most users. You'll create your agent scripts in this folder.
+        </Info>
+      </Tab>
+
+      <Tab title="Developer (Editable Install)">
+        Clone the repository for development or to run the example directly:
+
+        ```bash
+        git clone https://github.com/amd/gaia.git
+        cd gaia
+        uv venv .venv
+        source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
+        uv pip install -e ".[dev]"
+        ```
+
+        <Info>
+        Use this path if you want to modify GAIA source code or run the example from `examples/hardware_advisor_agent.py`.
+        </Info>
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step title="Start Lemonade Server">
@@ -102,9 +134,23 @@ Get a working agent running to understand the basic flow.
   </Step>
 
   <Step title="Run the Hardware Advisor">
-    ```bash
-    uv run examples/hardware_advisor_agent.py
-    ```
+    <Tabs>
+      <Tab title="PyPI Installation">
+        Create `hardware_advisor.py` in your project folder and follow the step-by-step build below, or copy the complete example from the [Building It](#building-it-the-step-by-step-journey) section.
+
+        ```bash
+        python hardware_advisor.py
+        ```
+      </Tab>
+
+      <Tab title="Developer Installation">
+        Run the example directly from the repository:
+
+        ```bash
+        uv run examples/hardware_advisor_agent.py
+        ```
+      </Tab>
+    </Tabs>
 
     **Try asking:**
     - "What size LLM can I run?"

--- a/docs/playbooks/index.mdx
+++ b/docs/playbooks/index.mdx
@@ -316,27 +316,36 @@ All playbooks assume you have:
 <Tabs>
   <Tab title="Python Environment">
     - Python 3.10 or higher
-    - Virtual environment (venv or conda)
-    - pip or uv for package management
+    - [uv](https://docs.astral.sh/uv/) package manager (recommended)
+    - A project folder for your agent code
   </Tab>
 
   <Tab title="GAIA Installed">
+    Create a project folder and install GAIA:
+
     ```bash
+    mkdir my-gaia-project
+    cd my-gaia-project
+    uv venv .venv
+    source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
     uv pip install amd-gaia
     ```
+
+    <Info>
+    Each playbook specifies additional extras you may need (e.g., `amd-gaia[rag]` for document processing).
+    </Info>
   </Tab>
 
   <Tab title="Lemonade Server">
-    ```bash
-    # Install Lemonade Server (AMD-optimized for Ryzen AI)
-    uv pip install lemonade-server
+    Lemonade Server is installed automatically with GAIA:
 
+    ```bash
     # Start with NPU/iGPU acceleration
     lemonade-server serve
     ```
 
     <Tip>
-    Lemonade Server provides AMD-optimized inference for AI PCs, utilizing NPU and iGPU acceleration.
+    Lemonade Server provides AMD-optimized inference for AI PCs, utilizing NPU and iGPU acceleration. GAIA will auto-start it if not running.
     </Tip>
   </Tab>
 
@@ -354,11 +363,11 @@ All playbooks assume you have:
 
 <Steps>
   <Step title="Start here" icon="rocket">
-    Begin with **[Document Q&A Agent](/playbooks/chat-agent-rag)** - it covers foundational concepts used in all other playbooks.
+    Begin with **[Document Q&A Agent](/playbooks/chat-agent/part-1-getting-started)** - it covers foundational concepts used in all other playbooks.
   </Step>
 
   <Step title="Add capabilities" icon="puzzle-piece">
-    Once comfortable, add voice with **[Voice-Enabled Assistant](/playbooks/voice-agent)** or code generation with **[Code Agent](/playbooks/code-agent)**.
+    Once comfortable, add voice with **[Voice-Enabled Assistant](/playbooks/voice-agent)** or code generation with **[Code Agent](/playbooks/code-agent/part-1-introduction)**.
   </Step>
 
   <Step title="Go advanced" icon="star">


### PR DESCRIPTION
Standardizes installation instructions across all playbooks to match the quickstart documentation pattern. Users are now guided to create a project folder before installing GAIA.

## Changes

- Added dual-path installation guidance (PyPI vs Developer) to all Part 1 playbooks
- Updated playbooks index with folder creation in Prerequisites section
- Fixed broken links in Learning Path section
- Fixed duplicate `import json` in chat-agent code example
- Added warning in EMR Part 2 that dashboard requires Developer installation