### PR TITLE
Fix installer BOM and logger permissions

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-﻿# GAIA Installer for Windows
+# GAIA Installer for Windows
 # One-command installation: irm https://amd-gaia.ai/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
## Summary

- Fix UTF-8 BOM issue in Windows installer script
- Update logger to write to user space by default
- Add permission error handling with helpful messages

## Changes

### Install Script Fix
- Remove UTF-8 BOM from `install.ps1` that caused PowerShell execution error
- Fixes: `The term '﻿#' is not recognized` error when running installer

### Logger Improvements
- Change default log location from current directory to `~/.gaia/gaia.log`
- Add PermissionError handling with user-friendly fallback
- Prevents errors when running from protected directories (e.g., `C:\windows\system32`)

## Testing

- Verified installer runs without BOM error
- Tested logger writes to user space from any directory
- Confirmed helpful error messages display when permissions are insufficient

These fixes improve the first-run experience and prevent common permission issues on Windows.