### PR TITLE
Fix gaia talk 'No module named pip' error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,7 @@ setup(
             "kokoro>=0.3.1",
             "soundfile",
             "sounddevice",
+            "pip",  # Required: spacy model download needs pip in venv (uv omits it)
         ],
         "youtube": [
             "llama-index-readers-youtube-transcript",


### PR DESCRIPTION
## Summary

- Adds `pip` to the `[talk]` extras in `setup.py` to fix `"No module named pip"` when running `gaia talk`

Fixes #343

## Root Cause

Kokoro TTS depends on `misaki` (phonemizer), which auto-downloads the `en_core_web_sm` spacy model via `spacy.cli.download()`. Internally, spacy calls `pip install` to fetch the model. However, `uv`-created virtual environments don't include `pip` by default, causing the import to fail with `ModuleNotFoundError: No module named 'pip'`.

Misaki's maintainers already fixed this upstream by adding `pip>=25.0.1` as a dependency ([hexgrad/misaki#77](https://github.com/hexgrad/misaki/commit/49ddead831fc1a46beab3f9cb6064d93fd3f6347)), but the fix hasn't been released to PyPI yet (latest is 0.9.4). Adding `pip` explicitly to our `[talk]` extras resolves the issue now and becomes harmless (but redundant) once misaki ships the fix.

## Testing

Verified locally on Linux (aarch64, Docker, no audio hardware):

1. `uv pip install -e ".[talk]"` — confirms `pip==26.0.1` is installed into the venv
2. `python -m pip --version` — confirms pip is importable
3. `gaia talk --no-tts --whisper-model-size tiny` — successfully initializes TalkSDK, downloads Whisper model, and reaches the "Listening..." state (fails only on audio device access, which is expected without a mic)

No `"No module named pip"` error observed.

## Test plan

- [x] `uv pip install -e ".[talk]"` installs `pip` into the venv
- [x] `gaia talk` gets past module imports without error
- [ ] End-to-end `gaia talk` on a machine with audio hardware