### PR TITLE
Release v0.15.4.1

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -342,7 +342,7 @@
           {
             "group": "Release Notes",
             "pages": [
-              "releases/v0.15.5",
+              "releases/v0.15.4.1",
               "releases/v0.15.4",
               "releases/v0.15.3.2",
               "releases/v0.15.3.1",
@@ -383,7 +383,7 @@
   "navbar": {
     "links": [
       {
-        "label": "v0.15.5 · Lemonade 9.3.0",
+        "label": "v0.15.4.1 · Lemonade 9.3.0",
         "href": "https://github.com/amd/gaia/releases"
       },
       {

--- a/docs/releases/v0.15.4.1.mdx
+++ b/docs/releases/v0.15.4.1.mdx
@@ -1,9 +1,9 @@
 ---
-title: "v0.15.5"
+title: "v0.15.4.1"
 description: "StructuredVLMExtractor API — extract tables, key-values, and chart data from images and documents"
 ---
 
-# GAIA v0.15.5 Release Notes
+# GAIA v0.15.4.1 Release Notes
 
 **Feature release** adding the `StructuredVLMExtractor` API for structured data extraction from images and documents. Also includes voice interaction improvements (mic sensitivity controls, sounddevice migration) and several bug fixes.
 
@@ -161,4 +161,4 @@ gaia init --profile vlm
 - `1198af5` - Fix gaia talk: mic sensitivity, LEMONADE_BASE_URL, stuck listening (#347) (#348)
 - `8d12a4a` - Fix gaia sd terminal preview and image viewer (#346)
 
-Full Changelog: [v0.15.4...v0.15.5](https://github.com/amd/gaia/compare/v0.15.4...v0.15.5)
+Full Changelog: [v0.15.4...v0.15.4.1](https://github.com/amd/gaia/compare/v0.15.4...v0.15.4.1)

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from importlib.metadata import version as get_package_version_metadata
 
-__version__ = "0.15.5"
+__version__ = "0.15.4.1"
 
 # Lemonade version used across CI and installer
 LEMONADE_VERSION = "9.3.0"


### PR DESCRIPTION
## Summary

- Add release notes for v0.15.4.1 (`docs/releases/v0.15.4.1.mdx`)
- Bump `__version__` from `0.15.4` → `0.15.4.1` in `src/gaia/version.py`
- Add `releases/v0.15.4.1` to nav and update navbar label in `docs/docs.json`

Closes #336, #339, #344, #345, #342, #348, #346

> **Note:** Do not tag `v0.15.4.1` until after this PR merges.