### PR TITLE
Update Lemonade Server to v9.3.4

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -28,23 +28,23 @@ Included demos:
 
 The agent connects to an OpenAI-compatible LLM server at `http://localhost:8000/api/v1` by default. The reference backend is [Lemonade Server](https://github.com/amd/lemonade), which runs models locally on AMD hardware.
 
-Download and install Lemonade Server v9.3.0, then start it:
+Download and install Lemonade Server v9.3.4, then start it:
 
 **Windows:**
 ```powershell
 # Download and run the MSI installer
-curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.0/lemonade-server-minimal.msi
+curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.4/lemonade-server-minimal.msi
 msiexec /i lemonade-server-minimal.msi
 ```
 
 **Linux:**
 ```bash
 # Download and install the .deb package
-curl -L -o lemonade_9.3.0_amd64.deb https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.0/lemonade_9.3.0_amd64.deb
-sudo dpkg -i lemonade_9.3.0_amd64.deb
+curl -L -o lemonade_9.3.4_amd64.deb https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.4/lemonade_9.3.4_amd64.deb
+sudo dpkg -i lemonade_9.3.4_amd64.deb
 ```
 
-Or download directly from the [Lemonade v9.3.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v9.3.0).
+Or download directly from the [Lemonade v9.3.4 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v9.3.4).
 
 After installation, start the server:
 ```bash

--- a/docs/cpp/setup.mdx
+++ b/docs/cpp/setup.mdx
@@ -76,17 +76,17 @@ icon: "wrench"
 
     The agent needs an OpenAI-compatible LLM server. [Lemonade Server](https://lemonade-server.ai) is recommended (optimized for AMD hardware).
 
-    Download and run the installer (v9.3.0):
+    Download and run the installer (v9.3.4):
 
     ```powershell
     # Download the MSI installer
-    curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.0/lemonade-server-minimal.msi
+    curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.4/lemonade-server-minimal.msi
 
     # Run the installer
     msiexec /i lemonade-server-minimal.msi
     ```
 
-    Or download directly from the [Lemonade v9.3.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v9.3.0).
+    Or download directly from the [Lemonade v9.3.4 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v9.3.4).
 
     After installation, restart your terminal and start the server:
     ```powershell
@@ -168,17 +168,17 @@ icon: "wrench"
 
     The agent needs an OpenAI-compatible LLM server. [Lemonade Server](https://lemonade-server.ai) is recommended (optimized for AMD hardware).
 
-    Download and install the `.deb` package (v9.3.0):
+    Download and install the `.deb` package (v9.3.4):
 
     ```bash
     # Download the .deb package
-    curl -L -o lemonade_9.3.0_amd64.deb https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.0/lemonade_9.3.0_amd64.deb
+    curl -L -o lemonade_9.3.4_amd64.deb https://github.com/lemonade-sdk/lemonade/releases/download/v9.3.4/lemonade_9.3.4_amd64.deb
 
     # Install it
-    sudo dpkg -i lemonade_9.3.0_amd64.deb
+    sudo dpkg -i lemonade_9.3.4_amd64.deb
     ```
 
-    Or download directly from the [Lemonade v9.3.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v9.3.0).
+    Or download directly from the [Lemonade v9.3.4 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v9.3.4).
 
     After installation, start the server:
     ```bash
@@ -221,7 +221,7 @@ icon: "wrench"
 | C++ Compiler | C++17 support (MSVC 2019+ or GCC 9+) | `cl` (Windows) or `g++ --version` (Linux) |
 | CMake | 3.14+ | `cmake --version` |
 | Git | any | `git --version` |
-| [Lemonade Server](https://lemonade-server.ai) | 9.3.0 | `lemonade-server --version` |
+| [Lemonade Server](https://lemonade-server.ai) | 9.3.4 | `lemonade-server --version` |
 | uvx | any (optional) | `uvx --version` |
 
 <Note>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -404,7 +404,7 @@
   "navbar": {
     "links": [
       {
-        "label": "v0.16.0 · Lemonade 9.3.0",
+        "label": "v0.16.0 · Lemonade 9.3.4",
         "href": "https://github.com/amd/gaia/releases"
       },
       {

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -9,7 +9,7 @@ from importlib.metadata import version as get_package_version_metadata
 __version__ = "0.16.0"
 
 # Lemonade version used across CI and installer
-LEMONADE_VERSION = "9.3.0"
+LEMONADE_VERSION = "9.3.4"
 
 
 def get_package_version() -> str:


### PR DESCRIPTION
## Summary
- Bump Lemonade Server target version from 9.3.0 to 9.3.4
- Update central `LEMONADE_VERSION` constant in `src/gaia/version.py`
- Update download URLs and version references in C++ docs (`docs/cpp/setup.mdx`, `cpp/README.md`)
- Update navbar version label in `docs/docs.json`

## Test plan
- [ ] Verify `gaia init` downloads Lemonade 9.3.4
- [ ] Verify C++ setup docs point to correct release URLs
- [ ] Verify CI action reads updated version from `version.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)