### PR TITLE
🚀 Feature: Expose packaging helpers as a package

### DIFF
--- a/src/gaia/packaging/__init__.py
+++ b/src/gaia/packaging/__init__.py
@@ -1,0 +1,6 @@
+from .channel import ChannelConfig
+
+# Provides a convenient shortcut to load a channel configuration.
+
+def load_channel_config(channel_name: str) -> ChannelConfig:
+    return ChannelConfig(channel_name)


### PR DESCRIPTION
## 🚀 New Feature

### Problem
Makes the new packaging sub‑module importable and provides a convenient shortcut to load a channel configuration.

**Severity**: `low`
**File**: `src/gaia/packaging/__init__.py`

### Solution
|

### Changes
- `src/gaia/packaging/__init__.py` (new)

## Changes


-
-
-


Closes #615