### PR TITLE
fix: isolate MCP unit tests from real ~/.gaia/mcp_servers.json

### DIFF
--- a/tests/unit/mcp/client/test_mcp_client_manager.py
+++ b/tests/unit/mcp/client/test_mcp_client_manager.py
@@ -21,6 +21,11 @@ def _mock_home(monkeypatch, home_dir: Path):
 class TestMCPClientManager:
     """Test MCPClientManager functionality."""
 
+    @pytest.fixture(autouse=True)
+    def isolate_home(self, monkeypatch, tmp_path):
+        """Redirect Path.home() to tmp_path so tests never touch ~/.gaia/."""
+        _mock_home(monkeypatch, tmp_path)
+
     @patch("gaia.mcp.client.mcp_client_manager.MCPClient")
     def test_add_server_creates_and_connects_client(self, mock_client_class):
         """Test that add_server creates and connects a client using config dict."""
@@ -662,6 +667,11 @@ class TestMCPConfig:
 
 class TestMCPClientManagerStatusReport:
     """Tests for MCPClientManager._failed tracking and get_status_report()."""
+
+    @pytest.fixture(autouse=True)
+    def isolate_home(self, monkeypatch, tmp_path):
+        """Redirect Path.home() to tmp_path so tests never touch ~/.gaia/."""
+        _mock_home(monkeypatch, tmp_path)
 
     def test_get_status_report_empty_when_no_servers(self):
         manager = MCPClientManager()


### PR DESCRIPTION
## Summary

- Several tests in `TestMCPClientManager` and `TestMCPClientManagerStatusReport` called `MCPClientManager()` without a `config=` parameter and without monkeypatching `Path.home()`
- `MCPConfig()` in auto-load mode resolved `self.config_file` to the real `~/.gaia/mcp_servers.json`; when tests called `manager.add_server()`, fake server entries (`test`, `github`, `server1`, `server2`) were written to disk and never cleaned up
- On next GAIA startup, these ghost servers were loaded and GAIA would hang trying to invoke them

## Fix

Added an autouse `isolate_home` pytest fixture to both affected classes that redirects `Path.home()` → `tmp_path` for every test, matching the isolation pattern already used elsewhere in the suite (`_mock_home`).

## Test plan

- [x] All 38 tests in `tests/unit/mcp/client/test_mcp_client_manager.py` pass (`38 passed in 0.91s`)
- [x] `~/.gaia/mcp_servers.json` remains `{"mcpServers": {}}` after the full test run — no fake entries leak to disk