### PR TITLE
fix: bump webui package.json version to 0.17.1

### DIFF
--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.17.1-rc.1",
+  "version": "0.17.1",
   "type": "module",
   "productName": "GAIA Agent UI",
   "description": "Privacy-first agentic AI interface with document Q&A - runs 100% locally on AMD Ryzen AI",


### PR DESCRIPTION
## Summary

- Remove `-rc.1` suffix from `src/gaia/apps/webui/package.json` version to match the `v0.17.1` release tag
- Fixes CI version check failure: `package.json (0.17.1-rc.1) != tag (v0.17.1)`

## Test plan

- [ ] Verify CI version check passes: `package.json` version matches git tag `v0.17.1`