### PR TITLE
fix: upgrade npm to 11.5.1+ for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm-ui.yml
+++ b/.github/workflows/publish-npm-ui.yml
@@ -142,6 +142,11 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: |
+          npm install -g npm@latest
+          echo "npm version: $(npm -v)"
+
       - name: Install dependencies
         working-directory: src/gaia/apps/webui
         run: npm ci 2>/dev/null || npm install


### PR DESCRIPTION
## Summary
- Node 22 ships with npm 10.9.4, which does **not** support OIDC trusted publishing
- The npm publish workflow fails with `ENEEDAUTH` because npm 10.x can't authenticate via OIDC
- Adds an explicit `npm install -g npm@latest` step to get npm 11.5.1+ which supports OIDC

## Context
Trusted publishing was configured correctly on npmjs.com (`amd/gaia` → `publish-npm-ui.yml` → `npm` environment), and the workflow had `id-token: write` + `--provenance`. The only missing piece was the npm CLI version.

From the [failed run logs](https://github.com/amd/gaia/actions/runs/23814112600):
```
npm: 10.9.4   ← too old, needs 11.5.1+
npm error code ENEEDAUTH
```

## Test plan
- [ ] Merge this PR
- [ ] Re-tag `v0.17.1` (or create `v0.17.2`) to trigger the publish workflow
- [ ] Verify the publish job prints npm 11.5.1+ and `@amd-gaia/agent-ui` publishes successfully