### PR TITLE
fix: Claude workflow fails on fork PRs when head branch is 'main'

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -368,6 +368,10 @@ jobs:
           # Fetch base branch from origin BEFORE any URL changes
           git fetch origin $BASE_BRANCH
 
+          # Save base branch SHA before any origin URL changes (fork fetches can overwrite origin/$BASE_BRANCH)
+          BASE_SHA=$(git rev-parse origin/$BASE_BRANCH)
+          echo "Base SHA: $BASE_SHA"
+
           # Extract branch name first
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.headRefName')
 
@@ -385,9 +389,11 @@ jobs:
               exit 1
             }
 
-            git checkout -b $HEAD_REF origin/$HEAD_REF
+            # Use -B to force-create branch (handles case where HEAD_REF matches an existing
+            # branch like 'main' — common when contributors push to their fork's default branch)
+            git checkout -B pr-head origin/$HEAD_REF
 
-            echo "Successfully checked out $HEAD_REF (origin now points to fork)"
+            echo "Successfully checked out $HEAD_REF as pr-head (origin now points to fork)"
           else
             echo "Non-fork PR, fetching from origin"
             git fetch origin $PR_HEAD_SHA
@@ -395,12 +401,13 @@ jobs:
             git checkout -b "$HEAD_REF" $PR_HEAD_SHA 2>/dev/null || git checkout "$HEAD_REF"
           fi
 
-          # Generate diff in repo root (where Claude has access)
-          echo "Generating diff between $BASE_BRANCH and PR head..."
-          git diff origin/$BASE_BRANCH...$PR_HEAD_SHA > pr-diff.txt
+          # Generate diff using saved base SHA (not origin/$BASE_BRANCH which may have been
+          # overwritten when origin was redirected to the fork)
+          echo "Generating diff between base ($BASE_SHA) and PR head ($PR_HEAD_SHA)..."
+          git diff $BASE_SHA...$PR_HEAD_SHA > pr-diff.txt
 
           # Also get list of changed files
-          git diff --name-status origin/$BASE_BRANCH...$PR_HEAD_SHA > pr-files.txt
+          git diff --name-status $BASE_SHA...$PR_HEAD_SHA > pr-files.txt
 
           echo "Diff generated: $(wc -l < pr-diff.txt) lines"
           echo "Files changed: $(wc -l < pr-files.txt) files"


### PR DESCRIPTION
## Summary

- Fix `fatal: a branch named 'main' already exists` error when reviewing fork PRs where the contributor's head branch is `main` (their default branch)
- Fix corrupted diff base — after redirecting origin to the fork, `origin/$BASE_BRANCH` gets overwritten, so save the base SHA before any URL changes
- Use fixed branch name `pr-head` with `-B` (force-create) instead of `-b $HEAD_REF` to avoid name collisions

## Root Cause

When a fork PR uses `main` as its head branch ([PR #684](https://github.com/amd/gaia/pull/684)):
1. `actions/checkout` creates local `main` branch from the base repo
2. `git checkout -b main origin/main` fails because `main` already exists
3. Even if that succeeded, `git fetch origin main` (from fork) would overwrite `origin/main`, making the diff compare fork-vs-fork instead of base-vs-fork

Failed run: https://github.com/amd/gaia/actions/runs/23859641383/job/69562473226

## Test plan

- [ ] Trigger Claude review on [PR #684](https://github.com/amd/gaia/pull/684) (fork PR with `main` as head branch) — should succeed
- [ ] Trigger Claude review on a non-fork PR — should still work as before
- [ ] Verify the generated diff in logs shows correct base-vs-fork comparison