### PR TITLE
feat: MCP tool execution visualization in activity history

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -1159,6 +1159,9 @@ You must respond ONLY in valid JSON. No text before { or after }.
         """
         logger.debug(f"Executing tool {tool_name} with args: {tool_args}")
 
+        if not tool_name:
+            return {"status": "error", "error": "No tool name provided"}
+
         if tool_name not in _TOOL_REGISTRY:
             # Try to resolve unprefixed MCP tool names (e.g. "get_current_time"
             # when registry has "mcp_time_get_current_time"). Local LLMs often
@@ -1682,10 +1685,10 @@ You must respond ONLY in valid JSON. No text before { or after }.
                         tool_name, tool_result, conversation, tool_args
                     )
 
-                    # Display the tool result in real-time (show full result to user)
-                    self.console.print_tool_complete()
-
+                    # Display the tool result in real-time (show full result to user).
+                    # Emit result BEFORE complete so SSE latency is captured.
                     self.console.pretty_print_json(tool_result, "Tool Result")
+                    self.console.print_tool_complete()
 
                     # Store the truncated output for future context
                     previous_outputs.append(
@@ -2397,10 +2400,10 @@ You must respond ONLY in valid JSON. No text before { or after }.
                     tool_name, tool_result, conversation, tool_args
                 )
 
-                # Display the tool result in real-time (show full result to user)
-                self.console.print_tool_complete()
-
+                # Display the tool result in real-time (show full result to user).
+                # Emit result BEFORE complete so SSE latency is captured.
                 self.console.pretty_print_json(tool_result, "Result")
+                self.console.print_tool_complete()
 
                 # Store the truncated output for future context
                 previous_outputs.append(

--- a/src/gaia/agents/base/tools.py
+++ b/src/gaia/agents/base/tools.py
@@ -108,3 +108,13 @@ def get_tool_display_name(tool_name: str) -> str:
     if not tool:
         return tool_name
     return tool.get("display_name", tool_name)
+
+
+def get_tool_metadata(tool_name: str):
+    """Return the full registry entry for a tool, or ``None`` if not found.
+
+    This is the public accessor for ``_TOOL_REGISTRY``.  Consumers outside
+    the agent base layer (e.g. the SSE handler) should use this instead of
+    importing ``_TOOL_REGISTRY`` directly.
+    """
+    return _TOOL_REGISTRY.get(tool_name)

--- a/src/gaia/apps/webui/src/components/AgentActivity.css
+++ b/src/gaia/apps/webui/src/components/AgentActivity.css
@@ -293,6 +293,63 @@
     }
 }
 
+/* Activity filter bar */
+.activity-filter-bar {
+    display: flex;
+    gap: 6px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border-light);
+}
+
+.activity-filter-input {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 3px 8px;
+    border: 1px solid var(--border-light);
+    border-radius: 3px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    outline: none;
+}
+
+.activity-filter-input:focus {
+    border-color: var(--accent-color, #3b82f6);
+}
+
+.activity-filter-select {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 3px 6px;
+    border: 1px solid var(--border-light);
+    border-radius: 3px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    outline: none;
+    cursor: pointer;
+}
+
+/* MCP server badge */
+.flow-tool-mcp-server {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    padding: 1px 5px;
+    border-radius: 2px;
+    background: color-mix(in srgb, #7c3aed 10%, transparent);
+    color: #7c3aed;
+    white-space: nowrap;
+    font-weight: 500;
+}
+
+/* Tool latency */
+.flow-tool-latency {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    margin-right: 4px;
+}
+
 /* Chevron */
 .flow-tool-chevron {
     display: flex;

--- a/src/gaia/apps/webui/src/components/AgentActivity.tsx
+++ b/src/gaia/apps/webui/src/components/AgentActivity.tsx
@@ -81,6 +81,9 @@ const DEFAULT_TOOL_META: ToolMeta = {
 
 function getToolMeta(toolName?: string): ToolMeta {
     if (!toolName) return DEFAULT_TOOL_META;
+    if (toolName.startsWith('mcp_')) {
+        return { label: 'MCP tool', activeLabel: 'Running MCP tool', icon: Globe, color: '#7c3aed' };
+    }
     return TOOL_META[toolName] || DEFAULT_TOOL_META;
 }
 
@@ -152,15 +155,33 @@ export function AgentActivity({ steps, isActive, variant = 'inline' }: AgentActi
     }, [steps]);
 
     const toolSteps = displaySteps.filter((s) => s.type === 'tool');
+
+    // ── Filter state (for MCP tool visualization) ───────────────────
+    const [toolNameFilter, setToolNameFilter] = useState('');
+    const [statusFilter, setStatusFilter] = useState<'all' | 'success' | 'error'>('all');
+
+    // filteredSteps drives rendering; toolSteps/errorSteps use unfiltered
+    // displaySteps so counters and the filter-bar threshold stay stable.
+    const filteredSteps = useMemo(() => {
+        if (!toolNameFilter && statusFilter === 'all') return displaySteps;
+        return displaySteps.filter(s => {
+            if (s.type !== 'tool') return true;
+            if (toolNameFilter && !s.tool?.toLowerCase().includes(toolNameFilter.toLowerCase())) return false;
+            if (statusFilter === 'success' && s.success !== true) return false;
+            if (statusFilter === 'error' && s.success !== false) return false;
+            return true;
+        });
+    }, [displaySteps, toolNameFilter, statusFilter]);
+
     const errorSteps = displaySteps.filter((s) => s.type === 'error');
     const hasErrors = errorSteps.length > 0;
 
-    // Keep all tools expanded — auto-collapse is disabled for now to
-    // let users observe all activity. Will add adaptive collapse later.
+    // Auto-expand native tools for visibility. MCP tools start collapsed
+    // by default (users expand on demand) to reduce noise in busy sessions.
     useEffect(() => {
         prevStepCountRef.current = displaySteps.length;
         const toolIds = displaySteps
-            .filter((s) => s.type === 'tool')
+            .filter((s) => s.type === 'tool' && !s.mcpServer)
             .map((s) => s.id);
         if (toolIds.length > 0) {
             setExpandedTools((prev) => {
@@ -222,8 +243,31 @@ export function AgentActivity({ steps, isActive, variant = 'inline' }: AgentActi
                 the height transition on collapse/expand. */}
             {displaySteps.length > 0 && (
                 <div className={`agent-flow-wrap ${expanded ? 'flow-expanded' : 'flow-collapsed'}`}>
+                    {/* Filter bar — shown when expanded and 2+ tool steps */}
+                    {expanded && toolSteps.length >= 2 && (
+                        <div className="activity-filter-bar">
+                            <input
+                                type="text"
+                                className="activity-filter-input"
+                                placeholder="Filter by tool name..."
+                                aria-label="Filter by tool name"
+                                value={toolNameFilter}
+                                onChange={(e) => setToolNameFilter(e.target.value)}
+                            />
+                            <select
+                                className="activity-filter-select"
+                                aria-label="Filter by status"
+                                value={statusFilter}
+                                onChange={(e) => setStatusFilter(e.target.value as 'all' | 'success' | 'error')}
+                            >
+                                <option value="all">All</option>
+                                <option value="success">Success</option>
+                                <option value="error">Error</option>
+                            </select>
+                        </div>
+                    )}
                     <div className="agent-flow">
-                        {displaySteps.map((step) => {
+                        {filteredSteps.map((step) => {
                             if (step.type === 'thinking') {
                                 return <FlowThought key={step.id} step={step} />;
                             }
@@ -412,8 +456,14 @@ function FlowToolCard({ step, isExpanded, onToggle }: FlowToolCardProps) {
                     <span className="flow-tool-badge" style={{ '--badge-color': color } as React.CSSProperties}>
                         {step.tool}
                     </span>
+                    {step.mcpServer && (
+                        <span className="flow-tool-mcp-server">via {step.mcpServer}</span>
+                    )}
                 </div>
                 <div className="flow-tool-right">
+                    {step.latencyMs != null && !step.active && (
+                        <span className="flow-tool-latency">{Math.round(step.latencyMs)}ms</span>
+                    )}
                     {hasDetail && (
                         <span className={`flow-tool-chevron ${isExpanded ? 'expanded' : ''}`}>
                             <ChevronRight size={12} />

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -87,6 +87,7 @@ function agentEventToStep(event: StreamEvent, stepIdRef: React.MutableRefObject<
                 tool: event.tool,
                 detail: event.detail,
                 active: true, timestamp: ts,
+                mcpServer: event.mcp_server,
             };
         case 'plan':
             return {
@@ -697,6 +698,7 @@ export function ChatView({ sessionId }: ChatViewProps) {
                         result: event.summary || event.title || 'Done',
                         active: false,
                         success: event.success !== false,
+                        latencyMs: event.latency_ms,
                     };
                     // Pass through structured command output if available
                     if (event.command_output) {

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -236,6 +236,10 @@ export interface AgentStep {
         files: Array<Record<string, unknown>>;
         total: number;
     };
+    /** MCP server name (for MCP tools). */
+    mcpServer?: string;
+    /** Tool call latency in milliseconds. */
+    latencyMs?: number;
 }
 
 /** Extended SSE event types for agent communication. */
@@ -295,6 +299,10 @@ export interface StreamEvent {
     confirm_id?: string;
     /** Timeout in seconds (for tool_confirm events). */
     timeout_seconds?: number;
+    /** MCP server name (for tool_start of MCP tools). */
+    mcp_server?: string;
+    /** Tool call latency in milliseconds (for tool_result). */
+    latency_ms?: number;
     /** Structured result data (for tool_result with search results, file lists, etc.). */
     result_data?: {
         type: string;

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -861,6 +861,7 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                             "detail": event.get("detail"),
                             "active": True,
                             "timestamp": int(asyncio.get_running_loop().time() * 1000),
+                            "mcpServer": event.get("mcp_server"),
                         }
                     )
                 elif event_type == "tool_args" and captured_steps:
@@ -882,6 +883,9 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                             event.get("summary") or event.get("title") or "Done"
                         )
                         tool_step["success"] = event.get("success", True)
+                        # Persist MCP tool latency
+                        if event.get("latency_ms") is not None:
+                            tool_step["latencyMs"] = event["latency_ms"]
                         # Persist structured command output for terminal rendering
                         if event.get("command_output"):
                             tool_step["commandOutput"] = event["command_output"]

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -183,6 +183,8 @@ class AgentStepResponse(BaseModel):
     timestamp: int = 0
     commandOutput: Optional[CommandOutputResponse] = None
     fileList: Optional[FileListResponse] = None
+    mcpServer: Optional[str] = None
+    latencyMs: Optional[float] = None
 
 
 class InferenceStatsResponse(BaseModel):

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from gaia.agents.base.console import OutputHandler
+from gaia.agents.base.tools import get_tool_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,7 @@ class SSEOutputHandler(OutputHandler):
         self._confirm_event: Optional[threading.Event] = None
         self._confirm_result: bool = False
         self._confirm_id: Optional[str] = None
+        self._tool_start_time: Optional[float] = None
 
     def _emit(self, event: Dict[str, Any]):
         """Push an event to the queue for SSE delivery."""
@@ -199,15 +201,24 @@ class SSEOutputHandler(OutputHandler):
     def print_tool_usage(self, tool_name: str):
         self._tool_count += 1
         self._last_tool_name = tool_name
-        self._emit(
-            {
-                "type": "tool_start",
-                "tool": tool_name,
-                "detail": _tool_description(tool_name),
-            }
-        )
+        self._tool_start_time = time.monotonic()
+        event = {
+            "type": "tool_start",
+            "tool": tool_name,
+            "detail": _tool_description(tool_name),
+        }
+        # Attach MCP server name if this is an MCP tool.
+        # _mcp_server is set by MCPTool.to_gaia_format() during registration
+        # in MCPClientMixin._register_mcp_tools() (see mcp/client/mcp_client.py).
+        meta = get_tool_metadata(tool_name)
+        if meta:
+            mcp_server = meta.get("_mcp_server")
+            if mcp_server:
+                event["mcp_server"] = mcp_server
+        self._emit(event)
 
     def print_tool_complete(self):
+        self._tool_start_time = None  # Reset in case tool_result was skipped
         self._emit(
             {
                 "type": "tool_end",
@@ -240,6 +251,14 @@ class SSEOutputHandler(OutputHandler):
                 data.get("status") != "error" if isinstance(data, dict) else True
             ),
         }
+
+        # Attach latency for tool calls (measured from print_tool_usage)
+        if self._tool_start_time is not None:
+            latency_ms = round(
+                (time.monotonic() - self._tool_start_time) * 1000, 1
+            )
+            event["latency_ms"] = latency_ms
+            self._tool_start_time = None
 
         # For command execution results, include structured output data
         # so the frontend can render a proper terminal view

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -254,9 +254,7 @@ class SSEOutputHandler(OutputHandler):
 
         # Attach latency for tool calls (measured from print_tool_usage)
         if self._tool_start_time is not None:
-            latency_ms = round(
-                (time.monotonic() - self._tool_start_time) * 1000, 1
-            )
+            latency_ms = round((time.monotonic() - self._tool_start_time) * 1000, 1)
             event["latency_ms"] = latency_ms
             self._tool_start_time = None
 

--- a/tests/unit/chat/ui/test_models.py
+++ b/tests/unit/chat/ui/test_models.py
@@ -371,16 +371,24 @@ class TestAgentStepResponse:
 
     def test_mcp_fields_set(self):
         step = AgentStepResponse(
-            id=1, type="tool", label="MCP tool",
-            timestamp=0, mcpServer="github", latencyMs=47.2,
+            id=1,
+            type="tool",
+            label="MCP tool",
+            timestamp=0,
+            mcpServer="github",
+            latencyMs=47.2,
         )
         assert step.mcpServer == "github"
         assert step.latencyMs == 47.2
 
     def test_mcp_fields_serialization(self):
         step = AgentStepResponse(
-            id=1, type="tool", label="MCP tool",
-            timestamp=0, mcpServer="filesystem", latencyMs=123.0,
+            id=1,
+            type="tool",
+            label="MCP tool",
+            timestamp=0,
+            mcpServer="filesystem",
+            latencyMs=123.0,
         )
         data = step.model_dump()
         assert data["mcpServer"] == "filesystem"

--- a/tests/unit/chat/ui/test_models.py
+++ b/tests/unit/chat/ui/test_models.py
@@ -7,6 +7,7 @@ Tests model validation, defaults, and serialization.
 """
 
 from gaia.ui.models import (
+    AgentStepResponse,
     AttachDocumentRequest,
     ChatRequest,
     ChatResponse,
@@ -360,3 +361,33 @@ class TestAttachDocumentRequest:
     def test_document_id_required(self):
         request = AttachDocumentRequest(document_id="doc123")
         assert request.document_id == "doc123"
+
+
+class TestAgentStepResponse:
+    def test_mcp_fields_default_to_none(self):
+        step = AgentStepResponse(id=1, type="tool", label="Used tool", timestamp=0)
+        assert step.mcpServer is None
+        assert step.latencyMs is None
+
+    def test_mcp_fields_set(self):
+        step = AgentStepResponse(
+            id=1, type="tool", label="MCP tool",
+            timestamp=0, mcpServer="github", latencyMs=47.2,
+        )
+        assert step.mcpServer == "github"
+        assert step.latencyMs == 47.2
+
+    def test_mcp_fields_serialization(self):
+        step = AgentStepResponse(
+            id=1, type="tool", label="MCP tool",
+            timestamp=0, mcpServer="filesystem", latencyMs=123.0,
+        )
+        data = step.model_dump()
+        assert data["mcpServer"] == "filesystem"
+        assert data["latencyMs"] == 123.0
+
+    def test_mcp_fields_none_serialization(self):
+        step = AgentStepResponse(id=1, type="tool", label="Used tool", timestamp=0)
+        data = step.model_dump()
+        assert data["mcpServer"] is None
+        assert data["latencyMs"] is None

--- a/tests/unit/chat/ui/test_sse_handler.py
+++ b/tests/unit/chat/ui/test_sse_handler.py
@@ -12,6 +12,7 @@ import time
 
 import pytest
 
+from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.ui.sse_handler import (
     SSEOutputHandler,
     _fix_double_escaped,
@@ -1587,3 +1588,93 @@ class TestEventSequences:
         combined = "".join(e["content"] for e in chunk_events)
         assert combined == "Hello world!"
         assert events[-1] is None
+
+
+# ===========================================================================
+# MCP Tool Visualization (Issue #712)
+# ===========================================================================
+
+
+class TestMCPToolVisualization:
+    """Tests for MCP tool server name and latency in SSE events."""
+
+    def _register_mcp_tool(self, name, server):
+        _TOOL_REGISTRY[name] = {
+            "name": name,
+            "description": f"MCP tool from {server}",
+            "parameters": {},
+            "_mcp_server": server,
+        }
+
+    def _cleanup_registry(self, name):
+        _TOOL_REGISTRY.pop(name, None)
+
+    def test_tool_start_includes_mcp_server(self, handler):
+        tool_name = "mcp_github_search_code"
+        self._register_mcp_tool(tool_name, "github")
+        try:
+            handler.print_tool_usage(tool_name)
+            events = _drain(handler)
+            assert events[0]["mcp_server"] == "github"
+        finally:
+            self._cleanup_registry(tool_name)
+
+    def test_tool_start_no_mcp_server_for_native_tools(self, handler):
+        handler.print_tool_usage("search_file")
+        events = _drain(handler)
+        assert "mcp_server" not in events[0]
+
+    def test_tool_result_includes_latency_ms(self, handler):
+        handler.print_tool_usage("search_file")
+        _drain(handler)
+        handler.pretty_print_json({"status": "success", "data": {}}, title="Result")
+        events = _drain(handler)
+        assert events[0]["latency_ms"] >= 0
+
+    def test_latency_resets_between_tool_calls(self, handler):
+        handler.print_tool_usage("tool_a")
+        _drain(handler)
+        handler.pretty_print_json({"status": "success"}, title="Result")
+        events1 = _drain(handler)
+        handler.print_tool_usage("tool_b")
+        _drain(handler)
+        handler.pretty_print_json({"status": "success"}, title="Result")
+        events2 = _drain(handler)
+        assert events1[0]["latency_ms"] >= 0
+        assert events2[0]["latency_ms"] >= 0
+
+    def test_latency_not_present_without_tool_start(self, handler):
+        handler.pretty_print_json({"status": "success"}, title="Result")
+        events = _drain(handler)
+        assert "latency_ms" not in events[0]
+
+    def test_tool_complete_resets_start_time(self, handler):
+        handler.print_tool_usage("tool_a")
+        _drain(handler)
+        handler.print_tool_complete()
+        _drain(handler)
+        assert handler._tool_start_time is None
+        handler.print_tool_usage("tool_b")
+        _drain(handler)
+        handler.pretty_print_json({"status": "success"}, title="Result")
+        events = _drain(handler)
+        assert events[0]["latency_ms"] < 1000
+
+    def test_mcp_tool_full_flow(self, handler):
+        tool_name = "mcp_filesystem_read_file"
+        self._register_mcp_tool(tool_name, "filesystem")
+        try:
+            handler.print_tool_usage(tool_name)
+            assert _drain(handler)[0]["mcp_server"] == "filesystem"
+            handler.pretty_print_json({"path": "/tmp/test.txt"}, title="Arguments")
+            assert _drain(handler)[0]["type"] == "tool_args"
+            handler.pretty_print_json(
+                {"status": "success", "data": {"content": "hello"}}, title="Result"
+            )
+            result = _drain(handler)[0]
+            assert result["type"] == "tool_result"
+            assert result["latency_ms"] >= 0
+            handler.print_tool_complete()
+            assert _drain(handler)[0]["type"] == "tool_end"
+        finally:
+            self._cleanup_registry(tool_name)


### PR DESCRIPTION
## Summary

Closes #712

- MCP tool calls in the Agent Activity panel now show a purple **"via {server}"** badge identifying the MCP server
- **Latency** (in ms) is displayed in the collapsed tool header, measured at the SSE handler layer via `time.monotonic()`
- MCP tool cards start **collapsed by default** (native tools still auto-expand)
- **Filter bar** appears when 2+ tool steps exist — filter by tool name text or status (All/Success/Error)
- Server name resolved via `_TOOL_REGISTRY` lookup (no fragile prefix parsing)
- No new SSE event types, no DB migration, no new API endpoints

## Changes

| File | Change |
|------|--------|
| `src/gaia/ui/sse_handler.py` | `mcp_server` on `tool_start`, `latency_ms` on `tool_result` |
| `src/gaia/ui/_chat_helpers.py` | `mcpServer`/`latencyMs` in captured steps |
| `src/gaia/ui/models.py` | New fields on `AgentStepResponse` |
| `src/gaia/apps/webui/src/types/index.ts` | Extend `AgentStep` + `StreamEvent` |
| `src/gaia/apps/webui/src/components/ChatView.tsx` | Forward `mcp_server`/`latency_ms` in event handlers |
| `src/gaia/apps/webui/src/components/AgentActivity.tsx` | MCP meta, badge, latency, filter bar, collapsed-by-default |
| `src/gaia/apps/webui/src/components/AgentActivity.css` | Filter bar, MCP badge, latency styles |
| `tests/unit/chat/ui/test_sse_handler.py` | 7 new MCP visualization tests |
| `tests/unit/chat/ui/test_models.py` | 4 new AgentStepResponse tests |

## Test plan

- [x] 216 unit tests pass (`python -m pytest tests/unit/chat/ui/`)
- [x] Frontend builds clean (`npm run build`)
- [x] Lint passes (`python util/lint.py --all --fix`)
- [x] Manual: `gaia chat --ui` → configure MCP server → trigger tool calls → verify badge/latency/filter/collapse
- [x] Manual: Refresh page → verify tool traces persist in session

## Images
<img width="813" height="751" alt="image" src="https://github.com/user-attachments/assets/82f6d6d1-a272-4c30-a5cc-9aebfe64b92f" />
