### PR TITLE
fix: surface document indexing failures instead of silent 0-chunk success

### DIFF
--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1102,6 +1102,9 @@ async def _index_document(filepath: Path) -> int:
     Runs the synchronous RAG indexing in a thread pool executor
     to avoid blocking the async event loop.
 
+    Note: A return value of 0 means RAG reported success but produced
+    no chunks. Callers must treat 0 chunks as a failure condition.
+
     Raises:
         RuntimeError: If indexing fails for any reason.
     """

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1101,6 +1101,9 @@ async def _index_document(filepath: Path) -> int:
 
     Runs the synchronous RAG indexing in a thread pool executor
     to avoid blocking the async event loop.
+
+    Raises:
+        RuntimeError: If indexing fails for any reason.
     """
 
     def _do_index():
@@ -1113,32 +1116,28 @@ async def _index_document(filepath: Path) -> int:
         rag = RAGSDK(config)
         result = rag.index_document(str(filepath))
         logger.info("RAG index_document result for %s: %s", filepath, result)
-        if isinstance(result, dict):
-            if result.get("error"):
-                logger.warning(
-                    "RAG returned error for %s: %s", filepath, result["error"]
-                )
-            if not result.get("success"):
-                logger.warning(
-                    "RAG indexing unsuccessful for %s (success=False)", filepath
-                )
-            # RAG SDK returns "num_chunks", not "chunk_count"
-            chunks = result.get("num_chunks", 0) or result.get("chunk_count", 0)
-            logger.info(
-                "Indexed %s: %d chunks (success=%s)",
-                filepath,
-                chunks,
-                result.get("success"),
+
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"RAG returned unexpected type for {filepath.name}: "
+                f"{type(result).__name__}"
             )
-            return chunks
-        logger.warning(
-            "RAG index_document returned non-dict for %s: %r", filepath, result
-        )
-        return 0
+
+        error = result.get("error")
+        if error:
+            raise RuntimeError(f"RAG indexing failed for {filepath.name}: {error}")
+
+        if not result.get("success"):
+            raise RuntimeError(f"RAG indexing unsuccessful for {filepath.name}")
+
+        chunks = result.get("num_chunks", 0) or result.get("chunk_count", 0)
+        logger.info("Indexed %s: %d chunks", filepath, chunks)
+        return chunks
 
     try:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, _do_index)
+    except RuntimeError:
+        raise
     except Exception as e:
-        logger.error("Failed to index document %s: %s", filepath, e, exc_info=True)
-        return 0
+        raise RuntimeError(f"Failed to index {filepath.name}: {e}") from e

--- a/src/gaia/ui/document_monitor.py
+++ b/src/gaia/ui/document_monitor.py
@@ -220,14 +220,22 @@ class DocumentMonitor:
 
         try:
             chunk_count = await self._index_fn(Path(filepath))
-            self._db.reindex_document(doc_id, new_hash, mtime, chunk_count, size)
-            self._reindex_count += 1
-            logger.info(
-                "Re-indexed %s: %d chunks (doc_id=%s)",
-                filepath,
-                chunk_count,
-                doc_id,
-            )
+            if chunk_count == 0:
+                self._db.update_document_status(doc_id, "failed")
+                logger.warning(
+                    "Re-indexing returned 0 chunks for %s (doc_id=%s)",
+                    filepath,
+                    doc_id,
+                )
+            else:
+                self._db.reindex_document(doc_id, new_hash, mtime, chunk_count, size)
+                self._reindex_count += 1
+                logger.info(
+                    "Re-indexed %s: %d chunks (doc_id=%s)",
+                    filepath,
+                    chunk_count,
+                    doc_id,
+                )
         except Exception:
             self._db.update_document_status(doc_id, "failed")
             logger.exception("Re-indexing failed for %s", filepath)

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -129,7 +129,15 @@ async def upload_by_path(
                 try:
                     chunk_count = await _index_document(temp_path)
                 except Exception as e:
-                    logger.error("Indexing failed for %s: %s", safe_filepath.name, e)
+                    logger.error(
+                        "Indexing failed for %s: %s",
+                        safe_filepath.name,
+                        e,
+                        exc_info=True,
+                    )
+                    chunk_count = 0
+
+                if chunk_count == 0:
                     doc = db.add_document(
                         filename=safe_filepath.name,
                         filepath=str(safe_filepath),

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -126,7 +126,22 @@ async def upload_by_path(
         try:
             if file_size <= LARGE_FILE_THRESHOLD:
                 # Small file: index synchronously
-                chunk_count = await _index_document(temp_path)
+                try:
+                    chunk_count = await _index_document(temp_path)
+                except Exception as e:
+                    logger.error("Indexing failed for %s: %s", safe_filepath.name, e)
+                    doc = db.add_document(
+                        filename=safe_filepath.name,
+                        filepath=str(safe_filepath),
+                        file_hash=file_hash,
+                        file_size=file_size,
+                        chunk_count=0,
+                        file_mtime=file_mtime,
+                    )
+                    db.update_document_status(doc["id"], "failed")
+                    doc["indexing_status"] = "failed"
+                    return doc_to_response(doc)
+
                 doc = db.add_document(
                     filename=safe_filepath.name,
                     filepath=str(safe_filepath),
@@ -164,14 +179,21 @@ async def upload_by_path(
                     )
                     chunk_count = await _index_document(temp_file)
                     if doc_id in indexing_tasks:
-                        db.update_document_status(
-                            doc_id, "complete", chunk_count=chunk_count
-                        )
-                        logger.info(
-                            "Background indexing complete for %s: %d chunks",
-                            original_name,
-                            chunk_count,
-                        )
+                        if chunk_count == 0:
+                            db.update_document_status(doc_id, "failed", chunk_count=0)
+                            logger.warning(
+                                "Background indexing returned 0 chunks for %s",
+                                original_name,
+                            )
+                        else:
+                            db.update_document_status(
+                                doc_id, "complete", chunk_count=chunk_count
+                            )
+                            logger.info(
+                                "Background indexing complete for %s: %d chunks",
+                                original_name,
+                                chunk_count,
+                            )
                 except asyncio.CancelledError:
                     db.update_document_status(doc_id, "cancelled")
                     logger.info("Background indexing cancelled for %s", original_name)

--- a/tests/unit/chat/ui/test_document_monitor.py
+++ b/tests/unit/chat/ui/test_document_monitor.py
@@ -290,3 +290,42 @@ class TestDocumentMonitor:
             assert call_count[0] == 0
         finally:
             await monitor.stop()
+
+    @pytest.mark.asyncio
+    async def test_reindex_zero_chunks_sets_failed(self, db, temp_file):
+        """Re-indexing that returns 0 chunks should set status to 'failed'."""
+        file_hash = _compute_file_hash(temp_file)
+        file_stat = os.stat(temp_file)
+
+        doc = db.add_document(
+            filename="test.txt",
+            filepath=temp_file,
+            file_hash=file_hash,
+            file_size=file_stat.st_size,
+            chunk_count=3,
+            file_mtime=file_stat.st_mtime,
+        )
+        doc_id = doc["id"]
+
+        # Modify the file to trigger re-indexing
+        time.sleep(0.1)
+        with open(temp_file, "a") as f:
+            f.write("\nModified content")
+
+        index_called = asyncio.Event()
+
+        async def zero_chunk_index(filepath) -> int:
+            index_called.set()
+            return 0
+
+        monitor = DocumentMonitor(db=db, index_fn=zero_chunk_index, interval=0.5)
+
+        await monitor.start()
+        try:
+            await asyncio.wait_for(index_called.wait(), timeout=10.0)
+            # Give monitor time to update DB
+            await asyncio.sleep(0.2)
+            updated = db.get_document(doc_id)
+            assert updated["indexing_status"] == "failed"
+        finally:
+            await monitor.stop()

--- a/tests/unit/chat/ui/test_indexing_errors.py
+++ b/tests/unit/chat/ui/test_indexing_errors.py
@@ -1,0 +1,214 @@
+# Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for _index_document error propagation (Issue #590).
+
+Verifies that indexing failures raise RuntimeError instead of silently
+returning 0 chunks, and that callers set indexing_status='failed'.
+"""
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# ── _index_document unit tests ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_rag_module():
+    """Create a mock RAGSDK module for patching."""
+    mock_sdk = MagicMock()
+    mock_config = MagicMock()
+    return mock_sdk, mock_config
+
+
+class TestIndexDocumentErrorPropagation:
+    """Tests that _index_document raises on failure instead of returning 0."""
+
+    @pytest.mark.asyncio
+    async def test_returns_chunks_on_success(self):
+        """Successful indexing returns the chunk count."""
+        from gaia.ui._chat_helpers import _index_document
+
+        mock_rag = MagicMock()
+        mock_rag.index_document.return_value = {
+            "success": True,
+            "num_chunks": 5,
+        }
+
+        with (
+            patch("gaia.rag.sdk.RAGSDK", return_value=mock_rag),
+            patch("gaia.rag.sdk.RAGConfig"),
+        ):
+            result = await _index_document(Path("/tmp/test.txt"))
+
+        assert result == 5
+
+    @pytest.mark.asyncio
+    async def test_raises_on_rag_error(self):
+        """RAG returning an error dict must raise RuntimeError."""
+        from gaia.ui._chat_helpers import _index_document
+
+        mock_rag = MagicMock()
+        mock_rag.index_document.return_value = {
+            "success": False,
+            "num_chunks": 0,
+            "error": "embedder not loaded",
+        }
+
+        with (
+            patch("gaia.rag.sdk.RAGSDK", return_value=mock_rag),
+            patch("gaia.rag.sdk.RAGConfig"),
+        ):
+            with pytest.raises(RuntimeError, match="embedder not loaded"):
+                await _index_document(Path("/tmp/test.txt"))
+
+    @pytest.mark.asyncio
+    async def test_raises_on_success_false(self):
+        """RAG returning success=False without error must raise RuntimeError."""
+        from gaia.ui._chat_helpers import _index_document
+
+        mock_rag = MagicMock()
+        mock_rag.index_document.return_value = {
+            "success": False,
+            "num_chunks": 0,
+        }
+
+        with (
+            patch("gaia.rag.sdk.RAGSDK", return_value=mock_rag),
+            patch("gaia.rag.sdk.RAGConfig"),
+        ):
+            with pytest.raises(RuntimeError, match="unsuccessful"):
+                await _index_document(Path("/tmp/test.txt"))
+
+    @pytest.mark.asyncio
+    async def test_raises_on_non_dict_result(self):
+        """RAG returning a non-dict must raise RuntimeError."""
+        from gaia.ui._chat_helpers import _index_document
+
+        mock_rag = MagicMock()
+        mock_rag.index_document.return_value = None
+
+        with (
+            patch("gaia.rag.sdk.RAGSDK", return_value=mock_rag),
+            patch("gaia.rag.sdk.RAGConfig"),
+        ):
+            with pytest.raises(RuntimeError, match="unexpected type"):
+                await _index_document(Path("/tmp/test.txt"))
+
+    @pytest.mark.asyncio
+    async def test_raises_on_executor_exception(self):
+        """Exceptions from RAG SDK must propagate as RuntimeError."""
+        from gaia.ui._chat_helpers import _index_document
+
+        mock_rag = MagicMock()
+        mock_rag.index_document.side_effect = ConnectionError("server down")
+
+        with (
+            patch("gaia.rag.sdk.RAGSDK", return_value=mock_rag),
+            patch("gaia.rag.sdk.RAGConfig"),
+        ):
+            with pytest.raises(RuntimeError, match="server down"):
+                await _index_document(Path("/tmp/test.txt"))
+
+
+# ── Upload endpoint failure handling tests ───────────────────────────────────
+
+
+@pytest.fixture
+def home_tmp_dir():
+    """Create a temporary directory under $HOME for tests."""
+    d = Path.home() / ".gaia_test_indexing"
+    d.mkdir(exist_ok=True)
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+class TestUploadIndexingFailure:
+    """Tests that upload endpoint sets indexing_status='failed' on errors."""
+
+    @pytest.fixture
+    def app(self):
+        from gaia.ui.server import create_app
+
+        return create_app(db_path=":memory:")
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app)
+
+    @pytest.fixture
+    def db(self, app):
+        return app.state.db
+
+    def test_small_file_failure_sets_status_failed(self, home_tmp_dir, client, db):
+        """When _index_document raises, the document should be stored with
+        indexing_status='failed' and chunk_count=0."""
+        doc_file = home_tmp_dir / "test.txt"
+        doc_file.write_text("hello world")
+
+        async def mock_index_fail(path):
+            raise RuntimeError("embedder not loaded")
+
+        with patch("gaia.ui.server._index_document", mock_index_fail):
+            resp = client.post(
+                "/api/documents/upload-path",
+                json={"filepath": str(doc_file)},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["chunk_count"] == 0
+        assert data["indexing_status"] == "failed"
+
+    def test_small_file_success_has_chunks(self, home_tmp_dir, client):
+        """Successful indexing returns chunk_count > 0."""
+        doc_file = home_tmp_dir / "test.txt"
+        doc_file.write_text("hello world")
+
+        async def mock_index_ok(path):
+            return 5
+
+        with patch("gaia.ui.server._index_document", mock_index_ok):
+            resp = client.post(
+                "/api/documents/upload-path",
+                json={"filepath": str(doc_file)},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["chunk_count"] == 5
+
+    def test_large_file_zero_chunks_sets_failed(self, home_tmp_dir, app, db):
+        """Background indexing returning 0 chunks should set status='failed'."""
+        doc_file = home_tmp_dir / "large.txt"
+        # Create a file larger than LARGE_FILE_THRESHOLD (5MB)
+        doc_file.write_bytes(b"x" * (6 * 1024 * 1024))
+
+        async def mock_index_zero(path):
+            return 0
+
+        error_client = TestClient(app, raise_server_exceptions=False)
+        with patch("gaia.ui.server._index_document", mock_index_zero):
+            resp = error_client.post(
+                "/api/documents/upload-path",
+                json={"filepath": str(doc_file)},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        doc_id = data["id"]
+
+        # Wait briefly for background task
+        import time
+
+        time.sleep(0.5)
+
+        # Check DB state — background task should have set status to "failed"
+        doc = db.get_document(doc_id)
+        assert doc is not None
+        assert doc["indexing_status"] == "failed"
+        assert doc["chunk_count"] == 0

--- a/tests/unit/chat/ui/test_indexing_errors.py
+++ b/tests/unit/chat/ui/test_indexing_errors.py
@@ -120,7 +120,11 @@ class TestIndexDocumentErrorPropagation:
 
 @pytest.fixture
 def home_tmp_dir():
-    """Create a temporary directory under $HOME for tests."""
+    """Create a temporary directory under $HOME for tests.
+
+    Must be under $HOME because safe_open_document rejects paths
+    outside the user's home directory.
+    """
     d = Path.home() / ".gaia_test_indexing"
     d.mkdir(exist_ok=True)
     yield d
@@ -202,12 +206,16 @@ class TestUploadIndexingFailure:
         data = resp.json()
         doc_id = data["id"]
 
-        # Wait briefly for background task
+        # Poll DB until background task updates the status
         import time
 
-        time.sleep(0.5)
+        for _ in range(20):
+            doc = db.get_document(doc_id)
+            if doc and doc["indexing_status"] != "indexing":
+                break
+            time.sleep(0.1)
 
-        # Check DB state — background task should have set status to "failed"
+        # Background task should have set status to "failed"
         doc = db.get_document(doc_id)
         assert doc is not None
         assert doc["indexing_status"] == "failed"

--- a/tests/unit/chat/ui/test_toctou.py
+++ b/tests/unit/chat/ui/test_toctou.py
@@ -169,7 +169,7 @@ class TestUploadByPathTOCTOU:
         # Temp file should be cleaned up
         assert not temp_paths[0].exists()
 
-    def test_upload_cleans_up_temp_on_failure(self, home_tmp_dir, app):
+    def test_upload_cleans_up_temp_on_failure(self, home_tmp_dir, client):
         """Temp file must be removed even when indexing fails."""
         doc_file = home_tmp_dir / "test.txt"
         doc_file.write_text("hello world")
@@ -179,17 +179,15 @@ class TestUploadByPathTOCTOU:
             temp_paths.append(Path(str(path)))
             raise RuntimeError("indexing failed")
 
-        # Use raise_server_exceptions=False so we get the 500 response
-        # instead of the TestClient re-raising the RuntimeError.
-        error_client = TestClient(app, raise_server_exceptions=False)
         with patch("gaia.ui.server._index_document", mock_index_fail):
-            resp = error_client.post(
+            resp = client.post(
                 "/api/documents/upload-path",
                 json={"filepath": str(doc_file)},
             )
 
-        # Should get 500 (global exception handler catches it)
-        assert resp.status_code == 500
+        # Indexing failure now returns 200 with status="failed" (not 500)
+        assert resp.status_code == 200
+        assert resp.json()["indexing_status"] == "failed"
         # Temp file should still be cleaned up
         if temp_paths:
             assert not temp_paths[0].exists()


### PR DESCRIPTION
## Summary

Fixes #590 — Documents indexed via the Agent UI silently reported `indexing_status: "complete"` with `chunk_count: 0`, making RAG completely non-functional with no visible error.

- **`_index_document` now raises `RuntimeError` on failure** instead of silently returning `0`. This covers: RAG SDK errors, `success=False` results, non-dict returns, and unexpected exceptions.
- **`upload_by_path` catches failures** and stores the document with `indexing_status="failed"` (returns HTTP 200 so the UI can display the failed state).
- **Background indexing and document monitor** both guard against 0-chunk success, setting status to `"failed"`.
- **9 new tests** covering error propagation, upload failure handling, background 0-chunk detection, and monitor re-index failure.

## Files Changed

| File | Change |
|------|--------|
| `src/gaia/ui/_chat_helpers.py` | `_index_document` raises on failure |
| `src/gaia/ui/routers/documents.py` | Catch failures in small-file and background paths |
| `src/gaia/ui/document_monitor.py` | 0-chunk guard for re-index path |
| `tests/unit/chat/ui/test_indexing_errors.py` | 8 new tests (TDD) |
| `tests/unit/chat/ui/test_document_monitor.py` | 1 new test for monitor 0-chunk |
| `tests/unit/chat/ui/test_toctou.py` | Updated failure test expectations |

## Test plan

- [x] 535 unit tests pass (`python -m pytest tests/unit/chat/ui/ -x`)
- [x] 29 RAG SDK tests pass (`python -m pytest tests/test_rag.py -x`)
- [x] E2E: empty file correctly shows `indexing_status="failed"` via Agent UI MCP
- [x] E2E: embedding model failure correctly shows `"failed"` (not `"complete"` with 0 chunks)
- [x] E2E: pre-existing indexed documents (with chunks) remain unaffected
- [ ] E2E: full RAG query test (blocked by Lemonade model loading on test machine)