### PR TITLE
fix: Ask Agent indexes and attaches files before sending to chat

### DIFF
--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -132,6 +132,7 @@ export function ChatView({ sessionId }: ChatViewProps) {
     } = useChatStore();
 
     const { addNotification } = useNotificationStore();
+    const pendingPrompt = useChatStore((s) => s.pendingPrompt);
 
     const session = sessions.find((s) => s.id === sessionId);
     const sessionDocIds = new Set(session?.document_ids ?? []);
@@ -259,20 +260,21 @@ export function ChatView({ sessionId }: ChatViewProps) {
             .catch(() => {});
     }, [setDocuments]);
 
-    // Consume pending prompt from store (set by WelcomeScreen suggestions).
-    // This replaces the fragile event-dispatch-with-setTimeout pattern —
-    // the prompt is stored in Zustand before the session is created, so
-    // ChatView reliably picks it up on mount regardless of render timing.
+    // Consume pending prompt from store (set by WelcomeScreen suggestions
+    // or Ask Agent in FileBrowser). Reactive subscription ensures prompts
+    // are consumed both on mount AND when set while ChatView is already
+    // mounted (e.g., Ask Agent from file browser in an existing session).
     useEffect(() => {
+        // Use getState() as authoritative source to prevent double-fire
+        // in React StrictMode (effects mount/unmount/remount).
         const pending = useChatStore.getState().pendingPrompt;
-        if (pending) {
-            log.chat.info(`Consuming pending prompt: "${pending.slice(0, 60)}"`);
-            useChatStore.getState().setPendingPrompt(null);
-            setInput(pending);
-            // Defer send to next tick so React finishes mount
-            requestAnimationFrame(() => sendMessageRef.current(pending));
-        }
-    }, [sessionId]);
+        if (!pending) return;
+        log.chat.info(`Consuming pending prompt: "${pending.slice(0, 60)}"`);
+        useChatStore.getState().setPendingPrompt(null);
+        setInput(pending);
+        // Defer send to next tick so React finishes mount
+        requestAnimationFrame(() => sendMessageRef.current(pending));
+    }, [pendingPrompt]);
 
     // Auto-scroll (throttled) — scrolls at most once per 100ms while
     // streaming, and also schedules a trailing scroll so the final chunk

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -272,8 +272,13 @@ export function ChatView({ sessionId }: ChatViewProps) {
         log.chat.info(`Consuming pending prompt: "${pending.slice(0, 60)}"`);
         useChatStore.getState().setPendingPrompt(null);
         setInput(pending);
-        // Defer send to next tick so React finishes mount
-        requestAnimationFrame(() => sendMessageRef.current(pending));
+        // Defer send to next tick so React finishes mount.
+        // Guard against component unmounting before the frame fires.
+        let cancelled = false;
+        requestAnimationFrame(() => {
+            if (!cancelled) sendMessageRef.current(pending);
+        });
+        return () => { cancelled = true; };
     }, [pendingPrompt]);
 
     // Auto-scroll (throttled) — scrolls at most once per 100ms while

--- a/src/gaia/apps/webui/src/components/FileBrowser.tsx
+++ b/src/gaia/apps/webui/src/components/FileBrowser.tsx
@@ -80,8 +80,78 @@ interface FilePreview {
     row_count: number | null;
 }
 
+/** Result of indexing and attaching files to a session. */
+interface IndexResult {
+    docIds: string[];
+    supported: string[];
+    unsupported: string[];
+    failed: number;
+    lastError: string;
+}
+
+/**
+ * Core indexing + attaching logic shared by "Index Selected" and "Ask Agent".
+ * Validates extensions, indexes supported files, and attaches them to the session.
+ */
+async function indexAndAttachFiles(
+    files: string[],
+    entries: FileEntry[],
+    sessionId: string | null,
+    updateSessionInList: (id: string, patch: Record<string, unknown>) => void,
+): Promise<IndexResult> {
+    const supported: string[] = [];
+    const unsupported: string[] = [];
+    for (const filepath of files) {
+        const ext = filepath.includes('.') ? '.' + filepath.split('.').pop()?.toLowerCase() : '';
+        if (ext && !isExtensionSupported(ext)) {
+            unsupported.push(filepath);
+        } else {
+            supported.push(filepath);
+        }
+    }
+
+    const docIds: string[] = [];
+    let failed = 0;
+    let lastError = '';
+    const folderPaths = new Set(entries.filter(e => e.type === 'folder').map(e => e.path));
+
+    for (const filepath of supported) {
+        try {
+            if (folderPaths.has(filepath)) {
+                const result = await api.indexFolder(filepath);
+                result.documents.forEach(d => { if (d.id) docIds.push(d.id); });
+            } else {
+                const doc = await api.uploadDocumentByPath(filepath);
+                if (doc?.id) docIds.push(doc.id);
+            }
+        } catch (err) {
+            failed++;
+            lastError = err instanceof Error ? err.message : 'Unknown error';
+        }
+    }
+
+    // Attach indexed documents to the active session
+    if (sessionId && docIds.length > 0) {
+        for (const docId of docIds) {
+            try {
+                await api.attachDocument(sessionId, docId);
+            } catch (attachErr) {
+                log.doc.warn(`Could not attach document to session: ${attachErr}`);
+            }
+        }
+        const freshSession = useChatStore.getState().sessions.find(s => s.id === sessionId);
+        const existing = freshSession?.document_ids ?? [];
+        const toAdd = docIds.filter(id => !existing.includes(id));
+        if (toAdd.length > 0) {
+            updateSessionInList(sessionId, { document_ids: [...existing, ...toAdd] });
+        }
+    }
+
+    return { docIds, supported, unsupported, failed, lastError };
+}
+
 export function FileBrowser() {
-    const { setShowFileBrowser, currentSessionId, updateSessionInList } = useChatStore();
+    const { setShowFileBrowser, currentSessionId, updateSessionInList, setPendingPrompt } = useChatStore();
 
     // Browse state
     const [currentPath, setCurrentPath] = useState<string>('');
@@ -194,27 +264,19 @@ export function FileBrowser() {
         const files = Array.from(selectedFiles);
         setIndexError(null);
 
-        // Pre-check: filter out unsupported file types and warn the user
-        const supportedFiles: string[] = [];
-        const unsupportedFiles: string[] = [];
-        for (const filepath of files) {
-            const ext = filepath.includes('.') ? '.' + filepath.split('.').pop()?.toLowerCase() : '';
-            if (ext && !isExtensionSupported(ext)) {
-                unsupportedFiles.push(filepath);
-            } else {
-                supportedFiles.push(filepath);
-            }
-        }
-
-        if (unsupportedFiles.length > 0 && supportedFiles.length === 0) {
-            // All selected files are unsupported
-            const firstFile = unsupportedFiles[0];
+        // Quick pre-check for all-unsupported case (show error immediately)
+        const hasSupported = files.some(f => {
+            const ext = f.includes('.') ? '.' + f.split('.').pop()?.toLowerCase() : '';
+            return !ext || isExtensionSupported(ext);
+        });
+        if (!hasSupported) {
+            const firstFile = files[0];
             const ext = '.' + firstFile.split('.').pop()?.toLowerCase();
             const category = getUnsupportedCategory(ext);
             setIndexError({
-                filename: unsupportedFiles.length === 1
+                filename: files.length === 1
                     ? firstFile.split(/[\\/]/).pop() || firstFile
-                    : `${unsupportedFiles.length} files`,
+                    : `${files.length} files`,
                 error: category
                     ? category.message
                     : `File type "${ext}" is not supported for indexing.`,
@@ -222,87 +284,79 @@ export function FileBrowser() {
             return;
         }
 
-        if (unsupportedFiles.length > 0) {
-            // Some files are unsupported — warn but continue with supported ones
-            log.doc.warn(`Skipping ${unsupportedFiles.length} unsupported file(s)`);
-            setIndexStatus(`Skipping ${unsupportedFiles.length} unsupported file(s)...`);
-        }
+        setIndexingFiles(new Set(files));
+        setIndexStatus(`Indexing ${files.length} file(s)...`);
 
-        if (supportedFiles.length === 0) return;
-
-        setIndexingFiles(new Set(supportedFiles));
-        setIndexStatus(`Indexing ${supportedFiles.length} file(s)...`);
-
-        let success = 0;
-        let failed = 0;
-        let lastError = '';
-        const newDocIds: string[] = [];
-        const folderPaths = new Set(entries.filter(e => e.type === 'folder').map(e => e.path));
-        for (const filepath of supportedFiles) {
-            try {
-                if (folderPaths.has(filepath)) {
-                    const result = await api.indexFolder(filepath);
-                    result.documents.forEach(d => { if (d.id) newDocIds.push(d.id); });
-                } else {
-                    const doc = await api.uploadDocumentByPath(filepath);
-                    if (doc?.id) newDocIds.push(doc.id);
-                }
-                success++;
-                setIndexStatus(`Indexed ${success}/${supportedFiles.length}...`);
-            } catch (err) {
-                failed++;
-                lastError = err instanceof Error ? err.message : 'Unknown error';
-            }
-        }
-
-        // Auto-attach successfully indexed documents to the active session
-        if (currentSessionId && newDocIds.length > 0) {
-            for (const docId of newDocIds) {
-                try {
-                    await api.attachDocument(currentSessionId, docId);
-                } catch (attachErr) {
-                    log.doc.warn(`Could not attach document to session: ${attachErr}`);
-                }
-            }
-            const freshSession = useChatStore.getState().sessions.find(s => s.id === currentSessionId);
-            const existing = freshSession?.document_ids ?? [];
-            const toAdd = newDocIds.filter(id => !existing.includes(id));
-            if (toAdd.length > 0) {
-                updateSessionInList(currentSessionId, { document_ids: [...existing, ...toAdd] });
-            }
-        }
+        const result = await indexAndAttachFiles(files, entries, currentSessionId, updateSessionInList);
 
         setIndexingFiles(new Set());
-        if (failed > 0) {
-            setIndexStatus(`Done: ${success} indexed, ${failed} failed`);
+        if (result.failed > 0) {
+            setIndexStatus(`Done: ${result.docIds.length} indexed, ${result.failed} failed`);
             setIndexError({
-                filename: `${failed} file(s)`,
-                error: lastError || 'Indexing failed for some files',
+                filename: `${result.failed} file(s)`,
+                error: result.lastError || 'Indexing failed for some files',
             });
         } else {
-            const skippedNote = unsupportedFiles.length > 0
-                ? ` (${unsupportedFiles.length} skipped — unsupported type)`
+            const skippedNote = result.unsupported.length > 0
+                ? ` (${result.unsupported.length} skipped — unsupported type)`
                 : '';
-            setIndexStatus(`Successfully indexed ${success} file(s)${skippedNote}`);
+            setIndexStatus(`Successfully indexed ${result.docIds.length} file(s)${skippedNote}`);
         }
         if (indexStatusTimerRef.current) clearTimeout(indexStatusTimerRef.current);
         indexStatusTimerRef.current = setTimeout(() => setIndexStatus(null), 5000);
         setSelectedFiles(new Set());
-    }, [selectedFiles, currentSessionId, updateSessionInList]);
+    }, [selectedFiles, currentSessionId, updateSessionInList, entries]);
 
-    const handleAskAgent = useCallback(() => {
+    const handleAskAgent = useCallback(async () => {
         if (selectedFiles.size === 0) return;
         const files = Array.from(selectedFiles);
-        // Close file browser and send a prompt to the chat
-        setShowFileBrowser(false);
-        // Dispatch event for ChatView to pick up
-        const prompt = files.length === 1
-            ? `Analyze this file for me: ${files[0]}`
-            : `Analyze these files for me:\n${files.map(f => `- ${f}`).join('\n')}`;
-        setTimeout(() => {
-            window.dispatchEvent(new CustomEvent('gaia:send-prompt', { detail: { prompt } }));
-        }, 100);
-    }, [selectedFiles, setShowFileBrowser]);
+        setIndexError(null);
+        setIndexingFiles(new Set(files));
+        setIndexStatus(`Indexing ${files.length} file(s) for analysis...`);
+
+        try {
+            const result = await indexAndAttachFiles(files, entries, currentSessionId, updateSessionInList);
+
+            if (result.supported.length === 0) {
+                const ext = '.' + files[0].split('.').pop()?.toLowerCase();
+                const category = getUnsupportedCategory(ext);
+                setIndexError({
+                    filename: files.length === 1 ? files[0].split(/[\\/]/).pop() || files[0] : `${files.length} files`,
+                    error: category?.message ?? `File type "${ext}" is not supported for indexing.`,
+                });
+                return;
+            }
+
+            if (result.docIds.length === 0) {
+                setIndexError({
+                    filename: result.supported.length === 1
+                        ? result.supported[0].split(/[\\/]/).pop() || result.supported[0]
+                        : `${result.supported.length} files`,
+                    error: 'Failed to index selected file(s). Please try again.',
+                });
+                return;
+            }
+
+            // Build prompt with file names (not paths) and send to chat
+            const fileNames = result.supported.map(f => f.split(/[\\/]/).pop() || f);
+            const prompt = fileNames.length === 1
+                ? `Please analyze this document for me: ${fileNames[0]}`
+                : `Please analyze these documents for me:\n${fileNames.map(n => `- ${n}`).join('\n')}`;
+
+            setPendingPrompt(prompt);
+            setShowFileBrowser(false);
+            setSelectedFiles(new Set());
+        } catch (err) {
+            log.doc.error('Ask Agent failed', err);
+            setIndexError({
+                filename: files.length === 1 ? files[0].split(/[\\/]/).pop() || files[0] : `${files.length} files`,
+                error: err instanceof Error ? err.message : 'An unexpected error occurred.',
+            });
+        } finally {
+            setIndexingFiles(new Set());
+            setIndexStatus(null);
+        }
+    }, [selectedFiles, currentSessionId, updateSessionInList, entries, setPendingPrompt, setShowFileBrowser]);
 
     // Build breadcrumb segments from current path
     const pathSegments = currentPath ? currentPath.replace(/\\/g, '/').split('/').filter(Boolean) : [];
@@ -548,8 +602,8 @@ export function FileBrowser() {
                             <button
                                 className="fb-action-btn primary"
                                 onClick={handleAskAgent}
-                                disabled={selectedFiles.size === 0}
-                                title="Send selected files to the chat agent for analysis"
+                                disabled={selectedFiles.size === 0 || indexingFiles.size > 0}
+                                title="Index and send selected files to the chat agent for analysis"
                             >
                                 <Brain size={14} />
                                 Ask Agent

--- a/src/gaia/apps/webui/src/components/FileBrowser.tsx
+++ b/src/gaia/apps/webui/src/components/FileBrowser.tsx
@@ -287,24 +287,33 @@ export function FileBrowser() {
         setIndexingFiles(new Set(files));
         setIndexStatus(`Indexing ${files.length} file(s)...`);
 
-        const result = await indexAndAttachFiles(files, entries, currentSessionId, updateSessionInList);
+        try {
+            const result = await indexAndAttachFiles(files, entries, currentSessionId, updateSessionInList);
 
-        setIndexingFiles(new Set());
-        if (result.failed > 0) {
-            setIndexStatus(`Done: ${result.docIds.length} indexed, ${result.failed} failed`);
+            if (result.failed > 0) {
+                setIndexStatus(`Done: ${result.docIds.length} indexed, ${result.failed} failed`);
+                setIndexError({
+                    filename: `${result.failed} file(s)`,
+                    error: result.lastError || 'Indexing failed for some files',
+                });
+            } else {
+                const skippedNote = result.unsupported.length > 0
+                    ? ` (${result.unsupported.length} skipped — unsupported type)`
+                    : '';
+                setIndexStatus(`Successfully indexed ${result.docIds.length} file(s)${skippedNote}`);
+            }
+            if (indexStatusTimerRef.current) clearTimeout(indexStatusTimerRef.current);
+            indexStatusTimerRef.current = setTimeout(() => setIndexStatus(null), 5000);
+            setSelectedFiles(new Set());
+        } catch (err) {
+            log.doc.error('Index selected failed', err);
             setIndexError({
-                filename: `${result.failed} file(s)`,
-                error: result.lastError || 'Indexing failed for some files',
+                filename: files.length === 1 ? files[0].split(/[\\/]/).pop() || files[0] : `${files.length} files`,
+                error: err instanceof Error ? err.message : 'An unexpected error occurred.',
             });
-        } else {
-            const skippedNote = result.unsupported.length > 0
-                ? ` (${result.unsupported.length} skipped — unsupported type)`
-                : '';
-            setIndexStatus(`Successfully indexed ${result.docIds.length} file(s)${skippedNote}`);
+        } finally {
+            setIndexingFiles(new Set());
         }
-        if (indexStatusTimerRef.current) clearTimeout(indexStatusTimerRef.current);
-        indexStatusTimerRef.current = setTimeout(() => setIndexStatus(null), 5000);
-        setSelectedFiles(new Set());
     }, [selectedFiles, currentSessionId, updateSessionInList, entries]);
 
     const handleAskAgent = useCallback(async () => {
@@ -337,8 +346,15 @@ export function FileBrowser() {
                 return;
             }
 
-            // Build prompt with file names (not paths) and send to chat
-            const fileNames = result.supported.map(f => f.split(/[\\/]/).pop() || f);
+            // Surface partial-failure before closing modal so user knows some files were dropped
+            if (result.failed > 0) {
+                setIndexStatus(`Warning: ${result.failed} file(s) failed to index and will be excluded.`);
+            }
+
+            // Build prompt with successfully indexed file names (not paths)
+            const fileNames = result.docIds.length > 0
+                ? result.supported.filter((_, i) => i < result.docIds.length).map(f => f.split(/[\\/]/).pop() || f)
+                : result.supported.map(f => f.split(/[\\/]/).pop() || f);
             const prompt = fileNames.length === 1
                 ? `Please analyze this document for me: ${fileNames[0]}`
                 : `Please analyze these documents for me:\n${fileNames.map(n => `- ${n}`).join('\n')}`;

--- a/src/gaia/apps/webui/src/components/FileBrowser.tsx
+++ b/src/gaia/apps/webui/src/components/FileBrowser.tsx
@@ -84,6 +84,7 @@ interface FilePreview {
 interface IndexResult {
     docIds: string[];
     supported: string[];
+    succeededFiles: string[];
     unsupported: string[];
     failed: number;
     lastError: string;
@@ -111,6 +112,7 @@ async function indexAndAttachFiles(
     }
 
     const docIds: string[] = [];
+    const succeededFiles: string[] = [];
     let failed = 0;
     let lastError = '';
     const folderPaths = new Set(entries.filter(e => e.type === 'folder').map(e => e.path));
@@ -119,10 +121,18 @@ async function indexAndAttachFiles(
         try {
             if (folderPaths.has(filepath)) {
                 const result = await api.indexFolder(filepath);
-                result.documents.forEach(d => { if (d.id) docIds.push(d.id); });
+                const newIds: string[] = [];
+                result.documents.forEach(d => { if (d.id) newIds.push(d.id); });
+                if (newIds.length > 0) {
+                    newIds.forEach(id => docIds.push(id));
+                    succeededFiles.push(filepath);
+                }
             } else {
                 const doc = await api.uploadDocumentByPath(filepath);
-                if (doc?.id) docIds.push(doc.id);
+                if (doc?.id) {
+                    docIds.push(doc.id);
+                    succeededFiles.push(filepath);
+                }
             }
         } catch (err) {
             failed++;
@@ -147,7 +157,7 @@ async function indexAndAttachFiles(
         }
     }
 
-    return { docIds, supported, unsupported, failed, lastError };
+    return { docIds, supported, succeededFiles, unsupported, failed, lastError };
 }
 
 export function FileBrowser() {
@@ -351,10 +361,9 @@ export function FileBrowser() {
                 setIndexStatus(`Warning: ${result.failed} file(s) failed to index and will be excluded.`);
             }
 
-            // Build prompt with successfully indexed file names (not paths)
-            const fileNames = result.docIds.length > 0
-                ? result.supported.filter((_, i) => i < result.docIds.length).map(f => f.split(/[\\/]/).pop() || f)
-                : result.supported.map(f => f.split(/[\\/]/).pop() || f);
+            // Build prompt from files that were actually indexed (not just supported)
+            const fileNames = (result.succeededFiles.length > 0 ? result.succeededFiles : result.supported)
+                .map(f => f.split(/[\\/]/).pop() || f);
             const prompt = fileNames.length === 1
                 ? `Please analyze this document for me: ${fileNames[0]}`
                 : `Please analyze these documents for me:\n${fileNames.map(n => `- ${n}`).join('\n')}`;

--- a/tests/unit/chat/ui/test_ask_agent_workflow.py
+++ b/tests/unit/chat/ui/test_ask_agent_workflow.py
@@ -133,3 +133,36 @@ class TestAskAgentWorkflow:
         doc_ids = session_arg.get("document_ids", [])
         assert doc1["id"] in doc_ids
         assert doc2["id"] in doc_ids
+
+    @patch("gaia.ui.server._get_chat_response")
+    def test_upload_without_attach_has_no_rag_context(self, mock_chat, client, db):
+        """Uploaded but unattached documents must NOT appear in session context.
+
+        Verifies that the attachment step (POST /api/sessions/{id}/documents)
+        is required for RAG context to flow through to _get_chat_response.
+        """
+        mock_chat.return_value = "I have no document context."
+
+        # 1. Create session
+        session_resp = client.post("/api/sessions", json={})
+        session_id = session_resp.json()["id"]
+
+        # 2. Add a document to DB (simulates successful upload) but do NOT attach
+        doc = db.add_document("report.pdf", "/home/user/report.pdf", "abc123hash")
+
+        # 3. Send chat message without attaching the document
+        chat_resp = client.post(
+            "/api/chat/send",
+            json={
+                "session_id": session_id,
+                "message": "Summarize report.pdf",
+                "stream": False,
+            },
+        )
+        assert chat_resp.status_code == 200
+
+        # 4. Verify _get_chat_response received session WITHOUT the doc_id
+        mock_chat.assert_called_once()
+        session_arg = mock_chat.call_args[0][1]
+        doc_ids = session_arg.get("document_ids", [])
+        assert doc["id"] not in doc_ids

--- a/tests/unit/chat/ui/test_ask_agent_workflow.py
+++ b/tests/unit/chat/ui/test_ask_agent_workflow.py
@@ -1,0 +1,135 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the Ask Agent workflow: index → attach → chat with document context.
+
+Validates that when documents are indexed and attached to a session,
+the chat endpoint passes those document_ids to _get_chat_response,
+enabling RAG-powered answers about the file content.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gaia.ui.server import create_app
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def app():
+    """Create FastAPI app with in-memory database."""
+    return create_app(db_path=":memory:")
+
+
+@pytest.fixture
+def client(app):
+    """Create test client for the app."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def db(app):
+    """Access the database from app state."""
+    return app.state.db
+
+
+class TestAskAgentWorkflow:
+    """Tests that the index → attach → chat pipeline passes document context."""
+
+    @patch("gaia.ui.server._get_chat_response")
+    def test_upload_attach_then_chat_has_document_context(self, mock_chat, client, db):
+        """Core test: attached documents appear in session.document_ids
+        when _get_chat_response is called."""
+        mock_chat.return_value = "Here is my analysis of the document."
+
+        # 1. Create session
+        session_resp = client.post("/api/sessions", json={})
+        session_id = session_resp.json()["id"]
+
+        # 2. Add a document directly via DB (simulates successful upload)
+        doc = db.add_document("report.pdf", "/home/user/report.pdf", "abc123hash")
+
+        # 3. Attach document to session
+        attach_resp = client.post(
+            f"/api/sessions/{session_id}/documents",
+            json={"document_id": doc["id"]},
+        )
+        assert attach_resp.status_code == 200
+
+        # 4. Send chat message
+        chat_resp = client.post(
+            "/api/chat/send",
+            json={
+                "session_id": session_id,
+                "message": "Please analyze this document for me: report.pdf",
+                "stream": False,
+            },
+        )
+        assert chat_resp.status_code == 200
+
+        # 5. Verify _get_chat_response received session with document_ids
+        mock_chat.assert_called_once()
+        call_args = mock_chat.call_args
+        session_arg = call_args[0][1]  # second positional arg is session dict
+        assert doc["id"] in session_arg.get("document_ids", [])
+
+    @patch("gaia.ui.server._get_chat_response")
+    def test_chat_without_documents_has_no_rag_context(self, mock_chat, client, db):
+        """Chat without attached docs passes empty document_ids."""
+        mock_chat.return_value = "I have no document context."
+
+        session_resp = client.post("/api/sessions", json={})
+        session_id = session_resp.json()["id"]
+
+        chat_resp = client.post(
+            "/api/chat/send",
+            json={
+                "session_id": session_id,
+                "message": "Tell me about the document",
+                "stream": False,
+            },
+        )
+        assert chat_resp.status_code == 200
+
+        mock_chat.assert_called_once()
+        session_arg = mock_chat.call_args[0][1]
+        assert session_arg.get("document_ids", []) == []
+
+    @patch("gaia.ui.server._get_chat_response")
+    def test_upload_multiple_attach_then_chat(self, mock_chat, client, db):
+        """Multiple attached documents all appear in session.document_ids."""
+        mock_chat.return_value = "Analysis of both documents."
+
+        session_resp = client.post("/api/sessions", json={})
+        session_id = session_resp.json()["id"]
+
+        doc1 = db.add_document("report.pdf", "/home/user/report.pdf", "hash1")
+        doc2 = db.add_document("notes.md", "/home/user/notes.md", "hash2")
+
+        client.post(
+            f"/api/sessions/{session_id}/documents",
+            json={"document_id": doc1["id"]},
+        )
+        client.post(
+            f"/api/sessions/{session_id}/documents",
+            json={"document_id": doc2["id"]},
+        )
+
+        chat_resp = client.post(
+            "/api/chat/send",
+            json={
+                "session_id": session_id,
+                "message": "Analyze these documents",
+                "stream": False,
+            },
+        )
+        assert chat_resp.status_code == 200
+
+        session_arg = mock_chat.call_args[0][1]
+        doc_ids = session_arg.get("document_ids", [])
+        assert doc1["id"] in doc_ids
+        assert doc2["id"] in doc_ids


### PR DESCRIPTION
## Summary

- **Root cause**: `handleAskAgent` in FileBrowser dispatched a `gaia:send-prompt` CustomEvent that nothing listened for (dead code), performing zero indexing or session attachment
- **Fix**: Rewrote `handleAskAgent` to index files, attach them to the active session, and deliver the prompt via the existing `pendingPrompt` Zustand mechanism
- **Reactive consumption**: Replaced imperative `useEffect([sessionId])` in ChatView with reactive `useEffect([pendingPrompt])` + `getState()` StrictMode guard so prompts are consumed whether ChatView is already mounted or not

## Changes

- `FileBrowser.tsx`: Extract shared `indexAndAttachFiles()` helper, rewrite `handleAskAgent`, add try/catch/finally to `handleIndexSelected`, surface partial-failure warning
- `ChatView.tsx`: Reactive pendingPrompt useEffect with StrictMode guard and rAF cancellation on unmount
- `tests/unit/chat/ui/test_ask_agent_workflow.py`: 3 backend tests covering index→attach→chat pipeline (519 passing)

## Test plan

- [x] `python -m pytest tests/unit/chat/ui/ --ignore=tests/unit/chat/ui/test_sse_confirmation.py` — 519 passed
- [x] `npm run build` — clean TypeScript compile
- [x] `python util/lint.py --all` — all checks passed
- [x] End-to-end MCP test with Qwen3.5-35B-A3B-GGUF: indexed employee_records.csv, attached to session, agent correctly returned CFO salary ($200,000) from document content

Closes #583