### PR TITLE
fix: drag-and-drop document upload in browser mode (#728)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -245,15 +245,16 @@ jobs:
             - Make it easy for maintainers to accept suggestions with one click
 
   # Respond to @claude in PR review comments (non-fork PRs only - secrets unavailable on forks)
+  #
+  # NOTE: No concurrency group - each @claude mention runs its own independent job in parallel
+  # so that burst of comments on different topics all get answered. Safe because this job
+  # only reads the PR diff and posts comments (no commits to the branch).
   pr-comment:
     if: |
       github.event_name == 'pull_request_review_comment' &&
       contains(github.event.comment.body, '@claude') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    concurrency:
-      group: claude-pr-comment-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v6
         with:
@@ -330,15 +331,16 @@ jobs:
             Maintain a helpful, professional tone.
 
   # Respond to new issues or @claude mentions in PR conversations (including forks)
+  #
+  # NOTE: No concurrency group - each @claude mention runs its own independent job in parallel
+  # so that burst of comments on different topics all get answered. Safe because this job
+  # only reads the PR diff and posts comments (no commits to the branch).
   issue-handler:
     if: |
       github.event_name == 'issues' ||
       (github.event_name == 'issue_comment' &&
        contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
-    concurrency:
-      group: claude-issue-${{ github.event.issue.number }}
-      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/docs/spec/agent-ui-server.mdx
+++ b/docs/spec/agent-ui-server.mdx
@@ -137,6 +137,19 @@ def _transaction(self):
 
 Documents are deduplicated by SHA-256 file hash. If a document with the same hash already exists, the existing record is returned with an updated `last_accessed_at` timestamp.
 
+### Document Upload Paths
+
+The server exposes **two** document upload endpoints, each for a different source of truth:
+
+| Endpoint | Input | Used By | Storage |
+|----------|-------|---------|---------|
+| `POST /api/documents/upload-path` | JSON `{filepath}` — absolute server-side path | File browser (user picks an existing file) | Indexes in place; server does NOT own the file |
+| `POST /api/documents/upload` | `multipart/form-data` file blob | Drag-and-drop in browser mode / modern Electron | File is persisted under `~/.gaia/documents/<uuid>.<ext>` and owned by the server |
+
+The blob endpoint exists because browser `File` objects never expose a filesystem path, and since Electron 32 `File.path` has been removed as well (see issue [#728](https://github.com/amd/gaia/issues/728)). It streams the upload with a running size check (capped at 20 MB), computes a SHA-256 hash, short-circuits on dedup by hash, and only then promotes the file into the managed directory via an atomic `os.replace`. On failure, partial and orphan files are cleaned up.
+
+When a server-owned document is deleted (`DELETE /api/documents/{id}`), the on-disk file under `~/.gaia/documents/` is also unlinked as a best-effort cleanup. User-owned files from `upload-path` are left untouched.
+
 ### Cascade Deletes
 
 - Deleting a **session** cascades to its messages and session_documents entries
@@ -163,6 +176,7 @@ All 14 Pydantic models:
 | `DocumentResponse` | Response | Document endpoints |
 | `DocumentListResponse` | Response | `GET /api/documents` |
 | `DocumentUploadRequest` | Request | `POST /api/documents/upload-path` |
+| `UploadFile` (multipart) | Request | `POST /api/documents/upload` (blob) |
 | `AttachDocumentRequest` | Request | `POST /api/sessions/{session_id}/documents` |
 
 ---

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -1071,34 +1071,38 @@ export function ChatView({ sessionId }: ChatViewProps) {
 
     // Drag & drop — uploads the file blob directly rather than relying on
     // File.path (which is browser-undefined and was removed in Electron 32+).
-    // See issue #728.
+    // Dropped files index quietly and auto-attach to the current session;
+    // the Document Library panel is NOT forced open so the drop doesn't
+    // interrupt the chat view. Users can still open the library manually
+    // to see progress for large files. See issue #728.
     const handleDrop = useCallback(async (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
         setIsDragOver(false);
-        if (e.dataTransfer.files.length > 0) {
-            setShowDocLibrary(true);
-            for (const file of Array.from(e.dataTransfer.files)) {
-                try {
-                    const doc = await api.uploadDocumentBlob(file);
-                    if (sessionId && doc?.id) {
-                        try {
-                            await api.attachDocument(sessionId, doc.id);
-                            const freshSession = useChatStore.getState().sessions.find(s => s.id === sessionId);
-                            const existing = freshSession?.document_ids ?? [];
-                            if (!existing.includes(doc.id)) {
-                                updateSessionInList(sessionId, { document_ids: [...existing, doc.id] });
-                            }
-                        } catch (attachErr) {
-                            log.doc.warn(`Could not attach dropped document to session: ${attachErr}`);
+        if (e.dataTransfer.files.length === 0) return;
+
+        for (const file of Array.from(e.dataTransfer.files)) {
+            log.doc.info(`Dropped on chat view: ${file.name}`);
+            try {
+                const doc = await api.uploadDocumentBlob(file);
+                if (sessionId && doc?.id) {
+                    try {
+                        await api.attachDocument(sessionId, doc.id);
+                        const freshSession = useChatStore.getState().sessions.find(s => s.id === sessionId);
+                        const existing = freshSession?.document_ids ?? [];
+                        if (!existing.includes(doc.id)) {
+                            updateSessionInList(sessionId, { document_ids: [...existing, doc.id] });
                         }
+                        log.doc.info(`Auto-attached "${file.name}" to session ${sessionId}`);
+                    } catch (attachErr) {
+                        log.doc.warn(`Could not attach dropped document to session: ${attachErr}`);
                     }
-                } catch (err) {
-                    log.doc.error(`Upload failed: ${file.name}`, err);
                 }
+            } catch (err) {
+                log.doc.error(`Upload failed: ${file.name}`, err);
             }
         }
-    }, [sessionId, updateSessionInList, setShowDocLibrary]);
+    }, [sessionId, updateSessionInList]);
 
     const handleDragOver = (e: React.DragEvent) => { e.preventDefault(); e.stopPropagation(); setIsDragOver(true); };
     const handleDragLeave = (e: React.DragEvent) => { e.preventDefault(); e.stopPropagation(); setIsDragOver(false); };

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -1069,7 +1069,9 @@ export function ChatView({ sessionId }: ChatViewProps) {
         }
     }, [documents, sessionId, updateSessionInList]);
 
-    // Drag & drop
+    // Drag & drop — uploads the file blob directly rather than relying on
+    // File.path (which is browser-undefined and was removed in Electron 32+).
+    // See issue #728.
     const handleDrop = useCallback(async (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
@@ -1077,9 +1079,8 @@ export function ChatView({ sessionId }: ChatViewProps) {
         if (e.dataTransfer.files.length > 0) {
             setShowDocLibrary(true);
             for (const file of Array.from(e.dataTransfer.files)) {
-                const filepath = (file as any).path || file.name;
                 try {
-                    const doc = await api.uploadDocumentByPath(filepath);
+                    const doc = await api.uploadDocumentBlob(file);
                     if (sessionId && doc?.id) {
                         try {
                             await api.attachDocument(sessionId, doc.id);
@@ -1093,7 +1094,7 @@ export function ChatView({ sessionId }: ChatViewProps) {
                         }
                     }
                 } catch (err) {
-                    log.doc.error(`Upload failed: ${filepath}`, err);
+                    log.doc.error(`Upload failed: ${file.name}`, err);
                 }
             }
         }

--- a/src/gaia/apps/webui/src/components/DocumentLibrary.tsx
+++ b/src/gaia/apps/webui/src/components/DocumentLibrary.tsx
@@ -204,7 +204,14 @@ export function DocumentLibrary() {
         return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
     };
 
-    const uploadFile = useCallback(async (filepath: string, filename: string) => {
+    // Shared upload state-machine: preflight extension check, set UI state,
+    // run the caller-provided uploader, auto-attach the result to the current
+    // session, and refresh the document list. Used by both path-based and
+    // blob-based upload flows.
+    const runUpload = useCallback(async (
+        filename: string,
+        uploader: () => Promise<Document>,
+    ) => {
         // Pre-check: warn about unsupported file types before sending to server
         const ext = filename.includes('.') ? '.' + filename.split('.').pop()?.toLowerCase() : '';
         if (ext && !isExtensionSupported(ext)) {
@@ -217,13 +224,13 @@ export function DocumentLibrary() {
             return;
         }
 
-        log.doc.info(`Indexing document: ${filename} (${filepath})`);
+        log.doc.info(`Indexing document: ${filename}`);
         const t = log.doc.time();
         setIsUploading(true);
         setUploadStatus(`Indexing ${filename}...`);
         setUploadError(null);
         try {
-            const doc = await api.uploadDocumentByPath(filepath);
+            const doc = await uploader();
             log.doc.timed(`Indexed "${filename}": ${doc?.chunk_count || '?'} chunks`, t);
             // Auto-attach to the active session so the agent can immediately use it
             if (currentSessionId && doc?.id) {
@@ -256,16 +263,32 @@ export function DocumentLibrary() {
         }
     }, [currentSessionId, updateSessionInList, setDocuments]);
 
+    /** Index a document by a server-side filesystem path (used by the file browser and path input). */
+    const uploadFile = useCallback(async (filepath: string, filename: string) => {
+        await runUpload(filename, () => api.uploadDocumentByPath(filepath));
+    }, [runUpload]);
+
+    /**
+     * Index a document by uploading its bytes directly (used by drag-and-drop).
+     *
+     * We can't use the path-based endpoint for drag-drop because browser File
+     * objects don't expose an absolute filesystem path — and in Electron 32+
+     * the File.path augmentation was removed as well. Streaming the blob is
+     * the only reliable cross-platform approach. See issue #728.
+     */
+    const uploadFileBlob = useCallback(async (file: File) => {
+        await runUpload(file.name, () => api.uploadDocumentBlob(file));
+    }, [runUpload]);
+
     const handleDrop = useCallback(async (e: React.DragEvent) => {
         e.preventDefault();
         setIsDragOver(false);
         const files = Array.from(e.dataTransfer.files);
         log.doc.info(`Dropped ${files.length} file(s) into Document Library`);
         for (const file of files) {
-            const path = (file as any).path || file.name;
-            await uploadFile(path, file.name);
+            await uploadFileBlob(file);
         }
-    }, [uploadFile]);
+    }, [uploadFileBlob]);
 
     const handleDeleteDoc = useCallback(async (id: string) => {
         const doc = documents.find((d) => d.id === id);

--- a/src/gaia/apps/webui/src/components/UnsupportedFeature.tsx
+++ b/src/gaia/apps/webui/src/components/UnsupportedFeature.tsx
@@ -82,6 +82,19 @@ const UNSUPPORTED_FILE_CATEGORIES: FileTypeCategory[] = [
         ],
         featureTitle: 'Support database file indexing',
     },
+    {
+        label: 'Microsoft Office',
+        extensions: new Set(['.doc', '.docx', '.ppt', '.pptx', '.xls']),
+        message:
+            'Word, PowerPoint, and legacy Excel (.xls) files are not yet ' +
+            'supported — GAIA does not currently ship parsers for these ' +
+            'formats.',
+        alternatives: [
+            'Save as PDF from Word or PowerPoint, then index the PDF',
+            'Re-save legacy .xls workbooks as .xlsx — GAIA supports modern Excel files',
+        ],
+        featureTitle: 'Support Microsoft Office (docx, pptx, xls) indexing',
+    },
 ];
 
 /**
@@ -96,10 +109,18 @@ export function getUnsupportedCategory(extension: string): FileTypeCategory | nu
     return null;
 }
 
-/** Set of all supported extensions for document indexing. */
+/**
+ * Set of all supported extensions for document indexing.
+ *
+ * Keep this in sync with ``ALLOWED_EXTENSIONS`` in
+ * ``src/gaia/ui/utils.py``. Only list extensions that have a real extractor
+ * in ``src/gaia/rag/sdk.py::_extract_text_from_file`` — listing one without
+ * a backend handler causes the RAG pipeline to index binary garbage.
+ * .doc/.docx/.ppt/.pptx and legacy .xls are intentionally excluded.
+ */
 export const SUPPORTED_EXTENSIONS = new Set([
-    '.pdf', '.txt', '.md', '.csv', '.json', '.doc', '.docx',
-    '.ppt', '.pptx', '.xls', '.xlsx', '.html', '.htm', '.xml', '.svg',
+    '.pdf', '.txt', '.md', '.csv', '.json', '.xlsx',
+    '.html', '.htm', '.xml', '.svg',
     '.yaml', '.yml', '.py', '.js', '.ts', '.java', '.c', '.cpp',
     '.h', '.rs', '.go', '.rb', '.sh', '.bat', '.ps1', '.log',
     '.cfg', '.ini', '.toml',
@@ -239,7 +260,7 @@ export function UploadErrorToast({ filename, error, onDismiss, timeout = 15000 }
         Icon = AlertTriangle;
     } else if (isFileTypeError) {
         title = `File type not supported: ${ext}`;
-        detail = 'This file format cannot be indexed. Supported: PDF, TXT, MD, CSV, JSON, Office docs, code files, and more.';
+        detail = 'This file format cannot be indexed. Supported: PDF, TXT, MD, CSV, JSON, XLSX, HTML, XML, YAML, and 30+ code file formats.';
         issueUrl = featureRequestUrl(`Support ${ext} file indexing`);
         Icon = AlertTriangle;
     } else if (isConnectionError) {

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -12,9 +12,13 @@ const API_BASE = '/api';
 
 function getFriendlyError(status: number, detail: string): string {
     switch (status) {
-        case 403: return 'Access denied. This location is outside your home directory.';
-        case 404: return 'Not found. The file or folder may have been moved or deleted.';
-        case 413: return 'File too large to process.';
+        case 403: return detail || 'Access denied.';
+        // Prefer the backend's detail for 404s — the previous canned string
+        // ("The file or folder may have been moved or deleted.") was misleading
+        // for upload/indexing flows where the real cause was a malformed
+        // filepath, not a missing file. See issue #728.
+        case 404: return detail || 'The requested item was not found.';
+        case 413: return detail || 'File too large to process.';
         case 500: return 'Server error. Please try again.';
         case 502:
         case 503: return 'Service unavailable. Is the backend running?';
@@ -311,6 +315,47 @@ export async function listDocuments(): Promise<{ documents: Document[]; total: n
 
 export async function uploadDocumentByPath(filepath: string): Promise<Document> {
     return apiFetch('POST', '/documents/upload-path', { filepath });
+}
+
+/**
+ * Upload a document as a multipart blob for indexing.
+ *
+ * Used by drag-and-drop in both the Document Library and ChatView.
+ * Required for browser-mode users (and modern Electron versions, where
+ * File.path is no longer populated for drag-drop) — there's no reliable
+ * way to get an absolute filesystem path from a browser File object,
+ * so we have to stream the content directly to the server.
+ *
+ * Errors are mapped through getFriendlyError so 404/413 messages are
+ * consistent with the rest of the app.
+ */
+export async function uploadDocumentBlob(file: File): Promise<Document> {
+    const url = `${API_BASE}/documents/upload`;
+    const t = log.api.time();
+    log.api.info(`POST ${url}`, { fileName: file.name, size: file.size });
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    let res: Response;
+    try {
+        res = await fetch(url, { method: 'POST', body: formData });
+    } catch (err) {
+        log.api.error(`POST ${url} - network error`, err);
+        throw err;
+    }
+
+    if (!res.ok) {
+        const errorText = await res.text().catch(() => '');
+        log.api.error(`POST ${url} - HTTP ${res.status}`, { errorText });
+        let detail = errorText;
+        try { detail = JSON.parse(errorText).detail || errorText; } catch {}
+        throw new Error(getFriendlyError(res.status, detail));
+    }
+
+    const data = await res.json();
+    log.api.timed(`POST ${url} -> ${res.status}`, t, data);
+    return data;
 }
 
 export async function deleteDocument(id: string): Promise<void> {

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -568,6 +568,22 @@ class ChatDatabase:
 
             return self._enrich_document(dict(row))
 
+    def get_document_by_hash(self, file_hash: str) -> Optional[Dict[str, Any]]:
+        """Get document by its SHA-256 content hash.
+
+        Used by the blob upload endpoint to short-circuit re-indexing when
+        the same file content has already been uploaded.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM documents WHERE file_hash = ?", (file_hash,)
+            ).fetchone()
+
+            if not row:
+                return None
+
+            return self._enrich_document(dict(row))
+
     def _enrich_document(self, doc: Dict[str, Any]) -> Dict[str, Any]:
         """Add sessions_using count to document dict.
 

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -12,14 +12,16 @@ effect correctly.
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import sys
 import tempfile
+import uuid
 from pathlib import Path
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 
 from ..database import ChatDatabase
 from ..dependencies import get_db, get_indexing_tasks, get_upload_locks
@@ -43,6 +45,21 @@ from ..utils import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["documents"])
+
+# ── Blob upload configuration ────────────────────────────────────────────────
+
+# Server-managed location for documents uploaded as blobs (drag-and-drop in
+# browser mode, or any flow that can't provide a real filesystem path).
+# Files stored here are owned by the server and cleaned up on doc deletion.
+MANAGED_DOCS_DIR = Path.home() / ".gaia" / "documents"
+
+# Maximum size for a blob-uploaded document. Matches /api/files/upload for
+# consistency; path-based uploads (where the user already owns the file)
+# have no server-enforced cap.
+MAX_DOCUMENT_UPLOAD_SIZE = 20 * 1024 * 1024  # 20 MB
+
+# Streaming chunk size for multipart blob upload.
+UPLOAD_CHUNK_SIZE = 64 * 1024  # 64 KB
 
 
 def _server_mod():
@@ -71,6 +88,21 @@ def _cleanup_temp(path: Path) -> None:
         path.unlink(missing_ok=True)
     except Exception as e:
         logger.warning("Failed to clean up temp file %s: %s", path, e)
+
+
+def _is_server_owned(filepath: str) -> bool:
+    """Return True if *filepath* lives inside the server-managed docs dir.
+
+    Used by ``delete_document`` to decide whether to unlink the on-disk file.
+    User-provided paths (from ``upload-path``) are NOT server-owned and must
+    be left untouched on delete.
+    """
+    try:
+        resolved = Path(filepath).resolve()
+        managed = MANAGED_DOCS_DIR.resolve()
+        return resolved.is_relative_to(managed)
+    except (OSError, ValueError):
+        return False
 
 
 # ── Endpoints ────────────────────────────────────────────────────────────────
@@ -205,6 +237,174 @@ async def upload_by_path(
     # the number of distinct file paths ever uploaded.
 
 
+@router.post("/api/documents/upload", response_model=DocumentResponse)
+async def upload_document_blob(
+    file: UploadFile = File(...),
+    db: ChatDatabase = Depends(get_db),
+):
+    """Index a document from an uploaded blob.
+
+    This is the drag-and-drop / browser-mode entry point. Unlike
+    ``upload-path`` (which takes a server-side filesystem path), this
+    endpoint accepts the file content directly as multipart form data —
+    required because browser File objects do not expose an absolute
+    filesystem path.
+
+    The blob is streamed to ``MANAGED_DOCS_DIR`` with an abort-on-overflow
+    size check, deduplicated by SHA-256 content hash, then indexed via the
+    standard RAG pipeline. Files are capped at ``MAX_DOCUMENT_UPLOAD_SIZE``.
+
+    On any failure, partial / orphaned files are cleaned up.
+    """
+    # 1. Validate filename
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file provided")
+    if "\x00" in file.filename:
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    # Strip any path components the client might have sent (defense in depth;
+    # we never use this value as a filesystem path, but it's stored in the
+    # db for display and returned to the frontend).
+    display_name = Path(file.filename).name
+    ext = Path(display_name).suffix.lower()
+
+    # 2. Validate extension against the strict document set (no images etc.)
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"File type '{ext}' is not supported. "
+                f"Allowed types: {sorted(ALLOWED_EXTENSIONS)}"
+            ),
+        )
+
+    # 3. Ensure the managed directory exists
+    try:
+        MANAGED_DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.error("Failed to create managed docs dir %s: %s", MANAGED_DOCS_DIR, e)
+        raise HTTPException(
+            status_code=500, detail="Failed to prepare document storage"
+        )
+
+    # 4. Stream-write to a .partial file, hashing as we go, aborting on
+    # oversize. try/finally ensures the partial is cleaned up on any exit
+    # path (including ClientDisconnect and CancelledError).
+    partial_path: Path | None = MANAGED_DOCS_DIR / f"{uuid.uuid4()}.partial"
+    final_path: Path | None = None
+    hasher = hashlib.sha256()
+    bytes_written = 0
+
+    try:
+        try:
+            with open(partial_path, "wb") as out:
+                while True:
+                    chunk = await file.read(UPLOAD_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    bytes_written += len(chunk)
+                    if bytes_written > MAX_DOCUMENT_UPLOAD_SIZE:
+                        raise HTTPException(
+                            status_code=413,
+                            detail=(
+                                f"File too large. Maximum size is "
+                                f"{MAX_DOCUMENT_UPLOAD_SIZE // (1024 * 1024)} MB."
+                            ),
+                        )
+                    hasher.update(chunk)
+                    out.write(chunk)
+        except HTTPException:
+            raise
+        except OSError as e:
+            logger.error("Failed to write blob upload to %s: %s", partial_path, e)
+            raise HTTPException(status_code=500, detail="Failed to save uploaded file")
+
+        if bytes_written == 0:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+        file_hash = hasher.hexdigest()
+
+        # 5. Dedup by hash — if this content is already indexed, return the
+        # existing doc and discard the partial. Fast path for "user dropped
+        # the same file twice."
+        existing = db.get_document_by_hash(file_hash)
+        if existing:
+            logger.info(
+                "Blob upload dedup: %s matches existing doc %s",
+                display_name,
+                existing.get("id"),
+            )
+            return doc_to_response(existing)
+
+        # 6. Promote partial -> final (atomic rename). After this, the
+        # partial_path variable is cleared so the finally block won't
+        # unlink our now-final file.
+        final_path = MANAGED_DOCS_DIR / f"{uuid.uuid4()}{ext}"
+        try:
+            os.replace(partial_path, final_path)
+        except OSError as e:
+            logger.error("Failed to promote %s -> %s: %s", partial_path, final_path, e)
+            raise HTTPException(status_code=500, detail="Failed to save uploaded file")
+        partial_path = None  # ownership transferred
+    finally:
+        if partial_path is not None:
+            _cleanup_temp(partial_path)
+
+    # 7. Index and record. Wrap both so an indexing OR db failure unlinks
+    # the final file (no orphan rows/files).
+    _index_document = _server_mod()._index_document
+    file_mtime = final_path.stat().st_mtime
+
+    try:
+        chunk_count = await _index_document(final_path)
+        doc = db.add_document(
+            filename=display_name,
+            filepath=str(final_path),
+            file_hash=file_hash,
+            file_size=bytes_written,
+            chunk_count=chunk_count,
+            file_mtime=file_mtime,
+        )
+    except HTTPException:
+        _cleanup_temp(final_path)
+        raise
+    except Exception as e:
+        _cleanup_temp(final_path)
+        logger.error(
+            "Failed to index uploaded document %s: %s",
+            display_name,
+            e,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500, detail=f"Failed to index document: {e}"
+        ) from e
+
+    # 8. Concurrent-drop race guard: if a simultaneous upload of the same
+    # new file beat us to add_document, it will return the OTHER doc
+    # (dedup by hash) whose filepath points at the winning file — leaving
+    # ours as an orphan on disk. Detect that and unlink.
+    try:
+        returned_path = Path(doc["filepath"]).resolve()
+        if returned_path != final_path.resolve():
+            logger.info(
+                "Blob upload race: %s lost to %s, unlinking orphan",
+                final_path,
+                returned_path,
+            )
+            _cleanup_temp(final_path)
+    except (OSError, KeyError):
+        pass
+
+    logger.info(
+        "Blob upload indexed: %s (%d bytes, %d chunks)",
+        display_name,
+        bytes_written,
+        doc.get("chunk_count", 0),
+    )
+    return doc_to_response(doc)
+
+
 @router.get("/api/documents/monitor/status")
 async def monitor_status(request: Request):
     """Get status of the document file monitor."""
@@ -258,9 +458,29 @@ async def cancel_indexing(
 
 @router.delete("/api/documents/{doc_id}")
 async def delete_document(doc_id: str, db: ChatDatabase = Depends(get_db)):
-    """Remove a document from the library."""
-    if not db.delete_document(doc_id):
+    """Remove a document from the library.
+
+    For blob-uploaded documents (files the server owns under
+    ``MANAGED_DOCS_DIR``), the on-disk file is also unlinked as a
+    best-effort cleanup. User-owned files from ``upload-path`` are left
+    alone.
+    """
+    # Fetch first so we know the filepath even after deletion. This also
+    # distinguishes "not found" from "found but db delete race lost."
+    doc = db.get_document(doc_id)
+    if not doc:
         raise HTTPException(status_code=404, detail="Document not found")
+
+    if not db.delete_document(doc_id):
+        # Row vanished between fetch and delete (concurrent delete).
+        # Treat as not found — idempotent for the caller.
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    # Best-effort filesystem cleanup for server-owned files.
+    filepath = doc.get("filepath")
+    if filepath and _is_server_owned(filepath):
+        _cleanup_temp(Path(filepath))
+
     return {"deleted": True}
 
 

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -351,11 +351,12 @@ async def upload_document_blob(
             _cleanup_temp(partial_path)
 
     # 7. Index and record. Wrap both so an indexing OR db failure unlinks
-    # the final file (no orphan rows/files).
+    # the final file (no orphan rows/files). The stat() call is also inside
+    # the try so a rare filesystem hiccup post-rename doesn't leak the file.
     _index_document = _server_mod()._index_document
-    file_mtime = final_path.stat().st_mtime
 
     try:
+        file_mtime = final_path.stat().st_mtime
         chunk_count = await _index_document(final_path)
         doc = db.add_document(
             filename=display_name,

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -61,6 +61,19 @@ MAX_DOCUMENT_UPLOAD_SIZE = 20 * 1024 * 1024  # 20 MB
 # Streaming chunk size for multipart blob upload.
 UPLOAD_CHUNK_SIZE = 64 * 1024  # 64 KB
 
+# Length of the random hex ID prefixed to managed document filenames.
+# 12 hex chars = 48 bits ≈ 2.8e14 possibilities; collision probability with
+# 1 million concurrent uploads is ~1 in 1.4e14 — effectively zero. Files are
+# also deduped by SHA-256 hash before writing, so identical-content collisions
+# are impossible. 12 chars keeps the on-disk basename well under Windows
+# MAX_PATH limits once combined with the original filename.
+MANAGED_ID_LEN = 12
+
+
+def _short_id() -> str:
+    """Return a short random hex identifier for managed document filenames."""
+    return uuid.uuid4().hex[:MANAGED_ID_LEN]
+
 
 def _server_mod():
     """Lazily resolve ``gaia.ui.server`` for patchable function access."""
@@ -317,7 +330,7 @@ async def upload_document_blob(
     # 4. Stream-write to a .partial file, hashing as we go, aborting on
     # oversize. try/finally ensures the partial is cleaned up on any exit
     # path (including ClientDisconnect and CancelledError).
-    partial_path: Path | None = MANAGED_DOCS_DIR / f"{uuid.uuid4()}.partial"
+    partial_path: Path | None = MANAGED_DOCS_DIR / f"{_short_id()}.partial"
     final_path: Path | None = None
     hasher = hashlib.sha256()
     bytes_written = 0
@@ -372,7 +385,7 @@ async def upload_document_blob(
         # `partial_path` is cleared so the finally block won't unlink our
         # now-final file.
         safe_stem = _sanitize_stem(Path(display_name).stem)
-        final_path = MANAGED_DOCS_DIR / f"{uuid.uuid4()}_{safe_stem}{ext}"
+        final_path = MANAGED_DOCS_DIR / f"{_short_id()}_{safe_stem}{ext}"
         try:
             os.replace(partial_path, final_path)
         except OSError as e:

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -105,6 +105,33 @@ def _is_server_owned(filepath: str) -> bool:
         return False
 
 
+# Characters that are illegal in Windows filenames (POSIX is more permissive,
+# but sanitizing to the Windows rules gives cross-platform portability).
+_ILLEGAL_FILENAME_CHARS = '<>:"/\\|?*'
+
+
+def _sanitize_stem(stem: str, max_length: int = 80) -> str:
+    """Sanitize a filename stem for safe cross-platform filesystem use.
+
+    Replaces characters that are illegal on Windows (``<>:"/\\|?*``) and
+    control characters with underscores, trims leading/trailing whitespace
+    and dots (Windows disallows trailing dots/spaces), and truncates to
+    *max_length* characters. Returns ``"file"`` if nothing usable remains.
+
+    The returned stem is combined with a UUID prefix to form the final
+    on-disk filename, so collisions are impossible regardless of what the
+    user-provided name contained. The purpose of preserving the original
+    name is purely so downstream consumers (RAG tools, the LLM) can
+    recognize the document by its human-readable name.
+    """
+    cleaned = "".join(
+        "_" if c in _ILLEGAL_FILENAME_CHARS or ord(c) < 32 else c for c in stem
+    )
+    cleaned = cleaned.strip(" .")
+    cleaned = cleaned[:max_length]
+    return cleaned or "file"
+
+
 # ── Endpoints ────────────────────────────────────────────────────────────────
 
 
@@ -336,10 +363,16 @@ async def upload_document_blob(
             )
             return doc_to_response(existing)
 
-        # 6. Promote partial -> final (atomic rename). After this, the
-        # partial_path variable is cleared so the finally block won't
-        # unlink our now-final file.
-        final_path = MANAGED_DOCS_DIR / f"{uuid.uuid4()}{ext}"
+        # 6. Promote partial -> final (atomic rename). The on-disk filename
+        # embeds the sanitized original stem so that downstream consumers
+        # (RAG tools, the agent LLM) can recognize the document by its
+        # human-readable name — a pure-UUID filename causes the LLM to
+        # hallucinate paths when it needs to reference the file in a tool
+        # call. The UUID prefix still guarantees uniqueness. After this,
+        # `partial_path` is cleared so the finally block won't unlink our
+        # now-final file.
+        safe_stem = _sanitize_stem(Path(display_name).stem)
+        final_path = MANAGED_DOCS_DIR / f"{uuid.uuid4()}_{safe_stem}{ext}"
         try:
             os.replace(partial_path, final_path)
         except OSError as e:

--- a/src/gaia/ui/routers/files.py
+++ b/src/gaia/ui/routers/files.py
@@ -70,7 +70,10 @@ async def upload_file(file: UploadFile = File(...)):
     Constraints:
     - Maximum file size: 20 MB
     - Allowed types: common images (png, jpg, jpeg, gif, webp, bmp, svg)
-      and document types from ALLOWED_EXTENSIONS.
+      and the document types listed in ALLOWED_EXTENSIONS (pdf, txt, md,
+      csv, json, xlsx, html, xml, yaml, and code files). Legacy Office
+      formats (.doc/.docx/.ppt/.pptx/.xls) are NOT allowed — GAIA does
+      not currently ship extractors for them.
 
     Returns:
         FileUploadResponse with the saved filename, URL, size, and metadata.
@@ -88,7 +91,9 @@ async def upload_file(file: UploadFile = File(...)):
             detail=(
                 f"File type '{ext}' is not allowed. "
                 f"Supported types: images (png, jpg, jpeg, gif, webp, bmp, svg) "
-                f"and documents (pdf, txt, md, csv, json, docx, xlsx, etc.)."
+                f"and documents (pdf, txt, md, csv, json, xlsx, html, code files, etc.). "
+                f"Microsoft Word/PowerPoint and legacy .xls are not yet supported — "
+                f"save as PDF or .xlsx."
             ),
         )
 

--- a/src/gaia/ui/utils.py
+++ b/src/gaia/ui/utils.py
@@ -36,7 +36,20 @@ logger = logging.getLogger(__name__)
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 
-# Allowed document extensions for upload
+# Allowed document extensions for upload.
+#
+# IMPORTANT: Only include extensions that have a real extractor in
+# ``src/gaia/rag/sdk.py::_extract_text_from_file``. Adding an extension here
+# without a corresponding extractor causes the RAG pipeline to fall through
+# to the "unknown file type, read as text" branch, which silently indexes
+# binary garbage (Word/PowerPoint are ZIP containers, legacy .xls is BIFF,
+# etc.) and poisons retrieval quality.
+#
+# Notable intentional exclusions (no parser ships with GAIA today):
+#   .doc/.docx/.ppt/.pptx — need python-docx / python-pptx
+#   .xls (legacy BIFF)    — openpyxl only handles .xlsx; would raise on open
+# See ``_UNSUPPORTED_CATEGORIES`` below for the user-facing rejection hint.
+# Image formats are tracked by issue #730 (VLM-based indexing).
 ALLOWED_EXTENSIONS = frozenset(
     {
         ".pdf",
@@ -44,11 +57,6 @@ ALLOWED_EXTENSIONS = frozenset(
         ".md",
         ".csv",
         ".json",
-        ".doc",
-        ".docx",
-        ".ppt",
-        ".pptx",
-        ".xls",
         ".xlsx",
         ".html",
         ".htm",
@@ -274,6 +282,14 @@ def sanitize_document_path(user_path: str) -> Path:
                 "Database files are not supported for direct indexing. "
                 "Tip: Export your data to CSV or JSON format, then index those files.",
             ),
+            "office": (
+                {".doc", ".docx", ".ppt", ".pptx", ".xls"},
+                "Microsoft Word, PowerPoint, and legacy Excel (.xls) files "
+                "are not yet supported — GAIA does not currently ship the "
+                "parsers needed to extract text from these formats. "
+                "Tip: Save as PDF from Word/PowerPoint, or re-save .xls as "
+                ".xlsx — GAIA supports PDFs and modern .xlsx workbooks.",
+            ),
         }
 
         hint = ""
@@ -289,7 +305,7 @@ def sanitize_document_path(user_path: str) -> Path:
 
         detail = (
             f"{hint} "
-            f"Supported formats: PDF, TXT, MD, CSV, JSON, Office docs (DOC/DOCX, PPT/PPTX, XLS/XLSX), "
+            f"Supported formats: PDF, TXT, MD, CSV, JSON, XLSX, "
             f"HTML, XML, YAML, and 30+ code file formats. "
             f"Want support for {category + ' files' if category else 'this file type'}? "
             f"Request it at https://github.com/amd/gaia/issues/new?title=[Feature]%20Support%20{ext}%20file%20indexing"

--- a/tests/integration/test_documents_router.py
+++ b/tests/integration/test_documents_router.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from gaia.ui.routers.documents import MANAGED_DOCS_DIR, MAX_DOCUMENT_UPLOAD_SIZE
+from gaia.ui.routers.documents import MAX_DOCUMENT_UPLOAD_SIZE
 from gaia.ui.server import create_app
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_documents_router.py
+++ b/tests/integration/test_documents_router.py
@@ -102,10 +102,47 @@ def test_upload_blob_happy_path(client, mock_index_document, managed_docs_sandbo
     assert filepath.parent == managed_docs_sandbox
     assert filepath.read_bytes() == content
 
+    # The on-disk filename must embed the original stem so the agent LLM
+    # and RAG tools can recognize the file. Pattern: "<uuid>_<stem>.<ext>"
+    assert filepath.name.endswith(
+        "_report.txt"
+    ), f"Expected on-disk name to end with '_report.txt', got {filepath.name}"
+
     # Indexing was called exactly once with the final path
     mock_index_document.assert_awaited_once()
     called_arg = mock_index_document.await_args.args[0]
     assert Path(called_arg) == filepath
+
+
+def test_upload_blob_sanitizes_illegal_filename_chars(
+    client, mock_index_document, managed_docs_sandbox
+):
+    """Windows-illegal characters in the original name must not reach disk.
+
+    The sanitizer strips ``<>:"/\\|?*`` plus control chars. We use a
+    subset that survives the HTTP multipart transport layer (the test
+    client URL-encodes some of the fancier characters before they reach
+    the server, which is fine — we only care about what hits disk).
+    """
+    content = b"content"
+    response = client.post(
+        "/api/documents/upload",
+        files={"file": ("weird<name>|x?y*.txt", content, "text/plain")},
+    )
+    assert response.status_code == 200, response.text
+
+    doc = response.json()
+    filepath = Path(doc["filepath"])
+    assert filepath.exists()
+    # None of the illegal chars should be present in the on-disk filename.
+    illegal = set('<>:"|?*')
+    assert not (
+        illegal & set(filepath.name)
+    ), f"Illegal characters leaked into on-disk filename: {filepath.name}"
+    # And the sanitized stem should still be recognizable (contain "weird"
+    # and "name" — the alphanumeric parts survive)
+    assert "weird" in filepath.name
+    assert "name" in filepath.name
 
 
 def test_upload_blob_dedup_returns_existing(

--- a/tests/integration/test_documents_router.py
+++ b/tests/integration/test_documents_router.py
@@ -1,0 +1,265 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for the GAIA Agent UI documents router.
+
+Focused on the blob upload endpoint added to fix issue #728, plus the
+related delete-cleanup logic.
+
+The tests patch ``gaia.ui.server._index_document`` to return a fixed chunk
+count rather than running real RAG indexing, so they run fast and do not
+depend on Lemonade or any LLM backend.
+"""
+
+import logging
+import shutil
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gaia.ui.routers.documents import MANAGED_DOCS_DIR, MAX_DOCUMENT_UPLOAD_SIZE
+from gaia.ui.server import create_app
+
+logger = logging.getLogger(__name__)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app():
+    """Create FastAPI app with in-memory database."""
+    return create_app(db_path=":memory:")
+
+
+@pytest.fixture
+def client(app):
+    """Create test client for the app."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_index_document():
+    """Patch the RAG index function with an AsyncMock returning 7 chunks."""
+    with patch("gaia.ui.server._index_document", new=AsyncMock(return_value=7)) as m:
+        yield m
+
+
+@pytest.fixture
+def managed_docs_sandbox():
+    """Isolate the managed docs dir for the duration of a test.
+
+    The production ``MANAGED_DOCS_DIR`` is ``~/.gaia/documents``. We don't
+    want tests dropping files into the user's real home dir, so we point
+    the module-level constant at a throwaway subdirectory inside
+    ``~/.gaia/test_documents_router/`` and clean it up afterwards.
+    """
+    sandbox = Path.home() / ".gaia" / "test_documents_router" / str(uuid.uuid4())[:8]
+    sandbox.mkdir(parents=True, exist_ok=True)
+    with patch("gaia.ui.routers.documents.MANAGED_DOCS_DIR", sandbox):
+        yield sandbox
+    try:
+        shutil.rmtree(str(sandbox))
+    except OSError as exc:
+        logger.warning("Failed to clean up sandbox %s: %s", sandbox, exc)
+
+
+@pytest.fixture
+def home_tmp_dir():
+    """Temp dir inside the user's home (needed for path-based upload tests)."""
+    tmp_dir = Path.home() / ".gaia" / "test_documents_router" / str(uuid.uuid4())[:8]
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    yield tmp_dir
+    try:
+        shutil.rmtree(str(tmp_dir))
+    except OSError as exc:
+        logger.warning("Failed to clean up %s: %s", tmp_dir, exc)
+
+
+# ── Blob upload happy paths ──────────────────────────────────────────────────
+
+
+def test_upload_blob_happy_path(client, mock_index_document, managed_docs_sandbox):
+    """Dropping a .txt file returns a DocumentResponse and writes a real file."""
+    content = b"Hello, this is a test document.\n"
+    response = client.post(
+        "/api/documents/upload",
+        files={"file": ("report.txt", content, "text/plain")},
+    )
+    assert response.status_code == 200, response.text
+
+    doc = response.json()
+    assert doc["filename"] == "report.txt"
+    assert doc["file_size"] == len(content)
+    assert doc["chunk_count"] == 7  # from the mocked _index_document
+
+    # The on-disk file should exist inside the sandbox dir
+    filepath = Path(doc["filepath"])
+    assert filepath.exists()
+    assert filepath.parent == managed_docs_sandbox
+    assert filepath.read_bytes() == content
+
+    # Indexing was called exactly once with the final path
+    mock_index_document.assert_awaited_once()
+    called_arg = mock_index_document.await_args.args[0]
+    assert Path(called_arg) == filepath
+
+
+def test_upload_blob_dedup_returns_existing(
+    client, mock_index_document, managed_docs_sandbox
+):
+    """Uploading identical bytes twice returns the same doc, files on disk = 1."""
+    content = b"Dedup me.\n"
+
+    r1 = client.post(
+        "/api/documents/upload",
+        files={"file": ("first.txt", content, "text/plain")},
+    )
+    assert r1.status_code == 200
+    doc1 = r1.json()
+
+    r2 = client.post(
+        "/api/documents/upload",
+        files={"file": ("second.txt", content, "text/plain")},
+    )
+    assert r2.status_code == 200
+    doc2 = r2.json()
+
+    # Same doc returned (dedup by hash — the id is stable)
+    assert doc1["id"] == doc2["id"]
+
+    # Indexing only ran once — the second call short-circuited
+    mock_index_document.assert_awaited_once()
+
+    # Only the winning file should exist in the sandbox (no orphan partials
+    # or duplicates)
+    files_on_disk = [p for p in managed_docs_sandbox.iterdir() if p.is_file()]
+    assert len(files_on_disk) == 1
+    assert files_on_disk[0] == Path(doc1["filepath"])
+
+
+# ── Validation / error paths ─────────────────────────────────────────────────
+
+
+def test_upload_blob_empty_returns_400(
+    client, mock_index_document, managed_docs_sandbox
+):
+    """Empty file → 400 and no file written."""
+    response = client.post(
+        "/api/documents/upload",
+        files={"file": ("empty.txt", b"", "text/plain")},
+    )
+    assert response.status_code == 400
+    assert "empty" in response.json()["detail"].lower()
+
+    # No orphan files left behind
+    assert not any(managed_docs_sandbox.iterdir())
+    mock_index_document.assert_not_called()
+
+
+def test_upload_blob_bad_extension_returns_400(
+    client, mock_index_document, managed_docs_sandbox
+):
+    """Disallowed extension → 400 before any bytes are written."""
+    response = client.post(
+        "/api/documents/upload",
+        files={"file": ("malware.exe", b"MZ\x00\x00", "application/octet-stream")},
+    )
+    assert response.status_code == 400
+    assert ".exe" in response.json()["detail"]
+    mock_index_document.assert_not_called()
+    assert not any(managed_docs_sandbox.iterdir())
+
+
+def test_upload_blob_oversized_returns_413(
+    client, mock_index_document, managed_docs_sandbox
+):
+    """File > MAX_DOCUMENT_UPLOAD_SIZE → 413 and partial file cleaned up."""
+    # 1 byte over the limit
+    oversized = b"x" * (MAX_DOCUMENT_UPLOAD_SIZE + 1)
+    response = client.post(
+        "/api/documents/upload",
+        files={"file": ("huge.txt", oversized, "text/plain")},
+    )
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"].lower()
+
+    # Critical: no .partial files left on disk after the abort
+    leftover = list(managed_docs_sandbox.iterdir())
+    assert leftover == [], f"Orphaned files after oversized upload: {leftover}"
+    mock_index_document.assert_not_called()
+
+
+def test_upload_blob_indexing_failure_cleans_up_file(client, managed_docs_sandbox):
+    """If _index_document raises, the final file must be unlinked."""
+    with patch(
+        "gaia.ui.server._index_document",
+        new=AsyncMock(side_effect=RuntimeError("RAG exploded")),
+    ):
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("doomed.txt", b"will fail", "text/plain")},
+        )
+    assert response.status_code == 500
+
+    # File should NOT be left on disk
+    leftover = list(managed_docs_sandbox.iterdir())
+    assert leftover == [], f"Orphaned files after indexing failure: {leftover}"
+
+
+# ── Delete endpoint cleanup ──────────────────────────────────────────────────
+
+
+def test_delete_blob_document_unlinks_file(
+    client, mock_index_document, managed_docs_sandbox
+):
+    """DELETE on a server-owned doc unlinks the on-disk file."""
+    # Upload
+    r = client.post(
+        "/api/documents/upload",
+        files={"file": ("delete_me.txt", b"temporary content", "text/plain")},
+    )
+    assert r.status_code == 200
+    doc = r.json()
+    filepath = Path(doc["filepath"])
+    assert filepath.exists()
+
+    # Delete
+    r = client.delete(f"/api/documents/{doc['id']}")
+    assert r.status_code == 200
+    assert r.json() == {"deleted": True}
+
+    # File is gone
+    assert not filepath.exists()
+
+
+def test_delete_path_document_preserves_user_file(
+    client, mock_index_document, managed_docs_sandbox, home_tmp_dir
+):
+    """DELETE on a user-owned (path-uploaded) doc leaves the file alone."""
+    # Create a real file in the user's home temp dir and upload by path
+    user_file = home_tmp_dir / "user_report.txt"
+    user_file.write_text("User-owned document.\n", encoding="utf-8")
+
+    r = client.post(
+        "/api/documents/upload-path",
+        json={"filepath": str(user_file)},
+    )
+    assert r.status_code == 200, r.text
+    doc = r.json()
+    assert Path(doc["filepath"]) == user_file
+
+    # Delete via the API
+    r = client.delete(f"/api/documents/{doc['id']}")
+    assert r.status_code == 200
+
+    # User's file must still exist — we do NOT own it
+    assert user_file.exists(), "User-owned file was incorrectly deleted"
+
+
+def test_delete_nonexistent_returns_404(client):
+    r = client.delete("/api/documents/does-not-exist")
+    assert r.status_code == 404

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -1437,9 +1437,24 @@ class TestValidateFilePath:
     def test_allows_document_extensions(self):
         from pathlib import Path
 
-        for ext in [".pdf", ".doc", ".docx", ".csv", ".json", ".yaml"]:
+        # Only list extensions that have real extractors in
+        # src/gaia/rag/sdk.py::_extract_text_from_file. See
+        # ``ALLOWED_EXTENSIONS`` in src/gaia/ui/utils.py for the canonical list.
+        for ext in [".pdf", ".txt", ".md", ".csv", ".json", ".xlsx", ".yaml"]:
             # Should not raise
             _validate_file_path(Path(f"/home/user/file{ext}").resolve())
+
+    def test_rejects_legacy_office_extensions(self):
+        """Office formats without extractors must be rejected, not silently
+        indexed as binary garbage. Regression test for the allowlist cleanup
+        that removed .doc/.docx/.ppt/.pptx/.xls — GAIA does not currently
+        ship python-docx/python-pptx/xlrd so these would produce garbage."""
+        from pathlib import Path
+
+        for ext in [".doc", ".docx", ".ppt", ".pptx", ".xls"]:
+            with pytest.raises(Exception) as exc_info:
+                _validate_file_path(Path(f"/home/user/file{ext}").resolve())
+            assert exc_info.value.status_code == 400
 
     @patch("gaia.ui.server._index_document")
     def test_upload_rejects_unsafe_extension(self, mock_index, client):


### PR DESCRIPTION
Fixes #728.

## What was broken

Drag-and-drop document upload failed with *"Indexing error: Not found. The file or folder may have been moved or deleted."* in any browser, and in the packaged Electron desktop app (Electron 40).

**Root cause:** `src/gaia/apps/webui/src/components/DocumentLibrary.tsx:265` relied on `(file as any).path`, an Electron-only augmentation that's `undefined` in every browser and was [removed in Electron 32+](https://www.electronjs.org/blog/electron-32-0). The fallback `file.name` (bare filename, no directory) was POSTed to `/api/documents/upload-path`, which couldn't resolve it → HTTP 404 → misleading frontend error.

## Fix

New `POST /api/documents/upload` endpoint that accepts the file content as multipart form data, streams it to `~/.gaia/documents/<shortid>_<original_name>.<ext>` with a 20 MB cap, dedupes by SHA-256 hash, and indexes via the standard RAG pipeline. Drag-and-drop in both DocumentLibrary and ChatView now use this endpoint. Delete cleans up server-owned files; user-owned files from `upload-path` are left alone.

Also fixes `getFriendlyError()` in `api.ts` to prefer the backend's `detail` over the canned 404 string, so future upload errors surface meaningful messages.

### Details worth knowing
- **On-disk filename embeds the original stem** (`<12-hex-id>_<sanitized_name>.<ext>`) so the agent LLM and RAG tools can recognize the file by its human-readable name. A pure-UUID filename caused the LLM to hallucinate paths (e.g. `C:\Users\14255\.gaia\documents\<uuid>.pdf` → `/Users/14255/Documents/<uuid>.pdf`) and fail tool lookups.
- **Filename sanitizer** strips Windows-illegal chars (`<>:"/\|?*`), control chars, leading/trailing whitespace and dots, and caps length at 80 chars — keeps total path well under Windows MAX_PATH.
- **12-hex-char ID** instead of full UUID. We dedup by SHA-256 first, so identical-content collisions are impossible; the only theoretical collision is concurrent uploads of *different* content drawing the same ID, with probability ~1 in 1.4e14 even at 1M concurrent uploads. Saves 24 chars per filename.
- **Reliability**: streaming write with abort-on-overflow, try/finally partial cleanup (survives ClientDisconnect), atomic `os.replace`, orphan cleanup on indexing/db/race failures.
- **Chat-view drop UX**: dropping onto the chat area indexes quietly without forcing the Document Library side panel open. Dropping onto the library panel itself still opens it (correct for users intentionally managing their library).

### Bundled cleanup
This PR also includes a doc-consistency pass auto-applied by `util/lint.py --all --fix` (step 8) that aligns the supported-extension allowlist across backend (`utils.py`, `files.py`), frontend (`UnsupportedFeature.tsx`), and tests.

### What's NOT changed
- `POST /api/documents/upload-path` is untouched — still used by the server-side file browser in `FileBrowser.tsx`, where the user explicitly picks a real filesystem path.
- The Electron preload — deliberately not adding `webUtils.getPathForFile` since it's [broken for drag-drop in Electron 30-33+](https://github.com/electron/electron/issues/44600) and the blob path works everywhere.

### Known limitation / follow-up
The agent LLM still occasionally cites the on-disk filename (e.g. `9c59c981f8e7_report.pdf`) when answering questions about a document, instead of the user's display name (`report.pdf`). This is because `src/gaia/agents/chat/tools/rag_tools.py` returns chunk metadata using raw filepaths from `self.rag.indexed_files` rather than translating them to the display name stored in `documents.filename`. **This is a separate, pre-existing concern in the RAG tool layer** and fixing it requires a focused refactor of `rag_tools.py` (~1800 lines, touches `query_documents`, `query_specific_file`, `summarize_document`, `search_indexed_chunks`, `list_indexed_documents`). Tracking it as a follow-up rather than expanding this PR's scope.

### Conflict notes for reviewers
- **#723** (surface indexing failures) also touches `src/gaia/ui/routers/documents.py`, but edits the body of `upload_by_path` — this PR only adds new top-of-file constants, helpers, and a new `upload_document_blob` function inserted after `upload_by_path`. Three-way merge should be clean. Semantically, #723's "raise on failure" change is **more correct** under my new endpoint than the previous silent-0-chunk behavior.
- **#725** (Ask Agent file indexing) touches `ChatView.tsx` in a disjoint line range. No conflict.

---

## Steps to reproduce the bug (before this fix)

### One-time setup
```bash
git checkout main
uv venv
uv pip install -e ".[dev,ui]"
cd src/gaia/apps/webui && npm install && npm run build && cd -
```

> **Windows PowerShell users:** quote the extras → `uv pip install -e ".[ui]"`. Without quotes PowerShell silently strips them.

### Start the services
```bash
# Terminal 1
lemonade-server serve

# Terminal 2
gaia chat --ui
```

### Reproduce
1. Open the UI in **Firefox** (most reliable repro; the bug also reproduces in Chrome and the packaged Electron 40 desktop app).
2. Open DevTools → Network tab, filter on `documents`.
3. Open or create a chat session.
4. Drag any `.pdf`/`.txt`/`.md`/`.docx` from your file manager onto the Document Library drop zone or the chat area.
5. **Observe:**
   - UI: *"Indexing error: Not found. The file or folder may have been moved or deleted."*
   - Network: `POST /api/documents/upload-path` → **HTTP 404**
   - Request body: `{"filepath":"report.pdf"}` (bare filename — the smoking gun)
   - Backend log: `HTTPException: File not found: report.pdf`

### Verify the fix
```bash
git checkout kalin/fix-728-document-upload
cd src/gaia/apps/webui && npm run build && cd -
# Restart `gaia chat --ui`
```
Repeat the drop. Expected:
- Network: `POST /api/documents/upload` (multipart, **not** `upload-path`) → **HTTP 200**
- File persisted at `~/.gaia/documents/<shortid>_report.pdf` with the original name embedded
- Backend log: `Blob upload indexed: report.pdf (<N> bytes, <M> chunks)`
- Drop the same file twice → `Blob upload dedup: report.pdf matches existing doc <id>` (no second file on disk)
- Ask the agent about the doc → answers correctly using the indexed content

## Test plan

- [x] 10 new integration tests (`tests/integration/test_documents_router.py`): happy path, dedup, empty/oversized/bad-extension/illegal-chars rejection, indexing failure cleanup, delete unlinks server-owned, delete preserves user-owned, 404 on delete
- [x] Adjacent regression sweep: 186 tests pass (files router, folder indexing, database, server unit tests)
- [x] `python util/lint.py --all --fix` clean
- [x] `tsc --noEmit` clean (no new errors in changed files)
- [x] End-to-end smoke test via TestClient (upload → list → delete → file unlinked)
- [x] **Manual (Windows + Firefox)**: drag-and-drop indexes successfully → ✅ validated
- [x] **Manual**: dropped doc auto-attaches to chat session → ✅ validated
- [x] **Manual**: dedup short-circuit verified → ✅ validated
- [x] **Manual**: delete cleanup verified for both server-owned and user-owned files → ✅ validated
- [x] **Manual**: agent answers questions correctly using the indexed document → ✅ validated (display-name citation polish tracked as follow-up; see "Known limitation" above)