### PR TITLE
fix(linux): chrome-sandbox SUID and gaia init non-interactive mode

### DIFF
--- a/installer/debian/postinst
+++ b/installer/debian/postinst
@@ -11,6 +11,13 @@ set -e
 
 case "$1" in
     configure)
+        # Chromium's SUID sandbox helper must be owned by root and have mode
+        # 4755. electron-builder packages it as 755; we fix it here so the
+        # app can start without --no-sandbox.
+        if [ -f /opt/GAIA/chrome-sandbox ]; then
+            chown root:root /opt/GAIA/chrome-sandbox
+            chmod 4755 /opt/GAIA/chrome-sandbox
+        fi
         # Refresh the desktop database so the installed .desktop entry is
         # picked up by menus, launchers, and file associations.
         if command -v update-desktop-database >/dev/null 2>&1; then

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -840,7 +840,7 @@ async function installBackend(opts = {}) {
 
     const initResult = await runCommand(
       GAIA_BIN,
-      ["init", "--profile", "minimal"],
+      ["init", "--profile", "minimal", "--yes"],
       { stageLabel: "gaia-init" }
     );
 


### PR DESCRIPTION
Fixes two critical bugs found during end-to-end install testing on Ubuntu 24.04 (amd64), testing against PR #731.

## Bug 1: chrome-sandbox missing SUID bit

**Symptom:** App crashes immediately after `apt install` with:
```
FATAL: The SUID sandbox helper binary was found, but is not configured correctly.
Rather than run without sandboxing I'm aborting now. You need to make sure that
/opt/GAIA/chrome-sandbox is owned by root and has mode 4755.
```

**Root cause:** `electron-builder` packages `chrome-sandbox` with mode `755`. Chromium's sandbox helper requires `4755` (setuid root) to function. Without it, no user can launch the app after a clean install.

**Fix:** `installer/debian/postinst` now sets `chown root:root` + `chmod 4755` on `/opt/GAIA/chrome-sandbox` during package configuration, which runs as root via `apt`.

## Bug 2: Model download silently skipped — app crashes when user types

**Symptom:** Bootstrap completes and reports `ready`, but Qwen3-0.6B is never downloaded. Lemonade has no model loaded, so the app crashes when the user sends their first message.

**Root cause:** `backend-installer.cjs` runs `gaia init --profile minimal` with piped stdio (for log streaming). With no TTY attached, `gaia init`'s interactive prompts ("Continue? [Y/n]:" and "Run model verification? [Y/n]:") receive EOF and answer themselves as "Skipping". The non-zero-ish exit is treated as non-fatal, so state reaches `ready` despite no model existing.

**Fix:** Pass `--yes` to `gaia init` so prompts are auto-answered. The flag already exists for this purpose.

## Testing

Both bugs reproduced on Ubuntu 24.04.4 LTS (x86_64, kernel 6.17) with the `.deb` from CI run [24255947495](https://github.com/amd/gaia/actions/runs/24255947495). Verified manually:
- Before fix: immediate crash on launch (Bug 1), silent model skip + crash on chat (Bug 2)
- After applying patches locally: app launches, bootstrap downloads model, chat works

Closes part of #530.