### PR TITLE
fix(ci): grant contents:write for build-electron in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -273,6 +273,8 @@ jobs:
   build-electron:
     name: Build Electron Apps
     needs: validate
+    permissions:
+      contents: write   # build-electron-apps.yml declares contents: write
     uses: ./.github/workflows/build-electron-apps.yml
 
   # Build the GAIA Agent UI desktop installers (NSIS / DMG / DEB / AppImage)


### PR DESCRIPTION
## Summary

- Fixes the `startup_failure` on the Publish Release workflow: https://github.com/amd/gaia/actions/runs/24278877956
- **Root cause:** `build-electron-apps.yml` declares `permissions: contents: write` at its top level. When called as a reusable workflow from `publish.yml`, the calling `build-electron` job only had `contents: read` (inherited from publish.yml's workflow-level permissions). GitHub Actions validates this at startup and rejects the run before any jobs start.
- **Fix:** Add explicit `permissions: contents: write` to the `build-electron` job in publish.yml so it matches what the reusable workflow declares.

> **Note:** The previous PR #747 fixed a YAML block scalar issue (heredoc indentation) that was also causing a parse error. This PR fixes the second startup_failure — the permissions mismatch discovered from the GitHub Actions error annotation.

## Test plan

- [ ] Merge, move v0.17.2 tag, verify Publish Release workflow starts and reaches the Validate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)