### PR TITLE
fix(ci): skip macOS code signing when APPLE_ID is not set

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -240,7 +240,16 @@ jobs:
           # try to sign with a random keychain cert on CI runners.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ env.APPLE_ID != '' && 'true' || 'false' }}
         # --publish never: we upload artifacts ourselves via action-gh-release.
-        run: npm run ${{ matrix.npm_script }} -- --publish never
+        # On macOS without signing secrets, pass identity=null to skip signing
+        # entirely. electron-builder auto-skips for PRs but NOT for tag pushes,
+        # so without this flag non-PR unsigned builds fail with "not a file".
+        run: |
+          EXTRA_ARGS=""
+          if [ "${{ matrix.platform }}" = "macos" ] && [ -z "$APPLE_ID" ]; then
+            echo "No APPLE_ID set — skipping macOS code signing (identity=null)"
+            EXTRA_ARGS="--config.mac.identity=null"
+          fi
+          npm run ${{ matrix.npm_script }} -- --publish never $EXTRA_ARGS
 
       # ─── Inspect build output ───────────────────────────────────────
       - name: List build artifacts


### PR DESCRIPTION
## Summary

- Fixes the macOS DMG build failure in the Publish Release workflow: https://github.com/amd/gaia/actions/runs/24278980001
- **Root cause:** electron-builder auto-skips code signing for PR builds (`Current build is a part of pull request, code signing will be skipped`) but NOT for tag pushes. Without valid signing secrets, it tries to sign with empty credentials and fails with `⨯ .../src/gaia/apps/webui not a file`.
- **Fix:** Pass `--config.mac.identity=null` when `APPLE_ID` is not set, explicitly telling electron-builder to skip signing. Windows and Linux builds are unaffected (they don't attempt signing without their respective secrets).

> This is the third fix for the v0.17.2 publish pipeline, after #747 (YAML heredoc indentation) and #748 (reusable workflow permissions).

## Test plan

- [x] The PR itself triggers `build-installers.yml` (via `paths:` filter) — the macOS job will validate the fix
- [ ] After merge, move v0.17.2 tag and re-trigger publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)