### PR TITLE
fix(ui): add explicit types to terminalStore callbacks

### DIFF
--- a/src/gaia/apps/webui/src/stores/terminalStore.ts
+++ b/src/gaia/apps/webui/src/stores/terminalStore.ts
@@ -222,27 +222,27 @@ export const useTerminalStore = create<TerminalState>((set) => ({
       paused: { ...state.paused, [agentId]: !(state.paused[agentId] ?? false) },
     })),
 
-  setPaused: (agentId, paused) =>
+  setPaused: (agentId: string, paused: boolean) =>
     set((state) => ({
       paused: { ...state.paused, [agentId]: paused },
     })),
 
   // ── Tab Actions ──────────────────────────────────────────────────────
 
-  setActiveTab: (agentId, tab) =>
+  setActiveTab: (agentId: string, tab: TerminalTab) =>
     set((state) => ({
       activeTabs: { ...state.activeTabs, [agentId]: tab },
     })),
 
   // ── UI Actions ───────────────────────────────────────────────────────
 
-  openTerminal: (agentId) =>
+  openTerminal: (agentId: string) =>
     set({ activeTerminalAgentId: agentId, showTerminal: true }),
 
   closeTerminal: () =>
     set({ showTerminal: false }),
 
-  setShowTerminal: (show) =>
+  setShowTerminal: (show: boolean) =>
     set({ showTerminal: show }),
 }));
 


### PR DESCRIPTION
## Summary

- Fixes TypeScript compilation failure in the `Publish to npm` job: https://github.com/amd/gaia/actions/runs/24279178148/job/70898457497
- `terminalStore.ts` callbacks (`setPaused`, `setActiveTab`, `openTerminal`, `setShowTerminal`) relied on Zustand type inference for parameter types, but `tsc` flagged them as implicit `any` during the build
- Added explicit parameter type annotations matching the `TerminalState` interface

## Test plan

- [x] `npx tsc --noEmit` passes locally with zero errors
- [ ] Merge, move tag, verify npm publish step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)