### PR TITLE
fix(ci): skip prepublishOnly during npm publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -369,7 +369,11 @@ jobs:
         run: npm ci --omit=dev 2>/dev/null || npm install --omit=dev
       - name: Publish @amd-gaia/agent-ui
         working-directory: src/gaia/apps/webui
-        run: npm publish --access public --provenance
+        # --ignore-scripts: skip prepublishOnly (which runs tsc && vite build)
+        # because the dist/ was already built in the build-npm job and
+        # downloaded from the artifact. Dev dependencies are omitted, so
+        # tsc would fail with missing @types/react.
+        run: npm publish --access public --provenance --ignore-scripts
       - name: Verify publication
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
## Summary

- Fixes the `Publish to npm` job failure: https://github.com/amd/gaia/actions/runs/24279365243/job/70899004478
- **Root cause:** `npm publish` triggers `prepublishOnly` → `tsc && vite build`, but the job installs only production deps (`--omit=dev`). `tsc` fails because `@types/react`, `typescript`, etc. are missing.
- **Fix:** Add `--ignore-scripts` to `npm publish`. The dist/ is already pre-built in the `build-npm` job and downloaded as an artifact — the prepublishOnly rebuild is redundant.

> Fix #5 for the v0.17.2 publish pipeline, after #747 (YAML indent), #748 (permissions), #749 (macOS signing), #750 (terminalStore types).

## Test plan

- [ ] Merge, move tag, verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)