### PR TITLE
fix(ci): add registry-url to setup-node for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -359,6 +359,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
       - name: Download validated build
         uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
## Summary

- Fixes `ENEEDAUTH` in the `Publish to npm` job: https://github.com/amd/gaia/actions/runs/24279785278/job/70899991808
- **Root cause:** `setup-node` was missing `registry-url`, so the OIDC token for provenance-based npm publishing was never wired into `.npmrc`. npm had no auth credentials.
- **Fix:** Add `registry-url: 'https://registry.npmjs.org'` to `setup-node`. This configures `.npmrc` with the `NODE_AUTH_TOKEN` env var that npm needs.

> Fix #6 for the v0.17.2 publish pipeline.

## Test plan

- [ ] Merge, move tag, verify npm publish authenticates and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)