### PR TITLE
fix(ci): add npm environment for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -351,6 +351,9 @@ jobs:
     name: Publish to npm
     needs: approve-publish
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@amd-gaia/agent-ui
     permissions:
       contents: read
       id-token: write
@@ -359,6 +362,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
+      - name: Upgrade npm for OIDC trusted publishing
+        run: |
+          npm install -g npm@latest
+          echo "npm version: $(npm -v)"
       - name: Download validated build
         uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
## Summary

- Fixes `ENEEDAUTH` in the `Publish to npm` job: https://github.com/amd/gaia/actions/runs/24279785278/job/70899991808
- **Root cause:** The old `publish-npm-ui.yml` workflow used `environment: npm` which carries the OIDC claims npm needs for trusted publishing. The new unified `publish.yml` dropped this block, so npm rejected auth.
- **Fix:** Restore the `environment: npm` block and the `npm install -g npm@latest` upgrade step, both matching the old working workflow.

## Test plan

- [ ] Merge, move tag, verify npm publish authenticates and publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)