### PR TITLE
fix(ci): remove npm upgrade step that corrupts npm on Node 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -362,10 +362,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
-      - name: Upgrade npm for OIDC trusted publishing
-        run: |
-          npm install -g npm@latest
-          echo "npm version: $(npm -v)"
       - name: Download validated build
         uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
## Summary

- Fixes `Cannot find module 'promise-retry'` in the npm publish job: https://github.com/amd/gaia/actions/runs/24280075274/job/70900655694
- **Root cause:** `npm install -g npm@latest` replaces the bundled npm with a version incompatible with the runner's Node 22 layout, corrupting npm's own dependencies.
- **Fix:** Remove the upgrade step. Node 22 ships with npm 10+ which already supports OIDC trusted publishing.

## Test plan

- [ ] Merge, move tag, verify npm publish works

🤖 Generated with [Claude Code](https://claude.com/claude-code)