### PR TITLE
fix(ci): ad-hoc sign macOS DMG instead of skipping code signing

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -252,6 +252,12 @@ jobs:
           EXTRA_ARGS=""
           if [ "${{ matrix.platform }}" = "macos" ] && [ -z "$APPLE_ID" ]; then
             echo "No APPLE_ID set — using ad-hoc code signing (identity=-)"
+            # electron-builder skips signing for pull-request builds unless this
+            # env var is set. Safe to enable for ad-hoc: there are no real signing
+            # credentials to leak. Remove this if real Developer ID certs are added
+            # (the security warning in electron-builder's output only matters when
+            # CSC_LINK / APPLE_ID secrets are present and fork PRs are allowed).
+            export CSC_FOR_PULL_REQUEST=true
             EXTRA_ARGS="--config.mac.identity=-"
           fi
           npm run ${{ matrix.npm_script }} -- --publish never $EXTRA_ARGS

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -258,6 +258,11 @@ jobs:
             # (the security warning in electron-builder's output only matters when
             # CSC_LINK / APPLE_ID secrets are present and fork PRs are allowed).
             export CSC_FOR_PULL_REQUEST=true
+            # CSC_LINK is set to "" at the job level (secrets expand to empty
+            # strings when unset). @electron/osx-sign resolves "" to the working
+            # directory and fails with "not a file". Unset it so osx-sign skips
+            # the certificate-file path entirely and honours identity=- directly.
+            unset CSC_LINK
             EXTRA_ARGS="--config.mac.identity=-"
           fi
           npm run ${{ matrix.npm_script }} -- --publish never $EXTRA_ARGS

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -235,19 +235,24 @@ jobs:
           # softprops/action-gh-release in a later step. `publish: never`
           # is implied by the CLI flag below.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # On macOS, only auto-discover signing identity when APPLE_ID is set.
-          # Otherwise force-disable auto-discovery so electron-builder doesn't
-          # try to sign with a random keychain cert on CI runners.
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ env.APPLE_ID != '' && 'true' || 'false' }}
+          # Always allow identity auto-discovery. When APPLE_ID is set,
+          # electron-builder finds the real Developer ID cert in the keychain.
+          # When APPLE_ID is absent, the explicit --config.mac.identity=-
+          # below overrides auto-discovery and forces ad-hoc signing.
+          # Setting this to 'false' would suppress signing entirely — even
+          # when an explicit identity is passed on the CLI.
+          CSC_IDENTITY_AUTO_DISCOVERY: "true"
         # --publish never: we upload artifacts ourselves via action-gh-release.
-        # On macOS without signing secrets, pass identity=null to skip signing
-        # entirely. electron-builder auto-skips for PRs but NOT for tag pushes,
-        # so without this flag non-PR unsigned builds fail with "not a file".
+        # On macOS without signing secrets, ad-hoc sign with identity="-".
+        # This produces a valid code signature (sealed resources, correct
+        # bundle ID) without a Developer ID cert. Users see "cannot be
+        # verified" (bypassable via right-click → Open) instead of the
+        # unrecoverable "is damaged" error that identity=null caused.
         run: |
           EXTRA_ARGS=""
           if [ "${{ matrix.platform }}" = "macos" ] && [ -z "$APPLE_ID" ]; then
-            echo "No APPLE_ID set — skipping macOS code signing (identity=null)"
-            EXTRA_ARGS="--config.mac.identity=null"
+            echo "No APPLE_ID set — using ad-hoc code signing (identity=-)"
+            EXTRA_ARGS="--config.mac.identity=-"
           fi
           npm run ${{ matrix.npm_script }} -- --publish never $EXTRA_ARGS
 
@@ -269,6 +274,37 @@ jobs:
               -exec ls -lh {} \; || true
           else
             echo "(dist-app/ does not exist — build may have failed)"
+          fi
+
+      # ─── Verify macOS code signature ─────────────────────────────────
+      # Guards against shipping a broken .app bundle (the class of bug
+      # that caused #745 — identity=null produced a linker-only ad-hoc
+      # signature with no sealed resources, which macOS reported as
+      # "damaged"). This step fails the build if the signature is invalid.
+      - name: Verify macOS code signature
+        if: matrix.platform == 'macos'
+        working-directory: src/gaia/apps/webui
+        shell: bash
+        run: |
+          APP=$(find dist-app -name "*.app" -maxdepth 2 -print -quit 2>/dev/null)
+          if [ -z "$APP" ]; then
+            echo "No .app found in dist-app/ — skipping verification"
+            exit 0
+          fi
+          echo "=== Verifying: $APP ==="
+          # --deep validates nested code (frameworks, helpers).
+          # --strict is omitted: it rejects valid ad-hoc signatures on macOS 13+.
+          codesign --verify --deep "$APP"
+          echo ""
+          echo "=== Signature details ==="
+          codesign -dv --verbose=4 "$APP" 2>&1
+          echo ""
+          echo "=== Sealed Resources check ==="
+          if codesign -dv --verbose=4 "$APP" 2>&1 | grep -q "Sealed Resources"; then
+            echo "OK: Resources are sealed"
+          else
+            echo "FAIL: No sealed resources — the .app bundle has a broken signature"
+            exit 1
           fi
 
       # ─── Upload to workflow run (always, for debugging) ─────────────

--- a/docs/reference/install-troubleshooting.mdx
+++ b/docs/reference/install-troubleshooting.mdx
@@ -16,16 +16,31 @@ This guide covers common problems people encounter when installing GAIA. If your
 
 ## macOS: Gatekeeper blocks the app {#gatekeeper}
 
-**Symptom**: "GAIA cannot be opened because the developer cannot be verified."
+**Symptom**: A dialog appears saying **"gaia-desktop" Not Opened** — "Apple could not verify gaia-desktop is free of malware…" with only **Move to Trash** and **Done** buttons. Or on older macOS: "GAIA cannot be opened because the developer cannot be verified."
 
-**Cause**: The DMG is unsigned (we're working on Apple notarization — see [#530](https://github.com/amd/gaia/issues/530)).
+**Cause**: The DMG is ad-hoc signed but not notarized with an Apple Developer ID (we're working on notarization — see [#733](https://github.com/amd/gaia/issues/733)).
 
-**Fix**: Right-click GAIA in Applications and choose **Open**. In the dialog that appears, click **Open**. macOS remembers this choice for future launches.
+**Fix — macOS 15 Sequoia and later:**
 
-If that doesn't work:
+1. Click **Done** in the dialog (do not click "Move to Trash").
+2. Open **System Settings → Privacy & Security**.
+3. Scroll down to the Security section. You will see:
+   > "gaia-desktop" was blocked from use because it is not from an identified developer.
+4. Click **Open Anyway**.
+5. Enter your Mac password when prompted.
+6. The app opens. macOS remembers this choice for future launches.
+
+**Fix — macOS 14 Ventura and earlier:**
+
+Right-click (or Control-click) **GAIA** in the Applications folder and choose **Open**. In the dialog that appears, click **Open**.
+
+**Alternative fix — terminal (all macOS versions):**
+
 ```bash
-xattr -d com.apple.quarantine /Applications/GAIA.app
+xattr -cr /Applications/GAIA.app
 ```
+
+Then double-click the app — it will open without the Gatekeeper dialog.
 
 ## First-launch backend install fails
 


### PR DESCRIPTION
Closes #745

## Summary

- **`identity=null` → `identity="-"`**: The build workflow was passing `identity=null` to electron-builder when no Apple Developer credentials existed, which skipped the `@electron/osx-sign` pipeline entirely. The resulting `.app` had only linker-provided signatures with no sealed resources, causing macOS Gatekeeper to report the app as \"damaged and can't be opened\" — an unrecoverable error with no bypass. Changing to `identity=\"-\"` invokes the full signing pipeline with an ad-hoc identity, producing a valid code signature with sealed resources.

- **User experience after fix**: Users see **\"gaia-desktop\" Not Opened** (\"Apple could not verify…\") instead of the unrecoverable \"is damaged\" error. This is bypassable:
  - **macOS 15 Sequoia+**: Click Done → System Settings → Privacy & Security → **Open Anyway**
  - **macOS 14 and earlier**: Right-click the app in Applications → **Open**
  - **Terminal (all versions)**: \`xattr -cr /Applications/GAIA.app\`
  - macOS remembers the choice — the dialog only appears once per install.

- **\`CSC_IDENTITY_AUTO_DISCOVERY\` set to \`\"true\"\` unconditionally**: Was conditionally \`\"false\"\` when \`APPLE_ID\` was absent, which suppressed the signing step before the explicit identity override was evaluated.

- **\`CSC_FOR_PULL_REQUEST=true\`**: electron-builder skips signing in PR builds by default. Exported only when \`APPLE_ID\` is absent (ad-hoc path) — safe because there are no real signing credentials to leak.

- **\`unset CSC_LINK\`**: \`CSC_LINK\` is set at the job level via secrets expansion; when the secret is not configured GitHub emits an empty string. \`@electron/osx-sign\` resolves \`\"\"\` to the working directory and fails with \"not a file\". Unsetting it allows \`identity=-\` to be honoured directly.

- **Post-build \`codesign --verify\` step**: Validates the \`.app\` signature and checks for sealed resources in CI, catching this class of regression automatically in future builds.

- **Updated \`docs/reference/install-troubleshooting.mdx\`**: Added macOS 15 Sequoia bypass instructions (Privacy & Security path) and terminal workaround. The old right-click → Open method no longer works on Sequoia.

## Test plan

- [x] macOS matrix leg of \`build-installers.yml\` exits 0
- [x] \`macos-installer\` artifact contains a \`.dmg\`
- [x] New \"Verify macOS code signature\" step reports \"OK: Resources are sealed\"
- [x] Windows and Linux matrix legs unaffected
- [x] Installed the DMG on macOS 15 — confirmed \"cannot be verified\" dialog (not \"is damaged\")
- [x] Verified bypass via System Settings → Privacy & Security → Open Anyway
- [x] Verified bypass via \`xattr -cr /Applications/GAIA.app\`