### PR TITLE
cpp: support Ollama-compatible /v1 endpoints

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -53,7 +53,7 @@ lemonade-server serve
 
 Default model: `Qwen3-4B-GGUF` (configurable via `AgentConfig::modelId`)
 
-> **Any OpenAI-compatible server works.** The agent talks to a standard `/v1/chat/completions` endpoint. You can use [llama.cpp server](https://github.com/ggerganov/llama.cpp), [Ollama](https://ollama.com/), [vLLM](https://github.com/vllm-project/vllm), or any other OpenAI-compatible backend — just set `AgentConfig::baseUrl` and `AgentConfig::modelId` to match your endpoint. See the [Integration Guide](../docs/cpp/integration.mdx) for details.
+> **Any OpenAI-compatible server works.** The agent talks to a standard `/v1/chat/completions` endpoint. You can use [llama.cpp server](https://github.com/ggerganov/llama.cpp), [Ollama](https://ollama.com/), [vLLM](https://github.com/vllm-project/vllm), or any other OpenAI-compatible backend — just set `AgentConfig::baseUrl` and `AgentConfig::modelId` to match your endpoint. Endpoints that already use `/v1` are preserved as-is; Lemonade-style endpoints continue to use `/api/v1`. See the [Integration Guide](../docs/cpp/integration.mdx) for details.
 
 ### 3. Windows MCP Server (for the demo)
 
@@ -192,6 +192,11 @@ GAIA_STREAMING=1 ./build/my_agent
 **Example — point to a remote server:**
 ```bash
 GAIA_CPP_BASE_URL=http://192.168.1.50:8000 ./build/my_agent
+```
+
+**Example — point to Ollama's OpenAI-compatible endpoint:**
+```bash
+GAIA_CPP_BASE_URL=http://localhost:11434/v1 LEMONADE_MODEL=gemma4:e2b ./build/my_agent
 ```
 
 Code-level config always takes precedence over environment variables when explicitly set, but these variables control the *default* value of each field in `AgentConfig`.

--- a/cpp/examples/fetch_content_consumer/main.cpp
+++ b/cpp/examples/fetch_content_consumer/main.cpp
@@ -5,7 +5,8 @@
 // Subclasses gaia::Agent with a single get_current_time tool.
 //
 // Prerequisites:
-//   - LLM server running at http://localhost:8000/api/v1 (e.g. lemonade-server start)
+//   - LLM server running at http://localhost:8000/api/v1 (Lemonade) or
+//     http://localhost:11434/v1 (Ollama-compatible)
 //
 // Build (FetchContent — no install needed):
 //   cmake -B build -S .

--- a/cpp/include/gaia/lemonade_client.h
+++ b/cpp/include/gaia/lemonade_client.h
@@ -212,7 +212,7 @@ public:
     // ---- Configuration ----
 
     const std::string& baseUrl() const { return baseUrl_; }
-    /// Normalize and store the URL (appends /api/v1 if missing).
+    /// Normalize and store the URL (preserves /v1 or /api/v1, otherwise appends /api/v1).
     void setBaseUrl(const std::string& url);
 
     const std::string& model() const { return model_; }
@@ -225,7 +225,7 @@ public:
     void setDebug(bool d) { debug_ = d; }
 
 private:
-    /// Normalize URL: strip trailing slashes, append /api/v1 if missing.
+    /// Normalize URL: strip trailing slashes, preserve /v1 or /api/v1, append /api/v1 otherwise.
     static std::string normalizeUrl(const std::string& url);
 
     /// Parsed URL components.

--- a/cpp/src/lemonade_client.cpp
+++ b/cpp/src/lemonade_client.cpp
@@ -25,11 +25,18 @@ namespace gaia {
         result.pop_back();
     }
 
-    // Append /api/v1 if not already present
-    const std::string suffix = "/api/v1";
-    if (result.size() < suffix.size() ||
-        result.substr(result.size() - suffix.size()) != suffix) {
-        result += suffix;
+    // Preserve OpenAI-compatible /v1 endpoints and Lemonade /api/v1 endpoints.
+    const std::string lemonadeSuffix = "/api/v1";
+    const std::string openaiSuffix = "/v1";
+    const bool hasLemonadeSuffix =
+        result.size() >= lemonadeSuffix.size() &&
+        result.substr(result.size() - lemonadeSuffix.size()) == lemonadeSuffix;
+    const bool hasOpenAiSuffix =
+        result.size() >= openaiSuffix.size() &&
+        result.substr(result.size() - openaiSuffix.size()) == openaiSuffix;
+
+    if (!hasLemonadeSuffix && !hasOpenAiSuffix) {
+        result += lemonadeSuffix;
     }
 
     return result;
@@ -361,6 +368,16 @@ void LemonadeClient::ensureModelLoaded(const std::string& modelName, int ctxSize
     if (effectiveModel.empty()) {
         if (debug_) {
             std::cerr << "[Lemonade] ensureModelLoaded: no model specified, skipping" << std::endl;
+        }
+        return;
+    }
+
+    // Non-Lemonade OpenAI-compatible servers such as Ollama do not expose
+    // Lemonade's /health and /load endpoints. In that case, skip model
+    // management and let the server handle model selection from the request.
+    if (baseUrl_.size() < 7 || baseUrl_.substr(baseUrl_.size() - 7) != "/api/v1") {
+        if (debug_) {
+            std::cerr << "[Lemonade] ensureModelLoaded: non-Lemonade endpoint detected, skipping" << std::endl;
         }
         return;
     }

--- a/cpp/tests/test_lemonade_client.cpp
+++ b/cpp/tests/test_lemonade_client.cpp
@@ -59,6 +59,11 @@ TEST(LemonadeClientTest, LegacyConstructorUrlAlreadyHasApiV1) {
     EXPECT_EQ(client.baseUrl(), "http://192.168.1.100:9000/api/v1");
 }
 
+TEST(LemonadeClientTest, LegacyConstructorUrlPreservesOpenAiV1) {
+    LemonadeClient client("http://192.168.1.100:11434/v1");
+    EXPECT_EQ(client.baseUrl(), "http://192.168.1.100:11434/v1");
+}
+
 // ---------------------------------------------------------------------------
 // URL normalization
 // ---------------------------------------------------------------------------
@@ -71,6 +76,11 @@ TEST(LemonadeClientTest, UrlNormalizationAddsApiV1) {
 TEST(LemonadeClientTest, UrlNormalizationNoopWhenPresent) {
     LemonadeClient client("http://localhost:8000/api/v1");
     EXPECT_EQ(client.baseUrl(), "http://localhost:8000/api/v1");
+}
+
+TEST(LemonadeClientTest, UrlNormalizationPreservesOpenAiV1) {
+    LemonadeClient client("http://localhost:11434/v1");
+    EXPECT_EQ(client.baseUrl(), "http://localhost:11434/v1");
 }
 
 TEST(LemonadeClientTest, UrlNormalizationStripsTrailingSlash) {
@@ -93,6 +103,12 @@ TEST(LemonadeClientTest, SetBaseUrlNoopWhenApiV1Present) {
     LemonadeClient client("http://localhost:8000");
     client.setBaseUrl("http://remotehost:1234/api/v1");
     EXPECT_EQ(client.baseUrl(), "http://remotehost:1234/api/v1");
+}
+
+TEST(LemonadeClientTest, SetBaseUrlNoopWhenOpenAiV1Present) {
+    LemonadeClient client("http://localhost:8000");
+    client.setBaseUrl("http://remotehost:11434/v1");
+    EXPECT_EQ(client.baseUrl(), "http://remotehost:11434/v1");
 }
 
 // ---------------------------------------------------------------------------
@@ -177,6 +193,28 @@ TEST(LemonadeClientTest, ValidateContextSizeOfflineDoesNotBlock) {
     auto [ok, msg] = client.validateContextSize(4096);
     // Non-fatal: either {true, "Server not running…"} or {true, "Validation skipped…"}
     EXPECT_TRUE(ok);
+}
+
+TEST(LemonadeClientTest, EnsureModelLoadedSkipsForOpenAiCompatibleV1Endpoints) {
+    LemonadeClient client(LemonadeClientConfig{
+        "http://127.0.0.1:19753/v1",
+        "gemma4:e2b",
+        8192,
+        false,
+    });
+
+    EXPECT_NO_THROW(client.ensureModelLoaded());
+}
+
+TEST(LemonadeClientTest, EnsureModelLoadedStillFailsForOfflineLemonadeEndpoint) {
+    LemonadeClient client(LemonadeClientConfig{
+        "http://127.0.0.1:19753/api/v1",
+        "Qwen3-4B-GGUF",
+        8192,
+        false,
+    });
+
+    EXPECT_THROW(client.ensureModelLoaded(), std::exception);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve OpenAI-compatible `/v1` base URLs instead of rewriting them to `/api/v1`
- skip Lemonade-specific model preload logic for non-Lemonade backends such as Ollama
- add C++ unit coverage and small docs/example wording updates for the new behavior

## Problem
GAIA C++ currently normalizes every base URL to `/api/v1` and always attempts Lemonade-specific `/health` and `/load` model management. That breaks OpenAI-compatible backends like Ollama, where `http://localhost:11434/v1` was being rewritten to `/v1/api/v1` and model preloading hit unsupported endpoints.

## Validation
- rebuilt `cpp/build/tests_mock`
- ran `./tests_mock --gtest_color=yes` successfully (283 tests passed)
- rebuilt the local Ollama-backed consumer example against the updated library

## Notes
This change is scoped to the C++ framework, tests, and minimal C++ docs/example wording only.