### PR TITLE
fix(cpp): add null-safety checks for JSON string fields in LLM response parsing

### DIFF
--- a/cpp/src/agent.cpp
+++ b/cpp/src/agent.cpp
@@ -305,7 +305,8 @@ std::string Agent::callLlm(const std::vector<Message>& messages, const std::stri
                 const json responseJson = json::parse(rawResponse);
                 if (responseJson.contains("choices") && !responseJson["choices"].empty()) {
                     const auto& choice = responseJson["choices"][0];
-                    if (choice.contains("message") && choice["message"].contains("content")) {
+                    if (choice.contains("message") && choice["message"].contains("content")
+                        && choice["message"]["content"].is_string()) {
                         return choice["message"]["content"].get<std::string>();
                     }
                 }
@@ -324,7 +325,8 @@ std::string Agent::callLlm(const std::vector<Message>& messages, const std::stri
 
         if (responseJson.contains("choices") && !responseJson["choices"].empty()) {
             auto& choice = responseJson["choices"][0];
-            if (choice.contains("message") && choice["message"].contains("content")) {
+            if (choice.contains("message") && choice["message"].contains("content")
+                && choice["message"]["content"].is_string()) {
                 return choice["message"]["content"].get<std::string>();
             }
         }

--- a/cpp/src/clean_console.cpp
+++ b/cpp/src/clean_console.cpp
@@ -84,7 +84,7 @@ void CleanConsole::printPlan(const json& plan, int /*currentStep*/) {
     std::cout << color::BOLD << color::CYAN << "  Plan: " << color::RESET;
     for (size_t i = 0; i < plan.size(); ++i) {
         if (i > 0) std::cout << color::GRAY << " -> " << color::RESET;
-        if (plan[i].is_object() && plan[i].contains("tool")) {
+        if (plan[i].is_object() && plan[i].contains("tool") && plan[i]["tool"].is_string()) {
             std::cout << color::CYAN
                       << plan[i]["tool"].get<std::string>()
                       << color::RESET;
@@ -127,7 +127,7 @@ void CleanConsole::prettyPrintJson(const json& data,
     if (title != "Tool Result" || !data.is_object()) return;
 
     // Show the command that was executed (registered-tool format)
-    if (data.contains("command")) {
+    if (data.contains("command") && data["command"].is_string()) {
         std::string cmd = data["command"].get<std::string>();
         std::cout << color::CYAN << "      Cmd: " << color::RESET
                   << color::GRAY;
@@ -136,7 +136,7 @@ void CleanConsole::prettyPrintJson(const json& data,
     }
 
     // Show error if present
-    if (data.contains("error")) {
+    if (data.contains("error") && data["error"].is_string()) {
         std::cout << color::RED << color::BOLD << "      Error: "
                   << color::RESET << color::RED
                   << data["error"].get<std::string>()
@@ -145,7 +145,7 @@ void CleanConsole::prettyPrintJson(const json& data,
     }
 
     // Show tool output preview — registered-tool format: {"output": "..."}
-    if (data.contains("output")) {
+    if (data.contains("output") && data["output"].is_string()) {
         std::string output = data["output"].get<std::string>();
         if (output.empty() || output.find("(no output)") != std::string::npos) {
             std::cout << color::GREEN << "      Result: "
@@ -180,7 +180,7 @@ void CleanConsole::prettyPrintJson(const json& data,
     }
 
     // Show status (registered-tool format)
-    if (data.contains("status")) {
+    if (data.contains("status") && data["status"].is_string()) {
         auto status = data["status"].get<std::string>();
         const char* statusColor = (status == "completed")
             ? color::GREEN : color::YELLOW;

--- a/cpp/src/json_utils.cpp
+++ b/cpp/src/json_utils.cpp
@@ -250,7 +250,7 @@ ParsedResponse parseLlmResponse(const std::string& response) {
             if (j.contains("answer")) {
                 parsed.answer = jsonToString(j["answer"]);
             }
-            if (j.contains("tool")) {
+            if (j.contains("tool") && j["tool"].is_string()) {
                 parsed.toolName = j["tool"].get<std::string>();
                 parsed.toolArgs = (j.contains("tool_args") && j["tool_args"].is_object())
                     ? j["tool_args"] : json::object();
@@ -275,10 +275,10 @@ ParsedResponse parseLlmResponse(const std::string& response) {
         parsed.thought = j.value("thought", "");
         parsed.goal = j.value("goal", "");
 
-        if (j.contains("answer")) {
+        if (j.contains("answer") && !j["answer"].is_null()) {
             parsed.answer = jsonToString(j["answer"]);
         }
-        if (j.contains("tool")) {
+        if (j.contains("tool") && j["tool"].is_string()) {
             parsed.toolName = j["tool"].get<std::string>();
             parsed.toolArgs = (j.contains("tool_args") && j["tool_args"].is_object())
                 ? j["tool_args"] : json::object();


### PR DESCRIPTION
## Summary
- Add `.is_string()` / `.is_null()` guards before all `.get<std::string>()` calls on LLM response JSON fields
- Fixes crash (`json.exception.type_error.302: type must be string, but is null`) when smaller LLM models (e.g. `qwen3.5:9b`) return `null` for fields like `"tool"` or `"content"` instead of omitting them
- `json.contains()` returns `true` for null values, so the existing checks were insufficient

## Files changed
- `cpp/src/json_utils.cpp` — `parseLlmResponse()`: guard `tool` and `answer` fields
- `cpp/src/agent.cpp` — `callLlm()`: guard `content` field in both streaming fallback and non-streaming paths
- `cpp/src/clean_console.cpp` — display methods: guard `tool`, `command`, `error`, `output`, `status` fields

## Test plan
- [x] Verified `qwen3.5:9b` (previously crashing) now completes successfully
- [x] Verified `qwen3:8b` and `qwen3.5:cloud` still work
- [x] All 278 unit tests pass (`./tests_mock`)