### PR TITLE
fix(rag): detect encrypted and corrupted PDFs with actionable errors (#451)

### DIFF
--- a/src/gaia/rag/__init__.py
+++ b/src/gaia/rag/__init__.py
@@ -5,6 +5,23 @@
 """GAIA RAG (Retrieval-Augmented Generation) Module"""
 
 from .app import main as rag_main
-from .sdk import RAGSDK, RAGConfig, quick_rag
+from .sdk import (
+    RAGSDK,
+    CorruptedPDFError,
+    EmptyPDFError,
+    EncryptedPDFError,
+    PDFExtractionError,
+    RAGConfig,
+    quick_rag,
+)
 
-__all__ = ["RAGConfig", "RAGSDK", "quick_rag", "rag_main"]
+__all__ = [
+    "CorruptedPDFError",
+    "EmptyPDFError",
+    "EncryptedPDFError",
+    "PDFExtractionError",
+    "RAGConfig",
+    "RAGSDK",
+    "quick_rag",
+    "rag_main",
+]

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -46,6 +46,42 @@ CACHE_HEADER = b"GAIA_CACHE_V1\n"
 MAX_CACHE_SIZE = 500 * 1024 * 1024  # 500 MB
 
 
+# --- PDF extraction errors ---------------------------------------------------
+# These inherit from ValueError so existing `except ValueError` blocks in
+# callers (and the index_document error path) keep working, while allowing
+# callers that care to distinguish the specific failure mode.
+
+
+class PDFExtractionError(ValueError):
+    """Base class for PDF extraction failures with actionable messages."""
+
+    #: Short stable status code (e.g. "encrypted", "corrupted", "empty")
+    #: suitable for surfacing in document metadata / telemetry.
+    status: str = "unreadable"
+
+
+class EncryptedPDFError(PDFExtractionError):
+    """Raised when a PDF is password-protected and cannot be decrypted."""
+
+    status = "encrypted"
+
+
+class CorruptedPDFError(PDFExtractionError):
+    """Raised when a PDF is malformed, truncated, or otherwise unreadable."""
+
+    status = "corrupted"
+
+
+class EmptyPDFError(PDFExtractionError):
+    """Raised when a PDF parses successfully but contains no extractable text.
+
+    Typical causes: scanned image-only PDFs (no OCR layer), or documents
+    where all pages are blank / contain only non-text glyphs.
+    """
+
+    status = "empty"
+
+
 @dataclass
 class RAGConfig:
     """Configuration for RAG SDK."""
@@ -475,12 +511,62 @@ class RAGSDK:
             - num_pages: int
             - vlm_pages: int (number of pages enhanced with VLM)
             - total_images: int (total images processed)
+            - pdf_status: str ("readable", "encrypted", "corrupted", "empty")
+
+        Raises:
+            EncryptedPDFError: PDF is password-protected.
+            CorruptedPDFError: PDF is malformed / unreadable.
+            EmptyPDFError: PDF parsed OK but contained no extractable text.
         """
         import time as time_module  # pylint: disable=reimported
 
+        file_name = Path(pdf_path).name
+
+        # Step 0: Open the PDF. pypdf raises EmptyFileError / PdfStreamError
+        # (both subclasses of PdfReadError) for empty/corrupted files. We map
+        # those to our own exceptions so callers can react and users get
+        # actionable guidance instead of a generic stack trace.
+        try:
+            from pypdf.errors import (  # pylint: disable=import-outside-toplevel
+                PdfReadError,
+            )
+        except ImportError:  # pragma: no cover - pypdf is required for PDFs
+            PdfReadError = Exception  # type: ignore[assignment,misc]
+
+        try:
+            reader = PdfReader(pdf_path)
+        except PdfReadError as e:
+            msg = (
+                f"Could not read PDF: {file_name}\n"
+                f"Reason: {e}\n"
+                "The file appears to be corrupted, truncated, or not a valid PDF.\n"
+                "Suggestions:\n"
+                "  1. Re-download or re-export the PDF from the original source\n"
+                "  2. Try opening the file in a PDF viewer to confirm it is readable\n"
+                "  3. If the source is a scan, re-run OCR and export a fresh PDF"
+            )
+            self.log.error(f"Corrupted PDF {pdf_path}: {e}")
+            raise CorruptedPDFError(msg) from e
+
+        # Step 1: Refuse password-protected PDFs up-front. Without this check
+        # pypdf silently returns empty text for every page and the document
+        # gets "indexed" with zero chunks (see issue #451).
+        if getattr(reader, "is_encrypted", False):
+            msg = (
+                f"PDF is password-protected: {file_name}\n"
+                "GAIA cannot index encrypted PDFs.\n"
+                "Suggestions:\n"
+                "  1. Remove the password with qpdf:\n"
+                "     qpdf --decrypt --password=YOUR_PASSWORD input.pdf output.pdf\n"
+                "  2. Or with pdftk:\n"
+                "     pdftk input.pdf input_pw YOUR_PASSWORD output output.pdf\n"
+                "  3. Then re-index the decrypted file"
+            )
+            self.log.error(f"Encrypted PDF rejected: {pdf_path}")
+            raise EncryptedPDFError(msg)
+
         try:
             extract_start = time_module.time()
-            reader = PdfReader(pdf_path)
             total_pages = len(reader.pages)
             self.log.info(f"📄 Extracting text from {total_pages} pages...")
 
@@ -627,6 +713,30 @@ class RAGSDK:
                 f"📝 Extracted {len(full_text):,} characters in {extract_duration:.2f}s (VLM: {vlm_pages_count} pages)"
             )
 
+            # If pypdf parsed the file but every page came back blank, surface
+            # this as EmptyPDFError rather than pretending it succeeded. The
+            # common cause is a scanned image-only PDF without an OCR layer.
+            #
+            # NOTE: `full_text` always carries `[Page N]` prefix lines even for
+            # blank pages (see the join above), so we can't just check
+            # full_text.strip(). Inspect the per-page content instead.
+            has_any_content = any((p["text"] or "").strip() for p in pages_data)
+            if not has_any_content:
+                msg = (
+                    f"No extractable text in PDF: {file_name}\n"
+                    f"The file has {total_pages} page(s) but none contained "
+                    "machine-readable text.\n"
+                    "Common causes:\n"
+                    "  1. The PDF is a scan with no OCR layer\n"
+                    "  2. All content is rendered as images or vector glyphs\n"
+                    "Suggestions:\n"
+                    "  1. Run OCR on the PDF (e.g. `ocrmypdf input.pdf output.pdf`)\n"
+                    "  2. Or enable VLM image extraction by downloading "
+                    f"{self.config.vlm_model} in Lemonade"
+                )
+                self.log.error(f"Empty PDF (no text): {pdf_path}")
+                raise EmptyPDFError(msg)
+
             # Build metadata
             metadata = {
                 "num_pages": total_pages,
@@ -634,9 +744,14 @@ class RAGSDK:
                 "total_images": total_images_processed,
                 "vlm_checked": True,  # Indicates this cache was created with VLM capability check
                 "vlm_available": vlm_available,  # Whether VLM was actually available
+                "pdf_status": "readable",
             }
 
             return full_text, total_pages, metadata
+        except PDFExtractionError:
+            # Already a well-formed extraction error with actionable guidance —
+            # re-raise without wrapping or re-logging (callers will log).
+            raise
         except Exception as e:
             self.log.error(f"Error reading PDF {pdf_path}: {e}")
             raise
@@ -2179,8 +2294,20 @@ These positions indicate where to split the text."""
             stats["num_chunks"] = len(new_chunks)
             stats["total_indexed_files"] = len(self.indexed_files)
             stats["total_chunks"] = len(self.chunks)
+            if file_type == ".pdf":
+                stats["pdf_status"] = "readable"
             return stats
 
+        except PDFExtractionError as e:
+            # Specific, user-actionable PDF failure. Surface the short status
+            # code separately so UIs can badge the document (e.g. "encrypted")
+            # rather than showing the full multi-line remediation blob.
+            if self.config.show_stats:
+                print(f"❌ Failed to index {Path(file_path).name}: {e}")
+            self.log.error(f"PDF extraction failed for {file_path}: {e.status}")
+            stats["error"] = str(e)
+            stats["pdf_status"] = e.status
+            return stats
         except Exception as e:
             if self.config.show_stats:
                 print(f"❌ Failed to index {Path(file_path).name}: {e}")

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -126,6 +126,10 @@ class TestRAGSDK:
 
             # Mock PDF reader
             mock_pdf_instance = Mock()
+            # Default mocks to "not encrypted"; without this, Mock auto-creates
+            # is_encrypted as a truthy Mock attribute and the PDF extractor's
+            # encryption guard (added in #451) would short-circuit.
+            mock_pdf_instance.is_encrypted = False
             mock_pdf_instance.pages = [Mock()]
             mock_pdf_instance.pages[0].extract_text.return_value = (
                 "Sample PDF content for testing."
@@ -837,6 +841,10 @@ class TestMemoryLimits:
             mock_lemonade.return_value = mock_lemonade_instance
 
             mock_pdf_instance = Mock()
+            # Default mocks to "not encrypted"; without this, Mock auto-creates
+            # is_encrypted as a truthy Mock attribute and the PDF extractor's
+            # encryption guard (added in #451) would short-circuit.
+            mock_pdf_instance.is_encrypted = False
             mock_pdf_instance.pages = [Mock()]
             mock_pdf_instance.pages[0].extract_text.return_value = (
                 "Sample PDF content for testing."

--- a/tests/unit/rag/__init__.py
+++ b/tests/unit/rag/__init__.py
@@ -1,0 +1,3 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the GAIA RAG SDK."""

--- a/tests/unit/rag/test_pdf_extraction_errors.py
+++ b/tests/unit/rag/test_pdf_extraction_errors.py
@@ -1,0 +1,271 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for PDF extraction error handling in gaia.rag.sdk (#451).
+
+Covers the three failure modes RAGSDK._extract_text_from_pdf must surface
+with actionable guidance:
+
+- Encrypted / password-protected PDFs  -> EncryptedPDFError
+- Corrupted / truncated PDFs           -> CorruptedPDFError
+- PDFs with no extractable text        -> EmptyPDFError
+
+Fixtures are built programmatically with pypdf so the tests remain hermetic
+and don't require committing binary fixture files to the repo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pypdf = pytest.importorskip("pypdf")
+
+from pypdf import PdfWriter  # noqa: E402
+
+from gaia.rag.sdk import (  # noqa: E402
+    RAGSDK,
+    CorruptedPDFError,
+    EmptyPDFError,
+    EncryptedPDFError,
+    PDFExtractionError,
+    RAGConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rag(tmp_path: Path) -> RAGSDK:
+    """
+    A RAGSDK instance scoped to tmp_path with heavy ML deps stubbed out.
+
+    The unit under test (`_extract_text_from_pdf` and the error-handling
+    branch of `index_document`) does not need sentence-transformers, faiss,
+    or a live Lemonade server, so we bypass the import-time dependency
+    check and skip chat/LLM initialization. We also stub the VLM client so
+    the blank-PDF test doesn't spend ~4s timing out against localhost:8000.
+    """
+    config = RAGConfig(
+        cache_dir=str(tmp_path / ".gaia"),
+        show_stats=False,
+        use_local_llm=False,
+    )
+
+    fake_vlm = MagicMock(name="VLMClient")
+    fake_vlm.check_availability.return_value = False
+
+    with (
+        patch.object(RAGSDK, "_check_dependencies", return_value=None),
+        patch("gaia.rag.sdk.AgentSDK", autospec=True) as mock_agent_sdk,
+        patch("gaia.llm.VLMClient", return_value=fake_vlm),
+    ):
+        mock_agent_sdk.return_value = MagicMock(name="AgentSDK")
+        instance = RAGSDK(config=config)
+
+    # The VLM import inside _extract_text_from_pdf is lazy, so keep the patch
+    # active for the lifetime of the test instance via a context wrapper.
+    instance._test_vlm_patch = patch("gaia.llm.VLMClient", return_value=fake_vlm)
+    instance._test_vlm_patch.start()
+    yield instance
+    instance._test_vlm_patch.stop()
+
+
+def _write_blank_pdf(path: Path) -> None:
+    """Write a minimal valid single-page PDF with no text content."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with open(path, "wb") as f:
+        writer.write(f)
+
+
+def _write_encrypted_pdf(path: Path, password: str = "hunter2") -> None:
+    """Write a password-protected PDF with a single blank page."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.encrypt(user_password=password, owner_password=password + "-owner")
+    with open(path, "wb") as f:
+        writer.write(f)
+
+
+def _write_corrupted_pdf(path: Path) -> None:
+    """
+    Write an obviously invalid PDF — bytes that don't match the PDF header.
+    This triggers pypdf's PdfStreamError/PdfReadError at construction time.
+    """
+    path.write_bytes(b"%PDF-1.7\nnot actually a pdf, just garbage\n")
+
+
+def _write_truncated_pdf(path: Path) -> None:
+    """Write a valid PDF then truncate it to simulate a corrupted download."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with open(path, "wb") as f:
+        writer.write(f)
+    data = path.read_bytes()
+    # Keep only the first third — far past the header, well before EOF marker.
+    path.write_bytes(data[: max(10, len(data) // 3)])
+
+
+# ---------------------------------------------------------------------------
+# Encrypted PDFs
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptedPDF:
+    def test_raises_encrypted_error(self, rag: RAGSDK, tmp_path: Path) -> None:
+        pdf = tmp_path / "secret.pdf"
+        _write_encrypted_pdf(pdf)
+
+        with pytest.raises(EncryptedPDFError) as excinfo:
+            rag._extract_text_from_pdf(str(pdf))
+
+        msg = str(excinfo.value)
+        # Actionable remediation must be present so users know how to recover.
+        assert "password-protected" in msg
+        assert "qpdf" in msg or "pdftk" in msg
+        # File name should be in the message (not just the absolute path).
+        assert "secret.pdf" in msg
+
+    def test_is_value_error_subclass(self) -> None:
+        """Existing `except ValueError:` sites keep working (backward-compat)."""
+        assert issubclass(EncryptedPDFError, ValueError)
+        assert issubclass(EncryptedPDFError, PDFExtractionError)
+
+    def test_status_code(self) -> None:
+        assert EncryptedPDFError.status == "encrypted"
+
+    def test_index_document_surfaces_encrypted_status(
+        self, rag: RAGSDK, tmp_path: Path
+    ) -> None:
+        """index_document() should convert the exception to a stats dict."""
+        pdf = tmp_path / "locked.pdf"
+        _write_encrypted_pdf(pdf)
+
+        stats = rag.index_document(str(pdf))
+
+        assert stats["success"] is False
+        assert stats.get("pdf_status") == "encrypted"
+        assert "password-protected" in stats["error"]
+
+
+# ---------------------------------------------------------------------------
+# Corrupted PDFs
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptedPDF:
+    def test_raises_corrupted_error_on_garbage(
+        self, rag: RAGSDK, tmp_path: Path
+    ) -> None:
+        pdf = tmp_path / "garbage.pdf"
+        _write_corrupted_pdf(pdf)
+
+        with pytest.raises(CorruptedPDFError) as excinfo:
+            rag._extract_text_from_pdf(str(pdf))
+
+        msg = str(excinfo.value)
+        assert "corrupted" in msg.lower() or "not a valid pdf" in msg.lower()
+        assert "garbage.pdf" in msg
+
+    def test_raises_corrupted_error_on_truncated(
+        self, rag: RAGSDK, tmp_path: Path
+    ) -> None:
+        pdf = tmp_path / "truncated.pdf"
+        _write_truncated_pdf(pdf)
+
+        with pytest.raises(CorruptedPDFError):
+            rag._extract_text_from_pdf(str(pdf))
+
+    def test_status_code(self) -> None:
+        assert CorruptedPDFError.status == "corrupted"
+
+    def test_chained_from_pypdf_error(self, rag: RAGSDK, tmp_path: Path) -> None:
+        """
+        The original pypdf exception should be preserved via `raise ... from e`
+        so operators can see the underlying failure in logs/tracebacks.
+        """
+        pdf = tmp_path / "garbage.pdf"
+        _write_corrupted_pdf(pdf)
+
+        with pytest.raises(CorruptedPDFError) as excinfo:
+            rag._extract_text_from_pdf(str(pdf))
+
+        assert excinfo.value.__cause__ is not None
+
+    def test_index_document_surfaces_corrupted_status(
+        self, rag: RAGSDK, tmp_path: Path
+    ) -> None:
+        pdf = tmp_path / "bad.pdf"
+        _write_corrupted_pdf(pdf)
+
+        stats = rag.index_document(str(pdf))
+
+        assert stats["success"] is False
+        assert stats.get("pdf_status") == "corrupted"
+
+
+# ---------------------------------------------------------------------------
+# Empty / no-text PDFs
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyPDF:
+    def test_raises_empty_error_on_blank_pdf(self, rag: RAGSDK, tmp_path: Path) -> None:
+        pdf = tmp_path / "blank.pdf"
+        _write_blank_pdf(pdf)
+
+        with pytest.raises(EmptyPDFError) as excinfo:
+            rag._extract_text_from_pdf(str(pdf))
+
+        msg = str(excinfo.value)
+        # Message should hint at OCR as the remediation path — otherwise users
+        # see "no text" and have no idea how to proceed.
+        assert "OCR" in msg or "ocr" in msg.lower() or "ocrmypdf" in msg.lower()
+        assert "blank.pdf" in msg
+
+    def test_status_code(self) -> None:
+        assert EmptyPDFError.status == "empty"
+
+    def test_index_document_surfaces_empty_status(
+        self, rag: RAGSDK, tmp_path: Path
+    ) -> None:
+        pdf = tmp_path / "scan.pdf"
+        _write_blank_pdf(pdf)
+
+        stats = rag.index_document(str(pdf))
+
+        assert stats["success"] is False
+        assert stats.get("pdf_status") == "empty"
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — the error classes should not swallow each other
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHierarchy:
+    def test_all_errors_inherit_pdfextractionerror(self) -> None:
+        assert issubclass(EncryptedPDFError, PDFExtractionError)
+        assert issubclass(CorruptedPDFError, PDFExtractionError)
+        assert issubclass(EmptyPDFError, PDFExtractionError)
+
+    def test_pdfextractionerror_is_valueerror(self) -> None:
+        """
+        Kept as a ValueError so pre-existing `except ValueError:` blocks
+        (including callers in index_document and reindex_document) stay
+        compatible after this change.
+        """
+        assert issubclass(PDFExtractionError, ValueError)
+
+    def test_distinct_status_codes(self) -> None:
+        statuses = {
+            EncryptedPDFError.status,
+            CorruptedPDFError.status,
+            EmptyPDFError.status,
+        }
+        assert statuses == {"encrypted", "corrupted", "empty"}


### PR DESCRIPTION
## Summary

Closes #451.

Password-protected PDFs were silently indexed as 0 chunks (pypdf returns empty text for encrypted pages without raising), and corrupted PDFs surfaced vague `Failed to process document` errors. Both cases left users with no actionable path forward.

This PR makes `RAGSDK._extract_text_from_pdf` detect three distinct failure modes and surface them with user-facing remediation guidance:

| Mode | Exception | Trigger | Remediation hinted |
|---|---|---|---|
| Password-protected | `EncryptedPDFError` | `reader.is_encrypted` | `qpdf --decrypt` / `pdftk` commands |
| Malformed / truncated | `CorruptedPDFError` | `pypdf.errors.PdfReadError` at construction | Re-download / re-export / re-OCR |
| No extractable text | `EmptyPDFError` | All pages blank after extraction | `ocrmypdf` or enable VLM image extraction |

All three inherit from a new `PDFExtractionError` base, which in turn inherits from `ValueError` so existing `except ValueError:` callers (including `reindex_document`) keep working unchanged.

## Changes

- `src/gaia/rag/sdk.py`
  - New exception classes `PDFExtractionError`, `EncryptedPDFError`, `CorruptedPDFError`, `EmptyPDFError`, each carrying a stable short `status` code
  - `_extract_text_from_pdf`:
    - Wraps `PdfReader(path)` to catch `PdfReadError` and re-raise as `CorruptedPDFError` via `raise ... from e` (preserves the pypdf cause for operator logs)
    - Checks `reader.is_encrypted` up-front and refuses before attempting extraction
    - Detects all-blank pages (where pypdf returns empty text for every page) and raises `EmptyPDFError`
    - Adds `pdf_status: "readable" | "encrypted" | "corrupted" | "empty"` to returned metadata
  - `index_document`: adds a dedicated `except PDFExtractionError` clause that sets `stats["pdf_status"]` separately from `stats["error"]` so UIs can badge documents with the short status code instead of showing the full remediation blob
- `src/gaia/rag/__init__.py`: re-exports the four error classes

## Tests

New suite at `tests/unit/rag/test_pdf_extraction_errors.py` (15 tests, all passing in < 1s):

- Fixtures built programmatically with `pypdf.PdfWriter` — no binary fixture files committed to the repo
- Encrypted: asserts raises `EncryptedPDFError` with `qpdf`/`pdftk` in message; asserts `index_document` returns `pdf_status="encrypted"`
- Corrupted: covers both garbage-bytes and truncated-valid-PDF; asserts `__cause__` preserves the pypdf exception
- Empty: asserts raises `EmptyPDFError` with OCR hint on a blank-page PDF
- Hierarchy guards: all three remain `ValueError` subclasses; status codes are distinct

The fixture patches `_check_dependencies`, `AgentSDK`, and `VLMClient` so tests run without sentence-transformers / faiss / a live Lemonade server.

## Test plan

- [x] `pytest tests/unit/rag/ -xvs` — 15/15 pass locally
- [x] `pytest tests/unit/test_rag_tools.py` — 17/17 still pass (no regression in adjacent RAG tests)
- [x] `black --check` + `isort --check-only` on touched files — clean
- [ ] CI runs pass on the remote
- [ ] Manual verification with a real password-protected PDF via `gaia chat`