### PR TITLE
docs(faq): clarify data-privacy answer re: external LLM providers

### DIFF
--- a/docs/reference/faq.mdx
+++ b/docs/reference/faq.mdx
@@ -31,9 +31,11 @@ icon: "circle-question"
   </Accordion>
 
   <Accordion title="Does GAIA send my data anywhere?" icon="shield">
-    **No.** GAIA runs entirely on your machine. There is no telemetry, no crash reporting, and no usage analytics.
+    **Not by default.** GAIA runs entirely on your machine. There is no telemetry, no crash reporting, and no usage analytics.
 
-    The only network traffic is package downloads during install (from PyPI, npm, GitHub, and Astral's `uv` distribution). Once installed, GAIA can run fully offline. This is a deliberate design choice — see §2 of the [desktop installer plan](/plans/desktop-installer) for the rationale.
+    The only network traffic is package downloads during install (from PyPI, npm, GitHub, and Astral's `uv` distribution). Once installed, GAIA can run fully offline with the default Lemonade Server backend. This is a deliberate design choice — see §2 of the [desktop installer plan](/plans/desktop-installer) for the rationale.
+
+    **Caveat:** If you explicitly configure an external LLM provider (Claude API or OpenAI) via the provider settings, prompts and responses for those sessions are sent to the provider you selected. Local-first is the default; cloud is opt-in.
   </Accordion>
 
   <Accordion title="How do I install GAIA on a machine without internet?" icon="wifi">


### PR DESCRIPTION
## Summary

The FAQ's "Does GAIA send my data anywhere?" answer said a flat **No**, but that only holds when you're on the default Lemonade backend. If you configure the Claude API or OpenAI provider via settings, prompts leave the machine. Updating the lead to "Not by default" and adding a one-sentence caveat closes a minor-but-real accuracy gap.

## Test plan

- [ ] Skim the rendered FAQ section on the docs site after merge — confirm the caveat reads naturally in Mintlify rendering
- [ ] **Primary test purpose:** validate that `.github/workflows/claude.yml` (merged in #797) produces a real review comment on this PR via `pull_request_target` — the first post-merge validation that the v1.0.99 migration works end-to-end.