### PR TITLE
ci(claude): bump pr-review and pr-comment --max-turns 20 -> 50

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -301,7 +301,7 @@ jobs:
             - Make it easy for maintainers to accept suggestions with one click
 
           claude_args: |
-            --max-turns 20
+            --max-turns 50
             --model claude-opus-4-7
             --allowedTools Edit,Read,Write,Grep,Glob,Bash
 
@@ -416,7 +416,7 @@ jobs:
             Maintain a helpful, professional tone.
 
           claude_args: |
-            --max-turns 20
+            --max-turns 50
             --model claude-opus-4-7
             --allowedTools Edit,Read,Write,Grep,Glob,Bash
 


### PR DESCRIPTION
## Summary

PR #795 ([run 24586335693](https://github.com/amd/gaia/actions/runs/24586335693)) exceeded pr-review's `--max-turns 20` budget and failed with `error_max_turns` — no review comment posted. That failure is visible (not silently swallowed) thanks to #797 removing the `continue-on-error` mask. The fix is the same bump I applied to `issue-handler` during the v1 migration: 20 → 50.

Matching `pr-comment` at the same time for consistency — same failure mode would apply on a large-diff PR conversation. `release-notes` stays at 30 since release diffs are bounded to a tag-to-tag range.

## Test plan

- [ ] After merge, re-run `pr-review` on PR #795 (close+reopen or push an empty commit) — confirm Claude completes the review within 50 turns and posts the comment
- [ ] Spot-check next 2-3 post-merge PRs don't regress to failures