### PR TITLE
fix(mcp): guard JSON-RPC handler against non-dict body

### DIFF
--- a/src/gaia/mcp/mcp_bridge.py
+++ b/src/gaia/mcp/mcp_bridge.py
@@ -622,6 +622,17 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
 
     def handle_jsonrpc(self, data):
         """Handle JSON-RPC requests."""
+        # Validate that data is a dict (JSON-RPC requires an object)
+        if not isinstance(data, dict):
+            self.send_json(
+                400,
+                {
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32600, "message": "Invalid Request: expected JSON object"},
+                    "id": None,
+                },
+            )
+            return
         # Validate JSON-RPC
         if "jsonrpc" not in data or data["jsonrpc"] != "2.0":
             self.send_json(


### PR DESCRIPTION
## Bug

`handle_jsonrpc` assumes `data` is always a `dict`. Sending a top-level JSON integer, string, list, or null triggers `TypeError` from the `in` operator, which surfaces as HTTP 500 instead of the spec-correct `-32600 Invalid Request`.

## Fix

Added an `isinstance(data, dict)` guard before the `"jsonrpc" not in data` check. Non-dict payloads now return `400` with `Invalid Request: expected JSON object`.

Closes #790