### PR TITLE
fix(filebrowser): handle dotless filenames in extension parsing

### DIFF
--- a/src/gaia/apps/webui/src/components/FileBrowser.tsx
+++ b/src/gaia/apps/webui/src/components/FileBrowser.tsx
@@ -281,7 +281,8 @@ export function FileBrowser() {
         });
         if (!hasSupported) {
             const firstFile = files[0];
-            const ext = '.' + firstFile.split('.').pop()?.toLowerCase();
+            const dotIdx = firstFile.lastIndexOf('.');
+            const ext = dotIdx > 0 ? firstFile.slice(dotIdx).toLowerCase() : '';
             const category = getUnsupportedCategory(ext);
             setIndexError({
                 filename: files.length === 1
@@ -337,7 +338,8 @@ export function FileBrowser() {
             const result = await indexAndAttachFiles(files, entries, currentSessionId, updateSessionInList);
 
             if (result.supported.length === 0) {
-                const ext = '.' + files[0].split('.').pop()?.toLowerCase();
+                const dotIdx = files[0].lastIndexOf('.');
+                const ext = dotIdx > 0 ? files[0].slice(dotIdx).toLowerCase() : '';
                 const category = getUnsupportedCategory(ext);
                 setIndexError({
                     filename: files.length === 1 ? files[0].split(/[\\/]/).pop() || files[0] : `${files.length} files`,


### PR DESCRIPTION
## Bug

`FileBrowser.tsx` builds an extension string from `filename.split('.').pop()`, which returns the entire filename when there's no dot. A file named `README` produces extension `.readme` instead of being recognized as having no extension.

## Fix

Use `lastIndexOf('.')` to check for a dot before extracting the extension. Dotless filenames now get an empty string, skipping the unsupported-type error path.

Affected locations:
- `handleIndexSelected` (line ~284)
- `handleAskAgent` (line ~340)

Closes #793