### PR TITLE
fix(lemonade): remove shell=True from Popen calls with list args

### DIFF
--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -709,7 +709,6 @@ class LemonadeClient:
                     stderr=self._log_file,
                     text=True,
                     bufsize=1,
-                    shell=True,
                 )
             except Exception:
                 self._log_file.close()
@@ -723,7 +722,6 @@ class LemonadeClient:
                 stderr=subprocess.PIPE,
                 text=True,
                 bufsize=1,
-                shell=True,
             )
 
             # Print stdout and stderr in real-time only for foreground mode


### PR DESCRIPTION
## Bug

`lemonade_client.py` passes `shell=True` to `subprocess.Popen` while also passing `base_cmd` as a list. On POSIX, this causes only the first list element to be used as the shell command — `serve`, `--log-level`, `--ctx-size` etc. are silently dropped.

## Fix

Remove `shell=True` from the two Popen calls that use list-form `base_cmd`. The Windows path already correctly joins into a single string and keeps `shell=True`.

Affected:
- `start_server` silent mode (line ~712)
- `start_server` foreground mode (line ~726)

Closes #787