### PR TITLE
fix(security): validate port is integer in kill_process_on_port

### DIFF
--- a/src/gaia/util.py
+++ b/src/gaia/util.py
@@ -8,6 +8,11 @@ import time
 
 def kill_process_on_port(port):
     """Kill any process running on the specified port."""
+    # Validate port is an integer to prevent shell injection
+    try:
+        port = int(port)
+    except (ValueError, TypeError):
+        raise ValueError(f"Invalid port number: {port!r}")
     try:
         if sys.platform.startswith("win"):
             # Windows: use netstat + taskkill


### PR DESCRIPTION
## Bug

`kill_process_on_port` interpolates the `port` argument into shell commands with `shell=True`. If `port` is not an integer (e.g. a string like `8080; rm -rf /`), arbitrary shell commands execute.

## Fix

Add `int(port)` conversion at the top of the function with explicit ValueError for non-integer values. Since port is validated as an integer before any string interpolation, shell injection is no longer possible.

Closes #789