### PR TITLE
fix(document-monitor): transition status to missing when file vanishes

### DIFF
--- a/src/gaia/ui/document_monitor.py
+++ b/src/gaia/ui/document_monitor.py
@@ -173,6 +173,7 @@ class DocumentMonitor:
                         filepath,
                         doc_id,
                     )
+                    self._db.update_document_status(doc_id, "missing")
                 continue
 
             current_mtime, current_size = file_info


### PR DESCRIPTION
## Bug

`_check_documents` logs a warning when an indexed file disappears but never updates the DB row's `indexing_status`. The API continues reporting the doc as `complete`, and downstream chat requests use stale RAG-cached chunks.

## Fix

Call `self._db.update_document_status(doc_id, "missing")` after the warning log, inside the existing `status != "missing"` guard.

Closes #791