### PR TITLE
fix(system): retain asyncio.create_task references to prevent GC

### DIFF
--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -29,6 +29,9 @@ from ..models import (
 
 logger = logging.getLogger(__name__)
 
+# Hold references to background tasks to prevent GC
+_background_tasks: set[asyncio.Task] = set()
+
 router = APIRouter(tags=["system"])
 
 # Default model required for GAIA Chat agent
@@ -458,9 +461,11 @@ async def load_model_endpoint(body: LoadModelRequest):
 
     ctx_size = body.ctx_size if body.ctx_size is not None else _MIN_CONTEXT_SIZE
     payload = {"model_name": model_name, "ctx_size": ctx_size}
-    asyncio.create_task(
+    task = asyncio.create_task(
         _lemonade_post("load", payload, timeout=300.0, log_context=f"Load {model_name}")
     )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
     return {"status": "loading", "model": model_name, "ctx_size": ctx_size}
 
 
@@ -485,9 +490,11 @@ async def download_model_endpoint(body: DownloadModelRequest):
     payload: dict = {"model_name": model_name}
     if body.force:
         payload["force"] = True
-    asyncio.create_task(
+    task = asyncio.create_task(
         _lemonade_post(
             "pull", payload, timeout=7200.0, log_context=f"Download {model_name}"
         )
     )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
     return {"status": "downloading", "model": model_name}


### PR DESCRIPTION
## Bug

`load-model` and `download-model` endpoints call `asyncio.create_task()` without saving the reference. Per Python docs, the event loop only holds weak references to tasks — under GC pressure, the background download or load can be cancelled mid-stream.

## Fix

Add a module-level `_background_tasks` set. Store each task reference and attach a `done` callback that discards it automatically.

Affected:
- `POST /api/system/load-model` (line ~464)
- `POST /api/system/download-model` (line ~493)

Closes #788