### PR TITLE
fix(ui): allow horizontal table scroll on mobile

### DIFF
--- a/src/gaia/apps/webui/src/components/MessageBubble.css
+++ b/src/gaia/apps/webui/src/components/MessageBubble.css
@@ -189,7 +189,7 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
     padding-left: 32px;
-    overflow: hidden;
+    overflow-y: hidden;
     min-width: 0;
 }
 


### PR DESCRIPTION
## Bug

Tables in chat messages are not horizontally scrollable on mobile. The `.msg-body` container has `overflow: hidden` which clips the `.md-table-wrap` scroll container, preventing the table from scrolling horizontally.

## Fix

Change `overflow: hidden` to `overflow-y: hidden` on `.msg-body`. This preserves vertical clipping while allowing the table wrapper's `overflow-x: auto` to work.

Closes #642