### PR TITLE
fix: bundle small bug fixes originally submitted by @CodeLine9

### DIFF
--- a/src/gaia/apps/webui/src/components/FileBrowser.tsx
+++ b/src/gaia/apps/webui/src/components/FileBrowser.tsx
@@ -281,7 +281,8 @@ export function FileBrowser() {
         });
         if (!hasSupported) {
             const firstFile = files[0];
-            const ext = '.' + firstFile.split('.').pop()?.toLowerCase();
+            const dotIdx = firstFile.lastIndexOf('.');
+            const ext = dotIdx > 0 ? firstFile.slice(dotIdx).toLowerCase() : '';
             const category = getUnsupportedCategory(ext);
             setIndexError({
                 filename: files.length === 1
@@ -337,7 +338,8 @@ export function FileBrowser() {
             const result = await indexAndAttachFiles(files, entries, currentSessionId, updateSessionInList);
 
             if (result.supported.length === 0) {
-                const ext = '.' + files[0].split('.').pop()?.toLowerCase();
+                const dotIdx = files[0].lastIndexOf('.');
+                const ext = dotIdx > 0 ? files[0].slice(dotIdx).toLowerCase() : '';
                 const category = getUnsupportedCategory(ext);
                 setIndexError({
                     filename: files.length === 1 ? files[0].split(/[\\/]/).pop() || files[0] : `${files.length} files`,

--- a/src/gaia/apps/webui/src/components/MessageBubble.css
+++ b/src/gaia/apps/webui/src/components/MessageBubble.css
@@ -189,7 +189,7 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
     padding-left: 32px;
-    overflow: hidden;
+    overflow-y: hidden;
     min-width: 0;
 }
 

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -709,7 +709,6 @@ class LemonadeClient:
                     stderr=self._log_file,
                     text=True,
                     bufsize=1,
-                    shell=True,
                 )
             except Exception:
                 self._log_file.close()
@@ -723,7 +722,6 @@ class LemonadeClient:
                 stderr=subprocess.PIPE,
                 text=True,
                 bufsize=1,
-                shell=True,
             )
 
             # Print stdout and stderr in real-time only for foreground mode

--- a/src/gaia/mcp/mcp_bridge.py
+++ b/src/gaia/mcp/mcp_bridge.py
@@ -628,7 +628,10 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
                 400,
                 {
                     "jsonrpc": "2.0",
-                    "error": {"code": -32600, "message": "Invalid Request: expected JSON object"},
+                    "error": {
+                        "code": -32600,
+                        "message": "Invalid Request: expected JSON object",
+                    },
                     "id": None,
                 },
             )

--- a/src/gaia/ui/document_monitor.py
+++ b/src/gaia/ui/document_monitor.py
@@ -173,6 +173,7 @@ class DocumentMonitor:
                         filepath,
                         doc_id,
                     )
+                    self._db.update_document_status(doc_id, "missing")
                 continue
 
             current_mtime, current_size = file_info

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -29,6 +29,9 @@ from ..models import (
 
 logger = logging.getLogger(__name__)
 
+# Hold references to background tasks to prevent GC
+_background_tasks: set[asyncio.Task] = set()
+
 router = APIRouter(tags=["system"])
 
 # Default model required for GAIA Chat agent
@@ -458,9 +461,11 @@ async def load_model_endpoint(body: LoadModelRequest):
 
     ctx_size = body.ctx_size if body.ctx_size is not None else _MIN_CONTEXT_SIZE
     payload = {"model_name": model_name, "ctx_size": ctx_size}
-    asyncio.create_task(
+    task = asyncio.create_task(
         _lemonade_post("load", payload, timeout=300.0, log_context=f"Load {model_name}")
     )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
     return {"status": "loading", "model": model_name, "ctx_size": ctx_size}
 
 
@@ -485,9 +490,11 @@ async def download_model_endpoint(body: DownloadModelRequest):
     payload: dict = {"model_name": model_name}
     if body.force:
         payload["force"] = True
-    asyncio.create_task(
+    task = asyncio.create_task(
         _lemonade_post(
             "pull", payload, timeout=7200.0, log_context=f"Download {model_name}"
         )
     )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
     return {"status": "downloading", "model": model_name}

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -106,6 +106,7 @@ class SSEOutputHandler(OutputHandler):
         self._in_thinking = False  # True while inside a <think>...</think> block
         self._json_filtered = False  # True after a JSON block was suppressed; used to eat trailing } artifacts
         # Tool confirmation state (blocking until frontend responds)
+        self._confirm_lock = threading.Lock()
         self._confirm_event: Optional[threading.Event] = None
         self._confirm_result: bool = False
         self._confirm_id: Optional[str] = None
@@ -691,8 +692,9 @@ class SSEOutputHandler(OutputHandler):
         ``False`` otherwise.
         """
         confirm_id = str(uuid.uuid4())
-        self._confirm_event = threading.Event()
-        self._confirm_result = False
+        with self._confirm_lock:
+            self._confirm_event = threading.Event()
+            self._confirm_result = False
         self._confirm_id = confirm_id
 
         self._emit(
@@ -739,12 +741,13 @@ class SSEOutputHandler(OutputHandler):
         Called by the ``POST /api/chat/confirm-tool`` HTTP endpoint.  Returns
         ``False`` if there is no pending confirmation request.
         """
-        if self._confirm_event is None:
-            # No pending confirmation — initialise state anyway so callers can
-            # inspect _confirm_result and _confirm_event after the call.
-            self._confirm_event = threading.Event()
-        self._confirm_result = approved
-        self._confirm_event.set()
+        with self._confirm_lock:
+            if self._confirm_event is None:
+                # No pending confirmation — initialise state anyway so callers can
+                # inspect _confirm_result and _confirm_event after the call.
+                self._confirm_event = threading.Event()
+            self._confirm_result = approved
+            self._confirm_event.set()
         return True
 
     def signal_done(self):

--- a/src/gaia/util.py
+++ b/src/gaia/util.py
@@ -8,6 +8,11 @@ import time
 
 def kill_process_on_port(port):
     """Kill any process running on the specified port."""
+    # Validate port is an integer to prevent shell injection
+    try:
+        port = int(port)
+    except (ValueError, TypeError):
+        raise ValueError(f"Invalid port number: {port!r}")
     try:
         if sys.platform.startswith("win"):
             # Windows: use netstat + taskkill


### PR DESCRIPTION
## Summary

Bundles 7 small, disjoint bug fixes originally submitted by @CodeLine9 in #804–#810. He closed them himself citing bandwidth; the underlying issues (#642, #787, #788, #789, #791, #792, #793) are all still open and the fixes are still valid. Each commit preserves CodeLine9's authorship.

All fixes target different files, so the bundle carries **zero merge conflicts** and is easy to review as a single unit.

## Fixes (one commit each)

- **fix(lemonade): remove `shell=True` from `Popen(list, …)`** (closes #787) — On POSIX, `sh -c` silently dropped `serve`/`--log-level`/`--ctx-size`. Highest-impact item in the bundle: Linux/macOS users were running Lemonade with wrong context size and missing flags.
- **fix(security): validate port is integer in `kill_process_on_port`** (closes #789) — Casts `port` to `int` before shell interpolation. Closes a latent shell-injection vector in `src/gaia/util.py`. (Follow-up candidate: consolidate onto the `psutil`-based impl already used elsewhere.)
- **fix(document-monitor): transition status to `missing` when file vanishes** (closes #791) — Flips DB status so `/api/documents` stops reporting a deleted file as `complete` and log spam stops after the first poll.
- **fix(system): retain `asyncio.create_task` refs to prevent GC** (closes #788) — Adds a module-level `_background_tasks` set for `/api/system/load-model` and `/api/system/download-model`. Fixes a latent reliability bug where model downloads (7200s timeout) could be cancelled mid-stream under GC pressure.
- **fix(sse): add lock to tool confirmation flow** (closes #792) — `threading.Lock` around the reset/set critical sections in `confirm_tool_execution` / `resolve_tool_confirmation`. Closes a race where an early approval could be clobbered.
- **fix(filebrowser): handle dotless filenames in extension parsing** (closes #793) — `README` no longer produces extension `.readme` in the unsupported-file error toast.
- **fix(ui): allow horizontal table scroll on mobile** (closes #642) — `overflow: hidden` → `overflow-y: hidden` on `.msg-body` so the inner `.md-table-wrap` can scroll horizontally.

## Attribution

All 7 commits carry CodeLine9 <ty0907@hotmail.com> as `Author:`. cc @CodeLine9 — thank you for the triage and the clean small-diff style; these are all worth having in main.

## Test plan

- [ ] `python util/lint.py --black` passes on touched Python files (pre-existing `mcp_bridge.py` failure from #803 is unrelated)
- [ ] Launch Lemonade from `gaia` on Linux; confirm `--ctx-size` is respected (previously silently dropped)
- [ ] `gaia chat --ui`, upload a file, delete it from disk, wait >30s; confirm `/api/documents` flips to `indexing_status: "missing"`
- [ ] Agent UI webui builds (`cd src/gaia/apps/webui && npm run build`)
- [ ] Mobile viewport: table in chat message scrolls horizontally
- [ ] Smoke: `/api/system/download-model` survives a forced `gc.collect()` cycle mid-download