### PR TITLE
style(mcp): fix black failure in mcp_bridge.py

### DIFF
--- a/src/gaia/mcp/mcp_bridge.py
+++ b/src/gaia/mcp/mcp_bridge.py
@@ -628,7 +628,10 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
                 400,
                 {
                     "jsonrpc": "2.0",
-                    "error": {"code": -32600, "message": "Invalid Request: expected JSON object"},
+                    "error": {
+                        "code": -32600,
+                        "message": "Invalid Request: expected JSON object",
+                    },
                     "id": None,
                 },
             )


### PR DESCRIPTION
## Summary

`python util/lint.py --black` is currently failing on `main` because a line in `mcp_bridge.py` exceeds black's 88-char limit. Pure formatting fix — wraps the error dict onto multiple lines. No behaviour change.

The regression slipped in with #803 (merged a few hours ago) where the new `"Invalid Request: expected JSON object"` message pushed the line over.

## Why merge this

A red baseline hides real new lint failures. Fixing this makes `util/lint.py --black` green again so the next contributor's PR doesn't inherit a pre-existing failure.

## Test plan

- [ ] `python util/lint.py --black` passes on `main` after merge