### PR TITLE
feat(governance): optional governance layer for GAIA agents

### DIFF
--- a/examples/governed_weather_agent.py
+++ b/examples/governed_weather_agent.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Governed Weather Agent Example.
+
+Same as :mod:`examples.weather_agent` but wraps every tool call through
+a :class:`GaiaGovernanceAdapter`. The adapter is composed from the
+in-repo reference implementations (stub policy engine, in-memory
+checkpoint bridge / receipt service / static policy binding) so the
+example runs with zero external services.
+
+This example registers two **local tools** (alongside the open-meteo
+MCP tools) so governance decisions are guaranteed to trigger:
+
+* ``clear_weather_cache`` — tagged ``blocked``. When the LLM calls
+  this tool, governance short-circuits with a BLOCK decision, issues
+  a signed receipt, and the tool body never runs.
+* ``subscribe_weather_alerts`` — tagged ``review``. Governance opens
+  a checkpoint and asks the configured reviewer (the CLI prompt in
+  ``_cli_reviewer`` below). On approve the tool runs; on reject it is
+  refused. Either way the resolution is logged to the receipt store.
+
+Run::
+
+    uv run examples/governed_weather_agent.py
+
+Say "clear the weather cache please" to see a BLOCK decision, or
+"subscribe me to severe weather alerts for Austin" to see a REVIEW
+decision, or ask any normal weather question to see ALLOW decisions on
+the MCP tools.
+
+The base ``Agent`` class is **not modified**. Governance is composed
+onto the agent via :class:`GovernedAgentMixin`.
+"""
+from gaia import Agent, tool
+from gaia.governance import (
+    GaiaGovernanceAdapter,
+    GovernedAgentMixin,
+)
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import JsonlReceiptService
+from gaia.governance.stubs import RuleBasedPolicyEngine
+from gaia.mcp import MCPClientMixin
+from gaia.mcp.client.config import MCPConfig
+from gaia.mcp.client.mcp_client_manager import MCPClientManager
+
+# Append-only audit log. Tail with `tail -f receipts.jsonl` to watch
+# decisions live while the agent runs.
+RECEIPTS_PATH = "receipts.jsonl"
+# --- Local tools that will actually be reachable by the LLM --------------
+
+
+@tool
+def clear_weather_cache() -> dict:
+    """Destructively clear all cached weather data.
+
+    Use this when the user explicitly asks to reset, clear, or purge
+    the weather cache.
+    """
+    # Body only executes if governance ALLOWs. With the default adapter
+    # this tool is risk-tagged "blocked" and never runs.
+    return {"status": "ok", "message": "weather cache cleared"}
+
+
+@tool
+def subscribe_weather_alerts(location: str, severity: str = "severe") -> dict:
+    """Subscribe the user to recurring weather alerts for a location.
+
+    Use this when the user asks to be notified, subscribed, or alerted
+    about weather conditions at a specific location.
+    """
+    return {
+        "status": "ok",
+        "message": f"subscribed to {severity} alerts for {location}",
+    }
+
+
+# --- Agent -----------------------------------------------------------------
+
+
+class WeatherAgent(Agent, MCPClientMixin):
+    """Base weather agent — mirrors examples/weather_agent.py."""
+
+    WEATHER_SERVER = {
+        "name": "weather",
+        "config": {
+            "command": "uvx",
+            "args": ["--from", "open-meteo-mcp", "open_meteo_mcp"],
+        },
+    }
+
+    def __init__(self, **kwargs):
+        self._mcp_manager = MCPClientManager(config=MCPConfig(config_file=None))
+        kwargs.setdefault("model_id", "Qwen3-4B-Instruct-2507-GGUF")
+        kwargs.setdefault("max_steps", 10)
+        super().__init__(**kwargs)
+
+    def _get_system_prompt(self) -> str:
+        return (
+            "You are a helpful weather assistant. Use the available MCP "
+            "weather tools to answer weather questions. You also have two "
+            "local tools:\n"
+            "- clear_weather_cache: call this if the user asks to reset "
+            "or clear the cache.\n"
+            "- subscribe_weather_alerts: call this if the user asks to "
+            "be notified or subscribed to alerts for a location."
+        )
+
+    def _register_tools(self) -> None:
+        print("Connecting to MCP weather server...")
+        success = self.connect_mcp_server(
+            self.WEATHER_SERVER["name"], self.WEATHER_SERVER["config"]
+        )
+        print("  Connected" if success else "  Failed to connect")
+
+
+class GovernedWeatherAgent(GovernedAgentMixin, WeatherAgent):
+    """Weather agent with governance wired in via the mixin."""
+
+
+# --- Adapter + demo wiring ------------------------------------------------
+
+
+def build_default_adapter() -> GaiaGovernanceAdapter:
+    """Compose an adapter using the in-repo reference implementations."""
+    return GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(policy_version="v0"),
+        checkpoint_runtime=InMemoryCheckpointBridge(),
+        receipt_service=JsonlReceiptService(RECEIPTS_PATH),
+        policy_binding=StaticPolicyBindingService(
+            version="v0", constitution_hash="constitution-dev"
+        ),
+    )
+
+
+def _cli_reviewer(tool_name, tool_args, decision) -> bool:
+    """Interactive CLI reviewer for REVIEW decisions.
+
+    Used when the GAIA console's confirmation surface isn't available.
+    Returning False fails the tool closed.
+    """
+    print(
+        f"\n[review] tool={tool_name!r} args={tool_args!r} "
+        f"reason={decision.reason!r}"
+    )
+    answer = input("[review] approve? [y/N]: ").strip().lower()
+    return answer in ("y", "yes")
+
+
+DEFAULT_RISK_TAGS = {
+    "clear_weather_cache": ["blocked"],
+    "subscribe_weather_alerts": ["review"],
+}
+
+
+def _log_decision(tool_name, _tool_args, _action, decision):
+    print(
+        f"[governance] tool={tool_name!r} decision={decision.decision} "
+        f"reason={decision.reason!r} policy={decision.policy_version}"
+    )
+
+
+def main():
+    print("=" * 60)
+    print("Governed Weather Agent — ACGS-lite action governance demo")
+    print("=" * 60)
+    print(
+        "\nTry:\n"
+        "  - 'What is the weather in Austin?'        (ALLOW)\n"
+        "  - 'Subscribe me to alerts for Seattle.'   (REVIEW)\n"
+        "  - 'Clear the weather cache please.'       (BLOCK)\n"
+    )
+
+    adapter = build_default_adapter()
+
+    try:
+        agent = GovernedWeatherAgent(
+            governance_adapter=adapter,
+            governance_actor_id="demo-user",
+            governance_workflow_id="wf_demo",
+            governance_risk_tags=DEFAULT_RISK_TAGS,
+            governance_callback=_log_decision,
+            governance_reviewer=_cli_reviewer,
+        )
+        print(f"Governed Weather Agent ready. Audit log: {RECEIPTS_PATH}\n")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # Demo harness: report any startup failure (Lemonade, uvx, MCP)
+        # as a single friendly message instead of a traceback.
+        print(f"Error initializing agent: {exc}")
+        print(
+            "Make sure Lemonade server is running and `uv` is installed "
+            "so `uvx` can fetch the weather MCP server."
+        )
+        return
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+            if not user_input:
+                continue
+            if user_input.lower() in ("quit", "exit", "q"):
+                print("Goodbye!")
+                break
+            result = agent.process_query(user_input)
+            if result.get("result"):
+                print(f"\nAgent: {result['result']}\n")
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye!")
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gaia/governance/README.md
+++ b/src/gaia/governance/README.md
@@ -1,0 +1,148 @@
+# gaia.governance
+
+Optional governance layer for GAIA agents. Opt-in. Off by default.
+
+## Quick start (5 minutes)
+
+```python
+from gaia import Agent, tool
+from gaia.governance import GaiaGovernanceAdapter, GovernedAgentMixin, govern
+
+
+@tool
+@govern(risk="blocked", reason="destructive")
+def wipe_disk() -> dict:
+    return {"status": "ok"}
+
+
+class MyAgent(GovernedAgentMixin, Agent):
+    ...
+
+
+agent = MyAgent(
+    governance_adapter=GaiaGovernanceAdapter.default(),
+)
+```
+
+That's it. When the model calls `wipe_disk`, governance short-circuits
+the call, issues a signed receipt to `receipts.jsonl`, and returns a
+denied result to the agent loop.
+
+## How decisions work
+
+| Decision | Effect |
+|---|---|
+| `ALLOW` | Tool runs as usual. |
+| `BLOCK` | Tool is refused. A receipt is written to the audit log with the full evidence envelope (action, policy version, constitution hash, timestamp). |
+| `REVIEW` | A checkpoint is opened. The mixin asks your `governance_reviewer` callback (or fails closed if none). On `APPROVE` the tool runs; on `REJECT` it is refused. Either way a receipt is written. |
+
+Decisions are produced by a `PolicyEngine`. The shipped
+`RuleBasedPolicyEngine` reads tags from `@govern(risk=...)` and/or a
+`governance_risk_tags` dict on the agent. Swap in any
+`PolicyEngine`-shaped object (ACGS-lite, your own rules, an LLM judge,
+etc.) without touching agent code.
+
+## Two tagging styles
+
+**Decorator — colocates policy with the tool (recommended):**
+
+```python
+@tool
+@govern(risk="review", reason="sends money")
+def transfer(amount: float): ...
+```
+
+**Dict — centralizes policy on the agent:**
+
+```python
+agent = MyAgent(
+    governance_adapter=GaiaGovernanceAdapter.default(),
+    governance_risk_tags={"transfer": ["review"]},
+)
+```
+
+Both work together. If both declare tags for the same tool, the dict
+wins so you can override decorator defaults at configuration time
+without editing source.
+
+## Configuration
+
+Two equivalent styles. Pick whichever reads better:
+
+```python
+# Structured config object
+from gaia.governance import GovernanceConfig
+
+agent = MyAgent(governance=GovernanceConfig(
+    adapter=adapter,
+    actor_id="alice",
+    workflow_id="session-42",
+    risk_tags={"delete_record": ["blocked"]},
+    reviewer=my_reviewer,
+))
+
+# Individual kwargs (also supported)
+agent = MyAgent(
+    governance_adapter=adapter,
+    governance_actor_id="alice",
+    governance_risk_tags={"delete_record": ["blocked"]},
+    governance_reviewer=my_reviewer,
+)
+```
+
+## Reviewers
+
+When a `REVIEW` decision fires, the mixin calls your
+`governance_reviewer` callback — nothing else. There is no "fall back to
+the console" path, because GAIA's default `AgentConsole.confirm_tool_execution`
+returns `True`, and a silent auto-approve would defeat the decision.
+
+```python
+def my_reviewer(tool_name, tool_args, decision) -> bool:
+    # UI, Slack, a web form, whatever you like
+    return input(f"approve {tool_name}? [y/N]: ") == "y"
+
+agent = MyAgent(
+    governance_adapter=GaiaGovernanceAdapter.default(),
+    governance_reviewer=my_reviewer,
+)
+```
+
+If no reviewer is set, REVIEW decisions **fail closed** (tool denied).
+
+## Security properties
+
+- **Canonical name resolution:** governance resolves the registered
+  tool name before checking risk tags, so an LLM cannot bypass a tag
+  on `mcp_time_get_current_time` by calling the unprefixed alias
+  `get_current_time`.
+- **Envelope-bound receipts:** each receipt's `payload_hash` covers
+  the full evidence envelope (action, decision, policy version,
+  constitution hash, actor, timestamp) with strict canonical JSON. Any
+  field tampered in the log changes the hash.
+- **Workflow-bound checkpoint resolution:** the adapter refuses to
+  resolve a checkpoint under a workflow_id that differs from the one
+  recorded when the checkpoint was opened.
+- **Atomic checkpoint resolution:** `InMemoryCheckpointBridge` uses a
+  lock so a race between two concurrent resolutions cannot produce two
+  terminal outcomes.
+
+## Extension points
+
+| Interface                   | Shipped reference                                 | Swap with                                  |
+|-----------------------------|---------------------------------------------------|--------------------------------------------|
+| `PolicyEngine`              | `RuleBasedPolicyEngine`                           | ACGS-lite engine, LLM judge, OPA, etc.     |
+| `CheckpointRuntime`         | `InMemoryCheckpointBridge`                        | constitutional-swarm checkpoint service    |
+| `ReceiptServiceProtocol`    | `InMemoryReceiptService` / `JsonlReceiptService`  | DB, log forwarder, chain anchor            |
+| `PolicyBindingProtocol`     | `StaticPolicyBindingService`                      | constitutional-swarm policy control plane  |
+
+All four are `@runtime_checkable` Protocols — no inheritance required.
+
+## What's not here (yet)
+
+- Policy control plane; `PolicyBindingProtocol` is static in PR 1.
+- Attestation / trust routing.
+- Precedent memory or validator marketplace.
+- Plan-step / multi-agent workflow transitions (the
+  `workflow_mapper` helper is a forward-compatibility seam for when
+  the base agent starts emitting those events).

--- a/src/gaia/governance/__init__.py
+++ b/src/gaia/governance/__init__.py
@@ -1,0 +1,57 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Optional governance layer for GAIA agents.
+
+Provides action-level governance (ACGS-lite semantics) plus seams for
+future workflow checkpoint / receipt / policy-version binding
+(constitutional-swarm semantics).
+
+This package is opt-in. Importing it has no side effects on existing
+GAIA agents. To govern an agent, mix :class:`GovernedAgentMixin` into
+your agent class and pass a :class:`GaiaGovernanceAdapter` via the
+``governance_adapter`` keyword argument.
+"""
+from .adapter import GaiaGovernanceAdapter
+from .action_mapper import map_gaia_tool_call_to_action_request
+from .config import GovernanceConfig
+from .decorators import govern, read_risk_tags
+from .exceptions import (
+    CheckpointNotFoundError,
+    GaiaGovernanceError,
+    InvalidResolutionError,
+)
+from .mixin import GovernedAgentMixin
+from .schemas import (
+    ActionRequest,
+    CheckpointRecord,
+    CheckpointResolution,
+    GovernanceDecision,
+    PolicyVersionRef,
+    ReceiptRecord,
+    TransitionOutcome,
+    WorkflowTransition,
+    new_id,
+    utc_now_iso,
+)
+
+__all__ = [
+    "ActionRequest",
+    "CheckpointNotFoundError",
+    "CheckpointRecord",
+    "CheckpointResolution",
+    "GaiaGovernanceAdapter",
+    "GaiaGovernanceError",
+    "GovernanceConfig",
+    "GovernanceDecision",
+    "GovernedAgentMixin",
+    "InvalidResolutionError",
+    "PolicyVersionRef",
+    "ReceiptRecord",
+    "TransitionOutcome",
+    "WorkflowTransition",
+    "govern",
+    "map_gaia_tool_call_to_action_request",
+    "new_id",
+    "read_risk_tags",
+    "utc_now_iso",
+]

--- a/src/gaia/governance/action_mapper.py
+++ b/src/gaia/governance/action_mapper.py
@@ -1,0 +1,27 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Maps a GAIA tool call into a governance ActionRequest."""
+from __future__ import annotations
+
+from typing import Any
+
+from .schemas import ActionRequest, new_id
+
+
+def map_gaia_tool_call_to_action_request(
+    tool_name: str,
+    args: dict[str, Any],
+    context: dict[str, Any] | None = None,
+) -> ActionRequest:
+    ctx = context or {}
+    return ActionRequest(
+        action_id=ctx.get("action_id", new_id("action")),
+        actor_id=ctx.get("actor_id", "unknown-actor"),
+        tool_name=tool_name,
+        action_type=ctx.get("action_type", tool_name),
+        args=dict(args),
+        risk_tags=list(ctx.get("risk_tags", [])),
+        workflow_id=ctx.get("workflow_id"),
+        step_id=ctx.get("step_id"),
+        source=ctx.get("source", "gaia"),
+    )

--- a/src/gaia/governance/adapter.py
+++ b/src/gaia/governance/adapter.py
@@ -1,0 +1,210 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Governance adapter: entry point for action-level and workflow-level flows."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+
+from .exceptions import InvalidResolutionError
+from .protocols import (
+    CheckpointRuntime,
+    PolicyBindingProtocol,
+    PolicyEngine,
+    ReceiptServiceProtocol,
+)
+from .schemas import (
+    ActionRequest,
+    CheckpointResolution,
+    GovernanceDecision,
+    ReceiptRecord,
+    TransitionOutcome,
+    WorkflowTransition,
+    new_id,
+    utc_now_iso,
+)
+
+
+def _canonical_hash(payload: dict) -> str:
+    """Stable SHA-256 of a JSON-canonicalized payload.
+
+    Refuses non-canonical types rather than silently coercing them via
+    ``default=str`` — an audit hash must be reproducible given the
+    same logical content.
+    """
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+class GaiaGovernanceAdapter:
+    """Compose a policy engine, checkpoint runtime, receipt service, and
+    policy-version binding into a single entry point used by agents.
+    """
+
+    def __init__(
+        self,
+        policy_engine: PolicyEngine,
+        checkpoint_runtime: CheckpointRuntime,
+        receipt_service: ReceiptServiceProtocol,
+        policy_binding: PolicyBindingProtocol,
+    ) -> None:
+        self.policy_engine = policy_engine
+        self.checkpoint_runtime = checkpoint_runtime
+        self.receipt_service = receipt_service
+        self.policy_binding = policy_binding
+
+    @classmethod
+    def default(
+        cls,
+        audit_log: str | None = "receipts.jsonl",
+        policy_version: str = "v0",
+        constitution_hash: str = "constitution-dev",
+    ) -> "GaiaGovernanceAdapter":
+        """Pre-wired adapter using the in-repo reference implementations.
+
+        Pass ``audit_log=None`` to use in-memory receipts (tests).
+        Otherwise receipts are appended to the given JSONL path.
+        """
+        # Lazy imports avoid a circular namespace at package import time.
+        from .checkpoint_bridge import InMemoryCheckpointBridge
+        from .policy_binding import StaticPolicyBindingService
+        from .receipt_service import InMemoryReceiptService, JsonlReceiptService
+        from .stubs import RuleBasedPolicyEngine
+
+        receipts: ReceiptServiceProtocol = (
+            InMemoryReceiptService()
+            if audit_log is None
+            else JsonlReceiptService(audit_log)
+        )
+        return cls(
+            policy_engine=RuleBasedPolicyEngine(policy_version=policy_version),
+            checkpoint_runtime=InMemoryCheckpointBridge(),
+            receipt_service=receipts,
+            policy_binding=StaticPolicyBindingService(
+                version=policy_version, constitution_hash=constitution_hash
+            ),
+        )
+
+    def govern_action(self, action_request: ActionRequest) -> GovernanceDecision:
+        return self.policy_engine.evaluate_action(action_request)
+
+    def handle_transition(
+        self, transition: WorkflowTransition, decision: GovernanceDecision
+    ) -> TransitionOutcome:
+        if decision.decision == "ALLOW":
+            return TransitionOutcome(status="CONTINUE", reason="action allowed")
+        if decision.decision == "BLOCK":
+            receipt = self._issue_receipt(
+                workflow_id=transition.workflow_id,
+                checkpoint_id=None,
+                decision="BLOCK",
+                actor_id=None,
+                evidence={
+                    "transition": asdict(transition),
+                    "decision": asdict(decision),
+                },
+            )
+            return TransitionOutcome(
+                status="TERMINATED",
+                reason="action blocked",
+                metadata={"receipt_id": receipt.receipt_id},
+            )
+
+        checkpoint = self.checkpoint_runtime.create_checkpoint(transition, decision)
+        return TransitionOutcome(
+            status="CHECKPOINT_OPEN",
+            reason="review required",
+            checkpoint_id=checkpoint.checkpoint_id,
+            metadata={"checkpoint_id": checkpoint.checkpoint_id},
+        )
+
+    def resolve_checkpoint(
+        self,
+        checkpoint_id: str,
+        resolution: CheckpointResolution,
+        workflow_id: str,
+    ) -> TransitionOutcome:
+        # MED-4 fix: refuse to resolve a checkpoint whose stored workflow
+        # does not match the caller's claimed workflow_id. The
+        # CheckpointRuntime Protocol is extended with an optional
+        # ``get_checkpoint`` method (duck-typed) for this validation;
+        # runtimes that don't expose it skip the check.
+        get = getattr(self.checkpoint_runtime, "get_checkpoint", None)
+        if callable(get):
+            record = get(checkpoint_id)
+            if record is not None and record.workflow_id != workflow_id:
+                raise InvalidResolutionError(
+                    f"workflow mismatch: checkpoint {checkpoint_id} belongs to "
+                    f"{record.workflow_id!r}, not {workflow_id!r}"
+                )
+        outcome = self.checkpoint_runtime.resolve_checkpoint(checkpoint_id, resolution)
+        if outcome.status in {"RESUMED", "TERMINATED"}:
+            receipt = self._issue_receipt(
+                workflow_id=workflow_id,
+                checkpoint_id=checkpoint_id,
+                decision=resolution.resolution,
+                actor_id=resolution.actor_id,
+                evidence={
+                    "resolution": asdict(resolution),
+                    "outcome_status": outcome.status,
+                },
+            )
+            merged = {**outcome.metadata, "receipt_id": receipt.receipt_id}
+            return TransitionOutcome(
+                status=outcome.status,
+                reason=outcome.reason,
+                checkpoint_id=outcome.checkpoint_id,
+                metadata=merged,
+            )
+        return outcome
+
+    def _issue_receipt(
+        self,
+        workflow_id: str,
+        checkpoint_id: str | None,
+        decision: str,
+        actor_id: str | None,
+        evidence: dict,
+    ) -> ReceiptRecord:
+        """Issue a receipt whose payload_hash covers the full evidence envelope.
+
+        The hash input is canonicalized JSON of: receipt identity fields
+        (decision, workflow_id, checkpoint_id, actor_id, policy_version,
+        constitution_hash, timestamp) plus the supplied evidence. This
+        means any tampering — to the decision, the action args, the
+        policy version, the resolution actor, etc. — changes the hash.
+        """
+        policy_version = self.policy_binding.current_version()
+        created_at = utc_now_iso()
+        receipt_id = new_id("rcpt")
+        envelope = {
+            "receipt_id": receipt_id,
+            "workflow_id": workflow_id,
+            "checkpoint_id": checkpoint_id,
+            "decision": decision,
+            "actor_id": actor_id,
+            "policy_version": policy_version.version,
+            "constitution_hash": policy_version.constitution_hash,
+            "created_at": created_at,
+            "evidence": evidence,
+        }
+        payload_hash = _canonical_hash(envelope)
+        record = ReceiptRecord(
+            receipt_id=receipt_id,
+            workflow_id=workflow_id,
+            checkpoint_id=checkpoint_id,
+            decision=decision,
+            policy_version=policy_version.version,
+            actor_id=actor_id,
+            validator_set_id=None,
+            created_at=created_at,
+            payload_hash=payload_hash,
+            metadata={
+                "constitution_hash": policy_version.constitution_hash,
+                "evidence": evidence,
+            },
+        )
+        self.receipt_service.issue_receipt(record)
+        return record

--- a/src/gaia/governance/checkpoint_bridge.py
+++ b/src/gaia/governance/checkpoint_bridge.py
@@ -1,0 +1,102 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""In-memory CheckpointRuntime reference implementation.
+
+Production deployments will swap this for a persistent bridge backed by
+constitutional-swarm. Kept tiny so unit tests and the governed example
+can run with no external dependencies.
+"""
+from __future__ import annotations
+
+from threading import Lock
+
+from .exceptions import CheckpointNotFoundError, InvalidResolutionError
+from .schemas import (
+    CheckpointRecord,
+    CheckpointResolution,
+    GovernanceDecision,
+    TransitionOutcome,
+    WorkflowTransition,
+    new_id,
+    utc_now_iso,
+)
+
+
+class InMemoryCheckpointBridge:
+    def __init__(self) -> None:
+        self._records: dict[str, CheckpointRecord] = {}
+        self._lock = Lock()
+
+    def get_checkpoint(self, checkpoint_id: str) -> CheckpointRecord | None:
+        """Return the stored checkpoint or ``None`` — used by the adapter
+        to validate workflow ownership before resolution."""
+        with self._lock:
+            return self._records.get(checkpoint_id)
+
+    def create_checkpoint(
+        self, transition: WorkflowTransition, decision: GovernanceDecision
+    ) -> CheckpointRecord:
+        record = CheckpointRecord(
+            checkpoint_id=new_id("chk"),
+            workflow_id=transition.workflow_id,
+            transition_id=transition.transition_id,
+            status="OPEN",
+            created_at=utc_now_iso(),
+            decision_context={
+                "transition_type": transition.transition_type,
+                "from_state": transition.from_state,
+                "to_state": transition.to_state,
+                "decision_reason": decision.reason,
+                "policy_version": decision.policy_version,
+                "rule_ids": list(decision.rule_ids),
+            },
+        )
+        self._records[record.checkpoint_id] = record
+        return record
+
+    def resolve_checkpoint(
+        self, checkpoint_id: str, resolution: CheckpointResolution
+    ) -> TransitionOutcome:
+        # MED-5 fix: check-and-set must be atomic so a concurrent second
+        # caller sees the terminal status and raises InvalidResolutionError
+        # instead of also succeeding.
+        with self._lock:
+            if checkpoint_id not in self._records:
+                raise CheckpointNotFoundError(checkpoint_id)
+
+            current = self._records[checkpoint_id]
+            if current.status != "OPEN":
+                raise InvalidResolutionError(
+                    f"checkpoint is not open: {checkpoint_id}"
+                )
+
+            mapping = {
+                "APPROVE": ("APPROVED", "RESUMED", "checkpoint approved"),
+                "REJECT": ("REJECTED", "TERMINATED", "checkpoint rejected"),
+                "ESCALATE": ("ESCALATED", "CHECKPOINT_OPEN", "checkpoint escalated"),
+                "TIMEOUT_REJECT": (
+                    "TIMEOUT_REJECTED",
+                    "TERMINATED",
+                    "checkpoint timed out",
+                ),
+            }
+            status, outcome_status, reason = mapping[resolution.resolution]
+            self._records[checkpoint_id] = CheckpointRecord(
+                checkpoint_id=current.checkpoint_id,
+                workflow_id=current.workflow_id,
+                transition_id=current.transition_id,
+                status=status,
+                created_at=current.created_at,
+                decision_context={
+                    **current.decision_context,
+                    "resolved_by": resolution.actor_id,
+                    "resolution_reason": resolution.reason,
+                    "resolution_metadata": resolution.metadata,
+                },
+            )
+            return TransitionOutcome(
+                status=outcome_status,
+                reason=reason,
+                checkpoint_id=checkpoint_id,
+                metadata={"resolution": resolution.resolution},
+            )

--- a/src/gaia/governance/config.py
+++ b/src/gaia/governance/config.py
@@ -1,0 +1,44 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Consolidated governance configuration.
+
+:class:`GovernanceConfig` bundles every governance knob the
+:class:`GovernedAgentMixin` accepts into a single object, so user
+agents do not carry six ``governance_*`` keywords in their
+``__init__`` signatures.
+
+Both styles are supported — use whichever feels more ergonomic::
+
+    agent = MyAgent(governance=GovernanceConfig(
+        adapter=adapter,
+        risk_tags={"delete_record": ["blocked"]},
+    ))
+
+or, equivalently::
+
+    agent = MyAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"delete_record": ["blocked"]},
+    )
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .adapter import GaiaGovernanceAdapter
+
+GovernanceCallback = Callable[[str, dict, Any, Any], None]
+GovernanceReviewer = Callable[[str, dict, Any], bool]
+
+
+@dataclass(slots=True)
+class GovernanceConfig:
+    """All governance options in one object."""
+
+    adapter: GaiaGovernanceAdapter
+    actor_id: str = "gaia-agent"
+    workflow_id: str | None = None
+    risk_tags: dict[str, list[str]] = field(default_factory=dict)
+    callback: GovernanceCallback | None = None
+    reviewer: GovernanceReviewer | None = None

--- a/src/gaia/governance/decorators.py
+++ b/src/gaia/governance/decorators.py
@@ -1,0 +1,70 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Decorator-based risk tagging — the idiomatic Python alternative to
+maintaining a central ``risk_tags`` dict on every agent.
+
+Usage::
+
+    from gaia import tool
+    from gaia.governance import govern
+
+    @tool
+    @govern(risk="blocked", reason="destructive filesystem operation")
+    def wipe_disk() -> dict:
+        ...
+
+    @tool
+    @govern(risk="review")
+    def send_money(amount: float, recipient: str) -> dict:
+        ...
+
+The mixin reads ``__gaia_governance__`` off the tool function at call
+time and merges those tags with any dict passed via
+``governance_risk_tags=``. The explicit dict wins when a tool appears
+in both, so callers can override decorator defaults without editing
+source.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+_ATTR = "__gaia_governance__"
+
+
+def govern(
+    *,
+    risk: str | list[str],
+    reason: str = "",
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Attach governance metadata to a tool function.
+
+    ``risk`` may be a single tag ("blocked", "review", or any custom
+    tag your policy engine understands) or a list of tags.
+    ``reason`` is optional free-form text surfaced in decision reports.
+    """
+    tags = [risk] if isinstance(risk, str) else list(risk)
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        existing = getattr(fn, _ATTR, None) or {}
+        merged_tags = list(dict.fromkeys([*existing.get("risk_tags", []), *tags]))
+        setattr(
+            fn,
+            _ATTR,
+            {
+                "risk_tags": merged_tags,
+                "reason": reason or existing.get("reason", ""),
+            },
+        )
+        return fn
+
+    return decorator
+
+
+def read_risk_tags(fn: Callable[..., Any] | None) -> list[str]:
+    """Return risk tags declared via :func:`govern`, or an empty list."""
+    if fn is None:
+        return []
+    meta = getattr(fn, _ATTR, None)
+    if not meta:
+        return []
+    return list(meta.get("risk_tags", []))

--- a/src/gaia/governance/exceptions.py
+++ b/src/gaia/governance/exceptions.py
@@ -1,0 +1,15 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Governance-layer exceptions."""
+
+
+class GaiaGovernanceError(Exception):
+    """Base error for the GAIA governance package."""
+
+
+class CheckpointNotFoundError(GaiaGovernanceError):
+    """Raised when a checkpoint cannot be found."""
+
+
+class InvalidResolutionError(GaiaGovernanceError):
+    """Raised when a checkpoint resolution is invalid for its current state."""

--- a/src/gaia/governance/mixin.py
+++ b/src/gaia/governance/mixin.py
@@ -1,0 +1,330 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Optional mixin that adds governance to a GAIA ``Agent`` subclass.
+
+Usage::
+
+    from gaia import Agent
+    from gaia.governance import GaiaGovernanceAdapter, GovernedAgentMixin
+
+    class MyGovernedAgent(GovernedAgentMixin, MyAgent):
+        pass
+
+    agent = MyGovernedAgent(governance_adapter=my_adapter, actor_id="alice")
+
+The mixin wraps :meth:`Agent._execute_tool` through ``super()``. If no
+adapter is supplied it is a no-op, so adding the mixin to an agent has
+zero runtime cost by default. **No edits to ``gaia.agents.base.agent``
+are required.**
+
+Decision flow
+-------------
+
+Every intercepted tool call drives the full adapter pipeline:
+
+1. The tool call is mapped to an :class:`ActionRequest`.
+2. ``adapter.govern_action`` yields a :class:`GovernanceDecision`.
+3. A synthetic :class:`WorkflowTransition` is built and passed through
+   ``adapter.handle_transition``.
+4. **ALLOW** → the underlying ``_execute_tool`` runs.
+5. **BLOCK** → the tool is short-circuited with a denied result and
+   the adapter issues a BLOCK receipt.
+6. **REVIEW** → a checkpoint is opened. The mixin asks the first
+   available reviewer — ``self.console.confirm_tool_execution`` (GAIA's
+   existing confirmation surface) or an explicit
+   ``governance_reviewer`` callback — and resolves the checkpoint
+   APPROVE / REJECT accordingly. An APPROVE runs the tool; a REJECT
+   short-circuits. Either way, a receipt is issued.
+
+If ``REVIEW`` decisions are returned and neither a console nor a
+reviewer is available, the mixin **fails closed** and rejects the
+tool. This matches the intent of the decision type ("do not execute
+without review") and avoids silent pass-through.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .action_mapper import map_gaia_tool_call_to_action_request
+from .adapter import GaiaGovernanceAdapter
+from .config import GovernanceConfig
+from .decorators import read_risk_tags
+from .schemas import (
+    ActionRequest,
+    CheckpointResolution,
+    GovernanceDecision,
+    WorkflowTransition,
+    new_id,
+)
+
+# Observational callback: (tool_name, tool_args, action, decision) -> None.
+GovernanceCallback = Callable[
+    [str, dict[str, Any], ActionRequest, GovernanceDecision], None
+]
+
+# Reviewer callback: (tool_name, tool_args, decision) -> bool.
+# Called when REVIEW is returned and no GAIA console is available.
+# Return True to approve, False to reject.
+GovernanceReviewer = Callable[[str, dict[str, Any], GovernanceDecision], bool]
+
+
+class GovernedAgentMixin:
+    """Mix-in: intercept ``_execute_tool`` and drive the full adapter flow."""
+
+    governance_adapter: GaiaGovernanceAdapter | None
+    _governance_actor_id: str
+    _governance_workflow_id: str | None
+    _governance_risk_tags: dict[str, list[str]]
+    _governance_callback: GovernanceCallback | None
+    _governance_reviewer: GovernanceReviewer | None
+
+    def __init__(
+        self,
+        *args: Any,
+        governance: GovernanceConfig | None = None,
+        governance_adapter: GaiaGovernanceAdapter | None = None,
+        governance_actor_id: str = "gaia-agent",
+        governance_workflow_id: str | None = None,
+        governance_risk_tags: dict[str, list[str]] | None = None,
+        governance_callback: GovernanceCallback | None = None,
+        governance_reviewer: GovernanceReviewer | None = None,
+        **kwargs: Any,
+    ) -> None:
+        # Prefer the structured config if supplied; fall back to the
+        # per-kwarg form so both styles work.
+        if governance is not None:
+            self.governance_adapter = governance.adapter
+            self._governance_actor_id = governance.actor_id
+            self._governance_workflow_id = governance.workflow_id
+            self._governance_risk_tags = dict(governance.risk_tags)
+            self._governance_callback = governance.callback
+            self._governance_reviewer = governance.reviewer
+        else:
+            self.governance_adapter = governance_adapter
+            self._governance_actor_id = governance_actor_id
+            self._governance_workflow_id = governance_workflow_id
+            self._governance_risk_tags = dict(governance_risk_tags or {})
+            self._governance_callback = governance_callback
+            self._governance_reviewer = governance_reviewer
+        super().__init__(*args, **kwargs)
+
+    # ---- public plumbing --------------------------------------------------
+
+    def _execute_tool(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+        adapter = self.governance_adapter
+        if adapter is None:
+            return super()._execute_tool(tool_name, tool_args)  # type: ignore[misc]
+
+        # HIGH-2 fix: resolve the canonical tool name BEFORE governance so
+        # risk tags keyed to the canonical name (e.g. ``mcp_time_get_current_time``)
+        # cannot be bypassed by the LLM calling the unprefixed alias
+        # (e.g. ``get_current_time``). Falls through to the raw name when
+        # the base Agent does not expose a resolver.
+        canonical = self._resolve_canonical_tool_name(tool_name)
+        action = self._build_action_request(canonical, tool_args)
+        decision = adapter.govern_action(action)
+        self._invoke_callback(tool_name, tool_args, action, decision)
+
+        transition = self._build_transition(action, tool_args)
+        outcome = adapter.handle_transition(transition, decision)
+
+        if outcome.status == "CONTINUE":
+            return super()._execute_tool(tool_name, tool_args)  # type: ignore[misc]
+
+        if outcome.status == "TERMINATED":
+            return self._denied_result(
+                tool_name,
+                decision.decision,
+                decision.reason,
+                decision.policy_version,
+                decision.rule_ids,
+                outcome.metadata.get("receipt_id"),
+            )
+
+        if outcome.status == "CHECKPOINT_OPEN":
+            return self._handle_review_checkpoint(
+                tool_name,
+                tool_args,
+                decision,
+                transition,
+                outcome.checkpoint_id,
+            )
+
+        # Unknown outcome → fail closed.
+        return self._denied_result(
+            tool_name,
+            "ERROR",
+            f"unknown transition outcome: {outcome.status}",
+            decision.policy_version,
+            [],
+            None,
+        )
+
+    # ---- internals --------------------------------------------------------
+
+    def _resolve_canonical_tool_name(self, tool_name: str) -> str:
+        """Return the canonical tool name if the base Agent can resolve it.
+
+        GAIA's ``Agent._resolve_tool_name`` maps unprefixed aliases
+        (e.g. ``get_current_time``) to registry keys
+        (e.g. ``mcp_time_get_current_time``). Governance must key on the
+        canonical name or risk tags can be trivially bypassed.
+        """
+        resolver = getattr(self, "_resolve_tool_name", None)
+        if callable(resolver):
+            try:
+                resolved = resolver(tool_name)  # pylint: disable=not-callable
+            except Exception:  # pylint: disable=broad-exception-caught
+                resolved = None
+            if resolved:
+                return resolved
+        return tool_name
+
+    def _build_action_request(
+        self, tool_name: str, tool_args: dict[str, Any]
+    ) -> ActionRequest:
+        # Merge decorator-declared tags with explicit dict tags. Explicit
+        # dict wins when both declare a tag for the same tool, so users
+        # can override decorator defaults without editing source.
+        decorated_tags = read_risk_tags(self._lookup_tool_fn(tool_name))
+        explicit_tags = self._governance_risk_tags.get(tool_name, [])
+        merged_tags = list(dict.fromkeys([*decorated_tags, *explicit_tags]))
+        return map_gaia_tool_call_to_action_request(
+            tool_name,
+            tool_args,
+            {
+                "actor_id": self._governance_actor_id,
+                "workflow_id": self._governance_workflow_id,
+                "risk_tags": merged_tags,
+                "source": "gaia",
+            },
+        )
+
+    @staticmethod
+    def _lookup_tool_fn(tool_name: str) -> Any | None:
+        """Return the registered tool function, or None if absent.
+
+        Read through GAIA's tool registry so we can inspect
+        ``__gaia_governance__`` attributes placed by :func:`govern`.
+        """
+        try:
+            from gaia.agents.base.tools import _TOOL_REGISTRY  # type: ignore
+        except Exception:  # pylint: disable=broad-exception-caught
+            return None
+        entry = _TOOL_REGISTRY.get(tool_name)
+        if not entry:
+            return None
+        return entry.get("function")
+
+    def _build_transition(
+        self, action: ActionRequest, tool_args: dict[str, Any]
+    ) -> WorkflowTransition:
+        workflow_id = self._governance_workflow_id or f"wf_{self._governance_actor_id}"
+        return WorkflowTransition(
+            workflow_id=workflow_id,
+            transition_id=new_id("tx"),
+            from_state="READY",
+            to_state=f"TOOL:{action.tool_name}",
+            transition_type="tool_call",
+            related_action_id=action.action_id,
+            payload={"tool_args": dict(tool_args)},
+        )
+
+    def _invoke_callback(
+        self,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        action: ActionRequest,
+        decision: GovernanceDecision,
+    ) -> None:
+        if self._governance_callback is None:
+            return
+        try:
+            self._governance_callback(tool_name, tool_args, action, decision)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Observational callbacks must never break tool execution.
+            pass
+
+    def _handle_review_checkpoint(
+        self,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        decision: GovernanceDecision,
+        transition: WorkflowTransition,
+        checkpoint_id: str | None,
+    ) -> Any:
+        assert checkpoint_id is not None, "CHECKPOINT_OPEN without checkpoint_id"
+        approved = self._prompt_review(tool_name, tool_args, decision)
+        resolution = CheckpointResolution(
+            resolution="APPROVE" if approved else "REJECT",
+            actor_id=self._governance_actor_id,
+            reason="reviewer approved" if approved else "reviewer rejected",
+        )
+        resolved = self.governance_adapter.resolve_checkpoint(  # type: ignore[union-attr]
+            checkpoint_id, resolution, transition.workflow_id
+        )
+        if resolved.status == "RESUMED":
+            return super()._execute_tool(tool_name, tool_args)  # type: ignore[misc]
+        return self._denied_result(
+            tool_name,
+            "REVIEW_REJECTED",
+            "tool rejected at review checkpoint",
+            decision.policy_version,
+            decision.rule_ids,
+            resolved.metadata.get("receipt_id"),
+        )
+
+    def _prompt_review(
+        self,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        decision: GovernanceDecision,
+    ) -> bool:
+        """Ask the registered reviewer to approve or reject.
+
+        Only an **explicit** ``governance_reviewer`` callback is
+        honored. GAIA's ``AgentConsole.confirm_tool_execution`` is NOT
+        consulted automatically because its default implementation
+        auto-approves (``OutputHandler.confirm_tool_execution`` returns
+        ``True`` unless a subclass overrides it). Silently treating an
+        auto-approving console as a reviewer would break the
+        fail-closed contract.
+
+        Callers that want console-driven review must pass::
+
+            governance_reviewer=lambda name, args, _d: (
+                self.console.confirm_tool_execution(name, args)
+            )
+
+        when they have verified their console actually blocks
+        (e.g. ``SSEOutputHandler`` which awaits a frontend response).
+        """
+        reviewer = self._governance_reviewer
+        if reviewer is None:
+            # Fail closed: REVIEW means "do not run without review".
+            return False
+        try:
+            return bool(reviewer(tool_name, tool_args, decision))
+        except Exception:  # pylint: disable=broad-exception-caught
+            return False
+
+    @staticmethod
+    def _denied_result(
+        tool_name: str,
+        governance_decision: str,
+        reason: str,
+        policy_version: str,
+        rule_ids: list[str],
+        receipt_id: str | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status": "denied",
+            "error": f"Tool '{tool_name}' blocked by governance: {reason}",
+            "governance_decision": governance_decision,
+            "policy_version": policy_version,
+            "rule_ids": list(rule_ids),
+            "error_displayed": True,
+        }
+        if receipt_id is not None:
+            payload["receipt_id"] = receipt_id
+        return payload

--- a/src/gaia/governance/policy_binding.py
+++ b/src/gaia/governance/policy_binding.py
@@ -1,0 +1,39 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Static PolicyBinding reference implementation.
+
+Swap for constitutional-swarm's PolicyBinding once the policy control
+plane is in place. The receipt issuer depends on this to stamp
+policy-version + constitution-hash onto every decision.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .schemas import PolicyVersionRef, ReceiptRecord, utc_now_iso
+
+
+class StaticPolicyBindingService:
+    def __init__(
+        self,
+        version: str = "v0",
+        constitution_hash: str = "constitution-dev",
+    ) -> None:
+        self._current = PolicyVersionRef(
+            version=version,
+            constitution_hash=constitution_hash,
+            activated_at=utc_now_iso(),
+        )
+
+    def current_version(self) -> PolicyVersionRef:
+        return self._current
+
+    def bind_receipt(self, record: ReceiptRecord) -> ReceiptRecord:
+        return replace(
+            record,
+            policy_version=self._current.version,
+            metadata={
+                **record.metadata,
+                "constitution_hash": self._current.constitution_hash,
+            },
+        )

--- a/src/gaia/governance/protocols.py
+++ b/src/gaia/governance/protocols.py
@@ -1,0 +1,50 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Runtime-checkable protocol contracts for governance services.
+
+Keeping these as Protocols (not ABCs) lets downstream implementations
+live in ACGS-lite, constitutional-swarm, or GAIA itself without forcing
+an inheritance relationship.
+"""
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .schemas import (
+    ActionRequest,
+    CheckpointRecord,
+    CheckpointResolution,
+    GovernanceDecision,
+    PolicyVersionRef,
+    ReceiptRecord,
+    TransitionOutcome,
+    WorkflowTransition,
+)
+
+
+@runtime_checkable
+class PolicyEngine(Protocol):
+    def evaluate_action(self, action_request: ActionRequest) -> GovernanceDecision: ...
+
+
+@runtime_checkable
+class CheckpointRuntime(Protocol):
+    def create_checkpoint(
+        self, transition: WorkflowTransition, decision: GovernanceDecision
+    ) -> CheckpointRecord: ...
+
+    def resolve_checkpoint(
+        self, checkpoint_id: str, resolution: CheckpointResolution
+    ) -> TransitionOutcome: ...
+
+
+@runtime_checkable
+class ReceiptServiceProtocol(Protocol):
+    def issue_receipt(self, record: ReceiptRecord) -> str: ...
+
+    def get_receipt(self, receipt_id: str) -> ReceiptRecord: ...
+
+
+@runtime_checkable
+class PolicyBindingProtocol(Protocol):
+    def current_version(self) -> PolicyVersionRef: ...

--- a/src/gaia/governance/receipt_service.py
+++ b/src/gaia/governance/receipt_service.py
@@ -1,0 +1,98 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Receipt service reference implementations.
+
+Two variants are shipped:
+
+* :class:`InMemoryReceiptService` — ephemeral, for tests and in-process
+  inspection.
+* :class:`JsonlReceiptService` — append-only JSONL audit log on disk.
+  Survives process exit and is trivially tailable / grep-able. This is
+  the minimum viable shape for a real audit trail and is the default
+  in the governed example.
+
+Both implement :class:`gaia.governance.protocols.ReceiptServiceProtocol`.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from threading import Lock
+from typing import Iterator
+
+from .exceptions import GaiaGovernanceError
+from .schemas import ReceiptRecord
+
+
+class InMemoryReceiptService:
+    """Process-local receipt store. Lost on exit."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, ReceiptRecord] = {}
+
+    def issue_receipt(self, record: ReceiptRecord) -> str:
+        self._records[record.receipt_id] = record
+        return record.receipt_id
+
+    def get_receipt(self, receipt_id: str) -> ReceiptRecord:
+        try:
+            return self._records[receipt_id]
+        except KeyError as exc:
+            raise GaiaGovernanceError(f"receipt not found: {receipt_id}") from exc
+
+    def __iter__(self) -> Iterator[ReceiptRecord]:
+        return iter(self._records.values())
+
+
+class JsonlReceiptService:
+    """Append-only JSONL receipt log on disk.
+
+    Each receipt is serialized as one JSON object per line. Opens the
+    file in append mode, flushes on every write, and uses a process-local
+    lock so concurrent in-process callers don't interleave lines.
+
+    Intentionally not cross-process safe — use a dedicated receipt
+    service (e.g. a log-forwarder or database) for multi-process
+    deployments.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._cache: dict[str, ReceiptRecord] = {}
+        self._lock = Lock()
+
+    def issue_receipt(self, record: ReceiptRecord) -> str:
+        line = json.dumps(asdict(record), default=str, sort_keys=True)
+        with self._lock:
+            with self.path.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+                fh.flush()
+            self._cache[record.receipt_id] = record
+        return record.receipt_id
+
+    def get_receipt(self, receipt_id: str) -> ReceiptRecord:
+        if receipt_id in self._cache:
+            return self._cache[receipt_id]
+        # Cold-read path: scan the log. O(n) but acceptable for audit
+        # queries and avoids loading the whole log eagerly.
+        for record in self._read_all():
+            if record.receipt_id == receipt_id:
+                self._cache[receipt_id] = record
+                return record
+        raise GaiaGovernanceError(f"receipt not found: {receipt_id}")
+
+    def _read_all(self) -> Iterator[ReceiptRecord]:
+        if not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                yield ReceiptRecord(**data)
+
+    def __iter__(self) -> Iterator[ReceiptRecord]:
+        return self._read_all()

--- a/src/gaia/governance/schemas.py
+++ b/src/gaia/governance/schemas.py
@@ -1,0 +1,109 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Data classes shared across the governance layer.
+
+Ported from the gaia-acgs starter scaffold; these types are intentionally
+framework-agnostic dataclasses so they can be exchanged with ACGS-lite
+and constitutional-swarm without importing GAIA runtime symbols.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+DecisionType = Literal["ALLOW", "REVIEW", "BLOCK"]
+CheckpointStatus = Literal[
+    "OPEN", "APPROVED", "REJECTED", "ESCALATED", "TIMEOUT_REJECTED"
+]
+TransitionStatus = Literal["CONTINUE", "CHECKPOINT_OPEN", "TERMINATED", "RESUMED"]
+ResolutionType = Literal["APPROVE", "REJECT", "ESCALATE", "TIMEOUT_REJECT"]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:12]}"
+
+
+@dataclass(frozen=True, slots=True)
+class ActionRequest:
+    action_id: str
+    actor_id: str
+    tool_name: str
+    action_type: str
+    args: dict[str, Any]
+    risk_tags: list[str] = field(default_factory=list)
+    workflow_id: str | None = None
+    step_id: str | None = None
+    source: str = "gaia"
+
+
+@dataclass(frozen=True, slots=True)
+class GovernanceDecision:
+    decision: DecisionType
+    reason: str
+    policy_version: str
+    rule_ids: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowTransition:
+    workflow_id: str
+    transition_id: str
+    from_state: str
+    to_state: str
+    transition_type: str
+    related_action_id: str | None
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointRecord:
+    checkpoint_id: str
+    workflow_id: str
+    transition_id: str
+    status: CheckpointStatus
+    created_at: str
+    decision_context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointResolution:
+    resolution: ResolutionType
+    actor_id: str
+    reason: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionOutcome:
+    status: TransitionStatus
+    reason: str
+    checkpoint_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptRecord:
+    receipt_id: str
+    workflow_id: str
+    checkpoint_id: str | None
+    decision: str
+    policy_version: str
+    actor_id: str | None
+    validator_set_id: str | None
+    created_at: str
+    payload_hash: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyVersionRef:
+    version: str
+    constitution_hash: str
+    activated_at: str

--- a/src/gaia/governance/stubs.py
+++ b/src/gaia/governance/stubs.py
@@ -1,0 +1,46 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Stub policy engine for demos and tests.
+
+Real engines will come from ACGS-lite. This stub decides purely from
+``risk_tags`` on the :class:`ActionRequest`.
+"""
+from __future__ import annotations
+
+from .schemas import ActionRequest, GovernanceDecision
+
+
+class RuleBasedPolicyEngine:
+    """Tiny stub engine.
+
+    Rules:
+    - risk tag 'blocked' -> BLOCK
+    - risk tag 'review'  -> REVIEW
+    - otherwise          -> ALLOW
+    """
+
+    def __init__(self, policy_version: str = "v0") -> None:
+        self.policy_version = policy_version
+
+    def evaluate_action(self, action_request: ActionRequest) -> GovernanceDecision:
+        tags = set(action_request.risk_tags)
+        if "blocked" in tags:
+            return GovernanceDecision(
+                decision="BLOCK",
+                reason="blocked by policy",
+                policy_version=self.policy_version,
+                rule_ids=["rule:block"],
+            )
+        if "review" in tags:
+            return GovernanceDecision(
+                decision="REVIEW",
+                reason="requires operator review",
+                policy_version=self.policy_version,
+                rule_ids=["rule:review"],
+            )
+        return GovernanceDecision(
+            decision="ALLOW",
+            reason="allowed by policy",
+            policy_version=self.policy_version,
+            rule_ids=["rule:allow"],
+        )

--- a/src/gaia/governance/workflow_mapper.py
+++ b/src/gaia/governance/workflow_mapper.py
@@ -1,0 +1,29 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Maps a GAIA workflow event into a governance WorkflowTransition.
+
+Included in PR 1 as a future-hook seam for constitutional-swarm. The
+base agent loop does not currently emit workflow events; callers can
+use this mapper once such events exist.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .schemas import WorkflowTransition, new_id
+
+
+def map_gaia_event_to_transition(
+    event_name: str,
+    payload: dict[str, Any],
+    workflow_context: dict[str, Any],
+) -> WorkflowTransition:
+    return WorkflowTransition(
+        workflow_id=workflow_context["workflow_id"],
+        transition_id=workflow_context.get("transition_id", new_id("transition")),
+        from_state=workflow_context.get("from_state", "UNKNOWN"),
+        to_state=workflow_context.get("to_state", event_name.upper()),
+        transition_type=event_name,
+        related_action_id=workflow_context.get("related_action_id"),
+        payload=dict(payload),
+    )

--- a/tests/integration/test_governed_agent_workflow.py
+++ b/tests/integration/test_governed_agent_workflow.py
@@ -1,0 +1,127 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# pylint: disable=protected-access
+"""Integration test for GovernedAgentMixin + GaiaGovernanceAdapter.
+
+Uses a minimal fake base agent so the test does not depend on Lemonade
+or MCP. The goal is to prove that:
+
+1. Tool execution flows through the mixin unchanged when no adapter is set.
+2. An adapter with a BLOCK rule short-circuits tool execution.
+3. An ALLOW decision passes through to the underlying tool.
+4. The governance callback receives the decision.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from gaia.governance import (
+    GaiaGovernanceAdapter,
+    GovernedAgentMixin,
+)
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import InMemoryReceiptService
+from gaia.governance.stubs import RuleBasedPolicyEngine
+
+
+class _FakeAgent:
+    """Stand-in for gaia.Agent that records tool invocations.
+
+    The mixin's contract is purely that ``super()._execute_tool`` exists
+    and returns whatever the tool returns. This fake honors that contract
+    without pulling the full Agent runtime into the test.
+    """
+
+    def __init__(self, **_: Any) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _execute_tool(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+        self.calls.append((tool_name, dict(tool_args)))
+        return {"status": "ok", "tool": tool_name, "args": tool_args}
+
+
+class _GovernedFakeAgent(GovernedAgentMixin, _FakeAgent):
+    pass
+
+
+def _adapter() -> GaiaGovernanceAdapter:
+    return GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(),
+        checkpoint_runtime=InMemoryCheckpointBridge(),
+        receipt_service=InMemoryReceiptService(),
+        policy_binding=StaticPolicyBindingService(),
+    )
+
+
+def test_no_adapter_is_pure_pass_through():
+    agent = _GovernedFakeAgent()
+    result = agent._execute_tool("get_weather", {"city": "Austin"})
+    assert result["status"] == "ok"
+    assert agent.calls == [("get_weather", {"city": "Austin"})]
+
+
+def test_adapter_with_allow_decision_executes_tool():
+    seen: list[str] = []
+    agent = _GovernedFakeAgent(
+        governance_adapter=_adapter(),
+        governance_actor_id="tester",
+        governance_risk_tags={},  # nothing tagged -> ALLOW
+        governance_callback=lambda tn, *_: seen.append(tn),
+    )
+    result = agent._execute_tool("get_weather", {"city": "Austin"})
+    assert result["status"] == "ok"
+    assert agent.calls == [("get_weather", {"city": "Austin"})]
+    assert seen == ["get_weather"]
+
+
+def test_adapter_with_block_decision_short_circuits():
+    decisions: list[str] = []
+
+    def cb(_tn, _args, _action, decision):
+        decisions.append(decision.decision)
+
+    agent = _GovernedFakeAgent(
+        governance_adapter=_adapter(),
+        governance_risk_tags={"drop_table": ["blocked"]},
+        governance_callback=cb,
+    )
+    result = agent._execute_tool("drop_table", {"name": "users"})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "BLOCK"
+    assert "blocked by governance" in result["error"]
+    # tool was NOT invoked on the underlying agent
+    assert agent.calls == []
+    assert decisions == ["BLOCK"]
+
+
+def test_review_decision_without_reviewer_fails_closed():
+    decisions: list[str] = []
+
+    def cb(_tn, _args, _action, decision):
+        decisions.append(decision.decision)
+
+    agent = _GovernedFakeAgent(
+        governance_adapter=_adapter(),
+        governance_risk_tags={"publish_post": ["review"]},
+        governance_callback=cb,
+    )
+    result = agent._execute_tool("publish_post", {"body": "hi"})
+    # No reviewer + no console -> REVIEW fails closed.
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "REVIEW_REJECTED"
+    assert agent.calls == []
+    # Callback still sees the original REVIEW decision.
+    assert decisions == ["REVIEW"]
+
+
+def test_callback_exception_does_not_break_execution():
+    def boom(*_a, **_kw):
+        raise RuntimeError("callback exploded")
+
+    agent = _GovernedFakeAgent(
+        governance_adapter=_adapter(),
+        governance_callback=boom,
+    )
+    result = agent._execute_tool("get_weather", {"city": "Austin"})
+    assert result["status"] == "ok"

--- a/tests/integration/test_governed_canonical_name.py
+++ b/tests/integration/test_governed_canonical_name.py
@@ -1,0 +1,84 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# pylint: disable=protected-access
+"""HIGH-2 regression: canonical tool name resolution before governance.
+
+If governance checks risk tags against the raw LLM-supplied name, a
+model can bypass a blocked MCP tool by calling the unprefixed alias
+(``get_current_time`` instead of ``mcp_time_get_current_time``). The
+mixin must resolve through the base Agent's ``_resolve_tool_name``
+before building the ActionRequest.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from gaia.governance import GaiaGovernanceAdapter, GovernedAgentMixin
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import InMemoryReceiptService
+from gaia.governance.stubs import RuleBasedPolicyEngine
+
+
+class _FakeAgentWithResolver:
+    """Stand-in that mirrors GAIA's alias-resolution behavior."""
+
+    ALIAS_MAP = {"get_current_time": "mcp_time_get_current_time"}
+
+    def __init__(self, **_: Any) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _resolve_tool_name(self, tool_name: str) -> str | None:
+        return self.ALIAS_MAP.get(tool_name)
+
+    def _execute_tool(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+        # Mirror base Agent: resolve alias internally before running
+        canonical = self.ALIAS_MAP.get(tool_name, tool_name)
+        self.calls.append((canonical, dict(tool_args)))
+        return {"status": "ok", "tool": canonical}
+
+
+class _GovernedFakeWithResolver(GovernedAgentMixin, _FakeAgentWithResolver):
+    pass
+
+
+def _adapter():
+    return GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(),
+        checkpoint_runtime=InMemoryCheckpointBridge(),
+        receipt_service=InMemoryReceiptService(),
+        policy_binding=StaticPolicyBindingService(),
+    )
+
+
+def test_unprefixed_alias_is_governed_under_canonical_name():
+    agent = _GovernedFakeWithResolver(
+        governance_adapter=_adapter(),
+        governance_risk_tags={"mcp_time_get_current_time": ["blocked"]},
+    )
+    # LLM calls the unprefixed alias; governance must still block.
+    result = agent._execute_tool("get_current_time", {})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "BLOCK"
+    assert agent.calls == []
+
+
+def test_raw_name_still_governed_directly():
+    agent = _GovernedFakeWithResolver(
+        governance_adapter=_adapter(),
+        governance_risk_tags={"mcp_time_get_current_time": ["blocked"]},
+    )
+    result = agent._execute_tool("mcp_time_get_current_time", {})
+    assert result["status"] == "denied"
+    assert agent.calls == []
+
+
+def test_unresolved_name_falls_through_to_raw():
+    # A tool with no alias mapping must still be governable by its
+    # own name.
+    agent = _GovernedFakeWithResolver(
+        governance_adapter=_adapter(),
+        governance_risk_tags={"never_heard_of_it": ["blocked"]},
+    )
+    result = agent._execute_tool("never_heard_of_it", {})
+    assert result["status"] == "denied"

--- a/tests/integration/test_governed_real_agent.py
+++ b/tests/integration/test_governed_real_agent.py
@@ -1,0 +1,112 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# pylint: disable=protected-access
+"""Integration test: GovernedAgentMixin against the real gaia.Agent class.
+
+The full ``Agent.__init__`` starts Lemonade / MCP, which we don't want
+to depend on in a unit-level gate. This test proves the mixin's MRO
+binds correctly against the real class by:
+
+1. Building a ``GovernedAgentMixin + gaia.Agent`` subclass.
+2. Instantiating via ``__new__`` and setting only the state
+   ``_execute_tool`` actually reads (``console`` for confirmation gate,
+   the governance state attributes).
+3. Registering a real ``@tool`` and calling ``_execute_tool`` through
+   the mixin, verifying BLOCK short-circuits and ALLOW reaches the tool.
+
+If this test ever breaks, the mixin's contract with the real Agent has
+regressed — long before anyone runs the full interactive demo.
+"""
+from __future__ import annotations
+
+from gaia import Agent, tool
+from gaia.governance import (
+    GaiaGovernanceAdapter,
+    GovernedAgentMixin,
+)
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import InMemoryReceiptService
+from gaia.governance.stubs import RuleBasedPolicyEngine
+
+
+@tool
+def _governed_real_agent_probe(x: int = 1) -> dict:
+    """Minimal tool used only by this test."""
+    return {"status": "ok", "x": x}
+
+
+class _StubConsole:
+    """Minimal console stand-in to satisfy the confirmation gate path."""
+
+    def confirm_tool_execution(self, _tool_name, _tool_args):
+        return True
+
+
+class _GovernedRealAgent(GovernedAgentMixin, Agent):
+    """Real Agent subclass with the governance mixin mixed in."""
+
+    def _register_tools(self) -> None:
+        # Abstract on Agent; no-op here because we bypass __init__ and
+        # rely on the module-level tool registry populated by @tool.
+        return None
+
+    def _get_system_prompt(self) -> str:  # pragma: no cover - unused
+        return ""
+
+
+def _build_agent(adapter: GaiaGovernanceAdapter | None, risk_tags: dict):
+    """Build a _GovernedRealAgent bypassing __init__ (no Lemonade/MCP)."""
+    agent = _GovernedRealAgent.__new__(_GovernedRealAgent)
+    # Governance state that the mixin reads.
+    agent.governance_adapter = adapter
+    agent._governance_actor_id = "real-agent-test"
+    agent._governance_workflow_id = "wf_real"
+    agent._governance_risk_tags = risk_tags
+    agent._governance_callback = None
+    # Minimal Agent state touched by _execute_tool.
+    agent.console = _StubConsole()
+    agent.error_history = []
+    agent._current_query = None
+    agent.current_plan = None
+    agent.current_step = 0
+    agent.total_plan_steps = 0
+    return agent
+
+
+def _adapter() -> GaiaGovernanceAdapter:
+    return GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(),
+        checkpoint_runtime=InMemoryCheckpointBridge(),
+        receipt_service=InMemoryReceiptService(),
+        policy_binding=StaticPolicyBindingService(),
+    )
+
+
+def test_mro_places_mixin_before_agent():
+    mro = _GovernedRealAgent.__mro__
+    names = [c.__name__ for c in mro]
+    assert names.index("GovernedAgentMixin") < names.index("Agent")
+
+
+def test_mixin_passes_through_to_real_agent_when_no_adapter():
+    agent = _build_agent(adapter=None, risk_tags={})
+    result = agent._execute_tool("_governed_real_agent_probe", {"x": 7})
+    assert result == {"status": "ok", "x": 7}
+
+
+def test_block_decision_short_circuits_real_agent():
+    agent = _build_agent(
+        adapter=_adapter(),
+        risk_tags={"_governed_real_agent_probe": ["blocked"]},
+    )
+    result = agent._execute_tool("_governed_real_agent_probe", {"x": 9})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "BLOCK"
+    assert "blocked by governance" in result["error"]
+
+
+def test_allow_decision_reaches_real_tool_registry():
+    agent = _build_agent(adapter=_adapter(), risk_tags={})  # no tags -> ALLOW
+    result = agent._execute_tool("_governed_real_agent_probe", {"x": 42})
+    assert result == {"status": "ok", "x": 42}

--- a/tests/integration/test_governed_review_flow.py
+++ b/tests/integration/test_governed_review_flow.py
@@ -1,0 +1,163 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# pylint: disable=protected-access,attribute-defined-outside-init
+"""Integration test for the REVIEW checkpoint flow.
+
+Proves that when a policy returns REVIEW, the mixin opens a checkpoint,
+asks a reviewer, records a receipt for the resolution, and either runs
+or denies the tool based on the reviewer's response.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from gaia.governance import (
+    GaiaGovernanceAdapter,
+    GovernedAgentMixin,
+)
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import InMemoryReceiptService
+from gaia.governance.stubs import RuleBasedPolicyEngine
+
+
+class _FakeAgent:
+    def __init__(self, **_: Any) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _execute_tool(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+        self.calls.append((tool_name, dict(tool_args)))
+        return {"status": "ok", "tool": tool_name}
+
+
+class _GovernedFakeAgent(GovernedAgentMixin, _FakeAgent):
+    pass
+
+
+class _StubConsoleAccept:
+    """Represents a console that WOULD approve — but must not be used
+    as an implicit reviewer. Kept to prove the console is now ignored."""
+
+    def confirm_tool_execution(self, _tn, _args):
+        return True
+
+
+def _build_adapter():
+    receipts = InMemoryReceiptService()
+    adapter = GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(),
+        checkpoint_runtime=InMemoryCheckpointBridge(),
+        receipt_service=receipts,
+        policy_binding=StaticPolicyBindingService(),
+    )
+    return adapter, receipts
+
+
+def test_review_with_explicit_approver_runs_tool_and_records_receipt():
+    adapter, receipts = _build_adapter()
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"publish_post": ["review"]},
+        governance_reviewer=lambda *_a, **_kw: True,
+    )
+    result = agent._execute_tool("publish_post", {"body": "hi"})
+    assert result["status"] == "ok"
+    assert agent.calls == [("publish_post", {"body": "hi"})]
+    # one receipt (APPROVE) recorded
+    receipts_list = list(receipts)
+    assert len(receipts_list) == 1
+    assert receipts_list[0].decision == "APPROVE"
+
+
+def test_review_with_explicit_rejecter_denies_and_records_receipt():
+    adapter, receipts = _build_adapter()
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"publish_post": ["review"]},
+        governance_reviewer=lambda *_a, **_kw: False,
+    )
+    result = agent._execute_tool("publish_post", {"body": "hi"})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "REVIEW_REJECTED"
+    assert result["receipt_id"].startswith("rcpt_")
+    assert agent.calls == []
+    receipts_list = list(receipts)
+    assert len(receipts_list) == 1
+    assert receipts_list[0].decision == "REJECT"
+
+
+def test_review_ignores_default_console_and_fails_closed():
+    # HIGH-1 regression: GAIA's default AgentConsole.confirm_tool_execution
+    # returns True, so treating it as an implicit reviewer would
+    # auto-approve. The mixin must NOT use the console unless the caller
+    # explicitly opts in via governance_reviewer.
+    adapter, _ = _build_adapter()
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"publish_post": ["review"]},
+    )
+    agent.console = _StubConsoleAccept()  # would approve if consulted
+    result = agent._execute_tool("publish_post", {"body": "hi"})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "REVIEW_REJECTED"
+    assert agent.calls == []
+
+
+def test_review_honors_explicit_reviewer_that_delegates_to_console():
+    # Opt-in path: caller wraps the console explicitly, which is safe
+    # because they've verified their console actually blocks.
+    adapter, _ = _build_adapter()
+    console = _StubConsoleAccept()
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"publish_post": ["review"]},
+        governance_reviewer=lambda tn, args, _d: console.confirm_tool_execution(
+            tn, args
+        ),
+    )
+    result = agent._execute_tool("publish_post", {"body": "hi"})
+    assert result["status"] == "ok"
+
+
+def test_review_fails_closed_when_no_reviewer():
+    adapter, _ = _build_adapter()
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"publish_post": ["review"]},
+    )
+    # no console, no reviewer -> deny
+    result = agent._execute_tool("publish_post", {"body": "hi"})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "REVIEW_REJECTED"
+    assert agent.calls == []
+
+
+def test_block_decision_records_receipt_and_returns_receipt_id():
+    adapter, receipts = _build_adapter()
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"drop_table": ["blocked"]},
+    )
+    result = agent._execute_tool("drop_table", {"name": "users"})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "BLOCK"
+    assert result["receipt_id"].startswith("rcpt_")
+    receipts_list = list(receipts)
+    assert len(receipts_list) == 1
+    assert receipts_list[0].decision == "BLOCK"
+
+
+def test_reviewer_exception_is_treated_as_reject():
+    adapter, _ = _build_adapter()
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("bad reviewer")
+
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"publish_post": ["review"]},
+        governance_reviewer=boom,
+    )
+    result = agent._execute_tool("publish_post", {"body": "hi"})
+    assert result["status"] == "denied"
+    assert agent.calls == []

--- a/tests/integration/test_governed_workflow_binding.py
+++ b/tests/integration/test_governed_workflow_binding.py
@@ -1,0 +1,128 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""MED-4 regression: checkpoint resolution is workflow-bound.
+
+A caller must not be able to resolve checkpoint ``A`` under an arbitrary
+workflow_id ``B`` and have a receipt issued under workflow B. The
+adapter validates the checkpoint's stored workflow against the
+caller-supplied workflow_id before resolving.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from gaia.governance import (
+    CheckpointResolution,
+    GaiaGovernanceAdapter,
+    InvalidResolutionError,
+    WorkflowTransition,
+)
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import InMemoryReceiptService
+from gaia.governance.schemas import ActionRequest
+from gaia.governance.stubs import RuleBasedPolicyEngine
+
+
+def _make():
+    receipts = InMemoryReceiptService()
+    bridge = InMemoryCheckpointBridge()
+    adapter = GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(),
+        checkpoint_runtime=bridge,
+        receipt_service=receipts,
+        policy_binding=StaticPolicyBindingService(),
+    )
+    return adapter, receipts, bridge
+
+
+def _review_action(workflow_id: str) -> ActionRequest:
+    return ActionRequest(
+        action_id="a1",
+        actor_id="actor",
+        tool_name="t",
+        action_type="t",
+        args={},
+        risk_tags=["review"],
+        workflow_id=workflow_id,
+    )
+
+
+def _transition(workflow_id: str) -> WorkflowTransition:
+    return WorkflowTransition(
+        workflow_id=workflow_id,
+        transition_id="tx1",
+        from_state="S",
+        to_state="R",
+        transition_type="tool_call",
+        related_action_id="a1",
+    )
+
+
+def test_resolve_with_mismatched_workflow_id_is_rejected():
+    adapter, _, _ = _make()
+    opened = adapter.handle_transition(
+        _transition("wf_A"),
+        adapter.govern_action(_review_action("wf_A")),
+    )
+    with pytest.raises(InvalidResolutionError):
+        adapter.resolve_checkpoint(
+            opened.checkpoint_id,
+            CheckpointResolution(resolution="APPROVE", actor_id="mallory"),
+            workflow_id="wf_B",
+        )
+
+
+def test_resolve_with_correct_workflow_id_succeeds():
+    adapter, _, _ = _make()
+    opened = adapter.handle_transition(
+        _transition("wf_A"),
+        adapter.govern_action(_review_action("wf_A")),
+    )
+    outcome = adapter.resolve_checkpoint(
+        opened.checkpoint_id,
+        CheckpointResolution(resolution="APPROVE", actor_id="alice"),
+        workflow_id="wf_A",
+    )
+    assert outcome.status == "RESUMED"
+
+
+def test_concurrent_double_resolution_only_one_wins():
+    # MED-5 regression: the checkpoint bridge uses a lock so only one
+    # of two concurrent resolutions produces a terminal outcome; the
+    # other raises InvalidResolutionError.
+    adapter, _, _ = _make()
+    opened = adapter.handle_transition(
+        _transition("wf_race"),
+        adapter.govern_action(_review_action("wf_race")),
+    )
+
+    outcomes: list = []
+    errors: list = []
+
+    def attempt(tag: str):
+        try:
+            outcomes.append(
+                adapter.resolve_checkpoint(
+                    opened.checkpoint_id,
+                    CheckpointResolution(resolution="APPROVE", actor_id=tag),
+                    workflow_id="wf_race",
+                )
+            )
+        except InvalidResolutionError as exc:  # expected for loser
+            errors.append(exc)
+
+    t1 = threading.Thread(target=attempt, args=("t1",))
+    t2 = threading.Thread(target=attempt, args=("t2",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    # exactly one success, one InvalidResolutionError
+    assert len(outcomes) == 1
+    assert len(errors) == 1
+    # keep timing-sensitive assertions robust on slow machines
+    _ = time  # silence unused-import when we don't need a sleep path

--- a/tests/unit/test_governance_adapter.py
+++ b/tests/unit/test_governance_adapter.py
@@ -1,0 +1,102 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for GaiaGovernanceAdapter."""
+from __future__ import annotations
+
+from gaia.governance import (
+    ActionRequest,
+    CheckpointResolution,
+    GaiaGovernanceAdapter,
+    WorkflowTransition,
+)
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import InMemoryReceiptService
+from gaia.governance.stubs import RuleBasedPolicyEngine
+
+
+def _adapter() -> GaiaGovernanceAdapter:
+    return GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(),
+        checkpoint_runtime=InMemoryCheckpointBridge(),
+        receipt_service=InMemoryReceiptService(),
+        policy_binding=StaticPolicyBindingService(),
+    )
+
+
+def _action(tool_name: str, risk_tags: list[str]) -> ActionRequest:
+    return ActionRequest(
+        action_id="a1",
+        actor_id="actor",
+        tool_name=tool_name,
+        action_type=tool_name,
+        args={},
+        risk_tags=risk_tags,
+        workflow_id="wf_test",
+    )
+
+
+def _transition() -> WorkflowTransition:
+    return WorkflowTransition(
+        workflow_id="wf_test",
+        transition_id="t1",
+        from_state="START",
+        to_state="RUN",
+        transition_type="tool_call",
+        related_action_id="a1",
+    )
+
+
+def test_allow_decision_is_pass_through():
+    adapter = _adapter()
+    decision = adapter.govern_action(_action("get_weather", []))
+    assert decision.decision == "ALLOW"
+
+
+def test_block_decision_for_blocked_tag():
+    adapter = _adapter()
+    decision = adapter.govern_action(_action("drop_table", ["blocked"]))
+    assert decision.decision == "BLOCK"
+    assert decision.policy_version == "v0"
+
+
+def test_review_decision_for_review_tag():
+    adapter = _adapter()
+    decision = adapter.govern_action(_action("publish_post", ["review"]))
+    assert decision.decision == "REVIEW"
+
+
+def test_handle_transition_allow_continues():
+    adapter = _adapter()
+    decision = adapter.govern_action(_action("get_weather", []))
+    outcome = adapter.handle_transition(_transition(), decision)
+    assert outcome.status == "CONTINUE"
+
+
+def test_handle_transition_block_issues_receipt():
+    adapter = _adapter()
+    decision = adapter.govern_action(_action("delete_all", ["blocked"]))
+    outcome = adapter.handle_transition(_transition(), decision)
+    assert outcome.status == "TERMINATED"
+    assert "receipt_id" in outcome.metadata
+
+
+def test_handle_transition_review_opens_checkpoint():
+    adapter = _adapter()
+    decision = adapter.govern_action(_action("publish_post", ["review"]))
+    outcome = adapter.handle_transition(_transition(), decision)
+    assert outcome.status == "CHECKPOINT_OPEN"
+    assert outcome.checkpoint_id is not None
+
+
+def test_resolve_checkpoint_approve_resumes_and_records_receipt():
+    adapter = _adapter()
+    decision = adapter.govern_action(_action("publish_post", ["review"]))
+    opened = adapter.handle_transition(_transition(), decision)
+    outcome = adapter.resolve_checkpoint(
+        opened.checkpoint_id,
+        CheckpointResolution(resolution="APPROVE", actor_id="reviewer", reason="ok"),
+        workflow_id="wf_test",
+    )
+    assert outcome.status == "RESUMED"
+    assert "receipt_id" in outcome.metadata

--- a/tests/unit/test_governance_dx.py
+++ b/tests/unit/test_governance_dx.py
@@ -1,0 +1,149 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# pylint: disable=protected-access
+"""Tests for the DX ergonomic surfaces: `.default()`, GovernanceConfig, @govern."""
+from __future__ import annotations
+
+from typing import Any
+
+from gaia import tool
+from gaia.governance import (
+    GaiaGovernanceAdapter,
+    GovernanceConfig,
+    GovernedAgentMixin,
+    govern,
+    read_risk_tags,
+)
+
+
+@tool
+@govern(risk="blocked", reason="dx test blocked")
+def _dx_decorated_blocked(x: int = 1) -> dict:
+    return {"x": x}
+
+
+@tool
+@govern(risk=["review", "slow"])
+def _dx_decorated_review(x: int = 1) -> dict:
+    return {"x": x}
+
+
+class _FakeAgent:
+    def __init__(self, **_: Any) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def _execute_tool(self, tool_name, tool_args):
+        self.calls.append((tool_name, dict(tool_args)))
+        return {"status": "ok"}
+
+
+class _GovernedFakeAgent(GovernedAgentMixin, _FakeAgent):
+    pass
+
+
+# ---- GaiaGovernanceAdapter.default() ------------------------------------
+
+
+def test_default_adapter_uses_inmemory_when_audit_log_is_none():
+    adapter = GaiaGovernanceAdapter.default(audit_log=None)
+    # Satisfies all four protocols with ready instances.
+    assert adapter.policy_engine is not None
+    assert adapter.checkpoint_runtime is not None
+    assert adapter.receipt_service is not None
+    assert adapter.policy_binding is not None
+
+
+def test_default_adapter_writes_jsonl_when_path_given(tmp_path):
+    path = tmp_path / "r.jsonl"
+    adapter = GaiaGovernanceAdapter.default(audit_log=str(path))
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"t": ["blocked"]},
+    )
+    agent._execute_tool("t", {})
+    assert path.exists()
+    assert path.read_text(encoding="utf-8").strip() != ""
+
+
+# ---- GovernanceConfig ----------------------------------------------------
+
+
+def test_governance_config_drives_mixin_the_same_as_kwargs():
+    adapter = GaiaGovernanceAdapter.default(audit_log=None)
+    config = GovernanceConfig(
+        adapter=adapter,
+        actor_id="alice",
+        risk_tags={"drop_table": ["blocked"]},
+    )
+    agent = _GovernedFakeAgent(governance=config)
+    assert agent.governance_adapter is adapter
+    assert agent._governance_actor_id == "alice"
+    assert agent._governance_risk_tags == {"drop_table": ["blocked"]}
+
+    result = agent._execute_tool("drop_table", {})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "BLOCK"
+
+
+def test_kwargs_style_still_works_for_backward_compat():
+    adapter = GaiaGovernanceAdapter.default(audit_log=None)
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_actor_id="bob",
+        governance_risk_tags={"x": ["blocked"]},
+    )
+    assert agent._governance_actor_id == "bob"
+    assert agent._governance_risk_tags == {"x": ["blocked"]}
+
+
+# ---- @govern decorator ---------------------------------------------------
+
+
+def test_govern_decorator_sets_risk_tags_attribute():
+    assert read_risk_tags(_dx_decorated_blocked) == ["blocked"]
+    assert read_risk_tags(_dx_decorated_review) == ["review", "slow"]
+
+
+def test_govern_decorator_stacks_without_duplicates():
+    @govern(risk="blocked")
+    @govern(risk="blocked")
+    @govern(risk="audit")
+    def fn():  # pragma: no cover
+        return None
+
+    # inner-to-outer: audit first, then blocked (deduped)
+    assert read_risk_tags(fn) == ["audit", "blocked"]
+
+
+def test_mixin_reads_decorated_tags_from_registry():
+    adapter = GaiaGovernanceAdapter.default(audit_log=None)
+    agent = _GovernedFakeAgent(governance_adapter=adapter)
+    # No explicit risk_tags dict; tags come purely from @govern decorator.
+    result = agent._execute_tool("_dx_decorated_blocked", {})
+    assert result["status"] == "denied"
+    assert result["governance_decision"] == "BLOCK"
+    assert agent.calls == []
+
+
+def test_explicit_dict_overrides_decorated_tags():
+    adapter = GaiaGovernanceAdapter.default(audit_log=None)
+    # Decorator says "blocked" but explicit dict downgrades to no tags ->
+    # ALLOW. Use case: ops override during incident.
+    agent = _GovernedFakeAgent(
+        governance_adapter=adapter,
+        governance_risk_tags={"_dx_decorated_blocked": []},
+    )
+    # Merged tags will be ["blocked"] (from decorator) + [] (explicit).
+    # With the current merge rule (union, dedup), explicit-empty does
+    # NOT downgrade. Document this as "additive only" — tightening in
+    # a future revision if needed.
+    result = agent._execute_tool("_dx_decorated_blocked", {})
+    assert result["status"] == "denied"  # decorator tag still applies
+
+
+def test_read_risk_tags_handles_missing_attribute():
+    def plain():  # pragma: no cover
+        return None
+
+    assert read_risk_tags(plain) == []
+    assert read_risk_tags(None) == []

--- a/tests/unit/test_governance_jsonl_receipts.py
+++ b/tests/unit/test_governance_jsonl_receipts.py
@@ -1,0 +1,73 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for JsonlReceiptService."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gaia.governance import GaiaGovernanceError
+from gaia.governance.receipt_service import JsonlReceiptService
+from gaia.governance.schemas import ReceiptRecord
+
+
+def _record(rid: str = "rcpt_test_1") -> ReceiptRecord:
+    return ReceiptRecord(
+        receipt_id=rid,
+        workflow_id="wf_1",
+        checkpoint_id=None,
+        decision="BLOCK",
+        policy_version="v0",
+        actor_id="alice",
+        validator_set_id=None,
+        created_at="2026-04-19T00:00:00+00:00",
+        payload_hash="deadbeef",
+        metadata={"constitution_hash": "c1"},
+    )
+
+
+def test_issue_writes_one_line_per_receipt(tmp_path):
+    path = tmp_path / "receipts.jsonl"
+    svc = JsonlReceiptService(path)
+    svc.issue_receipt(_record("rcpt_a"))
+    svc.issue_receipt(_record("rcpt_b"))
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    parsed = [json.loads(line) for line in lines]
+    assert {p["receipt_id"] for p in parsed} == {"rcpt_a", "rcpt_b"}
+
+
+def test_get_receipt_reads_from_cache_and_disk(tmp_path):
+    path = tmp_path / "audit.jsonl"
+    svc = JsonlReceiptService(path)
+    svc.issue_receipt(_record("rcpt_cached"))
+
+    # Fresh service on same file must still find the receipt via cold read.
+    svc2 = JsonlReceiptService(path)
+    got = svc2.get_receipt("rcpt_cached")
+    assert got.receipt_id == "rcpt_cached"
+    assert got.decision == "BLOCK"
+
+
+def test_missing_receipt_raises(tmp_path):
+    svc = JsonlReceiptService(tmp_path / "none.jsonl")
+    with pytest.raises(GaiaGovernanceError):
+        svc.get_receipt("rcpt_missing")
+
+
+def test_iter_yields_all_records(tmp_path):
+    svc = JsonlReceiptService(tmp_path / "r.jsonl")
+    svc.issue_receipt(_record("rcpt_1"))
+    svc.issue_receipt(_record("rcpt_2"))
+    svc.issue_receipt(_record("rcpt_3"))
+    seen = {r.receipt_id for r in svc}
+    assert seen == {"rcpt_1", "rcpt_2", "rcpt_3"}
+
+
+def test_parent_directory_auto_created(tmp_path):
+    path = tmp_path / "nested" / "deeper" / "r.jsonl"
+    svc = JsonlReceiptService(path)
+    svc.issue_receipt(_record("rcpt_nested"))
+    assert path.exists()
+    assert path.parent.is_dir()

--- a/tests/unit/test_governance_receipts.py
+++ b/tests/unit/test_governance_receipts.py
@@ -1,0 +1,142 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for receipt issuance and policy-version binding."""
+from __future__ import annotations
+
+import pytest
+
+from gaia.governance import (
+    CheckpointResolution,
+    GaiaGovernanceAdapter,
+    GaiaGovernanceError,
+    WorkflowTransition,
+)
+from gaia.governance.checkpoint_bridge import InMemoryCheckpointBridge
+from gaia.governance.policy_binding import StaticPolicyBindingService
+from gaia.governance.receipt_service import InMemoryReceiptService
+from gaia.governance.schemas import ActionRequest, ReceiptRecord
+from gaia.governance.stubs import RuleBasedPolicyEngine
+
+
+def _make_adapter(policy_version: str = "v0", constitution_hash: str = "c1"):
+    receipts = InMemoryReceiptService()
+    binding = StaticPolicyBindingService(
+        version=policy_version, constitution_hash=constitution_hash
+    )
+    adapter = GaiaGovernanceAdapter(
+        policy_engine=RuleBasedPolicyEngine(policy_version=policy_version),
+        checkpoint_runtime=InMemoryCheckpointBridge(),
+        receipt_service=receipts,
+        policy_binding=binding,
+    )
+    return adapter, receipts
+
+
+def _action(tool: str, tags: list[str]) -> ActionRequest:
+    return ActionRequest(
+        action_id="a1",
+        actor_id="actor",
+        tool_name=tool,
+        action_type=tool,
+        args={},
+        risk_tags=tags,
+        workflow_id="wf_rcpt",
+    )
+
+
+def _transition() -> WorkflowTransition:
+    return WorkflowTransition(
+        workflow_id="wf_rcpt",
+        transition_id="t1",
+        from_state="S",
+        to_state="R",
+        transition_type="tool_call",
+        related_action_id="a1",
+    )
+
+
+def test_block_decision_persists_receipt_with_policy_binding():
+    adapter, receipts = _make_adapter(policy_version="v0", constitution_hash="c_hash")
+    decision = adapter.govern_action(_action("bad", ["blocked"]))
+    outcome = adapter.handle_transition(_transition(), decision)
+    receipt_id = outcome.metadata["receipt_id"]
+    record = receipts.get_receipt(receipt_id)
+    assert isinstance(record, ReceiptRecord)
+    assert record.policy_version == "v0"
+    assert record.metadata["constitution_hash"] == "c_hash"
+    assert record.decision == "BLOCK"
+
+
+def test_resolve_checkpoint_records_receipt_for_approved_review():
+    adapter, receipts = _make_adapter()
+    opened = adapter.handle_transition(
+        _transition(),
+        adapter.govern_action(_action("needs_review", ["review"])),
+    )
+    outcome = adapter.resolve_checkpoint(
+        opened.checkpoint_id,
+        CheckpointResolution(
+            resolution="APPROVE", actor_id="reviewer", reason="looks good"
+        ),
+        workflow_id="wf_rcpt",
+    )
+    record = receipts.get_receipt(outcome.metadata["receipt_id"])
+    assert record.decision == "APPROVE"
+    assert record.checkpoint_id == opened.checkpoint_id
+    assert record.actor_id == "reviewer"
+
+
+def test_payload_hash_differs_per_receipt_because_envelope_is_unique():
+    # The payload_hash covers the full evidence envelope including
+    # receipt_id and created_at, so two logically-identical decisions
+    # produce distinct hashes. Tamper-evidence, not de-duplication.
+    adapter, receipts = _make_adapter()
+    a = adapter.handle_transition(
+        _transition(),
+        adapter.govern_action(_action("bad", ["blocked"])),
+    )
+    b = adapter.handle_transition(
+        _transition(),
+        adapter.govern_action(_action("bad", ["blocked"])),
+    )
+    ra = receipts.get_receipt(a.metadata["receipt_id"])
+    rb = receipts.get_receipt(b.metadata["receipt_id"])
+    assert ra.payload_hash != rb.payload_hash
+    assert ra.receipt_id != rb.receipt_id
+
+
+def test_payload_hash_changes_when_policy_version_changes():
+    adapter_v0, receipts_v0 = _make_adapter(policy_version="v0")
+    adapter_v1, receipts_v1 = _make_adapter(policy_version="v1")
+    outcome_v0 = adapter_v0.handle_transition(
+        _transition(),
+        adapter_v0.govern_action(_action("bad", ["blocked"])),
+    )
+    outcome_v1 = adapter_v1.handle_transition(
+        _transition(),
+        adapter_v1.govern_action(_action("bad", ["blocked"])),
+    )
+    r0 = receipts_v0.get_receipt(outcome_v0.metadata["receipt_id"])
+    r1 = receipts_v1.get_receipt(outcome_v1.metadata["receipt_id"])
+    assert r0.policy_version != r1.policy_version
+    assert r0.payload_hash != r1.payload_hash
+
+
+def test_payload_hash_changes_when_constitution_hash_changes():
+    a0, r0 = _make_adapter(constitution_hash="c_a")
+    a1, r1 = _make_adapter(constitution_hash="c_b")
+    o0 = a0.handle_transition(
+        _transition(), a0.govern_action(_action("bad", ["blocked"]))
+    )
+    o1 = a1.handle_transition(
+        _transition(), a1.govern_action(_action("bad", ["blocked"]))
+    )
+    rec0 = r0.get_receipt(o0.metadata["receipt_id"])
+    rec1 = r1.get_receipt(o1.metadata["receipt_id"])
+    assert rec0.payload_hash != rec1.payload_hash
+
+
+def test_missing_receipt_raises():
+    receipts = InMemoryReceiptService()
+    with pytest.raises(GaiaGovernanceError):
+        receipts.get_receipt("rcpt_does_not_exist")

--- a/tests/unit/test_governance_schemas.py
+++ b/tests/unit/test_governance_schemas.py
@@ -1,0 +1,79 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.governance.schemas and gaia.governance.action_mapper."""
+from __future__ import annotations
+
+import pytest
+
+from gaia.governance import (
+    ActionRequest,
+    GovernanceDecision,
+    map_gaia_tool_call_to_action_request,
+    new_id,
+    utc_now_iso,
+)
+
+
+def test_new_id_has_prefix_and_is_unique():
+    a = new_id("action")
+    b = new_id("action")
+    assert a.startswith("action_") and b.startswith("action_")
+    assert a != b
+
+
+def test_utc_now_iso_is_iso_formatted():
+    value = utc_now_iso()
+    # crude but sufficient: must include T and either +00:00 or Z
+    assert "T" in value
+    assert value.endswith("+00:00") or value.endswith("Z")
+
+
+def test_action_request_defaults_and_frozen():
+    req = ActionRequest(
+        action_id="a1",
+        actor_id="actor",
+        tool_name="tool",
+        action_type="tool",
+        args={"x": 1},
+    )
+    assert req.risk_tags == []
+    assert req.source == "gaia"
+    assert req.workflow_id is None
+    with pytest.raises(AttributeError):
+        req.actor_id = "other"  # frozen
+
+
+def test_governance_decision_frozen_and_metadata_default():
+    d = GovernanceDecision(
+        decision="ALLOW",
+        reason="ok",
+        policy_version="v0",
+    )
+    assert d.metadata == {}
+    assert d.rule_ids == []
+
+
+def test_action_mapper_applies_context_and_defaults():
+    req = map_gaia_tool_call_to_action_request(
+        "get_weather",
+        {"city": "Austin"},
+        {
+            "actor_id": "alice",
+            "workflow_id": "wf_1",
+            "risk_tags": ["read-only"],
+        },
+    )
+    assert req.tool_name == "get_weather"
+    assert req.actor_id == "alice"
+    assert req.workflow_id == "wf_1"
+    assert req.risk_tags == ["read-only"]
+    assert req.source == "gaia"
+    assert req.args == {"city": "Austin"}
+
+
+def test_action_mapper_defaults_when_context_missing():
+    req = map_gaia_tool_call_to_action_request("t", {})
+    assert req.actor_id == "unknown-actor"
+    assert req.workflow_id is None
+    assert req.risk_tags == []
+    assert req.action_id.startswith("action_")


### PR DESCRIPTION
## Summary

Adds **`gaia.governance`** — an opt-in, additive governance package that wraps tool execution with an ACGS-lite-style action kernel and forward-compatibility seams for workflow checkpoints, receipts, and policy-version binding (constitutional-swarm semantics).

- **Zero edits to `Agent`.** `GovernedAgentMixin` overrides `_execute_tool` via `super()`; adding it costs nothing when no adapter is supplied.
- **Additive only.** 26 new files, 0 existing files modified. Everything gated behind an explicit opt-in.

## Design properties

| Property | Implementation |
|---|---|
| Canonical name resolution before governance | `_resolve_canonical_tool_name` so unprefixed MCP aliases can't bypass risk tags on their canonical names |
| Fail-closed REVIEW | Only an explicit `governance_reviewer` callback counts; the default `AgentConsole.confirm_tool_execution` auto-approves and is intentionally not consulted |
| Envelope-bound receipts | `payload_hash` covers receipt id + workflow + decision + policy version + constitution hash + timestamp + evidence, with strict canonical JSON |
| Workflow-bound checkpoint resolution | Adapter refuses cross-workflow resolutions via `InvalidResolutionError` |
| Atomic checkpoint check-and-set | `threading.Lock` in `InMemoryCheckpointBridge` |

## Ergonomics

```python
from gaia import Agent, tool
from gaia.governance import GaiaGovernanceAdapter, GovernedAgentMixin, govern

@tool
@govern(risk="blocked", reason="destructive")
def wipe_disk(): ...

class MyAgent(GovernedAgentMixin, Agent):
    ...

agent = MyAgent(governance_adapter=GaiaGovernanceAdapter.default())
```

- `GaiaGovernanceAdapter.default(audit_log=...)` — one-line adapter wiring.
- `GovernanceConfig` dataclass consolidates six `governance_*` kwargs; per-kwarg form preserved.
- `@govern(risk=..., reason=...)` decorator colocates policy with tool source; merges with explicit `governance_risk_tags` dict.

## What's here (PR 1, this PR)

- `src/gaia/governance/` — package: adapter, mixin, config, decorators, schemas, protocols, action/workflow mappers, in-memory + JSONL receipts, static policy binding, stub rule-based policy engine
- `src/gaia/governance/README.md` — quickstart, decision table, extension points
- `examples/governed_weather_agent.py` — runnable demo with CLI reviewer and JSONL audit
- **55 tests** (unit + integration)

## What's deferred (PR 2+)

- ACGS-lite-backed `PolicyEngine`
- Persistent `CheckpointRuntime` backed by constitutional-swarm
- Policy control plane wiring (static binding in PR 1)
- Plan-step / multi-agent workflow transitions (`workflow_mapper` exists as a forward-compatibility seam)

## Test plan

- [x] 55 tests pass: `PYTHONPATH=src pytest -q tests/unit/test_governance_*.py tests/integration/test_governed_*.py --import-mode=importlib`
- [x] Pylint clean against repo `.pylintrc` on `src/gaia/governance/`, `examples/governed_weather_agent.py`, and the new test files
- [x] Regression tests for each finding caught during iterative review: canonical-name bypass, REVIEW auto-approve, workflow mismatch, concurrent resolution race, payload-hash tamper evidence on policy-version and constitution-hash changes
- [ ] End-to-end interactive run on a machine with Lemonade + `uvx` available (example deps)

## Review context

This PR was iterated against automated architecture / correctness / security review (GPT-5.4) and DX / API ergonomics / docs review (Gemini). All HIGH and MEDIUM findings were addressed with targeted fixes and accompanying regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)