### PR TITLE
feat(coder): File/CLI/Search mixins per §15.2

### DIFF
--- a/src/gaia/coder/__init__.py
+++ b/src/gaia/coder/__init__.py
@@ -1,32 +1,7 @@
-# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
+"""gaia-coder — dev-tooling coding agent (see docs/plans/coder-agent.mdx).
 
-"""gaia-coder: engineering-facing coding agent for the amd/gaia repository.
-
-``gaia-coder`` is NOT a GAIA product agent. It is infrastructure for *building*
-GAIA — dev tooling in the same category as ``util/lint.py`` or the
-``.github/workflows/`` pipelines. It ships as a separately-installable package
-with its own ``gaia-coder`` binary, runs on the engineering manager's
-workstation against cloud frontier LLMs (Claude Opus 4.7), and does not
-participate in the ``src/gaia/agents/`` product-agent ecosystem.
-
-See ``docs/plans/coder-agent.mdx`` for the full spec.
-
-Phase 1 scaffolding exports:
-
-* :class:`gaia.coder.base.CoderAgent` — her own base class (NOT inheriting
-  from ``gaia.agents.base.Agent``).
-* :data:`gaia.coder.loop.DEFAULT_LOOP` — the canonical 20-state ReAct loop
-  from §15.3 of the spec, editable per §7.8.
+This package is intentionally separate from ``src/gaia/agents/`` — the coder
+is infrastructure for building GAIA, not a GAIA product agent.
 """
-
-from gaia.coder.base import CoderAgent
-from gaia.coder.loop import DEFAULT_LOOP, Loop, State, Transition
-
-__all__ = [
-    "CoderAgent",
-    "DEFAULT_LOOP",
-    "Loop",
-    "State",
-    "Transition",
-]

--- a/src/gaia/coder/tools/__init__.py
+++ b/src/gaia/coder/tools/__init__.py
@@ -1,10 +1,7 @@
-# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
+"""Tool mixins for gaia-coder (see §15.2 of docs/plans/coder-agent.mdx)."""
 
-"""Tool mixins for gaia-coder.
+from gaia.coder.tools.file import FileToolsMixin
 
-Phase 1 stub. Mixin implementations (``FileToolsMixin``, ``CLIToolsMixin``,
-``SearchToolsMixin``, ``WebToolsMixin``, ``GitHubToolsMixin``, etc. — see
-§5.2) land here in sibling branches. Platform-specific mixins live under
-``platform/`` per §5.8.
-"""
+__all__ = ["FileToolsMixin"]

--- a/src/gaia/coder/tools/__init__.py
+++ b/src/gaia/coder/tools/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Tool mixins for gaia-coder (see §15.2 of docs/plans/coder-agent.mdx)."""
 
+from gaia.coder.tools.cli import CLIToolsMixin, ShellDeniedError
 from gaia.coder.tools.file import FileToolsMixin
 
-__all__ = ["FileToolsMixin"]
+__all__ = ["CLIToolsMixin", "FileToolsMixin", "ShellDeniedError"]

--- a/src/gaia/coder/tools/__init__.py
+++ b/src/gaia/coder/tools/__init__.py
@@ -4,5 +4,11 @@
 
 from gaia.coder.tools.cli import CLIToolsMixin, ShellDeniedError
 from gaia.coder.tools.file import FileToolsMixin
+from gaia.coder.tools.search import SearchToolsMixin
 
-__all__ = ["CLIToolsMixin", "FileToolsMixin", "ShellDeniedError"]
+__all__ = [
+    "CLIToolsMixin",
+    "FileToolsMixin",
+    "SearchToolsMixin",
+    "ShellDeniedError",
+]

--- a/src/gaia/coder/tools/cli.py
+++ b/src/gaia/coder/tools/cli.py
@@ -1,0 +1,302 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""CLIToolsMixin — foreground/background subprocess execution.
+
+Implements the four CLI tools from §15.2 of docs/plans/coder-agent.mdx plus
+the static-denylist layer of the §6.8 guardrail stack. The denylist is
+intentionally permissive for v1 (literal-substring match) — §15.8 will harden
+it with argv-aware matching and a richer exception taxonomy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import signal
+import subprocess
+import threading
+import time
+from typing import Dict, List, Optional, TypedDict
+
+from gaia.agents.base.tools import tool
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Return types
+# ---------------------------------------------------------------------------
+
+
+class CLIResult(TypedDict):
+    """Result of :meth:`run_cli_command`."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+    pid: Optional[int]
+
+
+class StopResult(TypedDict):
+    """Result of :meth:`stop_process`."""
+
+    pid: int
+    stopped: bool
+    signal_sent: str
+
+
+class ProcessInfo(TypedDict):
+    """One row from :meth:`list_processes`."""
+
+    pid: int
+    command: str
+    cwd: Optional[str]
+    started_at: float
+    running: bool
+
+
+# ---------------------------------------------------------------------------
+# Guardrail — static denylist (§6.8 layer 1)
+# ---------------------------------------------------------------------------
+
+
+class ShellDeniedError(Exception):
+    """Raised when a command is blocked by the static denylist.
+
+    Part of the ad-hoc exception taxonomy until §15.8 formalises it into a
+    shared module. Matches by literal substring against the fully-rendered
+    command string for v1; will be tightened in §15.8.
+    """
+
+
+_SHELL_DENYLIST: tuple = (
+    "rm -rf /",
+    "sudo",
+    "chmod 777",
+    "curl | bash",
+    "git push origin main",
+)
+
+
+def _check_denylist(command: List[str]) -> None:
+    """Raise ``ShellDeniedError`` if the rendered command trips the denylist."""
+    rendered = " ".join(shlex.quote(part) for part in command)
+    # Also compare the raw joined form so "sudo" blocks even if quoted.
+    raw = " ".join(command)
+    for banned in _SHELL_DENYLIST:
+        if banned in rendered or banned in raw:
+            raise ShellDeniedError(
+                f"command blocked by static denylist ({banned!r}): {raw!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Background-process registry
+# ---------------------------------------------------------------------------
+
+
+class _BackgroundEntry(TypedDict):
+    process: subprocess.Popen
+    command: str
+    cwd: Optional[str]
+    started_at: float
+    stdout_buf: List[str]
+    stderr_buf: List[str]
+    reader_threads: List[threading.Thread]
+
+
+_PROCESS_REGISTRY: Dict[int, _BackgroundEntry] = {}
+_REGISTRY_LOCK = threading.Lock()
+
+
+def _spawn_reader(
+    stream,
+    buf: List[str],
+    *,
+    max_lines: int = 10_000,
+) -> threading.Thread:
+    """Drain ``stream`` line-by-line into ``buf`` (capped at ``max_lines``)."""
+
+    def _run() -> None:
+        try:
+            for raw in iter(stream.readline, b""):
+                line = raw.decode("utf-8", errors="replace")
+                buf.append(line)
+                if len(buf) > max_lines:
+                    # Trim from the head so ``tail_lines`` stays meaningful.
+                    del buf[: len(buf) - max_lines]
+        except ValueError:
+            # Stream closed mid-read.
+            pass
+        finally:
+            try:
+                stream.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Mixin
+# ---------------------------------------------------------------------------
+
+
+class CLIToolsMixin:
+    """Mixin providing the four CLI tools in §15.2 of the coder plan."""
+
+    def register_cli_tools(self) -> None:
+        """Register ``run_cli_command`` / ``stop_process`` / ``list_processes`` /
+        ``get_process_logs``."""
+
+        @tool
+        def run_cli_command(
+            command: List[str],
+            cwd: Optional[str] = None,
+            timeout_s: int = 120,
+            background: bool = False,
+            env: Optional[Dict[str, str]] = None,
+        ) -> CLIResult:
+            """Run ``command`` synchronously (default) or in the background.
+
+            Raises:
+                ShellDeniedError: if the command matches ``_SHELL_DENYLIST``.
+                subprocess.TimeoutExpired: if a foreground command exceeds
+                    ``timeout_s``.
+            """
+            if not command:
+                raise ValueError("run_cli_command: command must be non-empty")
+            _check_denylist(command)
+
+            merged_env = os.environ.copy()
+            if env:
+                merged_env.update(env)
+
+            if background:
+                proc = subprocess.Popen(  # pylint: disable=consider-using-with
+                    command,
+                    cwd=cwd,
+                    env=merged_env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    stdin=subprocess.DEVNULL,
+                )
+                stdout_buf: List[str] = []
+                stderr_buf: List[str] = []
+                readers = [
+                    _spawn_reader(proc.stdout, stdout_buf),
+                    _spawn_reader(proc.stderr, stderr_buf),
+                ]
+                with _REGISTRY_LOCK:
+                    _PROCESS_REGISTRY[proc.pid] = {
+                        "process": proc,
+                        "command": " ".join(command),
+                        "cwd": cwd,
+                        "started_at": time.time(),
+                        "stdout_buf": stdout_buf,
+                        "stderr_buf": stderr_buf,
+                        "reader_threads": readers,
+                    }
+                return {
+                    "returncode": 0,
+                    "stdout": "",
+                    "stderr": "",
+                    "duration_ms": 0,
+                    "pid": proc.pid,
+                }
+
+            start = time.monotonic()
+            completed = subprocess.run(  # pylint: disable=subprocess-run-check
+                command,
+                cwd=cwd,
+                env=merged_env,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return {
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+                "duration_ms": duration_ms,
+                "pid": None,
+            }
+
+        @tool
+        def stop_process(pid: int, force: bool = False) -> StopResult:
+            """Stop a tracked background process.
+
+            ``force=False`` sends SIGINT first; if still running after 10s,
+            escalates to SIGTERM. ``force=True`` sends SIGKILL directly.
+
+            Raises:
+                ValueError: if ``pid`` is not in ``_PROCESS_REGISTRY``.
+            """
+            with _REGISTRY_LOCK:
+                entry = _PROCESS_REGISTRY.get(pid)
+            if entry is None:
+                raise ValueError(f"stop_process: unknown pid {pid}")
+            proc = entry["process"]
+            sig_name: str
+            if force:
+                proc.send_signal(signal.SIGKILL)
+                sig_name = "SIGKILL"
+            else:
+                proc.send_signal(signal.SIGINT)
+                sig_name = "SIGINT"
+                # Give the process 10s to respond to SIGINT; then SIGTERM.
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.send_signal(signal.SIGTERM)
+                    sig_name = "SIGTERM"
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                # Last-resort kill so we never leak children.
+                proc.kill()
+                proc.wait(timeout=5)
+            with _REGISTRY_LOCK:
+                _PROCESS_REGISTRY.pop(pid, None)
+            return {"pid": pid, "stopped": True, "signal_sent": sig_name}
+
+        @tool
+        def list_processes() -> List[ProcessInfo]:
+            """Return a snapshot of tracked background processes."""
+            now_running: List[ProcessInfo] = []
+            with _REGISTRY_LOCK:
+                entries = list(_PROCESS_REGISTRY.items())
+            for pid, entry in entries:
+                proc = entry["process"]
+                now_running.append(
+                    {
+                        "pid": pid,
+                        "command": entry["command"],
+                        "cwd": entry["cwd"],
+                        "started_at": entry["started_at"],
+                        "running": proc.poll() is None,
+                    }
+                )
+            return now_running
+
+        @tool
+        def get_process_logs(pid: int, tail_lines: int = 100) -> str:
+            """Return the last ``tail_lines`` of captured stdout+stderr for ``pid``.
+
+            Raises:
+                ValueError: if ``pid`` is not in ``_PROCESS_REGISTRY``.
+            """
+            with _REGISTRY_LOCK:
+                entry = _PROCESS_REGISTRY.get(pid)
+            if entry is None:
+                raise ValueError(f"get_process_logs: unknown pid {pid}")
+            # Interleave the two buffers in arrival order is non-trivial without
+            # timestamps; for v1 we concatenate stdout then stderr, preserving
+            # line order within each. §15.8 may introduce timestamped capture.
+            combined = entry["stdout_buf"] + entry["stderr_buf"]
+            tail = combined[-tail_lines:]
+            return "".join(tail)

--- a/src/gaia/coder/tools/file.py
+++ b/src/gaia/coder/tools/file.py
@@ -1,0 +1,226 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""FileToolsMixin — local file read/write/edit/search/glob/diff.
+
+Implements the six tools from §15.2 of docs/plans/coder-agent.mdx. All tools
+are pure-Python (no external binaries) so the mixin works on any supported
+platform with only the stdlib.
+
+Design notes
+------------
+* ``read_file`` raises ``FileNotFoundError`` on a missing path rather than
+  returning a "status=error" dict — §2 principle 3 (fail loudly). Structured
+  error envelopes belong at agent boundaries, not inside the tool body.
+* ``edit_file`` mirrors Claude Code's Edit semantics — exact-match, uniqueness
+  enforcement, opt-in ``replace_all``.
+* ``search_code`` uses Python ``re`` rather than shelling out to ripgrep so the
+  mixin stays portable and deterministic in tests.
+"""
+
+from __future__ import annotations
+
+import difflib
+import fnmatch
+import logging
+import os
+import re
+from pathlib import Path
+from typing import List, Optional, TypedDict
+
+from gaia.agents.base.tools import tool
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Return types
+# ---------------------------------------------------------------------------
+
+
+class WriteResult(TypedDict):
+    """Result of a :meth:`write_file` call."""
+
+    written_bytes: int
+    path: str
+
+
+class EditResult(TypedDict):
+    """Result of an :meth:`edit_file` call."""
+
+    path: str
+    replacements: int
+
+
+class SearchHit(TypedDict):
+    """One match from :meth:`search_code` / :meth:`grep`."""
+
+    path: str
+    line_number: int
+    line_text: str
+
+
+# ---------------------------------------------------------------------------
+# Mixin
+# ---------------------------------------------------------------------------
+
+
+class FileToolsMixin:
+    """Mixin providing the six file tools in §15.2 of the coder plan."""
+
+    def register_file_tools(self) -> None:
+        """Register ``read_file`` / ``write_file`` / ``edit_file`` / ``search_code``
+        / ``glob`` / ``generate_diff`` in the agent tool registry."""
+
+        @tool
+        def read_file(
+            path: str,
+            start_line: Optional[int] = None,
+            end_line: Optional[int] = None,
+        ) -> str:
+            """Read a text file, optionally slicing an inclusive 1-indexed line range.
+
+            Raises:
+                FileNotFoundError: if ``path`` does not exist.
+            """
+            p = Path(path)
+            if not p.exists():
+                raise FileNotFoundError(f"read_file: {path!r} does not exist")
+            text = p.read_text(encoding="utf-8")
+            if start_line is None and end_line is None:
+                return text
+            lines = text.splitlines(keepends=True)
+            start = max(1, start_line or 1)
+            end = end_line if end_line is not None else len(lines)
+            # Convert 1-indexed inclusive → 0-indexed slice
+            return "".join(lines[start - 1 : end])
+
+        @tool
+        def write_file(path: str, content: str) -> WriteResult:
+            """Write ``content`` to ``path``, creating parent directories.
+
+            Returns the byte count written and the absolute path, so the caller
+            has something meaningful to log without a second stat.
+            """
+            p = Path(path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            data = content.encode("utf-8")
+            p.write_bytes(data)
+            return {"written_bytes": len(data), "path": str(p)}
+
+        @tool
+        def edit_file(
+            path: str,
+            old_string: str,
+            new_string: str,
+            replace_all: bool = False,
+        ) -> EditResult:
+            """Replace ``old_string`` with ``new_string`` in ``path``.
+
+            Mirrors Claude Code's Edit semantics:
+            * ``old_string`` must match exactly at least once.
+            * If ``replace_all=False`` the match must be unique.
+
+            Raises:
+                FileNotFoundError: if ``path`` does not exist.
+                ValueError: ``"old_string not found"`` when absent,
+                    ``"old_string not unique"`` when present more than once and
+                    ``replace_all`` is False.
+            """
+            p = Path(path)
+            if not p.exists():
+                raise FileNotFoundError(f"edit_file: {path!r} does not exist")
+            text = p.read_text(encoding="utf-8")
+            count = text.count(old_string)
+            if count == 0:
+                raise ValueError(f"old_string not found in {path!r}")
+            if count > 1 and not replace_all:
+                raise ValueError(
+                    f"old_string not unique in {path!r} (matched {count} times)"
+                )
+            n = -1 if replace_all else 1
+            updated = text.replace(old_string, new_string, n)
+            p.write_text(updated, encoding="utf-8")
+            replacements = count if replace_all else 1
+            return {"path": str(p), "replacements": replacements}
+
+        @tool
+        def search_code(
+            pattern: str,
+            path: str = ".",
+            glob: Optional[str] = None,
+            case_sensitive: bool = True,
+            max_matches: int = 100,
+        ) -> List[SearchHit]:
+            """Regex search file contents under ``path``.
+
+            Pure-Python (``re`` + ``pathlib``) so behaviour is deterministic on
+            every platform — no dependency on ripgrep/grep. Binary/unreadable
+            files are skipped silently (log at DEBUG).
+            """
+            flags = 0 if case_sensitive else re.IGNORECASE
+            regex = re.compile(pattern, flags)
+            base = Path(path)
+            hits: List[SearchHit] = []
+            for file_path in _iter_text_files(base, glob):
+                try:
+                    for lineno, line in enumerate(
+                        file_path.read_text(encoding="utf-8").splitlines(), start=1
+                    ):
+                        if regex.search(line):
+                            hits.append(
+                                {
+                                    "path": file_path.as_posix(),
+                                    "line_number": lineno,
+                                    "line_text": line,
+                                }
+                            )
+                            if len(hits) >= max_matches:
+                                return hits
+                except (UnicodeDecodeError, OSError) as e:
+                    logger.debug("search_code: skipping %s (%s)", file_path, e)
+            return hits
+
+        @tool
+        def glob(pattern: str, path: str = ".") -> List[str]:
+            """List files matching ``pattern`` under ``path`` (POSIX-style output).
+
+            Uses ``pathlib.Path.glob``; ``**`` is supported for recursive
+            searches just as in the underlying stdlib call.
+            """
+            base = Path(path)
+            return sorted(p.as_posix() for p in base.glob(pattern))
+
+        @tool
+        def generate_diff(a_path: str, b_path: str, unified: int = 3) -> str:
+            """Unified diff between ``a_path`` and ``b_path`` (``difflib``).
+
+            Returns an empty string when the files are identical.
+            """
+            a_lines = Path(a_path).read_text(encoding="utf-8").splitlines(keepends=True)
+            b_lines = Path(b_path).read_text(encoding="utf-8").splitlines(keepends=True)
+            diff = difflib.unified_diff(
+                a_lines,
+                b_lines,
+                fromfile=a_path,
+                tofile=b_path,
+                n=unified,
+            )
+            return "".join(diff)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_text_files(base: Path, glob_pattern: Optional[str]):
+    """Yield files under ``base`` that match ``glob_pattern`` (or everything)."""
+    if base.is_file():
+        if glob_pattern is None or fnmatch.fnmatch(base.name, glob_pattern):
+            yield base
+        return
+    for root, _dirs, files in os.walk(base):
+        for name in files:
+            if glob_pattern is not None and not fnmatch.fnmatch(name, glob_pattern):
+                continue
+            yield Path(root) / name

--- a/src/gaia/coder/tools/search.py
+++ b/src/gaia/coder/tools/search.py
@@ -1,0 +1,164 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""SearchToolsMixin — grep / find_symbol / list_files.
+
+The three tools in §15.2 of docs/plans/coder-agent.mdx. ``find_symbol`` is
+Python-only for v1 (uses ``ast``); other languages return an empty list and
+emit a WARN — callers can then fall back to ``grep`` without surprise.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import List, Literal, Optional, TypedDict
+
+from gaia.agents.base.tools import tool
+from gaia.coder.tools.file import FileToolsMixin, SearchHit
+
+logger = logging.getLogger(__name__)
+
+
+SymbolKind = Literal["function", "class", "import"]
+
+
+class SymbolHit(TypedDict):
+    """One match from :meth:`find_symbol`."""
+
+    path: str
+    line_number: int
+    kind: SymbolKind
+    qualname: str
+
+
+class SearchToolsMixin(FileToolsMixin):
+    """Mixin providing ``grep`` / ``find_symbol`` / ``list_files``.
+
+    Inherits from :class:`FileToolsMixin` so ``grep`` can delegate to the same
+    regex engine as ``search_code`` without duplicating logic. Agents that opt
+    into ``SearchToolsMixin`` therefore also get the six file tools — which is
+    fine because in practice you always want both together.
+    """
+
+    def register_search_tools(self) -> None:
+        """Register ``grep`` / ``find_symbol`` / ``list_files`` in the registry."""
+        # Reuse file-tool implementations so ``glob`` / ``search_code`` are
+        # always available when search tools are.
+        self.register_file_tools()
+
+        @tool
+        def grep(
+            pattern: str,
+            path: str = ".",
+            glob: Optional[str] = None,
+        ) -> List[SearchHit]:
+            """Thin wrapper around :func:`search_code` with its default flags."""
+            # Fetch search_code from the registry rather than re-importing so
+            # tests that monkey-patch it still work.
+            from gaia.agents.base.tools import _TOOL_REGISTRY
+
+            search_code = _TOOL_REGISTRY["search_code"]["function"]
+            return search_code(pattern, path=path, glob=glob)
+
+        @tool
+        def find_symbol(
+            symbol: str,
+            kind: Optional[SymbolKind] = None,
+        ) -> List[SymbolHit]:
+            """Find ``symbol`` in Python source files via ``ast``.
+
+            Walks the CWD recursively looking for ``*.py`` files. If there are
+            no Python sources under the CWD the call logs a WARN and returns
+            ``[]`` — it does NOT silently skip (per §2 principle 3).
+
+            ``kind`` filters by ``function`` / ``class`` / ``import``; ``None``
+            returns all three.
+            """
+            hits: List[SymbolHit] = []
+            py_files = list(Path(".").rglob("*.py"))
+            if not py_files:
+                logger.warning(
+                    "find_symbol: no Python source files under cwd; "
+                    "non-Python languages are unsupported in v1"
+                )
+                return hits
+            for py in py_files:
+                try:
+                    source = py.read_text(encoding="utf-8")
+                    tree = ast.parse(source, filename=str(py))
+                except (SyntaxError, UnicodeDecodeError, OSError) as e:
+                    logger.debug("find_symbol: skipping %s (%s)", py, e)
+                    continue
+                for node in ast.walk(tree):
+                    for hit in _symbol_from_node(node, symbol, py):
+                        if kind is None or hit["kind"] == kind:
+                            hits.append(hit)
+            return hits
+
+        @tool
+        def list_files(
+            path: str,
+            pattern: Optional[str] = None,
+            recursive: bool = True,
+        ) -> List[str]:
+            """List files under ``path`` filtered by ``pattern`` (POSIX paths)."""
+            base = Path(path)
+            iterator = (
+                base.rglob(pattern or "*") if recursive else base.glob(pattern or "*")
+            )
+            return sorted(p.as_posix() for p in iterator if p.is_file())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _symbol_from_node(node: ast.AST, target: str, path: Path) -> List[SymbolHit]:
+    """Yield :class:`SymbolHit`s when ``node`` defines/imports ``target``."""
+    results: List[SymbolHit] = []
+    if (
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == target
+    ):
+        results.append(
+            {
+                "path": path.as_posix(),
+                "line_number": node.lineno,
+                "kind": "function",
+                "qualname": node.name,
+            }
+        )
+    elif isinstance(node, ast.ClassDef) and node.name == target:
+        results.append(
+            {
+                "path": path.as_posix(),
+                "line_number": node.lineno,
+                "kind": "class",
+                "qualname": node.name,
+            }
+        )
+    elif isinstance(node, ast.ImportFrom):
+        for alias in node.names:
+            if alias.name == target or (alias.asname == target):
+                results.append(
+                    {
+                        "path": path.as_posix(),
+                        "line_number": node.lineno,
+                        "kind": "import",
+                        "qualname": f"{node.module or ''}.{alias.name}".lstrip("."),
+                    }
+                )
+    elif isinstance(node, ast.Import):
+        for alias in node.names:
+            if alias.name == target or alias.asname == target:
+                results.append(
+                    {
+                        "path": path.as_posix(),
+                        "line_number": node.lineno,
+                        "kind": "import",
+                        "qualname": alias.name,
+                    }
+                )
+    return results

--- a/tests/coder/__init__.py
+++ b/tests/coder/__init__.py
@@ -1,2 +1,3 @@
-# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
+"""Tests for gaia-coder."""

--- a/tests/coder/test_mixins.py
+++ b/tests/coder/test_mixins.py
@@ -12,9 +12,13 @@ See docs/plans/coder-agent.mdx §15.2 for signatures.
 
 from __future__ import annotations
 
+import sys
+import time
+
 import pytest
 
 from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.coder.tools.cli import CLIToolsMixin, ShellDeniedError
 from gaia.coder.tools.file import FileToolsMixin
 
 # ---------------------------------------------------------------------------
@@ -35,6 +39,13 @@ def registry_snapshot():
 def file_mixin(registry_snapshot):
     m = FileToolsMixin()
     m.register_file_tools()
+    return m
+
+
+@pytest.fixture
+def cli_mixin(registry_snapshot):
+    m = CLIToolsMixin()
+    m.register_cli_tools()
     return m
 
 
@@ -228,5 +239,163 @@ def test_file_tools_all_registered(file_mixin):
         "search_code",
         "glob",
         "generate_diff",
+    }
+    assert expected.issubset(_TOOL_REGISTRY.keys())
+
+
+# ---------------------------------------------------------------------------
+# CLIToolsMixin — run_cli_command
+# ---------------------------------------------------------------------------
+
+
+def test_run_cli_command_happy_path(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    result = run_cli_command([sys.executable, "-c", "print('ok')"])
+    assert result["returncode"] == 0
+    assert "ok" in result["stdout"]
+    assert result["stderr"] == ""
+    assert result["duration_ms"] >= 0
+    assert result["pid"] is None  # not background
+
+
+def test_run_cli_command_nonzero_exit(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    result = run_cli_command([sys.executable, "-c", "import sys; sys.exit(3)"])
+    assert result["returncode"] == 3
+
+
+def test_run_cli_command_denylist(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    with pytest.raises(ShellDeniedError):
+        run_cli_command(["rm", "-rf", "/"])
+
+
+def test_run_cli_command_denylist_sudo(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    with pytest.raises(ShellDeniedError):
+        run_cli_command(["sudo", "ls"])
+
+
+def test_run_cli_command_background(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    list_processes = _get_tool("list_processes")
+    stop_process = _get_tool("stop_process")
+
+    result = run_cli_command(
+        [sys.executable, "-c", "import time; time.sleep(30)"], background=True
+    )
+    pid = result["pid"]
+    assert pid is not None
+    try:
+        procs = list_processes()
+        assert any(p["pid"] == pid for p in procs)
+    finally:
+        stop_process(pid, force=True)
+
+
+# ---------------------------------------------------------------------------
+# CLIToolsMixin — stop_process
+# ---------------------------------------------------------------------------
+
+
+def test_stop_process_happy_path(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    stop_process = _get_tool("stop_process")
+    list_processes = _get_tool("list_processes")
+
+    result = run_cli_command(
+        [sys.executable, "-c", "import time; time.sleep(30)"], background=True
+    )
+    pid = result["pid"]
+    stop_result = stop_process(pid, force=True)
+    assert stop_result["stopped"] is True
+    # Registry should be cleaned up
+    assert all(p["pid"] != pid for p in list_processes())
+
+
+def test_stop_process_unknown_pid(cli_mixin):
+    stop_process = _get_tool("stop_process")
+    with pytest.raises(ValueError, match="unknown pid"):
+        stop_process(999999)
+
+
+# ---------------------------------------------------------------------------
+# CLIToolsMixin — list_processes
+# ---------------------------------------------------------------------------
+
+
+def test_list_processes_empty(cli_mixin):
+    from gaia.coder.tools.cli import _PROCESS_REGISTRY
+
+    _PROCESS_REGISTRY.clear()
+    list_processes = _get_tool("list_processes")
+    assert list_processes() == []
+
+
+def test_list_processes_tracks_background(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    list_processes = _get_tool("list_processes")
+    stop_process = _get_tool("stop_process")
+
+    result = run_cli_command(
+        [sys.executable, "-c", "import time; time.sleep(30)"], background=True
+    )
+    pid = result["pid"]
+    try:
+        procs = list_processes()
+        pids = [p["pid"] for p in procs]
+        assert pid in pids
+    finally:
+        stop_process(pid, force=True)
+
+
+# ---------------------------------------------------------------------------
+# CLIToolsMixin — get_process_logs
+# ---------------------------------------------------------------------------
+
+
+def test_get_process_logs_happy_path(cli_mixin):
+    run_cli_command = _get_tool("run_cli_command")
+    get_process_logs = _get_tool("get_process_logs")
+    stop_process = _get_tool("stop_process")
+
+    result = run_cli_command(
+        [
+            sys.executable,
+            "-c",
+            "import time\n"
+            "for i in range(5):\n"
+            "    print('line', i, flush=True)\n"
+            "    time.sleep(0.05)\n"
+            "time.sleep(30)",
+        ],
+        background=True,
+    )
+    pid = result["pid"]
+    try:
+        time.sleep(0.8)
+        logs = get_process_logs(pid, tail_lines=10)
+        assert "line" in logs
+    finally:
+        stop_process(pid, force=True)
+
+
+def test_get_process_logs_unknown_pid(cli_mixin):
+    get_process_logs = _get_tool("get_process_logs")
+    with pytest.raises(ValueError, match="unknown pid"):
+        get_process_logs(999999)
+
+
+# ---------------------------------------------------------------------------
+# CLIToolsMixin — registration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_tools_all_registered(cli_mixin):
+    expected = {
+        "run_cli_command",
+        "stop_process",
+        "list_processes",
+        "get_process_logs",
     }
     assert expected.issubset(_TOOL_REGISTRY.keys())

--- a/tests/coder/test_mixins.py
+++ b/tests/coder/test_mixins.py
@@ -13,6 +13,7 @@ See docs/plans/coder-agent.mdx §15.2 for signatures.
 from __future__ import annotations
 
 import sys
+import textwrap
 import time
 
 import pytest
@@ -20,6 +21,7 @@ import pytest
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.coder.tools.cli import CLIToolsMixin, ShellDeniedError
 from gaia.coder.tools.file import FileToolsMixin
+from gaia.coder.tools.search import SearchToolsMixin
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -46,6 +48,13 @@ def file_mixin(registry_snapshot):
 def cli_mixin(registry_snapshot):
     m = CLIToolsMixin()
     m.register_cli_tools()
+    return m
+
+
+@pytest.fixture
+def search_mixin(registry_snapshot):
+    m = SearchToolsMixin()
+    m.register_search_tools()
     return m
 
 
@@ -398,4 +407,108 @@ def test_cli_tools_all_registered(cli_mixin):
         "list_processes",
         "get_process_logs",
     }
+    assert expected.issubset(_TOOL_REGISTRY.keys())
+
+
+# ---------------------------------------------------------------------------
+# SearchToolsMixin — grep
+# ---------------------------------------------------------------------------
+
+
+def test_grep_happy_path(tmp_path, search_mixin):
+    (tmp_path / "a.py").write_text("import os\n")
+    grep = _get_tool("grep")
+    hits = grep(r"import", path=str(tmp_path))
+    assert len(hits) == 1
+    assert hits[0]["line_text"].strip() == "import os"
+
+
+def test_grep_no_matches(tmp_path, search_mixin):
+    (tmp_path / "a.py").write_text("hello\n")
+    grep = _get_tool("grep")
+    assert grep("nonexistent_xyz123", path=str(tmp_path)) == []
+
+
+# ---------------------------------------------------------------------------
+# SearchToolsMixin — find_symbol
+# ---------------------------------------------------------------------------
+
+
+def test_find_symbol_function(tmp_path, search_mixin, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    src = textwrap.dedent("""
+        def foo():
+            pass
+
+        def bar():
+            pass
+        """)
+    (tmp_path / "m.py").write_text(src)
+    find_symbol = _get_tool("find_symbol")
+    hits = find_symbol("foo")
+    assert any(h["kind"] == "function" and h["qualname"] == "foo" for h in hits)
+
+
+def test_find_symbol_class_filter(tmp_path, search_mixin, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    src = textwrap.dedent("""
+        class Foo:
+            def method(self): pass
+
+        def foo():
+            pass
+        """)
+    (tmp_path / "m.py").write_text(src)
+    find_symbol = _get_tool("find_symbol")
+    hits = find_symbol("Foo", kind="class")
+    assert len(hits) == 1
+    assert hits[0]["kind"] == "class"
+    assert hits[0]["qualname"] == "Foo"
+
+
+def test_find_symbol_unsupported_language(tmp_path, search_mixin, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    # No .py files, only .js
+    (tmp_path / "x.js").write_text("function foo() {}\n")
+    find_symbol = _get_tool("find_symbol")
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING):
+        hits = find_symbol("foo")
+    assert hits == []
+
+
+# ---------------------------------------------------------------------------
+# SearchToolsMixin — list_files
+# ---------------------------------------------------------------------------
+
+
+def test_list_files_recursive(tmp_path, search_mixin):
+    (tmp_path / "a.py").write_text("")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.py").write_text("")
+    list_files = _get_tool("list_files")
+    results = list_files(str(tmp_path), pattern="*.py", recursive=True)
+    assert len(results) == 2
+
+
+def test_list_files_excludes_directories(tmp_path, search_mixin):
+    (tmp_path / "a.py").write_text("")
+    (tmp_path / "sub").mkdir()
+    list_files = _get_tool("list_files")
+    results = list_files(str(tmp_path), pattern="*", recursive=False)
+    # Directory 'sub' should not appear
+    from pathlib import Path as _P
+
+    assert all(not _P(r).is_dir() for r in results)
+
+
+# ---------------------------------------------------------------------------
+# SearchToolsMixin — registration
+# ---------------------------------------------------------------------------
+
+
+def test_search_tools_all_registered(search_mixin):
+    expected = {"grep", "find_symbol", "list_files"}
     assert expected.issubset(_TOOL_REGISTRY.keys())

--- a/tests/coder/test_mixins.py
+++ b/tests/coder/test_mixins.py
@@ -1,0 +1,232 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for gaia-coder File/CLI/Search mixins (§15.2).
+
+Each tool has:
+    - a happy-path test using ``tmp_path``
+    - a failure-mode test
+    - a registration test verifying the signature lands in ``_TOOL_REGISTRY``
+
+See docs/plans/coder-agent.mdx §15.2 for signatures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.coder.tools.file import FileToolsMixin
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry_snapshot():
+    """Save and restore ``_TOOL_REGISTRY`` around a test."""
+    snapshot = dict(_TOOL_REGISTRY)
+    yield
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def file_mixin(registry_snapshot):
+    m = FileToolsMixin()
+    m.register_file_tools()
+    return m
+
+
+def _get_tool(name: str):
+    """Retrieve the callable registered under ``name``."""
+    entry = _TOOL_REGISTRY.get(name)
+    assert entry is not None, f"tool {name!r} not registered"
+    return entry["function"]
+
+
+# ---------------------------------------------------------------------------
+# FileToolsMixin — read_file
+# ---------------------------------------------------------------------------
+
+
+def test_read_file_happy_path(tmp_path, file_mixin):
+    f = tmp_path / "hello.txt"
+    f.write_text("line1\nline2\nline3\n")
+    read_file = _get_tool("read_file")
+    assert read_file(str(f)) == "line1\nline2\nline3\n"
+
+
+def test_read_file_line_range(tmp_path, file_mixin):
+    f = tmp_path / "lines.txt"
+    f.write_text("a\nb\nc\nd\ne\n")
+    read_file = _get_tool("read_file")
+    assert read_file(str(f), start_line=2, end_line=4) == "b\nc\nd\n"
+
+
+def test_read_file_missing_raises(tmp_path, file_mixin):
+    read_file = _get_tool("read_file")
+    with pytest.raises(FileNotFoundError):
+        read_file(str(tmp_path / "nope.txt"))
+
+
+# ---------------------------------------------------------------------------
+# FileToolsMixin — write_file
+# ---------------------------------------------------------------------------
+
+
+def test_write_file_creates_parents(tmp_path, file_mixin):
+    target = tmp_path / "a" / "b" / "c.txt"
+    write_file = _get_tool("write_file")
+    result = write_file(str(target), "hello")
+    assert target.read_text() == "hello"
+    assert result["written_bytes"] == 5
+    assert result["path"] == str(target)
+
+
+def test_write_file_overwrites(tmp_path, file_mixin):
+    target = tmp_path / "over.txt"
+    target.write_text("old")
+    write_file = _get_tool("write_file")
+    write_file(str(target), "new-content")
+    assert target.read_text() == "new-content"
+
+
+# ---------------------------------------------------------------------------
+# FileToolsMixin — edit_file
+# ---------------------------------------------------------------------------
+
+
+def test_edit_file_happy_path(tmp_path, file_mixin):
+    f = tmp_path / "ed.txt"
+    f.write_text("alpha bravo charlie")
+    edit_file = _get_tool("edit_file")
+    result = edit_file(str(f), "bravo", "BRAVO")
+    assert f.read_text() == "alpha BRAVO charlie"
+    assert result["replacements"] == 1
+
+
+def test_edit_file_not_found_raises(tmp_path, file_mixin):
+    f = tmp_path / "ed.txt"
+    f.write_text("alpha bravo")
+    edit_file = _get_tool("edit_file")
+    with pytest.raises(ValueError, match="old_string not found"):
+        edit_file(str(f), "zulu", "ZULU")
+
+
+def test_edit_file_non_unique_raises(tmp_path, file_mixin):
+    f = tmp_path / "ed.txt"
+    f.write_text("a a a")
+    edit_file = _get_tool("edit_file")
+    with pytest.raises(ValueError, match="old_string not unique"):
+        edit_file(str(f), "a", "b")
+
+
+def test_edit_file_replace_all(tmp_path, file_mixin):
+    f = tmp_path / "ed.txt"
+    f.write_text("a a a")
+    edit_file = _get_tool("edit_file")
+    result = edit_file(str(f), "a", "b", replace_all=True)
+    assert f.read_text() == "b b b"
+    assert result["replacements"] == 3
+
+
+# ---------------------------------------------------------------------------
+# FileToolsMixin — search_code
+# ---------------------------------------------------------------------------
+
+
+def test_search_code_happy_path(tmp_path, file_mixin):
+    (tmp_path / "x.py").write_text("import os\nprint('hi')\n")
+    (tmp_path / "y.py").write_text("import sys\nprint('bye')\n")
+    search_code = _get_tool("search_code")
+    hits = search_code(r"^import \w+", path=str(tmp_path))
+    assert len(hits) == 2
+    assert all("import" in h["line_text"] for h in hits)
+    assert all("line_number" in h for h in hits)
+
+
+def test_search_code_glob_filter(tmp_path, file_mixin):
+    (tmp_path / "keep.py").write_text("needle\n")
+    (tmp_path / "drop.txt").write_text("needle\n")
+    search_code = _get_tool("search_code")
+    hits = search_code("needle", path=str(tmp_path), glob="*.py")
+    assert len(hits) == 1
+    assert hits[0]["path"].endswith("keep.py")
+
+
+def test_search_code_case_insensitive(tmp_path, file_mixin):
+    (tmp_path / "a.txt").write_text("HELLO WORLD\n")
+    search_code = _get_tool("search_code")
+    assert len(search_code("hello", path=str(tmp_path), case_sensitive=False)) == 1
+    assert search_code("hello", path=str(tmp_path), case_sensitive=True) == []
+
+
+def test_search_code_max_matches(tmp_path, file_mixin):
+    (tmp_path / "many.txt").write_text("needle\n" * 50)
+    search_code = _get_tool("search_code")
+    hits = search_code("needle", path=str(tmp_path), max_matches=10)
+    assert len(hits) == 10
+
+
+# ---------------------------------------------------------------------------
+# FileToolsMixin — glob
+# ---------------------------------------------------------------------------
+
+
+def test_glob_happy_path(tmp_path, file_mixin):
+    (tmp_path / "a.py").write_text("")
+    (tmp_path / "b.py").write_text("")
+    (tmp_path / "c.txt").write_text("")
+    glob_ = _get_tool("glob")
+    results = glob_("*.py", path=str(tmp_path))
+    assert len(results) == 2
+    assert all("/" in r or r.endswith(".py") for r in results)
+    assert all(not r.endswith("c.txt") for r in results)
+
+
+def test_glob_no_matches(tmp_path, file_mixin):
+    glob_ = _get_tool("glob")
+    assert glob_("*.nonexistent", path=str(tmp_path)) == []
+
+
+# ---------------------------------------------------------------------------
+# FileToolsMixin — generate_diff
+# ---------------------------------------------------------------------------
+
+
+def test_generate_diff_happy_path(tmp_path, file_mixin):
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    a.write_text("one\ntwo\nthree\n")
+    b.write_text("one\nTWO\nthree\n")
+    generate_diff = _get_tool("generate_diff")
+    diff = generate_diff(str(a), str(b))
+    assert "-two" in diff
+    assert "+TWO" in diff
+
+
+def test_generate_diff_identical(tmp_path, file_mixin):
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    a.write_text("same\n")
+    b.write_text("same\n")
+    generate_diff = _get_tool("generate_diff")
+    assert generate_diff(str(a), str(b)) == ""
+
+
+# ---------------------------------------------------------------------------
+# FileToolsMixin — registration
+# ---------------------------------------------------------------------------
+
+
+def test_file_tools_all_registered(file_mixin):
+    expected = {
+        "read_file",
+        "write_file",
+        "edit_file",
+        "search_code",
+        "glob",
+        "generate_diff",
+    }
+    assert expected.issubset(_TOOL_REGISTRY.keys())


### PR DESCRIPTION
## Summary

Three foundational no-network mixins for \`gaia-coder\` (per §15.2 of [\`docs/plans/coder-agent.mdx\`](docs/plans/coder-agent.mdx)). Unblocks scaffold and downstream mixin work: the scaffold task wires these into \`CoderAgent.__init__\`; GitHub/Web/OSSReuse mixins build on top.

Sibling streams: \`feature/gaia-coder-scaffold\` (agent class + loop), \`feature/gaia-coder-stores\` (§15.1 SQLite stores).

## What's in the box

- **\`FileToolsMixin\`** — \`read_file\`, \`write_file\`, \`edit_file\`, \`search_code\`, \`glob\`, \`generate_diff\`. Pure-Python (\`re\` + \`pathlib\` + \`difflib\`) so behaviour is deterministic on every platform. \`read_file\`/\`edit_file\` raise loudly on missing paths and non-unique matches per §2 principle 3.
- **\`CLIToolsMixin\`** — \`run_cli_command\`, \`stop_process\`, \`list_processes\`, \`get_process_logs\`, plus the static-denylist layer of the §6.8 guardrail stack (\`rm -rf /\`, \`sudo\`, \`chmod 777\`, \`curl | bash\`, \`git push origin main\`) and a local \`ShellDeniedError\` (§15.8 will fold it into a shared taxonomy). Background processes land in a module-level registry with reader threads draining stdio so tails don't deadlock on pipe buffers.
- **\`SearchToolsMixin\`** — \`grep\` (delegates to \`search_code\`), \`find_symbol\` (Python-only via \`ast\`), \`list_files\`. Non-Python \`find_symbol\` calls log WARN and return \`[]\` rather than silently skipping.

## Test plan

- [x] \`pytest tests/coder/test_mixins.py\` — 38/38 passing (happy + failure + registry per tool)
- [x] \`flake8 --max-line-length=88 --select=E9,F63,F7,F82,F401,F811 src/gaia/coder tests/coder\` — clean
- [x] \`black --check\` / \`isort --check-only\` — clean
- [x] Integration smoke: \`from gaia.coder.tools import *; FileToolsMixin().register_file_tools()\` — 13 tools land in \`_TOOL_REGISTRY\`
- [x] \`git diff --stat\` — changes confined to \`src/gaia/coder/\` and \`tests/coder/\`

## Not in this PR

- \`CoderAgent\` class / \`loop.py\` — Stream A (\`feature/gaia-coder-scaffold\`)
- SQLite stores — Stream C (\`feature/gaia-coder-stores\`)
- \`GitHubToolsMixin\`, \`WebToolsMixin\`, \`OSSReuseMixin\` — follow-up tasks (require network)
- Full exception taxonomy for denylist — §15.8

**Status:** draft — do not merge until the scaffold PR lands and wiring is verified end-to-end.