### PR TITLE
feat(coder): package skeleton + loop.py with DEFAULT_LOOP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,15 @@ setup(
         "gaia.sd",
         "gaia.vlm",
         "gaia.api",
+        "gaia.coder",
+        "gaia.coder.prompts",
+        "gaia.coder.stores",
+        "gaia.coder.tools",
+        "gaia.coder.review",
+        "gaia.coder.introspect",
+        "gaia.coder.self_fix",
+        "gaia.coder.tests",
+        "gaia.coder.skills",
     ],
     package_data={
         "gaia.eval": [
@@ -83,6 +92,14 @@ setup(
             "webapp/public/*.html",
             "webapp/public/*.css",
             "webapp/public/*.js",
+        ],
+        "gaia.coder": [
+            "GAIA.md",
+            "ARCHITECTURE.md",
+            "PROJECT_MAP.md",
+        ],
+        "gaia.coder.skills": [
+            "catalog.toml",
         ],
     },
     install_requires=[
@@ -199,6 +216,7 @@ setup(
             "gaia-mcp = gaia.mcp.mcp_bridge:main",
             "gaia-emr = gaia.agents.emr.cli:main",
             "gaia-code = gaia.agents.code.cli:main",
+            "gaia-coder = gaia.coder.cli:main",
         ]
     },
     python_requires=">=3.10",

--- a/src/gaia/coder/ARCHITECTURE.md
+++ b/src/gaia/coder/ARCHITECTURE.md
@@ -1,0 +1,52 @@
+# ARCHITECTURE.md — Composition map for gaia-coder
+
+> Phase 1 placeholder. Per §6.5 of `docs/plans/coder-agent.mdx` this file
+> describes **how she is composed** — mixins, state machine, tool registry,
+> invariants. It is injected into every system prompt alongside `GAIA.md` and
+> is expected to mutate as her composition changes. Phase 3+ wires the
+> auto-regenerated sections (Surface, Mixin stack, State machine); Phase 1
+> ships the skeleton so downstream tasks have a stable file to read and
+> edit.
+
+## Surface
+
+Auto-generated from `introspect_tool_registry` once the introspection
+mixin lands in Phase 3. Holds one row per publicly-registered tool: name,
+mixin source, signature, atomic flag.
+
+## Mixin stack
+
+Auto-generated from `introspect_mixin_stack`. Holds the MRO of the running
+`CoderAgent` subclass, each mixin's file path, and a one-line
+responsibility statement.
+
+## State machine
+
+A Mermaid render of the current ReAct graph, produced by
+`gaia.coder.loop.introspect_state_machine`. The stock v1 graph has 20
+states grouped into the 7 stages defined in §5.1 of the spec. The graph
+is editable per §7.8 — every merged edit bumps `Loop.version` and records
+the before/after diagram in the PR body.
+
+## Invariants
+
+Rules she must preserve, each citing the spec section that defines it:
+
+- Fail loudly — never a silent fallback (repo `CLAUDE.md`; §2 principle 3).
+- Never push to `main`; she integrates on the `code` branch (§4.2, §5.7).
+- Every change is covered by at least one test (`declare_done` gate, §2
+  principle 5).
+- Seven review passes before every PR (§8).
+- Self-edit is gated by dev mode AND EM opt-in (§2 principle 6, §7.1).
+
+## Open questions
+
+Things she knows she does not yet know about her own design. Phase 1
+seeds this list with: "loop runner not yet implemented", "introspection
+mixin is a stub", "memory stores are in a sibling branch".
+
+## Change log
+
+Append-only. One line per merged self-edit PR with PR link, fix-class,
+and `loop_version` before/after. Seeded in Phase 1 with the scaffolding
+PR itself.

--- a/src/gaia/coder/GAIA.md
+++ b/src/gaia/coder/GAIA.md
@@ -1,0 +1,37 @@
+# GAIA.md — Identity of gaia-coder
+
+> Phase 1 placeholder. The canonical content — eight principles (§2), persona
+> block (§4.6), and Andrej Karpathy's four working-style rules verbatim — is
+> authored in Phase 5 of `docs/plans/coder-agent.mdx`. This file is kept short
+> on purpose: every edit goes through the `prompt` fix-class with EM review,
+> and Phase 1 is not that time.
+
+## 1. Principles
+
+The eight principles from §2 of the spec (trust through visible correction;
+single repo, deep memory; fail loudly; living architecture + introspection;
+test every change with seven-pass self-review; self-edit gated by development
+mode; cloud-first agent for local-first deploy targets; queued EM input with
+persona + working-style rules in every system prompt) land here verbatim in
+Phase 5.
+
+## 2. Persona
+
+The persona block ("you are gaia-coder, the engineering apprentice for
+amd/gaia; your character is the combination of the great software engineers
+of our era — Knuth, Carmack, Hopper, Hamilton, Hickey, Kernighan — with a
+touch of da Vinci's Mona Lisa…"), voice anti-patterns, positive patterns, and
+she/her pronoun convention land here in Phase 5.
+
+## 3. Working-style rules (Andrej Karpathy, verbatim)
+
+Source: github.com/forrestchang/andrej-karpathy-skills/blob/main/CLAUDE.md
+
+1. **Think Before Coding** — don't assume, don't hide confusion, surface
+   tradeoffs.
+2. **Simplicity First** — minimum code, nothing speculative.
+3. **Surgical Changes** — touch only what you must; match existing style.
+4. **Goal-Driven Execution** — define success criteria, loop until verified.
+
+Full bullet lists per Karpathy verbatim (with the attribution line
+preserved) are filled in in Phase 5.

--- a/src/gaia/coder/PROJECT_MAP.md
+++ b/src/gaia/coder/PROJECT_MAP.md
@@ -1,0 +1,43 @@
+# PROJECT_MAP.md — Map of amd/gaia (the project gaia-coder is building)
+
+> Phase 1 placeholder. Per §6.5 of `docs/plans/coder-agent.mdx` this file
+> describes the **project she is building** — the subsystem map of
+> `amd/gaia`, its public-API surface, in-flight initiatives, architectural
+> decisions, known gotchas. It is maintained continuously from her RAG index
+> once that index is online (Phase 3+). Phase 1 ships the skeleton so
+> downstream tasks can rely on the file's existence.
+
+## Subsystem map
+
+One-line summaries of the top-level modules under `src/gaia/` (agents,
+api, apps, audio, chat, cli, electron, eval, llm, mcp, rag, sd, shell,
+talk, ui, vlm, coder). Auto-populated from the RAG index and the repo
+root `CLAUDE.md` in Phase 3.
+
+## Public-API surface
+
+CLI commands (`gaia <subcommand>`), console scripts (`gaia`, `gaia-mcp`,
+`gaia-emr`, `gaia-code`, `gaia-coder`), REST API routes, the
+`KNOWN_TOOLS` registry. What external contracts a change might break.
+
+## In-flight initiatives
+
+Two-line entries summarising active `docs/plans/*.mdx` work with
+milestone and owner. Auto-populated in Phase 3+.
+
+## Architectural decisions (ADRs)
+
+Things the project has decided and the rationale. Drawn from the
+companion analysis, `docs/plans/`, and significant merged PRs.
+
+## Known gotchas
+
+Things learned while working in the project ("pypdf must be tried before
+PyPDF2 per #495", "Lemonade needs `--ctx-size 32768` for the code
+agent"). Sourced from her `failure_patterns` memory and audit log as
+Phase 3+ comes online.
+
+## Open questions about the project
+
+Areas where her understanding is thin. She flags these in the weekly
+standup so the EM can fill them in.

--- a/src/gaia/coder/__init__.py
+++ b/src/gaia/coder/__init__.py
@@ -1,0 +1,20 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""gaia-coder: engineering-facing coding agent for the amd/gaia repository.
+
+``gaia-coder`` is NOT a GAIA product agent. It is infrastructure for *building*
+GAIA — dev tooling in the same category as ``util/lint.py`` or the
+``.github/workflows/`` pipelines. It ships as a separately-installable package
+with its own ``gaia-coder`` binary, runs on the engineering manager's
+workstation against cloud frontier LLMs (Claude Opus 4.7), and does not
+participate in the ``src/gaia/agents/`` product-agent ecosystem.
+
+See ``docs/plans/coder-agent.mdx`` for the full spec.
+
+This module is the Phase 1 scaffold entry point. ``CoderAgent`` and
+``DEFAULT_LOOP`` are added as re-exports once the corresponding modules
+land in follow-up commits on this same branch.
+"""
+
+__all__: list[str] = []

--- a/src/gaia/coder/__init__.py
+++ b/src/gaia/coder/__init__.py
@@ -12,9 +12,21 @@ participate in the ``src/gaia/agents/`` product-agent ecosystem.
 
 See ``docs/plans/coder-agent.mdx`` for the full spec.
 
-This module is the Phase 1 scaffold entry point. ``CoderAgent`` and
-``DEFAULT_LOOP`` are added as re-exports once the corresponding modules
-land in follow-up commits on this same branch.
+Phase 1 scaffolding exports:
+
+* :class:`gaia.coder.base.CoderAgent` — her own base class (NOT inheriting
+  from ``gaia.agents.base.Agent``).
+* :data:`gaia.coder.loop.DEFAULT_LOOP` — the canonical 20-state ReAct loop
+  from §15.3 of the spec, editable per §7.8.
 """
 
-__all__: list[str] = []
+from gaia.coder.base import CoderAgent
+from gaia.coder.loop import DEFAULT_LOOP, Loop, State, Transition
+
+__all__ = [
+    "CoderAgent",
+    "DEFAULT_LOOP",
+    "Loop",
+    "State",
+    "Transition",
+]

--- a/src/gaia/coder/base.py
+++ b/src/gaia/coder/base.py
@@ -1,0 +1,200 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""``CoderAgent`` — the base class for gaia-coder (§5.1).
+
+She does NOT inherit from :class:`gaia.agents.base.Agent`. That base is
+designed for GAIA product agents (chat, blender, jira, etc.) with a generic
+"call tools, return answer" ReAct loop. ``gaia-coder``'s work is
+fundamentally different: long-lived daemon lifecycle, durable queues,
+self-governance, multi-pass review, editable ReAct graph. A generic base
+cannot carry that weight without a dozen forced overrides — so she has her
+own base, built from first principles.
+
+Phase 1 scaffolding: this module defines the class surface and holds the
+canonical references to the default loop, her identity document, and her
+two living architecture files. The runtime loop runner, mixin resolution,
+and durable-queue plumbing land in later phases per
+``docs/plans/coder-agent.mdx``.
+
+Composition (not inheritance) from the GAIA agent base is intentionally
+allowed and encouraged for well-designed pieces:
+
+* ``@tool`` decorator from :mod:`gaia.agents.base.tools` — the
+  tool-registration pattern is solid and worth reusing.
+* :class:`gaia.agents.base.console.AgentConsole` — standardised CLI output
+  (silent mode, colour, progress bars).
+* :class:`gaia.security.PathValidator` — sandboxed filesystem access.
+
+None of those imports are pulled in at module import time during Phase 1
+— the subsystems that need them will import at use-site to keep the
+skeleton cheap and the dependency surface obvious.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from gaia.coder.loop import DEFAULT_LOOP, Loop
+
+# ---------------------------------------------------------------------------
+# Canonical filesystem anchors for identity / architecture docs (§4.6, §6.5).
+# ---------------------------------------------------------------------------
+
+#: Absolute path to ``GAIA.md`` — the always-present identity document
+#: (principles, persona, working-style) injected into every system prompt.
+GAIA_MD_PATH: Path = Path(__file__).resolve().parent / "GAIA.md"
+
+#: Absolute path to ``ARCHITECTURE.md`` — how *she* is composed (mixins,
+#: state machine, invariants). Updated on every self-edit that changes
+#: composition.
+ARCHITECTURE_MD_PATH: Path = Path(__file__).resolve().parent / "ARCHITECTURE.md"
+
+#: Absolute path to ``PROJECT_MAP.md`` — how the *project she is building*
+#: (``amd/gaia``) is composed. Updated continuously from the RAG index.
+PROJECT_MAP_MD_PATH: Path = Path(__file__).resolve().parent / "PROJECT_MAP.md"
+
+
+@dataclass
+class CoderAgentConfig:
+    """Minimal construction-time configuration for :class:`CoderAgent`.
+
+    Phase 1 holds only the values the skeleton needs to be constructible in
+    tests. Later phases extend this with model selection, prompt-caching
+    flags, tier, EM identity, auto-merge classes, etc. — all of which are
+    already specified in ``docs/plans/coder-agent.mdx`` and parked in
+    ``~/.gaia/coder/*.toml`` per §3.2, §4.1, §6.6, §6.7.
+
+    Attributes:
+        repo_root: Absolute path to the bound ``amd/gaia`` checkout. If
+            ``None``, the agent is running in "unbound" mode (tests, docs,
+            CI smoke runs) and may not write to any repo path.
+        loop: The ReAct graph she runs. Defaults to
+            :data:`gaia.coder.loop.DEFAULT_LOOP`. Supplied explicitly for
+            tests that want to exercise a narrower loop.
+    """
+
+    repo_root: Optional[Path] = None
+    loop: Loop = DEFAULT_LOOP
+
+
+class CoderAgent:
+    """Base class for ``gaia-coder`` (§5.1).
+
+    Phase 1 exposes the minimum surface needed by downstream tasks
+    (stores, mixins) to import from a stable location:
+
+    * :attr:`loop` — the active :class:`~gaia.coder.loop.Loop`.
+    * :attr:`gaia_md_path` / :attr:`architecture_md_path` /
+      :attr:`project_map_md_path` — absolute paths to her three living
+      documents (§4.6 + §6.5).
+    * :meth:`identity_document` / :meth:`architecture_document` /
+      :meth:`project_map_document` — readers that return the *current*
+      on-disk content (important: these files are expected to mutate at
+      runtime in later phases, so every caller reads them on demand
+      rather than at init).
+
+    No behaviour beyond reading the canonical paths is wired up yet.
+    Constructing the class is cheap; no network, no LLM, no side
+    effects.
+
+    Example::
+
+        from gaia.coder import CoderAgent
+
+        agent = CoderAgent()
+        print(agent.loop.version)          # 1
+        print(agent.identity_document())   # contents of GAIA.md
+    """
+
+    #: Default loop every instance uses unless the caller supplies one.
+    DEFAULT_LOOP: Loop = DEFAULT_LOOP
+
+    def __init__(self, config: Optional[CoderAgentConfig] = None) -> None:
+        self._config = config or CoderAgentConfig()
+
+    # ------------------------------------------------------------------
+    # Core properties
+    # ------------------------------------------------------------------
+
+    @property
+    def config(self) -> CoderAgentConfig:
+        """Return the construction-time configuration."""
+        return self._config
+
+    @property
+    def loop(self) -> Loop:
+        """Return the ReAct graph this instance is running."""
+        return self._config.loop
+
+    @property
+    def gaia_md_path(self) -> Path:
+        """Absolute path to her identity document (``GAIA.md``)."""
+        return GAIA_MD_PATH
+
+    @property
+    def architecture_md_path(self) -> Path:
+        """Absolute path to her composition map (``ARCHITECTURE.md``)."""
+        return ARCHITECTURE_MD_PATH
+
+    @property
+    def project_map_md_path(self) -> Path:
+        """Absolute path to her project map (``PROJECT_MAP.md``)."""
+        return PROJECT_MAP_MD_PATH
+
+    # ------------------------------------------------------------------
+    # Document readers
+    # ------------------------------------------------------------------
+
+    def identity_document(self) -> str:
+        """Return the current contents of ``GAIA.md``.
+
+        Raises:
+            FileNotFoundError: If the file is missing. Fail-loudly per the
+                repo ``CLAUDE.md`` rule — the identity document is
+                always-present; absence is a bug, not a fallback case.
+        """
+        return self.gaia_md_path.read_text(encoding="utf-8")
+
+    def architecture_document(self) -> str:
+        """Return the current contents of ``ARCHITECTURE.md``.
+
+        Raises:
+            FileNotFoundError: If the file is missing.
+        """
+        return self.architecture_md_path.read_text(encoding="utf-8")
+
+    def project_map_document(self) -> str:
+        """Return the current contents of ``PROJECT_MAP.md``.
+
+        Raises:
+            FileNotFoundError: If the file is missing.
+        """
+        return self.project_map_md_path.read_text(encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Phase-1 placeholders
+    # ------------------------------------------------------------------
+
+    def run_once(self, *_args: Any, **_kwargs: Any) -> None:
+        """Execute a single heartbeat tick through the ReAct graph.
+
+        Phase 1 placeholder. The real implementation lands in Phase 3
+        alongside the loop runner, event bridge, and durable queues.
+        """
+        raise NotImplementedError(
+            "CoderAgent.run_once is a Phase 3 deliverable — see "
+            "docs/plans/coder-agent.mdx §5.1 for the full state machine "
+            "and §15.3 for the canonical loop.py contract."
+        )
+
+
+__all__ = [
+    "ARCHITECTURE_MD_PATH",
+    "CoderAgent",
+    "CoderAgentConfig",
+    "GAIA_MD_PATH",
+    "PROJECT_MAP_MD_PATH",
+]

--- a/src/gaia/coder/cli.py
+++ b/src/gaia/coder/cli.py
@@ -1,0 +1,148 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""``gaia-coder`` CLI entry point (§3.1).
+
+Phase 1 scaffolding: every subcommand is registered with a stub body that
+prints ``"<subcommand>: not yet implemented"`` and exits ``0``. The real
+implementations land in later phases.
+
+Argparse is used (matching the existing ``gaia`` CLI in
+``src/gaia/cli.py``) rather than ``click``, which is not currently in the
+project's dependency set. Switching frameworks is out of scope for Phase
+1 and not required for the stub subcommand surface.
+
+Subcommand inventory (must match §3.1):
+
+* ``daemon`` — long-lived process that owns the heartbeat and queues.
+* ``status`` — one-shot snapshot of the agent's current state.
+* ``ask`` — fire a single question at the EM inbox.
+* ``note`` — append a line to the learnings log.
+* ``critical`` — post a ``critical``-severity EM inbox item (soft
+  interrupt; see §4.5).
+* ``inbox`` — read / drain the EM inbox.
+* ``feedback`` — submit a feedback record (§7.3).
+* ``promote`` / ``demote`` — EM-signed tier changes (§4.2).
+* ``trust`` — show the current trust contract snapshot (§4.2).
+* ``audit`` — tail the append-only audit log.
+* ``spend`` — cloud-spend report (§6.6).
+* ``egress`` — egress-policy status and recent denials (§6.7).
+* ``introspect`` — introspect the running agent (§7.7).
+* ``skill`` — skills catalog management (§4.7).
+* ``doctor`` — self-diagnostics.
+* ``rag`` — RAG index management (§6.9).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Callable, Iterable
+
+# ---------------------------------------------------------------------------
+# Stub body shared by every Phase 1 subcommand.
+# ---------------------------------------------------------------------------
+
+
+def _not_yet_implemented(subcommand: str) -> Callable[[argparse.Namespace], int]:
+    """Return a handler that prints a stub message and exits ``0``.
+
+    Phase 1 subcommands are intentionally no-ops so the CLI surface can
+    be wired, documented, tested, and imported by downstream tasks
+    without waiting for the full implementation. Every real
+    implementation replaces the returned callable with a real handler in
+    its own PR.
+    """
+
+    def handler(_args: argparse.Namespace) -> int:
+        print(f"gaia-coder {subcommand}: not yet implemented")
+        return 0
+
+    handler.__name__ = f"_handle_{subcommand.replace('-', '_')}"
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Subcommand inventory (§3.1). Tuple entries are (name, help-text).
+# ---------------------------------------------------------------------------
+
+_SUBCOMMANDS: tuple[tuple[str, str], ...] = (
+    ("daemon", "Run the long-lived gaia-coder daemon."),
+    ("status", "Print a snapshot of the agent's current state."),
+    ("ask", "Post a question to the EM inbox."),
+    ("note", "Append a line to the learnings log."),
+    ("critical", "Post a critical-severity EM inbox item (soft interrupt)."),
+    ("inbox", "Read or drain the EM inbox."),
+    ("feedback", "Submit a feedback record to the self-correction loop."),
+    ("promote", "Promote the agent to a higher capability tier."),
+    ("demote", "Demote the agent to a lower capability tier."),
+    ("trust", "Show the current trust contract snapshot."),
+    ("audit", "Tail the append-only audit log."),
+    ("spend", "Report cloud-spend against budget ceilings."),
+    ("egress", "Show egress policy status and recent denials."),
+    ("introspect", "Introspect the running agent (state machine, tools, etc.)."),
+    ("skill", "Skills catalog management."),
+    ("doctor", "Run self-diagnostics."),
+    ("rag", "Manage the amd/gaia RAG index."),
+)
+
+
+def _build_parser(
+    subcommands: Iterable[tuple[str, str]] = _SUBCOMMANDS,
+) -> argparse.ArgumentParser:
+    """Build the ``gaia-coder`` top-level argparse parser.
+
+    Kept as a function (rather than a module-level constant) so it is
+    cheap to rebuild in tests and so each subcommand's handler can be
+    bound without side effects at import time.
+    """
+    parser = argparse.ArgumentParser(
+        prog="gaia-coder",
+        description=(
+            "gaia-coder: engineering-facing coding agent for amd/gaia. "
+            "Phase 1 scaffold — every subcommand is a stub. See "
+            "docs/plans/coder-agent.mdx for the full spec."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(
+        dest="subcommand",
+        metavar="<subcommand>",
+        help="Run `gaia-coder <subcommand> -h` for subcommand help.",
+    )
+
+    for name, help_text in subcommands:
+        sub = subparsers.add_parser(
+            name,
+            help=help_text,
+            description=help_text
+            + " (Phase 1 stub — prints 'not yet implemented' and exits 0.)",
+        )
+        sub.set_defaults(handler=_not_yet_implemented(name))
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``gaia-coder`` entry point.
+
+    Args:
+        argv: Optional explicit argument vector (for tests). When ``None``,
+            ``sys.argv[1:]`` is used.
+
+    Returns:
+        Process exit code.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if not getattr(args, "subcommand", None):
+        parser.print_help()
+        return 0
+
+    handler: Callable[[argparse.Namespace], int] = args.handler
+    return handler(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    sys.exit(main())

--- a/src/gaia/coder/introspect/__init__.py
+++ b/src/gaia/coder/introspect/__init__.py
@@ -1,0 +1,12 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Introspection tools for gaia-coder (§7.7).
+
+Phase 1 stub. The ``introspect_*`` tools (state machine, tool registry,
+mixin stack, system prompt, memory, RAG index, audit log, dev mode,
+capability, feedback queue, paused tasks, self-fix PRs, EM inbox) land here.
+
+The canonical state-machine introspection helper is in
+:mod:`gaia.coder.loop` and re-exported once the mixin is written.
+"""

--- a/src/gaia/coder/loop.py
+++ b/src/gaia/coder/loop.py
@@ -1,0 +1,608 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""The editable ReAct state machine for gaia-coder.
+
+This module is the canonical source of truth for the agent's default control
+flow. It implements the schema and default loop defined in
+``docs/plans/coder-agent.mdx`` §15.3.
+
+Three immutable dataclasses model the graph:
+
+* :class:`Transition` — an edge: target state, guard predicate, optional
+  side-effect, and a human-readable label used in Mermaid renders.
+* :class:`State` — a node: name, stage grouping, optional enter/exit hooks,
+  outbound transitions, memory-topic hooks, and two flags controlling
+  breakpoint polling and continuous-critique emission.
+* :class:`Loop` — the whole graph: a version integer (bumped on every merged
+  state-machine edit per §7.8), the ordered tuple of states, the entry
+  state, and the terminal state(s).
+
+:data:`DEFAULT_LOOP` is the stock 20-state loop grouped into the seven
+stages (Intake, Understand, Design, Build, Verify, Publish, Land) described
+in §5.1. It is the default the daemon runs with. Every merged edit to this
+file bumps ``Loop.version`` so audit-log entries can be traced back to the
+exact loop edition they ran under.
+
+The loop is **editable**: per §7.8 the agent herself can propose source
+edits to this file (under strict guardrails). That mutability is why the
+graph is declarative and the dataclasses are frozen — an edit means a diff
+to this file, not a runtime mutation API.
+
+A minimal :class:`LoopContext` type is declared here as a forward-reference
+stub. The real context lives alongside the runtime loop runner, which is a
+Phase 3 deliverable.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Optional
+
+# ---------------------------------------------------------------------------
+# Context (forward-reference stub)
+# ---------------------------------------------------------------------------
+
+
+class LoopContext:
+    """Forward-reference placeholder for the runtime loop context.
+
+    The real :class:`LoopContext` — the mutable per-turn scratch space that
+    a state's ``on_enter`` / ``on_exit`` hooks and a transition's ``when``
+    guard consult — is implemented in a later phase alongside the loop
+    runner. It exposes attributes such as ``needs_clarification``,
+    ``task.class_``, ``em_approved_plan``, ``failure_is_complex``, etc.
+
+    Declaring it here as a bare class keeps type annotations below
+    resolvable without pulling the runner into this module.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Stage labels
+# ---------------------------------------------------------------------------
+
+Stage = Literal[
+    "Intake",
+    "Understand",
+    "Design",
+    "Build",
+    "Verify",
+    "Publish",
+    "Land",
+]
+
+
+# ---------------------------------------------------------------------------
+# Immutable graph dataclasses (§15.3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Transition:
+    """A directed edge in the ReAct graph.
+
+    Attributes:
+        to: Target state name. Must match some :attr:`State.name` in the
+            parent :class:`Loop`.
+        when: Guard predicate. Called with the active :class:`LoopContext`;
+            the transition is taken when it returns ``True``. Guards are
+            evaluated in declaration order and the first match wins.
+        action: Optional side-effect invoked on traversal (logging, memory
+            writes, etc.). Kept separate from ``when`` so guards stay pure.
+        label: Human-readable label used when rendering the graph as
+            Mermaid for introspection.
+    """
+
+    to: str
+    when: Callable[[LoopContext], bool]
+    action: Optional[Callable[[LoopContext], None]] = None
+    label: str = ""
+
+
+@dataclass(frozen=True)
+class State:
+    """A node in the ReAct graph.
+
+    Attributes:
+        name: Unique state identifier.
+        stage: One of the seven stage labels. Stage transitions are
+            natural breakpoints (§4.5).
+        on_enter: Optional hook run before outbound transitions are
+            evaluated.
+        on_exit: Optional hook run after the chosen transition is picked
+            but before control moves to the target state.
+        transitions: Tuple of outbound transitions. Order is significant:
+            guards evaluate in this order and the first ``True`` wins.
+        memory_read: Memory topic names to query on enter (§6.8 hooks).
+        memory_write: Memory topic names to write on exit.
+        is_breakpoint: When ``True``, the EM inbox is polled and the
+            heartbeat cost is metered on entry. Stage boundaries and
+            user-facing gates are breakpoints.
+        emit_critique: When ``True`` (default), the continuous-critique
+            pass from §7.2 runs after this state exits. Turned off for
+            pure bookkeeping states such as ``boot``.
+    """
+
+    name: str
+    stage: Stage
+    on_enter: Optional[Callable[[LoopContext], None]] = None
+    on_exit: Optional[Callable[[LoopContext], None]] = None
+    transitions: tuple[Transition, ...] = ()
+    memory_read: tuple[str, ...] = ()
+    memory_write: tuple[str, ...] = ()
+    is_breakpoint: bool = False
+    emit_critique: bool = True
+
+
+@dataclass(frozen=True)
+class Loop:
+    """The declarative ReAct graph.
+
+    Attributes:
+        version: Monotonically-increasing integer bumped on every merged
+            state-machine edit (§7.8). Audit-log rows record the
+            ``loop_version`` they ran under so behaviour regressions can
+            be traced back to the exact loop edition.
+        states: Ordered tuple of all states in the graph.
+        entry_state: Name of the start state. Defaults to ``"boot"``.
+        terminal_states: Names of the terminal states. Defaults to
+            ``("end",)``.
+    """
+
+    version: int
+    states: tuple[State, ...]
+    entry_state: str = "boot"
+    terminal_states: tuple[str, ...] = ("end",)
+
+    def state_by_name(self, name: str) -> State:
+        """Return the :class:`State` with the given ``name``.
+
+        Raises:
+            KeyError: If no state with that name exists. Fail-loudly per
+                the repo ``CLAUDE.md`` rule.
+        """
+        for state in self.states:
+            if state.name == name:
+                return state
+        raise KeyError(
+            f"No state named {name!r} in loop version {self.version}. "
+            f"Known states: {[s.name for s in self.states]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Default loop — 20 states grouped into 7 stages (§5.1, §15.3)
+# ---------------------------------------------------------------------------
+
+# Guards are written as lambdas reading well-known attributes from the
+# runtime :class:`LoopContext`. The context is a forward reference until
+# Phase 3 wires the runner.
+
+DEFAULT_LOOP: Loop = Loop(
+    version=1,
+    states=(
+        # ------------------------------------------------------------------
+        # Stage 1 — Intake
+        # ------------------------------------------------------------------
+        State(
+            name="boot",
+            stage="Intake",
+            is_breakpoint=False,
+            emit_critique=False,
+            transitions=(
+                Transition(to="triage", when=lambda c: True, label="boot complete"),
+            ),
+        ),
+        State(
+            name="triage",
+            stage="Intake",
+            is_breakpoint=True,
+            memory_read=("failure_patterns", "task_outcomes", "adr_decisions"),
+            transitions=(
+                Transition(
+                    to="clarify",
+                    when=lambda c: c.needs_clarification,
+                    label="ambiguous",
+                ),
+                Transition(
+                    to="explore",
+                    when=lambda c: c.task.class_ in ("architectural", "feature"),
+                    label="broad scope",
+                ),
+                Transition(
+                    to="localise",
+                    when=lambda c: c.task.class_ in ("tool", "test", "prompt", "doc"),
+                    label="narrow fix",
+                ),
+                Transition(
+                    to="debug",
+                    when=lambda c: c.task.kind == "bug",
+                    label="bug report",
+                ),
+            ),
+        ),
+        State(
+            name="clarify",
+            stage="Intake",
+            is_breakpoint=True,
+            transitions=(
+                Transition(
+                    to="triage",
+                    when=lambda c: c.em_answered,
+                    label="EM answered",
+                ),
+            ),
+        ),
+        # ------------------------------------------------------------------
+        # Stage 2 — Understand
+        # ------------------------------------------------------------------
+        State(
+            name="explore",
+            stage="Understand",
+            is_breakpoint=True,
+            memory_read=("adr_decisions",),
+            transitions=(
+                Transition(
+                    to="plan_draft",
+                    when=lambda c: c.explored,
+                    label="explored",
+                ),
+            ),
+        ),
+        State(
+            name="localise",
+            stage="Understand",
+            is_breakpoint=False,
+            memory_read=("review_patterns", "adr_decisions"),
+            transitions=(
+                Transition(
+                    to="plan_draft",
+                    when=lambda c: c.localised,
+                    label="localised",
+                ),
+            ),
+        ),
+        # ------------------------------------------------------------------
+        # Stage 3 — Design
+        # ------------------------------------------------------------------
+        State(
+            name="plan_draft",
+            stage="Design",
+            is_breakpoint=False,
+            memory_read=("em_preferences", "adr_decisions"),
+            transitions=(
+                Transition(
+                    to="plan_review",
+                    when=lambda c: c.is_large_job,
+                    label="large job -> review",
+                ),
+                Transition(
+                    to="test_first",
+                    when=lambda c: not c.is_large_job,
+                    label="small job -> build",
+                ),
+            ),
+        ),
+        State(
+            name="plan_review",
+            stage="Design",
+            is_breakpoint=True,
+            transitions=(
+                Transition(
+                    to="test_first",
+                    when=lambda c: c.em_approved_plan,
+                    label="EM approved",
+                ),
+                Transition(
+                    to="plan_refine",
+                    when=lambda c: c.em_requested_changes,
+                    label="EM requested changes",
+                ),
+            ),
+        ),
+        State(
+            name="plan_refine",
+            stage="Design",
+            is_breakpoint=False,
+            transitions=(
+                Transition(
+                    to="plan_draft",
+                    when=lambda c: c.refinement_rounds < 3,
+                    label="refine (<3 rounds)",
+                ),
+            ),
+        ),
+        # ------------------------------------------------------------------
+        # Stage 4 — Build
+        # ------------------------------------------------------------------
+        State(
+            name="test_first",
+            stage="Build",
+            is_breakpoint=False,
+            transitions=(
+                Transition(
+                    to="edit",
+                    when=lambda c: c.regression_test_written,
+                    label="test written",
+                ),
+            ),
+        ),
+        State(
+            name="edit",
+            stage="Build",
+            is_breakpoint=False,
+            transitions=(
+                Transition(
+                    to="verify_local",
+                    when=lambda c: c.edit_complete,
+                    label="edit complete",
+                ),
+            ),
+        ),
+        # ------------------------------------------------------------------
+        # Stage 5 — Verify
+        # ------------------------------------------------------------------
+        State(
+            name="verify_local",
+            stage="Verify",
+            is_breakpoint=False,
+            transitions=(
+                Transition(
+                    to="debug",
+                    when=lambda c: c.local_verification_failed,
+                    label="verification failed",
+                ),
+                Transition(
+                    to="self_review",
+                    when=lambda c: c.local_verification_passed,
+                    label="verification passed",
+                ),
+            ),
+        ),
+        State(
+            name="debug",
+            stage="Verify",
+            is_breakpoint=True,
+            memory_read=("failure_patterns", "flaky_tests"),
+            memory_write=("failure_patterns",),
+            transitions=(
+                Transition(
+                    to="edit",
+                    when=lambda c: c.fix_candidate_ready,
+                    label="fix ready",
+                ),
+                Transition(
+                    to="plan_draft",
+                    when=lambda c: c.requires_replan,
+                    label="needs replan",
+                ),
+            ),
+        ),
+        State(
+            name="self_review",
+            stage="Verify",
+            is_breakpoint=False,
+            memory_read=("review_patterns", "mutation_seeds"),
+            transitions=(
+                # Publish if every review pass is green (§8).
+                Transition(
+                    to="publish",
+                    when=lambda c: c.all_passes_green,
+                    label="all passes green",
+                ),
+                # A complex failure warrants the dedicated debug sub-loop
+                # (§5.9) — root cause is deeper than a surface edit.
+                Transition(
+                    to="debug",
+                    when=lambda c: c.any_pass_failed and c.failure_is_complex,
+                    label="complex failure -> debug",
+                ),
+                # A shallow failure goes straight back to edit for a
+                # surgical fix without re-entering the full debug loop.
+                Transition(
+                    to="edit",
+                    when=lambda c: c.any_pass_failed and not c.failure_is_complex,
+                    label="shallow failure -> edit",
+                ),
+            ),
+        ),
+        # ------------------------------------------------------------------
+        # Stage 6 — Publish & iterate
+        # ------------------------------------------------------------------
+        State(
+            name="publish",
+            stage="Publish",
+            is_breakpoint=True,
+            transitions=(
+                Transition(
+                    to="notify",
+                    when=lambda c: c.pr_opened,
+                    label="PR opened",
+                ),
+            ),
+        ),
+        State(
+            name="notify",
+            stage="Publish",
+            is_breakpoint=False,
+            transitions=(Transition(to="wait", when=lambda c: True, label="notified"),),
+        ),
+        State(
+            name="wait",
+            stage="Publish",
+            is_breakpoint=True,
+            transitions=(
+                Transition(
+                    to="revise",
+                    when=lambda c: c.review_requested_changes,
+                    label="review requested changes",
+                ),
+                Transition(
+                    to="verify_merge",
+                    when=lambda c: c.pr_merged,
+                    label="PR merged",
+                ),
+                Transition(
+                    to="end",
+                    when=lambda c: c.pr_rejected,
+                    label="PR rejected",
+                ),
+            ),
+        ),
+        State(
+            name="revise",
+            stage="Publish",
+            is_breakpoint=False,
+            transitions=(
+                Transition(to="edit", when=lambda c: True, label="loop back to edit"),
+            ),
+        ),
+        # ------------------------------------------------------------------
+        # Stage 7 — Land & learn
+        # ------------------------------------------------------------------
+        State(
+            name="verify_merge",
+            stage="Land",
+            is_breakpoint=False,
+            memory_write=("review_patterns", "failure_patterns", "task_outcomes"),
+            transitions=(
+                Transition(to="learn", when=lambda c: True, label="merge verified"),
+            ),
+        ),
+        State(
+            name="learn",
+            stage="Land",
+            is_breakpoint=False,
+            transitions=(Transition(to="end", when=lambda c: True, label="learned"),),
+        ),
+        State(
+            name="end",
+            stage="Land",
+            is_breakpoint=False,
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Introspection helpers (§7.7)
+# ---------------------------------------------------------------------------
+
+
+def _mermaid(loop: Loop) -> str:
+    """Render ``loop`` as a Mermaid ``stateDiagram-v2`` string.
+
+    The ``stateDiagram-v2`` dialect is chosen over ``graph TD`` because it
+    groups states into ``state <Stage> { ... }`` blocks, which matches the
+    seven-stage grouping from §5.1 and makes the rendered diagram far more
+    readable in the Mermaid preview that ``gaia-coder introspect`` will
+    surface.
+    """
+    lines: list[str] = ["stateDiagram-v2"]
+
+    # Group states by stage, preserving encounter order inside each stage.
+    stages: dict[str, list[State]] = {}
+    stage_order: list[str] = []
+    for state in loop.states:
+        if state.stage not in stages:
+            stages[state.stage] = []
+            stage_order.append(state.stage)
+        stages[state.stage].append(state)
+
+    # Entry arrow.
+    lines.append(f"    [*] --> {loop.entry_state}")
+
+    # Nested state blocks per stage (renders as a labelled container).
+    for stage in stage_order:
+        block_name = f"Stage_{stage}"
+        lines.append(f'    state "{stage}" as {block_name} {{')
+        for state in stages[stage]:
+            if state.is_breakpoint:
+                lines.append(f"        {state.name} : breakpoint")
+            else:
+                lines.append(f"        {state.name}")
+        lines.append("    }")
+
+    # Transitions.
+    for state in loop.states:
+        for transition in state.transitions:
+            label = transition.label or ""
+            if label:
+                lines.append(f"    {state.name} --> {transition.to} : {label}")
+            else:
+                lines.append(f"    {state.name} --> {transition.to}")
+
+    # Terminal arrows.
+    for terminal in loop.terminal_states:
+        lines.append(f"    {terminal} --> [*]")
+
+    return "\n".join(lines)
+
+
+def introspect_state_machine(loop: Loop = DEFAULT_LOOP) -> dict[str, Any]:
+    """Return a JSON-serialisable snapshot of the ReAct loop plus a Mermaid render.
+
+    This is the ``loop``-flavoured introspection helper described in §7.7.
+    The ``IntrospectionToolsMixin`` (Phase 3) will wrap this as a
+    ``@tool``-decorated public tool; exposing it as a plain function here
+    keeps the canonical implementation next to the loop it describes and
+    lets the sibling ``introspect/`` package re-export without duplicating
+    logic.
+
+    Args:
+        loop: The loop to snapshot. Defaults to :data:`DEFAULT_LOOP`.
+
+    Returns:
+        A dict with two top-level keys:
+
+        * ``json``: a nested dict describing the loop (version, entry,
+          terminals, and per-state name / stage / flags / transitions).
+        * ``mermaid``: a ``stateDiagram-v2`` render — the string always
+          contains the literal substring ``stateDiagram`` so introspection
+          callers can assert the render shape.
+    """
+    states_payload: list[dict[str, Any]] = []
+    for state in loop.states:
+        states_payload.append(
+            {
+                "name": state.name,
+                "stage": state.stage,
+                "is_breakpoint": state.is_breakpoint,
+                "emit_critique": state.emit_critique,
+                "memory_read": list(state.memory_read),
+                "memory_write": list(state.memory_write),
+                "transitions": [
+                    {"to": t.to, "label": t.label} for t in state.transitions
+                ],
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "version": loop.version,
+        "entry_state": loop.entry_state,
+        "terminal_states": list(loop.terminal_states),
+        "states": states_payload,
+    }
+
+    # Round-trip through ``json.dumps`` -> ``json.loads`` so the caller
+    # knows the payload is definitely JSON-serialisable (no stray
+    # callables leaking through).
+    json_payload = json.loads(json.dumps(payload))
+
+    return {
+        "json": json_payload,
+        "mermaid": _mermaid(loop),
+    }
+
+
+__all__ = [
+    "DEFAULT_LOOP",
+    "Loop",
+    "LoopContext",
+    "Stage",
+    "State",
+    "Transition",
+    "introspect_state_machine",
+]

--- a/src/gaia/coder/prompts/__init__.py
+++ b/src/gaia/coder/prompts/__init__.py
@@ -1,0 +1,9 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Prompt composition helpers for gaia-coder.
+
+Phase 1 stub. The prompt composer lands here — ``GAIA.md`` (identity) and
+``ARCHITECTURE.md`` (composition map) are injected into every turn per §4.6
+and §6.5 of the spec.
+"""

--- a/src/gaia/coder/review/__init__.py
+++ b/src/gaia/coder/review/__init__.py
@@ -1,0 +1,8 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Multi-pass self-review for gaia-coder.
+
+Phase 1 stub. The seven review passes (static, functional, architectural,
+security, prose, adversarial, feedback-binding — see §8) land here.
+"""

--- a/src/gaia/coder/self_fix/__init__.py
+++ b/src/gaia/coder/self_fix/__init__.py
@@ -1,0 +1,8 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Self-fix primitives for gaia-coder (§7).
+
+Phase 1 stub. The self-fix loop, fix-class classifier, state-machine
+self-edit machinery, and project-level rollback primitives land here.
+"""

--- a/src/gaia/coder/skills/catalog.toml
+++ b/src/gaia/coder/skills/catalog.toml
@@ -1,0 +1,23 @@
+# gaia-coder skills catalog (§4.7).
+#
+# Phase 1 placeholder. This file is the machine-readable index of
+# context-loaded skills — rules that only apply in specific contexts
+# (touching release scripts, responding to an external contributor,
+# triaging a CI failure on main, etc.).
+#
+# Real skill entries are added as Phase 2+ proceeds. Each entry has the
+# shape:
+#
+#     [[skill]]
+#     name = "touching-release-scripts"
+#     path = "skills/touching-release-scripts.md"
+#     priority = "high"
+#     description = "Rules when editing files under .github/workflows/release-*"
+#     triggers = [
+#         { kind = "path_glob", value = ".github/workflows/release-*" },
+#     ]
+#
+# See docs/plans/coder-agent.mdx §4.7 for the full schema and loading
+# algorithm.
+
+skills = []

--- a/src/gaia/coder/stores/__init__.py
+++ b/src/gaia/coder/stores/__init__.py
@@ -1,0 +1,9 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""SQLite stores backing gaia-coder's durable state.
+
+Phase 1 stub. Store implementations (``tasks.db``, ``em_inbox.db``,
+``feedback.db``, ``audit.db``, etc. — see §15.1) land here in the
+``feature/gaia-coder-stores`` sibling branch.
+"""

--- a/src/gaia/coder/tests/__init__.py
+++ b/src/gaia/coder/tests/__init__.py
@@ -1,0 +1,9 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""In-tree test helpers and fixtures for gaia-coder.
+
+Phase 1 stub. External tests live under ``tests/coder/``; this package is
+for any in-tree fixture or test double the coder needs to ship with the
+package itself.
+"""

--- a/src/gaia/coder/tools/__init__.py
+++ b/src/gaia/coder/tools/__init__.py
@@ -1,0 +1,10 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tool mixins for gaia-coder.
+
+Phase 1 stub. Mixin implementations (``FileToolsMixin``, ``CLIToolsMixin``,
+``SearchToolsMixin``, ``WebToolsMixin``, ``GitHubToolsMixin``, etc. — see
+§5.2) land here in sibling branches. Platform-specific mixins live under
+``platform/`` per §5.8.
+"""

--- a/tests/coder/__init__.py
+++ b/tests/coder/__init__.py
@@ -1,0 +1,2 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT

--- a/tests/coder/test_skeleton.py
+++ b/tests/coder/test_skeleton.py
@@ -1,0 +1,104 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Phase 1 skeleton tests for ``gaia.coder``.
+
+These tests pin the public surface downstream sibling branches rely on:
+
+* The ``gaia-coder`` console script runs and shows its subcommand list.
+* ``from gaia.coder import CoderAgent`` works.
+* ``from gaia.coder.loop import DEFAULT_LOOP`` works.
+* The default loop has exactly the 20 states defined in §15.3 of the
+  spec, including the updated three-way ``self_review`` transition
+  (``publish`` | ``debug`` | ``edit``).
+* :func:`gaia.coder.loop.introspect_state_machine` returns a Mermaid
+  render (any of the ``graph TD`` or ``stateDiagram`` dialects satisfy
+  §7.7).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_cli_help_runs() -> None:
+    """``gaia-coder --help`` must exit 0 and list subcommands."""
+    # Invoke via `python -m gaia.coder.cli` so the test works whether or
+    # not the ``gaia-coder`` console script has been installed. This is
+    # the same invariant either route exercises.
+    result = subprocess.run(
+        [sys.executable, "-m", "gaia.coder.cli", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"gaia-coder --help exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # A handful of subcommands must appear in the help output.
+    for expected in ("daemon", "status", "introspect", "trust"):
+        assert expected in result.stdout, (
+            f"Expected subcommand {expected!r} missing from help output:\n"
+            f"{result.stdout}"
+        )
+
+
+def test_package_imports() -> None:
+    """Public re-exports must resolve from the top-level package."""
+    from gaia.coder import CoderAgent  # noqa: F401  (import is the assertion)
+    from gaia.coder.loop import DEFAULT_LOOP  # noqa: F401
+
+    # Sanity: ``CoderAgent`` is constructible without arguments.
+    agent = CoderAgent()
+    assert agent.loop is DEFAULT_LOOP
+
+
+def test_default_loop_has_20_states() -> None:
+    """§15.3: the default loop has exactly 20 states."""
+    from gaia.coder.loop import DEFAULT_LOOP
+
+    assert (
+        len(DEFAULT_LOOP.states) == 20
+    ), f"DEFAULT_LOOP has {len(DEFAULT_LOOP.states)} states, expected 20"
+
+
+def test_self_review_has_three_transitions() -> None:
+    """§15.3: ``self_review`` transitions are publish | debug | edit."""
+    from gaia.coder.loop import DEFAULT_LOOP
+
+    self_review = DEFAULT_LOOP.state_by_name("self_review")
+    targets = [t.to for t in self_review.transitions]
+
+    assert len(self_review.transitions) == 3, (
+        f"self_review should have exactly 3 transitions, found "
+        f"{len(self_review.transitions)}: {targets}"
+    )
+    assert set(targets) == {"publish", "debug", "edit"}, (
+        f"self_review targets should be {{publish, debug, edit}}, got "
+        f"{set(targets)}"
+    )
+
+
+def test_introspect_state_machine_returns_mermaid() -> None:
+    """The introspection helper must return a Mermaid-compatible string.
+
+    §7.7 specifies the tool renders both JSON and a Mermaid diagram for
+    the EM's inspection. The dialect (``graph TD`` vs ``stateDiagram``)
+    is an implementation detail; the test accepts either.
+    """
+    from gaia.coder.loop import introspect_state_machine
+
+    payload = introspect_state_machine()
+
+    assert isinstance(payload, dict)
+    assert "json" in payload
+    assert "mermaid" in payload
+
+    mermaid = payload["mermaid"]
+    assert isinstance(mermaid, str)
+    assert "graph TD" in mermaid or "stateDiagram" in mermaid, (
+        "Mermaid render should use either `graph TD` or `stateDiagram` "
+        f"dialect; got:\n{mermaid[:200]}"
+    )


### PR DESCRIPTION
## Summary

Phase 1 scaffolding for `gaia-coder` per [`docs/plans/coder-agent.mdx`](docs/plans/coder-agent.mdx). Creates the package structure every follow-up task imports from — no runtime behaviour, no LLM calls, no network, no SQLite. Just the load-bearing shapes: her own base class, the editable 20-state ReAct loop, the CLI surface, and the three living documents the spec anchors on.

This is the trunk the two sibling branches (`feature/gaia-coder-stores`, `feature/gaia-coder-mixins-1`) rebase onto once it lands.

## Threads

- **Package skeleton (§3.1)** — `src/gaia/coder/` with sub-packages for `prompts/`, `stores/`, `tools/`, `review/`, `introspect/`, `self_fix/`, `tests/`, `skills/`. Every `__init__.py` is a stub pointing at the phase that fills it in. Matters because downstream tasks need stable import paths *now* without racing on who creates which directory.
- **CLI stub (§3.1)** — `gaia-coder` console script wired through `setup.py`. All 17 subcommands from the spec (`daemon`, `status`, `ask`, `note`, `critical`, `inbox`, `feedback`, `promote`, `demote`, `trust`, `audit`, `spend`, `egress`, `introspect`, `skill`, `doctor`, `rag`) print `"<name>: not yet implemented"` and exit 0. Matters so docs, tests, and muscle memory can start using the real surface immediately. Uses argparse (matching existing `gaia` CLI) rather than click, which is not a project dependency.
- **State machine (§5.1, §15.3)** — `src/gaia/coder/loop.py` with immutable `Transition`, `State`, `Loop` dataclasses and `DEFAULT_LOOP` containing all 20 states grouped into the seven stages. The `self_review` state carries the **updated three-way transition** (`publish` | `debug` | `edit` based on `failure_is_complex`) from §15.3 — shallow failures go straight back to edit, complex ones enter the dedicated debug sub-loop. Matters because a typo here silently regresses her review discipline.
- **Base class (§5.1)** — `CoderAgent` that does **NOT** inherit from `gaia.agents.base.Agent`. Product-agent assumptions (request-scoped, single LLM round-trip) do not match her daemon-scoped lifecycle with durable queues and editable control flow. Composition from the GAIA base is still allowed at use-site (`@tool`, `AgentConsole`, `PathValidator`). Matters so sibling tasks can `from gaia.coder import CoderAgent` today.
- **Living documents (§4.6, §6.5)** — `GAIA.md` (identity: principles, persona, Karpathy working-style rules), `ARCHITECTURE.md` (how *she* is composed), `PROJECT_MAP.md` (how the project *she's building* is composed), plus `skills/catalog.toml` seed. All short Phase-1 placeholders; real content lands in Phase 3/5. Matters because both docs are referenced from every system prompt — they need to exist on disk before the runner does.
- **Introspection seed (§7.7)** — `introspect_state_machine()` in `loop.py` returns a JSON snapshot + `stateDiagram-v2` Mermaid render of the loop. The Phase 3 `IntrospectionToolsMixin` wraps this as the public `@tool`; keeping the implementation next to the loop it describes avoids duplication.

## Deviations from spec

- **Spec says "wired via click (already a project dep)"** — click is not actually in `setup.py` or any extras. Switched to `argparse` to match the existing `src/gaia/cli.py` convention and avoid adding a dependency. The subcommand surface is unchanged.
- **Spec suggests 4 commits; this PR has 3.** Splitting `loop.py` across two commits (dataclasses in b, `DEFAULT_LOOP` + introspection helper in c) required temporarily deleting and re-adding content, which felt worse than a clean "state machine + base class" commit. Commits are: (1) scaffold + CLI, (2) loop.py + base.py + `__init__.py` re-exports, (3) tests.

## Test plan

- [x] `pytest tests/coder/test_skeleton.py -xvs` — 5/5 pass, including the guard against regressing `self_review`'s three-way transition.
- [x] `python util/lint.py --black --isort --flake8` on the new files — all clean (project flake8 uses `--max-line-length=88` with E501 ignored per `util/lint.py`).
- [x] `uv pip install -e .` — succeeds; `gaia-coder --help` prints the 17-subcommand list; stub subcommands exit 0 (`gaia-coder introspect`, `gaia-coder status`, etc.).
- [x] `git diff feature/coding-agent...HEAD --stat` — changes only under `src/gaia/coder/`, `tests/coder/`, and `setup.py`. No edits to `src/gaia/agents/` or other existing modules.
- [x] Existing `gaia-code` entry (legacy Next.js scaffolder) untouched per §1.