### PR TITLE
feat(coder): SQLite stores per §15.1 DDL

### DIFF
--- a/src/gaia/coder/stores/__init__.py
+++ b/src/gaia/coder/stores/__init__.py
@@ -1,9 +1,131 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-
 """SQLite stores backing gaia-coder's durable state.
 
-Phase 1 stub. Store implementations (``tasks.db``, ``em_inbox.db``,
-``feedback.db``, ``audit.db``, etc. — see §15.1) land here in the
-``feature/gaia-coder-stores`` sibling branch.
+This package contains one module per persistent store listed in §15.1 of
+``docs/plans/coder-agent.mdx``:
+
+========================  ======================  =============================
+Module                    File on disk            Purpose
+========================  ======================  =============================
+``em_inbox``              ``em_inbox.db``         EM input queue (§4.5)
+``tasks``                 ``tasks.db``            Task queue (§6.3)
+``feedback``              ``feedback.db``         Feedback queue (§7.3)
+``spend``                 ``spend.db``            Cost ledger (§6.6)
+``audit``                 ``audit.log.db``        Tool-call audit log (§15.1)
+``ci_history``            ``ci_history.db``       CI workflow duration cache (§6.2)
+``memory``                ``memory.db``           Hybrid SQL+FAISS memory (§6.8)
+``paused_tasks``          ``paused-tasks/*.json`` Paused-task snapshots (§7.5)
+``self_edits_log``        ``self-edits.log``      Self-edit JSONL log (§6.4)
+``learnings_log``         ``learnings.log``       Promotion-candidate log (§4.6)
+========================  ======================  =============================
+
+Each SQLite module exposes ``DDL``, ``create_tables(conn)``, ``open_store(path)``,
+and typed ``insert_row`` / ``get_row`` / ``update_row`` / ``list_rows`` helpers.
+FAISS index wiring for ``memory`` is explicitly Phase 10 work and not present
+here.
 """
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from gaia.coder.stores import (  # noqa: F401 — re-exported for convenience
+    audit,
+    ci_history,
+    em_inbox,
+    feedback,
+    learnings_log,
+    memory,
+    paused_tasks,
+    self_edits_log,
+    spend,
+    tasks,
+)
+
+__all__ = [
+    "audit",
+    "ci_history",
+    "em_inbox",
+    "feedback",
+    "learnings_log",
+    "memory",
+    "paused_tasks",
+    "self_edits_log",
+    "spend",
+    "tasks",
+    "create_all_stores",
+]
+
+
+# Canonical layout of ``~/.gaia/coder/`` for the seven SQLite stores plus the
+# three non-SQL stores. Keys match store-module names; the values are relative
+# paths under the ``root`` passed to :func:`create_all_stores`.
+_SQLITE_LAYOUT: dict[str, str] = {
+    "em_inbox": "em_inbox.db",
+    "tasks": "tasks.db",
+    "feedback": "feedback.db",
+    "spend": "spend.db",
+    "audit": "audit.log.db",
+    "ci_history": "ci_history.db",
+    "memory": "memory.db",
+}
+
+_NON_SQL_LAYOUT: dict[str, str] = {
+    "paused_tasks": "paused-tasks",
+    "self_edits_log": "self-edits.log",
+    "learnings_log": "learnings.log",
+}
+
+
+def create_all_stores(root: str | Path) -> Dict[str, Path]:
+    """Create every store under ``root`` and return a ``{store_name: path}`` map.
+
+    * For SQLite stores, the database file is opened (creating it if missing)
+      with the canonical PRAGMAs, the DDL is applied, and the connection is
+      closed. The returned path points at the ``.db`` file.
+    * For non-SQL stores, the target directory / log file's parent directory
+      is created. The returned path points at the directory (paused-tasks) or
+      the log file (self-edits.log, learnings.log) — callers do not have to
+      touch the file before appending.
+
+    The function is idempotent: re-running it on the same ``root`` is a no-op
+    for existing tables and files.
+    """
+    root_path = Path(root)
+    root_path.mkdir(parents=True, exist_ok=True)
+    paths: Dict[str, Path] = {}
+
+    sqlite_modules = {
+        "em_inbox": em_inbox,
+        "tasks": tasks,
+        "feedback": feedback,
+        "spend": spend,
+        "audit": audit,
+        "ci_history": ci_history,
+        "memory": memory,
+    }
+    for name, relative in _SQLITE_LAYOUT.items():
+        db_path = root_path / relative
+        conn = sqlite_modules[name].open_store(db_path)
+        try:
+            conn.commit()
+        finally:
+            conn.close()
+        paths[name] = db_path
+
+    # paused-tasks/ is a directory of per-task JSON snapshots.
+    paused_dir = root_path / _NON_SQL_LAYOUT["paused_tasks"]
+    paused_dir.mkdir(parents=True, exist_ok=True)
+    paths["paused_tasks"] = paused_dir
+
+    # self-edits.log and learnings.log are files — make sure their parent
+    # directory exists but do not create empty files (so an empty log is
+    # distinguishable from "never written").
+    for name in ("self_edits_log", "learnings_log"):
+        log_path = root_path / _NON_SQL_LAYOUT[name]
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        paths[name] = log_path
+
+    return paths

--- a/src/gaia/coder/stores/_common.py
+++ b/src/gaia/coder/stores/_common.py
@@ -1,0 +1,128 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Shared SQLite helpers for ``gaia.coder.stores``.
+
+Every SQLite-backed store in this package uses :func:`open_connection` to get a
+properly-configured :class:`sqlite3.Connection`: WAL journalling, foreign keys
+enforced, and a 5-second busy timeout. This matches the behaviour required by
+§15.1 of ``docs/plans/coder-agent.mdx``.
+
+The module also exposes small CRUD primitives that individual store modules
+wrap with typed signatures. The primitives intentionally stay untyped at the
+row level — each store attaches its own Pydantic model for that.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+def open_connection(db_path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite connection with the store's canonical PRAGMAs.
+
+    PRAGMAs applied:
+
+    * ``journal_mode=WAL`` — write-ahead logging for concurrent readers.
+    * ``foreign_keys=ON`` — enforce declared FK constraints.
+    * ``busy_timeout=5000`` — 5-second wait when the DB is locked.
+
+    The parent directory of ``db_path`` is created if it does not exist so
+    callers can point at a nested path under ``~/.gaia/coder/`` without first
+    making the directory themselves.
+    """
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def exec_script(conn: sqlite3.Connection, ddl: str) -> None:
+    """Execute a multi-statement DDL script inside a transaction."""
+    with conn:
+        conn.executescript(ddl)
+
+
+def _compile_where(filter_: Mapping[str, Any] | None) -> tuple[str, list[Any]]:
+    """Build a ``WHERE`` clause and parameter list from an equality filter.
+
+    Empty/``None`` filter returns ``("", [])`` so callers can concatenate
+    unconditionally. Values are passed as positional parameters — no string
+    interpolation — so this is safe against injection.
+    """
+    if not filter_:
+        return "", []
+    parts = []
+    params: list[Any] = []
+    for key, value in filter_.items():
+        if value is None:
+            parts.append(f"{key} IS NULL")
+        else:
+            parts.append(f"{key} = ?")
+            params.append(value)
+    return " WHERE " + " AND ".join(parts), params
+
+
+def insert(conn: sqlite3.Connection, table: str, row: Mapping[str, Any]) -> None:
+    """Insert a single row into ``table``. All columns present in ``row`` are written."""
+    columns = list(row.keys())
+    placeholders = ", ".join("?" for _ in columns)
+    cols_sql = ", ".join(columns)
+    sql = f"INSERT INTO {table} ({cols_sql}) VALUES ({placeholders})"
+    with conn:
+        conn.execute(sql, [row[c] for c in columns])
+
+
+def fetch_one(
+    conn: sqlite3.Connection,
+    table: str,
+    filter_: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Fetch at most one row from ``table`` matching the equality filter."""
+    where, params = _compile_where(filter_)
+    sql = f"SELECT * FROM {table}{where} LIMIT 1"
+    cur = conn.execute(sql, params)
+    row = cur.fetchone()
+    return dict(row) if row is not None else None
+
+
+def fetch_all(
+    conn: sqlite3.Connection,
+    table: str,
+    filter_: Mapping[str, Any] | None = None,
+    *,
+    order_by: str | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch every row from ``table`` matching the equality filter."""
+    where, params = _compile_where(filter_)
+    order_sql = f" ORDER BY {order_by}" if order_by else ""
+    sql = f"SELECT * FROM {table}{where}{order_sql}"
+    cur = conn.execute(sql, params)
+    return [dict(r) for r in cur.fetchall()]
+
+
+def update(
+    conn: sqlite3.Connection,
+    table: str,
+    filter_: Mapping[str, Any],
+    patch: Mapping[str, Any],
+) -> int:
+    """Update rows matching ``filter_`` with values from ``patch``.
+
+    Returns the number of rows affected. Raises :class:`ValueError` if the
+    patch is empty (prevents accidental no-op UPDATEs that hide caller bugs).
+    """
+    if not patch:
+        raise ValueError("update requires at least one column in patch")
+    set_clause = ", ".join(f"{k} = ?" for k in patch.keys())
+    where, where_params = _compile_where(filter_)
+    sql = f"UPDATE {table} SET {set_clause}{where}"
+    params: Iterable[Any] = list(patch.values()) + where_params
+    with conn:
+        cur = conn.execute(sql, list(params))
+        return cur.rowcount

--- a/src/gaia/coder/stores/audit.py
+++ b/src/gaia/coder/stores/audit.py
@@ -1,0 +1,132 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``audit.log.db`` — append-only tool-call audit log.
+
+Backs §15.1 of ``docs/plans/coder-agent.mdx``. Every tool call the agent makes
+appends one row here: the tool name, arguments, result, duration, error (if
+any), plus the loop version and state it ran under. This is the ground-truth
+timeline used by §7.7 introspection and §8 review passes.
+
+The primary key is ``INTEGER PRIMARY KEY AUTOINCREMENT``, so ``insert_row``
+does not require an ``id`` — the database assigns one and we return it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel
+
+from gaia.coder.stores._common import (
+    exec_script,
+    fetch_all,
+    fetch_one,
+    open_connection,
+    update,
+)
+
+DDL = """
+CREATE TABLE audit (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  occurred_at  TEXT NOT NULL,
+  task_id      TEXT,                        -- FK tasks.id; NULL outside tasks
+  stage        TEXT,                        -- §5.1 stage name
+  state_name   TEXT,                        -- §5.1 current state
+  tool_name    TEXT NOT NULL,
+  args_json    TEXT NOT NULL,
+  result_json  TEXT,
+  duration_ms  INTEGER,
+  error        TEXT,                        -- exception class name; NULL on success
+  loop_version INTEGER NOT NULL
+);
+CREATE INDEX idx_audit_occurred ON audit(occurred_at);
+CREATE INDEX idx_audit_task ON audit(task_id);
+CREATE INDEX idx_audit_tool ON audit(tool_name);
+"""
+
+TABLE = "audit"
+
+
+class AuditRow(BaseModel):
+    """Row mirror of the ``audit`` table."""
+
+    id: Optional[int] = None
+    occurred_at: str
+    task_id: Optional[str] = None
+    stage: Optional[str] = None
+    state_name: Optional[str] = None
+    tool_name: str
+    args_json: str
+    result_json: Optional[str] = None
+    duration_ms: Optional[int] = None
+    error: Optional[str] = None
+    loop_version: int
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create the ``audit`` table and its indices."""
+    exec_script(conn, DDL)
+
+
+def open_store(db_path: str | Path) -> sqlite3.Connection:
+    """Open ``audit.log.db`` with canonical PRAGMAs, creating tables on first use."""
+    conn = open_connection(db_path)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE,),
+    )
+    if cur.fetchone() is None:
+        create_tables(conn)
+    return conn
+
+
+def insert_row(conn: sqlite3.Connection, row: AuditRow) -> int:
+    """Insert an ``AuditRow`` and return the auto-generated id.
+
+    ``row.id`` is ignored — the database assigns it. The returned integer is
+    the new row's ``id`` (``lastrowid``).
+    """
+    payload = row.model_dump(exclude={"id"})
+    columns = list(payload.keys())
+    placeholders = ", ".join("?" for _ in columns)
+    cols_sql = ", ".join(columns)
+    sql = f"INSERT INTO {TABLE} ({cols_sql}) VALUES ({placeholders})"
+    with conn:
+        cur = conn.execute(sql, [payload[c] for c in columns])
+        row_id = cur.lastrowid
+    # SQLite guarantees a positive integer rowid after INSERT into an
+    # AUTOINCREMENT column; surface loudly if somehow not.
+    if row_id is None:
+        raise RuntimeError("audit insert did not return a lastrowid")
+    return row_id
+
+
+def get_row(conn: sqlite3.Connection, row_id: int) -> AuditRow | None:
+    """Fetch an audit row by integer primary key."""
+    raw = fetch_one(conn, TABLE, {"id": row_id})
+    return AuditRow(**raw) if raw is not None else None
+
+
+def update_row(
+    conn: sqlite3.Connection,
+    row_id: int,
+    patch: Mapping[str, Any],
+) -> int:
+    """Apply ``patch`` to the audit row with matching ``id``. Returns rows affected.
+
+    Audit is conceptually append-only; callers should generally treat rows as
+    immutable. ``update_row`` is provided for late-arriving data (e.g., filling
+    in ``duration_ms`` after a tool completes) and for tests.
+    """
+    return update(conn, TABLE, {"id": row_id}, patch)
+
+
+def list_rows(
+    conn: sqlite3.Connection,
+    filter: Mapping[str, Any] | None = None,
+) -> list[AuditRow]:
+    """List audit rows matching the equality filter (oldest first)."""
+    rows = fetch_all(conn, TABLE, filter, order_by="occurred_at, id")
+    return [AuditRow(**r) for r in rows]

--- a/src/gaia/coder/stores/ci_history.py
+++ b/src/gaia/coder/stores/ci_history.py
@@ -1,0 +1,110 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``ci_history.db`` — workflow-duration cache.
+
+Backs §6.2 of ``docs/plans/coder-agent.mdx``. Stores one row per GitHub Actions
+run so the agent can estimate expected duration for a workflow on a given
+branch without re-querying the API. The primary key is a compound
+``(workflow_name, branch, run_id)``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel
+
+from gaia.coder.stores._common import (
+    exec_script,
+    fetch_all,
+    fetch_one,
+    insert,
+    open_connection,
+    update,
+)
+
+DDL = """
+CREATE TABLE ci_history (
+  workflow_name  TEXT NOT NULL,
+  branch         TEXT NOT NULL,
+  run_id         INTEGER NOT NULL,
+  started_at     TEXT NOT NULL,
+  completed_at   TEXT,
+  duration_s     INTEGER,
+  conclusion     TEXT,                      -- success | failure | cancelled | timed_out
+  PRIMARY KEY (workflow_name, branch, run_id)
+);
+"""
+
+TABLE = "ci_history"
+
+
+class CiHistoryRow(BaseModel):
+    """Row mirror of the ``ci_history`` table."""
+
+    workflow_name: str
+    branch: str
+    run_id: int
+    started_at: str
+    completed_at: Optional[str] = None
+    duration_s: Optional[int] = None
+    conclusion: Optional[str] = None
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create the ``ci_history`` table."""
+    exec_script(conn, DDL)
+
+
+def open_store(db_path: str | Path) -> sqlite3.Connection:
+    """Open ``ci_history.db`` with canonical PRAGMAs, creating tables on first use."""
+    conn = open_connection(db_path)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE,),
+    )
+    if cur.fetchone() is None:
+        create_tables(conn)
+    return conn
+
+
+def _pk_filter(workflow_name: str, branch: str, run_id: int) -> dict[str, Any]:
+    return {"workflow_name": workflow_name, "branch": branch, "run_id": run_id}
+
+
+def insert_row(conn: sqlite3.Connection, row: CiHistoryRow) -> None:
+    """Insert a ``CiHistoryRow``."""
+    insert(conn, TABLE, row.model_dump())
+
+
+def get_row(
+    conn: sqlite3.Connection,
+    workflow_name: str,
+    branch: str,
+    run_id: int,
+) -> CiHistoryRow | None:
+    """Fetch by compound primary key."""
+    raw = fetch_one(conn, TABLE, _pk_filter(workflow_name, branch, run_id))
+    return CiHistoryRow(**raw) if raw is not None else None
+
+
+def update_row(
+    conn: sqlite3.Connection,
+    workflow_name: str,
+    branch: str,
+    run_id: int,
+    patch: Mapping[str, Any],
+) -> int:
+    """Apply ``patch`` to the row keyed by ``(workflow_name, branch, run_id)``."""
+    return update(conn, TABLE, _pk_filter(workflow_name, branch, run_id), patch)
+
+
+def list_rows(
+    conn: sqlite3.Connection,
+    filter: Mapping[str, Any] | None = None,
+) -> list[CiHistoryRow]:
+    """List CI history rows matching the equality filter (most recent first)."""
+    rows = fetch_all(conn, TABLE, filter, order_by="started_at DESC")
+    return [CiHistoryRow(**r) for r in rows]

--- a/src/gaia/coder/stores/em_inbox.py
+++ b/src/gaia/coder/stores/em_inbox.py
@@ -1,0 +1,123 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``em_inbox.db`` — the EM input queue.
+
+Backs §4.5 of ``docs/plans/coder-agent.mdx``. Every inbound message from the
+bound Engineering Manager (CLI, TUI, gh-comment, email, daily-standup reply)
+lands here first and is graduated into ``feedback.db`` only if the triage
+classifier decides it is feedback-class.
+
+The DDL below is the §15.1 schema verbatim.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, Field
+
+from gaia.coder.stores._common import (
+    exec_script,
+    fetch_all,
+    fetch_one,
+    insert,
+    open_connection,
+    update,
+)
+
+DDL = """
+CREATE TABLE em_inbox (
+  id                 TEXT PRIMARY KEY,               -- UUIDv7
+  received_at        TEXT NOT NULL,                  -- ISO-8601 UTC
+  from_handle        TEXT NOT NULL,                  -- GitHub handle
+  channel            TEXT NOT NULL                   -- cli | tui | gh-comment | email | daily-standup-reply
+                     CHECK (channel IN ('cli','tui','gh-comment','email','daily-standup-reply')),
+  severity           TEXT NOT NULL
+                     CHECK (severity IN ('info','question','critical')),
+  body               TEXT NOT NULL,
+  state              TEXT NOT NULL DEFAULT 'pending' -- pending → seen → (answered|escalated) → closed
+                     CHECK (state IN ('pending','seen','answered','escalated','closed')),
+  answer             TEXT,
+  escalated_to       TEXT,                           -- feedback.id if reclassified
+  ack_sent_at        TEXT,                           -- < 5s after received_at (§10.6)
+  answered_at        TEXT,
+  closed_at          TEXT
+);
+CREATE INDEX idx_em_inbox_state ON em_inbox(state);
+CREATE INDEX idx_em_inbox_received ON em_inbox(received_at);
+"""
+
+TABLE = "em_inbox"
+
+
+class EmInboxRow(BaseModel):
+    """Row mirror of the ``em_inbox`` table."""
+
+    id: str
+    received_at: str
+    from_handle: str
+    channel: str = Field(
+        description="cli | tui | gh-comment | email | daily-standup-reply"
+    )
+    severity: str = Field(description="info | question | critical")
+    body: str
+    state: str = Field(
+        default="pending",
+        description="pending | seen | answered | escalated | closed",
+    )
+    answer: Optional[str] = None
+    escalated_to: Optional[str] = None
+    ack_sent_at: Optional[str] = None
+    answered_at: Optional[str] = None
+    closed_at: Optional[str] = None
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create the ``em_inbox`` table and its indices."""
+    exec_script(conn, DDL)
+
+
+def open_store(db_path: str | Path) -> sqlite3.Connection:
+    """Open ``em_inbox.db`` with canonical PRAGMAs, creating tables on first use."""
+    conn = open_connection(db_path)
+    # ``CREATE TABLE`` without ``IF NOT EXISTS`` is verbatim from §15.1. We skip
+    # re-running the DDL if the table is already present so callers can reopen
+    # the store freely.
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE,),
+    )
+    if cur.fetchone() is None:
+        create_tables(conn)
+    return conn
+
+
+def insert_row(conn: sqlite3.Connection, row: EmInboxRow) -> None:
+    """Insert an ``EmInboxRow``."""
+    insert(conn, TABLE, row.model_dump())
+
+
+def get_row(conn: sqlite3.Connection, row_id: str) -> EmInboxRow | None:
+    """Fetch a row by primary key."""
+    raw = fetch_one(conn, TABLE, {"id": row_id})
+    return EmInboxRow(**raw) if raw is not None else None
+
+
+def update_row(
+    conn: sqlite3.Connection,
+    row_id: str,
+    patch: Mapping[str, Any],
+) -> int:
+    """Apply ``patch`` to the row with matching ``id``. Returns rows affected."""
+    return update(conn, TABLE, {"id": row_id}, patch)
+
+
+def list_rows(
+    conn: sqlite3.Connection,
+    filter: Mapping[str, Any] | None = None,
+) -> list[EmInboxRow]:
+    """List rows matching the equality filter (most recent first)."""
+    rows = fetch_all(conn, TABLE, filter, order_by="received_at DESC")
+    return [EmInboxRow(**r) for r in rows]

--- a/src/gaia/coder/stores/feedback.py
+++ b/src/gaia/coder/stores/feedback.py
@@ -1,0 +1,128 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``feedback.db`` — the feedback queue graduated from ``em_inbox``.
+
+Backs §7.3 of ``docs/plans/coder-agent.mdx``. Every EM-authored critique that
+the triage classifier accepts as feedback lives here through its full fix
+lifecycle. The ``fix_class`` CHECK lists **eight** values — the seven agent-fix
+classes plus ``out-of-scope``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, Field
+
+from gaia.coder.stores._common import (
+    exec_script,
+    fetch_all,
+    fetch_one,
+    insert,
+    open_connection,
+    update,
+)
+
+DDL = """
+CREATE TABLE feedback (
+  id                    TEXT PRIMARY KEY,            -- UUIDv7
+  received_at           TEXT NOT NULL,
+  from_handle           TEXT NOT NULL,               -- bound EM or pre-authorised reviewer
+  channel               TEXT NOT NULL,
+  severity              TEXT NOT NULL
+                        CHECK (severity IN ('low','med','high','critical')),
+  body                  TEXT NOT NULL,
+  context_url           TEXT,                        -- PR/issue/commit URL
+  fix_class             TEXT                         -- prompt|doc|test|tool|policy|architectural|state-machine|out-of-scope
+                        CHECK (fix_class IN ('prompt','doc','test','tool','policy','architectural','state-machine','out-of-scope')),
+  state                 TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (state IN ('pending','triaged','in-fix','fix-pr-open','verified','rejected','closed')),
+  fix_pr_url            TEXT,
+  regression_test_path  TEXT,                        -- required non-null for state='verified'
+  root_cause            TEXT,
+  success_criterion     TEXT,                        -- from Stage 3 §5.1 plan
+  notes_json            TEXT NOT NULL DEFAULT '[]'   -- append-only state-transition audit
+);
+CREATE INDEX idx_feedback_state ON feedback(state);
+CREATE INDEX idx_feedback_fix_class ON feedback(fix_class);
+"""
+
+TABLE = "feedback"
+
+
+class FeedbackRow(BaseModel):
+    """Row mirror of the ``feedback`` table."""
+
+    id: str
+    received_at: str
+    from_handle: str
+    channel: str
+    severity: str = Field(description="low | med | high | critical")
+    body: str
+    context_url: Optional[str] = None
+    fix_class: Optional[str] = Field(
+        default=None,
+        description=(
+            "prompt | doc | test | tool | policy | architectural | "
+            "state-machine | out-of-scope"
+        ),
+    )
+    state: str = Field(
+        default="pending",
+        description=(
+            "pending | triaged | in-fix | fix-pr-open | verified | rejected | closed"
+        ),
+    )
+    fix_pr_url: Optional[str] = None
+    regression_test_path: Optional[str] = None
+    root_cause: Optional[str] = None
+    success_criterion: Optional[str] = None
+    notes_json: str = "[]"
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create the ``feedback`` table and its indices."""
+    exec_script(conn, DDL)
+
+
+def open_store(db_path: str | Path) -> sqlite3.Connection:
+    """Open ``feedback.db`` with canonical PRAGMAs, creating tables on first use."""
+    conn = open_connection(db_path)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE,),
+    )
+    if cur.fetchone() is None:
+        create_tables(conn)
+    return conn
+
+
+def insert_row(conn: sqlite3.Connection, row: FeedbackRow) -> None:
+    """Insert a ``FeedbackRow``."""
+    insert(conn, TABLE, row.model_dump())
+
+
+def get_row(conn: sqlite3.Connection, row_id: str) -> FeedbackRow | None:
+    """Fetch feedback by primary key."""
+    raw = fetch_one(conn, TABLE, {"id": row_id})
+    return FeedbackRow(**raw) if raw is not None else None
+
+
+def update_row(
+    conn: sqlite3.Connection,
+    row_id: str,
+    patch: Mapping[str, Any],
+) -> int:
+    """Apply ``patch`` to feedback with matching ``id``. Returns rows affected."""
+    return update(conn, TABLE, {"id": row_id}, patch)
+
+
+def list_rows(
+    conn: sqlite3.Connection,
+    filter: Mapping[str, Any] | None = None,
+) -> list[FeedbackRow]:
+    """List feedback matching the equality filter (most recent first)."""
+    rows = fetch_all(conn, TABLE, filter, order_by="received_at DESC")
+    return [FeedbackRow(**r) for r in rows]

--- a/src/gaia/coder/stores/learnings_log.py
+++ b/src/gaia/coder/stores/learnings_log.py
@@ -1,0 +1,121 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``learnings.log`` — append-only plain-text log of candidate ``GAIA.md`` edits.
+
+Backs §4.6 and §15.1 of ``docs/plans/coder-agent.mdx``. Each line is a single
+human-readable observation that the agent flagged as *possibly* worth
+promoting to her always-present identity document. The weekly summary (§4.4)
+walks this log and proposes the top-3 candidates to the EM.
+
+Canonical line format (§15.1):
+
+    <ISO-8601 UTC> [task=<task_id>] Observed: "<one-line observation>" → <promotion_candidate: GAIA.md | skill:<name> | dismissed>
+
+Newlines in the observation are rejected — each observation must fit on a
+single line so grep/awk stay useful.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterator, Optional
+
+from pydantic import BaseModel, field_validator
+
+# Promotion candidate vocabulary per §4.6:
+# - ``GAIA.md`` — propose promoting into the always-present identity doc.
+# - ``skill:<name>`` — demote into a context-loaded skill file.
+# - ``dismissed`` — recorded but no promotion proposed.
+_SKILL_RE = re.compile(r"^skill:[A-Za-z0-9._\-]+$")
+
+
+class LearningEntry(BaseModel):
+    """One line of ``learnings.log``."""
+
+    ts: str  # ISO-8601 UTC
+    task_id: str  # task identifier (``t_01H...``)
+    observation: str  # one-line observation
+    promotion_candidate: str  # "GAIA.md" | "skill:<name>" | "dismissed"
+
+    @field_validator("observation")
+    @classmethod
+    def _no_newlines(cls, v: str) -> str:
+        if "\n" in v or "\r" in v:
+            raise ValueError("observation must be a single line")
+        return v
+
+    @field_validator("promotion_candidate")
+    @classmethod
+    def _known_candidate(cls, v: str) -> str:
+        if v in {"GAIA.md", "dismissed"}:
+            return v
+        if _SKILL_RE.match(v):
+            return v
+        raise ValueError(
+            "promotion_candidate must be 'GAIA.md', 'dismissed', or 'skill:<name>'"
+        )
+
+
+# Pattern for parsing:
+#   <ts> [task=<task_id>] Observed: "<obs>" → <candidate>
+_LINE_RE = re.compile(
+    r"^(?P<ts>\S+)\s+\[task=(?P<task_id>[^\]]+)\]\s+Observed:\s+"
+    r"\"(?P<observation>.*)\"\s+→\s+(?P<candidate>\S.*)$"
+)
+
+
+def format_entry(entry: LearningEntry) -> str:
+    """Render a :class:`LearningEntry` to its canonical single-line form."""
+    return (
+        f"{entry.ts} [task={entry.task_id}] Observed: "
+        f'"{entry.observation}" → {entry.promotion_candidate}'
+    )
+
+
+def parse_line(line: str) -> Optional[LearningEntry]:
+    """Parse one canonical line into a :class:`LearningEntry`.
+
+    Returns ``None`` for blank lines. Raises :class:`ValueError` if the line
+    does not match the canonical format — callers decide whether to tolerate
+    or fail loudly.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+    match = _LINE_RE.match(stripped)
+    if not match:
+        raise ValueError(
+            f"learnings.log line does not match canonical format: {line!r}"
+        )
+    return LearningEntry(
+        ts=match["ts"],
+        task_id=match["task_id"],
+        observation=match["observation"],
+        promotion_candidate=match["candidate"].strip(),
+    )
+
+
+def append(log_path: str | Path, entry: LearningEntry) -> None:
+    """Append ``entry`` to ``log_path`` as one canonical line."""
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(format_entry(entry) + "\n")
+
+
+def iter_entries(log_path: str | Path) -> Iterator[LearningEntry]:
+    """Yield every entry in ``log_path``. Skips blank lines."""
+    path = Path(log_path)
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            parsed = parse_line(line)
+            if parsed is not None:
+                yield parsed
+
+
+def read_all(log_path: str | Path) -> list[LearningEntry]:
+    """Read every entry into a list."""
+    return list(iter_entries(log_path))

--- a/src/gaia/coder/stores/memory.py
+++ b/src/gaia/coder/stores/memory.py
@@ -1,0 +1,137 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``memory.db`` — the relational side of the hybrid memory store.
+
+Backs §6.8 and §15.1 of ``docs/plans/coder-agent.mdx``. Production-plan is a
+single ``memory`` table keyed by ``topic``, with one FAISS index file per
+topic co-located alongside this SQLite database. **FAISS wiring is explicitly
+out of scope for this module** (Phase 10, §6.8); we only create the SQL side
+and expose an ``embedding_key`` column that later phases will populate.
+
+Topics (CHECK constraint — 8 values):
+
+* ``review_patterns`` — cross-review learnings (§8).
+* ``failure_patterns`` — canonical failure signatures (§7.2).
+* ``flaky_tests`` — known flakes with evidence.
+* ``em_preferences`` — EM-specific style rules (§4.4).
+* ``adr_decisions`` — architectural decisions (ADR log).
+* ``tool_usage_heuristics`` — when-to-use-what rules per tool.
+* ``task_outcomes`` — what-worked / what-didn't per task.
+* ``mutation_seeds`` — §8.4 adversarial mutation seeds.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, Field
+
+from gaia.coder.stores._common import (
+    exec_script,
+    fetch_all,
+    fetch_one,
+    insert,
+    open_connection,
+    update,
+)
+
+DDL = """
+-- One table per topic for simple cases; in production these are views over a single `memory` table
+-- keyed by topic for FAISS co-location.
+CREATE TABLE memory (
+  id               TEXT PRIMARY KEY,         -- UUIDv7
+  topic            TEXT NOT NULL             -- review_patterns | failure_patterns | flaky_tests | em_preferences | adr_decisions | tool_usage_heuristics | task_outcomes | mutation_seeds
+                   CHECK (topic IN ('review_patterns','failure_patterns','flaky_tests',
+                                    'em_preferences','adr_decisions','tool_usage_heuristics',
+                                    'task_outcomes','mutation_seeds')),
+  created_at       TEXT NOT NULL,
+  source_kind      TEXT NOT NULL,            -- feedback | pr | issue | task | event | audit | reconcile
+  source_id        TEXT,                     -- FK-like reference into feedback/tasks/audit
+  payload_json     TEXT NOT NULL,            -- topic-specific schema (see §6.8.1)
+  embedding_key    TEXT NOT NULL,            -- FAISS id
+  confidence       INTEGER NOT NULL DEFAULT 80
+                   CHECK (confidence BETWEEN 0 AND 100),
+  last_recalled_at TEXT,
+  recall_count     INTEGER NOT NULL DEFAULT 0,
+  superseded_by    TEXT                      -- FK memory.id; soft-replacement
+);
+CREATE INDEX idx_memory_topic ON memory(topic);
+CREATE INDEX idx_memory_recalled ON memory(last_recalled_at);
+"""
+
+TABLE = "memory"
+
+
+class MemoryRow(BaseModel):
+    """Row mirror of the ``memory`` table."""
+
+    id: str
+    topic: str = Field(
+        description=(
+            "review_patterns | failure_patterns | flaky_tests | em_preferences | "
+            "adr_decisions | tool_usage_heuristics | task_outcomes | mutation_seeds"
+        )
+    )
+    created_at: str
+    source_kind: str = Field(
+        description="feedback | pr | issue | task | event | audit | reconcile"
+    )
+    source_id: Optional[str] = None
+    payload_json: str
+    embedding_key: str = Field(description="FAISS id; wired up in Phase 10")
+    confidence: int = 80
+    last_recalled_at: Optional[str] = None
+    recall_count: int = 0
+    superseded_by: Optional[str] = None
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create the ``memory`` table and its indices."""
+    exec_script(conn, DDL)
+
+
+def open_store(db_path: str | Path) -> sqlite3.Connection:
+    """Open ``memory.db`` with canonical PRAGMAs, creating tables on first use."""
+    conn = open_connection(db_path)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE,),
+    )
+    if cur.fetchone() is None:
+        create_tables(conn)
+    return conn
+
+
+def insert_row(conn: sqlite3.Connection, row: MemoryRow) -> None:
+    """Insert a ``MemoryRow``.
+
+    FAISS indexing is intentionally left to Phase 10; callers supply a
+    pre-computed ``embedding_key`` so the relational side is complete now.
+    """
+    insert(conn, TABLE, row.model_dump())
+
+
+def get_row(conn: sqlite3.Connection, row_id: str) -> MemoryRow | None:
+    """Fetch a memory row by primary key."""
+    raw = fetch_one(conn, TABLE, {"id": row_id})
+    return MemoryRow(**raw) if raw is not None else None
+
+
+def update_row(
+    conn: sqlite3.Connection,
+    row_id: str,
+    patch: Mapping[str, Any],
+) -> int:
+    """Apply ``patch`` to the memory row with matching ``id``. Returns rows affected."""
+    return update(conn, TABLE, {"id": row_id}, patch)
+
+
+def list_rows(
+    conn: sqlite3.Connection,
+    filter: Mapping[str, Any] | None = None,
+) -> list[MemoryRow]:
+    """List memory rows matching the equality filter (most recent first)."""
+    rows = fetch_all(conn, TABLE, filter, order_by="created_at DESC")
+    return [MemoryRow(**r) for r in rows]

--- a/src/gaia/coder/stores/paused_tasks.py
+++ b/src/gaia/coder/stores/paused_tasks.py
@@ -1,0 +1,78 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``paused-tasks/<task-id>.json`` — one JSON snapshot per paused task.
+
+Backs §7.5 (self-fix pause/resume) of ``docs/plans/coder-agent.mdx``. When the
+agent pauses a task — either because she detects a self-bug or because the EM
+says "pause" — she persists everything needed to resume it to a JSON file
+under ``paused-tasks/``. Each file is self-describing so a later agent
+instance (possibly on a different ``loop_version``) can still parse it.
+
+**Not SQLite.** JSON is the right shape here because snapshots are read
+whole, written whole, never queried, and need to round-trip arbitrary tool
+histories without schema migrations.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _validate_task_id(task_id: str) -> None:
+    """Refuse path-separator characters in ``task_id`` to keep reads/writes contained."""
+    if not task_id:
+        raise ValueError("task_id must be non-empty")
+    if "/" in task_id or "\\" in task_id or task_id in {".", ".."}:
+        raise ValueError(
+            f"task_id must not contain path separators or be '.'/'..': {task_id!r}"
+        )
+
+
+def snapshot_path(root: Path, task_id: str) -> Path:
+    """Return the canonical path of a snapshot for ``task_id`` under ``root``.
+
+    ``root`` is the ``paused-tasks/`` directory; the returned path is
+    ``root / f"{task_id}.json"``.
+    """
+    _validate_task_id(task_id)
+    return Path(root) / f"{task_id}.json"
+
+
+def write_snapshot(root: Path, task_id: str, data: dict[str, Any]) -> Path:
+    """Write ``data`` as a pretty-printed JSON snapshot for ``task_id``.
+
+    Returns the absolute :class:`Path` of the written file. The parent
+    directory is created if missing. Writes are atomic via ``.tmp`` rename.
+    """
+    _validate_task_id(task_id)
+    root_path = Path(root)
+    root_path.mkdir(parents=True, exist_ok=True)
+    final_path = root_path / f"{task_id}.json"
+    tmp_path = final_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(final_path)
+    return final_path
+
+
+def read_snapshot(root: Path, task_id: str) -> dict[str, Any]:
+    """Read the JSON snapshot for ``task_id``.
+
+    Raises :class:`FileNotFoundError` if no snapshot exists — callers should
+    surface that loudly (per CLAUDE.md "no silent fallbacks") rather than
+    treating it as "no paused state".
+    """
+    _validate_task_id(task_id)
+    path = Path(root) / f"{task_id}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"no paused-task snapshot at {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def list_snapshots(root: Path) -> list[str]:
+    """Return task_ids of every snapshot present under ``root`` (sorted)."""
+    root_path = Path(root)
+    if not root_path.exists():
+        return []
+    return sorted(p.stem for p in root_path.iterdir() if p.suffix == ".json")

--- a/src/gaia/coder/stores/self_edits_log.py
+++ b/src/gaia/coder/stores/self_edits_log.py
@@ -1,0 +1,89 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``self-edits.log`` — append-only JSONL of every self-edit PR.
+
+Backs §6.4 (self-fix transparency) of ``docs/plans/coder-agent.mdx``. One JSON
+object per line, newline-terminated. Each record captures the PR URL, fix
+class, touched files, before/after SHAs, review-pass verdicts, confidence,
+EM review outcome, auto-merge flag, and the originating ``feedback_id``.
+
+The log is append-only on the write side. Reads iterate the file line by
+line and parse each record.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from pydantic import BaseModel
+
+
+class ReviewPasses(BaseModel):
+    """Verdicts from each review pass (§8)."""
+
+    static: str
+    functional: str
+    arch: str
+    security: str
+    prose: str
+    adversarial: str
+    feedback_binding: str
+
+
+class SelfEditRecord(BaseModel):
+    """One line of ``self-edits.log``; schema per §15.1."""
+
+    ts: str
+    pr: str
+    fix_class: str
+    files: list[str]
+    before_sha: str
+    after_sha: str
+    review_passes: ReviewPasses
+    confidence: int
+    em_review: str
+    auto_merged: bool
+    feedback_id: Optional[str] = None
+
+
+def append(log_path: str | Path, record: SelfEditRecord) -> None:
+    """Append ``record`` to ``log_path`` as a single JSON line.
+
+    The parent directory is created if missing. The file is opened in
+    line-buffered append mode so concurrent appends on POSIX are safe for
+    records shorter than ``PIPE_BUF`` (4096 bytes on Linux/macOS).
+    """
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = record.model_dump_json()
+    # ``model_dump_json`` does not include a trailing newline.
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def iter_records(log_path: str | Path) -> Iterator[SelfEditRecord]:
+    """Yield every record in ``log_path`` as a :class:`SelfEditRecord`.
+
+    Skips empty lines. Raises :class:`ValueError` via Pydantic if a line is
+    corrupt — the caller should decide whether to fail loudly or log.
+    """
+    path = Path(log_path)
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            yield SelfEditRecord.model_validate_json(stripped)
+
+
+def read_all(log_path: str | Path) -> list[SelfEditRecord]:
+    """Read every record from ``log_path`` into a list."""
+    return list(iter_records(log_path))
+
+
+def append_dict(log_path: str | Path, payload: dict[str, Any]) -> None:
+    """Convenience: append a raw ``dict`` after validating it against the schema."""
+    append(log_path, SelfEditRecord.model_validate(payload))

--- a/src/gaia/coder/stores/spend.py
+++ b/src/gaia/coder/stores/spend.py
@@ -1,0 +1,105 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``spend.db`` — cost ledger for every Anthropic API call.
+
+Backs §6.6 of ``docs/plans/coder-agent.mdx``. One row per model call — input,
+cache, and output tokens plus the resolved USD amount. Used by the budget
+tooling and the weekly spend summary.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel
+
+from gaia.coder.stores._common import (
+    exec_script,
+    fetch_all,
+    fetch_one,
+    insert,
+    open_connection,
+    update,
+)
+
+DDL = """
+CREATE TABLE spend (
+  id             TEXT PRIMARY KEY,          -- UUIDv7
+  occurred_at    TEXT NOT NULL,
+  task_id        TEXT,                      -- FK tasks.id; NULL for non-task calls
+  call_site      TEXT NOT NULL,             -- 'triage' | 'plan' | 'pass_6_adversarial' | 'continuous_critique' | etc.
+  model          TEXT NOT NULL,             -- 'claude-opus-4-7'
+  input_tokens   INTEGER NOT NULL,
+  cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+  cache_create_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens  INTEGER NOT NULL,
+  usd            REAL NOT NULL
+);
+CREATE INDEX idx_spend_occurred ON spend(occurred_at);
+CREATE INDEX idx_spend_task ON spend(task_id);
+"""
+
+TABLE = "spend"
+
+
+class SpendRow(BaseModel):
+    """Row mirror of the ``spend`` table."""
+
+    id: str
+    occurred_at: str
+    task_id: Optional[str] = None
+    call_site: str
+    model: str
+    input_tokens: int
+    cache_read_tokens: int = 0
+    cache_create_tokens: int = 0
+    output_tokens: int
+    usd: float
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create the ``spend`` table and its indices."""
+    exec_script(conn, DDL)
+
+
+def open_store(db_path: str | Path) -> sqlite3.Connection:
+    """Open ``spend.db`` with canonical PRAGMAs, creating tables on first use."""
+    conn = open_connection(db_path)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE,),
+    )
+    if cur.fetchone() is None:
+        create_tables(conn)
+    return conn
+
+
+def insert_row(conn: sqlite3.Connection, row: SpendRow) -> None:
+    """Insert a ``SpendRow``."""
+    insert(conn, TABLE, row.model_dump())
+
+
+def get_row(conn: sqlite3.Connection, row_id: str) -> SpendRow | None:
+    """Fetch a spend entry by primary key."""
+    raw = fetch_one(conn, TABLE, {"id": row_id})
+    return SpendRow(**raw) if raw is not None else None
+
+
+def update_row(
+    conn: sqlite3.Connection,
+    row_id: str,
+    patch: Mapping[str, Any],
+) -> int:
+    """Apply ``patch`` to the spend entry. Returns rows affected."""
+    return update(conn, TABLE, {"id": row_id}, patch)
+
+
+def list_rows(
+    conn: sqlite3.Connection,
+    filter: Mapping[str, Any] | None = None,
+) -> list[SpendRow]:
+    """List spend entries matching the equality filter (most recent first)."""
+    rows = fetch_all(conn, TABLE, filter, order_by="occurred_at DESC")
+    return [SpendRow(**r) for r in rows]

--- a/src/gaia/coder/stores/tasks.py
+++ b/src/gaia/coder/stores/tasks.py
@@ -1,0 +1,113 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``tasks.db`` — the coder's task queue.
+
+Backs §6.3 of ``docs/plans/coder-agent.mdx``. Every engineering task the agent
+picks up lives here through its full lifecycle (pending → running → waiting →
+blocked → paused → done → abandoned).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, Field
+
+from gaia.coder.stores._common import (
+    exec_script,
+    fetch_all,
+    fetch_one,
+    insert,
+    open_connection,
+    update,
+)
+
+DDL = """
+CREATE TABLE tasks (
+  id                 TEXT PRIMARY KEY,               -- UUIDv7
+  priority           INTEGER NOT NULL DEFAULT 50,    -- 0 (lowest) .. 100 (highest)
+  state              TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (state IN ('pending','running','waiting','blocked','paused','done','abandoned')),
+  created_at         TEXT NOT NULL,
+  last_heartbeat_at  TEXT,
+  stage              TEXT,                           -- current §5.1 stage name
+  current_state_name TEXT,                           -- current §5.1 state
+  inputs_json        TEXT NOT NULL,                  -- original prompt + params
+  result_json        TEXT,                           -- summary + artifacts
+  trace_file         TEXT,                           -- path to JSONL trace under sessions/
+  cost_usd           REAL NOT NULL DEFAULT 0.0,
+  loop_version       INTEGER NOT NULL                -- §7.8 state-machine version
+);
+CREATE INDEX idx_tasks_state ON tasks(state);
+CREATE INDEX idx_tasks_priority ON tasks(priority DESC, created_at);
+"""
+
+TABLE = "tasks"
+
+
+class TaskRow(BaseModel):
+    """Row mirror of the ``tasks`` table."""
+
+    id: str
+    priority: int = 50
+    state: str = Field(
+        default="pending",
+        description="pending | running | waiting | blocked | paused | done | abandoned",
+    )
+    created_at: str
+    last_heartbeat_at: Optional[str] = None
+    stage: Optional[str] = None
+    current_state_name: Optional[str] = None
+    inputs_json: str
+    result_json: Optional[str] = None
+    trace_file: Optional[str] = None
+    cost_usd: float = 0.0
+    loop_version: int
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create the ``tasks`` table and its indices."""
+    exec_script(conn, DDL)
+
+
+def open_store(db_path: str | Path) -> sqlite3.Connection:
+    """Open ``tasks.db`` with canonical PRAGMAs, creating tables on first use."""
+    conn = open_connection(db_path)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (TABLE,),
+    )
+    if cur.fetchone() is None:
+        create_tables(conn)
+    return conn
+
+
+def insert_row(conn: sqlite3.Connection, row: TaskRow) -> None:
+    """Insert a ``TaskRow``."""
+    insert(conn, TABLE, row.model_dump())
+
+
+def get_row(conn: sqlite3.Connection, row_id: str) -> TaskRow | None:
+    """Fetch a task by primary key."""
+    raw = fetch_one(conn, TABLE, {"id": row_id})
+    return TaskRow(**raw) if raw is not None else None
+
+
+def update_row(
+    conn: sqlite3.Connection,
+    row_id: str,
+    patch: Mapping[str, Any],
+) -> int:
+    """Apply ``patch`` to the task with matching ``id``. Returns rows affected."""
+    return update(conn, TABLE, {"id": row_id}, patch)
+
+
+def list_rows(
+    conn: sqlite3.Connection,
+    filter: Mapping[str, Any] | None = None,
+) -> list[TaskRow]:
+    """List tasks matching the equality filter (priority DESC, created_at ASC)."""
+    rows = fetch_all(conn, TABLE, filter, order_by="priority DESC, created_at")
+    return [TaskRow(**r) for r in rows]

--- a/tests/coder/conftest.py
+++ b/tests/coder/conftest.py
@@ -1,0 +1,72 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Pytest configuration for ``tests/coder/``.
+
+The sibling ``feature/gaia-coder-scaffold`` branch owns ``gaia.coder.__init__``,
+``gaia.coder.base``, and ``gaia.coder.loop``. While that work is in flight the
+top-level ``gaia.coder`` package may transiently reference names that are not
+yet defined (``CoderAgent``, ``DEFAULT_LOOP``, …) — which breaks imports of
+``gaia.coder.stores.*`` even though our store modules don't depend on any of
+that.
+
+This conftest isolates the stores tests from that churn by:
+
+1. Trying a normal ``import gaia.coder`` first. If it succeeds the sibling
+   scaffold is present and working — we do nothing and let the real modules
+   run.
+2. If the import fails for any reason, we pre-populate ``sys.modules`` with
+   minimal stubs of the offending sub-modules so a fresh import of
+   ``gaia.coder`` succeeds against them.
+
+Once the sibling branch lands, step 1 stays green forever and this file
+becomes effectively inert.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def _try_real_import() -> bool:
+    """Attempt the real import; return True on success."""
+    try:
+        import gaia.coder  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _install_stubs() -> None:
+    """Replace ``gaia.coder`` and its sibling-owned submodules with stubs."""
+    # Remove any half-imported entries so the stubs take effect cleanly.
+    for key in list(sys.modules):
+        if key == "gaia.coder" or key.startswith("gaia.coder."):
+            if key == "gaia.coder.stores" or key.startswith("gaia.coder.stores"):
+                # Preserve any already-loaded stores modules — they are ours.
+                continue
+            del sys.modules[key]
+
+    coder_mod = types.ModuleType("gaia.coder")
+    # Make ``gaia.coder`` behave as a package so submodule imports work.
+    import os
+
+    coder_mod.__path__ = [os.path.join(os.path.dirname(__file__), "..", "..", "src", "gaia", "coder")]  # type: ignore[attr-defined]
+    sys.modules["gaia.coder"] = coder_mod
+
+    base_mod = types.ModuleType("gaia.coder.base")
+
+    class _CoderAgentStub:  # pragma: no cover - placeholder only
+        """Placeholder; real implementation lands in feature/gaia-coder-scaffold."""
+
+    base_mod.CoderAgent = _CoderAgentStub  # type: ignore[attr-defined]
+    sys.modules["gaia.coder.base"] = base_mod
+
+    loop_mod = types.ModuleType("gaia.coder.loop")
+    for attr in ("DEFAULT_LOOP", "Loop", "State", "Transition"):
+        setattr(loop_mod, attr, object())
+    sys.modules["gaia.coder.loop"] = loop_mod
+
+
+if not _try_real_import():
+    _install_stubs()

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -477,3 +477,75 @@ def test_ci_history_check_constraints(tmp_path: Path) -> None:
             ci_history.insert_row(conn, row)
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# memory
+# ---------------------------------------------------------------------------
+
+
+def test_create_memory(tmp_path: Path) -> None:
+    conn = memory.open_store(tmp_path / "memory.db")
+    try:
+        assert _table_exists(conn, "memory")
+    finally:
+        conn.close()
+
+
+def test_round_trip_memory(tmp_path: Path) -> None:
+    conn = memory.open_store(tmp_path / "memory.db")
+    try:
+        row = memory.MemoryRow(
+            id="m_1",
+            topic="review_patterns",
+            created_at=_ISO,
+            source_kind="pr",
+            source_id="pr_941",
+            payload_json=json.dumps({"pattern": "always cite file:line"}),
+            embedding_key="faiss_0001",
+            confidence=85,
+        )
+        memory.insert_row(conn, row)
+
+        fetched = memory.get_row(conn, "m_1")
+        assert fetched is not None
+        assert fetched.topic == "review_patterns"
+        assert fetched.recall_count == 0
+
+        memory.update_row(
+            conn,
+            "m_1",
+            {"last_recalled_at": _ISO, "recall_count": 1},
+        )
+        updated = memory.get_row(conn, "m_1")
+        assert updated is not None
+        assert updated.recall_count == 1
+
+        rows = memory.list_rows(conn, {"topic": "review_patterns"})
+        assert len(rows) == 1
+    finally:
+        conn.close()
+
+
+def test_memory_check_constraints(tmp_path: Path) -> None:
+    conn = memory.open_store(tmp_path / "memory.db")
+    try:
+        # Invalid topic — CHECK should reject.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO memory (id, topic, created_at, source_kind, payload_json, embedding_key) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("bad_1", "launch_codes", _ISO, "pr", "{}", "faiss_x"),
+            )
+        conn.rollback()
+
+        # confidence out of range — CHECK should reject.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO memory (id, topic, created_at, source_kind, payload_json, embedding_key, confidence) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("bad_2", "review_patterns", _ISO, "pr", "{}", "faiss_x", 101),
+            )
+        conn.rollback()
+    finally:
+        conn.close()

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -592,3 +592,48 @@ def test_paused_tasks_rejects_path_traversal(tmp_path: Path) -> None:
 def test_paused_tasks_missing_raises(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         paused_tasks.read_snapshot(tmp_path, "never_written")
+
+
+# ---------------------------------------------------------------------------
+# self_edits_log
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_self_edits_log(tmp_path: Path) -> None:
+    path = tmp_path / "self-edits.log"
+    record = self_edits_log.SelfEditRecord(
+        ts=_ISO,
+        pr="https://github.com/amd/gaia/pull/941",
+        fix_class="prompt",
+        files=["src/gaia/coder/GAIA.md"],
+        before_sha="abc123",
+        after_sha="def456",
+        review_passes=self_edits_log.ReviewPasses(
+            static="pass",
+            functional="pass",
+            arch="pass",
+            security="pass",
+            prose="pass",
+            adversarial="pass",
+            feedback_binding="pass",
+        ),
+        confidence=94,
+        em_review="approved",
+        auto_merged=False,
+        feedback_id="fb_01HA",
+    )
+    self_edits_log.append(path, record)
+    self_edits_log.append(path, record)  # append again — log must grow, not overwrite.
+
+    records = self_edits_log.read_all(path)
+    assert len(records) == 2
+    assert records[0].pr == "https://github.com/amd/gaia/pull/941"
+    assert records[0].review_passes.adversarial == "pass"
+
+
+def test_self_edits_log_rejects_bad_schema(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError):
+        self_edits_log.append_dict(
+            tmp_path / "self-edits.log",
+            {"ts": _ISO, "pr": "x", "fix_class": "prompt"},  # missing required fields
+        )

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -549,3 +549,46 @@ def test_memory_check_constraints(tmp_path: Path) -> None:
         conn.rollback()
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# paused_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_paused_tasks(tmp_path: Path) -> None:
+    root = tmp_path / "paused-tasks"
+    data = {
+        "task_id": "t_abc",
+        "paused_at": _ISO,
+        "reason": "self-bug",
+        "resume_hint": "re-enter state=edit",
+        "cwd": "/tmp/gaia",
+        "original_prompt": "scaffold agent",
+        "tool_call_history": [],
+        "partial_outputs": {},
+        "context_hash": "sha256-deadbeef",
+        "loop_version": 1,
+        "stage_at_pause": "Build",
+        "state_at_pause": "edit",
+    }
+    written = paused_tasks.write_snapshot(root, "t_abc", data)
+    assert written.exists()
+    assert written.name == "t_abc.json"
+
+    read = paused_tasks.read_snapshot(root, "t_abc")
+    assert read == data
+
+    assert paused_tasks.list_snapshots(root) == ["t_abc"]
+
+
+def test_paused_tasks_rejects_path_traversal(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        paused_tasks.write_snapshot(tmp_path, "../escape", {})
+    with pytest.raises(ValueError):
+        paused_tasks.write_snapshot(tmp_path, "a/b", {})
+
+
+def test_paused_tasks_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        paused_tasks.read_snapshot(tmp_path, "never_written")

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -266,3 +266,69 @@ def test_feedback_check_constraints(tmp_path: Path) -> None:
         conn.rollback()
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# spend
+# ---------------------------------------------------------------------------
+
+
+def test_create_spend(tmp_path: Path) -> None:
+    conn = spend.open_store(tmp_path / "spend.db")
+    try:
+        assert _table_exists(conn, "spend")
+    finally:
+        conn.close()
+
+
+def test_round_trip_spend(tmp_path: Path) -> None:
+    conn = spend.open_store(tmp_path / "spend.db")
+    try:
+        row = spend.SpendRow(
+            id="s_1",
+            occurred_at=_ISO,
+            task_id="t_1",
+            call_site="pass_6_adversarial",
+            model="claude-opus-4-7",
+            input_tokens=1000,
+            cache_read_tokens=800,
+            cache_create_tokens=200,
+            output_tokens=500,
+            usd=0.042,
+        )
+        spend.insert_row(conn, row)
+
+        fetched = spend.get_row(conn, "s_1")
+        assert fetched is not None
+        assert fetched.cache_read_tokens == 800
+        assert fetched.usd == pytest.approx(0.042)
+
+        rows = spend.list_rows(conn, {"task_id": "t_1"})
+        assert len(rows) == 1
+    finally:
+        conn.close()
+
+
+def test_spend_check_constraints(tmp_path: Path) -> None:
+    """``spend`` has no enum CHECK constraints — verify the NOT NULL columns are enforced."""
+    conn = spend.open_store(tmp_path / "spend.db")
+    try:
+        # Missing required `usd` (NOT NULL) should fail.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO spend (id, occurred_at, call_site, model, input_tokens, output_tokens) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("bad_1", _ISO, "triage", "claude-opus-4-7", 100, 50),
+            )
+        conn.rollback()
+
+        # Missing required `input_tokens` (NOT NULL) should fail.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO spend (id, occurred_at, call_site, model, output_tokens, usd) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("bad_2", _ISO, "triage", "claude-opus-4-7", 50, 0.001),
+            )
+        conn.rollback()
+    finally:
+        conn.close()

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -1,0 +1,129 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for ``gaia.coder.stores`` — §15.1 persistent store DDL + CRUD.
+
+Each SQLite store has three tests: create, round-trip, and a CHECK-constraint
+test that proves the DDL constraint rejects invalid enum values. The non-SQL
+stores (``paused_tasks``, ``self_edits_log``, ``learnings_log``) each have a
+round-trip test plus a schema-rejection test where applicable.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from gaia.coder.stores import (
+    audit,
+    ci_history,
+    create_all_stores,
+    em_inbox,
+    feedback,
+    learnings_log,
+    memory,
+    paused_tasks,
+    self_edits_log,
+    spend,
+    tasks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+_ISO = "2026-04-20T12:34:56Z"
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    cur = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    )
+    return cur.fetchone() is not None
+
+
+# ---------------------------------------------------------------------------
+# em_inbox
+# ---------------------------------------------------------------------------
+
+
+def test_create_em_inbox(tmp_path: Path) -> None:
+    conn = em_inbox.open_store(tmp_path / "em_inbox.db")
+    try:
+        assert _table_exists(conn, "em_inbox")
+        index_names = {
+            r["name"]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='em_inbox'"
+            )
+        }
+        assert {"idx_em_inbox_state", "idx_em_inbox_received"}.issubset(index_names)
+    finally:
+        conn.close()
+
+
+def test_round_trip_em_inbox(tmp_path: Path) -> None:
+    conn = em_inbox.open_store(tmp_path / "em_inbox.db")
+    try:
+        row = em_inbox.EmInboxRow(
+            id="msg_1",
+            received_at=_ISO,
+            from_handle="kovtcharov-amd",
+            channel="cli",
+            severity="question",
+            body="is the agent up?",
+        )
+        em_inbox.insert_row(conn, row)
+
+        fetched = em_inbox.get_row(conn, "msg_1")
+        assert fetched is not None
+        assert fetched.from_handle == "kovtcharov-amd"
+        assert fetched.state == "pending"
+
+        em_inbox.update_row(conn, "msg_1", {"state": "answered", "answer": "yes"})
+        updated = em_inbox.get_row(conn, "msg_1")
+        assert updated is not None
+        assert updated.state == "answered"
+        assert updated.answer == "yes"
+
+        rows = em_inbox.list_rows(conn, {"state": "answered"})
+        assert len(rows) == 1
+        assert rows[0].id == "msg_1"
+    finally:
+        conn.close()
+
+
+def test_em_inbox_check_constraints(tmp_path: Path) -> None:
+    conn = em_inbox.open_store(tmp_path / "em_inbox.db")
+    try:
+        # Invalid channel value — CHECK should reject.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO em_inbox (id, received_at, from_handle, channel, severity, body) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("bad_1", _ISO, "kovtcharov-amd", "sms", "info", "body"),
+            )
+        conn.rollback()
+
+        # Invalid severity value — CHECK should reject.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO em_inbox (id, received_at, from_handle, channel, severity, body) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("bad_2", _ISO, "kovtcharov-amd", "cli", "nuclear", "body"),
+            )
+        conn.rollback()
+
+        # Invalid state value — CHECK should reject.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO em_inbox (id, received_at, from_handle, channel, severity, body, state) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("bad_3", _ISO, "kovtcharov-amd", "cli", "info", "body", "loitering"),
+            )
+        conn.rollback()
+    finally:
+        conn.close()

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -637,3 +637,58 @@ def test_self_edits_log_rejects_bad_schema(tmp_path: Path) -> None:
             tmp_path / "self-edits.log",
             {"ts": _ISO, "pr": "x", "fix_class": "prompt"},  # missing required fields
         )
+
+
+# ---------------------------------------------------------------------------
+# learnings_log
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_learnings_log(tmp_path: Path) -> None:
+    path = tmp_path / "learnings.log"
+    entry = learnings_log.LearningEntry(
+        ts="2026-05-03",
+        task_id="t_8f2",
+        observation="I added a defensive try/except that the EM rejected",
+        promotion_candidate="GAIA.md",
+    )
+    learnings_log.append(path, entry)
+    learnings_log.append(
+        path,
+        learnings_log.LearningEntry(
+            ts="2026-05-04",
+            task_id="t_914",
+            observation="EM prefers PR bodies that cite the exact CLAUDE.md rule",
+            promotion_candidate="skill:em-kalin-preferences",
+        ),
+    )
+
+    entries = learnings_log.read_all(path)
+    assert len(entries) == 2
+    assert entries[0].promotion_candidate == "GAIA.md"
+    assert entries[1].promotion_candidate == "skill:em-kalin-preferences"
+
+    # Human-readable single-line format is preserved on disk.
+    lines = path.read_text().splitlines()
+    assert lines[0].startswith("2026-05-03 [task=t_8f2] Observed: ")
+    assert lines[0].endswith("→ GAIA.md")
+
+
+def test_learnings_log_rejects_bad_candidate() -> None:
+    with pytest.raises(ValidationError):
+        learnings_log.LearningEntry(
+            ts=_ISO,
+            task_id="t_1",
+            observation="x",
+            promotion_candidate="promote",  # invalid
+        )
+
+
+def test_learnings_log_rejects_multiline_observation() -> None:
+    with pytest.raises(ValidationError):
+        learnings_log.LearningEntry(
+            ts=_ISO,
+            task_id="t_1",
+            observation="line one\nline two",
+            promotion_candidate="dismissed",
+        )

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -127,3 +127,68 @@ def test_em_inbox_check_constraints(tmp_path: Path) -> None:
         conn.rollback()
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# tasks
+# ---------------------------------------------------------------------------
+
+
+def test_create_tasks(tmp_path: Path) -> None:
+    conn = tasks.open_store(tmp_path / "tasks.db")
+    try:
+        assert _table_exists(conn, "tasks")
+    finally:
+        conn.close()
+
+
+def test_round_trip_tasks(tmp_path: Path) -> None:
+    conn = tasks.open_store(tmp_path / "tasks.db")
+    try:
+        row = tasks.TaskRow(
+            id="t_1",
+            priority=70,
+            created_at=_ISO,
+            inputs_json=json.dumps({"prompt": "scaffold weather agent"}),
+            loop_version=1,
+        )
+        tasks.insert_row(conn, row)
+
+        fetched = tasks.get_row(conn, "t_1")
+        assert fetched is not None
+        assert fetched.priority == 70
+        assert fetched.cost_usd == 0.0
+
+        tasks.update_row(conn, "t_1", {"state": "running", "cost_usd": 0.23})
+        updated = tasks.get_row(conn, "t_1")
+        assert updated is not None
+        assert updated.state == "running"
+        assert updated.cost_usd == pytest.approx(0.23)
+
+        # list_rows ordering: priority DESC, created_at — insert a second row.
+        row2 = tasks.TaskRow(
+            id="t_2",
+            priority=90,
+            created_at=_ISO,
+            inputs_json="{}",
+            loop_version=1,
+        )
+        tasks.insert_row(conn, row2)
+        rows = tasks.list_rows(conn)
+        assert [r.id for r in rows] == ["t_2", "t_1"]
+    finally:
+        conn.close()
+
+
+def test_tasks_check_constraints(tmp_path: Path) -> None:
+    conn = tasks.open_store(tmp_path / "tasks.db")
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO tasks (id, created_at, inputs_json, state, loop_version) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("bad_state", _ISO, "{}", "interpretive-dance", 1),
+            )
+        conn.rollback()
+    finally:
+        conn.close()

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -413,3 +413,67 @@ def test_audit_check_constraints(tmp_path: Path) -> None:
         assert second > first
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# ci_history
+# ---------------------------------------------------------------------------
+
+
+def test_create_ci_history(tmp_path: Path) -> None:
+    conn = ci_history.open_store(tmp_path / "ci_history.db")
+    try:
+        assert _table_exists(conn, "ci_history")
+    finally:
+        conn.close()
+
+
+def test_round_trip_ci_history(tmp_path: Path) -> None:
+    conn = ci_history.open_store(tmp_path / "ci_history.db")
+    try:
+        row = ci_history.CiHistoryRow(
+            workflow_name="ci.yml",
+            branch="feature/x",
+            run_id=42,
+            started_at=_ISO,
+        )
+        ci_history.insert_row(conn, row)
+
+        fetched = ci_history.get_row(conn, "ci.yml", "feature/x", 42)
+        assert fetched is not None
+        assert fetched.duration_s is None
+
+        ci_history.update_row(
+            conn,
+            "ci.yml",
+            "feature/x",
+            42,
+            {"completed_at": _ISO, "duration_s": 300, "conclusion": "success"},
+        )
+        updated = ci_history.get_row(conn, "ci.yml", "feature/x", 42)
+        assert updated is not None
+        assert updated.duration_s == 300
+        assert updated.conclusion == "success"
+
+        rows = ci_history.list_rows(conn, {"workflow_name": "ci.yml"})
+        assert len(rows) == 1
+    finally:
+        conn.close()
+
+
+def test_ci_history_check_constraints(tmp_path: Path) -> None:
+    """``ci_history`` has no CHECK enums; verify compound PK uniqueness is enforced."""
+    conn = ci_history.open_store(tmp_path / "ci_history.db")
+    try:
+        row = ci_history.CiHistoryRow(
+            workflow_name="ci.yml",
+            branch="main",
+            run_id=1,
+            started_at=_ISO,
+        )
+        ci_history.insert_row(conn, row)
+        # Duplicate PK — must fail.
+        with pytest.raises(sqlite3.IntegrityError):
+            ci_history.insert_row(conn, row)
+    finally:
+        conn.close()

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -692,3 +692,55 @@ def test_learnings_log_rejects_multiline_observation() -> None:
             observation="line one\nline two",
             promotion_candidate="dismissed",
         )
+
+
+# ---------------------------------------------------------------------------
+# create_all_stores
+# ---------------------------------------------------------------------------
+
+
+def test_create_all_stores(tmp_path: Path) -> None:
+    paths = create_all_stores(tmp_path)
+
+    expected_keys = {
+        "em_inbox",
+        "tasks",
+        "feedback",
+        "spend",
+        "audit",
+        "ci_history",
+        "memory",
+        "paused_tasks",
+        "self_edits_log",
+        "learnings_log",
+    }
+    assert set(paths.keys()) == expected_keys
+
+    # Every SQLite db exists on disk with its expected table.
+    sqlite_stores = {
+        "em_inbox": "em_inbox",
+        "tasks": "tasks",
+        "feedback": "feedback",
+        "spend": "spend",
+        "audit": "audit",
+        "ci_history": "ci_history",
+        "memory": "memory",
+    }
+    for store_name, table in sqlite_stores.items():
+        db_path = paths[store_name]
+        assert db_path.exists()
+        conn = sqlite3.connect(db_path)
+        try:
+            assert _table_exists(conn, table)
+        finally:
+            conn.close()
+
+    # paused-tasks is a directory; the log files are not yet materialised but
+    # their parents exist.
+    assert paths["paused_tasks"].is_dir()
+    assert paths["self_edits_log"].parent.exists()
+    assert paths["learnings_log"].parent.exists()
+
+    # Idempotent re-run.
+    second = create_all_stores(tmp_path)
+    assert second == paths

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -192,3 +192,77 @@ def test_tasks_check_constraints(tmp_path: Path) -> None:
         conn.rollback()
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# feedback
+# ---------------------------------------------------------------------------
+
+
+def test_create_feedback(tmp_path: Path) -> None:
+    conn = feedback.open_store(tmp_path / "feedback.db")
+    try:
+        assert _table_exists(conn, "feedback")
+    finally:
+        conn.close()
+
+
+def test_round_trip_feedback(tmp_path: Path) -> None:
+    conn = feedback.open_store(tmp_path / "feedback.db")
+    try:
+        # Exercise all 8 fix_class values.
+        valid_classes = [
+            "prompt",
+            "doc",
+            "test",
+            "tool",
+            "policy",
+            "architectural",
+            "state-machine",
+            "out-of-scope",
+        ]
+        for idx, fc in enumerate(valid_classes):
+            row = feedback.FeedbackRow(
+                id=f"fb_{idx}",
+                received_at=_ISO,
+                from_handle="kovtcharov-amd",
+                channel="cli",
+                severity="high",
+                body=f"feedback #{idx}",
+                fix_class=fc,
+            )
+            feedback.insert_row(conn, row)
+
+        assert len(feedback.list_rows(conn)) == len(valid_classes)
+        assert len(feedback.list_rows(conn, {"fix_class": "doc"})) == 1
+
+        feedback.update_row(conn, "fb_0", {"state": "triaged"})
+        triaged = feedback.get_row(conn, "fb_0")
+        assert triaged is not None
+        assert triaged.state == "triaged"
+    finally:
+        conn.close()
+
+
+def test_feedback_check_constraints(tmp_path: Path) -> None:
+    conn = feedback.open_store(tmp_path / "feedback.db")
+    try:
+        # Invalid fix_class — CHECK should reject.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO feedback (id, received_at, from_handle, channel, severity, body, fix_class) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("bad_1", _ISO, "em", "cli", "high", "body", "vibes"),
+            )
+        conn.rollback()
+
+        # Invalid severity — CHECK should reject.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO feedback (id, received_at, from_handle, channel, severity, body) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("bad_2", _ISO, "em", "cli", "maybe", "body"),
+            )
+        conn.rollback()
+    finally:
+        conn.close()

--- a/tests/coder/test_stores.py
+++ b/tests/coder/test_stores.py
@@ -332,3 +332,84 @@ def test_spend_check_constraints(tmp_path: Path) -> None:
         conn.rollback()
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# audit
+# ---------------------------------------------------------------------------
+
+
+def test_create_audit(tmp_path: Path) -> None:
+    conn = audit.open_store(tmp_path / "audit.log.db")
+    try:
+        assert _table_exists(conn, "audit")
+    finally:
+        conn.close()
+
+
+def test_round_trip_audit(tmp_path: Path) -> None:
+    conn = audit.open_store(tmp_path / "audit.log.db")
+    try:
+        row = audit.AuditRow(
+            occurred_at=_ISO,
+            task_id="t_1",
+            stage="Build",
+            state_name="edit",
+            tool_name="write_file",
+            args_json=json.dumps({"path": "foo.py"}),
+            result_json=json.dumps({"bytes": 42}),
+            duration_ms=17,
+            loop_version=1,
+        )
+        row_id = audit.insert_row(conn, row)
+        assert isinstance(row_id, int) and row_id >= 1
+
+        fetched = audit.get_row(conn, row_id)
+        assert fetched is not None
+        assert fetched.tool_name == "write_file"
+        assert fetched.error is None
+
+        audit.update_row(conn, row_id, {"error": "TimeoutError"})
+        err = audit.get_row(conn, row_id)
+        assert err is not None and err.error == "TimeoutError"
+
+        rows = audit.list_rows(conn, {"task_id": "t_1"})
+        assert len(rows) == 1
+    finally:
+        conn.close()
+
+
+def test_audit_check_constraints(tmp_path: Path) -> None:
+    """``audit`` has no CHECK enums; verify NOT NULL columns + AUTOINCREMENT semantics."""
+    conn = audit.open_store(tmp_path / "audit.log.db")
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO audit (occurred_at, tool_name, loop_version) "
+                "VALUES (?, ?, ?)",
+                (_ISO, "write_file", 1),
+            )
+        conn.rollback()
+
+        # Two inserts should get strictly-increasing ids (AUTOINCREMENT semantics).
+        first = audit.insert_row(
+            conn,
+            audit.AuditRow(
+                occurred_at=_ISO,
+                tool_name="read_file",
+                args_json="{}",
+                loop_version=1,
+            ),
+        )
+        second = audit.insert_row(
+            conn,
+            audit.AuditRow(
+                occurred_at=_ISO,
+                tool_name="read_file",
+                args_json="{}",
+                loop_version=1,
+            ),
+        )
+        assert second > first
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Implements the ten persistent stores called out in §15.1 of [`docs/plans/coder-agent.mdx`](../blob/feature/coding-agent/docs/plans/coder-agent.mdx) — the durable-state layer every Phase 1 / Phase 3 gaia-coder feature depends on (task queue, EM inbox, feedback queue, spend ledger, audit log, CI history, memory, paused-task snapshots, self-edit JSONL, learnings plain-text log). No business logic — just DDL, Pydantic row models, typed CRUD, and tests.

- **Seven SQLite stores** — `em_inbox.db`, `tasks.db`, `feedback.db`, `spend.db`, `audit.log.db`, `ci_history.db`, `memory.db`. Each ships the §15.1 DDL verbatim (grep-verifiable), a `create_tables()` / `open_store()` pair with canonical PRAGMAs (WAL, `foreign_keys=ON`, `busy_timeout=5000`), and `insert_row` / `get_row` / `update_row` / `list_rows` helpers keyed off a per-store Pydantic v2 model.
- **Three append-only stores** — `paused_tasks` (JSON-per-file), `self_edits_log` (JSONL), `learnings_log` (plain text with a strict single-line grammar). All three use Pydantic for schema validation on the write side and fail loudly on read errors.
- **`stores/__init__.py::create_all_stores(root)`** — idempotent convenience that materialises every store under one directory and returns a `{store_name: Path}` map.
- **30 tests** in `tests/coder/test_stores.py` — create / round-trip / CHECK-constraint for every SQLite store, round-trip / schema-rejection for the append-only logs, smoke test for `create_all_stores`.
- **`tests/coder/conftest.py`** — defensive `sys.modules` stubs for `gaia.coder.base` / `gaia.coder.loop` so these tests stay isolated from sibling scaffold churn; becomes inert once the sibling branch stabilises.

FAISS index wiring for the `memory` store is intentionally out of scope — that's Phase 10.

## Dependencies

Branched off `feature/gaia-coder-scaffold` (sibling task, already merged into this branch via rebase). The three scaffold commits (`daefa1d`, `a160148`, `da051cd`) at the tip are required for `from gaia.coder import CoderAgent` to resolve, but nothing in this PR's 12 commits depends on the scaffold beyond defensive test stubs.

## Commits

One commit per store module (ten) plus one for the infra (`_common.py` + test conftest) and one for the package `__init__` with `create_all_stores`:

1. `feat(coder): stores — SQLite connection helpers + test harness`
2. `feat(coder): em_inbox store + CRUD + tests`
3. `feat(coder): tasks store + CRUD + tests`
4. `feat(coder): feedback store + CRUD + tests`
5. `feat(coder): spend store + CRUD + tests`
6. `feat(coder): audit store + CRUD + tests`
7. `feat(coder): ci_history store + CRUD + tests`
8. `feat(coder): memory store + CRUD + tests (SQL side only)`
9. `feat(coder): paused_tasks snapshot store + tests`
10. `feat(coder): self_edits_log JSONL append-only store + tests`
11. `feat(coder): learnings_log plain-text append-only store + tests`
12. `feat(coder): stores/__init__ with create_all_stores + smoke test`

## Test plan

- [ ] `python -m pytest tests/coder/test_stores.py -xvs` — 30 passed locally.
- [ ] `python util/lint.py --black --isort` — clean.
- [ ] Grep-verify that every §15.1 DDL string appears verbatim under `src/gaia/coder/stores/`:
  ```bash
  for t in em_inbox tasks feedback spend audit ci_history memory; do
    grep -l "CREATE TABLE $t" src/gaia/coder/stores/*.py || echo "MISSING: $t"
  done
  ```

## Do not merge

Draft — blocked on the sibling `feature/gaia-coder-scaffold` PR landing first so the git history stays clean once both land on `feature/coding-agent`.