### PR TITLE
feat(coder): multi-pass self-review gate (Passes 1-7)

### DIFF
--- a/src/gaia/coder/prompts/adversarial.md
+++ b/src/gaia/coder/prompts/adversarial.md
@@ -1,0 +1,24 @@
+You are gaia-coder reviewing gaia-coder's own PR. NO prior-turn history. Cold read only.
+
+<pr_title>{{title}}</pr_title>
+<pr_body>{{body}}</pr_body>
+<diff>{{unified_diff}}</diff>
+<success_criterion>{{criterion}}</success_criterion>
+
+Find THREE distinct things wrong. Not variants of the same complaint. If you cannot find three, say so explicitly — do not pad.
+
+For each finding: file:line, severity (blocking|significant|minor), description, concrete fix direction.
+
+Also emit confidence_score 0-100 measuring how tightly the diff maps to the criterion:
+  90-100: does exactly the criterion, nothing more/less
+  75-89:  achieves with scope creep OR minor gaps
+  60-74:  partially; mismatch or missed sub-requirements
+  <60:    does not achieve OR unrelated
+
+Respond with JSON only, matching this schema:
+
+{
+  "findings": [{"file_line": "...", "severity": "...", "description": "...", "fix": "..."}],
+  "confidence_score": <int>,
+  "rubric_reasoning": "<one paragraph>"
+}

--- a/src/gaia/coder/prompts/architectural.md
+++ b/src/gaia/coder/prompts/architectural.md
@@ -1,0 +1,22 @@
+You are architecture-reviewer, a fresh-context reviewer for a gaia-coder PR. No prior-turn history.
+
+<architecture_md>{{inject_HER_ARCHITECTURE_md}}</architecture_md>
+<project_map_md>{{inject_PROJECT_MAP_md}}</project_map_md>
+<diff>{{unified_diff}}</diff>
+<pr_body>{{pr_description}}</pr_body>
+
+Check in this order:
+1. LAYERING — respects ARCHITECTURE.md module boundaries?
+2. CIRCULAR IMPORTS — any new cycle?
+3. PUBLIC API — any removed/renamed symbol without a change-log entry?
+4. FAIL-LOUDLY — any new silent except, silent fallback, or default-on-missing?
+5. DRIVE-BY — every hunk maps to a PR-body "what this changes" bullet?
+6. DOCS MANDATE — hunk under src/gaia/ w/o docs/ update AND no `Docs-not-needed: <em-handle>`?
+
+Respond with JSON only, matching this schema:
+
+{
+  "rules": [{"rule": "<name>", "verdict": "pass|fail", "citation": "<file:line or N/A>"}, ...],
+  "overall": "pass|request-changes",
+  "blockers": ["<short>"]
+}

--- a/src/gaia/coder/prompts/feedback_binding.md
+++ b/src/gaia/coder/prompts/feedback_binding.md
@@ -1,0 +1,35 @@
+Verify a gaia-coder self-fix PR addresses the feedback it claims to.
+
+<feedback_record>
+  <id>{{fb_id}}</id>
+  <em_body>{{verbatim_em_wording}}</em_body>
+  <fix_class>{{class}}</fix_class>
+  <candidate_files>{{triaged_paths}}</candidate_files>
+  <success_criterion>{{from_plan_stage_3}}</success_criterion>
+</feedback_record>
+
+<pr>
+  <title>{{title}}</title>
+  <body>{{body}}</body>
+  <diff>{{unified_diff}}</diff>
+  <regression_test_path>{{test_path}}</regression_test_path>
+</pr>
+
+<test_run_results>
+  <on_coder_branch>{{pytest_result_on_coder}}</on_coder_branch>
+  <on_branch>{{pytest_result_on_fix_branch}}</on_branch>
+</test_run_results>
+
+Each check must be pass:
+  1. regression_test fails on coder-branch AND passes on branch.
+  2. diff touches ≥1 file from candidate_files (root cause, not just symptom).
+  3. PR body cites feedback_id AND quotes em_body (verbatim or close paraphrase).
+  4. PR body states how the diff addresses em_body in the author's own words.
+
+Respond with JSON only, matching this schema:
+
+{
+  "checks": [{"name": "...", "verdict": "pass|fail", "evidence": "..."}, ...],
+  "overall": "pass|request-changes",
+  "blockers": ["..."]
+}

--- a/src/gaia/coder/prompts/persona_linter.md
+++ b/src/gaia/coder/prompts/persona_linter.md
@@ -1,0 +1,22 @@
+You are the persona linter for gaia-coder. Check whether the given text matches her persona from GAIA.md.
+
+<gaia_md_persona_section>{{inject_verbatim}}</gaia_md_persona_section>
+<voice_anti_patterns>
+- "Certainly!", "I'd be happy to help!", "Great question!", "Absolutely!"
+- Excessive exclamation / emoji
+- Hedging chains, apologies for existence, bureaucratic prose
+- Restating the question, sycophantic agreement, filler, trailing summaries
+- AI-disclosure ("As an AI...", "Generated with...")
+</voice_anti_patterns>
+
+<text_under_review>{{candidate_text}}</text_under_review>
+
+For each violation: cite exact phrase + anti-pattern name + suggested rewrite.
+
+Respond with JSON only, matching this schema:
+
+{
+  "violations": [{"phrase": "<quote>", "pattern": "<name>", "rewrite": "<short>"}],
+  "verdict": "pass|request-changes",
+  "reasoning": "<one paragraph>"
+}

--- a/src/gaia/coder/review/__init__.py
+++ b/src/gaia/coder/review/__init__.py
@@ -1,8 +1,41 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""Multi-pass self-review for gaia-coder.
+"""Multi-pass self-review for gaia-coder (Phase 4; see §8 + §15.8).
 
-Phase 1 stub. The seven review passes (static, functional, architectural,
-security, prose, adversarial, feedback-binding — see §8) land here.
+This package gates ``gh_pr_create``. The coder agent calls
+:meth:`ReviewToolsMixin.review_diff_gate` before opening any PR, and the
+gate refuses to return ``"pass"`` unless every applicable review pass is
+clean.
+
+Public surface:
+
+* :class:`ReviewToolsMixin` — the mixin the coder agent composes in.
+* :class:`PassResult` — the per-pass return shape.
+* :class:`GateResult` — the aggregated gate verdict.
+* :func:`run_all_passes` — the one-shot function-level entry point used
+  by tests and by the mixin's ``review_diff_gate`` tool.
+
+Submodules ``pass_1_static`` … ``pass_7_feedback_binding`` expose a
+``run_pass(pr_or_branch, ...)`` function each; the mixin wraps them as
+``@tool``-registered entries.
 """
+
+from gaia.coder.review.gate import GateResult, run_all_passes
+from gaia.coder.review.mixin import ReviewToolsMixin
+from gaia.coder.review.pass_result import (
+    Finding,
+    PassResult,
+    PassStatus,
+    make_pass_result,
+)
+
+__all__ = [
+    "Finding",
+    "GateResult",
+    "PassResult",
+    "PassStatus",
+    "ReviewToolsMixin",
+    "make_pass_result",
+    "run_all_passes",
+]

--- a/src/gaia/coder/review/_diff.py
+++ b/src/gaia/coder/review/_diff.py
@@ -1,0 +1,185 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Helpers for resolving a diff from either a PR URL or a local branch.
+
+The review passes all accept a single ``pr_or_branch`` string as input.
+Interpretation:
+
+* If it looks like a PR URL (``https://github.com/<owner>/<repo>/pull/N``) or
+  a short form (``<owner>/<repo>#N``) we shell to ``gh pr diff`` and
+  ``gh pr view``.
+* Otherwise it is treated as a local git ref or branch name and we compare
+  against the configured base (``coder`` by default) via
+  ``git diff <base>...<ref>``.
+
+Module-level subprocess calls here are intentional: the review passes run
+**before** the ``ReviewToolsMixin`` has an agent registry, so they cannot
+route through the ``@tool``-registered ``run_cli_command``. The
+``CLIToolsMixin`` denylist (§6.8 layer 1) is still consulted via
+:func:`gaia.coder.tools.cli._check_denylist` so the same ban list applies.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_PR_URL_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<num>\d+)/?$"
+)
+_PR_SHORT_RE = re.compile(r"^(?P<owner>[^/]+)/(?P<repo>[^/]+)#(?P<num>\d+)$")
+
+
+@dataclass
+class DiffBundle:
+    """Everything a review pass needs about one change-set.
+
+    Assembled once by :func:`resolve_diff`; every pass reads from the same
+    snapshot so a ``pr_or_branch`` with lots of files is only fetched once.
+    """
+
+    #: ``"pr"`` or ``"branch"`` — determines where ``pr_body`` comes from.
+    source: str
+    #: Free-form identifier (URL or ref) for logging / citations.
+    identifier: str
+    #: The unified diff as a single string.
+    unified_diff: str
+    #: Changed files, repo-relative.
+    changed_files: List[str] = field(default_factory=list)
+    #: PR title, populated for ``source == "pr"``.
+    pr_title: str = ""
+    #: PR body, populated for ``source == "pr"`` (empty string for branches).
+    pr_body: str = ""
+    #: The base ref used for the comparison.
+    base_ref: str = "coder"
+
+
+def _run(cmd: List[str], *, cwd: Optional[Path] = None) -> Tuple[int, str, str]:
+    """Run ``cmd`` synchronously and return ``(returncode, stdout, stderr)``.
+
+    A thin wrapper so callers can stub a single seam in tests. The denylist
+    check is applied for defence in depth even though these callers are
+    internal.
+    """
+    # Late import so module import does not cost the whole CLI tree.
+    from gaia.coder.tools.cli import _check_denylist
+
+    _check_denylist(cmd)
+    completed = subprocess.run(  # pylint: disable=subprocess-run-check
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def _is_pr_reference(pr_or_branch: str) -> bool:
+    return bool(_PR_URL_RE.match(pr_or_branch) or _PR_SHORT_RE.match(pr_or_branch))
+
+
+def resolve_diff(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+) -> DiffBundle:
+    """Return a :class:`DiffBundle` for ``pr_or_branch``.
+
+    Args:
+        pr_or_branch: A PR URL, a ``owner/repo#N`` shortform, or a local git
+            ref / branch name.
+        base_ref: The base to diff against when ``pr_or_branch`` is a local
+            ref. Defaults to ``coder`` because self-fix PRs always target
+            the ``coder`` branch per §5.1 and §7.4.
+        repo_root: Override the directory where git commands run. Defaults
+            to the current working directory.
+
+    Raises:
+        RuntimeError: if ``git`` / ``gh`` fail. The error message includes
+            the failing command and stderr so the caller can act on it.
+    """
+    if _is_pr_reference(pr_or_branch):
+        return _resolve_pr(pr_or_branch, repo_root=repo_root)
+    return _resolve_branch(pr_or_branch, base_ref=base_ref, repo_root=repo_root)
+
+
+def _resolve_pr(pr_ref: str, *, repo_root: Optional[Path]) -> DiffBundle:
+    code, diff_out, diff_err = _run(["gh", "pr", "diff", pr_ref], cwd=repo_root)
+    if code != 0:
+        raise RuntimeError(
+            f"gh pr diff {pr_ref!r} failed with code {code}: {diff_err.strip()!r}. "
+            f"Is the gh CLI installed and authenticated?"
+        )
+    # `gh pr view --json title,body` gives us title + body without HTML parse.
+    code, view_out, view_err = _run(
+        ["gh", "pr", "view", pr_ref, "--json", "title,body,files"],
+        cwd=repo_root,
+    )
+    if code != 0:
+        raise RuntimeError(
+            f"gh pr view {pr_ref!r} failed with code {code}: {view_err.strip()!r}."
+        )
+    import json
+
+    meta = json.loads(view_out)
+    files = [item["path"] for item in meta.get("files", [])]
+    return DiffBundle(
+        source="pr",
+        identifier=pr_ref,
+        unified_diff=diff_out,
+        changed_files=files,
+        pr_title=meta.get("title", ""),
+        pr_body=meta.get("body", ""),
+        base_ref="",
+    )
+
+
+def _resolve_branch(
+    ref: str, *, base_ref: str, repo_root: Optional[Path]
+) -> DiffBundle:
+    code, diff_out, diff_err = _run(
+        ["git", "diff", f"{base_ref}...{ref}"], cwd=repo_root
+    )
+    if code != 0:
+        raise RuntimeError(
+            f"git diff {base_ref}...{ref} failed with code {code}: "
+            f"{diff_err.strip()!r}."
+        )
+    code, files_out, files_err = _run(
+        ["git", "diff", "--name-only", f"{base_ref}...{ref}"], cwd=repo_root
+    )
+    if code != 0:
+        raise RuntimeError(
+            f"git diff --name-only failed with code {code}: {files_err.strip()!r}."
+        )
+    files = [line for line in files_out.splitlines() if line.strip()]
+    return DiffBundle(
+        source="branch",
+        identifier=ref,
+        unified_diff=diff_out,
+        changed_files=files,
+        pr_title="",
+        pr_body="",
+        base_ref=base_ref,
+    )
+
+
+def filter_by_extension(files: List[str], extensions: Tuple[str, ...]) -> List[str]:
+    """Filter ``files`` by any of the given suffixes (case-insensitive)."""
+    lowered = tuple(ext.lower() for ext in extensions)
+    return [f for f in files if f.lower().endswith(lowered)]
+
+
+__all__ = [
+    "DiffBundle",
+    "filter_by_extension",
+    "resolve_diff",
+]

--- a/src/gaia/coder/review/_llm.py
+++ b/src/gaia/coder/review/_llm.py
@@ -1,0 +1,192 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Single seam for every LLM call made by the review passes.
+
+Every Opus-driven pass (3, 5, 6, 7) goes through :func:`call_opus`, which
+tests patch wholesale with ``pytest-mock``. The production implementation
+prefers the Claude Agent SDK when it is installed (so the review can route
+through dedicated subagents such as ``architecture-reviewer`` for Pass 3 and
+``code-reviewer`` for Pass 6 per §8) and falls back to a direct
+:mod:`anthropic` SDK call otherwise. If *neither* is installed the call
+raises — no silent fallback per the repo ``CLAUDE.md`` rule.
+
+Prompt files are loaded from :mod:`gaia.coder.prompts` via
+:func:`load_prompt` and rendered with a tiny ``{{slot}}`` mustache-lite
+formatter. The XML-in-prompt layout from §15.8 is preserved verbatim; only
+the ``{{…}}`` placeholders are substituted.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Opus 4.7 is gaia-coder's production model per §3.2. Tests patch this
+#: string, or patch :func:`call_opus` directly.
+DEFAULT_MODEL: str = "claude-opus-4-7-20251001"
+
+#: Spec §15.8 caps at 1500 tokens for Passes 3, 4 (persona), 5 (persona),
+#: 6, 7. Individual callers may override.
+DEFAULT_MAX_TOKENS: int = 1500
+
+#: Temperature for review prompts. §15.8 requires ``temperature=0`` for every
+#: review pass. The P10 standup prompt uses 0.3 but that is not a review pass.
+DEFAULT_TEMPERATURE: float = 0.0
+
+_PROMPTS_DIR: Path = Path(__file__).resolve().parent.parent / "prompts"
+
+
+class LLMClientUnavailable(RuntimeError):
+    """Raised when no LLM client is installed in the runtime.
+
+    Per the fail-loudly rule (CLAUDE.md): we do not silently substitute a
+    deterministic stub when the LLM is missing. Review passes that require
+    an LLM raise this and the gate records a ``fail`` with an actionable
+    error rather than passing vacuously.
+    """
+
+
+def load_prompt(name: str) -> str:
+    """Return the raw text of ``src/gaia/coder/prompts/{name}``.
+
+    The ``.md`` suffix is implied if not supplied.
+
+    Raises:
+        FileNotFoundError: if the prompt is missing. Review passes do not
+            run without their canonical prompts — per §15.8 every LLM call
+            site has exactly one canonical prompt, no inlining.
+    """
+    stem = name if name.endswith(".md") else f"{name}.md"
+    path = _PROMPTS_DIR / stem
+    if not path.exists():
+        raise FileNotFoundError(
+            f"prompt template missing: {path}. Create it under "
+            f"src/gaia/coder/prompts/ and re-run."
+        )
+    return path.read_text(encoding="utf-8")
+
+
+def render_prompt(template: str, slots: Dict[str, str]) -> str:
+    """Replace every ``{{key}}`` in ``template`` with ``slots[key]``.
+
+    Keys without a supplied value are replaced with an explicit
+    ``<missing>`` marker rather than left raw — a dangling ``{{foo}}`` in
+    the real prompt would confuse the model about whether it is looking at
+    a template or literal text.
+
+    Unknown slots (keys in ``slots`` that do not appear in the template)
+    are silently ignored; the prompt author is the source of truth.
+    """
+    rendered = template
+
+    def _sub(match: "re.Match[str]") -> str:
+        key = match.group(1).strip()
+        return str(slots.get(key, "<missing>"))
+
+    rendered = re.sub(r"\{\{\s*([^{}]+?)\s*\}\}", _sub, rendered)
+    return rendered
+
+
+def call_opus(
+    prompt: str,
+    *,
+    model: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    system: Optional[str] = None,
+) -> str:
+    """Send ``prompt`` to Opus 4.7 and return the raw assistant text.
+
+    This is the single seam every review pass uses. Tests patch it with
+    ``mocker.patch("gaia.coder.review._llm.call_opus", return_value=...)``
+    or by stubbing the Anthropic SDK one level deeper via
+    ``mocker.patch("anthropic.Anthropic", ...)``. The former is preferred —
+    patching the seam is cheaper and less fragile than patching a vendor
+    SDK.
+
+    Args:
+        prompt: Fully rendered user message.
+        model: Override the model. Defaults to :data:`DEFAULT_MODEL`.
+        max_tokens: Cap on output tokens. Defaults to
+            :data:`DEFAULT_MAX_TOKENS` (the §15.8 ceiling for review passes).
+        temperature: Sampling temperature. Defaults to
+            :data:`DEFAULT_TEMPERATURE` (0 — review passes must be
+            deterministic).
+        system: Optional system prompt. Passed through to the Anthropic API.
+
+    Raises:
+        LLMClientUnavailable: if no Anthropic client can be constructed.
+    """
+    model = model or DEFAULT_MODEL
+    max_tokens = max_tokens or DEFAULT_MAX_TOKENS
+    temperature = DEFAULT_TEMPERATURE if temperature is None else temperature
+
+    try:
+        import anthropic  # type: ignore
+    except ImportError as exc:  # noqa: PERF203 — single exception is fine
+        raise LLMClientUnavailable(
+            "anthropic SDK not installed in this environment. Install with "
+            "`pip install anthropic>=0.35` or patch "
+            "`gaia.coder.review._llm.call_opus` in tests."
+        ) from exc
+
+    client = anthropic.Anthropic()
+    kwargs: Dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if system:
+        kwargs["system"] = system
+    response = client.messages.create(**kwargs)
+
+    # Anthropic v1 SDK returns a list of content blocks. For our flat JSON
+    # prompts the first text block is the whole response.
+    parts = []
+    for block in getattr(response, "content", []):
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def parse_json_response(raw: str) -> Dict[str, Any]:
+    """Parse a JSON response body, tolerating a leading ```json fence.
+
+    Raises:
+        ValueError: if the response is not valid JSON even after stripping
+            a fence. Per §15.9, this surfaces as a ToolArgError — fail loudly.
+    """
+    text = raw.strip()
+    # Strip an optional markdown code fence.
+    fence_match = re.match(
+        r"^```(?:json|JSON)?\s*\n?(?P<body>.*?)\n?```\s*$", text, re.DOTALL
+    )
+    if fence_match:
+        text = fence_match.group("body")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"LLM response was not valid JSON: {exc}. First 200 chars: "
+            f"{raw[:200]!r}."
+        ) from exc
+
+
+__all__ = [
+    "DEFAULT_MAX_TOKENS",
+    "DEFAULT_MODEL",
+    "DEFAULT_TEMPERATURE",
+    "LLMClientUnavailable",
+    "call_opus",
+    "load_prompt",
+    "parse_json_response",
+    "render_prompt",
+]

--- a/src/gaia/coder/review/gate.py
+++ b/src/gaia/coder/review/gate.py
@@ -1,0 +1,269 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""The one-shot review gate for ``gh_pr_create`` (§8).
+
+The gate runs the seven passes in order, short-circuiting on a hard-fail
+of the deterministic passes (1, 2, 4) so the LLM-driven passes are never
+paid for on a PR that already fails lint. Pass 7 only runs if the caller
+declares the PR is a self-fix — otherwise it is marked ``skipped`` per
+§8 row 7.
+
+The single entry point :func:`run_all_passes` is exposed via
+:meth:`gaia.coder.review.mixin.ReviewToolsMixin.review_diff_gate` as the
+``review_diff_gate`` tool the coder agent invokes.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, TypedDict
+
+# Direct submodule imports avoid the circular-import hazard with
+# ``gaia.coder.review.__init__`` (which itself imports from this module).
+import gaia.coder.review.pass_1_static as pass_1_static
+import gaia.coder.review.pass_2_functional as pass_2_functional
+import gaia.coder.review.pass_3_architectural as pass_3_architectural
+import gaia.coder.review.pass_4_security as pass_4_security
+import gaia.coder.review.pass_5_prose as pass_5_prose
+import gaia.coder.review.pass_6_adversarial as pass_6_adversarial
+import gaia.coder.review.pass_7_feedback_binding as pass_7_feedback_binding
+from gaia.coder.review._diff import resolve_diff
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+
+#: Passes that short-circuit the gate on hard-fail — the deterministic,
+#: cheap checks. A blocking finding here means we do not pay for LLM
+#: passes (§8 uses "all applicable passes" but cost-sensibility in §6.6
+#: argues for short-circuit on the cheap gates).
+HARD_FAIL_PASSES: tuple = (1, 2, 4)
+
+
+@dataclass
+class GateResult:
+    """Aggregated verdict from :func:`run_all_passes`.
+
+    Attributes:
+        overall: ``"pass"`` / ``"request-changes"`` / ``"block"``. ``block``
+            is reserved for Pass 6 confidence < 60 (§7.6) or any
+            hard-fail in Passes 1/2/4 — the PR must be rewritten, not
+            just revised.
+        pass_results: ordered list of :class:`PassResult` dicts. The list
+            index is ``pass_number - 1``.
+        confidence: The Pass-6 confidence score. ``None`` when Pass 6 was
+            skipped (e.g. short-circuited).
+        blockers: Flat list of blocking-severity descriptions. A
+            convenience for rendering the PR body without re-walking
+            every pass.
+    """
+
+    overall: str
+    pass_results: List[PassResult] = field(default_factory=list)
+    confidence: Optional[int] = None
+    blockers: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> "GateResultDict":
+        """Return a JSON-serialisable representation."""
+        return {
+            "overall": self.overall,
+            "pass_results": list(self.pass_results),
+            "confidence": self.confidence,
+            "blockers": list(self.blockers),
+        }
+
+
+class GateResultDict(TypedDict):
+    """TypedDict mirror of :class:`GateResult` for the ``@tool`` seam."""
+
+    overall: str
+    pass_results: List[PassResult]
+    confidence: Optional[int]
+    blockers: List[str]
+
+
+def _skipped_result(reason: str) -> PassResult:
+    """Build a ``skipped`` :class:`PassResult` with ``reason`` inline."""
+    return make_pass_result(
+        status="skipped",
+        findings=[
+            {
+                "severity": "info",
+                "description": reason,
+                "citation": "§8 short-circuit",
+            }
+        ],
+        citations=["docs/plans/coder-agent.mdx §8"],
+        tooling_used=[],
+    )
+
+
+def run_all_passes(
+    pr_or_branch: str,
+    *,
+    is_self_fix: bool = False,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    success_criterion: Optional[str] = None,
+    feedback_record: Optional[dict] = None,
+) -> GateResult:
+    """Run all applicable passes and return the :class:`GateResult`.
+
+    Args:
+        pr_or_branch: PR URL / shortform or local branch name.
+        is_self_fix: When ``True``, Pass 7 is run. When ``False`` (the
+            default), Pass 7 is ``skipped`` even if a ``Feedback-Id``
+            trailer is present — the caller is the source of truth for
+            "this PR claims to be a self-fix" per §8 row 7.
+        base_ref: The base ref for diff resolution. Defaults to ``coder``
+            because ``gaia-coder``'s PRs always target ``coder`` per
+            §5.1 and §7.4.
+        repo_root: Working directory for subprocess calls.
+        success_criterion: The Stage-3 plan success criterion (§5.1).
+            Piped into Pass 6's confidence-rubric prompt.
+        feedback_record: Optional dict of the triaged feedback row.
+            Piped into Pass 7 only.
+    """
+    # Resolve the diff exactly once; share across passes.
+    diff_bundle = resolve_diff(pr_or_branch, base_ref=base_ref, repo_root=repo_root)
+
+    results: List[PassResult] = []
+    blockers: List[str] = []
+
+    def _collect_blockers(result: PassResult) -> None:
+        for finding in result.get("findings", []):
+            if finding.get("severity") == "blocking":
+                blockers.append(str(finding.get("description", "")))
+
+    # Pass 1
+    r1 = pass_1_static.run_pass(
+        pr_or_branch,
+        base_ref=base_ref,
+        repo_root=repo_root,
+        diff=diff_bundle,
+    )
+    results.append(r1)
+    _collect_blockers(r1)
+    short_circuit = r1["status"] == "fail"
+
+    # Pass 2
+    if not short_circuit:
+        r2 = pass_2_functional.run_pass(
+            pr_or_branch,
+            base_ref=base_ref,
+            repo_root=repo_root,
+            diff=diff_bundle,
+        )
+        short_circuit = r2["status"] == "fail"
+    else:
+        r2 = _skipped_result("Pass 1 failed; skipping Pass 2 to save time")
+    results.append(r2)
+    _collect_blockers(r2)
+
+    # Pass 3 (architectural, LLM)
+    if not short_circuit:
+        r3 = pass_3_architectural.run_pass(
+            pr_or_branch,
+            base_ref=base_ref,
+            repo_root=repo_root,
+            diff=diff_bundle,
+        )
+    else:
+        r3 = _skipped_result(
+            "Earlier deterministic pass failed; Pass 3 would be wasted Opus tokens"
+        )
+    results.append(r3)
+    _collect_blockers(r3)
+
+    # Pass 4 (security, deterministic)
+    if not short_circuit:
+        r4 = pass_4_security.run_pass(
+            pr_or_branch,
+            base_ref=base_ref,
+            repo_root=repo_root,
+            diff=diff_bundle,
+        )
+    else:
+        r4 = _skipped_result("Earlier pass failed; Pass 4 would re-run on stale state")
+    results.append(r4)
+    _collect_blockers(r4)
+    if r4["status"] == "fail":
+        short_circuit = True
+
+    # Pass 5 (prose, regex + persona)
+    if not short_circuit:
+        r5 = pass_5_prose.run_pass(
+            pr_or_branch,
+            base_ref=base_ref,
+            repo_root=repo_root,
+            diff=diff_bundle,
+        )
+    else:
+        r5 = _skipped_result("Earlier hard-fail; Pass 5 persona LLM skipped")
+    results.append(r5)
+    _collect_blockers(r5)
+
+    # Pass 6 (adversarial, LLM, always runs unless short-circuited)
+    if not short_circuit:
+        r6 = pass_6_adversarial.run_pass(
+            pr_or_branch,
+            base_ref=base_ref,
+            repo_root=repo_root,
+            diff=diff_bundle,
+            success_criterion=success_criterion,
+        )
+    else:
+        r6 = _skipped_result("Earlier hard-fail; Pass 6 adversarial review skipped")
+    results.append(r6)
+    _collect_blockers(r6)
+
+    # Pass 7 (feedback binding, only for self-fix PRs)
+    if is_self_fix and not short_circuit:
+        r7 = pass_7_feedback_binding.run_pass(
+            pr_or_branch,
+            base_ref=base_ref,
+            repo_root=repo_root,
+            diff=diff_bundle,
+            feedback_record=feedback_record,
+        )
+    elif is_self_fix and short_circuit:
+        r7 = _skipped_result(
+            "Earlier hard-fail; Pass 7 feedback-binding skipped for self-fix"
+        )
+    else:
+        r7 = _skipped_result(
+            "is_self_fix=False; Pass 7 only runs on self-fix PRs per §8 row 7"
+        )
+    results.append(r7)
+    _collect_blockers(r7)
+
+    # Decide overall verdict.
+    confidence = r6.get("confidence")
+    from gaia.coder.review.pass_6_adversarial import HARD_FAIL_CONFIDENCE
+
+    if short_circuit:
+        overall = "block"
+    elif confidence is not None and confidence < HARD_FAIL_CONFIDENCE:
+        overall = "block"
+    elif any(r["status"] == "fail" for r in results):
+        overall = "request-changes"
+    else:
+        overall = "pass"
+
+    return GateResult(
+        overall=overall,
+        pass_results=results,
+        confidence=confidence,
+        blockers=blockers,
+    )
+
+
+__all__ = [
+    "GateResult",
+    "GateResultDict",
+    "HARD_FAIL_PASSES",
+    "run_all_passes",
+]

--- a/src/gaia/coder/review/mixin.py
+++ b/src/gaia/coder/review/mixin.py
@@ -1,0 +1,188 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""``ReviewToolsMixin`` — one ``@tool`` per pass plus the one-shot gate.
+
+The coder agent composes this mixin into her tool set so the seven-pass
+gate is addressable as a tool call (``review_diff_gate``) and each
+individual pass is addressable for partial / debug runs
+(``review_diff_self_static``, etc.).
+
+Call pattern::
+
+    from gaia.coder.review import ReviewToolsMixin
+
+    m = ReviewToolsMixin()
+    m.register_review_tools()
+    # Now the tool registry has 8 new entries — 7 individual passes plus
+    # review_diff_gate.
+
+Every tool accepts ``pr_or_branch`` as its only required arg and returns
+either a :class:`gaia.coder.review.pass_result.PassResult` or a
+:class:`gaia.coder.review.gate.GateResultDict` depending on which tool was
+called. The TypedDict return shapes mean the agent can feed the result
+into downstream tool calls without custom serialisation.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+# Direct submodule imports avoid the circular-import hazard with
+# ``gaia.coder.review.__init__`` (which itself imports from this module).
+import gaia.coder.review.pass_1_static as pass_1_static
+import gaia.coder.review.pass_2_functional as pass_2_functional
+import gaia.coder.review.pass_3_architectural as pass_3_architectural
+import gaia.coder.review.pass_4_security as pass_4_security
+import gaia.coder.review.pass_5_prose as pass_5_prose
+import gaia.coder.review.pass_6_adversarial as pass_6_adversarial
+import gaia.coder.review.pass_7_feedback_binding as pass_7_feedback_binding
+from gaia.agents.base.tools import tool
+from gaia.coder.review.gate import GateResultDict, run_all_passes
+from gaia.coder.review.pass_result import PassResult
+
+logger = logging.getLogger(__name__)
+
+
+class ReviewToolsMixin:
+    """Mixin exposing the seven review passes + the gate as agent tools."""
+
+    def register_review_tools(self) -> None:
+        """Register ``review_diff_self_*`` and ``review_diff_gate``.
+
+        Registration defines eight tools in the agent tool registry:
+
+        * ``review_diff_self_static``
+        * ``review_diff_self_functional``
+        * ``review_diff_self_architectural``
+        * ``review_diff_self_security``
+        * ``review_diff_self_prose``
+        * ``review_diff_self_adversarial``
+        * ``review_diff_self_feedback_binding``
+        * ``review_diff_gate`` — the one-shot entry that runs all applicable
+          passes and returns an aggregated :class:`GateResultDict`.
+
+        The ``base_ref`` and ``repo_root`` parameters on the individual
+        passes are kept as agent-visible kwargs so the EM can diagnose a
+        gate rejection by rerunning one pass by hand via the TUI.
+        """
+
+        @tool
+        def review_diff_self_static(
+            pr_or_branch: str,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+        ) -> PassResult:
+            """Pass 1 — deterministic lint / tsc / regex guards (§8 row 1)."""
+            return pass_1_static.run_pass(
+                pr_or_branch,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+            )
+
+        @tool
+        def review_diff_self_functional(
+            pr_or_branch: str,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+        ) -> PassResult:
+            """Pass 2 — pytest / npm test / optional mutmut (§8 row 2)."""
+            return pass_2_functional.run_pass(
+                pr_or_branch,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+            )
+
+        @tool
+        def review_diff_self_architectural(
+            pr_or_branch: str,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+        ) -> PassResult:
+            """Pass 3 — LLM architectural review via Opus 4.7 (§8 row 3)."""
+            return pass_3_architectural.run_pass(
+                pr_or_branch,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+            )
+
+        @tool
+        def review_diff_self_security(
+            pr_or_branch: str,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+        ) -> PassResult:
+            """Pass 4 — gitleaks / AST scan / pip-audit / npm audit (§8 row 4)."""
+            return pass_4_security.run_pass(
+                pr_or_branch,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+            )
+
+        @tool
+        def review_diff_self_prose(
+            pr_or_branch: str,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+        ) -> PassResult:
+            """Pass 5 — PR prose + persona linter (§8 row 5)."""
+            return pass_5_prose.run_pass(
+                pr_or_branch,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+            )
+
+        @tool
+        def review_diff_self_adversarial(
+            pr_or_branch: str,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+            success_criterion: Optional[str] = None,
+        ) -> PassResult:
+            """Pass 6 — adversarial fresh-context Opus review (§8 row 6)."""
+            return pass_6_adversarial.run_pass(
+                pr_or_branch,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+                success_criterion=success_criterion,
+            )
+
+        @tool
+        def review_diff_self_feedback_binding(
+            pr_or_branch: str,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+        ) -> PassResult:
+            """Pass 7 — feedback binding for self-fix PRs (§8 row 7)."""
+            return pass_7_feedback_binding.run_pass(
+                pr_or_branch,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+            )
+
+        @tool
+        def review_diff_gate(
+            pr_or_branch: str,
+            is_self_fix: bool = False,
+            base_ref: str = "coder",
+            repo_root: Optional[str] = None,
+            success_criterion: Optional[str] = None,
+        ) -> GateResultDict:
+            """Run all applicable review passes and return the aggregated verdict.
+
+            This is the tool the coder agent calls *before* invoking
+            ``gh_pr_create``. If ``overall`` is not ``"pass"`` the agent
+            must revise before opening the PR per §8.
+            """
+            return run_all_passes(
+                pr_or_branch,
+                is_self_fix=is_self_fix,
+                base_ref=base_ref,
+                repo_root=Path(repo_root) if repo_root else None,
+                success_criterion=success_criterion,
+            ).as_dict()
+
+
+__all__ = ["ReviewToolsMixin"]

--- a/src/gaia/coder/review/pass_1_static.py
+++ b/src/gaia/coder/review/pass_1_static.py
@@ -1,0 +1,245 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pass 1 — self-static review (§8 row 1).
+
+Deterministic. Runs the project's lint harness on changed Python files,
+``tsc --noEmit`` on changed TypeScript files, and a handful of regex
+guards that catch the classes of mistake the agent's own feedback loop
+has flagged in past iterations (debug prints, TODOs without an issue
+link, commented-out code).
+
+Output contract: :class:`gaia.coder.review.pass_result.PassResult` with
+``status="pass"`` iff every tool returns 0 and no regex finding is
+emitted.
+
+Per §15.8 (Deterministic checks): ``python util/lint.py --all``,
+``tsc --noEmit``, debug-print regex, TODO-without-issue regex. This
+module implements all four.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from gaia.coder.review._diff import (
+    DiffBundle,
+    filter_by_extension,
+    resolve_diff,
+)
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Regex guards
+# ---------------------------------------------------------------------------
+
+# Matches a bare ``print(`` at the start of a line (ignoring indentation),
+# excluding inside pytest fixtures or CLI tools that legitimately print. We
+# only flag *added* lines in the diff, so false positives on library code
+# we did not touch are impossible.
+_DEBUG_PRINT_RE = re.compile(
+    r"^\+(?P<indent>\s*)(?:print\(|console\.log\(|pprint\()",
+    re.MULTILINE,
+)
+
+# Matches ``TODO`` / ``FIXME`` / ``XXX`` comments *without* a trailing issue
+# link like ``(#123)`` or ``#123`` or a URL. Issue links are the project's
+# convention for giving a TODO an owner and an expiry; bare TODOs tend to
+# rot silently.
+_BARE_TODO_RE = re.compile(
+    r"^\+.*?\b(?P<marker>TODO|FIXME|XXX)\b(?![^\n]*?(?:#\d+|https?://))",
+    re.MULTILINE,
+)
+
+# Matches *added* lines that are entirely a commented-out code line. We use
+# a conservative rule: the line starts with a comment character and the
+# remainder looks like code (contains `=`, `(`, or `:` but not a docstring
+# fragment). Still regex-fallible, but flagging a false positive is
+# preferable to letting a commented-out ``# foo = compute()`` slip through.
+_COMMENTED_CODE_RE = re.compile(
+    r"^\+(?P<indent>\s*)(?:#|//)\s*[a-zA-Z_][a-zA-Z0-9_]*\s*[=(]",
+    re.MULTILINE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool runners
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: List[str], *, cwd: Optional[Path] = None) -> Tuple[int, str, str]:
+    """Run ``cmd`` synchronously, returning ``(returncode, stdout, stderr)``."""
+    # Reuse the denylist guard from CLIToolsMixin (§6.8 layer 1).
+    from gaia.coder.tools.cli import _check_denylist
+
+    _check_denylist(cmd)
+    completed = subprocess.run(  # pylint: disable=subprocess-run-check
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def _lint_python(files: List[str], *, cwd: Optional[Path]) -> Tuple[bool, str]:
+    """Run ``python util/lint.py --all`` and report pass/fail + stderr tail.
+
+    The lint script lints the whole tree; filtering by changed files
+    happens in a follow-up hardening pass when the script supports it.
+    Running the whole tree is still cheap (seconds) and strictly stronger
+    — a lint failure anywhere is a lint failure.
+    """
+    if not files:
+        return True, "no python files in diff; skipped lint"
+    code, out, err = _run(["python", "util/lint.py", "--all"], cwd=cwd)
+    if code == 0:
+        return True, ""
+    tail = (err or out).strip().splitlines()[-30:]
+    return False, "\n".join(tail)
+
+
+def _tsc_no_emit(files: List[str], *, cwd: Optional[Path]) -> Tuple[bool, str]:
+    """Run ``tsc --noEmit`` if TS files are in the diff.
+
+    If ``tsc`` is missing (no TS toolchain installed), return a "skipped"
+    marker — not a fail. TypeScript-free diffs should not be blocked by a
+    missing TS compiler.
+    """
+    if not files:
+        return True, "no TS files in diff; skipped tsc"
+    try:
+        code, out, err = _run(["tsc", "--noEmit"], cwd=cwd)
+    except FileNotFoundError:
+        return True, "tsc not installed; skipped"
+    if code == 0:
+        return True, ""
+    tail = (err or out).strip().splitlines()[-30:]
+    return False, "\n".join(tail)
+
+
+def _regex_findings(unified_diff: str) -> List[dict]:
+    """Scan ``unified_diff`` for debug prints / bare TODOs / commented code."""
+    findings: List[dict] = []
+    for match in _DEBUG_PRINT_RE.finditer(unified_diff):
+        findings.append(
+            {
+                "severity": "minor",
+                "description": "debug print / console.log on an added line",
+                "snippet": match.group(0).rstrip(),
+                "citation": "§8 Pass 1 — no debug prints",
+            }
+        )
+    for match in _BARE_TODO_RE.finditer(unified_diff):
+        findings.append(
+            {
+                "severity": "minor",
+                "description": (
+                    f"bare {match.group('marker')} without issue link "
+                    f"(#NNN or a URL)"
+                ),
+                "snippet": match.group(0).rstrip(),
+                "citation": "§8 Pass 1 — no TODO without issue link",
+            }
+        )
+    for match in _COMMENTED_CODE_RE.finditer(unified_diff):
+        findings.append(
+            {
+                "severity": "minor",
+                "description": "commented-out code on an added line",
+                "snippet": match.group(0).rstrip(),
+                "citation": "§8 Pass 1 — no commented-out code",
+            }
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_pass(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    diff: Optional[DiffBundle] = None,
+) -> PassResult:
+    """Execute Pass 1 and return the :class:`PassResult`.
+
+    Args:
+        pr_or_branch: PR URL / shortform or local ref. Ignored if ``diff``
+            is supplied (tests use this seam to avoid shelling to git).
+        base_ref: Passed to :func:`resolve_diff` when ``diff`` is ``None``.
+        repo_root: Working directory for subprocess calls.
+        diff: Pre-resolved :class:`DiffBundle`. When present the function
+            does not shell out to git / gh — used by the gate orchestrator
+            to fetch the diff exactly once.
+    """
+    diff_bundle = diff or resolve_diff(
+        pr_or_branch, base_ref=base_ref, repo_root=repo_root
+    )
+    py_files = filter_by_extension(diff_bundle.changed_files, (".py",))
+    ts_files = filter_by_extension(diff_bundle.changed_files, (".ts", ".tsx"))
+
+    findings: List[dict] = []
+    tooling_used: List[str] = []
+
+    lint_ok, lint_tail = _lint_python(py_files, cwd=repo_root)
+    if py_files:
+        tooling_used.append("python util/lint.py --all")
+    if not lint_ok:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": "python util/lint.py --all failed",
+                "output_tail": lint_tail,
+                "citation": "§8 Pass 1 — lint must pass",
+            }
+        )
+
+    tsc_ok, tsc_tail = _tsc_no_emit(ts_files, cwd=repo_root)
+    if ts_files:
+        tooling_used.append("tsc --noEmit")
+    if not tsc_ok:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": "tsc --noEmit failed",
+                "output_tail": tsc_tail,
+                "citation": "§8 Pass 1 — types must check",
+            }
+        )
+
+    regex_hits = _regex_findings(diff_bundle.unified_diff)
+    if regex_hits:
+        findings.extend(regex_hits)
+        tooling_used.append("regex guards (debug print, TODO, commented code)")
+
+    # Regex-only findings are minor and do not hard-fail the pass by
+    # themselves — they surface in the PR description as "author's
+    # pre-review notes" per §8 row 6 spirit. The hard-fail trigger is a
+    # blocking finding (lint / tsc).
+    hard_fail = any(f.get("severity") == "blocking" for f in findings)
+    status = "fail" if hard_fail else "pass"
+
+    return make_pass_result(
+        status=status,
+        findings=findings,
+        confidence=None,
+        citations=[
+            "docs/plans/coder-agent.mdx §8 Pass 1",
+            "docs/plans/coder-agent.mdx §15.8 deterministic checks",
+        ],
+        tooling_used=tooling_used,
+    )
+
+
+__all__ = ["run_pass"]

--- a/src/gaia/coder/review/pass_2_functional.py
+++ b/src/gaia/coder/review/pass_2_functional.py
@@ -1,0 +1,253 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pass 2 — self-functional review (§8 row 2).
+
+Deterministic. Runs the test suite for every changed Python module,
+``npm test`` if the diff touches a ``package.json``-rooted tree, and
+optionally a mutation-testing sample (``mutmut run``) that confirms new
+tests actually fail without the change.
+
+The pass emits ``confidence`` = 0-100 coverage percentage when
+``coverage`` is available; otherwise ``None``.
+
+Per §15.8 deterministic checks: ``pytest``, ``npm test``, ``mutmut run``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from gaia.coder.review._diff import (
+    DiffBundle,
+    filter_by_extension,
+    resolve_diff,
+)
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: List[str], *, cwd: Optional[Path] = None) -> Tuple[int, str, str]:
+    """Run ``cmd`` and return ``(returncode, stdout, stderr)``."""
+    from gaia.coder.tools.cli import _check_denylist
+
+    _check_denylist(cmd)
+    completed = subprocess.run(  # pylint: disable=subprocess-run-check
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def _extract_coverage_pct(pytest_output: str) -> Optional[int]:
+    """Parse coverage % out of ``pytest --cov`` output, if present.
+
+    The ``pytest-cov`` plugin prints a ``TOTAL`` footer line like::
+
+        TOTAL                   123    45  63%
+
+    We return that last percentage as an int. Absence returns ``None``
+    (we pass but do not report a coverage figure).
+    """
+    match = re.search(r"TOTAL\s+\d+\s+\d+\s+(\d+)%", pytest_output)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _infer_test_paths(py_files: List[str]) -> List[str]:
+    """Given changed ``.py`` paths, guess the corresponding test paths.
+
+    Heuristic (good-enough for v1):
+
+    1. Anything already under ``tests/`` is itself a test path.
+    2. ``src/gaia/foo/bar.py`` → look for ``tests/**/test_bar.py`` or
+       ``tests/**/test_foo.py``.
+
+    We never *exclude* tests; unknown candidates fall through to a
+    whole-tests run. The runner then fails loudly if no tests are
+    collected, which is the actionable message we want.
+    """
+    paths: List[str] = []
+    for fn in py_files:
+        if fn.startswith("tests/"):
+            paths.append(fn)
+            continue
+        stem = Path(fn).stem
+        parent = Path(fn).parent.name
+        candidate = f"tests/**/test_{stem}.py"
+        paths.append(candidate)
+        if parent:
+            paths.append(f"tests/**/test_{parent}.py")
+    # De-dup preserving order
+    return list(dict.fromkeys(paths))
+
+
+def _run_pytest(
+    test_paths: List[str], *, cwd: Optional[Path]
+) -> Tuple[bool, str, Optional[int]]:
+    """Run pytest. Return ``(passed, tail, coverage_pct)``.
+
+    Missing pytest is a hard fail (we cannot verify functional correctness
+    without it), not a skip.
+    """
+    if shutil.which("pytest") is None:
+        return (
+            False,
+            "pytest not on PATH. Install dev deps: `uv pip install -e .[dev]`.",
+            None,
+        )
+    # Try with coverage first; fall back to plain pytest if pytest-cov
+    # is missing.
+    cmd = ["pytest", "-x", "--tb=short", "--cov", *test_paths]
+    code, out, err = _run(cmd, cwd=cwd)
+    # If pytest-cov missing, the --cov flag errors. Retry without.
+    combined = out + err
+    if "unrecognized arguments: --cov" in combined:
+        code, out, err = _run(["pytest", "-x", "--tb=short", *test_paths], cwd=cwd)
+        combined = out + err
+    tail = "\n".join(combined.strip().splitlines()[-30:])
+    coverage = _extract_coverage_pct(combined)
+    return (code == 0, tail, coverage)
+
+
+def _run_npm_test(*, cwd: Optional[Path]) -> Tuple[str, bool, str]:
+    """Run ``npm test`` if ``package.json`` exists.
+
+    Returns ``(status, ok, tail)`` where ``status`` is one of
+    ``"run"`` / ``"skipped"``.
+    """
+    package_json = (cwd or Path(".")) / "package.json"
+    if not package_json.exists():
+        return ("skipped", True, "no package.json at repo root; skipped")
+    if shutil.which("npm") is None:
+        return ("skipped", True, "npm not on PATH; skipped")
+    code, out, err = _run(["npm", "test", "--silent"], cwd=cwd)
+    tail = "\n".join((out + err).strip().splitlines()[-30:])
+    return ("run", code == 0, tail)
+
+
+def _run_mutmut(
+    py_files: List[str], *, cwd: Optional[Path]
+) -> Tuple[str, Optional[int]]:
+    """Run ``mutmut run`` on the changed Python files if installed.
+
+    Returns ``(status, surviving_mutants)``. ``surviving_mutants`` is
+    ``None`` when the run is skipped or mutmut returned an unparseable
+    result.
+
+    Per the task spec: "Optional ``mutmut run --paths-to-mutate <files>``
+    — skip if not installed, log a WARN." We follow that literally.
+    """
+    if not py_files:
+        return ("skipped", None)
+    if shutil.which("mutmut") is None:
+        logger.warning(
+            "pass 2: mutmut not installed; mutation sample skipped. "
+            "Install with `pip install mutmut` to raise coverage rigor."
+        )
+        return ("skipped", None)
+    joined = ",".join(py_files)
+    code, out, _err = _run(["mutmut", "run", "--paths-to-mutate", joined], cwd=cwd)
+    # mutmut exit code is non-zero when surviving mutants exist; that is
+    # informational for us, not a hard failure in v1.
+    match = re.search(r"(\d+)\s+surviv", out, re.IGNORECASE)
+    surviving = int(match.group(1)) if match else None
+    return ("run" if code in (0, 2) else "error", surviving)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_pass(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    diff: Optional[DiffBundle] = None,
+) -> PassResult:
+    """Execute Pass 2 and return the :class:`PassResult`."""
+    diff_bundle = diff or resolve_diff(
+        pr_or_branch, base_ref=base_ref, repo_root=repo_root
+    )
+    py_files = filter_by_extension(diff_bundle.changed_files, (".py",))
+
+    findings: List[dict] = []
+    tooling_used: List[str] = []
+
+    # --- pytest ---
+    test_paths = _infer_test_paths(py_files)
+    if py_files:
+        tooling_used.append("pytest")
+    pytest_ok, pytest_tail, coverage = _run_pytest(test_paths, cwd=repo_root)
+    if py_files and not pytest_ok:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": "pytest failed",
+                "output_tail": pytest_tail,
+                "citation": "§8 Pass 2 — tests must pass",
+            }
+        )
+
+    # --- npm test ---
+    npm_status, npm_ok, npm_tail = _run_npm_test(cwd=repo_root)
+    if npm_status == "run":
+        tooling_used.append("npm test")
+    if npm_status == "run" and not npm_ok:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": "npm test failed",
+                "output_tail": npm_tail,
+                "citation": "§8 Pass 2 — tests must pass",
+            }
+        )
+
+    # --- mutmut (advisory) ---
+    mutmut_status, surviving = _run_mutmut(py_files, cwd=repo_root)
+    if mutmut_status == "run":
+        tooling_used.append("mutmut run")
+        if surviving and surviving > 0:
+            findings.append(
+                {
+                    "severity": "significant",
+                    "description": (
+                        f"mutmut found {surviving} surviving mutant(s); "
+                        f"your tests may not be exercising the change"
+                    ),
+                    "citation": "§8 Pass 2 — mutation sample",
+                }
+            )
+    elif mutmut_status == "error":
+        logger.warning("pass 2: mutmut exited abnormally; treating as advisory skip.")
+
+    hard_fail = any(f.get("severity") == "blocking" for f in findings)
+    return make_pass_result(
+        status="fail" if hard_fail else "pass",
+        findings=findings,
+        confidence=coverage,
+        citations=[
+            "docs/plans/coder-agent.mdx §8 Pass 2",
+            "docs/plans/coder-agent.mdx §15.8 deterministic checks",
+        ],
+        tooling_used=tooling_used,
+    )
+
+
+__all__ = ["run_pass"]

--- a/src/gaia/coder/review/pass_3_architectural.py
+++ b/src/gaia/coder/review/pass_3_architectural.py
@@ -1,0 +1,208 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pass 3 — self-architectural review (§8 row 3).
+
+LLM-driven. Claude Opus 4.7 reads the diff with her ``ARCHITECTURE.md`` +
+``PROJECT_MAP.md`` + the PR body in a **fresh context** and returns a
+structured verdict on layering, circular imports, public-API breaks,
+silent fallbacks, drive-by changes, and the docs mandate.
+
+Per §15.8 P5: "invoked via ``architecture-reviewer`` subagent". In
+production this dispatches through the Claude Agent SDK's
+``architecture-reviewer`` subagent (``.claude/agents/architecture-reviewer.md``).
+In v1 we call the Anthropic SDK directly behind the :func:`call_opus`
+seam — the prompt text is identical either way. When a real
+``claude_agent_sdk`` is available, :func:`_via_subagent` switches over
+transparently.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from gaia.coder.review._diff import DiffBundle, resolve_diff
+from gaia.coder.review._llm import (
+    DEFAULT_MAX_TOKENS,
+    LLMClientUnavailable,
+    call_opus,
+    load_prompt,
+    parse_json_response,
+    render_prompt,
+)
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+#: Prompt file (relative to ``src/gaia/coder/prompts/``).
+PROMPT_NAME: str = "architectural.md"
+
+
+def _read_document(path: Path) -> str:
+    """Read a living architecture document, returning ``""`` if missing.
+
+    Missing is not fatal — the §8 doc-mandate check still fires via the
+    PR-body scan, and the LLM is trained to flag an empty
+    ``<architecture_md>`` slot rather than hallucinating content. This is
+    an intentional exception to the fail-loudly rule: a doc-not-yet-written
+    day-one run should not hard-block the first PR she ever opens.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning(
+            "pass 3: document missing at %s; sending empty slot to Opus.",
+            path,
+        )
+        return ""
+
+
+def _via_subagent(prompt: str) -> Optional[str]:
+    """Return the subagent's response, or ``None`` if the SDK is absent.
+
+    When the ``claude_agent_sdk`` package is installed we dispatch to the
+    ``architecture-reviewer`` agent so the review runs in a dedicated
+    context window. Otherwise we return ``None`` and let the caller fall
+    back to :func:`call_opus`.
+
+    Today the SDK is not a hard dep of GAIA; this wrapper is a shim so the
+    wiring is explicit for when we add it.
+    """
+    try:
+        import claude_agent_sdk  # type: ignore
+    except ImportError:
+        return None
+    dispatch = getattr(claude_agent_sdk, "dispatch_subagent", None)
+    if dispatch is None:  # pragma: no cover - SDK shape changing
+        return None
+    return dispatch("architecture-reviewer", prompt)  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_pass(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    diff: Optional[DiffBundle] = None,
+    architecture_md: Optional[Path] = None,
+    project_map_md: Optional[Path] = None,
+) -> PassResult:
+    """Execute Pass 3 and return the :class:`PassResult`.
+
+    Args:
+        architecture_md: Override the ``ARCHITECTURE.md`` path. Defaults
+            to :data:`gaia.coder.base.ARCHITECTURE_MD_PATH`.
+        project_map_md: Override the ``PROJECT_MAP.md`` path. Defaults
+            to :data:`gaia.coder.base.PROJECT_MAP_MD_PATH`.
+    """
+    # Late import so the review package remains importable before the
+    # CoderAgent base has been fully wired up.
+    from gaia.coder.base import ARCHITECTURE_MD_PATH, PROJECT_MAP_MD_PATH
+
+    diff_bundle = diff or resolve_diff(
+        pr_or_branch, base_ref=base_ref, repo_root=repo_root
+    )
+
+    architecture_text = _read_document(architecture_md or ARCHITECTURE_MD_PATH)
+    project_map_text = _read_document(project_map_md or PROJECT_MAP_MD_PATH)
+
+    template = load_prompt(PROMPT_NAME)
+    rendered = render_prompt(
+        template,
+        {
+            "inject_HER_ARCHITECTURE_md": architecture_text,
+            "inject_PROJECT_MAP_md": project_map_text,
+            "unified_diff": diff_bundle.unified_diff,
+            "pr_description": diff_bundle.pr_body or "(local branch; no PR body)",
+        },
+    )
+
+    tooling_used: List[str] = []
+    try:
+        subagent_response = _via_subagent(rendered)
+        if subagent_response is not None:
+            raw = subagent_response
+            tooling_used.append("claude-agent-sdk → architecture-reviewer subagent")
+        else:
+            raw = call_opus(rendered, max_tokens=DEFAULT_MAX_TOKENS)
+            tooling_used.append("anthropic SDK → Opus 4.7 (direct)")
+    except LLMClientUnavailable as exc:
+        return make_pass_result(
+            status="fail",
+            findings=[
+                {
+                    "severity": "blocking",
+                    "description": ("architectural pass could not run: " + str(exc)),
+                    "citation": "§8 Pass 3",
+                }
+            ],
+            citations=["docs/plans/coder-agent.mdx §8 Pass 3"],
+            tooling_used=tooling_used,
+        )
+
+    try:
+        payload = parse_json_response(raw)
+    except ValueError as exc:
+        return make_pass_result(
+            status="fail",
+            findings=[
+                {
+                    "severity": "blocking",
+                    "description": f"Opus response was not valid JSON: {exc}",
+                    "raw_head": raw[:500],
+                    "citation": "§15.9 fail-loudly",
+                }
+            ],
+            citations=["docs/plans/coder-agent.mdx §8 Pass 3"],
+            tooling_used=tooling_used,
+        )
+
+    overall = str(payload.get("overall", "request-changes")).lower()
+    blockers = payload.get("blockers", []) or []
+    rule_verdicts = payload.get("rules", []) or []
+
+    findings: List[dict] = []
+    for blocker in blockers:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": str(blocker),
+                "citation": "§8 Pass 3 blocker",
+            }
+        )
+    for rule in rule_verdicts:
+        if str(rule.get("verdict", "")).lower() == "fail":
+            findings.append(
+                {
+                    "severity": "significant",
+                    "description": (
+                        f"architectural rule failed: "
+                        f"{rule.get('rule', '<unnamed>')} — "
+                        f"{rule.get('citation', '<no citation>')}"
+                    ),
+                    "citation": "§8 Pass 3 rule",
+                }
+            )
+
+    status = "pass" if overall == "pass" and not blockers else "fail"
+
+    return make_pass_result(
+        status=status,
+        findings=findings,
+        confidence=None,
+        citations=[
+            "docs/plans/coder-agent.mdx §8 Pass 3",
+            "docs/plans/coder-agent.mdx §15.8 P5",
+        ],
+        tooling_used=tooling_used,
+    )
+
+
+__all__ = ["run_pass"]

--- a/src/gaia/coder/review/pass_4_security.py
+++ b/src/gaia/coder/review/pass_4_security.py
@@ -1,0 +1,341 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pass 4 — self-security review (§8 row 4).
+
+Deterministic. Runs:
+
+* ``gitleaks detect --source=<repo>`` to catch added secrets.
+* An AST scanner that flags ``eval``, ``exec``, ``subprocess.*(shell=True)``,
+  SQL-by-string-concat, and ``os.system`` usage on added Python files.
+* ``pip-audit`` (if ``requirements.txt`` / ``pyproject.toml`` moved).
+* ``npm audit --json`` (if ``package-lock.json`` moved).
+
+Missing tools produce a single ``skipped`` finding *per tool* — we do not
+silently pass if gitleaks is unavailable, because secrets are the highest
+-cost false negative in the review. The EM gets an actionable message
+telling them to install the tool.
+
+Per §15.8 deterministic checks: ``gitleaks detect``, AST scanner for
+``eval``/``exec``/``shell=True``, ``pip-audit``, ``npm audit --json``.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from gaia.coder.review._diff import (
+    DiffBundle,
+    filter_by_extension,
+    resolve_diff,
+)
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helper
+# ---------------------------------------------------------------------------
+
+
+def _run(
+    cmd: List[str], *, cwd: Optional[Path] = None, timeout_s: int = 60
+) -> Tuple[int, str, str]:
+    """Run ``cmd`` with a bounded timeout."""
+    from gaia.coder.tools.cli import _check_denylist
+
+    _check_denylist(cmd)
+    try:
+        completed = subprocess.run(  # pylint: disable=subprocess-run-check
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return (
+            124,
+            exc.stdout or "",
+            f"{' '.join(cmd)} timed out after {timeout_s}s",
+        )
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+# ---------------------------------------------------------------------------
+# gitleaks
+# ---------------------------------------------------------------------------
+
+
+def _run_gitleaks(*, cwd: Optional[Path]) -> List[dict]:
+    """Scan with gitleaks. Returns findings or a single ``skipped`` finding."""
+    if shutil.which("gitleaks") is None:
+        return [
+            {
+                "severity": "info",
+                "description": (
+                    "gitleaks not installed; secret scan skipped. "
+                    "Install with `brew install gitleaks` or see "
+                    "https://github.com/gitleaks/gitleaks."
+                ),
+                "status": "skipped",
+                "citation": "§8 Pass 4 — gitleaks",
+            }
+        ]
+    code, out, err = _run(
+        [
+            "gitleaks",
+            "detect",
+            "--source=.",
+            "--no-banner",
+            "--redact",
+            "--exit-code=1",
+        ],
+        cwd=cwd,
+    )
+    if code == 0:
+        return []
+    tail = "\n".join((out + err).strip().splitlines()[-30:])
+    return [
+        {
+            "severity": "blocking",
+            "description": "gitleaks detected potential secrets",
+            "output_tail": tail,
+            "citation": "§8 Pass 4 — no secrets in diff",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AST scanner
+# ---------------------------------------------------------------------------
+
+
+class _UnsafeCallVisitor(ast.NodeVisitor):
+    """Walk a module AST and collect dangerous patterns."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.findings: List[dict] = []
+
+    def _emit(self, node: ast.AST, description: str) -> None:
+        self.findings.append(
+            {
+                "severity": "blocking",
+                "description": description,
+                "file": self.path,
+                "line": getattr(node, "lineno", 0),
+                "citation": "§8 Pass 4 — no unsafe dynamic exec",
+            }
+        )
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        func = node.func
+        # eval(...) / exec(...)
+        if isinstance(func, ast.Name) and func.id in {"eval", "exec"}:
+            self._emit(node, f"use of {func.id}() on added code")
+        # os.system(...)
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "os"
+            and func.attr == "system"
+        ):
+            self._emit(node, "os.system() call")
+        # subprocess.*(shell=True)
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "subprocess"
+        ):
+            for kw in node.keywords:
+                if (
+                    kw.arg == "shell"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is True
+                ):
+                    self._emit(
+                        node,
+                        f"subprocess.{func.attr}(..., shell=True) — prefer "
+                        "argv lists",
+                    )
+        self.generic_visit(node)
+
+    # SQL-by-string-concat detection is intentionally regex-based in the
+    # caller; walking every BinOp is noisy. This visitor focuses on the
+    # high-value dynamic-exec family.
+
+
+def _scan_python_file(path: Path) -> List[dict]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        # Syntax errors are Pass-1 territory; don't double-report.
+        return []
+    visitor = _UnsafeCallVisitor(str(path))
+    visitor.visit(tree)
+    return visitor.findings
+
+
+def _scan_python(py_files: List[str], *, cwd: Optional[Path]) -> List[dict]:
+    findings: List[dict] = []
+    root = cwd or Path(".")
+    for relpath in py_files:
+        full = root / relpath
+        findings.extend(_scan_python_file(full))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# pip-audit / npm audit
+# ---------------------------------------------------------------------------
+
+
+def _run_pip_audit(changed_files: List[str], *, cwd: Optional[Path]) -> List[dict]:
+    touched = any(
+        f in {"pyproject.toml", "requirements.txt", "setup.py", "setup.cfg"}
+        or f.endswith("/requirements.txt")
+        for f in changed_files
+    )
+    if not touched:
+        return []
+    if shutil.which("pip-audit") is None:
+        return [
+            {
+                "severity": "info",
+                "description": (
+                    "pip-audit not installed; Python dep audit skipped. "
+                    "Install with `pip install pip-audit`."
+                ),
+                "status": "skipped",
+                "citation": "§8 Pass 4 — pip-audit",
+            }
+        ]
+    code, out, err = _run(["pip-audit", "--strict"], cwd=cwd)
+    if code == 0:
+        return []
+    tail = "\n".join((out + err).strip().splitlines()[-20:])
+    return [
+        {
+            "severity": "significant",
+            "description": "pip-audit reported vulnerable dependencies",
+            "output_tail": tail,
+            "citation": "§8 Pass 4 — pip-audit",
+        }
+    ]
+
+
+def _run_npm_audit(changed_files: List[str], *, cwd: Optional[Path]) -> List[dict]:
+    touched = any(
+        f == "package.json"
+        or f == "package-lock.json"
+        or f.endswith("/package.json")
+        or f.endswith("/package-lock.json")
+        for f in changed_files
+    )
+    if not touched:
+        return []
+    if shutil.which("npm") is None:
+        return [
+            {
+                "severity": "info",
+                "description": "npm not installed; npm audit skipped.",
+                "status": "skipped",
+                "citation": "§8 Pass 4 — npm audit",
+            }
+        ]
+    code, out, err = _run(["npm", "audit", "--json"], cwd=cwd)
+    # npm audit exit code: 0 = no vulns; 1 = vulns found. Either way the JSON
+    # payload is on stdout. For v1 we treat a non-zero exit as "has findings".
+    if code == 0:
+        return []
+    tail = "\n".join((out + err).strip().splitlines()[-10:])
+    return [
+        {
+            "severity": "significant",
+            "description": "npm audit reported vulnerable dependencies",
+            "output_tail": tail,
+            "citation": "§8 Pass 4 — npm audit",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_pass(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    diff: Optional[DiffBundle] = None,
+) -> PassResult:
+    """Execute Pass 4 and return the :class:`PassResult`."""
+    diff_bundle = diff or resolve_diff(
+        pr_or_branch, base_ref=base_ref, repo_root=repo_root
+    )
+    py_files = filter_by_extension(diff_bundle.changed_files, (".py",))
+
+    findings: List[dict] = []
+    tooling_used: List[str] = []
+
+    # gitleaks
+    gitleaks_findings = _run_gitleaks(cwd=repo_root)
+    findings.extend(gitleaks_findings)
+    if gitleaks_findings and gitleaks_findings[0].get("status") != "skipped":
+        tooling_used.append("gitleaks detect --source=.")
+    elif not gitleaks_findings:
+        tooling_used.append("gitleaks detect --source=.")
+
+    # AST scanner
+    ast_findings = _scan_python(py_files, cwd=repo_root)
+    findings.extend(ast_findings)
+    if py_files:
+        tooling_used.append("AST scan (eval/exec/shell=True/os.system)")
+
+    # pip-audit / npm audit
+    pip_findings = _run_pip_audit(diff_bundle.changed_files, cwd=repo_root)
+    findings.extend(pip_findings)
+    if any(f.get("status") != "skipped" for f in pip_findings) or not pip_findings:
+        if any(
+            f.endswith(("pyproject.toml", "requirements.txt"))
+            or f in {"pyproject.toml", "setup.py", "setup.cfg"}
+            for f in diff_bundle.changed_files
+        ):
+            tooling_used.append("pip-audit")
+
+    npm_findings = _run_npm_audit(diff_bundle.changed_files, cwd=repo_root)
+    findings.extend(npm_findings)
+    if any(
+        f.endswith(("package.json", "package-lock.json"))
+        for f in diff_bundle.changed_files
+    ):
+        tooling_used.append("npm audit --json")
+
+    # A single blocking finding is enough to fail Pass 4.
+    hard_fail = any(f.get("severity") == "blocking" for f in findings)
+    return make_pass_result(
+        status="fail" if hard_fail else "pass",
+        findings=findings,
+        confidence=None,
+        citations=[
+            "docs/plans/coder-agent.mdx §8 Pass 4",
+            "docs/plans/coder-agent.mdx §15.8 deterministic checks",
+        ],
+        tooling_used=tooling_used,
+    )
+
+
+__all__ = ["run_pass"]

--- a/src/gaia/coder/review/pass_5_prose.py
+++ b/src/gaia/coder/review/pass_5_prose.py
@@ -1,0 +1,333 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pass 5 — self-prose review (§8 row 5).
+
+Two-stage:
+
+1. **Regex / structural linter** (cheap, deterministic). Checks:
+
+   * PR title is conventional-commits shape
+     (``<type>(<scope>)?: <subject>``).
+   * PR body contains a ``## Summary`` / ``## Test plan`` section or
+     equivalent bullets.
+   * No ``Co-Authored-By: Claude`` trailer / ``Generated with Claude
+     Code`` attribution.
+   * Banned phrase list ("Certainly!", "As an AI", …).
+
+2. **Persona linter** (LLM). Renders ``prompts/persona_linter.md`` with
+   the GAIA.md persona section as a cacheable prefix and the PR body as
+   the candidate text. Returns the verdict and violations.
+
+The LLM step only runs if stage 1 passed — a body that already fails
+conventional-commits + deterministic checks does not need an Opus call
+to tell the author it's broken.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from gaia.coder.review._diff import DiffBundle, resolve_diff
+from gaia.coder.review._llm import (
+    LLMClientUnavailable,
+    call_opus,
+    load_prompt,
+    parse_json_response,
+    render_prompt,
+)
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+PROMPT_NAME: str = "persona_linter.md"
+
+# Conventional-commits shape: ``type(scope)?: subject``. Allowed types match
+# the project's ``CLAUDE.md`` convention.
+_CONV_COMMIT_RE = re.compile(
+    r"^(?P<type>feat|fix|docs|chore|refactor|test|perf|ci|build|style|revert)"
+    r"(?:\(.+?\))?(!)?:\s.+",
+)
+
+# Claude-attribution trailer variants. The repo explicitly forbids every
+# permutation per CLAUDE.md.
+_CLAUDE_ATTRIBUTION_RE = re.compile(
+    r"(?i)(?:"
+    r"Co-Authored-By:\s*Claude"
+    r"|Generated with\s+\[?Claude Code\]?"
+    r"|Authored by\s+Claude"
+    r"|Written by\s+Claude"
+    r"|As an AI"
+    r")",
+)
+
+# Banned persona phrases caught by regex before we ask Opus.
+_BANNED_PHRASES = (
+    "Certainly!",
+    "Absolutely!",
+    "I'd be happy to help",
+    "Great question!",
+    "As an AI",
+    "Generated with",
+)
+
+# Simple check for the "why" on bullets: every bullet line that starts with
+# ``- `` or ``* `` must contain either a ``—`` / `` - `` separator OR end
+# in a clause-terminating sentence (punctuation). We implement the heuristic
+# as: "bullet must be at least 10 words OR contain a dash separator". Short
+# pure-noun bullets trip it.
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(?P<text>.+)$", re.MULTILINE)
+
+
+def _stage1_regex(pr_title: str, pr_body: str) -> Tuple[List[dict], List[str]]:
+    """Run the cheap deterministic checks.
+
+    Returns ``(findings, citations_added)``.
+    """
+    findings: List[dict] = []
+    citations: List[str] = [
+        "docs/plans/coder-agent.mdx §8 Pass 5 — deterministic",
+        "CLAUDE.md PR description rules",
+    ]
+
+    if not pr_title or not _CONV_COMMIT_RE.match(pr_title.strip()):
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": (
+                    "PR title is not conventional-commits shape "
+                    "(expected 'feat(scope): …' / 'fix(scope): …' / etc.)"
+                ),
+                "title_seen": pr_title,
+                "citation": "CLAUDE.md title convention",
+            }
+        )
+
+    if pr_body:
+        lower = pr_body.lower()
+        if "summary" not in lower:
+            findings.append(
+                {
+                    "severity": "significant",
+                    "description": "PR body has no Summary section",
+                    "citation": "CLAUDE.md PR description",
+                }
+            )
+        if "test plan" not in lower and "test-plan" not in lower:
+            findings.append(
+                {
+                    "severity": "significant",
+                    "description": "PR body has no Test plan section",
+                    "citation": "CLAUDE.md PR description",
+                }
+            )
+        if _CLAUDE_ATTRIBUTION_RE.search(pr_body):
+            findings.append(
+                {
+                    "severity": "blocking",
+                    "description": (
+                        "PR body contains forbidden Claude attribution / "
+                        "'Generated with Claude Code' / 'Co-Authored-By: Claude' "
+                        "/ 'As an AI' trailer"
+                    ),
+                    "citation": "CLAUDE.md no-attribution rule",
+                }
+            )
+        for phrase in _BANNED_PHRASES:
+            if phrase.lower() in lower:
+                findings.append(
+                    {
+                        "severity": "significant",
+                        "description": f"PR body contains banned phrase: {phrase!r}",
+                        "citation": "§8 Pass 5 persona",
+                    }
+                )
+        # Bullets-too-short heuristic (only informational)
+        short_bullets = [
+            match.group("text").strip()
+            for match in _BULLET_RE.finditer(pr_body)
+            if len(match.group("text").split()) < 4
+            and "—" not in match.group("text")
+            and " - " not in match.group("text")
+        ]
+        if len(short_bullets) >= 3:
+            findings.append(
+                {
+                    "severity": "minor",
+                    "description": (
+                        "several bullets lack a 'why' clause; each non-trivial "
+                        "bullet should explain why the change matters"
+                    ),
+                    "examples": short_bullets[:3],
+                    "citation": "CLAUDE.md PR description — why over what",
+                }
+            )
+
+    return findings, citations
+
+
+def _stage2_persona(
+    pr_body: str, *, gaia_md_path: Optional[Path]
+) -> Tuple[List[dict], List[str]]:
+    """Run the persona linter (LLM).
+
+    Returns ``(findings, tooling_used_additions)``.
+    """
+    # Late import so the module can be imported without ``gaia.coder.base``.
+    from gaia.coder.base import GAIA_MD_PATH
+
+    persona_section: str = ""
+    candidate_path = gaia_md_path or GAIA_MD_PATH
+    try:
+        persona_section = candidate_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning(
+            "pass 5: %s missing; persona linter gets empty slot.",
+            candidate_path,
+        )
+
+    template = load_prompt(PROMPT_NAME)
+    rendered = render_prompt(
+        template,
+        {
+            "inject_verbatim": persona_section,
+            "candidate_text": pr_body,
+        },
+    )
+
+    tooling: List[str] = ["anthropic SDK → Opus 4.7 (persona linter)"]
+    try:
+        raw = call_opus(rendered)
+    except LLMClientUnavailable as exc:
+        return (
+            [
+                {
+                    "severity": "info",
+                    "description": (
+                        "persona linter LLM unavailable: " + str(exc) + " — "
+                        "deterministic checks still applied."
+                    ),
+                    "status": "skipped",
+                    "citation": "§15.9 fail-loudly",
+                }
+            ],
+            tooling,
+        )
+
+    try:
+        payload = parse_json_response(raw)
+    except ValueError as exc:
+        return (
+            [
+                {
+                    "severity": "blocking",
+                    "description": f"persona linter JSON parse failed: {exc}",
+                    "raw_head": raw[:500],
+                    "citation": "§15.9 fail-loudly",
+                }
+            ],
+            tooling,
+        )
+
+    findings: List[dict] = []
+    for violation in payload.get("violations", []) or []:
+        findings.append(
+            {
+                "severity": "significant",
+                "description": (
+                    f"persona violation: {violation.get('pattern', '?')} — "
+                    f"{violation.get('phrase', '?')!r}"
+                ),
+                "suggested_rewrite": violation.get("rewrite", ""),
+                "citation": "§8 Pass 5 persona linter",
+            }
+        )
+    if str(payload.get("verdict", "")).lower() == "request-changes":
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": (
+                    "persona linter overall verdict: request-changes — "
+                    + str(payload.get("reasoning", "")).strip()
+                ),
+                "citation": "§8 Pass 5 persona linter",
+            }
+        )
+    return findings, tooling
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_pass(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    diff: Optional[DiffBundle] = None,
+    gaia_md_path: Optional[Path] = None,
+    skip_llm: bool = False,
+) -> PassResult:
+    """Execute Pass 5 and return the :class:`PassResult`.
+
+    Args:
+        skip_llm: Stop after stage 1. Used by the gate orchestrator when
+            stage 1 already failed hard — no point paying the Opus call.
+    """
+    diff_bundle = diff or resolve_diff(
+        pr_or_branch, base_ref=base_ref, repo_root=repo_root
+    )
+
+    pr_title = diff_bundle.pr_title or ""
+    pr_body = diff_bundle.pr_body or ""
+
+    findings, citations = _stage1_regex(pr_title, pr_body)
+    tooling_used: List[str] = ["regex + conventional-commits matcher"]
+
+    hard_fail_stage1 = any(f.get("severity") == "blocking" for f in findings)
+
+    if not skip_llm and not hard_fail_stage1 and pr_body:
+        stage2_findings, stage2_tooling = _stage2_persona(
+            pr_body, gaia_md_path=gaia_md_path
+        )
+        findings.extend(stage2_findings)
+        tooling_used.extend(stage2_tooling)
+
+    # Branch-without-PR body has no prose to review; do not hard-fail in
+    # that case — the gate calls this pass knowing the context.
+    if not pr_body and not pr_title:
+        findings.append(
+            {
+                "severity": "info",
+                "description": (
+                    "no PR title or body provided (local branch, no PR yet) "
+                    "— Pass 5 deferred until PR is opened"
+                ),
+                "status": "deferred",
+                "citation": "§8 Pass 5",
+            }
+        )
+        return make_pass_result(
+            status="pass",
+            findings=findings,
+            confidence=None,
+            citations=citations,
+            tooling_used=tooling_used,
+        )
+
+    hard_fail = any(f.get("severity") == "blocking" for f in findings)
+    return make_pass_result(
+        status="fail" if hard_fail else "pass",
+        findings=findings,
+        confidence=None,
+        citations=citations + ["docs/plans/coder-agent.mdx §15.8 P4"],
+        tooling_used=tooling_used,
+    )
+
+
+__all__ = ["run_pass"]

--- a/src/gaia/coder/review/pass_6_adversarial.py
+++ b/src/gaia/coder/review/pass_6_adversarial.py
@@ -1,0 +1,226 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pass 6 — adversarial self-review (§8 row 6).
+
+LLM-driven, **fresh context** (no prior-turn history). Opus 4.7 gets the
+diff cold, tries to find three distinct things wrong, and emits the
+``confidence_score`` (0-100) the §7.6 auto-merge gate reads.
+
+Per §15.8 P6: *"If you cannot find three, say so explicitly — do not
+pad."* The prompt template enforces that; this module only maps the
+parsed JSON onto :class:`PassResult`.
+
+The confidence-score rubric (from §15.8 P6 / §7.6):
+
+* ``90-100`` — does exactly the criterion, nothing more/less. Auto-merge
+  eligible once the EM has graduated the fix-class.
+* ``75-89``  — achieves with scope creep OR minor gaps. Opens the PR but
+  does not auto-merge.
+* ``60-74``  — partial / mismatch. Do not auto-merge; flag for rewrite.
+* ``<60``    — does not achieve OR unrelated. Blocks the PR entirely.
+
+This module does not implement the merge policy itself (that lives in
+the §7.6 merge orchestrator) — it only surfaces the score.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from gaia.coder.review._diff import DiffBundle, resolve_diff
+from gaia.coder.review._llm import (
+    LLMClientUnavailable,
+    call_opus,
+    load_prompt,
+    parse_json_response,
+    render_prompt,
+)
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+PROMPT_NAME: str = "adversarial.md"
+
+#: Auto-merge threshold per §7.6 — "only at ≥ 90%".
+AUTO_MERGE_CONFIDENCE_THRESHOLD: int = 90
+
+#: Lower bound; below this the PR is blocked entirely per §7.6.
+HARD_FAIL_CONFIDENCE: int = 60
+
+
+def _via_subagent(prompt: str) -> Optional[str]:
+    """Route via the ``code-reviewer`` subagent when the SDK is installed.
+
+    Per §7.6 the adversarial pass for self-code PRs must run as a fresh
+    Opus 4.7 session. Using the SDK's ``code-reviewer`` gives us that
+    isolation plus a stable subagent identity. Absent the SDK we fall
+    back to a direct call with no conversation history — still fresh
+    context.
+    """
+    try:
+        import claude_agent_sdk  # type: ignore
+    except ImportError:
+        return None
+    dispatch = getattr(claude_agent_sdk, "dispatch_subagent", None)
+    if dispatch is None:  # pragma: no cover
+        return None
+    return dispatch("code-reviewer", prompt)  # pragma: no cover
+
+
+def run_pass(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    diff: Optional[DiffBundle] = None,
+    success_criterion: Optional[str] = None,
+) -> PassResult:
+    """Execute Pass 6.
+
+    Args:
+        success_criterion: The plan-stage-3 success criterion (§5.1 Stage 3).
+            When ``None`` and no PR body is available we pass a single
+            placeholder line — the prompt still asks for a confidence score
+            but the model has less to compare against. The gate
+            orchestrator is expected to pipe through the actual criterion
+            once Phase 5 lands the loop-runner.
+    """
+    diff_bundle = diff or resolve_diff(
+        pr_or_branch, base_ref=base_ref, repo_root=repo_root
+    )
+
+    criterion = (
+        success_criterion
+        or diff_bundle.pr_body
+        or "(success criterion unavailable — judge diff on its own merits)"
+    )
+
+    template = load_prompt(PROMPT_NAME)
+    rendered = render_prompt(
+        template,
+        {
+            "title": diff_bundle.pr_title or "(local branch; no PR title)",
+            "body": diff_bundle.pr_body or "(local branch; no PR body)",
+            "unified_diff": diff_bundle.unified_diff,
+            "criterion": criterion,
+        },
+    )
+
+    tooling_used: List[str] = []
+    try:
+        subagent_response = _via_subagent(rendered)
+        if subagent_response is not None:
+            raw = subagent_response
+            tooling_used.append(
+                "claude-agent-sdk → code-reviewer subagent (fresh context)"
+            )
+        else:
+            raw = call_opus(rendered)
+            tooling_used.append("anthropic SDK → Opus 4.7 (fresh context, no history)")
+    except LLMClientUnavailable as exc:
+        return make_pass_result(
+            status="fail",
+            findings=[
+                {
+                    "severity": "blocking",
+                    "description": ("adversarial pass could not run: " + str(exc)),
+                    "citation": "§8 Pass 6",
+                }
+            ],
+            citations=["docs/plans/coder-agent.mdx §8 Pass 6"],
+            tooling_used=tooling_used,
+        )
+
+    try:
+        payload = parse_json_response(raw)
+    except ValueError as exc:
+        return make_pass_result(
+            status="fail",
+            findings=[
+                {
+                    "severity": "blocking",
+                    "description": f"Opus response was not valid JSON: {exc}",
+                    "raw_head": raw[:500],
+                    "citation": "§15.9 fail-loudly",
+                }
+            ],
+            citations=["docs/plans/coder-agent.mdx §8 Pass 6"],
+            tooling_used=tooling_used,
+        )
+
+    # Parse confidence — may arrive as int or string
+    confidence_raw = payload.get("confidence_score")
+    try:
+        confidence = int(confidence_raw) if confidence_raw is not None else None
+    except (TypeError, ValueError):
+        confidence = None
+
+    findings: List[dict] = []
+    for item in payload.get("findings", []) or []:
+        severity = str(item.get("severity", "minor")).lower()
+        if severity not in {"blocking", "significant", "minor"}:
+            severity = "minor"
+        findings.append(
+            {
+                "severity": severity,
+                "description": str(item.get("description", "")),
+                "file_line": item.get("file_line", ""),
+                "fix": item.get("fix", ""),
+                "citation": "§8 Pass 6",
+            }
+        )
+
+    if "rubric_reasoning" in payload:
+        findings.append(
+            {
+                "severity": "info",
+                "description": str(payload.get("rubric_reasoning", "")),
+                "kind": "rubric_reasoning",
+                "citation": "§15.8 P6 rubric",
+            }
+        )
+
+    # Status:
+    # - If confidence < HARD_FAIL_CONFIDENCE (60) → fail (PR blocked)
+    # - Else if any finding is "blocking" → fail
+    # - Else pass (auto-merge eligibility is a separate property the gate
+    #   computes from ``confidence`` vs. AUTO_MERGE_CONFIDENCE_THRESHOLD)
+    if confidence is not None and confidence < HARD_FAIL_CONFIDENCE:
+        status = "fail"
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": (
+                    f"adversarial confidence {confidence} < "
+                    f"{HARD_FAIL_CONFIDENCE}; §7.6 requires rewrite before "
+                    "opening a PR"
+                ),
+                "citation": "§7.6 confidence gate",
+            }
+        )
+    else:
+        status = (
+            "fail" if any(f.get("severity") == "blocking" for f in findings) else "pass"
+        )
+
+    return make_pass_result(
+        status=status,
+        findings=findings,
+        confidence=confidence,
+        citations=[
+            "docs/plans/coder-agent.mdx §8 Pass 6",
+            "docs/plans/coder-agent.mdx §7.6 confidence gate",
+            "docs/plans/coder-agent.mdx §15.8 P6",
+        ],
+        tooling_used=tooling_used,
+    )
+
+
+__all__ = [
+    "AUTO_MERGE_CONFIDENCE_THRESHOLD",
+    "HARD_FAIL_CONFIDENCE",
+    "run_pass",
+]

--- a/src/gaia/coder/review/pass_7_feedback_binding.py
+++ b/src/gaia/coder/review/pass_7_feedback_binding.py
@@ -1,0 +1,368 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pass 7 — feedback-binding (§8 row 7).
+
+Only runs for self-fix PRs, signalled by a ``Feedback-Id:`` trailer or a
+``feedback_id`` token in the PR body. Has both a deterministic half
+(differential pytest: the regression test must fail on ``coder`` and
+pass on the fix branch) and an LLM half (``feedback_binding.md``), per
+§15.8 P7.
+
+If the PR body does not declare a feedback record this pass short-
+circuits as ``status="skipped"`` and the gate honours that: Pass 7 is
+required only for self-fix PRs per §8 row 7.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from gaia.coder.review._diff import DiffBundle, resolve_diff
+from gaia.coder.review._llm import (
+    LLMClientUnavailable,
+    call_opus,
+    load_prompt,
+    parse_json_response,
+    render_prompt,
+)
+from gaia.coder.review.pass_result import PassResult, make_pass_result
+
+logger = logging.getLogger(__name__)
+
+PROMPT_NAME: str = "feedback_binding.md"
+
+#: ``Feedback-Id: <uuid>`` trailer or inline ``feedback_id=<uuid>`` token.
+_FEEDBACK_ID_RE = re.compile(
+    r"(?:Feedback-Id|feedback[_-]?id)\s*[:=]\s*(?P<id>[A-Za-z0-9_-]{4,})",
+    re.IGNORECASE,
+)
+
+#: Matches a regression-test path declaration in the PR body. Either
+#: ``regression_test: tests/foo/test_bar.py`` or the markdown-list form.
+_REGRESSION_TEST_RE = re.compile(
+    r"(?:^|\s)regression[_-]?test\s*[:=]\s*(?P<path>[\w./\-]+\.py)",
+    re.IGNORECASE,
+)
+
+
+def extract_feedback_id(pr_body: str) -> Optional[str]:
+    """Return the feedback-record UUID declared in ``pr_body``, if any."""
+    if not pr_body:
+        return None
+    match = _FEEDBACK_ID_RE.search(pr_body)
+    if match:
+        return match.group("id")
+    return None
+
+
+def _extract_regression_test_path(pr_body: str) -> Optional[str]:
+    if not pr_body:
+        return None
+    match = _REGRESSION_TEST_RE.search(pr_body)
+    if match:
+        return match.group("path")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Differential pytest run
+# ---------------------------------------------------------------------------
+
+
+def _run_pytest_on_ref(
+    test_path: str,
+    ref: str,
+    *,
+    repo_root: Optional[Path],
+) -> Tuple[str, str]:
+    """Run the regression test on ``ref`` in a scratch worktree.
+
+    Returns ``(outcome, tail)`` where outcome is one of ``"pass"``,
+    ``"fail"``, or ``"error"`` (worktree/setup failure). We *do not*
+    silently swallow worktree errors — ``"error"`` surfaces as a blocking
+    finding so the EM knows the check was not actually performed.
+    """
+    if shutil.which("git") is None:
+        return "error", "git not on PATH"
+    if shutil.which("pytest") is None:
+        return "error", "pytest not on PATH"
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="gaia-coder-pass7-") as scratch:
+        add_cmd = ["git", "worktree", "add", "--detach", scratch, ref]
+        add_proc = subprocess.run(  # pylint: disable=subprocess-run-check
+            add_cmd,
+            cwd=str(repo_root) if repo_root else None,
+            capture_output=True,
+            text=True,
+        )
+        if add_proc.returncode != 0:
+            return (
+                "error",
+                f"worktree add failed: {add_proc.stderr.strip()!r}",
+            )
+        try:
+            test_proc = subprocess.run(  # pylint: disable=subprocess-run-check
+                ["pytest", "-x", "--tb=short", test_path],
+                cwd=scratch,
+                capture_output=True,
+                text=True,
+            )
+            tail = "\n".join(
+                (test_proc.stdout + test_proc.stderr).strip().splitlines()[-15:]
+            )
+            outcome = "pass" if test_proc.returncode == 0 else "fail"
+            return outcome, tail
+        finally:
+            remove_proc = subprocess.run(  # pylint: disable=subprocess-run-check
+                ["git", "worktree", "remove", "--force", scratch],
+                cwd=str(repo_root) if repo_root else None,
+                capture_output=True,
+                text=True,
+            )
+            if remove_proc.returncode != 0:
+                logger.warning(
+                    "pass 7: failed to remove worktree %s: %s",
+                    scratch,
+                    remove_proc.stderr.strip(),
+                )
+
+
+def _differential_pytest(
+    test_path: str,
+    *,
+    fix_ref: str,
+    base_ref: str,
+    repo_root: Optional[Path],
+) -> Tuple[dict, str, str]:
+    """Run pytest on ``base_ref`` then on ``fix_ref``.
+
+    Returns ``(finding_or_none, base_tail, fix_tail)``.
+
+    The contract is: the regression test must FAIL on ``base_ref`` and
+    PASS on ``fix_ref``. Any other combination is a blocking finding.
+    """
+    base_outcome, base_tail = _run_pytest_on_ref(
+        test_path, base_ref, repo_root=repo_root
+    )
+    fix_outcome, fix_tail = _run_pytest_on_ref(test_path, fix_ref, repo_root=repo_root)
+    if base_outcome == "error" or fix_outcome == "error":
+        return (
+            {
+                "severity": "blocking",
+                "description": (
+                    "differential pytest could not run: "
+                    f"base={base_outcome!r}, fix={fix_outcome!r}. "
+                    f"base_tail: {base_tail[:200]} fix_tail: {fix_tail[:200]}"
+                ),
+                "citation": "§8 Pass 7 — differential pytest",
+            },
+            base_tail,
+            fix_tail,
+        )
+    if base_outcome == "fail" and fix_outcome == "pass":
+        return {}, base_tail, fix_tail
+    return (
+        {
+            "severity": "blocking",
+            "description": (
+                f"regression test {test_path} should FAIL on {base_ref!r} "
+                f"and PASS on {fix_ref!r}; got base={base_outcome}, "
+                f"fix={fix_outcome}"
+            ),
+            "base_outcome": base_outcome,
+            "fix_outcome": fix_outcome,
+            "citation": "§8 Pass 7 — differential pytest",
+        },
+        base_tail,
+        fix_tail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_pass(
+    pr_or_branch: str,
+    *,
+    base_ref: str = "coder",
+    repo_root: Optional[Path] = None,
+    diff: Optional[DiffBundle] = None,
+    feedback_record: Optional[dict] = None,
+    skip_differential_pytest: bool = False,
+) -> PassResult:
+    """Execute Pass 7 and return the :class:`PassResult`.
+
+    Args:
+        feedback_record: Optional pre-fetched feedback record (dict with
+            at least ``id``, ``body``, ``fix_class``, ``candidate_files``,
+            ``success_criterion``). When absent we build a minimal one
+            from the PR body — enough to run the LLM half but not the
+            root-cause-file check.
+        skip_differential_pytest: Short-circuit the pytest half. Used by
+            tests to isolate the LLM half without shelling out to git /
+            pytest.
+    """
+    diff_bundle = diff or resolve_diff(
+        pr_or_branch, base_ref=base_ref, repo_root=repo_root
+    )
+
+    feedback_id = (feedback_record or {}).get("id") or extract_feedback_id(
+        diff_bundle.pr_body
+    )
+    if not feedback_id:
+        return make_pass_result(
+            status="skipped",
+            findings=[
+                {
+                    "severity": "info",
+                    "description": (
+                        "no Feedback-Id trailer in PR body; Pass 7 is a "
+                        "self-fix-PR-only pass per §8 row 7"
+                    ),
+                    "citation": "§8 Pass 7",
+                }
+            ],
+            citations=["docs/plans/coder-agent.mdx §8 Pass 7"],
+            tooling_used=[],
+        )
+
+    findings: List[dict] = []
+    tooling_used: List[str] = []
+
+    # --- deterministic half: differential pytest ---
+    if not skip_differential_pytest:
+        test_path = (feedback_record or {}).get(
+            "regression_test_path"
+        ) or _extract_regression_test_path(diff_bundle.pr_body)
+        if test_path:
+            tooling_used.append("pytest (differential: coder vs fix-branch)")
+            diff_finding, _base_tail, _fix_tail = _differential_pytest(
+                test_path,
+                fix_ref=pr_or_branch,
+                base_ref=base_ref,
+                repo_root=repo_root,
+            )
+            if diff_finding:
+                findings.append(diff_finding)
+        else:
+            findings.append(
+                {
+                    "severity": "blocking",
+                    "description": (
+                        "self-fix PR has no regression_test_path declared; "
+                        "§7.4 step 5 requires a regression test"
+                    ),
+                    "citation": "§8 Pass 7 — regression test required",
+                }
+            )
+
+    # --- LLM half ---
+    fb = feedback_record or {}
+    template = load_prompt(PROMPT_NAME)
+    rendered = render_prompt(
+        template,
+        {
+            "fb_id": str(feedback_id),
+            "verbatim_em_wording": str(fb.get("body", "<unknown>")),
+            "class": str(fb.get("fix_class", "<unknown>")),
+            "triaged_paths": "\n".join(fb.get("candidate_files", []) or []),
+            "from_plan_stage_3": str(fb.get("success_criterion", "<unknown>")),
+            "title": diff_bundle.pr_title,
+            "body": diff_bundle.pr_body,
+            "unified_diff": diff_bundle.unified_diff,
+            "test_path": str(
+                (feedback_record or {}).get("regression_test_path")
+                or _extract_regression_test_path(diff_bundle.pr_body)
+                or "<not declared>"
+            ),
+            "pytest_result_on_coder": "see differential_pytest results",
+            "pytest_result_on_fix_branch": "see differential_pytest results",
+        },
+    )
+
+    try:
+        raw = call_opus(rendered)
+        tooling_used.append("anthropic SDK → Opus 4.7 (feedback binding)")
+    except LLMClientUnavailable as exc:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": ("feedback-binding LLM unavailable: " + str(exc)),
+                "citation": "§15.9 fail-loudly",
+            }
+        )
+        return make_pass_result(
+            status="fail",
+            findings=findings,
+            citations=["docs/plans/coder-agent.mdx §8 Pass 7"],
+            tooling_used=tooling_used,
+        )
+
+    try:
+        payload = parse_json_response(raw)
+    except ValueError as exc:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": f"Opus response was not valid JSON: {exc}",
+                "raw_head": raw[:500],
+                "citation": "§15.9 fail-loudly",
+            }
+        )
+        return make_pass_result(
+            status="fail",
+            findings=findings,
+            citations=["docs/plans/coder-agent.mdx §8 Pass 7"],
+            tooling_used=tooling_used,
+        )
+
+    for blocker in payload.get("blockers", []) or []:
+        findings.append(
+            {
+                "severity": "blocking",
+                "description": f"feedback-binding blocker: {blocker}",
+                "citation": "§8 Pass 7",
+            }
+        )
+    for check in payload.get("checks", []) or []:
+        if str(check.get("verdict", "")).lower() == "fail":
+            findings.append(
+                {
+                    "severity": "significant",
+                    "description": (
+                        f"feedback-binding check failed: "
+                        f"{check.get('name', '?')} — "
+                        f"{check.get('evidence', '')}"
+                    ),
+                    "citation": "§8 Pass 7",
+                }
+            )
+
+    hard_fail = any(f.get("severity") == "blocking" for f in findings)
+    overall = str(payload.get("overall", "request-changes")).lower()
+
+    status = "fail" if hard_fail or overall == "request-changes" else "pass"
+
+    return make_pass_result(
+        status=status,
+        findings=findings,
+        confidence=None,
+        citations=[
+            "docs/plans/coder-agent.mdx §8 Pass 7",
+            "docs/plans/coder-agent.mdx §15.8 P7",
+        ],
+        tooling_used=tooling_used,
+    )
+
+
+__all__ = ["extract_feedback_id", "run_pass"]

--- a/src/gaia/coder/review/pass_result.py
+++ b/src/gaia/coder/review/pass_result.py
@@ -1,0 +1,87 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Common return type for every self-review pass.
+
+Every pass (1-7) returns a :class:`PassResult`. The gate orchestrator
+(:mod:`gaia.coder.review.gate`) reads these to decide pass/fail and
+aggregates them into a :class:`GateResult` attached to the PR description.
+
+The shape is a ``TypedDict`` rather than a dataclass so passes can be
+generated from LLM JSON responses with minimal adaptation (:meth:`dict` is
+the native envelope), and so it serialises cleanly to the audit log and to
+the PR body without custom encoders.
+
+Per §8 of ``docs/plans/coder-agent.mdx``, the fields mean:
+
+* ``status``          — ``"pass"`` / ``"fail"`` / ``"skipped"``.
+* ``findings``        — free-form list of dicts produced by the pass. Each
+  deterministic pass documents its own finding shape in the pass module's
+  docstring; LLM-driven passes echo the Pydantic-parsed JSON directly.
+* ``confidence``      — 0–100 score where meaningful (Pass 2 = coverage
+  %, Pass 6 = Opus adversarial confidence). ``None`` for deterministic
+  passes that do not produce a score.
+* ``citations``       — docs/spec references the pass consulted. Surfaced
+  in the PR body so reviewers can trace a finding back to the rule.
+* ``tooling_used``    — the actual binaries / APIs the pass invoked. Used
+  by :mod:`gaia.coder.review.gate` to render the "how was this checked"
+  section.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional, TypedDict
+
+PassStatus = Literal["pass", "fail", "skipped"]
+
+
+class Finding(TypedDict, total=False):
+    """One structured finding emitted by a pass.
+
+    Passes are free to include additional fields; only ``severity`` and
+    ``description`` are read by the gate orchestrator today. ``file`` and
+    ``line`` are conventional and should be populated whenever applicable.
+    """
+
+    severity: Literal["blocking", "significant", "minor", "info"]
+    description: str
+    file: str
+    line: int
+    fix: str
+    citation: str
+
+
+class PassResult(TypedDict):
+    """Envelope returned by every self-review pass (Passes 1–7)."""
+
+    status: PassStatus
+    findings: List[dict]
+    confidence: Optional[int]
+    citations: List[str]
+    tooling_used: List[str]
+
+
+def make_pass_result(
+    status: PassStatus,
+    findings: Optional[List[dict]] = None,
+    confidence: Optional[int] = None,
+    citations: Optional[List[str]] = None,
+    tooling_used: Optional[List[str]] = None,
+) -> PassResult:
+    """Construct a :class:`PassResult` with sensible empty defaults.
+
+    Prefer this constructor over a bare dict literal — it protects the
+    callers from typos in field names (at least at call sites that pass
+    through this helper) and centralises the "empty list not None"
+    convention so the gate never needs to None-guard ``findings``.
+    """
+    return {
+        "status": status,
+        "findings": list(findings or []),
+        "confidence": confidence,
+        "citations": list(citations or []),
+        "tooling_used": list(tooling_used or []),
+    }
+
+
+__all__ = ["Finding", "PassResult", "PassStatus", "make_pass_result"]

--- a/tests/coder/test_review.py
+++ b/tests/coder/test_review.py
@@ -1,0 +1,560 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the seven-pass self-review gate (Phase 4; §8 + §15.8).
+
+No real Anthropic calls are made. Every LLM call is patched at the
+:func:`gaia.coder.review._llm.call_opus` seam — the cheapest and most
+stable patch point per the module docstring.
+
+Subprocess calls are not mocked globally — the deterministic passes
+*should* exercise real ``subprocess.run`` so a regression in how we
+invoke tools surfaces here rather than in the integration suite. A
+handful of targeted ``mocker.patch`` calls stub out specific commands
+(``gitleaks``, ``pip-audit``) when a test needs a particular outcome.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+import pytest_mock  # noqa: F401 — used in the `patch_opus` fixture type hint
+
+from gaia.coder.review import (
+    ReviewToolsMixin,
+    make_pass_result,
+    run_all_passes,
+)
+from gaia.coder.review._diff import DiffBundle
+
+# ---------------------------------------------------------------------------
+# Shared fixtures — fabricated diff bundles for the passes to chew on.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_diff() -> DiffBundle:
+    """A tidy diff: small .py change, no debug prints, no TODOs."""
+    return DiffBundle(
+        source="branch",
+        identifier="feature/tidy",
+        unified_diff=(
+            "diff --git a/src/example.py b/src/example.py\n"
+            "index abc..def 100644\n"
+            "--- a/src/example.py\n"
+            "+++ b/src/example.py\n"
+            "@@ -1,2 +1,3 @@\n"
+            " def add(a, b):\n"
+            "-    return a + b\n"
+            "+    # Compute the sum of two numbers.\n"
+            "+    return a + b\n"
+        ),
+        changed_files=["src/example.py"],
+        pr_title="feat(example): annotate add()",
+        pr_body=(
+            "## Summary\n"
+            "Adds a one-line docstring to `add()` so future readers know "
+            "why this exists — without the comment the function is "
+            "indistinguishable from a stray utility.\n\n"
+            "## Test plan\n"
+            "- [x] pytest tests/unit/test_example.py\n"
+        ),
+        base_ref="coder",
+    )
+
+
+@pytest.fixture
+def dirty_diff() -> DiffBundle:
+    """A diff with a debug print, a bare TODO, and forbidden attribution."""
+    return DiffBundle(
+        source="branch",
+        identifier="feature/messy",
+        unified_diff=(
+            "diff --git a/src/bad.py b/src/bad.py\n"
+            "index abc..def 100644\n"
+            "--- a/src/bad.py\n"
+            "+++ b/src/bad.py\n"
+            "@@ -1,2 +1,6 @@\n"
+            " def add(a, b):\n"
+            "+    print('debugging')\n"
+            "+    # TODO remember to fix this someday\n"
+            "+    # old_value = 42\n"
+            "     return a + b\n"
+        ),
+        changed_files=["src/bad.py"],
+        pr_title="updated stuff",  # not conventional commits
+        pr_body=(
+            "some thing i did\n\n"
+            "Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>\n"
+        ),
+        base_ref="coder",
+    )
+
+
+@pytest.fixture
+def patch_opus(mocker: pytest_mock.MockerFixture):
+    """Return a helper that patches ``call_opus`` with a canned JSON body.
+
+    Usage::
+
+        patch_opus({"overall": "pass", "rules": [], "blockers": []})
+        result = pass_3_architectural.run_pass(...)
+    """
+
+    def _patch(payload: Dict[str, Any], *, target: str = "all") -> List[Any]:
+        """Patch call_opus in one or all review-pass modules.
+
+        ``target`` may be ``"all"`` or one of ``"3"``/``"5"``/``"6"``/``"7"``.
+        We patch the *imported* name inside each pass module — patching
+        the source module alone does not catch the already-bound names.
+        """
+        body = json.dumps(payload)
+        mocks = []
+        module_targets = {
+            "3": "gaia.coder.review.pass_3_architectural.call_opus",
+            "5": "gaia.coder.review.pass_5_prose.call_opus",
+            "6": "gaia.coder.review.pass_6_adversarial.call_opus",
+            "7": "gaia.coder.review.pass_7_feedback_binding.call_opus",
+        }
+        if target == "all":
+            for path in module_targets.values():
+                mocks.append(mocker.patch(path, return_value=body))
+        else:
+            mocks.append(mocker.patch(module_targets[target], return_value=body))
+        return mocks
+
+    return _patch
+
+
+# ---------------------------------------------------------------------------
+# Pass-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestPass1Static:
+    def test_pass_on_clean_diff(self, clean_diff, mocker):
+        from gaia.coder.review import pass_1_static
+
+        # Stub out the lint subprocess — lint passes.
+        mocker.patch(
+            "gaia.coder.review.pass_1_static._run",
+            return_value=(0, "", ""),
+        )
+        result = pass_1_static.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "pass"
+        assert result["confidence"] is None
+        assert "docs/plans/coder-agent.mdx §8 Pass 1" in result["citations"]
+
+    def test_fail_on_dirty_diff(self, dirty_diff, mocker):
+        from gaia.coder.review import pass_1_static
+
+        # Lint passes so the *only* failure signal is the regex guards.
+        mocker.patch(
+            "gaia.coder.review.pass_1_static._run",
+            return_value=(0, "", ""),
+        )
+        result = pass_1_static.run_pass("feature/messy", diff=dirty_diff)
+        descriptions = [f["description"] for f in result["findings"]]
+        # Regex guards are "minor" so status stays "pass" unless lint hard
+        # -fails — this asserts the regex still *surfaced* the issues.
+        assert any("debug print" in d for d in descriptions)
+        assert any("TODO" in d for d in descriptions)
+
+    def test_fail_when_lint_subprocess_fails(self, clean_diff, mocker):
+        from gaia.coder.review import pass_1_static
+
+        mocker.patch(
+            "gaia.coder.review.pass_1_static._run",
+            return_value=(1, "", "lint failed: 3 errors"),
+        )
+        result = pass_1_static.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "fail"
+        assert any(f["severity"] == "blocking" for f in result["findings"])
+
+
+class TestPass2Functional:
+    def test_pass_when_pytest_ok(self, clean_diff, mocker):
+        from gaia.coder.review import pass_2_functional
+
+        mocker.patch(
+            "gaia.coder.review.pass_2_functional._run",
+            return_value=(0, "TOTAL 100 0 87%\n", ""),
+        )
+        mocker.patch(
+            "gaia.coder.review.pass_2_functional.shutil.which",
+            side_effect=lambda name: "/usr/bin/pytest" if name == "pytest" else None,
+        )
+        result = pass_2_functional.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "pass"
+        assert result["confidence"] == 87
+
+    def test_fail_when_pytest_fails(self, clean_diff, mocker):
+        from gaia.coder.review import pass_2_functional
+
+        mocker.patch(
+            "gaia.coder.review.pass_2_functional._run",
+            return_value=(1, "", "FAILED tests/unit/test_add.py::test_add"),
+        )
+        mocker.patch(
+            "gaia.coder.review.pass_2_functional.shutil.which",
+            side_effect=lambda name: "/usr/bin/pytest" if name == "pytest" else None,
+        )
+        result = pass_2_functional.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "fail"
+        assert any("pytest failed" in f["description"] for f in result["findings"])
+
+
+class TestPass3Architectural:
+    def test_pass_when_opus_says_pass(self, clean_diff, patch_opus):
+        from gaia.coder.review import pass_3_architectural
+
+        patch_opus(
+            {
+                "rules": [{"rule": "LAYERING", "verdict": "pass", "citation": "N/A"}],
+                "overall": "pass",
+                "blockers": [],
+            },
+            target="3",
+        )
+        result = pass_3_architectural.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "pass"
+
+    def test_fail_when_opus_says_request_changes(self, clean_diff, patch_opus):
+        from gaia.coder.review import pass_3_architectural
+
+        patch_opus(
+            {
+                "rules": [
+                    {"rule": "LAYERING", "verdict": "fail", "citation": "src/x.py:10"}
+                ],
+                "overall": "request-changes",
+                "blockers": ["new cycle between x and y"],
+            },
+            target="3",
+        )
+        result = pass_3_architectural.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "fail"
+        assert any("cycle" in f["description"] for f in result["findings"])
+
+
+class TestPass4Security:
+    def test_pass_when_nothing_dangerous(self, clean_diff, mocker, tmp_path):
+        from gaia.coder.review import pass_4_security
+
+        mocker.patch(
+            "gaia.coder.review.pass_4_security.shutil.which",
+            return_value=None,  # no gitleaks, no pip-audit, no npm
+        )
+        # No .py files actually exist — pass_4 safely returns no AST hits.
+        result = pass_4_security.run_pass(
+            "feature/tidy", diff=clean_diff, repo_root=tmp_path
+        )
+        assert result["status"] == "pass"
+
+    def test_fail_when_eval_on_added_code(self, clean_diff, tmp_path, mocker):
+        from gaia.coder.review import pass_4_security
+
+        mocker.patch(
+            "gaia.coder.review.pass_4_security.shutil.which",
+            return_value=None,
+        )
+        bad_py = tmp_path / "src" / "bad.py"
+        bad_py.parent.mkdir(parents=True)
+        bad_py.write_text("def run(x):\n    return eval(x)\n")
+        diff = DiffBundle(
+            source="branch",
+            identifier="feature/danger",
+            unified_diff=(
+                "diff --git a/src/bad.py b/src/bad.py\n"
+                "+def run(x):\n+    return eval(x)\n"
+            ),
+            changed_files=["src/bad.py"],
+            pr_title="feat: add runner",
+            pr_body="## Summary\n\n## Test plan\n",
+            base_ref="coder",
+        )
+        result = pass_4_security.run_pass(
+            "feature/danger", diff=diff, repo_root=tmp_path
+        )
+        assert result["status"] == "fail"
+        assert any("eval" in f["description"] for f in result["findings"])
+
+
+class TestPass5Prose:
+    def test_pass_when_regex_clean_and_llm_clean(self, clean_diff, patch_opus):
+        from gaia.coder.review import pass_5_prose
+
+        patch_opus(
+            {"violations": [], "verdict": "pass", "reasoning": "clean"},
+            target="5",
+        )
+        result = pass_5_prose.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "pass"
+
+    def test_fail_on_claude_attribution(self, dirty_diff):
+        from gaia.coder.review import pass_5_prose
+
+        # No LLM patch needed — stage-1 regex short-circuits on the
+        # Co-Authored-By trailer before we call Opus.
+        result = pass_5_prose.run_pass("feature/messy", diff=dirty_diff, skip_llm=True)
+        assert result["status"] == "fail"
+        assert any(
+            "attribution" in f["description"].lower() for f in result["findings"]
+        )
+
+
+class TestPass6Adversarial:
+    def test_pass_when_confidence_high(self, clean_diff, patch_opus):
+        from gaia.coder.review import pass_6_adversarial
+
+        patch_opus(
+            {
+                "findings": [
+                    {
+                        "file_line": "src/example.py:3",
+                        "severity": "minor",
+                        "description": "docstring could reference add arity",
+                        "fix": "clarify",
+                    }
+                ],
+                "confidence_score": 92,
+                "rubric_reasoning": "tight match to criterion",
+            },
+            target="6",
+        )
+        result = pass_6_adversarial.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "pass"
+        assert result["confidence"] == 92
+
+    def test_fail_when_confidence_low(self, clean_diff, patch_opus):
+        from gaia.coder.review import pass_6_adversarial
+
+        patch_opus(
+            {
+                "findings": [],
+                "confidence_score": 42,
+                "rubric_reasoning": "unrelated",
+            },
+            target="6",
+        )
+        result = pass_6_adversarial.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "fail"
+        assert result["confidence"] == 42
+
+
+class TestPass7FeedbackBinding:
+    def test_skipped_without_feedback_id(self, clean_diff):
+        from gaia.coder.review import pass_7_feedback_binding
+
+        # clean_diff's pr_body has no Feedback-Id.
+        result = pass_7_feedback_binding.run_pass("feature/tidy", diff=clean_diff)
+        assert result["status"] == "skipped"
+
+    def test_pass_with_feedback_id_and_clean_llm(self, patch_opus):
+        from gaia.coder.review import pass_7_feedback_binding
+
+        diff = DiffBundle(
+            source="pr",
+            identifier="https://github.com/amd/gaia/pull/999",
+            unified_diff="diff\n",
+            changed_files=["src/example.py"],
+            pr_title="fix(example): address feedback",
+            pr_body=(
+                "## Summary\nAddresses EM feedback.\n"
+                "Feedback-Id: 9f8e7d6c\n"
+                "regression_test: tests/coder/test_example.py\n"
+            ),
+            base_ref="coder",
+        )
+        patch_opus(
+            {
+                "checks": [
+                    {
+                        "name": "regression_test",
+                        "verdict": "pass",
+                        "evidence": "differential pytest confirmed",
+                    }
+                ],
+                "overall": "pass",
+                "blockers": [],
+            },
+            target="7",
+        )
+        result = pass_7_feedback_binding.run_pass(
+            "feature/selffix",
+            diff=diff,
+            skip_differential_pytest=True,
+        )
+        assert result["status"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Gate-level tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_all_passes(mocker, clean_diff):
+    """Patch every pass's ``run_pass`` to return a canned result.
+
+    Returns a helper ``set_status(pass_index, status, **kwargs)`` that
+    tests can use to mark individual passes pass/fail/skipped.
+    """
+    # Also stub resolve_diff so the gate does not shell to git.
+    mocker.patch("gaia.coder.review.gate.resolve_diff", return_value=clean_diff)
+
+    module_names = {
+        1: "pass_1_static",
+        2: "pass_2_functional",
+        3: "pass_3_architectural",
+        4: "pass_4_security",
+        5: "pass_5_prose",
+        6: "pass_6_adversarial",
+        7: "pass_7_feedback_binding",
+    }
+    calls = {}
+
+    def _make_result(idx, status, **extras):
+        return make_pass_result(
+            status=status,
+            findings=extras.get("findings", []),
+            confidence=extras.get("confidence"),
+            citations=[f"stub-pass-{idx}"],
+            tooling_used=[f"stub-{idx}"],
+        )
+
+    def _install():
+        for idx, name in module_names.items():
+            calls[idx] = mocker.patch(
+                f"gaia.coder.review.gate.{name}.run_pass",
+                return_value=_make_result(idx, "pass"),
+            )
+
+    def _set_status(idx, status, **extras):
+        calls[idx].return_value = _make_result(idx, status, **extras)
+
+    _install()
+    return _set_status, calls
+
+
+def test_gate_short_circuits_on_hard_fail(stub_all_passes):
+    set_status, calls = stub_all_passes
+    set_status(
+        1,
+        "fail",
+        findings=[{"severity": "blocking", "description": "lint failed"}],
+    )
+    result = run_all_passes("feature/x", is_self_fix=False, base_ref="coder")
+    # Gate returns "block" on a hard-fail in Passes 1/2/4.
+    assert result.overall == "block"
+    # Pass 1 ran; Passes 2-7 did not.
+    assert calls[1].call_count == 1
+    for idx in (2, 3, 4, 5, 6, 7):
+        assert calls[idx].call_count == 0
+    # The pass_results list is still length 7 with skipped placeholders.
+    assert len(result.pass_results) == 7
+    assert result.pass_results[0]["status"] == "fail"
+    for idx in range(1, 7):
+        assert result.pass_results[idx]["status"] == "skipped"
+
+
+def test_pass_7_runs_only_for_self_fix(stub_all_passes):
+    _set_status, calls = stub_all_passes
+    # Default: everything passes. is_self_fix=False → Pass 7 is skipped.
+    result = run_all_passes("feature/x", is_self_fix=False, base_ref="coder")
+    assert result.pass_results[6]["status"] == "skipped"
+    assert calls[7].call_count == 0
+
+    # Now flip is_self_fix=True and confirm Pass 7 is actually invoked.
+    # (Reset everything; use a fresh gate call.)
+    result = run_all_passes("feature/selffix", is_self_fix=True, base_ref="coder")
+    assert calls[7].call_count == 1
+
+
+def test_gate_pass_when_all_pass(stub_all_passes):
+    _set_status, _ = stub_all_passes
+    # stub_all_passes defaults every pass to "pass".
+    result = run_all_passes("feature/x", is_self_fix=False, base_ref="coder")
+    assert result.overall == "pass"
+
+
+def test_gate_request_changes_when_non_hardfail_pass_fails(stub_all_passes):
+    set_status, _ = stub_all_passes
+    # Pass 3 is LLM-driven and is NOT in HARD_FAIL_PASSES (1, 2, 4).
+    # A fail there should surface as "request-changes", not "block".
+    set_status(
+        3,
+        "fail",
+        findings=[{"severity": "blocking", "description": "layering violated"}],
+    )
+    result = run_all_passes("feature/x", is_self_fix=False, base_ref="coder")
+    assert result.overall == "request-changes"
+
+
+def test_pass_6_emits_confidence_score_integer(clean_diff, patch_opus):
+    """§7.6 auto-merge gate needs an integer confidence from Pass 6."""
+    from gaia.coder.review import pass_6_adversarial
+
+    patch_opus(
+        {
+            "findings": [],
+            "confidence_score": 88,
+            "rubric_reasoning": "minor gaps",
+        },
+        target="6",
+    )
+    result = pass_6_adversarial.run_pass("feature/tidy", diff=clean_diff)
+    assert isinstance(result["confidence"], int)
+    assert 0 <= result["confidence"] <= 100
+    assert result["confidence"] == 88
+
+
+# ---------------------------------------------------------------------------
+# Prompt-file existence
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_files_exist():
+    """§15.8 says every LLM call site has a canonical prompt on disk."""
+    prompts_dir = (
+        Path(__file__).resolve().parents[2] / "src" / "gaia" / "coder" / "prompts"
+    )
+    expected = {
+        "architectural.md",
+        "persona_linter.md",
+        "adversarial.md",
+        "feedback_binding.md",
+    }
+    for name in expected:
+        path = prompts_dir / name
+        assert path.exists(), f"missing prompt: {path}"
+        assert path.read_text(encoding="utf-8").strip(), f"prompt {name} is empty"
+
+
+# ---------------------------------------------------------------------------
+# Mixin registration smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_mixin_registers_eight_tools():
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    before = set(_TOOL_REGISTRY.keys())
+    m = ReviewToolsMixin()
+    m.register_review_tools()
+    new = set(_TOOL_REGISTRY.keys()) - before
+    expected = {
+        "review_diff_self_static",
+        "review_diff_self_functional",
+        "review_diff_self_architectural",
+        "review_diff_self_security",
+        "review_diff_self_prose",
+        "review_diff_self_adversarial",
+        "review_diff_self_feedback_binding",
+        "review_diff_gate",
+    }
+    assert expected.issubset(new), f"missing: {expected - new}"
+    assert len(new) >= 8


### PR DESCRIPTION
## Summary

Phase 4 of the `gaia-coder` plan: the seven-pass self-review gate that runs before she ever calls `gh_pr_create`. Implements the full §8 table — deterministic checks (lint, tests, security, prose) plus LLM-driven passes (architectural, persona, adversarial, feedback-binding) — and surfaces an aggregated verdict with the confidence score the §7.6 auto-merge path reads.

This is the "deep-review discipline" the trust contract is built on. Every PR she opens must clear this gate; self-fix PRs additionally require Pass 7 (feedback-binding), which confirms the diff actually addresses the EM's wording and that the regression test fails on `coder` and passes on the branch.

## What this PR adds

- **Seven review passes** (`pass_1_static` through `pass_7_feedback_binding`) — each a focused module that returns a common `PassResult` envelope, so the gate never has to special-case any of them.
- **`gate.run_all_passes`** — orchestrator with cost-aware short-circuiting: a hard-fail on the deterministic cheap gates (1, 2, 4) skips the expensive Opus calls, because there is no point paying for adversarial review on a branch that fails lint.
- **`ReviewToolsMixin`** — exposes every pass as a `@tool` (`review_diff_self_static`, …) plus the one-shot `review_diff_gate`, so the agent, the EM's TUI, and the evaluation harness all share one code path.
- **Canonical prompt files** for Passes 3, 5, 6, 7 under `src/gaia/coder/prompts/`, materialised verbatim from §15.8 — self-fix PRs that touch a prompt are now a single-file `git diff`, the whole point of the §6.4 whitelist.
- **22 unit tests** that cover every pass (one pass + one fail per module), the gate's short-circuit behaviour, the self-fix gating of Pass 7, the confidence-score contract, and a prompt-files-exist guard so the canonical templates can't silently drift.

## Why the LLM seam matters

Every Opus call flows through `gaia.coder.review._llm.call_opus`. Tests patch that one name — cheap, stable, vendor-agnostic — rather than reaching into the Anthropic SDK. When we ship the Claude Agent SDK integration for Passes 3 and 6 (the `architecture-reviewer` / `code-reviewer` subagents in §15.8), the switch happens at a single module boundary without churning every test.

## Scope constraint

Changes are confined to `src/gaia/coder/review/`, `src/gaia/coder/prompts/`, and `tests/coder/test_review.py`. No other files are touched. Pass 7's differential-pytest worktree machinery is wired but opt-out via `skip_differential_pytest=True` for unit tests, because Phase 4 intentionally does not ship a running daemon — that's Phase 5.

## Dependencies

- Stacks on top of #818 (mixins; uses `gaia.coder.tools.cli._check_denylist` for subprocess safety) and #819 (scaffold). Both appear in this PR until they merge to `coder` — the diff will clean itself up afterwards.
- Does not depend on #820 (stores).

## Citations

- [`docs/plans/coder-agent.mdx`](../blob/feature/gaia-coder-review/docs/plans/coder-agent.mdx) §8 — the seven-pass table
- §15.8 — canonical prompt templates for Passes 3/5/6/7
- §7.6 — confidence-score gate on auto-merge
- §7.4 — self-correction loop that Pass 7 bookends

## Test plan

- [x] `pytest tests/coder/test_review.py -xvs` — 22/22 pass
- [x] `pytest tests/coder/` — 65/65 pass (sibling tests untouched)
- [x] `python util/lint.py --black --isort` — clean on in-scope files
- [x] Smoke: `from gaia.coder.review import ReviewToolsMixin; m = ReviewToolsMixin(); m.register_review_tools()` registers exactly 8 tools
- [ ] Integration run against a real branch with Anthropic creds present (Phase 5 territory — deferred to the daemon wiring task)

## Do not merge

Draft: this stacks on two unmerged sibling PRs and the Phase 4 runtime wiring lives in Phase 5.