### PR TITLE
fix(coder): restore package exports + CLAUDE.md fail-loudly compliance

### DIFF
--- a/src/gaia/coder/__init__.py
+++ b/src/gaia/coder/__init__.py
@@ -5,3 +5,14 @@
 This package is intentionally separate from ``src/gaia/agents/`` — the coder
 is infrastructure for building GAIA, not a GAIA product agent.
 """
+
+from gaia.coder.base import CoderAgent
+from gaia.coder.loop import DEFAULT_LOOP, Loop, State, Transition
+
+__all__ = [
+    "CoderAgent",
+    "DEFAULT_LOOP",
+    "Loop",
+    "State",
+    "Transition",
+]

--- a/src/gaia/coder/tools/cli.py
+++ b/src/gaia/coder/tools/cli.py
@@ -132,8 +132,11 @@ def _spawn_reader(
         finally:
             try:
                 stream.close()
-            except Exception:  # pylint: disable=broad-except
-                pass
+            except OSError as close_err:
+                # Torn-down pipe on subprocess termination — real but not
+                # recoverable here. Log with context per CLAUDE.md fail-loudly
+                # rule; do not silently swallow.
+                logger.debug("reader thread: stream close failed (%s)", close_err)
 
     t = threading.Thread(target=_run, daemon=True)
     t.start()

--- a/src/gaia/coder/tools/search.py
+++ b/src/gaia/coder/tools/search.py
@@ -54,12 +54,17 @@ class SearchToolsMixin(FileToolsMixin):
             glob: Optional[str] = None,
         ) -> List[SearchHit]:
             """Thin wrapper around :func:`search_code` with its default flags."""
-            # Fetch search_code from the registry rather than re-importing so
-            # tests that monkey-patch it still work.
-            from gaia.agents.base.tools import _TOOL_REGISTRY
+            # Fetch via the public accessor rather than reaching into the
+            # private registry; preserves monkey-patch behaviour in tests.
+            from gaia.agents.base.tools import get_tool_metadata
 
-            search_code = _TOOL_REGISTRY["search_code"]["function"]
-            return search_code(pattern, path=path, glob=glob)
+            meta = get_tool_metadata("search_code")
+            if meta is None:
+                raise RuntimeError(
+                    "grep(): search_code tool is not registered — "
+                    "SearchToolsMixin must be registered after FileToolsMixin."
+                )
+            return meta["function"](pattern, path=path, glob=glob)
 
         @tool
         def find_symbol(


### PR DESCRIPTION
## Summary

Three review-followups from the #818 / #819 / #820 merge, flagged by the auto-review bot. All tests (73/73 on `coder`) pass with the fixes.

## What this changes

- **Critical** — `src/gaia/coder/__init__.py`: restore the `CoderAgent` / `DEFAULT_LOOP` / `Loop` / `State` / `Transition` re-exports that #819 added and #818's rebase accidentally dropped. Without this, `tests/coder/test_skeleton.py::test_package_imports` fails on `coder` HEAD.

- **Important** — `src/gaia/coder/tools/cli.py:135`: replace bare `except Exception: pass` in the stream-reader teardown with a targeted `OSError` catch + `logger.debug`. CLAUDE.md's *No Silent Fallbacks* rule explicitly forbids this pattern.

- **Important** — `src/gaia/coder/tools/search.py:59`: stop reaching into the private `_TOOL_REGISTRY` from `grep()`. Use `get_tool_metadata()` — the public accessor at `src/gaia/agents/base/tools.py:113` exists for this.

## Test plan

- [x] `pytest tests/coder/ -x` — 73/73 pass (5 skeleton + 38 mixins + 30 stores)
- [x] `python -c "from gaia.coder import CoderAgent, DEFAULT_LOOP, Loop, State, Transition"` — all imports resolve