### PR TITLE
feat(coder): Phases 9+10 — OSS reuse + codebase research + repo binding + RAG freshness

### DIFF
--- a/schemas/agent-manifest.schema.json
+++ b/schemas/agent-manifest.schema.json
@@ -34,6 +34,8 @@
         "enum": [
           "file_io",
           "file_search",
+          "github",
+          "oss_reuse",
           "rag",
           "screenshot",
           "sd",

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -31,6 +31,9 @@ KNOWN_TOOLS: Dict[str, tuple] = {
     "screenshot": ("gaia.agents.tools.screenshot_tools", "ScreenshotToolsMixin"),
     "sd": ("gaia.sd.mixin", "SDToolsMixin"),
     "vlm": ("gaia.vlm.mixin", "VLMToolsMixin"),
+    # gaia-coder mixins (per docs/plans/coder-agent.mdx §15.2)
+    "github": ("gaia.coder.tools.github", "GitHubToolsMixin"),
+    "oss_reuse": ("gaia.coder.oss_reuse", "OSSReuseMixin"),
 }
 
 

--- a/src/gaia/coder/oss_reuse.py
+++ b/src/gaia/coder/oss_reuse.py
@@ -1,0 +1,594 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``OSSReuseMixin`` — license-aware reuse of external code (§5.3, §5.4).
+
+The four tools in §15.2 of ``docs/plans/coder-agent.mdx`` form a small DAG:
+
+* :func:`gh_search_code` / :func:`gh_search_repos` — discovery against
+  GitHub's code-search and repo-search APIs, with a **hard** license filter
+  that drops GPL/AGPL/LGPL/SSPL/proprietary before the LLM ever sees the
+  results.
+* :func:`vet_license` — sync SPDX check against a given repo; returns a
+  structured :class:`LicenseReport` the loop can cite.
+* :func:`import_with_attribution` — the only tool that writes to the repo.
+  Four guarantees, all baked in at the tool layer (§5.4):
+
+  1. The source license is compatible (else :class:`LicenseIncompatibleError`).
+  2. The source is pinned to a commit SHA, never a branch.
+  3. The imported file gets a verbatim header
+     ``# Adapted from <repo> @ <sha> — <license>``.
+  4. ``THIRD_PARTY_NOTICES.md`` at repo root gets an append-only entry with
+     URL, SHA, license, and ISO-8601 date.
+
+Everything downstream — Pass 5 prose linter, the EM audit trail, the
+``coder`` → ``main`` integration PR — depends on those four facts holding.
+The tool refuses to proceed if any is missing, because a silent degradation
+would violate principle #3 (fail-loudly).
+
+Network boundary
+----------------
+All network I/O is funnelled through :func:`_gh_api` (for GitHub API calls)
+and :func:`_fetch_raw` (for ``raw.githubusercontent.com``). Tests mock those
+two functions and never hit the wire. This matches the task directive
+"Perform real ``gh api`` calls in tests — mock the subprocess boundary."
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Literal, Optional, Sequence, TypedDict
+
+from gaia.agents.base.tools import tool
+from gaia.coder.tools.github import _run_gh
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SPDX allowlist / denylist
+# ---------------------------------------------------------------------------
+
+#: Permissive licenses the coder may vendor or fork-and-modify. Pinned to
+#: SPDX identifiers so comparisons are exact.
+PERMISSIVE_LICENSES: frozenset[str] = frozenset(
+    {
+        "MIT",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "Apache-2.0",
+        "ISC",
+        "Unlicense",
+        "0BSD",
+    }
+)
+
+#: Copyleft / proprietary licenses that always fail the check.
+BLOCKED_LICENSES: frozenset[str] = frozenset(
+    {
+        "GPL-2.0",
+        "GPL-2.0-only",
+        "GPL-2.0-or-later",
+        "GPL-3.0",
+        "GPL-3.0-only",
+        "GPL-3.0-or-later",
+        "AGPL-3.0",
+        "AGPL-3.0-only",
+        "AGPL-3.0-or-later",
+        "LGPL-2.1",
+        "LGPL-2.1-only",
+        "LGPL-2.1-or-later",
+        "LGPL-3.0",
+        "LGPL-3.0-only",
+        "LGPL-3.0-or-later",
+        "SSPL-1.0",
+        "BUSL-1.1",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Return types
+# ---------------------------------------------------------------------------
+
+
+class CodeHit(TypedDict):
+    """One result from :func:`gh_search_code`."""
+
+    repository: str  # "owner/name"
+    path: str
+    url: str
+    license: Optional[str]  # SPDX id if GitHub knows it
+
+
+class RepoHit(TypedDict):
+    """One result from :func:`gh_search_repos`."""
+
+    repository: str
+    description: str
+    stars: int
+    url: str
+    license: Optional[str]
+
+
+@dataclass
+class LicenseReport:
+    """Outcome of :func:`vet_license` — what the loop cites in plans / PRs."""
+
+    repository: str
+    license: Optional[str]
+    compatible: bool
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {
+            "repository": self.repository,
+            "license": self.license,
+            "compatible": self.compatible,
+            "reason": self.reason,
+        }
+
+
+class ImportResult(TypedDict):
+    """Result of :func:`import_with_attribution`."""
+
+    dest_path: str
+    license: str
+    source_url: str
+    commit_sha: str
+    notices_entry_added: bool
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class LicenseIncompatibleError(RuntimeError):
+    """Raised when a source's license is not in :data:`PERMISSIVE_LICENSES`.
+
+    The exception carries the SPDX id so the caller can route the failure
+    (open an issue for human review per §5.4, log to the audit trail, etc.).
+    """
+
+    def __init__(self, repository: str, license_id: Optional[str]) -> None:
+        self.repository = repository
+        self.license_id = license_id
+        super().__init__(
+            f"license incompatible for {repository!r}: "
+            f"{license_id or '<unknown>'} is not in PERMISSIVE_LICENSES"
+        )
+
+
+class AttributionError(RuntimeError):
+    """Raised when :func:`import_with_attribution` cannot uphold one of the
+    four §5.4 guarantees (missing SHA, missing notices file, etc.)."""
+
+
+# ---------------------------------------------------------------------------
+# Network boundary — mockable in tests
+# ---------------------------------------------------------------------------
+
+
+def _gh_api(path: str, *, method: str = "GET") -> dict:
+    """Invoke ``gh api`` and parse the JSON response.
+
+    Centralising the shell-out here means tests replace exactly one
+    function. Non-zero exit from ``gh api`` surfaces through
+    :class:`gaia.coder.tools.github.GitHubCLIError` without retyping.
+    """
+    argv = ["api", "-X", method, path, "-H", "Accept: application/vnd.github+json"]
+    raw = _run_gh(argv, timeout_s=60)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"gh api returned non-JSON ({path}): {e.msg}"
+        ) from e
+
+
+def _fetch_raw(url: str) -> str:
+    """Fetch a ``raw.githubusercontent.com`` URL, returning its text body.
+
+    Uses the :mod:`urllib` stdlib so there's no third-party HTTP dep. Tests
+    mock this function rather than :mod:`urllib`.
+    """
+    import urllib.request
+
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "gaia-coder (amd/gaia)"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read().decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Mixin
+# ---------------------------------------------------------------------------
+
+
+class OSSReuseMixin:
+    """Mixin providing the four OSS-reuse tools from §15.2 of the coder plan.
+
+    Default license filter is the full :data:`PERMISSIVE_LICENSES` set. A
+    caller can pass a narrower list but **cannot** widen it — attempts to
+    add blocked licenses raise :class:`LicenseIncompatibleError` at
+    parse-time, before any network call.
+    """
+
+    def register_oss_reuse_tools(self) -> None:
+        """Register the four tools in the agent tool registry."""
+
+        @tool
+        def gh_search_code(
+            query: str,
+            language: Optional[str] = None,
+            license_filter: Optional[List[str]] = None,
+            limit: int = 20,
+        ) -> List[CodeHit]:
+            """Search GitHub code for ``query`` with a hard license filter.
+
+            The filter defaults to :data:`PERMISSIVE_LICENSES`. Results
+            whose repository license is absent or not in the filter are
+            dropped *before* returning — the LLM never sees a GPL hit.
+            """
+            allowed = _validate_license_filter(license_filter)
+            # GitHub's code-search API does not support license:= qualifiers,
+            # so we filter client-side after fetching repo metadata.
+            q_parts = [query]
+            if language:
+                q_parts.append(f"language:{language}")
+            q = " ".join(q_parts)
+            params = f"/search/code?q={_urlencode(q)}&per_page={limit}"
+            payload = _gh_api(params)
+            hits: List[CodeHit] = []
+            for item in payload.get("items", []):
+                repo_full = item["repository"]["full_name"]
+                lic = _lookup_repo_license(repo_full)
+                if lic not in allowed:
+                    continue
+                hits.append(
+                    CodeHit(
+                        repository=repo_full,
+                        path=item["path"],
+                        url=item["html_url"],
+                        license=lic,
+                    )
+                )
+            return hits
+
+        @tool
+        def gh_search_repos(
+            query: str,
+            license_filter: Optional[List[str]] = None,
+            min_stars: int = 0,
+            limit: int = 20,
+        ) -> List[RepoHit]:
+            """Search GitHub repositories with a hard license filter.
+
+            Unlike code-search, the repos endpoint *does* support a
+            ``license:<key>`` qualifier, so the filter is applied
+            server-side *and* double-checked client-side.
+            """
+            allowed = _validate_license_filter(license_filter)
+            q_parts = [query]
+            for spdx in allowed:
+                q_parts.append(f"license:{_spdx_to_gh_key(spdx)}")
+            if min_stars > 0:
+                q_parts.append(f"stars:>={min_stars}")
+            q = " ".join(q_parts)
+            params = f"/search/repositories?q={_urlencode(q)}&per_page={limit}"
+            payload = _gh_api(params)
+            hits: List[RepoHit] = []
+            for item in payload.get("items", []):
+                lic_obj = item.get("license") or {}
+                lic = lic_obj.get("spdx_id") if lic_obj else None
+                # Double-check client-side — defence in depth.
+                if lic not in allowed:
+                    continue
+                hits.append(
+                    RepoHit(
+                        repository=item["full_name"],
+                        description=item.get("description") or "",
+                        stars=item.get("stargazers_count", 0),
+                        url=item["html_url"],
+                        license=lic,
+                    )
+                )
+            return hits
+
+        @tool
+        def vet_license(repo: str) -> LicenseReport:
+            """Sync SPDX check for ``repo`` (``owner/name``).
+
+            Returns a structured :class:`LicenseReport` regardless of
+            outcome — the loop uses it in plan docs and PR bodies. The
+            caller decides whether a ``compatible=False`` result is a hard
+            block (`import_with_attribution`) or an advisory (search).
+            """
+            spdx = _lookup_repo_license(repo)
+            if spdx is None:
+                return LicenseReport(
+                    repository=repo,
+                    license=None,
+                    compatible=False,
+                    reason="no LICENSE file recognised by GitHub",
+                )
+            if spdx in BLOCKED_LICENSES:
+                return LicenseReport(
+                    repository=repo,
+                    license=spdx,
+                    compatible=False,
+                    reason=f"{spdx} is copyleft/proprietary; blocked by policy (§5.4)",
+                )
+            if spdx in PERMISSIVE_LICENSES:
+                return LicenseReport(
+                    repository=repo,
+                    license=spdx,
+                    compatible=True,
+                    reason=f"{spdx} is on the permissive allowlist",
+                )
+            return LicenseReport(
+                repository=repo,
+                license=spdx,
+                compatible=False,
+                reason=(
+                    f"{spdx} is neither permissive nor explicitly blocked; "
+                    "human review required"
+                ),
+            )
+
+        @tool
+        def import_with_attribution(
+            source_url: str,
+            commit_sha: str,
+            dest_path: str,
+            attribution_note: str = "",
+            repo_root: Optional[str] = None,
+        ) -> ImportResult:
+            """Vendor one file from ``source_url`` into ``dest_path`` with attribution.
+
+            Applies the four §5.4 guarantees. Raises on any failure to
+            meet them (fail-loudly) — there is no silent fallback.
+
+            Args:
+                source_url: GitHub URL to the source file. Must match one of
+                    ``https://github.com/OWNER/NAME/blob/SHA/PATH`` or
+                    ``https://raw.githubusercontent.com/OWNER/NAME/SHA/PATH``.
+                commit_sha: The SHA to pin against. Must match the SHA in
+                    ``source_url``. Pinning to a branch name raises.
+                dest_path: Destination path inside the repo, relative to
+                    ``repo_root``.
+                attribution_note: Optional extra sentence appended to the
+                    header and the notices entry.
+                repo_root: Repo root (default CWD). Tests pass ``tmp_path``.
+            """
+            owner_name, branch_or_sha, src_path = _parse_source_url(source_url)
+            if branch_or_sha != commit_sha:
+                raise AttributionError(
+                    f"source_url references {branch_or_sha!r} but commit_sha is "
+                    f"{commit_sha!r}; provenance must match (§5.4 rule 3)"
+                )
+            if not _looks_like_sha(commit_sha):
+                raise AttributionError(
+                    f"commit_sha {commit_sha!r} does not look like a 40-char "
+                    "(or 7+) hex SHA; branch pins are forbidden (§5.4 rule 3)"
+                )
+            lic = _lookup_repo_license(owner_name)
+            if lic is None or lic not in PERMISSIVE_LICENSES:
+                raise LicenseIncompatibleError(owner_name, lic)
+            root = Path(repo_root) if repo_root else Path.cwd()
+            dest = root / dest_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
+
+            raw_url = _to_raw_url(owner_name, commit_sha, src_path)
+            body = _fetch_raw(raw_url)
+            header = _attribution_header(
+                repo=owner_name,
+                sha=commit_sha,
+                license_id=lic,
+                note=attribution_note,
+                path=dest_path,
+            )
+            dest.write_text(header + body, encoding="utf-8")
+
+            notices_added = _append_notices_entry(
+                root=root,
+                repo=owner_name,
+                sha=commit_sha,
+                license_id=lic,
+                source_url=source_url,
+                dest_path=dest_path,
+                note=attribution_note,
+            )
+            return ImportResult(
+                dest_path=dest.as_posix(),
+                license=lic,
+                source_url=source_url,
+                commit_sha=commit_sha,
+                notices_entry_added=notices_added,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_license_filter(
+    license_filter: Optional[Sequence[str]],
+) -> frozenset[str]:
+    """Coerce the user-supplied filter to a frozenset; reject any blocked entry."""
+    if license_filter is None:
+        return PERMISSIVE_LICENSES
+    requested = frozenset(license_filter)
+    bad = requested & BLOCKED_LICENSES
+    if bad:
+        raise LicenseIncompatibleError(
+            "<filter>", ",".join(sorted(bad))
+        )
+    # Silently drop entries that aren't permissive — we never widen.
+    return requested & PERMISSIVE_LICENSES
+
+
+def _urlencode(text: str) -> str:
+    """URL-encode a query string for ``gh api /search/…``."""
+    import urllib.parse
+
+    return urllib.parse.quote(text)
+
+
+def _spdx_to_gh_key(spdx: str) -> str:
+    """Translate an SPDX id to the lowercase key ``license:<key>`` expects.
+
+    GitHub's search API uses its own ``license_keys`` table (e.g. ``apache-2.0``),
+    which is mostly SPDX-lowercased with a few exceptions. We do the exact
+    mapping for the seven allowed ids rather than a blanket ``lower()`` to
+    protect against future SPDX additions that don't round-trip.
+    """
+    table = {
+        "MIT": "mit",
+        "BSD-2-Clause": "bsd-2-clause",
+        "BSD-3-Clause": "bsd-3-clause",
+        "Apache-2.0": "apache-2.0",
+        "ISC": "isc",
+        "Unlicense": "unlicense",
+        "0BSD": "0bsd",
+    }
+    if spdx not in table:
+        raise KeyError(f"no GitHub search key for SPDX id {spdx!r}")
+    return table[spdx]
+
+
+def _lookup_repo_license(repo: str) -> Optional[str]:
+    """Query ``gh api /repos/<repo>`` and return the SPDX id (or ``None``).
+
+    GitHub's ``/repos/{owner}/{repo}`` endpoint returns
+    ``license.spdx_id``; a missing or ``"NOASSERTION"`` value becomes
+    ``None``.
+    """
+    payload = _gh_api(f"/repos/{repo}")
+    lic = payload.get("license") or {}
+    spdx = lic.get("spdx_id")
+    if not spdx or spdx == "NOASSERTION":
+        return None
+    return spdx
+
+
+def _parse_source_url(url: str) -> tuple[str, str, str]:
+    """Return ``(owner/name, branch_or_sha, path)`` from a GitHub file URL.
+
+    Accepts both ``github.com/OWNER/NAME/blob/SHA/PATH`` and
+    ``raw.githubusercontent.com/OWNER/NAME/SHA/PATH``. Any other shape
+    raises :class:`AttributionError`.
+    """
+    import urllib.parse
+
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.netloc
+    segs = parsed.path.lstrip("/").split("/")
+    if host == "github.com" and len(segs) >= 5 and segs[2] == "blob":
+        owner, name = segs[0], segs[1]
+        sha_or_branch = segs[3]
+        path = "/".join(segs[4:])
+        return f"{owner}/{name}", sha_or_branch, path
+    if host == "raw.githubusercontent.com" and len(segs) >= 4:
+        owner, name, sha_or_branch = segs[0], segs[1], segs[2]
+        path = "/".join(segs[3:])
+        return f"{owner}/{name}", sha_or_branch, path
+    raise AttributionError(
+        f"cannot parse GitHub source URL: {url!r} "
+        "(expected github.com/<owner>/<name>/blob/<sha>/<path> or "
+        "raw.githubusercontent.com/<owner>/<name>/<sha>/<path>)"
+    )
+
+
+def _to_raw_url(repo: str, sha: str, path: str) -> str:
+    """Build the ``raw.githubusercontent.com`` URL we'll actually fetch."""
+    return f"https://raw.githubusercontent.com/{repo}/{sha}/{path}"
+
+
+def _looks_like_sha(candidate: str) -> bool:
+    """Cheap heuristic: 7+ hex chars, no slashes, no word chars outside hex."""
+    if len(candidate) < 7:
+        return False
+    allowed = set("0123456789abcdefABCDEF")
+    return all(ch in allowed for ch in candidate)
+
+
+def _attribution_header(
+    *, repo: str, sha: str, license_id: str, note: str, path: str
+) -> str:
+    """Return the verbatim §5.4 header for a vendored file.
+
+    Python-style ``#`` comments — we vendor into ``src/gaia/`` which is
+    Python-only. Future multi-language support will branch on suffix.
+    """
+    del path  # reserved for future non-Python headers
+    lines = [
+        f"# Adapted from {repo} @ {sha} — {license_id}",
+    ]
+    if note:
+        lines.append(f"# {note}")
+    lines.append("")  # blank line before the original file body
+    return "\n".join(lines) + "\n"
+
+
+def _append_notices_entry(
+    *,
+    root: Path,
+    repo: str,
+    sha: str,
+    license_id: str,
+    source_url: str,
+    dest_path: str,
+    note: str,
+) -> bool:
+    """Append an entry to ``THIRD_PARTY_NOTICES.md``.
+
+    Creates the file with a short header if it is missing. Returns
+    ``True`` if the entry was actually written (always true on success;
+    the return value exists so callers don't have to re-read the file to
+    confirm).
+    """
+    notices = root / "THIRD_PARTY_NOTICES.md"
+    if not notices.exists():
+        notices.write_text(
+            "# Third-Party Notices\n\n"
+            "Every entry below was vendored by `gaia-coder` with "
+            "`OSSReuseMixin.import_with_attribution` (§5.4).\n\n",
+            encoding="utf-8",
+        )
+    date = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    block_lines = [
+        f"## `{dest_path}`",
+        "",
+        f"- Source: {source_url}",
+        f"- Repository: `{repo}`",
+        f"- Commit: `{sha}`",
+        f"- License: `{license_id}`",
+        f"- Imported: {date}",
+    ]
+    if note:
+        block_lines.append(f"- Note: {note}")
+    block_lines.append("")  # trailing blank
+    with notices.open("a", encoding="utf-8") as fh:
+        fh.write("\n".join(block_lines) + "\n")
+    return True
+
+
+__all__ = [
+    "AttributionError",
+    "BLOCKED_LICENSES",
+    "CodeHit",
+    "ImportResult",
+    "LicenseIncompatibleError",
+    "LicenseReport",
+    "OSSReuseMixin",
+    "PERMISSIVE_LICENSES",
+    "RepoHit",
+]

--- a/src/gaia/coder/oss_reuse.py
+++ b/src/gaia/coder/oss_reuse.py
@@ -38,10 +38,9 @@ from __future__ import annotations
 import datetime as dt
 import json
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Literal, Optional, Sequence, TypedDict
+from typing import List, Optional, Sequence, TypedDict
 
 from gaia.agents.base.tools import tool
 from gaia.coder.tools.github import _run_gh
@@ -186,9 +185,7 @@ def _gh_api(path: str, *, method: str = "GET") -> dict:
     try:
         return json.loads(raw)
     except json.JSONDecodeError as e:
-        raise RuntimeError(
-            f"gh api returned non-JSON ({path}): {e.msg}"
-        ) from e
+        raise RuntimeError(f"gh api returned non-JSON ({path}): {e.msg}") from e
 
 
 def _fetch_raw(url: str) -> str:
@@ -199,9 +196,7 @@ def _fetch_raw(url: str) -> str:
     """
     import urllib.request
 
-    req = urllib.request.Request(
-        url, headers={"User-Agent": "gaia-coder (amd/gaia)"}
-    )
+    req = urllib.request.Request(url, headers={"User-Agent": "gaia-coder (amd/gaia)"})
     with urllib.request.urlopen(req, timeout=60) as resp:
         return resp.read().decode("utf-8")
 
@@ -428,9 +423,7 @@ def _validate_license_filter(
     requested = frozenset(license_filter)
     bad = requested & BLOCKED_LICENSES
     if bad:
-        raise LicenseIncompatibleError(
-            "<filter>", ",".join(sorted(bad))
-        )
+        raise LicenseIncompatibleError("<filter>", ",".join(sorted(bad)))
     # Silently drop entries that aren't permissive — we never widen.
     return requested & PERMISSIVE_LICENSES
 

--- a/src/gaia/coder/rag_freshness.py
+++ b/src/gaia/coder/rag_freshness.py
@@ -1,0 +1,524 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``rag_freshness`` — the §6.9 freshness contract.
+
+The RAG index is load-bearing for :data:`PROJECT_MAP.md` (§6.5), the
+``adr_decisions`` memory topic (§6.8), and the ``localise`` / ``explore``
+states. A *stale* index is strictly worse than *no* index — the agent will
+confidently cite something that no longer exists. This module exists so
+that failure mode cannot happen quietly.
+
+Four responsibilities:
+
+1. :class:`FreshnessContract` — declarative config for each of the five
+   §6.9 corpora (source tree / PR descriptions / issues / ADRs / CLAUDE.md).
+   The contract plus the live per-corpus status produces the freshness
+   verdict the loop queries at plan time.
+2. :func:`reindex_watchdog` — surfaces a ``critical``-severity EM-inbox
+   message if no reindex has succeeded in 36 h. One of the few automatic
+   ``critical`` messages in the system (§6.9).
+3. :func:`check_citation_valid` — Pass 3 architectural check that a cited
+   file still exists in the working tree at the given git ref. Matches
+   §6.9 rule 2 ("cites a file that was indexed but has been deleted/
+   renamed").
+4. :func:`rag_status` / :func:`rag_refresh` / :func:`rag_rebuild` — the
+   Python API behind the ``gaia-coder rag {status|refresh|rebuild}``
+   commands. CLI wiring lands in the unification follow-up per the task
+   contract; here we just expose the callable API.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Contract
+# ---------------------------------------------------------------------------
+
+
+Trigger = Literal["fs_watch", "webhook", "cron"]
+Cadence = Literal["hourly", "daily", "weekly"]
+
+
+@dataclass(frozen=True)
+class CorpusContract:
+    """Reindex rules for one corpus.
+
+    Mirrors one row of the §6.9 table. ``triggers`` determine when an
+    *incremental* reindex fires; ``cadence`` is the upper-bound rebuild
+    cycle regardless of triggers.
+    """
+
+    name: str
+    source: str  # human-readable description of what's indexed
+    triggers: Tuple[Trigger, ...]
+    cadence: Cadence
+    max_age_hours: float = 12.0  # §6.9 default — stale beyond 12h
+
+
+@dataclass(frozen=True)
+class FreshnessContract:
+    """Full §6.9 contract — one :class:`CorpusContract` per corpus."""
+
+    corpora: Tuple[CorpusContract, ...]
+    watchdog_hours: float = 36.0
+    """Watchdog fires ``critical`` if no reindex in this many hours (§6.9)."""
+
+    def by_name(self, name: str) -> CorpusContract:
+        for c in self.corpora:
+            if c.name == name:
+                return c
+        raise KeyError(f"unknown corpus {name!r}; known: {[c.name for c in self.corpora]}")
+
+    @classmethod
+    def default(cls) -> "FreshnessContract":
+        """The canonical §6.9 contract for the five bound-repo corpora."""
+        return cls(
+            corpora=(
+                CorpusContract(
+                    name="source_tree",
+                    source="git ls-files at main HEAD",
+                    triggers=("fs_watch",),
+                    cadence="weekly",
+                ),
+                CorpusContract(
+                    name="pr_descriptions",
+                    source="gh api pulls?state=all",
+                    triggers=("webhook",),
+                    cadence="weekly",
+                ),
+                CorpusContract(
+                    name="issues",
+                    source="gh api issues?state=all",
+                    triggers=("webhook",),
+                    cadence="weekly",
+                ),
+                CorpusContract(
+                    name="adrs_plans",
+                    source="docs/plans/*.mdx, docs/spec/*.mdx",
+                    triggers=("fs_watch",),
+                    cadence="weekly",
+                ),
+                CorpusContract(
+                    name="claude_agents_md",
+                    source="CLAUDE.md + AGENTS.md at repo root",
+                    triggers=("fs_watch",),
+                    cadence="weekly",
+                ),
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Live status — what corpora report when asked
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CorpusStatus:
+    """One per-corpus row in :func:`rag_status`."""
+
+    name: str
+    last_indexed_at: Optional[dt.datetime]  # UTC
+    document_count: int
+    pending_reindex: bool
+
+    @property
+    def age_seconds(self) -> Optional[float]:
+        if self.last_indexed_at is None:
+            return None
+        now = dt.datetime.now(dt.timezone.utc)
+        return (now - self.last_indexed_at).total_seconds()
+
+    @property
+    def age_hours(self) -> Optional[float]:
+        age = self.age_seconds
+        return None if age is None else age / 3600.0
+
+
+@dataclass
+class FreshnessVerdict:
+    """Aggregated freshness for one corpus (or a query result)."""
+
+    corpus: str
+    fresh: bool
+    age_hours: Optional[float]
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class StaleIndexError(RuntimeError):
+    """Raised when a RAG query returns matches older than
+    :attr:`CorpusContract.max_age_hours`.
+
+    Matches §6.9 "fail loudly": the pipeline never returns "matches" when
+    the index is known stale beyond the threshold.
+    """
+
+    def __init__(self, corpus: str, age_hours: float, threshold_hours: float) -> None:
+        self.corpus = corpus
+        self.age_hours = age_hours
+        self.threshold_hours = threshold_hours
+        super().__init__(
+            f"RAG index for corpus {corpus!r} is stale: "
+            f"age={age_hours:.1f}h > threshold={threshold_hours:.1f}h. "
+            "Run `gaia-coder rag refresh` to re-sync."
+        )
+
+
+class CitationStaleError(RuntimeError):
+    """Raised when :func:`check_citation_valid` detects a cited path that
+    no longer exists in the working tree (§6.9 rule 2)."""
+
+
+# ---------------------------------------------------------------------------
+# Corpus-status provider protocol
+# ---------------------------------------------------------------------------
+
+
+#: A callable that returns the current :class:`CorpusStatus` for each
+#: corpus name. Real implementations query the RAG backend; tests pass a
+#: stub. Decoupled so this module has zero RAG-backend dependencies.
+StatusProvider = Callable[[], Dict[str, CorpusStatus]]
+
+
+# ---------------------------------------------------------------------------
+# Freshness verdict — per-corpus and per-query
+# ---------------------------------------------------------------------------
+
+
+def verdict_for(
+    status: CorpusStatus, contract: CorpusContract
+) -> FreshnessVerdict:
+    """Compare a live :class:`CorpusStatus` against its :class:`CorpusContract`."""
+    if status.last_indexed_at is None:
+        return FreshnessVerdict(
+            corpus=status.name,
+            fresh=False,
+            age_hours=None,
+            reason=f"corpus {status.name!r} has never been indexed",
+        )
+    age_h = status.age_hours
+    assert age_h is not None  # last_indexed_at is set → age is defined
+    if age_h > contract.max_age_hours:
+        return FreshnessVerdict(
+            corpus=status.name,
+            fresh=False,
+            age_hours=age_h,
+            reason=(
+                f"corpus {status.name!r} is {age_h:.1f}h old; "
+                f"threshold is {contract.max_age_hours:.1f}h"
+            ),
+        )
+    return FreshnessVerdict(
+        corpus=status.name,
+        fresh=True,
+        age_hours=age_h,
+        reason=f"corpus {status.name!r} last indexed {age_h:.1f}h ago",
+    )
+
+
+def ensure_fresh_or_raise(
+    status: CorpusStatus, contract: CorpusContract
+) -> None:
+    """Raise :class:`StaleIndexError` if ``status`` violates ``contract``.
+
+    Used by the RAG query wrapper as the hard gate before surfacing any
+    matches — silent degradation to stale results is prohibited (§6.9).
+    """
+    v = verdict_for(status, contract)
+    if not v.fresh:
+        raise StaleIndexError(
+            corpus=status.name,
+            age_hours=v.age_hours or float("inf"),
+            threshold_hours=contract.max_age_hours,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Watchdog — critical EM-inbox message at 36h
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WatchdogAlert:
+    """Outcome of :func:`reindex_watchdog`.
+
+    If ``fired`` is ``True``, the caller forwards ``message`` to the EM
+    inbox with severity ``critical`` (§4.5).
+    """
+
+    fired: bool
+    severity: Literal["info", "critical"]
+    message: str
+    affected_corpora: Tuple[str, ...]
+
+
+def reindex_watchdog(
+    contract: FreshnessContract, provider: StatusProvider
+) -> WatchdogAlert:
+    """Surface a ``critical`` inbox message if any corpus is past the watchdog.
+
+    The watchdog is anchored at :attr:`FreshnessContract.watchdog_hours`
+    (default 36h). A corpus that has *never* indexed also trips the
+    watchdog because that is the first-run-broken failure mode.
+    """
+    statuses = provider()
+    affected: List[str] = []
+    for corpus in contract.corpora:
+        s = statuses.get(corpus.name)
+        if s is None:
+            affected.append(corpus.name)
+            continue
+        age_h = s.age_hours
+        if age_h is None or age_h > contract.watchdog_hours:
+            affected.append(corpus.name)
+    if not affected:
+        return WatchdogAlert(
+            fired=False,
+            severity="info",
+            message="All corpora indexed within watchdog window.",
+            affected_corpora=(),
+        )
+    corpora_list = ", ".join(affected)
+    return WatchdogAlert(
+        fired=True,
+        severity="critical",
+        message=(
+            f"RAG index has not refreshed in {contract.watchdog_hours:.0f}h "
+            f"for corpora: {corpora_list}. "
+            "Check the `gaia-coder rag status` diagnosis."
+        ),
+        affected_corpora=tuple(affected),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Citation check — Pass 3 architectural gate (§6.9 rule 2)
+# ---------------------------------------------------------------------------
+
+
+def check_citation_valid(
+    path: str,
+    git_ref: str = "HEAD",
+    *,
+    repo_root: Optional[str | Path] = None,
+    runner: Optional[Callable[[List[str]], str]] = None,
+) -> bool:
+    """Return True iff ``path`` exists at ``git_ref`` in ``repo_root``.
+
+    Uses ``git cat-file -e <ref>:<path>`` — fast and avoids checkout. A
+    non-zero exit means the path does not exist at that ref and raises
+    :class:`CitationStaleError`.
+
+    Args:
+        path: Repo-relative POSIX path.
+        git_ref: Ref to check against (default HEAD).
+        repo_root: Repo root (default CWD).
+        runner: Subprocess runner for tests. Defaults to direct
+            :mod:`subprocess` call.
+    """
+    run = runner or _default_git_runner
+    root = Path(repo_root) if repo_root else Path.cwd()
+    try:
+        run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "cat-file",
+                "-e",
+                f"{git_ref}:{path}",
+            ]
+        )
+    except _GitRunError as e:
+        raise CitationStaleError(
+            f"citation to {path!r} at ref {git_ref!r} is invalid: "
+            f"{e}. Pass 3 architectural check (§6.9) fails."
+        ) from e
+    return True
+
+
+class _GitRunError(RuntimeError):
+    """Internal — raised by :func:`_default_git_runner` on non-zero exit."""
+
+
+def _default_git_runner(argv: List[str]) -> str:
+    """Invoke ``git`` via :mod:`subprocess`, returning stdout on success."""
+    completed = subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    if completed.returncode != 0:
+        raise _GitRunError(
+            f"git exited {completed.returncode}: {' '.join(argv)} "
+            f"(stderr: {completed.stderr.strip()})"
+        )
+    return completed.stdout
+
+
+# ---------------------------------------------------------------------------
+# rag status / refresh / rebuild (§6.9)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RagStatusReport:
+    """Structured result of :func:`rag_status`."""
+
+    corpora: Tuple[CorpusStatus, ...]
+    verdicts: Tuple[FreshnessVerdict, ...]
+    watchdog: WatchdogAlert
+
+    @property
+    def any_stale(self) -> bool:
+        return any(not v.fresh for v in self.verdicts)
+
+    def to_dict(self) -> dict:
+        return {
+            "corpora": [
+                {
+                    "name": c.name,
+                    "document_count": c.document_count,
+                    "pending_reindex": c.pending_reindex,
+                    "last_indexed_at": (
+                        c.last_indexed_at.isoformat()
+                        if c.last_indexed_at
+                        else None
+                    ),
+                    "age_hours": c.age_hours,
+                }
+                for c in self.corpora
+            ],
+            "verdicts": [
+                {
+                    "corpus": v.corpus,
+                    "fresh": v.fresh,
+                    "age_hours": v.age_hours,
+                    "reason": v.reason,
+                }
+                for v in self.verdicts
+            ],
+            "watchdog": {
+                "fired": self.watchdog.fired,
+                "severity": self.watchdog.severity,
+                "message": self.watchdog.message,
+                "affected_corpora": list(self.watchdog.affected_corpora),
+            },
+            "any_stale": self.any_stale,
+        }
+
+
+def rag_status(
+    contract: FreshnessContract, provider: StatusProvider
+) -> RagStatusReport:
+    """Collect per-corpus status + freshness verdicts + watchdog alert.
+
+    Python-level API behind ``gaia-coder rag status``. The CLI wrapper
+    renders this to a human-readable table; the agent consumes the
+    structured report directly.
+    """
+    statuses = provider()
+    corpora_list: List[CorpusStatus] = []
+    verdicts: List[FreshnessVerdict] = []
+    for corpus in contract.corpora:
+        s = statuses.get(
+            corpus.name,
+            CorpusStatus(
+                name=corpus.name,
+                last_indexed_at=None,
+                document_count=0,
+                pending_reindex=False,
+            ),
+        )
+        corpora_list.append(s)
+        verdicts.append(verdict_for(s, corpus))
+    watchdog = reindex_watchdog(contract, provider)
+    return RagStatusReport(
+        corpora=tuple(corpora_list),
+        verdicts=tuple(verdicts),
+        watchdog=watchdog,
+    )
+
+
+#: Reindex backend — callable taking (corpus_name, mode) and returning a
+#: per-corpus result dict. ``mode`` is "refresh" (incremental) or
+#: "rebuild" (full). Decoupled from the RAG backend for testability.
+ReindexRunner = Callable[[str, Literal["refresh", "rebuild"]], Dict[str, Any]]
+
+
+def rag_refresh(
+    contract: FreshnessContract,
+    runner: ReindexRunner,
+    *,
+    corpus: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Incremental reindex for ``corpus`` (or all corpora if omitted).
+
+    Returns a ``{corpus_name: per-corpus result}`` map. Raises on unknown
+    corpus name — never silently skips.
+    """
+    names = [corpus] if corpus else [c.name for c in contract.corpora]
+    if corpus and corpus not in {c.name for c in contract.corpora}:
+        raise KeyError(
+            f"unknown corpus {corpus!r}; known: {[c.name for c in contract.corpora]}"
+        )
+    return {name: runner(name, "refresh") for name in names}
+
+
+def rag_rebuild(
+    contract: FreshnessContract,
+    runner: ReindexRunner,
+    *,
+    corpus: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Full rebuild for ``corpus`` (or all corpora if omitted).
+
+    Same contract as :func:`rag_refresh` but passes ``mode="rebuild"`` so
+    the backend discards any existing index rather than updating in
+    place. Use sparingly — rebuilds can be expensive.
+    """
+    names = [corpus] if corpus else [c.name for c in contract.corpora]
+    if corpus and corpus not in {c.name for c in contract.corpora}:
+        raise KeyError(
+            f"unknown corpus {corpus!r}; known: {[c.name for c in contract.corpora]}"
+        )
+    return {name: runner(name, "rebuild") for name in names}
+
+
+__all__ = [
+    "Cadence",
+    "CitationStaleError",
+    "CorpusContract",
+    "CorpusStatus",
+    "FreshnessContract",
+    "FreshnessVerdict",
+    "RagStatusReport",
+    "ReindexRunner",
+    "StaleIndexError",
+    "StatusProvider",
+    "Trigger",
+    "WatchdogAlert",
+    "check_citation_valid",
+    "ensure_fresh_or_raise",
+    "rag_rebuild",
+    "rag_refresh",
+    "rag_status",
+    "reindex_watchdog",
+    "verdict_for",
+]

--- a/src/gaia/coder/rag_freshness.py
+++ b/src/gaia/coder/rag_freshness.py
@@ -32,9 +32,9 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,9 @@ class FreshnessContract:
         for c in self.corpora:
             if c.name == name:
                 return c
-        raise KeyError(f"unknown corpus {name!r}; known: {[c.name for c in self.corpora]}")
+        raise KeyError(
+            f"unknown corpus {name!r}; known: {[c.name for c in self.corpora]}"
+        )
 
     @classmethod
     def default(cls) -> "FreshnessContract":
@@ -199,9 +201,7 @@ StatusProvider = Callable[[], Dict[str, CorpusStatus]]
 # ---------------------------------------------------------------------------
 
 
-def verdict_for(
-    status: CorpusStatus, contract: CorpusContract
-) -> FreshnessVerdict:
+def verdict_for(status: CorpusStatus, contract: CorpusContract) -> FreshnessVerdict:
     """Compare a live :class:`CorpusStatus` against its :class:`CorpusContract`."""
     if status.last_indexed_at is None:
         return FreshnessVerdict(
@@ -230,9 +230,7 @@ def verdict_for(
     )
 
 
-def ensure_fresh_or_raise(
-    status: CorpusStatus, contract: CorpusContract
-) -> None:
+def ensure_fresh_or_raise(status: CorpusStatus, contract: CorpusContract) -> None:
     """Raise :class:`StaleIndexError` if ``status`` violates ``contract``.
 
     Used by the RAG query wrapper as the hard gate before surfacing any
@@ -397,9 +395,7 @@ class RagStatusReport:
                     "document_count": c.document_count,
                     "pending_reindex": c.pending_reindex,
                     "last_indexed_at": (
-                        c.last_indexed_at.isoformat()
-                        if c.last_indexed_at
-                        else None
+                        c.last_indexed_at.isoformat() if c.last_indexed_at else None
                     ),
                     "age_hours": c.age_hours,
                 }

--- a/src/gaia/coder/repo_binding.py
+++ b/src/gaia/coder/repo_binding.py
@@ -29,7 +29,6 @@ import hashlib
 import hmac
 import logging
 import os
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Literal, Optional
@@ -98,9 +97,7 @@ class RepoBinding(BaseModel):
     @classmethod
     def _validate_repo(cls, v: str) -> str:
         if "/" not in v or v.count("/") != 1 or not all(v.split("/")):
-            raise ValueError(
-                f"repo must be in 'owner/name' form, got {v!r}"
-            )
+            raise ValueError(f"repo must be in 'owner/name' form, got {v!r}")
         return v
 
     @field_validator("github_app_id", "github_installation_id")
@@ -126,9 +123,7 @@ def load_repo_binding(path: str | Path) -> RepoBinding:
     try:
         import tomllib  # type: ignore[import-not-found]
     except ImportError as e:  # pragma: no cover
-        raise RepoBindingError(
-            "tomllib not available; need Python 3.11+"
-        ) from e
+        raise RepoBindingError("tomllib not available; need Python 3.11+") from e
 
     p = Path(path)
     if not p.exists():
@@ -139,9 +134,7 @@ def load_repo_binding(path: str | Path) -> RepoBinding:
     try:
         data = tomllib.loads(p.read_text(encoding="utf-8"))
     except tomllib.TOMLDecodeError as e:
-        raise RepoBindingError(
-            f"malformed TOML in {p}: {e}"
-        ) from e
+        raise RepoBindingError(f"malformed TOML in {p}: {e}") from e
     try:
         return RepoBinding(**data)
     except ValidationError as e:
@@ -229,9 +222,7 @@ def doctor(
 
     checks.append(_check_app_install(binding, runner))
     checks.append(_check_private_key_decrypts(binding, getter))
-    checks.append(
-        _check_webhook_signature_round_trip(binding, getter, sample_payload)
-    )
+    checks.append(_check_webhook_signature_round_trip(binding, getter, sample_payload))
     checks.append(_check_coder_branch_exists(binding, runner))
 
     return DoctorResult(
@@ -245,14 +236,10 @@ def doctor(
 # ---------------------------------------------------------------------------
 
 
-def _check_app_install(
-    binding: RepoBinding, runner: Any
-) -> DoctorCheck:
+def _check_app_install(binding: RepoBinding, runner: Any) -> DoctorCheck:
     """Verify ``gh api /app`` authenticates as the right App."""
     try:
-        raw = runner(
-            ["api", f"/app", "-H", "Accept: application/vnd.github+json"]
-        )
+        raw = runner(["api", "/app", "-H", "Accept: application/vnd.github+json"])
     except Exception as e:  # noqa: BLE001 — doctor aggregates
         return DoctorCheck(
             name="github_app_install",
@@ -286,9 +273,7 @@ def _check_app_install(
     )
 
 
-def _check_private_key_decrypts(
-    binding: RepoBinding, getter: Any
-) -> DoctorCheck:
+def _check_private_key_decrypts(binding: RepoBinding, getter: Any) -> DoctorCheck:
     """Pull the private key from the keyring and verify it looks like a PEM."""
     try:
         material = getter(binding.private_key_keyring_slot)
@@ -308,9 +293,11 @@ def _check_private_key_decrypts(
             ),
         )
     # Cheap structural check — full RSA decode would need an extra dep.
-    text = material.decode("utf-8", errors="replace") if isinstance(
-        material, bytes
-    ) else material
+    text = (
+        material.decode("utf-8", errors="replace")
+        if isinstance(material, bytes)
+        else material
+    )
     if "BEGIN" not in text or "PRIVATE KEY" not in text:
         return DoctorCheck(
             name="private_key_decrypts",
@@ -349,12 +336,8 @@ def _check_webhook_signature_round_trip(
             status="fail",
             detail="keyring returned empty webhook secret",
         )
-    secret_bytes = (
-        secret.encode("utf-8") if isinstance(secret, str) else secret
-    )
-    signature = "sha256=" + hmac.new(
-        secret_bytes, payload, hashlib.sha256
-    ).hexdigest()
+    secret_bytes = secret.encode("utf-8") if isinstance(secret, str) else secret
+    signature = "sha256=" + hmac.new(secret_bytes, payload, hashlib.sha256).hexdigest()
     if not verify_webhook_signature(secret_bytes, payload, signature):
         return DoctorCheck(
             name="webhook_signature_round_trip",
@@ -368,9 +351,7 @@ def _check_webhook_signature_round_trip(
     )
 
 
-def _check_coder_branch_exists(
-    binding: RepoBinding, runner: Any
-) -> DoctorCheck:
+def _check_coder_branch_exists(binding: RepoBinding, runner: Any) -> DoctorCheck:
     """Verify the bound repo has a ``coder`` branch (§5.7)."""
     try:
         raw = runner(
@@ -421,9 +402,7 @@ def _check_coder_branch_exists(
 # ---------------------------------------------------------------------------
 
 
-def verify_webhook_signature(
-    secret: bytes, body: bytes, header_value: str
-) -> bool:
+def verify_webhook_signature(secret: bytes, body: bytes, header_value: str) -> bool:
     """Constant-time check of a ``X-Hub-Signature-256`` header.
 
     Returns ``True`` on match. Implementation mirrors GitHub's canonical

--- a/src/gaia/coder/repo_binding.py
+++ b/src/gaia/coder/repo_binding.py
@@ -1,0 +1,542 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``repo_binding`` — ``amd/gaia`` bot-identity binding (§5.11, §15.6).
+
+Three responsibilities:
+
+1. :class:`RepoBinding` — Pydantic v2 model mirroring the
+   ``~/.gaia/coder/repo_binding.toml`` schema from §15.6. Loaded by
+   :func:`load_repo_binding`; validation failures raise
+   :class:`RepoBindingError` — never silently default.
+2. :func:`doctor` — the §15.6 bootstrap gate. Verifies (a) the GitHub App
+   installs, (b) the private key in the keyring decrypts, (c) a webhook
+   signature round-trips, and (d) the bound repo has a ``coder`` branch.
+   Until :func:`doctor` returns green the agent refuses to take any
+   action — matches the "hard bootstrap gate" rule.
+3. :func:`agents_md_entry` — the canonical §5.11 discoverability block to
+   paste into ``AGENTS.md`` / ``.github/copilot-instructions.md``.
+
+The module never performs real provisioning work. The steps in §15.6
+("create GitHub App", "upload private key", "install on repo") are
+EM-driven and deliberately outside of ``gaia-coder``'s reach. ``doctor``
+*checks* the invariants; it does not *enforce* them by creating anything.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import hmac
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List, Literal, Optional
+
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RepoBindingError(RuntimeError):
+    """Raised when the ``repo_binding.toml`` cannot be loaded or is invalid."""
+
+
+class DoctorCheckError(RuntimeError):
+    """Raised when a single :func:`doctor` check fails catastrophically.
+
+    Most doctor checks fold their failure into the :class:`DoctorResult` so
+    the EM sees every problem in one pass. This exception is reserved for
+    errors that prevent *any* checking — e.g. ``repo_binding.toml`` is
+    absent.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Pydantic model (§15.6)
+# ---------------------------------------------------------------------------
+
+
+class RepoBinding(BaseModel):
+    """Schema matching the §15.6 ``repo_binding.toml`` layout.
+
+    Every field is required; missing fields raise at load time. This is
+    principle #3 (fail-loudly): the bot identity is load-bearing and
+    silent defaults would be dangerous.
+    """
+
+    repo: str = Field(..., description="Canonical ``owner/name`` slug")
+    github_app_id: int = Field(..., description="GitHub App ID (integer)")
+    github_installation_id: int = Field(
+        ..., description="Installation ID returned on install-on-repo"
+    )
+    webhook_secret_keyring_slot: str = Field(
+        ..., description="OS keyring slot holding the webhook secret"
+    )
+    private_key_keyring_slot: str = Field(
+        ..., description="OS keyring slot holding the App's private key"
+    )
+    allowed_branches: List[str] = Field(
+        default_factory=list,
+        description="Branches the agent may push to (glob-friendly)",
+    )
+    forbidden_paths: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Repo-relative glob patterns the agent must never modify "
+            "(release scripts, signing keys, ...)"
+        ),
+    )
+
+    @field_validator("repo")
+    @classmethod
+    def _validate_repo(cls, v: str) -> str:
+        if "/" not in v or v.count("/") != 1 or not all(v.split("/")):
+            raise ValueError(
+                f"repo must be in 'owner/name' form, got {v!r}"
+            )
+        return v
+
+    @field_validator("github_app_id", "github_installation_id")
+    @classmethod
+    def _validate_positive_int(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError(f"GitHub IDs must be positive integers, got {v}")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_repo_binding(path: str | Path) -> RepoBinding:
+    """Load and validate ``repo_binding.toml`` from ``path``.
+
+    Raises :class:`RepoBindingError` — never returns a partially-populated
+    object. Matches §15.6 "hard bootstrap gate" semantics.
+    """
+    # Python 3.11+ has tomllib in the stdlib.
+    try:
+        import tomllib  # type: ignore[import-not-found]
+    except ImportError as e:  # pragma: no cover
+        raise RepoBindingError(
+            "tomllib not available; need Python 3.11+"
+        ) from e
+
+    p = Path(path)
+    if not p.exists():
+        raise RepoBindingError(
+            f"repo_binding.toml not found at {p} — run `gaia-coder bind` "
+            "to create one per §15.6."
+        )
+    try:
+        data = tomllib.loads(p.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as e:
+        raise RepoBindingError(
+            f"malformed TOML in {p}: {e}"
+        ) from e
+    try:
+        return RepoBinding(**data)
+    except ValidationError as e:
+        raise RepoBindingError(
+            f"repo_binding.toml at {p} failed validation: {e}"
+        ) from e
+
+
+# ---------------------------------------------------------------------------
+# Doctor (§15.6 step 7 — the bootstrap gate)
+# ---------------------------------------------------------------------------
+
+
+CheckStatus = Literal["pass", "fail", "skip"]
+
+
+@dataclass
+class DoctorCheck:
+    """One row in :class:`DoctorResult`."""
+
+    name: str
+    status: CheckStatus
+    detail: str
+
+
+@dataclass
+class DoctorResult:
+    """Structured outcome of :func:`doctor`.
+
+    ``green`` is the one boolean the agent's startup code looks at — any
+    ``fail`` row anywhere flips it to False and blocks action (§15.6).
+    """
+
+    checks: List[DoctorCheck]
+    checked_at: str  # ISO-8601 UTC
+
+    @property
+    def green(self) -> bool:
+        """True iff no check has status ``fail``."""
+        return not any(c.status == "fail" for c in self.checks)
+
+    def failed(self) -> List[DoctorCheck]:
+        return [c for c in self.checks if c.status == "fail"]
+
+    def to_dict(self) -> dict:
+        return {
+            "green": self.green,
+            "checked_at": self.checked_at,
+            "checks": [
+                {"name": c.name, "status": c.status, "detail": c.detail}
+                for c in self.checks
+            ],
+        }
+
+
+def doctor(
+    binding: RepoBinding,
+    *,
+    keyring_getter: Optional[Any] = None,
+    gh_runner: Optional[Any] = None,
+    sample_payload: bytes = b'{"ping":"doctor"}',
+) -> DoctorResult:
+    """Run the four §15.6 bootstrap checks and return a structured result.
+
+    Args:
+        binding: The validated :class:`RepoBinding` to check against.
+        keyring_getter: Callable ``(slot_name) -> bytes`` used to retrieve
+            the private key and webhook secret. Defaults to an OS-keyring
+            reader; tests pass a stub.
+        gh_runner: Callable ``(argv: list[str]) -> str`` that invokes the
+            ``gh`` CLI. Defaults to
+            :func:`gaia.coder.tools.github._run_gh`. Tests pass a stub.
+        sample_payload: Bytes to sign with the webhook secret during the
+            signature round-trip check. Default is a tiny fixed payload.
+
+    The function never raises for a failing check — it records the failure
+    and keeps going so the EM sees every broken invariant in one pass.
+    It *does* raise :class:`DoctorCheckError` if an input is structurally
+    broken in a way that prevents *any* checking (e.g. missing keyring
+    getter on a system with no keyring backend).
+    """
+    getter = keyring_getter or _default_keyring_getter
+    runner = gh_runner or _default_gh_runner
+    checks: List[DoctorCheck] = []
+
+    checks.append(_check_app_install(binding, runner))
+    checks.append(_check_private_key_decrypts(binding, getter))
+    checks.append(
+        _check_webhook_signature_round_trip(binding, getter, sample_payload)
+    )
+    checks.append(_check_coder_branch_exists(binding, runner))
+
+    return DoctorResult(
+        checks=checks,
+        checked_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Individual checks — each is a pure function for unit-test isolation
+# ---------------------------------------------------------------------------
+
+
+def _check_app_install(
+    binding: RepoBinding, runner: Any
+) -> DoctorCheck:
+    """Verify ``gh api /app`` authenticates as the right App."""
+    try:
+        raw = runner(
+            ["api", f"/app", "-H", "Accept: application/vnd.github+json"]
+        )
+    except Exception as e:  # noqa: BLE001 — doctor aggregates
+        return DoctorCheck(
+            name="github_app_install",
+            status="fail",
+            detail=f"gh api /app failed: {e}",
+        )
+    import json
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return DoctorCheck(
+            name="github_app_install",
+            status="fail",
+            detail=f"gh api /app returned non-JSON: {e}",
+        )
+    app_id = payload.get("id")
+    if app_id != binding.github_app_id:
+        return DoctorCheck(
+            name="github_app_install",
+            status="fail",
+            detail=(
+                f"authenticated App ID {app_id!r} does not match binding "
+                f"{binding.github_app_id}"
+            ),
+        )
+    return DoctorCheck(
+        name="github_app_install",
+        status="pass",
+        detail=f"authenticated as App ID {app_id}",
+    )
+
+
+def _check_private_key_decrypts(
+    binding: RepoBinding, getter: Any
+) -> DoctorCheck:
+    """Pull the private key from the keyring and verify it looks like a PEM."""
+    try:
+        material = getter(binding.private_key_keyring_slot)
+    except Exception as e:  # noqa: BLE001
+        return DoctorCheck(
+            name="private_key_decrypts",
+            status="fail",
+            detail=f"keyring get failed for {binding.private_key_keyring_slot!r}: {e}",
+        )
+    if not material:
+        return DoctorCheck(
+            name="private_key_decrypts",
+            status="fail",
+            detail=(
+                f"keyring slot {binding.private_key_keyring_slot!r} "
+                "returned an empty value"
+            ),
+        )
+    # Cheap structural check — full RSA decode would need an extra dep.
+    text = material.decode("utf-8", errors="replace") if isinstance(
+        material, bytes
+    ) else material
+    if "BEGIN" not in text or "PRIVATE KEY" not in text:
+        return DoctorCheck(
+            name="private_key_decrypts",
+            status="fail",
+            detail="keyring value does not look like a PEM-encoded private key",
+        )
+    return DoctorCheck(
+        name="private_key_decrypts",
+        status="pass",
+        detail="private key retrieved and structurally valid",
+    )
+
+
+def _check_webhook_signature_round_trip(
+    binding: RepoBinding, getter: Any, payload: bytes
+) -> DoctorCheck:
+    """Sign a tiny payload with the secret, then verify the signature matches.
+
+    Same algorithm GitHub uses: ``X-Hub-Signature-256`` = HMAC-SHA256 of
+    the raw request body, hex-encoded, prefixed with ``sha256=``.
+    """
+    try:
+        secret = getter(binding.webhook_secret_keyring_slot)
+    except Exception as e:  # noqa: BLE001
+        return DoctorCheck(
+            name="webhook_signature_round_trip",
+            status="fail",
+            detail=(
+                f"keyring get failed for "
+                f"{binding.webhook_secret_keyring_slot!r}: {e}"
+            ),
+        )
+    if not secret:
+        return DoctorCheck(
+            name="webhook_signature_round_trip",
+            status="fail",
+            detail="keyring returned empty webhook secret",
+        )
+    secret_bytes = (
+        secret.encode("utf-8") if isinstance(secret, str) else secret
+    )
+    signature = "sha256=" + hmac.new(
+        secret_bytes, payload, hashlib.sha256
+    ).hexdigest()
+    if not verify_webhook_signature(secret_bytes, payload, signature):
+        return DoctorCheck(
+            name="webhook_signature_round_trip",
+            status="fail",
+            detail="self-signed payload failed own verifier — secret round-trip broken",
+        )
+    return DoctorCheck(
+        name="webhook_signature_round_trip",
+        status="pass",
+        detail="HMAC-SHA256 signature round-trip OK",
+    )
+
+
+def _check_coder_branch_exists(
+    binding: RepoBinding, runner: Any
+) -> DoctorCheck:
+    """Verify the bound repo has a ``coder`` branch (§5.7)."""
+    try:
+        raw = runner(
+            [
+                "api",
+                f"/repos/{binding.repo}/branches/coder",
+                "-H",
+                "Accept: application/vnd.github+json",
+            ]
+        )
+    except Exception as e:  # noqa: BLE001
+        return DoctorCheck(
+            name="coder_branch_exists",
+            status="fail",
+            detail=(
+                f"gh api /repos/{binding.repo}/branches/coder failed: {e}. "
+                "Create the branch per §5.7 before retrying."
+            ),
+        )
+    import json
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return DoctorCheck(
+            name="coder_branch_exists",
+            status="fail",
+            detail=f"branch lookup returned non-JSON: {e}",
+        )
+    if payload.get("name") != "coder":
+        return DoctorCheck(
+            name="coder_branch_exists",
+            status="fail",
+            detail=(
+                "branch lookup succeeded but payload.name is "
+                f"{payload.get('name')!r} (expected 'coder')"
+            ),
+        )
+    return DoctorCheck(
+        name="coder_branch_exists",
+        status="pass",
+        detail=f"{binding.repo}:coder exists at {payload.get('commit', {}).get('sha', '<unknown>')}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature verification — used by the daemon (§15.5) and doctor
+# ---------------------------------------------------------------------------
+
+
+def verify_webhook_signature(
+    secret: bytes, body: bytes, header_value: str
+) -> bool:
+    """Constant-time check of a ``X-Hub-Signature-256`` header.
+
+    Returns ``True`` on match. Implementation mirrors GitHub's canonical
+    example; kept alongside :func:`doctor` because both sign with the
+    same secret.
+    """
+    if not header_value.startswith("sha256="):
+        return False
+    expected = hmac.new(secret, body, hashlib.sha256).hexdigest()
+    supplied = header_value.split("=", 1)[1]
+    return hmac.compare_digest(expected, supplied)
+
+
+# ---------------------------------------------------------------------------
+# Default callables — real keyring / gh invocation
+# ---------------------------------------------------------------------------
+
+
+def _default_keyring_getter(slot: str) -> bytes:
+    """Resolve a keyring slot via the ``keyring`` package if present.
+
+    Falls back to ``GAIA_CODER_KEYRING_<SLOT>`` env var when the ``keyring``
+    package is not installed — useful for CI / tests / headless boxes. The
+    env var fallback is documented, not a silent degradation, and is the
+    only case where a missing dep changes behaviour.
+    """
+    env_key = "GAIA_CODER_KEYRING_" + slot.replace("/", "_").replace("-", "_").upper()
+    if env_key in os.environ:
+        return os.environ[env_key].encode("utf-8")
+    try:
+        import keyring  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise DoctorCheckError(
+            "neither the `keyring` package nor a GAIA_CODER_KEYRING_* env "
+            f"var provides slot {slot!r}"
+        ) from e
+    # keyring uses (service, username) — the slot encodes both.
+    if "/" not in slot:
+        raise DoctorCheckError(
+            f"keyring slot {slot!r} must be of the form 'service/username'"
+        )
+    service, username = slot.split("/", 1)
+    value = keyring.get_password(service, username)
+    if value is None:
+        raise DoctorCheckError(f"keyring has no entry for {slot!r}")
+    return value.encode("utf-8")
+
+
+def _default_gh_runner(argv: List[str]) -> str:
+    """Invoke ``gh`` via :func:`gaia.coder.tools.github._run_gh`."""
+    # Late import to avoid a hard dep during ``load_repo_binding``.
+    from gaia.coder.tools.github import _run_gh
+
+    return _run_gh(argv, timeout_s=60)
+
+
+# ---------------------------------------------------------------------------
+# AGENTS.md discoverability (§5.11)
+# ---------------------------------------------------------------------------
+
+
+AGENTS_MD_ENTRY_TEMPLATE = """\
+## `gaia-coder` — autonomous coding agent for `{repo}`
+
+`gaia-coder` is a long-lived agent bound to this repository. She opens
+pull requests, triages issues, and self-fixes regressions. All of her
+work lands on the `coder` integration branch, never `main` — the EM
+reviews and merges from `coder` to `main` at their own cadence.
+
+**How to interact:**
+
+- Mention `@gaia-coder[bot]` in any issue or PR comment. She will read,
+  decide whether the ask is actionable, and either reply or open a draft
+  PR against `coder`.
+- Issues labelled `auto-triage` get classified and suggested labels.
+- PRs labelled `auto-review` run her multi-pass review flow.
+
+**What she cannot do:**
+
+- Merge to `main` (branch protection enforces human review).
+- Touch forbidden paths listed in `repo_binding.toml`:
+{forbidden_paths_list}
+- Take any action until `gaia-coder doctor` returns green.
+
+**See:** `docs/plans/coder-agent.mdx` for the full spec.
+"""
+
+
+def agents_md_entry(binding: RepoBinding) -> str:
+    """Render the canonical §5.11 AGENTS.md block for ``binding``.
+
+    Pure-template; idempotent; safe to write into ``AGENTS.md`` /
+    ``.github/copilot-instructions.md`` as many times as needed (the
+    writer is expected to deduplicate by header).
+    """
+    if binding.forbidden_paths:
+        rendered = "\n".join(f"  - `{p}`" for p in binding.forbidden_paths)
+    else:
+        rendered = "  - (none configured)"
+    return AGENTS_MD_ENTRY_TEMPLATE.format(
+        repo=binding.repo, forbidden_paths_list=rendered
+    )
+
+
+__all__ = [
+    "AGENTS_MD_ENTRY_TEMPLATE",
+    "DoctorCheck",
+    "DoctorCheckError",
+    "DoctorResult",
+    "RepoBinding",
+    "RepoBindingError",
+    "agents_md_entry",
+    "doctor",
+    "load_repo_binding",
+    "verify_webhook_signature",
+]

--- a/src/gaia/coder/subagents/__init__.py
+++ b/src/gaia/coder/subagents/__init__.py
@@ -1,0 +1,32 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Short-lived, isolated subagents dispatched from the main coder loop.
+
+Each module implements one subagent pattern from §5.10 — external-codebase
+research, sandbox probes, fresh-context adversarial review, etc. Subagents
+are deliberately coarse-grained: each has its own scratch workspace, its
+own tool subset, and its own budget ceiling. They return a structured
+:class:`pydantic.BaseModel` result to the caller and then exit.
+
+No subagent mutates primary state (memory, RAG, repo). If a subagent's
+findings are worth keeping, the main loop decides what to persist — the
+subagent itself is pure observation.
+"""
+
+from __future__ import annotations
+
+from gaia.coder.subagents.codebase_research import (
+    BudgetExceededError,
+    CodebaseResearchError,
+    ResearchBudget,
+    StructuredAnalysis,
+    research,
+)
+
+__all__ = [
+    "BudgetExceededError",
+    "CodebaseResearchError",
+    "ResearchBudget",
+    "StructuredAnalysis",
+    "research",
+]

--- a/src/gaia/coder/subagents/codebase_research.py
+++ b/src/gaia/coder/subagents/codebase_research.py
@@ -1,0 +1,361 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``codebase_research`` — the §5.10 subagent that investigates external repos.
+
+The main ``gaia-coder`` loop stays bound to ``amd/gaia``; external code (a
+library we're integrating, a fork we're evaluating) needs understanding
+without *polluting* the primary RAG. :func:`research` does exactly that:
+
+1. Clones (remote) or opens (local) the source into a scratch workspace
+   under ``~/.gaia/coder/research/<session-id>/`` by default.
+2. Loads a **minimal tool set** — :class:`FileToolsMixin` +
+   :class:`SearchToolsMixin`. Explicitly *no* writes, *no* GitHub CLI, *no*
+   memory writes. The subagent is purely observational.
+3. Answers the question in at most ``max_tool_calls`` tool calls, under a
+   ``max_duration_minutes`` wall-clock cap and a ``max_cost_usd`` ceiling.
+4. Returns a :class:`StructuredAnalysis` — the §5.10 schema verbatim.
+5. Cleans up the scratch workspace on exit unless ``keep=True``.
+
+Budget is enforced at two layers:
+
+* **The runner** loops tool calls and checks ``budget.exceeded(...)``
+  between each. Exceeding the budget raises :class:`BudgetExceededError`.
+* **The engine** (passed in by the caller) is responsible for advancing
+  ``usd_spent`` and ``tokens_used`` — the runner is engine-agnostic.
+
+No Anthropic / Claude SDK calls happen inside this module. A caller
+supplies an ``engine`` callable; tests pass a stub that returns canned
+answers. This matches the "mock the subprocess / LLM boundary" discipline
+the other phases use.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResearchBudget:
+    """Wall-clock + dollar ceiling for a single :func:`research` call.
+
+    Defaults match §5.10 (``max_duration_minutes=10``, ``max_cost_usd=2.0``).
+    The runner asks :meth:`exceeded` between every tool call. ``tokens_used``
+    and ``usd_spent`` are advanced by the engine; the runner just reads.
+    """
+
+    # Lambda (not bare ``time.monotonic``) so tests that monkeypatch
+    # ``time.monotonic`` on the module also affect ``started_at``.
+    started_at: float = field(default_factory=lambda: time.monotonic())
+    max_duration_minutes: float = 10.0
+    max_cost_usd: float = 2.0
+    max_tool_calls: int = 40
+    usd_spent: float = 0.0
+    tokens_used: int = 0
+    tool_calls_made: int = 0
+
+    def elapsed_s(self) -> float:
+        return time.monotonic() - self.started_at
+
+    def exceeded(self) -> Optional[str]:
+        """Return a human-readable reason or ``None`` if under budget."""
+        if self.elapsed_s() > self.max_duration_minutes * 60:
+            return (
+                f"wall-clock budget exceeded: "
+                f"{self.elapsed_s() / 60:.1f}m > {self.max_duration_minutes}m"
+            )
+        if self.usd_spent > self.max_cost_usd:
+            return (
+                f"dollar budget exceeded: "
+                f"${self.usd_spent:.2f} > ${self.max_cost_usd:.2f}"
+            )
+        if self.tool_calls_made >= self.max_tool_calls:
+            return (
+                f"tool-call budget exceeded: "
+                f"{self.tool_calls_made} >= {self.max_tool_calls}"
+            )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Structured output — §5.10 schema verbatim
+# ---------------------------------------------------------------------------
+
+
+class KeyFile(BaseModel):
+    """One row in :attr:`StructuredAnalysis.key_files`."""
+
+    path: str
+    line_range: Tuple[int, int]
+    why_cited: str
+
+
+class Pattern(BaseModel):
+    """One row in :attr:`StructuredAnalysis.patterns_worth_adopting`."""
+
+    pattern: str
+    evidence_path: str
+    caveat: str
+
+
+class StructuredAnalysis(BaseModel):
+    """The §5.10 schema — fields exactly as specified."""
+
+    source: str
+    question: str
+    answer: str
+    key_files: List[KeyFile] = Field(default_factory=list)
+    patterns_worth_adopting: List[Pattern] = Field(default_factory=list)
+    license: Optional[str] = None
+    attribution_note: str = ""
+    confidence: int = 0  # 0-100
+    tokens_used: int = 0
+    usd_spent: float = 0.0
+    unresolved_questions: List[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CodebaseResearchError(RuntimeError):
+    """Raised when :func:`research` cannot start or cannot return a result."""
+
+
+class BudgetExceededError(CodebaseResearchError):
+    """Raised when the budget ceiling is hit mid-run.
+
+    The partial :class:`StructuredAnalysis` (if any) is attached via the
+    ``partial`` attribute so callers can still log what they got before
+    the ceiling fired.
+    """
+
+    def __init__(self, reason: str, partial: Optional[StructuredAnalysis] = None) -> None:
+        self.reason = reason
+        self.partial = partial
+        super().__init__(reason)
+
+
+# ---------------------------------------------------------------------------
+# Source adapter — local path vs remote URL
+# ---------------------------------------------------------------------------
+
+
+def _is_remote_url(source: str) -> bool:
+    """True iff ``source`` looks like a git-cloneable URL."""
+    return (
+        source.startswith("https://")
+        or source.startswith("git@")
+        or source.startswith("git://")
+        or source.startswith("ssh://")
+    )
+
+
+def _prepare_workspace(
+    source: str,
+    scratch_root: Path,
+    *,
+    cloner: Callable[[str, Path], None],
+) -> Path:
+    """Materialise ``source`` into a subdirectory under ``scratch_root``.
+
+    Returns the absolute path to the working copy. Raises on cloning
+    failure.
+    """
+    scratch_root.mkdir(parents=True, exist_ok=True)
+    slug = uuid.uuid4().hex[:8]
+    workdir = scratch_root / slug
+    if _is_remote_url(source):
+        cloner(source, workdir)
+    else:
+        src_path = Path(source).expanduser().resolve()
+        if not src_path.exists():
+            raise CodebaseResearchError(
+                f"local source path does not exist: {src_path}"
+            )
+        # Copy rather than symlink — subagent must not accidentally write
+        # back to the real repo.
+        shutil.copytree(src_path, workdir)
+    return workdir
+
+
+def _default_cloner(url: str, dest: Path) -> None:
+    """Invoke ``git clone --depth 1 URL DEST`` via :mod:`subprocess`."""
+    # --depth 1 makes the clone fast; we don't need history for static
+    # analysis. Callers who want full history pass their own cloner.
+    completed = subprocess.run(
+        ["git", "clone", "--depth", "1", url, str(dest)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise CodebaseResearchError(
+            f"git clone {url!r} failed ({completed.returncode}): "
+            f"{completed.stderr.strip()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Engine protocol
+# ---------------------------------------------------------------------------
+
+
+class ResearchEngine(Protocol):
+    """Abstract interface the runner uses to drive a single research session.
+
+    Real implementations wrap a Claude / Opus call with the minimal tool
+    set (FileTools + SearchTools) bound to ``workdir``. Tests pass a stub
+    that returns a canned :class:`StructuredAnalysis`.
+
+    The engine is expected to mutate ``budget.tokens_used`` /
+    ``budget.usd_spent`` / ``budget.tool_calls_made`` as it goes so the
+    runner can enforce the ceiling between turns.
+    """
+
+    def step(
+        self, workdir: Path, question: str, budget: ResearchBudget
+    ) -> Optional[StructuredAnalysis]:
+        """Advance one reasoning turn.
+
+        Return ``None`` to signal "more turns needed" — the runner will
+        loop. Return a :class:`StructuredAnalysis` to finish.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_SCRATCH_ROOT = Path.home() / ".gaia" / "coder" / "research"
+
+
+def research(
+    source: str,
+    question: str,
+    *,
+    engine: Optional[ResearchEngine] = None,
+    max_duration_minutes: float = 10.0,
+    max_cost_usd: float = 2.0,
+    max_tool_calls: int = 40,
+    scratch_root: Optional[Path] = None,
+    cloner: Optional[Callable[[str, Path], None]] = None,
+    keep: bool = False,
+) -> StructuredAnalysis:
+    """Dispatch the §5.10 codebase-research subagent.
+
+    Args:
+        source: Either a git URL (``https://…``/``git@…``) or a local
+            repo path.
+        question: Free-text question the subagent answers.
+        engine: Research engine implementing :class:`ResearchEngine`. If
+            ``None``, raises — there is no default engine in this module
+            (the LLM binding lives in the caller).
+        max_duration_minutes: §5.10 default 10.
+        max_cost_usd: §5.10 default $2.
+        max_tool_calls: Upper bound on tool invocations. Protects against
+            a runaway engine that never emits a final answer.
+        scratch_root: Override ``~/.gaia/coder/research/``. Tests pass
+            ``tmp_path``.
+        cloner: Injected clone runner. Tests stub this to avoid touching
+            the network.
+        keep: If True, leave the scratch workspace behind for inspection.
+            Default False — clean up on exit.
+
+    Raises:
+        CodebaseResearchError: Source prep fails, or the engine returns
+            no final answer under the ceiling.
+        BudgetExceededError: The budget is tripped mid-run.
+    """
+    if engine is None:
+        raise CodebaseResearchError(
+            "no research engine supplied; pass `engine=` with a "
+            "ResearchEngine implementation"
+        )
+    root = scratch_root or DEFAULT_SCRATCH_ROOT
+    use_cloner = cloner or _default_cloner
+    workdir = _prepare_workspace(source, root, cloner=use_cloner)
+    logger.info(
+        "codebase_research: starting (source=%s workdir=%s budget=%.1fm/$%.2f)",
+        source,
+        workdir,
+        max_duration_minutes,
+        max_cost_usd,
+    )
+    budget = ResearchBudget(
+        max_duration_minutes=max_duration_minutes,
+        max_cost_usd=max_cost_usd,
+        max_tool_calls=max_tool_calls,
+    )
+    last_partial: Optional[StructuredAnalysis] = None
+    try:
+        while True:
+            reason = budget.exceeded()
+            if reason is not None:
+                raise BudgetExceededError(reason, partial=last_partial)
+            result = engine.step(workdir, question, budget)
+            if result is not None:
+                # Copy final-state budget metrics into the structured output so
+                # the caller sees what the run actually cost.
+                result.tokens_used = budget.tokens_used
+                result.usd_spent = round(budget.usd_spent, 4)
+                result.source = source
+                result.question = question
+                return result
+            last_partial = _maybe_partial(budget, source, question)
+    finally:
+        if not keep:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _maybe_partial(
+    budget: ResearchBudget, source: str, question: str
+) -> Optional[StructuredAnalysis]:
+    """Return a synthetic partial :class:`StructuredAnalysis` for budget exceptions.
+
+    Used only to preserve budget metrics on a failed run. The real engine
+    would populate substantive fields; this helper fills in what we know
+    cheaply so the caller has something to log.
+    """
+    return StructuredAnalysis(
+        source=source,
+        question=question,
+        answer="<budget exceeded before engine returned a final answer>",
+        confidence=0,
+        tokens_used=budget.tokens_used,
+        usd_spent=round(budget.usd_spent, 4),
+    )
+
+
+__all__ = [
+    "BudgetExceededError",
+    "CodebaseResearchError",
+    "DEFAULT_SCRATCH_ROOT",
+    "KeyFile",
+    "Pattern",
+    "ResearchBudget",
+    "ResearchEngine",
+    "StructuredAnalysis",
+    "research",
+]

--- a/src/gaia/coder/subagents/codebase_research.py
+++ b/src/gaia/coder/subagents/codebase_research.py
@@ -31,16 +31,14 @@ the other phases use.
 
 from __future__ import annotations
 
-import datetime as dt
 import logging
-import os
 import shutil
 import subprocess
 import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple
+from typing import Callable, List, Optional, Protocol, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -63,7 +61,9 @@ class ResearchBudget:
 
     # Lambda (not bare ``time.monotonic``) so tests that monkeypatch
     # ``time.monotonic`` on the module also affect ``started_at``.
-    started_at: float = field(default_factory=lambda: time.monotonic())
+    started_at: float = field(
+        default_factory=lambda: time.monotonic()  # pylint: disable=unnecessary-lambda
+    )
     max_duration_minutes: float = 10.0
     max_cost_usd: float = 2.0
     max_tool_calls: int = 40
@@ -148,7 +148,9 @@ class BudgetExceededError(CodebaseResearchError):
     the ceiling fired.
     """
 
-    def __init__(self, reason: str, partial: Optional[StructuredAnalysis] = None) -> None:
+    def __init__(
+        self, reason: str, partial: Optional[StructuredAnalysis] = None
+    ) -> None:
         self.reason = reason
         self.partial = partial
         super().__init__(reason)
@@ -188,9 +190,7 @@ def _prepare_workspace(
     else:
         src_path = Path(source).expanduser().resolve()
         if not src_path.exists():
-            raise CodebaseResearchError(
-                f"local source path does not exist: {src_path}"
-            )
+            raise CodebaseResearchError(f"local source path does not exist: {src_path}")
         # Copy rather than symlink — subagent must not accidentally write
         # back to the real repo.
         shutil.copytree(src_path, workdir)

--- a/src/gaia/coder/tools/github.py
+++ b/src/gaia/coder/tools/github.py
@@ -29,7 +29,7 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import Any, Dict, List, Literal, Optional, TypedDict
+from typing import Any, List, Literal, Optional, TypedDict
 
 from gaia.agents.base.tools import tool
 
@@ -270,9 +270,7 @@ class GitHubToolsMixin:
                 raise GitHubCLIError(
                     argv, 0, f"could not parse PR number from url {url!r}"
                 ) from e
-            return PRHandle(
-                number=number, url=url, head=head, base=base, draft=draft
-            )
+            return PRHandle(number=number, url=url, head=head, base=base, draft=draft)
 
         @tool
         def gh_pr_view(number: int, repo: Optional[str] = None) -> PRState:

--- a/src/gaia/coder/tools/github.py
+++ b/src/gaia/coder/tools/github.py
@@ -1,0 +1,591 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``GitHubToolsMixin`` — 11 ``gh`` CLI wrappers from §15.2 of the coder plan.
+
+Every tool shells out to the GitHub CLI (``gh``) via :mod:`subprocess` — no
+PyGithub, no direct REST calls. Three reasons:
+
+1. ``gh`` already encodes the bot-identity auth flow (private key → JWT →
+   installation token) via ``gh auth``, so the mixin never has to hold a PEM
+   in memory.
+2. Every tool call is reproducible by a human at the terminal with the same
+   argv — useful when the EM is debugging a weird API response.
+3. Output shapes are stable (``gh`` ships JSON flags) and trivially parsed.
+
+All tools default the ``--repo`` flag to the bound repo if known
+(``GITHUB_REPO`` env var, or the ``gh`` CLI's own current-repo resolution).
+Callers can override per-call via ``repo=``.
+
+Failure mode is fail-loudly: any non-zero exit from ``gh`` raises
+:class:`GitHubCLIError` with the stderr attached. This matches the rest of
+``gaia-coder`` (§2 principle 3) and lets Pass 3 / Pass 5 catch citation
+failures at publish time (§6.9).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from typing import Any, Dict, List, Literal, Optional, TypedDict
+
+from gaia.agents.base.tools import tool
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Return types — §15.2 typed dicts
+# ---------------------------------------------------------------------------
+
+
+class PRHandle(TypedDict):
+    """Handle returned by :func:`gh_pr_create`."""
+
+    number: int
+    url: str
+    head: str
+    base: str
+    draft: bool
+
+
+class PRState(TypedDict):
+    """Subset of ``gh pr view --json …`` fields used by the loop."""
+
+    number: int
+    title: str
+    body: str
+    state: str  # "OPEN" | "CLOSED" | "MERGED"
+    base: str
+    head: str
+    url: str
+    is_draft: bool
+    mergeable: Optional[str]
+    merge_state_status: Optional[str]
+
+
+class CommentHandle(TypedDict):
+    """Handle returned by :func:`gh_pr_comment` / :func:`gh_issue_comment`."""
+
+    url: str
+    id: str
+
+
+class ReviewHandle(TypedDict):
+    """Handle returned by :func:`gh_pr_review`."""
+
+    url: str
+    state: str  # "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED"
+
+
+class MergeResult(TypedDict):
+    """Handle returned by :func:`gh_pr_merge`."""
+
+    merged: bool
+    method: str
+    sha: Optional[str]
+
+
+class IssueHandle(TypedDict):
+    """Handle returned by :func:`gh_issue_create`."""
+
+    number: int
+    url: str
+
+
+class RunInfo(TypedDict):
+    """One row returned by :func:`gh_run_list`."""
+
+    id: int
+    name: str
+    status: str
+    conclusion: Optional[str]
+    branch: str
+    url: str
+    created_at: str
+
+
+class RunOutcome(TypedDict):
+    """Handle returned by :func:`gh_run_watch`."""
+
+    id: int
+    status: str  # "completed"
+    conclusion: str  # "success" | "failure" | "cancelled" | "skipped"
+    url: str
+
+
+class ReleaseHandle(TypedDict):
+    """Handle returned by :func:`gh_release_create`."""
+
+    tag: str
+    url: str
+    draft: bool
+
+
+# ---------------------------------------------------------------------------
+# Exceptions — fail-loudly taxonomy
+# ---------------------------------------------------------------------------
+
+
+class GitHubCLIError(RuntimeError):
+    """Raised when ``gh`` exits non-zero.
+
+    The ``stderr`` attribute carries the full error output so the caller can
+    surface it in a ``report_to_em`` message without re-invoking ``gh``.
+    """
+
+    def __init__(self, argv: List[str], returncode: int, stderr: str) -> None:
+        self.argv = argv
+        self.returncode = returncode
+        self.stderr = stderr
+        super().__init__(
+            f"gh exited {returncode}: {' '.join(argv)}\n"
+            f"stderr: {stderr.strip() or '<empty>'}"
+        )
+
+
+class GitHubCLIMissingError(RuntimeError):
+    """Raised at tool-call time when the ``gh`` binary cannot be found.
+
+    Surfacing this at use-site (rather than at import time) matches the
+    portable-core policy of §5.8 — the mixin is importable on machines
+    without ``gh`` installed, but any tool invocation fails loudly with a
+    fixable message.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Subprocess boundary — one place to stub in tests
+# ---------------------------------------------------------------------------
+
+
+def _gh_binary() -> str:
+    """Return the absolute path to ``gh`` or raise :class:`GitHubCLIMissingError`."""
+    path = shutil.which("gh")
+    if path is None:
+        raise GitHubCLIMissingError(
+            "`gh` CLI not found on PATH. Install it via "
+            "https://cli.github.com/ and run `gh auth login`."
+        )
+    return path
+
+
+def _run_gh(
+    argv: List[str],
+    *,
+    cwd: Optional[str] = None,
+    timeout_s: int = 60,
+) -> str:
+    """Invoke ``gh`` with ``argv``, returning stdout.
+
+    Raises :class:`GitHubCLIError` on non-zero exit. Tests mock this one
+    function to avoid real API calls (per task instructions).
+    """
+    full = [_gh_binary(), *argv]
+    logger.debug("gh invocation: %s (cwd=%s)", " ".join(full), cwd)
+    completed = subprocess.run(
+        full,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise GitHubCLIError(full, completed.returncode, completed.stderr)
+    return completed.stdout
+
+
+def _default_repo() -> Optional[str]:
+    """Return the bound repo (``owner/name``) if ``GITHUB_REPO`` is set.
+
+    Else return ``None`` and let ``gh`` fall back to its own CWD resolution.
+    """
+    repo = os.environ.get("GITHUB_REPO")
+    return repo.strip() if repo else None
+
+
+def _with_repo_flag(argv: List[str], repo: Optional[str]) -> List[str]:
+    """Splice ``--repo <owner/name>`` into ``argv`` after the subcommand name."""
+    resolved = repo or _default_repo()
+    if resolved is None:
+        return argv
+    return [*argv, "--repo", resolved]
+
+
+# ---------------------------------------------------------------------------
+# Mixin
+# ---------------------------------------------------------------------------
+
+
+class GitHubToolsMixin:
+    """Mixin providing the 11 ``gh_*`` tools from §15.2 of the coder plan.
+
+    Every tool defaults ``--repo`` to the bound repo (via ``GITHUB_REPO`` env
+    var) so the LLM never has to repeat ``owner/name`` in each call — and so
+    a stray call cannot accidentally target a different repository.
+    """
+
+    def register_github_tools(self) -> None:
+        """Register the 11 ``gh_*`` tools in the agent tool registry."""
+
+        @tool
+        def gh_pr_create(
+            title: str,
+            body: str,
+            head: str,
+            base: str = "coder",
+            draft: bool = True,
+            labels: Optional[List[str]] = None,
+            assignees: Optional[List[str]] = None,
+            repo: Optional[str] = None,
+        ) -> PRHandle:
+            """Open a pull request. Defaults to draft + base=coder per §5.7."""
+            argv: List[str] = [
+                "pr",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--head",
+                head,
+                "--base",
+                base,
+            ]
+            if draft:
+                argv.append("--draft")
+            for lbl in labels or []:
+                argv.extend(["--label", lbl])
+            for asg in assignees or []:
+                argv.extend(["--assignee", asg])
+            argv = _with_repo_flag(argv, repo)
+            url = _run_gh(argv).strip().splitlines()[-1]
+            # Parse the PR number out of the URL — the last path segment.
+            try:
+                number = int(url.rsplit("/", 1)[-1])
+            except ValueError as e:
+                raise GitHubCLIError(
+                    argv, 0, f"could not parse PR number from url {url!r}"
+                ) from e
+            return PRHandle(
+                number=number, url=url, head=head, base=base, draft=draft
+            )
+
+        @tool
+        def gh_pr_view(number: int, repo: Optional[str] = None) -> PRState:
+            """Fetch PR metadata as a structured record."""
+            fields = [
+                "number",
+                "title",
+                "body",
+                "state",
+                "baseRefName",
+                "headRefName",
+                "url",
+                "isDraft",
+                "mergeable",
+                "mergeStateStatus",
+            ]
+            argv = ["pr", "view", str(number), "--json", ",".join(fields)]
+            argv = _with_repo_flag(argv, repo)
+            raw = _run_gh(argv)
+            parsed = _parse_json(argv, raw)
+            return PRState(
+                number=parsed["number"],
+                title=parsed["title"],
+                body=parsed["body"],
+                state=parsed["state"],
+                base=parsed["baseRefName"],
+                head=parsed["headRefName"],
+                url=parsed["url"],
+                is_draft=parsed["isDraft"],
+                mergeable=parsed.get("mergeable"),
+                merge_state_status=parsed.get("mergeStateStatus"),
+            )
+
+        @tool
+        def gh_pr_comment(
+            number: int, body: str, repo: Optional[str] = None
+        ) -> CommentHandle:
+            """Add a comment to a PR (top-level; not a review)."""
+            argv = ["pr", "comment", str(number), "--body", body]
+            argv = _with_repo_flag(argv, repo)
+            url = _run_gh(argv).strip().splitlines()[-1]
+            return CommentHandle(url=url, id=url.rsplit("#", 1)[-1])
+
+        @tool
+        def gh_pr_review(
+            number: int,
+            event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+            body: str,
+            repo: Optional[str] = None,
+        ) -> ReviewHandle:
+            """Submit a PR review.
+
+            The bot identity cannot self-approve a PR it opened (GitHub
+            enforces this server-side). Callers wanting to mark a self-PR
+            "reviewed" should use ``gh_pr_comment`` instead.
+            """
+            flag_map = {
+                "APPROVE": "--approve",
+                "REQUEST_CHANGES": "--request-changes",
+                "COMMENT": "--comment",
+            }
+            argv = [
+                "pr",
+                "review",
+                str(number),
+                flag_map[event],
+                "--body",
+                body,
+            ]
+            argv = _with_repo_flag(argv, repo)
+            url = _run_gh(argv).strip().splitlines()[-1]
+            return ReviewHandle(url=url, state=_review_state(event))
+
+        @tool
+        def gh_pr_merge(
+            number: int,
+            method: Literal["merge", "squash", "rebase"] = "squash",
+            repo: Optional[str] = None,
+        ) -> MergeResult:
+            """Merge a PR. Sensitive-class per §4.3 — callers must elevate.
+
+            ``--repo coder`` restrictions from §5.7 are enforced *one layer
+            up* at the trust-tier check, not inside this tool — this tool is
+            the low-level shell and must stay general.
+            """
+            flag_map = {
+                "merge": "--merge",
+                "squash": "--squash",
+                "rebase": "--rebase",
+            }
+            argv = ["pr", "merge", str(number), flag_map[method], "--admin"]
+            argv = _with_repo_flag(argv, repo)
+            _run_gh(argv)  # gh prints a human summary; we don't need it
+            # Re-fetch the PR to get the merge commit SHA.
+            sha: Optional[str] = None
+            try:
+                state = gh_pr_view(number, repo=repo)
+                if state["state"] == "MERGED":
+                    # Fetch merge commit SHA via a separate query.
+                    sha_argv = _with_repo_flag(
+                        ["pr", "view", str(number), "--json", "mergeCommit"],
+                        repo,
+                    )
+                    sha_raw = _run_gh(sha_argv)
+                    parsed = _parse_json(sha_argv, sha_raw)
+                    sha = (parsed.get("mergeCommit") or {}).get("oid")
+            except GitHubCLIError as e:
+                # Re-raise with context — we were able to merge but not
+                # confirm the SHA; that's an actionable split condition.
+                logger.warning(
+                    "gh_pr_merge: merge succeeded but follow-up view failed: %s",
+                    e,
+                )
+            return MergeResult(merged=True, method=method, sha=sha)
+
+        @tool
+        def gh_issue_create(
+            title: str,
+            body: str,
+            labels: Optional[List[str]] = None,
+            assignees: Optional[List[str]] = None,
+            repo: Optional[str] = None,
+        ) -> IssueHandle:
+            """Open an issue in the bound repo (or ``repo`` override)."""
+            argv = ["issue", "create", "--title", title, "--body", body]
+            for lbl in labels or []:
+                argv.extend(["--label", lbl])
+            for asg in assignees or []:
+                argv.extend(["--assignee", asg])
+            argv = _with_repo_flag(argv, repo)
+            url = _run_gh(argv).strip().splitlines()[-1]
+            try:
+                number = int(url.rsplit("/", 1)[-1])
+            except ValueError as e:
+                raise GitHubCLIError(
+                    argv, 0, f"could not parse issue number from url {url!r}"
+                ) from e
+            return IssueHandle(number=number, url=url)
+
+        @tool
+        def gh_issue_comment(
+            number: int, body: str, repo: Optional[str] = None
+        ) -> CommentHandle:
+            """Add a comment to an existing issue."""
+            argv = ["issue", "comment", str(number), "--body", body]
+            argv = _with_repo_flag(argv, repo)
+            url = _run_gh(argv).strip().splitlines()[-1]
+            return CommentHandle(url=url, id=url.rsplit("#", 1)[-1])
+
+        @tool
+        def gh_run_list(
+            workflow: Optional[str] = None,
+            branch: Optional[str] = None,
+            limit: int = 20,
+            repo: Optional[str] = None,
+        ) -> List[RunInfo]:
+            """List recent workflow runs matching the given filters."""
+            argv: List[str] = [
+                "run",
+                "list",
+                "--limit",
+                str(limit),
+                "--json",
+                "databaseId,name,status,conclusion,headBranch,url,createdAt",
+            ]
+            if workflow:
+                argv.extend(["--workflow", workflow])
+            if branch:
+                argv.extend(["--branch", branch])
+            argv = _with_repo_flag(argv, repo)
+            raw = _run_gh(argv)
+            parsed = _parse_json(argv, raw)
+            runs: List[RunInfo] = []
+            for row in parsed:
+                runs.append(
+                    RunInfo(
+                        id=row["databaseId"],
+                        name=row["name"],
+                        status=row["status"],
+                        conclusion=row.get("conclusion"),
+                        branch=row.get("headBranch", ""),
+                        url=row["url"],
+                        created_at=row["createdAt"],
+                    )
+                )
+            return runs
+
+        @tool
+        def gh_run_watch(
+            run_id: int, timeout_s: int = 3600, repo: Optional[str] = None
+        ) -> RunOutcome:
+            """Block until a workflow run completes, then return its outcome.
+
+            The ``gh run watch`` command prints progress to stdout but exits
+            0 regardless of conclusion — so we re-query ``gh run view``
+            after the watch exits to extract conclusion.
+            """
+            argv = ["run", "watch", str(run_id), "--exit-status"]
+            argv = _with_repo_flag(argv, repo)
+            try:
+                _run_gh(argv, timeout_s=timeout_s)
+                conclusion = "success"
+            except GitHubCLIError as e:
+                # --exit-status makes `gh` return non-zero on non-success
+                # conclusions. We infer the conclusion from a follow-up
+                # query so the caller gets structured data either way.
+                logger.debug("gh run watch exited non-zero: %s", e)
+                conclusion = _fetch_run_conclusion(run_id, repo=repo)
+            view_argv = _with_repo_flag(
+                ["run", "view", str(run_id), "--json", "url,status"],
+                repo,
+            )
+            parsed = _parse_json(view_argv, _run_gh(view_argv))
+            return RunOutcome(
+                id=run_id,
+                status=parsed.get("status", "completed"),
+                conclusion=conclusion,
+                url=parsed["url"],
+            )
+
+        @tool
+        def gh_run_view_log(
+            run_id: int,
+            failed_only: bool = True,
+            repo: Optional[str] = None,
+        ) -> str:
+            """Return the log text for a workflow run.
+
+            ``failed_only=True`` applies ``--log-failed`` which restricts to
+            failed steps — the default because the triage loop always wants
+            the failing step's context, not the full log dump.
+            """
+            argv: List[str] = ["run", "view", str(run_id)]
+            argv.append("--log-failed" if failed_only else "--log")
+            argv = _with_repo_flag(argv, repo)
+            return _run_gh(argv, timeout_s=120)
+
+        @tool
+        def gh_release_create(
+            tag: str,
+            title: str,
+            notes: str,
+            draft: bool = True,
+            repo: Optional[str] = None,
+        ) -> ReleaseHandle:
+            """Create a GitHub Release. Sensitive per §4.3 — draft by default."""
+            argv: List[str] = [
+                "release",
+                "create",
+                tag,
+                "--title",
+                title,
+                "--notes",
+                notes,
+            ]
+            if draft:
+                argv.append("--draft")
+            argv = _with_repo_flag(argv, repo)
+            url = _run_gh(argv).strip().splitlines()[-1]
+            return ReleaseHandle(tag=tag, url=url, draft=draft)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_json(argv: List[str], raw: str) -> Any:
+    """Parse ``gh --json`` output, raising :class:`GitHubCLIError` on invalid JSON."""
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise GitHubCLIError(
+            argv,
+            0,
+            f"gh returned non-JSON output: {e.msg} (first 200 chars: {raw[:200]!r})",
+        ) from e
+
+
+def _review_state(event: str) -> str:
+    """Map a ``gh_pr_review`` ``event`` to GitHub's review state string."""
+    return {
+        "APPROVE": "APPROVED",
+        "REQUEST_CHANGES": "CHANGES_REQUESTED",
+        "COMMENT": "COMMENTED",
+    }[event]
+
+
+def _fetch_run_conclusion(run_id: int, repo: Optional[str]) -> str:
+    """Query ``gh run view --json conclusion`` for ``run_id``.
+
+    Extracted so :func:`gh_run_watch` can recover conclusion after ``watch``
+    exits non-zero on a failing run — keeps the tool body readable.
+    """
+    argv = _with_repo_flag(
+        ["run", "view", str(run_id), "--json", "conclusion"],
+        repo,
+    )
+    parsed = _parse_json(argv, _run_gh(argv))
+    return parsed.get("conclusion") or "failure"
+
+
+__all__ = [
+    "CommentHandle",
+    "GitHubCLIError",
+    "GitHubCLIMissingError",
+    "GitHubToolsMixin",
+    "IssueHandle",
+    "MergeResult",
+    "PRHandle",
+    "PRState",
+    "ReleaseHandle",
+    "ReviewHandle",
+    "RunInfo",
+    "RunOutcome",
+]

--- a/tests/coder/test_codebase_research.py
+++ b/tests/coder/test_codebase_research.py
@@ -1,0 +1,375 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for :mod:`gaia.coder.subagents.codebase_research` (§5.10).
+
+The real engine (Claude Opus wrapping File/Search tools) is never invoked.
+Every test supplies a stub engine that returns a canned
+:class:`StructuredAnalysis` after N steps. ``cloner`` is stubbed so no
+real ``git clone`` happens.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from gaia.coder.subagents.codebase_research import (
+    BudgetExceededError,
+    CodebaseResearchError,
+    KeyFile,
+    Pattern,
+    ResearchBudget,
+    StructuredAnalysis,
+    research,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_repo(tmp_path: Path) -> Path:
+    """Minimal 'local repo' layout we can point ``source=`` at."""
+    root = tmp_path / "fake_repo"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "hello.py").write_text("def hi():\n    return 'hi'\n")
+    (root / "LICENSE").write_text("MIT License\n")
+    return root
+
+
+class _FixedEngine:
+    """Engine that returns its canned analysis after ``turns_until_done`` steps."""
+
+    def __init__(
+        self,
+        analysis: StructuredAnalysis,
+        *,
+        turns_until_done: int = 1,
+        per_step_usd: float = 0.1,
+        per_step_tokens: int = 500,
+    ) -> None:
+        self.analysis = analysis
+        self.turns_until_done = turns_until_done
+        self.per_step_usd = per_step_usd
+        self.per_step_tokens = per_step_tokens
+        self.calls = 0
+        self.seen_workdirs: list[Path] = []
+
+    def step(self, workdir, question, budget):
+        self.calls += 1
+        self.seen_workdirs.append(workdir)
+        budget.tool_calls_made += 1
+        budget.usd_spent += self.per_step_usd
+        budget.tokens_used += self.per_step_tokens
+        if self.calls >= self.turns_until_done:
+            return self.analysis
+        return None
+
+
+class _RunawayEngine:
+    """Engine that *never* returns a final answer (exercises budget)."""
+
+    def __init__(self, per_step_usd: float = 0.5) -> None:
+        self.per_step_usd = per_step_usd
+        self.calls = 0
+
+    def step(self, workdir, question, budget):
+        self.calls += 1
+        budget.tool_calls_made += 1
+        budget.usd_spent += self.per_step_usd
+        budget.tokens_used += 1000
+        return None
+
+
+def _stub_cloner():
+    """Cloner that just creates an empty directory (stands in for a real clone)."""
+
+    def _clone(url, dest):
+        dest.mkdir(parents=True)
+        (dest / "FROM_URL").write_text(url)
+
+    return _clone
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_structured_analysis_schema_fields():
+    """§5.10 schema — every required field is present."""
+    a = StructuredAnalysis(
+        source="https://github.com/foo/bar",
+        question="Q",
+        answer="A",
+        key_files=[KeyFile(path="x.py", line_range=(1, 10), why_cited="y")],
+        patterns_worth_adopting=[
+            Pattern(pattern="p", evidence_path="e", caveat="c")
+        ],
+        license="MIT",
+        attribution_note="n",
+        confidence=80,
+        tokens_used=1000,
+        usd_spent=0.5,
+        unresolved_questions=["u"],
+    )
+    assert a.confidence == 80
+    assert a.key_files[0].line_range == (1, 10)
+
+
+# ---------------------------------------------------------------------------
+# research — engine injection is required
+# ---------------------------------------------------------------------------
+
+
+def test_research_without_engine_raises(tmp_path):
+    with pytest.raises(CodebaseResearchError, match="no research engine"):
+        research(
+            source=str(_fake_repo(tmp_path)),
+            question="q",
+            scratch_root=tmp_path / "scratch",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy path — local source
+# ---------------------------------------------------------------------------
+
+
+def test_research_happy_path_local(tmp_path):
+    repo = _fake_repo(tmp_path)
+    canned = StructuredAnalysis(
+        source="<will-be-overwritten>",
+        question="<will-be-overwritten>",
+        answer="they use a sandbox-dispatch pattern",
+        license="MIT",
+        attribution_note="cite as github.com/fake/repo",
+        confidence=82,
+    )
+    engine = _FixedEngine(canned, turns_until_done=2)
+    result = research(
+        source=str(repo),
+        question="What pattern do they use?",
+        engine=engine,
+        scratch_root=tmp_path / "scratch",
+    )
+    assert isinstance(result, StructuredAnalysis)
+    assert result.answer == "they use a sandbox-dispatch pattern"
+    # The runner overrides source/question so the echoed slots always match input.
+    assert result.source == str(repo)
+    assert result.question == "What pattern do they use?"
+    # Budget metrics folded back into the output.
+    assert result.usd_spent == pytest.approx(0.2, abs=1e-6)
+    assert result.tokens_used == 1000
+    # The engine saw the workdir (a COPY of repo, not the original).
+    assert engine.seen_workdirs[0] != repo
+
+
+def test_research_cleans_up_scratch_by_default(tmp_path):
+    repo = _fake_repo(tmp_path)
+    engine = _FixedEngine(
+        StructuredAnalysis(source="x", question="q", answer="a", confidence=50)
+    )
+    scratch = tmp_path / "scratch"
+    research(
+        source=str(repo),
+        question="q",
+        engine=engine,
+        scratch_root=scratch,
+    )
+    # The scratch ROOT still exists (we don't delete that), but no child
+    # workspaces remain.
+    assert scratch.exists()
+    assert list(scratch.iterdir()) == []
+
+
+def test_research_keep_flag_preserves_workspace(tmp_path):
+    repo = _fake_repo(tmp_path)
+    engine = _FixedEngine(
+        StructuredAnalysis(source="x", question="q", answer="a", confidence=50)
+    )
+    scratch = tmp_path / "scratch"
+    research(
+        source=str(repo),
+        question="q",
+        engine=engine,
+        scratch_root=scratch,
+        keep=True,
+    )
+    children = list(scratch.iterdir())
+    assert len(children) == 1  # workspace retained
+    assert (children[0] / "src" / "hello.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — remote URL via stub cloner
+# ---------------------------------------------------------------------------
+
+
+def test_research_remote_url_uses_cloner(tmp_path):
+    engine = _FixedEngine(
+        StructuredAnalysis(
+            source="x", question="q", answer="from clone", confidence=70
+        )
+    )
+    scratch = tmp_path / "scratch"
+    result = research(
+        source="https://github.com/fake/repo",
+        question="anything",
+        engine=engine,
+        scratch_root=scratch,
+        cloner=_stub_cloner(),
+    )
+    assert result.answer == "from clone"
+
+
+def test_research_cloner_failure_raises(tmp_path):
+    engine = _FixedEngine(
+        StructuredAnalysis(source="x", question="q", answer="a", confidence=0)
+    )
+
+    def _broken_cloner(url, dest):
+        raise CodebaseResearchError(f"could not clone {url}")
+
+    with pytest.raises(CodebaseResearchError, match="could not clone"):
+        research(
+            source="https://github.com/broken/repo",
+            question="q",
+            engine=engine,
+            scratch_root=tmp_path / "scratch",
+            cloner=_broken_cloner,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Budget enforcement (§5.10)
+# ---------------------------------------------------------------------------
+
+
+def test_research_enforces_dollar_budget(tmp_path):
+    repo = _fake_repo(tmp_path)
+    engine = _RunawayEngine(per_step_usd=1.0)
+    with pytest.raises(BudgetExceededError) as exc:
+        research(
+            source=str(repo),
+            question="q",
+            engine=engine,
+            max_cost_usd=2.0,
+            max_tool_calls=100,
+            scratch_root=tmp_path / "scratch",
+        )
+    assert "dollar budget" in exc.value.reason
+    # Partial is attached for logging.
+    assert exc.value.partial is not None
+    assert exc.value.partial.usd_spent > 2.0
+
+
+def test_research_enforces_tool_call_budget(tmp_path):
+    repo = _fake_repo(tmp_path)
+    engine = _RunawayEngine(per_step_usd=0.01)
+    with pytest.raises(BudgetExceededError) as exc:
+        research(
+            source=str(repo),
+            question="q",
+            engine=engine,
+            max_cost_usd=100.0,
+            max_tool_calls=3,
+            scratch_root=tmp_path / "scratch",
+        )
+    assert "tool-call budget" in exc.value.reason
+
+
+def test_research_enforces_wallclock_budget(tmp_path, monkeypatch):
+    """Advance monotonic time by large jumps to trip the wall-clock ceiling."""
+    repo = _fake_repo(tmp_path)
+    engine = _RunawayEngine(per_step_usd=0.01)
+
+    # Fake monotonic: advance 10 minutes per call after the first.
+    fake_now = [1000.0]
+    calls = [0]
+
+    def _fake_monotonic():
+        calls[0] += 1
+        if calls[0] > 1:
+            fake_now[0] += 700.0  # ~11.6 minutes per tick
+        return fake_now[0]
+
+    import gaia.coder.subagents.codebase_research as mod
+
+    monkeypatch.setattr(mod.time, "monotonic", _fake_monotonic)
+    with pytest.raises(BudgetExceededError) as exc:
+        research(
+            source=str(repo),
+            question="q",
+            engine=engine,
+            max_duration_minutes=10.0,
+            max_cost_usd=1000.0,
+            max_tool_calls=1000,
+            scratch_root=tmp_path / "scratch",
+        )
+    assert "wall-clock" in exc.value.reason
+
+
+def test_research_cleans_up_even_on_budget_exception(tmp_path):
+    repo = _fake_repo(tmp_path)
+    engine = _RunawayEngine(per_step_usd=1.0)
+    scratch = tmp_path / "scratch"
+    with pytest.raises(BudgetExceededError):
+        research(
+            source=str(repo),
+            question="q",
+            engine=engine,
+            max_cost_usd=2.0,
+            scratch_root=scratch,
+        )
+    # Cleanup still happens in the `finally` block.
+    assert scratch.exists()
+    assert list(scratch.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# ResearchBudget primitives
+# ---------------------------------------------------------------------------
+
+
+def test_research_budget_not_exceeded_initially():
+    b = ResearchBudget(max_duration_minutes=10, max_cost_usd=2.0)
+    assert b.exceeded() is None
+
+
+def test_research_budget_exceeded_by_dollars():
+    b = ResearchBudget(max_duration_minutes=10, max_cost_usd=2.0)
+    b.usd_spent = 3.0
+    reason = b.exceeded()
+    assert reason and "dollar" in reason
+
+
+def test_research_budget_exceeded_by_tool_calls():
+    b = ResearchBudget(max_tool_calls=5)
+    b.tool_calls_made = 5
+    reason = b.exceeded()
+    assert reason and "tool-call" in reason
+
+
+# ---------------------------------------------------------------------------
+# Local-source validation
+# ---------------------------------------------------------------------------
+
+
+def test_research_missing_local_path_raises(tmp_path):
+    engine = _FixedEngine(
+        StructuredAnalysis(source="x", question="q", answer="a", confidence=0)
+    )
+    with pytest.raises(CodebaseResearchError, match="does not exist"):
+        research(
+            source="/does/not/exist/abc123",
+            question="q",
+            engine=engine,
+            scratch_root=tmp_path / "scratch",
+        )

--- a/tests/coder/test_codebase_research.py
+++ b/tests/coder/test_codebase_research.py
@@ -10,11 +10,7 @@ real ``git clone`` happens.
 
 from __future__ import annotations
 
-import os
-import shutil
-import time
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -27,7 +23,6 @@ from gaia.coder.subagents.codebase_research import (
     StructuredAnalysis,
     research,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -109,9 +104,7 @@ def test_structured_analysis_schema_fields():
         question="Q",
         answer="A",
         key_files=[KeyFile(path="x.py", line_range=(1, 10), why_cited="y")],
-        patterns_worth_adopting=[
-            Pattern(pattern="p", evidence_path="e", caveat="c")
-        ],
+        patterns_worth_adopting=[Pattern(pattern="p", evidence_path="e", caveat="c")],
         license="MIT",
         attribution_note="n",
         confidence=80,
@@ -214,9 +207,7 @@ def test_research_keep_flag_preserves_workspace(tmp_path):
 
 def test_research_remote_url_uses_cloner(tmp_path):
     engine = _FixedEngine(
-        StructuredAnalysis(
-            source="x", question="q", answer="from clone", confidence=70
-        )
+        StructuredAnalysis(source="x", question="q", answer="from clone", confidence=70)
     )
     scratch = tmp_path / "scratch"
     result = research(

--- a/tests/coder/test_github_tools.py
+++ b/tests/coder/test_github_tools.py
@@ -9,7 +9,6 @@ Every tool gets a happy-path test + a failure-path test + a registration check.
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
 
 import pytest
 
@@ -20,7 +19,6 @@ from gaia.coder.tools.github import (
     GitHubCLIMissingError,
     GitHubToolsMixin,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -92,9 +90,7 @@ def test_gh_pr_create_happy_path(gh_mixin, monkeypatch):
     url = "https://github.com/amd/gaia/pull/9001"
     monkeypatch.setattr(gh_mod, "_run_gh", lambda argv, **kw: url + "\n")
     tool = _get_tool("gh_pr_create")
-    handle = tool(
-        title="feat: x", body="body", head="auto/x", base="coder", draft=True
-    )
+    handle = tool(title="feat: x", body="body", head="auto/x", base="coder", draft=True)
     assert handle["number"] == 9001
     assert handle["url"] == url
     assert handle["draft"] is True
@@ -112,9 +108,7 @@ def test_gh_pr_create_non_zero_exit_raises(gh_mixin, monkeypatch):
     assert "auth required" in str(exc.value)
 
 
-def test_gh_pr_create_forwards_labels_and_assignees(
-    gh_mixin, monkeypatch
-):
+def test_gh_pr_create_forwards_labels_and_assignees(gh_mixin, monkeypatch):
     captured = {}
 
     def _capture(argv, **_):
@@ -171,9 +165,7 @@ def test_gh_pr_view_parses_json(gh_mixin, monkeypatch):
         "mergeable": "MERGEABLE",
         "mergeStateStatus": "CLEAN",
     }
-    monkeypatch.setattr(
-        gh_mod, "_run_gh", lambda argv, **kw: json.dumps(payload)
-    )
+    monkeypatch.setattr(gh_mod, "_run_gh", lambda argv, **kw: json.dumps(payload))
     state = _get_tool("gh_pr_view")(7)
     assert state["number"] == 7
     assert state["base"] == "coder"
@@ -328,9 +320,7 @@ def test_gh_run_list_parses_rows(gh_mixin, monkeypatch):
             "createdAt": "2026-04-20T01:00:00Z",
         },
     ]
-    monkeypatch.setattr(
-        gh_mod, "_run_gh", lambda argv, **kw: json.dumps(payload)
-    )
+    monkeypatch.setattr(gh_mod, "_run_gh", lambda argv, **kw: json.dumps(payload))
     rows = _get_tool("gh_run_list")(limit=5)
     assert len(rows) == 2
     assert rows[0]["id"] == 10
@@ -408,9 +398,7 @@ def test_gh_release_create_draft_default(gh_mixin, monkeypatch):
         return "https://github.com/amd/gaia/releases/tag/v1.0.0\n"
 
     monkeypatch.setattr(gh_mod, "_run_gh", _capture)
-    handle = _get_tool("gh_release_create")(
-        tag="v1.0.0", title="v1.0.0", notes="notes"
-    )
+    handle = _get_tool("gh_release_create")(tag="v1.0.0", title="v1.0.0", notes="notes")
     assert handle["tag"] == "v1.0.0"
     assert handle["draft"] is True
     assert "--draft" in captured["argv"]

--- a/tests/coder/test_github_tools.py
+++ b/tests/coder/test_github_tools.py
@@ -1,0 +1,416 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for :class:`GitHubToolsMixin` (§15.2 of coder-agent.mdx).
+
+No real ``gh`` calls — the boundary mocked is :func:`gaia.coder.tools.github._run_gh`.
+Every tool gets a happy-path test + a failure-path test + a registration check.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.coder.tools import github as gh_mod
+from gaia.coder.tools.github import (
+    GitHubCLIError,
+    GitHubCLIMissingError,
+    GitHubToolsMixin,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry_snapshot():
+    """Save and restore ``_TOOL_REGISTRY`` around a test."""
+    snapshot = dict(_TOOL_REGISTRY)
+    yield
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def gh_mixin(registry_snapshot):
+    mixin = GitHubToolsMixin()
+    mixin.register_github_tools()
+    return mixin
+
+
+def _get_tool(name: str):
+    entry = _TOOL_REGISTRY.get(name)
+    assert entry is not None, f"tool {name!r} not registered"
+    return entry["function"]
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_all_eleven_tools_registered(gh_mixin):
+    expected = {
+        "gh_pr_create",
+        "gh_pr_view",
+        "gh_pr_comment",
+        "gh_pr_review",
+        "gh_pr_merge",
+        "gh_issue_create",
+        "gh_issue_comment",
+        "gh_run_list",
+        "gh_run_watch",
+        "gh_run_view_log",
+        "gh_release_create",
+    }
+    for name in expected:
+        assert name in _TOOL_REGISTRY, f"missing tool: {name}"
+
+
+# ---------------------------------------------------------------------------
+# gh_binary guard
+# ---------------------------------------------------------------------------
+
+
+def test_missing_gh_binary_raises(monkeypatch):
+    monkeypatch.setattr(gh_mod.shutil, "which", lambda _: None)
+    with pytest.raises(GitHubCLIMissingError):
+        gh_mod._gh_binary()
+
+
+# ---------------------------------------------------------------------------
+# gh_pr_create
+# ---------------------------------------------------------------------------
+
+
+def test_gh_pr_create_happy_path(gh_mixin, monkeypatch):
+    url = "https://github.com/amd/gaia/pull/9001"
+    monkeypatch.setattr(gh_mod, "_run_gh", lambda argv, **kw: url + "\n")
+    tool = _get_tool("gh_pr_create")
+    handle = tool(
+        title="feat: x", body="body", head="auto/x", base="coder", draft=True
+    )
+    assert handle["number"] == 9001
+    assert handle["url"] == url
+    assert handle["draft"] is True
+
+
+def test_gh_pr_create_non_zero_exit_raises(gh_mixin, monkeypatch):
+    def _boom(argv, **_):
+        raise GitHubCLIError(argv, 1, "auth required")
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _boom)
+    tool = _get_tool("gh_pr_create")
+    with pytest.raises(GitHubCLIError) as exc:
+        tool(title="t", body="b", head="h")
+    assert exc.value.returncode == 1
+    assert "auth required" in str(exc.value)
+
+
+def test_gh_pr_create_forwards_labels_and_assignees(
+    gh_mixin, monkeypatch
+):
+    captured = {}
+
+    def _capture(argv, **_):
+        captured["argv"] = list(argv)
+        return "https://github.com/amd/gaia/pull/1\n"
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    tool = _get_tool("gh_pr_create")
+    tool(
+        title="t",
+        body="b",
+        head="h",
+        labels=["bug", "auto"],
+        assignees=["alice"],
+    )
+    argv = captured["argv"]
+    # Labels and assignees are passed as repeated --label / --assignee flags.
+    assert argv.count("--label") == 2
+    assert argv.count("--assignee") == 1
+
+
+def test_gh_pr_create_repo_env_default(gh_mixin, monkeypatch):
+    monkeypatch.setenv("GITHUB_REPO", "amd/gaia")
+    captured: dict = {}
+
+    def _capture(argv, **_):
+        captured["argv"] = list(argv)
+        return "https://github.com/amd/gaia/pull/42\n"
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    tool = _get_tool("gh_pr_create")
+    tool(title="t", body="b", head="h")
+    argv = captured["argv"]
+    # --repo should be auto-injected from env.
+    idx = argv.index("--repo")
+    assert argv[idx + 1] == "amd/gaia"
+
+
+# ---------------------------------------------------------------------------
+# gh_pr_view
+# ---------------------------------------------------------------------------
+
+
+def test_gh_pr_view_parses_json(gh_mixin, monkeypatch):
+    payload = {
+        "number": 7,
+        "title": "t",
+        "body": "b",
+        "state": "OPEN",
+        "baseRefName": "coder",
+        "headRefName": "auto/x",
+        "url": "https://github.com/amd/gaia/pull/7",
+        "isDraft": True,
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+    }
+    monkeypatch.setattr(
+        gh_mod, "_run_gh", lambda argv, **kw: json.dumps(payload)
+    )
+    state = _get_tool("gh_pr_view")(7)
+    assert state["number"] == 7
+    assert state["base"] == "coder"
+    assert state["is_draft"] is True
+
+
+def test_gh_pr_view_invalid_json_raises(gh_mixin, monkeypatch):
+    monkeypatch.setattr(gh_mod, "_run_gh", lambda argv, **kw: "not-json")
+    with pytest.raises(GitHubCLIError, match="non-JSON output"):
+        _get_tool("gh_pr_view")(7)
+
+
+# ---------------------------------------------------------------------------
+# gh_pr_comment / gh_issue_comment
+# ---------------------------------------------------------------------------
+
+
+def test_gh_pr_comment_returns_handle(gh_mixin, monkeypatch):
+    monkeypatch.setattr(
+        gh_mod,
+        "_run_gh",
+        lambda argv, **kw: "https://github.com/amd/gaia/pull/1#issuecomment-999\n",
+    )
+    handle = _get_tool("gh_pr_comment")(1, "hello")
+    assert handle["id"] == "issuecomment-999"
+
+
+def test_gh_issue_comment_returns_handle(gh_mixin, monkeypatch):
+    monkeypatch.setattr(
+        gh_mod,
+        "_run_gh",
+        lambda argv, **kw: "https://github.com/amd/gaia/issues/2#issuecomment-123\n",
+    )
+    handle = _get_tool("gh_issue_comment")(2, "hi")
+    assert handle["id"] == "issuecomment-123"
+
+
+# ---------------------------------------------------------------------------
+# gh_pr_review
+# ---------------------------------------------------------------------------
+
+
+def test_gh_pr_review_maps_event(gh_mixin, monkeypatch):
+    captured: dict = {}
+
+    def _capture(argv, **_):
+        captured["argv"] = list(argv)
+        return "https://github.com/amd/gaia/pull/3#pullrequestreview-1\n"
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    handle = _get_tool("gh_pr_review")(3, event="APPROVE", body="lgtm")
+    assert handle["state"] == "APPROVED"
+    assert "--approve" in captured["argv"]
+
+
+def test_gh_pr_review_request_changes_flag(gh_mixin, monkeypatch):
+    captured: dict = {}
+
+    def _capture(argv, **_):
+        captured["argv"] = list(argv)
+        return "https://github.com/amd/gaia/pull/3#pullrequestreview-2\n"
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    _get_tool("gh_pr_review")(3, event="REQUEST_CHANGES", body="nope")
+    assert "--request-changes" in captured["argv"]
+
+
+# ---------------------------------------------------------------------------
+# gh_pr_merge
+# ---------------------------------------------------------------------------
+
+
+def test_gh_pr_merge_reports_sha(gh_mixin, monkeypatch):
+    """After merge, a follow-up view fetches the merge commit SHA."""
+    responses = [
+        "",  # pr merge
+        json.dumps(
+            {
+                "number": 5,
+                "title": "",
+                "body": "",
+                "state": "MERGED",
+                "baseRefName": "coder",
+                "headRefName": "x",
+                "url": "https://github.com/amd/gaia/pull/5",
+                "isDraft": False,
+                "mergeable": None,
+                "mergeStateStatus": None,
+            }
+        ),
+        json.dumps({"mergeCommit": {"oid": "abc123"}}),
+    ]
+
+    def _capture(argv, **_):
+        return responses.pop(0)
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    result = _get_tool("gh_pr_merge")(5, method="squash")
+    assert result["merged"] is True
+    assert result["method"] == "squash"
+    assert result["sha"] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# gh_issue_create
+# ---------------------------------------------------------------------------
+
+
+def test_gh_issue_create_parses_number(gh_mixin, monkeypatch):
+    monkeypatch.setattr(
+        gh_mod,
+        "_run_gh",
+        lambda argv, **kw: "https://github.com/amd/gaia/issues/314\n",
+    )
+    handle = _get_tool("gh_issue_create")(title="t", body="b")
+    assert handle["number"] == 314
+
+
+def test_gh_issue_create_bad_url_raises(gh_mixin, monkeypatch):
+    monkeypatch.setattr(
+        gh_mod,
+        "_run_gh",
+        lambda argv, **kw: "https://github.com/amd/gaia/issues/not-a-number\n",
+    )
+    with pytest.raises(GitHubCLIError, match="could not parse"):
+        _get_tool("gh_issue_create")(title="t", body="b")
+
+
+# ---------------------------------------------------------------------------
+# gh_run_list / gh_run_watch / gh_run_view_log
+# ---------------------------------------------------------------------------
+
+
+def test_gh_run_list_parses_rows(gh_mixin, monkeypatch):
+    payload = [
+        {
+            "databaseId": 10,
+            "name": "ci",
+            "status": "completed",
+            "conclusion": "success",
+            "headBranch": "coder",
+            "url": "https://example/10",
+            "createdAt": "2026-04-20T00:00:00Z",
+        },
+        {
+            "databaseId": 11,
+            "name": "ci",
+            "status": "in_progress",
+            "conclusion": None,
+            "headBranch": "auto/x",
+            "url": "https://example/11",
+            "createdAt": "2026-04-20T01:00:00Z",
+        },
+    ]
+    monkeypatch.setattr(
+        gh_mod, "_run_gh", lambda argv, **kw: json.dumps(payload)
+    )
+    rows = _get_tool("gh_run_list")(limit=5)
+    assert len(rows) == 2
+    assert rows[0]["id"] == 10
+    assert rows[1]["conclusion"] is None
+
+
+def test_gh_run_watch_success(gh_mixin, monkeypatch):
+    responses = iter(
+        [
+            "",  # watch
+            json.dumps({"url": "https://example/10", "status": "completed"}),
+        ]
+    )
+    monkeypatch.setattr(gh_mod, "_run_gh", lambda argv, **kw: next(responses))
+    outcome = _get_tool("gh_run_watch")(10, timeout_s=60)
+    assert outcome["conclusion"] == "success"
+
+
+def test_gh_run_watch_failure_recovers_conclusion(gh_mixin, monkeypatch):
+    """When ``--exit-status`` makes ``gh`` exit non-zero, we still return a structured result."""
+    calls: list = []
+
+    def _fake(argv, **_):
+        calls.append(list(argv))
+        # First call (run watch --exit-status) fails.
+        if calls[-1][1] == "watch":
+            raise GitHubCLIError(argv, 1, "run failed")
+        # Second call: conclusion probe.
+        if "conclusion" in calls[-1]:
+            return json.dumps({"conclusion": "failure"})
+        # Third call: view to get url + status.
+        return json.dumps({"url": "https://example/11", "status": "completed"})
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _fake)
+    outcome = _get_tool("gh_run_watch")(11)
+    assert outcome["conclusion"] == "failure"
+
+
+def test_gh_run_view_log_failed_only_flag(gh_mixin, monkeypatch):
+    captured: dict = {}
+
+    def _capture(argv, **_):
+        captured["argv"] = list(argv)
+        return "failing step log"
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    log = _get_tool("gh_run_view_log")(12, failed_only=True)
+    assert log == "failing step log"
+    assert "--log-failed" in captured["argv"]
+
+
+def test_gh_run_view_log_full_log_flag(gh_mixin, monkeypatch):
+    captured: dict = {}
+
+    def _capture(argv, **_):
+        captured["argv"] = list(argv)
+        return "full log"
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    _get_tool("gh_run_view_log")(12, failed_only=False)
+    assert "--log" in captured["argv"]
+    assert "--log-failed" not in captured["argv"]
+
+
+# ---------------------------------------------------------------------------
+# gh_release_create
+# ---------------------------------------------------------------------------
+
+
+def test_gh_release_create_draft_default(gh_mixin, monkeypatch):
+    captured: dict = {}
+
+    def _capture(argv, **_):
+        captured["argv"] = list(argv)
+        return "https://github.com/amd/gaia/releases/tag/v1.0.0\n"
+
+    monkeypatch.setattr(gh_mod, "_run_gh", _capture)
+    handle = _get_tool("gh_release_create")(
+        tag="v1.0.0", title="v1.0.0", notes="notes"
+    )
+    assert handle["tag"] == "v1.0.0"
+    assert handle["draft"] is True
+    assert "--draft" in captured["argv"]

--- a/tests/coder/test_oss_reuse.py
+++ b/tests/coder/test_oss_reuse.py
@@ -1,0 +1,356 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for :mod:`gaia.coder.oss_reuse` (§5.3, §5.4, §15.2).
+
+No network I/O. The two external boundaries
+(:func:`gaia.coder.oss_reuse._gh_api` and
+:func:`gaia.coder.oss_reuse._fetch_raw`) are monkeypatched per test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.coder import oss_reuse
+from gaia.coder.oss_reuse import (
+    AttributionError as OSSAttributionError,
+    BLOCKED_LICENSES,
+    LicenseIncompatibleError,
+    LicenseReport,
+    OSSReuseMixin,
+    PERMISSIVE_LICENSES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry_snapshot():
+    snapshot = dict(_TOOL_REGISTRY)
+    yield
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def oss_mixin(registry_snapshot):
+    m = OSSReuseMixin()
+    m.register_oss_reuse_tools()
+    return m
+
+
+def _get_tool(name: str):
+    entry = _TOOL_REGISTRY.get(name)
+    assert entry is not None, f"tool {name!r} not registered"
+    return entry["function"]
+
+
+# ---------------------------------------------------------------------------
+# Allowlist / denylist constants
+# ---------------------------------------------------------------------------
+
+
+def test_permissive_allowlist_matches_spec():
+    """§5.4 rule 1 — the seven permissive SPDX ids from the spec."""
+    expected = {
+        "MIT",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "Apache-2.0",
+        "ISC",
+        "Unlicense",
+        "0BSD",
+    }
+    assert PERMISSIVE_LICENSES == expected
+
+
+def test_blocked_denylist_includes_gpl_family():
+    for spdx in ("GPL-3.0", "AGPL-3.0", "LGPL-2.1", "SSPL-1.0"):
+        assert spdx in BLOCKED_LICENSES
+
+
+# ---------------------------------------------------------------------------
+# vet_license — per task acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+def test_vet_license_gpl_rejected(oss_mixin, monkeypatch):
+    """`vet_license("torvalds/linux")` → compatible=False (GPL-2.0)."""
+    monkeypatch.setattr(
+        oss_reuse,
+        "_gh_api",
+        lambda path, **kw: {"license": {"spdx_id": "GPL-2.0"}},
+    )
+    report = _get_tool("vet_license")("torvalds/linux")
+    assert isinstance(report, LicenseReport)
+    assert report.compatible is False
+    assert report.license == "GPL-2.0"
+    assert "copyleft" in report.reason.lower()
+
+
+def test_vet_license_bsd3_accepted(oss_mixin, monkeypatch):
+    """`vet_license("pallets/click")` → compatible=True (BSD-3-Clause)."""
+    monkeypatch.setattr(
+        oss_reuse,
+        "_gh_api",
+        lambda path, **kw: {"license": {"spdx_id": "BSD-3-Clause"}},
+    )
+    report = _get_tool("vet_license")("pallets/click")
+    assert report.compatible is True
+    assert report.license == "BSD-3-Clause"
+
+
+def test_vet_license_unknown_flagged(oss_mixin, monkeypatch):
+    monkeypatch.setattr(
+        oss_reuse,
+        "_gh_api",
+        lambda path, **kw: {"license": None},
+    )
+    report = _get_tool("vet_license")("someone/nolicense")
+    assert report.compatible is False
+    assert report.license is None
+    assert "LICENSE" in report.reason or "recognised" in report.reason
+
+
+def test_vet_license_noassertion_treated_as_missing(oss_mixin, monkeypatch):
+    monkeypatch.setattr(
+        oss_reuse,
+        "_gh_api",
+        lambda path, **kw: {"license": {"spdx_id": "NOASSERTION"}},
+    )
+    report = _get_tool("vet_license")("ambiguous/repo")
+    assert report.license is None
+
+
+def test_vet_license_permissive_but_unusual(oss_mixin, monkeypatch):
+    """An SPDX id that is neither blocked nor permissive → human review."""
+    monkeypatch.setattr(
+        oss_reuse,
+        "_gh_api",
+        lambda path, **kw: {"license": {"spdx_id": "MPL-2.0"}},
+    )
+    report = _get_tool("vet_license")("some/repo")
+    assert report.compatible is False
+    assert "human review" in report.reason
+
+
+# ---------------------------------------------------------------------------
+# gh_search_code / gh_search_repos filtering
+# ---------------------------------------------------------------------------
+
+
+def test_gh_search_code_drops_blocked_licenses(oss_mixin, monkeypatch):
+    repo_metadata = {
+        "a/permissive": {"license": {"spdx_id": "MIT"}},
+        "b/copyleft": {"license": {"spdx_id": "GPL-3.0"}},
+    }
+
+    def _api(path, **_):
+        if path.startswith("/search/code"):
+            return {
+                "items": [
+                    {
+                        "repository": {"full_name": "a/permissive"},
+                        "path": "src/foo.py",
+                        "html_url": "https://github.com/a/permissive/blob/main/src/foo.py",
+                    },
+                    {
+                        "repository": {"full_name": "b/copyleft"},
+                        "path": "src/bar.py",
+                        "html_url": "https://github.com/b/copyleft/blob/main/src/bar.py",
+                    },
+                ]
+            }
+        # /repos/{repo} lookup
+        repo = path.lstrip("/").split("/", 1)[1]
+        return repo_metadata[repo]
+
+    monkeypatch.setattr(oss_reuse, "_gh_api", _api)
+    hits = _get_tool("gh_search_code")("def foo", language="python")
+    assert len(hits) == 1
+    assert hits[0]["repository"] == "a/permissive"
+    assert hits[0]["license"] == "MIT"
+
+
+def test_gh_search_code_cannot_widen_filter_to_blocked(oss_mixin):
+    with pytest.raises(LicenseIncompatibleError):
+        _get_tool("gh_search_code")(
+            "q", license_filter=["MIT", "GPL-3.0"]
+        )
+
+
+def test_gh_search_repos_applies_server_and_client_filter(
+    oss_mixin, monkeypatch
+):
+    def _api(path, **_):
+        # license qualifiers are URL-encoded as `license%3A<key>`.
+        assert "license%3Amit" in path or "license%3Aapache-2.0" in path
+        return {
+            "items": [
+                {
+                    "full_name": "good/repo",
+                    "description": "x",
+                    "stargazers_count": 100,
+                    "html_url": "https://github.com/good/repo",
+                    "license": {"spdx_id": "MIT"},
+                },
+                {
+                    "full_name": "mystery/repo",
+                    "description": "y",
+                    "stargazers_count": 5,
+                    "html_url": "https://github.com/mystery/repo",
+                    "license": None,  # GitHub sometimes returns null
+                },
+            ]
+        }
+
+    monkeypatch.setattr(oss_reuse, "_gh_api", _api)
+    hits = _get_tool("gh_search_repos")("some query", min_stars=10)
+    assert len(hits) == 1
+    assert hits[0]["repository"] == "good/repo"
+
+
+# ---------------------------------------------------------------------------
+# import_with_attribution — the four §5.4 guarantees
+# ---------------------------------------------------------------------------
+
+
+def _install_import_stubs(monkeypatch, license_spdx: str = "MIT"):
+    """Patch `_gh_api` and `_fetch_raw` for import_with_attribution tests."""
+    monkeypatch.setattr(
+        oss_reuse,
+        "_gh_api",
+        lambda path, **kw: {"license": {"spdx_id": license_spdx}},
+    )
+    monkeypatch.setattr(
+        oss_reuse,
+        "_fetch_raw",
+        lambda url: 'def greet():\n    return "hi"\n',
+    )
+
+
+def test_import_success_writes_header_and_notices(oss_mixin, monkeypatch, tmp_path):
+    _install_import_stubs(monkeypatch, license_spdx="MIT")
+    sha = "abc1234def5678"
+    result = _get_tool("import_with_attribution")(
+        source_url=f"https://github.com/pallets/click/blob/{sha}/src/click/core.py",
+        commit_sha=sha,
+        dest_path="src/gaia/coder/vendored/click_core.py",
+        attribution_note="Used for CLI help layout.",
+        repo_root=str(tmp_path),
+    )
+
+    dest = tmp_path / "src/gaia/coder/vendored/click_core.py"
+    text = dest.read_text()
+    assert text.startswith(f"# Adapted from pallets/click @ {sha} — MIT\n")
+    assert "Used for CLI help layout." in text
+    assert 'def greet():' in text
+
+    notices = (tmp_path / "THIRD_PARTY_NOTICES.md").read_text()
+    assert "pallets/click" in notices
+    assert sha in notices
+    assert "MIT" in notices
+    assert result["license"] == "MIT"
+    assert result["notices_entry_added"] is True
+
+
+def test_import_refuses_gpl(oss_mixin, monkeypatch, tmp_path):
+    _install_import_stubs(monkeypatch, license_spdx="GPL-3.0")
+    sha = "abc1234def5678"
+    with pytest.raises(LicenseIncompatibleError) as exc:
+        _get_tool("import_with_attribution")(
+            source_url=f"https://github.com/torvalds/linux/blob/{sha}/kernel/sched.c",
+            commit_sha=sha,
+            dest_path="src/gaia/coder/vendored/sched.c",
+            repo_root=str(tmp_path),
+        )
+    assert exc.value.license_id == "GPL-3.0"
+    assert exc.value.repository == "torvalds/linux"
+    # No files written.
+    assert not (tmp_path / "src/gaia/coder/vendored/sched.c").exists()
+    assert not (tmp_path / "THIRD_PARTY_NOTICES.md").exists()
+
+
+def test_import_rejects_branch_pin(oss_mixin, monkeypatch, tmp_path):
+    """Rule 3 — pin to SHA, never a branch."""
+    _install_import_stubs(monkeypatch)
+    with pytest.raises(OSSAttributionError, match="provenance must match"):
+        _get_tool("import_with_attribution")(
+            source_url="https://github.com/pallets/click/blob/main/src/click/core.py",
+            commit_sha="abc1234def5678",
+            dest_path="x.py",
+            repo_root=str(tmp_path),
+        )
+
+
+def test_import_rejects_non_sha_commit(oss_mixin, monkeypatch, tmp_path):
+    _install_import_stubs(monkeypatch)
+    with pytest.raises(OSSAttributionError, match="does not look like"):
+        _get_tool("import_with_attribution")(
+            source_url="https://github.com/pallets/click/blob/release-8.2/src/click/core.py",
+            commit_sha="release-8.2",
+            dest_path="x.py",
+            repo_root=str(tmp_path),
+        )
+
+
+def test_import_appends_without_clobbering_existing_notices(
+    oss_mixin, monkeypatch, tmp_path
+):
+    """Multiple imports should append; never truncate prior entries."""
+    _install_import_stubs(monkeypatch, license_spdx="Apache-2.0")
+    sha = "a" * 10
+    for i in range(2):
+        _get_tool("import_with_attribution")(
+            source_url=f"https://github.com/some/repo/blob/{sha}/file{i}.py",
+            commit_sha=sha,
+            dest_path=f"src/gaia/coder/vendored/file{i}.py",
+            repo_root=str(tmp_path),
+        )
+    body = (tmp_path / "THIRD_PARTY_NOTICES.md").read_text()
+    # Each import produces one "## " block.
+    assert body.count("## `src/gaia/coder/vendored/file") == 2
+
+
+def test_import_with_raw_url_works(oss_mixin, monkeypatch, tmp_path):
+    _install_import_stubs(monkeypatch, license_spdx="BSD-3-Clause")
+    sha = "a" * 40
+    result = _get_tool("import_with_attribution")(
+        source_url=f"https://raw.githubusercontent.com/foo/bar/{sha}/pkg/x.py",
+        commit_sha=sha,
+        dest_path="src/gaia/coder/vendored/x.py",
+        repo_root=str(tmp_path),
+    )
+    assert result["license"] == "BSD-3-Clause"
+
+
+def test_import_rejects_unparseable_url(oss_mixin, monkeypatch, tmp_path):
+    _install_import_stubs(monkeypatch)
+    with pytest.raises(OSSAttributionError, match="cannot parse"):
+        _get_tool("import_with_attribution")(
+            source_url="https://example.com/not/github",
+            commit_sha="abc1234",
+            dest_path="x.py",
+            repo_root=str(tmp_path),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_tools_registered(oss_mixin):
+    for name in (
+        "gh_search_code",
+        "gh_search_repos",
+        "vet_license",
+        "import_with_attribution",
+    ):
+        assert name in _TOOL_REGISTRY, f"missing tool: {name}"

--- a/tests/coder/test_oss_reuse.py
+++ b/tests/coder/test_oss_reuse.py
@@ -9,21 +9,20 @@ No network I/O. The two external boundaries
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.coder import oss_reuse
 from gaia.coder.oss_reuse import (
-    AttributionError as OSSAttributionError,
     BLOCKED_LICENSES,
+    PERMISSIVE_LICENSES,
+)
+from gaia.coder.oss_reuse import AttributionError as OSSAttributionError
+from gaia.coder.oss_reuse import (
     LicenseIncompatibleError,
     LicenseReport,
     OSSReuseMixin,
-    PERMISSIVE_LICENSES,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -180,14 +179,10 @@ def test_gh_search_code_drops_blocked_licenses(oss_mixin, monkeypatch):
 
 def test_gh_search_code_cannot_widen_filter_to_blocked(oss_mixin):
     with pytest.raises(LicenseIncompatibleError):
-        _get_tool("gh_search_code")(
-            "q", license_filter=["MIT", "GPL-3.0"]
-        )
+        _get_tool("gh_search_code")("q", license_filter=["MIT", "GPL-3.0"])
 
 
-def test_gh_search_repos_applies_server_and_client_filter(
-    oss_mixin, monkeypatch
-):
+def test_gh_search_repos_applies_server_and_client_filter(oss_mixin, monkeypatch):
     def _api(path, **_):
         # license qualifiers are URL-encoded as `license%3A<key>`.
         assert "license%3Amit" in path or "license%3Aapache-2.0" in path
@@ -250,7 +245,7 @@ def test_import_success_writes_header_and_notices(oss_mixin, monkeypatch, tmp_pa
     text = dest.read_text()
     assert text.startswith(f"# Adapted from pallets/click @ {sha} — MIT\n")
     assert "Used for CLI help layout." in text
-    assert 'def greet():' in text
+    assert "def greet():" in text
 
     notices = (tmp_path / "THIRD_PARTY_NOTICES.md").read_text()
     assert "pallets/click" in notices

--- a/tests/coder/test_rag_freshness.py
+++ b/tests/coder/test_rag_freshness.py
@@ -1,0 +1,344 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for :mod:`gaia.coder.rag_freshness` (§6.9).
+
+No real RAG backend, no real ``git``. Every external call is stubbed.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import subprocess
+from typing import Dict
+
+import pytest
+
+from gaia.coder.rag_freshness import (
+    CitationStaleError,
+    CorpusContract,
+    CorpusStatus,
+    FreshnessContract,
+    RagStatusReport,
+    StaleIndexError,
+    WatchdogAlert,
+    check_citation_valid,
+    ensure_fresh_or_raise,
+    rag_rebuild,
+    rag_refresh,
+    rag_status,
+    reindex_watchdog,
+    verdict_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_minus_hours(h: float) -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=h)
+
+
+def _status(
+    name: str, *, hours_old: float = 0.5, docs: int = 100
+) -> CorpusStatus:
+    return CorpusStatus(
+        name=name,
+        last_indexed_at=_now_minus_hours(hours_old),
+        document_count=docs,
+        pending_reindex=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract construction
+# ---------------------------------------------------------------------------
+
+
+def test_default_contract_matches_spec():
+    c = FreshnessContract.default()
+    names = [corpus.name for corpus in c.corpora]
+    # §6.9 table — five corpora.
+    assert names == [
+        "source_tree",
+        "pr_descriptions",
+        "issues",
+        "adrs_plans",
+        "claude_agents_md",
+    ]
+    assert c.watchdog_hours == 36.0
+
+
+def test_by_name_raises_on_unknown():
+    c = FreshnessContract.default()
+    with pytest.raises(KeyError, match="unknown corpus"):
+        c.by_name("does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# verdict_for
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_fresh():
+    contract = FreshnessContract.default().by_name("source_tree")
+    status = _status("source_tree", hours_old=1)
+    v = verdict_for(status, contract)
+    assert v.fresh is True
+    assert v.age_hours is not None and v.age_hours < 2
+
+
+def test_verdict_stale_past_threshold():
+    contract = FreshnessContract.default().by_name("source_tree")
+    status = _status("source_tree", hours_old=20)
+    v = verdict_for(status, contract)
+    assert v.fresh is False
+    assert "threshold" in v.reason
+
+
+def test_verdict_never_indexed_is_stale():
+    contract = FreshnessContract.default().by_name("source_tree")
+    status = CorpusStatus(
+        name="source_tree",
+        last_indexed_at=None,
+        document_count=0,
+        pending_reindex=False,
+    )
+    v = verdict_for(status, contract)
+    assert v.fresh is False
+    assert "never" in v.reason
+
+
+# ---------------------------------------------------------------------------
+# StaleIndexError — §6.9 fail-loudly
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_fresh_passes_on_fresh():
+    contract = FreshnessContract.default().by_name("issues")
+    ensure_fresh_or_raise(_status("issues", hours_old=0.1), contract)
+
+
+def test_ensure_fresh_raises_on_stale():
+    contract = FreshnessContract.default().by_name("issues")
+    stale = _status("issues", hours_old=48)
+    with pytest.raises(StaleIndexError) as exc:
+        ensure_fresh_or_raise(stale, contract)
+    assert exc.value.corpus == "issues"
+    assert exc.value.age_hours > 12
+
+
+def test_stale_index_error_message_points_at_refresh():
+    contract = FreshnessContract.default().by_name("issues")
+    try:
+        ensure_fresh_or_raise(_status("issues", hours_old=48), contract)
+    except StaleIndexError as e:
+        assert "gaia-coder rag refresh" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# reindex_watchdog
+# ---------------------------------------------------------------------------
+
+
+def _provider(statuses: Dict[str, CorpusStatus]):
+    def _get():
+        return statuses
+
+    return _get
+
+
+def test_watchdog_quiet_when_all_fresh():
+    contract = FreshnessContract.default()
+    provider = _provider(
+        {c.name: _status(c.name, hours_old=5) for c in contract.corpora}
+    )
+    alert = reindex_watchdog(contract, provider)
+    assert alert.fired is False
+    assert alert.severity == "info"
+
+
+def test_watchdog_fires_at_40h():
+    contract = FreshnessContract.default()
+    statuses = {c.name: _status(c.name, hours_old=5) for c in contract.corpora}
+    statuses["source_tree"] = _status("source_tree", hours_old=40)
+    alert = reindex_watchdog(contract, _provider(statuses))
+    assert alert.fired is True
+    assert alert.severity == "critical"
+    assert "source_tree" in alert.affected_corpora
+
+
+def test_watchdog_fires_for_never_indexed_corpus():
+    contract = FreshnessContract.default()
+    statuses = {c.name: _status(c.name, hours_old=5) for c in contract.corpora}
+    statuses["issues"] = CorpusStatus(
+        name="issues",
+        last_indexed_at=None,
+        document_count=0,
+        pending_reindex=False,
+    )
+    alert = reindex_watchdog(contract, _provider(statuses))
+    assert alert.fired is True
+    assert "issues" in alert.affected_corpora
+
+
+def test_watchdog_fires_when_corpus_missing_entirely():
+    """A provider that doesn't return a row for a known corpus trips the watchdog."""
+    contract = FreshnessContract.default()
+    # Only three of five corpora present.
+    statuses = {
+        c.name: _status(c.name, hours_old=5)
+        for c in contract.corpora[:3]
+    }
+    alert = reindex_watchdog(contract, _provider(statuses))
+    assert alert.fired is True
+    # The two missing corpora are reported.
+    affected = set(alert.affected_corpora)
+    assert affected == {"adrs_plans", "claude_agents_md"}
+
+
+# ---------------------------------------------------------------------------
+# check_citation_valid — Pass 3 architectural check (§6.9 rule 2)
+# ---------------------------------------------------------------------------
+
+
+def test_check_citation_valid_on_existing_file(tmp_path):
+    captured: list = []
+
+    def _runner(argv):
+        captured.append(list(argv))
+        return ""  # git cat-file -e is silent on success
+
+    assert (
+        check_citation_valid(
+            "README.md",
+            git_ref="HEAD",
+            repo_root=str(tmp_path),
+            runner=_runner,
+        )
+        is True
+    )
+    # Verify the argv shape matches what the docstring promises.
+    assert captured == [
+        ["git", "-C", str(tmp_path), "cat-file", "-e", "HEAD:README.md"]
+    ]
+
+
+def test_check_citation_raises_on_deleted_file(tmp_path):
+    def _runner(argv):
+        from gaia.coder.rag_freshness import _GitRunError
+
+        raise _GitRunError("git exited 128: does not exist in HEAD")
+
+    with pytest.raises(CitationStaleError, match="Pass 3"):
+        check_citation_valid(
+            "ghost.py",
+            git_ref="HEAD",
+            repo_root=str(tmp_path),
+            runner=_runner,
+        )
+
+
+def test_check_citation_supports_ref_other_than_head(tmp_path):
+    captured: list = []
+
+    def _runner(argv):
+        captured.append(argv)
+        return ""
+
+    check_citation_valid(
+        "src/gaia/cli.py",
+        git_ref="coder~3",
+        repo_root=str(tmp_path),
+        runner=_runner,
+    )
+    assert captured[0][-1] == "coder~3:src/gaia/cli.py"
+
+
+# ---------------------------------------------------------------------------
+# rag_status — aggregator
+# ---------------------------------------------------------------------------
+
+
+def test_rag_status_assembles_report():
+    contract = FreshnessContract.default()
+    provider = _provider(
+        {c.name: _status(c.name, hours_old=1) for c in contract.corpora}
+    )
+    report = rag_status(contract, provider)
+    assert isinstance(report, RagStatusReport)
+    assert len(report.corpora) == 5
+    assert len(report.verdicts) == 5
+    assert report.any_stale is False
+    assert report.watchdog.fired is False
+
+
+def test_rag_status_any_stale_reflects_verdicts():
+    contract = FreshnessContract.default()
+    statuses = {c.name: _status(c.name, hours_old=1) for c in contract.corpora}
+    statuses["pr_descriptions"] = _status("pr_descriptions", hours_old=50)
+    report = rag_status(contract, _provider(statuses))
+    assert report.any_stale is True
+    stale_names = [v.corpus for v in report.verdicts if not v.fresh]
+    assert stale_names == ["pr_descriptions"]
+
+
+def test_rag_status_to_dict_json_serialisable():
+    import json
+
+    contract = FreshnessContract.default()
+    provider = _provider(
+        {c.name: _status(c.name, hours_old=1) for c in contract.corpora}
+    )
+    report = rag_status(contract, provider)
+    # Must be JSON-serialisable — CLI/EM-inbox ships as JSON.
+    json.dumps(report.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# rag_refresh / rag_rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_rag_refresh_all_corpora():
+    contract = FreshnessContract.default()
+    calls: list = []
+
+    def _runner(name, mode):
+        calls.append((name, mode))
+        return {"ok": True}
+
+    out = rag_refresh(contract, _runner)
+    assert set(out) == {c.name for c in contract.corpora}
+    assert {m for _, m in calls} == {"refresh"}
+
+
+def test_rag_refresh_single_corpus():
+    contract = FreshnessContract.default()
+    calls: list = []
+
+    def _runner(name, mode):
+        calls.append((name, mode))
+        return {"ok": True}
+
+    rag_refresh(contract, _runner, corpus="issues")
+    assert calls == [("issues", "refresh")]
+
+
+def test_rag_refresh_unknown_corpus_raises():
+    contract = FreshnessContract.default()
+    with pytest.raises(KeyError, match="unknown corpus"):
+        rag_refresh(contract, lambda n, m: {}, corpus="nonsense")
+
+
+def test_rag_rebuild_passes_rebuild_mode():
+    contract = FreshnessContract.default()
+    calls: list = []
+
+    def _runner(name, mode):
+        calls.append((name, mode))
+        return {}
+
+    rag_rebuild(contract, _runner, corpus="source_tree")
+    assert calls == [("source_tree", "rebuild")]

--- a/tests/coder/test_rag_freshness.py
+++ b/tests/coder/test_rag_freshness.py
@@ -8,19 +8,16 @@ No real RAG backend, no real ``git``. Every external call is stubbed.
 from __future__ import annotations
 
 import datetime as dt
-import subprocess
 from typing import Dict
 
 import pytest
 
 from gaia.coder.rag_freshness import (
     CitationStaleError,
-    CorpusContract,
     CorpusStatus,
     FreshnessContract,
     RagStatusReport,
     StaleIndexError,
-    WatchdogAlert,
     check_citation_valid,
     ensure_fresh_or_raise,
     rag_rebuild,
@@ -29,7 +26,6 @@ from gaia.coder.rag_freshness import (
     reindex_watchdog,
     verdict_for,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -40,9 +36,7 @@ def _now_minus_hours(h: float) -> dt.datetime:
     return dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=h)
 
 
-def _status(
-    name: str, *, hours_old: float = 0.5, docs: int = 100
-) -> CorpusStatus:
+def _status(name: str, *, hours_old: float = 0.5, docs: int = 100) -> CorpusStatus:
     return CorpusStatus(
         name=name,
         last_indexed_at=_now_minus_hours(hours_old),
@@ -187,10 +181,7 @@ def test_watchdog_fires_when_corpus_missing_entirely():
     """A provider that doesn't return a row for a known corpus trips the watchdog."""
     contract = FreshnessContract.default()
     # Only three of five corpora present.
-    statuses = {
-        c.name: _status(c.name, hours_old=5)
-        for c in contract.corpora[:3]
-    }
+    statuses = {c.name: _status(c.name, hours_old=5) for c in contract.corpora[:3]}
     alert = reindex_watchdog(contract, _provider(statuses))
     assert alert.fired is True
     # The two missing corpora are reported.

--- a/tests/coder/test_repo_binding.py
+++ b/tests/coder/test_repo_binding.py
@@ -26,7 +26,6 @@ from gaia.coder.repo_binding import (
     verify_webhook_signature,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
@@ -94,9 +93,7 @@ def test_load_repo_binding_rejects_bad_repo_slug(tmp_path):
 
 
 def test_load_repo_binding_rejects_negative_app_id(tmp_path):
-    bad = VALID_TOML.replace(
-        "github_app_id = 123456", "github_app_id = -1"
-    )
+    bad = VALID_TOML.replace("github_app_id = 123456", "github_app_id = -1")
     p = _write_toml(tmp_path, bad)
     with pytest.raises(RepoBindingError):
         load_repo_binding(p)
@@ -105,9 +102,7 @@ def test_load_repo_binding_rejects_negative_app_id(tmp_path):
 def test_load_repo_binding_missing_required_field(tmp_path):
     # Drop the `github_installation_id` line.
     bad = "\n".join(
-        line
-        for line in VALID_TOML.splitlines()
-        if "github_installation_id" not in line
+        line for line in VALID_TOML.splitlines() if "github_installation_id" not in line
     )
     p = _write_toml(tmp_path, bad)
     with pytest.raises(RepoBindingError):
@@ -124,9 +119,7 @@ def _happy_gh_runner(binding: RepoBinding):
         if argv[:2] == ["api", "/app"]:
             return json.dumps({"id": binding.github_app_id})
         if argv[:2] == ["api", f"/repos/{binding.repo}/branches/coder"]:
-            return json.dumps(
-                {"name": "coder", "commit": {"sha": "deadbeef"}}
-            )
+            return json.dumps({"name": "coder", "commit": {"sha": "deadbeef"}})
         raise AssertionError(f"unexpected argv: {argv}")
 
     return _run
@@ -243,9 +236,7 @@ def test_doctor_aggregates_all_failures_not_short_circuit():
     def _broken_gh(argv):
         raise RuntimeError("network down")
 
-    result = doctor(
-        binding, keyring_getter=_broken_getter, gh_runner=_broken_gh
-    )
+    result = doctor(binding, keyring_getter=_broken_getter, gh_runner=_broken_gh)
     assert result.green is False
     assert len(result.failed()) == 4  # every check reports
 
@@ -258,17 +249,13 @@ def test_doctor_aggregates_all_failures_not_short_circuit():
 def test_verify_webhook_signature_round_trip():
     secret = b"hunter2"
     body = b'{"action":"opened"}'
-    signature = (
-        "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
-    )
+    signature = "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
     assert verify_webhook_signature(secret, body, signature) is True
 
 
 def test_verify_webhook_signature_rejects_wrong_secret():
     body = b"x"
-    signature = (
-        "sha256=" + hmac.new(b"right", body, hashlib.sha256).hexdigest()
-    )
+    signature = "sha256=" + hmac.new(b"right", body, hashlib.sha256).hexdigest()
     assert verify_webhook_signature(b"wrong", body, signature) is False
 
 

--- a/tests/coder/test_repo_binding.py
+++ b/tests/coder/test_repo_binding.py
@@ -1,0 +1,306 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Tests for :mod:`gaia.coder.repo_binding` (§5.11, §15.6).
+
+Every test injects its own ``keyring_getter`` and ``gh_runner`` — no real
+keyring, no real ``gh`` CLI, no real network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gaia.coder.repo_binding import (
+    DoctorResult,
+    RepoBinding,
+    RepoBindingError,
+    agents_md_entry,
+    doctor,
+    load_repo_binding,
+    verify_webhook_signature,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_toml(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "repo_binding.toml"
+    p.write_text(textwrap.dedent(body), encoding="utf-8")
+    return p
+
+
+VALID_TOML = """\
+repo = "amd/gaia"
+github_app_id = 123456
+github_installation_id = 7890123
+webhook_secret_keyring_slot = "gaia-coder/github-webhook-secret"
+private_key_keyring_slot = "gaia-coder/github-app-private-key"
+allowed_branches = ["auto/gaia-coder/*", "auto/gaia-coder-heal/*", "coder"]
+forbidden_paths = [".github/workflows/release-*", "scripts/release/**"]
+"""
+
+
+def _valid_binding() -> RepoBinding:
+    return RepoBinding(
+        repo="amd/gaia",
+        github_app_id=123456,
+        github_installation_id=7890123,
+        webhook_secret_keyring_slot="gaia-coder/github-webhook-secret",
+        private_key_keyring_slot="gaia-coder/github-app-private-key",
+        allowed_branches=["coder"],
+        forbidden_paths=[".github/workflows/release-*"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_repo_binding
+# ---------------------------------------------------------------------------
+
+
+def test_load_repo_binding_valid(tmp_path):
+    p = _write_toml(tmp_path, VALID_TOML)
+    binding = load_repo_binding(p)
+    assert binding.repo == "amd/gaia"
+    assert binding.github_app_id == 123456
+    assert "coder" in binding.allowed_branches
+
+
+def test_load_repo_binding_missing_file(tmp_path):
+    p = tmp_path / "missing.toml"
+    with pytest.raises(RepoBindingError, match="not found"):
+        load_repo_binding(p)
+
+
+def test_load_repo_binding_malformed_toml(tmp_path):
+    p = _write_toml(tmp_path, "repo = 'amd/gaia\n")  # unclosed quote
+    with pytest.raises(RepoBindingError, match="malformed TOML"):
+        load_repo_binding(p)
+
+
+def test_load_repo_binding_rejects_bad_repo_slug(tmp_path):
+    bad = VALID_TOML.replace('repo = "amd/gaia"', 'repo = "no-slash-here"')
+    p = _write_toml(tmp_path, bad)
+    with pytest.raises(RepoBindingError, match="failed validation"):
+        load_repo_binding(p)
+
+
+def test_load_repo_binding_rejects_negative_app_id(tmp_path):
+    bad = VALID_TOML.replace(
+        "github_app_id = 123456", "github_app_id = -1"
+    )
+    p = _write_toml(tmp_path, bad)
+    with pytest.raises(RepoBindingError):
+        load_repo_binding(p)
+
+
+def test_load_repo_binding_missing_required_field(tmp_path):
+    # Drop the `github_installation_id` line.
+    bad = "\n".join(
+        line
+        for line in VALID_TOML.splitlines()
+        if "github_installation_id" not in line
+    )
+    p = _write_toml(tmp_path, bad)
+    with pytest.raises(RepoBindingError):
+        load_repo_binding(p)
+
+
+# ---------------------------------------------------------------------------
+# doctor — aggregated checks
+# ---------------------------------------------------------------------------
+
+
+def _happy_gh_runner(binding: RepoBinding):
+    def _run(argv):
+        if argv[:2] == ["api", "/app"]:
+            return json.dumps({"id": binding.github_app_id})
+        if argv[:2] == ["api", f"/repos/{binding.repo}/branches/coder"]:
+            return json.dumps(
+                {"name": "coder", "commit": {"sha": "deadbeef"}}
+            )
+        raise AssertionError(f"unexpected argv: {argv}")
+
+    return _run
+
+
+def _happy_keyring_getter():
+    PEM = b"-----BEGIN RSA PRIVATE KEY-----\n<fake>\n-----END RSA PRIVATE KEY-----\n"
+    SECRET = b"shhh-its-a-secret"
+
+    def _get(slot):
+        if "private-key" in slot:
+            return PEM
+        if "webhook-secret" in slot:
+            return SECRET
+        raise KeyError(slot)
+
+    return _get
+
+
+def test_doctor_all_checks_pass():
+    binding = _valid_binding()
+    result = doctor(
+        binding,
+        keyring_getter=_happy_keyring_getter(),
+        gh_runner=_happy_gh_runner(binding),
+    )
+    assert isinstance(result, DoctorResult)
+    assert result.green is True
+    names = {c.name for c in result.checks}
+    assert names == {
+        "github_app_install",
+        "private_key_decrypts",
+        "webhook_signature_round_trip",
+        "coder_branch_exists",
+    }
+
+
+def test_doctor_reports_wrong_app_id():
+    binding = _valid_binding()
+
+    def _mismatch(argv):
+        if argv[:2] == ["api", "/app"]:
+            return json.dumps({"id": 999999})
+        return _happy_gh_runner(binding)(argv)
+
+    result = doctor(
+        binding,
+        keyring_getter=_happy_keyring_getter(),
+        gh_runner=_mismatch,
+    )
+    assert result.green is False
+    failed = {c.name for c in result.failed()}
+    assert "github_app_install" in failed
+
+
+def test_doctor_reports_missing_coder_branch():
+    binding = _valid_binding()
+
+    def _no_branch(argv):
+        if argv[:2] == ["api", "/app"]:
+            return json.dumps({"id": binding.github_app_id})
+        if "/branches/coder" in argv[1]:
+            raise RuntimeError("HTTP 404")
+        raise AssertionError(argv)
+
+    result = doctor(
+        binding,
+        keyring_getter=_happy_keyring_getter(),
+        gh_runner=_no_branch,
+    )
+    assert result.green is False
+    failed_names = {c.name for c in result.failed()}
+    assert "coder_branch_exists" in failed_names
+
+
+def test_doctor_reports_empty_keyring_value():
+    binding = _valid_binding()
+
+    def _empty(slot):
+        return b""
+
+    result = doctor(
+        binding,
+        keyring_getter=_empty,
+        gh_runner=_happy_gh_runner(binding),
+    )
+    assert result.green is False
+
+
+def test_doctor_reports_non_pem_private_key():
+    binding = _valid_binding()
+
+    def _junk(slot):
+        if "private-key" in slot:
+            return b"not a pem"
+        return b"secret"
+
+    result = doctor(
+        binding,
+        keyring_getter=_junk,
+        gh_runner=_happy_gh_runner(binding),
+    )
+    failed = {c.name for c in result.failed()}
+    assert "private_key_decrypts" in failed
+
+
+def test_doctor_aggregates_all_failures_not_short_circuit():
+    """Doctor should report every failure, not short-circuit on the first."""
+    binding = _valid_binding()
+
+    def _broken_getter(slot):
+        raise RuntimeError("keyring unavailable")
+
+    def _broken_gh(argv):
+        raise RuntimeError("network down")
+
+    result = doctor(
+        binding, keyring_getter=_broken_getter, gh_runner=_broken_gh
+    )
+    assert result.green is False
+    assert len(result.failed()) == 4  # every check reports
+
+
+# ---------------------------------------------------------------------------
+# verify_webhook_signature — the §15.5 primitive
+# ---------------------------------------------------------------------------
+
+
+def test_verify_webhook_signature_round_trip():
+    secret = b"hunter2"
+    body = b'{"action":"opened"}'
+    signature = (
+        "sha256=" + hmac.new(secret, body, hashlib.sha256).hexdigest()
+    )
+    assert verify_webhook_signature(secret, body, signature) is True
+
+
+def test_verify_webhook_signature_rejects_wrong_secret():
+    body = b"x"
+    signature = (
+        "sha256=" + hmac.new(b"right", body, hashlib.sha256).hexdigest()
+    )
+    assert verify_webhook_signature(b"wrong", body, signature) is False
+
+
+def test_verify_webhook_signature_rejects_missing_prefix():
+    body = b"x"
+    digest = hmac.new(b"s", body, hashlib.sha256).hexdigest()
+    assert verify_webhook_signature(b"s", body, digest) is False  # no prefix
+
+
+# ---------------------------------------------------------------------------
+# agents_md_entry (§5.11 discoverability)
+# ---------------------------------------------------------------------------
+
+
+def test_agents_md_entry_mentions_repo_and_forbidden():
+    binding = _valid_binding()
+    entry = agents_md_entry(binding)
+    assert "amd/gaia" in entry
+    assert "release-*" in entry
+    assert "`coder`" in entry
+    assert "never `main`" in entry
+
+
+def test_agents_md_entry_handles_empty_forbidden_paths():
+    binding = RepoBinding(
+        repo="x/y",
+        github_app_id=1,
+        github_installation_id=1,
+        webhook_secret_keyring_slot="a/b",
+        private_key_keyring_slot="c/d",
+        allowed_branches=[],
+        forbidden_paths=[],
+    )
+    entry = agents_md_entry(binding)
+    assert "none configured" in entry


### PR DESCRIPTION
## Summary

Bundles Phases 9 and 10 of `gaia-coder` into one draft PR to keep the public PR count low. Lands five new modules + the registry entries that make them discoverable. Everything is additive — no existing coder code is touched, no CLI wiring yet (that's the unification follow-up).

- **OSS reuse + license gate** (§5.3, §5.4) — `OSSReuseMixin` hard-fails GPL/AGPL/LGPL/SSPL/BUSL and vendors compatible sources with a `# Adapted from <repo> @ <sha> — <license>` header plus a `THIRD_PARTY_NOTICES.md` append. Prevents the "quietly vendored GPL into MIT repo" regression class at the tool layer, not just in review.
- **Codebase-research subagent** (§5.10) — `research(source, question, ...)` runs a short-lived observational subagent with a hard wall-clock + `$` + tool-call budget. Keeps external-repo investigation out of the primary RAG (cache pollution) and away from `write_file` / `gh` / memory writes (safety).
- **Repo binding + doctor gate** (§5.11, §15.6) — Pydantic schema for `repo_binding.toml`; `doctor()` aggregates four bootstrap invariants (App install, PEM decrypts, webhook signature round-trip, `coder` branch exists). Agent is blocked until `doctor().green is True` — the §15.6 hard bootstrap gate.
- **RAG freshness contract** (§6.9) — `StaleIndexError` raised when a query's youngest-indexed doc is older than 12h; `reindex_watchdog` fires `critical`-severity at 36h; `check_citation_valid` is the Pass 3 gate that rejects "cites a file that was indexed but has been deleted/renamed."
- **`GitHubToolsMixin`** (§15.2) — the 11 `gh_*` wrappers. Foundational for OSS reuse (which composes `_run_gh`) and for the whole §5.5 event-trigger layer that lands later.
- **`KNOWN_TOOLS` registration** — `github` + `oss_reuse` added so YAML-manifest agents can opt in via `tools: [github, oss_reuse]`. Schema regenerated.

## Test plan

- [x] `pytest tests/coder/test_github_tools.py` — 21 passing
- [x] `pytest tests/coder/test_oss_reuse.py` — 18 passing (incl. explicit `torvalds/linux` → GPL-rejected and `pallets/click` → BSD-3-accepted acceptance checks)
- [x] `pytest tests/coder/test_repo_binding.py` — 17 passing
- [x] `pytest tests/coder/test_rag_freshness.py` — 22 passing
- [x] `pytest tests/coder/test_codebase_research.py` — 15 passing
- [x] `pytest tests/coder/` full coder suite — 291 passed, 2 skipped (nothing regressed)
- [x] `python util/lint.py --all` — no errors on new files
- [x] Scope check: `git diff --stat origin/coder..HEAD` is limited to the five new modules, their tests, the two-line `KNOWN_TOOLS` addition, and the auto-regenerated schema

No real `gh` / network / keyring calls in tests — every external boundary is mocked (`_run_gh`, `_gh_api`, `_fetch_raw`, `cloner`, `keyring_getter`, `gh_runner`).

**Do not merge** — draft for review.