### PR TITLE
feat(coder): Phases 7+8 — dev-mode + self-heal + debug sub-loop

### DIFF
--- a/src/gaia/coder/debug_loop.py
+++ b/src/gaia/coder/debug_loop.py
@@ -1,0 +1,559 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Debug sub-loop state machine (§5.9).
+
+The main ReAct loop hands off to this sub-loop whenever ``verify_local`` or
+``self_review`` surfaces a failure that can't be resolved by a trivial patch,
+or when a task *is* a bug-fix (triage routes straight here). The sub-loop
+returns control to the parent on one of two outcomes:
+
+* ``propose_fix`` succeeds — parent resumes ``edit`` with the fix candidate.
+* ``plan_draft`` required — parent resumes planning with the diagnosis as
+  additional context (used when the fix needs architectural change).
+
+Seven states mirror §5.9's table:
+
+    reproduce → bisect → hypothesise → probe → localise_bug → propose_fix → postmortem
+
+The class enforces the four discipline rules from the spec at the
+state-machine layer (not just in prompts), so a caller that bypasses the
+prompts still cannot land an undisciplined fix:
+
+1. ``propose_fix`` refuses unless ``reproduced=True``.
+2. ``propose_fix`` refuses unless top-hypothesis confidence ≥ 80%
+   (override requires ``--shotgun`` + EM elevation).
+3. ``hypothesise`` enforces ``len(hypotheses) >= 3``.
+4. ``postmortem`` writes to ``feedback.db`` + ``failure_patterns`` memory.
+
+The actual tool implementations live in :mod:`gaia.coder.tools.debug`
+(Phase 8). This module only owns the control flow — it is deliberately
+*not* wired into the main ReAct loop yet (Phase 11 production swap).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple
+
+from gaia.coder.stores import feedback as feedback_store
+from gaia.coder.stores import memory as memory_store
+
+logger = logging.getLogger(__name__)
+
+
+#: Confidence threshold below which ``propose_fix`` refuses. §5.9 "Discipline
+#: enforced by the loop": *"propose_fix refuses to run if the top-confidence
+#: hypothesis is below 80%."*
+PROPOSE_FIX_CONFIDENCE_THRESHOLD: int = 80
+
+#: Minimum hypotheses §5.9 requires at ``hypothesise``. "Single-hypothesis
+#: debugging is the most common self-deception pattern."
+MIN_HYPOTHESES: int = 3
+
+#: Hard cap on ``hypothesise → probe`` iterations before surfacing to the EM
+#: as stuck. §5.9: "cap of 5 rounds before surfacing to EM as stuck."
+MAX_DEBUG_ROUNDS: int = 5
+
+
+class DebugState(str, Enum):
+    """The seven debug sub-loop states (§5.9)."""
+
+    REPRODUCE = "reproduce"
+    BISECT = "bisect"
+    HYPOTHESISE = "hypothesise"
+    PROBE = "probe"
+    LOCALISE_BUG = "localise_bug"
+    PROPOSE_FIX = "propose_fix"
+    POSTMORTEM = "postmortem"
+
+
+class DebugDisciplineError(Exception):
+    """Raised when a discipline rule would be violated.
+
+    Subclass-free by design: the message carries the rule number and the
+    fix direction (§5.9's discipline list). The caller either surfaces to
+    the EM or retries the offending state.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Hypothesis:
+    """One root-cause hypothesis generated at the ``hypothesise`` state.
+
+    Attributes:
+        text: One-line description ("off-by-one in the loop counter").
+        confidence: 0-100. Updated at every ``probe`` iteration based on
+            experiment outcomes.
+        evidence: Free-text log of probes that confirmed/refuted this
+            hypothesis.
+    """
+
+    text: str
+    confidence: int = 0
+    evidence: List[str] = field(default_factory=list)
+
+
+@dataclass
+class DebugContext:
+    """Mutable context passed across sub-loop transitions.
+
+    Kept as a plain dataclass (not a BaseModel) because it is read/written
+    by the state-machine many times per task — Pydantic validation on every
+    mutation is more expensive than we need. Validation happens at the
+    state-transition boundary via the guards on :class:`DebugSubLoop`.
+    """
+
+    task_id: str
+    feedback_id: str
+    error_signature: str
+    repro_command: str
+
+    reproduced: bool = False
+    repro_attempts: int = 0
+    repro_attempts_matched: int = 0
+    repro_actual_output: str = ""
+
+    culprit_sha: Optional[str] = None
+    bisect_log: str = ""
+    bisect_skipped: bool = False
+
+    hypotheses: List[Hypothesis] = field(default_factory=list)
+    probes_run: int = 0
+    round_count: int = 0
+
+    localised_file: Optional[str] = None
+    localised_line: Optional[int] = None
+
+    fix_summary: Optional[str] = None
+    fix_is_architectural: bool = False
+    shotgun: bool = False
+
+    postmortem_written: bool = False
+    notes: List[str] = field(default_factory=list)
+
+    def record_note(self, line: str) -> None:
+        """Append a timestamped breadcrumb to :attr:`notes`."""
+        self.notes.append(f"{_utc_now_iso()} :: {line}")
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+
+def _stack_hash(error_signature: str) -> str:
+    """Derive a short stable signature for a traceback string.
+
+    Used as the ``stack_hash`` key on ``failure_patterns`` memory rows.
+    Intentionally *not* a cryptographic hash — a readable-but-stable
+    digest is friendlier in audit logs and memory lookups.
+    """
+    import hashlib
+
+    return hashlib.sha1(
+        error_signature.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# The sub-loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DebugSubLoop:
+    """Seven-state debug sub-loop (§5.9).
+
+    Methods named after each state mutate the context and return the next
+    :class:`DebugState`. The caller drives transitions explicitly so the
+    loop composes with the main ReAct loop — see the module docstring for
+    why this is Phase-8 scaffolding rather than a wired-in mixin.
+
+    Discipline rules are enforced at method entry / exit — violating one
+    raises :class:`DebugDisciplineError` rather than silently continuing.
+    """
+
+    context: DebugContext
+    em_elevation_granted: bool = False
+
+    # Injected collaborators — all tests replace these with deterministic stubs.
+    repro_fn: Optional[Callable[..., Mapping[str, Any]]] = None
+    bisect_fn: Optional[Callable[..., Mapping[str, Any]]] = None
+    probe_fn: Optional[Callable[[Hypothesis, DebugContext], Tuple[bool, str, int]]] = (
+        None
+    )
+    memory_conn_factory: Optional[Callable[[], sqlite3.Connection]] = None
+    feedback_db_path: Optional[Path] = None
+    memory_db_path: Optional[Path] = None
+
+    # -----------------------------------------------------------------
+    # State: reproduce
+    # -----------------------------------------------------------------
+
+    def reproduce(self, *, attempts: int = 3) -> DebugState:
+        """Enter the reproduce state — confirm we can trigger the failure.
+
+        §5.9: "Failure here (can't repro in ≥ 3 of 3 attempts) pauses
+        debug and asks the EM." We call the injected repro function; on
+        failure we raise :class:`DebugDisciplineError` with the exact
+        question to surface to the EM.
+        """
+        if self.repro_fn is None:
+            raise DebugDisciplineError(
+                "reproduce: no repro_fn wired. Inject a callable that returns "
+                "{reproduced, actual_output, match_score, ...}."
+            )
+        result = self.repro_fn(
+            command=self.context.repro_command,
+            expected_failure_signature=self.context.error_signature,
+            attempts=attempts,
+        )
+        self.context.reproduced = bool(result.get("reproduced", False))
+        self.context.repro_attempts = int(result.get("attempts", attempts))
+        self.context.repro_attempts_matched = int(result.get("attempts_reproduced", 0))
+        self.context.repro_actual_output = str(result.get("actual_output", ""))
+        self.context.record_note(
+            f"reproduce: reproduced={self.context.reproduced} "
+            f"matched={self.context.repro_attempts_matched}/{self.context.repro_attempts}"
+        )
+        if not self.context.reproduced:
+            raise DebugDisciplineError(
+                "reproduce: failed in "
+                f"{self.context.repro_attempts_matched}/{self.context.repro_attempts}"
+                " attempts. Pause debug and ask the EM: "
+                '"I cannot reproduce; is this environment-specific?"'
+            )
+        return DebugState.BISECT
+
+    # -----------------------------------------------------------------
+    # State: bisect
+    # -----------------------------------------------------------------
+
+    def bisect(
+        self,
+        good_ref: str,
+        bad_ref: str,
+        *,
+        skip: bool = False,
+    ) -> DebugState:
+        """Run automated bisection between ``good_ref`` and ``bad_ref``.
+
+        Passes ``skip=True`` when the bug was not recently introduced
+        (e.g. a pre-existing bug surfaced by a new test) — bisection is
+        meaningless there and only the ``hypothesise`` state is useful.
+        """
+        if skip:
+            self.context.bisect_skipped = True
+            self.context.record_note("bisect: skipped (caller opted out)")
+            return DebugState.HYPOTHESISE
+        if self.bisect_fn is None:
+            raise DebugDisciplineError(
+                "bisect: no bisect_fn wired. Inject `tools.debug.git_bisect` "
+                "or a test stub."
+            )
+        result = self.bisect_fn(
+            good_ref=good_ref,
+            bad_ref=bad_ref,
+            repro_command=self.context.repro_command,
+        )
+        self.context.culprit_sha = result.get("culprit_sha")
+        self.context.bisect_log = str(result.get("log", ""))
+        self.context.record_note(f"bisect: culprit={self.context.culprit_sha}")
+        return DebugState.HYPOTHESISE
+
+    # -----------------------------------------------------------------
+    # State: hypothesise
+    # -----------------------------------------------------------------
+
+    def hypothesise(self, hypotheses: Sequence[Hypothesis]) -> DebugState:
+        """Record ≥ 3 distinct root-cause hypotheses.
+
+        Enforces Discipline rule 3 at the state-machine layer. §5.9:
+        *"enforces len(hypotheses) >= 3. Single-hypothesis debugging is
+        caught here."*
+
+        Re-entering ``hypothesise`` after a ``probe`` round replaces the
+        hypothesis set rather than appending — the caller is expected to
+        carry forward high-confidence survivors and add new candidates.
+        """
+        cleaned = [h for h in hypotheses if h.text.strip()]
+        if len(cleaned) < MIN_HYPOTHESES:
+            raise DebugDisciplineError(
+                f"hypothesise: require >= {MIN_HYPOTHESES} distinct hypotheses "
+                f"(got {len(cleaned)}). "
+                "Generate more root causes before probing — single-hypothesis "
+                "debugging is blocked at the loop layer."
+            )
+        self.context.hypotheses = list(cleaned)
+        self.context.record_note(f"hypothesise: recorded {len(cleaned)} hypotheses")
+        return DebugState.PROBE
+
+    # -----------------------------------------------------------------
+    # State: probe
+    # -----------------------------------------------------------------
+
+    def probe(self) -> DebugState:
+        """Run a distinguishing experiment for each hypothesis.
+
+        Each probe returns ``(confirmed, evidence_line, confidence_delta)``.
+        The sub-loop updates each hypothesis's confidence and records the
+        evidence for audit. After probing, it returns LOCALISE_BUG when
+        the top hypothesis already clears the propose_fix bar, otherwise
+        HYPOTHESISE so the caller can refine. Round-count is bounded by
+        :data:`MAX_DEBUG_ROUNDS`.
+        """
+        if self.probe_fn is None:
+            raise DebugDisciplineError(
+                "probe: no probe_fn wired. Inject a callable that accepts a "
+                "Hypothesis + DebugContext and returns "
+                "(confirmed, evidence, confidence_delta)."
+            )
+        self.context.round_count += 1
+        if self.context.round_count > MAX_DEBUG_ROUNDS:
+            raise DebugDisciplineError(
+                f"probe: exceeded MAX_DEBUG_ROUNDS ({MAX_DEBUG_ROUNDS}) without "
+                "localising. Surface to the EM as stuck (§5.9)."
+            )
+
+        for hyp in self.context.hypotheses:
+            confirmed, evidence_line, delta = self.probe_fn(hyp, self.context)
+            hyp.evidence.append(evidence_line)
+            new_confidence = max(0, min(100, hyp.confidence + int(delta)))
+            hyp.confidence = (
+                new_confidence if confirmed else max(0, new_confidence - 10)
+            )
+            self.context.probes_run += 1
+
+        top = self._top_hypothesis()
+        self.context.record_note(
+            f"probe: round {self.context.round_count} top={top.text!r} "
+            f"confidence={top.confidence}"
+        )
+        if top.confidence >= PROPOSE_FIX_CONFIDENCE_THRESHOLD:
+            return DebugState.LOCALISE_BUG
+        return DebugState.HYPOTHESISE
+
+    # -----------------------------------------------------------------
+    # State: localise_bug
+    # -----------------------------------------------------------------
+
+    def localise_bug(
+        self,
+        file: str,
+        line: int,
+    ) -> DebugState:
+        """Pin the top-confidence hypothesis to a concrete ``file:line``.
+
+        Deterministic — the caller has already done the searching. The
+        sub-loop just records where the bug lives and advances.
+        """
+        if (
+            not self._top_hypothesis()
+            or self._top_hypothesis().confidence < PROPOSE_FIX_CONFIDENCE_THRESHOLD
+        ):
+            # This should have been caught by `probe` — raise to keep the
+            # invariant visible in tests.
+            raise DebugDisciplineError(
+                "localise_bug: top hypothesis confidence is below the "
+                f"{PROPOSE_FIX_CONFIDENCE_THRESHOLD}% bar; do not localise yet."
+            )
+        self.context.localised_file = file
+        self.context.localised_line = line
+        self.context.record_note(f"localise_bug: {file}:{line}")
+        return DebugState.PROPOSE_FIX
+
+    # -----------------------------------------------------------------
+    # State: propose_fix
+    # -----------------------------------------------------------------
+
+    def propose_fix(
+        self,
+        *,
+        summary: str,
+        is_architectural: bool = False,
+        shotgun: bool = False,
+    ) -> DebugState:
+        """Propose a fix candidate — enforces the two hard discipline rules.
+
+        Rule 1: no fix before repro (``context.reproduced`` must be True).
+        Rule 2: no fix before root cause — the top hypothesis must clear
+        :data:`PROPOSE_FIX_CONFIDENCE_THRESHOLD`, unless ``shotgun=True``
+        *and* ``self.em_elevation_granted=True`` (the override pair from
+        §5.9).
+        """
+        if not self.context.reproduced:
+            raise DebugDisciplineError(
+                "propose_fix: refused — reproduce did not return reproduced=True. "
+                '"I think this is the bug but I can\'t repro it" is blocked (§5.9 rule 1).'
+            )
+        top = self._top_hypothesis()
+        if top is None:
+            raise DebugDisciplineError(
+                "propose_fix: no hypotheses recorded; run hypothesise first."
+            )
+        if top.confidence < PROPOSE_FIX_CONFIDENCE_THRESHOLD:
+            if not (shotgun and self.em_elevation_granted):
+                raise DebugDisciplineError(
+                    f"propose_fix: top hypothesis confidence {top.confidence}% "
+                    f"< {PROPOSE_FIX_CONFIDENCE_THRESHOLD}%. "
+                    "Pass shotgun=True AND request EM elevation "
+                    "(em_elevation_granted) to override (§5.9 rule 2)."
+                )
+            self.context.shotgun = True
+            self.context.record_note(
+                "propose_fix: shotgun override ACTIVE (EM elevation granted)"
+            )
+
+        self.context.fix_summary = summary.strip()
+        self.context.fix_is_architectural = is_architectural
+        self.context.record_note(
+            f"propose_fix: summary={summary!r} architectural={is_architectural}"
+        )
+        return DebugState.POSTMORTEM
+
+    # -----------------------------------------------------------------
+    # State: postmortem
+    # -----------------------------------------------------------------
+
+    def postmortem(
+        self,
+        *,
+        feedback_conn: Optional[sqlite3.Connection] = None,
+        memory_conn: Optional[sqlite3.Connection] = None,
+        fix_pr_url: Optional[str] = None,
+        loop_version: int = 1,
+    ) -> DebugState:
+        """Write postmortem notes to ``feedback.db`` + ``failure_patterns`` memory.
+
+        §5.9 last state. Mandatory — the sub-loop does NOT return to the
+        parent until the postmortem is recorded. Discipline rule 5
+        ("Postmortem in the feedback record") is enforced by
+        :meth:`require_postmortem_or_raise`.
+        """
+        if self.context.fix_summary is None:
+            raise DebugDisciplineError(
+                "postmortem: cannot write before propose_fix has run."
+            )
+
+        # Feedback-record update (§7.4 step 10 "verify on merge" half —
+        # we append a postmortem line to notes_json, not transition state).
+        if feedback_conn is not None and self.context.feedback_id:
+            row = feedback_store.get_row(feedback_conn, self.context.feedback_id)
+            if row is None:
+                raise DebugDisciplineError(
+                    f"postmortem: feedback row {self.context.feedback_id!r} not found. "
+                    "Create the feedback record before entering debug, or "
+                    "point the sub-loop at a different feedback_id."
+                )
+            try:
+                notes = json.loads(row.notes_json) if row.notes_json else []
+            except json.JSONDecodeError:
+                notes = []
+            notes.append(
+                {
+                    "ts": _utc_now_iso(),
+                    "stage": "postmortem",
+                    "summary": self.context.fix_summary,
+                    "top_hypothesis": (
+                        self._top_hypothesis().text if self._top_hypothesis() else ""
+                    ),
+                    "fix_pr_url": fix_pr_url,
+                }
+            )
+            feedback_store.update_row(
+                feedback_conn,
+                self.context.feedback_id,
+                {"notes_json": json.dumps(notes)},
+            )
+
+        # Memory write — failure_patterns topic per §6.8.1.
+        if memory_conn is not None:
+            payload = {
+                "error_signature": self.context.error_signature,
+                "stack_hash": _stack_hash(self.context.error_signature),
+                "root_cause": (
+                    self._top_hypothesis().text if self._top_hypothesis() else ""
+                ),
+                "fix_pr_url": fix_pr_url,
+                "affected_files": (
+                    [self.context.localised_file] if self.context.localised_file else []
+                ),
+                "fix_class": (
+                    "architectural" if self.context.fix_is_architectural else "tool"
+                ),
+                "summary": self.context.fix_summary,
+                "shotgun": self.context.shotgun,
+                "loop_version": loop_version,
+            }
+            row = memory_store.MemoryRow(
+                id=str(uuid.uuid4()),
+                topic="failure_patterns",
+                created_at=_utc_now_iso(),
+                source_kind="feedback",
+                source_id=self.context.feedback_id,
+                payload_json=json.dumps(payload, sort_keys=True),
+                embedding_key=_stack_hash(self.context.error_signature),
+                confidence=max(
+                    self._top_hypothesis().confidence if self._top_hypothesis() else 80,
+                    80,
+                ),
+            )
+            memory_store.insert_row(memory_conn, row)
+
+        self.context.postmortem_written = True
+        self.context.record_note("postmortem: feedback + failure_patterns written")
+        return DebugState.POSTMORTEM  # terminal — caller exits the sub-loop
+
+    # -----------------------------------------------------------------
+    # Invariants callers can assert externally
+    # -----------------------------------------------------------------
+
+    def require_postmortem_or_raise(self) -> None:
+        """Discipline rule 5 — refuse to close the sub-loop without postmortem.
+
+        Called from the parent ReAct loop's ``verify_merge`` state once this
+        Phase-8 module is wired in (Phase 11). For now it's a free-standing
+        check callers can invoke.
+        """
+        if not self.context.postmortem_written:
+            raise DebugDisciplineError(
+                "verify_merge: refuse to close bug-fix feedback without a "
+                "postmortem (§5.9 rule 5)."
+            )
+
+    def _top_hypothesis(self) -> Optional[Hypothesis]:
+        """Return the hypothesis with the highest confidence, or None."""
+        if not self.context.hypotheses:
+            return None
+        return max(self.context.hypotheses, key=lambda h: h.confidence)
+
+
+__all__ = [
+    "DebugContext",
+    "DebugDisciplineError",
+    "DebugState",
+    "DebugSubLoop",
+    "Hypothesis",
+    "MAX_DEBUG_ROUNDS",
+    "MIN_HYPOTHESES",
+    "PROPOSE_FIX_CONFIDENCE_THRESHOLD",
+]

--- a/src/gaia/coder/dev_mode.py
+++ b/src/gaia/coder/dev_mode.py
@@ -1,0 +1,585 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Dev-mode gate for gaia-coder self-edit (§7.1).
+
+Self-edit of the agent's own source is **disabled by default**. Dev mode has
+two switches, both of which must be ON for :func:`is_enabled` to return True:
+
+1. **Hard precondition** (auto-detected, non-negotiable — §7.1). The running
+   ``gaia.coder`` source resolves into a writable git working tree whose
+   ``origin`` remote matches ``repo_binding.toml.repo``. End-user installs
+   (PyPI wheel, Electron bundle) cannot satisfy this no matter what.
+
+2. **Soft enablement** — either a session flag in
+   ``~/.gaia/coder/session.json`` (written by :func:`enable_session`, cleared
+   by :func:`disable_session`, auto-cleared on daemon exit) or
+   ``dev_mode_self_edit = true`` in ``em.toml`` (written by
+   :func:`enable_permanent`).
+
+Every enablement / disablement appends a row to ``audit.log.db`` when an
+audit connection is supplied — the conversational UX is the primary
+affordance, but the audit trail is the source of truth for "when did dev
+mode flip and why" (§7.1).
+
+Fail-loudly per repo ``CLAUDE.md``: a corrupt session file or a bogus
+``em.toml`` raises with the path and next-action. There is no "fall back to
+off" silent path — either the check is honoured, or the caller hears about
+it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from gaia.coder import trust as trust_mod
+from gaia.coder.stores import audit as audit_store
+
+logger = logging.getLogger(__name__)
+
+#: Default location of the per-daemon session flag. Kept next to ``em.toml``
+#: so the EM (and the agent) can always find it.
+DEFAULT_SESSION_PATH: Path = Path.home() / ".gaia" / "coder" / "session.json"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class DevModeError(Exception):
+    """Dev-mode invariant violated.
+
+    Raised when :func:`enable_session` / :func:`enable_permanent` are asked to
+    turn on dev mode without the hard precondition being met, or when the
+    session file is structurally invalid. Not raised by :func:`is_enabled`
+    — that returns ``False`` instead.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Hard-precondition detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DevModeStatus:
+    """Result of :func:`detect_dev_mode` — which of the §7.1 checks passed.
+
+    Fields:
+        editable_install: ``True`` iff the running source resolves into a git
+            working tree whose ``origin`` remote matches
+            ``repo_binding.toml.repo``. Concretely the §7.1 "hard precondition"
+            — always False on PyPI / Electron installs.
+        em_allowlist: ``True`` iff ``em.toml`` sets
+            ``dev_mode_self_edit = true``. Independent of the session flag.
+        repo_root: The git toplevel that ``editable_install`` was computed
+            from, or ``None`` when the precondition failed. Useful in error
+            messages and in tests that stage alternate repos.
+        origin_url: The ``git remote get-url origin`` output that was
+            compared against ``repo_binding.repo``, or ``None`` on failure.
+        reason: Short human-readable string explaining why either check is
+            off. Empty when both are on.
+    """
+
+    editable_install: bool
+    em_allowlist: bool
+    repo_root: Optional[Path] = None
+    origin_url: Optional[str] = None
+    reason: str = ""
+
+    @property
+    def hard_precondition_met(self) -> bool:
+        """Convenience: does the agent *technically* qualify for dev mode?
+
+        The hard precondition is the editable-install check; the EM allowlist
+        is the soft gate. ``is_enabled`` composes both (plus the session
+        file); this property only tells callers whether they'd be allowed to
+        opt in at all.
+        """
+        return self.editable_install
+
+
+def _git(*args: str, cwd: Path) -> Optional[str]:
+    """Run ``git <args>`` under ``cwd`` and return stdout; ``None`` on failure.
+
+    Used for ``rev-parse --show-toplevel`` and ``remote get-url origin``. We
+    swallow :class:`subprocess.CalledProcessError` *only* here — the calling
+    function surfaces a structured ``DevModeStatus`` instead of an exception,
+    because "no git available" is a legitimate "not editable" signal, not a
+    bug to raise on.
+    """
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ) as exc:
+        logger.debug("git %s under %s failed: %s", args, cwd, exc)
+        return None
+    return out.stdout.strip() or None
+
+
+def _source_root() -> Path:
+    """Return the parent directory of this module.
+
+    Centralised so tests can monkeypatch a single entry point instead of
+    ``Path(__file__).parent`` scattered across call sites.
+    """
+    return Path(__file__).resolve().parent
+
+
+def _match_origin(origin_url: str, repo: str) -> bool:
+    """Return True if ``origin_url`` references the ``owner/name`` in ``repo``.
+
+    ``git remote get-url`` can return ``https://github.com/owner/name.git``,
+    ``git@github.com:owner/name.git``, or a non-GitHub URL. We compare on the
+    ``owner/name`` suffix (case-insensitive, ``.git`` stripped) rather than
+    the full URL so HTTPS ↔ SSH switches do not break dev mode.
+    """
+    if not origin_url or not repo:
+        return False
+    cleaned = origin_url.strip()
+    # Trim protocol / host so only "owner/name" remains.
+    if cleaned.endswith(".git"):
+        cleaned = cleaned[: -len(".git")]
+    # Handle SSH form "git@github.com:owner/name"
+    if ":" in cleaned and cleaned.startswith("git@"):
+        cleaned = cleaned.split(":", 1)[1]
+    # Handle HTTPS form by keeping last two path segments.
+    parts = [p for p in cleaned.replace("\\", "/").split("/") if p]
+    if len(parts) < 2:
+        return False
+    tail = "/".join(parts[-2:]).lower()
+    return tail == repo.strip().lower()
+
+
+def detect_dev_mode(
+    *,
+    em_cfg_path: Optional[Path] = None,
+    repo_binding_path: Optional[Path] = None,
+    source_root: Optional[Path] = None,
+) -> DevModeStatus:
+    """Perform the two §7.1 checks and return a :class:`DevModeStatus`.
+
+    Args:
+        em_cfg_path: Path to ``em.toml``. Defaults to
+            ``~/.gaia/coder/em.toml``. When the file is missing the EM
+            allowlist is reported as ``False`` (not an error — unconfigured
+            installs are a valid "off" state).
+        repo_binding_path: Path to ``repo_binding.toml``. Defaults to the
+            ``repo_binding.toml`` co-located with this module (the
+            production layout). A missing binding is treated as "precondition
+            failed" — without a bound repo we cannot verify origin.
+        source_root: Override the directory used for the ``git
+            rev-parse --show-toplevel`` probe. Tests pass a ``tmp_path`` that
+            has been initialised as a git repo.
+
+    Returns:
+        :class:`DevModeStatus` with both booleans plus the diagnostic fields.
+
+    The function never raises — it reports. Use :func:`is_enabled` if you
+    want a single boolean; call this helper when you need to tell the user
+    *why* dev mode is off.
+    """
+    cfg_path = em_cfg_path or (Path.home() / ".gaia" / "coder" / "em.toml")
+    binding_path = repo_binding_path or (_source_root() / "repo_binding.toml")
+    probe_root = source_root or _source_root()
+
+    # -- Hard precondition: editable install.
+    repo_root: Optional[Path] = None
+    origin: Optional[str] = None
+    editable = False
+    reason = ""
+    try:
+        binding = trust_mod.load_repo_binding(binding_path)
+    except trust_mod.TrustError as exc:
+        reason = f"repo_binding.toml not usable: {exc}"
+        binding = None
+
+    if binding is not None:
+        toplevel = _git("rev-parse", "--show-toplevel", cwd=probe_root)
+        if toplevel is None:
+            reason = (
+                f"git rev-parse --show-toplevel failed under {probe_root}; "
+                "source is not inside a writable git working tree (likely a "
+                "PyPI / Electron install). Dev mode cannot be enabled."
+            )
+        else:
+            repo_root = Path(toplevel)
+            origin = _git("remote", "get-url", "origin", cwd=repo_root)
+            if origin is None:
+                reason = (
+                    f"git remote get-url origin failed under {repo_root}; "
+                    "no origin remote bound."
+                )
+            elif not _match_origin(origin, binding.repo):
+                reason = (
+                    f"origin remote {origin!r} does not match bound repo "
+                    f"{binding.repo!r} from {binding_path}."
+                )
+            else:
+                editable = True
+
+    # -- Soft gate: em.toml allowlist (independent of session flag).
+    em_allowlist = False
+    if cfg_path.exists():
+        try:
+            em_cfg = trust_mod.load_em_config(cfg_path)
+            em_allowlist = bool(em_cfg.dev_mode_self_edit)
+        except trust_mod.TrustError as exc:
+            # A broken em.toml is surfacing-worthy but not fatal here — we
+            # report it in the reason and continue.
+            reason = reason or f"em.toml unreadable: {exc}"
+
+    if editable and em_allowlist and not reason:
+        reason = ""
+
+    return DevModeStatus(
+        editable_install=editable,
+        em_allowlist=em_allowlist,
+        repo_root=repo_root,
+        origin_url=origin,
+        reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session flag (file-backed)
+# ---------------------------------------------------------------------------
+
+
+def _utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+
+def _read_session(session_path: Path) -> dict:
+    """Parse ``session.json`` (or return ``{}`` when missing).
+
+    A corrupt JSON file raises :class:`DevModeError` rather than being
+    silently ignored — per CLAUDE.md fail-loudly. The caller (CLI or agent)
+    can then choose to delete the file explicitly.
+    """
+    if not session_path.exists():
+        return {}
+    try:
+        return json.loads(session_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise DevModeError(
+            f"session file at {session_path} is not valid JSON: {exc}. "
+            "Delete the file and re-enable dev mode, or inspect by hand."
+        ) from exc
+
+
+def _write_session(session_path: Path, data: dict) -> None:
+    """Atomically write ``session.json``.
+
+    Atomic via ``.tmp`` + ``replace`` so a crash mid-write never leaves a
+    half-written file (which would raise on next load).
+    """
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = session_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(session_path)
+
+
+def _audit(
+    conn: Optional[sqlite3.Connection],
+    *,
+    tool_name: str,
+    em_handle: str,
+    reason: str,
+    scope: str,
+    loop_version: int,
+) -> None:
+    """Append a dev-mode transition row to ``audit.log.db``.
+
+    Best-effort: when ``conn`` is ``None`` we skip — the CLI always supplies
+    one in production, but library callers (tests, ad-hoc scripts) may
+    legitimately not have one. No exception-swallowing outside the ``None``
+    guard; a real SQLite error bubbles up.
+    """
+    if conn is None:
+        return
+    row = audit_store.AuditRow(
+        occurred_at=_utc_now_iso(),
+        tool_name=tool_name,
+        args_json=json.dumps(
+            {
+                "em_handle": em_handle,
+                "reason": reason,
+                "scope": scope,
+            },
+            sort_keys=True,
+        ),
+        loop_version=loop_version,
+    )
+    audit_store.insert_row(conn, row)
+
+
+def enable_session(
+    em_cfg: trust_mod.EMConfig,
+    reason: str,
+    *,
+    session_path: Path = DEFAULT_SESSION_PATH,
+    audit_conn: Optional[sqlite3.Connection] = None,
+    loop_version: int = 1,
+    status: Optional[DevModeStatus] = None,
+) -> None:
+    """Turn dev mode ON for the current session.
+
+    Writes ``{"dev_mode_session": true, ...}`` to ``session_path``. Refuses
+    when the hard precondition (editable install + matching origin) is not
+    met — §7.1 is explicit that conversation cannot enable dev mode on a
+    PyPI install.
+
+    Args:
+        em_cfg: Current :class:`EMConfig` — used for the audit row
+            (``em_handle``) and no other purpose.
+        reason: Free-text conversational rationale. Persisted into
+            ``session.json`` *and* into the audit row so ``gaia-coder
+            introspect audit`` can reconstruct who enabled and why.
+        session_path: Override for the session file. Tests pass a
+            ``tmp_path``.
+        audit_conn: Open ``audit.log.db`` connection. Optional; the CLI
+            always supplies one.
+        loop_version: Loop version stamped into the audit row.
+        status: Optional pre-computed :class:`DevModeStatus`. Skip the
+            ``detect_dev_mode`` round-trip when the caller already has one.
+
+    Raises:
+        DevModeError: when the hard precondition is not met. The message
+            names the failing check and points at §7.1 — never a silent
+            no-op.
+    """
+    effective = status or detect_dev_mode()
+    if not effective.editable_install:
+        raise DevModeError(
+            "Cannot enable dev mode: hard precondition failed. "
+            f"{effective.reason or 'editable install + matching origin required'}. "
+            "See §7.1 of docs/plans/coder-agent.mdx."
+        )
+    if not reason or not reason.strip():
+        raise DevModeError(
+            "enable_session requires a non-empty reason (audit-trail invariant, §7.1)."
+        )
+
+    data = _read_session(session_path)
+    data["dev_mode_session"] = True
+    data["dev_mode_session_enabled_at"] = _utc_now_iso()
+    data["dev_mode_session_reason"] = reason
+    data["em_handle"] = em_cfg.em_handle
+    _write_session(session_path, data)
+
+    _audit(
+        audit_conn,
+        tool_name="dev_mode.enable_session",
+        em_handle=em_cfg.em_handle,
+        reason=reason,
+        scope="session",
+        loop_version=loop_version,
+    )
+    logger.info(
+        "dev_mode.enable_session: ON for session (em=%s, reason=%r)",
+        em_cfg.em_handle,
+        reason,
+    )
+
+
+def disable_session(
+    *,
+    session_path: Path = DEFAULT_SESSION_PATH,
+    audit_conn: Optional[sqlite3.Connection] = None,
+    em_handle: str = "",
+    loop_version: int = 1,
+) -> None:
+    """Clear the session flag (removes the three ``dev_mode_session_*`` keys).
+
+    Idempotent: a missing or already-cleared session file is a no-op, not
+    an error. Does NOT touch ``em.toml`` — use :func:`disable_permanent` for
+    that (or equivalently, flip ``dev_mode_self_edit`` via the conversational
+    intent handler, §15.4).
+    """
+    data = _read_session(session_path)
+    for key in (
+        "dev_mode_session",
+        "dev_mode_session_enabled_at",
+        "dev_mode_session_reason",
+        "em_handle",
+    ):
+        data.pop(key, None)
+    if data:
+        _write_session(session_path, data)
+    elif session_path.exists():
+        session_path.unlink()
+
+    _audit(
+        audit_conn,
+        tool_name="dev_mode.disable_session",
+        em_handle=em_handle,
+        reason="",
+        scope="session",
+        loop_version=loop_version,
+    )
+    logger.info("dev_mode.disable_session: OFF")
+
+
+def enable_permanent(
+    em_cfg: trust_mod.EMConfig,
+    reason: str,
+    *,
+    em_cfg_path: Optional[Path] = None,
+    audit_conn: Optional[sqlite3.Connection] = None,
+    loop_version: int = 1,
+    status: Optional[DevModeStatus] = None,
+) -> trust_mod.EMConfig:
+    """Persist ``dev_mode_self_edit = true`` to ``em.toml`` + audit-log.
+
+    Returns the updated :class:`EMConfig`. Callers must keep the returned
+    instance — the input is not mutated.
+
+    Raises:
+        DevModeError: hard precondition not met or reason empty.
+    """
+    effective = status or detect_dev_mode(em_cfg_path=em_cfg_path)
+    if not effective.editable_install:
+        raise DevModeError(
+            "Cannot enable dev mode permanently: hard precondition failed. "
+            f"{effective.reason or 'editable install + matching origin required'}. "
+            "See §7.1 of docs/plans/coder-agent.mdx."
+        )
+    if not reason or not reason.strip():
+        raise DevModeError(
+            "enable_permanent requires a non-empty reason (§7.1 audit-trail invariant)."
+        )
+
+    now = _utc_now_iso()
+    updated = em_cfg.model_copy(
+        update={
+            "dev_mode_self_edit": True,
+            "dev_mode_enabled_at": now,
+            "dev_mode_enabled_reason": reason,
+        }
+    )
+    cfg_path = em_cfg_path or (Path.home() / ".gaia" / "coder" / "em.toml")
+    trust_mod.save_em_config(cfg_path, updated)
+
+    _audit(
+        audit_conn,
+        tool_name="dev_mode.enable_permanent",
+        em_handle=em_cfg.em_handle,
+        reason=reason,
+        scope="permanent",
+        loop_version=loop_version,
+    )
+    logger.info(
+        "dev_mode.enable_permanent: em.toml updated (em=%s, reason=%r)",
+        em_cfg.em_handle,
+        reason,
+    )
+    return updated
+
+
+def disable_permanent(
+    em_cfg: trust_mod.EMConfig,
+    *,
+    em_cfg_path: Optional[Path] = None,
+    audit_conn: Optional[sqlite3.Connection] = None,
+    loop_version: int = 1,
+) -> trust_mod.EMConfig:
+    """Flip ``dev_mode_self_edit = false`` in ``em.toml``.
+
+    Symmetric with :func:`enable_permanent`. Provided here so callers have
+    one import for the full dev-mode surface rather than reaching into
+    :mod:`gaia.coder.intent` for the inverse.
+    """
+    updated = em_cfg.model_copy(
+        update={
+            "dev_mode_self_edit": False,
+            "dev_mode_enabled_reason": None,
+        }
+    )
+    cfg_path = em_cfg_path or (Path.home() / ".gaia" / "coder" / "em.toml")
+    trust_mod.save_em_config(cfg_path, updated)
+    _audit(
+        audit_conn,
+        tool_name="dev_mode.disable_permanent",
+        em_handle=em_cfg.em_handle,
+        reason="",
+        scope="permanent",
+        loop_version=loop_version,
+    )
+    logger.info("dev_mode.disable_permanent: em.toml updated")
+    return updated
+
+
+def is_enabled(
+    *,
+    em_cfg_path: Optional[Path] = None,
+    session_path: Path = DEFAULT_SESSION_PATH,
+    repo_binding_path: Optional[Path] = None,
+    source_root: Optional[Path] = None,
+) -> bool:
+    """Composite check — are we currently allowed to self-edit?
+
+    Formula::
+
+        is_enabled = hard_precondition_met
+                     AND (session_flag OR em.toml dev_mode_self_edit)
+
+    A corrupt ``session.json`` raises :class:`DevModeError` (surfaced, not
+    silently downgraded) — the caller chooses whether to delete it.
+    """
+    status = detect_dev_mode(
+        em_cfg_path=em_cfg_path,
+        repo_binding_path=repo_binding_path,
+        source_root=source_root,
+    )
+    if not status.editable_install:
+        return False
+    if status.em_allowlist:
+        return True
+    session = _read_session(session_path)
+    return bool(session.get("dev_mode_session"))
+
+
+def session_state(
+    *,
+    session_path: Path = DEFAULT_SESSION_PATH,
+) -> dict:
+    """Return the current session dict (empty if no session file).
+
+    Read-only helper for introspection / CLI ``gaia-coder status`` output.
+    """
+    return dict(_read_session(session_path))
+
+
+__all__ = [
+    "DEFAULT_SESSION_PATH",
+    "DevModeError",
+    "DevModeStatus",
+    "detect_dev_mode",
+    "disable_permanent",
+    "disable_session",
+    "enable_permanent",
+    "enable_session",
+    "is_enabled",
+    "session_state",
+]

--- a/src/gaia/coder/prompts/classify_failure.md
+++ b/src/gaia/coder/prompts/classify_failure.md
@@ -1,0 +1,30 @@
+You are gaia-coder classifying a failure that occurred during your work. Decide: user-task bug, self-code bug, or external/transient.
+
+<error>
+  <message>{{error_message}}</message>
+  <stack_trace>{{stack}}</stack_trace>
+  <tool_that_failed>{{tool_name}}</tool_that_failed>
+  <args>{{tool_args_json}}</args>
+</error>
+
+<recent_tool_calls count="10">{{from_audit_log}}</recent_tool_calls>
+<dev_mode_status>{{dev_mode_status}}</dev_mode_status>
+
+Classify as exactly one:
+- user-task: user asked for something that can't be done / is ill-specified → surface to EM, do not self-fix.
+- self-code: bug in gaia-coder's own source is the proximate cause → self-fix appropriate IF dev_mode=on.
+- external:  network timeout, rate limit, Anthropic outage, disk full → retry or surface.
+
+Be CONSERVATIVE. When uncertain, classify external (a wrong self-code diagnosis burns self-edit churn; a wrong external at worst delays by one tick).
+
+Return ONLY a JSON object, no prose before or after:
+
+{
+  "kind": "user-task|self-code|external",
+  "evidence": "<2-3 sentences>",
+  "confidence": <0-100>,
+  "suggested_next_action": "<imperative>"
+}
+
+If dev_mode=off AND kind=self-code, include in suggested_next_action:
+"Request EM permission to self-edit via the inbox."

--- a/src/gaia/coder/self_fix/self_heal.py
+++ b/src/gaia/coder/self_fix/self_heal.py
@@ -1,0 +1,633 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Self-detected bug mid-task (§7.5).
+
+The Phase-7 sub-loop covered here runs when the agent encounters a failure
+in the middle of a user task and diagnoses it as a bug in its *own* source.
+Four public entry points:
+
+* :func:`classify_failure` — LLM-driven triage via
+  ``prompts/classify_failure.md`` (§15.8 P8). Conservative: uncertain
+  classifications return ``external`` so a wrong diagnosis never burns
+  self-edit churn.
+* :func:`pause_current_task` — snapshots a task's in-flight state to
+  ``~/.gaia/coder/paused-tasks/<task-id>.json`` via the existing
+  :mod:`gaia.coder.stores.paused_tasks` helpers.
+* :func:`resume_task` — hydrates a snapshot back into a structured
+  :class:`ResumeResult` so the caller can rebuild the paused task's context.
+* :func:`restart_self` — hot-reload for prompt-only / doc-only changes,
+  graceful exit code 42 for code changes. The fork-bomb guard (§7.5 last
+  bullet: "no more than 3 restarts in 1 hour") runs on every call.
+
+Only the Python side is exported — wiring into the main ReAct loop and the
+CLI is a Phase 11 (production swap) concern, explicitly out of scope for
+this module.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Protocol
+
+from gaia.coder.stores import audit as audit_store
+from gaia.coder.stores import paused_tasks
+
+logger = logging.getLogger(__name__)
+
+#: Canonical kinds returned by the P8 classifier (§7.5).
+FAILURE_KINDS: tuple[str, ...] = ("user-task", "self-code", "external")
+
+#: Confidence floor below which a classification is force-rewritten to
+#: ``external`` — mirrors §7.2's conservative triage discipline.
+CLASSIFY_LOW_CONFIDENCE_FLOOR: int = 50
+
+#: Restart rate-limit window: at most ``_RESTART_MAX_IN_WINDOW`` restarts in
+#: ``_RESTART_COUNT_WINDOW`` seconds. §7.5 spells out "no more than 3 in 1
+#: hour"; the constants are at module scope so tests and the CLI can reason
+#: about the bound.
+_RESTART_COUNT_WINDOW: float = 60.0 * 60.0  # one hour, seconds
+_RESTART_MAX_IN_WINDOW: int = 3
+
+#: Exit code the supervisor (Autonomy Engine / `gaia-coder daemon`)
+#: interprets as "respawn me with the same args" (§7.5 step 7).
+RESTART_EXIT_CODE: int = 42
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SelfHealError(Exception):
+    """Self-heal invariant violated (bad snapshot, restart storm, etc.)."""
+
+
+class RestartStormError(SelfHealError):
+    """Raised by :func:`restart_self` when the rate limit would be exceeded.
+
+    §7.5: "No self-restart fork bomb. > 3 restarts / hour halts the
+    heartbeat and pages the EM." The caller surfaces the error to the EM
+    rather than retrying.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FailureClassification:
+    """Structured result of :func:`classify_failure`.
+
+    Mirrors the JSON shape the P8 prompt must return, with the addition of
+    :attr:`escalated_low_confidence` — set when the classifier's confidence
+    fell below :data:`CLASSIFY_LOW_CONFIDENCE_FLOOR` and the kind was
+    force-rewritten to ``external``.
+    """
+
+    kind: str
+    evidence: str
+    confidence: int
+    suggested_next_action: str
+    escalated_low_confidence: bool = False
+
+
+class ClassifyClient(Protocol):
+    """Callable contract for the P8 LLM call.
+
+    Accepts the fully-rendered prompt plus the structured context and
+    returns the raw JSON string the model produced. Tests pass a lambda;
+    production wires an Anthropic Opus 4.7 client in Phase 11.
+    """
+
+    def __call__(
+        self,
+        *,
+        prompt: str,
+        error: Mapping[str, Any],
+        recent_tool_calls: list[Mapping[str, Any]],
+        dev_mode_on: bool,
+    ) -> str: ...
+
+
+ClassifyClientFn = Callable[..., str]
+
+
+def _default_classify_client(**_kwargs: Any) -> str:  # pragma: no cover
+    """Default client refuses to run — forces callers to inject a real one.
+
+    Keeps this module import-clean on systems without the ``anthropic``
+    package (e.g. CI runs that only exercise stores / audit). Fail-loudly.
+    """
+    raise RuntimeError(
+        "No ClassifyClient configured. Inject one via classify_failure(client=...) "
+        "or wire the default Anthropic client at production swap (Phase 11)."
+    )
+
+
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+
+def _load_prompt(name: str) -> str:
+    path = _PROMPTS_DIR / name
+    if not path.exists():
+        raise FileNotFoundError(f"prompt template missing: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _render_classify_prompt(
+    template: str,
+    *,
+    error_message: str,
+    stack: str,
+    tool_name: str,
+    tool_args_json: str,
+    from_audit_log: str,
+    dev_mode_status: str,
+) -> str:
+    """Substitute the ``{{...}}`` slots used by P8.
+
+    Deterministic string templating — no LLM involvement. Same
+    double-brace convention as ``prompts/triage.md`` so the files stay
+    human-editable.
+    """
+    subs: dict[str, str] = {
+        "error_message": error_message,
+        "stack": stack,
+        "tool_name": tool_name,
+        "tool_args_json": tool_args_json,
+        "from_audit_log": from_audit_log,
+        "dev_mode_status": dev_mode_status,
+    }
+    rendered = template
+    for key, value in subs.items():
+        rendered = rendered.replace("{{" + key + "}}", value)
+    return rendered
+
+
+def classify_failure(
+    error: Mapping[str, Any],
+    context_json: Mapping[str, Any],
+    *,
+    dev_mode_on: bool = False,
+    client: Optional[ClassifyClientFn] = None,
+) -> FailureClassification:
+    """Classify a mid-task failure as user-task / self-code / external.
+
+    Args:
+        error: Dict with at least ``message``, ``stack``, ``tool_name``,
+            ``tool_args`` keys. ``tool_args`` is serialised to JSON inside
+            the prompt.
+        context_json: Arbitrary JSON-serialisable context. The
+            ``recent_tool_calls`` key (list of audit-log summaries) is
+            injected into the prompt at ``{{from_audit_log}}``.
+        dev_mode_on: Whether dev mode is currently enabled. Controls the
+            ``{{dev_mode_status}}`` slot — the classifier uses this when
+            composing ``suggested_next_action``.
+        client: Mockable LLM call; see :class:`ClassifyClient`.
+
+    Returns:
+        :class:`FailureClassification` — kind is always one of
+        :data:`FAILURE_KINDS`; confidence is clamped to [0, 100]; below
+        the floor the kind is force-rewritten to ``external`` and
+        ``escalated_low_confidence`` is set.
+
+    Raises:
+        ValueError: when the model returns invalid JSON, an unknown kind,
+            or an out-of-range confidence. Fail-loudly — we refuse to let
+            corrupt classifier output drive a self-fix.
+    """
+    client = client or _default_classify_client
+    template = _load_prompt("classify_failure.md")
+    tool_args_json = json.dumps(
+        error.get("tool_args") or error.get("args") or {}, sort_keys=True
+    )
+    recent = context_json.get("recent_tool_calls") or []
+    recent_rendered = (
+        json.dumps(recent, indent=2)
+        if isinstance(recent, (list, tuple))
+        else str(recent)
+    )
+    prompt = _render_classify_prompt(
+        template,
+        error_message=str(error.get("message", "")),
+        stack=str(error.get("stack", "")),
+        tool_name=str(error.get("tool_name", "")),
+        tool_args_json=tool_args_json,
+        from_audit_log=recent_rendered,
+        dev_mode_status="on" if dev_mode_on else "off",
+    )
+    raw = client(
+        prompt=prompt,
+        error=dict(error),
+        recent_tool_calls=list(recent) if isinstance(recent, (list, tuple)) else [],
+        dev_mode_on=dev_mode_on,
+    )
+    return _parse_classify_response(raw)
+
+
+def _parse_classify_response(raw: str) -> FailureClassification:
+    """Parse the P8 JSON payload into :class:`FailureClassification`."""
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError("classify_failure response was empty")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"classify_failure response is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("classify_failure response is not a JSON object")
+
+    kind = parsed.get("kind")
+    if kind not in FAILURE_KINDS:
+        raise ValueError(
+            f"classify_failure returned unknown kind {kind!r}; "
+            f"expected one of {FAILURE_KINDS}"
+        )
+    confidence = parsed.get("confidence")
+    if not isinstance(confidence, int) or not 0 <= confidence <= 100:
+        raise ValueError(
+            f"classify_failure returned invalid confidence {confidence!r}; "
+            "expected int in [0, 100]"
+        )
+    evidence = parsed.get("evidence") or ""
+    if not isinstance(evidence, str):
+        raise ValueError("classify_failure evidence must be a string")
+    suggested = parsed.get("suggested_next_action") or ""
+    if not isinstance(suggested, str):
+        raise ValueError("classify_failure suggested_next_action must be a string")
+
+    escalated = False
+    if kind != "external" and confidence < CLASSIFY_LOW_CONFIDENCE_FLOOR:
+        logger.info(
+            "classify_failure escalated to external (confidence=%d < %d)",
+            confidence,
+            CLASSIFY_LOW_CONFIDENCE_FLOOR,
+        )
+        kind = "external"
+        escalated = True
+
+    return FailureClassification(
+        kind=kind,
+        evidence=evidence,
+        confidence=confidence,
+        suggested_next_action=suggested,
+        escalated_low_confidence=escalated,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pause / resume
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PausedTaskPath:
+    """Result of :func:`pause_current_task`.
+
+    Fields:
+        task_id: The task id that was paused.
+        path: Absolute path of the on-disk snapshot.
+        reason: Echoed back for caller's logging convenience.
+    """
+
+    task_id: str
+    path: Path
+    reason: str
+
+
+def _utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+
+def pause_current_task(
+    task_id: str,
+    reason: str,
+    *,
+    root: Path,
+    cwd: Optional[Path] = None,
+    tool_call_history: Optional[list[Mapping[str, Any]]] = None,
+    partial_outputs: Optional[Mapping[str, Any]] = None,
+    original_prompt: Optional[str] = None,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> PausedTaskPath:
+    """Snapshot the in-flight task state to ``paused-tasks/<task-id>.json``.
+
+    Thin wrapper over :func:`gaia.coder.stores.paused_tasks.write_snapshot`
+    that assembles the §7.5 required context (cwd, tool-call history,
+    partial outputs, original prompt) plus a ``paused_at`` timestamp and a
+    ``reason`` line so the later resume step has everything the task needs.
+
+    Args:
+        task_id: Stable task identifier (a UUID in production; any path-safe
+            string in tests).
+        reason: One-liner explaining why the task is being paused (shown in
+            the EM standup and included in the snapshot).
+        root: Path to the ``paused-tasks/`` directory. Normally
+            ``~/.gaia/coder/paused-tasks`` — tests pass a ``tmp_path``.
+        cwd: Working directory at pause time. Defaults to :func:`Path.cwd`
+            so the snapshot captures "where was I?" without the caller
+            having to pass it.
+        tool_call_history: Serialised recent tool calls for the audit
+            trail. Empty list when unknown.
+        partial_outputs: Arbitrary per-task partial output map. Kept as a
+            dict of JSON-friendly values.
+        original_prompt: The user's original task prompt — required for
+            resume to make sense.
+        extra: Escape hatch for task-specific additional fields. Merged
+            into the snapshot under ``extra``.
+
+    Returns:
+        :class:`PausedTaskPath` with the written file's absolute path.
+    """
+    snapshot: dict[str, Any] = {
+        "task_id": task_id,
+        "paused_at": _utc_now_iso(),
+        "reason": reason,
+        "cwd": str(cwd or Path.cwd()),
+        "tool_call_history": list(tool_call_history or []),
+        "partial_outputs": dict(partial_outputs or {}),
+        "original_prompt": original_prompt or "",
+        "extra": dict(extra or {}),
+    }
+    path = paused_tasks.write_snapshot(Path(root), task_id, snapshot)
+    logger.info("pause_current_task: snapshot at %s (reason=%r)", path, reason)
+    return PausedTaskPath(task_id=task_id, path=path, reason=reason)
+
+
+@dataclass(frozen=True)
+class ResumeResult:
+    """Return shape of :func:`resume_task` — hydrated snapshot for the caller.
+
+    Fields mirror :func:`pause_current_task`. ``snapshot_path`` is preserved
+    so callers that want to move or delete the file after successful resume
+    can do so without another ``list_snapshots`` lookup.
+    """
+
+    task_id: str
+    cwd: Path
+    tool_call_history: list[Mapping[str, Any]]
+    partial_outputs: Mapping[str, Any]
+    original_prompt: str
+    paused_at: str
+    reason: str
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    snapshot_path: Optional[Path] = None
+
+
+def resume_task(
+    task_id: str,
+    *,
+    root: Path,
+    delete_snapshot: bool = False,
+) -> ResumeResult:
+    """Hydrate a paused-task snapshot into a structured :class:`ResumeResult`.
+
+    Args:
+        task_id: Snapshot id to read.
+        root: Paused-tasks directory.
+        delete_snapshot: When True, delete the snapshot file after a
+            successful read. Defaults to False — the caller decides when
+            the task has resumed far enough to discard the evidence.
+
+    Raises:
+        FileNotFoundError: when no snapshot exists for ``task_id`` (raised
+            directly by :func:`paused_tasks.read_snapshot`). Surfaced, not
+            silently treated as "no paused state".
+        SelfHealError: when the snapshot file is structurally corrupt
+            (missing required fields).
+    """
+    data = paused_tasks.read_snapshot(Path(root), task_id)
+
+    required = {"task_id", "paused_at", "reason"}
+    missing = sorted(required - set(data))
+    if missing:
+        raise SelfHealError(
+            f"paused-task snapshot at {paused_tasks.snapshot_path(root, task_id)} "
+            f"is missing required fields: {missing}. Delete the snapshot or "
+            "rehydrate it by hand."
+        )
+
+    snapshot_path = paused_tasks.snapshot_path(Path(root), task_id)
+    result = ResumeResult(
+        task_id=str(data["task_id"]),
+        cwd=Path(str(data.get("cwd") or Path.cwd())),
+        tool_call_history=list(data.get("tool_call_history") or []),
+        partial_outputs=dict(data.get("partial_outputs") or {}),
+        original_prompt=str(data.get("original_prompt") or ""),
+        paused_at=str(data["paused_at"]),
+        reason=str(data["reason"]),
+        extra=dict(data.get("extra") or {}),
+        snapshot_path=snapshot_path,
+    )
+    if delete_snapshot and snapshot_path.exists():
+        snapshot_path.unlink()
+        logger.info("resume_task: deleted snapshot %s", snapshot_path)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Restart self — hot reload or exit-42
+# ---------------------------------------------------------------------------
+
+#: In-process rolling list of restart UNIX timestamps. Kept as module state
+#: because the fork-bomb guard has to survive within one process lifetime;
+#: across restarts the supervisor re-instantiates module state from scratch,
+#: which is fine — the supervisor is the other half of the bound (it refuses
+#: to respawn more than _RESTART_MAX_IN_WINDOW times in _RESTART_COUNT_WINDOW
+#: seconds too).
+_RESTART_TIMESTAMPS: list[float] = []
+
+
+def _reset_restart_window() -> None:
+    """Clear the in-process restart timestamp list.
+
+    Exported for tests via the ``__all__`` hook below. Production callers
+    never touch this.
+    """
+    _RESTART_TIMESTAMPS.clear()
+
+
+def _record_restart_attempt(now: float) -> None:
+    """Drop stale timestamps, append ``now``; raise if the bound is breached."""
+    cutoff = now - _RESTART_COUNT_WINDOW
+    # Purge stale entries in-place so memory does not grow unbounded over a
+    # long-running daemon.
+    _RESTART_TIMESTAMPS[:] = [t for t in _RESTART_TIMESTAMPS if t >= cutoff]
+    if len(_RESTART_TIMESTAMPS) >= _RESTART_MAX_IN_WINDOW:
+        raise RestartStormError(
+            f"Refusing to restart: would exceed {_RESTART_MAX_IN_WINDOW} "
+            f"restarts in {_RESTART_COUNT_WINDOW / 60.0:.0f} minutes. "
+            "Recent restart times: "
+            f"{[datetime.fromtimestamp(t, tz=timezone.utc).isoformat() for t in _RESTART_TIMESTAMPS]}. "
+            "Halt the daemon and page the EM per §7.5."
+        )
+    _RESTART_TIMESTAMPS.append(now)
+
+
+#: Valid ``kind`` values for :func:`restart_self`.
+RESTART_KINDS: tuple[str, ...] = ("prompt-only", "doc-only", "code")
+
+# Modules safe to hot-reload for prompt-only / doc-only restarts. Kept here
+# rather than inside the function so tests can monkeypatch the set.
+_HOT_RELOAD_MODULES: tuple[str, ...] = (
+    "gaia.coder.prompts",
+    "gaia.coder.GAIA",
+    "gaia.coder.ARCHITECTURE",
+)
+
+
+@dataclass(frozen=True)
+class RestartResult:
+    """Return shape of :func:`restart_self`.
+
+    For hot-reload restarts, ``exited`` is False and ``reloaded_modules``
+    lists the importlib-reloaded names. For cold restarts the function
+    calls :func:`sys.exit` before returning — callers on that path see
+    :class:`SystemExit`, not a :class:`RestartResult`.
+    """
+
+    kind: str
+    reason: str
+    reloaded_modules: tuple[str, ...]
+    exited: bool
+
+
+def restart_self(
+    reason: str,
+    kind: str = "code",
+    *,
+    audit_conn: Optional[sqlite3.Connection] = None,
+    em_handle: str = "",
+    loop_version: int = 1,
+    now: Optional[float] = None,
+    exit_fn: Callable[[int], None] = sys.exit,
+) -> RestartResult:
+    """Restart the agent — hot reload (prompts/docs) or cold exit (code).
+
+    §7.5 step 7: prompt-only / doc-only changes hot-reload via
+    :func:`importlib.reload`; code changes return exit code
+    :data:`RESTART_EXIT_CODE` (42) so the supervisor respawns the process.
+
+    Args:
+        reason: Free text (audit-logged).
+        kind: One of :data:`RESTART_KINDS`. Unknown values raise.
+        audit_conn: Optional ``audit.log.db`` connection.
+        em_handle: EM handle for the audit row.
+        loop_version: Loop version for the audit row.
+        now: Override clock (tests). Defaults to :func:`time.time`.
+        exit_fn: Override exit call (tests). Defaults to :func:`sys.exit`.
+
+    Returns:
+        :class:`RestartResult` for hot reloads. Cold restarts never return —
+        they call ``exit_fn(RESTART_EXIT_CODE)``.
+
+    Raises:
+        RestartStormError: more than :data:`_RESTART_MAX_IN_WINDOW`
+            restarts would be recorded inside
+            :data:`_RESTART_COUNT_WINDOW` seconds.
+        ValueError: unknown ``kind``.
+    """
+    if kind not in RESTART_KINDS:
+        raise ValueError(
+            f"restart_self: unknown kind {kind!r}; expected one of {RESTART_KINDS}"
+        )
+
+    _record_restart_attempt(now if now is not None else time.time())
+
+    if audit_conn is not None:
+        row = audit_store.AuditRow(
+            occurred_at=_utc_now_iso(),
+            tool_name="self_heal.restart_self",
+            args_json=json.dumps(
+                {"reason": reason, "kind": kind, "em_handle": em_handle},
+                sort_keys=True,
+            ),
+            loop_version=loop_version,
+        )
+        audit_store.insert_row(audit_conn, row)
+
+    if kind in ("prompt-only", "doc-only"):
+        reloaded = _hot_reload_prompts()
+        logger.info(
+            "restart_self: hot-reloaded %d modules (%s, reason=%r)",
+            len(reloaded),
+            kind,
+            reason,
+        )
+        return RestartResult(
+            kind=kind,
+            reason=reason,
+            reloaded_modules=tuple(reloaded),
+            exited=False,
+        )
+
+    # kind == "code" — cold restart. Log BEFORE calling exit_fn so tests
+    # that patch exit_fn into a lambda can still assert the log line.
+    logger.warning(
+        "restart_self: cold restart (exit code %d, reason=%r)",
+        RESTART_EXIT_CODE,
+        reason,
+    )
+    exit_fn(RESTART_EXIT_CODE)
+    # Defensive: if an injected exit_fn does not actually exit (tests pass
+    # ``calls.append`` which just records the code), return a result so
+    # callers can observe the "did-NOT-exit" outcome. The ``pylint: disable``
+    # is scoped to the single line — the default ``sys.exit`` path DOES make
+    # the return unreachable, but we need it for test injection.
+    return RestartResult(  # pylint: disable=unreachable
+        kind=kind,
+        reason=reason,
+        reloaded_modules=(),
+        exited=True,
+    )
+
+
+def _hot_reload_prompts() -> list[str]:
+    """Call :func:`importlib.reload` on every already-loaded prompt module.
+
+    Skips modules that are not in :data:`sys.modules` — a fresh process that
+    has never imported prompts has nothing to reload, which is fine.
+    Returns the list of module names that were actually reloaded.
+    """
+    reloaded: list[str] = []
+    for name in _HOT_RELOAD_MODULES:
+        mod = sys.modules.get(name)
+        if mod is None:
+            continue
+        importlib.reload(mod)
+        reloaded.append(name)
+    return reloaded
+
+
+__all__ = [
+    "CLASSIFY_LOW_CONFIDENCE_FLOOR",
+    "ClassifyClient",
+    "FAILURE_KINDS",
+    "FailureClassification",
+    "PausedTaskPath",
+    "RESTART_EXIT_CODE",
+    "RESTART_KINDS",
+    "RestartResult",
+    "RestartStormError",
+    "ResumeResult",
+    "SelfHealError",
+    "_RESTART_COUNT_WINDOW",
+    "_RESTART_MAX_IN_WINDOW",
+    "_reset_restart_window",
+    "classify_failure",
+    "pause_current_task",
+    "restart_self",
+    "resume_task",
+]

--- a/src/gaia/coder/tools/debug.py
+++ b/src/gaia/coder/tools/debug.py
@@ -1,0 +1,856 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""DebugToolsMixin — the eight debug sub-loop tools (§5.9).
+
+§5.9 of ``docs/plans/coder-agent.mdx`` treats debugging as a first-class
+capability: a self-contained sub-loop with its own tool mixin. This module
+is the Python side of that — the eight tools the loop uses to drive
+``reproduce → bisect → hypothesise → probe → localise_bug → propose_fix →
+postmortem``.
+
+All eight tools are registered via :meth:`DebugToolsMixin.register_debug_tools`
+and integrate with the hybrid memory store (``failure_patterns`` topic,
+§6.8.1) for recall of prior similar failures.
+
+The discipline rules that gate ``propose_fix`` (§5.9: "no fix before
+repro", "no fix before root cause", "three hypotheses minimum") live in
+:mod:`gaia.coder.debug_loop` on the sub-loop state machine — this module
+only provides the raw primitives. Tests for the mixin live in
+``tests/coder/test_debug_tools.py`` and cover each of the eight tools
+plus the mixin-registration smoke test.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shlex
+import sqlite3
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Callable, List, Mapping, Optional, Sequence, TypedDict
+
+from gaia.agents.base.tools import tool
+from gaia.coder.stores import memory as memory_store
+
+logger = logging.getLogger(__name__)
+
+#: Default timeout for subprocess commands driven by the debug tools
+#: (``repro_attempt``, ``run_with_tracing``, etc.). 5 minutes — long enough
+#: for slow test suites, short enough that a hung probe surfaces quickly.
+DEFAULT_DEBUG_TIMEOUT_S: int = 300
+
+#: Minimum repro attempts §5.9 requires before declaring "can't repro".
+#: "3 of 3" in the spec — a reproducing failure is the starting gate.
+DEFAULT_REPRO_ATTEMPTS: int = 3
+
+#: Default flake-check sample size. §5.9: "run N times; flake rate > 10%
+#: → flaky_tests topic write, not debug".
+DEFAULT_FLAKE_ATTEMPTS: int = 5
+FLAKE_RATE_THRESHOLD: float = 0.10
+
+
+# ---------------------------------------------------------------------------
+# Typed results
+# ---------------------------------------------------------------------------
+
+
+class ReproResult(TypedDict):
+    """Result shape for :func:`repro_attempt`."""
+
+    reproduced: bool
+    actual_output: str
+    match_score: float
+    returncode: int
+    attempts: int
+    attempts_reproduced: int
+    duration_ms: int
+
+
+class BisectResult(TypedDict):
+    """Result shape for :func:`git_bisect`."""
+
+    culprit_sha: Optional[str]
+    log: str
+    tested_refs: List[str]
+    returncode: int
+
+
+class TraceResult(TypedDict):
+    """Result shape for :func:`run_with_tracing`."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    trace_output: str
+    duration_ms: int
+
+
+class BehaviorDiff(TypedDict):
+    """Result shape for :func:`diff_behavior`."""
+
+    good_ref: str
+    bad_ref: str
+    good_output: str
+    bad_output: str
+    diff: str
+
+
+class PatternHit(TypedDict):
+    """One row from :func:`query_failure_patterns`."""
+
+    memory_id: str
+    stack_hash: str
+    root_cause: str
+    fix_pr_url: Optional[str]
+    similarity: float
+    confidence: int
+
+
+class FlakeResult(TypedDict):
+    """Result shape for :func:`flake_check`."""
+
+    test_fqn: str
+    attempts: int
+    passed: int
+    failed: int
+    flake_rate: float
+    is_flaky: bool
+
+
+class MinimizeResult(TypedDict):
+    """Result shape for :func:`minimize_repro`."""
+
+    minimized: str
+    original_length: int
+    minimized_length: int
+    iterations: int
+
+
+class InstrumentResult(TypedDict):
+    """Result shape for :func:`add_instrumented_trace`."""
+
+    branch: str
+    file: str
+    line: int
+    applied_message: str
+    revert_handle: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Optional[Path] = None,
+    env: Optional[Mapping[str, str]] = None,
+    timeout: int = DEFAULT_DEBUG_TIMEOUT_S,
+) -> "subprocess.CompletedProcess[str]":
+    """Run a subprocess with defaults appropriate for debug tooling.
+
+    Fail-loudly on :class:`subprocess.TimeoutExpired` (re-raised) so a
+    hung probe is surfaced rather than silently succeeding. Capture both
+    streams as text for downstream diffing.
+    """
+    return subprocess.run(  # noqa: S603 — explicit command list; inputs are tool args
+        list(command),
+        cwd=str(cwd) if cwd else None,
+        env={**os.environ, **(env or {})},
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _similarity(a: str, b: str) -> float:
+    """Return a 0-1 similarity score between two strings.
+
+    Cheap token-overlap similarity — enough to decide "did the repro output
+    match the expected failure signature?" without depending on
+    ``difflib``'s slower routines. 1.0 = identical, 0.0 = no overlap.
+    """
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    tokens_a = set(re.findall(r"\w+", a.lower()))
+    tokens_b = set(re.findall(r"\w+", b.lower()))
+    if not tokens_a or not tokens_b:
+        return 0.0
+    inter = tokens_a & tokens_b
+    union = tokens_a | tokens_b
+    return len(inter) / len(union)
+
+
+def _stable_ms() -> int:
+    """Monotonic milliseconds — used for duration fields across result dicts."""
+    return int(time.monotonic() * 1000)
+
+
+def _shell_split(command: str | Sequence[str]) -> List[str]:
+    """Normalise ``command`` to a list, shelling-splitting strings."""
+    if isinstance(command, str):
+        return shlex.split(command)
+    return list(command)
+
+
+# ---------------------------------------------------------------------------
+# The eight tools — pure functions first, then the mixin binds them to @tool.
+# ---------------------------------------------------------------------------
+
+
+def repro_attempt(
+    command: str | Sequence[str],
+    expected_failure_signature: str,
+    *,
+    attempts: int = DEFAULT_REPRO_ATTEMPTS,
+    cwd: Optional[Path] = None,
+    timeout: int = DEFAULT_DEBUG_TIMEOUT_S,
+) -> ReproResult:
+    """Run ``command`` up to ``attempts`` times, checking for the signature.
+
+    §5.9 step 1: "create a reliable repro. A flaky failure you can't repro
+    on demand is unfixable." We declare ``reproduced=True`` only when the
+    signature matches on every successful-to-fail attempt AND the match
+    score is ≥ 0.5 on at least one of them. Returns the merged output of
+    the last attempt so the hypothesise step has something to chew on.
+    """
+    if attempts < 1:
+        raise ValueError(f"repro_attempt: attempts must be >= 1 (got {attempts})")
+    start = _stable_ms()
+    argv = _shell_split(command)
+    best_output = ""
+    best_score = 0.0
+    best_rc = 0
+    hits = 0
+    for i in range(attempts):
+        completed = _run(argv, cwd=cwd, timeout=timeout)
+        merged = f"{completed.stdout}\n{completed.stderr}"
+        score = _similarity(expected_failure_signature, merged)
+        logger.debug(
+            "repro_attempt %d/%d: rc=%d score=%.2f",
+            i + 1,
+            attempts,
+            completed.returncode,
+            score,
+        )
+        if score > best_score:
+            best_score = score
+            best_output = merged
+            best_rc = completed.returncode
+        if score >= 0.5 and completed.returncode != 0:
+            hits += 1
+    reproduced = hits >= attempts and best_score >= 0.5
+    return {
+        "reproduced": reproduced,
+        "actual_output": best_output,
+        "match_score": best_score,
+        "returncode": best_rc,
+        "attempts": attempts,
+        "attempts_reproduced": hits,
+        "duration_ms": _stable_ms() - start,
+    }
+
+
+def git_bisect(
+    good_ref: str,
+    bad_ref: str,
+    repro_command: str | Sequence[str],
+    *,
+    cwd: Optional[Path] = None,
+    timeout: int = DEFAULT_DEBUG_TIMEOUT_S * 4,
+    git_runner: Optional[Callable[..., "subprocess.CompletedProcess[str]"]] = None,
+) -> BisectResult:
+    """Automated ``git bisect`` driver — returns the culprit SHA on success.
+
+    Internally runs ``git bisect start / good / bad / run <cmd>`` and
+    parses the output. The caller is expected to provide a ``repro_command``
+    that exits non-zero on the bad side and zero on the good side — the
+    standard bisect contract.
+
+    ``git_runner`` is an injection point for tests: they replace subprocess
+    calls with a deterministic stub. Production passes ``None`` and we use
+    :func:`_run`.
+    """
+    runner = git_runner or _run
+    argv_repro = _shell_split(repro_command)
+
+    tested_refs: List[str] = []
+    full_log: List[str] = []
+
+    def _git(args: Sequence[str]) -> "subprocess.CompletedProcess[str]":
+        proc = runner(["git", *args], cwd=cwd, timeout=timeout)
+        full_log.append(
+            f"$ git {' '.join(args)} (rc={proc.returncode})\n"
+            f"{proc.stdout}\n{proc.stderr}"
+        )
+        return proc
+
+    start = _git(["bisect", "start"])
+    if start.returncode != 0:
+        return {
+            "culprit_sha": None,
+            "log": "\n".join(full_log),
+            "tested_refs": tested_refs,
+            "returncode": start.returncode,
+        }
+    _git(["bisect", "bad", bad_ref])
+    _git(["bisect", "good", good_ref])
+
+    run_cmd = ["bisect", "run", *argv_repro]
+    run_proc = _git(run_cmd)
+
+    # Parse the classic bisect output line:
+    #   "<sha> is the first bad commit"
+    culprit: Optional[str] = None
+    for line in run_proc.stdout.splitlines():
+        m = re.match(r"^([0-9a-fA-F]{7,40}) is the first bad commit", line.strip())
+        if m:
+            culprit = m.group(1)
+            break
+    # Capture which refs were tested for the audit trail.
+    for line in run_proc.stdout.splitlines():
+        m = re.search(r"\[([0-9a-fA-F]{7,40})\]", line)
+        if m:
+            tested_refs.append(m.group(1))
+
+    _git(["bisect", "reset"])
+
+    return {
+        "culprit_sha": culprit,
+        "log": "\n".join(full_log),
+        "tested_refs": tested_refs,
+        "returncode": run_proc.returncode,
+    }
+
+
+def add_instrumented_trace(
+    file: str,
+    line: int,
+    message: str,
+    *,
+    cwd: Optional[Path] = None,
+    branch_prefix: str = "auto/gaia-coder-probe",
+) -> InstrumentResult:
+    """Insert a targeted ``logger.debug()`` at ``file:line`` on a scratch branch.
+
+    §5.9 "probe" step. Creates a new branch from the current HEAD, patches
+    the file in-place, and returns the branch name + a revert handle so
+    ``propose_fix`` can refuse to run until the instrumentation is cleaned
+    up.
+
+    The inserted line is always ``logger.debug(<message>)`` at the original
+    line's indentation level — not a bare ``print()`` — because the agent's
+    own linting rejects debug prints (§8 Pass 1). The caller removes the
+    trace by checking out the base branch (the ``revert_handle`` is the
+    base SHA).
+    """
+    repo_root = Path(cwd) if cwd else Path.cwd()
+    target = repo_root / file
+    if not target.exists():
+        raise FileNotFoundError(f"add_instrumented_trace: no such file {target}")
+
+    base_sha_proc = _run(["git", "rev-parse", "HEAD"], cwd=repo_root)
+    if base_sha_proc.returncode != 0:
+        raise RuntimeError(
+            f"add_instrumented_trace: could not resolve HEAD under {repo_root}: "
+            f"{base_sha_proc.stderr.strip()}"
+        )
+    base_sha = base_sha_proc.stdout.strip()
+    branch = f"{branch_prefix}-{uuid.uuid4().hex[:8]}"
+
+    checkout = _run(["git", "checkout", "-b", branch], cwd=repo_root)
+    if checkout.returncode != 0:
+        raise RuntimeError(
+            f"add_instrumented_trace: `git checkout -b {branch}` failed: "
+            f"{checkout.stderr.strip()}"
+        )
+
+    text = target.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    if line < 1 or line > len(lines) + 1:
+        raise ValueError(
+            f"add_instrumented_trace: line {line} is out of range (1..{len(lines) + 1})"
+        )
+    # Preserve indentation from the target line (or previous line if EOF).
+    template_line = lines[line - 1] if line <= len(lines) else lines[-1]
+    indent_match = re.match(r"^(\s*)", template_line)
+    indent = indent_match.group(1) if indent_match else ""
+    inserted = f"{indent}logger.debug({json.dumps(message)})  # gaia-coder probe\n"
+    new_lines = lines[: line - 1] + [inserted] + lines[line - 1 :]
+    target.write_text("".join(new_lines), encoding="utf-8")
+
+    return {
+        "branch": branch,
+        "file": file,
+        "line": line,
+        "applied_message": message,
+        "revert_handle": base_sha,
+    }
+
+
+def run_with_tracing(
+    command: str | Sequence[str],
+    trace_flags: Optional[Sequence[str]] = None,
+    *,
+    cwd: Optional[Path] = None,
+    timeout: int = DEFAULT_DEBUG_TIMEOUT_S,
+) -> TraceResult:
+    """Execute ``command`` with Python / Node tracing env vars enabled.
+
+    Sets ``PYTHONFAULTHANDLER=1`` and ``PYTHONDEVMODE=1`` by default —
+    cheap, forces more diagnostics out of :mod:`sys` and :mod:`warnings`.
+    Extra tags passed via ``trace_flags`` are appended to the command:
+
+    * ``python-dev`` → prepend ``python -X dev`` if the command starts
+      with ``python``.
+    * ``node-inspect`` → set ``NODE_OPTIONS=--inspect``.
+    """
+    argv = _shell_split(command)
+    env: dict[str, str] = {
+        "PYTHONFAULTHANDLER": "1",
+        "PYTHONDEVMODE": "1",
+    }
+    flags = list(trace_flags or [])
+    if "node-inspect" in flags:
+        env["NODE_OPTIONS"] = "--inspect"
+    if "python-dev" in flags and argv and argv[0] in ("python", "python3"):
+        argv = [argv[0], "-X", "dev", *argv[1:]]
+
+    start = _stable_ms()
+    completed = _run(argv, cwd=cwd, env=env, timeout=timeout)
+    return {
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "trace_output": completed.stderr,  # faulthandler writes to stderr
+        "duration_ms": _stable_ms() - start,
+    }
+
+
+def diff_behavior(
+    good_ref: str,
+    bad_ref: str,
+    harness_script: str | Sequence[str],
+    *,
+    cwd: Optional[Path] = None,
+    timeout: int = DEFAULT_DEBUG_TIMEOUT_S,
+) -> BehaviorDiff:
+    """Run ``harness_script`` on ``good_ref`` and ``bad_ref``; return a diff.
+
+    §5.9 tool: used when bisection is too coarse (e.g. failures coupled to
+    a build artifact). We ``git stash`` the working tree, check out each
+    ref, run the harness, collect stdout+stderr, then restore HEAD via
+    ``git switch -`` and pop the stash.
+
+    The diff is computed with :mod:`difflib.unified_diff` so the caller
+    can render it as a patch-style summary.
+    """
+    import difflib
+
+    repo_root = Path(cwd) if cwd else Path.cwd()
+    argv = _shell_split(harness_script)
+
+    # Stash first to keep the working tree clean.
+    stash = _run(
+        ["git", "stash", "push", "--include-untracked", "-m", "gaia-coder-debug"],
+        cwd=repo_root,
+    )
+    stashed = stash.returncode == 0 and "No local changes" not in (
+        stash.stdout + stash.stderr
+    )
+
+    def _run_on(ref: str) -> str:
+        co = _run(["git", "switch", "--detach", ref], cwd=repo_root)
+        if co.returncode != 0:
+            raise RuntimeError(
+                f"diff_behavior: could not switch to {ref}: {co.stderr.strip()}"
+            )
+        proc = _run(argv, cwd=repo_root, timeout=timeout)
+        return f"{proc.stdout}\n{proc.stderr}"
+
+    try:
+        good_output = _run_on(good_ref)
+        bad_output = _run_on(bad_ref)
+    finally:
+        _run(["git", "switch", "-"], cwd=repo_root)
+        if stashed:
+            _run(["git", "stash", "pop"], cwd=repo_root)
+
+    diff = "".join(
+        difflib.unified_diff(
+            good_output.splitlines(keepends=True),
+            bad_output.splitlines(keepends=True),
+            fromfile=f"output@{good_ref}",
+            tofile=f"output@{bad_ref}",
+            n=3,
+        )
+    )
+    return {
+        "good_ref": good_ref,
+        "bad_ref": bad_ref,
+        "good_output": good_output,
+        "bad_output": bad_output,
+        "diff": diff,
+    }
+
+
+def query_failure_patterns(
+    error_signature: str,
+    *,
+    memory_conn: sqlite3.Connection,
+    limit: int = 5,
+) -> List[PatternHit]:
+    """Look up prior failures with a similar error signature.
+
+    Wraps :func:`gaia.coder.stores.memory.list_rows` filtered to the
+    ``failure_patterns`` topic and ranks by token-similarity against
+    ``error_signature``. Until FAISS lands in Phase 10 this is the
+    retrieval path the memory topic exposes — it is intentionally
+    conservative (exact-token recall) so we do not return spurious
+    matches.
+    """
+    all_rows = memory_store.list_rows(memory_conn, filter={"topic": "failure_patterns"})
+    hits: List[PatternHit] = []
+    for row in all_rows:
+        try:
+            payload = json.loads(row.payload_json)
+        except json.JSONDecodeError:
+            continue
+        stack_hash = str(payload.get("stack_hash", ""))
+        recorded_signature = str(payload.get("error_signature", ""))
+        score = max(
+            _similarity(error_signature, recorded_signature),
+            _similarity(error_signature, stack_hash),
+        )
+        if score <= 0.0:
+            continue
+        hits.append(
+            {
+                "memory_id": row.id,
+                "stack_hash": stack_hash,
+                "root_cause": str(payload.get("root_cause", "")),
+                "fix_pr_url": payload.get("fix_pr_url"),
+                "similarity": score,
+                "confidence": int(row.confidence),
+            }
+        )
+    hits.sort(key=lambda h: h["similarity"], reverse=True)
+    return hits[:limit]
+
+
+def flake_check(
+    test_fqn: str,
+    *,
+    attempts: int = DEFAULT_FLAKE_ATTEMPTS,
+    cwd: Optional[Path] = None,
+    timeout: int = DEFAULT_DEBUG_TIMEOUT_S,
+    runner: Optional[Callable[[str, int, Optional[Path]], int]] = None,
+) -> FlakeResult:
+    """Run a single test N times; compute the flake rate.
+
+    ``test_fqn`` is the pytest FQN (e.g. ``tests/coder/test_foo.py::test_bar``).
+    ``runner`` is an injection point for tests — it accepts
+    ``(test_fqn, attempt_index, cwd)`` and returns the process exit code.
+    Production omits it and we run ``pytest <fqn> -x`` under ``_run``.
+
+    Flake rate above :data:`FLAKE_RATE_THRESHOLD` flips ``is_flaky`` on;
+    the caller writes to the ``flaky_tests`` topic rather than pursuing
+    debug.
+    """
+    if attempts < 1:
+        raise ValueError(f"flake_check: attempts must be >= 1 (got {attempts})")
+
+    def _default_runner(fqn: str, _idx: int, workdir: Optional[Path]) -> int:
+        # ``_idx`` is required by the runner contract (flake_check also
+        # accepts test-injected runners that key off the attempt number);
+        # the default implementation ignores it.
+        return _run(
+            ["pytest", fqn, "-x", "--no-header", "-q"],
+            cwd=workdir,
+            timeout=timeout,
+        ).returncode
+
+    use_runner = runner or _default_runner
+    passed = 0
+    failed = 0
+    for i in range(attempts):
+        rc = use_runner(test_fqn, i, cwd)
+        if rc == 0:
+            passed += 1
+        else:
+            failed += 1
+    flake_rate = 0.0
+    if attempts > 0 and 0 < passed < attempts:
+        # A test that neither always passes nor always fails is flaky.
+        flake_rate = min(passed, failed) / attempts
+    return {
+        "test_fqn": test_fqn,
+        "attempts": attempts,
+        "passed": passed,
+        "failed": failed,
+        "flake_rate": flake_rate,
+        "is_flaky": flake_rate > FLAKE_RATE_THRESHOLD,
+    }
+
+
+def minimize_repro(
+    command: str | Sequence[str],
+    repro_input: str,
+    *,
+    reproducer: Optional[Callable[[str], bool]] = None,
+    cwd: Optional[Path] = None,
+    timeout: int = DEFAULT_DEBUG_TIMEOUT_S,
+    max_iterations: int = 32,
+) -> MinimizeResult:
+    """Binary-search ``repro_input`` down to a minimal version that still repros.
+
+    §5.9 tool: the "2000-char input becomes a 20-char one" case. The loop
+    drops half of the input at each step and verifies the result still
+    reproduces via ``reproducer``. When ``reproducer`` is None we fall back
+    to running ``command`` with ``repro_input`` piped to stdin — production
+    usage.
+
+    The caller is responsible for ensuring the reproducer is deterministic.
+    """
+    if not repro_input:
+        return {
+            "minimized": "",
+            "original_length": 0,
+            "minimized_length": 0,
+            "iterations": 0,
+        }
+
+    def _default_reproducer(candidate: str) -> bool:
+        argv = _shell_split(command)
+        proc = subprocess.run(  # noqa: S603
+            argv,
+            input=candidate,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return proc.returncode != 0
+
+    check = reproducer or _default_reproducer
+    if not check(repro_input):
+        raise ValueError(
+            "minimize_repro: the original input does not reproduce the failure; "
+            "nothing to minimise."
+        )
+
+    current = repro_input
+    iterations = 0
+    while iterations < max_iterations:
+        iterations += 1
+        if len(current) <= 1:
+            break
+        mid = len(current) // 2
+        left, right = current[:mid], current[mid:]
+        if check(left):
+            current = left
+            continue
+        if check(right):
+            current = right
+            continue
+        break
+    return {
+        "minimized": current,
+        "original_length": len(repro_input),
+        "minimized_length": len(current),
+        "iterations": iterations,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mixin registration
+# ---------------------------------------------------------------------------
+
+
+class DebugToolsMixin:
+    """Register the eight §5.9 debug tools on an agent.
+
+    The mixin is stateless — each tool is a @tool-decorated closure that
+    delegates to the pure helpers above. Call
+    :meth:`register_debug_tools` during agent bootstrap; it returns the
+    list of registered tool names so the smoke test can assert the
+    eight-tool contract.
+    """
+
+    def register_debug_tools(self) -> List[str]:
+        """Register the debug tools and return their names in §5.9 order."""
+        registered: List[str] = []
+
+        @tool
+        def repro_attempt_tool(
+            command: str,
+            expected_failure_signature: str,
+            attempts: int = DEFAULT_REPRO_ATTEMPTS,
+            cwd: Optional[str] = None,
+        ) -> ReproResult:
+            """Run ``command`` up to ``attempts`` times, matching the signature."""
+            return repro_attempt(
+                command,
+                expected_failure_signature,
+                attempts=attempts,
+                cwd=Path(cwd) if cwd else None,
+            )
+
+        registered.append("repro_attempt")
+
+        @tool
+        def git_bisect_tool(
+            good_ref: str,
+            bad_ref: str,
+            repro_command: str,
+            cwd: Optional[str] = None,
+        ) -> BisectResult:
+            """Drive ``git bisect`` between ``good_ref`` and ``bad_ref``."""
+            return git_bisect(
+                good_ref,
+                bad_ref,
+                repro_command,
+                cwd=Path(cwd) if cwd else None,
+            )
+
+        registered.append("git_bisect")
+
+        @tool
+        def add_instrumented_trace_tool(
+            file: str,
+            line: int,
+            message: str,
+            cwd: Optional[str] = None,
+        ) -> InstrumentResult:
+            """Insert a ``logger.debug`` probe at file:line on a scratch branch."""
+            return add_instrumented_trace(
+                file,
+                line,
+                message,
+                cwd=Path(cwd) if cwd else None,
+            )
+
+        registered.append("add_instrumented_trace")
+
+        @tool
+        def run_with_tracing_tool(
+            command: str,
+            trace_flags: Optional[List[str]] = None,
+            cwd: Optional[str] = None,
+        ) -> TraceResult:
+            """Run ``command`` with Python/Node tracing enabled."""
+            return run_with_tracing(
+                command,
+                trace_flags=trace_flags,
+                cwd=Path(cwd) if cwd else None,
+            )
+
+        registered.append("run_with_tracing")
+
+        @tool
+        def diff_behavior_tool(
+            good_ref: str,
+            bad_ref: str,
+            harness_script: str,
+            cwd: Optional[str] = None,
+        ) -> BehaviorDiff:
+            """Run ``harness_script`` on each ref; return a unified diff."""
+            return diff_behavior(
+                good_ref,
+                bad_ref,
+                harness_script,
+                cwd=Path(cwd) if cwd else None,
+            )
+
+        registered.append("diff_behavior")
+
+        @tool
+        def query_failure_patterns_tool(
+            error_signature: str,
+            memory_db_path: str,
+            limit: int = 5,
+        ) -> List[PatternHit]:
+            """Memory lookup against the ``failure_patterns`` topic."""
+            conn = memory_store.open_store(Path(memory_db_path))
+            try:
+                return query_failure_patterns(
+                    error_signature, memory_conn=conn, limit=limit
+                )
+            finally:
+                conn.close()
+
+        registered.append("query_failure_patterns")
+
+        @tool
+        def flake_check_tool(
+            test_fqn: str,
+            attempts: int = DEFAULT_FLAKE_ATTEMPTS,
+            cwd: Optional[str] = None,
+        ) -> FlakeResult:
+            """Run ``test_fqn`` ``attempts`` times and compute flake rate."""
+            return flake_check(
+                test_fqn,
+                attempts=attempts,
+                cwd=Path(cwd) if cwd else None,
+            )
+
+        registered.append("flake_check")
+
+        @tool
+        def minimize_repro_tool(
+            command: str,
+            repro_input: str,
+            max_iterations: int = 32,
+            cwd: Optional[str] = None,
+        ) -> MinimizeResult:
+            """Binary-search ``repro_input`` down to a minimal reproducer."""
+            return minimize_repro(
+                command,
+                repro_input,
+                max_iterations=max_iterations,
+                cwd=Path(cwd) if cwd else None,
+            )
+
+        registered.append("minimize_repro")
+
+        logger.info(
+            "DebugToolsMixin.register_debug_tools: registered %d tools",
+            len(registered),
+        )
+        return registered
+
+
+__all__ = [
+    "BehaviorDiff",
+    "BisectResult",
+    "DEFAULT_DEBUG_TIMEOUT_S",
+    "DEFAULT_FLAKE_ATTEMPTS",
+    "DEFAULT_REPRO_ATTEMPTS",
+    "DebugToolsMixin",
+    "FLAKE_RATE_THRESHOLD",
+    "FlakeResult",
+    "InstrumentResult",
+    "MinimizeResult",
+    "PatternHit",
+    "ReproResult",
+    "TraceResult",
+    "add_instrumented_trace",
+    "diff_behavior",
+    "flake_check",
+    "git_bisect",
+    "minimize_repro",
+    "query_failure_patterns",
+    "repro_attempt",
+    "run_with_tracing",
+]

--- a/tests/coder/test_debug_loop.py
+++ b/tests/coder/test_debug_loop.py
@@ -1,0 +1,289 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for :mod:`gaia.coder.debug_loop` (§5.9)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+from gaia.coder.debug_loop import (
+    MAX_DEBUG_ROUNDS,
+    MIN_HYPOTHESES,
+    PROPOSE_FIX_CONFIDENCE_THRESHOLD,
+    DebugContext,
+    DebugDisciplineError,
+    DebugState,
+    DebugSubLoop,
+    Hypothesis,
+)
+from gaia.coder.stores import feedback as feedback_store
+from gaia.coder.stores import memory as memory_store
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _ctx(**kwargs) -> DebugContext:
+    return DebugContext(
+        task_id=kwargs.pop("task_id", "t1"),
+        feedback_id=kwargs.pop("feedback_id", ""),
+        error_signature=kwargs.pop("error_signature", "KeyError"),
+        repro_command=kwargs.pop("repro_command", "pytest"),
+        **kwargs,
+    )
+
+
+def _good_repro_fn(**kw):
+    return {
+        "reproduced": True,
+        "attempts": 3,
+        "attempts_reproduced": 3,
+        "actual_output": "KeyError: user_id",
+        "match_score": 0.9,
+    }
+
+
+def _bad_repro_fn(**kw):
+    return {
+        "reproduced": False,
+        "attempts": 3,
+        "attempts_reproduced": 1,
+        "actual_output": "nope",
+        "match_score": 0.1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# reproduce
+# ---------------------------------------------------------------------------
+
+
+def test_reproduce_happy_path_advances_to_bisect():
+    loop = DebugSubLoop(context=_ctx(), repro_fn=_good_repro_fn)
+    next_state = loop.reproduce()
+    assert next_state == DebugState.BISECT
+    assert loop.context.reproduced is True
+
+
+def test_reproduce_raises_when_not_reproduced():
+    loop = DebugSubLoop(context=_ctx(), repro_fn=_bad_repro_fn)
+    with pytest.raises(DebugDisciplineError, match="I cannot reproduce"):
+        loop.reproduce()
+
+
+def test_reproduce_missing_fn_raises():
+    loop = DebugSubLoop(context=_ctx())
+    with pytest.raises(DebugDisciplineError, match="no repro_fn wired"):
+        loop.reproduce()
+
+
+# ---------------------------------------------------------------------------
+# bisect
+# ---------------------------------------------------------------------------
+
+
+def test_bisect_advances_to_hypothesise():
+    def fake_bisect(**kw):
+        return {"culprit_sha": "abc123", "log": "..."}
+
+    loop = DebugSubLoop(context=_ctx(), repro_fn=_good_repro_fn, bisect_fn=fake_bisect)
+    assert loop.bisect("HEAD~10", "HEAD") == DebugState.HYPOTHESISE
+    assert loop.context.culprit_sha == "abc123"
+
+
+def test_bisect_can_be_skipped():
+    loop = DebugSubLoop(context=_ctx())
+    assert loop.bisect("a", "b", skip=True) == DebugState.HYPOTHESISE
+    assert loop.context.bisect_skipped is True
+
+
+# ---------------------------------------------------------------------------
+# hypothesise — discipline rule 3
+# ---------------------------------------------------------------------------
+
+
+def test_hypothesise_requires_three():
+    loop = DebugSubLoop(context=_ctx())
+    with pytest.raises(DebugDisciplineError, match=f">= {MIN_HYPOTHESES}"):
+        loop.hypothesise([Hypothesis("only one")])
+
+
+def test_hypothesise_accepts_three():
+    loop = DebugSubLoop(context=_ctx())
+    hyps = [Hypothesis(f"hyp{i}") for i in range(MIN_HYPOTHESES)]
+    assert loop.hypothesise(hyps) == DebugState.PROBE
+    assert len(loop.context.hypotheses) == MIN_HYPOTHESES
+
+
+# ---------------------------------------------------------------------------
+# probe
+# ---------------------------------------------------------------------------
+
+
+def test_probe_advances_to_localise_when_confidence_tips():
+    """A probe that boosts one hypothesis past the threshold → LOCALISE_BUG."""
+
+    def probe_fn(hyp: Hypothesis, ctx: DebugContext) -> Tuple[bool, str, int]:
+        if hyp.text == "correct":
+            return (True, "experiment confirms", 90)
+        return (False, "refuted", 5)
+
+    loop = DebugSubLoop(context=_ctx(), probe_fn=probe_fn)
+    loop.context.hypotheses = [
+        Hypothesis("wrong-a"),
+        Hypothesis("correct"),
+        Hypothesis("wrong-b"),
+    ]
+    assert loop.probe() == DebugState.LOCALISE_BUG
+
+
+def test_probe_returns_to_hypothesise_when_inconclusive():
+    def probe_fn(hyp, ctx):
+        return (False, "flat", 10)
+
+    loop = DebugSubLoop(context=_ctx(), probe_fn=probe_fn)
+    loop.context.hypotheses = [Hypothesis(f"h{i}") for i in range(3)]
+    assert loop.probe() == DebugState.HYPOTHESISE
+
+
+def test_probe_enforces_round_cap():
+    """> MAX_DEBUG_ROUNDS → DebugDisciplineError."""
+    loop = DebugSubLoop(context=_ctx(), probe_fn=lambda h, c: (False, "", 0))
+    loop.context.hypotheses = [Hypothesis("h") for _ in range(3)]
+    loop.context.round_count = MAX_DEBUG_ROUNDS  # next probe will exceed
+    with pytest.raises(DebugDisciplineError, match="exceeded MAX_DEBUG_ROUNDS"):
+        loop.probe()
+
+
+# ---------------------------------------------------------------------------
+# propose_fix — discipline rules 1 & 2
+# ---------------------------------------------------------------------------
+
+
+def test_propose_fix_refuses_without_reproduce():
+    """Discipline rule 1."""
+    loop = DebugSubLoop(context=_ctx())
+    loop.context.hypotheses = [
+        Hypothesis("h", confidence=PROPOSE_FIX_CONFIDENCE_THRESHOLD + 5)
+    ]
+    with pytest.raises(
+        DebugDisciplineError, match="reproduce did not return reproduced=True"
+    ):
+        loop.propose_fix(summary="...")
+
+
+def test_propose_fix_refuses_below_confidence_threshold():
+    """Discipline rule 2."""
+    ctx = _ctx()
+    ctx.reproduced = True
+    ctx.hypotheses = [Hypothesis("maybe", confidence=50)]
+    loop = DebugSubLoop(context=ctx)
+    with pytest.raises(
+        DebugDisciplineError, match=f"< {PROPOSE_FIX_CONFIDENCE_THRESHOLD}%"
+    ):
+        loop.propose_fix(summary="shotgun attempt")
+
+
+def test_propose_fix_shotgun_override_requires_em_elevation():
+    ctx = _ctx()
+    ctx.reproduced = True
+    ctx.hypotheses = [Hypothesis("maybe", confidence=40)]
+    loop = DebugSubLoop(context=ctx, em_elevation_granted=False)
+    with pytest.raises(DebugDisciplineError, match="Pass shotgun=True AND"):
+        loop.propose_fix(summary="x", shotgun=True)
+
+
+def test_propose_fix_shotgun_with_elevation_allows_low_confidence():
+    ctx = _ctx()
+    ctx.reproduced = True
+    ctx.hypotheses = [Hypothesis("maybe", confidence=40)]
+    loop = DebugSubLoop(context=ctx, em_elevation_granted=True)
+    next_state = loop.propose_fix(summary="x", shotgun=True)
+    assert next_state == DebugState.POSTMORTEM
+    assert ctx.shotgun is True
+
+
+def test_propose_fix_happy_path():
+    ctx = _ctx()
+    ctx.reproduced = True
+    ctx.hypotheses = [
+        Hypothesis("solid", confidence=PROPOSE_FIX_CONFIDENCE_THRESHOLD + 5)
+    ]
+    loop = DebugSubLoop(context=ctx)
+    assert loop.propose_fix(summary="fix it") == DebugState.POSTMORTEM
+    assert ctx.fix_summary == "fix it"
+
+
+# ---------------------------------------------------------------------------
+# postmortem
+# ---------------------------------------------------------------------------
+
+
+def test_postmortem_writes_to_memory_and_feedback(tmp_path: Path):
+    """feedback row + memory row both updated."""
+    memory_conn = memory_store.open_store(tmp_path / "memory.db")
+    feedback_conn = feedback_store.open_store(tmp_path / "feedback.db")
+    try:
+        # Seed the feedback row the postmortem will update.
+        feedback_id = "fb-1"
+        feedback_store.insert_row(
+            feedback_conn,
+            feedback_store.FeedbackRow(
+                id=feedback_id,
+                received_at="2026-04-20T00:00:00Z",
+                from_handle="em",
+                channel="cli",
+                severity="high",
+                body="...",
+            ),
+        )
+        ctx = _ctx(feedback_id=feedback_id)
+        ctx.reproduced = True
+        ctx.hypotheses = [Hypothesis("solid", confidence=95)]
+        ctx.fix_summary = "one-line fix"
+        ctx.localised_file = "src/x.py"
+        loop = DebugSubLoop(context=ctx)
+        loop.postmortem(
+            feedback_conn=feedback_conn,
+            memory_conn=memory_conn,
+            fix_pr_url="https://pr/1",
+        )
+
+        mem_rows = memory_store.list_rows(
+            memory_conn, filter={"topic": "failure_patterns"}
+        )
+        fb_row = feedback_store.get_row(feedback_conn, feedback_id)
+    finally:
+        memory_conn.close()
+        feedback_conn.close()
+
+    assert len(mem_rows) == 1
+    payload = json.loads(mem_rows[0].payload_json)
+    assert payload["root_cause"] == "solid"
+    assert payload["fix_pr_url"] == "https://pr/1"
+
+    notes = json.loads(fb_row.notes_json)
+    assert any(n["stage"] == "postmortem" for n in notes)
+    assert loop.context.postmortem_written is True
+
+
+def test_postmortem_requires_propose_fix_to_have_run():
+    loop = DebugSubLoop(context=_ctx())
+    with pytest.raises(DebugDisciplineError, match="before propose_fix"):
+        loop.postmortem()
+
+
+def test_require_postmortem_or_raise():
+    """§5.9 rule 5 — closing without postmortem is blocked."""
+    loop = DebugSubLoop(context=_ctx())
+    with pytest.raises(DebugDisciplineError, match="refuse to close"):
+        loop.require_postmortem_or_raise()
+
+    loop.context.postmortem_written = True
+    loop.require_postmortem_or_raise()  # no longer raises

--- a/tests/coder/test_debug_tools.py
+++ b/tests/coder/test_debug_tools.py
@@ -1,0 +1,349 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for :mod:`gaia.coder.tools.debug` (§5.9).
+
+Each of the eight tools has its own unit test plus a smoke test for the
+mixin. External subprocess calls (``subprocess.run``) are stubbed via
+monkeypatching to keep these tests hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from gaia.coder.stores import memory as memory_store
+from gaia.coder.tools import debug as debug_tools
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompleted:
+    """Stand-in for :class:`subprocess.CompletedProcess`."""
+
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+# ---------------------------------------------------------------------------
+# repro_attempt
+# ---------------------------------------------------------------------------
+
+
+def test_repro_attempt_reproduced_on_all_attempts(monkeypatch):
+    """Signature matches every run → reproduced=True."""
+
+    def fake_run(argv, **kw):
+        return _FakeCompleted(stdout="KeyError: user_id", returncode=1)
+
+    monkeypatch.setattr(debug_tools, "_run", fake_run)
+    result = debug_tools.repro_attempt(
+        "pytest tests/", expected_failure_signature="KeyError user_id", attempts=3
+    )
+    assert result["reproduced"] is True
+    assert result["attempts"] == 3
+    assert result["attempts_reproduced"] == 3
+    assert result["match_score"] > 0.5
+
+
+def test_repro_attempt_not_reproduced_when_signature_mismatches(monkeypatch):
+    def fake_run(argv, **kw):
+        return _FakeCompleted(stdout="totally unrelated error", returncode=1)
+
+    monkeypatch.setattr(debug_tools, "_run", fake_run)
+    result = debug_tools.repro_attempt("pytest", "KeyError user_id", attempts=3)
+    assert result["reproduced"] is False
+    assert result["attempts_reproduced"] == 0
+
+
+def test_repro_attempt_zero_attempts_raises():
+    with pytest.raises(ValueError, match="attempts must be >= 1"):
+        debug_tools.repro_attempt("cmd", "sig", attempts=0)
+
+
+# ---------------------------------------------------------------------------
+# git_bisect
+# ---------------------------------------------------------------------------
+
+
+def test_git_bisect_parses_first_bad_commit(monkeypatch):
+    """The bisect-run output line is parsed into culprit_sha."""
+
+    def fake_runner(argv, **kw):
+        if argv[:2] == ["git", "bisect"] and "run" in argv:
+            return _FakeCompleted(
+                stdout=(
+                    "[deadbeefcafe1234567890abcdef1234567890ab] running tests\n"
+                    "deadbeefcafe1234567890abcdef1234567890ab is the first bad commit\n"
+                ),
+                returncode=0,
+            )
+        return _FakeCompleted(returncode=0)
+
+    result = debug_tools.git_bisect(
+        "HEAD~10", "HEAD", "pytest -x", git_runner=fake_runner
+    )
+    assert result["culprit_sha"] == "deadbeefcafe1234567890abcdef1234567890ab"
+    assert "first bad commit" in result["log"]
+    assert len(result["tested_refs"]) >= 1
+
+
+def test_git_bisect_returns_none_on_failure(monkeypatch):
+    def fake_runner(argv, **kw):
+        if "start" in argv:
+            return _FakeCompleted(stderr="not a git repo", returncode=128)
+        return _FakeCompleted(returncode=0)
+
+    result = debug_tools.git_bisect("a", "b", "cmd", git_runner=fake_runner)
+    assert result["culprit_sha"] is None
+    assert result["returncode"] == 128
+
+
+# ---------------------------------------------------------------------------
+# add_instrumented_trace
+# ---------------------------------------------------------------------------
+
+
+def test_add_instrumented_trace_inserts_logger_debug(tmp_path, monkeypatch):
+    """The probe adds a logger.debug line at the indicated position."""
+    target = tmp_path / "mymod.py"
+    target.write_text("def foo():\n    return 1\n")
+
+    calls = {"branch_created": False, "head_resolved": False}
+
+    def fake_run(argv, **kw):
+        if argv[:3] == ["git", "rev-parse", "HEAD"]:
+            calls["head_resolved"] = True
+            return _FakeCompleted(stdout="abc123\n", returncode=0)
+        if argv[:3] == ["git", "checkout", "-b"]:
+            calls["branch_created"] = True
+            return _FakeCompleted(returncode=0)
+        return _FakeCompleted(returncode=0)
+
+    monkeypatch.setattr(debug_tools, "_run", fake_run)
+    result = debug_tools.add_instrumented_trace(
+        "mymod.py", 2, "probe message", cwd=tmp_path
+    )
+    text = target.read_text()
+    assert "logger.debug" in text
+    assert "probe message" in text
+    assert calls["head_resolved"] and calls["branch_created"]
+    assert result["revert_handle"] == "abc123"
+    assert result["branch"].startswith("auto/gaia-coder-probe-")
+
+
+def test_add_instrumented_trace_missing_file_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(debug_tools, "_run", lambda *a, **k: _FakeCompleted())
+    with pytest.raises(FileNotFoundError):
+        debug_tools.add_instrumented_trace("nope.py", 1, "msg", cwd=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# run_with_tracing
+# ---------------------------------------------------------------------------
+
+
+def test_run_with_tracing_sets_faulthandler(monkeypatch):
+    captured_env = {}
+
+    def fake_run(argv, cwd=None, env=None, timeout=0):
+        captured_env.update(env or {})
+        return _FakeCompleted(stdout="ok", stderr="trace goes here")
+
+    monkeypatch.setattr(debug_tools, "_run", fake_run)
+    result = debug_tools.run_with_tracing(
+        "python script.py", trace_flags=["python-dev"]
+    )
+    assert captured_env["PYTHONFAULTHANDLER"] == "1"
+    assert captured_env["PYTHONDEVMODE"] == "1"
+    assert result["trace_output"] == "trace goes here"
+
+
+def test_run_with_tracing_prepends_X_dev(monkeypatch):
+    captured_argv = []
+
+    def fake_run(argv, cwd=None, env=None, timeout=0):
+        captured_argv.extend(argv)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(debug_tools, "_run", fake_run)
+    debug_tools.run_with_tracing("python foo.py", trace_flags=["python-dev"])
+    assert captured_argv[:3] == ["python", "-X", "dev"]
+
+
+# ---------------------------------------------------------------------------
+# diff_behavior
+# ---------------------------------------------------------------------------
+
+
+def test_diff_behavior_returns_unified_diff(monkeypatch, tmp_path):
+    """good/bad outputs differ → diff string includes @@ markers."""
+    sequence = iter(
+        [
+            _FakeCompleted(stdout="stashed\n"),  # stash push
+            _FakeCompleted(returncode=0),  # switch good
+            _FakeCompleted(stdout="pass 42\n", returncode=0),  # good harness
+            _FakeCompleted(returncode=0),  # switch bad
+            _FakeCompleted(stdout="fail 42\n", returncode=1),  # bad harness
+            _FakeCompleted(returncode=0),  # switch -
+            _FakeCompleted(returncode=0),  # stash pop
+        ]
+    )
+
+    def fake_run(argv, **kw):
+        return next(sequence)
+
+    monkeypatch.setattr(debug_tools, "_run", fake_run)
+    result = debug_tools.diff_behavior("goodref", "badref", "./harness", cwd=tmp_path)
+    assert "pass 42" in result["good_output"]
+    assert "fail 42" in result["bad_output"]
+    assert "@@" in result["diff"]
+
+
+# ---------------------------------------------------------------------------
+# query_failure_patterns
+# ---------------------------------------------------------------------------
+
+
+def test_query_failure_patterns_ranks_by_similarity(tmp_path):
+    """Similar signatures rank higher; exact-match beats partial."""
+    conn = memory_store.open_store(tmp_path / "memory.db")
+    try:
+        for i, sig in enumerate(
+            ["KeyError user_id missing", "IndexError bounds", "AttributeError"]
+        ):
+            row = memory_store.MemoryRow(
+                id=str(uuid.uuid4()),
+                topic="failure_patterns",
+                created_at=f"2026-01-0{i + 1}T00:00:00Z",
+                source_kind="feedback",
+                payload_json=json.dumps(
+                    {
+                        "error_signature": sig,
+                        "stack_hash": f"hash{i}",
+                        "root_cause": f"cause{i}",
+                        "fix_pr_url": f"https://pr/{i}",
+                    }
+                ),
+                embedding_key=f"hash{i}",
+                confidence=80,
+            )
+            memory_store.insert_row(conn, row)
+
+        hits = debug_tools.query_failure_patterns(
+            "KeyError user_id missing", memory_conn=conn, limit=5
+        )
+    finally:
+        conn.close()
+
+    assert hits
+    # Exact-match signature should be first.
+    assert "cause0" in hits[0]["root_cause"]
+    assert hits[0]["similarity"] >= hits[-1]["similarity"]
+
+
+def test_query_failure_patterns_empty_when_no_rows(tmp_path):
+    conn = memory_store.open_store(tmp_path / "memory.db")
+    try:
+        hits = debug_tools.query_failure_patterns("anything", memory_conn=conn)
+    finally:
+        conn.close()
+    assert hits == []
+
+
+# ---------------------------------------------------------------------------
+# flake_check
+# ---------------------------------------------------------------------------
+
+
+def test_flake_check_detects_flaky_test():
+    """3 pass / 2 fail out of 5 → flake_rate=0.4, is_flaky=True."""
+    outcomes = iter([0, 1, 0, 1, 0])  # pass, fail, pass, fail, pass
+
+    def runner(fqn, idx, cwd):
+        return next(outcomes)
+
+    result = debug_tools.flake_check(
+        "tests/test_x.py::test_y", attempts=5, runner=runner
+    )
+    assert result["passed"] == 3
+    assert result["failed"] == 2
+    assert result["flake_rate"] == pytest.approx(0.4)
+    assert result["is_flaky"] is True
+
+
+def test_flake_check_all_pass_not_flaky():
+    result = debug_tools.flake_check("t", attempts=3, runner=lambda *a: 0)
+    assert result["is_flaky"] is False
+    assert result["flake_rate"] == 0.0
+
+
+def test_flake_check_all_fail_not_flaky():
+    """All-fail is a real bug, not a flake (mirrors §5.9)."""
+    result = debug_tools.flake_check("t", attempts=3, runner=lambda *a: 1)
+    assert result["is_flaky"] is False
+
+
+# ---------------------------------------------------------------------------
+# minimize_repro
+# ---------------------------------------------------------------------------
+
+
+def test_minimize_repro_halves_input():
+    """A deterministic reproducer narrows to a small prefix."""
+
+    def reproducer(candidate: str) -> bool:
+        # "B" appears exactly once in the original; each successful halving
+        # MUST preserve it for the binary search to make progress.
+        return "B" in candidate
+
+    result = debug_tools.minimize_repro(
+        "cmd", "xxxxxxxxxxxxxxxxB", reproducer=reproducer
+    )
+    assert "B" in result["minimized"]
+    assert result["minimized_length"] < result["original_length"]
+    assert result["iterations"] >= 1
+
+
+def test_minimize_repro_refuses_non_reproducer():
+    with pytest.raises(ValueError, match="does not reproduce"):
+        debug_tools.minimize_repro("cmd", "nothing-matches", reproducer=lambda c: False)
+
+
+def test_minimize_repro_empty_input():
+    result = debug_tools.minimize_repro("cmd", "", reproducer=lambda c: True)
+    assert result["minimized"] == ""
+    assert result["iterations"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Mixin smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_debug_tools_mixin_registers_all_eight():
+    """register_debug_tools returns exactly the eight §5.9 tool names."""
+
+    class _Agent(debug_tools.DebugToolsMixin):
+        pass
+
+    agent = _Agent()
+    registered = agent.register_debug_tools()
+    assert set(registered) == {
+        "repro_attempt",
+        "git_bisect",
+        "add_instrumented_trace",
+        "run_with_tracing",
+        "diff_behavior",
+        "query_failure_patterns",
+        "flake_check",
+        "minimize_repro",
+    }
+    assert len(registered) == 8

--- a/tests/coder/test_dev_mode.py
+++ b/tests/coder/test_dev_mode.py
@@ -1,0 +1,367 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for :mod:`gaia.coder.dev_mode` (§7.1).
+
+The hard precondition is ``editable-install + matching origin`` — our
+fixture gives us a tmp git repo initialised with a fake origin remote. The
+soft gate is ``em.toml``; ``session.json`` lives under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gaia.coder import dev_mode, trust
+from gaia.coder.stores import audit as audit_store
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """Initialise a tmp git repo with a bogus origin URL and return the root.
+
+    The repo contains a single committed file so ``git rev-parse`` returns a
+    valid toplevel. The origin remote points at ``git@github.com:amd/gaia.git``
+    so tests exercise the "matching origin" branch by default.
+    """
+    subprocess.run(
+        ["git", "init", "-q", str(tmp_path)], check=True, capture_output=True
+    )
+    (tmp_path / "README.md").write_text("stub")
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "add", "README.md"],
+        check=True,
+        capture_output=True,
+    )
+    # Git refuses to commit without a user.email/name — set them locally so
+    # the fixture is hermetic.
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "-c",
+            "user.email=test@test",
+            "-c",
+            "user.name=test",
+            "commit",
+            "-qm",
+            "init",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:amd/gaia.git",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def repo_binding_toml(tmp_path: Path) -> Path:
+    """Write a minimal repo_binding.toml under tmp_path."""
+    path = tmp_path / "repo_binding.toml"
+    path.write_text("""
+repo = "amd/gaia"
+github_app_id = 12345
+github_installation_id = 67890
+webhook_secret_keyring_slot = "gaia-coder/webhook"
+private_key_keyring_slot = "gaia-coder/pem"
+""".strip())
+    return path
+
+
+@pytest.fixture
+def em_cfg_off(tmp_path: Path) -> Path:
+    """em.toml with dev_mode_self_edit=false."""
+    path = tmp_path / "em.toml"
+    cfg = trust.EMConfig(
+        em_handle="kovtcharov-amd",
+        em_channel="github-issue-comment",
+        dev_mode_self_edit=False,
+    )
+    trust.save_em_config(path, cfg)
+    return path
+
+
+@pytest.fixture
+def em_cfg_on(tmp_path: Path) -> Path:
+    """em.toml with dev_mode_self_edit=true."""
+    path = tmp_path / "em.toml"
+    cfg = trust.EMConfig(
+        em_handle="kovtcharov-amd",
+        em_channel="github-issue-comment",
+        dev_mode_self_edit=True,
+        dev_mode_enabled_at="2026-04-20T00:00:00Z",
+        dev_mode_enabled_reason="test",
+    )
+    trust.save_em_config(path, cfg)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# detect_dev_mode
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_false_when_not_in_git_repo(
+    tmp_path: Path,
+    em_cfg_off: Path,
+    repo_binding_toml: Path,
+):
+    """No git repo at all → editable_install=False."""
+    status = dev_mode.detect_dev_mode(
+        em_cfg_path=em_cfg_off,
+        repo_binding_path=repo_binding_toml,
+        source_root=tmp_path,  # no .git here
+    )
+    assert status.editable_install is False
+    assert "git rev-parse" in status.reason
+
+
+def test_detect_returns_true_when_origin_matches(
+    fake_repo: Path, em_cfg_on: Path, repo_binding_toml: Path
+):
+    """Matching origin + em.toml allow = both booleans True."""
+    status = dev_mode.detect_dev_mode(
+        em_cfg_path=em_cfg_on,
+        repo_binding_path=repo_binding_toml,
+        source_root=fake_repo,
+    )
+    assert status.editable_install is True
+    assert status.em_allowlist is True
+    assert status.hard_precondition_met is True
+    assert status.reason == ""
+
+
+def test_detect_returns_false_when_origin_mismatches(
+    fake_repo: Path, em_cfg_off: Path, repo_binding_toml: Path
+):
+    """Origin remote does not match binding.repo → editable_install=False."""
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(fake_repo),
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/someone-else/other-repo.git",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    status = dev_mode.detect_dev_mode(
+        em_cfg_path=em_cfg_off,
+        repo_binding_path=repo_binding_toml,
+        source_root=fake_repo,
+    )
+    assert status.editable_install is False
+    assert "does not match" in status.reason
+
+
+def test_detect_em_allowlist_is_independent_of_precondition(
+    tmp_path: Path, em_cfg_on: Path, repo_binding_toml: Path
+):
+    """Even when precondition fails, em_allowlist reflects em.toml truthfully."""
+    status = dev_mode.detect_dev_mode(
+        em_cfg_path=em_cfg_on,
+        repo_binding_path=repo_binding_toml,
+        source_root=tmp_path,
+    )
+    assert status.editable_install is False
+    assert status.em_allowlist is True
+
+
+def test_match_origin_handles_ssh_and_https():
+    """_match_origin should accept SSH, HTTPS, with and without .git."""
+    assert dev_mode._match_origin("git@github.com:amd/gaia.git", "amd/gaia")
+    assert dev_mode._match_origin("https://github.com/amd/gaia.git", "amd/gaia")
+    assert dev_mode._match_origin("https://github.com/amd/gaia", "amd/gaia")
+    assert not dev_mode._match_origin("https://github.com/amd/other", "amd/gaia")
+    assert not dev_mode._match_origin("", "amd/gaia")
+
+
+# ---------------------------------------------------------------------------
+# enable_session / disable_session
+# ---------------------------------------------------------------------------
+
+
+def test_enable_session_refuses_when_precondition_fails(
+    tmp_path: Path, em_cfg_off: Path
+):
+    """No editable install → enable_session raises DevModeError."""
+    em_cfg = trust.load_em_config(em_cfg_off)
+    status = dev_mode.DevModeStatus(
+        editable_install=False, em_allowlist=False, reason="PyPI install"
+    )
+    session = tmp_path / "session.json"
+    with pytest.raises(dev_mode.DevModeError, match="precondition failed"):
+        dev_mode.enable_session(em_cfg, "try", session_path=session, status=status)
+
+
+def test_enable_and_disable_session_roundtrip(
+    fake_repo: Path,
+    em_cfg_off: Path,
+    repo_binding_toml: Path,
+    tmp_path: Path,
+):
+    """Happy path: enable then disable clears the file entirely."""
+    em_cfg = trust.load_em_config(em_cfg_off)
+    status = dev_mode.detect_dev_mode(
+        em_cfg_path=em_cfg_off,
+        repo_binding_path=repo_binding_toml,
+        source_root=fake_repo,
+    )
+    assert status.editable_install
+    session = tmp_path / "sub" / "session.json"
+    dev_mode.enable_session(em_cfg, "test reason", session_path=session, status=status)
+    data = json.loads(session.read_text())
+    assert data["dev_mode_session"] is True
+    assert data["dev_mode_session_reason"] == "test reason"
+    assert data["em_handle"] == em_cfg.em_handle
+
+    dev_mode.disable_session(session_path=session)
+    assert not session.exists()
+
+
+def test_enable_session_requires_non_empty_reason(
+    fake_repo: Path,
+    em_cfg_off: Path,
+    repo_binding_toml: Path,
+    tmp_path: Path,
+):
+    """An empty reason is a fail-loudly violation, not silently accepted."""
+    em_cfg = trust.load_em_config(em_cfg_off)
+    status = dev_mode.DevModeStatus(editable_install=True, em_allowlist=False)
+    session = tmp_path / "session.json"
+    with pytest.raises(dev_mode.DevModeError, match="non-empty reason"):
+        dev_mode.enable_session(em_cfg, "", session_path=session, status=status)
+
+
+def test_enable_session_writes_audit_row(
+    fake_repo: Path,
+    em_cfg_off: Path,
+    repo_binding_toml: Path,
+    tmp_path: Path,
+):
+    """enable_session appends one row to audit.log.db when a conn is provided."""
+    em_cfg = trust.load_em_config(em_cfg_off)
+    status = dev_mode.DevModeStatus(editable_install=True, em_allowlist=False)
+    audit_conn = audit_store.open_store(tmp_path / "audit.db")
+    try:
+        dev_mode.enable_session(
+            em_cfg,
+            "trial",
+            session_path=tmp_path / "session.json",
+            status=status,
+            audit_conn=audit_conn,
+        )
+        rows = audit_store.list_rows(audit_conn)
+    finally:
+        audit_conn.close()
+    assert len(rows) == 1
+    assert rows[0].tool_name == "dev_mode.enable_session"
+    payload = json.loads(rows[0].args_json)
+    assert payload["reason"] == "trial"
+    assert payload["scope"] == "session"
+
+
+# ---------------------------------------------------------------------------
+# enable_permanent
+# ---------------------------------------------------------------------------
+
+
+def test_enable_permanent_updates_em_toml(
+    fake_repo: Path,
+    em_cfg_off: Path,
+    repo_binding_toml: Path,
+    tmp_path: Path,
+):
+    """enable_permanent flips dev_mode_self_edit=true in em.toml."""
+    em_cfg = trust.load_em_config(em_cfg_off)
+    status = dev_mode.DevModeStatus(editable_install=True, em_allowlist=False)
+    updated = dev_mode.enable_permanent(
+        em_cfg, "long-term dev", em_cfg_path=em_cfg_off, status=status
+    )
+    assert updated.dev_mode_self_edit is True
+    assert updated.dev_mode_enabled_reason == "long-term dev"
+
+    # Reload to confirm persistence.
+    reloaded = trust.load_em_config(em_cfg_off)
+    assert reloaded.dev_mode_self_edit is True
+
+
+def test_enable_permanent_refuses_when_precondition_fails(em_cfg_off: Path):
+    em_cfg = trust.load_em_config(em_cfg_off)
+    status = dev_mode.DevModeStatus(editable_install=False, em_allowlist=False)
+    with pytest.raises(dev_mode.DevModeError, match="hard precondition failed"):
+        dev_mode.enable_permanent(em_cfg, "x", em_cfg_path=em_cfg_off, status=status)
+
+
+# ---------------------------------------------------------------------------
+# is_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_false_without_precondition(
+    tmp_path: Path, em_cfg_on: Path, repo_binding_toml: Path
+):
+    """em.toml says yes, but no editable install → is_enabled=False."""
+    assert not dev_mode.is_enabled(
+        em_cfg_path=em_cfg_on,
+        repo_binding_path=repo_binding_toml,
+        source_root=tmp_path,
+    )
+
+
+def test_is_enabled_true_via_em_toml(
+    fake_repo: Path, em_cfg_on: Path, repo_binding_toml: Path, tmp_path: Path
+):
+    """Hard precondition + em.toml allow = True."""
+    assert dev_mode.is_enabled(
+        em_cfg_path=em_cfg_on,
+        repo_binding_path=repo_binding_toml,
+        source_root=fake_repo,
+        session_path=tmp_path / "no-session.json",
+    )
+
+
+def test_is_enabled_true_via_session_flag_alone(
+    fake_repo: Path, em_cfg_off: Path, repo_binding_toml: Path, tmp_path: Path
+):
+    """session.json flag alone is sufficient when precondition passes."""
+    session = tmp_path / "session.json"
+    session.write_text(json.dumps({"dev_mode_session": True}))
+    assert dev_mode.is_enabled(
+        em_cfg_path=em_cfg_off,
+        repo_binding_path=repo_binding_toml,
+        source_root=fake_repo,
+        session_path=session,
+    )
+
+
+def test_corrupt_session_file_raises(tmp_path: Path):
+    """Bad JSON surfaces as DevModeError (no silent fallback)."""
+    session = tmp_path / "session.json"
+    session.write_text("{not json}")
+    with pytest.raises(dev_mode.DevModeError, match="not valid JSON"):
+        dev_mode._read_session(session)

--- a/tests/coder/test_self_heal.py
+++ b/tests/coder/test_self_heal.py
@@ -1,0 +1,277 @@
+#  Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for :mod:`gaia.coder.self_fix.self_heal` (§7.5, §15.8 P8).
+
+classify_failure's LLM call is mocked — we never hit Anthropic from tests.
+pause/resume use :func:`gaia.coder.stores.paused_tasks.write_snapshot`
+(exercised with tmp_path). restart_self's exit path uses ``exit_fn``
+injection so tests can assert the 42 exit code without terminating pytest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaia.coder.self_fix import self_heal
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_restart_window():
+    """Reset the module-level restart-timestamp list between tests."""
+    self_heal._reset_restart_window()
+    yield
+    self_heal._reset_restart_window()
+
+
+def _valid_response(kind="self-code", confidence=85) -> str:
+    return json.dumps(
+        {
+            "kind": kind,
+            "evidence": "Pattern matches fp_812 cache-key collision.",
+            "confidence": confidence,
+            "suggested_next_action": "Open a self-fix PR.",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_failure
+# ---------------------------------------------------------------------------
+
+
+def test_classify_failure_happy_path():
+    """A well-formed Opus response round-trips into FailureClassification."""
+
+    def client(**_kw):
+        return _valid_response("self-code", 85)
+
+    result = self_heal.classify_failure(
+        error={
+            "message": "KeyError",
+            "stack": "...",
+            "tool_name": "write_file",
+            "tool_args": {"path": "a"},
+        },
+        context_json={"recent_tool_calls": []},
+        dev_mode_on=True,
+        client=client,
+    )
+    assert result.kind == "self-code"
+    assert result.confidence == 85
+    assert result.escalated_low_confidence is False
+
+
+def test_classify_failure_low_confidence_escalates_to_external():
+    """confidence < 50 AND non-external → force-rewritten to external."""
+
+    def client(**_kw):
+        return _valid_response("self-code", 30)
+
+    result = self_heal.classify_failure(
+        error={"message": "x", "stack": "", "tool_name": "t", "tool_args": {}},
+        context_json={},
+        client=client,
+    )
+    assert result.kind == "external"
+    assert result.escalated_low_confidence is True
+
+
+def test_classify_failure_external_keeps_low_confidence():
+    """An already-external classification is NOT rewritten, just passed through."""
+
+    def client(**_kw):
+        return _valid_response("external", 30)
+
+    result = self_heal.classify_failure(
+        error={"message": "x", "stack": "", "tool_name": "t", "tool_args": {}},
+        context_json={},
+        client=client,
+    )
+    assert result.kind == "external"
+    assert result.escalated_low_confidence is False
+
+
+def test_classify_failure_unknown_kind_raises():
+    def client(**_kw):
+        return json.dumps(
+            {
+                "kind": "unknown",
+                "evidence": "",
+                "confidence": 50,
+                "suggested_next_action": "",
+            }
+        )
+
+    with pytest.raises(ValueError, match="unknown kind"):
+        self_heal.classify_failure(
+            error={"message": "", "stack": "", "tool_name": "t", "tool_args": {}},
+            context_json={},
+            client=client,
+        )
+
+
+def test_classify_failure_bad_json_raises():
+    def client(**_kw):
+        return "not json"
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        self_heal.classify_failure(
+            error={"message": "", "stack": "", "tool_name": "t", "tool_args": {}},
+            context_json={},
+            client=client,
+        )
+
+
+def test_classify_failure_prompt_renders_with_substitutions(monkeypatch):
+    """The prompt template placeholders ({{error_message}}) get substituted."""
+    captured = {}
+
+    def fake_client(*, prompt, **kw):
+        captured["prompt"] = prompt
+        return _valid_response()
+
+    self_heal.classify_failure(
+        error={
+            "message": "DivZero",
+            "stack": "trace",
+            "tool_name": "run",
+            "tool_args": {"a": 1},
+        },
+        context_json={"recent_tool_calls": [{"tool": "x"}]},
+        dev_mode_on=True,
+        client=fake_client,
+    )
+    assert "DivZero" in captured["prompt"]
+    assert '"a": 1' in captured["prompt"]
+    assert "on" in captured["prompt"]  # dev_mode_status
+    assert "{{" not in captured["prompt"]  # all placeholders substituted
+
+
+# ---------------------------------------------------------------------------
+# pause_current_task / resume_task
+# ---------------------------------------------------------------------------
+
+
+def test_pause_and_resume_roundtrip(tmp_path: Path):
+    """Snapshot content survives round-trip through JSON."""
+    paused = self_heal.pause_current_task(
+        "task-42",
+        "self-bug in classify_failure",
+        root=tmp_path,
+        cwd=tmp_path,
+        tool_call_history=[{"tool": "read_file", "args": {"path": "x"}}],
+        partial_outputs={"stdout": "blah"},
+        original_prompt="scaffold a weather agent",
+    )
+    assert paused.path.exists()
+    assert paused.task_id == "task-42"
+
+    result = self_heal.resume_task("task-42", root=tmp_path)
+    assert result.task_id == "task-42"
+    assert result.original_prompt == "scaffold a weather agent"
+    assert result.tool_call_history == [{"tool": "read_file", "args": {"path": "x"}}]
+    assert result.partial_outputs == {"stdout": "blah"}
+    assert paused.path.exists(), "resume_task should not auto-delete by default"
+
+
+def test_resume_missing_snapshot_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        self_heal.resume_task("never-existed", root=tmp_path)
+
+
+def test_resume_corrupt_snapshot_raises(tmp_path: Path):
+    """Missing required fields = SelfHealError, not a silent downgrade."""
+    (tmp_path / "weird.json").write_text(json.dumps({"task_id": "weird"}))
+    with pytest.raises(self_heal.SelfHealError, match="missing required fields"):
+        self_heal.resume_task("weird", root=tmp_path)
+
+
+def test_resume_can_delete_snapshot(tmp_path: Path):
+    self_heal.pause_current_task("t1", "reason", root=tmp_path, original_prompt="x")
+    result = self_heal.resume_task("t1", root=tmp_path, delete_snapshot=True)
+    assert result.task_id == "t1"
+    assert not (tmp_path / "t1.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# restart_self
+# ---------------------------------------------------------------------------
+
+
+def test_restart_self_cold_exit_code_42():
+    """kind='code' → exit_fn called with 42."""
+    calls = []
+    self_heal.restart_self(
+        "code changed",
+        kind="code",
+        exit_fn=calls.append,
+        now=1000.0,
+    )
+    assert calls == [self_heal.RESTART_EXIT_CODE]
+
+
+def test_restart_self_hot_reload_prompt_only():
+    """kind='prompt-only' does NOT call exit_fn; returns reloaded list."""
+    calls = []
+    result = self_heal.restart_self(
+        "prompt tweak",
+        kind="prompt-only",
+        exit_fn=calls.append,
+        now=1000.0,
+    )
+    assert calls == []
+    assert result.exited is False
+    assert result.kind == "prompt-only"
+
+
+def test_restart_self_rate_limit_triggers_on_fourth():
+    """§7.5: > 3 restarts / hour → RestartStormError."""
+    calls = []
+    for i in range(self_heal._RESTART_MAX_IN_WINDOW):
+        self_heal.restart_self(
+            f"attempt {i}",
+            kind="code",
+            exit_fn=calls.append,
+            now=1000.0 + i,
+        )
+    with pytest.raises(self_heal.RestartStormError, match="Refusing to restart"):
+        self_heal.restart_self(
+            "one too many",
+            kind="code",
+            exit_fn=calls.append,
+            now=1000.0 + self_heal._RESTART_MAX_IN_WINDOW,
+        )
+
+
+def test_restart_self_stale_timestamps_are_purged():
+    """Old restarts outside the window do not count against the cap."""
+    calls = []
+    for i in range(self_heal._RESTART_MAX_IN_WINDOW):
+        self_heal.restart_self(
+            f"old {i}",
+            kind="code",
+            exit_fn=calls.append,
+            now=0.0 + i,
+        )
+    # Now jump far outside the window — the cap should reset.
+    future = self_heal._RESTART_COUNT_WINDOW + 1000.0
+    self_heal.restart_self(
+        "fresh",
+        kind="code",
+        exit_fn=calls.append,
+        now=future,
+    )
+    assert len(calls) == self_heal._RESTART_MAX_IN_WINDOW + 1
+
+
+def test_restart_self_unknown_kind_raises():
+    with pytest.raises(ValueError, match="unknown kind"):
+        self_heal.restart_self("x", kind="banana", exit_fn=lambda _: None)


### PR DESCRIPTION
## Summary

Lands Phases 7 and 8 of `docs/plans/coder-agent.mdx` as a single PR to
minimise public PR count per the project's PR-minimisation directive.
The agent now has: (a) a real dev-mode gate backed by the §7.1 hard
precondition + em.toml + session.json triad, (b) self-heal primitives
for pausing, resuming, and restarting a task when it hits a bug in its
own source (§7.5), and (c) the eight-tool debug sub-loop from §5.9 with
the four discipline rules enforced at the state-machine layer rather
than only in prompts. Public API only — wiring into the main ReAct
loop is a Phase 11 concern.

## Threads

- **Dev-mode gate (§7.1) — `src/gaia/coder/dev_mode.py`** — detection
  (editable install + matching origin), session.json + em.toml toggles
  with audit-log side effects, composite `is_enabled`. Fail-loudly on
  corrupt session files so an undetected bad state can't silently
  enable self-edit.
- **Self-heal sub-loop (§7.5) — `src/gaia/coder/self_fix/self_heal.py`**
  — classify_failure (P8 prompt, conservative escalation), pause/resume
  via the existing paused_tasks store, and restart_self with a
  module-level rate-limit window (`_RESTART_COUNT_WINDOW` = 1h,
  `_RESTART_MAX_IN_WINDOW` = 3) so a broken self-edit can't fork-bomb
  the supervisor.
- **P8 prompt — `src/gaia/coder/prompts/classify_failure.md`** —
  the §15.8 template the classifier renders; same double-brace
  placeholder convention as `triage.md`.
- **Debug tool mixin (§5.9) — `src/gaia/coder/tools/debug.py`** —
  eight @tool-decorated closures (repro_attempt, git_bisect,
  add_instrumented_trace, run_with_tracing, diff_behavior,
  query_failure_patterns, flake_check, minimize_repro) with all
  subprocess calls funneled through a single injectable `_run` so
  tests never spawn real processes.
- **Debug sub-loop state machine — `src/gaia/coder/debug_loop.py`** —
  the seven-state FSM. Discipline enforcement is the load-bearing
  piece: `propose_fix` refuses without repro AND without ≥ 80%
  top-hypothesis confidence (override requires `shotgun=True` AND
  `em_elevation_granted=True`); `hypothesise` enforces three
  hypotheses minimum; `postmortem` writes both `feedback.db` notes
  and a `failure_patterns` memory row.

## Test plan

- [x] `pytest tests/coder/test_dev_mode.py` — 15 tests
- [x] `pytest tests/coder/test_self_heal.py` — 15 tests
- [x] `pytest tests/coder/test_debug_tools.py` — 19 tests
- [x] `pytest tests/coder/test_debug_loop.py` — 18 tests
- [x] Full coder suite: `pytest tests/coder/` — 265 passed, 2 pre-existing skipped
- [x] `python util/lint.py --all` — clean on all new files (black, isort, flake8 with project config, pylint); remaining critical errors are in pre-existing files unrelated to this PR
- [x] Smoke imports:
  ```
  from gaia.coder.dev_mode import detect_dev_mode
  from gaia.coder.self_fix.self_heal import classify_failure, pause_current_task, resume_task, restart_self
  from gaia.coder.tools.debug import DebugToolsMixin
  from gaia.coder.debug_loop import DebugSubLoop
  ```

## Out of scope

Wiring into `src/gaia/coder/loop.py` / `src/gaia/coder/base.py` / the
`gaia-coder` CLI is **not** in this PR — Phase 11 (production swap) is
the right place for that, and doing it here would have pulled in the
scaffold branch's churn. The Python APIs are complete and tested in
isolation; the integration surface is the follow-up.

Spec references: §7.1 (dev mode), §7.5 (self-detected bug), §5.9
(debug sub-loop), §15.8 P8 (classify_failure prompt), §6.8.1
(failure_patterns memory topic).