### PR TITLE
fix(coder): address #825 + #829 + #832 auto-review findings (final review pass)

### DIFF
--- a/src/gaia/coder/self_fix/loop_driver.py
+++ b/src/gaia/coder/self_fix/loop_driver.py
@@ -104,13 +104,26 @@ def _now_iso() -> str:
 
 
 def _append_notes(existing: str, entry: Mapping[str, Any]) -> str:
-    """Append a state-transition note to the feedback row's JSON array."""
-    try:
-        parsed = json.loads(existing or "[]")
-    except json.JSONDecodeError:
-        parsed = []
-    if not isinstance(parsed, list):
-        parsed = []
+    """Append a state-transition note to the feedback row's JSON array.
+
+    ``notes_json`` is the canonical audit trail per the module docstring —
+    silently replacing corrupted / mistyped content with ``[]`` would hide
+    a real regression. Fail loudly per CLAUDE.md. Cf. #825 auto-review.
+    """
+    if not existing:
+        parsed: list = []
+    else:
+        try:
+            parsed = json.loads(existing)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"feedback notes_json is corrupted and cannot be extended: {exc}"
+            ) from exc
+        if not isinstance(parsed, list):
+            raise ValueError(
+                f"feedback notes_json must be a JSON array, got "
+                f"{type(parsed).__name__}"
+            )
     parsed.append(dict(entry))
     return json.dumps(parsed)
 
@@ -365,9 +378,11 @@ class FeedbackLoopDriver:
                     feedback_body=row.body,
                 )
                 drive.notes.append(f"review gate overall={review_gate_result.overall}")
-            except Exception as exc:  # pylint: disable=broad-except
-                # Loose coupling: a Phase-4 runtime problem must not block a
-                # Phase-6 drive. Re-raise only for clear programming errors.
+            except (RuntimeError, subprocess.CalledProcessError, OSError) as exc:
+                # Loose coupling to Phase 4: a runtime/subprocess/IO problem
+                # in the review gate must not block a Phase-6 drive.
+                # Programming errors (AttributeError/TypeError/etc.) still
+                # surface per CLAUDE.md fail-loudly. Cf. #825 auto-review.
                 logger.warning(
                     "review gate runner failed for feedback %s: %s",
                     row.id,
@@ -417,9 +432,10 @@ class FeedbackLoopDriver:
                 gh_runner=self._gh_runner,
             )
             drive.notes.append("notified EM")
-        except Exception as exc:  # pylint: disable=broad-except
-            # Fail-loudly translation: surface as a DriveResult note but do
-            # not throw away the already-open PR.
+        except (RuntimeError, subprocess.CalledProcessError, OSError) as exc:
+            # Same shape as the review-gate block: tolerate runtime / subprocess
+            # / IO failures of the notification step without discarding the
+            # open PR. Programming errors still surface. Cf. #825 auto-review.
             logger.warning("notify_em failed for feedback %s: %s", row.id, exc)
             drive.notes.append(f"notify_em failed: {exc}")
 

--- a/src/gaia/coder/self_fix/verifier.py
+++ b/src/gaia/coder/self_fix/verifier.py
@@ -97,13 +97,26 @@ def _run_regression_test(
 
 
 def _append_note(existing_notes_json: str, entry: Mapping[str, Any]) -> str:
-    """Append a note to the JSON array stored in ``feedback.notes_json``."""
-    try:
-        parsed = json.loads(existing_notes_json or "[]")
-    except json.JSONDecodeError:
-        parsed = []
-    if not isinstance(parsed, list):
-        parsed = []
+    """Append a note to the JSON array stored in ``feedback.notes_json``.
+
+    Corrupted / wrong-type content raises — the audit trail is canonical
+    and silently replacing it with ``[]`` would hide a regression.
+    Cf. #825 auto-review. Mirrors :func:`loop_driver._append_notes`.
+    """
+    if not existing_notes_json:
+        parsed: list = []
+    else:
+        try:
+            parsed = json.loads(existing_notes_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"feedback notes_json is corrupted and cannot be extended: {exc}"
+            ) from exc
+        if not isinstance(parsed, list):
+            raise ValueError(
+                f"feedback notes_json must be a JSON array, got "
+                f"{type(parsed).__name__}"
+            )
     parsed.append(dict(entry))
     return json.dumps(parsed)
 

--- a/tests/coder/test_fixes_827_828.py
+++ b/tests/coder/test_fixes_827_828.py
@@ -13,8 +13,6 @@ Each test corresponds to one of the six fixes in the follow-up PR:
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from gaia.coder import oss_reuse

--- a/tests/coder/test_integration_e2e.py
+++ b/tests/coder/test_integration_e2e.py
@@ -27,6 +27,7 @@ import json
 import os
 import sqlite3
 import subprocess
+import sys
 from pathlib import Path
 from typing import Callable
 
@@ -221,6 +222,7 @@ def test_full_flow_feedback_to_fix(
     e2e_repo: Path,
     gaia_coder_home: Path,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Full §7.3 / §7.4 round-trip with every external boundary mocked."""
 
@@ -377,8 +379,13 @@ def test_full_flow_feedback_to_fix(
     # Point at the same Python interpreter pytest is running with so the
     # subprocess `python -m pytest` call inside verify_on_merge can find
     # pytest. Windows CI occasionally resolves `sys.executable` to a path
-    # that the subprocess loses, so we set it explicitly on PATH too.
-    os.environ["PATH"] = os.environ.get("PATH", "")
+    # that the subprocess loses, so we prepend its directory to PATH.
+    # Uses monkeypatch so the change reverts after the test (no leak to
+    # sibling tests). Cf. #829 auto-review.
+    py_dir = str(Path(sys.executable).parent)
+    current_path = os.environ.get("PATH", "")
+    if py_dir not in current_path.split(os.pathsep):
+        monkeypatch.setenv("PATH", py_dir + os.pathsep + current_path)
     verify_result = verify_on_merge(
         merged_sha=merged_sha,
         feedback_id="fb-e2e-1",

--- a/tests/coder/test_self_fix/test_cli.py
+++ b/tests/coder/test_self_fix/test_cli.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from gaia.coder import cli as coder_cli
 from gaia.coder.stores import feedback as feedback_store
 
@@ -53,8 +55,14 @@ def test_cli_feedback_enqueues(
 
 
 def test_cli_feedback_rejects_invalid_severity(capsys) -> None:
-    """argparse enforces the severity enum."""
-    try:
+    """argparse enforces the severity enum.
+
+    Uses ``pytest.raises`` so that an argparse regression that *silently
+    accepts* the invalid value fails this test. The earlier
+    ``try/except SystemExit`` pattern passed with zero assertions in
+    that scenario. Cf. #825 and #829 auto-reviews.
+    """
+    with pytest.raises(SystemExit) as excinfo:
         coder_cli.main(
             [
                 "feedback",
@@ -63,9 +71,7 @@ def test_cli_feedback_rejects_invalid_severity(capsys) -> None:
                 "nonsense",
             ]
         )
-    except SystemExit as exc:
-        # argparse raises SystemExit on invalid args.
-        assert exc.code != 0
+    assert excinfo.value.code != 0
 
 
 def test_cli_self_fix_subcommand_without_action_prints_help(capsys) -> None:


### PR DESCRIPTION
## Summary

Final cleanup pass to complete the `coder` branch for EM testing. Five Important + three Minor findings across the Phase 5/6/11 auto-reviews. All 395 tests pass.

## Changes

- `test_self_fix/test_cli.py` — `pytest.raises` so a silent-pass regression in argparse can't pass the test. [#825, #829]
- `test_integration_e2e.py` — real `PATH` prepend via `monkeypatch.setenv` instead of a no-op assignment that leaked env. [#829]
- `test_fixes_827_828.py` — drop unused `Path` import. [#832]
- `loop_driver.py` — narrow broad `except Exception` around `review_gate` and `notify_em` to `(RuntimeError, CalledProcessError, OSError)`. Programming errors now surface per CLAUDE.md fail-loudly. [#825]
- `loop_driver.py` + `verifier.py` — `_append_notes` / `_append_note` raise `ValueError` on corrupted or wrong-type `notes_json` instead of silently replacing with `[]`. [#825]

## Test plan

- [x] `pytest tests/coder/ tests/eval/` — 395/395 pass