### PR TITLE
fix(ui): honor custom agent model_id when session is at DB default

### DIFF
--- a/docs/plans/email-triage-agent.mdx
+++ b/docs/plans/email-triage-agent.mdx
@@ -2598,7 +2598,7 @@ Choices the spec implies but does not resolve:
 - [Whittaker & Sidner, "Email Overload" (CHI 1996)](https://dl.acm.org/doi/10.1145/238386.238530)
 - [Bellotti et al., "Taking Email to Task" / Taskmaster (CHI 2003)](https://www.semanticscholar.org/paper/Taking-email-to-task/8a28a1ee766d87ca9acbd741a7c1972d69217359)
 - [Aberdeen, Pacovsky & Slater, "Gmail Priority Inbox" (NIPS 2010)](https://research.google/pubs/pub36955/)
-- [Cohen, Carvalho & Mitchell, "Email Speech Acts" (EMNLP 2004)](https://www.cs.cmu.edu/~tom/EMNLP2004_final.pdf)
+- [Cohen, Carvalho & Mitchell, "Learning to Classify Email into 'Speech Acts'" (EMNLP 2004)](https://aclanthology.org/W04-3240/)
 - [Vellum, "Levels of Agentic Behavior"](https://www.vellum.ai/blog/levels-of-agentic-behavior)
 - [Knight Institute, "Levels of Autonomy for AI Agents"](https://knightcolumbia.org/content/levels-of-autonomy-for-ai-agents-1)
 

--- a/src/gaia/mcp/mcp_bridge.py
+++ b/src/gaia/mcp/mcp_bridge.py
@@ -628,7 +628,10 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
                 400,
                 {
                     "jsonrpc": "2.0",
-                    "error": {"code": -32600, "message": "Invalid Request: expected JSON object"},
+                    "error": {
+                        "code": -32600,
+                        "message": "Invalid Request: expected JSON object",
+                    },
                     "id": None,
                 },
             )

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -621,7 +621,7 @@ async def _get_chat_response(
                 )
                 _store_agent(
                     session_id,
-                    _effective_model(agent, model_id),
+                    model_id,
                     document_ids,
                     agent,
                     agent_type,
@@ -1001,7 +1001,7 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
 
                         _store_agent(
                             session_id,
-                            _effective_model(agent, model_id),
+                            model_id,
                             document_ids,
                             agent,
                             agent_type,

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -73,6 +73,11 @@ _agent_cache: dict[str, dict] = (
 _agent_cache_lock = threading.Lock()
 _MAX_CACHED_AGENTS = 10
 
+# Matches the fallback default in gaia.ui.database.create_session (~line 233).
+# Kept local to avoid widening _chat_helpers.py's coupling to database.py for
+# a cosmetic rename. If that value changes, update here too.
+_DB_DEFAULT_MODEL = "Qwen3.5-35B-A3B-GGUF"
+
 # Last known MCP runtime status — updated after each agent setup so
 # GET /api/mcp/status can return it without needing a running chat.
 _mcp_status_cache: list[dict] = []
@@ -554,19 +559,38 @@ async def _get_chat_response(
                     agent_type,
                     session_id[:8],
                 )
-                agent = registry.create_agent(
-                    agent_type,
-                    model_id=model_id,
-                    silent_mode=True,
-                    debug=False,
-                )
+                create_kwargs: dict = {"silent_mode": True, "debug": False}
+                if custom_model:
+                    create_kwargs["model_id"] = custom_model
+                    logger.info(
+                        "create_agent: custom_model override -> %r", custom_model
+                    )
+                elif model_id and model_id != _DB_DEFAULT_MODEL:
+                    create_kwargs["model_id"] = model_id
+                    logger.info("create_agent: session-explicit model -> %r", model_id)
+                else:
+                    # Omit model_id so kwargs.setdefault in the agent's __init__ fires.
+                    # setdefault only works when the key is ABSENT — passing None or the
+                    # DB default explicitly defeats it. This is the fix for issue #841.
+                    logger.info(
+                        "create_agent: omitting model_id kwarg (session at DB default %r); "
+                        "agent's kwargs.setdefault or AgentConfig fallback will govern",
+                        _DB_DEFAULT_MODEL,
+                    )
+                agent = registry.create_agent(agent_type, **create_kwargs)
                 logger.info(
                     "chat: Invoking agent %s for session %s, model=%s",
                     agent_type,
                     session_id[:8],
-                    model_id,
+                    getattr(agent, "model_id", model_id),
                 )
-                _store_agent(session_id, model_id, document_ids, agent, agent_type)
+                _store_agent(
+                    session_id,
+                    getattr(agent, "model_id", None) or model_id,
+                    document_ids,
+                    agent,
+                    agent_type,
+                )
 
         # Restore conversation history (limited to prevent context overflow).
         # Always re-inject from DB so the history is consistent with what was
@@ -585,8 +609,11 @@ async def _get_chat_response(
             agent.conversation_history.append({"role": "user", "content": u})
             agent.conversation_history.append({"role": "assistant", "content": a})
 
-        # Pre-flight: same fix as the streaming path — see _maybe_load_expected_model.
-        _maybe_load_expected_model(model_id)
+        # Pre-flight on agent's ACTUAL effective model. When model_id kwarg was
+        # omitted above, the agent's __init__ set model_id via kwargs.setdefault —
+        # a value invisible to us pre-construction. Using agent.model_id preserves
+        # the existing 100-900s silent-hang protection for all code paths.
+        _maybe_load_expected_model(getattr(agent, "model_id", None) or model_id)
 
         result = agent.process_query(request.message)
         if isinstance(result, dict):
@@ -913,19 +940,36 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                             session_id[:8],
                         )
                         t_construct = _time.monotonic()
-                        agent = registry.create_agent(
-                            agent_type,
-                            model_id=model_id,
-                            streaming=True,
-                            silent_mode=False,
-                            debug=False,
-                        )
+                        create_kwargs = {
+                            "streaming": True,
+                            "silent_mode": False,
+                            "debug": False,
+                        }
+                        if custom_model:
+                            create_kwargs["model_id"] = custom_model
+                            logger.info(
+                                "create_agent: custom_model override -> %r (streaming)",
+                                custom_model,
+                            )
+                        elif model_id and model_id != _DB_DEFAULT_MODEL:
+                            create_kwargs["model_id"] = model_id
+                            logger.info(
+                                "create_agent: session-explicit model -> %r (streaming)",
+                                model_id,
+                            )
+                        else:
+                            logger.info(
+                                "create_agent: omitting model_id kwarg (session at DB default %r); "
+                                "agent's kwargs.setdefault or AgentConfig fallback will govern (streaming)",
+                                _DB_DEFAULT_MODEL,
+                            )
+                        agent = registry.create_agent(agent_type, **create_kwargs)
                         agent.console = sse_handler
                         logger.info(
                             "chat: Invoking agent %s for session %s, model=%s took=%.3fs",
                             agent_type,
                             session_id[:8],
-                            model_id,
+                            getattr(agent, "model_id", model_id),
                             _time.monotonic() - t_construct,
                         )
 
@@ -937,7 +981,11 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                             _index_rag_with_progress(agent, rag_file_paths, sse_handler)
 
                         _store_agent(
-                            session_id, model_id, document_ids, agent, agent_type
+                            session_id,
+                            getattr(agent, "model_id", None) or model_id,
+                            document_ids,
+                            agent,
+                            agent_type,
                         )
 
                     sse_handler._emit(
@@ -987,10 +1035,13 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                 if sse_handler.cancelled.is_set():
                     return
 
-                # Pre-flight: ensure a chat-capable LLM is active before sending the query.
-                # Lemonade silently hangs when no model is loaded or the embedding model is
-                # active — no error is returned, so _execute_with_auto_download never fires.
-                _maybe_load_expected_model(model_id, sse_handler)
+                # Pre-flight on agent's ACTUAL effective model. When model_id kwarg was
+                # omitted, the agent's __init__ set model_id via kwargs.setdefault — a value
+                # invisible pre-construction. Using agent.model_id preserves the existing
+                # 100-900s silent-hang protection for all code paths including setdefault.
+                _maybe_load_expected_model(
+                    getattr(agent, "model_id", None) or model_id, sse_handler
+                )
 
                 # -- Phase 5: Query processing --
                 t_query = _time.monotonic()

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -23,7 +23,7 @@ import threading
 import time as _time
 from pathlib import Path
 
-from .database import ChatDatabase
+from .database import SESSION_DEFAULT_MODEL, ChatDatabase
 from .models import ChatRequest
 from .sse_handler import (
     _ANSWER_JSON_SUB_RE,
@@ -73,10 +73,8 @@ _agent_cache: dict[str, dict] = (
 _agent_cache_lock = threading.Lock()
 _MAX_CACHED_AGENTS = 10
 
-# Matches the fallback default in gaia.ui.database.create_session (~line 233).
-# Kept local to avoid widening _chat_helpers.py's coupling to database.py for
-# a cosmetic rename. If that value changes, update here too.
-_DB_DEFAULT_MODEL = "Qwen3.5-35B-A3B-GGUF"
+# Alias so call-sites read naturally; the canonical value lives in database.py.
+_DB_DEFAULT_MODEL = SESSION_DEFAULT_MODEL
 
 # Last known MCP runtime status — updated after each agent setup so
 # GET /api/mcp/status can return it without needing a running chat.
@@ -87,6 +85,56 @@ _mcp_status_lock = threading.Lock()
 # path (_maybe_load_expected_model) and the boot-time preload task in server.py.
 # Public (no underscore) because it is intentionally accessed cross-module.
 model_load_lock = threading.Lock()
+
+
+def _build_create_kwargs(
+    *,
+    custom_model: str | None,
+    model_id: str | None,
+    streaming: bool = False,
+) -> dict:
+    """Return the kwargs dict for registry.create_agent().
+
+    Precedence (high → low):
+      1. custom_model setting (explicit user override from db)
+      2. session-explicit model (differs from SESSION_DEFAULT_MODEL)
+      3. omit model_id — lets the agent's kwargs.setdefault govern (fix #841)
+
+    Note: if registry.resolve_model() already promoted model_id before this
+    call, it is forwarded as-is via branch 2 (resolve_model result ≠ default).
+    """
+    suffix = " (streaming)" if streaming else ""
+    kwargs: dict = {"silent_mode": not streaming, "debug": False}
+    if streaming:
+        kwargs["streaming"] = True
+
+    if custom_model:
+        kwargs["model_id"] = custom_model
+        logger.info("create_agent: custom_model override -> %s%s", custom_model, suffix)
+    elif model_id and model_id != _DB_DEFAULT_MODEL:
+        kwargs["model_id"] = model_id
+        logger.info("create_agent: session-explicit model -> %s%s", model_id, suffix)
+    else:
+        # Omit model_id so kwargs.setdefault in the agent's __init__ fires.
+        # setdefault only works when the key is ABSENT. Passing the DB default
+        # (or None / empty) explicitly defeats it — this is the fix for #841.
+        logger.info(
+            "create_agent: omitting model_id kwarg (session at DB default %s); "
+            "agent's kwargs.setdefault or AgentConfig fallback will govern%s",
+            _DB_DEFAULT_MODEL,
+            suffix,
+        )
+    return kwargs
+
+
+def _effective_model(agent, fallback: str | None) -> str | None:
+    """Return agent.model_id if set, else fallback.
+
+    Uses explicit None check (not `or`) to avoid treating empty-string
+    model_id as missing — which would silently load the wrong model.
+    """
+    effective = getattr(agent, "model_id", None)
+    return effective if effective is not None else fallback
 
 
 def get_cached_mcp_status() -> list[dict]:
@@ -559,34 +607,21 @@ async def _get_chat_response(
                     agent_type,
                     session_id[:8],
                 )
-                create_kwargs: dict = {"silent_mode": True, "debug": False}
-                if custom_model:
-                    create_kwargs["model_id"] = custom_model
-                    logger.info(
-                        "create_agent: custom_model override -> %r", custom_model
-                    )
-                elif model_id and model_id != _DB_DEFAULT_MODEL:
-                    create_kwargs["model_id"] = model_id
-                    logger.info("create_agent: session-explicit model -> %r", model_id)
-                else:
-                    # Omit model_id so kwargs.setdefault in the agent's __init__ fires.
-                    # setdefault only works when the key is ABSENT — passing None or the
-                    # DB default explicitly defeats it. This is the fix for issue #841.
-                    logger.info(
-                        "create_agent: omitting model_id kwarg (session at DB default %r); "
-                        "agent's kwargs.setdefault or AgentConfig fallback will govern",
-                        _DB_DEFAULT_MODEL,
-                    )
-                agent = registry.create_agent(agent_type, **create_kwargs)
+                agent = registry.create_agent(
+                    agent_type,
+                    **_build_create_kwargs(
+                        custom_model=custom_model, model_id=model_id
+                    ),
+                )
                 logger.info(
                     "chat: Invoking agent %s for session %s, model=%s",
                     agent_type,
                     session_id[:8],
-                    getattr(agent, "model_id", model_id),
+                    _effective_model(agent, model_id),
                 )
                 _store_agent(
                     session_id,
-                    getattr(agent, "model_id", None) or model_id,
+                    _effective_model(agent, model_id),
                     document_ids,
                     agent,
                     agent_type,
@@ -610,10 +645,10 @@ async def _get_chat_response(
             agent.conversation_history.append({"role": "assistant", "content": a})
 
         # Pre-flight on agent's ACTUAL effective model. When model_id kwarg was
-        # omitted above, the agent's __init__ set model_id via kwargs.setdefault —
-        # a value invisible to us pre-construction. Using agent.model_id preserves
+        # omitted, the agent's __init__ set model_id via kwargs.setdefault —
+        # a value invisible pre-construction. Using _effective_model preserves
         # the existing 100-900s silent-hang protection for all code paths.
-        _maybe_load_expected_model(getattr(agent, "model_id", None) or model_id)
+        _maybe_load_expected_model(_effective_model(agent, model_id))
 
         result = agent.process_query(request.message)
         if isinstance(result, dict):
@@ -940,36 +975,20 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                             session_id[:8],
                         )
                         t_construct = _time.monotonic()
-                        create_kwargs = {
-                            "streaming": True,
-                            "silent_mode": False,
-                            "debug": False,
-                        }
-                        if custom_model:
-                            create_kwargs["model_id"] = custom_model
-                            logger.info(
-                                "create_agent: custom_model override -> %r (streaming)",
-                                custom_model,
-                            )
-                        elif model_id and model_id != _DB_DEFAULT_MODEL:
-                            create_kwargs["model_id"] = model_id
-                            logger.info(
-                                "create_agent: session-explicit model -> %r (streaming)",
-                                model_id,
-                            )
-                        else:
-                            logger.info(
-                                "create_agent: omitting model_id kwarg (session at DB default %r); "
-                                "agent's kwargs.setdefault or AgentConfig fallback will govern (streaming)",
-                                _DB_DEFAULT_MODEL,
-                            )
-                        agent = registry.create_agent(agent_type, **create_kwargs)
+                        agent = registry.create_agent(
+                            agent_type,
+                            **_build_create_kwargs(
+                                custom_model=custom_model,
+                                model_id=model_id,
+                                streaming=True,
+                            ),
+                        )
                         agent.console = sse_handler
                         logger.info(
                             "chat: Invoking agent %s for session %s, model=%s took=%.3fs",
                             agent_type,
                             session_id[:8],
-                            getattr(agent, "model_id", model_id),
+                            _effective_model(agent, model_id),
                             _time.monotonic() - t_construct,
                         )
 
@@ -982,7 +1001,7 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
 
                         _store_agent(
                             session_id,
-                            getattr(agent, "model_id", None) or model_id,
+                            _effective_model(agent, model_id),
                             document_ids,
                             agent,
                             agent_type,
@@ -1040,7 +1059,7 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                 # invisible pre-construction. Using agent.model_id preserves the existing
                 # 100-900s silent-hang protection for all code paths including setdefault.
                 _maybe_load_expected_model(
-                    getattr(agent, "model_id", None) or model_id, sse_handler
+                    _effective_model(agent, model_id), sse_handler
                 )
 
                 # -- Phase 5: Query processing --

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = Path.home() / ".gaia" / "chat" / "gaia_chat.db"
 
+# Default model for new sessions — kept in sync with the SQL schema DEFAULT and
+# any code that reads session["model"] and falls back when the field is NULL.
+SESSION_DEFAULT_MODEL = "Qwen3.5-35B-A3B-GGUF"
+
 SCHEMA_SQL = """
 -- Global document library
 CREATE TABLE IF NOT EXISTS documents (
@@ -230,7 +234,7 @@ class ChatDatabase:
         """Create a new chat session."""
         session_id = str(uuid.uuid4())
         now = self._now()
-        model = model or "Qwen3.5-35B-A3B-GGUF"
+        model = model or SESSION_DEFAULT_MODEL
         title = title or "New Chat"
         agent_type = agent_type or "chat"
 

--- a/tests/integration/test_chat_ui_integration.py
+++ b/tests/integration/test_chat_ui_integration.py
@@ -1591,3 +1591,94 @@ class TestMessageDeletion:
         """DELETE .../and-below returns 404 for non-existent session."""
         resp = client.delete("/api/sessions/nonexistent/messages/1/and-below")
         assert resp.status_code == 404
+
+
+# ── Issue #841 regression: custom agent model_id honored through API ──────────
+
+
+class TestCustomAgentModelChoice:
+    """Verify that a custom Python agent's kwargs.setdefault model_id reaches the
+    registry.create_agent call without model_id being passed as an explicit kwarg.
+
+    This is the integration-layer pin for issue #841. It exercises the full
+    path: HTTP POST → session → _get_chat_response → registry.create_agent.
+    """
+
+    def test_custom_agent_model_id_honored_through_api(self, tmp_path):
+        import textwrap
+
+        agents_dir = tmp_path / ".gaia" / "agents" / "smallbot"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "agent.py").write_text(textwrap.dedent("""
+            from gaia.agents.base.agent import Agent
+
+            class SmallBot(Agent):
+                AGENT_ID = "smallbot"
+                AGENT_NAME = "SmallBot"
+
+                def __init__(self, **kwargs):
+                    kwargs.setdefault("model_id", "Qwen3.5-4B-GGUF")
+                    super().__init__(skip_lemonade=True, **kwargs)
+
+                def _get_system_prompt(self):
+                    return "x"
+
+                def _register_tools(self):
+                    pass
+        """))
+
+        # HOME patch must wrap the full lifespan: discover() fires on __enter__.
+        with patch("gaia.agents.registry.Path.home", return_value=tmp_path):
+            app = create_app(db_path=":memory:")
+
+            with TestClient(app) as client:
+                # Spy on create_agent AFTER lifespan fires (registry exists now).
+                captured = {}
+                original_create = app.state.agent_registry.create_agent
+
+                def _spy(agent_id, **kwargs):
+                    if agent_id == "smallbot":
+                        captured["model_id_kwarg"] = kwargs.get("model_id", "<omitted>")
+                    agent = original_create(agent_id, **kwargs)
+                    if agent_id == "smallbot":
+                        captured["agent_model_id"] = getattr(agent, "model_id", None)
+                    return agent
+
+                app.state.agent_registry.create_agent = _spy
+
+                # Create a session typed to our custom agent.
+                sess_resp = client.post(
+                    "/api/sessions",
+                    json={"title": "841-test", "agent_type": "smallbot"},
+                )
+                assert sess_resp.status_code == 200, sess_resp.text
+                sid = sess_resp.json()["id"]
+
+                # Send a chat message, bypassing Lemonade and LLM.
+                with (
+                    patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+                    patch(
+                        "gaia.ui._chat_helpers._agent_registry",
+                        app.state.agent_registry,
+                    ),
+                ):
+                    chat_resp = client.post(
+                        "/api/chat/send",
+                        json={
+                            "session_id": sid,
+                            "message": "hi",
+                            "stream": False,
+                        },
+                    )
+
+                assert chat_resp.status_code == 200, chat_resp.text
+
+        assert captured, "create_agent spy was never called for smallbot"
+        assert captured["model_id_kwarg"] == "<omitted>", (
+            f"Issue #841: model_id kwarg must be omitted when session is at DB default; "
+            f"got model_id_kwarg={captured['model_id_kwarg']!r}"
+        )
+        assert captured["agent_model_id"] == "Qwen3.5-4B-GGUF", (
+            f"Issue #841: agent.model_id must reflect kwargs.setdefault value; "
+            f"got {captured['agent_model_id']!r}"
+        )

--- a/tests/unit/chat/ui/test_agent_model_override.py
+++ b/tests/unit/chat/ui/test_agent_model_override.py
@@ -1,0 +1,58 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Regression test for issue #841: custom agent's model_id ignored by UI."""
+
+import textwrap
+from unittest.mock import patch
+
+from gaia.agents.registry import AgentRegistry
+
+
+def test_issue_841_custom_python_agent_model_id_respected(tmp_path):
+    """A custom Python agent using kwargs.setdefault in __init__ must be
+    instantiated with its own model_id when the UI omits the kwarg.
+
+    On pre-fix main, the UI always passes model_id=<session model> explicitly
+    to registry.create_agent — defeating kwargs.setdefault, which only fires
+    when the key is ABSENT. After T3 lands, the UI omits model_id when no
+    explicit user choice exists, so setdefault fires as the agent intends.
+
+    This test simulates the fixed UI call pattern: calling create_agent without
+    model_id, and asserting the agent's declared default is respected.
+    """
+    agents_dir = tmp_path / ".gaia" / "agents" / "foo"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "agent.py").write_text(textwrap.dedent("""
+        from gaia.agents.base.agent import Agent
+
+        class FooAgent(Agent):
+            AGENT_ID = "foo"
+            AGENT_NAME = "Foo"
+
+            def __init__(self, **kwargs):
+                kwargs.setdefault("model_id", "Qwen3.5-4B-GGUF")
+                super().__init__(skip_lemonade=True, **kwargs)
+
+            def _get_system_prompt(self):
+                return "foo"
+
+            def _register_tools(self):
+                pass
+    """))
+
+    with patch("gaia.agents.registry.Path.home", return_value=tmp_path):
+        registry = AgentRegistry()
+        registry.discover()
+
+    reg = registry.get("foo")
+    assert reg is not None, "custom agent should be discovered under patched HOME"
+
+    # Simulate what the fixed UI does when no explicit user choice exists:
+    # OMIT the model_id kwarg entirely so setdefault fires.
+    agent = registry.create_agent("foo", silent_mode=True, debug=False)
+
+    assert agent.model_id == "Qwen3.5-4B-GGUF", (
+        f"Issue #841: custom agent's kwargs.setdefault('model_id', ...) must "
+        f"govern when UI omits the kwarg; got {agent.model_id!r}"
+    )

--- a/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
+++ b/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
@@ -18,9 +18,7 @@ import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-# DB default must match the value used by gaia.ui.database.create_session
-_DB_DEFAULT = "Qwen3.5-35B-A3B-GGUF"
-
+from gaia.ui.database import SESSION_DEFAULT_MODEL as _DB_DEFAULT
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -211,9 +209,10 @@ class TestStaticRegressionGuard:
         import re
 
         src = (Path(__file__).parents[4] / "src/gaia/ui/_chat_helpers.py").read_text()
-        # Matches the old antipattern: create_agent(... model_id=model_id ...)
-        # Uses DOTALL so it catches multiline calls.
-        match = re.search(r"create_agent\([^)]*model_id=model_id", src, re.DOTALL)
+        # Matches the old antipattern: create_agent(... model_id=model_id ...) as a
+        # DIRECT kwarg (not inside a nested call like _build_create_kwargs).
+        # [^()]* stops at any parenthesis so nested helper calls aren't matched.
+        match = re.search(r"create_agent\([^()]*model_id=model_id", src, re.DOTALL)
         assert not match, (
             "Issue #841 regression: registry.create_agent must not receive "
             "model_id=model_id as a direct kwarg. Build create_kwargs conditionally "

--- a/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
+++ b/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
@@ -1,0 +1,288 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the model_id kwarg selection logic in _chat_helpers.py.
+
+Covers the three-branch precedence chain introduced by the #841 fix:
+  1. custom_model setting wins over everything
+  2. Session-explicit model (anything != DB default) is honored
+  3. model_id kwarg OMITTED when session is at the DB default, so that the
+     custom agent's kwargs.setdefault("model_id", ...) fires (the #841 fix)
+
+Also pins: streaming vs non-streaming silent_mode values, static source-grep
+guard against reintroduction of the antipattern, post-construction pre-flight
+contract, and built-in ChatAgent (agent_type="chat") behavior unchanged.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# DB default must match the value used by gaia.ui.database.create_session
+_DB_DEFAULT = "Qwen3.5-35B-A3B-GGUF"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _run_sync(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _make_session(model=_DB_DEFAULT, agent_type="bot"):
+    return {
+        "document_ids": [],
+        "model": model,
+        "agent_type": agent_type,
+        "session_id": "sess-1",
+    }
+
+
+def _make_db(custom_model=None):
+    db = MagicMock()
+    db.get_messages.return_value = []
+    db.get_setting.return_value = custom_model
+    db.list_documents.return_value = []
+    db.update_session.return_value = None
+    db.get_session.return_value = {}
+    return db
+
+
+def _make_registry(resolve_model_return=None, setdefault_model="SetdefaultChose-GGUF"):
+    """Return (registry_mock, captured_dict).
+
+    captured["kwargs"] holds the kwargs received by create_agent.
+    The fake agent's model_id mimics kwargs.setdefault: if model_id was NOT
+    passed, it is set to setdefault_model; otherwise it keeps the passed value.
+    """
+    registry = MagicMock()
+    registry.get.return_value = True  # agent_type is registered
+    registry.resolve_model.return_value = resolve_model_return
+
+    captured = {}
+
+    def _spy(agent_id, **kwargs):
+        captured["kwargs"] = dict(kwargs)
+        fake = MagicMock()
+        fake.model_id = kwargs.get("model_id", setdefault_model)
+        fake.process_query.return_value = "ok"
+        fake.conversation_history = []
+        fake.indexed_files = set()
+        return fake
+
+    registry.create_agent.side_effect = _spy
+    return registry, captured
+
+
+def _call_non_streaming(session, db, agent_type_override=None, session_id="sess-1"):
+    import gaia.ui._chat_helpers as _helpers
+    from gaia.ui._chat_helpers import _get_chat_response
+    from gaia.ui.models import ChatRequest
+
+    # Clear the agent cache so tests don't interfere with each other.
+    with _helpers._agent_cache_lock:
+        _helpers._agent_cache.clear()
+
+    request = ChatRequest(
+        session_id=session_id,
+        message="hi",
+        stream=False,
+        agent_type=agent_type_override,
+    )
+    session = dict(session)
+    session.setdefault("session_id", session_id)
+    return _run_sync(_get_chat_response(db, session, request))
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestModelKwargSelection:
+    """Verify the three-branch model_id selection at both call sites."""
+
+    def test_custom_model_setting_wins_over_everything(self):
+        """db.get_setting('custom_model') result always reaches create_agent as model_id."""
+        registry, captured = _make_registry(setdefault_model="AgentPref-GGUF")
+        db = _make_db(custom_model="UserPicked-GGUF")
+        session = _make_session(model=_DB_DEFAULT)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured["kwargs"].get("model_id") == "UserPicked-GGUF"
+
+    def test_session_explicit_model_honored(self):
+        """A session model that differs from the DB default is forwarded as model_id."""
+        registry, captured = _make_registry()
+        db = _make_db(custom_model=None)
+        session = _make_session(model="UserChose-GGUF")
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured["kwargs"].get("model_id") == "UserChose-GGUF"
+
+    def test_model_id_kwarg_omitted_when_session_at_db_default(self):
+        """Core #841 fix: model_id kwarg must be ABSENT when session == DB default.
+
+        kwargs.setdefault only fires when the key is absent. The pre-fix code
+        always passes model_id=<session default> explicitly, defeating setdefault.
+        After the fix, model_id is omitted so the agent's __init__ governs.
+        """
+        registry, captured = _make_registry(setdefault_model="SetdefaultChose-GGUF")
+        db = _make_db(custom_model=None)
+        session = _make_session(model=_DB_DEFAULT)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert "model_id" not in captured.get("kwargs", {}), (
+            "Issue #841: model_id kwarg must be omitted when session is at DB default; "
+            f"got kwargs={captured.get('kwargs')}"
+        )
+        # The spy's setdefault model should be what the agent ends up with.
+        assert (
+            captured.get("kwargs", {}).get("model_id", "SetdefaultChose-GGUF")
+            == "SetdefaultChose-GGUF"
+        )
+
+    def test_model_id_kwarg_omitted_when_session_model_is_none(self):
+        """model_id kwarg is omitted when session model is None (unset session)."""
+        registry, captured = _make_registry(setdefault_model="SetdefaultChose-GGUF")
+        db = _make_db(custom_model=None)
+        session = _make_session(model=None)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert "model_id" not in captured.get("kwargs", {}), (
+            f"model_id kwarg must be omitted when session model is None; "
+            f"got kwargs={captured.get('kwargs')}"
+        )
+
+    def test_non_streaming_path_silent_mode_true_preserved(self):
+        """Non-streaming create_agent call must pass silent_mode=True."""
+        registry, captured = _make_registry()
+        db = _make_db(custom_model=None)
+        session = _make_session(model=_DB_DEFAULT)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured.get("kwargs", {}).get("silent_mode") is True, (
+            "Non-streaming path must pass silent_mode=True to create_agent; "
+            f"got kwargs={captured.get('kwargs')}"
+        )
+        assert "streaming" not in captured.get(
+            "kwargs", {}
+        ), "Non-streaming path must not pass streaming=True to create_agent"
+
+
+class TestStaticRegressionGuard:
+    """Source-level pin against reintroduction of the antipattern."""
+
+    def test_no_direct_model_id_kwarg_in_create_agent_calls(self):
+        """registry.create_agent must never be called with model_id=model_id directly.
+
+        The pre-fix antipattern was:
+            registry.create_agent(agent_type, model_id=model_id, ...)
+        which always passes the kwarg explicitly, defeating kwargs.setdefault.
+
+        ChatAgentConfig(model_id=model_id, ...) is legitimate and intentionally
+        excluded from this check — only create_agent calls are guarded.
+
+        This test catches future regressions at the source level in <5ms.
+        """
+        import re
+
+        src = (Path(__file__).parents[4] / "src/gaia/ui/_chat_helpers.py").read_text()
+        # Matches the old antipattern: create_agent(... model_id=model_id ...)
+        # Uses DOTALL so it catches multiline calls.
+        match = re.search(r"create_agent\([^)]*model_id=model_id", src, re.DOTALL)
+        assert not match, (
+            "Issue #841 regression: registry.create_agent must not receive "
+            "model_id=model_id as a direct kwarg. Build create_kwargs conditionally "
+            "and omit model_id when no explicit user choice exists.\n"
+            f"Match found at: {match.group()[:80]!r}"
+        )
+
+
+class TestPostConstructionPreflight:
+    """Verify pre-flight uses agent.model_id (not pre-call model_id variable)."""
+
+    def test_preflight_receives_agent_effective_model(self):
+        """_maybe_load_expected_model must be called with the agent's actual model_id.
+
+        When model_id kwarg is omitted, the agent's __init__ sets model_id via
+        setdefault AFTER construction. The pre-fix code called
+        _maybe_load_expected_model(model_id) with the pre-call variable (DB
+        default), missing the agent's actual effective model. The fix calls it
+        with agent.model_id so Lemonade pre-flight fires for the right model.
+        """
+        registry, captured = _make_registry(setdefault_model="SetdefaultChose-GGUF")
+        db = _make_db(custom_model=None)
+        session = _make_session(model=_DB_DEFAULT)
+
+        preflight_calls = []
+
+        def _spy_preflight(model_id, *args, **kwargs):
+            preflight_calls.append(model_id)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch(
+                "gaia.ui._chat_helpers._maybe_load_expected_model",
+                side_effect=_spy_preflight,
+            ),
+        ):
+            _call_non_streaming(session, db)
+
+        assert preflight_calls, "_maybe_load_expected_model was never called"
+        # After the fix, pre-flight must use the agent's actual model_id
+        # ("SetdefaultChose-GGUF"), not the DB default it was seeded with.
+        assert preflight_calls[-1] == "SetdefaultChose-GGUF", (
+            f"Pre-flight must use agent.model_id after construction; "
+            f"got {preflight_calls[-1]!r} (expected 'SetdefaultChose-GGUF')"
+        )
+
+
+class TestBuiltinChatAgentUnchanged:
+    """Pin AC4: built-in ChatAgent (agent_type='chat') behavior is unchanged."""
+
+    def test_chat_agent_type_bypasses_registry(self):
+        """agent_type='chat' must not go through registry.create_agent."""
+        registry, captured = _make_registry()
+        db = _make_db(custom_model=None)
+        session = _make_session(model=_DB_DEFAULT, agent_type="chat")
+
+        fake_agent = MagicMock()
+        fake_agent.process_query.return_value = "ok"
+        fake_agent.conversation_history = []
+        fake_agent.indexed_files = set()
+        fake_agent.rag = None
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+            patch("gaia.agents.chat.agent.ChatAgent", return_value=fake_agent),
+            patch("gaia.agents.chat.agent.ChatAgentConfig"),
+        ):
+            _call_non_streaming(session, db, agent_type_override=None)
+
+        # registry.create_agent must NOT have been called for the chat path
+        registry.create_agent.assert_not_called()

--- a/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
+++ b/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
@@ -190,6 +190,69 @@ class TestModelKwargSelection:
             "kwargs", {}
         ), "Non-streaming path must not pass streaming=True to create_agent"
 
+    def test_cache_hit_on_second_turn_for_setdefault_agent(self):
+        """Cache regression guard for #842 fix: custom agents must hit the cache
+        on turn 2 even when their setdefault model differs from the session model.
+
+        Pre-fix _store_agent used _effective_model(agent, model_id) (the
+        post-construction value, e.g. "SetdefaultChose-GGUF") as the cache key,
+        while _get_cached_agent looked up using the pre-construction model_id
+        (the DB default). The keys never matched → cache miss every turn.
+
+        After the fix, _store_agent uses model_id (pre-construction intent)
+        and the keys agree regardless of what setdefault chose.
+        """
+        import gaia.ui._chat_helpers as _helpers
+        from gaia.ui._chat_helpers import _get_chat_response
+        from gaia.ui.models import ChatRequest
+
+        sid = "cache-test-session"
+        registry, _ = _make_registry(setdefault_model="SetdefaultChose-GGUF")
+        db = _make_db(custom_model=None)
+        session = dict(_make_session(model=_DB_DEFAULT))
+        session["session_id"] = sid
+
+        # Clear cache once; do NOT clear between turns (that's the whole point).
+        with _helpers._agent_cache_lock:
+            _helpers._agent_cache.clear()
+
+        request = ChatRequest(session_id=sid, message="hi", stream=False)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            # Turn 1 — agent constructed, stored in cache.
+            _run_sync(_get_chat_response(db, session, request))
+            first_agent = _helpers._agent_cache.get(sid, {}).get("agent")
+
+            # Turn 2 — must hit the cache; no second create_agent call.
+            _run_sync(_get_chat_response(db, session, request))
+            second_agent = _helpers._agent_cache.get(sid, {}).get("agent")
+
+        # 1. Only one construction (cache hit on turn 2).
+        assert registry.create_agent.call_count == 1, (
+            f"Cache regression: create_agent called {registry.create_agent.call_count} "
+            "times; expected 1 (turn 2 must be a cache hit, not a rebuild)"
+        )
+        # 2. Object identity proves the cache returned the same agent.
+        assert second_agent is first_agent, (
+            "Cache regression: turn 2 returned a different agent object — "
+            "cache hit must return the SAME instance, not a reconstructed one"
+        )
+        # 3. Stored key is the pre-construction intent (the actual regression pin).
+        stored_model = _helpers._agent_cache.get(sid, {}).get("model_id")
+        assert stored_model == _DB_DEFAULT, (
+            f"Cache regression: stored model_id={stored_model!r} must equal the "
+            f"pre-construction session model {_DB_DEFAULT!r}, not the agent's "
+            "post-setdefault value — otherwise lookup/store keys diverge"
+        )
+        # 4. Agent's own model_id reflects what setdefault chose.
+        assert first_agent.model_id == "SetdefaultChose-GGUF", (
+            f"Agent model_id={first_agent.model_id!r} must reflect kwargs.setdefault "
+            "value 'SetdefaultChose-GGUF'"
+        )
+
 
 class TestStaticRegressionGuard:
     """Source-level pin against reintroduction of the antipattern."""
@@ -218,6 +281,23 @@ class TestStaticRegressionGuard:
             "model_id=model_id as a direct kwarg. Build create_kwargs conditionally "
             "and omit model_id when no explicit user choice exists.\n"
             f"Match found at: {match.group()[:80]!r}"
+        )
+
+    def test_no_effective_model_in_store_agent_calls(self):
+        """Cache-key divergence guard for the #842 fix. _store_agent is the cache
+        STORE; its 2nd arg must be the pre-construction model_id so it matches
+        the lookup key used by _get_cached_agent. Passing _effective_model(...)
+        (post-construction) causes the store/lookup keys to diverge whenever the
+        agent's setdefault differs from the session model — agents rebuild every turn.
+        """
+        import re
+
+        src = (Path(__file__).parents[4] / "src/gaia/ui/_chat_helpers.py").read_text()
+        match = re.search(r"_store_agent\([^()]*_effective_model", src, re.DOTALL)
+        assert not match, (
+            "Cache regression (#842): _store_agent must not receive _effective_model(...) "
+            "as a positional arg — store/lookup keys would diverge for setdefault agents. "
+            f"Match: {match.group()[:80]!r}"
         )
 
 


### PR DESCRIPTION
Fixes #841 — Agent UI ignores custom agent model choice.

## Summary

`_chat_helpers.py` unconditionally passed `model_id=<session model>` to `registry.create_agent()`, defeating `kwargs.setdefault("model_id", ...)` in custom agents. `setdefault` only fires when the key is **absent** — an explicit kwarg, even if it equals the default, silences it.

- Export `SESSION_DEFAULT_MODEL` from `database.py` — single source of truth replacing a duplicate string literal
- Build `create_kwargs` conditionally via `_build_create_kwargs()`: omit `model_id` when the session is at the DB default so the agent's `__init__` setdefault governs
- Three-branch precedence: `custom_model` setting > session-explicit (≠ DB default) > omit kwarg
- Use `_effective_model(agent, fallback)` (explicit `None` check, not `or`) for `_maybe_load_expected_model` pre-flight — Lemonade warm-up targets the agent's actual effective model after construction; log statements use it for observability
- `_store_agent` cache key uses the pre-construction `model_id` (session intent) to match `_get_cached_agent`'s lookup key — keeping store/lookup keys in sync regardless of what setdefault chooses

The initial implementation used `_effective_model` for the cache store key too, which caused a cache miss every turn for custom agents (e.g. those scaffolded from `builder/template.py`) whose setdefault model differs from the session default. A follow-up commit fixes that regression.

## Test plan

- [ ] `pytest tests/unit/chat/ui/test_agent_model_override.py` — registry mechanism: custom agent with `setdefault` gets its own model when UI omits kwarg
- [ ] `pytest tests/unit/chat/ui/test_chat_helpers_model_resolution.py` — 10 unit tests: three-branch precedence, pre-flight contract, two static regression guards (#841 antipattern + cache-key divergence), cache-hit on second turn, ChatAgent bypass
- [ ] `pytest tests/integration/test_chat_ui_integration.py::TestCustomAgentModelChoice` — end-to-end HTTP path
- [ ] `pytest tests/unit/ --ignore=tests/unit/chat/ui/test_sse_confirmation.py` — full unit suite