### PR TITLE
fix(ci): break AppImage smoke-test/PyPI circular dependency with GAIA_LOCAL_WHEEL

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -626,6 +626,7 @@ jobs:
             --security-opt apparmor=unconfined
             --ipc=host
             -v "${APPIMAGE_HOST}:/work/gaia.AppImage:ro"
+            # Expand to nothing if WHEEL_MOUNTS is empty (set -u compat)
             "${WHEEL_MOUNTS[@]+"${WHEEL_MOUNTS[@]}"}"
           )
 

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -463,6 +463,31 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: src/gaia/apps/webui/dist-app/
 
+      # ─── Build Python wheel (Linux release builds only) ─────────────
+      # The wheel is consumed by the AppImage smoke tests so they can
+      # install the backend from a local file instead of pulling from PyPI.
+      # This breaks the circular dependency where smoke tests run before
+      # PyPI publish in the release pipeline.
+      - name: Build Python wheel
+        if: matrix.platform == 'linux'
+        id: build-wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          pip install build --quiet
+          python -m build --wheel --outdir /tmp/gaia-wheel
+          WHEEL=$(ls /tmp/gaia-wheel/*.whl | head -n1)
+          echo "path=${WHEEL}" >> "$GITHUB_OUTPUT"
+          echo "Built wheel: ${WHEEL}"
+
+      - name: Upload Python wheel artifact
+        if: matrix.platform == 'linux' && steps.build-wheel.outputs.path != ''
+        uses: actions/upload-artifact@v6
+        with:
+          name: gaia-wheel
+          path: /tmp/gaia-wheel/*.whl
+          retention-days: 14
+
   # ─── AppImage smoke tests (issue #782) ──────────────────────────────
   # Consume the linux-installer artifact produced by the `build` matrix
   # and run structural + distro-level smoke checks against the AppImage.
@@ -522,6 +547,35 @@ jobs:
           name: linux-installer
           path: ${{ runner.temp }}/linux-installer
 
+      # Download the Python wheel built alongside the installer so the
+      # AppImage smoke test can install from a local file instead of PyPI.
+      # continue-on-error: the wheel is absent on PR builds (fine — PyPI
+      # still has the previous release), but required on release builds.
+      - name: Download Python wheel
+        id: download-wheel
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          name: gaia-wheel
+          path: ${{ runner.temp }}/gaia-wheel
+
+      - name: Locate Python wheel
+        id: locate-wheel
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          WHEEL=$(ls "${RUNNER_TEMP}/gaia-wheel"/*.whl 2>/dev/null | head -n1 || true)
+          echo "path=${WHEEL}" >> "$GITHUB_OUTPUT"
+          if [ -n "${WHEEL}" ]; then
+            echo "Found wheel: ${WHEEL} — smoke tests will use GAIA_LOCAL_WHEEL"
+          elif [ -n "${RELEASE_TAG}" ]; then
+            echo "::error::No Python wheel artifact found for release build (tag=${RELEASE_TAG}). The wheel is required to avoid the PyPI circular dependency — the Build Python wheel step must have failed."
+            exit 1
+          else
+            echo "No wheel artifact — smoke tests will install from PyPI (non-release build)"
+          fi
+
       - name: Prepare AppImage
         id: prep
         shell: bash
@@ -540,6 +594,7 @@ jobs:
         shell: bash
         env:
           APPIMAGE_HOST: ${{ steps.prep.outputs.appimage }}
+          WHEEL_PATH: ${{ steps.locate-wheel.outputs.path }}
         run: |
           set -euo pipefail
 
@@ -551,6 +606,18 @@ jobs:
             -f tests/electron/fixtures/Dockerfile.fedora-41 \
             tests/electron/fixtures
 
+          # If a local wheel is available, mount it and set GAIA_LOCAL_WHEEL
+          # so the AppImage installs the backend from file instead of PyPI.
+          # This is the release-pipeline path — on PR builds WHEEL_PATH is
+          # empty and the app falls back to pulling from PyPI normally.
+          WHEEL_MOUNTS=()
+          if [ -n "${WHEEL_PATH}" ]; then
+            WHEEL_MOUNTS=(
+              -v "${WHEEL_PATH}:/work/gaia.whl:ro"
+              --env GAIA_LOCAL_WHEEL=/work/gaia.whl
+            )
+          fi
+
           DOCKER_RUN_COMMON=(
             --rm
             --cap-add SYS_ADMIN
@@ -559,6 +626,7 @@ jobs:
             --security-opt apparmor=unconfined
             --ipc=host
             -v "${APPIMAGE_HOST}:/work/gaia.AppImage:ro"
+            "${WHEEL_MOUNTS[@]+"${WHEEL_MOUNTS[@]}"}"
           )
 
           # ── Row 1: Ubuntu 24.04 + libfuse2, curl purged ──────────────
@@ -735,6 +803,31 @@ jobs:
           name: linux-installer
           path: ${{ runner.temp }}/linux-installer
 
+      - name: Download Python wheel
+        id: download-wheel
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          name: gaia-wheel
+          path: ${{ runner.temp }}/gaia-wheel
+
+      - name: Locate Python wheel
+        id: locate-wheel
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          WHEEL=$(ls "${RUNNER_TEMP}/gaia-wheel"/*.whl 2>/dev/null | head -n1 || true)
+          echo "path=${WHEEL}" >> "$GITHUB_OUTPUT"
+          if [ -n "${WHEEL}" ]; then
+            echo "Found wheel: ${WHEEL} — will set GAIA_LOCAL_WHEEL"
+          elif [ -n "${RELEASE_TAG}" ]; then
+            echo "::error::No Python wheel artifact found for release build (tag=${RELEASE_TAG}). The wheel is required to avoid the PyPI circular dependency — the Build Python wheel step must have failed."
+            exit 1
+          else
+            echo "No wheel artifact — will install from PyPI (non-release build)"
+          fi
+
       - name: Enable AppArmor userns restriction on host
         shell: bash
         run: |
@@ -746,12 +839,18 @@ jobs:
 
       - name: Launch AppImage under xvfb with userns restricted
         shell: bash
+        env:
+          WHEEL_PATH: ${{ steps.locate-wheel.outputs.path }}
         run: |
           set -euo pipefail
           APPIMAGE=$(ls "${RUNNER_TEMP}/linux-installer"/*.AppImage | head -n1)
           chmod +x "${APPIMAGE}"
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends libfuse2 xvfb xauth
+          if [ -n "${WHEEL_PATH}" ]; then
+            export GAIA_LOCAL_WHEEL="${WHEEL_PATH}"
+            echo "GAIA_LOCAL_WHEEL=${GAIA_LOCAL_WHEEL}"
+          fi
           xvfb-run --auto-servernum "${APPIMAGE}" \
             >/tmp/stdout.log 2>/tmp/stderr.log &
           APP_PID=$!

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -987,9 +987,14 @@ async function installBackend(opts = {}) {
   const version = resolveBackendVersion(opts);
   // GAIA_LOCAL_WHEEL: CI-only. When set, install from the given wheel path
   // instead of pulling from PyPI. This breaks the circular dependency in
-  // release pipeline smoke tests that run before PyPI publish.
+  // release pipeline smoke tests that run before PyPI publish. The `[ui]`
+  // extras marker is preserved so the local install matches the PyPI path
+  // (fastapi, uvicorn, python-multipart, httpx, psutil) — otherwise the
+  // backend venv comes up missing every UI dep and /api/health never binds.
   const localWheel = process.env.GAIA_LOCAL_WHEEL || null;
-  const pipPackage = localWheel || `amd-gaia[ui]==${version}`;
+  const pipPackage = localWheel
+    ? `${localWheel}[ui]`
+    : `amd-gaia[ui]==${version}`;
 
   log("================================================");
   log("  Installing GAIA backend");

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -950,9 +950,15 @@ async function ensureUv({ onProgress, isPackaged } = {}) {
 
 /**
  * Read the pinned backend version from package.json (or a caller override).
+ * Returns null when GAIA_LOCAL_WHEEL is set — the caller uses the wheel path
+ * directly and skips the PyPI version pin (CI release-build fast-path).
  */
 function resolveBackendVersion(opts = {}) {
   if (opts.version) return opts.version;
+  // CI override: install from a local wheel instead of a pinned PyPI version.
+  // Breaks the circular dependency in release builds where the AppImage smoke
+  // test runs before PyPI publish.
+  if (process.env.GAIA_LOCAL_WHEEL) return null;
   try {
     // package.json is one directory up from the services/ (or bin/) directory.
     // We look relative to this module's own location.
@@ -979,7 +985,11 @@ function resolveBackendVersion(opts = {}) {
 async function installBackend(opts = {}) {
   const report = makeProgressReporter(opts.onProgress);
   const version = resolveBackendVersion(opts);
-  const pipPackage = `amd-gaia[ui]==${version}`;
+  // GAIA_LOCAL_WHEEL: CI-only. When set, install from the given wheel path
+  // instead of pulling from PyPI. This breaks the circular dependency in
+  // release pipeline smoke tests that run before PyPI publish.
+  const localWheel = process.env.GAIA_LOCAL_WHEEL || null;
+  const pipPackage = localWheel || `amd-gaia[ui]==${version}`;
 
   log("================================================");
   log("  Installing GAIA backend");
@@ -1045,7 +1055,8 @@ async function installBackend(opts = {}) {
     GAIA_PYTHON_BIN,
   ];
   // Linux/macOS: use CPU-only PyTorch to avoid huge CUDA wheels.
-  if (!IS_WINDOWS) {
+  // Skip when installing from a local wheel — PyPI index not needed.
+  if (!IS_WINDOWS && !localWheel) {
     pipArgs.push("--extra-index-url", "https://download.pytorch.org/whl/cpu");
   }
 
@@ -1224,11 +1235,13 @@ async function ensureBackend(opts = {}) {
     }
 
     // Fast-path: already installed at the expected version.
+    // Skip when expectedVersion is null (GAIA_LOCAL_WHEEL is set) — always
+    // reinstall from the local wheel so CI gets a fresh install each run.
     const expectedVersion = resolveBackendVersion(opts);
     const existingBin = findGaiaBin();
     if (existingBin) {
       const installedVersion = getInstalledVersion(existingBin);
-      if (installedVersion === expectedVersion) {
+      if (expectedVersion !== null && installedVersion === expectedVersion) {
         log(
           `GAIA backend already installed at version ${installedVersion} — nothing to do`
         );


### PR DESCRIPTION
AppImage smoke tests (added in #847) launch the real AppImage, which triggers `backend-installer.cjs` and calls `uv pip install amd-gaia[ui]==<version>`. On a release build the new version isn't on PyPI yet — it publishes *after* smoke tests pass — so every release build fails at the smoke-test stage. This blocked the v0.17.4 tag push.

## Fix

**`backend-installer.cjs`** — add `GAIA_LOCAL_WHEEL` env var support:
- `resolveBackendVersion()` returns `null` when `GAIA_LOCAL_WHEEL` is set
- `installBackend()` uses the wheel path as `pipPackage` instead of the PyPI pin; skips `--extra-index-url` (not needed for local installs)
- `ensureBackend()` fast-path guards `expectedVersion !== null` so CI always reinstalls from the local wheel

**`build-installers.yml`** — build and wire the wheel into smoke tests:
- Linux build job runs `python -m build --wheel` after the installer and uploads it as `gaia-wheel` artifact
- `appimage-distro-matrix` downloads the wheel and passes `GAIA_LOCAL_WHEEL` into Docker containers via volume mount + `--env`
- `appimage-userns-restricted` downloads the wheel and exports `GAIA_LOCAL_WHEEL` before `xvfb-run`
- On release builds (`inputs.tag` set), the `Locate Python wheel` step fails loudly if the artifact is absent — prevents silent fallback to the broken PyPI path
- On PR builds (no tag), the wheel download uses `continue-on-error: true` and the app falls back to PyPI normally

## Test plan

- [ ] `appimage-distro-matrix` and `appimage-userns-restricted` pass on a release-tagged build
- [ ] PR builds (no tag) still pass — wheel absent, PyPI fallback works
- [ ] `GAIA_LOCAL_WHEEL` set in release builds → `uv pip install <path/to/wheel>` succeeds, no PyPI 404