### PR TITLE
fix(ci): correct version to 0.17.4 and fix wheel filename in distro-matrix

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -612,9 +612,11 @@ jobs:
           # empty and the app falls back to pulling from PyPI normally.
           WHEEL_MOUNTS=()
           if [ -n "${WHEEL_PATH}" ]; then
+            WHEEL_BASENAME=$(basename "${WHEEL_PATH}")
+            WHEEL_DIR=$(dirname "${WHEEL_PATH}")
             WHEEL_MOUNTS=(
-              -v "${WHEEL_PATH}:/work/gaia.whl:ro"
-              --env GAIA_LOCAL_WHEEL=/work/gaia.whl
+              -v "${WHEEL_DIR}:/work/wheels:ro"
+              --env "GAIA_LOCAL_WHEEL=/work/wheels/${WHEEL_BASENAME}"
             )
           fi
 

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from importlib.metadata import version as get_package_version_metadata
 
-__version__ = "0.17.3"
+__version__ = "0.17.4"
 
 # Lemonade version used across CI and installer
 LEMONADE_VERSION = "10.0.0"


### PR DESCRIPTION
Fixes the two remaining blockers preventing the v0.17.4 tag from being pushed.

## Summary

PR #847 squash-merged from a branch predating the `version.py` auto-bump, silently reverting `__version__` back to `"0.17.3"`. This means the Python wheel built in CI carries version `0.17.3`, while `package.json` already shows `0.17.4`, and the planned PyPI publish would try to publish the wrong version.

The `appimage-distro-matrix` smoke job (added in #856) was mounting the wheel into Docker as `/work/gaia.whl`. uv rejects filenames without the canonical `{name}-{version}-{tags}.whl` format: `error: The wheel filename "gaia.whl" is invalid: Must have a version`. The fix mounts the wheel directory at `/work/wheels/` and references the file by its original basename.

## Changes

- `src/gaia/version.py` — `__version__ = "0.17.3"` → `"0.17.4"`
- `.github/workflows/build-installers.yml` — mount wheel dir at `/work/wheels/` and set `GAIA_LOCAL_WHEEL=/work/wheels/<original-filename>` instead of renaming to `gaia.whl`

## Test plan

- [ ] CI `appimage-distro-matrix` passes (wheel filename is valid, uv installs successfully)
- [ ] Built wheel is named `amd_gaia-0.17.4-py3-none-any.whl`
- [ ] `python -c "import gaia; print(gaia.__version__)"` returns `0.17.4` after install

Closes #856 follow-up (distro-matrix failure from run 24888889163).