### PR TITLE
ci: add Context7 + DeepWiki documentation steering

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -1,0 +1,40 @@
+{
+  "repo_notes": [
+    {
+      "content": "GAIA is AMD's open-source framework for building AI agents in Python and C++ that run entirely on local hardware. No cloud dependency — all processing stays on-device with AMD NPU and GPU acceleration on Ryzen AI processors. The repository has two frameworks: a Python SDK (src/gaia/) and a C++ SDK (cpp/). Documentation lives in docs/ using .mdx format (Mintlify), published at https://amd-gaia.ai. Python agents inherit from the base Agent class in src/gaia/agents/base/agent.py and register tools via the @tool decorator. LLM inference runs locally via Lemonade Server. Default models: Qwen3-0.6B-GGUF (general), Qwen3.5-35B-A3B-GGUF (agents/code), Qwen3-VL-4B-Instruct-GGUF (vision). CLI entry point: src/gaia/cli.py. Development setup: uv pip install -e '.[dev]'."
+    }
+  ],
+  "pages": [
+    {
+      "title": "Architecture Overview",
+      "purpose": "High-level architecture of both Python and C++ frameworks: agent system, LLM backends (Lemonade Server), MCP integration, and how components connect"
+    },
+    {
+      "title": "Python Agent Framework",
+      "purpose": "Base Agent class (src/gaia/agents/base/), tool registration with @tool decorator, mixins (MCPAgent, ApiAgent), and how to create new agents",
+      "parent": "Architecture Overview"
+    },
+    {
+      "title": "C++ Agent Framework",
+      "purpose": "C++ SDK for building native agents (cpp/), gaia::Agent base class, tool registration, health/wifi/process agent examples",
+      "parent": "Architecture Overview"
+    },
+    {
+      "title": "Agent UI",
+      "purpose": "Privacy-first desktop chat with drag-and-drop document Q&A. FastAPI backend (src/gaia/ui/), React/Electron frontend (src/gaia/apps/webui/), launched via gaia --ui"
+    },
+    {
+      "title": "Core Capabilities",
+      "purpose": "Document Q&A with RAG (src/gaia/rag/), speech-to-speech (Whisper ASR + Kokoro TTS in src/gaia/audio/), image generation (Stable Diffusion in src/gaia/agents/sd/), agent routing, and MCP integration"
+    },
+    {
+      "title": "Code Index",
+      "purpose": "Semantic code search over repositories using FAISS + Lemonade embeddings (src/gaia/code_index/), CLI via gaia index, dedicated CodeIndexAgent",
+      "parent": "Core Capabilities"
+    },
+    {
+      "title": "CLI and Configuration",
+      "purpose": "CLI entry point (gaia command) with subcommands: chat, talk, llm, api, mcp, index, sd, blender, jira, docker, eval. Also gaia --ui for Agent UI"
+    }
+  ]
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -484,3 +484,22 @@ jobs:
             release-assets/*
             dist/**
           body_path: RELEASE_BODY.md
+
+  refresh-context7:
+    runs-on: ubuntu-latest
+    needs: [github-release]
+    steps:
+      - name: Refresh Context7
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST https://context7.com/api/v1/refresh \
+            -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{"libraryName": "/amd/gaia"}')
+          if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "202" ]; then
+            echo "Context7 refresh triggered (HTTP $HTTP_STATUS)"
+          elif [ "$HTTP_STATUS" = "429" ]; then
+            echo "::warning::Context7 rate limited — refresh skipped"
+          else
+            echo "::warning::Context7 refresh returned HTTP $HTTP_STATUS"
+          fi

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "GAIA",
+  "description": "AMD's open-source framework for building AI agents in Python and C++ that run entirely on local hardware, with AMD NPU and GPU acceleration on Ryzen AI processors.",
+  "folders": ["docs"],
+  "excludeFolders": ["tests", "scripts", "workshop", "docs/spec"],
+  "excludeFiles": ["CHANGELOG.md"],
+  "rules": [
+    "GAIA has two frameworks: Python (src/gaia/) and C++ (cpp/). Most documentation covers the Python SDK.",
+    "Python agents inherit from the base Agent class in src/gaia/agents/base/agent.py",
+    "Tools are registered using the @tool decorator from gaia.agents.base.tools",
+    "LLM inference runs locally via Lemonade Server on AMD NPU/GPU hardware",
+    "Default models: Qwen3-0.6B-GGUF (general), Qwen3.5-35B-A3B-GGUF (agents/code), Qwen3-VL-4B-Instruct-GGUF (vision)",
+    "Agent UI is the primary user interface — launch with 'gaia --ui' for privacy-first desktop chat with document Q&A",
+    "All new features require tests in tests/ and documentation in docs/ (.mdx format for Mintlify)",
+    "Use 'uv pip install -e .[dev]' for development setup",
+    "The code index (gaia.code_index) provides semantic search over repositories using local FAISS + Lemonade embeddings"
+  ],
+  "previousVersions": [
+    {"tag": "v0.17.1"},
+    {"tag": "v0.17.0"},
+    {"tag": "v0.16.0"},
+    {"tag": "v0.15.0"}
+  ]
+}

--- a/context7.json
+++ b/context7.json
@@ -15,11 +15,5 @@
     "All new features require tests in tests/ and documentation in docs/ (.mdx format for Mintlify)",
     "Use 'uv pip install -e .[dev]' for development setup",
     "The code index (gaia.code_index) provides semantic search over repositories using local FAISS + Lemonade embeddings"
-  ],
-  "previousVersions": [
-    {"tag": "v0.17.1"},
-    {"tag": "v0.17.0"},
-    {"tag": "v0.16.0"},
-    {"tag": "v0.15.0"}
   ]
 }


### PR DESCRIPTION
## Summary

Adds external documentation-steering config for Context7 and DeepWiki (Devin Wiki). These files help both services index GAIA's docs correctly — no behavior changes to the SDK, CLI, or agents. Originally bundled in #721 but unrelated to the code-index feature; splitting them out so each PR stays focused.

## Changes

- **`context7.json`** — declares `docs/` as the indexed scope, excludes `tests/scripts/workshop/docs/spec`, and provides 9 rules so Context7 answers reflect GAIA conventions (base Agent class location, `@tool` decorator, local Lemonade inference, default models, UI-first guidance).
- **`.devin/wiki.json`** — DeepWiki repo notes plus a 7-page structure (Architecture Overview, Python/C++ Agent Framework, Agent UI, Core Capabilities, Code Index, CLI). The Code Index page resolves once #721 merges.
- **`.github/workflows/publish.yml`** — new `refresh-context7` job runs after `github-release` and POSTs to the Context7 refresh API so each release picks up doc changes.

## Merge order

Intended to merge **after #721** so the `Code Index` wiki page entry resolves on the first DeepWiki refresh.

## Test plan

- [ ] `actionlint .github/workflows/publish.yml` (or CI lint) passes
- [ ] `jq . context7.json .devin/wiki.json` returns valid JSON
- [ ] On next release after merge: `refresh-context7` job runs and returns HTTP 200/202 (or logs a warning for 429/non-2xx)
- [ ] Verify `CONTEXT7_API_KEY` secret exists in repo settings before first release