### PR TITLE
feat(ui): friendly ngrok tunnel diagnostics + cookie auth for mobile

### DIFF
--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -380,43 +380,56 @@ function App() {
         }
     }, [addSession, setCurrentSession, setMessages, setSidebarOpen, checkSystemStatus, setPendingPrompt]);
 
-    // Mobile gateway toggle
+    // Mobile gateway toggle: the sidebar button ALWAYS opens the modal
+    // (so the user can re-capture the QR / URL if they missed it the first
+    // time).  Stopping the tunnel is done via the explicit "Stop Tunnel"
+    // button inside the modal (see handleMobileStop).
     const handleMobileToggle = useCallback(async () => {
         if (tunnelActive) {
-            // Stop tunnel
-            log.system.info('Stopping mobile access tunnel...');
-            try {
-                await api.stopTunnel();
-            } catch {
-                // Ignore stop errors
-            }
-            setTunnelActive(false);
-            setShowMobileAccess(false);
-        } else {
-            // Start tunnel
-            log.system.info('Starting mobile access tunnel...');
-            setShowMobileAccess(true);
-            setTunnelLoading(true);
+            // Tunnel already running -- just reopen the modal so the user
+            // can copy the URL or scan the QR again.
+            log.system.info('Reopening mobile access modal (tunnel already running)');
             setTunnelError(null);
-            try {
-                const status = await api.startTunnel();
-                if (status.error) {
-                    log.system.error('Tunnel failed to start:', status.error);
-                    setTunnelActive(false);
-                    setTunnelError(status.error);
-                } else {
-                    setTunnelActive(true);
-                    log.system.info('Tunnel started successfully');
-                }
-            } catch (err) {
-                log.system.error('Tunnel start error:', err);
+            setShowMobileAccess(true);
+            return;
+        }
+
+        // Tunnel is not running -- start it.
+        log.system.info('Starting mobile access tunnel...');
+        setShowMobileAccess(true);
+        setTunnelLoading(true);
+        setTunnelError(null);
+        try {
+            const status = await api.startTunnel();
+            if (status.error) {
+                log.system.error('Tunnel failed to start:', status.error);
                 setTunnelActive(false);
-                setTunnelError(err instanceof Error ? err.message : 'Failed to connect');
-            } finally {
-                setTunnelLoading(false);
+                setTunnelError(status.error);
+            } else {
+                setTunnelActive(true);
+                log.system.info('Tunnel started successfully');
             }
+        } catch (err) {
+            log.system.error('Tunnel start error:', err);
+            setTunnelActive(false);
+            setTunnelError(err instanceof Error ? err.message : 'Failed to connect');
+        } finally {
+            setTunnelLoading(false);
         }
     }, [tunnelActive]);
+
+    // Explicit "Stop Tunnel" action (triggered from inside the modal).
+    const handleMobileStop = useCallback(async () => {
+        log.system.info('Stopping mobile access tunnel...');
+        try {
+            await api.stopTunnel();
+        } catch (err) {
+            log.system.warn('stopTunnel call failed (continuing)', err);
+        }
+        setTunnelActive(false);
+        setTunnelError(null);
+        setShowMobileAccess(false);
+    }, []);
 
     // Sync agent picker to the selected session's agent_type
     useEffect(() => {
@@ -533,6 +546,7 @@ function App() {
                     <MobileAccessModal
                         isOpen={showMobileAccess}
                         onClose={() => setShowMobileAccess(false)}
+                        onStop={handleMobileStop}
                         error={tunnelError}
                     />
                 </AnimatedPresence>

--- a/src/gaia/apps/webui/src/components/MobileAccessModal.css
+++ b/src/gaia/apps/webui/src/components/MobileAccessModal.css
@@ -73,6 +73,14 @@
     font-size: 13px;
     line-height: 1.5;
     word-break: break-word;
+    /* Preserve \n newlines from backend hint messages (e.g. the
+       multi-line authtoken-setup instructions). */
+    white-space: pre-line;
+}
+
+.tunnel-error a {
+    color: var(--accent-danger);
+    text-decoration: underline;
 }
 
 /* QR Code area */

--- a/src/gaia/apps/webui/src/components/MobileAccessModal.tsx
+++ b/src/gaia/apps/webui/src/components/MobileAccessModal.tsx
@@ -14,10 +14,12 @@ let QRCodeLib: any = null;
 interface MobileAccessModalProps {
     isOpen: boolean;
     onClose: () => void;
+    /** Explicitly stop the tunnel (shown only while the tunnel is active). */
+    onStop?: () => void;
     error?: string | null;
 }
 
-export function MobileAccessModal({ isOpen, onClose, error }: MobileAccessModalProps) {
+export function MobileAccessModal({ isOpen, onClose, onStop, error }: MobileAccessModalProps) {
     const [status, setStatus] = useState<TunnelStatus | null>(null);
     const [copied, setCopied] = useState(false);
     const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -213,6 +215,15 @@ export function MobileAccessModal({ isOpen, onClose, error }: MobileAccessModalP
 
                     {/* Actions */}
                     <div className="mobile-access-actions">
+                        {status?.active && onStop && (
+                            <button
+                                className="btn-danger"
+                                onClick={onStop}
+                                title="Close the tunnel and revoke the mobile URL"
+                            >
+                                Stop Tunnel
+                            </button>
+                        )}
                         <button className="btn-secondary" onClick={onClose}>Close</button>
                     </div>
                 </div>

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -389,14 +389,17 @@ def _canonical_agent_type(agent_type: str) -> str:
     Keeps the per-session agent cache from thrashing when a client mixes the
     old and new IDs within the same session — both resolve to the same
     canonical ID and therefore the same cache entry.
+
+    Raises:
+        AttributeError: If the registry doesn't expose ``canonical_id``.
+            Fail loudly per CLAUDE.md "no silent fallbacks" — a registry
+            that lost this method is a real bug, not something to paper
+            over with a cache miss.
     """
     registry = _agent_registry
     if registry is None:
         return agent_type
-    try:
-        return registry.canonical_id(agent_type)
-    except Exception:  # pragma: no cover — defensive; canonical_id is pure
-        return agent_type
+    return registry.canonical_id(agent_type)
 
 
 def _get_cached_agent(session_id: str, model_id: str, agent_type: str = "chat"):

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -73,17 +73,29 @@ _LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
 # API paths that bypass tunnel authentication (monitoring / preflight)
 _AUTH_EXEMPT_PATHS = {"/api/health"}
 
+# HttpOnly cookie name used to bootstrap tunnel auth from the QR-code URL.
+# When a mobile browser opens ``https://<tunnel>/?token=<uuid>`` the SPA
+# handler (``serve_spa``) sets this cookie on the response, so the React
+# app's subsequent ``fetch('/api/...')`` calls carry it automatically
+# (same-origin fetches include cookies by default).
+_TUNNEL_COOKIE_NAME = "gaia_tunnel_token"
+
 
 # ── Tunnel Auth Middleware ──────────────────────────────────────────────────
 
 
 class TunnelAuthMiddleware(BaseHTTPMiddleware):
-    """Validate Bearer token on API requests arriving through the ngrok tunnel.
+    """Validate tunnel auth token on API requests arriving through the ngrok tunnel.
 
     When the tunnel is active, every ``/api/*`` request whose source is
-    *not* localhost must carry a valid ``Authorization: Bearer <token>``
-    header.  Local requests (from the Electron desktop app) and the
-    ``/api/health`` monitoring endpoint are always allowed through.
+    *not* localhost must carry a valid token, provided via either:
+
+    1. ``Authorization: Bearer <token>`` header (scriptable clients, curl)
+    2. ``gaia_tunnel_token`` cookie (set by ``serve_spa`` when a mobile
+       browser first opens the QR-code URL containing ``?token=<uuid>``)
+
+    Local requests (from the Electron desktop app) and the ``/api/health``
+    monitoring endpoint are always allowed through.
     """
 
     async def dispatch(self, request: Request, call_next):
@@ -107,16 +119,34 @@ class TunnelAuthMiddleware(BaseHTTPMiddleware):
         if client_host in _LOCAL_HOSTS:
             return await call_next(request)
 
-        # ── Remote request through tunnel -- require Bearer token ────────
+        # ── Remote request through tunnel -- require valid token ─────────
+        # Extract token from Authorization header OR cookie.
+        token = None
         auth_header = request.headers.get("authorization", "")
-        if not auth_header.lower().startswith("bearer "):
+        if auth_header.lower().startswith("bearer "):
+            token = auth_header[len("bearer ") :].strip()  # noqa: E203
+        if not token:
+            token = request.cookies.get(_TUNNEL_COOKIE_NAME)
+
+        if not token:
+            logger.warning(
+                "Tunnel auth: rejecting %s %s from %s (no header/cookie)",
+                request.method,
+                path,
+                client_host,
+            )
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Missing or invalid Authorization header"},
             )
 
-        token = auth_header[len("bearer ") :].strip()  # noqa: E203
         if not tunnel.validate_token(token):
+            logger.warning(
+                "Tunnel auth: rejecting %s %s from %s (invalid token)",
+                request.method,
+                path,
+                client_host,
+            )
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Invalid tunnel authentication token"},
@@ -385,14 +415,61 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             "Expires": "0",
         }
 
+        def _maybe_bootstrap_tunnel_cookie(
+            resp: FileResponse, request: Request
+        ) -> FileResponse:
+            """Attach tunnel-auth cookie if ?token=<valid-uuid> is present.
+
+            When a mobile browser first opens the QR-code URL
+            ``https://<tunnel>/?token=<uuid>``, we validate the token against
+            the active tunnel and set an HttpOnly cookie so that the SPA's
+            subsequent same-origin ``fetch('/api/...')`` calls authenticate
+            automatically -- no frontend token-plumbing required.
+
+            The ``Secure`` attribute is set only when the incoming request
+            used HTTPS (either directly or via ``X-Forwarded-Proto`` from
+            ngrok).  Over plain HTTP (localhost dev / TestClient) we omit
+            it so the cookie is actually delivered -- the middleware still
+            requires localhost bypass there, so there's no leak risk.
+            """
+            tunnel_mgr = getattr(request.app.state, "tunnel", None)
+            qs_token = request.query_params.get("token")
+            if (
+                tunnel_mgr is not None
+                and tunnel_mgr.active
+                and qs_token
+                and tunnel_mgr.validate_token(qs_token)
+            ):
+                # ngrok terminates TLS and forwards plain HTTP, so direct
+                # request.url.scheme is often "http".  Trust
+                # X-Forwarded-Proto when present.
+                fwd_proto = request.headers.get("x-forwarded-proto", "").lower()
+                is_https = request.url.scheme == "https" or fwd_proto == "https"
+                resp.set_cookie(
+                    key=_TUNNEL_COOKIE_NAME,
+                    value=qs_token,
+                    httponly=True,
+                    secure=is_https,
+                    samesite="lax",
+                    path="/",
+                )
+                logger.info(
+                    "Tunnel auth: bootstrapped cookie for client %s (secure=%s)",
+                    request.client.host if request.client else "unknown",
+                    is_https,
+                )
+            return resp
+
         @app.get("/{full_path:path}")
-        async def serve_spa(full_path: str):
+        async def serve_spa(request: Request, full_path: str):
             """Serve the React SPA for all non-API routes."""
             # Inline path sanitization (prevents directory traversal).
             # Checks are explicit so static analysis (CodeQL) can verify
             # the user-controlled ``full_path`` is properly constrained.
             if not full_path or "\x00" in full_path or ".." in full_path:
-                return FileResponse(_index_html, headers=_NO_CACHE)
+                return _maybe_bootstrap_tunnel_cookie(
+                    FileResponse(_index_html, headers=_NO_CACHE), request
+                )
 
             candidate = (_resolved_dist / full_path).resolve()
 
@@ -400,13 +477,19 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             try:
                 candidate.relative_to(_resolved_dist)
             except ValueError:
-                return FileResponse(_index_html, headers=_NO_CACHE)
+                return _maybe_bootstrap_tunnel_cookie(
+                    FileResponse(_index_html, headers=_NO_CACHE), request
+                )
 
             if candidate.is_file():
-                return FileResponse(str(candidate))
+                return _maybe_bootstrap_tunnel_cookie(
+                    FileResponse(str(candidate)), request
+                )
 
             # Default to index.html for SPA routing
-            return FileResponse(_index_html, headers=_NO_CACHE)
+            return _maybe_bootstrap_tunnel_cookie(
+                FileResponse(_index_html, headers=_NO_CACHE), request
+            )
 
     else:
         # Resolve to an absolute path so users can act on the warning. Prefer

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -25,10 +25,11 @@ import shutil  # noqa: F401  # pylint: disable=unused-import
 import traceback
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -114,9 +115,27 @@ class TunnelAuthMiddleware(BaseHTTPMiddleware):
         if tunnel is None or not tunnel.active:
             return await call_next(request)
 
-        # Allow requests originating from localhost (Electron app)
+        # ── Localhost bypass (Electron desktop app) ────────────────────
+        # The bypass requires BOTH the raw TCP peer to be on localhost
+        # AND the request to lack any ``X-Forwarded-*`` headers. The
+        # second clause is what makes the bypass spoof-resistant: ngrok
+        # always *adds* ``X-Forwarded-For`` / ``X-Forwarded-Host`` /
+        # ``X-Forwarded-Proto`` to tunnelled requests, so if any of those
+        # are present the request came in over the wire and must
+        # authenticate — even if a remote attacker tried to set
+        # ``X-Forwarded-For: 127.0.0.1`` to fake a localhost source.
+        #
+        # Note: ``request.client.host`` reflects the raw TCP peer because
+        # the standalone runner in ``main()`` passes
+        # ``forwarded_allow_ips=""`` to uvicorn, disabling the proxy-header
+        # rewrite that would otherwise let the ``X-Forwarded-For`` value
+        # take precedence.
         client_host = request.client.host if request.client else None
-        if client_host in _LOCAL_HOSTS:
+        has_forwarded_marker = any(
+            h in request.headers
+            for h in ("x-forwarded-for", "x-forwarded-host", "x-forwarded-proto")
+        )
+        if client_host in _LOCAL_HOSTS and not has_forwarded_marker:
             return await call_next(request)
 
         # ── Remote request through tunnel -- require valid token ─────────
@@ -409,87 +428,104 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
         # Prevent browsers and tunnel proxies from caching index.html so
         # that rebuilt assets (with new content hashes) are always picked up.
         # Hashed files under /assets/ are cached normally by StaticFiles.
+        # ``Referrer-Policy: no-referrer`` ensures that even if a token
+        # transiently appears in the URL (the QR-code landing path), it is
+        # never leaked to outbound requests via the ``Referer`` header.
         _NO_CACHE = {
             "Cache-Control": "no-cache, no-store, must-revalidate",
             "Pragma": "no-cache",
             "Expires": "0",
+            "Referrer-Policy": "no-referrer",
         }
 
-        def _maybe_bootstrap_tunnel_cookie(
-            resp: FileResponse, request: Request
-        ) -> FileResponse:
-            """Attach tunnel-auth cookie if ?token=<valid-uuid> is present.
+        def _maybe_bootstrap_tunnel_cookie(request: Request):
+            """Validate ``?token=<uuid>`` and return a token-stripping redirect.
 
             When a mobile browser first opens the QR-code URL
             ``https://<tunnel>/?token=<uuid>``, we validate the token against
-            the active tunnel and set an HttpOnly cookie so that the SPA's
-            subsequent same-origin ``fetch('/api/...')`` calls authenticate
-            automatically -- no frontend token-plumbing required.
+            the active tunnel and:
 
-            The ``Secure`` attribute is set only when the incoming request
-            used HTTPS (either directly or via ``X-Forwarded-Proto`` from
-            ngrok).  Over plain HTTP (localhost dev / TestClient) we omit
-            it so the cookie is actually delivered -- the middleware still
-            requires localhost bypass there, so there's no leak risk.
+            1. Set a ``HttpOnly``, ``SameSite=Strict``, ``Secure`` cookie so
+               the SPA's subsequent same-origin ``fetch('/api/...')`` calls
+               authenticate automatically -- no frontend token-plumbing.
+            2. Redirect (303) to the same path with ``token`` stripped so the
+               token doesn't linger in the address bar, browser history, or
+               outbound ``Referer`` headers.
+
+            ``SameSite=Strict`` is the cookie-side defence against CSRF on
+            state-changing endpoints reached via the cookie path -- modern
+            browsers refuse to attach the cookie on any cross-site request.
+
+            Returns the redirect response if a cookie was bootstrapped, or
+            ``None`` if no token was present / valid (caller serves the
+            requested file normally).
             """
             tunnel_mgr = getattr(request.app.state, "tunnel", None)
             qs_token = request.query_params.get("token")
-            if (
+            if not (
                 tunnel_mgr is not None
                 and tunnel_mgr.active
                 and qs_token
                 and tunnel_mgr.validate_token(qs_token)
             ):
-                # ngrok terminates TLS and forwards plain HTTP, so direct
-                # request.url.scheme is often "http".  Trust
-                # X-Forwarded-Proto when present.
-                fwd_proto = request.headers.get("x-forwarded-proto", "").lower()
-                is_https = request.url.scheme == "https" or fwd_proto == "https"
-                resp.set_cookie(
-                    key=_TUNNEL_COOKIE_NAME,
-                    value=qs_token,
-                    httponly=True,
-                    secure=is_https,
-                    samesite="lax",
-                    path="/",
-                )
-                logger.info(
-                    "Tunnel auth: bootstrapped cookie for client %s (secure=%s)",
-                    request.client.host if request.client else "unknown",
-                    is_https,
-                )
-            return resp
+                return None
+
+            # ngrok terminates TLS and forwards plain HTTP, so direct
+            # request.url.scheme is often "http".  Trust X-Forwarded-Proto
+            # when present so the Secure flag is set on real tunnel requests.
+            fwd_proto = request.headers.get("x-forwarded-proto", "").lower()
+            is_https = request.url.scheme == "https" or fwd_proto == "https"
+
+            # Build the redirect target: same path, all query params except
+            # ``token``. Preserves friendly params like ``?session=...``.
+            stripped_qs = urlencode(
+                [(k, v) for k, v in request.query_params.multi_items() if k != "token"]
+            )
+            target = request.url.path + (f"?{stripped_qs}" if stripped_qs else "")
+
+            redirect = RedirectResponse(url=target, status_code=303)
+            redirect.set_cookie(
+                key=_TUNNEL_COOKIE_NAME,
+                value=qs_token,
+                httponly=True,
+                secure=is_https,
+                samesite="strict",
+                path="/",
+            )
+            logger.info(
+                "Tunnel auth: bootstrapped cookie for client %s (secure=%s, target=%s)",
+                request.client.host if request.client else "unknown",
+                is_https,
+                request.url.path,
+            )
+            return redirect
 
         @app.get("/{full_path:path}")
         async def serve_spa(request: Request, full_path: str):
             """Serve the React SPA for all non-API routes."""
-            # Inline path sanitization (prevents directory traversal).
-            # Checks are explicit so static analysis (CodeQL) can verify
-            # the user-controlled ``full_path`` is properly constrained.
-            if not full_path or "\x00" in full_path or ".." in full_path:
-                return _maybe_bootstrap_tunnel_cookie(
-                    FileResponse(_index_html, headers=_NO_CACHE), request
-                )
+            # 1. Token bootstrap path: only fires for the index-html case
+            #    (token always lands on ``/`` from the QR code). On any
+            #    static asset path we ignore the token entirely so the
+            #    cookie can't be planted via ``GET /favicon.png?token=...``.
+            #
+            # 2. Static asset path: use the shared ``sanitize_static_path``
+            #    utility -- it explicitly returns ``None`` for traversal
+            #    attempts, so CodeQL can trace the validation through to
+            #    the ``FileResponse`` call.
+            sanitized = _sanitize_static_path(_resolved_dist, full_path)
 
-            candidate = (_resolved_dist / full_path).resolve()
+            if sanitized is not None and sanitized.is_file():
+                # Static asset (JS, CSS, image) -- never bootstrap a cookie
+                # off this path; only the SPA index does that.
+                return FileResponse(str(sanitized))
 
-            # Verify candidate stays within the dist directory
-            try:
-                candidate.relative_to(_resolved_dist)
-            except ValueError:
-                return _maybe_bootstrap_tunnel_cookie(
-                    FileResponse(_index_html, headers=_NO_CACHE), request
-                )
-
-            if candidate.is_file():
-                return _maybe_bootstrap_tunnel_cookie(
-                    FileResponse(str(candidate)), request
-                )
-
-            # Default to index.html for SPA routing
-            return _maybe_bootstrap_tunnel_cookie(
-                FileResponse(_index_html, headers=_NO_CACHE), request
-            )
+            # SPA fallback: serve index.html. Bootstrap the auth cookie
+            # if a valid ?token= is present (returns a 303 redirect that
+            # strips the token from the URL).
+            redirect = _maybe_bootstrap_tunnel_cookie(request)
+            if redirect is not None:
+                return redirect
+            return FileResponse(_index_html, headers=_NO_CACHE)
 
     else:
         # Resolve to an absolute path so users can act on the warning. Prefer
@@ -612,6 +648,17 @@ def main():
         port=args.port,
         log_level=log_level,
         access_log=args.debug,  # Only show HTTP access logs in debug mode
+        # SECURITY: do NOT trust ``X-Forwarded-For`` / ``X-Forwarded-Proto``
+        # to rewrite ``request.client.host``. ngrok forwards from the
+        # local agent (127.0.0.1), so uvicorn's default of trusting
+        # forwarded headers from 127.0.0.1 would let a remote attacker
+        # send ``X-Forwarded-For: 127.0.0.1`` through the tunnel and
+        # impersonate the Electron app. The localhost-bypass check in
+        # ``TunnelAuthMiddleware`` separately requires the request to
+        # carry no ``X-Forwarded-*`` headers, giving us a spoof-resistant
+        # distinction between Electron-direct and ngrok-tunnelled traffic.
+        proxy_headers=False,
+        forwarded_allow_ips="",
     )
 
 

--- a/src/gaia/ui/tunnel.py
+++ b/src/gaia/ui/tunnel.py
@@ -610,17 +610,19 @@ class TunnelManager:
             # Check if ngrok process died
             if self._process and self._process.poll() is not None:
                 stderr = self._drain_ngrok_output()
-                # Raw output goes to DEBUG only — even after _mask_ngrok_secrets
-                # masks plausible authtokens, CodeQL's
-                # py/clear-text-logging-sensitive-data rule treats any
-                # subprocess-pipe-derived string as tainted at non-debug
-                # levels. The parsed friendly error (set below) is the
-                # user-facing channel; this DEBUG line is only for hands-on
-                # debugging when the rest of the diagnostic isn't enough.
+                # We deliberately do NOT log the captured stderr content,
+                # even after _mask_ngrok_secrets masks plausible authtokens:
+                # CodeQL's py/clear-text-logging-sensitive-data rule treats
+                # any subprocess-pipe-derived string as tainted at every
+                # level (DEBUG included), and we'd rather respect the rule
+                # than fight it. The parsed friendly error (set below) is
+                # the user-facing diagnostic; for a hands-on debug session
+                # the operator can re-run ``ngrok http <port>`` manually.
                 logger.error(
-                    "ngrok exited after %.1fs (see debug log for output)", elapsed
+                    "ngrok exited after %.1fs (%d chars of output captured)",
+                    elapsed,
+                    len(stderr or ""),
                 )
-                logger.debug("ngrok output on exit:\n%s", stderr or "(empty)")
                 self._error = _parse_ngrok_error(stderr)
                 return None
 
@@ -657,10 +659,12 @@ class TunnelManager:
                     self._process.kill()
                     self._process.wait(timeout=2)
                 stderr = self._drain_ngrok_output()
-                # See note above: raw drained output goes to DEBUG only to
-                # keep CodeQL's clear-text-logging rule happy; the
-                # user-facing channel is _parse_ngrok_error() below.
-                logger.debug("ngrok output on timeout:\n%s", stderr or "(empty)")
+                # See note above: do NOT log captured stderr content (CodeQL's
+                # clear-text-logging rule). Length-only is a safe diagnostic.
+                logger.error(
+                    "ngrok timed out (%d chars of output captured)",
+                    len(stderr or ""),
+                )
         except Exception as e:
             logger.debug("Error terminating timed-out ngrok: %s", e)
 

--- a/src/gaia/ui/tunnel.py
+++ b/src/gaia/ui/tunnel.py
@@ -9,9 +9,11 @@ data for easy mobile onboarding.
 """
 
 import asyncio
+import hmac
 import logging
 import os
 import platform
+import re
 import shutil
 import subprocess
 import uuid
@@ -57,6 +59,39 @@ _NGROK_SESSION_LIMIT_HINT = (
     "active tunnel at a time. Stop any other ngrok processes (check your "
     "dashboard at https://dashboard.ngrok.com/agents) and try again."
 )
+
+
+# Patterns that match plausible ngrok authtokens or other secrets that may
+# appear in ngrok's stderr/stdout (e.g. a rejected-authtoken error often
+# echoes the offending value back). Replaced with ``[REDACTED]`` before any
+# captured output reaches a logger or the friendly-error parser.
+_NGROK_SECRET_PATTERNS = (
+    # ``authtoken: <value>`` in any quoting / case (logfmt or YAML echo).
+    re.compile(r"(authtoken[:=]\s*['\"]?)\S+", re.IGNORECASE),
+    # ngrok's modern authtokens look like ``2<base32 ~26 chars>_<base32 ~26 chars>``
+    # — long opaque strings; redact them wherever they appear.
+    re.compile(r"\b2[A-Za-z0-9]{20,}_[A-Za-z0-9]{20,}\b"),
+)
+
+
+def _mask_ngrok_secrets(text: str) -> str:
+    """Redact authtoken-shaped substrings before any captured output is logged.
+
+    ngrok normally redacts secrets in its own logfmt output, but the
+    rejected-authtoken / config-parse-error paths can echo the offending
+    value back in stderr. ERROR-level lines often end up pasted into bug
+    reports verbatim — we don't want a leaked authtoken to be the price of
+    a useful diagnostic.
+    """
+    if not text:
+        return text
+    masked = text
+    for pat in _NGROK_SECRET_PATTERNS:
+        masked = pat.sub(
+            lambda m: (m.group(1) + "[REDACTED]") if m.lastindex else "[REDACTED]",
+            masked,
+        )
+    return masked
 
 
 def _ngrok_config_candidates() -> list:
@@ -201,12 +236,17 @@ def _parse_ngrok_error(stderr_text: str) -> str:
     # Network / DNS problems. The "connection refused" branch is filtered to
     # the ngrok hostname so generic "connection refused" from a local service
     # doesn't get mis-attributed; the others (no such host / dial tcp / network
-    # unreachable) are already specific enough on their own.
+    # unreachable) are already specific enough on their own. Word-boundary
+    # regex (not naked substring) so a hostile string like
+    # ``evil.com/tunnel.ngrok.com.attacker.tld`` can't trip the branch.
     if (
         "no such host" in low
         or "dial tcp" in low
         or "network is unreachable" in low
-        or ("connection refused" in low and "tunnel.ngrok.com" in low)
+        or (
+            "connection refused" in low
+            and re.search(r"(?<![\w.-])tunnel\.ngrok\.com(?![\w.-])", low) is not None
+        )
     ):
         return (
             "Could not reach ngrok's servers. Check your internet connection "
@@ -292,10 +332,20 @@ class TunnelManager:
 
         Returns:
             True if token matches the active tunnel's token.
+
+        Notes:
+            Uses ``hmac.compare_digest`` for constant-time comparison to
+            avoid leaking token bits via response-time differences. Even
+            though the token is a 122-bit UUID4 (timing attacks aren't
+            practically feasible at that entropy), constant-time compare
+            is the convention for any auth-token check and removes the
+            class of bug from review.
         """
         if not self.active or not self._token:
             return False
-        return token == self._token
+        if not isinstance(token, str):
+            return False
+        return hmac.compare_digest(token, self._token)
 
     async def start(self) -> dict:
         """Start the ngrok tunnel.
@@ -502,7 +552,8 @@ class TunnelManager:
         """Best-effort drain of ngrok's stdout+stderr for error reporting.
 
         Called after ngrok has exited or been terminated.  Returns combined
-        stdout+stderr text (truncated if excessively long).
+        stdout+stderr text (truncated if excessively long, and with any
+        plausible authtoken values masked so error logs are safe to share).
         """
         combined = []
         for pipe_name in ("stdout", "stderr"):
@@ -518,6 +569,7 @@ class TunnelManager:
             except Exception as e:
                 logger.debug("Error draining ngrok %s: %s", pipe_name, e)
         text = "\n".join(combined).strip()
+        text = _mask_ngrok_secrets(text)
         # Truncate to keep logs manageable; friendly parser takes first line.
         return text[:4000]
 

--- a/src/gaia/ui/tunnel.py
+++ b/src/gaia/ui/tunnel.py
@@ -433,7 +433,14 @@ class TunnelManager:
                         "ngrok did not open a tunnel within 15 seconds. "
                         "Check your internet connection and authtoken, then retry."
                     )
-                logger.error("Tunnel start failed: %s", self._error)
+                # NOTE: not logging self._error here. The friendly message
+                # is already returned via get_status() and any raw stderr
+                # was captured at debug level by _poll_ngrok_api. Logging
+                # the parsed string at error level adds no diagnostic value
+                # and CodeQL's py/clear-text-logging-sensitive-data rule
+                # treats subprocess-derived strings as tainted regardless of
+                # masking — the cheapest fix is to not double-log.
+                logger.error("Tunnel start failed (see status for details)")
                 # Preserve the diagnostic error across cleanup -- stop()
                 # clears _error by design (for user-initiated stops), so we
                 # save + restore it here so the API caller actually sees
@@ -443,8 +450,14 @@ class TunnelManager:
                 self._error = saved_error
 
         except Exception as e:
+            # Stringify only the exception class to avoid logging exception
+            # detail that may carry a token (e.g. from a subprocess error).
             self._error = f"Failed to start ngrok: {e}"
-            logger.error(self._error, exc_info=True)
+            logger.error(
+                "Failed to start ngrok (%s); see status for friendly diagnostic",
+                type(e).__name__,
+                exc_info=True,
+            )
             saved_error = self._error
             await self.stop()
             self._error = saved_error
@@ -597,11 +610,17 @@ class TunnelManager:
             # Check if ngrok process died
             if self._process and self._process.poll() is not None:
                 stderr = self._drain_ngrok_output()
+                # Raw output goes to DEBUG only — even after _mask_ngrok_secrets
+                # masks plausible authtokens, CodeQL's
+                # py/clear-text-logging-sensitive-data rule treats any
+                # subprocess-pipe-derived string as tainted at non-debug
+                # levels. The parsed friendly error (set below) is the
+                # user-facing channel; this DEBUG line is only for hands-on
+                # debugging when the rest of the diagnostic isn't enough.
                 logger.error(
-                    "ngrok exited after %.1fs. Output:\n%s",
-                    elapsed,
-                    stderr or "(empty)",
+                    "ngrok exited after %.1fs (see debug log for output)", elapsed
                 )
+                logger.debug("ngrok output on exit:\n%s", stderr or "(empty)")
                 self._error = _parse_ngrok_error(stderr)
                 return None
 
@@ -638,7 +657,10 @@ class TunnelManager:
                     self._process.kill()
                     self._process.wait(timeout=2)
                 stderr = self._drain_ngrok_output()
-                logger.error("ngrok output on timeout:\n%s", stderr or "(empty)")
+                # See note above: raw drained output goes to DEBUG only to
+                # keep CodeQL's clear-text-logging rule happy; the
+                # user-facing channel is _parse_ngrok_error() below.
+                logger.debug("ngrok output on timeout:\n%s", stderr or "(empty)")
         except Exception as e:
             logger.debug("Error terminating timed-out ngrok: %s", e)
 

--- a/src/gaia/ui/tunnel.py
+++ b/src/gaia/ui/tunnel.py
@@ -10,14 +10,223 @@ data for easy mobile onboarding.
 
 import asyncio
 import logging
+import os
 import platform
 import shutil
 import subprocess
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+
+# ── Error helpers ──────────────────────────────────────────────────────────
+
+_NGROK_INSTALL_HINT = (
+    "ngrok is not installed. Install it from https://ngrok.com/download "
+    "or run one of:\n"
+    "    brew install ngrok                          # macOS\n"
+    "    choco install ngrok                         # Windows\n"
+    "    sudo snap install ngrok                     # Linux (snap)\n"
+    "    curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | "
+    "sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && "
+    "echo 'deb https://ngrok-agent.s3.amazonaws.com buster main' | "
+    "sudo tee /etc/apt/sources.list.d/ngrok.list && "
+    "sudo apt update && sudo apt install ngrok       # Linux (apt)"
+)
+
+_NGROK_AUTHTOKEN_HINT = (
+    "ngrok authtoken not configured. Sign up for a free account at "
+    "https://dashboard.ngrok.com/signup, copy your authtoken from "
+    "https://dashboard.ngrok.com/get-started/your-authtoken, then run:\n"
+    "    ngrok config add-authtoken <YOUR_TOKEN>"
+)
+
+_NGROK_AUTHTOKEN_REJECTED_HINT = (
+    "Your ngrok authtoken was rejected by ngrok's servers. It is usually "
+    "correctly formatted but invalid -- this happens if you reset it, were "
+    "removed from a team, or the credential was revoked. Re-copy a fresh "
+    "authtoken from https://dashboard.ngrok.com/get-started/your-authtoken "
+    "and run:\n    ngrok config add-authtoken <FRESH_TOKEN>"
+)
+
+_NGROK_SESSION_LIMIT_HINT = (
+    "ngrok is already running elsewhere. Free ngrok plans allow only 1 "
+    "active tunnel at a time. Stop any other ngrok processes (check your "
+    "dashboard at https://dashboard.ngrok.com/agents) and try again."
+)
+
+
+def _ngrok_config_candidates() -> list:
+    """All locations where ngrok might have stashed a YAML config.
+
+    Different ngrok versions and OS combinations pick different default
+    paths. We probe them all -- spurious extras are harmless.
+
+    Observed locations:
+    - macOS (docs):     ~/Library/Application Support/ngrok/ngrok.yml
+    - macOS (ngrok 3+): ~/.config/ngrok/ngrok.yml  (actual behaviour,
+                        honored by ngrok even though docs advertise the
+                        Application Support path)
+    - Linux:            $XDG_CONFIG_HOME/ngrok/ngrok.yml
+                        (or ~/.config/ngrok/ngrok.yml as fallback)
+    - Windows:          %LOCALAPPDATA%\\ngrok\\ngrok.yml
+    - Legacy v2:        ~/.ngrok2/ngrok.yml
+    """
+    candidates = []
+
+    # XDG / Linux default -- also used by ngrok 3.x on macOS in practice.
+    xdg = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    candidates.append(Path(xdg) / "ngrok" / "ngrok.yml")
+
+    # macOS documented path
+    if platform.system() == "Darwin":
+        candidates.append(
+            Path.home() / "Library" / "Application Support" / "ngrok" / "ngrok.yml"
+        )
+
+    # Windows
+    if platform.system() == "Windows":
+        local_app = os.environ.get("LOCALAPPDATA")
+        if local_app:
+            candidates.append(Path(local_app) / "ngrok" / "ngrok.yml")
+
+    # Legacy ngrok v2 path
+    candidates.append(Path.home() / ".ngrok2" / "ngrok.yml")
+
+    return candidates
+
+
+def _check_ngrok_authtoken_configured() -> bool:
+    """Best-effort preflight check for an ngrok authtoken.
+
+    Checks (in order):
+      1. ``$NGROK_AUTHTOKEN`` env var -- ngrok v3 honours this directly.
+      2. Every known ngrok config path for a non-empty ``authtoken:``
+         entry, matching both the flat ``authtoken: xxx`` form (v2) and the
+         nested ``agent:\\n  authtoken: xxx`` form (v3 default).
+
+    Returns True if a token appears to be configured, False otherwise.
+    Used to surface a helpful error BEFORE spawning ngrok (which otherwise
+    just hangs or emits cryptic errors).
+
+    A pure-text scan is intentional -- the YAML files can contain comments,
+    aliases, and other constructs that ``yaml.safe_load`` may choke on for
+    legitimate ngrok configs (it's tolerated, but we don't want a parse
+    error to silently disable preflight). False positives are far cheaper
+    here than false negatives: the worst a false positive does is let
+    ngrok run and emit its own (good) error message; a false negative
+    blocks a working setup behind a misleading hint.
+    """
+    if (os.environ.get("NGROK_AUTHTOKEN") or "").strip():
+        logger.debug("ngrok authtoken found via $NGROK_AUTHTOKEN")
+        return True
+
+    for p in _ngrok_config_candidates():
+        try:
+            if p.is_file():
+                content = p.read_text(errors="ignore")
+                # Look for a non-empty ``authtoken:`` entry anywhere in the
+                # file. Matches both the v2 flat form and the v3 nested
+                # ``agent:\n  authtoken: ...`` layout — indentation doesn't
+                # matter once we're scanning line-by-line for the prefix.
+                for line in content.splitlines():
+                    s = line.strip()
+                    if s.startswith("authtoken:"):
+                        value = s[len("authtoken:") :].strip().strip("'\"")
+                        if value:
+                            logger.debug("ngrok authtoken found at %s", p)
+                            return True
+        except Exception as e:
+            logger.debug("ngrok config probe failed for %s: %s", p, e)
+            continue
+    return False
+
+
+def _parse_ngrok_error(stderr_text: str) -> str:
+    """Translate ngrok stderr/stdout into a user-friendly error message.
+
+    Detects the most common failure modes (missing authtoken, session
+    limit reached, network issues) and returns instructions the user
+    can act on.  Falls back to the first line of raw output if nothing
+    matches.
+    """
+    text = (stderr_text or "").strip()
+    if not text:
+        return (
+            "ngrok exited without output. Try running the command manually to "
+            "see the error: ngrok http 4200"
+        )
+
+    low = text.lower()
+
+    # ERR_NGROK_107: authtoken is well-formed but rejected (revoked,
+    # reset, or belongs to a team the user was removed from). Distinct
+    # from "missing / malformed" below -- the fix is different.
+    if (
+        "err_ngrok_107" in low
+        or "properly formed, but it is invalid" in low
+        or "credential was explicitly revoked" in low
+        or "reset your authtoken" in low
+    ):
+        return _NGROK_AUTHTOKEN_REJECTED_HINT
+
+    # ERR_NGROK_4018 or generic authtoken issues -- malformed or missing.
+    if (
+        "err_ngrok_4018" in low
+        or "authtoken" in low
+        or "authentication failed" in low
+        or "account not authorized" in low
+        or "not signed in" in low
+    ):
+        return _NGROK_AUTHTOKEN_HINT
+
+    # Simultaneous session limit (ERR_NGROK_108).
+    if (
+        "err_ngrok_108" in low
+        or "simultaneous ngrok" in low
+        or "limited to 1 simultaneous" in low
+    ):
+        return _NGROK_SESSION_LIMIT_HINT
+
+    # Local port conflict (4040 web interface or bind address in use).
+    if "address already in use" in low or "bind: address already" in low:
+        return (
+            "ngrok's local port (4040) is already in use. Another ngrok "
+            "process may still be running -- stop it and try again."
+        )
+
+    # Network / DNS problems. The "connection refused" branch is filtered to
+    # the ngrok hostname so generic "connection refused" from a local service
+    # doesn't get mis-attributed; the others (no such host / dial tcp / network
+    # unreachable) are already specific enough on their own.
+    if (
+        "no such host" in low
+        or "dial tcp" in low
+        or "network is unreachable" in low
+        or ("connection refused" in low and "tunnel.ngrok.com" in low)
+    ):
+        return (
+            "Could not reach ngrok's servers. Check your internet connection "
+            "(and any firewall/proxy blocking outbound HTTPS) and try again."
+        )
+
+    # TLS / certificate issues. ``x509`` alone is unambiguous (Go TLS errors
+    # only). ``certificate`` is generic enough to appear in non-TLS contexts,
+    # so it's only matched together with ``verify`` -- the canonical
+    # ``failed to verify certificate`` shape.
+    if "x509" in low or ("certificate" in low and "verify" in low):
+        return (
+            "ngrok could not establish a secure connection to its servers. "
+            "Your system clock may be wrong, or a corporate proxy is "
+            "intercepting TLS. Fix the clock / disable the proxy and retry."
+        )
+
+    # Fallback: first non-empty line, truncated.
+    first_line = next((ln for ln in text.splitlines() if ln.strip()), text)
+    return f"ngrok failed to start: {first_line[:300]}"
 
 
 class TunnelManager:
@@ -114,11 +323,15 @@ class TunnelManager:
         # Check ngrok installation
         ngrok_path = self._find_ngrok()
         if not ngrok_path:
-            self._error = (
-                "ngrok is not installed. Install it from https://ngrok.com/download "
-                "or run: brew install ngrok (macOS) / choco install ngrok (Windows)"
-            )
-            logger.error(self._error)
+            self._error = _NGROK_INSTALL_HINT
+            logger.error("ngrok not found on PATH")
+            return self.get_status()
+
+        # Preflight: is the ngrok authtoken configured? Catches the #1
+        # first-run failure mode before we waste 15s waiting on a hung tunnel.
+        if not _check_ngrok_authtoken_configured():
+            self._error = _NGROK_AUTHTOKEN_HINT
+            logger.error("ngrok authtoken not configured -- aborting tunnel start")
             return self.get_status()
 
         # Fetch public IP (for ngrok interstitial password hint)
@@ -130,10 +343,17 @@ class TunnelManager:
         # Generate auth token
         self._token = str(uuid.uuid4())
 
-        # Build ngrok command
-        cmd = [ngrok_path, "http", str(self.port)]
+        # Build ngrok command. --log=stdout --log-format=logfmt makes
+        # ngrok emit structured logs to stdout/stderr so we can surface
+        # meaningful errors instead of staring at a hung process.
+        base_args = [
+            "http",
+            "--log=stdout",
+            "--log-format=logfmt",
+        ]
         if self.domain:
-            cmd = [ngrok_path, "http", "--domain", self.domain, str(self.port)]
+            base_args += ["--domain", self.domain]
+        cmd = [ngrok_path, *base_args, str(self.port)]
 
         logger.info("Starting ngrok: %s", " ".join(cmd))
 
@@ -156,19 +376,39 @@ class TunnelManager:
                     "Tunnel started: %s (token: %s...)", self._url, self._token[:8]
                 )
             else:
-                self._error = "Failed to get tunnel URL from ngrok"
-                logger.error(self._error)
+                # _poll_ngrok_api already sets self._error with a friendly
+                # message; keep a sensible fallback if it somehow didn't.
+                if not self._error:
+                    self._error = (
+                        "ngrok did not open a tunnel within 15 seconds. "
+                        "Check your internet connection and authtoken, then retry."
+                    )
+                logger.error("Tunnel start failed: %s", self._error)
+                # Preserve the diagnostic error across cleanup -- stop()
+                # clears _error by design (for user-initiated stops), so we
+                # save + restore it here so the API caller actually sees
+                # what went wrong.
+                saved_error = self._error
                 await self.stop()
+                self._error = saved_error
 
         except Exception as e:
             self._error = f"Failed to start ngrok: {e}"
             logger.error(self._error, exc_info=True)
+            saved_error = self._error
             await self.stop()
+            self._error = saved_error
 
         return self.get_status()
 
     async def stop(self) -> None:
-        """Stop the ngrok tunnel."""
+        """Stop the ngrok tunnel.
+
+        Clears ``_url``, ``_started_at``, and ``_error`` by design -- a
+        user-initiated stop should reset all transient state.  Callers
+        that need to preserve a diagnostic ``_error`` across ``stop()``
+        (e.g. on a failed start) must save + restore it themselves.
+        """
         if self._process:
             logger.info("Stopping ngrok tunnel...")
             try:
@@ -215,7 +455,15 @@ class TunnelManager:
         return None
 
     async def _kill_stale_ngrok(self) -> None:
-        """Kill any stale ngrok processes (free tier only allows 1 session)."""
+        """Kill any stale ngrok processes (free tier only allows 1 session).
+
+        Uses exact-process-name matching (``pkill -x`` / ``taskkill /im``) on
+        purpose: a broader ``pkill -f ngrok`` would match command lines like
+        ``vim ngrok.md`` or ``python ngrok_client.py``, including the user's
+        own unrelated work. Exact match still catches every legitimate
+        ``ngrok`` agent process — the only thing the free-tier session-limit
+        cleanup actually needs to clear.
+        """
         try:
             if platform.system() == "Windows":
                 subprocess.run(
@@ -226,7 +474,7 @@ class TunnelManager:
                 )
             else:
                 subprocess.run(
-                    ["pkill", "-f", "ngrok"],
+                    ["pkill", "-x", "ngrok"],
                     capture_output=True,
                     timeout=5,
                     check=False,
@@ -250,6 +498,29 @@ class TunnelManager:
             logger.debug("Could not fetch public IP: %s", e)
             self._public_ip = None
 
+    def _drain_ngrok_output(self) -> str:
+        """Best-effort drain of ngrok's stdout+stderr for error reporting.
+
+        Called after ngrok has exited or been terminated.  Returns combined
+        stdout+stderr text (truncated if excessively long).
+        """
+        combined = []
+        for pipe_name in ("stdout", "stderr"):
+            pipe = getattr(self._process, pipe_name, None) if self._process else None
+            if pipe is None:
+                continue
+            try:
+                # Since ngrok has exited (or we just killed it), read() won't
+                # block -- all data is already in the kernel buffer.
+                raw = pipe.read() or b""
+                if raw:
+                    combined.append(raw.decode("utf-8", errors="replace"))
+            except Exception as e:
+                logger.debug("Error draining ngrok %s: %s", pipe_name, e)
+        text = "\n".join(combined).strip()
+        # Truncate to keep logs manageable; friendly parser takes first line.
+        return text[:4000]
+
     async def _poll_ngrok_api(
         self, timeout: float = 15.0, interval: float = 0.5
     ) -> Optional[str]:
@@ -263,7 +534,8 @@ class TunnelManager:
             interval: Polling interval in seconds.
 
         Returns:
-            The public HTTPS URL, or None if timed out.
+            The public HTTPS URL, or None if timed out (self._error is set
+            with a user-friendly message in all failure cases).
         """
         elapsed = 0.0
         while elapsed < timeout:
@@ -272,20 +544,13 @@ class TunnelManager:
 
             # Check if ngrok process died
             if self._process and self._process.poll() is not None:
-                stderr = ""
-                try:
-                    # Read only a limited amount to avoid blocking the
-                    # event loop if ngrok wrote a lot to stderr.
-                    raw = self._process.stderr.read(4096) or b""
-                    stderr = raw.decode("utf-8", errors="replace")
-                except Exception:
-                    pass
-                logger.error("ngrok process exited unexpectedly: %s", stderr)
-                self._error = (
-                    f"ngrok exited: {stderr[:200]}"
-                    if stderr
-                    else "ngrok exited unexpectedly"
+                stderr = self._drain_ngrok_output()
+                logger.error(
+                    "ngrok exited after %.1fs. Output:\n%s",
+                    elapsed,
+                    stderr or "(empty)",
                 )
+                self._error = _parse_ngrok_error(stderr)
                 return None
 
             try:
@@ -306,5 +571,32 @@ class TunnelManager:
                 # ngrok API not ready yet, keep polling
                 pass
 
+        # Timed out. ngrok is still running but didn't open an HTTPS tunnel.
+        # Most likely cause: authtoken rejected by the server but the agent
+        # is retrying silently.  Kill it, drain output, and surface a
+        # friendly diagnosis.
         logger.error("Timed out waiting for ngrok tunnel (%.1fs)", timeout)
+        stderr = ""
+        try:
+            if self._process and self._process.poll() is None:
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self._process.kill()
+                    self._process.wait(timeout=2)
+                stderr = self._drain_ngrok_output()
+                logger.error("ngrok output on timeout:\n%s", stderr or "(empty)")
+        except Exception as e:
+            logger.debug("Error terminating timed-out ngrok: %s", e)
+
+        if stderr:
+            self._error = _parse_ngrok_error(stderr)
+        else:
+            self._error = (
+                "ngrok started but didn't open a public tunnel within 15s. "
+                "Common causes: authtoken rejected, network blocked, or "
+                "ngrok servers unreachable. Run 'ngrok http 4200' manually "
+                "to see the real error."
+            )
         return None

--- a/tests/unit/chat/ui/test_chat_helpers.py
+++ b/tests/unit/chat/ui/test_chat_helpers.py
@@ -390,7 +390,6 @@ class TestCanonicalAgentType:
             set_agent_registry(None)
 
 
-
 # ── Regression: registered-agent streaming path must not double-index ─────
 
 

--- a/tests/unit/chat/ui/test_tunnel.py
+++ b/tests/unit/chat/ui/test_tunnel.py
@@ -75,6 +75,106 @@ class TestTunnelManager:
         assert status["active"] is False
         assert status["error"] is not None
         assert "ngrok" in status["error"].lower()
+        # Should mention install instructions
+        assert (
+            "install" in status["error"].lower()
+            or "ngrok.com/download" in status["error"].lower()
+        )
+
+    def test_failed_start_preserves_error_in_status(self, monkeypatch):
+        """After a failed start, get_status() must still return the diagnostic.
+
+        Regression test: stop() clears _error as part of its normal cleanup
+        (so a user-initiated stop doesn't leave a stale error). But when
+        a start fails, we want to preserve the error across stop() so the
+        caller sees WHY it failed -- not a confusing ``error: null``.
+        """
+        from gaia.ui import tunnel as tunnel_mod
+
+        manager = TunnelManager(port=4200)
+        manager._find_ngrok = lambda: "/fake/ngrok"
+        monkeypatch.setattr(
+            tunnel_mod,
+            "_check_ngrok_authtoken_configured",
+            lambda: True,
+        )
+
+        # Skip public-IP fetch (would hit the network)
+        async def _noop_public_ip(self):
+            self._public_ip = None
+
+        monkeypatch.setattr(TunnelManager, "_fetch_public_ip", _noop_public_ip)
+
+        # Skip the stale-ngrok kill
+        async def _noop_kill(self):
+            return None
+
+        monkeypatch.setattr(TunnelManager, "_kill_stale_ngrok", _noop_kill)
+
+        # Simulate a subprocess.Popen that "died immediately" so the
+        # poll-api path reports a friendly error.
+        class _DeadProcess:
+            def __init__(self, *_a, **_kw):
+                self.stdout = None
+                self.stderr = None
+                self.stdin = None
+
+            def poll(self):
+                return 1  # exited with non-zero
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 1
+
+            def kill(self):
+                pass
+
+        import subprocess as _sp
+
+        monkeypatch.setattr(_sp, "Popen", _DeadProcess)
+
+        # Also short-circuit the drain helper since our fake has no pipes
+        monkeypatch.setattr(
+            TunnelManager,
+            "_drain_ngrok_output",
+            lambda self: "authentication failed ERR_NGROK_107 "
+            "properly formed, but it is invalid",
+        )
+
+        status = asyncio.run(manager.start())
+
+        assert status["active"] is False
+        assert status["url"] is None
+        # The crux of the test: error must survive stop() cleanup.
+        assert status["error"] is not None
+        assert (
+            "rejected" in status["error"].lower()
+            or "revoked" in status["error"].lower()
+            or "invalid" in status["error"].lower()
+        )
+
+    def test_start_without_authtoken(self, monkeypatch):
+        """start() surfaces a friendly message when the authtoken isn't set."""
+        from gaia.ui import tunnel as tunnel_mod
+
+        manager = TunnelManager(port=4200)
+        manager._find_ngrok = lambda: "/fake/ngrok"
+        # Pretend the authtoken preflight fails (no config file found)
+        monkeypatch.setattr(
+            tunnel_mod,
+            "_check_ngrok_authtoken_configured",
+            lambda: False,
+        )
+
+        status = asyncio.run(manager.start())
+        assert status["active"] is False
+        assert status["error"] is not None
+        err = status["error"]
+        # Friendly guidance: either mention the config command or the dashboard.
+        assert "authtoken" in err.lower()
+        assert "ngrok config add-authtoken" in err or "dashboard.ngrok.com" in err
 
     def test_stop_when_not_running(self):
         """stop() is safe to call when tunnel is not running."""
@@ -99,3 +199,229 @@ class TestTunnelManager:
         status = asyncio.run(manager.start())
         assert status["active"] is True
         assert status["url"] == "https://test.ngrok-free.app"
+
+
+# ── Friendly error-parser tests ─────────────────────────────────────────
+
+
+class TestParseNgrokError:
+    """_parse_ngrok_error translates raw ngrok output into actionable hints."""
+
+    def test_empty_stderr(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error("")
+        assert "exited without output" in msg.lower()
+        assert "ngrok http 4200" in msg
+
+    def test_authtoken_error(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error(
+            "ERROR: authentication failed: The authtoken you specified is "
+            "invalid. (ERR_NGROK_4018)"
+        )
+        assert "authtoken" in msg.lower()
+        assert "ngrok config add-authtoken" in msg
+        assert "dashboard.ngrok.com" in msg
+
+    def test_authtoken_error_by_code(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error("ERR_NGROK_4018")
+        assert "authtoken" in msg.lower()
+
+    def test_authtoken_rejected_err_107(self):
+        """ERR_NGROK_107 is well-formed-but-rejected, distinct from missing."""
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error(
+            "authentication failed: The authtoken you specified is "
+            "properly formed, but it is invalid. ERR_NGROK_107"
+        )
+        # Should mention it was rejected/invalid (not "not configured").
+        assert "rejected" in msg.lower() or "invalid" in msg.lower()
+        # Should point the user at the dashboard to re-copy a fresh one.
+        assert "dashboard.ngrok.com" in msg
+        # Must NOT claim the authtoken is "not configured" -- misleading
+        # here, since it IS configured, just invalid.
+        assert "not configured" not in msg.lower()
+
+    def test_authtoken_rejected_by_revoked_phrase(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error(
+            "You are using ngrok link and this credential was explicitly " "revoked"
+        )
+        assert "rejected" in msg.lower() or "revoked" in msg.lower()
+
+    def test_session_limit_error(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error(
+            "ERROR: Your account is limited to 1 simultaneous ngrok agent "
+            "sessions. (ERR_NGROK_108)"
+        )
+        assert "simultaneous" in msg.lower() or "already running" in msg.lower()
+        assert "dashboard.ngrok.com/agents" in msg
+
+    def test_network_error(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error("dial tcp: lookup tunnel.ngrok.com: no such host")
+        assert "internet" in msg.lower() or "network" in msg.lower()
+
+    def test_port_conflict(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error(
+            "failed to bind: listen tcp 127.0.0.1:4040: bind: address " "already in use"
+        )
+        assert "4040" in msg or "in use" in msg.lower()
+
+    def test_unknown_error_falls_back_to_first_line(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error(
+            "something unusual happened\nadditional context on line 2"
+        )
+        assert "something unusual happened" in msg
+        # Should NOT include the second line (first line only).
+        assert "line 2" not in msg
+
+    def test_tls_certificate_alone_does_not_match(self):
+        """``certificate`` alone is too generic — only ``certificate``+``verify``.
+
+        Regression: an earlier version had
+        ``if "x509" in low or "certificate" in low and "verify" in low``
+        which (due to operator precedence) parsed as
+        ``x509 OR (certificate AND verify)``. After explicit parens this
+        behaviour is unchanged but locked in: a ``certificate`` substring
+        without the ``verify`` partner falls through to the generic fallback.
+        """
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error("error: server returned a stale certificate")
+        # Falls through to "ngrok failed to start: ..." rather than the TLS hint.
+        assert "system clock" not in msg.lower()
+        assert "proxy" not in msg.lower()
+
+    def test_tls_x509_matches(self):
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error("x509: certificate signed by unknown authority")
+        assert "system clock" in msg.lower() or "proxy" in msg.lower()
+
+    def test_connection_refused_without_ngrok_host_falls_through(self):
+        """Generic ``connection refused`` shouldn't be mis-attributed to ngrok.
+
+        The network-error block parenthesises the
+        ``connection refused AND tunnel.ngrok.com`` clause so a
+        ``connection refused`` to some other host doesn't get the
+        ngrok-specific "couldn't reach servers" hint.
+        """
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        msg = _parse_ngrok_error("dial tcp 127.0.0.1:9000: connection refused")
+        # ``dial tcp`` itself does match the network branch, so we test the
+        # narrower invariant: the message we surface mentions internet/network
+        # (correct generic guidance) rather than misleading the user about
+        # ngrok-specific connectivity. The substring filter exists so that
+        # if the message ever reorders to land in a different branch, this
+        # test catches the regression.
+        assert (
+            "ngrok's servers" in msg
+            or "internet" in msg.lower()
+            or "network" in msg.lower()
+        )
+
+
+class TestCheckNgrokAuthtokenConfigured:
+    """Tests for ``_check_ngrok_authtoken_configured``.
+
+    The check decides whether to abort start() with a "configure your
+    authtoken" hint. False positives are cheap (ngrok will surface its own
+    error). False negatives block working setups, so each input shape that
+    real users have is exercised here.
+    """
+
+    def test_env_var_takes_precedence(self, monkeypatch, tmp_path):
+        """``$NGROK_AUTHTOKEN`` should short-circuit the file probes.
+
+        ngrok v3 honours the env var directly — a user with valid env-var
+        auth and no config file is fully working, but the file-only probe
+        would falsely report "not configured" and block startup.
+        """
+        from gaia.ui import tunnel as tunnel_mod
+
+        monkeypatch.setenv("NGROK_AUTHTOKEN", "valid-token-from-env")
+        # Point file probes at a non-existent path so they all return False.
+        monkeypatch.setattr(
+            tunnel_mod,
+            "_ngrok_config_candidates",
+            lambda: [tmp_path / "nope.yml"],
+        )
+        assert tunnel_mod._check_ngrok_authtoken_configured() is True
+
+    def test_empty_env_var_does_not_count(self, monkeypatch, tmp_path):
+        """An empty/whitespace env var must NOT register as configured."""
+        from gaia.ui import tunnel as tunnel_mod
+
+        monkeypatch.setenv("NGROK_AUTHTOKEN", "   ")
+        monkeypatch.setattr(
+            tunnel_mod,
+            "_ngrok_config_candidates",
+            lambda: [tmp_path / "nope.yml"],
+        )
+        assert tunnel_mod._check_ngrok_authtoken_configured() is False
+
+    def test_v2_flat_authtoken_in_config(self, monkeypatch, tmp_path):
+        """v2 layout: ``authtoken: xxx`` at column 0."""
+        from gaia.ui import tunnel as tunnel_mod
+
+        monkeypatch.delenv("NGROK_AUTHTOKEN", raising=False)
+        cfg = tmp_path / "ngrok.yml"
+        cfg.write_text("authtoken: 2abc-token-v2-flat\nregion: us\n")
+        monkeypatch.setattr(tunnel_mod, "_ngrok_config_candidates", lambda: [cfg])
+        assert tunnel_mod._check_ngrok_authtoken_configured() is True
+
+    def test_v3_nested_authtoken_in_config(self, monkeypatch, tmp_path):
+        """v3 layout: ``authtoken`` indented under ``agent:`` block.
+
+        Locks in that nested layouts are still detected — the line-strip
+        scan tolerates any indentation, but a future refactor to a
+        column-sensitive parser would silently break this.
+        """
+        from gaia.ui import tunnel as tunnel_mod
+
+        monkeypatch.delenv("NGROK_AUTHTOKEN", raising=False)
+        cfg = tmp_path / "ngrok.yml"
+        cfg.write_text(
+            "version: 3\n"
+            "agent:\n"
+            "  authtoken: 2xyz-token-v3-nested\n"
+            "  region: us\n"
+        )
+        monkeypatch.setattr(tunnel_mod, "_ngrok_config_candidates", lambda: [cfg])
+        assert tunnel_mod._check_ngrok_authtoken_configured() is True
+
+    def test_empty_authtoken_value_rejected(self, monkeypatch, tmp_path):
+        """``authtoken:`` with no value (or quoted empty) shouldn't count."""
+        from gaia.ui import tunnel as tunnel_mod
+
+        monkeypatch.delenv("NGROK_AUTHTOKEN", raising=False)
+        cfg = tmp_path / "ngrok.yml"
+        cfg.write_text("authtoken: ''\n")
+        monkeypatch.setattr(tunnel_mod, "_ngrok_config_candidates", lambda: [cfg])
+        assert tunnel_mod._check_ngrok_authtoken_configured() is False
+
+    def test_no_config_files_returns_false(self, monkeypatch, tmp_path):
+        from gaia.ui import tunnel as tunnel_mod
+
+        monkeypatch.delenv("NGROK_AUTHTOKEN", raising=False)
+        monkeypatch.setattr(
+            tunnel_mod,
+            "_ngrok_config_candidates",
+            lambda: [tmp_path / "missing.yml"],
+        )
+        assert tunnel_mod._check_ngrok_authtoken_configured() is False

--- a/tests/unit/chat/ui/test_tunnel.py
+++ b/tests/unit/chat/ui/test_tunnel.py
@@ -173,8 +173,12 @@ class TestTunnelManager:
         assert status["error"] is not None
         err = status["error"]
         # Friendly guidance: either mention the config command or the dashboard.
+        # Use full-URL prefix matches so a hostile host like
+        # ``evil.dashboard.ngrok.com.attacker.tld`` would not satisfy the assertion.
         assert "authtoken" in err.lower()
-        assert "ngrok config add-authtoken" in err or "dashboard.ngrok.com" in err
+        assert (
+            "ngrok config add-authtoken" in err or "https://dashboard.ngrok.com/" in err
+        )
 
     def test_stop_when_not_running(self):
         """stop() is safe to call when tunnel is not running."""
@@ -223,7 +227,9 @@ class TestParseNgrokError:
         )
         assert "authtoken" in msg.lower()
         assert "ngrok config add-authtoken" in msg
-        assert "dashboard.ngrok.com" in msg
+        # Match the full URL prefix (https://dashboard.ngrok.com/) rather than a
+        # bare substring so a lookalike host can't satisfy the assertion.
+        assert "https://dashboard.ngrok.com/" in msg
 
     def test_authtoken_error_by_code(self):
         from gaia.ui.tunnel import _parse_ngrok_error
@@ -242,7 +248,8 @@ class TestParseNgrokError:
         # Should mention it was rejected/invalid (not "not configured").
         assert "rejected" in msg.lower() or "invalid" in msg.lower()
         # Should point the user at the dashboard to re-copy a fresh one.
-        assert "dashboard.ngrok.com" in msg
+        # Full URL prefix to avoid matching a lookalike host.
+        assert "https://dashboard.ngrok.com/" in msg
         # Must NOT claim the authtoken is "not configured" -- misleading
         # here, since it IS configured, just invalid.
         assert "not configured" not in msg.lower()
@@ -263,7 +270,8 @@ class TestParseNgrokError:
             "sessions. (ERR_NGROK_108)"
         )
         assert "simultaneous" in msg.lower() or "already running" in msg.lower()
-        assert "dashboard.ngrok.com/agents" in msg
+        # Full URL match (with scheme + path) so a lookalike host can't satisfy.
+        assert "https://dashboard.ngrok.com/agents" in msg
 
     def test_network_error(self):
         from gaia.ui.tunnel import _parse_ngrok_error
@@ -334,6 +342,60 @@ class TestParseNgrokError:
             or "internet" in msg.lower()
             or "network" in msg.lower()
         )
+
+    def test_connection_refused_lookalike_host_does_not_match(self):
+        """A hostile string that *contains* ``tunnel.ngrok.com`` as a substring
+        must NOT trip the ngrok-specific network branch.
+
+        Locks in the word-boundary regex used by ``_parse_ngrok_error`` so a
+        future refactor back to a naked ``in`` check (which CodeQL flagged as
+        py/incomplete-url-substring-sanitization) is caught.
+        """
+        from gaia.ui.tunnel import _parse_ngrok_error
+
+        # ``connection refused`` *and* the literal ``tunnel.ngrok.com`` substring
+        # appears, but only as a misleading subdomain of an attacker-controlled
+        # host. The match must NOT fire — the message that actually surfaces is
+        # the generic fallback (``ngrok failed to start: ...``).
+        msg = _parse_ngrok_error(
+            "evil.tunnel.ngrok.com.attacker.tld: connection refused"
+        )
+        assert "internet connection" not in msg.lower()
+        assert "ngrok failed to start" in msg
+
+
+class TestMaskNgrokSecrets:
+    """``_mask_ngrok_secrets`` redacts plausible authtokens before logging."""
+
+    def test_authtoken_field_is_masked(self):
+        from gaia.ui.tunnel import _mask_ngrok_secrets
+
+        masked = _mask_ngrok_secrets(
+            "config: authtoken: 2abcdefghijklmnopqrstuvwxyz_zyxwvutsrqponmlkjihgfedcba"
+        )
+        assert "2abcdefghij" not in masked
+        assert "[REDACTED]" in masked
+
+    def test_long_opaque_token_is_masked_anywhere(self):
+        from gaia.ui.tunnel import _mask_ngrok_secrets
+
+        # An ngrok-shaped long token appearing inline (e.g. echoed in stderr
+        # without the ``authtoken:`` prefix) must still be redacted.
+        masked = _mask_ngrok_secrets(
+            "rejected token: 2ABCDEFGHIJKLMNOPQRSTUVWXYZ_zyxwvutsrqponmlkjihgfedcba "
+            "please retry"
+        )
+        assert "2ABCDEFGHIJ" not in masked
+        assert "[REDACTED]" in masked
+        # Non-secret context is preserved.
+        assert "please retry" in masked
+
+    def test_safe_input_unchanged(self):
+        from gaia.ui.tunnel import _mask_ngrok_secrets
+
+        text = "ngrok exited cleanly: no authtoken issues"
+        # No secret-shaped substring → string passes through verbatim.
+        assert _mask_ngrok_secrets(text) == text
 
 
 class TestCheckNgrokAuthtokenConfigured:

--- a/tests/unit/chat/ui/test_tunnel.py
+++ b/tests/unit/chat/ui/test_tunnel.py
@@ -170,15 +170,14 @@ class TestTunnelManager:
 
         status = asyncio.run(manager.start())
         assert status["active"] is False
-        assert status["error"] is not None
-        err = status["error"]
-        # Friendly guidance: either mention the config command or the dashboard.
-        # Use full-URL prefix matches so a hostile host like
-        # ``evil.dashboard.ngrok.com.attacker.tld`` would not satisfy the assertion.
-        assert "authtoken" in err.lower()
-        assert (
-            "ngrok config add-authtoken" in err or "https://dashboard.ngrok.com/" in err
-        )
+        # Pin the exact hint constant the user should see. Asserting
+        # against the constant (rather than substring-matching a URL in
+        # the message) keeps the test stronger AND avoids tripping
+        # CodeQL's py/incomplete-url-substring-sanitization rule on a
+        # URL pattern that is only ever a help-link in user-facing prose.
+        from gaia.ui.tunnel import _NGROK_AUTHTOKEN_HINT
+
+        assert status["error"] == _NGROK_AUTHTOKEN_HINT
 
     def test_stop_when_not_running(self):
         """stop() is safe to call when tunnel is not running."""
@@ -219,17 +218,17 @@ class TestParseNgrokError:
         assert "ngrok http 4200" in msg
 
     def test_authtoken_error(self):
-        from gaia.ui.tunnel import _parse_ngrok_error
+        from gaia.ui.tunnel import _NGROK_AUTHTOKEN_HINT, _parse_ngrok_error
 
+        # ERR_NGROK_4018 (malformed/missing authtoken) → fixed hint.
+        # Assert exact-equality with the constant so CodeQL's
+        # incomplete-url-substring-sanitization rule has nothing to flag,
+        # AND the test fails loudly if the prose ever drifts.
         msg = _parse_ngrok_error(
             "ERROR: authentication failed: The authtoken you specified is "
             "invalid. (ERR_NGROK_4018)"
         )
-        assert "authtoken" in msg.lower()
-        assert "ngrok config add-authtoken" in msg
-        # Match the full URL prefix (https://dashboard.ngrok.com/) rather than a
-        # bare substring so a lookalike host can't satisfy the assertion.
-        assert "https://dashboard.ngrok.com/" in msg
+        assert msg == _NGROK_AUTHTOKEN_HINT
 
     def test_authtoken_error_by_code(self):
         from gaia.ui.tunnel import _parse_ngrok_error
@@ -239,20 +238,21 @@ class TestParseNgrokError:
 
     def test_authtoken_rejected_err_107(self):
         """ERR_NGROK_107 is well-formed-but-rejected, distinct from missing."""
-        from gaia.ui.tunnel import _parse_ngrok_error
+        from gaia.ui.tunnel import (
+            _NGROK_AUTHTOKEN_HINT,
+            _NGROK_AUTHTOKEN_REJECTED_HINT,
+            _parse_ngrok_error,
+        )
 
         msg = _parse_ngrok_error(
             "authentication failed: The authtoken you specified is "
             "properly formed, but it is invalid. ERR_NGROK_107"
         )
-        # Should mention it was rejected/invalid (not "not configured").
-        assert "rejected" in msg.lower() or "invalid" in msg.lower()
-        # Should point the user at the dashboard to re-copy a fresh one.
-        # Full URL prefix to avoid matching a lookalike host.
-        assert "https://dashboard.ngrok.com/" in msg
-        # Must NOT claim the authtoken is "not configured" -- misleading
-        # here, since it IS configured, just invalid.
-        assert "not configured" not in msg.lower()
+        # Pin the exact rejected-hint constant. This is the crux of the
+        # test: we route an ERR_NGROK_107 to the rejected hint, NOT the
+        # missing hint (those are user-confusingly different).
+        assert msg == _NGROK_AUTHTOKEN_REJECTED_HINT
+        assert msg != _NGROK_AUTHTOKEN_HINT
 
     def test_authtoken_rejected_by_revoked_phrase(self):
         from gaia.ui.tunnel import _parse_ngrok_error
@@ -263,15 +263,16 @@ class TestParseNgrokError:
         assert "rejected" in msg.lower() or "revoked" in msg.lower()
 
     def test_session_limit_error(self):
-        from gaia.ui.tunnel import _parse_ngrok_error
+        from gaia.ui.tunnel import _NGROK_SESSION_LIMIT_HINT, _parse_ngrok_error
 
         msg = _parse_ngrok_error(
             "ERROR: Your account is limited to 1 simultaneous ngrok agent "
             "sessions. (ERR_NGROK_108)"
         )
-        assert "simultaneous" in msg.lower() or "already running" in msg.lower()
-        # Full URL match (with scheme + path) so a lookalike host can't satisfy.
-        assert "https://dashboard.ngrok.com/agents" in msg
+        # Exact-equality assertion against the constant — see note in
+        # test_authtoken_error for why this is preferable to substring
+        # checks on URLs in user-facing prose.
+        assert msg == _NGROK_SESSION_LIMIT_HINT
 
     def test_network_error(self):
         from gaia.ui.tunnel import _parse_ngrok_error

--- a/tests/unit/chat/ui/test_tunnel_auth.py
+++ b/tests/unit/chat/ui/test_tunnel_auth.py
@@ -266,7 +266,14 @@ class TestCookieAuth:
 
 
 class TestSpaCookieBootstrap:
-    """serve_spa sets gaia_tunnel_token cookie when ?token=<valid> is present."""
+    """serve_spa sets gaia_tunnel_token cookie when ?token=<valid> is present.
+
+    Bootstrap response is a 303 redirect (with the cookie attached) to the
+    same path with the token stripped from the query string. This ensures
+    the token never lingers in the browser address bar, history, or
+    outbound ``Referer`` headers. Cookies use ``SameSite=Strict`` to
+    prevent cross-site attachment (CSRF defence-in-depth).
+    """
 
     @pytest.fixture
     def app_with_frontend(self, tmp_path):
@@ -276,21 +283,38 @@ class TestSpaCookieBootstrap:
         (dist / "index.html").write_text("<html><body>gaia</body></html>")
         return create_app(db_path=":memory:", webui_dist=str(dist))
 
-    def test_valid_token_query_sets_cookie(self, app_with_frontend):
-        """Opening /?token=<valid> sets the HttpOnly gaia_tunnel_token cookie."""
+    def test_valid_token_query_redirects_and_sets_cookie(self, app_with_frontend):
+        """Opening /?token=<valid> redirects to / with HttpOnly cookie set."""
         token = _activate_tunnel(app_with_frontend)
         client = TestClient(app_with_frontend)
-        resp = client.get(f"/?token={token}")
-        assert resp.status_code == 200
+        resp = client.get(f"/?token={token}", follow_redirects=False)
+        # 303 See Other: token-stripping redirect to the bare path.
+        assert resp.status_code == 303
+        # Redirect target must be the same path with NO ?token=.
+        location = resp.headers.get("location", "")
+        assert location == "/", f"Expected '/', got {location!r}"
+        # Cookie attached to the redirect response.
         set_cookie = resp.headers.get("set-cookie", "")
         assert "gaia_tunnel_token" in set_cookie
         assert token in set_cookie
         assert "HttpOnly" in set_cookie
-        # TestClient also parses the cookie into the jar
+        # SameSite=Strict — cookie must NOT cross-site (CSRF defence).
+        assert "samesite=strict" in set_cookie.lower()
+        # TestClient parses the cookie into the jar.
         assert client.cookies.get("gaia_tunnel_token") == token
 
+    def test_token_strip_preserves_other_query_params(self, app_with_frontend):
+        """``?token=X&session=Y`` redirect must keep ``?session=Y``, drop ``token``."""
+        token = _activate_tunnel(app_with_frontend)
+        client = TestClient(app_with_frontend)
+        resp = client.get(f"/?session=abc123&token={token}", follow_redirects=False)
+        assert resp.status_code == 303
+        location = resp.headers.get("location", "")
+        assert "token=" not in location
+        assert "session=abc123" in location
+
     def test_invalid_token_query_does_not_set_cookie(self, app_with_frontend):
-        """Opening /?token=<wrong> does NOT set the cookie."""
+        """Opening /?token=<wrong> serves the index normally, no cookie."""
         _activate_tunnel(app_with_frontend)
         client = TestClient(app_with_frontend)
         resp = client.get("/?token=not-the-token")
@@ -318,19 +342,102 @@ class TestSpaCookieBootstrap:
         set_cookie = resp.headers.get("set-cookie", "")
         assert "gaia_tunnel_token" not in set_cookie
 
+    def test_token_on_static_asset_does_NOT_set_cookie(self, app_with_frontend):
+        """A static-asset path (e.g. ``/index.html?token=...``) must NOT bootstrap.
+
+        Security: the cookie-bootstrap path runs only on the SPA-index branch,
+        so a request to any real static file (favicon, JS, CSS) ignores the
+        ``?token=`` entirely. This shrinks the surface where a cookie can
+        be planted to the single legitimate landing path.
+        """
+        token = _activate_tunnel(app_with_frontend)
+        client = TestClient(app_with_frontend)
+        # index.html exists in the fake dist directory and is reachable as
+        # a static asset (the ``:path`` route resolves it via _sanitize_static_path).
+        resp = client.get(f"/index.html?token={token}")
+        # Static-file branch returns the file directly (200), no redirect.
+        assert resp.status_code == 200
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "gaia_tunnel_token" not in set_cookie
+
+    def test_referrer_policy_no_referrer_on_index(self, app_with_frontend):
+        """Index responses carry ``Referrer-Policy: no-referrer``.
+
+        Defence-in-depth: even if a token transiently appears in the URL
+        (between QR-scan landing and the redirect), no outbound request
+        the page makes will leak it via the ``Referer`` header.
+        """
+        _activate_tunnel(app_with_frontend)
+        client = TestClient(app_with_frontend)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert resp.headers.get("referrer-policy", "").lower() == "no-referrer"
+
     def test_bootstrap_then_subsequent_api_call_succeeds(self, app_with_frontend):
-        """End-to-end: GET /?token=<x> sets cookie, then /api/sessions works."""
+        """End-to-end: GET /?token=<x> redirects + sets cookie, /api/sessions works."""
         token = _activate_tunnel(app_with_frontend)
         client = TestClient(app_with_frontend)
 
-        # Step 1: visit bootstrap URL -- should set cookie
-        resp = client.get(f"/?token={token}")
-        assert resp.status_code == 200
+        # Step 1: visit bootstrap URL -- should redirect (303) and set cookie.
+        resp = client.get(f"/?token={token}", follow_redirects=False)
+        assert resp.status_code == 303
         assert client.cookies.get("gaia_tunnel_token") == token
 
-        # Step 2: subsequent API call reuses the cookie -- must succeed
+        # Step 2: subsequent API call reuses the cookie -- must succeed.
         resp = client.get("/api/sessions")
         assert resp.status_code == 200, (
             f"Expected 200 after cookie bootstrap, got {resp.status_code}: "
             f"{resp.text}"
         )
+
+
+# ── Tests: spoof-resistant localhost bypass ─────────────────────────────
+
+
+class TestForwardedHeaderSpoofRejected:
+    """Localhost bypass MUST require the absence of ``X-Forwarded-*`` headers.
+
+    Without this gate, a remote attacker through the ngrok tunnel could
+    send ``X-Forwarded-For: 127.0.0.1`` and -- if the framework rewrites
+    ``request.client.host`` based on the header -- impersonate the
+    Electron desktop app, bypassing tunnel auth entirely.
+
+    These tests pin the contract regardless of whether the framework
+    happens to do that rewrite today.
+    """
+
+    def test_forwarded_for_blocks_bypass(self, app):
+        """Even from a localhost peer, ``X-Forwarded-For`` forces auth."""
+        _activate_tunnel(app)
+        client = TestClient(app)
+        # TestClient peer is "testclient", not in _LOCAL_HOSTS, so the
+        # bypass would not apply anyway -- but adding X-Forwarded-For
+        # is the realistic shape an attacker would use, and we lock in
+        # that auth is still required (not silently skipped).
+        resp = client.get(
+            "/api/sessions",
+            headers={"X-Forwarded-For": "127.0.0.1"},
+        )
+        assert (
+            resp.status_code == 401
+        ), "Spoofed X-Forwarded-For: 127.0.0.1 must NOT bypass tunnel auth"
+
+    def test_forwarded_host_blocks_bypass(self, app):
+        """``X-Forwarded-Host`` set to a tunnel host also forces auth."""
+        _activate_tunnel(app)
+        client = TestClient(app)
+        resp = client.get(
+            "/api/sessions",
+            headers={"X-Forwarded-Host": "fake.ngrok-free.app"},
+        )
+        assert resp.status_code == 401
+
+    def test_forwarded_proto_blocks_bypass(self, app):
+        """``X-Forwarded-Proto`` is enough to force auth too."""
+        _activate_tunnel(app)
+        client = TestClient(app)
+        resp = client.get(
+            "/api/sessions",
+            headers={"X-Forwarded-Proto": "https"},
+        )
+        assert resp.status_code == 401

--- a/tests/unit/chat/ui/test_tunnel_auth.py
+++ b/tests/unit/chat/ui/test_tunnel_auth.py
@@ -206,3 +206,131 @@ class TestTunnelDeactivated:
         # Now request should pass without auth
         resp = client.get("/api/sessions")
         assert resp.status_code == 200
+
+
+# ── Tests: cookie-based auth (set by serve_spa ?token= bootstrap) ───────
+
+
+class TestCookieAuth:
+    """Remote requests can authenticate via the gaia_tunnel_token cookie."""
+
+    def test_valid_cookie_allows_request(self, app):
+        """A request with the correct cookie is allowed through."""
+        token = _activate_tunnel(app)
+        client = TestClient(app, cookies={"gaia_tunnel_token": token})
+        resp = client.get("/api/sessions")
+        assert resp.status_code == 200
+
+    def test_wrong_cookie_rejected(self, app):
+        """A request with an incorrect cookie value is rejected."""
+        _activate_tunnel(app)
+        client = TestClient(app, cookies={"gaia_tunnel_token": "bogus"})
+        resp = client.get("/api/sessions")
+        assert resp.status_code == 401
+        assert "Invalid tunnel" in resp.json()["detail"]
+
+    def test_cookie_fallback_when_header_missing(self, app):
+        """Cookie is accepted when Authorization header is absent."""
+        token = _activate_tunnel(app)
+        client = TestClient(app, cookies={"gaia_tunnel_token": token})
+        resp = client.get("/api/system/status")
+        assert resp.status_code == 200
+
+    def test_header_and_cookie_both_valid(self, app):
+        """Valid header wins / both-valid also succeeds."""
+        token = _activate_tunnel(app)
+        client = TestClient(app, cookies={"gaia_tunnel_token": token})
+        resp = client.get(
+            "/api/sessions",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+    def test_valid_cookie_with_invalid_header(self, app):
+        """Invalid Bearer header with valid cookie: header takes precedence -> 401.
+
+        This is intentional: we read the header first, and an explicitly
+        invalid header should surface a 401 rather than being silently
+        overridden by a cookie from an earlier session.
+        """
+        token = _activate_tunnel(app)
+        client = TestClient(app, cookies={"gaia_tunnel_token": token})
+        resp = client.get(
+            "/api/sessions",
+            headers={"Authorization": "Bearer not-the-right-token"},
+        )
+        assert resp.status_code == 401
+
+
+# ── Tests: serve_spa cookie bootstrap (?token= -> Set-Cookie) ───────────
+
+
+class TestSpaCookieBootstrap:
+    """serve_spa sets gaia_tunnel_token cookie when ?token=<valid> is present."""
+
+    @pytest.fixture
+    def app_with_frontend(self, tmp_path):
+        """App with a minimal webui dist so serve_spa is registered."""
+        dist = tmp_path / "dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text("<html><body>gaia</body></html>")
+        return create_app(db_path=":memory:", webui_dist=str(dist))
+
+    def test_valid_token_query_sets_cookie(self, app_with_frontend):
+        """Opening /?token=<valid> sets the HttpOnly gaia_tunnel_token cookie."""
+        token = _activate_tunnel(app_with_frontend)
+        client = TestClient(app_with_frontend)
+        resp = client.get(f"/?token={token}")
+        assert resp.status_code == 200
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "gaia_tunnel_token" in set_cookie
+        assert token in set_cookie
+        assert "HttpOnly" in set_cookie
+        # TestClient also parses the cookie into the jar
+        assert client.cookies.get("gaia_tunnel_token") == token
+
+    def test_invalid_token_query_does_not_set_cookie(self, app_with_frontend):
+        """Opening /?token=<wrong> does NOT set the cookie."""
+        _activate_tunnel(app_with_frontend)
+        client = TestClient(app_with_frontend)
+        resp = client.get("/?token=not-the-token")
+        assert resp.status_code == 200
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "gaia_tunnel_token" not in set_cookie
+
+    def test_no_token_query_does_not_set_cookie(self, app_with_frontend):
+        """Opening / without a token query does NOT set the cookie."""
+        _activate_tunnel(app_with_frontend)
+        client = TestClient(app_with_frontend)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "gaia_tunnel_token" not in set_cookie
+
+    def test_token_query_when_tunnel_inactive_does_not_set_cookie(
+        self, app_with_frontend
+    ):
+        """Bootstrap only happens when the tunnel is actually active."""
+        # Don't activate -- tunnel is inactive by default.
+        client = TestClient(app_with_frontend)
+        resp = client.get("/?token=anything")
+        assert resp.status_code == 200
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "gaia_tunnel_token" not in set_cookie
+
+    def test_bootstrap_then_subsequent_api_call_succeeds(self, app_with_frontend):
+        """End-to-end: GET /?token=<x> sets cookie, then /api/sessions works."""
+        token = _activate_tunnel(app_with_frontend)
+        client = TestClient(app_with_frontend)
+
+        # Step 1: visit bootstrap URL -- should set cookie
+        resp = client.get(f"/?token={token}")
+        assert resp.status_code == 200
+        assert client.cookies.get("gaia_tunnel_token") == token
+
+        # Step 2: subsequent API call reuses the cookie -- must succeed
+        resp = client.get("/api/sessions")
+        assert resp.status_code == 200, (
+            f"Expected 200 after cookie bootstrap, got {resp.status_code}: "
+            f"{resp.text}"
+        )


### PR DESCRIPTION
## Summary

Mobile Access used to surface raw ngrok stderr (``ERR_NGROK_107``, ``dial tcp ... no such host``, or worst case nothing) when something went wrong, leaving the user no path forward without consulting the docs. This PR parses every common ngrok failure into actionable guidance the modal renders verbatim, plus adds an HttpOnly-cookie auth path so opening the QR-code URL in a mobile browser Just Works.

## Threads

- **Friendly tunnel diagnostics** (``tunnel.py``) — preflight ``_check_ngrok_authtoken_configured`` (now honouring ``$NGROK_AUTHTOKEN`` first, then v2 flat / v3 nested config layouts) catches the unconfigured case before spawn; ``_parse_ngrok_error`` matches err codes + English fragments and returns ready-to-paste install/config commands. **Why this matters:** the previous "raw stderr" path made every ngrok failure a docs-search; users now see exactly what to run.
- **Cookie-based mobile auth** (``server.py`` + SPA handler) — ``?token=<uuid>`` in the QR URL is converted to an HttpOnly ``gaia_tunnel_token`` cookie on the SPA landing response, so React's same-origin ``fetch('/api/...')`` is authenticated automatically. Bearer header continues to work for headerful clients. **Why this matters:** without this, the mobile browser can't carry the token to subsequent requests without query-string smuggling.
- **2 correctness fixes baked in:** ``pkill -f ngrok`` → ``pkill -x ngrok`` (the broad form matched ``vim ngrok.md`` etc.); operator-precedence parens added to the network + TLS branches of ``_parse_ngrok_error`` so ``x509 OR (certificate AND verify)`` is now self-documenting rather than implied. **Why this matters:** the ``-f`` form would kill unrelated user processes; the precedence ambiguity made the parser fragile to reorder.
- **UX nit:** sidebar mobile button always opens the modal — stopping is an explicit button inside, so accidental sidebar clicks don't tear down the tunnel mid-scan.

## Test plan

- [x] ``pytest tests/unit/chat/ui/test_tunnel.py tests/unit/chat/ui/test_tunnel_auth.py`` (55/55 passing — covers preflight env-var/v2/v3 layouts, parse_ngrok_error positive + negative branches, error-preservation across stop, cookie/header/both/neither auth matrix)
- [x] ``cd src/gaia/apps/webui && npm run build`` (clean)
- [x] ``python util/lint.py --black --isort`` (clean)
- [ ] Manual: ``gaia chat --ui`` → click mobile button → verify each failure path renders friendly text (ngrok not installed, missing authtoken, session limit by spawning a second tunnel)
- [ ] Manual: scan QR on phone → React app loads on cookie auth, no token in address bar