### PR TITLE
feat(packaging): ship Agent UI dist/ in PyPI wheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,18 +174,32 @@ jobs:
 
   build-pypi:
     name: Build PyPI Package
-    needs: validate
+    # Depends on build-npm so the wheel ships the *same* React bundle that the
+    # npm package publishes. Building twice (once per job) would risk hash
+    # drift between vite outputs across runners — see issue #846.
+    needs: [validate, build-npm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+      - name: Download pre-built frontend
+        uses: actions/download-artifact@v6
+        with:
+          name: npm-package-build
+          path: src/gaia/apps/webui/dist/
+      - name: Verify frontend dist/ is non-empty and clean
+        run: python util/verify_wheel_dist.py src/gaia/apps/webui/dist
       - name: Build distributions
         run: |
           rm -rf dist/ build/ *.egg-info
           python -m pip install build
           python -m build
+      - name: Verify wheel ships frontend assets
+        run: |
+          WHL=$(ls dist/*.whl | head -1)
+          python util/verify_wheel_dist.py --wheel "$WHL"
       - name: Verify with twine
         run: |
           python -m pip install twine
@@ -213,7 +227,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: src/gaia/apps/webui
-        run: npm ci 2>/dev/null || npm install
+        # No silent fallback: if package-lock.json is broken, we want the
+        # build to fail loudly here rather than ship a wheel with an
+        # unexpected dependency tree (see CLAUDE.md "No Silent Fallbacks").
+        run: npm ci
 
       - name: Build frontend
         working-directory: src/gaia/apps/webui
@@ -361,7 +378,9 @@ jobs:
           path: src/gaia/apps/webui/dist/
       - name: Install production dependencies
         working-directory: src/gaia/apps/webui
-        run: npm ci --omit=dev 2>/dev/null || npm install --omit=dev
+        # No silent fallback (see CLAUDE.md "No Silent Fallbacks"). If the
+        # lockfile is stale, fail here rather than publish a divergent tree.
+        run: npm ci --omit=dev
       - name: Publish @amd-gaia/agent-ui
         working-directory: src/gaia/apps/webui
         # --ignore-scripts: skip prepublishOnly (which runs tsc && vite build)

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,12 +22,45 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
       - name: Clean previous builds
         run: rm -rf dist/ build/ *.egg-info
+      - name: Install frontend dependencies
+        working-directory: src/gaia/apps/webui
+        # --ignore-scripts: this workflow runs on `pull_request`, including
+        # PRs from forks. A malicious lockfile could otherwise execute
+        # arbitrary postinstall code on the runner. publish.yml's build-npm
+        # job, which runs only on tag pushes from main, omits this flag.
+        run: npm ci --ignore-scripts
+      - name: Build frontend
+        working-directory: src/gaia/apps/webui
+        run: npm run build
+      - name: Verify frontend dist/ is non-empty and clean
+        run: python util/verify_wheel_dist.py src/gaia/apps/webui/dist
+      - name: Verify the gate actually bites (negative test)
+        # Plant a sourcemap, confirm the verifier exits non-zero, then revert.
+        # Without this step the verifier could silently regress to a no-op.
+        run: |
+          set -e
+          touch src/gaia/apps/webui/dist/leak.js.map
+          if python util/verify_wheel_dist.py src/gaia/apps/webui/dist; then
+            echo "FAIL: verifier did not catch planted sourcemap"
+            rm -f src/gaia/apps/webui/dist/leak.js.map
+            exit 1
+          fi
+          rm -f src/gaia/apps/webui/dist/leak.js.map
+          python util/verify_wheel_dist.py src/gaia/apps/webui/dist
+          echo "Verifier gate confirmed working"
       - name: Build release distributions
         run: |
           python -m pip install build
           python -m build
+      - name: Verify wheel ships frontend assets
+        run: |
+          WHL=$(ls dist/*.whl | head -1)
+          python util/verify_wheel_dist.py --wheel "$WHL"
       - name: Verify package with twine
         run: |
           python -m pip install twine

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,3 +13,18 @@ include README.md
 
 # Include evaluation webapp files
 recursive-include src/gaia/eval/webapp *
+
+# Include the pre-built Agent UI bundle so `pip install amd-gaia[ui]` ships a
+# working browser UI. setuptools `package_data` recursive globs are unreliable
+# across versions, so we list the bundle here as the authoritative inclusion
+# rule. The CI publish pipeline runs `npm run build` before `python -m build`;
+# util/verify_wheel_dist.py asserts the wheel actually contains these files.
+recursive-include src/gaia/apps/webui/dist *.html *.js *.css *.svg *.png *.jpg *.jpeg *.webp *.ico *.webmanifest *.json *.woff *.woff2 *.ttf *.txt
+
+# Backstop deny-list — these patterns must never reach a published wheel even
+# if a developer accidentally checks them in or `npm run build` emits them.
+prune src/gaia/apps/webui/dist/node_modules
+global-exclude *.map
+global-exclude .DS_Store
+global-exclude .env
+global-exclude .env.*

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import re
-import sys
-from pathlib import Path
 
 from setuptools import setup
 
@@ -15,37 +13,6 @@ with open("src/gaia/version.py", encoding="utf-8") as fp:
     gaia_version = version_match.group(1)
 
 tkml_version = "5.0.4"
-
-# Guard against shipping a wheel without the Agent UI bundle. When building a
-# wheel (anything other than `sdist`), the pre-built React assets MUST exist
-# under src/gaia/apps/webui/dist/ — otherwise `pip install amd-gaia[ui]` would
-# silently fall through to the "frontend not built" page on every install. The
-# CI publish pipeline runs `npm run build` before `python -m build`; this guard
-# turns a forgotten step into a loud failure rather than a quiet bad release.
-_WEBUI_DIST_INDEX = (
-    Path(__file__).parent / "src" / "gaia" / "apps" / "webui" / "dist" / "index.html"
-)
-# Bypass the guard for any setuptools command other than wheel building.
-# `egg_info`, `develop`, `editable_wheel`, `dist_info` are all invoked by
-# editable-install paths (`pip install -e .`) across pip/setuptools versions;
-# `sdist` doesn't need the bundle. We only fail when the user is actually
-# producing a binary wheel.
-_BUILD_BYPASS_COMMANDS = {
-    "sdist",
-    "egg_info",
-    "develop",
-    "editable_wheel",
-    "dist_info",
-    "check",
-    "--help-commands",
-}
-_GUARD_BYPASS = any(arg in _BUILD_BYPASS_COMMANDS for arg in sys.argv[1:])
-if not _WEBUI_DIST_INDEX.is_file() and not _GUARD_BYPASS:
-    raise SystemExit(
-        f"Frontend bundle not found at {_WEBUI_DIST_INDEX}.\n"
-        f"Run `npm ci && npm run build` in src/gaia/apps/webui/ before "
-        f"building the wheel, or use `python -m build --sdist` to skip the bundle."
-    )
 
 setup(
     name="amd-gaia",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 import re
+import sys
+from pathlib import Path
 
 from setuptools import setup
 
@@ -13,6 +15,37 @@ with open("src/gaia/version.py", encoding="utf-8") as fp:
     gaia_version = version_match.group(1)
 
 tkml_version = "5.0.4"
+
+# Guard against shipping a wheel without the Agent UI bundle. When building a
+# wheel (anything other than `sdist`), the pre-built React assets MUST exist
+# under src/gaia/apps/webui/dist/ — otherwise `pip install amd-gaia[ui]` would
+# silently fall through to the "frontend not built" page on every install. The
+# CI publish pipeline runs `npm run build` before `python -m build`; this guard
+# turns a forgotten step into a loud failure rather than a quiet bad release.
+_WEBUI_DIST_INDEX = (
+    Path(__file__).parent / "src" / "gaia" / "apps" / "webui" / "dist" / "index.html"
+)
+# Bypass the guard for any setuptools command other than wheel building.
+# `egg_info`, `develop`, `editable_wheel`, `dist_info` are all invoked by
+# editable-install paths (`pip install -e .`) across pip/setuptools versions;
+# `sdist` doesn't need the bundle. We only fail when the user is actually
+# producing a binary wheel.
+_BUILD_BYPASS_COMMANDS = {
+    "sdist",
+    "egg_info",
+    "develop",
+    "editable_wheel",
+    "dist_info",
+    "check",
+    "--help-commands",
+}
+_GUARD_BYPASS = any(arg in _BUILD_BYPASS_COMMANDS for arg in sys.argv[1:])
+if not _WEBUI_DIST_INDEX.is_file() and not _GUARD_BYPASS:
+    raise SystemExit(
+        f"Frontend bundle not found at {_WEBUI_DIST_INDEX}.\n"
+        f"Run `npm ci && npm run build` in src/gaia/apps/webui/ before "
+        f"building the wheel, or use `python -m build --sdist` to skip the bundle."
+    )
 
 setup(
     name="amd-gaia",
@@ -77,6 +110,7 @@ setup(
         "gaia.vlm",
         "gaia.api",
         "gaia.code_index",
+        "gaia.apps.webui",
     ],
     package_data={
         "gaia.eval": [
@@ -86,6 +120,21 @@ setup(
             "webapp/public/*.html",
             "webapp/public/*.css",
             "webapp/public/*.js",
+        ],
+        # Browser-mode Agent UI bundle. Recursive globs in package_data are
+        # unreliable across setuptools versions, so we list shallow patterns
+        # here and back them up with `recursive-include` in MANIFEST.in. The
+        # CI verifier (util/verify_wheel_dist.py) enforces that the wheel
+        # actually contains these entries before publish.
+        "gaia.apps.webui": [
+            "dist/index.html",
+            "dist/*.svg",
+            "dist/*.png",
+            "dist/*.ico",
+            "dist/*.webmanifest",
+            "dist/*.json",
+            "dist/*.txt",
+            "dist/assets/*",
         ],
     },
     install_requires=[

--- a/src/gaia/apps/webui/__init__.py
+++ b/src/gaia/apps/webui/__init__.py
@@ -1,0 +1,8 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Marker package so the pre-built Agent UI bundle ships with the wheel.
+
+The Python source under this package is intentionally empty — only the
+``dist/`` directory matters at runtime, and it is located via package-relative
+paths from ``gaia.ui.server.create_app``.
+"""

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -409,9 +409,24 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             return FileResponse(_index_html, headers=_NO_CACHE)
 
     else:
-        logger.info(
-            "No frontend build found at %s. Run 'npm run build' in the webui directory.",
-            _webui_dist,
+        # Resolve to an absolute path so users can act on the warning. Prefer
+        # the resolved form, but fall back to the raw value if the directory
+        # truly doesn't exist (resolve() of a missing path is harmless on POSIX
+        # but can surprise on Windows).
+        try:
+            _resolved_for_log = _webui_dist.resolve()
+        except OSError:
+            _resolved_for_log = _webui_dist
+        logger.warning(
+            "No frontend build found at %s (resolved from gaia.apps.webui). "
+            "If you installed via pip, the wheel may have shipped without "
+            "dist/ — diagnose with: "
+            "python -c 'import gaia.apps.webui as m; "
+            "from pathlib import Path; "
+            'print(Path(m.__file__).parent / "dist")\'. '
+            "If you installed from source, run 'npm ci && npm run build' "
+            "in src/gaia/apps/webui/.",
+            _resolved_for_log,
         )
 
         _FALLBACK_HTML = """<!DOCTYPE html>

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -1588,3 +1588,89 @@ class TestSanitizeStaticPath:
             import shutil
 
             shutil.rmtree(base)
+
+
+class TestSpaShellServing:
+    """Issue #846 — wheel ships dist/, server must serve it."""
+
+    def test_server_serves_spa_when_dist_present(self, tmp_path):
+        """When webui_dist is provided and contains index.html, GET / returns it."""
+        dist = tmp_path / "dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text(
+            '<!doctype html><html><body><div id="root"></div>'
+            '<script src="/assets/main-abc.js"></script></body></html>'
+        )
+        (dist / "assets" / "main-abc.js").write_text("// stub")
+
+        app = create_app(db_path=":memory:", webui_dist=str(dist))
+        client = TestClient(app)
+        r = client.get("/")
+        assert r.status_code == 200
+        assert 'id="root"' in r.text
+        # No-cache header is applied so browsers always pick up new builds
+        assert "no-cache" in r.headers.get("cache-control", "").lower()
+
+    def test_server_serves_hashed_asset_when_dist_present(self, tmp_path):
+        """Hashed assets under /assets/ are served as static files."""
+        dist = tmp_path / "dist"
+        (dist / "assets").mkdir(parents=True)
+        (dist / "index.html").write_text('<div id="root"></div>')
+        (dist / "assets" / "main-abc.js").write_text("const x = 1;")
+
+        app = create_app(db_path=":memory:", webui_dist=str(dist))
+        client = TestClient(app)
+        r = client.get("/assets/main-abc.js")
+        assert r.status_code == 200
+        assert "const x = 1" in r.text
+
+    def test_server_falls_back_when_dist_missing(self, tmp_path):
+        """When dist/ is absent, server returns the friendly HTML fallback."""
+        app = create_app(
+            db_path=":memory:",
+            webui_dist=str(tmp_path / "nonexistent-dist"),
+        )
+        client = TestClient(app)
+        r = client.get("/")
+        assert r.status_code == 200
+        # The fallback is HTML (not JSON) and explains the situation
+        assert "<html" in r.text.lower()
+        assert (
+            "frontend" in r.text.lower()
+            or "agent ui" in r.text.lower()
+            or "backend" in r.text.lower()
+        )
+
+    def test_default_webui_dist_resolves_under_gaia_apps_webui(self):
+        """The default dist/ path must resolve under the gaia.apps.webui package.
+
+        Catches refactors that rename the package, move __init__.py, or break
+        the path-math at server.py — any of which would silently land an
+        installed wheel in fallback mode.
+        """
+        from pathlib import Path
+
+        import gaia.apps.webui as webui_pkg
+
+        expected = Path(webui_pkg.__file__).resolve().parent / "dist"
+        # server.py:362 computes _default_dist via __file__-relative path math.
+        # Re-derive it the same way the server does and assert agreement.
+        from gaia.ui import server as server_module
+
+        server_dir = Path(server_module.__file__).resolve().parent
+        derived = (server_dir.parent / "apps" / "webui" / "dist").resolve()
+        assert derived == expected, (
+            f"server.py default dist path ({derived}) drifted from "
+            f"gaia.apps.webui location ({expected})"
+        )
+
+    def test_server_warns_with_diagnostic_when_dist_missing(self, tmp_path, caplog):
+        """The 'no dist' log line names the path so users can act on it."""
+        missing = tmp_path / "missing-dist"
+        with caplog.at_level(logging.WARNING, logger="gaia.ui.server"):
+            create_app(db_path=":memory:", webui_dist=str(missing))
+        # The warning must contain the path the server tried (so users can
+        # diagnose the wheel install) and a hint pointing to gaia.apps.webui.
+        joined = " ".join(rec.getMessage() for rec in caplog.records)
+        assert "missing-dist" in joined
+        assert "gaia.apps.webui" in joined

--- a/tests/unit/test_verify_wheel_dist.py
+++ b/tests/unit/test_verify_wheel_dist.py
@@ -1,0 +1,307 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for util/verify_wheel_dist.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module without making util/ a package.
+_VERIFY_PATH = Path(__file__).resolve().parents[2] / "util" / "verify_wheel_dist.py"
+_spec = importlib.util.spec_from_file_location("verify_wheel_dist", _VERIFY_PATH)
+verify = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+sys.modules["verify_wheel_dist"] = verify
+_spec.loader.exec_module(verify)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_clean_dist(root: Path) -> Path:
+    """Create a minimal, valid dist/ tree under root."""
+    dist = root / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text(
+        '<!doctype html><html><body><div id="root"></div>'
+        '<script src="/assets/main-abc123.js"></script></body></html>'
+    )
+    (dist / "assets" / "main-abc123.js").write_text("const x = 1; console.log(x);")
+    (dist / "assets" / "style-abc123.css").write_text("body { margin: 0; }")
+    (dist / "favicon.ico").write_bytes(b"\x00\x00\x01\x00")
+    return dist
+
+
+def _build_wheel(
+    dest_dir: Path,
+    *,
+    bundle_files: dict[str, bytes] | None = None,
+    pad_to_compressed_bytes: int | None = None,
+    pad_to_uncompressed_bytes: int | None = None,
+) -> Path:
+    """Build a synthetic wheel containing only the webui dist/ entries."""
+    wheel_path = dest_dir / "amd_gaia-0.0.0-py3-none-any.whl"
+    if bundle_files is None:
+        bundle_files = {
+            "gaia/apps/webui/dist/index.html": (
+                b'<!doctype html><div id="root"></div>'
+            ),
+            "gaia/apps/webui/dist/assets/main.js": b"const a = 1;",
+            "gaia/apps/webui/dist/assets/style.css": b"body{}",
+        }
+    with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, data in bundle_files.items():
+            zf.writestr(name, data)
+        if pad_to_uncompressed_bytes is not None:
+            # Add highly compressible padding so the uncompressed size is
+            # large but the compressed size stays small.
+            current = sum(zi.file_size for zi in zf.infolist())
+            need = pad_to_uncompressed_bytes - current
+            if need > 0:
+                zf.writestr("gaia/apps/webui/dist/assets/pad.txt", b"a" * need)
+    if pad_to_compressed_bytes is not None:
+        # Append incompressible random bytes inside a stored entry until the
+        # wheel's on-disk size exceeds the threshold.
+        import os as _os
+
+        with zipfile.ZipFile(wheel_path, "a", zipfile.ZIP_STORED) as zf:
+            current = wheel_path.stat().st_size
+            need = pad_to_compressed_bytes - current
+            if need > 0:
+                zf.writestr("gaia/apps/webui/dist/assets/pad.bin", _os.urandom(need))
+    return wheel_path
+
+
+# ---------------------------------------------------------------------------
+# Directory mode
+# ---------------------------------------------------------------------------
+
+
+def test_directory_mode_happy_path(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    assert verify.verify_directory(dist) == []
+
+
+def test_directory_mode_missing_dir(tmp_path):
+    errors = verify.verify_directory(tmp_path / "does-not-exist")
+    assert errors and "does not exist" in errors[0]
+
+
+def test_directory_mode_empty_dir(tmp_path):
+    empty = tmp_path / "dist"
+    empty.mkdir()
+    errors = verify.verify_directory(empty)
+    assert errors and any("empty" in e for e in errors)
+
+
+def test_directory_mode_rejects_sourcemap_files(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    (dist / "assets" / "main-abc123.js.map").write_text("{}")
+    errors = verify.verify_directory(dist)
+    assert any("sourcemap" in e and "main-abc123.js.map" in e for e in errors)
+
+
+def test_directory_mode_rejects_inline_sourcemap_data_uri(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    (dist / "assets" / "main-abc123.js").write_text(
+        "const x = 1;\n//# sourceMappingURL=data:application/json;base64,e30="
+    )
+    errors = verify.verify_directory(dist)
+    assert any("inline sourcemap" in e for e in errors)
+
+
+def test_directory_mode_rejects_dotfiles(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    (dist / ".env").write_text("SECRET=x")
+    errors = verify.verify_directory(dist)
+    assert any("dotfile" in e and ".env" in e for e in errors)
+
+
+def test_directory_mode_rejects_node_modules(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    leak = dist / "node_modules" / "foo"
+    leak.mkdir(parents=True)
+    (leak / "package.json").write_text("{}")
+    errors = verify.verify_directory(dist)
+    assert any("node_modules" in e for e in errors)
+
+
+def test_directory_mode_rejects_leaked_vite_value_in_html(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    (dist / "index.html").write_text(
+        '<html><head><script>VITE_API_KEY:"sk-real-secret-value"</script>'
+        '</head><body><div id="root"></div></body></html>'
+    )
+    errors = verify.verify_directory(dist)
+    assert any("VITE_" in e for e in errors)
+
+
+def test_directory_mode_rejects_leaked_vite_env_var_set(tmp_path, monkeypatch):
+    dist = _make_clean_dist(tmp_path)
+    monkeypatch.setenv("VITE_API_KEY", "sk-real-secret")
+    errors = verify.verify_directory(dist)
+    assert any("VITE_API_KEY" in e and "non-empty value" in e for e in errors)
+
+
+def test_directory_mode_allows_vite_placeholder_env(tmp_path, monkeypatch):
+    dist = _make_clean_dist(tmp_path)
+    monkeypatch.setenv("VITE_FOO", "__VITE_FOO__")
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    assert verify.verify_directory(dist) == []
+
+
+def test_directory_mode_missing_index_html(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    (dist / "index.html").unlink()
+    errors = verify.verify_directory(dist)
+    assert any("index.html" in e for e in errors)
+
+
+def test_directory_mode_rejects_unexpected_extension(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    (dist / "assets" / "weird.exe").write_bytes(b"MZ\x00")
+    errors = verify.verify_directory(dist)
+    assert any("unexpected file extension" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Wheel mode
+# ---------------------------------------------------------------------------
+
+
+def test_wheel_mode_happy_path(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    wheel = _build_wheel(tmp_path)
+    assert verify.verify_wheel(wheel) == []
+
+
+def test_wheel_mode_missing_assets_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    wheel = _build_wheel(
+        tmp_path,
+        bundle_files={
+            "gaia/apps/webui/dist/index.html": b"<html></html>",
+        },
+    )
+    errors = verify.verify_wheel(wheel)
+    assert any("assets/" in e for e in errors)
+
+
+def test_wheel_mode_missing_index_html(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    wheel = _build_wheel(
+        tmp_path,
+        bundle_files={"gaia/apps/webui/dist/assets/main.js": b"x = 1;"},
+    )
+    errors = verify.verify_wheel(wheel)
+    assert any("index.html" in e for e in errors)
+
+
+def test_wheel_mode_no_webui_files(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    wheel = _build_wheel(
+        tmp_path,
+        bundle_files={"gaia/__init__.py": b""},
+    )
+    errors = verify.verify_wheel(wheel)
+    assert any("frontend bundle missing" in e for e in errors)
+
+
+def test_wheel_mode_rejects_sourcemap(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    wheel = _build_wheel(
+        tmp_path,
+        bundle_files={
+            "gaia/apps/webui/dist/index.html": b'<div id="root"></div>',
+            "gaia/apps/webui/dist/assets/main.js": b"const a = 1;",
+            "gaia/apps/webui/dist/assets/main.js.map": b"{}",
+        },
+    )
+    errors = verify.verify_wheel(wheel)
+    assert any("sourcemap" in e for e in errors)
+
+
+def test_wheel_mode_size_hard_fail(tmp_path, monkeypatch):
+    """Hard-fail when wheel exceeds 95 MB compressed."""
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    # Build minimal wheel and pad with incompressible random bytes.
+    threshold = verify.WHEEL_SIZE_HARD_FAIL_BYTES + 1024 * 1024  # 1 MB over
+    wheel = _build_wheel(tmp_path, pad_to_compressed_bytes=threshold)
+    errors = verify.verify_wheel(wheel)
+    assert any("hard limit" in e for e in errors)
+
+
+def test_wheel_mode_size_warn_threshold(tmp_path, monkeypatch, capsys):
+    """Warn (not fail) when wheel between 50 MB and 95 MB compressed."""
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    threshold = verify.WHEEL_SIZE_WARN_BYTES + 5 * 1024 * 1024  # ~55 MB
+    wheel = _build_wheel(tmp_path, pad_to_compressed_bytes=threshold)
+    errors = verify.verify_wheel(wheel)
+    captured = capsys.readouterr()
+    # No size hard-fail expected.
+    assert not any("hard limit" in e for e in errors)
+    # Warning emitted.
+    assert "::warning::" in captured.out
+
+
+def test_wheel_mode_uncompressed_hard_fail(tmp_path, monkeypatch):
+    """Hard-fail when uncompressed size exceeds 250 MB even if compressed is small."""
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    target = verify.WHEEL_UNCOMPRESSED_HARD_FAIL_BYTES + 1024 * 1024
+    wheel = _build_wheel(tmp_path, pad_to_uncompressed_bytes=target)
+    errors = verify.verify_wheel(wheel)
+    assert any("uncompressed" in e for e in errors)
+
+
+def test_wheel_mode_not_a_zip(tmp_path):
+    fake = tmp_path / "fake.whl"
+    fake.write_text("not a zip")
+    errors = verify.verify_wheel(fake)
+    assert any("not a valid zip" in e for e in errors)
+
+
+def test_wheel_mode_does_not_exist(tmp_path):
+    errors = verify.verify_wheel(tmp_path / "missing.whl")
+    assert any("does not exist" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_directory_mode(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    dist = _make_clean_dist(tmp_path)
+    assert verify.main([str(dist)]) == 0
+
+
+def test_cli_wheel_mode(tmp_path, monkeypatch):
+    monkeypatch.delenv("VITE_API_KEY", raising=False)
+    wheel = _build_wheel(tmp_path)
+    assert verify.main(["--wheel", str(wheel)]) == 0
+
+
+def test_cli_rejects_both_args(tmp_path):
+    with pytest.raises(SystemExit):
+        verify.main([str(tmp_path), "--wheel", str(tmp_path / "x.whl")])
+
+
+def test_cli_rejects_no_args():
+    with pytest.raises(SystemExit):
+        verify.main([])

--- a/util/verify_wheel_dist.py
+++ b/util/verify_wheel_dist.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Verify the GAIA Agent UI ``dist/`` bundle is well-formed for shipping inside
+the Python wheel.
+
+Two modes:
+
+    python util/verify_wheel_dist.py <directory>
+        Validate a freshly built ``src/gaia/apps/webui/dist/`` directory.
+
+    python util/verify_wheel_dist.py --wheel <path-to-wheel>
+        Validate a built wheel contains a clean Agent UI bundle and is under
+        PyPI's size limits.
+
+Both modes enforce the same deny-list (no sourcemaps, dotfiles, ``node_modules``,
+or leaked ``VITE_*`` build-time env values) and require ``index.html`` plus at
+least one entry under ``assets/``. The wheel mode additionally enforces size
+guards: hard-fail at 95 MB compressed (5 MB headroom under PyPI's 100 MB limit)
+and 250 MB uncompressed; a GitHub Actions warning is emitted at 50 MB
+compressed so size growth is visible early.
+
+Exit code 0 on pass, 1 on any failure. Errors are printed loudly with the
+offending file path; no silent skips.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Deny-list rules
+# ---------------------------------------------------------------------------
+
+# Wheel-relative path prefix where the bundle lives once installed.
+WHEEL_DIST_PREFIX = "gaia/apps/webui/dist/"
+
+# Hard wheel-size limits. PyPI rejects > 100 MB compressed; the 95 MB
+# threshold gives 5 MB headroom so we fail loudly *before* we waste an upload.
+WHEEL_SIZE_HARD_FAIL_BYTES = 95 * 1024 * 1024
+WHEEL_SIZE_WARN_BYTES = 50 * 1024 * 1024
+WHEEL_UNCOMPRESSED_HARD_FAIL_BYTES = 250 * 1024 * 1024
+
+# Files we permit in the bundle. Everything else is rejected — keeping this
+# list narrow forces a deliberate update when vite emits a new asset type.
+ALLOWED_EXTENSIONS = {
+    ".html",
+    ".js",
+    ".css",
+    ".svg",
+    ".png",
+    ".ico",
+    ".webmanifest",
+    ".json",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".txt",
+}
+
+# Inverted VITE leak detection — see _check_vite_leak below.
+_VITE_LEAK_RE = re.compile(
+    r"""VITE_[A-Z0-9_]+\s*[:=]\s*["'](?!__VITE_|import\.meta)[^"'\\]{1,}["']"""
+)
+_INLINE_SOURCEMAP_RE = re.compile(rb"sourceMappingURL=data:")
+
+
+# ---------------------------------------------------------------------------
+# Result helpers
+# ---------------------------------------------------------------------------
+
+
+def _err(msg: str) -> None:
+    """Emit a fail-loud error to stderr."""
+    print(f"ERROR: {msg}", file=sys.stderr)
+
+
+def _warn(msg: str) -> None:
+    """Emit a GitHub Actions warning (visible in the run summary)."""
+    print(f"::warning::{msg}")
+
+
+# ---------------------------------------------------------------------------
+# Directory mode
+# ---------------------------------------------------------------------------
+
+
+def verify_directory(dist_dir: Path) -> list[str]:
+    """Run every directory-mode check; return a list of error messages."""
+    errors: list[str] = []
+
+    if not dist_dir.exists():
+        return [f"dist directory does not exist: {dist_dir}"]
+    if not dist_dir.is_dir():
+        return [f"dist path is not a directory: {dist_dir}"]
+
+    files = [p for p in dist_dir.rglob("*") if p.is_file()]
+    if not files:
+        return [f"dist directory is empty: {dist_dir}"]
+
+    index_html = dist_dir / "index.html"
+    if not index_html.is_file():
+        errors.append(f"missing required file: {index_html}")
+
+    has_assets = any(p.is_file() and (dist_dir / "assets") in p.parents for p in files)
+    if not has_assets:
+        errors.append(
+            f"no files under assets/: expected {dist_dir / 'assets'} — "
+            f"vite output structure may have changed"
+        )
+
+    relative_paths = [p.relative_to(dist_dir).as_posix() for p in files]
+    errors.extend(_check_denylist(relative_paths))
+    errors.extend(_check_inline_sourcemaps(files))
+    errors.extend(_check_vite_leak(files))
+    errors.extend(_check_extensions(files, dist_dir))
+
+    if not errors:
+        total_bytes = sum(p.stat().st_size for p in files)
+        print(
+            f"OK: dist contains {len(files)} files, "
+            f"{total_bytes // 1024} KB, no denylist hits"
+        )
+
+    return errors
+
+
+def _check_extensions(files: Iterable[Path], root: Path) -> list[str]:
+    """Reject any file with an extension not on the allow-list."""
+    errors: list[str] = []
+    for p in files:
+        suffix = p.suffix.lower()
+        if suffix and suffix not in ALLOWED_EXTENSIONS:
+            errors.append(
+                f"unexpected file extension {suffix!r}: {p.relative_to(root)}"
+            )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Wheel mode
+# ---------------------------------------------------------------------------
+
+
+def verify_wheel(wheel_path: Path) -> list[str]:
+    """Run every wheel-mode check; return a list of error messages."""
+    errors: list[str] = []
+
+    if not wheel_path.exists():
+        return [f"wheel does not exist: {wheel_path}"]
+    if not zipfile.is_zipfile(wheel_path):
+        return [f"file is not a valid zip/wheel: {wheel_path}"]
+
+    compressed_size = wheel_path.stat().st_size
+    if compressed_size > WHEEL_SIZE_HARD_FAIL_BYTES:
+        errors.append(
+            f"wheel is {compressed_size // (1024 * 1024)} MB compressed, "
+            f"exceeds {WHEEL_SIZE_HARD_FAIL_BYTES // (1024 * 1024)} MB hard limit "
+            f"(PyPI rejects > 100 MB)"
+        )
+    elif compressed_size > WHEEL_SIZE_WARN_BYTES:
+        _warn(
+            f"wheel is {compressed_size // (1024 * 1024)} MB compressed — "
+            f"approaching PyPI 100 MB limit"
+        )
+
+    with zipfile.ZipFile(wheel_path) as zf:
+        names = zf.namelist()
+        uncompressed_size = sum(zi.file_size for zi in zf.infolist())
+
+        if uncompressed_size > WHEEL_UNCOMPRESSED_HARD_FAIL_BYTES:
+            errors.append(
+                f"wheel uncompressed size is "
+                f"{uncompressed_size // (1024 * 1024)} MB, exceeds "
+                f"{WHEEL_UNCOMPRESSED_HARD_FAIL_BYTES // (1024 * 1024)} MB hard limit"
+            )
+
+        webui_entries = [n for n in names if n.startswith(WHEEL_DIST_PREFIX)]
+        if not webui_entries:
+            errors.append(
+                f"wheel ships no files under {WHEEL_DIST_PREFIX}: "
+                f"frontend bundle missing"
+            )
+            return errors
+
+        if f"{WHEEL_DIST_PREFIX}index.html" not in names:
+            errors.append(
+                f"wheel missing required entry: {WHEEL_DIST_PREFIX}index.html"
+            )
+
+        assets_prefix = f"{WHEEL_DIST_PREFIX}assets/"
+        if not any(n.startswith(assets_prefix) for n in names):
+            errors.append(
+                f"wheel ships no files under {assets_prefix}: "
+                f"vite output structure may have changed"
+            )
+
+        relative_paths = [n[len(WHEEL_DIST_PREFIX) :] for n in webui_entries]
+        errors.extend(_check_denylist(relative_paths))
+        errors.extend(_check_inline_sourcemaps_in_wheel(zf, webui_entries))
+        errors.extend(_check_vite_leak_in_wheel(zf, webui_entries))
+
+    if not errors:
+        print(
+            f"OK: wheel contains {len(webui_entries)} webui assets, "
+            f"compressed {compressed_size // 1024} KB, "
+            f"uncompressed {uncompressed_size // 1024} KB"
+        )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Shared deny-list checks (operate on path strings + content readers)
+# ---------------------------------------------------------------------------
+
+
+def _check_denylist(relative_paths: Iterable[str]) -> list[str]:
+    """Reject sourcemaps, dotfiles, and ``node_modules`` anywhere in the tree."""
+    errors: list[str] = []
+    for rel in relative_paths:
+        if not rel:
+            continue
+        if rel.endswith(".map"):
+            errors.append(f"sourcemap file present: {rel}")
+            continue
+        parts = rel.split("/")
+        if "node_modules" in parts:
+            errors.append(f"node_modules entry present: {rel}")
+            continue
+        # Dotfile check: any path component starting with "." (other than ".")
+        for part in parts:
+            if part.startswith(".") and part not in (".", ".."):
+                errors.append(f"dotfile present: {rel}")
+                break
+    return errors
+
+
+def _check_inline_sourcemaps(files: Iterable[Path]) -> list[str]:
+    """Reject ``sourceMappingURL=data:`` in any js/css file."""
+    errors: list[str] = []
+    for p in files:
+        if p.suffix.lower() not in {".js", ".css"}:
+            continue
+        try:
+            data = p.read_bytes()
+        except OSError as e:
+            errors.append(f"cannot read {p}: {e}")
+            continue
+        if _INLINE_SOURCEMAP_RE.search(data):
+            errors.append(f"inline sourcemap (data: URI) present: {p}")
+    return errors
+
+
+def _check_inline_sourcemaps_in_wheel(
+    zf: zipfile.ZipFile, entries: Iterable[str]
+) -> list[str]:
+    errors: list[str] = []
+    for name in entries:
+        if not name.endswith((".js", ".css")):
+            continue
+        with zf.open(name) as fh:
+            data = fh.read()
+        if _INLINE_SOURCEMAP_RE.search(data):
+            errors.append(f"inline sourcemap (data: URI) present in wheel: {name}")
+    return errors
+
+
+def _check_vite_leak(files: Iterable[Path]) -> list[str]:
+    """
+    VITE leak detection — inverted from the original regex-on-bundle approach.
+
+    Fail if any ``VITE_*`` env var is set with a non-empty, non-placeholder
+    value at the time the verifier runs (i.e. inside the workflow step that
+    just produced the bundle). This makes the build *environment* the source
+    of truth — far more reliable than scanning minified output.
+
+    As a backstop, we also scan ``index.html`` and ``assets/*.js`` for literal
+    ``VITE_FOO:"value"`` strings that survived minification.
+    """
+    errors: list[str] = []
+
+    # 1. Env-side check.
+    for key, value in os.environ.items():
+        if not key.startswith("VITE_"):
+            continue
+        if not value:
+            continue
+        if value.startswith("__VITE_") and value.endswith("__"):
+            continue  # placeholder, not a leak
+        errors.append(
+            f"environment variable {key} is set with a non-empty value at "
+            f"verify time — would be inlined by vite into the bundle. "
+            f"Unset {key} before running `npm run build`."
+        )
+
+    # 2. Output-scan backstop.
+    for p in files:
+        if p.suffix.lower() not in {".html", ".js"}:
+            continue
+        # Only scan top-level html and direct assets/*.js — avoid sourcemaps
+        # and deeply nested chunks where the regex over minified code is noisy.
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if _VITE_LEAK_RE.search(text):
+            errors.append(f"possible leaked VITE_* literal in bundle: {p}")
+    return errors
+
+
+def _check_vite_leak_in_wheel(zf: zipfile.ZipFile, entries: Iterable[str]) -> list[str]:
+    errors: list[str] = []
+    # Env-side check (same as directory mode).
+    for key, value in os.environ.items():
+        if not key.startswith("VITE_") or not value:
+            continue
+        if value.startswith("__VITE_") and value.endswith("__"):
+            continue
+        errors.append(
+            f"environment variable {key} is set with a non-empty value at "
+            f"verify time — vite would have inlined it. Unset before build."
+        )
+
+    # Bundle scan backstop (HTML + JS entries only).
+    for name in entries:
+        if not (name.endswith(".html") or name.endswith(".js")):
+            continue
+        with zf.open(name) as fh:
+            data = fh.read()
+        try:
+            text = data.decode("utf-8", errors="replace")
+        except UnicodeDecodeError:
+            continue
+        if _VITE_LEAK_RE.search(text):
+            errors.append(f"possible leaked VITE_* literal in wheel: {name}")
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a freshly built Agent UI dist/ directory or a Python "
+            "wheel containing it."
+        )
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        help="Path to a built dist/ directory (omit when using --wheel).",
+    )
+    parser.add_argument(
+        "--wheel",
+        metavar="WHEEL",
+        help="Path to a built .whl file to inspect instead of a directory.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.wheel and args.path:
+        parser.error("pass either a directory path or --wheel, not both")
+    if not args.wheel and not args.path:
+        parser.error("must pass a directory path or --wheel <path>")
+
+    if args.wheel:
+        errors = verify_wheel(Path(args.wheel))
+    else:
+        errors = verify_directory(Path(args.path))
+
+    if errors:
+        for e in errors:
+            _err(e)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #846.

## Summary

`pip install amd-gaia[ui] && gaia chat --ui` now serves a real React UI in the browser instead of the JSON / friendly-fallback page. The publish pipeline builds the bundle once in \`build-npm\` and \`build-pypi\` consumes the same artifact, so the wheel and the npm package ship a byte-identical bundle (no vite-hash drift between runners).

## Threads

- **Wheel ships dist/** — \`setup.py\` adds \`gaia.apps.webui\` to packages with shallow \`package_data\` globs; \`MANIFEST.in\` adds the authoritative \`recursive-include\` (since setuptools \`**\` recursion is unreliable). Local build produces a 1.41 MB wheel containing all 9 webui assets (index.html, hashed JS/CSS, woff2 fonts, favicon).
- **Build-once, fan-out** — \`build-pypi\` now \`needs: [validate, build-npm]\` and downloads \`npm-package-build\`. *Why this matters:* avoids hash drift between the wheel bundle and the npm publish bundle that two parallel \`vite build\`s would risk. Also drops the silent \`npm ci 2>/dev/null || npm install\` fallback in \`build-npm\` and \`publish-npm\`.
- **Hygiene gate** — new \`util/verify_wheel_dist.py\` enforces a deny-list at CI time: sourcemaps (\`*.map\` and inline \`sourceMappingURL=data:\`), dotfiles, \`node_modules\`, and leaked \`VITE_*\` env values (env-side check, not regex-on-bundle, with a regex backstop). Wheel-size guards: 95 MB compressed hard fail (5 MB headroom under PyPI's 100 MB), 250 MB uncompressed, GHA warning at 50 MB.
- **Per-PR safety** — \`pypi.yml\` runs the same npm build with \`npm ci --ignore-scripts\` to neutralise hostile lockfiles from fork PRs, and runs a **negative test** that plants a sourcemap to prove the gate bites.
- **Forgotten-build is loud, not silent** — \`setup.py\` raises \`SystemExit\` with a remediation hint if a wheel build can't find \`dist/index.html\`. Bypassed for \`sdist\`, \`egg_info\`, \`develop\`, \`editable_wheel\`, \`dist_info\` (covers \`pip install -e .\` paths across pip/setuptools versions).
- **Diagnostic logging** — \`gaia/ui/server.py\` now warns with the resolved absolute path and a \`python -c\` one-liner when \`dist/\` is missing, so a user on a busted install can self-triage.

## Test plan

- [x] \`python -m pytest tests/unit/test_verify_wheel_dist.py\` — 26/26 pass locally
- [x] \`npm run build\` in \`src/gaia/apps/webui/\` produces a 9-file dist/, 863 KB
- [x] \`python -m build --wheel\` produces \`amd_gaia-0.17.4-py3-none-any.whl\` (1.41 MB compressed, 4.98 MB uncompressed)
- [x] \`python util/verify_wheel_dist.py --wheel <whl>\` → OK
- [x] \`twine check dist/*\` → PASSED
- [x] Negative test: \`echo {} > dist/leak.js.map; util/verify_wheel_dist.py dist/\` → exits 1 with clear error
- [x] Setup.py guard fires correctly when dist/ is missing during \`python -m build --wheel\`
- [x] \`black --check\` clean on all touched Python files
- [ ] CI: \`pypi.yml\` runs the new npm build + verifier + negative test on this PR
- [ ] CI: full pytest suite passes via \`claude.yml\` review

## Wheel size

Measured locally with current source: **1.41 MB compressed / 4.98 MB uncompressed** — well under the 50 MB warn threshold. RAG extras are not in this wheel; if a future change adds them and pushes the wheel over 50 MB the GHA warning will surface; over 95 MB the verifier will hard-fail before twine even runs.