### PR TITLE
test(ui): regression coverage for renderer→backend port wiring

### DIFF
--- a/.github/workflows/test_electron.yml
+++ b/.github/workflows/test_electron.yml
@@ -63,6 +63,16 @@ jobs:
           cd tests/electron
           npm test
 
+      # node:test files (`.mjs`) for modules that don't fit Jest's CJS
+      # mocking model — port-manager and the index-query helper. Keep
+      # them here so the `services/*.cjs` extraction pattern stays
+      # CI-gated; without this step they would silently never run.
+      - name: Run node:test suites (services helpers)
+        run: |
+          node --test \
+            tests/electron/test_port_manager.mjs \
+            tests/electron/test_loadapp_query.mjs
+
       - name: Upload test coverage
         if: always()
         uses: actions/upload-artifact@v6

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -24,6 +24,7 @@ const TrayManager = require("./services/tray-manager.cjs");
 const AgentProcessManager = require("./services/agent-process-manager.cjs");
 const NotificationService = require("./services/notification-service.cjs");
 const PortManager = require("./services/port-manager.cjs");
+const { buildIndexQuery } = require("./services/index-query.cjs");
 const backendInstaller = require("./services/backend-installer.cjs");
 const installerProgressDialog = require("./services/backend-installer-progress-dialog.cjs");
 const autoUpdater = require("./services/auto-updater.cjs");
@@ -421,13 +422,13 @@ async function loadApp() {
     // http://localhost:4200/ would show raw JSON instead of the UI.
     //
     // Pass the real backend base URL as a query parameter so the renderer
-    // can reach whatever random port port-manager picked (see #851).
-    // Without this, the compiled bundle falls back to its hardcoded
-    // `http://localhost:4200/api` and every API call 404s.
+    // can reach whatever random port port-manager picked (see #851). The
+    // renderer (apiBase.ts) validates this value against an allowlist
+    // before using it — keep buildIndexQuery in sync with TRUSTED_API_RE.
     const indexPath = path.join(distPath, "index.html");
-    const apiBase = `http://127.0.0.1:${backendPort}/api`;
-    console.log("Loading app from:", indexPath, "api:", apiBase);
-    await mainWindow.loadFile(indexPath, { query: { api: apiBase } });
+    const indexQuery = buildIndexQuery(backendPort);
+    console.log("Loading app from:", indexPath, "api:", indexQuery.api);
+    await mainWindow.loadFile(indexPath, { query: indexQuery });
   } else {
     // Show a simple loading/error page
     mainWindow.loadURL(

--- a/src/gaia/apps/webui/services/index-query.cjs
+++ b/src/gaia/apps/webui/services/index-query.cjs
@@ -1,0 +1,49 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * index-query.cjs — Build the `?api=` query object that main.cjs hands
+ * to BrowserWindow.loadFile() so the renderer can reach the random
+ * backend port that PortManager picked.
+ *
+ * Extracted from main.cjs (issue #851) so it can be unit-tested without
+ * an Electron runtime. Pure CommonJS, no Node built-ins required, no
+ * Electron imports.
+ *
+ * Contract: this module must stay in sync with the TRUSTED_API_RE
+ * allowlist in src/gaia/apps/webui/src/utils/apiBase.ts. The renderer
+ * rejects any value that does not match that regex, so the URL produced
+ * here MUST satisfy `/^https?:\/\/(127\.0\.0\.1|localhost):\d+\/api$/`.
+ *
+ * The cross-file invariant is enforced by tests/electron/test_loadapp_query.mjs.
+ */
+
+"use strict";
+
+/** Path the backend serves its API under. Shared so a future change is one edit. */
+const API_PATH = "/api";
+
+/**
+ * Build the loadFile query object for a given backend port.
+ *
+ * @param {number} port - Integer in (0, 65535]. Typically chosen by
+ *   PortManager.findFreePort(); falls back to DEFAULT_BACKEND_PORT (4200)
+ *   in main.cjs if findFreePort fails.
+ * @returns {{api: string}} - Object passed as `loadFile(..., { query })`.
+ *   Electron URL-encodes the values; the renderer reads them back via
+ *   `URLSearchParams(window.location.search).get('api')`.
+ * @throws {Error} - If port is not a valid integer in (0, 65535].
+ */
+function buildIndexQuery(port) {
+  if (
+    typeof port !== "number" ||
+    !Number.isInteger(port) ||
+    port <= 0 ||
+    port > 65535
+  ) {
+    throw new Error(`buildIndexQuery: invalid port ${port}`);
+  }
+  return { api: `http://127.0.0.1:${port}${API_PATH}` };
+}
+
+module.exports = { buildIndexQuery, API_PATH };

--- a/src/gaia/apps/webui/src/utils/apiBase.ts
+++ b/src/gaia/apps/webui/src/utils/apiBase.ts
@@ -7,22 +7,40 @@
  * In the packaged Electron app the bundle is served via `file://`, the
  * backend binds a random free port picked by `services/port-manager.cjs`,
  * and `main.cjs` passes that port to the renderer as an `?api=` query
- * param when loading `dist/index.html`.
+ * param when loading `dist/index.html` (see `services/index-query.cjs`).
  *
  * In the vite dev server and when the backend serves the frontend itself,
  * a same-origin relative path works and no query param is present.
  *
+ * Defense-in-depth: the `?api=` value is validated against an allowlist
+ * (loopback URLs ending in `/api` only). Today no protocol handler or
+ * file association exists that could let an external party set this
+ * param, but the allowlist guards against a future regression that adds
+ * one — an attacker-controlled value would otherwise redirect every API
+ * call to a server they control (SSRF / data exfiltration). Keep the
+ * regex in sync with `services/index-query.cjs`'s `buildIndexQuery`
+ * output. The cross-file invariant is enforced by
+ * tests/electron/test_loadapp_query.mjs.
+ *
  * See issue #851 for the regression this resolves.
  */
+
+/** Loopback URLs ending in `/api` (no trailing slash). Anything else is rejected. */
+const TRUSTED_API_RE = /^https?:\/\/(127\.0\.0\.1|localhost):\d+\/api$/;
+
+/** Legacy fallback for manual `file://.../index.html` opens against a dev backend. */
+const LEGACY_FALLBACK = 'http://localhost:4200/api';
+
 export function getApiBase(): string {
     if (typeof window === 'undefined') return '/api';
 
     if (window.location.protocol === 'file:') {
         const fromQuery = new URLSearchParams(window.location.search).get('api');
-        if (fromQuery) return fromQuery;
-        // Legacy fallback: keeps manual `file://.../index.html` opens working
-        // against a dev backend on the historical default port.
-        return 'http://localhost:4200/api';
+        if (fromQuery && TRUSTED_API_RE.test(fromQuery)) return fromQuery;
+        // Untrusted or missing — fall back to legacy default. Keeps
+        // manual `file://.../index.html` opens working against a dev
+        // backend on the historical port; rejects attacker URLs.
+        return LEGACY_FALLBACK;
     }
 
     return '/api';

--- a/tests/electron/test_loadapp_query.mjs
+++ b/tests/electron/test_loadapp_query.mjs
@@ -1,0 +1,233 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Tests for src/gaia/apps/webui/services/index-query.cjs and the
+// renderer-side allowlist regex in src/gaia/apps/webui/src/utils/apiBase.ts.
+//
+// The literal #851 regression was: the renderer hardcoded `localhost:4200`
+// while port-manager picked a random port. Three layers must agree:
+//
+//   1. main.cjs spawns the backend with `--ui-port <N>` (port-manager picks N).
+//   2. main.cjs writes that same N into the index.html `?api=` query string.
+//   3. apiBase.ts in the renderer reads `?api=`, validates it against an
+//      allowlist (loopback only), and uses it as the API base URL.
+//
+// This file pins all three contracts so a future edit to any one of them
+// fails CI before the regression can ship. Uses `node:test` so it can run
+// via `node --test tests/electron/test_loadapp_query.mjs`, matching the
+// existing test_port_manager.mjs convention.
+//
+// Sister test: tests/electron/test_port_manager.mjs (port allocation).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const indexQueryPath = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "src",
+  "gaia",
+  "apps",
+  "webui",
+  "services",
+  "index-query.cjs"
+);
+
+const { buildIndexQuery, API_PATH } = require(indexQueryPath);
+
+// ─── buildIndexQuery: positive cases ─────────────────────────────────
+
+test("buildIndexQuery: typical random port produces loopback URL", () => {
+  assert.deepStrictEqual(
+    buildIndexQuery(9876),
+    { api: "http://127.0.0.1:9876/api" }
+  );
+});
+
+test("buildIndexQuery: default port (4200) still works", () => {
+  // The DEFAULT_BACKEND_PORT fallback path in main.cjs must produce a
+  // valid URL too — port-manager.findFreePort() rejection lands here.
+  assert.deepStrictEqual(
+    buildIndexQuery(4200),
+    { api: "http://127.0.0.1:4200/api" }
+  );
+});
+
+test("buildIndexQuery: max valid port (65535)", () => {
+  assert.deepStrictEqual(
+    buildIndexQuery(65535),
+    { api: "http://127.0.0.1:65535/api" }
+  );
+});
+
+// ─── buildIndexQuery: negative cases ─────────────────────────────────
+//
+// These are unreachable from the production path today (port-manager's
+// catch falls back to DEFAULT_BACKEND_PORT = 4200), but the throws guard
+// against future direct callers passing nonsense.
+
+test("buildIndexQuery: rejects 0", () => {
+  assert.throws(() => buildIndexQuery(0), /invalid port/);
+});
+
+test("buildIndexQuery: rejects negative", () => {
+  assert.throws(() => buildIndexQuery(-1), /invalid port/);
+});
+
+test("buildIndexQuery: rejects undefined", () => {
+  assert.throws(() => buildIndexQuery(undefined), /invalid port/);
+});
+
+test("buildIndexQuery: rejects > 65535", () => {
+  assert.throws(() => buildIndexQuery(70000), /invalid port/);
+});
+
+test("buildIndexQuery: rejects non-integer", () => {
+  assert.throws(() => buildIndexQuery(1234.5), /invalid port/);
+});
+
+test("buildIndexQuery: rejects string", () => {
+  assert.throws(() => buildIndexQuery("8080"), /invalid port/);
+});
+
+// ─── API_PATH constant ───────────────────────────────────────────────
+
+test("API_PATH is /api (no trailing slash)", () => {
+  // Trailing slash would produce `//path` URLs in apiFetch (api.ts).
+  assert.strictEqual(API_PATH, "/api");
+});
+
+// ─── Renderer-side allowlist regex round-trip ────────────────────────
+//
+// We intentionally re-derive the regex here from apiBase.ts source rather
+// than duplicate it as a literal: the source is the contract; if it
+// changes, the test must reflect the change deliberately.
+
+const apiBaseTsPath = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "src",
+  "gaia",
+  "apps",
+  "webui",
+  "src",
+  "utils",
+  "apiBase.ts"
+);
+
+function loadTrustedApiRegex() {
+  const src = fs.readFileSync(apiBaseTsPath, "utf8");
+  // Find: const TRUSTED_API_RE = /<pattern>/;
+  const match = src.match(/TRUSTED_API_RE\s*=\s*\/(.+?)\/;/);
+  assert.ok(
+    match,
+    "apiBase.ts must export TRUSTED_API_RE as a single-line regex literal " +
+      "ending in `/;`. If you reformatted the declaration (multi-line, " +
+      "added a flag, trailing comment), update loadTrustedApiRegex() here."
+  );
+  return new RegExp(match[1]);
+}
+
+test("renderer accepts the URL main.cjs writes (positive round-trip)", () => {
+  const re = loadTrustedApiRegex();
+  const q = buildIndexQuery(12345);
+  // Simulate the round-trip: main.cjs writes ?api=<encoded>; renderer
+  // reads via URLSearchParams (which auto-decodes); regex must accept.
+  const search = "?api=" + encodeURIComponent(q.api);
+  const parsed = new URLSearchParams(search).get("api");
+  assert.strictEqual(parsed, q.api);
+  assert.match(parsed, re, `regex ${re} must accept ${parsed}`);
+});
+
+test("renderer rejects attacker-controlled api param (negative)", () => {
+  // Defense-in-depth: if a future deep-link or file-association handler
+  // ever lets an external URL set ?api=, the regex must reject anything
+  // that is not loopback. SSRF/data-exfil class.
+  const re = loadTrustedApiRegex();
+  for (const evil of [
+    "http://evil.com/api",
+    "https://example.org/api",
+    "http://192.168.1.1:8080/api",
+    "http://127.0.0.1.attacker.com/api",
+    "javascript:alert(1)",
+    "file:///etc/passwd",
+    "http://127.0.0.1:9999/api/extra",   // path beyond /api
+    "http://127.0.0.1:9999/api/",         // trailing slash → would produce //
+    "http://127.0.0.1/api",               // no port
+    "http://127.0.0.1:abc/api",           // non-numeric port
+  ]) {
+    assert.doesNotMatch(
+      evil,
+      re,
+      `regex must reject hostile value: ${evil}`
+    );
+  }
+});
+
+test("renderer accepts both 127.0.0.1 and localhost", () => {
+  // main.cjs uses 127.0.0.1 today; legacy fallback in apiBase.ts uses
+  // localhost. Both must pass the allowlist.
+  const re = loadTrustedApiRegex();
+  assert.match("http://127.0.0.1:9876/api", re);
+  assert.match("http://localhost:9876/api", re);
+});
+
+// ─── Spawn-args ↔ query-string port-equality (the literal #851) ──────
+//
+// This is the regression the issue describes: port-manager picks N,
+// main.cjs spawns `gaia chat --ui --ui-port N`, but the renderer was
+// told a different port (or no port). We verify by reading main.cjs as
+// source and asserting both call sites consume the same `backendPort`
+// variable.
+
+const mainCjsPath = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "src",
+  "gaia",
+  "apps",
+  "webui",
+  "main.cjs"
+);
+
+test("main.cjs spawn args and index query share the same backendPort", () => {
+  const src = fs.readFileSync(mainCjsPath, "utf8");
+
+  // Spawn argument list must reference backendPort (issue #851 broke
+  // because the renderer side did not).
+  assert.match(
+    src,
+    /"--ui-port",\s*String\(backendPort\)/,
+    "spawn() must pass --ui-port String(backendPort) to gaia chat --ui"
+  );
+
+  // The index-query call must consume the same variable, not a literal
+  // or a separate constant.
+  assert.match(
+    src,
+    /buildIndexQuery\(backendPort\)/,
+    "loadApp() must call buildIndexQuery(backendPort) — not a literal"
+  );
+
+  // Belt-and-braces: there must NOT be any hardcoded literal API URL
+  // in loadApp() that would shadow the dynamic value.
+  const loadAppMatch = src.match(/async function loadApp\(\)\s*{([\s\S]*?)\n}/);
+  assert.ok(loadAppMatch, "main.cjs must declare loadApp()");
+  const loadAppBody = loadAppMatch[1];
+  assert.doesNotMatch(
+    loadAppBody,
+    /["'`]http:\/\/(127\.0\.0\.1|localhost):\d+\/api["'`]/,
+    "loadApp() must not contain a hardcoded API URL literal"
+  );
+});


### PR DESCRIPTION
## Summary

The production fix for #851 (query-string injection from `main.cjs` to `apiBase.ts`) shipped on `main` but had no test coverage. The issue body explicitly required *"a `loadURL` assertion in the existing `tests/electron/*` suite … so the frontend→backend wire regression can never reach main again."* This PR lands that test, plus a defense-in-depth allowlist on the renderer side. No behavior change in the happy path.

Fixes #851.

## What changed

- **Extract `buildIndexQuery` + `API_PATH`** into `services/index-query.cjs`. _Why:_ `main.cjs` requires `electron` with side effects, so it cannot be `require()`-d from a Node test. Mirrors the `services/port-manager.cjs` pattern.
- **Allowlist `?api=` in `apiBase.ts`** via `TRUSTED_API_RE = /^https?:\/\/(127\.0\.0\.1|localhost):\d+\/api\$/`. _Why:_ no protocol handler exists today that could let an attacker set this param, but a future deep-link or file-association would otherwise turn the renderer into an SSRF / data-exfil vector. Untrusted values fall back to the documented legacy URL.
- **Pin the cross-file invariant** with 14 `node:test` cases in `tests/electron/test_loadapp_query.mjs` covering: positive/negative port validation, regex round-trip with attacker URLs, and the literal #851 regression (spawn-args ↔ query-string port equality).
- **Wire `node:test` into `test_electron.yml`**. _Why:_ Jest's `testMatch` excludes `.mjs`, so `test_port_manager.mjs` was previously orphaned and never ran in CI. Adding it now means any latent failure surfaces — a positive signal, not a regression.

## Reviewer notes

- Happy path is byte-identical for any valid `backendPort` — same `http://127.0.0.1:<port>/api` URL is produced and accepted.
- The `buildIndexQuery` validation throws on invalid ports (0, negative, > 65535, non-integer). Unreachable from production today (port-manager's catch falls back to `DEFAULT_BACKEND_PORT = 4200`), but guards future direct callers.
- Out of scope: the `localhost:8000` reference in the issue body is Lemonade Server (separate); the `vite.config.ts:38` proxy to `:4200` is dev-only, untouched.

## Test plan

- [x] `node --test tests/electron/test_loadapp_query.mjs tests/electron/test_port_manager.mjs` → **20 passed, 0 failed** on both macOS and Linux (Ubuntu 24.04).
- [x] `npx tsc --noEmit src/utils/apiBase.ts` → clean (allowlist change compiles in isolation).
- [x] Code review pass (code-reviewer agent): 0 Critical findings.
- [x] **Production bundle inspection on Linux**: `grep -oE '/\^https?[^,;]{20,80}' dist/assets/index-*.js` → `/^https?:\/\/(127\.0\.0\.1|localhost):\d+\/api\$/`. The `localhost:4200` literal that remains is the documented `LEGACY_FALLBACK`.
- [x] **End-to-end Linux smoke** (`xvfb-run electron .`): reached `state: ready` and logged
  ```
  Starting backend: …/gaia chat --ui --ui-port 41155
  Loading app from: …/dist/index.html api: http://127.0.0.1:41155/api
  ```
  Same random port (`41155`) in both the spawn args and the `?api=` URL — the literal #851 regression is fixed end-to-end. No "Cannot connect to GAIA server" banner reached.
- [ ] CI `test-electron-framework` job runs both `.mjs` files (first PR to do so).