### PR TITLE
fix(installer): switch Linux Lemonade install from .deb to PPA

### DIFF
--- a/docs/cpp/setup.mdx
+++ b/docs/cpp/setup.mdx
@@ -168,17 +168,13 @@ icon: "wrench"
 
     The agent needs an OpenAI-compatible LLM server. [Lemonade Server](https://lemonade-server.ai) is recommended (optimized for AMD hardware).
 
-    Download and install the `.deb` package (v10.2.0):
+    Install via the Launchpad PPA (Ubuntu 24.04+):
 
     ```bash
-    # Download the .deb package
-    curl -L -o lemonade-server_10.2.0_amd64.deb https://github.com/lemonade-sdk/lemonade/releases/download/v10.2.0/lemonade-server_10.2.0_amd64.deb
-
-    # Install it
-    sudo dpkg -i lemonade-server_10.2.0_amd64.deb
+    sudo add-apt-repository ppa:lemonade-team/stable
+    sudo apt-get update
+    sudo apt-get install -y lemonade-server
     ```
-
-    Or download directly from the [Lemonade v10.2.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.2.0).
 
     After installation, start the server:
     ```bash

--- a/docs/plans/setup-wizard.mdx
+++ b/docs/plans/setup-wizard.mdx
@@ -591,7 +591,7 @@ Default is opt-out. Stored in `~/.gaia/preferences.json`.
 
 ### Linux
 
-- Lemonade Server installed via `.deb` package or pip.
+- Lemonade Server installed via `ppa:lemonade-team/stable` (Ubuntu 24.04+).
 - `gaia init` detects distro and uses appropriate package manager.
 - NPU detection via `lspci` and `/sys/class/` device tree.
 - Desktop packaging via AppImage.

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -4846,10 +4846,14 @@ Let me know your answer!
                     sys.exit(0)
 
             # Download and install
-            print("Downloading Lemonade Server...")
             try:
-                installer_path = installer.download_installer()
-                print("Installing...")
+                if installer.system == "linux":
+                    print("Adding Lemonade PPA and installing lemonade-server...")
+                    installer_path = None
+                else:
+                    print("Downloading Lemonade Server...")
+                    installer_path = installer.download_installer()
+                    print("Installing...")
                 result = installer.install(installer_path, silent=args.silent)
 
                 if result.success:

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -812,27 +812,36 @@ class InitCommand:
             True on success, False on failure
         """
         self._print("")
-        if RICH_AVAILABLE and self.console:
-            self.console.print(
-                f"   [bold]Downloading[/bold] Lemonade [cyan]v{LEMONADE_VERSION}[/cyan]..."
-            )
-        else:
-            self._print(f"   Downloading Lemonade v{LEMONADE_VERSION}...")
 
         try:
-            # Download installer
-            installer_path = self.installer.download_installer()
-            self._print("")
-            self._print_success("Download complete")
+            if self.installer.system == "linux":
+                label = f"Adding Lemonade [cyan]v{LEMONADE_VERSION}[/cyan] PPA and installing..."
+                installer_path = None
+            else:
+                label = f"Downloading Lemonade [cyan]v{LEMONADE_VERSION}[/cyan]..."
+                installer_path = self.installer.download_installer()
+                self._print("")
+                self._print_success("Download complete")
 
-            # Install (silent in CI with --yes, interactive otherwise for desktop icon)
-            self.console.print("   [bold]Installing...[/bold]")
-            if not self.yes:
-                self.console.print()
-                self.console.print(
-                    "   [yellow]⚠️  The installer window will appear - please complete the installation[/yellow]"
-                )
-                self.console.print()
+            if RICH_AVAILABLE and self.console:
+                self.console.print(f"   [bold]{label}[/bold]")
+            else:
+                import re as _re
+
+                plain_label = _re.sub(r"\[.*?\]", "", label)
+                self._print(f"   {plain_label}")
+
+            if installer_path is not None and not self.yes:
+                if RICH_AVAILABLE and self.console:
+                    self.console.print()
+                    self.console.print(
+                        "   [yellow]⚠️  The installer window will appear - please complete the installation[/yellow]"
+                    )
+                    self.console.print()
+                else:
+                    self._print(
+                        "   ⚠️  The installer window will appear - please complete the installation"
+                    )
             result = self.installer.install(installer_path, silent=self.yes)
 
             if result.success:

--- a/src/gaia/installer/lemonade_installer.py
+++ b/src/gaia/installer/lemonade_installer.py
@@ -348,32 +348,20 @@ class LemonadeInstaller:
         except Exception as e:
             raise RuntimeError(f"Download failed: {e}")
 
-    def install(self, installer_path: Path, silent: bool = True) -> InstallResult:
-        """
-        Install Lemonade Server from the downloaded installer.
-
-        Args:
-            installer_path: Path to the installer file
-            silent: Whether to run silent installation (no UI)
-
-        Returns:
-            InstallResult with success status
-
-        Raises:
-            RuntimeError: If installation fails
-        """
-        if not installer_path.exists():
-            return InstallResult(
-                success=False, error=f"Installer not found: {installer_path}"
-            )
-
-        self._print_status(f"Installing from {installer_path}")
-
+    def install(
+        self, installer_path: Optional[Path] = None, silent: bool = True
+    ) -> InstallResult:
+        """Install Lemonade Server. On Linux, installer_path is unused (PPA flow)."""
+        self._print_status(f"Installing Lemonade Server (system={self.system})")
         try:
             if self.system == "windows":
+                if installer_path is None or not installer_path.exists():
+                    return InstallResult(
+                        success=False, error=f"Installer not found: {installer_path}"
+                    )
                 return self._install_windows(installer_path, silent)
             elif self.system == "linux":
-                return self._install_linux(installer_path)
+                return self._install_via_ppa(non_interactive=silent)
             else:
                 return InstallResult(
                     success=False, error=f"Platform '{self.system}' is not supported"
@@ -615,75 +603,140 @@ class LemonadeInstaller:
 
         return None
 
-    def _install_linux(self, installer_path: Path) -> InstallResult:
-        """Install on Linux using apt (handles dependencies automatically)."""
+    def _install_via_ppa(self, non_interactive: bool = False) -> InstallResult:
+        """Install Lemonade Server on Linux via the Launchpad PPA.
+
+        Linux >= v10.0.1 is distributed only through ppa:lemonade-team/stable.
+        Requires Ubuntu 24.04+ (Debian and older Ubuntu are gated by
+        _check_linux_version).
+        """
         try:
-            # Check Linux version compatibility before attempting install
             version_error = self._check_linux_version()
             if version_error:
                 return InstallResult(success=False, error=version_error)
 
-            # Check if we have root access (geteuid only available on Unix)
-            is_root = False
-            if hasattr(os, "geteuid"):
-                is_root = os.geteuid() == 0
-
-            sudo_prefix = [] if is_root else ["sudo"]
-
-            # Update apt cache first to avoid 404 errors from stale package lists
-            self._print_status("Updating package cache...")
-            update_cmd = sudo_prefix + ["apt", "update"]
-            log.debug(f"Running: {' '.join(update_cmd)}")
-
-            update_result = subprocess.run(
-                update_cmd, capture_output=True, text=True, timeout=120, check=False
-            )
-
-            if update_result.returncode != 0:
-                log.warning(f"apt update failed: {update_result.stderr}")
-                # Continue anyway - update failure shouldn't block install
-
-            # Use 'apt install' instead of 'dpkg -i' so dependencies are
-            # automatically resolved from the system repositories.
-            # The ./ prefix is required for apt to treat it as a local file.
-            deb_path = str(installer_path)
-            if not deb_path.startswith("/"):
-                deb_path = f"./{deb_path}"
-
-            cmd = sudo_prefix + ["apt", "install", "-y", deb_path]
-            log.debug(f"Running: {' '.join(cmd)}")
-            self._print_status("Installing package and dependencies...")
-
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=300, check=False
-            )
-
-            if result.returncode != 0:
-                # Combine stdout + stderr for full diagnostic output.
-                # apt puts dependency resolution details in stdout,
-                # but only a generic warning in stderr.
-                full_output = (
-                    result.stdout.strip() + "\n" + result.stderr.strip()
-                ).strip()
+            # add-apt-repository ships pre-installed on Ubuntu 24.04+; if missing
+            # the user is on a minimal image and needs a clear error, not silent apt churn.
+            if shutil.which("add-apt-repository") is None:
                 return InstallResult(
                     success=False,
-                    error=f"apt install failed:\n{full_output}",
+                    error=(
+                        "add-apt-repository not found (required for PPA install).\n"
+                        "Install it first: sudo apt-get install software-properties-common\n"
+                        "Then re-run: gaia init"
+                    ),
+                )
+
+            is_root = hasattr(os, "geteuid") and os.geteuid() == 0
+            sudo_prefix = [] if is_root else ["sudo"]
+
+            # Pre-flight sudo when non-interactive: surface a clean error instead
+            # of hanging at a hidden TTY password prompt.
+            if not is_root and non_interactive:
+                sudo_check = subprocess.run(
+                    ["sudo", "-n", "true"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    stdin=subprocess.DEVNULL,
+                    check=False,
+                )
+                if sudo_check.returncode != 0:
+                    return InstallResult(
+                        success=False,
+                        error=(
+                            "sudo requires a password but gaia init --yes is non-interactive.\n"
+                            "Either run 'sudo -v' first to cache credentials, "
+                            "configure passwordless sudo, or run gaia init as root."
+                        ),
+                    )
+
+            env = os.environ.copy()
+            if non_interactive:
+                env["DEBIAN_FRONTEND"] = "noninteractive"
+
+            def _run(step: str, cmd: list, timeout: int) -> subprocess.CompletedProcess:
+                self._print_status(f"{step}: {' '.join(cmd)}")
+                return subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    env=env,
+                    stdin=subprocess.DEVNULL,
+                    check=False,
+                )
+
+            result = _run(
+                "Add PPA",
+                sudo_prefix + ["add-apt-repository", "-y", "ppa:lemonade-team/stable"],
+                timeout=120,
+            )
+            if result.returncode != 0:
+                return InstallResult(
+                    success=False,
+                    error=(
+                        f"Failed to add Lemonade PPA (system={self.system}, root={is_root}).\n"
+                        f"add-apt-repository output:\n{(result.stdout + result.stderr).strip()}\n"
+                        "See https://amd-gaia.ai/reference/troubleshooting"
+                    ),
+                )
+
+            # apt-get update failure is warn-only — stale cache is better than blocking.
+            update_result = _run(
+                "Update apt cache", sudo_prefix + ["apt-get", "update"], timeout=300
+            )
+            if update_result.returncode != 0:
+                log.warning(
+                    "apt-get update failed (rc=%s); continuing with possibly stale cache: %s",
+                    update_result.returncode,
+                    (update_result.stdout + update_result.stderr).strip()[-500:],
+                )
+
+            result = _run(
+                "Install lemonade-server",
+                sudo_prefix + ["apt-get", "install", "-y", "lemonade-server"],
+                timeout=600,
+            )
+            if result.returncode != 0:
+                return InstallResult(
+                    success=False,
+                    error=(
+                        f"apt-get install lemonade-server failed (step=Install, root={is_root}):\n"
+                        f"{(result.stdout + result.stderr).strip()}\n"
+                        "Your apt state may be partial — run 'sudo dpkg --configure -a' to recover.\n"
+                        "See https://amd-gaia.ai/reference/troubleshooting"
+                    ),
+                )
+
+            # Use the real installed version — PPA may ship a different version than target.
+            verify = self.check_installation()
+            installed_version = verify.version or "unknown"
+            if verify.installed and verify.version != self.target_version:
+                log.warning(
+                    "PPA installed Lemonade %s but GAIA expected %s",
+                    verify.version,
+                    self.target_version,
                 )
 
             return InstallResult(
                 success=True,
-                version=self.target_version,
-                message=f"Installed Lemonade v{self.target_version}",
+                version=installed_version,
+                message=f"Installed Lemonade v{installed_version} via PPA",
             )
 
-        except subprocess.TimeoutExpired:
-            return InstallResult(success=False, error="Installation timed out")
+        except subprocess.TimeoutExpired as e:
+            return InstallResult(
+                success=False,
+                error=(
+                    f"PPA install timed out during step (cmd={e.cmd}). "
+                    "If this happened during apt-get install, run 'sudo dpkg --configure -a'."
+                ),
+            )
         except FileNotFoundError as e:
             return InstallResult(
                 success=False, error=f"Required command not found: {e}"
             )
-        except Exception as e:
-            return InstallResult(success=False, error=str(e))
 
     def is_platform_supported(self) -> bool:
         """Check if the current platform is supported for installation."""

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -91,15 +91,6 @@ class TestLemonadeInstaller(unittest.TestCase):
         self.assertIn("github.com", url)
 
     @patch("platform.system")
-    def test_get_download_url_linux(self, mock_system):
-        """Test download URL generation for Linux."""
-        mock_system.return_value = "Linux"
-        installer = LemonadeInstaller(target_version="9.1.4")
-        url = installer.get_download_url()
-        self.assertIn("v9.1.4/lemonade-server_9.1.4_amd64.deb", url)
-        self.assertIn("github.com", url)
-
-    @patch("platform.system")
     def test_get_download_url_unsupported(self, mock_system):
         """Test download URL raises error for unsupported platform."""
         mock_system.return_value = "Darwin"
@@ -656,15 +647,12 @@ class TestEnsureLemonadeInstalledSkipsWhenPresent(unittest.TestCase):
 
 
 class TestLegacyFallback(unittest.TestCase):
-    """Regression: when Lemonade is NOT installed (e.g. bundled MSI install
-    failed or user is on Linux without a bundled installer), gaia init must
-    still fall through to the runtime download path.
-
-    Protects acceptance criterion AC5.
+    """Regression: when Lemonade is NOT installed, gaia init falls through to
+    the runtime install path.  Linux uses PPA; Windows uses download+install.
     """
 
-    def test_not_installed_proceeds_to_download(self):
-        """check_installation returns not-installed -> download + install called."""
+    def test_not_installed_on_linux_proceeds_to_install_via_ppa(self):
+        """On Linux: check_installation not-installed -> install called WITHOUT download."""
         from gaia.installer.init_command import InitCommand
 
         info = LemonadeInfo(installed=False, error="lemonade-server not found in PATH")
@@ -672,19 +660,13 @@ class TestLegacyFallback(unittest.TestCase):
         with patch("gaia.installer.init_command.LemonadeInstaller") as mock_cls:
             mock_installer = MagicMock()
             mock_installer.is_platform_supported.return_value = True
-            mock_installer.get_platform_name.return_value = "Linux"
-            mock_installer.check_installation.return_value = info
-            # Simulate successful download + install
-            from pathlib import Path as _P
-
-            mock_installer.download_installer.return_value = _P("/tmp/lemonade.deb")
+            mock_installer.system = "linux"
             mock_installer.install.return_value = InstallResult(
                 success=True, version=LEMONADE_VERSION, message="ok"
             )
-            # Verify step calls check_installation again — now installed
             mock_installer.check_installation.side_effect = [
-                info,  # first call: not installed
-                LemonadeInfo(  # post-install verification call
+                info,
+                LemonadeInfo(
                     installed=True,
                     version=LEMONADE_VERSION,
                     path="/usr/bin/lemonade-server",
@@ -696,9 +678,290 @@ class TestLegacyFallback(unittest.TestCase):
             result = cmd._ensure_lemonade_installed()
 
         self.assertTrue(result)
-        # The download path MUST be taken
+        mock_installer.download_installer.assert_not_called()
+        mock_installer.install.assert_called_once()
+
+    def test_not_installed_on_windows_proceeds_to_download_and_install(self):
+        """On Windows: check_installation not-installed -> download + install called."""
+        from pathlib import Path as _P
+
+        from gaia.installer.init_command import InitCommand
+
+        info = LemonadeInfo(installed=False, error="lemonade-server not found in PATH")
+
+        with patch("gaia.installer.init_command.LemonadeInstaller") as mock_cls:
+            mock_installer = MagicMock()
+            mock_installer.is_platform_supported.return_value = True
+            mock_installer.system = "windows"
+            mock_installer.download_installer.return_value = _P("/tmp/lemonade.msi")
+            mock_installer.install.return_value = InstallResult(
+                success=True, version=LEMONADE_VERSION, message="ok"
+            )
+            mock_installer.check_installation.side_effect = [
+                info,
+                LemonadeInfo(
+                    installed=True,
+                    version=LEMONADE_VERSION,
+                    path="C:\\lemonade-server.exe",
+                ),
+            ]
+            mock_cls.return_value = mock_installer
+
+            cmd = InitCommand(profile="minimal", yes=True)
+            result = cmd._ensure_lemonade_installed()
+
+        self.assertTrue(result)
         mock_installer.download_installer.assert_called_once()
         mock_installer.install.assert_called_once()
+
+
+class TestInstallViaPpa(unittest.TestCase):
+    """Tests for _install_via_ppa — the Linux PPA-based install path."""
+
+    def _make_linux_installer(self):
+        with patch("platform.system", return_value="Linux"):
+            return LemonadeInstaller(target_version="10.2.0")
+
+    def _ok_run(self):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    def _fail_run(self, stdout="", stderr="error output"):
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = stdout
+        result.stderr = stderr
+        return result
+
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value="/usr/bin/add-apt-repository")
+    @patch("subprocess.run")
+    def test_install_via_ppa_runs_commands_in_order(
+        self, mock_run, mock_which, mock_geteuid
+    ):
+        """Three subprocess calls in order: add-apt-repository, apt-get update, apt-get install."""
+        import subprocess as _sub
+
+        installer = self._make_linux_installer()
+        mock_run.return_value = self._ok_run()
+
+        with patch.object(LemonadeInstaller, "_check_linux_version", return_value=None):
+            with patch.object(installer, "check_installation") as mock_check:
+                mock_check.return_value = LemonadeInfo(
+                    installed=True, version="10.2.0", path="/usr/bin/lemonade-server"
+                )
+                result = installer._install_via_ppa(non_interactive=False)
+
+        self.assertTrue(result.success)
+        self.assertEqual(mock_run.call_count, 3)
+
+        calls = mock_run.call_args_list
+        first_cmd = calls[0][0][0]
+        self.assertIn("sudo", first_cmd)
+        self.assertIn("add-apt-repository", first_cmd)
+
+        second_cmd = calls[1][0][0]
+        self.assertIn("apt-get", second_cmd)
+        self.assertIn("update", second_cmd)
+
+        third_cmd = calls[2][0][0]
+        self.assertIn("apt-get", third_cmd)
+        self.assertIn("install", third_cmd)
+        self.assertIn("lemonade-server", third_cmd)
+
+        for call in calls:
+            self.assertEqual(call[1].get("stdin"), _sub.DEVNULL)
+
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value="/usr/bin/add-apt-repository")
+    @patch("subprocess.run")
+    def test_install_via_ppa_noninteractive_sets_env_and_devnull_stdin(
+        self, mock_run, mock_which, mock_geteuid
+    ):
+        """non_interactive=True: DEBIAN_FRONTEND=noninteractive and stdin=DEVNULL on all calls."""
+        import subprocess as _sub
+
+        installer = self._make_linux_installer()
+
+        sudo_ok = self._ok_run()
+        install_ok = self._ok_run()
+        mock_run.side_effect = [sudo_ok, install_ok, install_ok, install_ok]
+
+        with patch.object(LemonadeInstaller, "_check_linux_version", return_value=None):
+            with patch.object(installer, "check_installation") as mock_check:
+                mock_check.return_value = LemonadeInfo(
+                    installed=True, version="10.2.0", path="/usr/bin/lemonade-server"
+                )
+                result = installer._install_via_ppa(non_interactive=True)
+
+        self.assertTrue(result.success)
+        for call in mock_run.call_args_list:
+            self.assertEqual(call[1].get("stdin"), _sub.DEVNULL)
+            env = call[1].get("env", {})
+            if call[0][0] != ["sudo", "-n", "true"]:
+                self.assertEqual(env.get("DEBIAN_FRONTEND"), "noninteractive")
+
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value="/usr/bin/add-apt-repository")
+    @patch("subprocess.run")
+    def test_install_via_ppa_sudo_password_required_returns_clear_error(
+        self, mock_run, mock_which, mock_geteuid
+    ):
+        """non_interactive+not-root+sudo requires password -> clear error, not timeout."""
+        installer = self._make_linux_installer()
+        mock_run.return_value = self._fail_run(stderr="sudo: a password is required")
+
+        with patch.object(LemonadeInstaller, "_check_linux_version", return_value=None):
+            result = installer._install_via_ppa(non_interactive=True)
+
+        self.assertFalse(result.success)
+        self.assertIn("sudo", result.error.lower())
+        self.assertIn("passwordless", result.error.lower())
+        mock_run.assert_called_once()
+
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value="/usr/bin/add-apt-repository")
+    @patch("subprocess.run")
+    def test_install_via_ppa_apt_install_failure_returns_actionable_error(
+        self, mock_run, mock_which, mock_geteuid
+    ):
+        """apt-get install failure: error names step, stdout+stderr, docs URL."""
+        installer = self._make_linux_installer()
+
+        ok = self._ok_run()
+        fail = self._fail_run(stdout="E: Package not found", stderr="dpkg error")
+        mock_run.side_effect = [ok, ok, fail]
+
+        with patch.object(LemonadeInstaller, "_check_linux_version", return_value=None):
+            result = installer._install_via_ppa(non_interactive=False)
+
+        self.assertFalse(result.success)
+        self.assertIn("lemonade-server", result.error)
+        self.assertIn("amd-gaia.ai", result.error)
+
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value="/usr/bin/add-apt-repository")
+    @patch("subprocess.run")
+    def test_install_via_ppa_unsupported_distro_returns_clear_error(
+        self, mock_run, mock_which, mock_geteuid
+    ):
+        """_check_linux_version returns error string -> early return with that message."""
+        installer = self._make_linux_installer()
+        version_msg = "Requires Ubuntu 24.04+. Detected: Ubuntu 22.04"
+
+        with patch.object(
+            LemonadeInstaller, "_check_linux_version", return_value=version_msg
+        ):
+            result = installer._install_via_ppa(non_interactive=False)
+
+        self.assertFalse(result.success)
+        self.assertIn("Ubuntu 22.04", result.error)
+        mock_run.assert_not_called()
+
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_install_via_ppa_missing_add_apt_repository_clear_error(
+        self, mock_run, mock_which, mock_geteuid
+    ):
+        """add-apt-repository missing -> error mentions software-properties-common."""
+        installer = self._make_linux_installer()
+
+        with patch.object(LemonadeInstaller, "_check_linux_version", return_value=None):
+            result = installer._install_via_ppa(non_interactive=False)
+
+        self.assertFalse(result.success)
+        self.assertIn("software-properties-common", result.error)
+        mock_run.assert_not_called()
+
+    @patch("os.geteuid", return_value=1000)
+    @patch("shutil.which", return_value="/usr/bin/add-apt-repository")
+    @patch("subprocess.run")
+    def test_install_via_ppa_returns_real_version_from_check_installation(
+        self, mock_run, mock_which, mock_geteuid
+    ):
+        """Returned version comes from check_installation(), not self.target_version."""
+        installer = self._make_linux_installer()
+        mock_run.return_value = self._ok_run()
+
+        with patch.object(LemonadeInstaller, "_check_linux_version", return_value=None):
+            with patch.object(installer, "check_installation") as mock_check:
+                mock_check.return_value = LemonadeInfo(
+                    installed=True, version="10.3.0", path="/usr/bin/lemonade-server"
+                )
+                result = installer._install_via_ppa(non_interactive=False)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.version, "10.3.0")
+        self.assertNotEqual(result.version, installer.target_version)
+
+    @patch("platform.system", return_value="Linux")
+    def test_install_dispatches_to_ppa_on_linux(self, mock_system):
+        """install() on Linux calls _install_via_ppa without requiring installer_path."""
+        installer = LemonadeInstaller()
+
+        expected = InstallResult(success=True, version="10.2.0", message="via ppa")
+        with patch.object(
+            installer, "_install_via_ppa", return_value=expected
+        ) as mock_ppa:
+            result = installer.install(silent=True)
+
+        mock_ppa.assert_called_once_with(non_interactive=True)
+        self.assertTrue(result.success)
+
+    @patch("platform.system", return_value="Windows")
+    def test_install_windows_still_requires_installer_path(self, mock_system):
+        """install() on Windows with missing path returns failure immediately."""
+        from pathlib import Path
+
+        installer = LemonadeInstaller()
+        result = installer.install(
+            installer_path=Path("/nonexistent_does_not_exist.msi")
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("not found", result.error.lower())
+
+
+class TestUpgradeLemonadeOnLinux(unittest.TestCase):
+    """Verify _upgrade_lemonade routes through _install_lemonade which uses PPA on Linux."""
+
+    def test_upgrade_lemonade_on_linux_uses_ppa(self):
+        """_upgrade_lemonade calls _install_lemonade which routes Linux through install(None)."""
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller") as mock_cls:
+            mock_installer = MagicMock()
+            mock_installer.system = "linux"
+            mock_installer.uninstall.return_value = InstallResult(
+                success=True, message="uninstalled"
+            )
+            mock_installer.wait_for_msi_mutex.return_value = True
+            mock_installer.install.return_value = InstallResult(
+                success=True, version=LEMONADE_VERSION, message="ok"
+            )
+            mock_installer.check_installation.return_value = LemonadeInfo(
+                installed=True,
+                version=LEMONADE_VERSION,
+                path="/usr/bin/lemonade-server",
+            )
+            mock_cls.return_value = mock_installer
+
+            cmd = InitCommand(profile="minimal", yes=True)
+            cmd._upgrade_lemonade("10.1.0")
+
+        mock_installer.download_installer.assert_not_called()
+        mock_installer.install.assert_called_once()
+        call_kwargs = mock_installer.install.call_args
+        installer_path_arg = (
+            call_kwargs[0][0]
+            if call_kwargs[0]
+            else call_kwargs[1].get("installer_path")
+        )
+        self.assertIsNone(installer_path_arg)
 
 
 class TestWaitForMsiMutex(unittest.TestCase):


### PR DESCRIPTION
Lemonade dropped its `.deb` GitHub release asset in v10.0.1 and switched to `ppa:lemonade-team/stable`. GAIA's installer kept synthesising a URL that 404s, breaking `gaia init` on Linux for every release ≥ 10.0.1 (currently pinned at 10.2.0).

## Changes

- **PPA install path** (`_install_via_ppa`): `add-apt-repository ppa:lemonade-team/stable` → `apt-get update` (warn-only on failure) → `apt-get install lemonade-server`. Reports the real installed version from `check_installation()` rather than the pinned target.
- **Hang prevention**: sudo pre-flight (`sudo -n true`) when running non-interactively so `gaia init --yes` fails fast with an actionable error instead of hanging for 2 minutes. `stdin=subprocess.DEVNULL` on every subprocess call.
- **`install()` signature**: `installer_path` is now `Optional[Path] = None`. The `exists()` gate moved inside the Windows branch so Linux dispatch is no longer short-circuited.
- **Callers updated**: `init_command._install_lemonade` and `gaia install --lemonade` skip `download_installer()` on Linux and pass `installer_path=None`.
- **Tests**: 9 new `TestInstallViaPpa` tests (sudo pre-flight, env var, distro gate, missing binary, real version, dispatch), `TestUpgradeLemonadeOnLinux`, split `TestLegacyFallback` into Linux/Windows variants. 71 tests total, all passing.
- **Docs**: Updated `docs/cpp/setup.mdx` and `docs/plans/setup-wizard.mdx` to replace `.deb` instructions with the PPA flow.

## Test plan

- [x] `python -m pytest tests/unit/test_init_command.py` — 71 passed
- [x] `python util/lint.py --all` — all checks passed
- [ ] Manual: `gaia init --yes` on Ubuntu 24.04+ installs Lemonade and `lemonade-server --version` works (no Linux hardware in CI — flagged in PR for maintainer verification)
- [x] Windows behavior unchanged: `install()` without a valid MSI path still returns `InstallResult(success=False, error="Installer not found: ...")`

Closes #815