### PR TITLE
fix(packaging): add RAG deps to [ui] extra so AppImage RAG works

### DIFF
--- a/docs/guides/agent-ui.mdx
+++ b/docs/guides/agent-ui.mdx
@@ -239,6 +239,17 @@ See the [Agent UI MCP Server guide](/guides/mcp/agent-ui) for setup instructions
     - For PDF image extraction, download the VLM model: `gaia download --agent chat`
   </Accordion>
 
+  <Accordion title="First-run network egress to huggingface.co">
+    The first time you index a document, the embedding model
+    (`sentence-transformers`) is downloaded from `huggingface.co` (~100 MB,
+    cached under `~/.cache/huggingface/`). Subsequent runs are offline.
+
+    If your environment blocks `huggingface.co`, pre-seed the cache on a
+    machine with internet access and copy it to the target machine, or set
+    `HF_HOME` to point at a pre-populated cache directory before launching
+    the UI.
+  </Accordion>
+
   <Accordion title="Frontend shows JSON instead of the UI">
     The Agent UI frontend has not been built.
 

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,21 @@ setup(
             "python-multipart>=0.0.9",
             "httpx>=0.27.0",
             "psutil>=5.9.0",
+            # RAG runtime deps — gaia.ui.server boots faiss + sentence_transformers
+            # eagerly, and gaia.rag.sdk uses pypdf/pymupdf/numpy. See #845.
+            # Version specifiers match the standalone "rag" extra; "ui"
+            # additionally declares safetensors and a torch lower bound.
+            "faiss-cpu>=1.7.0",
+            "numpy>=1.24.0",
+            "pymupdf>=1.24.0",
+            "pypdf",
+            "sentence-transformers",
+            "safetensors",
+            # torch is pinned lower-bound only. The "audio" extra caps
+            # torch<2.4 because torchvision<0.19 / torchaudio require it,
+            # but "ui" ships neither — capping here would force resolver
+            # downgrades for users with torch 2.5+ already installed.
+            "torch>=2.0.0",
         ],
         "audio": [
             "torch>=2.0.0,<2.4",

--- a/tests/unit/test_ui_extras.py
+++ b/tests/unit/test_ui_extras.py
@@ -1,0 +1,72 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Regression test for issue #845.
+
+The Agent UI boot path (gaia.ui.server._import_modules) eagerly imports
+faiss + sentence_transformers, and gaia.rag.sdk lazily imports
+pypdf / numpy / fitz (pymupdf). After AppImage install — which only
+resolves setup.py[ui] — those modules were missing and RAG broke
+silently. This test asserts the [ui] extra in setup.py declares every
+distribution required by the boot path.
+
+This is a packaging assertion, not a runtime import test, so it works
+in the CI unit-tests venv that does not actually install [ui].
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SETUP_PY = Path(__file__).resolve().parents[2] / "setup.py"
+
+# PyPI distribution names (NOT importable module names) that
+# setup.py[ui] must declare. Each entry maps a distribution
+# requirement-string substring to the import-site that needs it,
+# for diagnostic clarity when the assertion fails.
+REQUIRED_UI_DISTS = {
+    "faiss-cpu": "src/gaia/ui/server.py boot import",
+    "sentence-transformers": "src/gaia/ui/server.py boot import",
+    "pypdf": "src/gaia/rag/sdk.py PdfReader",
+    "pymupdf": "src/gaia/rag/sdk.py fitz",
+    "numpy": "src/gaia/rag/sdk.py / faiss",
+}
+
+
+def _parse_ui_extra() -> list[str]:
+    """Extract the list of requirement strings from setup.py[ui].
+
+    Walks the file line by line so brackets that appear inside ``# comments``
+    don't confuse a naive non-greedy regex match.
+    """
+    lines = SETUP_PY.read_text().splitlines()
+    in_block = False
+    body: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if not in_block:
+            if re.match(r'"ui"\s*:\s*\[', stripped):
+                in_block = True
+            continue
+        if stripped.startswith("]"):
+            break
+        # Skip comment-only lines so brackets in comments don't matter.
+        if stripped.startswith("#"):
+            continue
+        body.append(raw)
+    assert in_block, 'Could not find "ui" extra in setup.py extras_require'
+    return re.findall(r'"([^"]+)"', "\n".join(body))
+
+
+@pytest.mark.parametrize("dist,reason", list(REQUIRED_UI_DISTS.items()))
+def test_ui_extra_declares_rag_runtime_dep(dist: str, reason: str) -> None:
+    """setup.py[ui] must declare each RAG runtime dependency — see #845."""
+    ui_reqs = _parse_ui_extra()
+    matches = [r for r in ui_reqs if r.lower().startswith(dist.lower())]
+    assert matches, (
+        f"setup.py[ui] is missing distribution '{dist}' (needed by {reason}).\n"
+        f"Current [ui] extra: {ui_reqs}"
+    )


### PR DESCRIPTION
After a clean AppImage install, the Python backend logged `No module named 'faiss'` and RAG was silently broken. The root cause: `setup.py["ui"]` listed only the web-server deps, but `gaia.ui.server` eagerly imports `faiss` and `sentence_transformers` at boot, and `gaia.rag.sdk` uses `pypdf`, `pymupdf`, and `numpy`.

## What changed

- **`setup.py["ui"]`** — adds `faiss-cpu>=1.7.0`, `numpy>=1.24.0`, `pymupdf>=1.24.0`, `pypdf`, `sentence-transformers`, `safetensors`, and `torch>=2.0.0` (lower-bound only — the `[audio]` extra caps `<2.4` because `torchvision`/`torchaudio` require it; `[ui]` ships neither, so capping here would force resolver downgrades for torch 2.5+ users).
- **`tests/unit/test_ui_extras.py`** — packaging assertion that parses `setup.py` and checks every required distribution is listed in `["ui"]`. Runs in any venv (CI's unit-tests job installs only `["api"]`), fails red before this fix and green after.
- **`docs/guides/agent-ui.mdx`** — new Troubleshooting accordion documenting first-run `huggingface.co` egress (~100 MB one-time cache) and the `HF_HOME` workaround for air-gapped environments.

The standalone `["rag"]` extra is unchanged — `init_command.py` still uses it for the `chat`/`rag`/`all` profiles.

## Platform notes

`faiss-cpu` has no `manylinux_aarch64` wheel — Linux ARM64 AppImage still breaks at the RAG step. Tracked separately; out of scope for this fix.

## Test plan

- [ ] `python -m pytest tests/unit/test_ui_extras.py -xvs` — 5 parametrized cases pass
- [ ] `python -m pytest tests/unit/test_packaging.py` — 6 existing cases still pass
- [ ] `python util/lint.py --black --isort` — clean
- [ ] In a clean `uv venv` with `uv pip install -e ".[ui]"`: `python -c "import faiss, sentence_transformers, pypdf, fitz, numpy"` — no import error

Closes #845