### PR TITLE
fix(installer): set Lemonade ctx-size on install and idle server (#839)

### DIFF
--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -1021,11 +1021,29 @@ class InitCommand:
                     if not lemonade_path:
                         raise FileNotFoundError("lemonade-server not found in PATH")
 
+                    # Pass --ctx-size so the auto-started server comes up with
+                    # GAIA's required context window (issue #839).  Without this
+                    # the server starts with its default (small) ctx and the
+                    # user is told to stop and restart it manually — bad UX.
+                    min_ctx = INIT_PROFILES[self.profile].get("min_context_size")
+                    if not min_ctx:
+                        raise RuntimeError(
+                            f"Profile {self.profile!r} is missing 'min_context_size' "
+                            f"in INIT_PROFILES; cannot determine --ctx-size for "
+                            f"lemonade-server. Add the key to INIT_PROFILES "
+                            f"in src/gaia/installer/init_command.py."
+                        )
+                    ctx_args = ["--ctx-size", str(min_ctx)]
+                    log.info(
+                        "Starting lemonade-server with %s",
+                        " ".join(ctx_args),
+                    )
+
                     # Start server in background
                     if sys.platform == "win32":
                         # Windows: use subprocess.Popen with no window
                         subprocess.Popen(
-                            [lemonade_path, "serve", "--no-tray"],
+                            [lemonade_path, "serve", "--no-tray", *ctx_args],
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL,
                             creationflags=(
@@ -1037,7 +1055,7 @@ class InitCommand:
                     else:
                         # Linux/Mac: background process
                         subprocess.Popen(
-                            [lemonade_path, "serve"],
+                            [lemonade_path, "serve", *ctx_args],
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL,
                         )

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -14,7 +14,11 @@ import time
 from enum import Enum
 from typing import Optional
 
-from gaia.llm.lemonade_client import LemonadeClient
+from gaia.llm.lemonade_client import (
+    DEFAULT_MODEL_NAME,
+    LemonadeClient,
+    LemonadeClientError,
+)
 from gaia.logger import get_logger
 
 # Default context size for GAIA agents (supports most complex tasks)
@@ -316,24 +320,55 @@ class LemonadeManager:
                         cls.print_server_error(min_context_size)
                     return False
 
-                # Cache server state for subsequent calls.
-                # We set initialized=True even if context check fails below,
-                # so future calls can use cached state without reconnecting.
+                # Defensive normalisation: some Lemonade versions can return
+                # `loaded_models: null` in their JSON, which would crash the
+                # `any(... for model in ...)` calls below.
+                if status.loaded_models is None:
+                    status.loaded_models = []
+
+                # Snapshot context size — we may overwrite it below if the
+                # preload helper successfully seeds the server.
+                context_size_value = status.context_size or 0
+
+                # Detect LLM-loaded state once for the branch decisions below.
+                llm_models_loaded = any(
+                    "image" not in model.get("labels", [])
+                    for model in status.loaded_models
+                )
+
+                # Idle server (no model loaded, no ctx reported): proactively
+                # load the default model with the required ctx_size.  Without
+                # this, the user would land on a server with a too-small
+                # default ctx and be told to manually stop and restart it
+                # (issue #839).  We run this BEFORE setting cls._initialized
+                # so a failed preload leaves the singleton retryable instead
+                # of poisoned with (initialized=True, ctx=0).
+                if context_size_value == 0 and not llm_models_loaded:
+                    cls._try_preload_with_ctx(
+                        client, min_context_size, quiet, cls._lock
+                    )
+                    context_size_value = min_context_size
+                    # Re-fetch model list so the small-ctx reload branch below
+                    # sees the freshly-loaded model.
+                    status = client.get_status()
+                    if status.loaded_models is None:
+                        status.loaded_models = []
+                    llm_models_loaded = any(
+                        "image" not in model.get("labels", [])
+                        for model in status.loaded_models
+                    )
+
+                # Cache server state for subsequent calls.  Setting
+                # _initialized=True after the preload guard ensures a failed
+                # preload does NOT poison the singleton: ensure_ready will
+                # re-enter this block on the next call.
                 cls._initialized = True
                 cls._base_url = client.base_url
-                cls._context_size = status.context_size or 0
+                cls._context_size = context_size_value
 
                 cls._log.debug(
                     f"Lemonade ready at {cls._base_url} "
                     f"(context: {cls._context_size} tokens)"
-                )
-
-                # Verify context size - only warn if insufficient AND LLM models are loaded
-                # SD models don't have context size, only LLM models do
-                # Check if any loaded models are LLMs (not SD models with "image" label)
-                llm_models_loaded = any(
-                    "image" not in model.get("labels", [])
-                    for model in status.loaded_models
                 )
 
                 # Only warn if:
@@ -361,11 +396,88 @@ class LemonadeManager:
 
                 return True
 
+            except LemonadeClientError:
+                # Actionable error from the preload helper — propagate so the
+                # caller sees the three-part guidance instead of a silent
+                # return False (CLAUDE.md "no silent fallbacks").
+                raise
             except Exception as e:
                 cls._log.warning(f"Failed to initialize Lemonade: {e}")
                 if not quiet:
                     cls.print_server_error(min_context_size)
                 return False
+
+    @classmethod
+    def _try_preload_with_ctx(
+        cls,
+        client: "LemonadeClient",
+        min_context_size: int,
+        quiet: bool,
+        lock: "threading.Lock",
+    ) -> None:
+        """Load the default LLM with the required ctx_size on an idle server.
+
+        Closes the gap left by `_try_reload_with_ctx`, which only handles the
+        "model already loaded with too-small ctx" path.  When the server is
+        running but idle (no model loaded, no ctx reported), this helper
+        proactively seeds it so the user does not see the legacy
+        "Restart with: lemonade-server serve --ctx-size N" message
+        (issue #839).
+
+        Releases `lock` for the duration of the blocking `load_model` call —
+        important because `auto_download=True` means a first-run user pays a
+        full model-download window (potentially minutes), and we must not
+        block other threads (status pollers, parallel `ensure_ready` callers)
+        for that long.  Mirrors the lock discipline of `_try_reload_with_ctx`.
+
+        Raises:
+            LemonadeClientError: if `load_model` fails. Carries an actionable
+                message (Lemonade / ctx_size= / lemonade-server serve) so the
+                user can recover manually if the auto-preload cannot.
+        """
+        cls._log.info(
+            "Preloading '%s' with ctx_size=%d on idle Lemonade server",
+            DEFAULT_MODEL_NAME,
+            min_context_size,
+        )
+        if not quiet:
+            print(
+                f"\n⏳ Loading {DEFAULT_MODEL_NAME} with ctx_size={min_context_size} "
+                f"tokens. This may take a moment (first run downloads the model)...",
+                flush=True,
+            )
+
+        # Release the lock for the duration of the blocking call so
+        # concurrent callers and status-pollers are not stalled.  The
+        # `finally` block re-acquires before any exception propagates back
+        # up to the surrounding `with cls._lock:` context manager.
+        lock.release()
+        try:
+            client.load_model(
+                DEFAULT_MODEL_NAME,
+                ctx_size=min_context_size,
+                prompt=False,
+                auto_download=True,
+            )
+        except Exception as e:
+            raise LemonadeClientError(
+                f"Failed to preload Lemonade model {DEFAULT_MODEL_NAME!r} with "
+                f"ctx_size={min_context_size} on idle server at "
+                f"{client.base_url}.\n"
+                f"To recover manually: stop the running server, then run "
+                f"'lemonade-server serve --ctx-size {min_context_size}' and "
+                f"re-run your GAIA command.\n"
+                f"See the Lemonade server log for details "
+                f"(typical path: ~/.cache/lemonade/server.log)."
+            ) from e
+        finally:
+            lock.acquire()
+
+        if not quiet:
+            print(
+                f"✅ Loaded {DEFAULT_MODEL_NAME} with ctx_size={min_context_size}.",
+                flush=True,
+            )
 
     @classmethod
     def _try_reload_with_ctx(

--- a/tests/unit/installer/test_init_ctx_size.py
+++ b/tests/unit/installer/test_init_ctx_size.py
@@ -1,0 +1,139 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests verifying `gaia init` auto-starts Lemonade with --ctx-size.
+
+Issue #839: when GAIA itself spawns the Lemonade server in CI/auto mode,
+the subprocess.Popen argv must include `--ctx-size <profile.min_context_size>`
+so the server doesn't come up with a default (small) context window that GAIA
+later has to fight to correct.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.installer.init_command import INIT_PROFILES, InitCommand
+
+
+@pytest.fixture(autouse=True)
+def _isolate_remote_env(monkeypatch):
+    """Strip LEMONADE_BASE_URL so InitCommand doesn't auto-flip to remote mode."""
+    monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+
+
+def _make_cmd(profile: str = "chat") -> InitCommand:
+    """Build an InitCommand wired for CI/auto mode."""
+    return InitCommand(profile=profile, yes=True, skip_models=True)
+
+
+def _patch_health_unreachable(client_mock):
+    """Configure the lazily-instantiated LemonadeClient to look 'not running'.
+
+    health_check() returns falsy on the first call so _ensure_server_running
+    falls through to the auto-start branch, then returns 'ok' once Popen has
+    been "called" so the wait-loop exits.
+    """
+    instance = client_mock.return_value
+    instance.health_check.side_effect = [
+        None,  # first call: server not running
+        {"status": "ok"},  # post-Popen wait-loop: server up
+    ]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Linux/macOS branch
+# ---------------------------------------------------------------------------
+
+
+@patch("sys.platform", "linux")
+@patch("subprocess.Popen")
+@patch("gaia.llm.lemonade_client.LemonadeClient")
+def test_linux_auto_start_includes_ctx_size(mock_client_cls, mock_popen):
+    """Linux Popen argv must contain `--ctx-size 32768` for profile=chat."""
+    _patch_health_unreachable(mock_client_cls)
+    mock_popen.return_value = MagicMock()
+
+    cmd = _make_cmd(profile="chat")
+    with patch.object(
+        cmd, "_find_lemonade_server", return_value="/usr/bin/lemonade-server"
+    ):
+        result = cmd._ensure_server_running()
+
+    assert result is True, "expected auto-start to report success"
+    assert mock_popen.called, "expected subprocess.Popen to be invoked"
+    argv = mock_popen.call_args.args[0]
+    # Literal 32768 — testing-against-the-imported-constant is circular and
+    # would not catch a future regression that flips the profile default.
+    assert "--ctx-size" in argv, f"--ctx-size missing from argv: {argv}"
+    idx = argv.index("--ctx-size")
+    assert (
+        argv[idx + 1] == "32768"
+    ), f"expected ctx-size value 32768, got {argv[idx + 1]}"
+    # And `serve` must come before `--ctx-size`
+    assert argv.index("serve") < idx
+
+
+# ---------------------------------------------------------------------------
+# Windows branch
+# ---------------------------------------------------------------------------
+
+
+@patch("sys.platform", "win32")
+@patch("subprocess.Popen")
+@patch("gaia.llm.lemonade_client.LemonadeClient")
+def test_windows_auto_start_includes_ctx_size(mock_client_cls, mock_popen):
+    """Windows Popen argv must contain --no-tray AND --ctx-size 32768."""
+    _patch_health_unreachable(mock_client_cls)
+    mock_popen.return_value = MagicMock()
+
+    cmd = _make_cmd(profile="chat")
+    with patch.object(cmd, "_find_lemonade_server", return_value=r"C:\lemonade.exe"):
+        result = cmd._ensure_server_running()
+
+    assert result is True
+    argv = mock_popen.call_args.args[0]
+    assert "--no-tray" in argv, f"--no-tray missing from Windows argv: {argv}"
+    assert "--ctx-size" in argv, f"--ctx-size missing from argv: {argv}"
+    idx = argv.index("--ctx-size")
+    assert argv[idx + 1] == "32768"
+
+
+# ---------------------------------------------------------------------------
+# Profile selection — value comes from profile, not hardcoded
+# ---------------------------------------------------------------------------
+
+
+def test_all_profiles_define_min_context_size():
+    """Every shipped profile must declare min_context_size so init never spawns
+    Lemonade without an explicit --ctx-size value."""
+    for name, profile in INIT_PROFILES.items():
+        assert (
+            "min_context_size" in profile
+        ), f"profile {name!r} missing min_context_size"
+        assert isinstance(profile["min_context_size"], int)
+        assert profile["min_context_size"] > 0
+
+
+@patch("sys.platform", "linux")
+@patch("subprocess.Popen")
+@patch("gaia.llm.lemonade_client.LemonadeClient")
+@pytest.mark.parametrize("profile_name", sorted(INIT_PROFILES.keys()))
+def test_profile_min_context_size_is_passed(mock_client_cls, mock_popen, profile_name):
+    """argv ctx-size value must equal INIT_PROFILES[profile]['min_context_size']."""
+    _patch_health_unreachable(mock_client_cls)
+    mock_popen.return_value = MagicMock()
+
+    cmd = _make_cmd(profile=profile_name)
+    with patch.object(
+        cmd, "_find_lemonade_server", return_value="/usr/bin/lemonade-server"
+    ):
+        cmd._ensure_server_running()
+
+    expected = str(INIT_PROFILES[profile_name]["min_context_size"])
+    argv = mock_popen.call_args.args[0]
+    idx = argv.index("--ctx-size")
+    assert (
+        argv[idx + 1] == expected
+    ), f"profile={profile_name}: expected ctx-size {expected}, got {argv[idx + 1]}"

--- a/tests/unit/test_lemonade_manager_preload.py
+++ b/tests/unit/test_lemonade_manager_preload.py
@@ -1,0 +1,286 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for `LemonadeManager._try_preload_with_ctx` (issue #839).
+
+The preload helper closes the gap in `_try_reload_with_ctx` (which only fires
+when `context_size > 0`): when the Lemonade server is up but **idle** — no
+model loaded, no context size reported — GAIA must proactively load the default
+model with the required `ctx_size` instead of asking the user to run a manual
+`lemonade-server serve --ctx-size N` command.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.llm.lemonade_client import LemonadeClientError, LemonadeStatus
+from gaia.llm.lemonade_manager import DEFAULT_CONTEXT_SIZE, LemonadeManager
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager():
+    """Reset the singleton's class state before AND after every test.
+
+    Without this, a test that successfully initialises the manager poisons the
+    next test (it hits the `_initialized=True` fast path and skips re-checking
+    server state). pytest-xdist would also flake otherwise.
+    """
+    LemonadeManager.reset()
+    yield
+    LemonadeManager.reset()
+
+
+def _status(running=True, context_size=0, loaded_models=None):
+    return LemonadeStatus(
+        running=running,
+        context_size=context_size,
+        loaded_models=[] if loaded_models is None else loaded_models,
+    )
+
+
+def _make_client_mock(status):
+    """Build a LemonadeClient mock returning the given status from get_status()."""
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/api/v1"
+    client.get_status.return_value = status
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — idle server: preload must fire with ctx_size + auto_download=True
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_idle_server_triggers_preload_with_ctx_size(mock_cls):
+    """server running, no model loaded → load_model(DEFAULT_MODEL_NAME, ctx_size=N, auto_download=True)."""
+    client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
+    # After load_model, get_status should report the new ctx_size so callers can
+    # observe the change (mirrors the real Lemonade response).
+    client.get_status.side_effect = [
+        _status(running=True, context_size=0, loaded_models=[]),  # first call (init)
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        ),  # post-load probe
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    assert ok is True
+    client.load_model.assert_called_once()
+    call = client.load_model.call_args
+    # Model name passed positionally in the helper; assert by either path.
+    args = call.args
+    kwargs = call.kwargs
+    assert (args and args[0] == "Gemma-4-E4B-it-GGUF") or kwargs.get(
+        "model_name"
+    ) == "Gemma-4-E4B-it-GGUF"
+    assert kwargs.get("ctx_size") == 32768  # Literal — catch value-drift regressions.
+    assert kwargs.get("prompt") is False
+    assert kwargs.get("auto_download") is True, (
+        "auto_download=True is required so first-run users (no model on disk) "
+        "get a download instead of a silent failure (AC3)."
+    )
+    assert LemonadeManager.get_context_size() >= 32768
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — happy path: ctx already big enough, no model load
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_sufficient_ctx_skips_preload(mock_cls):
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        )
+    )
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    assert ok is True
+    client.load_model.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — model loaded with too-small ctx routes through existing reload, not preload
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_small_ctx_with_loaded_model_uses_existing_reload(mock_cls):
+    """Existing `_try_reload_with_ctx` owns this path; new preload helper must NOT fire."""
+    client = _make_client_mock(
+        _status(
+            running=True,
+            context_size=8192,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        )
+    )
+    # Reload path: load_model is called with the existing model id.
+    client.get_status.side_effect = [
+        _status(
+            running=True,
+            context_size=8192,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        ),
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    assert ok is True
+    # load_model is called by the EXISTING reload path with the loaded model id,
+    # NOT by the new preload helper with DEFAULT_MODEL_NAME (which here happens to
+    # be the same string — distinguish by the *call-site*: the reload path does
+    # not pass auto_download).
+    assert client.load_model.called
+    kwargs = client.load_model.call_args.kwargs
+    # Existing _try_reload_with_ctx does not pass auto_download — that is the
+    # signature distinguishing it from the new preload helper.
+    assert "auto_download" not in kwargs or kwargs.get("auto_download") is False
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — preload failure raises LemonadeClientError with actionable message
+#          and leaves the singleton in a retryable state
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_preload_failure_raises_actionable_and_does_not_poison_singleton(mock_cls):
+    """If load_model raises, the helper re-raises a LemonadeClientError carrying
+    the three actionable substrings AND `_initialized` stays False so a retry
+    will reattempt initialisation (per adversarial reflection C1)."""
+    client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
+    client.load_model.side_effect = LemonadeClientError("server returned 500")
+    mock_cls.return_value = client
+
+    with pytest.raises(LemonadeClientError) as exc_info:
+        LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    msg = str(exc_info.value)
+    assert "Lemonade" in msg
+    assert "ctx_size=32768" in msg or "32768" in msg
+    assert "lemonade-server serve" in msg
+
+    # Singleton must NOT be in the broken (initialized=True, ctx=0) state.
+    assert (
+        LemonadeManager.is_initialized() is False
+    ), "Singleton must allow retry after a failed preload (adversarial reflection C1)."
+
+    # And the lock must be released.
+    assert LemonadeManager._lock.acquire(timeout=1.0) is True
+    LemonadeManager._lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — server not running: existing print_server_error path, no preload
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_server_not_running_skips_preload(mock_cls):
+    client = _make_client_mock(_status(running=False))
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    assert ok is False
+    client.load_model.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — server returns loaded_models=None (defensive: don't crash on null JSON)
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_loaded_models_none_does_not_crash(mock_cls):
+    """Some Lemonade versions can return `loaded_models: null`. We must not
+    `TypeError` from iterating None — the new guard normalises to []."""
+    bad_status = _status(running=True, context_size=0, loaded_models=[])
+    bad_status.loaded_models = None  # simulate a server returning null
+    client = _make_client_mock(bad_status)
+    client.get_status.side_effect = [
+        bad_status,
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        ),
+    ]
+    mock_cls.return_value = client
+
+    ok = LemonadeManager.ensure_ready(min_context_size=32768, quiet=True)
+
+    assert ok is True
+    client.load_model.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — concurrent ensure_ready() callers preload exactly once
+# ---------------------------------------------------------------------------
+
+
+@patch("gaia.llm.lemonade_manager.LemonadeClient")
+def test_concurrent_ensure_ready_loads_model_once(mock_cls):
+    """Two threads racing into ensure_ready() — only one load_model call."""
+    client = _make_client_mock(_status(running=True, context_size=0, loaded_models=[]))
+    # First call: idle. Subsequent: already loaded.
+    statuses = [
+        _status(running=True, context_size=0, loaded_models=[]),
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        ),
+        _status(
+            running=True,
+            context_size=32768,
+            loaded_models=[{"id": "Gemma-4-E4B-it-GGUF"}],
+        ),
+    ]
+    client.get_status.side_effect = statuses
+    mock_cls.return_value = client
+
+    results = []
+    barrier = threading.Barrier(2)
+
+    def _go():
+        barrier.wait()
+        results.append(LemonadeManager.ensure_ready(min_context_size=32768, quiet=True))
+
+    threads = [threading.Thread(target=_go) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5.0)
+
+    assert results == [True, True]
+    assert client.load_model.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — sanity: DEFAULT_CONTEXT_SIZE constant matches expected literal
+# ---------------------------------------------------------------------------
+
+
+def test_default_context_size_literal():
+    """Belt-and-braces: assert the *literal* 32768 — testing-against-the-import
+    is circular and would silently accept a value-drift regression."""
+    assert DEFAULT_CONTEXT_SIZE == 32768


### PR DESCRIPTION
## Summary

On a fresh system, `gaia init` installs Lemonade and starts it without a context-size flag, leaving the server with a too-small default. GAIA then tells the user to run `lemonade-server serve --ctx-size 32768` — but the server is already running, so they have to stop and restart it manually. This PR closes that gap so Lemonade ends up at the right context size automatically, on both Linux fresh installs and Windows machines where the MSI auto-starts a system service before `gaia init` ever runs.

## Changes

- **`src/gaia/installer/init_command.py`** — `_ensure_server_running` (CI/auto path) appends `--ctx-size <profile.min_context_size>` to the `subprocess.Popen` argv on both Windows and Linux branches. Why: on Linux fresh install GAIA itself spawns the server, so the right flag at spawn-time avoids any restart dance.
- **`src/gaia/llm/lemonade_manager.py`** — new `_try_preload_with_ctx` helper, called from `ensure_ready` when the server is running but **idle** (no model loaded, no ctx reported). Calls `load_model(DEFAULT_MODEL_NAME, ctx_size=N, auto_download=True)`. Why: Windows users typically hit a Lemonade service that already auto-started, so the installer-side flag never runs — this runtime preload is the load-bearing fix. Existing `_try_reload_with_ctx` (ctx > 0 path) is unchanged.
- **Singleton state hygiene** — `cls._initialized = True` is now set *after* the preload succeeds, so a failed first-run leaves the manager retryable instead of poisoned with `(initialized=True, ctx=0)`. Outer `try` in `ensure_ready` lets `LemonadeClientError` propagate (the helper carries a 3-part actionable message: what failed / what to do / where to look).
- **Lock discipline** — preload helper releases `cls._lock` around the blocking `load_model` call (mirrors the existing reload helper), so first-run model downloads don't stall concurrent callers.
- **Defensive**: `status.loaded_models is None` now normalizes to `[]` so a Lemonade build returning `null` doesn't crash the `any(...)` checks.

## Test plan

- [x] `python -m pytest tests/unit/installer/test_init_ctx_size.py` — argv assertions for Windows + Linux branches, parametrized over every shipped profile (10 tests).
- [x] `python -m pytest tests/unit/test_lemonade_manager_preload.py` — idle preload triggers `load_model(ctx_size=32768, auto_download=True)`; sufficient-ctx skips; small-ctx falls through to existing reload; preload failure raises `LemonadeClientError` with substrings `Lemonade`, `ctx_size=32768`, `lemonade-server serve`, AND leaves singleton retryable; server-not-running unchanged; `loaded_models=None` doesn't crash; two concurrent callers preload exactly once; literal `32768` (8 tests).
- [x] `python -m pytest tests/unit/` full unit suite — 468 passed (1 unrelated pre-existing flake in `test_sse_confirmation.py` confirmed to fail on `main`).
- [x] `python util/lint.py --all` — clean.
- [ ] Manual smoke (developer machine, post-merge): `gaia init --yes` on a clean Lemonade install, then `gaia chat "hello"`; confirm no "Restart with: …" message and the agent runs.

Closes #839