### PR TITLE
docs(agents): clear stale YAML-manifest references after #914

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -57,7 +57,7 @@ Structure reviews as:
 ## Common pitfalls to flag
 
 - **New tool class outside `tools/` or `<agent>/tools/`** — breaks mixin discoverability
-- **Mixin not added to `KNOWN_TOOLS`** — YAML-manifest agents can't opt in by name
+- **Mixin not added to `KNOWN_TOOLS`** — other agents can't compose it by name
 - **`Agent` subclass with wrong MRO** — mixin `__init__`s silently skipped
 - **Importing `gaia.cli` from a library module** — upward dependency
 - **Duplicated tool logic** — should be a mixin

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -70,5 +70,5 @@ For each finding: file, line number, the issue, and a concrete fix. Paste the fi
 - **`import logging` then `logging.getLogger(__name__)`** — replace with `gaia.logger.get_logger`
 - **Re-implemented file search / RAG / shell tools** — point to existing mixin in `KNOWN_TOOLS` (`src/gaia/agents/registry.py:26`)
 - **Tool registered outside `_register_tools`** — the `@tool` decorator needs `self` in closure scope
-- **New tool mixin not added to `KNOWN_TOOLS`** — YAML-manifest agents can't use it
+- **New tool mixin not added to `KNOWN_TOOLS`** — other agents can't compose it by name
 - **Docstring-less `@tool`** — the docstring is what the LLM sees; it MUST describe args and return

--- a/.claude/agents/gaia-agent-builder.md
+++ b/.claude/agents/gaia-agent-builder.md
@@ -1,15 +1,15 @@
 ---
 name: gaia-agent-builder
-description: GAIA agent creation specialist. Use PROACTIVELY when CREATING a new GAIA agent — inheriting from the base `Agent`, registering tools, wiring state management, or scaffolding via YAML manifest. Not for general LLM work (use `lemonade-specialist`) or SDK design (use `sdk-architect`).
+description: GAIA agent creation specialist. Use PROACTIVELY when CREATING a new GAIA agent — inheriting from the base `Agent`, registering tools, or wiring state management. Not for general LLM work (use `lemonade-specialist`) or SDK design (use `sdk-architect`).
 tools: Read, Write, Edit, Bash, Grep
 model: opus
 ---
 
-You create new GAIA agents. There are two shapes — Python class or YAML manifest — and you must pick the right one before writing code.
+You create new GAIA agents. Every agent is a Python class inheriting from `Agent` (or one of its `*Agent` subclasses); YAML manifests were removed in v0.17.5 (#912).
 
 ## When to use
 
-- Creating a new agent under `src/gaia/agents/<id>/agent.py` (built-in) or `~/.gaia/agents/<id>/agent.yaml` (user-authored)
+- Creating a new agent under `src/gaia/agents/<id>/agent.py` (built-in) or `~/.gaia/agents/<id>/agent.py` (user-authored)
 - Adding a new mixin and wiring it into `KNOWN_TOOLS`
 - Converting a prototype script into a proper `Agent` subclass
 - Designing state machines for multi-step agent flows
@@ -25,22 +25,17 @@ You create new GAIA agents. There are two shapes — Python class or YAML manife
 ## Before you write anything, read:
 - [`CLAUDE.md`](../../CLAUDE.md) — project conventions, "No Silent Fallbacks" rule, agent registry table
 - [`src/gaia/agents/base/agent.py`](../../src/gaia/agents/base/agent.py) — base `Agent`
-- [`src/gaia/agents/registry.py`](../../src/gaia/agents/registry.py) — `KNOWN_TOOLS` + `AgentManifest`
+- [`src/gaia/agents/registry.py`](../../src/gaia/agents/registry.py) — `KNOWN_TOOLS` map and `AgentRegistry`
 - [`docs/sdk/patterns.mdx`](../../docs/sdk/patterns.mdx) — canonical copy-pasteable patterns
 
-## The two agent shapes
+## Agent shape
 
-### A. Python class — `src/gaia/agents/<id>/agent.py`
-- Full control: custom `process_query`, state machine, `@tool` methods, mixin composition
-- Choose when the agent needs custom logic, a new tool set, or ships as built-in
-- Must: inherit from `Agent` (or `MCPAgent`); implement `_get_system_prompt` and `_register_tools`
+### Python class — `src/gaia/agents/<id>/agent.py` (built-in) or `~/.gaia/agents/<id>/agent.py` (user-authored)
+- Inherit from `Agent` (or `MCPAgent`); implement `_get_system_prompt` and `_register_tools`
+- Compose reusable mixins from `KNOWN_TOOLS` directly in the class declaration
+- An optional sidecar `agent.yaml` next to `agent.py` carries declarative `models:` only — anything else (legacy `manifest_version`, `tools`, `instructions`, `mcp_servers`, `id`) emits a `DeprecationWarning` and is ignored
 
-### B. YAML manifest — `~/.gaia/agents/<id>/agent.yaml`
-- Declarative: registry synthesises the class via `type()` at load time
-- Choose when the agent is just "system prompt + mixins from `KNOWN_TOOLS` + optional MCP servers"
-- Must: validate against `AgentManifest` (see `registry.py:37`); every `tools:` entry must be a `KNOWN_TOOLS` key
-
-Fastest path for end users: `gaia chat --ui` → "+" → **BuilderAgent** (interactive scaffolding).
+Fastest path for end users: `gaia chat --ui` → "+" → **BuilderAgent** (interactive scaffolding emits Python).
 
 ## Checklist for a built-in agent
 
@@ -62,13 +57,13 @@ Missing any of these will fail `python util/lint.py --agents` or silently produc
 
 **Optional:**
 - `_create_console(self) -> AgentConsole` — only override if you need a custom console; the base class provides a default
-- `AGENT_ID` / `AGENT_NAME` / `AGENT_DESCRIPTION` / `CONVERSATION_STARTERS` — required *only* for agents exposed through the registry/BuilderAgent flow (see `src/gaia/agents/builder/agent.py`). YAML-manifest agents carry these fields in the manifest; most concrete Python agents (`ChatAgent`, `CodeAgent`, `JiraAgent`, …) don't declare them at all.
+- `AGENT_ID` / `AGENT_NAME` / `AGENT_DESCRIPTION` / `CONVERSATION_STARTERS` — required *only* for agents exposed through the registry/BuilderAgent flow (see `src/gaia/agents/builder/agent.py`). Most concrete Python agents (`ChatAgent`, `CodeAgent`, `JiraAgent`, …) don't declare them at all.
 
 ### 2. Tools
 - [ ] Every tool decorated with `@tool` inside `_register_tools` so `self` is in closure scope
 - [ ] Docstring describes args + return (the LLM reads this)
 - [ ] Reusable tools → pull into a mixin under `src/gaia/agents/tools/` or `src/gaia/agents/<agent>/tools/`
-- [ ] Add the mixin to `KNOWN_TOOLS` in `registry.py:26` so YAML agents can opt in
+- [ ] Add the mixin to `KNOWN_TOOLS` in `registry.py:26` so other agents can compose it by name
 
 ### 3. Registry wiring
 - [ ] Add a `_register_*_agent` block in `AgentRegistry._register_builtin_agents`
@@ -134,7 +129,7 @@ Surface failures with: what failed, which resource, what the user should do.
 - **Forgot `_TOOL_REGISTRY.clear()`** at the top of `_register_tools` — tools from a prior agent leak in
 - **`@tool` at module top-level** — decorator needs `self` in closure; silently drops `self` binding
 - **MRO departure from convention** — every in-tree agent uses `class X(Agent, MyMixin)`; don't flip to `class X(MyMixin, Agent)` "for textbook Python MRO reasons." Agent-first works because `Agent.__init__` doesn't `super().__init__()` and mixins handle it (see the MRO note above). If your mixin must run custom init, make it lazy or override `__init__` on the concrete class.
-- **New tool mixin not added to `KNOWN_TOOLS`** — YAML manifests can't opt in by name
+- **New tool mixin not added to `KNOWN_TOOLS`** — other agents can't compose it by name
 - **Subprocess injection** — never pass user input directly to `subprocess.call`; use list args or `shlex.quote`
 - **`docs.json` not updated** — `.mdx` exists but Mintlify shows 404
 - **MCP init order** — if mixing `MCPClientMixin` with custom `__init__`, set `self._mcp_manager` *before* `super().__init__()`

--- a/.claude/agents/rag-specialist.md
+++ b/.claude/agents/rag-specialist.md
@@ -82,7 +82,7 @@ class MyAgent(RAGToolsMixin, Agent):   # Agent last in MRO
         # ... additional tools
 ```
 
-YAML-manifest agents just list `tools: [rag, file_search]` — the registry wires it up via `KNOWN_TOOLS`.
+Agents compose `RAGToolsMixin` directly in the class declaration; resolve it dynamically via `KNOWN_TOOLS["rag"]` (see [`src/gaia/agents/registry.py`](../../src/gaia/agents/registry.py)) when scaffolding.
 
 ## Chunking choices (trade-offs)
 

--- a/.claude/agents/sdk-architect.md
+++ b/.claude/agents/sdk-architect.md
@@ -29,7 +29,7 @@ src/gaia/
 ├── agents/base/       # Agent, MCPAgent, ApiAgent, @tool, AgentConsole, errors
 ├── agents/tools/      # Cross-agent tool mixins (file_tools, screenshot_tools)
 ├── agents/<name>/     # Concrete agents + per-agent tools/
-├── agents/registry.py # KNOWN_TOOLS + AgentManifest (YAML spec)
+├── agents/registry.py # AgentRegistry + KNOWN_TOOLS map
 ├── chat/              # AgentSDK (class `AgentSDK`, formerly `ChatSDK`)
 ├── rag/               # RAGSDK / RAGConfig
 ├── llm/               # LemonadeClient + providers/{claude,openai_provider,lemonade}.py

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -192,8 +192,8 @@ jobs:
             - **Standards Compliance:** Reference `CLAUDE.md` and `docs/reference/dev.mdx`
 
             ### 2. GAIA-Specific Architecture Checks
-            - **New agents** should preferably be registered via YAML manifest in `src/gaia/agents/registry.py` (Pydantic-validated) rather than a hand-rolled class, when the agent only needs existing tool mixins.
-            - **New tool mixins** MUST be added to `KNOWN_TOOLS` in `src/gaia/agents/registry.py` so YAML-manifest agents can declare them.
+            - **New agents** must be a Python `agent.py` (subclass of `Agent` with `AGENT_ID` / `AGENT_NAME` class attributes). YAML manifests were removed in v0.17.5 (#912).
+            - **New tool mixins** MUST be added to `KNOWN_TOOLS` in `src/gaia/agents/registry.py` so other agents can compose them by name; the BuilderAgent template uses this map to scaffold imports.
             - **New LLM providers** belong under `src/gaia/llm/providers/` with registration in `src/gaia/llm/factory.py` (`create_client`).
             - **AMD-specific paths** (NPU / Ryzen AI / Lemonade): use existing `src/gaia/llm/lemonade_client.py` — flag direct HTTP calls to the Lemonade server as a pattern violation.
             - **New CLI commands** need both an entry in `src/gaia/cli.py` subparsers AND `docs/reference/cli.mdx`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ gaia/
 │   │   ├── emr/        # MedicalIntakeAgent for healthcare (VLM)
 │   │   ├── routing/    # RoutingAgent for intelligent agent selection
 │   │   ├── sd/         # SDAgent for Stable Diffusion image generation
-│   │   └── registry.py # YAML-manifest agent registry + KNOWN_TOOLS map
+│   │   └── registry.py # Agent registry + KNOWN_TOOLS map
 │   ├── api/            # OpenAI-compatible REST API server
 │   ├── apps/           # Standalone applications
 │   │   ├── webui/      # Agent UI frontend (React/Vite/Electron)
@@ -374,7 +374,7 @@ Defined in [`setup.py`](setup.py) under `console_scripts`:
 
 ### Agent Registry & Tool Mixins
 
-New agents are preferably registered via YAML manifests validated by Pydantic in [`src/gaia/agents/registry.py`](src/gaia/agents/registry.py). The registry exposes `KNOWN_TOOLS` — a curated map of reusable tool mixins that agents opt into by name:
+New agents are Python classes inheriting from `Agent` (see [`src/gaia/agents/base/agent.py`](src/gaia/agents/base/agent.py)). Register tools with the `@tool` decorator and compose reusable mixins. [`src/gaia/agents/registry.py`](src/gaia/agents/registry.py) exposes `KNOWN_TOOLS` — a curated map of reusable tool mixins that agents can compose by name:
 
 | Tool name | Mixin | Purpose |
 |-----------|-------|---------|
@@ -386,7 +386,7 @@ New agents are preferably registered via YAML manifests validated by Pydantic in
 | `sd` | `gaia.sd.mixin.SDToolsMixin` | Stable Diffusion image generation |
 | `vlm` | `gaia.vlm.mixin.VLMToolsMixin` | Vision LLM / structured extraction |
 
-When adding a new tool, register it in `KNOWN_TOOLS` so YAML-manifest agents can declare it.
+When adding a new tool mixin, register it in `KNOWN_TOOLS` so other agents can compose it by name.
 
 ### Default Models
 - General tasks: `Qwen3-0.6B-GGUF`
@@ -677,7 +677,7 @@ Looking at your code, the issue is on line 45 where you're using subprocess.call
 Specialized agents live in `.claude/agents/` (23 total). Each agent file is the authoritative source for its scope, when-to-use / when-NOT-to-use triggers, and conventions — the summaries below are a pointer, not a replacement.
 
 ### Development
-- **gaia-agent-builder** — Creating a new GAIA agent (Python class or YAML manifest). Not for tuning an existing agent's prompt or adding a single tool.
+- **gaia-agent-builder** — Creating a new GAIA agent (Python class). Not for tuning an existing agent's prompt or adding a single tool.
 - **sdk-architect** — Public SDK surface design, cross-module consistency, breaking-change planning.
 - **python-developer** — Idiomatic Python 3.10+ inside `src/gaia/` (not new agents — use gaia-agent-builder).
 - **typescript-developer** — Type-safe TS for the Agent UI and Electron IPC.

--- a/docs/guides/code-index.mdx
+++ b/docs/guides/code-index.mdx
@@ -131,7 +131,7 @@ This launches `CodeAgent` with the `CodeIndexToolsMixin` already wired in, so th
 | `get_index_status` | Report current index state |
 | `clear_code_index` | Remove the cached index |
 
-YAML-manifest agents can opt in by listing `code_index` under `tools` — it's registered in `KNOWN_TOOLS` ([`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py)). For SDK-level composition see the [SDK reference](/sdk/sdks/code-index).
+Custom agents compose `CodeIndexToolsMixin` directly in their class declaration; it's also registered in `KNOWN_TOOLS["code_index"]` ([`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py)) for dynamic resolution. For SDK-level composition see the [SDK reference](/sdk/sdks/code-index).
 
 ### Example interaction
 

--- a/docs/sdk/sdks/code-index.mdx
+++ b/docs/sdk/sdks/code-index.mdx
@@ -201,17 +201,7 @@ class MyResearchAgent(CodeIndexToolsMixin, Agent):
 
 State is initialised lazily — calling `_init_code_index_state` is optional but recommended so the agent honours the repo path you intended.
 
-### Opting in from a YAML-manifest agent
-
-`code_index` is registered in `KNOWN_TOOLS` ([`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py)), so a manifest can list it directly:
-
-```yaml
-name: my_research_agent
-class_path: my_pkg.agent:MyResearchAgent
-tools:
-  - code_index   # composes CodeIndexToolsMixin
-  - file_search
-```
+`CodeIndexToolsMixin` is also registered in `KNOWN_TOOLS["code_index"]` ([`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py)) for dynamic composition when scaffolding agents — see the [custom-agent guide](/guides/custom-agent).
 
 ## Privacy and safety
 

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -280,11 +280,17 @@ class AgentRegistry:
                     if isinstance(raw_models, list):
                         bad = [m for m in raw_models if not isinstance(m, str)]
                         if bad:
+                            preview = bad[:5]
+                            suffix = (
+                                f" (and {len(bad) - 5} more)" if len(bad) > 5 else ""
+                            )
                             logger.warning(
                                 "registry: companion YAML %s: 'models' contains "
-                                "non-string entries %r — ignoring those",
+                                "%d non-string entries — ignoring (sample: %r%s)",
                                 yaml_file,
-                                bad,
+                                len(bad),
+                                preview,
+                                suffix,
                             )
                         models = [m for m in raw_models if isinstance(m, str)]
                     elif raw_models is not None:

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -278,6 +278,14 @@ class AgentRegistry:
                         )
                     raw_models = yaml_data.get("models")
                     if isinstance(raw_models, list):
+                        bad = [m for m in raw_models if not isinstance(m, str)]
+                        if bad:
+                            logger.warning(
+                                "registry: companion YAML %s: 'models' contains "
+                                "non-string entries %r — ignoring those",
+                                yaml_file,
+                                bad,
+                            )
                         models = [m for m in raw_models if isinstance(m, str)]
                     elif raw_models is not None:
                         logger.warning(

--- a/src/gaia/installer/export_import.py
+++ b/src/gaia/installer/export_import.py
@@ -144,10 +144,17 @@ def export_custom_agents(output_path: Path) -> ExportResult:
     if not agents_root.exists():
         raise ValueError("No custom agents found to export")
 
-    agent_dirs = sorted(
-        (d for d in agents_root.iterdir() if _is_custom_agent_dir(d)),
-        key=lambda p: p.name,
-    )
+    agent_dirs: List[Path] = []
+    for d in sorted(agents_root.iterdir(), key=lambda p: p.name):
+        if _is_custom_agent_dir(d):
+            agent_dirs.append(d)
+        elif d.is_dir() and (d / "agent.yaml").is_file():
+            log.warning(
+                "export: skipping legacy YAML-only agent directory %s "
+                "(YAML manifest agents were removed in v0.17.5; convert to "
+                "agent.py — see https://amd-gaia.ai/guides/custom-agent)",
+                d,
+            )
     if not agent_dirs:
         raise ValueError("No custom agents found to export")
 

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -196,6 +196,42 @@ class TestPythonAgentLoading:
         # Scalar models value must be rejected, leaving an empty list.
         assert reg.models == []
 
+    def test_companion_yaml_models_non_string_entries_warn(self, tmp_path, caplog):
+        """Non-string entries inside a list `models:` must be filtered with a
+        visible warning so users notice their YAML is malformed, instead of
+        silently dropping the bad values."""
+        agent_dir = tmp_path / "mixed-models"
+        agent_dir.mkdir()
+        (agent_dir / "agent.py").write_text(textwrap.dedent("""
+            from gaia.agents.base.agent import Agent
+
+            class MixedAgent(Agent):
+                AGENT_ID = "mixed-models"
+                AGENT_NAME = "Mixed Models"
+                def _get_system_prompt(self):
+                    return "test"
+                def _register_tools(self):
+                    pass
+        """))
+        (agent_dir / "agent.yaml").write_text(
+            "models:\n  - 123\n  - Qwen3-0.6B-GGUF\n  - null\n"
+        )
+
+        registry = AgentRegistry()
+        with caplog.at_level("WARNING", logger="gaia.agents.registry"):
+            registry._load_python_agent(
+                agent_dir, agent_dir / "agent.py", agent_dir / "agent.yaml"
+            )
+
+        reg = registry.get("mixed-models")
+        assert reg is not None
+        # String entries are kept; ints / None are filtered.
+        assert reg.models == ["Qwen3-0.6B-GGUF"]
+        # And there's an explicit warning naming the dropped entries.
+        assert any(
+            "non-string entries" in rec.getMessage() for rec in caplog.records
+        ), "expected a warning about non-string `models:` entries"
+
 
 # ---------------------------------------------------------------------------
 # Directory-based discovery

--- a/tests/unit/test_export_import.py
+++ b/tests/unit/test_export_import.py
@@ -503,9 +503,10 @@ def test_import_bundle_dir_with_no_agent_py_surfaces_error(
     assert not (agents_root / "no-py-bot").exists()
 
 
-def test_export_skips_yaml_only_dirs(tmp_path, fake_home, agents_root):
-    """Export should ignore legacy YAML-only directories silently rather
-    than emitting a bundle the importer would reject."""
+def test_export_skips_yaml_only_dirs(tmp_path, fake_home, agents_root, caplog):
+    """Export should drop legacy YAML-only directories from the bundle (the
+    importer would reject them) but emit a visible log warning per skipped
+    dir so users notice and migrate."""
     py_dir = agents_root / "py-bot"
     py_dir.mkdir()
     (py_dir / "agent.py").write_text("# python\n")
@@ -515,5 +516,11 @@ def test_export_skips_yaml_only_dirs(tmp_path, fake_home, agents_root):
     (yaml_dir / "agent.yaml").write_text("id: yaml-bot\nname: YAML Bot\n")
 
     out = tmp_path / "export.zip"
-    result = export_custom_agents(out)
+    with caplog.at_level("WARNING", logger="gaia.installer.export_import"):
+        result = export_custom_agents(out)
     assert result.agent_ids == ["py-bot"]
+    skip_warnings = [rec for rec in caplog.records if "yaml-bot" in rec.getMessage()]
+    assert (
+        len(skip_warnings) == 1
+    ), "expected exactly one warning naming the skipped YAML-only directory"
+    assert "v0.17.5" in skip_warnings[0].getMessage()

--- a/tests/unit/test_export_import.py
+++ b/tests/unit/test_export_import.py
@@ -523,4 +523,8 @@ def test_export_skips_yaml_only_dirs(tmp_path, fake_home, agents_root, caplog):
     assert (
         len(skip_warnings) == 1
     ), "expected exactly one warning naming the skipped YAML-only directory"
-    assert "v0.17.5" in skip_warnings[0].getMessage()
+    msg = skip_warnings[0].getMessage().lower()
+    assert "yaml" in msg and "agent.py" in msg, (
+        "warning should explain why the dir was skipped and what to do — "
+        f"got: {skip_warnings[0].getMessage()!r}"
+    )

--- a/util/check_agent_conventions.py
+++ b/util/check_agent_conventions.py
@@ -14,7 +14,6 @@ Hard checks (block CI on failure):
 - ``_register_tools`` contains ``_TOOL_REGISTRY.clear()`` (when defined locally)
 - Copyright header + SPDX line present
 - ``KNOWN_TOOLS`` entries in registry.py resolve to importable classes
-- Manifest JSON Schema is not stale
 
 Soft checks (non-blocking warnings):
 - A test file exists (``tests/test_<name>.py`` or ``tests/<name>/``)


### PR DESCRIPTION
## Summary

Follow-up to [#914](https://github.com/amd/gaia/pull/914). The github-actions review-bot left a batch of doc-cleanup suggestions that landed after merge — onboarding files (`CLAUDE.md`, `.github/workflows/claude.yml`, `.claude/agents/*.md`) and a couple of SDK doc subsections still told contributors to register agents via YAML manifests, directly contradicting the Python-only registry shipped in #914. Same drift class the [`TestRemovedSymbols`](https://github.com/amd/gaia/blob/main/tests/unit/agents/test_registry.py) regression guard exists to prevent — it just didn't extend to prose docs and `.claude/agents/`.

Also folds in the two silent-drop polish items the bot flagged: companion YAML `models:` filtering and `export_custom_agents` skipping legacy YAML-only directories.

## Threads

- **Onboarding/agent-doc cleanup** — `CLAUDE.md` (4 spots), `.github/workflows/claude.yml` (review-bot guidance), `.claude/agents/{gaia-agent-builder,sdk-architect,code-reviewer,architecture-reviewer,rag-specialist}.md`. Why: contributors and the `gaia-agent-builder` Claude agent read these as authoritative — leaving them stale would steer new agents back into the deleted YAML path.
- **SDK doc subsections** — drops the dead "Opting in from a YAML-manifest agent" snippet in [docs/sdk/sdks/code-index.mdx](docs/sdk/sdks/code-index.mdx) and rewrites the equivalent line in [docs/guides/code-index.mdx](docs/guides/code-index.mdx) to describe Python-class composition. Why: example showed a YAML format that no longer loads.
- **Linter docstring** — `util/check_agent_conventions.py` listed "Manifest JSON Schema is not stale" under hard checks, but the corresponding `_check_manifest_schema()` was deleted in #914. Drop the stale bullet.
- **Loud-failure polish** — [`registry.py`](src/gaia/agents/registry.py) now warns when companion YAML `models:` contains non-string entries instead of silently filtering them; [`export_import.py`](src/gaia/installer/export_import.py) emits one `log.warning` per skipped YAML-only directory during export so users get the same migration signal the discovery path already gives. Why: matches the "no silent fallback / actionable error" rule from CLAUDE.md.

Two new test cases guard the warnings.

## Test plan

- [x] `python -m pytest tests/unit/agents/test_registry.py tests/unit/test_export_import.py -xvs` — 46 passed
- [x] `python util/check_agent_conventions.py` — 0 errors
- [x] `python util/lint.py --black --isort` — pass
- [x] grep -rn "YAML-manifest agents can\|or YAML manifest\|registered via YAML manifest\|AgentManifest" `CLAUDE.md .claude/ .github/ docs/sdk/ docs/guides/code-index.mdx util/` — zero hits (migration guide and release notes intentionally retained)

Refs #914.