### PR TITLE
docs(contributing): refresh issue/PR templates and contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,203 +2,91 @@
 # SPDX-License-Identifier: MIT
 
 name: Bug Report
-description: Help us improve GAIA by sharing your experience. We appreciate your feedback!
+description: Report something that is broken in GAIA.
 title: '[Bug]: '
 labels: ['bug', 'triage']
 body:
   - type: markdown
     attributes:
       value: |
-        # Welcome! 👋
-
-        Thanks for taking the time to help improve GAIA! Before submitting, you might want to check our [Issues](https://github.com/amd/gaia/issues) to see if someone else has reported something similar
-        
-        Don't worry if you can't fill out all the fields - just share what you can and we'll work together to figure it out!
+        Thanks for taking the time to report a bug! Please [search existing issues](https://github.com/amd/gaia/issues) first — your bug may already be tracked.
 
   - type: checkboxes
-    id: issue-check
+    id: quick-check
     attributes:
-      label: Quick Check ✨
-      description: Let us know if you've had a chance to look around
+      label: Quick check
+      description: Help us route this faster.
       options:
-        - label: I've taken a look at existing issues and discussions
+        - label: I've searched existing issues and didn't find a duplicate.
           required: false
-        - label: I've checked the hardware requirements in the docs
+        - label: This issue relates to **Gaia Agent UI** (`gaia chat --ui`).
           required: false
-        - label: This issue relates to GAIA UI (Open-WebUI)
+        - label: This issue relates to a CLI command (`gaia ...`) or the SDK.
           required: false
 
   - type: input
     id: gaia-version
     attributes:
-      label: Which version of GAIA are you using?
-      description: For example, v0.8 - don't worry if you're not sure!
+      label: GAIA version
+      description: Output of `gaia --version`, or the installer/release you used.
+      placeholder: e.g. v0.19.0
     validations:
       required: false
 
   - type: textarea
-    id: reproduction-details
+    id: what-happened
     attributes:
-      label: Details to help us reproduce the issue
-      description: Please provide as much information as possible to help us understand what's happening
+      label: What happened?
+      description: Steps to reproduce, plus what you observed. Include error messages, logs, screenshots, or model/prompt details if relevant.
       placeholder: |
         Steps to reproduce:
-        1. Open GAIA
-        2. Click on '...'
-        3. Try to '...'
-        4. See error '...'
-        
-        Model used (if applicable): 
-        For example, Mistral-7B-Instruct-v0.3 or Llama3.1:8b
-        
-        Prompt used (if relevant):
-        Share what you asked the model
-        
-        Response received (if relevant):
-        Share what response you got back
-        
-        Error messages or screenshots:
-        - Installation logs (usually in C:\Users\<username>\AppData\Local\GAIA\gaia_install.log)
-        - Screenshots of Task Manager showing hardware usage
-        - Any error messages you saw
-    validations:
-      required: false
+        1. Run `gaia ...`
+        2. ...
+        3. See error: ...
 
-  - type: textarea
-    id: actual-behavior
-    attributes:
-      label: What actually happened?
-      description: Share what you observed instead
-      placeholder: For example, "I got an error message saying 'Connection failed'..." or "The application crashed when I tried to..."
+        Model used (if applicable): e.g. Qwen3.5-35B-A3B-GGUF
+        Prompt used (if relevant): ...
+        Error / log output: ...
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: expected-behavior
     attributes:
       label: What did you expect to happen?
-      description: Tell us what you were trying to do
-      placeholder: For example, "I expected the model to load when I clicked..."
+      placeholder: e.g. The model should have loaded and responded.
     validations:
       required: false
 
-  - type: dropdown
-    id: installation-method
+  - type: textarea
+    id: acceptance-criteria
     attributes:
-      label: How did you install GAIA?
-      description: This helps us understand your setup better
-      options:
-        - Installer
-        - Git Clone
-        - Manual Setup
+      label: Acceptance criteria
+      description: How will we know this is fixed? 1–3 short bullets, if you can.
+      placeholder: |
+        - `gaia chat` exits cleanly when Lemonade is unreachable
+        - User sees an actionable error pointing to `gaia init`
     validations:
       required: false
 
-  - type: dropdown
-    id: mode-selection
+  - type: textarea
+    id: environment
     attributes:
-      label: Which mode are you running?
-      description: Let us know how in what configuration you're running GAIA
-      options:
-        - Hybrid
-        - Generic
-        - NPU
-    validations:
-      required: false
-
-  - type: dropdown
-    id: cpu-model
-    attributes:
-      label: What's your CPU?
-      description: Tell us about your processor - please specify your exact model in the additional info section if selecting "Other". The current list of supported CPUs can be found [here](https://www.amd.com/en/products/software/ryzen-ai-software.html#tabs-2733982b05-item-7720bb7a69-tab).
-      options:
-        - AMD Ryzen AI 9 HX 9845HS
-        - AMD Ryzen AI 9 HX 9945HS
-        - AMD Ryzen AI 9 HX 370
-        - AMD Ryzen AI 9 365
-        - AMD Ryzen AI 7 HX 9745HS
-        - AMD Ryzen AI 7 HX 9845HS
-        - AMD Ryzen AI 7 HX 370
-        - AMD Ryzen AI 7 365
-        - AMD Ryzen AI 5 HX 9645HS
-        - AMD Ryzen AI 5 365
-        - AMD Ryzen 9 7945HX
-        - AMD Ryzen 9 7940HS
-        - AMD Ryzen 7 7840HS
-        - AMD Ryzen 5 7640HS
-        - Other (please specify in comments)
-    validations:
-      required: false
-
-  - type: dropdown
-    id: gpu-info
-    attributes:
-      label: What about your GPU setup?
-      description: Tell us about your graphics configuration. If selecting dGPU or Other, please provide more details in the additional info section
-      options:
-        - Integrated GPU (iGPU) only
-        - Discrete AMD GPU (dGPU)
-        - External GPU via Oculink/Thunderbolt
-        - NVIDIA GPU
-        - Intel GPU
-        - Other
-    validations:
-      required: false
-
-  - type: input
-    id: gpu-driver-version
-    attributes:
-      label: AMD GPU Driver Version
-      description: What's your AMD GPU driver version? To find this, go to Device Manager > Display adapters > AMD Radeon Graphics > Right-click Properties > Driver tab > Driver Version, or check in AMD Software.
-      placeholder: For example, 32.0.12033.1030
-    validations:
-      required: false
-
-  - type: input
-    id: npu-driver-version
-    attributes:
-      label: NPU Driver Version
-      description: What's your NPU driver version? To find this, go to Device Manager > System Devices > Neural Processing Unit > NPU Compute Accelerator Device > Right-click Properties > Driver tab > Driver Version.
-      placeholder: For example, 32.0.203.257
-    validations:
-      required: false
-
-  - type: input
-    id: lemonade-version
-    attributes:
-      label: Lemonade Version (if applicable)
-      description: If you're using Lemonade, which version? You can find this version by following the instructions [here](https://github.com/aigdat/genai/blob/8f034613f8d0acf18cf1846e1ea0090406c76546/docs/lemonade/server_integration.md#identifying-existing-installation).
-      placeholder: For example, v0.6.1.3
-    validations:
-      required: false
-
-  - type: input
-    id: operating-system
-    attributes:
-      label: What's your operating system?
+      label: Environment
       description: |
-        Which OS are you running GAIA on?
-        
-        For Windows: Right-click on Start > System > About, or press Win+I > System > About
-        For Linux: Open Terminal and type `lsb_release -a` or `cat /etc/os-release`
-      placeholder: For example, Windows 11 22H2, Windows 10 21H2, Ubuntu 22.04
+        Anything about your setup that could matter — OS, CPU/NPU model, GPU, driver versions, Lemonade Server version, install method (Installer / Git Clone / Manual), mode (Hybrid / Generic / NPU). Skip what doesn't apply. Please redact any tokens or credentials before pasting logs.
+      placeholder: |
+        OS: Windows 11 23H2
+        CPU / NPU: AMD Ryzen AI 9 HX 370
+        GPU: iGPU only
+        Lemonade: v0.6.1
+        Install: Installer
+        Mode: Hybrid
     validations:
       required: false
 
   - type: markdown
     attributes:
       value: |
-        ## Thank You! 🙌
-        
-        Your feedback helps make GAIA better for everyone! We'll look into this as soon as we can.
-        
-        The more details you can share, the better we can help, but don't worry if you can't provide everything.
-        Key things that often help us investigate:
-        - Steps to reproduce what you're seeing
-        - Any error messages or logs
-        - Your hardware and software setup
-        - Driver versions (if using NPU or GPU features)
-        
-        Feel free to check our [README.md](https://github.com/amd/gaia/blob/main/README.md) and [FAQ.md](https://github.com/amd/gaia/blob/main/FAQ.md) while you wait for a response.
-        
-        We appreciate your help in improving GAIA! 💫
+        ---
+        Need a hand? See the [README](https://github.com/amd/gaia/blob/main/README.md), [FAQ](https://amd-gaia.ai/reference/faq), and [troubleshooting guide](https://amd-gaia.ai/reference/troubleshooting). Thanks for helping make GAIA better!

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,55 +2,59 @@
 # SPDX-License-Identifier: MIT
 
 name: Feature Request
-description: Share your ideas to help make GAIA even better! 💡
+description: Suggest an improvement or new capability for GAIA.
 title: 'feat: '
-labels: ['triage', 'enhancement']
+labels: ['enhancement', 'triage']
 body:
   - type: markdown
     attributes:
       value: |
-        # Welcome! 👋 
-
-        Thanks for thinking about ways to improve GAIA! Your ideas help make this project better for everyone.
-        
-        Before sharing your idea, you might want to check our [Issues](https://github.com/amd/gaia/issues) to see if someone else has suggested something similar.
-        
-        We love hearing new ideas and appreciate constructive feedback! 🌟
+        Thanks for sharing your idea! Please [search existing issues](https://github.com/amd/gaia/issues) first — your idea may already be tracked or in progress.
 
   - type: checkboxes
-    id: existing-issue
+    id: quick-check
     attributes:
-      label: Quick Check ✨
-      description: Let us know if you've had a chance to look around
+      label: Quick check
+      description: Help us route this faster.
       options:
-        - label: I've taken a look at existing feature requests
+        - label: I've searched existing issues and didn't find a duplicate.
           required: false
-        - label: This feature request relates to GAIA UI (Open-WebUI)
+        - label: This relates to **Gaia Agent UI** (`gaia chat --ui`).
+          required: false
+        - label: This relates to the SDK, CLI, or a specific agent.
           required: false
 
   - type: textarea
-    id: feature-description
+    id: problem
     attributes:
-      label: What's on your mind?
-      description: |
-        Share what challenge you're facing and your proposed solution. For example:
-        - "It would be helpful if... because I often need to..."
-        - "I wish GAIA could... which would work by..."
-        - Feel free to include examples, similar features from other tools, or mockups
+      label: What problem are you trying to solve?
+      description: Describe the underlying need — the user, the workflow, what's painful or impossible today. Focus on the problem, not the solution.
+      placeholder: |
+        e.g. "When I run `gaia chat --ui` on a machine without an NPU, the error message doesn't tell me what to do — I have to dig through logs to figure out I need a different mode."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: If you have an idea for how to address it, share it here. Sketches, examples from other tools, and rough API shapes are all welcome.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? 1–3 short bullets, if you can.
+      placeholder: |
+        - `gaia chat --ui` on a non-NPU machine prints an actionable error
+        - The error names the supported alternatives and links to setup docs
     validations:
       required: false
 
   - type: markdown
     attributes:
       value: |
-        ## Thank You! 🙌
-        
-        We really appreciate you taking the time to share your ideas with us! Your feedback helps shape the future of GAIA.
-        
-        While we review all suggestions, please understand that we need to prioritize based on various factors and resources.
-        Feel free to:
-        - Add comments if you think of additional details
-        - Share more context or examples
-        - Help others by commenting on their ideas too
-        
-        Together, we can make GAIA even better! ✨
+        ---
+        Thanks for helping shape GAIA! We review every suggestion and prioritize based on impact and capacity.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,48 @@
+<!--
+Thanks for contributing to GAIA! Every PR must reference a GitHub issue —
+see CONTRIBUTING.md (https://github.com/amd/gaia/blob/main/CONTRIBUTING.md)
+if you don't have one yet.
+-->
+
+## Summary
+
+<!-- 1–2 sentences describing what this PR does, in plain English. -->
+
+## Why
+
+<!--
+Why is this change being made? What problem does it solve, what was missing,
+or what was painful? Reviewers need the motivation, not just the diff.
+-->
+
+## Linked issue
+
+<!--
+Required. Use a closing keyword so the issue auto-closes on merge.
+Example:  Closes #123
+If this PR only partially addresses an issue, use `Refs #123` instead.
+-->
+
+Closes #N <!-- replace N with the issue number, e.g. Closes #123 -->
+
 ## Changes
 
-<!-- Briefly describe your changes in bulleted form -->
+<!-- Bullet list of the meaningful changes a reviewer should know about. -->
+
 -
--
--
+
+## Test plan
+
+<!--
+How can a reviewer verify this works? Specific commands beat vague prose.
+Mix automated and manual checks as needed.
+-->
+
+- [ ]
+
+## Checklist
+
+- [ ] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
+- [ ] I have described **why** this change is being made, not just what changed.
+- [ ] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
+- [ ] I have updated documentation if user-visible behavior changed (see [CONTRIBUTING.md](../CONTRIBUTING.md)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,92 @@
 # Contributing to GAIA
 
-🚀 **Welcome to the GAIA Community!** 🚀
+Welcome! GAIA is AMD's open-source framework for running generative AI locally on AMD hardware. We appreciate your interest in making it better — bug reports, feature ideas, and pull requests are all valuable.
 
-We're excited that you're interested in making GAIA better! Whether you're reporting an issue, suggesting improvements, or contributing code, your help is valuable to us. Let's work together to make GAIA even more amazing!
+This guide covers the general contribution workflow. For documentation-specific contributions, see [`docs/reference/contributing-docs.mdx`](docs/reference/contributing-docs.mdx).
 
-### 🐛 Sharing Issues and Ideas
+---
 
-Found a bug or have a suggestion? We'd love to hear from you! Here's how you can help:
+## Before you open a pull request — open an issue first
 
-1. Take a quick look at our [Issues tab](https://github.com/amd/gaia/issues) to see if someone else has reported something similar
-2. If you don't find anything similar, feel free to open a new issue
-3. We have friendly templates to help guide you through sharing the information that will help us understand and address your report
+**Every pull request must reference a GitHub issue.** If an issue doesn't exist for what you're working on, please file one before you start coding using the [bug report](https://github.com/amd/gaia/issues/new?template=bug_report.yaml) or [feature request](https://github.com/amd/gaia/issues/new?template=feature_request.yaml) template.
 
-When reporting issues, try to include:
-- What you were trying to do
-- What happened instead
-- Any error messages or screenshots that might help
-- Your setup (OS, hardware, GAIA version)
+Why we ask:
 
-The more details you can share, the better we can help - but don't worry if you can't provide everything!
+- It lets us discuss scope, design, and prior art **before** code is written, so reviews focus on implementation rather than direction.
+- It avoids wasted effort if the change conflicts with planned work or the GAIA roadmap.
+- It keeps the changelog and release notes usable — every shipped change can be traced to a tracked issue.
 
-### 💡 Contributing Code
+**Rare exceptions** (still helpful, but no issue required):
 
-Want to help improve GAIA directly? That's fantastic! Here's how you can get started:
+- Typo fixes or single-line documentation tweaks.
+- Doc-only changes under ~10 lines.
 
-1. **Pick an Issue**: Find something you'd like to work on or fix
-2. **Let Us Know**: Comment on the issue to let others know you're working on it
-3. **Make Your Changes**: 
-   - Follow the project's coding style
-   - Add tests for new features if possible
-   - Update documentation as needed
-   - Keep your changes focused and specific
-4. **Submit a Pull Request**: 
-   - Describe what you're trying to solve
-   - Explain how your changes address the issue
-   - Keep an eye on any feedback or questions
+If you're unsure whether your change qualifies, file an issue — it costs nothing and we can fast-track it.
 
-### 📝 Documentation
+---
 
-Clear documentation helps everyone! You can help by:
-- Fixing typos or unclear instructions
-- Adding examples or use cases
-- Creating guides or tutorials
-- Improving existing documentation
+## Filing an issue
 
-### ⏱️ Timeline Expectations
+Use the templates — they're short and we genuinely use every field:
 
-We try to review and respond to contributions as quickly as we can. To help keep things moving:
-- We aim to acknowledge new issues and PRs within a few days
-- For pull requests, try to be responsive to any feedback
-- If you need to step away from a PR you're working on, just let us know
+- **[Bug report](https://github.com/amd/gaia/issues/new?template=bug_report.yaml)** — what broke, how to reproduce, what you expected.
+- **[Feature request](https://github.com/amd/gaia/issues/new?template=feature_request.yaml)** — the **problem** you're trying to solve. We can usually find a good solution if the problem is clear; the reverse is harder.
 
-### 🤝 Working Together
+Both templates have an optional **Acceptance criteria** field. If you can fill it in, please do — it makes the issue immediately ready to scope, and the resulting PR has a clear definition of done.
 
-Remember:
-- Every contribution, no matter how small, is valuable
-- Be kind and respectful in your interactions
-- Ask questions if you're unsure about anything
-- Help others when you can
+For security issues, **do not file a public issue** — open a private [security advisory](https://github.com/amd/gaia/security/advisories/new) instead.
 
-## 🌟 Thank You!
+---
 
-Your interest in improving GAIA means a lot to us. Whether you're reporting bugs, suggesting features, or contributing code, you're helping make GAIA better for everyone.
+## Submitting a pull request
 
-Let's build something amazing together! ✨
+1. **Claim the issue** — comment on it so others know you're working on it.
+2. **Branch off `main`** with a descriptive name (e.g. `fix/lemonade-startup-error`, `feat/jira-bulk-update`).
+3. **Use the [PR template](.github/pull_request_template.md)** — every field matters. Don't delete sections; if a section doesn't apply, say so.
+4. **Link the issue** with `Closes #N` (or `Fixes #N`, `Refs #N` for partial work). GitHub will auto-close the issue on merge.
+5. **Run lint and tests locally** before pushing:
+   ```bash
+   python util/lint.py --all --fix
+   pytest tests/unit/
+   ```
+6. **Keep the PR scope-clean** — one logical thread per PR. No drive-by formatting, no unrelated refactors. If you spot something else worth fixing, file a separate issue.
+
+### What we expect in the PR description
+
+The PR template asks for these because they make review faster and better:
+
+- **Summary** — what changed, in plain English. *Not* a copy of the commit log.
+- **Why** — the motivation. "Fixes a crash on startup" beats "Refactors `LemonadeClient`."
+- **Linked issue** — `Closes #N` at the top.
+- **Test plan** — specific commands or steps a reviewer can run. `pytest tests/unit/test_chat.py -k startup` is signal; "I tested it" is not.
+
+A good Summary + Why example:
+
+> **Summary:** Replace the silent fallback in `LemonadeClient` with a clear startup-time error.
+> **Why:** When Lemonade Server isn't running, GAIA was returning empty responses with no indication of why. Users were filing bugs for the silent failure rather than the underlying setup issue.
+
+---
+
+## Code style and testing
+
+Development setup, lint commands, and the test layout live in [`docs/reference/dev.mdx`](docs/reference/dev.mdx) — please follow that guide rather than relying on commands quoted here, since it's the canonical source. New features need tests; the [`tests/`](tests/) directory has examples for unit, integration, MCP, and CLI testing patterns.
+
+---
+
+## Documentation contributions
+
+If you're adding or updating documentation, see the [Documentation Contribution Guide](docs/reference/contributing-docs.mdx) for which `docs/` directory to use (guides, playbooks, SDK reference, specifications, or reference). Documentation contributions still follow the issue-then-PR rule, except for the typo/small-edit exceptions noted above.
+
+---
+
+## Review timeline
+
+We aim to acknowledge new issues and PRs within a few days. For pull requests, please stay responsive to review comments — if you need to step away, leave a quick comment so we know whether to wait or pick it up.
+
+---
+
+## Conduct
+
+Be kind, be patient, and assume good intent. Most contributors are working on this in their own time — that includes maintainers reviewing your PR. We're all here to make GAIA better.
+
+Thanks for contributing!

--- a/docs/reference/contributing-docs.mdx
+++ b/docs/reference/contributing-docs.mdx
@@ -6,6 +6,10 @@ icon: "pen-to-square"
 
 This guide clarifies what goes where in GAIA documentation and how to contribute.
 
+<Note>
+**Contributing code or filing issues?** See [CONTRIBUTING.md](https://github.com/amd/gaia/blob/main/CONTRIBUTING.md) for the general contribution guide, including the requirement that every pull request links a GitHub issue. This page covers documentation contributions only.
+</Note>
+
 ---
 
 ## The Problem


### PR DESCRIPTION
## Summary

Refresh the GitHub issue templates, PR template, and `CONTRIBUTING.md` so external contributors arrive with the structure maintainers already enforce in review. First of three PRs for the contributor-onboarding refresh tracked in #929.

## Why

The current templates are stale and under-enforced. Both issue templates ask whether the bug relates to "GAIA UI (Open-WebUI)" — a UI that no longer exists; the PR template is a four-line `## Changes` stub with no required fields, no linked-issue prompt, and no statement of *why*; and `CONTRIBUTING.md` never states the rule that every PR must reference an issue. The result is the same review-time coaching ("please file an issue first", "please describe why") happening on every external PR. This PR moves those rules into the templates and the contributing guide so reviewers can point at the docs instead of restating them.

The PR-template structure mirrors the rules already in [`CLAUDE.md`'s "PR Descriptions — Tight and Value-Focused"](https://github.com/amd/gaia/blob/main/CLAUDE.md#important-pr-descriptions--tight-and-value-focused) section so the rule and the form stay in sync.

## Linked issue

Refs #929 — first of three PRs. PR 2 (docs cleanup) and PR 3 (regression workflow) follow.

## Changes

- **`.github/ISSUE_TEMPLATE/bug_report.yaml`** — streamlined from 13 fields to 6. Replaced "GAIA UI (Open-WebUI)" with "Gaia Agent UI". Consolidated 7 hardware dropdowns/inputs into one freeform Environment textarea (uses `placeholder:` so untouched submissions stay clean). Added optional Acceptance Criteria. `What happened?` is now required. Added "redact tokens/credentials before pasting logs" guidance.
- **`.github/ISSUE_TEMPLATE/feature_request.yaml`** — streamlined. Replaced "GAIA UI (Open-WebUI)". Renamed primary field to "What problem are you trying to solve?" (required) so contributors lead with the problem, not a solution. Added optional Proposed solution and Acceptance Criteria fields.
- **`.github/pull_request_template.md`** — replaced 4-line stub with structured template: Summary / Why / Linked issue (`Closes #N`) / Changes / Test plan / Checklist. Linked-issue placeholder is visibly `Closes #N` so an unfilled template renders as obvious placeholder rather than a silently-empty `Closes #`.
- **`CONTRIBUTING.md`** — revamped as the canonical general guide. Adds a prominent "Before you open a pull request — open an issue first" section that explicitly states the rule, with the rare exceptions (typo fixes, doc-only changes under ~10 lines) called out.
- **`docs/reference/contributing-docs.mdx`** — added a Mintlify `<Note>` at the top pointing readers to `CONTRIBUTING.md` for code/issue contributions; the docs-taxonomy guide is otherwise unchanged.

## Test plan

- [x] YAML syntax valid: `python3 -c "import yaml; yaml.safe_load(open(...))"` passes for both issue templates.
- [x] Stale-string sweep on this PR's surface: `grep -rEn -i "open[-]?webui|GAIA UI" .github/ CONTRIBUTING.md` returns zero matches. (The remaining `docs/` hits are PR 2's scope, tracked in #929.)
- [x] `code-reviewer` agent reviewed the diff; two suggestions applied (dead `SECURITY.md` link removed; raw-YAML template links swapped for rendered `?template=` URLs).
- [x] Adversarial multi-agent reflection (`/reflect-plan`) completed; three auto-amendments applied: bug-report Environment field switched from `value:` → `placeholder:` (HTML-comment template was being submitted into issue bodies), `Closes #` → `Closes #N` for visible-placeholder UX, removed duplicate lint/test code block in `CONTRIBUTING.md` (already linked to `dev.mdx`).
- [ ] **Manual render check after merge**: open `https://github.com/amd/gaia/issues/new?template=bug_report.yaml` and `?template=feature_request.yaml` — confirm "Gaia Agent UI" text, no "Open-WebUI", required fields render with red asterisks.
- [ ] **Manual PR template check after merge**: next PR opened against `main` should pre-fill with the new structure.

## Checklist

- [x] I have linked a GitHub issue above (`Refs #929` — `Closes` will be on PR 3 of the series).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally — N/A for templates/markdown; YAML validity verified directly.
- [x] I have updated documentation if user-visible behavior changed (`CONTRIBUTING.md` and `docs/reference/contributing-docs.mdx` updated; `docs/docs.json` nav unchanged because the page IDs are stable).