### PR TITLE
docs(deployment): remove RAUX/Open-WebUI references from docs

### DIFF
--- a/docs/deployment/ui.mdx
+++ b/docs/deployment/ui.mdx
@@ -40,7 +40,7 @@ The GAIA Agent UI is distributed as an [npm package](https://www.npmjs.com/packa
   [Agent UI guide](/guides/agent-ui) for details.
 </Warning>
 
-Install GAIA UI on Windows and Ubuntu using the packages from the GitHub
+Install GAIA Agent UI on Windows and Ubuntu using the packages from the GitHub
 [Releases](https://github.com/amd/gaia/releases) page (when available).
 Artifact names follow
 `gaia-agent-ui-<version>-<arch>-setup.<ext>` (see `electron-builder.yml`).
@@ -108,13 +108,15 @@ gaia diagnostics
 ```
 Attach the resulting `~/.gaia/diagnostics-*.tgz` to your GitHub issue.
 
-# GAIA Chat (Lightweight Desktop)
+---
 
-GAIA Chat is a lightweight, privacy-first desktop chat application built with a Python FastAPI backend and a minimal web frontend. It is designed as a lighter alternative to RAUX, focused specifically on chat and document Q&A.
+# Gaia Agent UI Architecture
+
+The Gaia Agent UI is a privacy-first desktop chat application built with a Python FastAPI backend and a React/TypeScript frontend, packaged as an Electron desktop app.
 
 ## Key Features
 
-- **Privacy-first**: All data stays local -- no cloud, no telemetry
+- **Privacy-first**: All data stays local — no cloud, no telemetry
 - **Document Q&A**: Drag-and-drop 50+ file formats for RAG-powered search
 - **Session management**: Create, rename, export, and delete conversations
 - **Streaming responses**: Real-time SSE streaming from local LLMs
@@ -124,7 +126,7 @@ GAIA Chat is a lightweight, privacy-first desktop chat application built with a 
 ## Architecture
 
 ```
-GAIA Chat Desktop
+Gaia Agent UI
   Electron Shell (optional) or Browser
     |
     v
@@ -153,43 +155,11 @@ python -m gaia.ui.server
 ```
 
 For full documentation, see:
-- [GAIA Chat Desktop Guide](/guides/agent-ui) -- User guide with features and troubleshooting
-- [Agent UI SDK Reference](/sdk/sdks/agent-ui) -- Python backend API documentation
-- [Agent UI Server Spec](/spec/agent-ui-server) -- Technical specification
+- [Gaia Agent UI Guide](/guides/agent-ui) — User guide with features and troubleshooting
+- [Agent UI SDK Reference](/sdk/sdks/agent-ui) — Python backend API documentation
+- [Agent UI Server Spec](/spec/agent-ui-server) — Technical specification
 
 ---
-
-# GAIA UI (RAUX) Interface
-
-**GAIA UI (also referred to as RAUX for RyzenAI User Experience)** is a modern Electron-based desktop application that provides the primary interface for GAIA. Built as a fork from [Open-WebUI](https://github.com/open-webui/open-webui), it delivers an extensible, feature-rich, and user-friendly AI platform experience. GAIA UI is actively developed with regular feature updates and improvements.
-
-## New in GAIA UI (RAUX)
-- Improved error handling and progress reporting via inter-process communication (IPC) between the main and renderer processes.
-- Unified GAIA UI branding and updated messaging throughout the installer and UI.
-
-### 🙏 **Acknowledgments: RAUX & OpenWebUI**
-
-#### **Built on OpenWebUI Foundation**
-
-RAUX (RyzenAI UX) is built upon the excellent foundation provided by **OpenWebUI**, an outstanding open-source project that has revolutionized how users interact with AI models through web interfaces.
-
-#### **Special Thanks**
-
-We extend our heartfelt gratitude to:
-
-- **[Timothy Jaeryang Baek](https://github.com/tjbck)** and the entire **OpenWebUI team** for creating and maintaining such an exceptional open-source project
-- The **OpenWebUI community** for their continuous contributions, feedback, and innovation
-- All **open-source contributors** who have helped shape the modern AI interface landscape
-
-#### **Open Source Heritage**
-
-GAIA UI builds upon OpenWebUI's solid architectural foundation while adding AMD-specific optimizations and integrations tailored for the GAIA ecosystem. This collaboration exemplifies the power of open-source software in advancing AI accessibility and user experience. The OpenWebUI project's commitment to creating intuitive, powerful, and extensible AI interfaces has made GAIA UI possible. 
-
-**Learn more about OpenWebUI**: [https://github.com/open-webui/open-webui](https://github.com/open-webui/open-webui)
-
----
-
-For more information about GAIA UI (RAUX), including setup instructions and feature documentation, please refer to the [RAUX GitHub repository README](https://github.com/aigdat/raux/blob/main/README.md).
 
 # License
 

--- a/docs/guides/custom-agent.mdx
+++ b/docs/guides/custom-agent.mdx
@@ -10,7 +10,7 @@ icon: "wand-magic-sparkles"
 
 ## Overview
 
-GAIA's agent registry lets you extend the Agent UI with your own custom agents. Each agent lives in its own directory under `~/.gaia/agents/` as a Python module. Once placed there, the agent appears automatically in the **agent selector** dropdown of the GAIA UI.
+GAIA's agent registry lets you extend the Agent UI with your own custom agents. Each agent lives in its own directory under `~/.gaia/agents/` as a Python module. Once placed there, the agent appears automatically in the **agent selector** dropdown of the Gaia Agent UI.
 
 Custom agents can have their own:
 - **Personality and instructions** (system prompt)

--- a/docs/plans/axis-gaia-integration.md
+++ b/docs/plans/axis-gaia-integration.md
@@ -159,7 +159,7 @@ axis run --policy ~/.axis/policies/gaia-mvp.yaml -- \
 
 **Step 3 — Run the demo sequence**
 
-From the GAIA UI, send two chat messages to `ChatAgent`:
+From the Gaia Agent UI, send two chat messages to `ChatAgent`:
 
 1. *"Summarize the README from this directory."* — uses the local RAG/file tool. Expected: works normally. Confirm in the audit log that only `localhost:13305` network activity is recorded.
 

--- a/docs/plans/desktop-installer.mdx
+++ b/docs/plans/desktop-installer.mdx
@@ -416,7 +416,7 @@ Replace `forge.config.cjs` with electron-builder's `build` section. **The existi
 - `npm run package:linux` produces working `.deb` and `.AppImage` artifacts on Linux
 - Locale pruning still strips Chromium translations (~45 MB savings)
 - The 4-part → 3-part version normalization still works
-- Existing GAIA UI launches cleanly (no missing `electron-squirrel-startup` errors)
+- Existing Gaia Agent UI launches cleanly (no missing `electron-squirrel-startup` errors)
 
 ### Phase E — Installer assets and branding
 


### PR DESCRIPTION
## Summary

Removes all references to RAUX (the retired Open-WebUI fork) from the documentation. RAUX is no longer part of GAIA; the current UI is the Gaia Agent UI (`src/gaia/apps/webui/` + `src/gaia/ui/`).

## Why

`docs/deployment/ui.mdx` still contained a full "GAIA UI (RAUX) Interface" section, including an acknowledgment block for the OpenWebUI team and a link to the retired `aigdat/raux` repository. Three other doc files used the bare "GAIA UI" label (which pointed contributors toward the wrong product). These references misdirect external contributors and are factually wrong.

Refs #929

## Changes

- `docs/deployment/ui.mdx` — removed the "GAIA UI (RAUX) Interface" section entirely; renamed "GAIA Chat (Lightweight Desktop)" → "Gaia Agent UI Architecture" and removed the "lighter alternative to RAUX" framing; updated Developer Quick Start link text.
- `docs/guides/custom-agent.mdx` — "GAIA UI" → "Gaia Agent UI" (line 13).
- `docs/plans/axis-gaia-integration.md` — "GAIA UI" → "Gaia Agent UI" (line 162).
- `docs/plans/desktop-installer.mdx` — "GAIA UI" → "Gaia Agent UI" (line 419).

**Must land before PR 3** (the stale-strings CI workflow), which enforces the absence of these terms going forward.

## Test plan

- [ ] `grep -rn -i "raux\|open-webui\|openwebui" docs/` — zero hits
- [ ] `grep -rn "GAIA UI" docs/` (without "Agent") — zero hits
- [ ] All internal links in `docs/deployment/ui.mdx` resolve: `/guides/agent-ui`, `/sdk/sdks/agent-ui`, `/spec/agent-ui-server`, `/reference/troubleshooting#appimage-on-linux`

## Checklist

- [x] I have linked a GitHub issue above (`Refs #929`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] No code changes — docs only; lint and unit tests are not applicable.
- [x] Documentation updated (this PR is the documentation update).