### PR TITLE
ci(claude): allow fork-PR authors to trigger Claude review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,18 @@
 #
 # IMPORTANT: Never add steps that execute code from the PR (npm install, pip install, make, etc.)
 #
+# `allowed_non_write_users: "*"` on pr-review and issue-handler bypasses the action's
+# built-in actor-permission gate so fork PRs from external contributors get auto-reviewed
+# without a maintainer having to babysit. The action's own warning calls this "extreme
+# caution" territory: a malicious fork's diff gets fed to Claude, which has Bash in
+# --allowedTools and access to ANTHROPIC_API_KEY + GITHUB_TOKEN. Prompt injection in the
+# diff could try to coerce Claude into running an exfiltration command. The action mitigates
+# with subprocess secret scrubbing (CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1, auto-set when this
+# input is non-empty) + a pinned bun binary + hardened PATH. We accept the residual risk
+# in exchange for not maintaining a username allowlist. If a real injection lands, tighten
+# this to a literal username list (no `author_association` values supported — checked
+# upstream `src/github/validation/permissions.ts`, only literal usernames or `*`).
+#
 # NOTE: pull_request_target uses the workflow file from the BASE branch (main), not the PR head.
 # Changes to this file only take effect after merging to main.
 #
@@ -103,6 +115,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Allow fork-PR authors (no write perms) to trigger auto-review.
+          # See file header for the security trade-off.
+          allowed_non_write_users: "*"
           prompt: |
             Review this pull request following the custom_instructions exactly.
             First read (in order): pr-diff.txt, pr-files.txt, CLAUDE.md, and the PR title/description via `gh pr view ${{ github.event.pull_request.number }}`.
@@ -518,6 +533,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Allow non-write users (fork-PR authors, external issue reporters) to invoke
+          # @claude. See file header for the security trade-off.
+          allowed_non_write_users: "*"
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE/PR NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

The `claude-code-action` gates execution on the **actor's** repo permission. Fork-PR authors only have `read`, so the action exits with `"Actor does not have write permissions to the repository"` before ever calling Anthropic — which is why PR #924 from `@theonlychant` (and any future fork PR) gets a 5-second red ❌ on the Claude AI Assistant check. Setting `allowed_non_write_users: "*"` on `pr-review` and `issue-handler` bypasses that gate so external contributors get the same auto-review maintainers do, with no username allowlist to maintain.

## Threads

- **`pr-review` + `issue-handler` get `allowed_non_write_users: "*"`** — these are the two jobs that take input from non-maintainers (fork-PR diffs, `@claude` mentions on issues / PR conversations).
- **`pr-comment` and `release-notes` left alone** — `pr-comment` is already filtered to non-fork PRs (`head.repo.full_name == github.repository`), and `release-notes` only fires from a maintainer-owned tag push via `workflow_run`. The actor on those is always a write user, so the gate is a no-op there.
- **Header comment documents the residual risk** — fork-PR diff feeds into Claude, which has `Bash` in `--allowedTools` and access to `ANTHROPIC_API_KEY` + `GITHUB_TOKEN`. Prompt injection in the diff could try to coerce Claude into running an exfiltration command. The action's built-in mitigations (subprocess secret scrubbing via `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` auto-set when this input is non-empty, pinned bun binary, hardened PATH) reduce — but don't eliminate — the surface. Future-us reading the header knows what to tighten if a real attempt lands (swap `*` for a literal username list — verified upstream in `src/github/validation/permissions.ts` that `allowed_non_write_users` only takes literal usernames or `*`, **not** `author_association` values like `CONTRIBUTOR`).

## Test plan

`pull_request_target` uses the workflow from `main`, not the PR head, so this PR can't validate itself. The verification path is post-merge:

- [ ] Merge to `main`
- [ ] Re-trigger PR #924 (push a commit to it, or close/reopen) and confirm the Claude AI Assistant check now runs to completion instead of failing in 5s with the permission error
- [ ] Confirm the run log shows `⚠️ SECURITY WARNING: Bypassing write permission check for theonlychant due to allowed_non_write_users configuration` (the action emits this when the bypass takes effect)
- [ ] Sanity-check that `pr-comment` (non-fork-only) still works on a maintainer's `@claude` review-comment reply

Closes #1053

<!-- gaia-release-orphan-issue:v0.18.0:back-link -->
