### PR TITLE
ci(github): add stale-strings regression guard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -25,7 +25,7 @@ body:
           required: false
         - label: I've checked the hardware requirements in the docs
           required: false
-        - label: This issue relates to GAIA UI (Open-WebUI)
+        - label: This issue relates to Gaia Agent UI (`gaia chat --ui`)
           required: false
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -25,7 +25,7 @@ body:
       options:
         - label: I've taken a look at existing feature requests
           required: false
-        - label: This feature request relates to GAIA UI (Open-WebUI)
+        - label: This feature request relates to Gaia Agent UI (`gaia chat --ui`)
           required: false
 
   - type: textarea

--- a/.github/workflows/stale-strings.yml
+++ b/.github/workflows/stale-strings.yml
@@ -1,0 +1,57 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Prevents retired UI terminology from re-entering the repo.
+# Blocks: RAUX, "GAIA UI" (bare), Open-WebUI / openwebui.
+# Correct term: "Gaia Agent UI".
+
+name: Stale strings check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/**'
+      - 'CONTRIBUTING.md'
+      - 'docs/**'
+      - 'README.md'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/**'
+      - 'CONTRIBUTING.md'
+      - 'docs/**'
+      - 'README.md'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  stale-strings:
+    name: Check for retired UI references
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for retired terminology
+        run: |
+          # Word-boundary patterns block RAUX, bare "GAIA UI", and any spelling of Open-WebUI.
+          # The workflow file itself is excluded to avoid false positives from the pattern strings below.
+          HITS=$(grep -rn -iE '\bRAUX\b|\bGAIA UI\b|\bopen[-]?webui\b' \
+            --exclude="stale-strings.yml" \
+            .github/ CONTRIBUTING.md docs/ README.md 2>/dev/null || true)
+          if [ -n "$HITS" ]; then
+            echo "Retired UI terminology found. Use 'Gaia Agent UI' instead."
+            echo ""
+            echo "$HITS"
+            exit 1
+          fi
+          echo "OK — no retired UI terminology found."


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that blocks retired UI terminology — RAUX, bare "GAIA UI", and Open-WebUI variants — from re-entering the repo via future PRs. Also fixes the last two stale checkbox labels in the old issue templates.

## Why

Without a CI guard, the terminology cleaned up by PRs [#930](https://github.com/amd/gaia/pull/930) and [#931](https://github.com/amd/gaia/pull/931) can silently reappear through copy-paste from older branches or docs. The `/reflect-plan` adversarial review rated this the highest-ROI follow-up after the docs cleanup.

Refs #929

## Changes

- **`.github/workflows/stale-strings.yml`** — new workflow, runs on `pull_request` and `push` to `main` when `.github/**`, `docs/**`, `CONTRIBUTING.md`, or `README.md` change. Uses word-boundary regex (`\bRAUX\b`, `\bGAIA UI\b`, `\bopen[-]?webui\b`) to avoid false positives on "Gaia Agent UI". Excludes itself from the scan.
- **`.github/ISSUE_TEMPLATE/bug_report.yaml`** — fixes the last remaining "GAIA UI (Open-WebUI)" checkbox label (superseded by the full template rewrite in [#930](https://github.com/amd/gaia/pull/930) when that merges).
- **`.github/ISSUE_TEMPLATE/feature_request.yaml`** — same as above.

## Test plan

- [ ] `grep -rn -iE '\bRAUX\b|\bGAIA UI\b|\bopen[-]?webui\b' --exclude="stale-strings.yml" .github/ CONTRIBUTING.md docs/ README.md` — zero hits on this branch
- [ ] CI passes on this PR (the workflow runs on `.github/**` path changes)
- [ ] After merging: open a test PR that adds "GAIA UI" to a doc file and confirm the workflow blocks it

## Checklist

- [x] I have linked a GitHub issue above (`Refs #929`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] No Python code changes — lint and unit tests are not applicable.
- [x] No user-visible behavior change — CI infrastructure only.