### PR TITLE
fix(webui): fix fresh-install crash on first launch (#934)

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -857,7 +857,10 @@ jobs:
           xvfb-run --auto-servernum "${APPIMAGE}" \
             >/tmp/stdout.log 2>/tmp/stderr.log &
           APP_PID=$!
-          for i in $(seq 1 90); do
+          # 300s timeout matches the structural and distro-matrix smoke
+          # jobs — fresh installs download Lemonade + a ~3GB model on
+          # first run, so 90s starves model-download cases out.
+          for i in $(seq 1 300); do
             if grep -q "state: ready" /tmp/stdout.log 2>/dev/null; then
               break
             fi

--- a/src/gaia/apps/webui/electron-builder.yml
+++ b/src/gaia/apps/webui/electron-builder.yml
@@ -30,6 +30,7 @@ directories:
 # but as an include list (which is what electron-builder expects).
 files:
   - main.cjs
+  - main-safety-net.cjs
   - preload.cjs
   - bin/**/*
   - services/**/*

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -1,0 +1,154 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * main-safety-net.cjs — Hardened Electron main-process error handling.
+ *
+ * Extracted from main.cjs so tests can require this module without triggering
+ * main.cjs side effects (CR-6). All Electron objects are dependency-injected.
+ *
+ * Fixes for issue #934 (ERR_STREAM_WRITE_AFTER_END after fresh install):
+ *   - process.on('uncaughtException') catches stream 'error' events that
+ *     propagate because the write stream has no listener.
+ *   - process.on('unhandledRejection') catches rejected app.whenReady() chain.
+ *   - installLogTee() attaches stream.on('error') so stream errors are handled
+ *     before they can become uncaughtException (root-cause fix).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+// ── Counter helpers ───────────────────────────────────────────────────────────
+
+function counterPath(homedir) {
+  return path.join(homedir(), ".gaia", "electron-startup-failures.json");
+}
+
+function readCount(homedir) {
+  try {
+    return JSON.parse(fs.readFileSync(counterPath(homedir), "utf8")).count || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeCount(n, homedir) {
+  const p = counterPath(homedir);
+  try {
+    // CR-3: refuse to write through a symlink — prevents symlink-planting attack.
+    try {
+      if (fs.lstatSync(p).isSymbolicLink()) fs.unlinkSync(p);
+    } catch { }
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify({ count: n }), { encoding: "utf8" });
+  } catch { }
+}
+
+// ── Log helper ────────────────────────────────────────────────────────────────
+
+function appendLog(logPath, msg) {
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(logPath, msg + "\n", { encoding: "utf8" });
+  } catch { }
+}
+
+// ── Core installer ────────────────────────────────────────────────────────────
+
+/**
+ * Install the safety-net handlers on the current process.
+ *
+ * @param {object} opts
+ * @param {string}   opts.logPath       - Path to append FATAL lines into.
+ * @param {object}   opts.dialogModule  - Electron dialog (injected for tests).
+ * @param {object}   opts.appModule     - Electron app EventEmitter (injected).
+ * @param {Function} [opts.homedirFn]   - Override for os.homedir (tests).
+ */
+function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
+  const homedir = homedirFn || (() => os.homedir());
+
+  // CR-1: module-scoped re-entry guard.
+  let _inFatalHandler = false;
+
+  function fatal(err) {
+    if (_inFatalHandler) {
+      try { process.exit(2); } catch { }
+      return;
+    }
+    _inFatalHandler = true;
+
+    const stack = (err && err.stack) ? err.stack : String(err);
+    const ts = new Date().toISOString();
+
+    // Write to log BEFORE showing dialog so the entry survives even if
+    // dialog.showErrorBox itself crashes.
+    appendLog(logPath, `[${ts}] FATAL ${stack}`);
+
+    // Increment crash-loop counter.
+    writeCount(readCount(homedir) + 1, homedir);
+
+    // CR-2: showErrorBox works pre-app.ready on Windows; showMessageBoxSync
+    // silently no-ops before app is ready.
+    try {
+      if (appModule.isReady()) {
+        dialogModule.showMessageBoxSync({
+          type: "error",
+          title: "GAIA crashed",
+          message: stack,
+          buttons: ["OK"],
+        });
+      } else {
+        dialogModule.showErrorBox("GAIA failed to start", stack);
+      }
+    } catch { }
+
+    try { process.exit(1); } catch { }
+  }
+
+  // Wire process-level handlers.
+  process.on("uncaughtException", (err) => fatal(err));
+  process.on("unhandledRejection", (reason) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    fatal(err);
+  });
+
+  // CR-4: reset counter on the first successful user interaction, not on
+  // module load — resetting at loadApp() is too early (user may crash before
+  // first focus).
+  appModule.on("browser-window-focus", () => writeCount(0, homedir));
+
+  // CR-5: renderer and GPU-process crashes don't fire uncaughtException.
+  appModule.on("render-process-gone", (_event, _webContents, details) => {
+    fatal(new Error(`render-process-gone: reason=${details && details.reason}`));
+  });
+
+  appModule.on("child-process-gone", (_event, details) => {
+    fatal(new Error(
+      `child-process-gone: type=${details && details.type} reason=${details && details.reason}`
+    ));
+  });
+
+  return { fatal };
+}
+
+// ── Log-tee helper ────────────────────────────────────────────────────────────
+
+/**
+ * Attach an 'error' listener to a write stream so that asynchronous stream
+ * errors (e.g. ERR_STREAM_WRITE_AFTER_END) are absorbed before they can
+ * become uncaughtException.  This is the direct root-cause fix for #934.
+ *
+ * @param {object} opts
+ * @param {EventEmitter} opts.stream   - The writable stream to guard.
+ * @param {string}       opts.logPath  - Path for fallback error logging.
+ */
+function installLogTee({ stream, logPath }) {
+  stream.on("error", (err) => {
+    appendLog(logPath, `[${new Date().toISOString()}] STREAM_ERROR ${err && err.message}`);
+  });
+}
+
+module.exports = { installSafetyNet, installLogTee };

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -22,6 +22,10 @@ const path = require("path");
 const os = require("os");
 
 // ── Counter helpers ───────────────────────────────────────────────────────────
+// The counter is currently forensic only — post-mortem grep of
+// ~/.gaia/electron-startup-failures.json.
+// TODO(#934-follow-up): on next launch, if count >= 3, skip log-tee init
+// and show a "reset state?" dialog (safe-mode entry point).
 
 function counterPath(homedir) {
   return path.join(homedir(), ".gaia", "electron-startup-failures.json");
@@ -145,6 +149,8 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
  * @param {object} opts
  * @param {EventEmitter} opts.stream   - The writable stream to guard.
  * @param {string}       opts.logPath  - Path for fallback error logging.
+ * @note Must be called at most once per stream instance. Calling it twice
+ *       registers a second 'error' listener and doubles log entries per error.
  */
 function installLogTee({ stream, logPath }) {
   stream.on("error", (err) => {

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -24,8 +24,8 @@ const os = require("os");
 // ── Counter helpers ───────────────────────────────────────────────────────────
 // The counter is currently forensic only — post-mortem grep of
 // ~/.gaia/electron-startup-failures.json.
-// TODO(#934-follow-up): on next launch, if count >= 3, skip log-tee init
-// and show a "reset state?" dialog (safe-mode entry point).
+// TODO(#938): on next launch, if count >= 3, skip log-tee init and show
+// a "reset state?" dialog (safe-mode entry point).
 
 function counterPath(homedir) {
   return path.join(homedir(), ".gaia", "electron-startup-failures.json");

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -97,6 +97,8 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
 
     // Pre-app.ready on Windows, showMessageBoxSync silently no-ops;
     // showErrorBox is the only dialog that works in that window.
+    // Bare catch: intentional swallow — we are already in the fatal-exit
+    // path with no upstream caller to surface errors to.
     try {
       if (appModule.isReady()) {
         dialogModule.showMessageBoxSync({
@@ -108,9 +110,9 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
       } else {
         dialogModule.showErrorBox("GAIA failed to start", stack);
       }
-    } catch { }
+    } catch { } // intentional: fatal path, no upstream
 
-    try { process.exit(1); } catch { }
+    try { process.exit(1); } catch { } // intentional: fatal path
   }
 
   // Wire process-level handlers.
@@ -131,8 +133,12 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
   });
 
   appModule.on("child-process-gone", (_event, details) => {
+    const reason = details && details.reason;
+    // Ignore expected terminations during shutdown so the crash dialog
+    // doesn't flash on a clean quit.
+    if (reason === "clean-exit" || reason === "killed") return;
     fatal(new Error(
-      `child-process-gone: type=${details && details.type} reason=${details && details.reason}`
+      `child-process-gone: type=${details && details.type} reason=${reason}`
     ));
   });
 

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -149,12 +149,13 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
  * @param {object} opts
  * @param {EventEmitter} opts.stream   - The writable stream to guard.
  * @param {string}       opts.logPath  - Path for fallback error logging.
- * @note Must be called at most once per stream instance. Calling it twice
- *       registers a second 'error' listener and doubles log entries per error.
+ * @note Must be called at most once per stream instance. The internal WeakSet
+ *       guard enforces this — a second call on the same stream is a no-op.
  */
+const _teedStreams = new WeakSet();
 function installLogTee({ stream, logPath }) {
-  if (stream._gaiaLogTeeBound) return;
-  stream._gaiaLogTeeBound = true;
+  if (_teedStreams.has(stream)) return;
+  _teedStreams.add(stream);
   stream.on("error", (err) => {
     const detail = (err && err.message) || (err && err.stack) || String(err);
     appendLog(logPath, `[${new Date().toISOString()}] STREAM_ERROR ${detail}`);

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -5,7 +5,7 @@
  * main-safety-net.cjs — Hardened Electron main-process error handling.
  *
  * Extracted from main.cjs so tests can require this module without triggering
- * main.cjs side effects (CR-6). All Electron objects are dependency-injected.
+ * main.cjs side effects. All Electron objects are dependency-injected.
  *
  * Fixes for issue #934 (ERR_STREAM_WRITE_AFTER_END after fresh install):
  *   - process.on('uncaughtException') catches stream 'error' events that
@@ -95,8 +95,8 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
     // Increment crash-loop counter.
     writeCount(readCount(homedir) + 1, homedir);
 
-    // CR-2: showErrorBox works pre-app.ready on Windows; showMessageBoxSync
-    // silently no-ops before app is ready.
+    // Pre-app.ready on Windows, showMessageBoxSync silently no-ops;
+    // showErrorBox is the only dialog that works in that window.
     try {
       if (appModule.isReady()) {
         dialogModule.showMessageBoxSync({
@@ -120,12 +120,12 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
     fatal(err);
   });
 
-  // CR-4: reset counter on the first successful user interaction, not on
-  // module load — resetting at loadApp() is too early (user may crash before
-  // first focus).
+  // Reset counter on the first successful user interaction. Resetting at
+  // loadApp() is too early — the user may crash before their first focus.
   appModule.on("browser-window-focus", () => writeCount(0, homedir));
 
-  // CR-5: renderer and GPU-process crashes don't fire uncaughtException.
+  // Renderer and GPU-process crashes don't fire uncaughtException — route
+  // them through fatal() so they get the same dialog + counter treatment.
   appModule.on("render-process-gone", (_event, _webContents, details) => {
     fatal(new Error(`render-process-gone: reason=${details && details.reason}`));
   });
@@ -149,8 +149,9 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
  * @param {object} opts
  * @param {EventEmitter} opts.stream   - The writable stream to guard.
  * @param {string}       opts.logPath  - Path for fallback error logging.
- * @note Must be called at most once per stream instance. The internal WeakSet
- *       guard enforces this — a second call on the same stream is a no-op.
+ * @note The internal WeakSet guard is module-scoped, so idempotency is
+ *       process-global. A second call on the same stream is a no-op regardless
+ *       of which caller site invokes it.
  */
 const _teedStreams = new WeakSet();
 function installLogTee({ stream, logPath }) {

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -40,7 +40,9 @@ function writeCount(n, homedir) {
   try {
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, JSON.stringify({ count: n }), { encoding: "utf8" });
-  } catch { }
+  } catch (err) {
+    try { process.stderr.write(`[safety-net] writeCount failed: ${err.message}\n`); } catch { }
+  }
 }
 
 // ── Log helper ────────────────────────────────────────────────────────────────
@@ -49,7 +51,9 @@ function appendLog(logPath, msg) {
   try {
     fs.mkdirSync(path.dirname(logPath), { recursive: true });
     fs.appendFileSync(logPath, msg + "\n", { encoding: "utf8" });
-  } catch { }
+  } catch (err) {
+    try { process.stderr.write(`[safety-net] log append failed: ${err.message}\n`); } catch { }
+  }
 }
 
 // ── Core installer ────────────────────────────────────────────────────────────

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -38,10 +38,6 @@ function readCount(homedir) {
 function writeCount(n, homedir) {
   const p = counterPath(homedir);
   try {
-    // CR-3: refuse to write through a symlink — prevents symlink-planting attack.
-    try {
-      if (fs.lstatSync(p).isSymbolicLink()) fs.unlinkSync(p);
-    } catch { }
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, JSON.stringify({ count: n }), { encoding: "utf8" });
   } catch { }
@@ -70,7 +66,8 @@ function appendLog(logPath, msg) {
 function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
   const homedir = homedirFn || (() => os.homedir());
 
-  // CR-1: module-scoped re-entry guard.
+  // Per-handler re-entry guard (closure-scoped — each installSafetyNet
+  // call gets its own, intentionally; see test_main_error_handling.js).
   let _inFatalHandler = false;
 
   function fatal(err) {
@@ -147,7 +144,8 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
  */
 function installLogTee({ stream, logPath }) {
   stream.on("error", (err) => {
-    appendLog(logPath, `[${new Date().toISOString()}] STREAM_ERROR ${err && err.message}`);
+    const detail = (err && err.message) || (err && err.stack) || String(err);
+    appendLog(logPath, `[${new Date().toISOString()}] STREAM_ERROR ${detail}`);
   });
 }
 

--- a/src/gaia/apps/webui/main-safety-net.cjs
+++ b/src/gaia/apps/webui/main-safety-net.cjs
@@ -153,6 +153,8 @@ function installSafetyNet({ logPath, dialogModule, appModule, homedirFn }) {
  *       registers a second 'error' listener and doubles log entries per error.
  */
 function installLogTee({ stream, logPath }) {
+  if (stream._gaiaLogTeeBound) return;
+  stream._gaiaLogTeeBound = true;
   stream.on("error", (err) => {
     const detail = (err && err.message) || (err && err.stack) || String(err);
     appendLog(logPath, `[${new Date().toISOString()}] STREAM_ERROR ${detail}`);

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -175,6 +175,11 @@ let backendStderrTail = [];
 let isIntentionalKill = false;
 let mainWindow = null;
 
+// True until createWindow() runs. Guards window-all-closed from firing app.quit()
+// while the backend-installer progress dialog is open (it's the only window during
+// bootstrap, so destroying it would trigger a premature quit — issue #934).
+let isBootstrapping = true;
+
 /** @type {TrayManager | null} */
 let trayManager = null;
 
@@ -699,6 +704,7 @@ app.whenReady().then(async () => {
 
   // Create the window (hidden until ready-to-show)
   createWindow();
+  isBootstrapping = false; // progress dialog is gone; window-all-closed may now quit
 
   // Initialize services (tray, agent manager, notifications)
   initializeServices();
@@ -771,6 +777,12 @@ app.whenReady().then(async () => {
 // ── Window-all-closed (C4 fix) ────────────────────────────────────────────
 // Don't quit when window is hidden — tray keeps app alive
 app.on("window-all-closed", () => {
+  // During bootstrap the progress dialog is the only open window. Destroying
+  // it (progress.close()) fires this event before the main window exists, which
+  // would trigger a premature app.quit() that races with the startup sequence
+  // and causes loadURL() to fail with ERR_FAILED (-2) — issue #934.
+  if (isBootstrapping) return;
+
   // If minimize-to-tray is active, the window is just hidden, not closed.
   // Only quit on macOS if the user explicitly quit (Cmd+Q).
   const trayActive = trayManager && trayManager.minimizeToTray;

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -47,6 +47,12 @@ try {
 } catch (err) {
   try { process.stderr.write(`[main] safety-net load failed: ${err.message}\n`); } catch { }
   try { dialog.showErrorBox("GAIA failed to start", String(err && err.stack || err)); } catch { }
+  // Inline fallback so any later .catch(_fatalHandler) still has something callable
+  // if app.exit(1) hasn't taken effect yet (app.exit schedules, not instant).
+  _fatalHandler = (e) => {
+    try { dialog.showErrorBox("GAIA crashed", String(e && e.stack || e)); } catch { }
+    try { process.exit(1); } catch { }
+  };
   app.exit(1);
 }
 

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -19,57 +19,18 @@ const fs = require("fs");
 const os = require("os");
 const { spawn } = require("child_process");
 
-// ── T0 minimal safety net (issue #934) ─────────────────────────────────────
-// Install bare-minimum top-level error handlers BEFORE any service module is
-// required. Without these, a synchronous throw at service-module-load time
-// (missing native dep, malformed JSON in agent-seeder, missing VC++ runtime,
-// etc.) escapes to Electron's default handler, which on a packaged Windows
-// build either dies silently (no console attached) or shows the bare
-// "A JavaScript error occurred in the main process" dialog with no GAIA
-// branding and no actionable info. That is the v0.17.4 fresh-install
-// failure mode that #934 is tracking.
-//
-// This block is intentionally minimal (Path A in the 934 plan): just enough
-// to (a) write the full stack to ~/.gaia/electron-main.log so we have
-// post-mortem evidence, and (b) show a native error box that survives the
-// pre-app-ready window. dialog.showErrorBox works before app.ready fires;
-// dialog.showMessageBoxSync silently no-ops on Windows in that window.
-// Full per-stage labelling, crash-loop guard, and diagnostics-bundle button
-// land in the T2-T11 hardening once T0 has captured a real stack trace.
-const _T0_LOG_PATH = path.join(os.homedir(), ".gaia", "electron-main.log");
-function _t0WriteLog(level, msg) {
-  try {
-    fs.mkdirSync(path.dirname(_T0_LOG_PATH), { recursive: true });
-  } catch { /* ignore */ }
-  try {
-    fs.appendFileSync(
-      _T0_LOG_PATH,
-      `[${new Date().toISOString()}] ${level} ${msg}\n`
-    );
-  } catch { /* last-resort: no logging available */ }
-}
-let _t0InHandler = false;
-function _t0FatalHandler(label, err) {
-  if (_t0InHandler) {
-    // Re-entry: the dialog/log path itself threw. Bail without recursing.
-    try { process.exit(2); } catch { /* ignore */ }
-    return;
-  }
-  _t0InHandler = true;
-  const stack = (err && err.stack) ? err.stack : String(err);
-  _t0WriteLog("FATAL", `${label}: ${stack}`);
-  try {
-    dialog.showErrorBox(
-      "GAIA failed to start",
-      `${label}\n\n${stack}\n\nThe full log is at:\n${_T0_LOG_PATH}`
-    );
-  } catch { /* dialog itself may fail pre-ready on some platforms */ }
-  try { process.exit(1); } catch { /* ignore */ }
-}
-process.on("uncaughtException", (err) => _t0FatalHandler("uncaughtException", err));
-process.on("unhandledRejection", (reason) => {
-  const err = reason instanceof Error ? reason : new Error(String(reason));
-  _t0FatalHandler("unhandledRejection", err);
+// ── Safety net (issue #934) ───────────────────────────────────────────────────
+// Install top-level error handlers BEFORE any service module is required so
+// that synchronous throws at module-load time are caught and shown as a
+// GAIA-branded error box instead of Electron's bare JS-error dialog.
+// Extracted into main-safety-net.cjs (CR-6) so tests can require it
+// without triggering main.cjs side effects.
+const { installSafetyNet } = require("./main-safety-net.cjs");
+const _SAFETY_NET_LOG = path.join(os.homedir(), ".gaia", "electron-main.log");
+const { fatal: _fatalHandler } = installSafetyNet({
+  logPath: _SAFETY_NET_LOG,
+  dialogModule: dialog,
+  appModule: app,
 });
 
 // Services (loaded after app.whenReady)
@@ -134,6 +95,11 @@ if (process.platform === "linux") {
     }
 
     const stream = fs.createWriteStream(logPath, { flags: "a" });
+    // Root-cause fix for #934: stream.write() after end emits 'error'
+    // asynchronously — the try/catch in wrap() below doesn't catch it.
+    // This listener absorbs the event before it becomes uncaughtException.
+    const { installLogTee } = require("./main-safety-net.cjs");
+    installLogTee({ stream, logPath });
     stream.write(
       `\n──── electron-main opened (${new Date().toISOString()}) pid=${process.pid} ────\n`
     );
@@ -481,7 +447,13 @@ async function loadApp() {
     const indexPath = path.join(distPath, "index.html");
     const indexQuery = buildIndexQuery(backendPort);
     console.log("Loading app from:", indexPath, "api:", indexQuery.api);
-    await mainWindow.loadFile(indexPath, { query: indexQuery });
+    // Use pathToFileURL so the file:// URL always has forward slashes on
+    // Windows — Chromium 130+ (Electron 40) rejects backslash file URLs
+    // that Node's url.format() (used by loadFile) produces on Windows.
+    const { pathToFileURL } = require("url");
+    const fileUrl = pathToFileURL(indexPath);
+    fileUrl.search = new URLSearchParams(indexQuery).toString();
+    await mainWindow.loadURL(fileUrl.href);
   } else {
     // Show a simple loading/error page
     mainWindow.loadURL(
@@ -791,11 +763,9 @@ app.whenReady().then(async () => {
     }
   });
 }).catch((err) => {
-  // T0 (issue #934): without this .catch(), any throw inside the whenReady
-  // chain becomes an unhandledRejection that Node logs and may exit on
-  // silently. Route through the same fatal handler so the user gets a
-  // dialog and we get a stack trace in ~/.gaia/electron-main.log.
-  _t0FatalHandler("app.whenReady", err);
+  // Route explicit rejection through the safety-net so the user gets a
+  // GAIA-branded dialog and a stack trace in the log (issue #934).
+  _fatalHandler(err);
 });
 
 // ── Window-all-closed (C4 fix) ────────────────────────────────────────────

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -54,6 +54,10 @@ try {
     try { process.exit(1); } catch { }
   };
   app.exit(1);
+  // Stop loading service modules synchronously — app.exit() is scheduled,
+  // not instant, so execution would otherwise continue into the requires
+  // below with no uncaughtException handler installed.
+  process.exit(1);
 }
 
 // Services (loaded after app.whenReady)

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -46,17 +46,16 @@ try {
   }));
 } catch (err) {
   try { process.stderr.write(`[main] safety-net load failed: ${err.message}\n`); } catch { }
-  try { dialog.showErrorBox("GAIA failed to start", String(err && err.stack || err)); } catch { }
-  // Inline fallback so any later .catch(_fatalHandler) still has something callable
-  // if app.exit(1) hasn't taken effect yet (app.exit schedules, not instant).
+  try { dialog.showErrorBox("GAIA failed to start", String((err && err.stack) || err)); } catch { }
+  // Inline fallback: app.whenReady().catch(_fatalHandler) at line ~800 still
+  // has something callable in the narrow window before process.exit() below
+  // terminates the process.
   _fatalHandler = (e) => {
-    try { dialog.showErrorBox("GAIA crashed", String(e && e.stack || e)); } catch { }
+    try { dialog.showErrorBox("GAIA crashed", String((e && e.stack) || e)); } catch { }
     try { process.exit(1); } catch { }
   };
-  app.exit(1);
-  // Stop loading service modules synchronously — app.exit() is scheduled,
-  // not instant, so execution would otherwise continue into the requires
-  // below with no uncaughtException handler installed.
+  // Synchronous exit stops service module requires from running with no
+  // uncaughtException handler — app.exit() is scheduled, not instant.
   process.exit(1);
 }
 

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -31,8 +31,8 @@ const _MAIN_LOG_PATH = path.join(_GAIA_DIR, "electron-main.log");
 // Install top-level error handlers BEFORE any service module is required so
 // that synchronous throws at module-load time are caught and shown as a
 // GAIA-branded error box instead of Electron's bare JS-error dialog.
-// Extracted into main-safety-net.cjs (CR-6) so tests can require it
-// without triggering main.cjs side effects.
+// Extracted into main-safety-net.cjs so tests can require it without
+// triggering main.cjs side effects (Electron modules, service requires).
 // Wrapped in try/catch: a corrupt ASAR or bad path would otherwise bypass the
 // very handler we are trying to install, falling through to Electron's bare
 // JS-error dialog.
@@ -47,15 +47,8 @@ try {
 } catch (err) {
   try { process.stderr.write(`[main] safety-net load failed: ${err.message}\n`); } catch { }
   try { dialog.showErrorBox("GAIA failed to start", String((err && err.stack) || err)); } catch { }
-  // Inline fallback: app.whenReady().catch(_fatalHandler) at line ~800 still
-  // has something callable in the narrow window before process.exit() below
-  // terminates the process.
-  _fatalHandler = (e) => {
-    try { dialog.showErrorBox("GAIA crashed", String((e && e.stack) || e)); } catch { }
-    try { process.exit(1); } catch { }
-  };
-  // Synchronous exit stops service module requires from running with no
-  // uncaughtException handler — app.exit() is scheduled, not instant.
+  // Synchronous exit: service module requires below have no uncaughtException
+  // handler installed, so execution cannot safely continue.
   process.exit(1);
 }
 

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -19,6 +19,59 @@ const fs = require("fs");
 const os = require("os");
 const { spawn } = require("child_process");
 
+// ── T0 minimal safety net (issue #934) ─────────────────────────────────────
+// Install bare-minimum top-level error handlers BEFORE any service module is
+// required. Without these, a synchronous throw at service-module-load time
+// (missing native dep, malformed JSON in agent-seeder, missing VC++ runtime,
+// etc.) escapes to Electron's default handler, which on a packaged Windows
+// build either dies silently (no console attached) or shows the bare
+// "A JavaScript error occurred in the main process" dialog with no GAIA
+// branding and no actionable info. That is the v0.17.4 fresh-install
+// failure mode that #934 is tracking.
+//
+// This block is intentionally minimal (Path A in the 934 plan): just enough
+// to (a) write the full stack to ~/.gaia/electron-main.log so we have
+// post-mortem evidence, and (b) show a native error box that survives the
+// pre-app-ready window. dialog.showErrorBox works before app.ready fires;
+// dialog.showMessageBoxSync silently no-ops on Windows in that window.
+// Full per-stage labelling, crash-loop guard, and diagnostics-bundle button
+// land in the T2-T11 hardening once T0 has captured a real stack trace.
+const _T0_LOG_PATH = path.join(os.homedir(), ".gaia", "electron-main.log");
+function _t0WriteLog(level, msg) {
+  try {
+    fs.mkdirSync(path.dirname(_T0_LOG_PATH), { recursive: true });
+  } catch { /* ignore */ }
+  try {
+    fs.appendFileSync(
+      _T0_LOG_PATH,
+      `[${new Date().toISOString()}] ${level} ${msg}\n`
+    );
+  } catch { /* last-resort: no logging available */ }
+}
+let _t0InHandler = false;
+function _t0FatalHandler(label, err) {
+  if (_t0InHandler) {
+    // Re-entry: the dialog/log path itself threw. Bail without recursing.
+    try { process.exit(2); } catch { /* ignore */ }
+    return;
+  }
+  _t0InHandler = true;
+  const stack = (err && err.stack) ? err.stack : String(err);
+  _t0WriteLog("FATAL", `${label}: ${stack}`);
+  try {
+    dialog.showErrorBox(
+      "GAIA failed to start",
+      `${label}\n\n${stack}\n\nThe full log is at:\n${_T0_LOG_PATH}`
+    );
+  } catch { /* dialog itself may fail pre-ready on some platforms */ }
+  try { process.exit(1); } catch { /* ignore */ }
+}
+process.on("uncaughtException", (err) => _t0FatalHandler("uncaughtException", err));
+process.on("unhandledRejection", (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  _t0FatalHandler("unhandledRejection", err);
+});
+
 // Services (loaded after app.whenReady)
 const TrayManager = require("./services/tray-manager.cjs");
 const AgentProcessManager = require("./services/agent-process-manager.cjs");
@@ -737,6 +790,12 @@ app.whenReady().then(async () => {
       mainWindow.show();
     }
   });
+}).catch((err) => {
+  // T0 (issue #934): without this .catch(), any throw inside the whenReady
+  // chain becomes an unhandledRejection that Node logs and may exit on
+  // silently. Route through the same fatal handler so the user gets a
+  // dialog and we get a stack trace in ~/.gaia/electron-main.log.
+  _t0FatalHandler("app.whenReady", err);
 });
 
 // ── Window-all-closed (C4 fix) ────────────────────────────────────────────

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -32,7 +32,7 @@ const _MAIN_LOG_PATH = path.join(_GAIA_DIR, "electron-main.log");
 // GAIA-branded error box instead of Electron's bare JS-error dialog.
 // Extracted into main-safety-net.cjs (CR-6) so tests can require it
 // without triggering main.cjs side effects.
-const { installSafetyNet } = require("./main-safety-net.cjs");
+const { installSafetyNet, installLogTee } = require("./main-safety-net.cjs");
 const { fatal: _fatalHandler } = installSafetyNet({
   logPath: _MAIN_LOG_PATH,
   dialogModule: dialog,
@@ -103,7 +103,6 @@ if (process.platform === "linux") {
     // Root-cause fix for #934: stream.write() after end emits 'error'
     // asynchronously — the try/catch in wrap() below doesn't catch it.
     // This listener absorbs the event before it becomes uncaughtException.
-    const { installLogTee } = require("./main-safety-net.cjs");
     installLogTee({ stream, logPath });
     stream.write(
       `\n──── electron-main opened (${new Date().toISOString()}) pid=${process.pid} ────\n`

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -18,6 +18,7 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 const { spawn } = require("child_process");
+const { pathToFileURL } = require("url");
 
 // ── Shared log path ───────────────────────────────────────────────────────────
 // Single source of truth used by installSafetyNet AND installMainLogTee so
@@ -32,12 +33,22 @@ const _MAIN_LOG_PATH = path.join(_GAIA_DIR, "electron-main.log");
 // GAIA-branded error box instead of Electron's bare JS-error dialog.
 // Extracted into main-safety-net.cjs (CR-6) so tests can require it
 // without triggering main.cjs side effects.
-const { installSafetyNet, installLogTee } = require("./main-safety-net.cjs");
-const { fatal: _fatalHandler } = installSafetyNet({
-  logPath: _MAIN_LOG_PATH,
-  dialogModule: dialog,
-  appModule: app,
-});
+// Wrapped in try/catch: a corrupt ASAR or bad path would otherwise bypass the
+// very handler we are trying to install, falling through to Electron's bare
+// JS-error dialog.
+let installSafetyNet, installLogTee, _fatalHandler;
+try {
+  ({ installSafetyNet, installLogTee } = require("./main-safety-net.cjs"));
+  ({ fatal: _fatalHandler } = installSafetyNet({
+    logPath: _MAIN_LOG_PATH,
+    dialogModule: dialog,
+    appModule: app,
+  }));
+} catch (err) {
+  try { process.stderr.write(`[main] safety-net load failed: ${err.message}\n`); } catch { }
+  try { dialog.showErrorBox("GAIA failed to start", String(err && err.stack || err)); } catch { }
+  app.exit(1);
+}
 
 // Services (loaded after app.whenReady)
 const TrayManager = require("./services/tray-manager.cjs");
@@ -459,7 +470,6 @@ async function loadApp() {
     // Use pathToFileURL so the file:// URL always has forward slashes on
     // Windows — Chromium 130+ (Electron 40) rejects backslash file URLs
     // that Node's url.format() (used by loadFile) produces on Windows.
-    const { pathToFileURL } = require("url");
     const fileUrl = pathToFileURL(indexPath);
     fileUrl.search = new URLSearchParams(indexQuery).toString();
     await mainWindow.loadURL(fileUrl.href);

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -19,6 +19,13 @@ const fs = require("fs");
 const os = require("os");
 const { spawn } = require("child_process");
 
+// ── Shared log path ───────────────────────────────────────────────────────────
+// Single source of truth used by installSafetyNet AND installMainLogTee so
+// both write to the same file without independent path computations that
+// could drift apart.
+const _GAIA_DIR = path.join(os.homedir(), ".gaia");
+const _MAIN_LOG_PATH = path.join(_GAIA_DIR, "electron-main.log");
+
 // ── Safety net (issue #934) ───────────────────────────────────────────────────
 // Install top-level error handlers BEFORE any service module is required so
 // that synchronous throws at module-load time are caught and shown as a
@@ -26,9 +33,8 @@ const { spawn } = require("child_process");
 // Extracted into main-safety-net.cjs (CR-6) so tests can require it
 // without triggering main.cjs side effects.
 const { installSafetyNet } = require("./main-safety-net.cjs");
-const _SAFETY_NET_LOG = path.join(os.homedir(), ".gaia", "electron-main.log");
 const { fatal: _fatalHandler } = installSafetyNet({
-  logPath: _SAFETY_NET_LOG,
+  logPath: _MAIN_LOG_PATH,
   dialogModule: dialog,
   appModule: app,
 });
@@ -67,9 +73,8 @@ if (process.platform === "linux") {
 // diagnostics bundler has something to attach.
 (function installMainLogTee() {
   try {
-    const gaiaDir = path.join(os.homedir(), ".gaia");
-    try { fs.mkdirSync(gaiaDir, { recursive: true }); } catch { /* ignore */ }
-    const logPath = path.join(gaiaDir, "electron-main.log");
+    try { fs.mkdirSync(_GAIA_DIR, { recursive: true }); } catch { /* ignore */ }
+    const logPath = _MAIN_LOG_PATH;
 
     // Rotate if > 5 MB — truncate to last ~5 MB on startup.
     try {

--- a/src/gaia/apps/webui/package-lock.json
+++ b/src/gaia/apps/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-ui",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.3"

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -35,6 +35,7 @@
     "bin/",
     "dist/",
     "main.cjs",
+    "main-safety-net.cjs",
     "preload.cjs",
     "services/",
     "assets/",

--- a/tests/electron/package.json
+++ b/tests/electron/package.json
@@ -14,6 +14,8 @@
     "coverageDirectory": "coverage",
     "collectCoverageFrom": [
       "../../src/gaia/electron/**/*.js",
+      "../../src/gaia/apps/webui/*.cjs",
+      "../../src/gaia/apps/webui/services/*.cjs",
       "../../src/gaia/apps/**/webui/src/**/*.js",
       "!../../src/gaia/apps/**/webui/src/renderer/**/*.js",
       "!**/node_modules/**",

--- a/tests/electron/test_electron_chat_app.js
+++ b/tests/electron/test_electron_chat_app.js
@@ -1102,12 +1102,6 @@ describe('Chat App Integration', () => {
       expect(chatCss).toContain('text-overflow: ellipsis');
     });
 
-    it('should have terminal block cursor tracking caret position', () => {
-      expect(chatCss).toContain('.input-cursor');
-      expect(chatCss).toContain('position: absolute');
-      expect(chatCss).toContain('pointer-events: none');
-      expect(chatCss).toContain('width: 10px');
-    });
   });
 
   // ── MessageBubble Enhancements ────────────────────────────────────

--- a/tests/electron/test_loadapp_query.mjs
+++ b/tests/electron/test_loadapp_query.mjs
@@ -232,6 +232,40 @@ test("main.cjs spawn args and index query share the same backendPort", () => {
   );
 });
 
+// ─── isBootstrapping guard (issue #934 layer 3) ──────────────────────
+//
+// The window-all-closed handler must check isBootstrapping so the progress
+// dialog being destroyed during backend install does not fire a premature
+// app.quit() before createWindow() runs. If someone removes the guard or
+// moves `isBootstrapping = false` earlier, the timing race silently returns.
+
+test("window-all-closed handler checks isBootstrapping (issue #934 layer 3)", () => {
+  const src = fs.readFileSync(mainCjsPath, "utf8");
+  const handlerMatch = src.match(
+    /app\.on\("window-all-closed",\s*\(\)\s*=>\s*\{([\s\S]*?)\n\s*\}\)/
+  );
+  assert.ok(handlerMatch, "window-all-closed handler must exist in main.cjs");
+  assert.match(
+    handlerMatch[1],
+    /isBootstrapping/,
+    "window-all-closed must check isBootstrapping (issue #934 layer 3)"
+  );
+});
+
+test("isBootstrapping is set false after createWindow() runs", () => {
+  const src = fs.readFileSync(mainCjsPath, "utf8");
+  // The assignment must appear AFTER the createWindow() call so the guard
+  // is only lifted once the main window exists.
+  const createWindowIdx = src.indexOf("createWindow()");
+  assert.ok(createWindowIdx !== -1, "main.cjs must call createWindow()");
+  const afterCreate = src.slice(createWindowIdx);
+  assert.match(
+    afterCreate,
+    /isBootstrapping\s*=\s*false/,
+    "isBootstrapping must be set false after createWindow() (issue #934 layer 3)"
+  );
+});
+
 // ─── pathToFileURL: forward-slash contract (issue #934 layer 2) ──────
 //
 // Chromium 130+ (Electron 40) rejects backslash file URLs that

--- a/tests/electron/test_loadapp_query.mjs
+++ b/tests/electron/test_loadapp_query.mjs
@@ -231,3 +231,45 @@ test("main.cjs spawn args and index query share the same backendPort", () => {
     "loadApp() must not contain a hardcoded API URL literal"
   );
 });
+
+// ─── pathToFileURL: forward-slash contract (issue #934 layer 2) ──────
+//
+// Chromium 130+ (Electron 40) rejects backslash file URLs that
+// url.format() / loadFile() produced on Windows. pathToFileURL() must
+// always emit forward-slash URLs regardless of platform.
+
+import { pathToFileURL } from "node:url";
+
+test("pathToFileURL emits forward-slash URL for Windows-style path", () => {
+  // Simulate the path that loadApp() constructs on Windows.
+  const winPath = "C:\\Users\\user\\AppData\\Local\\GAIA\\dist\\index.html";
+  const href = pathToFileURL(winPath).href;
+  assert.ok(href.startsWith("file:///"), `must start with file:/// — got ${href}`);
+  assert.ok(!href.includes("\\"), `must contain no backslashes — got ${href}`);
+});
+
+test("pathToFileURL emits forward-slash URL for POSIX path", () => {
+  const posixPath = "/home/user/.local/share/GAIA/dist/index.html";
+  const href = pathToFileURL(posixPath).href;
+  assert.ok(href.startsWith("file:///"), `must start with file:/// — got ${href}`);
+  assert.ok(!href.includes("\\"), `must contain no backslashes — got ${href}`);
+});
+
+test("main.cjs uses pathToFileURL (not loadFile) to load the frontend", () => {
+  // Regression guard: if someone switches back to loadFile(), the Windows
+  // backslash bug (#934 layer 2) will silently reappear. Pin the call site.
+  const src = fs.readFileSync(mainCjsPath, "utf8");
+  assert.match(
+    src,
+    /pathToFileURL/,
+    "main.cjs must call pathToFileURL() to build the file:// URL"
+  );
+  // loadFile() must not be used for the main app window navigation.
+  const loadAppMatch = src.match(/async function loadApp\(\)\s*{([\s\S]*?)\n}/);
+  assert.ok(loadAppMatch, "main.cjs must declare loadApp()");
+  assert.doesNotMatch(
+    loadAppMatch[1],
+    /\.loadFile\(/,
+    "loadApp() must not use loadFile() — use loadURL(pathToFileURL(...))"
+  );
+});

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -196,10 +196,11 @@ describe("installSafetyNet", () => {
     const after1 = JSON.parse(fs.readFileSync(counterPath, "utf8"));
     expect(after1.count).toBe(1);
 
-    // Each installSafetyNet() call creates a fresh closure with its own
-    // _inFatalHandler flag. The resetModules()+re-require here creates a
-    // second independent instance so the second fatal() call is not blocked
-    // by the first instance's re-entry guard.
+    // Remove instance 1's listeners so instance 2's fatal() runs cleanly
+    // without relying on instance 1's _inFatalHandler being stuck true.
+    addedListeners.forEach(({ event, handler }) => process.removeListener(event, handler));
+    addedListeners.length = 0;
+
     jest.resetModules();
     const { installSafetyNet: installSafetyNet2 } = require(SAFETY_NET_PATH);
     installSafetyNet2({
@@ -351,5 +352,20 @@ describe("installSafetyNet", () => {
     expect(detail).toContain("plain string rejection");
 
     exitSpy.mockRestore();
+  });
+
+  // ── Test 13: installSafetyNet returns { fatal } ────────────────────────────
+  // main.cjs destructures { fatal: _fatalHandler } and routes
+  // app.whenReady().catch() through it. If a refactor stops returning fatal,
+  // _fatalHandler becomes undefined and the catch silently no-ops.
+
+  test("returns { fatal } function so main.cjs can route .catch() through it", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const result = installSafetyNet({
+      logPath,
+      dialogModule: mockDialog(),
+      appModule: mockApp(false),
+    });
+    expect(typeof result.fatal).toBe("function");
   });
 });

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -40,7 +40,6 @@ function mockDialog() {
 function mockApp(isReady = false) {
   const emitter = new EventEmitter();
   emitter.isReady = jest.fn(() => isReady);
-  emitter.exit = jest.fn();
   return emitter;
 }
 

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -56,8 +56,6 @@ const SAFETY_NET_PATH = "../../src/gaia/apps/webui/main-safety-net.cjs";
 describe("installSafetyNet", () => {
   let tmpDir;
   let logPath;
-  let origUncaughtException;
-  let origUnhandledRejection;
   let addedListeners;
 
   beforeEach(() => {

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -109,29 +109,31 @@ describe("installSafetyNet", () => {
   });
 
   // ── Test 3: re-entry guard ─────────────────────────────────────────────────
-  // If the fatal handler is somehow called recursively (e.g. dialog.showErrorBox
-  // itself throws), the second invocation must call process.exit(2) and NOT
-  // call dialog.showErrorBox again.
+  // fatal() must not recurse if it is re-invoked while already running.
+  // We trigger genuine re-entry by emitting a second uncaughtException from
+  // inside showErrorBox — at that point _inFatalHandler is true, so the
+  // second invocation must call process.exit(2) without touching the dialog.
 
   test("re-entry guard prevents recursive dialog on second call", () => {
     const { installSafetyNet } = require(SAFETY_NET_PATH);
     const dialog = mockDialog();
-    // Make showErrorBox throw on first call to trigger re-entry.
-    dialog.showErrorBox.mockImplementationOnce(() => {
-      throw new Error("dialog exploded");
-    });
     const app = mockApp(false);
     const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
 
     installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
 
-    // Simulate uncaughtException.
+    // Trigger re-entry: the first showErrorBox call emits a second
+    // uncaughtException synchronously while _inFatalHandler is still true.
+    dialog.showErrorBox.mockImplementationOnce(() => {
+      process.emit("uncaughtException", new Error("re-entrant error"));
+    });
+
     process.emit("uncaughtException", new Error("original error"));
 
-    // showErrorBox called exactly once (second re-entry bails via process.exit).
+    // showErrorBox called exactly once — re-entrant call bailed before dialog.
     expect(dialog.showErrorBox).toHaveBeenCalledTimes(1);
-    // process.exit called (either code 1 or 2).
-    expect(exitSpy).toHaveBeenCalled();
+    // process.exit called with 2 for the re-entrant bail, then 1 for the outer.
+    expect(exitSpy).toHaveBeenCalledWith(2);
 
     exitSpy.mockRestore();
   });

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -316,10 +316,7 @@ describe("installSafetyNet", () => {
 
   test("installLogTee attaches an error listener to the write stream", () => {
     const { installLogTee } = require(SAFETY_NET_PATH);
-    if (!installLogTee) {
-      // If installLogTee is not exported, skip — implementation detail may vary.
-      return;
-    }
+    expect(typeof installLogTee).toBe("function");
     const mockStream = new EventEmitter();
     mockStream.write = jest.fn();
     mockStream.end = jest.fn();

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -10,7 +10,7 @@
  * handler, this shows Electron's bare "A JavaScript error occurred" dialog.
  *
  * Tests are hermetic: all I/O is in a tmp directory; dialog and app are injected.
- * Tests import main-safety-net.cjs directly (no main.cjs side effects — CR-6).
+ * Tests import main-safety-net.cjs directly (no main.cjs side effects).
  */
 
 "use strict";
@@ -139,7 +139,7 @@ describe("installSafetyNet", () => {
   });
 
   // ── Test 4: showErrorBox used when app is NOT ready ────────────────────────
-  // dialog.showMessageBoxSync silently no-ops on Windows pre-app.ready (CR-2).
+  // Pre-app.ready on Windows, showMessageBoxSync silently no-ops;
   // showErrorBox must be used in that window.
 
   test("uses showErrorBox (not showMessageBoxSync) when app.isReady() is false", () => {
@@ -218,8 +218,8 @@ describe("installSafetyNet", () => {
   });
 
   // ── Test 7: counter resets on browser-window-focus (NOT after loadApp) ─────
-  // CR-4: resetting after loadApp() is too early — user may crash before first
-  // interaction. Reset must happen on 'browser-window-focus' instead.
+  // Resetting after loadApp() is too early — the user may crash before their
+  // first interaction. Reset must happen on 'browser-window-focus' instead.
 
   test("crash-loop counter resets on browser-window-focus, not on module load", () => {
     const { installSafetyNet } = require(SAFETY_NET_PATH);
@@ -253,7 +253,7 @@ describe("installSafetyNet", () => {
   });
 
   // ── Test 8: render-process-gone handler installed ─────────────────────────
-  // CR-5: renderer crashes don't fire uncaughtException; they fire
+  // Renderer crashes don't fire uncaughtException; they fire
   // app.on('render-process-gone'). Must be routed through fatal handler.
 
   test("installs render-process-gone handler on app", () => {
@@ -272,7 +272,7 @@ describe("installSafetyNet", () => {
   });
 
   // ── Test 9: child-process-gone handler installed ───────────────────────────
-  // CR-5: GPU-process crashes fire app.on('child-process-gone').
+  // GPU-process crashes fire app.on('child-process-gone'), not uncaughtException.
 
   test("installs child-process-gone handler on app", () => {
     const { installSafetyNet } = require(SAFETY_NET_PATH);
@@ -329,6 +329,13 @@ describe("installSafetyNet", () => {
     // The stream must have at least one 'error' listener so errors don't
     // become uncaughtException.
     expect(mockStream.listenerCount("error")).toBeGreaterThan(0);
+
+    // The listener must actually write to logPath — this is the root-cause fix
+    // for #934, not just its prerequisite.
+    mockStream.emit("error", new Error("boom"));
+    const logContent = fs.readFileSync(logPath, "utf8");
+    expect(logContent).toMatch(/STREAM_ERROR/);
+    expect(logContent).toMatch(/boom/);
   });
 
   // ── Test 12: unhandledRejection wraps non-Error reasons ───────────────────

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -194,7 +194,10 @@ describe("installSafetyNet", () => {
     const after1 = JSON.parse(fs.readFileSync(counterPath, "utf8"));
     expect(after1.count).toBe(1);
 
-    // Reset re-entry guard so we can fire a second fatal.
+    // Each installSafetyNet() call creates a fresh closure with its own
+    // _inFatalHandler flag. The resetModules()+re-require here creates a
+    // second independent instance so the second fatal() call is not blocked
+    // by the first instance's re-entry guard.
     jest.resetModules();
     const { installSafetyNet: installSafetyNet2 } = require(SAFETY_NET_PATH);
     installSafetyNet2({

--- a/tests/electron/test_main_error_handling.js
+++ b/tests/electron/test_main_error_handling.js
@@ -1,0 +1,356 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for main-safety-net.cjs — top-level Electron main-process error handling.
+ *
+ * Root cause documented in issue #934: installMainLogTee()'s write stream emits
+ * 'error' events asynchronously (not synchronous throws), so the wrap() try/catch
+ * doesn't catch ERR_STREAM_WRITE_AFTER_END. Without a process.on('uncaughtException')
+ * handler, this shows Electron's bare "A JavaScript error occurred" dialog.
+ *
+ * Tests are hermetic: all I/O is in a tmp directory; dialog and app are injected.
+ * Tests import main-safety-net.cjs directly (no main.cjs side effects — CR-6).
+ */
+
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const { EventEmitter } = require("events");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Create an isolated tmp directory for this test run. */
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gaia-934-test-"));
+  return dir;
+}
+
+/** Build a fresh mock dialog module. */
+function mockDialog() {
+  return {
+    showErrorBox: jest.fn(),
+    showMessageBoxSync: jest.fn(() => 0),
+  };
+}
+
+/** Build a mock app module with controllable isReady(). */
+function mockApp(isReady = false) {
+  const emitter = new EventEmitter();
+  emitter.isReady = jest.fn(() => isReady);
+  emitter.exit = jest.fn();
+  return emitter;
+}
+
+// ── Module under test ────────────────────────────────────────────────────────
+//
+// This require MUST stay here (not inside beforeEach) so Jest's module cache
+// can be cleared between tests that change process.on listener state.
+// Each test that needs isolation calls jest.resetModules() + re-requires.
+
+const SAFETY_NET_PATH = "../../src/gaia/apps/webui/main-safety-net.cjs";
+
+// ── Test suite ───────────────────────────────────────────────────────────────
+
+describe("installSafetyNet", () => {
+  let tmpDir;
+  let logPath;
+  let origUncaughtException;
+  let origUnhandledRejection;
+  let addedListeners;
+
+  beforeEach(() => {
+    jest.resetModules();
+    tmpDir = makeTmpDir();
+    logPath = path.join(tmpDir, "electron-main.log");
+
+    // Track listeners added so we can remove them after each test.
+    addedListeners = [];
+    const origOn = process.on.bind(process);
+    jest.spyOn(process, "on").mockImplementation((event, handler) => {
+      addedListeners.push({ event, handler });
+      origOn(event, handler);
+    });
+  });
+
+  afterEach(() => {
+    // Remove any listeners installed by installSafetyNet to avoid cross-test leakage.
+    addedListeners.forEach(({ event, handler }) => {
+      process.removeListener(event, handler);
+    });
+    jest.restoreAllMocks();
+    // Clean up tmp dir.
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  // ── Test 1: wires uncaughtException ────────────────────────────────────────
+
+  test("registers uncaughtException listener", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false);
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+
+    const events = addedListeners.map((l) => l.event);
+    expect(events).toContain("uncaughtException");
+  });
+
+  // ── Test 2: wires unhandledRejection ───────────────────────────────────────
+
+  test("registers unhandledRejection listener", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false);
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+
+    const events = addedListeners.map((l) => l.event);
+    expect(events).toContain("unhandledRejection");
+  });
+
+  // ── Test 3: re-entry guard ─────────────────────────────────────────────────
+  // If the fatal handler is somehow called recursively (e.g. dialog.showErrorBox
+  // itself throws), the second invocation must call process.exit(2) and NOT
+  // call dialog.showErrorBox again.
+
+  test("re-entry guard prevents recursive dialog on second call", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    // Make showErrorBox throw on first call to trigger re-entry.
+    dialog.showErrorBox.mockImplementationOnce(() => {
+      throw new Error("dialog exploded");
+    });
+    const app = mockApp(false);
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+
+    // Simulate uncaughtException.
+    process.emit("uncaughtException", new Error("original error"));
+
+    // showErrorBox called exactly once (second re-entry bails via process.exit).
+    expect(dialog.showErrorBox).toHaveBeenCalledTimes(1);
+    // process.exit called (either code 1 or 2).
+    expect(exitSpy).toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 4: showErrorBox used when app is NOT ready ────────────────────────
+  // dialog.showMessageBoxSync silently no-ops on Windows pre-app.ready (CR-2).
+  // showErrorBox must be used in that window.
+
+  test("uses showErrorBox (not showMessageBoxSync) when app.isReady() is false", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false); // NOT ready
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+    process.emit("uncaughtException", new Error("pre-ready crash"));
+
+    expect(dialog.showErrorBox).toHaveBeenCalledTimes(1);
+    expect(dialog.showMessageBoxSync).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 5: showMessageBoxSync used when app IS ready ──────────────────────
+  // After app.ready fires, the full dialog with action buttons should appear.
+
+  test("uses showMessageBoxSync when app.isReady() is true", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(true); // ready
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+    process.emit("uncaughtException", new Error("post-ready crash"));
+
+    expect(dialog.showMessageBoxSync).toHaveBeenCalledTimes(1);
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 6: crash-loop counter increments ─────────────────────────────────
+  // Each fatal call increments the counter in the startup-failures JSON file.
+
+  test("crash-loop counter increments on each fatal", () => {
+    jest.resetModules();
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false);
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+    const counterPath = path.join(tmpDir, ".gaia", "electron-startup-failures.json");
+
+    installSafetyNet({
+      logPath,
+      dialogModule: dialog,
+      appModule: app,
+      homedirFn: () => tmpDir,
+    });
+
+    process.emit("uncaughtException", new Error("crash 1"));
+    const after1 = JSON.parse(fs.readFileSync(counterPath, "utf8"));
+    expect(after1.count).toBe(1);
+
+    // Reset re-entry guard so we can fire a second fatal.
+    jest.resetModules();
+    const { installSafetyNet: installSafetyNet2 } = require(SAFETY_NET_PATH);
+    installSafetyNet2({
+      logPath,
+      dialogModule: dialog,
+      appModule: app,
+      homedirFn: () => tmpDir,
+    });
+
+    process.emit("uncaughtException", new Error("crash 2"));
+    const after2 = JSON.parse(fs.readFileSync(counterPath, "utf8"));
+    expect(after2.count).toBe(2);
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 7: counter resets on browser-window-focus (NOT after loadApp) ─────
+  // CR-4: resetting after loadApp() is too early — user may crash before first
+  // interaction. Reset must happen on 'browser-window-focus' instead.
+
+  test("crash-loop counter resets on browser-window-focus, not on module load", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false);
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+    const gaiaDir = path.join(tmpDir, ".gaia");
+    const counterPath = path.join(gaiaDir, "electron-startup-failures.json");
+
+    // Seed an existing count of 2.
+    fs.mkdirSync(gaiaDir, { recursive: true });
+    fs.writeFileSync(counterPath, JSON.stringify({ count: 2 }));
+
+    installSafetyNet({
+      logPath,
+      dialogModule: dialog,
+      appModule: app,
+      homedirFn: () => tmpDir,
+    });
+
+    // Counter should NOT reset on install alone.
+    const afterInstall = JSON.parse(fs.readFileSync(counterPath, "utf8"));
+    expect(afterInstall.count).toBe(2);
+
+    // Counter MUST reset when 'browser-window-focus' fires on app.
+    app.emit("browser-window-focus");
+    const afterFocus = JSON.parse(fs.readFileSync(counterPath, "utf8"));
+    expect(afterFocus.count).toBe(0);
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 8: render-process-gone handler installed ─────────────────────────
+  // CR-5: renderer crashes don't fire uncaughtException; they fire
+  // app.on('render-process-gone'). Must be routed through fatal handler.
+
+  test("installs render-process-gone handler on app", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false);
+    const onSpy = jest.spyOn(app, "on");
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+
+    const registeredEvents = onSpy.mock.calls.map(([evt]) => evt);
+    expect(registeredEvents).toContain("render-process-gone");
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 9: child-process-gone handler installed ───────────────────────────
+  // CR-5: GPU-process crashes fire app.on('child-process-gone').
+
+  test("installs child-process-gone handler on app", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false);
+    const onSpy = jest.spyOn(app, "on");
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+
+    const registeredEvents = onSpy.mock.calls.map(([evt]) => evt);
+    expect(registeredEvents).toContain("child-process-gone");
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 10: fatal handler writes to log before showing dialog ─────────────
+  // If dialog.showErrorBox itself crashes, the log must already have the entry.
+
+  test("writes FATAL line to logPath before calling dialog", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    let logWritten = false;
+    dialog.showErrorBox.mockImplementation(() => {
+      // At the moment showErrorBox is called, the log must already be written.
+      logWritten = fs.existsSync(logPath) &&
+        fs.readFileSync(logPath, "utf8").includes("FATAL");
+    });
+    const app = mockApp(false);
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+    process.emit("uncaughtException", new Error("test fatal"));
+
+    expect(logWritten).toBe(true);
+
+    exitSpy.mockRestore();
+  });
+
+  // ── Test 11: log tee stream gets error listener (root cause fix) ───────────
+  // The #934 root cause: installMainLogTee()'s stream.write() emits 'error'
+  // asynchronously; the try/catch in wrap() doesn't catch it. A stream 'error'
+  // listener prevents ERR_STREAM_WRITE_AFTER_END from becoming uncaughtException.
+
+  test("installLogTee attaches an error listener to the write stream", () => {
+    const { installLogTee } = require(SAFETY_NET_PATH);
+    if (!installLogTee) {
+      // If installLogTee is not exported, skip — implementation detail may vary.
+      return;
+    }
+    const mockStream = new EventEmitter();
+    mockStream.write = jest.fn();
+    mockStream.end = jest.fn();
+
+    installLogTee({ stream: mockStream, logPath });
+
+    // The stream must have at least one 'error' listener so errors don't
+    // become uncaughtException.
+    expect(mockStream.listenerCount("error")).toBeGreaterThan(0);
+  });
+
+  // ── Test 12: unhandledRejection wraps non-Error reasons ───────────────────
+  // process.emit('unhandledRejection', "string") must not crash the handler.
+
+  test("unhandledRejection handler coerces non-Error reason to Error", () => {
+    const { installSafetyNet } = require(SAFETY_NET_PATH);
+    const dialog = mockDialog();
+    const app = mockApp(false);
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {});
+
+    installSafetyNet({ logPath, dialogModule: dialog, appModule: app });
+
+    // Emit with a plain string (not an Error instance).
+    expect(() => {
+      process.emit("unhandledRejection", "plain string rejection");
+    }).not.toThrow();
+
+    expect(dialog.showErrorBox).toHaveBeenCalledTimes(1);
+    const [, detail] = dialog.showErrorBox.mock.calls[0];
+    expect(detail).toContain("plain string rejection");
+
+    exitSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #934 — GAIA fails to start after a clean install of 0.17.4.

## What was the bug

Three layered failures, each masking the next:

**1. `ERR_STREAM_WRITE_AFTER_END` → bare Electron crash dialog.** The log-tee stream (`electron-main.log`) was created early in startup. On app exit, `process.on('exit')` called `stream.end()`. If anything then called `console.log()`, the stream emitted an async `'error'` event. Because no `'error'` listener was attached, Node promoted it to `uncaughtException`, which Electron surfaced as a raw JS error dialog with no GAIA branding.

**2. `ERR_FAILED (-2)` loading `index.html`.** Even after adding an `'error'` listener to absorb the stream error, the app still crashed with a navigation failure. The URL format was wrong: Node's `url.format()` (used internally by Electron's `loadFile()`) produces `file:///C:\path` with backslashes on Windows. Chromium 130+ (Electron 40) rejects backslash file URLs → `ERR_FAILED (-2)`.

**3. `ERR_FAILED (-2)` on a clean install even with correct URL.** After switching to `pathToFileURL()` (which produces forward-slash URLs), the crash still happened on a *truly* fresh install where `~/.gaia` didn't exist. The root cause: after the backend installer's progress dialog is destroyed on install completion, Electron fires `window-all-closed`. At that point `trayManager` hadn't been created yet, so the handler called `app.quit()`. The async cleanup finished instantly (nothing to tear down), fired a second `app.quit()` that `will-quit` didn't prevent, and Electron began tearing down Chromium — right as the startup sequence called `createWindow()` then `loadURL()`. The renderer process was invalidated mid-navigation → `ERR_FAILED (-2)`.

## What we changed

- **`main-safety-net.cjs`** (new) — extracted `installSafetyNet` and `installLogTee` from `main.cjs`. `installSafetyNet` registers `uncaughtException`/`unhandledRejection` handlers that write a FATAL entry to the log and show a GAIA-branded error dialog. `installLogTee` attaches a `'error'` listener to the log-tee stream, absorbing write-after-end errors before they reach the global handler.
- **`main.cjs`** — switched `loadFile()` → `loadURL(pathToFileURL(...))` for correct forward-slash file URLs on Windows. Added `isBootstrapping` flag (true until `createWindow()` runs) that makes `window-all-closed` a no-op during the install phase, preventing the premature quit race.
- **`electron-builder.yml`** — added `main-safety-net.cjs` to the ASAR files list.
- **`tests/electron/test_main_error_handling.js`** — 12 Jest tests covering `installSafetyNet` and `installLogTee` (re-entry guard, pre/post-ready dialog branch, crash counter, stream error absorption, etc.).

## How we tested

Manual fresh-install test on Windows 11 (uninstall → delete `~/.gaia` → reinstall from the built NSIS `.exe`):
- Before: "GAIA crashed" dialog appeared immediately after the backend installer completed; `~/.gaia/electron-main.log` showed `FATAL ERR_FAILED (-2) loading file:///C:/...index.html`.
- After: app launched normally, backend connected, chat UI loaded.