### PR TITLE
docs(claude): sharpen PR description guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,17 +39,22 @@ If *any* of those is uncertain, **do not commit** — surface the uncertainty to
 
 **Keep PR descriptions short. Lead with *why* and *impact*, not *what*.** Reviewers skim; long walls of text get ignored. A PR description is a sales pitch for the change, not a changelog.
 
-**Target shape:**
+**Target shape (default — most PRs need only this):**
 
-1. **One-paragraph Summary** — what this PR does, in plain English, and the problem it solves. If a reader stops after this paragraph, they should understand the change's purpose.
-2. **Bullet list of threads** (if the PR has more than one logical thread) — one line each, with a *why this matters* clause for every bullet. Not every file changed — only changes a reviewer needs to evaluate.
-3. **Test plan** — checkbox list of how to verify. Specific commands beat vague prose.
+1. **One-paragraph "Why this matters"** — the user-observable impact in plain English. Lead with the *before-state* (what was broken / missing) and the *after-state* (what now works). If a reviewer stops after this paragraph, they should know whether to merge.
+2. **Test plan** — checkbox list of how to verify. Specific commands beat vague prose.
+
+That's it. No "What changed" / "Files modified" / "Implementation notes" sections by default — the diff shows what changed; the commit messages explain how. The PR description's job is to sell the merge.
+
+**Add a short threads list ONLY if** the PR genuinely bundles multiple logical changes a reviewer needs to evaluate independently. Each bullet: one line, with a *why this matters* clause. Not every commit — only changes a reviewer can't infer from the title.
+
+**The "user-observable impact" test:** can a non-author understand the value in <30 seconds without reading the diff? If your description is "supports X protocol" or "refactors Y handler", you've described the *change* but not the *value*. Rewrite to "before: feature Z silently failed for users running model M; after: it works." Concrete observable behaviour beats abstract capability claims.
 
 **Hard rules:**
 
 - **No section longer than ~5 lines of prose** before breaking into bullets or cutting.
 - **Every non-trivial claim earns its place with a why.** "Added a linter" is noise; "Added a linter so new agents stop shipping with missing docs/tests" is signal.
-- **Cut exhaustive file-by-file enumeration.** The diff is the source of truth for what files changed. The description is the source of truth for *why they changed*.
+- **Cut exhaustive file-by-file enumeration and implementation walkthroughs.** The diff is the source of truth for what files changed and how. The description is the source of truth for *why a reviewer should care*.
 - **No "Generated with Claude Code" tagline** (see attribution rule below).
 - **If the PR really does bundle many threads**, group them — don't list 16 commits. Reviewers scan 4 themes faster than 16 bullets.
 
@@ -59,6 +64,9 @@ If *any* of those is uncertain, **do not commit** — surface the uncertainty to
 - ❌ "This PR adds X, Y, Z, A, B, C, D, E, F, G" with no stated value
 - ❌ Mirroring every bullet in the summary inside the test plan (pick one)
 - ❌ Explaining implementation details a reviewer will read from the diff anyway
+- ❌ A "What changed" bullet list when the title + commit message body already cover it
+- ❌ Naming files in the description ("modified `agent.py`") — the diff already shows that
+- ❌ Burying the user impact under a section labelled "Summary"; lead with the impact
 
 **Title convention:** conventional commits style (`feat(scope):`, `fix(scope):`, `docs(scope):`, `ci(scope):`), under ~70 chars, descriptive of the *change*, not the *why* (the body carries the why).
 


### PR DESCRIPTION
The existing PR-description guidance in CLAUDE.md was directionally right ("tight and value-focused") but loose enough that a recent PR (#946 / #944) still shipped with a "What changed" enumeration the diff already showed and a "Summary" section that buried the user-observable impact behind implementation details. Future agents reading the file would do the same.

After this change the default shape is just two sections — "Why this matters" (with required before/after framing) and "Test plan" — with a "user-observable impact in <30s without reading the diff" litmus check, and three new anti-patterns lifted directly from the patterns the prior PR exhibited.

## Test plan

- [x] No code changed; doc-only edit
- [x] Re-read the new section against #946 to confirm the prior description fails the new rules