### PR TITLE
fix(installer): resolve default model falling back to Qwen on Windows

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -23,6 +23,7 @@ from gaia.agents.base.tools import _TOOL_REGISTRY
 
 # First-party imports
 from gaia.chat.sdk import AgentConfig, AgentSDK
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -248,10 +249,10 @@ Do NOT wrap conversational replies in JSON.
         # Initialize AgentSDK with proper configuration
         # Note: We don't set system_prompt in config, we pass it per request
         # Note: Context size is configured when starting Lemonade server, not here
-        # Use Qwen3.5-35B by default for better reasoning and JSON formatting
-        # The 0.5B model is too small for complex agent tasks
+        # Use the configured default model (Gemma) when no explicit model_id
+        # is provided. The 0.5B model is too small for complex agent tasks.
         chat_config = AgentConfig(
-            model=model_id or "Qwen3.5-35B-A3B-GGUF",
+            model=model_id or DEFAULT_MODEL_NAME,
             use_claude=use_claude,
             use_chatgpt=use_chatgpt,
             claude_model=claude_model,

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -21,6 +21,7 @@ from gaia.agents.chat.session import SessionManager
 from gaia.agents.chat.tools import FileToolsMixin, RAGToolsMixin, ShellToolsMixin
 from gaia.agents.code.tools.file_io import FileIOToolsMixin
 from gaia.agents.tools import FileSearchToolsMixin, ScreenshotToolsMixin  # Shared tools
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 from gaia.logger import get_logger
 from gaia.mcp.mixin import MCPClientMixin
 from gaia.rag.sdk import RAGSDK, RAGConfig
@@ -28,7 +29,6 @@ from gaia.sd.mixin import SDToolsMixin
 from gaia.security import PathValidator
 from gaia.utils.file_watcher import FileChangeHandler, check_watchdog_available
 from gaia.vlm.mixin import VLMToolsMixin
-from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 
 logger = get_logger(__name__)
 

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -28,6 +28,7 @@ from gaia.sd.mixin import SDToolsMixin
 from gaia.security import PathValidator
 from gaia.utils.file_watcher import FileChangeHandler, check_watchdog_available
 from gaia.vlm.mixin import VLMToolsMixin
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 
 logger = get_logger(__name__)
 
@@ -41,7 +42,7 @@ class ChatAgentConfig:
     use_chatgpt: bool = False
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
-    model_id: Optional[str] = None  # None = use default Qwen3.5-35B-A3B
+    model_id: Optional[str] = None  # None = use default model (Gemma)
 
     # Execution settings
     max_steps: int = 10
@@ -135,8 +136,8 @@ class ChatAgent(
         else:
             self.allowed_paths = [Path(p).resolve() for p in config.allowed_paths]
 
-        # Use Qwen3.5-35B-A3B by default for better tool-calling
-        effective_model_id = config.model_id or "Qwen3.5-35B-A3B-GGUF"
+        # Use the configured default model (Gemma) when no explicit model is set
+        effective_model_id = config.model_id or DEFAULT_MODEL_NAME
 
         # Debug logging for model selection
         logger.debug(


### PR DESCRIPTION
## Summary
Fixes GAIA ignoring the new Gemma default model and falling back to Qwen
on Windows 11, causing the wrong model to load in the frontend.

## Why
After commit 5d377713 made Gemma-4-E4B the default model, Windows users
reported that GAIA still attempts to load Qwen instead. This left the
new default model effectively unreachable on Windows, making the frontend
unusable for anyone who hadn't manually configured a model.

## Linked issue
Closes #948

## Changes
- Fixed model selection logic to correctly resolve the new Gemma default
  on Windows instead of falling back to Qwen

## Test plan
- [x] `pytest tests/unit/` - passing locally
- [x] `python util/lint.py --all` - no failures
- [ ] Manual: launch `gaia chat --ui` on Windows and verify Gemma loads
      instead of Qwen

## Checklist
- [x] I have linked a GitHub issue above (`Closes #948`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally.
- [ ] I have updated documentation if user-visible behavior changed.