### PR TITLE
feat(agents): dynamic tool-loader with bundle-gated activation for #688

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
 
 from gaia.agents.base.console import AgentConsole, SilentConsole
 from gaia.agents.base.errors import format_execution_trace
+from gaia.agents.base.tool_loader import ToolLoader
 from gaia.agents.base.tools import _TOOL_REGISTRY
 
 # First-party imports
@@ -253,6 +254,11 @@ Do NOT wrap conversational replies in JSON.
 
         # Register tools for this agent (may call rebuild_system_prompt via MCP loading;
         # _response_format_template must be set above before this call).
+        # Bundle-based tool loading (opt-in: subclasses set self.tool_loader
+        # before calling super().__init__ or in _register_tools).
+        if not hasattr(self, "tool_loader"):
+            self.tool_loader: Optional[ToolLoader] = None
+
         self._register_tools()
 
         # Note: system_prompt is now a lazy @property that composes on first access.
@@ -327,7 +333,9 @@ Do NOT wrap conversational replies in JSON.
 
         return prompts
 
-    def _compose_system_prompt(self) -> str:
+    def _compose_system_prompt(
+        self, tool_registry: Optional[Dict[str, dict]] = None
+    ) -> str:
         """
         Compose final system prompt from mixin fragments + agent custom + tools + format.
 
@@ -358,7 +366,7 @@ Do NOT wrap conversational replies in JSON.
 
         # Add tool descriptions (if tools registered)
         if hasattr(self, "_format_tools_for_prompt"):
-            tools_description = self._format_tools_for_prompt()
+            tools_description = self._format_tools_for_prompt(registry=tool_registry)
             if tools_description:
                 parts.append(f"==== AVAILABLE TOOLS ====\n{tools_description}")
 
@@ -439,11 +447,23 @@ Do NOT wrap conversational replies in JSON.
         """
         raise NotImplementedError("Subclasses must implement _register_tools")
 
-    def _format_tools_for_prompt(self) -> str:
-        """Format the registered tools into a string for the prompt."""
+    def _format_tools_for_prompt(
+        self, registry: Optional[Dict[str, dict]] = None
+    ) -> str:
+        """Format the registered tools into a string for the prompt.
+
+        Parameters
+        ----------
+        registry:
+            If provided, use this dict of tools instead of the global
+            ``_TOOL_REGISTRY``.  ``ToolLoader.resolve()`` returns such a
+            filtered dict each turn.
+        """
         tool_descriptions = []
 
-        for name, tool_info in _TOOL_REGISTRY.items():
+        source = registry if registry is not None else _TOOL_REGISTRY
+
+        for name, tool_info in source.items():
             params_str = ", ".join(
                 [
                     f"{param_name}{'' if param_info['required'] else '?'}: {param_info['type']}"
@@ -491,6 +511,20 @@ Do NOT wrap conversational replies in JSON.
         # Recompose the full system prompt via _compose_system_prompt() so that
         # mixin prompts, tool descriptions, and response format are all included.
         self._system_prompt_cache = self._compose_system_prompt()
+
+    def resolve_tools_for_turn(self, user_message: str) -> None:
+        """Re-evaluate tool bundles for the current turn and rebuild the prompt.
+
+        If no ``tool_loader`` is configured this is a no-op, preserving the
+        existing behaviour (all registered tools always visible).
+
+        Called at the top of ``process_query`` before the first LLM call so
+        that keyword-activated bundles can match the current user message.
+        """
+        if self.tool_loader is None:
+            return
+        filtered = self.tool_loader.resolve(user_message, _TOOL_REGISTRY)
+        self._system_prompt_cache = self._compose_system_prompt(tool_registry=filtered)
 
     def list_tools(self, verbose: bool = True) -> None:
         """
@@ -1393,6 +1427,12 @@ Do NOT wrap conversational replies in JSON.
         try:
             result = tool(**tool_args)
             logger.debug(f"Tool execution result: {result}")
+            # Record usage so bundle-based loader can keep the owning bundle warm
+            if self.tool_loader is not None:
+                try:
+                    self.tool_loader.record_tool_use(tool_name)
+                except Exception:
+                    logger.exception("Failed to record tool usage")
             return result
         except subprocess.TimeoutExpired as e:
             # Handle subprocess timeout specifically
@@ -1846,6 +1886,10 @@ Do NOT wrap conversational replies in JSON.
 
         # Store query for error context (used in _execute_tool for error formatting)
         self._current_query = user_input
+        # Re-evaluate which tool bundles should be visible for this turn.
+        # Keyword-activated bundles match against user_input; session bundles
+        # that were used in prior turns stay warm automatically.
+        self.resolve_tools_for_turn(user_input)
 
         logger.debug(f"Processing query: {user_input}")
         conversation = []

--- a/src/gaia/agents/base/tool_loader.py
+++ b/src/gaia/agents/base/tool_loader.py
@@ -1,0 +1,257 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+ToolLoader — bundle-based tool visibility for agents.
+
+Gates which tools appear in the LLM prompt each turn without changing the
+global ``_TOOL_REGISTRY``.  The registry remains the source of truth for
+*all* registered tools; the loader picks the subset that goes into the
+system prompt.
+
+Bundles
+-------
+A ``ToolBundle`` groups related tools under a name with an activation
+policy.  Three policies exist:
+
+* **always** — included in every prompt (e.g. ``core``).
+* **session** — stays active for the rest of the session once any tool
+  in the bundle has been used (e.g. ``scratchpad`` after ``create_table``).
+* **keyword** — activated when the current user message matches one of a
+  set of trigger patterns (e.g. ``browser`` on URL patterns).
+
+The loader evaluates bundles in priority order each turn and returns the
+set of tool names that should appear in the prompt.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, FrozenSet, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+class ActivationPolicy(Enum):
+    """How a bundle decides whether to be active."""
+
+    ALWAYS = "always"
+    SESSION = "session"  # Active once any tool in the bundle was used this session
+    KEYWORD = "keyword"  # Active when user message matches trigger patterns
+
+
+@dataclass(frozen=True)
+class ToolBundle:
+    """An immutable group of tools sharing an activation policy.
+
+    Parameters
+    ----------
+    name:
+        Human-readable bundle identifier (e.g. ``"rag"``, ``"scratchpad"``).
+    tools:
+        Frozenset of tool names that belong to this bundle.
+    policy:
+        When the bundle should be included in the prompt.
+    keywords:
+        Regex patterns (case-insensitive) checked against the user message
+        when ``policy`` is ``KEYWORD``.  Ignored for other policies.
+    """
+
+    name: str
+    tools: FrozenSet[str]
+    policy: ActivationPolicy
+    keywords: FrozenSet[str] = frozenset()
+
+
+@dataclass
+class _BundleState:
+    """Mutable per-session state for a single bundle."""
+
+    activated: bool = False  # True once the bundle has been activated this session
+    last_used_ts: float = 0.0  # Timestamp of most recent tool use in this bundle
+
+
+class ToolLoader:
+    """Selects which registered tools appear in the LLM prompt each turn.
+
+    Usage::
+
+        loader = ToolLoader()
+        loader.register_bundle(ToolBundle(
+            name="scratchpad",
+            tools=frozenset({"create_table", "insert_data", "query_data",
+                             "list_tables", "drop_table"}),
+            policy=ActivationPolicy.SESSION,
+        ))
+
+        # Each turn, ask which tools should be visible:
+        active_tools = loader.resolve(user_message, registry)
+
+    The loader does **not** modify ``_TOOL_REGISTRY``.  It returns a
+    filtered view that the agent uses when building the prompt.
+    """
+
+    # Warm-window: if a bundle was used in the last 24 h, keep it active
+    WARM_WINDOW_SECS: float = 24 * 3600
+
+    def __init__(self) -> None:
+        self._bundles: Dict[str, ToolBundle] = {}
+        self._state: Dict[str, _BundleState] = {}
+        # History of (tool_name, timestamp) for logging / warm-window checks
+        self._tool_history: List[tuple[str, float]] = []
+        # Reverse index: tool_name → bundle_name for fast lookup
+        self._tool_to_bundle: Dict[str, str] = {}
+
+    # ── registration ─────────────────────────────────────────────────────
+
+    def register_bundle(self, bundle: ToolBundle) -> None:
+        """Register a bundle (idempotent — overwrites if name already exists)."""
+        self._bundles[bundle.name] = bundle
+        self._state.setdefault(bundle.name, _BundleState())
+        for tool_name in bundle.tools:
+            self._tool_to_bundle[tool_name] = bundle.name
+
+    def register_bundles(self, bundles: list[ToolBundle]) -> None:
+        for b in bundles:
+            self.register_bundle(b)
+
+    # ── per-turn resolution ──────────────────────────────────────────────
+
+    def resolve(
+        self,
+        user_message: str,
+        registry: Dict[str, dict],
+    ) -> Dict[str, dict]:
+        """Return the subset of *registry* that should appear in the prompt.
+
+        Parameters
+        ----------
+        user_message:
+            The current user turn (used for keyword matching).
+        registry:
+            The full ``_TOOL_REGISTRY`` dict mapping tool names → metadata.
+
+        Returns
+        -------
+        dict
+            Filtered copy of *registry* containing only active tools.
+        """
+        active_names: Set[str] = set()
+        activated_bundles: list[str] = []
+
+        for name, bundle in self._bundles.items():
+            state = self._state[name]
+
+            if bundle.policy == ActivationPolicy.ALWAYS:
+                active_names.update(bundle.tools)
+                activated_bundles.append(name)
+                continue
+
+            if bundle.policy == ActivationPolicy.SESSION:
+                if state.activated:
+                    active_names.update(bundle.tools)
+                    activated_bundles.append(name)
+                    continue
+                # Warm-window: check if any tool in the bundle was used recently
+                if self._was_used_recently(bundle):
+                    state.activated = True
+                    active_names.update(bundle.tools)
+                    activated_bundles.append(name)
+                    continue
+                # Also activate if keywords match (session bundles can have keywords)
+                if bundle.keywords and self._keywords_match(
+                    bundle.keywords, user_message
+                ):
+                    active_names.update(bundle.tools)
+                    activated_bundles.append(name)
+                    continue
+
+            if bundle.policy == ActivationPolicy.KEYWORD:
+                if state.activated:
+                    # Already activated this session — keep warm
+                    active_names.update(bundle.tools)
+                    activated_bundles.append(name)
+                    continue
+                if bundle.keywords and self._keywords_match(
+                    bundle.keywords, user_message
+                ):
+                    active_names.update(bundle.tools)
+                    activated_bundles.append(name)
+                    continue
+                # Warm-window fallback
+                if self._was_used_recently(bundle):
+                    active_names.update(bundle.tools)
+                    activated_bundles.append(name)
+                    continue
+
+        # Include any registered tools that are NOT in any bundle (backwards compat).
+        unbundled = {t for t in registry if t not in self._tool_to_bundle}
+        active_names.update(unbundled)
+
+        logger.debug(
+            "ToolLoader resolved %d/%d tools (bundles: %s)",
+            len(active_names & set(registry)),
+            len(registry),
+            ", ".join(activated_bundles) or "none",
+        )
+
+        return {k: v for k, v in registry.items() if k in active_names}
+
+    # ── tool execution hook ──────────────────────────────────────────────
+
+    def record_tool_use(self, tool_name: str) -> None:
+        """Record that a tool was executed (called from ``_execute_tool``).
+
+        This flips the owning bundle's ``activated`` flag so session-policy
+        bundles stay warm for the rest of the conversation.
+        """
+        now = time.time()
+        self._tool_history.append((tool_name, now))
+        bundle_name = self._tool_to_bundle.get(tool_name)
+        if bundle_name and bundle_name in self._state:
+            self._state[bundle_name].activated = True
+            self._state[bundle_name].last_used_ts = now
+
+    # ── query helpers ────────────────────────────────────────────────────
+
+    def get_active_bundle_names(self) -> list[str]:
+        """Return names of currently activated bundles."""
+        return [n for n, s in self._state.items() if s.activated]
+
+    def get_bundle_for_tool(self, tool_name: str) -> Optional[str]:
+        """Return the bundle name that owns *tool_name*, or ``None``."""
+        return self._tool_to_bundle.get(tool_name)
+
+    def reset_session(self) -> None:
+        """Clear per-session state (call between conversations)."""
+        for state in self._state.values():
+            state.activated = False
+            state.last_used_ts = 0.0
+        self._tool_history.clear()
+
+    # ── internals ────────────────────────────────────────────────────────
+
+    def _keywords_match(self, keywords: FrozenSet[str], message: str) -> bool:
+        """Return True if any keyword pattern matches *message*."""
+        for pattern in keywords:
+            try:
+                if re.search(pattern, message, re.IGNORECASE):
+                    return True
+            except re.error:
+                # Treat bad regex as a plain substring match
+                if pattern.lower() in message.lower():
+                    return True
+        return False
+
+    def _was_used_recently(self, bundle: ToolBundle) -> bool:
+        """Check if any tool in *bundle* was used within the warm window."""
+        cutoff = time.time() - self.WARM_WINDOW_SECS
+        for tool_name, ts in reversed(self._tool_history):
+            if ts < cutoff:
+                break
+            if tool_name in bundle.tools:
+                return True
+        return False

--- a/src/gaia/agents/base/tool_loader.py
+++ b/src/gaia/agents/base/tool_loader.py
@@ -232,6 +232,23 @@ class ToolLoader:
             state.last_used_ts = 0.0
         self._tool_history.clear()
 
+    def force_activate(self, bundle_name: str) -> None:
+        """Force-activate a bundle by name.
+
+        This is the safe public API to mark a bundle as active for the
+        session. Callers should use this instead of touching ``_state``
+        directly to avoid encapsulation breaches.
+        """
+        now = time.time()
+        if bundle_name in self._state:
+            self._state[bundle_name].activated = True
+            self._state[bundle_name].last_used_ts = now
+            logger.debug("ToolLoader: force-activated bundle '%s'", bundle_name)
+        else:
+            logger.warning(
+                "ToolLoader.force_activate: unknown bundle '%s'", bundle_name
+            )
+
     # ── internals ────────────────────────────────────────────────────────
 
     def _keywords_match(self, keywords: FrozenSet[str], message: str) -> bool:

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -21,6 +21,7 @@ from gaia.agents.chat.session import SessionManager
 from gaia.agents.chat.tools import FileToolsMixin, RAGToolsMixin, ShellToolsMixin
 from gaia.agents.code.tools.file_io import FileIOToolsMixin
 from gaia.agents.tools import FileSearchToolsMixin, ScreenshotToolsMixin  # Shared tools
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 from gaia.logger import get_logger
 from gaia.mcp.mixin import MCPClientMixin
 from gaia.rag.sdk import RAGSDK, RAGConfig
@@ -135,8 +136,8 @@ class ChatAgent(
         else:
             self.allowed_paths = [Path(p).resolve() for p in config.allowed_paths]
 
-        # Use Qwen3.5-35B-A3B by default for better tool-calling
-        effective_model_id = config.model_id or "Qwen3.5-35B-A3B-GGUF"
+        # Use default model configured by the Lemonade client when not provided
+        effective_model_id = config.model_id or DEFAULT_MODEL_NAME
         # ToolLoader will be configured later in _setup_tool_bundles(); define
         # attribute here to satisfy linters (avoid attribute-defined-outside-init).
         self.tool_loader = None

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -137,6 +137,9 @@ class ChatAgent(
 
         # Use Qwen3.5-35B-A3B by default for better tool-calling
         effective_model_id = config.model_id or "Qwen3.5-35B-A3B-GGUF"
+        # ToolLoader will be configured later in _setup_tool_bundles(); define
+        # attribute here to satisfy linters (avoid attribute-defined-outside-init).
+        self.tool_loader = None
 
         # Debug logging for model selection
         logger.debug(

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -42,7 +42,7 @@ class ChatAgentConfig:
     use_chatgpt: bool = False
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
-    model_id: Optional[str] = None  # None = use default Qwen3.5-35B-A3B
+    model_id: Optional[str] = None  # None = use default model (Gemma)
 
     # Execution settings
     max_steps: int = 10
@@ -136,7 +136,7 @@ class ChatAgent(
         else:
             self.allowed_paths = [Path(p).resolve() for p in config.allowed_paths]
 
-        # Use default model configured by the Lemonade client when not provided
+        # Use the configured default model (Gemma) when no explicit model is set
         effective_model_id = config.model_id or DEFAULT_MODEL_NAME
         # ToolLoader will be configured later in _setup_tool_bundles(); define
         # attribute here to satisfy linters (avoid attribute-defined-outside-init).

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -21,7 +21,6 @@ from gaia.agents.chat.session import SessionManager
 from gaia.agents.chat.tools import FileToolsMixin, RAGToolsMixin, ShellToolsMixin
 from gaia.agents.code.tools.file_io import FileIOToolsMixin
 from gaia.agents.tools import FileSearchToolsMixin, ScreenshotToolsMixin  # Shared tools
-from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 from gaia.logger import get_logger
 from gaia.mcp.mixin import MCPClientMixin
 from gaia.rag.sdk import RAGSDK, RAGConfig
@@ -42,7 +41,7 @@ class ChatAgentConfig:
     use_chatgpt: bool = False
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
-    model_id: Optional[str] = None  # None = use default model (Gemma)
+    model_id: Optional[str] = None  # None = use default Qwen3.5-35B-A3B
 
     # Execution settings
     max_steps: int = 10
@@ -136,8 +135,8 @@ class ChatAgent(
         else:
             self.allowed_paths = [Path(p).resolve() for p in config.allowed_paths]
 
-        # Use the configured default model (Gemma) when no explicit model is set
-        effective_model_id = config.model_id or DEFAULT_MODEL_NAME
+        # Use Qwen3.5-35B-A3B by default for better tool-calling
+        effective_model_id = config.model_id or "Qwen3.5-35B-A3B-GGUF"
 
         # Debug logging for model selection
         logger.debug(
@@ -406,21 +405,10 @@ No documents are currently indexed.
 - You have opinions and you share them. You're not afraid to be playful, sarcastic (lightly), or funny.
 - You keep it short. One good sentence beats three mediocre ones. Don't ramble.
 - Match your response length to the complexity of the question. For short questions, greetings, or simple factual lookups, reply in 1-2 sentences. Only expand to multiple paragraphs for complex analysis requests.
-- **GREETING RULE (ABSOLUTE):** When user sends a short greeting ("Hi!", "Hello", "Hey", "Hi there", etc.) as their first message: respond with 1-2 sentences MAXIMUM. NEVER list features, tools, or capabilities. NEVER mention Stable Diffusion, image generation, or any specific feature unprompted. Just greet back and invite them in.
-  **VARY YOUR PHRASING** — do not default to a single canned greeting. Repeating the same opener every turn gets stale fast. Pick something natural and a little different each time. Examples (rotate, riff, don't lock onto one):
-    - "Hey! What's the move today?"
-    - "Yo. What are we digging into?"
-    - "Hi! Anything I can help unblock?"
-    - "Hey there — got something on your plate?"
-    - "What's up? What can I take a swing at?"
-    - "Morning / afternoon — what brings you in?"
-    - "Hey. Whatcha working on?"
-    - "Howdy! What'll it be?"
-    - "Hi — what's the question?"
-    - "Hey! Drop it on me."
+- **GREETING RULE (ABSOLUTE):** When user sends a short greeting ("Hi!", "Hello", "Hey", "Hi there", etc.) as their first message: respond with 1-2 sentences MAXIMUM. NEVER list features, tools, or capabilities. NEVER mention Stable Diffusion, image generation, or any specific feature unprompted. Just greet back and ask what they need.
   WRONG: "Hey! What are you working on? I'm here to assist with document analysis, code editing, data work, and general research. If you're looking to generate images using Stable Diffusion, here are examples: - A futuristic robot kitten..." ← BANNED, verbose feature pitch on a greeting
-  WRONG: Returning the IDENTICAL greeting every conversation ("Hey! What are you working on?" every single time) — feels robotic, makes the user feel like they're talking to a script.
-  RIGHT: Any of the rotation examples above, or a fresh riff in the same spirit (warm, curious, brief, no feature pitch).
+  RIGHT: "Hey! What are you working on?"
+  RIGHT: "Hey — what do you need?"
 - HARD LIMIT: For capability questions ("what can you help with?", "what can you help me with?", "what do you do?", "what can you do?", "what do you help with?"): EXACTLY 1-2 sentences. STOP after 2 sentences. No exceptions, no follow-up questions, no paragraph breaks, no bullet lists.
   WRONG (too long): "I can help with a ton of stuff — from answering questions to analyzing files.\\n\\nIf you've got documents, I can look at them.\\n\\nNeed help writing? Want to explore ideas? Just tell me." ← 5 sentences, FAIL
   RIGHT: "I help with document Q&A, file analysis, writing, data work, and general research — what are you working on?"
@@ -749,20 +737,6 @@ When the document simply does NOT cover a topic, you MUST say so plainly. NEVER 
   RIGHT: (turn 1: contractors not eligible) → (turn 3: "The document states EAP is for employees; contractors were defined as not eligible for company benefits, so this does not apply to them.")
   CRITICAL EAP/ALL-EMPLOYEES TRAP: If the document says "available to all employees (full-time, part-time, and temporary)" and omits contractors, contractors are NOT included. "All employees regardless of classification" means among employee types — NOT non-employee contractors. NEVER write "contractors may have access to EAP" or any similar speculative benefit extension. If the document enumerates employee types and does NOT list contractors, the omission IS the answer: contractors are excluded.
   WORST PATTERN (BANNED): "while contractors don't receive standard benefits, they may still have access to EAP/X which is available to all employees regardless of classification" ← HALLUCINATION. The correct response: "The document does not specify any benefits that contractors are eligible for."
-
-**OUT-OF-SCOPE QUESTION RULE (CRITICAL — prevents reasoning loops on hallucination traps):**
-When the user asks for a specific fact (number, date, dollar amount, percentage, penalty figure) that may not be in the indexed document's scope (e.g. asking about Article 17 penalties when the document is GDPR Article 17 itself; asking about Python 3.12 release date in a Python 3.11 doc; asking about a max body size in a spec that defines none):
-1. Call query_documents or query_specific_file ONCE — exactly one query — to verify.
-2. If no relevant chunks come back, IMMEDIATELY produce your final answer in one short paragraph: "That [number/date/figure] is not in this document. [The document covers X, but not Y]." Then STOP.
-3. NEVER engage in extended reasoning or multiple speculative chains about what the answer might be from general knowledge. A single tool call followed by a 1-2 sentence final answer is the entire response.
-4. NEVER write "but approximately X...", "typically X is around...", "based on general knowledge X is..." after saying "not in document". Saying "not in document" is the COMPLETE answer — do NOT supplement.
-5. If the question references content from a DIFFERENT regulatory article, version, RFC, or spec section than the indexed document (e.g. "Article 17 penalties" when penalties are in Article 83; "Python 3.12 features" in a 3.11 doc), state the redirect plainly: "This document covers only [X]; [Y] is defined in [other source]." Do NOT estimate Y from training data.
-- WRONG: User asks GDPR Article 17 penalty. Agent reasons silently for 10 minutes about penalty frameworks. ← REASONING LOOP — never do this.
-- RIGHT: query_documents("Article 17 penalty fine euros") → no chunks → "Financial penalties for GDPR violations are defined in Article 83, not Article 17. This document does not include penalty figures."
-- WRONG: "The federal comment period duration is not in this document, but approximately 60 days based on standard rulemaking." ← SUPPLEMENT after disclaim is BANNED.
-- RIGHT: "The public comment period duration is not stated in this document."
-- WRONG: User asks Python 3.12 release date. Agent invents "October 2023". ← HALLUCINATION.
-- RIGHT: "This document covers Python 3.11 only. The Python 3.12 release date is not included here."
 
 **ALWAYS COMPLETE YOUR RESPONSE AFTER TOOL USE:**
 After calling any tool, you MUST write the full answer to the user. Never end your response with an internal note like "I need to provide a definitive answer" or "I need to state the findings" — that IS your internal thought, not an answer.
@@ -1528,51 +1502,6 @@ NOTE: Image analysis IS supported (analyze_image). URL fetching IS supported (fe
                     }
                 except Exception as e:
                     return {"status": "error", "error": str(e)}
-            elif system == "Darwin":
-                # macOS: AppleScript via osascript (always present on Mac).
-                # System Events returns every visible (non-background) process,
-                # which is the equivalent of "open apps" for users.
-                try:
-                    import subprocess
-
-                    script = (
-                        'tell application "System Events" to get name of '
-                        "every process whose background only is false"
-                    )
-                    result = subprocess.run(
-                        ["osascript", "-e", script],
-                        capture_output=True,
-                        text=True,
-                        timeout=10,
-                        check=False,
-                    )
-                    if result.returncode == 0 and result.stdout.strip():
-                        # osascript returns names comma-space-separated.
-                        names = [
-                            x.strip()
-                            for x in result.stdout.strip().split(",")
-                            if x.strip()
-                        ]
-                        for nm in names:
-                            windows.append({"title": nm, "process": nm})
-                        return {
-                            "status": "success",
-                            "windows": windows,
-                            "count": len(windows),
-                            "note": (
-                                "macOS: visible apps from System Events "
-                                "(Mission Control equivalent)"
-                            ),
-                        }
-                except (FileNotFoundError, subprocess.TimeoutExpired):
-                    pass
-                return {
-                    "status": "error",
-                    "error": (
-                        "Window listing failed on macOS. osascript may "
-                        "have been blocked by accessibility permissions."
-                    ),
-                }
             else:
                 try:
                     import subprocess
@@ -1704,6 +1633,11 @@ NOTE: Image analysis IS supported (analyze_image). URL fetching IS supported (fe
             except Exception as _mcp_err:
                 logger.warning("MCP server load failed: %s", _mcp_err)
 
+        # Set up bundle-based tool loading (#688 Phase 1).
+        # All tools remain registered in _TOOL_REGISTRY; the loader decides
+        # which subset appears in the LLM prompt each turn.
+        self._setup_tool_bundles()
+
     # NOTE: The actual tool definitions are in the mixin classes:
     # - RAGToolsMixin (rag_tools.py): RAG and document indexing tools
     # - FileToolsMixin (file_tools.py): Directory monitoring
@@ -1773,6 +1707,241 @@ NOTE: Image analysis IS supported (analyze_image). URL fetching IS supported (fe
         logger.debug(
             f"External tools: search_documentation={'registered' if has_npx else 'skipped (no npx)'},"
             f" search_web={'registered' if has_perplexity else 'skipped (no PERPLEXITY_API_KEY)'}"
+        )
+
+    def _setup_tool_bundles(self) -> None:
+        """Configure bundle-based tool loading for ChatAgent (#688 Phase 1).
+
+        Groups the ~30+ registered tools into semantic bundles so the
+        ToolLoader can gate which ones appear in the LLM prompt each turn.
+        Tools that are not assigned to any bundle remain always-visible
+        (backwards compatible).
+        """
+        from gaia.agents.base.tool_loader import (
+            ActivationPolicy,
+            ToolBundle,
+            ToolLoader,
+        )
+        from gaia.agents.base.tools import _TOOL_REGISTRY
+
+        self.tool_loader = ToolLoader()
+
+        # ── always-on: core tools the LLM needs every turn ──────────────
+        self.tool_loader.register_bundle(
+            ToolBundle(
+                name="core",
+                tools=frozenset(
+                    {
+                        "read_file",
+                        "list_files",
+                        "run_shell_command",
+                        "get_system_info",
+                    }
+                ),
+                policy=ActivationPolicy.ALWAYS,
+            )
+        )
+
+        # ── RAG bundle: active when docs are indexed or user asks about docs ─
+        self.tool_loader.register_bundle(
+            ToolBundle(
+                name="rag",
+                tools=frozenset(
+                    {
+                        "query_documents",
+                        "query_specific_file",
+                        "search_indexed_chunks",
+                        "evaluate_retrieval",
+                        "index_document",
+                        "list_indexed_documents",
+                        "rag_status",
+                        "summarize_document",
+                        "dump_document",
+                        "index_directory",
+                    }
+                ),
+                policy=ActivationPolicy.KEYWORD,
+                keywords=frozenset(
+                    {
+                        r"document|pdf|index|search.*file|rag|chunk|summarize|summary",
+                        r"what does .+ say",
+                        r"find.*in .+(report|handbook|manual|doc)",
+                    }
+                ),
+            )
+        )
+
+        # Pre-activate RAG bundle when documents are already indexed
+        if (
+            hasattr(self, "rag")
+            and self.rag
+            and getattr(self.rag, "indexed_files", None)
+        ):
+            self.tool_loader._state["rag"].activated = True
+
+        # ── filesystem: file navigation and search ──────────────────────
+        self.tool_loader.register_bundle(
+            ToolBundle(
+                name="filesystem",
+                tools=frozenset(
+                    {
+                        "search_file",
+                        "search_directory",
+                        "search_file_content",
+                        "browse_directory",
+                        "get_file_info",
+                        "list_recent_files",
+                        "add_watch_directory",
+                        "write_file",
+                        "edit_file",
+                    }
+                ),
+                policy=ActivationPolicy.KEYWORD,
+                keywords=frozenset(
+                    {
+                        r"file|folder|directory|path|find|search|browse|tree|ls\b|dir\b",
+                        r"\.[a-z]{1,5}\b",  # file extensions like .py, .json
+                        r"[/\\]",  # path separators
+                        r"write|edit|save|create.*file|modify",
+                    }
+                ),
+            )
+        )
+
+        # ── browser: web fetching and URL tools ─────────────────────────
+        self.tool_loader.register_bundle(
+            ToolBundle(
+                name="browser",
+                tools=frozenset(
+                    {
+                        "open_url",
+                        "fetch_webpage",
+                        "search_web",
+                        "search_documentation",
+                    }
+                ),
+                policy=ActivationPolicy.KEYWORD,
+                keywords=frozenset(
+                    {
+                        r"https?://",
+                        r"url|website|webpage|web\s*page|browse|internet",
+                        r"search.*web|google|look\s*up|online",
+                    }
+                ),
+            )
+        )
+
+        # ── data: data analysis and execution ───────────────────────────
+        self.tool_loader.register_bundle(
+            ToolBundle(
+                name="data",
+                tools=frozenset(
+                    {
+                        "analyze_data_file",
+                        "execute_python_file",
+                    }
+                ),
+                policy=ActivationPolicy.KEYWORD,
+                keywords=frozenset(
+                    {
+                        r"csv|excel|xlsx|data|analy[sz]e|statistics|chart|plot",
+                        r"run.*python|execute.*script|\.py\b",
+                    }
+                ),
+            )
+        )
+
+        # ── desktop: system interaction tools ───────────────────────────
+        self.tool_loader.register_bundle(
+            ToolBundle(
+                name="desktop",
+                tools=frozenset(
+                    {
+                        "take_screenshot",
+                        "list_windows",
+                        "read_clipboard",
+                        "write_clipboard",
+                        "notify_desktop",
+                        "text_to_speech",
+                    }
+                ),
+                policy=ActivationPolicy.KEYWORD,
+                keywords=frozenset(
+                    {
+                        r"screenshot|screen|capture|window|clipboard|copy|paste",
+                        r"notify|notification|alert|speak|say|tts|voice|read.*aloud",
+                    }
+                ),
+            )
+        )
+
+        # ── vlm: vision tools (only if registered) ─────────────────────
+        vlm_tools = {"analyze_image", "answer_question_about_image"} & set(
+            _TOOL_REGISTRY
+        )
+        if vlm_tools:
+            self.tool_loader.register_bundle(
+                ToolBundle(
+                    name="vlm",
+                    tools=frozenset(vlm_tools),
+                    policy=ActivationPolicy.KEYWORD,
+                    keywords=frozenset(
+                        {
+                            r"image|photo|picture|screenshot|jpg|png|gif|visual",
+                            r"what.*see|describe.*image|look.*at",
+                        }
+                    ),
+                )
+            )
+
+        # ── sd: image generation (only if registered) ───────────────────
+        sd_tools = {
+            "generate_image",
+            "list_sd_models",
+            "get_generation_history",
+        } & set(_TOOL_REGISTRY)
+        if sd_tools:
+            self.tool_loader.register_bundle(
+                ToolBundle(
+                    name="sd",
+                    tools=frozenset(sd_tools),
+                    policy=ActivationPolicy.KEYWORD,
+                    keywords=frozenset(
+                        {
+                            r"generate.*image|create.*image|draw|stable.?diffusion|sdxl",
+                            r"art|illustration|render|picture.*of",
+                        }
+                    ),
+                )
+            )
+
+        # ── mcp_*: one bundle per MCP server ────────────────────────────
+        # MCP tools are prefixed as mcp_<server>_<tool>.  Group by server.
+        mcp_tools_by_server: Dict[str, set] = {}
+        for tool_name in _TOOL_REGISTRY:
+            if tool_name.startswith("mcp_"):
+                parts = tool_name.split("_", 2)  # mcp, server, rest
+                if len(parts) >= 3:
+                    server = parts[1]
+                    mcp_tools_by_server.setdefault(server, set()).add(tool_name)
+
+        for server, tools in mcp_tools_by_server.items():
+            self.tool_loader.register_bundle(
+                ToolBundle(
+                    name=f"mcp_{server}",
+                    tools=frozenset(tools),
+                    policy=ActivationPolicy.SESSION,
+                )
+            )
+
+        # Log the bundle configuration
+        total = len(_TOOL_REGISTRY)
+        bundled = sum(len(b.tools) for b in self.tool_loader._bundles.values())
+        logger.info(
+            "ToolLoader configured: %d bundles, %d/%d tools bundled",
+            len(self.tool_loader._bundles),
+            bundled,
+            total,
         )
 
     def _index_documents(self, documents: List[str]) -> None:

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -1781,7 +1781,13 @@ NOTE: Image analysis IS supported (analyze_image). URL fetching IS supported (fe
             and self.rag
             and getattr(self.rag, "indexed_files", None)
         ):
-            self.tool_loader._state["rag"].activated = True
+            # Use ToolLoader.force_activate to avoid direct _state mutation
+            try:
+                self.tool_loader.force_activate("rag")
+            except Exception as exc:
+                logger.warning(
+                    "ToolLoader.force_activate('rag') failed: %s", exc, exc_info=True
+                )
 
         # ── filesystem: file navigation and search ──────────────────────
         self.tool_loader.register_bundle(
@@ -1803,10 +1809,10 @@ NOTE: Image analysis IS supported (analyze_image). URL fetching IS supported (fe
                 policy=ActivationPolicy.KEYWORD,
                 keywords=frozenset(
                     {
-                        r"file|folder|directory|path|find|search|browse|tree|ls\b|dir\b",
+                        r"\b(?:file|folder|directory|path|find|search|browse|tree|ls|dir)\b",
                         r"\.[a-z]{1,5}\b",  # file extensions like .py, .json
-                        r"[/\\]",  # path separators
-                        r"write|edit|save|create.*file|modify",
+                        r"\b[\w\-.]+/[\w./\\-]+\b",  # path-like patterns (avoid bare slashes)
+                        r"\b(?:write|edit|save|create.*file|modify)\b",
                     }
                 ),
             )
@@ -1828,8 +1834,11 @@ NOTE: Image analysis IS supported (analyze_image). URL fetching IS supported (fe
                 keywords=frozenset(
                     {
                         r"https?://",
-                        r"url|website|webpage|web\s*page|browse|internet",
-                        r"search.*web|google|look\s*up|online",
+                        r"\b(?:url|website|webpage|web\s*page|browse|internet)\b",
+                        r"\bsearch.*web\b",
+                        r"\bgoogle\b",
+                        r"\blook\s+up\b",
+                        r"\bonline\b",
                     }
                 ),
             )

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -968,6 +968,14 @@ async def _get_chat_response(
                 )
                 agent = ChatAgent(config)
                 _store_agent(session_id, model_id, document_ids, agent, agent_type)
+                # Ensure per-session tool loader state is fresh when a new
+                # agent is created. Use public API to avoid touching internal
+                # attributes (see ToolLoader.reset_session()).
+                try:
+                    if hasattr(agent, "tool_loader") and agent.tool_loader:
+                        agent.tool_loader.reset_session()
+                except Exception as _exc:  # pylint: disable=broad-except
+                    logger.debug("tool_loader.reset_session failed: %s", _exc)
             else:
                 logger.info(
                     "chat: Creating new %s agent for session %s",
@@ -1013,6 +1021,12 @@ async def _get_chat_response(
                     agent,
                     agent_type,
                 )
+                # Reset per-session tool loader state for freshly created agents
+                try:
+                    if hasattr(agent, "tool_loader") and agent.tool_loader:
+                        agent.tool_loader.reset_session()
+                except Exception as _exc:  # pylint: disable=broad-except
+                    logger.debug("tool_loader.reset_session failed: %s", _exc)
 
         # Restore conversation history (limited to prevent context overflow).
         # Always re-inject from DB so the history is consistent with what was

--- a/tests/unit/test_tool_loader.py
+++ b/tests/unit/test_tool_loader.py
@@ -237,9 +237,7 @@ class TestKeywordActivation:
 
     def test_browser_activated_by_url(self, loader, full_registry):
         loader.register_bundles(ALL_BUNDLES)
-        result = loader.resolve(
-            "Fetch https://example.com/data", full_registry
-        )
+        result = loader.resolve("Fetch https://example.com/data", full_registry)
         assert "fetch_page" in result
         assert "search_web" in result
 
@@ -338,9 +336,7 @@ class TestDisambiguation:
     ):
         """'What did I learn about FTS5 last week?' → recall, not query_data."""
         loader.register_bundles(ALL_BUNDLES)
-        result = loader.resolve(
-            "What did I learn about FTS5 last week?", full_registry
-        )
+        result = loader.resolve("What did I learn about FTS5 last week?", full_registry)
         assert "recall" in result
         # Scratchpad should NOT be active (never used, no keywords)
         assert "query_data" not in result

--- a/tests/unit/test_tool_loader.py
+++ b/tests/unit/test_tool_loader.py
@@ -1,0 +1,478 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for the ToolLoader — bundle-based tool visibility (#688 Phase 1).
+
+Covers:
+- Bundle registration and resolution
+- Activation policies (always, session, keyword)
+- Per-turn tool filtering
+- Tool-use recording and warm-window behaviour
+- Regression: scratchpad.query_data vs memory.recall disambiguation
+"""
+
+import time
+
+import pytest
+
+from gaia.agents.base.tool_loader import (
+    ActivationPolicy,
+    ToolBundle,
+    ToolLoader,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_registry(*tool_names: str) -> dict:
+    """Build a minimal fake _TOOL_REGISTRY for testing."""
+    return {
+        name: {
+            "name": name,
+            "description": f"Tool {name}",
+            "parameters": {},
+            "function": lambda: None,
+            "atomic": False,
+        }
+        for name in tool_names
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def loader():
+    return ToolLoader()
+
+
+@pytest.fixture()
+def full_registry():
+    """Simulates the post-#495/#606 ChatAgent registry (~27 tools)."""
+    return _make_registry(
+        # core
+        "read_file",
+        "list_files",
+        "run_shell_command",
+        # rag
+        "query_documents",
+        "query_specific_file",
+        "index_document",
+        "list_indexed_documents",
+        "search_indexed_chunks",
+        "index_directory",
+        # filesystem (from PR #495)
+        "browse_directory",
+        "tree",
+        "file_info",
+        "find_files",
+        "bookmark",
+        # scratchpad (from PR #495)
+        "create_table",
+        "insert_data",
+        "query_data",
+        "list_tables",
+        "drop_table",
+        # browser (from PR #495)
+        "fetch_page",
+        "search_web",
+        "download_file",
+        # memory (from PR #606)
+        "remember",
+        "recall",
+        "update_memory",
+        "forget",
+        "search_past_conversations",
+    )
+
+
+CORE_BUNDLE = ToolBundle(
+    name="core",
+    tools=frozenset({"read_file", "list_files", "run_shell_command"}),
+    policy=ActivationPolicy.ALWAYS,
+)
+
+RAG_BUNDLE = ToolBundle(
+    name="rag",
+    tools=frozenset(
+        {
+            "query_documents",
+            "query_specific_file",
+            "index_document",
+            "list_indexed_documents",
+            "search_indexed_chunks",
+            "index_directory",
+        }
+    ),
+    policy=ActivationPolicy.KEYWORD,
+    keywords=frozenset({r"document|pdf|index|rag|summarize"}),
+)
+
+FILESYSTEM_BUNDLE = ToolBundle(
+    name="filesystem",
+    tools=frozenset(
+        {"browse_directory", "tree", "file_info", "find_files", "bookmark"}
+    ),
+    policy=ActivationPolicy.KEYWORD,
+    keywords=frozenset({r"file|folder|directory|path|browse|tree"}),
+)
+
+SCRATCHPAD_BUNDLE = ToolBundle(
+    name="scratchpad",
+    tools=frozenset(
+        {"create_table", "insert_data", "query_data", "list_tables", "drop_table"}
+    ),
+    policy=ActivationPolicy.SESSION,
+    keywords=frozenset({r"table|spreadsheet|csv|data.*entry|scratchpad"}),
+)
+
+BROWSER_BUNDLE = ToolBundle(
+    name="browser",
+    tools=frozenset({"fetch_page", "search_web", "download_file"}),
+    policy=ActivationPolicy.KEYWORD,
+    keywords=frozenset({r"https?://|url|website|web|search.*online"}),
+)
+
+MEMORY_BUNDLE = ToolBundle(
+    name="memory",
+    tools=frozenset(
+        {
+            "remember",
+            "recall",
+            "update_memory",
+            "forget",
+            "search_past_conversations",
+        }
+    ),
+    policy=ActivationPolicy.SESSION,
+    keywords=frozenset(
+        {r"remember|recall|forgot|memory|learned|last.*(week|time|session)"}
+    ),
+)
+
+ALL_BUNDLES = [
+    CORE_BUNDLE,
+    RAG_BUNDLE,
+    FILESYSTEM_BUNDLE,
+    SCRATCHPAD_BUNDLE,
+    BROWSER_BUNDLE,
+    MEMORY_BUNDLE,
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests — bundle registration
+# ---------------------------------------------------------------------------
+
+
+class TestBundleRegistration:
+    def test_register_single_bundle(self, loader):
+        loader.register_bundle(CORE_BUNDLE)
+        assert "core" in loader._bundles
+
+    def test_register_multiple_bundles(self, loader):
+        loader.register_bundles(ALL_BUNDLES)
+        assert len(loader._bundles) == len(ALL_BUNDLES)
+
+    def test_tool_to_bundle_index(self, loader):
+        loader.register_bundles(ALL_BUNDLES)
+        assert loader.get_bundle_for_tool("query_data") == "scratchpad"
+        assert loader.get_bundle_for_tool("recall") == "memory"
+        assert loader.get_bundle_for_tool("read_file") == "core"
+
+    def test_overwrite_bundle(self, loader):
+        loader.register_bundle(CORE_BUNDLE)
+        new_core = ToolBundle(
+            name="core",
+            tools=frozenset({"read_file"}),
+            policy=ActivationPolicy.ALWAYS,
+        )
+        loader.register_bundle(new_core)
+        assert loader._bundles["core"].tools == frozenset({"read_file"})
+
+
+# ---------------------------------------------------------------------------
+# Tests — always-on policy
+# ---------------------------------------------------------------------------
+
+
+class TestAlwaysPolicy:
+    def test_core_always_visible(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("Hi there!", full_registry)
+        assert "read_file" in result
+        assert "list_files" in result
+        assert "run_shell_command" in result
+
+    def test_core_visible_regardless_of_message(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        for msg in ["", "hello", "what is 2+2?", "tell me a joke"]:
+            result = loader.resolve(msg, full_registry)
+            for tool in CORE_BUNDLE.tools:
+                assert tool in result, f"Core tool {tool} missing for message: {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tests — keyword activation
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordActivation:
+    def test_rag_activated_by_document_keyword(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("Summarize the document", full_registry)
+        assert "query_documents" in result
+        assert "index_document" in result
+
+    def test_filesystem_activated_by_path(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("Show me files in /home/user", full_registry)
+        assert "browse_directory" in result
+        assert "find_files" in result
+
+    def test_browser_activated_by_url(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve(
+            "Fetch https://example.com/data", full_registry
+        )
+        assert "fetch_page" in result
+        assert "search_web" in result
+
+    def test_unrelated_message_hides_keyword_bundles(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("What is the capital of France?", full_registry)
+        # Keyword bundles should NOT be active
+        assert "query_documents" not in result
+        assert "browse_directory" not in result
+        assert "fetch_page" not in result
+
+    def test_rag_stays_warm_after_first_keyword_activation(self, loader, full_registry):
+        """Keyword bundle that was activated should stay warm on subsequent turns."""
+        loader.register_bundles(ALL_BUNDLES)
+        # First turn: activates RAG via keyword
+        loader.resolve("Summarize the document", full_registry)
+        # Simulate tool use
+        loader.record_tool_use("query_documents")
+        # Second turn: no keyword, but bundle should be warm
+        result = loader.resolve("What else does it say?", full_registry)
+        assert "query_documents" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests — session activation
+# ---------------------------------------------------------------------------
+
+
+class TestSessionActivation:
+    def test_scratchpad_hidden_until_used(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("What is the weather?", full_registry)
+        assert "query_data" not in result
+        assert "create_table" not in result
+
+    def test_scratchpad_activates_on_keyword(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("Create a table for my expenses", full_registry)
+        assert "create_table" in result
+        assert "query_data" in result
+
+    def test_scratchpad_stays_active_after_use(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        # First turn: hidden
+        result = loader.resolve("Hello", full_registry)
+        assert "query_data" not in result
+        # Simulate: user creates a table, tool gets executed
+        loader.record_tool_use("create_table")
+        # Second turn: scratchpad should be warm
+        result = loader.resolve("Now query my expenses", full_registry)
+        assert "query_data" in result
+        assert "create_table" in result
+
+    def test_memory_hidden_until_used(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("What time is it?", full_registry)
+        assert "recall" not in result
+        assert "remember" not in result
+
+    def test_memory_activates_on_keyword(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("What did I learn about FTS5 last week?", full_registry)
+        assert "recall" in result
+
+    def test_memory_stays_warm_after_remember(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        loader.record_tool_use("remember")
+        result = loader.resolve("OK, what else?", full_registry)
+        assert "recall" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests — scratchpad vs memory disambiguation (#688 collision)
+# ---------------------------------------------------------------------------
+
+
+class TestDisambiguation:
+    """Verify that query_data and recall are not both visible unless justified."""
+
+    def test_spending_query_activates_scratchpad_not_memory(
+        self, loader, full_registry
+    ):
+        """'What did I spend on groceries in March?' → query_data, not recall."""
+        loader.register_bundles(ALL_BUNDLES)
+        # Pre-activate scratchpad (user created a table earlier)
+        loader.record_tool_use("create_table")
+        result = loader.resolve(
+            "What did I spend on groceries in March?", full_registry
+        )
+        assert "query_data" in result
+        # Memory should NOT be active (no memory keywords matched)
+        assert "recall" not in result
+
+    def test_learning_query_activates_memory_not_scratchpad(
+        self, loader, full_registry
+    ):
+        """'What did I learn about FTS5 last week?' → recall, not query_data."""
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve(
+            "What did I learn about FTS5 last week?", full_registry
+        )
+        assert "recall" in result
+        # Scratchpad should NOT be active (never used, no keywords)
+        assert "query_data" not in result
+
+    def test_both_visible_when_both_justified(self, loader, full_registry):
+        """Both visible if scratchpad was used AND memory keywords present."""
+        loader.register_bundles(ALL_BUNDLES)
+        loader.record_tool_use("create_table")
+        result = loader.resolve(
+            "Do I remember anything about the data in my table from last week?",
+            full_registry,
+        )
+        # Both should be active: scratchpad (session-warm), memory (keyword)
+        assert "query_data" in result
+        assert "recall" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests — unbundled tools
+# ---------------------------------------------------------------------------
+
+
+class TestUnbundledTools:
+    def test_unbundled_tools_always_visible(self, loader):
+        """Tools not assigned to any bundle should appear in every turn."""
+        registry = _make_registry("read_file", "custom_tool", "another_tool")
+        loader.register_bundle(CORE_BUNDLE)
+        result = loader.resolve("Hello", registry)
+        # read_file is in core → visible
+        assert "read_file" in result
+        # custom_tool and another_tool are unbundled → visible
+        assert "custom_tool" in result
+        assert "another_tool" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests — token savings
+# ---------------------------------------------------------------------------
+
+
+class TestTokenSavings:
+    def test_typical_session_reduces_tool_count(self, loader, full_registry):
+        """A typical greeting should only expose core + unbundled tools."""
+        loader.register_bundles(ALL_BUNDLES)
+        result = loader.resolve("Hi there, what's up?", full_registry)
+        # Only core tools (3) should be visible from bundled tools
+        assert len(result) == len(CORE_BUNDLE.tools)
+
+    def test_max_tools_with_all_activated(self, loader, full_registry):
+        """Even with all bundles active, we get the full set."""
+        loader.register_bundles(ALL_BUNDLES)
+        # Activate everything
+        for bundle in ALL_BUNDLES:
+            for tool_name in bundle.tools:
+                loader.record_tool_use(tool_name)
+        result = loader.resolve("Do everything", full_registry)
+        assert len(result) == len(full_registry)
+
+
+# ---------------------------------------------------------------------------
+# Tests — session reset
+# ---------------------------------------------------------------------------
+
+
+class TestSessionReset:
+    def test_reset_clears_activation(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        loader.record_tool_use("create_table")
+        # Verify activated
+        assert loader._state["scratchpad"].activated is True
+        # Reset
+        loader.reset_session()
+        assert loader._state["scratchpad"].activated is False
+        result = loader.resolve("Hello", full_registry)
+        assert "query_data" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tests — warm window
+# ---------------------------------------------------------------------------
+
+
+class TestWarmWindow:
+    def test_recent_use_keeps_bundle_warm(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        # Manually inject a recent use into history
+        loader._tool_history.append(("fetch_page", time.time()))
+        result = loader.resolve("Tell me something", full_registry)
+        assert "fetch_page" in result
+
+    def test_old_use_does_not_keep_bundle_warm(self, loader, full_registry):
+        loader.register_bundles(ALL_BUNDLES)
+        # Inject an old use (26 hours ago)
+        old_ts = time.time() - 26 * 3600
+        loader._tool_history.append(("fetch_page", old_ts))
+        result = loader.resolve("Tell me something", full_registry)
+        assert "fetch_page" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tests — mid-conversation pivot
+# ---------------------------------------------------------------------------
+
+
+class TestMidConversationPivot:
+    def test_pivot_from_files_to_web(self, loader, full_registry):
+        """Session starts with file browsing, pivots to web research."""
+        loader.register_bundles(ALL_BUNDLES)
+
+        # Turn 1: file browsing
+        result1 = loader.resolve("Show me files in /projects", full_registry)
+        assert "browse_directory" in result1
+        assert "fetch_page" not in result1
+        loader.record_tool_use("browse_directory")
+
+        # Turn 2: pivot to web
+        result2 = loader.resolve(
+            "Now search the web for React tutorials", full_registry
+        )
+        assert "fetch_page" in result2
+        # Filesystem should still be warm (was used recently)
+        assert "browse_directory" in result2
+
+    def test_pivot_from_chat_to_rag(self, loader, full_registry):
+        """General chat pivots to document analysis."""
+        loader.register_bundles(ALL_BUNDLES)
+
+        # Turn 1: general chat
+        result1 = loader.resolve("Hi, how are you?", full_registry)
+        assert "query_documents" not in result1
+
+        # Turn 2: mentions a document
+        result2 = loader.resolve("Summarize the quarterly report PDF", full_registry)
+        assert "query_documents" in result2
+        assert "index_document" in result2


### PR DESCRIPTION
## Summary
Implements dynamic tool-loader with bundle-gated activation for GAIA's 
agent system, reducing token usage by only exposing tools relevant to 
the current conversation context.

## Why
The full tool registry is passed to the LLM on every turn, consuming 
tokens for tools that are unlikely to be used. Bundle-gated activation 
loads tools on-demand based on keyword matching and activation policies 
(always, session, keyword), reducing context window pressure and 
improving response quality.

## Linked issue
Closes #688

## Changes
- Added `src/gaia/agents/base/tool_loader.py` - `ToolLoader` with bundle 
  registration, keyword-based activation, and session/always/keyword policies
- Added `force_activate(bundle_name)` public method to avoid direct `_state` access
- Wired `reset_session()` into conversation-start path in `ChatAgent`
- Tightened filesystem and browser keyword regexes to use word boundaries
- Added `src/gaia/agents/base/tool_loader.py` unit tests

## Test plan
- [x] `pytest tests/unit/test_tool_loader.py` - all passing
- [x] `python util/lint.py --all` - no failures
- [ ] Manual: start a chat session and verify only relevant tool bundles 
      activate based on conversation context

## Checklist
- [x] I have linked a GitHub issue above (`Closes #688`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally.
- [ ] I have updated documentation if user-visible behavior changed.