### PR TITLE
fix(installer): bundle uv binary for mac-arm64

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -261,9 +261,13 @@ jobs:
           cp "${tmpdir}/uv-aarch64-apple-darwin/uv" "${DEST_DIR}/uv"
           chmod 0755 "${DEST_DIR}/uv"
           "${DEST_DIR}/uv" --version
-          # Echo the extracted-binary SHA so a maintainer bumping
-          # BUNDLED_UV_VERSION can cross-check BUNDLED_UV_SHA256[mac-arm64]
-          # without re-running T0 locally.
+          # Echo the extracted-binary SHA. This is the PRE-codesign digest
+          # (i.e., the upstream tarball's uv byte-for-byte), useful for
+          # confirming what feeds into electron-builder's codesign step.
+          # NOTE: this is NOT directly comparable to BUNDLED_UV_SHA256[mac-arm64],
+          # which is the POST-codesign digest — see backend-installer.cjs.
+          # To bump BUNDLED_UV_SHA256[mac-arm64], run the CI build and copy
+          # the SHA from the dmg-structural-smoke failure message.
           shasum -a 256 "${DEST_DIR}/uv"
 
       - name: Build frontend (Vite)

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -92,7 +92,10 @@ on:
       - 'src/gaia/apps/webui/main.cjs'
       - 'src/gaia/apps/webui/bin/**'
       - 'src/gaia/apps/webui/services/**'
-      - 'tests/electron/fixtures/**'
+      # Cover the whole installer-smoke test tree (issue #941) so a PR that
+      # only touches the smoke-test layer still triggers structural smoke.
+      # The narrower `tests/electron/fixtures/**` is subsumed by `**`.
+      - 'tests/electron/**'
       - 'src/gaia/version.py'
 
 # Least-privilege default. Only the release-upload step needs `contents:
@@ -228,6 +231,40 @@ jobs:
           cp "${tmpdir}/uv-x86_64-unknown-linux-gnu/uv" "${DEST_DIR}/uv"
           chmod 0755 "${DEST_DIR}/uv"
           "${DEST_DIR}/uv" --version
+
+      # ─── Fetch uv binary for macOS DMG (issue #941) ─────────────────
+      # Mirror of the Linux step above. Without this, the macOS .app
+      # ships no bundled uv even though backend-installer.cjs claims
+      # support for darwin-arm64, so first-launch on a clean Mac (no
+      # system uv on PATH) hard-fails in ensure-uv. The runtime hashes
+      # the *extracted* binary against BUNDLED_UV_SHA256["mac-arm64"]
+      # in src/gaia/apps/webui/services/backend-installer.cjs — those
+      # two pins MUST be bumped in lockstep with this step.
+      - name: Fetch uv binary (macOS)
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          UV_VERSION="0.5.14"
+          UV_TARBALL="uv-aarch64-apple-darwin.tar.gz"
+          UV_SHA256="d548dffc256014c4c8c693e148140a3a21bcc2bf066a35e1d5f0d24c91d32112"
+          UV_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TARBALL}"
+          DEST_DIR="src/gaia/apps/webui/build/vendor/uv/mac-arm64"
+          mkdir -p "${DEST_DIR}"
+          tmpdir="$(mktemp -d)"
+          # --retry 3/5s matches the Lemonade MSI step below; survives
+          # transient GitHub Releases CDN flakes on hosted macOS runners.
+          curl -fsSL --retry 3 --retry-delay 5 -o "${tmpdir}/${UV_TARBALL}" "${UV_URL}"
+          # macOS shasum -a 256 -c accepts the GNU "hash  file" format.
+          echo "${UV_SHA256}  ${tmpdir}/${UV_TARBALL}" | shasum -a 256 -c -
+          tar -xzf "${tmpdir}/${UV_TARBALL}" -C "${tmpdir}"
+          cp "${tmpdir}/uv-aarch64-apple-darwin/uv" "${DEST_DIR}/uv"
+          chmod 0755 "${DEST_DIR}/uv"
+          "${DEST_DIR}/uv" --version
+          # Echo the extracted-binary SHA so a maintainer bumping
+          # BUNDLED_UV_VERSION can cross-check BUNDLED_UV_SHA256[mac-arm64]
+          # without re-running T0 locally.
+          shasum -a 256 "${DEST_DIR}/uv"
 
       - name: Build frontend (Vite)
         working-directory: src/gaia/apps/webui
@@ -531,6 +568,44 @@ jobs:
         env:
           GAIA_APPIMAGE: ${{ steps.locate.outputs.appimage }}
         run: node --test tests/electron/appimage-smoke.test.mjs
+
+  # ─── DMG structural smoke (issue #941) ──────────────────────────────
+  # Mirrors appimage-structural-smoke for the macOS DMG. Catches the
+  # failure mode that bit v0.17.5: a darwin-arm64 install that hard-fails
+  # in ensure-uv on first launch because the bundled uv either was never
+  # shipped or has the wrong SHA256 against BUNDLED_UV_SHA256[mac-arm64]
+  # in backend-installer.cjs.
+  #
+  # MUST be present in build-complete `needs:` below — without that
+  # wiring, a failing DMG smoke does not block release-readiness.
+  dmg-structural-smoke:
+    name: DMG structural smoke
+    needs: build
+    if: always() && needs.build.result == 'success'
+    runs-on: macos-latest  # Apple Silicon (arm64) — matches build matrix
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download macOS installer artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: macos-installer  # ${{ matrix.platform }}-installer with platform=macos
+          path: ${{ runner.temp }}/macos-installer
+
+      - name: Locate DMG
+        id: locate
+        shell: bash
+        run: |
+          set -euo pipefail
+          DMG=$(ls "${RUNNER_TEMP}/macos-installer"/*.dmg | head -n1)
+          echo "Found DMG: ${DMG}"
+          echo "dmg=${DMG}" >> "$GITHUB_OUTPUT"
+
+      - name: Structural smoke (uv binary, mode, sha256, --version)
+        env:
+          GAIA_DMG: ${{ steps.locate.outputs.dmg }}
+        run: node --test tests/electron/dmg-smoke.test.mjs
 
   appimage-distro-matrix:
     name: AppImage distro matrix
@@ -971,6 +1046,7 @@ jobs:
       - appimage-structural-smoke
       - appimage-distro-matrix
       - appimage-userns-restricted
+      - dmg-structural-smoke
     if: always()
     steps:
       - name: Verify all platform builds and smoke tests succeeded
@@ -980,22 +1056,24 @@ jobs:
           structural_result="${{ needs.appimage-structural-smoke.result }}"
           distro_result="${{ needs.appimage-distro-matrix.result }}"
           userns_result="${{ needs.appimage-userns-restricted.result }}"
+          dmg_result="${{ needs.dmg-structural-smoke.result }}"
           echo "build:                       $build_result"
           echo "appimage-structural-smoke:   $structural_result"
           echo "appimage-distro-matrix:      $distro_result"
           echo "appimage-userns-restricted:  $userns_result"
+          echo "dmg-structural-smoke:        $dmg_result"
           fail=0
           if [ "$build_result" != "success" ]; then
             echo "::error::One or more platform installer builds failed"
             fail=1
           fi
-          for r in "$structural_result" "$distro_result" "$userns_result"; do
+          for r in "$structural_result" "$distro_result" "$userns_result" "$dmg_result"; do
             if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
-              echo "::error::AppImage smoke job failed (status: $r)"
+              echo "::error::Installer smoke job failed (status: $r)"
               fail=1
             fi
           done
           if [ "$fail" -eq 1 ]; then
             exit 1
           fi
-          echo "All platform installers built and AppImage smoke suite passed."
+          echo "All platform installers built and installer smoke suite passed."

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -92,10 +92,13 @@ on:
       - 'src/gaia/apps/webui/main.cjs'
       - 'src/gaia/apps/webui/bin/**'
       - 'src/gaia/apps/webui/services/**'
-      # Cover the whole installer-smoke test tree (issue #941) so a PR that
+      # Cover the installer-smoke test tree (issue #941) so a PR that
       # only touches the smoke-test layer still triggers structural smoke.
-      # The narrower `tests/electron/fixtures/**` is subsumed by `**`.
-      - 'tests/electron/**'
+      # Narrower than `tests/electron/**` so Jest-only edits to e.g.
+      # test_electron_chat_app.js don't re-run the multi-platform build.
+      - 'tests/electron/_helpers/**'
+      - 'tests/electron/*-smoke.test.mjs'
+      - 'tests/electron/fixtures/**'
       - 'src/gaia/version.py'
 
 # Least-privilege default. Only the release-upload step needs `contents:

--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -583,6 +583,8 @@ jobs:
     needs: build
     if: always() && needs.build.result == 'success'
     runs-on: macos-latest  # Apple Silicon (arm64) — matches build matrix
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,6 +58,7 @@ jobs:
   # Auto-review new PRs (including forks)
   pr-review:
     # Temporarily disabled — Anthropic credit balance exhausted (see commit a013e384).
+    # Tracked for re-enable in https://github.com/amd/gaia/issues/970
     # To re-enable: restore the original `repository / event_name / draft / label` gate.
     if: false
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,11 +57,7 @@ permissions:
 jobs:
   # Auto-review new PRs (including forks)
   pr-review:
-    if: |
-      github.repository == 'amd/gaia' &&
-      github.event_name == 'pull_request_target' &&
-      (github.event.pull_request.draft == false ||
-       contains(github.event.pull_request.labels.*.name, 'ready_for_ci'))
+    if: false
     runs-on: ubuntu-latest
     concurrency:
       group: claude-pr-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,6 +57,8 @@ permissions:
 jobs:
   # Auto-review new PRs (including forks)
   pr-review:
+    # Temporarily disabled — Anthropic credit balance exhausted (see commit a013e384).
+    # To re-enable: restore the original `repository / event_name / draft / label` gate.
     if: false
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,9 +57,15 @@ permissions:
 jobs:
   # Auto-review new PRs (including forks)
   pr-review:
-    # Temporarily disabled — Anthropic credit balance exhausted (see commit a013e384).
-    # Tracked for re-enable in https://github.com/amd/gaia/issues/970
-    # To re-enable: restore the original `repository / event_name / draft / label` gate.
+    # Temporarily disabled 2026-05 — Anthropic credit balance exhausted
+    # (see commit a013e384). Tracked for re-enable in
+    # https://github.com/amd/gaia/issues/970. To re-enable, replace the
+    # `if: false` line below with this commented gate:
+    # if: |
+    #   github.repository == 'amd/gaia' &&
+    #   github.event_name == 'pull_request_target' &&
+    #   (github.event.pull_request.draft == false ||
+    #    contains(github.event.pull_request.labels.*.name, 'ready_for_ci'))
     if: false
     runs-on: ubuntu-latest
     concurrency:

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.17.6",
+  "version": "0.17.5",
   "type": "module",
   "productName": "GAIA Agent UI",
   "description": "Privacy-first agentic AI interface with document Q&A - runs 100% locally on AMD Ryzen AI",

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "type": "module",
   "productName": "GAIA Agent UI",
   "description": "Privacy-first agentic AI interface with document Q&A - runs 100% locally on AMD Ryzen AI",

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -81,10 +81,14 @@ const NETWORK_CHECK_TIMEOUT_MS = 5000;
 // (win-x64 deferred to a follow-up issue — its SHA must ship together with an
 // NSIS structural-smoke verifier, not on its own; see the #849 lesson.)
 //
-// Note on mac-arm64: electron-builder code-signs the bundled uv binary during
-// packaging, so the hash here is the post-signing digest (what ensureUv() sees
-// at runtime), NOT the raw extracted-from-tarball digest. The workflow step
-// verifies the archive provenance; this constant verifies the packaged binary.
+// IMPORTANT: per-platform SHA origin differs:
+//   - linux-x64:  raw extracted-from-tarball digest (no post-build modification).
+//   - mac-arm64:  POST-CODESIGN digest. electron-builder code-signs the bundled
+//                 uv during packaging, so this hash matches what ensureUv() sees
+//                 at runtime, NOT the upstream tarball. Bumping this pin means
+//                 running the CI build, then copying the SHA from the
+//                 dmg-structural-smoke failure message — never from `shasum`
+//                 against the freshly downloaded tarball.
 const BUNDLED_UV_VERSION = "0.5.14";
 const BUNDLED_UV_SHA256 = {
   "linux-x64": "0e05d828b5708e8a927724124db3746396afddad6273c47283d7c562dc795bd6",

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -77,10 +77,13 @@ const NETWORK_CHECK_TIMEOUT_MS = 5000;
 // archive against upstream's published .sha256, then extracts the `uv` binary
 // which is what `ensureUv()` hashes at runtime.
 //
-// Currently pinned: uv v0.5.14 linux-x64.
+// Currently pinned: uv v0.5.14 linux-x64, mac-arm64.
+// (win-x64 deferred to a follow-up issue — its SHA must ship together with an
+// NSIS structural-smoke verifier, not on its own; see the #849 lesson.)
 const BUNDLED_UV_VERSION = "0.5.14";
 const BUNDLED_UV_SHA256 = {
   "linux-x64": "0e05d828b5708e8a927724124db3746396afddad6273c47283d7c562dc795bd6",
+  "mac-arm64": "415f73cab3771902db58f6a9ce4d9cf3e664a3eed26ee7e48a051453a79bd015",
 };
 
 const MANAGED_UV_DIR = path.join(GAIA_HOME, "bin");

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -80,10 +80,15 @@ const NETWORK_CHECK_TIMEOUT_MS = 5000;
 // Currently pinned: uv v0.5.14 linux-x64, mac-arm64.
 // (win-x64 deferred to a follow-up issue — its SHA must ship together with an
 // NSIS structural-smoke verifier, not on its own; see the #849 lesson.)
+//
+// Note on mac-arm64: electron-builder code-signs the bundled uv binary during
+// packaging, so the hash here is the post-signing digest (what ensureUv() sees
+// at runtime), NOT the raw extracted-from-tarball digest. The workflow step
+// verifies the archive provenance; this constant verifies the packaged binary.
 const BUNDLED_UV_VERSION = "0.5.14";
 const BUNDLED_UV_SHA256 = {
   "linux-x64": "0e05d828b5708e8a927724124db3746396afddad6273c47283d7c562dc795bd6",
-  "mac-arm64": "415f73cab3771902db58f6a9ce4d9cf3e664a3eed26ee7e48a051453a79bd015",
+  "mac-arm64": "6099aa8cd701f0c81227ee30c304777ce151e4d47c53a75ce53cd2243448d8c8",
 };
 
 const MANAGED_UV_DIR = path.join(GAIA_HOME, "bin");

--- a/tests/electron/_helpers/installer-smoke.mjs
+++ b/tests/electron/_helpers/installer-smoke.mjs
@@ -113,7 +113,7 @@ export function assertUvBinary(uvPath, platformKey, installerCjsPath) {
  */
 export function backendInstallerPath(testFileUrl) {
   return path.resolve(
-    path.dirname(new URL(testFileUrl).pathname),
+    path.dirname(decodeURIComponent(new URL(testFileUrl).pathname)),
     "..",
     "..",
     "src",

--- a/tests/electron/_helpers/installer-smoke.mjs
+++ b/tests/electron/_helpers/installer-smoke.mjs
@@ -17,6 +17,7 @@ import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 // Mirrors electron-builder.yml `extraResources.to: vendor/uv` — the single
 // source of truth for the in-resources layout. If electron-builder.yml
@@ -43,9 +44,9 @@ export function bundledUvPath(resourcesDir, platformKey) {
 /**
  * Parse `BUNDLED_UV_SHA256[platformKey]` from backend-installer.cjs source.
  *
- * The constant spans multiple lines once it has 2+ entries, so the regex
- * needs the dotall `/s` flag. The `[^}]*?` stop class on `}` is safe
- * because SHA hex strings cannot contain `}`.
+ * The constant spans multiple lines once it has 2+ entries. `[^}]*?` spans
+ * newlines natively (character classes match `\n` without dotall) and the
+ * stop class on `}` is safe because SHA hex strings cannot contain `}`.
  *
  * @param {string} installerCjsPath  absolute path to backend-installer.cjs
  * @param {string} platformKey       e.g. "linux-x64"
@@ -58,7 +59,6 @@ export function parseBundledUvSha(installerCjsPath, platformKey) {
   const escapedKey = platformKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(
     `BUNDLED_UV_SHA256\\s*=\\s*\\{[^}]*?"${escapedKey}"\\s*:\\s*"([0-9a-f]{64})"`,
-    "s",
   );
   const m = src.match(re);
   assert.ok(
@@ -113,7 +113,7 @@ export function assertUvBinary(uvPath, platformKey, installerCjsPath) {
  */
 export function backendInstallerPath(testFileUrl) {
   return path.resolve(
-    path.dirname(decodeURIComponent(new URL(testFileUrl).pathname)),
+    path.dirname(fileURLToPath(testFileUrl)),
     "..",
     "..",
     "src",

--- a/tests/electron/_helpers/installer-smoke.mjs
+++ b/tests/electron/_helpers/installer-smoke.mjs
@@ -99,7 +99,10 @@ export function assertUvBinary(uvPath, platformKey, installerCjsPath) {
   assert.equal(
     actual,
     expected,
-    `bundled uv binary SHA256 does not match BUNDLED_UV_SHA256["${platformKey}"]; ensureUv() will reject this at runtime`,
+    `bundled uv binary SHA256 does not match BUNDLED_UV_SHA256["${platformKey}"]; ` +
+      `ensureUv() will reject this at runtime. ` +
+      `To fix: update BUNDLED_UV_SHA256["${platformKey}"] in ` +
+      `src/gaia/apps/webui/services/backend-installer.cjs to: ${actual}`,
   );
 }
 

--- a/tests/electron/_helpers/installer-smoke.mjs
+++ b/tests/electron/_helpers/installer-smoke.mjs
@@ -1,0 +1,126 @@
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Shared assertions for installer structural smoke tests (issue #941).
+//
+// One source of truth for:
+//   1. The in-resources path layout for the bundled `uv` binary
+//      (mirrors electron-builder.yml `extraResources.to: vendor/uv`).
+//   2. Parsing BUNDLED_UV_SHA256 out of backend-installer.cjs.
+//   3. The full existence + executable-bit + SHA256 check.
+//
+// Consumed by tests/electron/appimage-smoke.test.mjs and
+// tests/electron/dmg-smoke.test.mjs. A future NSIS smoke test should
+// also consume this module so all three installers stay in lockstep.
+
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+// Mirrors electron-builder.yml `extraResources.to: vendor/uv` — the single
+// source of truth for the in-resources layout. If electron-builder.yml
+// changes the `to:` path, every smoke test breaks here with the same
+// actionable diff: update UV_RESOURCE_SUBPATH.
+export const UV_RESOURCE_SUBPATH = ["vendor", "uv"];
+
+/**
+ * Build the runtime-equivalent path to the bundled uv binary inside an
+ * already-extracted resources directory.
+ *
+ * @param {string} resourcesDir
+ *   Absolute path to the extracted resources directory. Examples:
+ *     - AppImage:  <squashfs-root>/resources
+ *     - DMG:       <mountpoint>/<App>.app/Contents/Resources
+ * @param {"linux-x64"|"mac-arm64"|"win-x64"} platformKey
+ * @returns {string} absolute path to the bundled `uv`/`uv.exe`
+ */
+export function bundledUvPath(resourcesDir, platformKey) {
+  const binary = platformKey === "win-x64" ? "uv.exe" : "uv";
+  return path.join(resourcesDir, ...UV_RESOURCE_SUBPATH, platformKey, binary);
+}
+
+/**
+ * Parse `BUNDLED_UV_SHA256[platformKey]` from backend-installer.cjs source.
+ *
+ * The constant spans multiple lines once it has 2+ entries, so the regex
+ * needs the dotall `/s` flag. The `[^}]*?` stop class on `}` is safe
+ * because SHA hex strings cannot contain `}`.
+ *
+ * @param {string} installerCjsPath  absolute path to backend-installer.cjs
+ * @param {string} platformKey       e.g. "linux-x64"
+ * @returns {string} the 64-character hex digest
+ */
+export function parseBundledUvSha(installerCjsPath, platformKey) {
+  const src = fs.readFileSync(installerCjsPath, "utf8");
+  // Defensive: escape regex metacharacters in the platform key, even
+  // though the keys we use have none today.
+  const escapedKey = platformKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(
+    `BUNDLED_UV_SHA256\\s*=\\s*\\{[^}]*?"${escapedKey}"\\s*:\\s*"([0-9a-f]{64})"`,
+    "s",
+  );
+  const m = src.match(re);
+  assert.ok(
+    m,
+    `could not parse BUNDLED_UV_SHA256["${platformKey}"] from ${installerCjsPath}`,
+  );
+  return m[1];
+}
+
+/**
+ * Existence + executable-bit (POSIX only) + SHA256-vs-pin check.
+ *
+ * Catches the failure mode that bit issue #849 and motivated #941:
+ * a packaged binary whose SHA does not match the pin in
+ * BUNDLED_UV_SHA256, which `ensureUv()` would reject at runtime with
+ * a hard SHA256 mismatch error on the user's first launch.
+ *
+ * @param {string} uvPath              absolute path to packaged `uv` binary
+ * @param {string} platformKey         e.g. "mac-arm64"
+ * @param {string} installerCjsPath    absolute path to backend-installer.cjs
+ */
+export function assertUvBinary(uvPath, platformKey, installerCjsPath) {
+  assert.ok(fs.existsSync(uvPath), `expected bundled uv at ${uvPath}`);
+  if (platformKey !== "win-x64") {
+    const st = fs.statSync(uvPath);
+    // Any execute bit on any class is enough; squashfs/HFS+/APFS all
+    // preserve 0o755 for the source mode set by the CI fetch step.
+    assert.ok(
+      (st.mode & 0o111) !== 0,
+      `uv binary should be executable; mode=${(st.mode & 0o777).toString(8)}`,
+    );
+  }
+  const expected = parseBundledUvSha(installerCjsPath, platformKey);
+  const actual = crypto
+    .createHash("sha256")
+    .update(fs.readFileSync(uvPath))
+    .digest("hex");
+  assert.equal(
+    actual,
+    expected,
+    `bundled uv binary SHA256 does not match BUNDLED_UV_SHA256["${platformKey}"]; ensureUv() will reject this at runtime`,
+  );
+}
+
+/**
+ * Resolve the absolute path to backend-installer.cjs from a smoke test
+ * file located under tests/electron/. Centralised so a future move of
+ * either tree only updates one place.
+ *
+ * @param {string} testFileUrl  pass `import.meta.url` from the caller
+ * @returns {string}
+ */
+export function backendInstallerPath(testFileUrl) {
+  return path.resolve(
+    path.dirname(new URL(testFileUrl).pathname),
+    "..",
+    "..",
+    "src",
+    "gaia",
+    "apps",
+    "webui",
+    "services",
+    "backend-installer.cjs",
+  );
+}

--- a/tests/electron/appimage-smoke.test.mjs
+++ b/tests/electron/appimage-smoke.test.mjs
@@ -134,12 +134,9 @@ if (!APPIMAGE) {
       const installerPath = backendInstallerPath(import.meta.url);
 
       test("AC4/T3: bundled uv binary is present under extraResources", () => {
+        // Existence + mode-bit assertions live in assertUvBinary (T3b).
+        // Block kept for CI-log name stability; see _helpers/installer-smoke.mjs.
         assert.ok(fs.existsSync(uvPath), `expected bundled uv at ${uvPath}`);
-        const st = fs.statSync(uvPath);
-        assert.ok(
-          (st.mode & 0o111) !== 0,
-          `uv binary should be executable; mode=${(st.mode & 0o777).toString(8)}`,
-        );
       });
 
       // Runtime ensureUv() hashes the extracted ELF and rejects any mismatch,

--- a/tests/electron/appimage-smoke.test.mjs
+++ b/tests/electron/appimage-smoke.test.mjs
@@ -26,12 +26,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  assertUvBinary,
+  backendInstallerPath,
+  bundledUvPath,
+} from "./_helpers/installer-smoke.mjs";
+
 const APPIMAGE = process.env.GAIA_APPIMAGE;
+const PLATFORM_KEY = "linux-x64";
 
 // node:test has no built-in skipAll; emit a clear SKIP message and
 // register a single trivially-passing test so runners don't think the
@@ -120,69 +126,26 @@ if (!APPIMAGE) {
       });
 
       // ── AC4 / T3: bundled uv binary present and executable ──────────
+      // Implementation lives in tests/electron/_helpers/installer-smoke.mjs
+      // and is shared with dmg-smoke.test.mjs (issue #941). Two named test
+      // blocks preserved for output stability with prior CI logs.
+      const resourcesDir = path.join(squashRoot, "resources");
+      const uvPath = bundledUvPath(resourcesDir, PLATFORM_KEY);
+      const installerPath = backendInstallerPath(import.meta.url);
+
       test("AC4/T3: bundled uv binary is present under extraResources", () => {
-        const uvPath = path.join(
-          squashRoot,
-          "resources",
-          "vendor",
-          "uv",
-          "linux-x64",
-          "uv"
-        );
-        assert.ok(
-          fs.existsSync(uvPath),
-          `expected bundled uv at ${uvPath}`
-        );
+        assert.ok(fs.existsSync(uvPath), `expected bundled uv at ${uvPath}`);
         const st = fs.statSync(uvPath);
-        // Any execute bit set on any class is enough; AppImage squashfs
-        // typically preserves 0o755.
         assert.ok(
           (st.mode & 0o111) !== 0,
-          `uv binary should be executable; mode=${(st.mode & 0o777).toString(8)}`
+          `uv binary should be executable; mode=${(st.mode & 0o777).toString(8)}`,
         );
       });
 
-      // ── AC4 / T3b: bundled uv binary SHA256 matches BUNDLED_UV_SHA256 ──
       // Runtime ensureUv() hashes the extracted ELF and rejects any mismatch,
       // so catch packaging/hash drift at smoke time instead of on user launch.
       test("AC4/T3b: bundled uv SHA256 matches BUNDLED_UV_SHA256[linux-x64]", () => {
-        const uvPath = path.join(
-          squashRoot,
-          "resources",
-          "vendor",
-          "uv",
-          "linux-x64",
-          "uv"
-        );
-        const installerPath = path.resolve(
-          path.dirname(new URL(import.meta.url).pathname),
-          "..",
-          "..",
-          "src",
-          "gaia",
-          "apps",
-          "webui",
-          "services",
-          "backend-installer.cjs"
-        );
-        const installerSrc = fs.readFileSync(installerPath, "utf8");
-        const m = installerSrc.match(
-          /BUNDLED_UV_SHA256\s*=\s*\{[^}]*?"linux-x64"\s*:\s*"([0-9a-f]{64})"/s
-        );
-        assert.ok(
-          m,
-          `could not parse BUNDLED_UV_SHA256["linux-x64"] from ${installerPath}`
-        );
-        const expected = m[1];
-        const actual = crypto
-          .createHash("sha256")
-          .update(fs.readFileSync(uvPath))
-          .digest("hex");
-        assert.equal(
-          actual,
-          expected,
-          `bundled uv binary SHA256 does not match BUNDLED_UV_SHA256["linux-x64"]; ensureUv() will reject this at runtime`
-        );
+        assertUvBinary(uvPath, PLATFORM_KEY, installerPath);
       });
 
       // ── AC3: pre-built React dist/ ships with the AppImage ──────────

--- a/tests/electron/dmg-smoke.test.mjs
+++ b/tests/electron/dmg-smoke.test.mjs
@@ -10,6 +10,13 @@
 //   GAIA_DMG=$(ls src/gaia/apps/webui/dist-app/*.dmg) \
 //     node --test tests/electron/dmg-smoke.test.mjs
 //
+// NOTE: the AC3/T5b SHA check compares against the POST-codesign digest in
+// BUNDLED_UV_SHA256["mac-arm64"]. A local build without Apple signing certs
+// (CSC_LINK unset) will produce an ad-hoc-signed uv whose SHA will NOT match
+// the pinned CI value — T5b will fail as expected. Local smoke runs are most
+// useful for T5a (.app presence) and T5c (`uv --version` runs); T5b is only
+// meaningful for signed CI builds.
+//
 // Acceptance-criteria mapping (issue #941):
 //   - AC3 / T5: bundled mac-arm64 uv binary is present, executable, has the
 //              SHA256 declared in BUNDLED_UV_SHA256, AND `uv --version` runs.
@@ -158,6 +165,15 @@ if (!DMG) {
             /^uv \d+\.\d+\.\d+/,
             `unexpected uv --version output: ${out}`,
           );
+        });
+      } else {
+        // Emit explicit skips so the CI log shows three subtest results
+        // regardless of T5a outcome — makes it obvious the gap is upstream.
+        await t.test("AC3/T5b: bundled mac-arm64 uv (skipped — no .app)", (st) => {
+          st.skip("T5a failed to locate .app bundle; downstream checks cannot run");
+        });
+        await t.test("AC3/T5c: bundled mac-arm64 uv --version (skipped — no .app)", (st) => {
+          st.skip("T5a failed to locate .app bundle; downstream checks cannot run");
         });
       }
     } finally {

--- a/tests/electron/dmg-smoke.test.mjs
+++ b/tests/electron/dmg-smoke.test.mjs
@@ -167,6 +167,12 @@ if (!DMG) {
             `stderr:\n${r.stderr}`,
         );
       }
+      try {
+        fs.rmSync(workdir, { recursive: true, force: true });
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(`[dmg-smoke] workdir cleanup failed: ${e.message}`);
+      }
     }
   });
 }

--- a/tests/electron/dmg-smoke.test.mjs
+++ b/tests/electron/dmg-smoke.test.mjs
@@ -102,7 +102,7 @@ if (!DMG) {
       // registered, but the kernel VFS layer can lag 1–2 ticks before
       // readdir sees the contents. Without this loop, an unguarded
       // path.join(mountpoint, undefined, …) throws an unactionable
-      // TypeError. 5×100ms is empirically enough on macos-latest.
+      // TypeError. 10×200ms (≤2s) is empirically enough on macos-latest.
       let entries = [];
       let appEntry;
       for (let i = 0; i < 10; i++) {

--- a/tests/electron/dmg-smoke.test.mjs
+++ b/tests/electron/dmg-smoke.test.mjs
@@ -1,0 +1,172 @@
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Structural smoke asserts for the built GAIA Agent UI macOS DMG (issue #941).
+// Driven by `node --test tests/electron/dmg-smoke.test.mjs`.
+//
+// Requires the environment variable GAIA_DMG to point at an already-built
+// DMG. In CI this is set after actions/download-artifact. Locally:
+//   cd src/gaia/apps/webui && npm run package:mac
+//   GAIA_DMG=$(ls src/gaia/apps/webui/dist-app/*.dmg) \
+//     node --test tests/electron/dmg-smoke.test.mjs
+//
+// Acceptance-criteria mapping (issue #941):
+//   - AC3 / T5: bundled mac-arm64 uv binary is present, executable, has the
+//              SHA256 declared in BUNDLED_UV_SHA256, AND `uv --version` runs.
+//              The exec check transitively validates DMG mode-bit
+//              preservation — if HFS+/APFS dropped the executable bit,
+//              execFileSync fails with EACCES.
+//
+// Implementation note — node:test scheduling vs. live mounts:
+//   Top-level `test()` calls register tests SYNCHRONOUSLY but the runner
+//   executes their bodies AFTER the entire module has finished loading.
+//   That makes `try { test(...) } finally { hdiutil detach }` a footgun:
+//   the detach fires before the test body runs, leaving a broken mount path.
+//   To keep the mount alive for the duration of all assertions, the
+//   mount-dependent block is wrapped in a single async top-level test that
+//   uses subtests via `t.test()`. The `finally { detach() }` then runs only
+//   after every subtest completes.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import {
+  assertUvBinary,
+  backendInstallerPath,
+  bundledUvPath,
+} from "./_helpers/installer-smoke.mjs";
+
+const DMG = process.env.GAIA_DMG;
+const PLATFORM_KEY = "mac-arm64";
+
+if (!DMG) {
+  test("dmg-smoke SKIP: GAIA_DMG is not set", (t) => {
+    t.skip(
+      "GAIA_DMG env var is unset — this test needs a built DMG path. " +
+        "In CI it is set after download-artifact. Locally: " +
+        "GAIA_DMG=$(ls src/gaia/apps/webui/dist-app/*.dmg) " +
+        "node --test tests/electron/dmg-smoke.test.mjs",
+    );
+  });
+} else if (process.platform !== "darwin") {
+  // hdiutil is macOS-only. A Linux-runner mistake should fail loudly with
+  // a skip message rather than try to attach the DMG.
+  test("dmg-smoke SKIP: not running on darwin", (t) => {
+    t.skip(
+      `DMG smoke requires hdiutil; current platform is ${process.platform}. ` +
+        `Run this test on a macOS host (CI uses macos-latest).`,
+    );
+  });
+} else {
+  test("AC3/T5: DMG structural smoke (mac-arm64)", async (t) => {
+    const dmgPath = path.resolve(DMG);
+    assert.ok(fs.existsSync(dmgPath), `GAIA_DMG=${dmgPath} does not exist`);
+
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "gaia-dmg-"));
+    const mountpoint = path.join(workdir, "mnt");
+    fs.mkdirSync(mountpoint, { recursive: true });
+
+    const attachResult = spawnSync(
+      "hdiutil",
+      [
+        "attach",
+        "-nobrowse",
+        "-readonly",
+        "-mountpoint",
+        mountpoint,
+        dmgPath,
+      ],
+      { stdio: ["ignore", "ignore", "pipe"], encoding: "utf8" },
+    );
+    assert.equal(
+      attachResult.status,
+      0,
+      `hdiutil attach exit=${attachResult.status}\n` +
+        `stderr:\n${attachResult.stderr}`,
+    );
+
+    // Cleanup MUST run regardless of subtest outcome — a left-mounted
+    // volume causes "Resource busy" failures on the next CI job that
+    // shares the runner. -force is mandatory: Spotlight can briefly
+    // hold a busy mount even after the test finishes. Errors are
+    // logged but NEVER thrown — surfacing detach failures must not
+    // mask earlier assertion failures from the subtests.
+    try {
+      // ── Locate the .app bundle inside the mounted DMG ───────────────
+      // hdiutil attach returns synchronously when the volume is
+      // registered, but the kernel VFS layer can lag 1–2 ticks before
+      // readdir sees the contents. Without this loop, an unguarded
+      // path.join(mountpoint, undefined, …) throws an unactionable
+      // TypeError. 5×100ms is empirically enough on macos-latest.
+      let entries = [];
+      let appEntry;
+      for (let i = 0; i < 5; i++) {
+        entries = fs.readdirSync(mountpoint);
+        appEntry = entries.find((n) => n.endsWith(".app"));
+        if (appEntry) break;
+        await sleep(100);
+      }
+
+      await t.test("AC3/T5a: DMG contains a .app bundle", () => {
+        assert.ok(
+          appEntry,
+          `no .app bundle found inside DMG at ${mountpoint}; entries: ${entries.join(", ")}`,
+        );
+      });
+
+      if (appEntry) {
+        const resourcesDir = path.join(
+          mountpoint,
+          appEntry,
+          "Contents",
+          "Resources",
+        );
+        const uvPath = bundledUvPath(resourcesDir, PLATFORM_KEY);
+        const installerPath = backendInstallerPath(import.meta.url);
+
+        // ── AC3/T5b: existence + mode bit + SHA256 against pin ────────
+        await t.test(
+          "AC3/T5b: bundled mac-arm64 uv is present, executable, sha-pinned",
+          () => {
+            assertUvBinary(uvPath, PLATFORM_KEY, installerPath);
+          },
+        );
+
+        // ── AC3/T5c: `uv --version` actually runs ─────────────────────
+        // Catches Gatekeeper-quarantine and stale-code-sign failure
+        // modes that pure existence/SHA checks miss. Also transitively
+        // validates DMG mode-bit preservation: if APFS dropped the
+        // executable bit, execFileSync fails with EACCES.
+        await t.test("AC3/T5c: bundled mac-arm64 uv --version runs", () => {
+          const out = execFileSync(uvPath, ["--version"], {
+            timeout: 10_000,
+            encoding: "utf8",
+          });
+          assert.match(
+            out,
+            /^uv \d+\.\d+\.\d+/,
+            `unexpected uv --version output: ${out}`,
+          );
+        });
+      }
+    } finally {
+      const r = spawnSync(
+        "hdiutil",
+        ["detach", "-force", mountpoint],
+        { stdio: ["ignore", "ignore", "pipe"], encoding: "utf8" },
+      );
+      if (r.status !== 0) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[dmg-smoke] hdiutil detach exit=${r.status}\n` +
+            `stderr:\n${r.stderr}`,
+        );
+      }
+    }
+  });
+}

--- a/tests/electron/dmg-smoke.test.mjs
+++ b/tests/electron/dmg-smoke.test.mjs
@@ -105,11 +105,11 @@ if (!DMG) {
       // TypeError. 5×100ms is empirically enough on macos-latest.
       let entries = [];
       let appEntry;
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < 10; i++) {
         entries = fs.readdirSync(mountpoint);
         appEntry = entries.find((n) => n.endsWith(".app"));
         if (appEntry) break;
-        await sleep(100);
+        await sleep(200);
       }
 
       await t.test("AC3/T5a: DMG contains a .app bundle", () => {

--- a/tests/electron/dmg-smoke.test.mjs
+++ b/tests/electron/dmg-smoke.test.mjs
@@ -69,26 +69,10 @@ if (!DMG) {
 
     const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "gaia-dmg-"));
     const mountpoint = path.join(workdir, "mnt");
-    fs.mkdirSync(mountpoint, { recursive: true });
-
-    const attachResult = spawnSync(
-      "hdiutil",
-      [
-        "attach",
-        "-nobrowse",
-        "-readonly",
-        "-mountpoint",
-        mountpoint,
-        dmgPath,
-      ],
-      { stdio: ["ignore", "ignore", "pipe"], encoding: "utf8" },
-    );
-    assert.equal(
-      attachResult.status,
-      0,
-      `hdiutil attach exit=${attachResult.status}\n` +
-        `stderr:\n${attachResult.stderr}`,
-    );
+    // attached tracks whether hdiutil attach succeeded so the finally block
+    // only attempts detach (and only detach) when there is actually a mount
+    // to clean up — avoids spurious "no such volume" errors if attach fails.
+    let attached = false;
 
     // Cleanup MUST run regardless of subtest outcome — a left-mounted
     // volume causes "Resource busy" failures on the next CI job that
@@ -97,6 +81,28 @@ if (!DMG) {
     // logged but NEVER thrown — surfacing detach failures must not
     // mask earlier assertion failures from the subtests.
     try {
+      fs.mkdirSync(mountpoint, { recursive: true });
+
+      const attachResult = spawnSync(
+        "hdiutil",
+        [
+          "attach",
+          "-nobrowse",
+          "-readonly",
+          "-mountpoint",
+          mountpoint,
+          dmgPath,
+        ],
+        { stdio: ["ignore", "ignore", "pipe"], encoding: "utf8" },
+      );
+      assert.equal(
+        attachResult.status,
+        0,
+        `hdiutil attach exit=${attachResult.status}\n` +
+          `stderr:\n${attachResult.stderr}`,
+      );
+      attached = true;
+
       // ── Locate the .app bundle inside the mounted DMG ───────────────
       // hdiutil attach returns synchronously when the volume is
       // registered, but the kernel VFS layer can lag 1–2 ticks before
@@ -155,17 +161,19 @@ if (!DMG) {
         });
       }
     } finally {
-      const r = spawnSync(
-        "hdiutil",
-        ["detach", "-force", mountpoint],
-        { stdio: ["ignore", "ignore", "pipe"], encoding: "utf8" },
-      );
-      if (r.status !== 0) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `[dmg-smoke] hdiutil detach exit=${r.status}\n` +
-            `stderr:\n${r.stderr}`,
+      if (attached) {
+        const r = spawnSync(
+          "hdiutil",
+          ["detach", "-force", mountpoint],
+          { stdio: ["ignore", "ignore", "pipe"], encoding: "utf8" },
         );
+        if (r.status !== 0) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[dmg-smoke] hdiutil detach exit=${r.status}\n` +
+              `stderr:\n${r.stderr}`,
+          );
+        }
       }
       try {
         fs.rmSync(workdir, { recursive: true, force: true });

--- a/tests/electron/test_electron_chat_app.js
+++ b/tests/electron/test_electron_chat_app.js
@@ -460,9 +460,9 @@ describe('Chat App Integration', () => {
       expect(appContent).toContain('DocumentLibrary');
     });
 
-    it('should conditionally render SettingsModal', () => {
+    it('should conditionally render SettingsPage', () => {
       expect(appContent).toContain('showSettings');
-      expect(appContent).toContain('SettingsModal');
+      expect(appContent).toContain('SettingsPage');
     });
   });
 
@@ -526,7 +526,7 @@ describe('Chat App Integration', () => {
   describe('additional components', () => {
     const additionalComponents = [
       'DocumentLibrary',
-      'SettingsModal',
+      'SettingsPage',
     ];
 
     additionalComponents.forEach(name => {
@@ -1182,23 +1182,18 @@ describe('Chat App Integration', () => {
     });
   });
 
-  // ── Settings Modal Enhancements ───────────────────────────────────
+  // ── Settings Page Enhancements ────────────────────────────────────
 
-  describe('SettingsModal enhancements', () => {
+  describe('SettingsPage enhancements', () => {
     let settingsContent;
 
     beforeAll(() => {
-      const settingsPath = path.join(CHAT_APP_PATH, 'src/components/SettingsModal.tsx');
+      const settingsPath = path.join(CHAT_APP_PATH, 'src/components/SettingsPage.tsx');
       settingsContent = fs.readFileSync(settingsPath, 'utf8');
     });
 
     it('should use dynamic version from build constant', () => {
       expect(settingsContent).toContain('__APP_VERSION__');
-    });
-
-    it('should have ARIA role dialog', () => {
-      expect(settingsContent).toContain('role="dialog"');
-      expect(settingsContent).toContain('aria-modal="true"');
     });
 
     it('should have danger zone section at bottom', () => {

--- a/tests/electron/test_electron_chat_app.js
+++ b/tests/electron/test_electron_chat_app.js
@@ -1197,7 +1197,6 @@ describe('Chat App Integration', () => {
     });
 
     it('should have danger zone section at bottom', () => {
-      expect(settingsContent).toContain('danger-zone');
       expect(settingsContent).toContain('danger-warning');
     });
 
@@ -1215,7 +1214,6 @@ describe('Chat App Integration', () => {
     });
 
     it('should have danger zone styles', () => {
-      expect(settingsCss).toContain('.danger-zone');
       expect(settingsCss).toContain('.danger-divider');
       expect(settingsCss).toContain('.danger-warning');
     });

--- a/tests/electron/test_electron_chat_installer.js
+++ b/tests/electron/test_electron_chat_installer.js
@@ -651,7 +651,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       // time but may legitimately differ pre-release. Assert package.json has a
       // valid semver and is not AHEAD of version.py (that would be a bug).
       // Allows PEP 440 pre-release suffixes (rcN, .devN, aN, bN) on either side;
-      // the lead-ahead comparison is on the numeric MAJOR.MINOR.PATCH prefix only.
+      // the lead-ahead comparison is on the numeric MAJOR.MINOR.PATCH prefix
+      // only — a released pkg vs a pre-release py with the same triple will
+      // not flag here, which is intentional (release tagging closes that gap).
       const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)([.\-+a-z0-9]*)$/i;
       const pkgSemver = pkg.version.match(SEMVER_RE);
       const pySemver = match[1].match(SEMVER_RE);

--- a/tests/electron/test_electron_chat_installer.js
+++ b/tests/electron/test_electron_chat_installer.js
@@ -645,7 +645,18 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       const content = fs.readFileSync(versionPyPath, 'utf8');
       const match = content.match(/__version__\s*=\s*"([^"]+)"/);
       expect(match).not.toBeNull();
-      expect(pkg.version).toBe(match[1]);
+
+      // package.json tracks the last *published* PyPI version; version.py is
+      // bumped ahead of PyPI during development. They must match at release
+      // time but may legitimately differ pre-release. Assert package.json has a
+      // valid semver and is not AHEAD of version.py (that would be a bug).
+      expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+      const pkgParts = pkg.version.split('.').map(Number);
+      const pyParts = match[1].split('.').map(Number);
+      const pkgAhead = pkgParts.some((n, i) =>
+        n > (pyParts[i] ?? 0) && pkgParts.slice(0, i).every((m, j) => m === (pyParts[j] ?? 0))
+      );
+      expect(pkgAhead).toBe(false);
     });
 
     it('should have .npmignore for clean publishing', () => {

--- a/tests/electron/test_electron_chat_installer.js
+++ b/tests/electron/test_electron_chat_installer.js
@@ -650,10 +650,15 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       // bumped ahead of PyPI during development. They must match at release
       // time but may legitimately differ pre-release. Assert package.json has a
       // valid semver and is not AHEAD of version.py (that would be a bug).
-      expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/);
-      expect(match[1]).toMatch(/^\d+\.\d+\.\d+$/);
-      const pkgParts = pkg.version.split('.').map(Number);
-      const pyParts = match[1].split('.').map(Number);
+      // Allows PEP 440 pre-release suffixes (rcN, .devN, aN, bN) on either side;
+      // the lead-ahead comparison is on the numeric MAJOR.MINOR.PATCH prefix only.
+      const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)([.\-+a-z0-9]*)$/i;
+      const pkgSemver = pkg.version.match(SEMVER_RE);
+      const pySemver = match[1].match(SEMVER_RE);
+      expect(pkgSemver).not.toBeNull();
+      expect(pySemver).not.toBeNull();
+      const pkgParts = [pkgSemver[1], pkgSemver[2], pkgSemver[3]].map(Number);
+      const pyParts = [pySemver[1], pySemver[2], pySemver[3]].map(Number);
       const pkgAhead = pkgParts.some((n, i) =>
         n > (pyParts[i] ?? 0) && pkgParts.slice(0, i).every((m, j) => m === (pyParts[j] ?? 0))
       );

--- a/tests/electron/test_electron_chat_installer.js
+++ b/tests/electron/test_electron_chat_installer.js
@@ -650,7 +650,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       // bumped ahead of PyPI during development. They must match at release
       // time but may legitimately differ pre-release. Assert package.json has a
       // valid semver and is not AHEAD of version.py (that would be a bug).
-      expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+      expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(match[1]).toMatch(/^\d+\.\d+\.\d+$/);
       const pkgParts = pkg.version.split('.').map(Number);
       const pyParts = match[1].split('.').map(Number);
       const pkgAhead = pkgParts.some((n, i) =>

--- a/tests/electron/test_electron_chat_installer.js
+++ b/tests/electron/test_electron_chat_installer.js
@@ -661,8 +661,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       expect(pySemver).not.toBeNull();
       const pkgParts = [pkgSemver[1], pkgSemver[2], pkgSemver[3]].map(Number);
       const pyParts = [pySemver[1], pySemver[2], pySemver[3]].map(Number);
-      const pkgAhead = pkgParts.some((n, i) =>
-        n > (pyParts[i] ?? 0) && pkgParts.slice(0, i).every((m, j) => m === (pyParts[j] ?? 0))
+      const pkgAhead = pkgParts.some(
+        (n, i) =>
+          n > pyParts[i] &&
+          pkgParts.slice(0, i).every((m, j) => m === pyParts[j]),
       );
       expect(pkgAhead).toBe(false);
     });


### PR DESCRIPTION
Before: installing the macOS DMG on a clean Apple-Silicon Mac with no system `uv` on `PATH` hard-failed during `ensure-uv` — `bundledUvPlatformKey()` claimed `mac-arm64` support, but no CI step ever fetched the binary. First-launch error: `"No bundled uv available for darwin-arm64 and no system uv found"`. After: the macOS build job fetches the pinned `uv` v0.5.14 `aarch64-apple-darwin` binary, verifies its archive SHA, and places it at `build/vendor/uv/mac-arm64/uv` so `electron-builder` ships it inside `Contents/Resources/vendor/uv/mac-arm64/uv`. A new `dmg-structural-smoke` CI job mounts the built DMG, asserts the binary is present + executable + SHA-pinned + actually runs (`uv --version`), and is wired into the `build-complete` gate so future drift fails at smoke time, not on a user's first launch.

Also bundled: the `pr-review` job in `.github/workflows/claude.yml` is temporarily disabled (`if: false`) because the CI bot's Anthropic API key is out of credits — auto-review will not run on this or any PR until the credit balance is restored. Tracked for re-enable separately from this fix.

Closes #941.

## Test plan

- [ ] Trigger `build-installers` workflow against this branch and confirm `dmg-structural-smoke` and `build-complete` are both green
- [ ] On a clean Apple-Silicon Mac with no system `uv` (verify: `which uv` → not found): download the DMG via browser (not `gh run download` — browser sets the quarantine xattr that Gatekeeper checks), install, launch GAIA, confirm it reaches `state: ready` with no `ensure-uv` error and no `Killed: 9` on the spawned uv child
- [ ] Confirm `~/.gaia/bin/uv --version` works after install
- [ ] Test on macOS Sequoia (15.x) — Sequoia tightened CS checks for child processes spawned by hardened-runtime apps