### PR TITLE
feat(ui): card layout with accent stripe for settings sections

### DIFF
--- a/src/gaia/apps/webui/src/components/SettingsModal.css
+++ b/src/gaia/apps/webui/src/components/SettingsModal.css
@@ -395,7 +395,7 @@
     cursor: not-allowed;
 }
 
-/* Danger zone */
+/* Danger actions */
 
 .danger-divider {
     height: 1px;

--- a/src/gaia/apps/webui/src/components/SettingsModal.css
+++ b/src/gaia/apps/webui/src/components/SettingsModal.css
@@ -21,7 +21,7 @@
     color: var(--text-secondary);
     margin-bottom: 14px;
     border-left: 2px solid var(--accent);
-    margin-left: -2px;
+    margin-left: -8px;
     padding-left: 6px;
 }
 
@@ -396,9 +396,6 @@
 }
 
 /* Danger zone */
-.danger-zone {
-    border-color: var(--border);
-}
 
 .danger-divider {
     height: 1px;

--- a/src/gaia/apps/webui/src/components/SettingsModal.css
+++ b/src/gaia/apps/webui/src/components/SettingsModal.css
@@ -3,17 +3,26 @@
 /* Settings Modal -- refined design */
 .settings-modal { width: 560px; }
 
-.settings-section { margin-bottom: 28px; }
+.settings-section {
+    margin-bottom: 10px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+    padding: 18px 20px;
+}
 .settings-section:last-child { margin-bottom: 0; }
 
 .settings-section h4 {
-    font-size: 11px;
+    font-size: 13px;
     font-weight: 600;
     font-family: var(--font-mono);
     text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--text-muted);
+    letter-spacing: 1.5px;
+    color: var(--text-secondary);
     margin-bottom: 14px;
+    border-left: 2px solid var(--accent);
+    margin-left: -2px;
+    padding-left: 6px;
 }
 
 .status-grid { display: flex; flex-direction: column; gap: 8px; }
@@ -388,9 +397,7 @@
 
 /* Danger zone */
 .danger-zone {
-    border-top: 1px solid var(--border);
-    padding-top: 20px;
-    margin-top: 8px;
+    border-color: var(--border);
 }
 
 .danger-divider {

--- a/src/gaia/apps/webui/src/components/SettingsPage.css
+++ b/src/gaia/apps/webui/src/components/SettingsPage.css
@@ -39,7 +39,7 @@
 .settings-page-body {
     flex: 1;
     overflow-y: auto;
-    padding: 24px;
+    padding: 16px 20px;
     max-width: 600px;
     width: 100%;
     margin: 0 auto;

--- a/src/gaia/apps/webui/src/components/SettingsPage.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsPage.tsx
@@ -502,7 +502,7 @@ export function SettingsPage() {
                 </section>
 
                 {/* Privacy & Data */}
-                <section className="settings-section danger-zone">
+                <section className="settings-section">
                     <h4>Privacy & Data</h4>
                     <div className="setting-row">
                         <span>Data location</span>


### PR DESCRIPTION
Before, settings sections were separated only by margin — the uppercase monospaced headings blended into the content and users couldn't easily tell where one section ended and the next began.

Each section is now an outlined card (1 px border, 10 px radius, inner padding). Section headings are 13 px (up from 11 px), use `--text-secondary` instead of `--text-muted` for legibility, and carry a 2 px `--accent` left stripe that sits flush with the card body text — heading text and body content share the same left edge.

## Test plan

- [ ] Open Settings and confirm each section renders as a distinct card
- [ ] Confirm heading text and body content are left-aligned
- [ ] Confirm accent stripe appears on all section headings (System Status, Active Model, Context Size, Custom Agents, Connectors, About, Privacy & Data)
- [ ] Check light and dark themes