### PR TITLE
ci(installer): remove stale 'macOS uv fetch removed' orphan comment

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -304,9 +304,6 @@ jobs:
           # run CI and copy the value from the dmg-structural-smoke output.
           shasum -a 256 "${DEST_DIR}/uv"
 
-      # macOS uv fetch removed in this PR to keep changes Windows-only.
-      # If needed, re-add a macOS fetch step in a follow-up PR coordinated with the mac team.
-
       - name: Build frontend (Vite)
         working-directory: src/gaia/apps/webui
         shell: bash


### PR DESCRIPTION
## Why this matters

PR #968 landed with a stale comment in [build-installers.yml](.github/workflows/build-installers.yml) that claims the macOS uv fetch step was \"removed in this PR to keep changes Windows-only\" — but the step is sitting right above the comment. The comment is a leftover from PR #968's merge resolution: when main was merged into the PR branch, the macOS step came back (PR #967 had added it), but the orphan comment from an earlier Windows-only sub-commit survived. After the squash-merge it now lies on main.

Before: workflow file contains a self-contradicting comment that misleads anyone touching this section in the future (\"why does the comment say it's removed when it's right there?\").
After: comment is gone, file matches reality.

No functional change — comment-only edit.

## Test plan

- [x] \`grep \"macOS uv fetch removed\" .github/workflows/build-installers.yml\` returns nothing
- [x] Diff is comment-only (3 deletions, 0 functional changes)