### PR TITLE
docs(guides): fix broken Lemonade CLI docs URL in docker.mdx

### DIFF
--- a/docs/guides/docker.mdx
+++ b/docs/guides/docker.mdx
@@ -37,7 +37,7 @@ The GAIA Docker Agent provides a natural language interface for containerizing a
 
    Note: The model is over 17GB and can take a while to download depending on your internet connection. It provides excellent results for Dockerfile generation and application analysis.
    
-   **Important**: The Docker agent requires a higher context size (8192) than the default (4096) to handle complex application analysis and Dockerfile generation. For more details on Lemonade Server CLI options, see the [Lemonade Server documentation](https://lemonade-server.ai/docs/lemonade-cli#options-for-run).
+   **Important**: The Docker agent requires a higher context size (8192) than the default (4096) to handle complex application analysis and Dockerfile generation. For more details on Lemonade Server CLI options, see the [Lemonade Server documentation](https://lemonade-server.ai/docs/guide/cli/#options-for-run).
 
 ### Verify Installation
 


### PR DESCRIPTION
## Summary

One-line URL update: Lemonade reorganized their docs site so the link in [docs/guides/docker.mdx:40](https://github.com/amd/gaia/blob/main/docs/guides/docker.mdx#L40) is 404'ing. The ``#options-for-run`` anchor still exists on the new page, so this is a path swap with no content change.

## Why

The ``Verify external URLs`` CI check is failing on every PR opened against main today because of this one broken link. Unblocks green CI for unrelated work.

Before:
\`\`\`
https://lemonade-server.ai/docs/lemonade-cli#options-for-run  →  HTTP 404
\`\`\`

After:
\`\`\`
https://lemonade-server.ai/docs/guide/cli/#options-for-run  →  HTTP 200
\`\`\`

Verified the new URL renders the same CLI reference and the ``#options-for-run`` anchor still resolves.

## Linked issue

No issue — drive-by maintenance fix.

## Test plan

- [x] \`curl -sI https://lemonade-server.ai/docs/guide/cli/\` returns 200.
- [x] \`curl -s https://lemonade-server.ai/docs/guide/cli/ | grep 'id="options-for-run"'\` matches.
- [ ] CI ``Verify external URLs`` job passes on this PR (will run after open).

## Checklist

- [x] I have described **why** this change is being made.
- [x] One-line diff; no tests or lint impact.

Closes #1050

<!-- gaia-release-orphan-issue:v0.18.0:back-link -->
