### PR TITLE
fix(connectors): MCP single-writer enforcement + security hardening (#976)

### DIFF
--- a/src/gaia/apps/webui/package-lock.json
+++ b/src/gaia/apps/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-ui",
-      "version": "0.17.5",
+      "version": "0.17.6",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.3"
@@ -25,7 +25,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^9.1.0",
-        "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "typescript": "^5.3.3",
@@ -3849,19 +3848,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4549,67 +4535,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-raw": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
-      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "hast-util-to-parse5": "^8.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "parse5": "^7.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-sanitize": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
@@ -4654,26 +4579,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
-      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "devlop": "^1.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -4682,24 +4587,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4748,17 +4635,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -6801,19 +6677,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7265,22 +7128,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/rehype-raw": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-raw": "^9.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-sanitize": {
@@ -8386,21 +8233,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -8484,17 +8316,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -71,7 +71,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^9.1.0",
-    "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "typescript": "^5.3.3",

--- a/src/gaia/apps/webui/src/components/MessageBubble.tsx
+++ b/src/gaia/apps/webui/src/components/MessageBubble.tsx
@@ -4,7 +4,7 @@
 import React, { useCallback, useRef, useState, useEffect, useMemo } from 'react';
 import { Copy, Check, AlertTriangle, Trash2, RefreshCw, FolderOpen } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
-import rehypeRaw from 'rehype-raw';
+import { SAFE_DISALLOWED_ELEMENTS, safeUrlTransform } from '../utils/markdown';
 import remarkGfm from 'remark-gfm';
 import { AgentActivity } from './AgentActivity';
 import * as api from '../services/api';
@@ -598,7 +598,8 @@ function RenderedContent({ content, showCursor }: { content: string; showCursor?
         <div className="md-content">
             <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
+                disallowedElements={[...SAFE_DISALLOWED_ELEMENTS]}
+                urlTransform={safeUrlTransform}
                 components={{
                     // Code block vs inline code detection.
                     // react-markdown calls `code` for both inline `code` and

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -3,7 +3,7 @@
 
 /** API client for GAIA Agent UI backend. */
 
-import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPCatalogEntry, MCPServerStatus, AgentInfo } from '../types';
+import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPServerStatus, AgentInfo } from '../types';
 import { getApiBase } from '../utils/apiBase';
 import { log } from '../utils/logger';
 
@@ -618,28 +618,14 @@ export async function getTunnelStatus(): Promise<TunnelStatus> {
 
 // -- MCP Server Management -------------------------------------------------------
 
+// MCP server configuration moved to the connectors framework (#927):
+//   - Catalog tiles  → POST /api/connectors/{id}/configure (see connectorsStore)
+//   - Custom servers → CLI `gaia connectors mcp add` today; UI in #977
+//   - Catalog list   → GET /api/connectors/catalog (filter by type='mcp_server')
+// Only read-only runtime endpoints remain:
+
 export async function listMCPServers(): Promise<{ servers: MCPServerInfo[] }> {
     return apiFetch('GET', '/mcp/servers');
-}
-
-export async function addMCPServer(data: { name: string; command: string; args?: string[]; env?: Record<string, string> }): Promise<{ status: string; name: string }> {
-    return apiFetch('POST', '/mcp/servers', data);
-}
-
-export async function removeMCPServer(name: string): Promise<{ status: string; name: string }> {
-    return apiFetch('DELETE', `/mcp/servers/${name}`);
-}
-
-export async function enableMCPServer(name: string): Promise<{ status: string; name: string }> {
-    return apiFetch('POST', `/mcp/servers/${name}/enable`);
-}
-
-export async function disableMCPServer(name: string): Promise<{ status: string; name: string }> {
-    return apiFetch('POST', `/mcp/servers/${name}/disable`);
-}
-
-export async function getMCPCatalog(): Promise<{ catalog: MCPCatalogEntry[] }> {
-    return apiFetch('GET', '/mcp/catalog');
 }
 
 export async function getMCPRuntimeStatus(): Promise<{ servers: MCPServerStatus[] }> {

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -302,18 +302,6 @@ export interface MCPServerInfo {
     enabled: boolean;
 }
 
-export interface MCPCatalogEntry {
-    name: string;
-    display_name: string;
-    description: string;
-    category: string;
-    tier: number;
-    command: string;
-    args: string[];
-    env: Record<string, string>;
-    requires_config: string[];
-}
-
 export interface MCPServerStatus {
     name: string;
     connected: boolean;

--- a/src/gaia/apps/webui/src/utils/markdown.ts
+++ b/src/gaia/apps/webui/src/utils/markdown.ts
@@ -1,0 +1,63 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Hardened-markdown utilities (#976).
+//
+// `react-markdown` is used in two contexts in GAIA:
+//
+//   1. Chat output (LLM-generated content)            — UNTRUSTED.
+//   2. Catalog metadata (`instructions_md`, `help_md`) — DEVELOPER-AUTHORED.
+//
+// Both routes through this module rather than carrying their own plugin
+// stacks, so the security posture is uniform. The previous chat pipeline
+// used `rehype-raw` without any disallow list or URL-scheme allow list;
+// LLM-generated `<script>` tags or `javascript:` URLs would execute in the
+// Electron renderer.
+//
+// Invariants enforced here:
+//   * No raw HTML pass-through (no `rehype-raw`).
+//   * `<script> <iframe> <object> <embed> <style>` are stripped if they
+//     somehow appear in the AST.
+//   * Anchor `href` values resolve only to `https:`, `http:`, or `mailto:`.
+//     Anything else (including `javascript:`, `data:`, `vbscript:`) becomes
+//     an empty string so React renders the anchor as an inert
+//     `<a href="">` rather than a navigatable link.
+//
+// `mailto:` is acceptable for catalog/developer-authored content; it should
+// be removed from this allow list if a future surface lets untrusted /
+// LLM-generated content drive `<SafeMarkdown>` directly without an
+// additional review pass.
+
+export const SAFE_DISALLOWED_ELEMENTS: ReadonlyArray<string> = [
+    'script',
+    'iframe',
+    'object',
+    'embed',
+    'style',
+] as const;
+
+/**
+ * URL transformer for ReactMarkdown's `urlTransform` prop.
+ * Returns the URL untouched if its scheme is in the allow list, otherwise
+ * returns an empty string (renders an inert anchor).
+ *
+ * Schemes are matched case-insensitively. Relative URLs (no scheme) and
+ * fragment-only URLs (`#anchor`) pass through unchanged — they cannot
+ * navigate cross-origin.
+ */
+export function safeUrlTransform(url: string): string {
+    if (!url) return '';
+
+    // Allow fragment-only links and same-page anchors.
+    if (url.startsWith('#') || url.startsWith('/')) return url;
+
+    // Extract scheme (case-insensitive). RFC 3986: scheme = ALPHA *(ALPHA / DIGIT / "+" / "-" / ".")
+    const colonIdx = url.indexOf(':');
+    if (colonIdx === -1) return url; // relative URL
+
+    const scheme = url.slice(0, colonIdx).toLowerCase();
+    if (scheme === 'https' || scheme === 'http' || scheme === 'mailto') {
+        return url;
+    }
+    return '';
+}

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1943,28 +1943,15 @@ Examples:
         "--verbose", action="store_true", help="Enable verbose logging"
     )
 
-    # MCP Client commands (connect to external MCP servers)
-    mcp_add_parser = mcp_subparsers.add_parser(
-        "add", help="Add an MCP server connection"
-    )
-    mcp_add_parser.add_argument("name", help="Friendly name for the server")
-    mcp_add_parser.add_argument("command", help="Command to start the MCP server")
-    mcp_add_parser.add_argument(
-        "--config",
-        help="Path to MCP servers config file (default: ~/.gaia/mcp_servers.json)",
-    )
+    # MCP Client commands (connect to external MCP servers).
+    # `add` and `remove` moved to `gaia connectors mcp add/remove` (#977) so
+    # configuration goes through the connectors framework with keyring-backed
+    # secrets and per-agent grants.
 
     mcp_list_parser = mcp_subparsers.add_parser(
         "list", help="List configured MCP servers"
     )
     mcp_list_parser.add_argument(
-        "--config",
-        help="Path to MCP servers config file (default: ~/.gaia/mcp_servers.json)",
-    )
-
-    mcp_remove_parser = mcp_subparsers.add_parser("remove", help="Remove an MCP server")
-    mcp_remove_parser.add_argument("name", help="Name of the server to remove")
-    mcp_remove_parser.add_argument(
         "--config",
         help="Path to MCP servers config file (default: ~/.gaia/mcp_servers.json)",
     )
@@ -4486,12 +4473,8 @@ def handle_mcp_command(args):
         handle_mcp_agent(args)
     elif args.mcp_action == "docker":
         handle_mcp_docker(args)
-    elif args.mcp_action == "add":
-        handle_mcp_add(args)
     elif args.mcp_action == "list":
         handle_mcp_list(args)
-    elif args.mcp_action == "remove":
-        handle_mcp_remove(args)
     elif args.mcp_action == "tools":
         handle_mcp_tools(args)
     elif args.mcp_action == "test-client":
@@ -5075,40 +5058,6 @@ def handle_mcp_docker(args):
         print(f"❌ Error starting Docker MCP server: {e}")
 
 
-def handle_mcp_add(args):
-    """Add an MCP server connection."""
-    import shlex
-
-    from gaia.mcp import MCPClientManager
-    from gaia.mcp.client.config import MCPConfig
-
-    config = MCPConfig(args.config) if args.config else MCPConfig()
-    manager = MCPClientManager(config=config)
-
-    try:
-        print(f"📡 Connecting to MCP server '{args.name}'...")
-
-        # Parse command string into config dict (Anthropic format)
-        parts = shlex.split(args.command)
-        server_config = {"command": parts[0]}
-        if len(parts) > 1:
-            server_config["args"] = parts[1:]
-
-        client = manager.add_server(args.name, server_config)
-
-        tools = client.list_tools()
-        print(f"✅ Successfully connected to '{args.name}'")
-        print(f"   Server: {client.server_info.get('name', 'Unknown')}")
-        print(f"   Version: {client.server_info.get('version', 'Unknown')}")
-        print(f"   Tools: {len(tools)} available")
-
-        config_path = args.config if args.config else "~/.gaia/mcp_servers.json"
-        print(f"   Saved to: {config_path}")
-
-    except Exception as e:
-        print(f"❌ Error connecting to MCP server: {e}")
-
-
 def handle_mcp_list(args):
     """List configured MCP servers."""
     from gaia.mcp import MCPConfig
@@ -5136,20 +5085,6 @@ def handle_mcp_list(args):
         command = server_config.get("command", "Unknown")
         print(f"\n🔹 {name}")
         print(f"   Command: {command}")
-
-
-def handle_mcp_remove(args):
-    """Remove an MCP server."""
-    from gaia.mcp import MCPConfig
-
-    config = MCPConfig(args.config) if args.config else MCPConfig()
-
-    if not config.server_exists(args.name):
-        print(f"❌ MCP server '{args.name}' not found")
-        return
-
-    config.remove_server(args.name)
-    print(f"✅ Removed MCP server '{args.name}'")
 
 
 def handle_mcp_tools(args):

--- a/src/gaia/connectors/catalog/mcp_servers.py
+++ b/src/gaia/connectors/catalog/mcp_servers.py
@@ -3,10 +3,14 @@
 """
 MCP server catalog entries.
 
-Translates the curated server list from ``src/gaia/ui/routers/mcp.py`` into
-``ConnectorSpec`` objects registered in the global ``REGISTRY``.  Importing
-this module also imports ``gaia.connectors.mcp_server`` so the handler is
-registered before any dispatch call.
+Curated, tested MCP servers exposed as ``ConnectorSpec`` objects in the global
+``REGISTRY``. Importing this module also imports ``gaia.connectors.mcp_server``
+so the handler is registered before any dispatch call.
+
+Scope: this catalog ships only entries that have explicit test coverage or are
+trivial enough (no API key required) to verify on the fly. Untested entries
+that previously shipped have been removed in favor of the user-supplied custom
+MCP path (see ``gaia connectors mcp add``).
 """
 
 import gaia.connectors.mcp_server  # noqa: F401  # pylint: disable=unused-import
@@ -14,7 +18,7 @@ from gaia.connectors.registry import REGISTRY
 from gaia.connectors.spec import ConfigField, ConnectorSpec
 
 # ---------------------------------------------------------------------------
-# Tier 1 — Essential
+# Curated catalog
 # ---------------------------------------------------------------------------
 
 _FILESYSTEM = ConnectorSpec(
@@ -36,18 +40,6 @@ _FILESYSTEM = ConnectorSpec(
             help_md="Comma-separated list of paths the server may access.",
         ),
     ),
-)
-
-_PLAYWRIGHT = ConnectorSpec(
-    id="mcp-playwright",
-    display_name="Browser (Playwright)",
-    icon="🎭",
-    category="browser",
-    tier=1,
-    type="mcp_server",
-    description="Web browsing and interaction via accessibility snapshots.",
-    mcp_command="npx",
-    mcp_args=("-y", "@anthropic/mcp-playwright"),
 )
 
 _GITHUB = ConnectorSpec(
@@ -110,378 +102,16 @@ _GIT = ConnectorSpec(
     mcp_args=("-y", "@modelcontextprotocol/server-git"),
 )
 
-_DESKTOP_COMMANDER = ConnectorSpec(
-    id="mcp-desktop-commander",
-    display_name="Desktop Commander",
-    icon="🖥️",
-    category="system",
-    tier=1,
-    type="mcp_server",
-    description="Terminal command execution + file operations with user control.",
-    mcp_command="npx",
-    mcp_args=("-y", "desktop-commander"),
-)
-
-# ---------------------------------------------------------------------------
-# Tier 2 — High Value
-# ---------------------------------------------------------------------------
-
-_BRAVE_SEARCH = ConnectorSpec(
-    id="mcp-brave-search",
-    display_name="Brave Search",
-    icon="🦁",
-    category="web-search",
-    tier=2,
-    type="mcp_server",
-    description="Web search via Brave Search API.",
-    mcp_command="npx",
-    mcp_args=("-y", "@anthropic/mcp-brave-search"),
-    mcp_env_keys=("BRAVE_API_KEY",),
-    config_schema=(
-        ConfigField(
-            key="BRAVE_API_KEY",
-            label="Brave API Key",
-            kind="secret",
-            placeholder="BSA…",
-            help_md="Get a key at [brave.com/search/api](https://brave.com/search/api/).",
-            secret=True,
-        ),
-    ),
-)
-
-_POSTGRES = ConnectorSpec(
-    id="mcp-postgres",
-    display_name="PostgreSQL",
-    icon="🐘",
-    category="database",
-    tier=2,
-    type="mcp_server",
-    description="Read-only database queries against a PostgreSQL database.",
-    mcp_command="npx",
-    mcp_args=(
-        "-y",
-        "@modelcontextprotocol/server-postgres",
-        "postgresql://localhost/mydb",
-    ),
-    config_schema=(
-        ConfigField(
-            key="connection_string",
-            label="Connection string",
-            kind="text",
-            placeholder="postgresql://user:pass@host/db",
-        ),
-    ),
-)
-
-_CONTEXT7 = ConnectorSpec(
-    id="mcp-context7",
-    display_name="Context7 Docs",
-    icon="📖",
-    category="documentation",
-    tier=2,
-    type="mcp_server",
-    description="Inject fresh, version-specific library docs into agent context.",
-    mcp_command="npx",
-    mcp_args=("-y", "context7-mcp"),
-)
-
-_GMAIL = ConnectorSpec(
-    id="mcp-gmail",
-    display_name="Gmail",
-    icon="✉️",
-    category="email",
-    tier=2,
-    type="mcp_server",
-    description="Read, search, send, label, and archive Gmail messages.",
-    mcp_command="npx",
-    mcp_args=("-y", "gmail-mcp-server"),
-    mcp_env_keys=("GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET"),
-    config_schema=(
-        ConfigField(
-            key="GMAIL_CLIENT_ID", label="Gmail Client ID", kind="text", secret=False
-        ),
-        ConfigField(
-            key="GMAIL_CLIENT_SECRET",
-            label="Gmail Client Secret",
-            kind="secret",
-            secret=True,
-        ),
-    ),
-)
-
-_GOOGLE_CALENDAR = ConnectorSpec(
-    id="mcp-google-calendar",
-    display_name="Google Calendar",
-    icon="📅",
-    category="calendar",
-    tier=2,
-    type="mcp_server",
-    description="Events, scheduling, availability, and RSVP management.",
-    mcp_command="npx",
-    mcp_args=("-y", "google-calendar-mcp"),
-    mcp_env_keys=("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"),
-    config_schema=(
-        ConfigField(
-            key="GOOGLE_CLIENT_ID", label="Google Client ID", kind="text", secret=False
-        ),
-        ConfigField(
-            key="GOOGLE_CLIENT_SECRET",
-            label="Google Client Secret",
-            kind="secret",
-            secret=True,
-        ),
-    ),
-)
-
-_OUTLOOK = ConnectorSpec(
-    id="mcp-outlook",
-    display_name="Outlook / Microsoft 365",
-    icon="📧",
-    category="email",
-    tier=2,
-    type="mcp_server",
-    description="Outlook email and calendar via Microsoft Graph API.",
-    mcp_command="npx",
-    mcp_args=("-y", "outlook-mcp-server"),
-    mcp_env_keys=("MS_CLIENT_ID", "MS_CLIENT_SECRET"),
-    config_schema=(
-        ConfigField(
-            key="MS_CLIENT_ID", label="Azure App Client ID", kind="text", secret=False
-        ),
-        ConfigField(
-            key="MS_CLIENT_SECRET",
-            label="Azure App Client Secret",
-            kind="secret",
-            secret=True,
-        ),
-    ),
-)
-
-_SPOTIFY = ConnectorSpec(
-    id="mcp-spotify",
-    display_name="Spotify",
-    icon="🎵",
-    category="media",
-    tier=2,
-    type="mcp_server",
-    description="Play, pause, skip, search tracks, and manage playlists.",
-    mcp_command="npx",
-    mcp_args=("-y", "spotify-mcp-server"),
-    mcp_env_keys=("SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET"),
-    config_schema=(
-        ConfigField(
-            key="SPOTIFY_CLIENT_ID",
-            label="Spotify Client ID",
-            kind="text",
-            secret=False,
-        ),
-        ConfigField(
-            key="SPOTIFY_CLIENT_SECRET",
-            label="Spotify Client Secret",
-            kind="secret",
-            secret=True,
-        ),
-    ),
-)
-
-_SLACK = ConnectorSpec(
-    id="mcp-slack",
-    display_name="Slack",
-    icon="💬",
-    category="communication",
-    tier=2,
-    type="mcp_server",
-    description="Channel management, messaging, and conversation history.",
-    mcp_command="npx",
-    mcp_args=("-y", "slack-mcp-server"),
-    mcp_env_keys=("SLACK_BOT_TOKEN",),
-    config_schema=(
-        ConfigField(
-            key="SLACK_BOT_TOKEN",
-            label="Slack Bot Token",
-            kind="secret",
-            placeholder="xoxb-…",
-            help_md="Create a bot at [api.slack.com/apps](https://api.slack.com/apps).",
-            secret=True,
-        ),
-    ),
-)
-
-_NOTION = ConnectorSpec(
-    id="mcp-notion",
-    display_name="Notion",
-    icon="📝",
-    category="productivity",
-    tier=2,
-    type="mcp_server",
-    description="Workspace pages, databases, and task management.",
-    mcp_command="npx",
-    mcp_args=("-y", "notion-mcp"),
-    mcp_env_keys=("NOTION_API_KEY",),
-    config_schema=(
-        ConfigField(
-            key="NOTION_API_KEY",
-            label="Notion Integration Token",
-            kind="secret",
-            placeholder="secret_…",
-            help_md="Create an integration at [notion.so/my-integrations](https://www.notion.so/my-integrations).",
-            secret=True,
-        ),
-    ),
-)
-
-_LINEAR = ConnectorSpec(
-    id="mcp-linear",
-    display_name="Linear",
-    icon="📋",
-    category="dev-tools",
-    tier=2,
-    type="mcp_server",
-    description="Issues, projects, and cycles — full Linear workspace access.",
-    mcp_command="npx",
-    mcp_args=("-y", "linear-mcp-server"),
-    mcp_env_keys=("LINEAR_API_KEY",),
-    config_schema=(
-        ConfigField(
-            key="LINEAR_API_KEY",
-            label="Linear API Key",
-            kind="secret",
-            placeholder="lin_api_…",
-            help_md="Generate a personal API key at [linear.app/settings/api](https://linear.app/settings/api).",
-            secret=True,
-        ),
-    ),
-)
-
-_JIRA = ConnectorSpec(
-    id="mcp-jira",
-    display_name="Jira",
-    icon="🟦",
-    category="dev-tools",
-    tier=2,
-    type="mcp_server",
-    description="Issues, sprints, and boards — full Jira project management.",
-    mcp_command="npx",
-    mcp_args=("-y", "jira-mcp-server"),
-    mcp_env_keys=("JIRA_API_TOKEN", "JIRA_BASE_URL", "JIRA_USER_EMAIL"),
-    config_schema=(
-        ConfigField(
-            key="JIRA_BASE_URL",
-            label="Jira Base URL",
-            kind="url",
-            placeholder="https://yourorg.atlassian.net",
-        ),
-        ConfigField(key="JIRA_USER_EMAIL", label="Jira User Email", kind="email"),
-        ConfigField(
-            key="JIRA_API_TOKEN", label="Jira API Token", kind="secret", secret=True
-        ),
-    ),
-)
-
-_STRIPE = ConnectorSpec(
-    id="mcp-stripe",
-    display_name="Stripe",
-    icon="💳",
-    category="payments",
-    tier=2,
-    type="mcp_server",
-    description="Payments, subscriptions, and customer management via Stripe API.",
-    mcp_command="npx",
-    mcp_args=("-y", "stripe-mcp-server"),
-    mcp_env_keys=("STRIPE_SECRET_KEY",),
-    config_schema=(
-        ConfigField(
-            key="STRIPE_SECRET_KEY",
-            label="Stripe Secret Key",
-            kind="secret",
-            placeholder="sk_live_…",
-            help_md="Find your key in the [Stripe Dashboard](https://dashboard.stripe.com/apikeys).",
-            secret=True,
-        ),
-    ),
-)
-
-_SENDGRID = ConnectorSpec(
-    id="mcp-sendgrid",
-    display_name="SendGrid",
-    icon="📨",
-    category="email",
-    tier=3,
-    type="mcp_server",
-    description="Transactional email sending and template management via SendGrid.",
-    mcp_command="npx",
-    mcp_args=("-y", "sendgrid-mcp-server"),
-    mcp_env_keys=("SENDGRID_API_KEY",),
-    config_schema=(
-        ConfigField(
-            key="SENDGRID_API_KEY",
-            label="SendGrid API Key",
-            kind="secret",
-            placeholder="SG.…",
-            secret=True,
-        ),
-    ),
-)
-
-# ---------------------------------------------------------------------------
-# Tier 3 — Desktop / Windows
-# ---------------------------------------------------------------------------
-
-_WINDOWS_AUTOMATION = ConnectorSpec(
-    id="mcp-windows-automation",
-    display_name="Windows Automation",
-    icon="🪟",
-    category="computer-use",
-    tier=3,
-    type="mcp_server",
-    description="Native Windows UI automation: open apps, control windows, simulate input.",
-    mcp_command="npx",
-    mcp_args=("-y", "mcp-windows-automation"),
-)
-
-# ---------------------------------------------------------------------------
-# Tier 4 — Microsoft Ecosystem
-# ---------------------------------------------------------------------------
-
-_MICROSOFT_LEARN = ConnectorSpec(
-    id="mcp-microsoft-learn",
-    display_name="Microsoft Learn",
-    icon="📘",
-    category="documentation",
-    tier=4,
-    type="mcp_server",
-    description="Real-time access to Microsoft documentation.",
-    mcp_command="npx",
-    mcp_args=("-y", "@microsoft/mcp-docs"),
-)
-
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 
 _ALL_SPECS = (
     _FILESYSTEM,
-    _PLAYWRIGHT,
     _GITHUB,
     _FETCH,
     _MEMORY,
     _GIT,
-    _DESKTOP_COMMANDER,
-    _BRAVE_SEARCH,
-    _POSTGRES,
-    _CONTEXT7,
-    _GMAIL,
-    _GOOGLE_CALENDAR,
-    _OUTLOOK,
-    _SPOTIFY,
-    _SLACK,
-    _NOTION,
-    _LINEAR,
-    _JIRA,
-    _STRIPE,
-    _SENDGRID,
-    _WINDOWS_AUTOMATION,
-    _MICROSOFT_LEARN,
 )
 
 for _spec in _ALL_SPECS:

--- a/src/gaia/connectors/grants.py
+++ b/src/gaia/connectors/grants.py
@@ -137,6 +137,14 @@ def _save_grants_locked(data: Dict[str, Dict[str, List[str]]]) -> None:
         # os.replace is atomic on POSIX and best-effort atomic on Windows
         # (MoveFileEx with MOVEFILE_REPLACE_EXISTING).
         os.replace(tmp_path, path)
+        # os.replace inherits the destination's prior mode (or umask for new
+        # files); enforce 0600 on the destination explicitly so prior runs
+        # with a permissive umask don't leave the grants file world-readable.
+        if sys.platform != "win32":
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
     except Exception:
         # Clean up the tempfile on any failure path so we don't leak.
         try:
@@ -181,6 +189,34 @@ def revoke_agent_grant(connector_id: str, agent_id: str) -> None:
             logger.debug(
                 "grants: revoked connector_id=%s agent_id=%s", connector_id, agent_id
             )
+
+
+def revoke_all_grants_for(connector_id: str) -> List[str]:
+    """
+    Remove every agent grant for ``connector_id``.
+
+    Called on connector ``disconnect()`` to prevent silent grant inheritance
+    when a connector with the same id is later re-added (which would otherwise
+    re-attach the previous user's consent to the new connector with no
+    confirmation prompt — a real security bypass).
+
+    Returns the list of agent_ids whose grants were revoked, useful for
+    callers that want to log or audit the revocation.
+    """
+    with _write_lock:
+        data = load_grants()
+        if connector_id not in data:
+            return []
+        revoked = sorted(data[connector_id].keys())
+        del data[connector_id]
+        _save_grants_locked(data)
+        logger.info(
+            "grants: revoked all agent grants for connector_id=%s (%d agents: %s)",
+            connector_id,
+            len(revoked),
+            revoked,
+        )
+        return revoked
 
 
 def list_agent_grants(connector_id: str) -> Dict[str, List[str]]:

--- a/src/gaia/connectors/mcp_server.py
+++ b/src/gaia/connectors/mcp_server.py
@@ -51,15 +51,34 @@ def _keyring_ref(connector_id: str, env_key: str) -> str:
 
 
 def _write_mcp_servers_json(servers: Dict[str, Any]) -> None:
-    """Atomically overwrite ``mcp_servers.json`` with *servers* dict."""
+    """Atomically overwrite ``mcp_servers.json`` with *servers* dict.
+
+    File is written mode 0600 (parent 0700). ``os.replace`` would otherwise
+    inherit the destination's prior mode (or umask for new files), which on a
+    multi-user machine leaves any plaintext env value (custom MCP entries
+    that escape the keyring path, ChatAgent dynamic registrations, etc.)
+    world-readable.
+    """
     path = _mcp_servers_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:  # Windows or read-only mount
+        pass
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".mcp_servers_", suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump({"mcpServers": servers}, f, indent=2)
             f.write("\n")
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:  # Windows
+            pass
         os.replace(tmp, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
     except Exception:
         try:
             os.unlink(tmp)
@@ -218,7 +237,7 @@ class McpServerHandler:
         *,
         account_id: Optional[str] = None,
     ) -> None:
-        """Remove the MCP server entry and delete keyring slots."""
+        """Remove the MCP server entry, keyring slots, and per-agent grants."""
         # Remove from mcp_servers.json.
         servers = _read_mcp_servers_json()
         if spec.id in servers:
@@ -232,6 +251,13 @@ class McpServerHandler:
                 keyring.delete_password(SERVICE_NAME, username)
             except keyring.errors.PasswordDeleteError:
                 pass  # already absent — idempotent
+
+        # Wipe per-agent grants. If the same connector_id is re-added later
+        # (custom MCP, repeat OAuth, etc.) the new connector must NOT inherit
+        # the previous user's consent without an explicit re-grant.
+        from gaia.connectors.grants import revoke_all_grants_for
+
+        revoke_all_grants_for(spec.id)
 
         logger.info("mcp_server: disconnected connector_id=%s", spec.id)
 

--- a/src/gaia/connectors/oauth_pkce.py
+++ b/src/gaia/connectors/oauth_pkce.py
@@ -131,12 +131,23 @@ class OAuthPkceHandler:
         *,
         account_id: Optional[str] = None,
     ) -> None:
-        """Remove stored tokens. The keyring deletion is the source of
-        truth — once the blob is gone, ``store.peek_connection`` returns
-        ``None`` and the catalog UI shows "not configured" automatically."""
+        """Remove stored tokens AND per-agent grants. Keyring deletion is the
+        source of truth for "is this configured" — once the blob is gone,
+        ``store.peek_connection`` returns ``None`` and the catalog UI shows
+        "not configured". Grant cleanup prevents silent inheritance: if the
+        same ``connector_id`` is reconnected later, the new tokens must NOT
+        carry the prior user's agent consents."""
         provider_id = spec.oauth_provider_ref or spec.id
         account_email = account_id or DEFAULT_ACCOUNT
         delete_connection(provider_id, account_email=account_email)
+
+        # Wipe per-agent grants for this connector_id. Local import keeps the
+        # module-level dependency graph identical to before (grants depends on
+        # nothing else here).
+        from gaia.connectors.grants import revoke_all_grants_for
+
+        revoke_all_grants_for(spec.id)
+
         logger.info("oauth_pkce: disconnected connector_id=%s", spec.id)
 
     async def test(self, spec: ConnectorSpec) -> Dict[str, Any]:

--- a/src/gaia/mcp/client/config.py
+++ b/src/gaia/mcp/client/config.py
@@ -1,10 +1,15 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-"""Configuration management for MCP clients."""
+"""Configuration management for MCP clients (read-only as of #976).
+
+Mutations to ``~/.gaia/mcp_servers.json`` go through the connectors framework
+(``gaia.connectors.mcp_server.McpServerHandler.configure`` / ``disconnect``).
+This class is the read path used by ``MCPClient``, ``ChatAgent`` and the
+agent-builder template.
+"""
 
 import json
 import sys
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -110,73 +115,45 @@ class MCPConfig:
         return None
 
     def _read_servers(self, path: Path) -> Dict[str, Any]:
-        """Read and return the server dict from *path* without side effects."""
+        """Read and return the server dict from *path* without side effects.
+
+        Fails loudly on malformed JSON: returning an empty dict on any error
+        masks the underlying problem and lets corrupted state propagate
+        silently into ``MCPClient`` (which then sees zero servers with no
+        actionable error). A missing file returns an empty dict — the caller
+        in ``__init__`` already gates on ``path.exists()``.
+        """
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                return data.get("mcpServers", data.get("servers", {}))
-        except Exception as e:
-            logger.error(f"Error reading config from {path}: {e}")
-            return {}
+        except json.JSONDecodeError as e:
+            from gaia.connectors.errors import ConnectorsError
+
+            raise ConnectorsError(
+                f"mcp_servers.json at {path} is corrupt: {e}. "
+                f"Inspect the file or remove it to start fresh; the connectors "
+                f"framework will recreate it on next configure()."
+            ) from e
+        except OSError as e:
+            from gaia.connectors.errors import ConnectorsError
+
+            raise ConnectorsError(
+                f"failed to read mcp_servers.json at {path}: {e}"
+            ) from e
+        return data.get("mcpServers", data.get("servers", {}))
 
     def _load(self) -> None:
-        """Load configuration from ``self.config_file`` (replaces current servers)."""
+        """Load configuration from ``self.config_file`` (replaces current servers).
+
+        Fails loudly via :meth:`_read_servers`; an actionable
+        ``ConnectorsError`` propagates rather than silently masking corruption.
+        """
         if not self.config_file.exists():
             logger.debug(f"Config file not found: {self.config_file}")
             return
 
-        try:
-            with open(self.config_file, "r", encoding="utf-8") as f:
-                data = json.load(f)
-                # Support both new 'mcpServers' and legacy 'servers' key
-                self._servers = data.get("mcpServers", data.get("servers", {}))
-            logger.debug(f"Loaded {len(self._servers)} servers from config")
-        except Exception as e:
-            logger.error(f"Error loading config: {e}")
-            self._servers = {}
-
-    def _save(self) -> None:
-        """Save configuration to file (always uses 'mcpServers' key)."""
-        try:
-            with open(self.config_file, "w", encoding="utf-8") as f:
-                json.dump({"mcpServers": self._servers}, f, indent=2)
-            logger.debug(f"Saved config to {self.config_file}")
-        except Exception as e:
-            logger.error(f"Error saving config: {e}")
-
-    def add_server(self, name: str, config: Dict[str, Any]) -> None:
-        """Add or update a server configuration.
-
-        .. deprecated::
-            Use ``gaia.connectors.mcp_server.McpServerHandler.configure()``
-            instead. The connectors framework is now the sole writer to
-            ``mcp_servers.json`` (plan amendment A6).
-        """
-        warnings.warn(
-            "MCPConfig.add_server() is deprecated. Use McpServerHandler.configure() "
-            "to write mcp_servers.json (plan amendment A6).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._servers[name] = config
-        self._save()
-
-    def remove_server(self, name: str) -> None:
-        """Remove a server configuration.
-
-        .. deprecated::
-            Use ``gaia.connectors.mcp_server.McpServerHandler.disconnect()``
-            instead (plan amendment A6).
-        """
-        warnings.warn(
-            "MCPConfig.remove_server() is deprecated. Use McpServerHandler.disconnect() "
-            "to write mcp_servers.json (plan amendment A6).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if name in self._servers:
-            del self._servers[name]
-            self._save()
+        self._servers = self._read_servers(self.config_file)
+        logger.debug(f"Loaded {len(self._servers)} servers from config")
 
     def get_server(self, name: str) -> Dict[str, Any]:
         """Get a server configuration.

--- a/src/gaia/mcp/client/mcp_client.py
+++ b/src/gaia/mcp/client/mcp_client.py
@@ -16,19 +16,31 @@ logger = get_logger(__name__)
 
 def _resolve_keyring_refs(env: Optional[Dict[str, Any]]) -> Dict[str, str]:
     """
-    Resolve ``{"$keyring": "service:username"}`` references in *env*.
+    Resolve ``{"$keyring": "<service>:<connector_id>:<env_key>"}`` references in *env*.
 
-    Each value that is a dict with a ``"$keyring"`` key is resolved via
-    ``keyring.get_password(service, username)`` where the reference string
-    is split on the first ``:`` as ``<service>:<username>``.
+    The keyring lookup uses ``service`` and the two-part username
+    ``<connector_id>:<env_key>`` (first ``:`` splits service from username, so
+    ``ref.partition(":")`` gives the correct ``service`` / ``username`` pair
+    that ``McpServerHandler.configure`` writes).
 
-    Raises ``RuntimeError`` if any referenced keyring entry is absent —
-    the server is refused to spawn (plan amendment A5b: fail-closed).
+    Security invariants:
+
+    * ``service`` MUST equal ``gaia.connections``. Any other value would let a
+      corrupted ``mcp_servers.json`` (e.g. a malicious entry pointing at
+      ``"Chrome Safe Storage:Chrome:..."``) exfiltrate other applications'
+      keyring entries into the spawned MCP subprocess env. We refuse to
+      spawn instead.
+    * Missing keyring entries fail closed (raise ``ConnectorsError``) — the
+      MCP server is never spawned with empty env in place of a secret.
+
     Plain string values pass through unchanged.
     """
     if not env:
         return {}
     import keyring  # pylint: disable=import-outside-toplevel
+
+    from gaia.connectors.errors import ConnectorsError
+    from gaia.connectors.store import SERVICE_NAME
 
     resolved: Dict[str, str] = {}
     missing: list[str] = []
@@ -36,6 +48,12 @@ def _resolve_keyring_refs(env: Optional[Dict[str, Any]]) -> Dict[str, str]:
         if isinstance(value, dict) and "$keyring" in value:
             ref = value["$keyring"]
             service, _, username = ref.partition(":")
+            if service != SERVICE_NAME:
+                raise ConnectorsError(
+                    f"MCPClient: refusing to spawn — $keyring reference "
+                    f"{ref!r} points outside the gaia namespace "
+                    f"(service={service!r}). Only {SERVICE_NAME!r} is allowed."
+                )
             password = keyring.get_password(service, username)
             if password is None:
                 missing.append(ref)
@@ -44,10 +62,34 @@ def _resolve_keyring_refs(env: Optional[Dict[str, Any]]) -> Dict[str, str]:
         else:
             resolved[key] = str(value)
     if missing:
-        raise RuntimeError(
-            f"MCPClient: refusing to spawn — missing keyring entries: {missing!r}. "
-            "Reconfigure the connector via Settings → Connectors or "
-            "`gaia connectors configure <id>`."
+        # Diagnostic parse — split each ref into (service, connector_id,
+        # env_key) for an actionable error pointing at `gaia connectors
+        # configure <id>`. Keep the raw refs in the message too for grep.
+        details = []
+        for ref in missing:
+            parts = ref.split(":", 2)
+            if len(parts) == 3:
+                _, connector_id, env_key = parts
+                details.append(
+                    f"connector_id={connector_id!r} env_key={env_key!r} ref={ref!r}"
+                )
+            else:
+                details.append(f"ref={ref!r}")
+        joined = "; ".join(details)
+        # Pull a connector_id from the first parseable ref for the recovery
+        # hint; if none parses, fall back to a generic message.
+        recovery_hint = ""
+        for ref in missing:
+            parts = ref.split(":", 2)
+            if len(parts) == 3:
+                recovery_hint = (
+                    f" Run `gaia connectors configure {parts[1]}` to "
+                    "re-supply the secret."
+                )
+                break
+        raise ConnectorsError(
+            f"MCPClient: refusing to spawn — missing keyring entries: "
+            f"{joined}.{recovery_hint}"
         )
     return resolved
 

--- a/src/gaia/mcp/client/mcp_client_manager.py
+++ b/src/gaia/mcp/client/mcp_client_manager.py
@@ -78,11 +78,11 @@ class MCPClientManager:
             detail = f": {client.last_error}" if client.last_error else ""
             raise RuntimeError(f"Failed to connect to MCP server '{name}'{detail}")
 
-        # Store client
+        # Store client (in-memory only).
+        # Persistence to ~/.gaia/mcp_servers.json goes through the connectors
+        # framework (see gaia.connectors.mcp_server.McpServerHandler.configure)
+        # — this manager is a runtime registry, not a writer (#976).
         self._clients[name] = client
-
-        # Save to config
-        self.config.add_server(name, config)
 
         logger.debug(f"Successfully added MCP server: {name}")
         return client
@@ -104,7 +104,9 @@ class MCPClientManager:
         del self._clients[name]
         self._failed.pop(name, None)
 
-        self.config.remove_server(name)
+        # Removal is in-memory only — persistence (clearing the
+        # mcp_servers.json entry + keyring + grants) goes through
+        # gaia.connectors.mcp_server.McpServerHandler.disconnect (#976).
 
         logger.debug(f"Successfully removed MCP server: {name}")
 

--- a/src/gaia/ui/routers/mcp.py
+++ b/src/gaia/ui/routers/mcp.py
@@ -1,12 +1,22 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""MCP server management endpoints for GAIA Agent UI."""
+"""MCP server status endpoints for GAIA Agent UI.
+
+Configuration of MCP servers (add / remove / enable / disable / catalog)
+moved to the connectors framework in #927. This module retains only the
+read-only runtime-status endpoints used by the UI's MCP status panel.
+
+Mutating operations now route through:
+  * Catalog tiles  → POST /api/connectors/{id}/configure
+  * Custom servers → gaia connectors mcp add (CLI; UI work in #977)
+  * Catalog        → GET  /api/connectors/catalog (filter by type='mcp_server')
+"""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from gaia.mcp.client.config import MCPConfig
@@ -16,238 +26,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["mcp"])
 
 
-def _require_ui_header(request: Request) -> None:
-    """Require ``X-Gaia-UI: 1`` header as a lightweight CSRF guard (plan amendment A8)."""
-    if request.headers.get("x-gaia-ui") != "1":
-        raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
-
-
 # ---------------------------------------------------------------------------
-# Curated MCP server catalog (Tier 1–4 popular servers)
+# Response models
 # ---------------------------------------------------------------------------
-
-_CATALOG: List[Dict[str, Any]] = [
-    # ── Tier 1 — Essential ──────────────────────────────────────────────────
-    {
-        "name": "filesystem",
-        "display_name": "File System",
-        "description": "Secure file read/write/search with configurable access controls.",
-        "category": "system",
-        "tier": 1,
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-filesystem", "~"],
-        "requires_config": ["allowed_directories"],
-        "env": {},
-    },
-    {
-        "name": "playwright",
-        "display_name": "Browser (Playwright)",
-        "description": "Web browsing and interaction via accessibility snapshots.",
-        "category": "browser",
-        "tier": 1,
-        "command": "npx",
-        "args": ["-y", "@anthropic/mcp-playwright"],
-        "requires_config": [],
-        "env": {},
-    },
-    {
-        "name": "github",
-        "display_name": "GitHub",
-        "description": "Repos, PRs, issues, workflows — full GitHub access.",
-        "category": "dev-tools",
-        "tier": 1,
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-github"],
-        "requires_config": ["GITHUB_TOKEN"],
-        "env": {"GITHUB_TOKEN": ""},
-    },
-    {
-        "name": "fetch",
-        "display_name": "Web Fetch",
-        "description": "Fetch web content and convert it to Markdown.",
-        "category": "web",
-        "tier": 1,
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-fetch"],
-        "requires_config": [],
-        "env": {},
-    },
-    {
-        "name": "memory",
-        "display_name": "Memory",
-        "description": "Knowledge graph-based persistent memory for agents.",
-        "category": "context",
-        "tier": 1,
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-memory"],
-        "requires_config": [],
-        "env": {},
-    },
-    {
-        "name": "git",
-        "display_name": "Git",
-        "description": "Git repository tools: log, diff, status, blame.",
-        "category": "dev-tools",
-        "tier": 1,
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-git"],
-        "requires_config": [],
-        "env": {},
-    },
-    {
-        "name": "desktop-commander",
-        "display_name": "Desktop Commander",
-        "description": "Terminal command execution + file operations with user control.",
-        "category": "system",
-        "tier": 1,
-        "command": "npx",
-        "args": ["-y", "desktop-commander"],
-        "requires_config": [],
-        "env": {},
-    },
-    # ── Tier 2 — High Value ─────────────────────────────────────────────────
-    {
-        "name": "brave-search",
-        "display_name": "Brave Search",
-        "description": "Web search via Brave Search API.",
-        "category": "web-search",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "@anthropic/mcp-brave-search"],
-        "requires_config": ["BRAVE_API_KEY"],
-        "env": {"BRAVE_API_KEY": ""},
-    },
-    {
-        "name": "postgres",
-        "display_name": "PostgreSQL",
-        "description": "Read-only database queries against a PostgreSQL database.",
-        "category": "database",
-        "tier": 2,
-        "command": "npx",
-        "args": [
-            "-y",
-            "@modelcontextprotocol/server-postgres",
-            "postgresql://localhost/mydb",
-        ],
-        "requires_config": ["connection_string"],
-        "env": {},
-    },
-    {
-        "name": "context7",
-        "display_name": "Context7 Docs",
-        "description": "Inject fresh, version-specific library docs into agent context.",
-        "category": "documentation",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "context7-mcp"],
-        "requires_config": [],
-        "env": {},
-    },
-    # ── Tier 3 — Windows Desktop Automation ────────────────────────────────
-    {
-        "name": "windows-automation",
-        "display_name": "Windows Automation",
-        "description": "Native Windows UI automation: open apps, control windows, simulate input.",
-        "category": "computer-use",
-        "tier": 3,
-        "command": "npx",
-        "args": ["-y", "mcp-windows-automation"],
-        "requires_config": [],
-        "env": {},
-    },
-    # ── Tier 4 — Microsoft Ecosystem ────────────────────────────────────────
-    {
-        "name": "microsoft-learn",
-        "display_name": "Microsoft Learn",
-        "description": "Real-time access to Microsoft documentation.",
-        "category": "documentation",
-        "tier": 4,
-        "command": "npx",
-        "args": ["-y", "@microsoft/mcp-docs"],
-        "requires_config": [],
-        "env": {},
-    },
-    # ── Tier 2 — Email & Calendar ───────────────────────────────────────────
-    {
-        "name": "gmail",
-        "display_name": "Gmail",
-        "description": "Read, search, send, label, and archive Gmail messages.",
-        "category": "email",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "gmail-mcp-server"],
-        "requires_config": ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET"],
-        "env": {"GMAIL_CLIENT_ID": "", "GMAIL_CLIENT_SECRET": ""},
-    },
-    {
-        "name": "google-calendar",
-        "display_name": "Google Calendar",
-        "description": "Events, scheduling, availability, and RSVP management.",
-        "category": "calendar",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "google-calendar-mcp"],
-        "requires_config": ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
-        "env": {"GOOGLE_CLIENT_ID": "", "GOOGLE_CLIENT_SECRET": ""},
-    },
-    {
-        "name": "outlook",
-        "display_name": "Outlook / Microsoft 365",
-        "description": "Outlook email and calendar via Microsoft Graph API.",
-        "category": "email",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "outlook-mcp-server"],
-        "requires_config": ["MS_CLIENT_ID", "MS_CLIENT_SECRET"],
-        "env": {"MS_CLIENT_ID": "", "MS_CLIENT_SECRET": ""},
-    },
-    # ── Tier 2 — Popular App Control ────────────────────────────────────────
-    {
-        "name": "spotify",
-        "display_name": "Spotify",
-        "description": "Play, pause, skip, search tracks, and manage playlists.",
-        "category": "media",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "spotify-mcp-server"],
-        "requires_config": ["SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET"],
-        "env": {"SPOTIFY_CLIENT_ID": "", "SPOTIFY_CLIENT_SECRET": ""},
-    },
-    {
-        "name": "slack",
-        "display_name": "Slack",
-        "description": "Channel management, messaging, and conversation history.",
-        "category": "communication",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "slack-mcp-server"],
-        "requires_config": ["SLACK_BOT_TOKEN"],
-        "env": {"SLACK_BOT_TOKEN": ""},
-    },
-    {
-        "name": "notion",
-        "display_name": "Notion",
-        "description": "Workspace pages, databases, and task management.",
-        "category": "productivity",
-        "tier": 2,
-        "command": "npx",
-        "args": ["-y", "notion-mcp"],
-        "requires_config": ["NOTION_API_KEY"],
-        "env": {"NOTION_API_KEY": ""},
-    },
-]
-
-
-# ---------------------------------------------------------------------------
-# Request / Response models
-# ---------------------------------------------------------------------------
-
-
-class MCPServerCreateRequest(BaseModel):
-    name: str
-    command: str
-    args: Optional[List[str]] = None
-    env: Optional[Dict[str, str]] = None
 
 
 class MCPServerInfo(BaseModel):
@@ -285,7 +66,7 @@ def _mask_env(env: Dict[str, str]) -> Dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
-# Endpoints
+# Read-only endpoints
 # ---------------------------------------------------------------------------
 
 
@@ -306,75 +87,6 @@ async def list_mcp_servers():
             )
         )
     return {"servers": [s.model_dump() for s in result]}
-
-
-@router.post(
-    "/api/mcp/servers", status_code=201, dependencies=[Depends(_require_ui_header)]
-)
-async def add_mcp_server(body: MCPServerCreateRequest):
-    """Add a new MCP server configuration (persisted to ~/.gaia/mcp_servers.json)."""
-    if not body.name or not body.name.strip():
-        raise HTTPException(status_code=400, detail="Server name must not be empty")
-    if not body.command or not body.command.strip():
-        raise HTTPException(status_code=400, detail="Command must not be empty")
-
-    config = _load_config()
-    if config.server_exists(body.name):
-        raise HTTPException(
-            status_code=409, detail=f"Server '{body.name}' already exists"
-        )
-
-    server_cfg: Dict[str, Any] = {"command": body.command, "args": body.args or []}
-    if body.env:
-        server_cfg["env"] = body.env
-
-    config.add_server(body.name, server_cfg)
-    logger.info("Added MCP server '%s' (command: %s)", body.name, body.command)
-    return {"status": "added", "name": body.name}
-
-
-@router.delete("/api/mcp/servers/{name}", dependencies=[Depends(_require_ui_header)])
-async def remove_mcp_server(name: str):
-    """Remove an MCP server configuration."""
-    config = _load_config()
-    if not config.server_exists(name):
-        raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
-
-    config.remove_server(name)
-    logger.info("Removed MCP server '%s'", name)
-    return {"status": "removed", "name": name}
-
-
-@router.post(
-    "/api/mcp/servers/{name}/enable", dependencies=[Depends(_require_ui_header)]
-)
-async def enable_mcp_server(name: str):
-    """Enable a previously disabled MCP server."""
-    config = _load_config()
-    if not config.server_exists(name):
-        raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
-
-    cfg = config.get_server(name)
-    cfg.pop("disabled", None)
-    config.add_server(name, cfg)
-    logger.info("Enabled MCP server '%s'", name)
-    return {"status": "enabled", "name": name}
-
-
-@router.post(
-    "/api/mcp/servers/{name}/disable", dependencies=[Depends(_require_ui_header)]
-)
-async def disable_mcp_server(name: str):
-    """Disable an MCP server without removing its configuration."""
-    config = _load_config()
-    if not config.server_exists(name):
-        raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
-
-    cfg = config.get_server(name)
-    cfg["disabled"] = True
-    config.add_server(name, cfg)
-    logger.info("Disabled MCP server '%s'", name)
-    return {"status": "disabled", "name": name}
 
 
 @router.get("/api/mcp/servers/{name}/tools")
@@ -417,12 +129,6 @@ async def list_mcp_server_tools(name: str):
         raise HTTPException(
             status_code=503, detail=f"Failed to connect to server '{name}': {exc}"
         )
-
-
-@router.get("/api/mcp/catalog")
-async def get_mcp_catalog():
-    """Return the curated list of popular MCP servers."""
-    return {"catalog": _CATALOG}
 
 
 @router.get("/api/mcp/status")

--- a/tests/unit/connectors/test_catalog_ledger.py
+++ b/tests/unit/connectors/test_catalog_ledger.py
@@ -1,0 +1,164 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Catalog ledger test (#976).
+
+Replaces the previous "legacy ⊆ new" parity check. The MCP catalog has been
+intentionally reduced from 22 deployed entries down to 5 tested entries; the
+17 dropped entries are gone for cause (untested or redundant with another
+connector). This test asserts both ends of that ledger:
+
+  * KEPT_IDS — exactly these 5 ids must remain in
+    ``connectors.catalog.mcp_servers``. For each, field-by-field equivalence
+    against the legacy ``mcp.py:_CATALOG`` row of the same name is asserted as
+    a guard against silent drift during the migration.
+  * DELETED_IDS — these 17 ids must NOT be present. Regression guard against
+    accidentally re-introducing untested catalog tiles.
+
+When ``src/gaia/ui/routers/mcp.py:_CATALOG`` is finally deleted (also part of
+this PR), the field-equivalence half of this test stops running (the legacy
+fixture is gone) but the kept-set/deleted-set membership half stays as the
+permanent regression guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.connectors.registry import REGISTRY
+
+KEPT_IDS = frozenset(
+    {
+        "mcp-filesystem",
+        "mcp-github",
+        "mcp-fetch",
+        "mcp-memory",
+        "mcp-git",
+    }
+)
+
+DELETED_IDS = frozenset(
+    {
+        "mcp-playwright",
+        "mcp-desktop-commander",
+        "mcp-brave-search",
+        "mcp-postgres",
+        "mcp-context7",
+        "mcp-gmail",
+        "mcp-google-calendar",
+        "mcp-outlook",
+        "mcp-spotify",
+        "mcp-slack",
+        "mcp-notion",
+        "mcp-linear",
+        "mcp-jira",
+        "mcp-stripe",
+        "mcp-sendgrid",
+        "mcp-windows-automation",
+        "mcp-microsoft-learn",
+    }
+)
+
+
+def _mcp_specs():
+    """All registered specs of type=mcp_server."""
+    # Importing the catalog module triggers REGISTRY.register() on each spec.
+    import gaia.connectors.catalog.mcp_servers  # noqa: F401
+
+    return {s.id: s for s in REGISTRY.all() if s.type == "mcp_server"}
+
+
+def _legacy_catalog_by_name():
+    """
+    Legacy ``_CATALOG`` from ``src/gaia/ui/routers/mcp.py`` keyed by name.
+    Returns an empty dict once the legacy catalog is deleted from the source —
+    in that case the field-equivalence assertions are skipped (the kept-set /
+    deleted-set membership assertions still run).
+    """
+    try:
+        from gaia.ui.routers.mcp import _CATALOG  # type: ignore[attr-defined]
+    except ImportError:
+        return {}
+    return {entry["name"]: entry for entry in _CATALOG}
+
+
+def test_kept_ids_present_in_catalog():
+    """Every id in KEPT_IDS exists in the registry as type=mcp_server."""
+    actual = _mcp_specs()
+    missing = KEPT_IDS - actual.keys()
+    assert not missing, f"Kept ids missing from catalog: {sorted(missing)}"
+
+
+def test_deleted_ids_absent_from_catalog():
+    """No id in DELETED_IDS may reappear in the registry."""
+    actual = _mcp_specs()
+    surfaced = DELETED_IDS & actual.keys()
+    assert not surfaced, (
+        f"Untested catalog ids were re-added: {sorted(surfaced)}. "
+        "If you want to ship one of these again, add explicit test coverage "
+        "first and remove the id from DELETED_IDS in this file."
+    )
+
+
+def test_no_unexpected_mcp_ids():
+    """The catalog contains only kept ids — no surprise additions."""
+    actual = _mcp_specs()
+    extra = actual.keys() - KEPT_IDS
+    assert not extra, (
+        f"Unexpected MCP catalog ids beyond the kept set: {sorted(extra)}. "
+        "Add the id to KEPT_IDS (with rationale) or remove it from the catalog."
+    )
+
+
+def test_mcp_id_naming_convention():
+    """Every type=mcp_server id matches the deployed prefix convention."""
+    for spec_id in _mcp_specs():
+        assert spec_id.startswith("mcp-"), (
+            f"Connector id {spec_id!r} violates the mcp- prefix convention "
+            "for type=mcp_server entries."
+        )
+
+
+@pytest.mark.parametrize("spec_id", sorted(KEPT_IDS))
+def test_kept_spec_matches_legacy_fields(spec_id):
+    """
+    Field-by-field equivalence against legacy ``_CATALOG``.
+    Skips automatically once the legacy catalog is deleted (post-#976 migration
+    completes). This is a one-shot guard for the migration commit.
+    """
+    legacy_by_name = _legacy_catalog_by_name()
+    if not legacy_by_name:
+        pytest.skip("legacy _CATALOG already removed; field-equivalence step done")
+
+    legacy_name = spec_id[len("mcp-") :]  # "mcp-github" → "github"
+    legacy = legacy_by_name.get(legacy_name)
+    assert legacy is not None, (
+        f"Kept id {spec_id!r} has no legacy counterpart with name={legacy_name!r}; "
+        "either the kept set is wrong or the legacy catalog drifted."
+    )
+
+    spec = _mcp_specs()[spec_id]
+
+    assert spec.display_name == legacy["display_name"], (
+        f"display_name drift for {spec_id}: "
+        f"new={spec.display_name!r} legacy={legacy['display_name']!r}"
+    )
+    assert spec.mcp_command == legacy["command"], (
+        f"command drift for {spec_id}: "
+        f"new={spec.mcp_command!r} legacy={legacy['command']!r}"
+    )
+    assert tuple(spec.mcp_args) == tuple(legacy["args"]), (
+        f"args drift for {spec_id}: "
+        f"new={tuple(spec.mcp_args)!r} legacy={tuple(legacy['args'])!r}"
+    )
+    assert set(spec.mcp_env_keys) == set(legacy["env"].keys()), (
+        f"env keys drift for {spec_id}: "
+        f"new={set(spec.mcp_env_keys)} legacy={set(legacy['env'].keys())}"
+    )
+
+    expected_config_keys = set(legacy.get("requires_config") or [])
+    actual_config_keys = {field.key for field in spec.config_schema}
+    assert actual_config_keys == expected_config_keys, (
+        f"config_schema key set drift for {spec_id}: "
+        f"new={actual_config_keys} legacy={expected_config_keys}"
+    )

--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -1,0 +1,165 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Per-agent grants must be wiped on connector disconnect (#976 security fix).
+
+Before this fix, ``McpServerHandler.disconnect`` and
+``OAuthPkceHandler.disconnect`` cleared keyring + state but never touched
+``grants.json``. Re-adding a connector with the same id later would silently
+re-attach the previous user's agent consents — a real bypass.
+
+This test exercises the cycle: configure → grant → disconnect → check that
+``list_agent_grants`` for that connector_id is empty. Both handler types
+share the ``revoke_all_grants_for`` helper.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+from gaia.connectors.grants import (
+    grant_agent,
+    list_agent_grants,
+    revoke_all_grants_for,
+)
+
+
+@pytest.fixture
+def grants_in_tmp(tmp_path, monkeypatch):
+    """Redirect grants.json to a tempdir for this test."""
+    grants_dir = tmp_path / ".gaia" / "connectors"
+    grants_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Re-evaluate _grants_path under the new HOME.
+    monkeypatch.setattr(
+        "gaia.connectors.grants._grants_path",
+        lambda: grants_dir / "grants.json",
+    )
+    yield grants_dir
+
+
+def test_revoke_all_grants_for_clears_every_agent(grants_in_tmp):
+    grant_agent("mcp-test", "agent-A", ["use"])
+    grant_agent("mcp-test", "agent-B", ["use"])
+    grant_agent("mcp-other", "agent-A", ["use"])
+
+    revoked = revoke_all_grants_for("mcp-test")
+    assert sorted(revoked) == ["agent-A", "agent-B"]
+
+    # mcp-test grants are gone.
+    assert list_agent_grants("mcp-test") == {}
+    # mcp-other is unaffected.
+    assert list_agent_grants("mcp-other") == {"agent-A": ["use"]}
+
+
+def test_revoke_all_grants_for_unknown_id_is_noop(grants_in_tmp):
+    grant_agent("mcp-test", "agent-A", ["use"])
+
+    revoked = revoke_all_grants_for("nonexistent")
+    assert revoked == []
+    # mcp-test untouched.
+    assert list_agent_grants("mcp-test") == {"agent-A": ["use"]}
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_disconnect_revokes_grants(grants_in_tmp, tmp_path):
+    """
+    End-to-end: configure → grant → disconnect → assert grants empty.
+    Re-configure with the same id and assert grants are still empty
+    (no silent inheritance).
+    """
+    from gaia.connectors.mcp_server import McpServerHandler
+    from gaia.connectors.spec import ConfigField, ConnectorSpec
+
+    spec = ConnectorSpec(
+        id="mcp-disconnect-test",
+        display_name="Disconnect Test",
+        icon="🧪",
+        category="test",
+        tier=1,
+        type="mcp_server",
+        description="ephemeral test entry",
+        mcp_command="echo",
+        mcp_args=("hello",),
+        mcp_env_keys=("API_KEY",),
+        config_schema=(
+            ConfigField(
+                key="API_KEY",
+                label="API Key",
+                kind="secret",
+                secret=True,
+            ),
+        ),
+    )
+
+    # Redirect ~/.gaia for the mcp_server module too.
+    monkey_home = tmp_path
+    with patch("gaia.connectors.mcp_server._mcp_servers_path") as mock_path:
+        mock_path.return_value = monkey_home / ".gaia" / "mcp_servers.json"
+
+        handler = McpServerHandler()
+
+        await handler.configure(spec, {"API_KEY": "secret-1"})
+
+        # Grant two agents.
+        grant_agent(spec.id, "agent-A", ["use"])
+        grant_agent(spec.id, "agent-B", ["use"])
+        assert sorted(list_agent_grants(spec.id).keys()) == ["agent-A", "agent-B"]
+
+        # Disconnect must wipe both grants.
+        await handler.disconnect(spec)
+        assert list_agent_grants(spec.id) == {}
+
+        # Re-configure with the same id (different secret value).
+        await handler.configure(spec, {"API_KEY": "secret-2"})
+        # Grants stay empty — no silent inheritance from the previous lifecycle.
+        assert list_agent_grants(spec.id) == {}, (
+            "Re-configuring a connector with the same id silently inherited "
+            "the previous user's agent grants — security bypass."
+        )
+
+
+@pytest.mark.asyncio
+async def test_oauth_pkce_disconnect_revokes_grants(grants_in_tmp, monkeypatch):
+    """OAuth-pkce disconnect must also wipe grants for the connector_id."""
+    from gaia.connectors.oauth_pkce import OAuthPkceHandler
+
+    captured: Dict[str, Any] = {}
+
+    async def _no_op_get_credential(*args, **kwargs):  # pragma: no cover
+        return {}
+
+    # delete_connection in oauth_pkce talks to the keyring; stub it out.
+    monkeypatch.setattr(
+        "gaia.connectors.oauth_pkce.delete_connection",
+        lambda provider_id, account_email: captured.update(
+            provider_id=provider_id, account_email=account_email
+        ),
+    )
+
+    from gaia.connectors.spec import ConnectorSpec
+
+    spec = ConnectorSpec(
+        id="oauth-test",
+        display_name="OAuth Test",
+        icon="🧪",
+        category="test",
+        tier=1,
+        type="oauth_pkce",
+        description="ephemeral",
+        oauth_provider_ref="oauth-test",
+    )
+
+    grant_agent(spec.id, "agent-A", ["scope.read"])
+    grant_agent(spec.id, "agent-B", ["scope.read"])
+    assert sorted(list_agent_grants(spec.id).keys()) == ["agent-A", "agent-B"]
+
+    handler = OAuthPkceHandler()
+    await handler.disconnect(spec)
+
+    assert list_agent_grants(spec.id) == {}
+    assert captured == {"provider_id": "oauth-test", "account_email": "default"}

--- a/tests/unit/connectors/test_mcp_server.py
+++ b/tests/unit/connectors/test_mcp_server.py
@@ -310,7 +310,9 @@ class TestHealthCheck:
 class TestResolveKeyringRefs:
     def test_resolves_reference(self):
         with patch("keyring.get_password", return_value="resolved"):
-            result = _resolve_keyring_refs({"KEY": {"$keyring": "svc:user:KEY"}})
+            result = _resolve_keyring_refs(
+                {"KEY": {"$keyring": "gaia.connections:mcp-test:KEY"}}
+            )
         assert result["KEY"] == "resolved"
 
     def test_passes_through_plain_string(self):
@@ -318,9 +320,34 @@ class TestResolveKeyringRefs:
         assert result["KEY"] == "plain"
 
     def test_fails_closed_on_missing_entry(self):
+        from gaia.connectors.errors import ConnectorsError
+
         with patch("keyring.get_password", return_value=None):
-            with pytest.raises(RuntimeError, match="missing keyring entries"):
-                _resolve_keyring_refs({"KEY": {"$keyring": "svc:user:KEY"}})
+            with pytest.raises(ConnectorsError, match="missing keyring entries"):
+                _resolve_keyring_refs(
+                    {"KEY": {"$keyring": "gaia.connections:mcp-test:KEY"}}
+                )
+
+    def test_refuses_foreign_service(self):
+        """A $keyring ref outside ``gaia.connections`` is refused — never
+        forwarded to the keyring, preventing cross-service exfiltration via
+        a corrupted ``mcp_servers.json``."""
+        from gaia.connectors.errors import ConnectorsError
+
+        called = {"n": 0}
+
+        def fake_get(service, username):
+            called["n"] += 1
+            return "leaked-secret"
+
+        with patch("keyring.get_password", side_effect=fake_get):
+            with pytest.raises(ConnectorsError, match="outside the gaia namespace"):
+                _resolve_keyring_refs(
+                    {"KEY": {"$keyring": "Chrome Safe Storage:Chrome:K"}}
+                )
+        assert (
+            called["n"] == 0
+        ), "keyring.get_password must NOT be called for foreign services"
 
     def test_empty_env_returns_empty_dict(self):
         assert _resolve_keyring_refs({}) == {}
@@ -328,13 +355,16 @@ class TestResolveKeyringRefs:
 
     def test_resolves_multiple_refs(self):
         def fake_get(service, username):
-            return {"svc:key1": "val1", "svc:key2": "val2"}.get(f"{service}:{username}")
+            return {
+                "gaia.connections:mcp-test:K1": "val1",
+                "gaia.connections:mcp-test:K2": "val2",
+            }.get(f"{service}:{username}")
 
         with patch("keyring.get_password", side_effect=fake_get):
             result = _resolve_keyring_refs(
                 {
-                    "K1": {"$keyring": "svc:key1"},
-                    "K2": {"$keyring": "svc:key2"},
+                    "K1": {"$keyring": "gaia.connections:mcp-test:K1"},
+                    "K2": {"$keyring": "gaia.connections:mcp-test:K2"},
                 }
             )
         assert result == {"K1": "val1", "K2": "val2"}
@@ -416,13 +446,16 @@ class TestSecretHygiene:
 
 class TestCatalog:
     def test_mcp_catalog_entries_have_mcp_server_type(self):
+        # Count assertion lives in test_catalog_ledger.py; this just checks
+        # that the catalog still contains ``type="mcp_server"`` entries and
+        # that registration fires at import time.
         from gaia.connectors import catalog  # noqa: F401 — triggers registration
         from gaia.connectors.registry import REGISTRY
 
         mcp_specs = [s for s in REGISTRY.all() if s.type == "mcp_server"]
-        assert (
-            len(mcp_specs) >= 18
-        ), f"Expected >= 18 mcp_server specs, got {len(mcp_specs)}"
+        assert mcp_specs, "Expected at least one mcp_server spec in the registry"
+        for spec in mcp_specs:
+            assert spec.type == "mcp_server"
 
     def test_mcp_server_handler_registered(self):
         import gaia.connectors.mcp_server  # noqa: F401

--- a/tests/unit/connectors/test_no_dual_writer.py
+++ b/tests/unit/connectors/test_no_dual_writer.py
@@ -1,0 +1,143 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Regression guard against re-introducing the dual-writer pattern (#976).
+
+Before #976, both ``MCPConfig.add_server`` and the connectors framework
+wrote ``mcp_servers.json``, with the legacy path bypassing the keyring and
+storing API keys plaintext. The cleanup deleted the legacy writers and
+narrowed the legacy router to read-only routes.
+
+This test codifies the post-cleanup invariants as failing assertions so a
+future PR cannot silently revive them. Each check is a static grep against
+source files — no runtime imports, no side effects.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC = REPO_ROOT / "src"
+WEBUI_SRC = SRC / "gaia" / "apps" / "webui" / "src"
+WEBUI_PKG = SRC / "gaia" / "apps" / "webui" / "package.json"
+
+
+def _grep(pattern: str, root: Path, *, suffixes: tuple[str, ...]) -> list[str]:
+    """Return ``"file:line: text"`` strings for every match under ``root``."""
+    regex = re.compile(pattern)
+    hits: list[str] = []
+    for p in root.rglob("*"):
+        if not p.is_file() or p.suffix not in suffixes:
+            continue
+        # Skip __pycache__, node_modules, build outputs, and this test file.
+        if any(part in {"__pycache__", "node_modules", "dist"} for part in p.parts):
+            continue
+        if p.resolve() == Path(__file__).resolve():
+            continue
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for n, line in enumerate(text.splitlines(), 1):
+            if regex.search(line):
+                hits.append(f"{p.relative_to(REPO_ROOT)}:{n}: {line.strip()}")
+    return hits
+
+
+def test_mcpconfig_writer_methods_have_no_callers():
+    """
+    ``MCPConfig.add_server`` / ``remove_server`` / ``_save`` were deleted in
+    #976. Any new caller is a regression — even a re-introduced definition
+    on the class itself counts.
+    """
+    pattern = r"\bMCPConfig\.(add_server|remove_server|_save)\b"
+    matches = _grep(pattern, SRC, suffixes=(".py",))
+    assert not matches, (
+        "MCPConfig writer methods reappeared as callers — they were removed "
+        f"in #976 to enforce single-writer for mcp_servers.json:\n" + "\n".join(matches)
+    )
+
+
+def test_mcpconfig_class_has_no_writer_method_definitions():
+    """The class itself must not redefine the writer methods."""
+    config_py = SRC / "gaia" / "mcp" / "client" / "config.py"
+    text = config_py.read_text(encoding="utf-8")
+    for name in ("add_server", "remove_server", "_save"):
+        pattern = rf"^\s*def {name}\b"
+        bad = [ln for ln in text.splitlines() if re.match(pattern, ln)]
+        assert not bad, (
+            f"{config_py.relative_to(REPO_ROOT)} re-defines MCPConfig.{name}; "
+            "it was deleted in #976. The connectors framework "
+            "(McpServerHandler.configure / disconnect) is the sole writer."
+        )
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        # Legacy write routes — deleted in #976.
+        r'@router\.post\("/api/mcp/servers"',
+        r'@router\.delete\("/api/mcp/servers/{name}"',
+        r'@router\.post\(\s*"/api/mcp/servers/{name}/enable"',
+        r'@router\.post\(\s*"/api/mcp/servers/{name}/disable"',
+        # Legacy catalog endpoint — replaced by /api/connectors/catalog.
+        r'@router\.get\("/api/mcp/catalog"',
+    ],
+)
+def test_legacy_mcp_routes_not_redefined(endpoint):
+    mcp_router = SRC / "gaia" / "ui" / "routers" / "mcp.py"
+    text = mcp_router.read_text(encoding="utf-8")
+    matches = re.findall(endpoint, text)
+    assert not matches, (
+        f"Legacy MCP route {endpoint!r} reappeared in mcp.py — it was deleted "
+        "in #976. Configuration goes through /api/connectors/* now."
+    )
+
+
+def test_webui_dead_mcp_stubs_not_re_added():
+    """The five api.ts stubs that proxied the deleted write routes must stay gone."""
+    pattern = r"\b(addMCPServer|removeMCPServer|enableMCPServer|disableMCPServer|getMCPCatalog)\b"
+    matches = _grep(pattern, WEBUI_SRC, suffixes=(".ts", ".tsx"))
+    assert not matches, (
+        "Dead webui MCP stubs reappeared — they were deleted in #976 because "
+        "no React code consumed them and the underlying routes are gone:\n"
+        + "\n".join(matches)
+    )
+
+
+def test_rehype_raw_not_imported():
+    """``rehype-raw`` was removed from MessageBubble.tsx and package.json in #976.
+
+    Re-adding it would re-open the LLM-output XSS vector (raw <script> and
+    `javascript:` URLs from agent responses executing in the Electron
+    renderer). We only flag actual imports / plugin uses — comments
+    explaining the security history (in markdown.ts) are allowed.
+    """
+    # Match real import / usage forms, not comments that mention the name.
+    pattern = (
+        r"^\s*import\s+.*['\"]rehype-raw['\"]"  # import default/named from 'rehype-raw'
+        r"|"
+        r"\bfrom\s+['\"]rehype-raw['\"]"  # `from 'rehype-raw'` after a renamed import
+        r"|"
+        r"\brequire\(\s*['\"]rehype-raw['\"]"  # CommonJS
+        r"|"
+        r"\brehypePlugins\s*=\s*\[[^\]]*\brehypeRaw\b"  # JSX prop usage
+    )
+    matches = _grep(pattern, WEBUI_SRC, suffixes=(".ts", ".tsx"))
+    assert not matches, (
+        "rehype-raw reappeared in the webui as an import / plugin use — "
+        "removed in #976 for XSS hardening:\n" + "\n".join(matches)
+    )
+
+    if WEBUI_PKG.exists():
+        pkg_text = WEBUI_PKG.read_text(encoding="utf-8")
+        # Only flag actual dependency entries, not freeform text.
+        if re.search(r'"rehype-raw"\s*:', pkg_text):
+            pytest.fail(
+                "rehype-raw reappeared in webui/package.json dependencies — "
+                "removed in #976."
+            )

--- a/tests/unit/mcp/client/test_mcp_client_manager.py
+++ b/tests/unit/mcp/client/test_mcp_client_manager.py
@@ -239,35 +239,26 @@ class TestMCPConfig:
         expected_path = tmp_path / ".gaia" / "mcp_servers.json"
         assert config.config_file == expected_path
 
-    def test_add_server_saves_config(self, tmp_path):
-        """Test that add_server persists to file."""
-        config_file = tmp_path / "test_config.json"
-        config = MCPConfig(str(config_file))
-
-        config.add_server("test", {"command": "npx", "args": ["-y", "server"]})
-
-        assert config_file.exists()
-        assert config.server_exists("test")
-
-    def test_remove_server_deletes_from_config(self, tmp_path):
-        """Test that remove_server removes from file."""
-        config_file = tmp_path / "test_config.json"
-        config = MCPConfig(str(config_file))
-
-        config.add_server("test", {"command": "npx", "args": ["-y", "server"]})
-        config.remove_server("test")
-
-        assert not config.server_exists("test")
-
     def test_get_server_returns_config(self, tmp_path):
         """Test that get_server returns correct configuration."""
-        config_file = tmp_path / "test_config.json"
-        config = MCPConfig(str(config_file))
+        import json
 
-        config.add_server(
-            "test", {"command": "npx", "args": ["-y", "server"], "env": {"DEBUG": "1"}}
+        config_file = tmp_path / "test_config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "test": {
+                            "command": "npx",
+                            "args": ["-y", "server"],
+                            "env": {"DEBUG": "1"},
+                        }
+                    }
+                }
+            )
         )
 
+        config = MCPConfig(str(config_file))
         server_config = config.get_server("test")
         assert server_config["command"] == "npx"
         assert server_config["args"] == ["-y", "server"]
@@ -275,59 +266,44 @@ class TestMCPConfig:
 
     def test_get_servers_returns_all(self, tmp_path):
         """Test that get_servers returns all configurations."""
+        import json
+
         config_file = tmp_path / "test_config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "server1": {"command": "npx", "args": ["-y", "s1"]},
+                        "server2": {"command": "npx", "args": ["-y", "s2"]},
+                    }
+                }
+            )
+        )
+
         config = MCPConfig(str(config_file))
-
-        config.add_server("server1", {"command": "npx", "args": ["-y", "s1"]})
-        config.add_server("server2", {"command": "npx", "args": ["-y", "s2"]})
-
         servers = config.get_servers()
         assert len(servers) == 2
         assert "server1" in servers
         assert "server2" in servers
 
     def test_config_persists_across_instances(self, tmp_path):
-        """Test that configuration persists across instances."""
+        """File-on-disk state survives across MCPConfig instances."""
+        import json
+
         config_file = tmp_path / "test_config.json"
+        config_file.write_text(
+            json.dumps(
+                {"mcpServers": {"test": {"command": "npx", "args": ["-y", "server"]}}}
+            )
+        )
 
-        # First instance
+        # Both instances load the same on-disk state.
         config1 = MCPConfig(str(config_file))
-        config1.add_server("test", {"command": "npx", "args": ["-y", "server"]})
-
-        # Second instance should load from file
+        assert config1.server_exists("test")
         config2 = MCPConfig(str(config_file))
         assert config2.server_exists("test")
         assert config2.get_server("test")["command"] == "npx"
         assert config2.get_server("test")["args"] == ["-y", "server"]
-
-    def test_config_uses_mcpServers_key(self, tmp_path):
-        """Test that config file uses 'mcpServers' as root key (Anthropic format)."""
-        import json
-
-        config_file = tmp_path / "test_config.json"
-        config = MCPConfig(str(config_file))
-
-        config.add_server(
-            "github",
-            {
-                "command": "npx",
-                "args": ["-y", "@modelcontextprotocol/server-github"],
-                "env": {"GITHUB_TOKEN": "ghp_xxx"},
-            },
-        )
-
-        # Read the file directly and verify format
-        with open(config_file, "r") as f:
-            data = json.load(f)
-
-        assert "mcpServers" in data
-        assert "servers" not in data  # Old key should not be present
-        assert "github" in data["mcpServers"]
-        assert data["mcpServers"]["github"]["command"] == "npx"
-        assert data["mcpServers"]["github"]["args"] == [
-            "-y",
-            "@modelcontextprotocol/server-github",
-        ]
 
     def test_config_reads_command_and_args_separately(self, tmp_path):
         """Test that config correctly reads command and args as separate fields."""
@@ -353,28 +329,15 @@ class TestMCPConfig:
         assert server["args"] == ["mcp-server-time"]
 
     def test_config_handles_missing_file(self, tmp_path):
-        """Test that config handles missing file gracefully."""
-        # Config file doesn't exist yet (but parent dir does)
+        """Test that config handles missing file gracefully (read-only)."""
         config_file = tmp_path / "config.json"
         assert not config_file.exists()
 
         config = MCPConfig(str(config_file))
 
-        # Should have empty servers when file doesn't exist
+        # Should have empty servers when file doesn't exist; no crash.
         assert config.get_servers() == {}
         assert not config.server_exists("any")
-
-        # Should be able to add servers (creates file)
-        config.add_server("test", {"command": "echo", "args": ["test"]})
-        assert config.server_exists("test")
-        assert config_file.exists()
-
-        # Verify file contents
-        import json
-
-        data = json.loads(config_file.read_text())
-        assert "mcpServers" in data
-        assert "test" in data["mcpServers"]
 
     def test_config_reads_env_field(self, tmp_path):
         """Test that config reads env field from mcpServers format."""


### PR DESCRIPTION
Closes #976. Part of #927.

Three vulnerabilities shipped on `main` that this PR fixes:

1. **Dual-writer / plaintext secret leak** — `MCPConfig.add_server`, `POST /api/mcp/servers`, and `gaia mcp add` all wrote `mcp_servers.json` directly, bypassing the keyring. API keys ended up plaintext on disk. Now `McpServerHandler.configure()` is the sole writer; everything else is read-only or deleted.

2. **Keyring exfiltration at MCP spawn time** — `_resolve_keyring_refs` accepted any service string in a `$keyring` reference. A corrupted `mcp_servers.json` could carry `"Chrome Safe Storage:Chrome:..."` and inject another app's secrets into a spawned MCP subprocess env. Now any service other than `gaia.connections` is rejected before `keyring.get_password` is called.

3. **Silent grant inheritance on reconnect** — `disconnect()` cleared keyring entries but left `grants.json` intact. Re-adding a connector with the same id silently re-attached prior agent consents — a real bypass. Both `McpServerHandler` and `OAuthPkceHandler` now call `revoke_all_grants_for(connector_id)` on disconnect.

Plus: `rehype-raw` in `MessageBubble.tsx` allowed LLM-generated `<script>` tags and `javascript:` URLs to execute in the Electron renderer. Replaced with `SAFE_DISALLOWED_ELEMENTS` + `safeUrlTransform` (new `src/utils/markdown.ts`).

## Catalog reduction

The 22-entry MCP catalog is reduced to 5 tested entries: `mcp-github`, `mcp-filesystem`, `mcp-fetch`, `mcp-memory`, `mcp-git`. The other 17 had zero test or doc coverage and are deleted. Users who want the deleted servers use the custom MCP path (tracked in #977).

## Test plan

```bash
# New regression guards (22 new tests across 3 new files)
pytest tests/unit/connectors/test_catalog_ledger.py -v         # catalog ledger: 4 pass, 5 skip
pytest tests/unit/connectors/test_no_dual_writer.py -v         # dual-writer guard: 9 pass
pytest tests/unit/connectors/test_disconnect_clears_grants.py -v  # grant cleanup: 4 pass

# Keyring security (service pinning + fail-closed)
pytest tests/unit/connectors/test_mcp_server.py::TestResolveKeyringRefs -v  # 6 pass

# Full connectors suite
pytest tests/unit/connectors/ -q  # 305 pass, 5 skip, 1 pre-existing failure (test_oauth_pkce unrelated)

# Verify deletions
grep "rehype-raw" src/gaia/apps/webui/package.json            # nothing
grep -c "ConnectorSpec(" src/gaia/connectors/catalog/mcp_servers.py  # 5
python -m gaia.cli mcp --help                                  # no add/remove subcommands
```