### PR TITLE
feat(connectors): per-MCP enable/disable toggle in Settings UI (#1004)

### DIFF
--- a/src/gaia/apps/webui/src/components/ConnectorTileMenu.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorTileMenu.tsx
@@ -1,0 +1,168 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Per-tile overflow menu for Settings → Connectors (#1004).
+ *
+ * Shows a small ⋯ button in the tile header. Clicking opens a dropdown
+ * with quick actions:
+ *
+ *   - For configured + enabled MCP connectors:  Disable, Disconnect
+ *   - For configured + disabled MCP connectors: Enable,  Disconnect
+ *   - For not-configured MCP connectors:        nothing (button hidden)
+ *   - For oauth_pkce connectors:                nothing (button hidden)
+ *
+ * The component is self-positioning (no portal): a relative-positioned
+ * wrapper holds the trigger button and the absolutely-positioned popup.
+ * Click-outside closes the menu via a document-level listener; Escape
+ * also closes.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+import * as api from '../services/api';
+import type { ConnectorRow } from '../types';
+
+interface Props {
+    connector: ConnectorRow;
+    /** Called after every successful action so the parent re-fetches. */
+    onChanged: () => void;
+}
+
+/**
+ * The menu is meaningful only for configured MCP connectors. Returning
+ * ``null`` from the component is the simplest way to suppress it for
+ * everything else.
+ */
+function shouldRenderMenu(connector: ConnectorRow): boolean {
+    return connector.type === 'mcp_server' && connector.configured;
+}
+
+export function ConnectorTileMenu({ connector, onChanged }: Props) {
+    const [open, setOpen] = useState(false);
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
+    // Close on click outside.
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: MouseEvent) => {
+            if (
+                wrapperRef.current &&
+                !wrapperRef.current.contains(e.target as Node)
+            ) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [open]);
+
+    // Close on Escape.
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false);
+        };
+        document.addEventListener('keydown', handler);
+        return () => document.removeEventListener('keydown', handler);
+    }, [open]);
+
+    if (!shouldRenderMenu(connector)) return null;
+
+    const stop = (e: React.MouseEvent) => {
+        // Prevent the tile from toggling open when the menu trigger is clicked.
+        e.stopPropagation();
+        e.preventDefault();
+    };
+
+    const runAction = async (action: () => Promise<unknown>) => {
+        setBusy(true);
+        setErr(null);
+        try {
+            await action();
+            setOpen(false);
+            onChanged();
+        } catch (e) {
+            setErr(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div
+            ref={wrapperRef}
+            className="connector-tile-menu"
+            onClick={stop}
+            onKeyDown={stop as unknown as React.KeyboardEventHandler<HTMLDivElement>}
+        >
+            <button
+                type="button"
+                className="connector-tile-menu-trigger"
+                aria-haspopup="menu"
+                aria-expanded={open}
+                aria-label="Connector actions"
+                onClick={(e) => {
+                    stop(e);
+                    setOpen((v) => !v);
+                }}
+                disabled={busy}
+            >
+                <MoreHorizontal size={14} />
+            </button>
+
+            {open && (
+                <div role="menu" className="connector-tile-menu-popup">
+                    {connector.enabled ? (
+                        <button
+                            role="menuitem"
+                            type="button"
+                            className="connector-tile-menu-item"
+                            onClick={() =>
+                                void runAction(() =>
+                                    api.disableConnector(connector.id),
+                                )
+                            }
+                            disabled={busy}
+                        >
+                            Disable
+                        </button>
+                    ) : (
+                        <button
+                            role="menuitem"
+                            type="button"
+                            className="connector-tile-menu-item"
+                            onClick={() =>
+                                void runAction(() =>
+                                    api.enableConnector(connector.id),
+                                )
+                            }
+                            disabled={busy}
+                        >
+                            Enable
+                        </button>
+                    )}
+                    <div className="connector-tile-menu-divider" />
+                    <button
+                        role="menuitem"
+                        type="button"
+                        className="connector-tile-menu-item connector-tile-menu-item--danger"
+                        onClick={() =>
+                            void runAction(() =>
+                                api.disconnectConnector(connector.id),
+                            )
+                        }
+                        disabled={busy}
+                    >
+                        Disconnect
+                    </button>
+                    {err && (
+                        <div className="connector-tile-menu-error">{err}</div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/ConnectorTileMenu.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorTileMenu.tsx
@@ -12,10 +12,13 @@
  *   - For not-configured MCP connectors:        nothing (button hidden)
  *   - For oauth_pkce connectors:                nothing (button hidden)
  *
- * The component is self-positioning (no portal): a relative-positioned
- * wrapper holds the trigger button and the absolutely-positioned popup.
- * Click-outside closes the menu via a document-level listener; Escape
- * also closes.
+ * Positioning: the popup uses `position: fixed` with viewport coordinates
+ * computed from the trigger button's `getBoundingClientRect()`. This lets
+ * it escape the `overflow: hidden` on `.connector-tile` without a portal.
+ * A scroll + resize listener repositions the popup while it is open so it
+ * stays anchored to the trigger as the settings panel scrolls.
+ *
+ * Click-outside (mousedown on document) and Escape close the menu.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -42,15 +45,20 @@ export function ConnectorTileMenu({ connector, onChanged }: Props) {
     const [open, setOpen] = useState(false);
     const [busy, setBusy] = useState(false);
     const [err, setErr] = useState<string | null>(null);
-    const wrapperRef = useRef<HTMLDivElement>(null);
+    const [popupPos, setPopupPos] = useState<{ top: number; right: number } | null>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const popupRef = useRef<HTMLDivElement>(null);
 
     // Close on click outside.
     useEffect(() => {
         if (!open) return;
         const handler = (e: MouseEvent) => {
+            const target = e.target as Node;
             if (
-                wrapperRef.current &&
-                !wrapperRef.current.contains(e.target as Node)
+                triggerRef.current &&
+                !triggerRef.current.contains(target) &&
+                popupRef.current &&
+                !popupRef.current.contains(target)
             ) {
                 setOpen(false);
             }
@@ -69,12 +77,46 @@ export function ConnectorTileMenu({ connector, onChanged }: Props) {
         return () => document.removeEventListener('keydown', handler);
     }, [open]);
 
+    // Reposition popup on scroll/resize so it stays anchored to the trigger
+    // even as the settings panel scrolls. Using capture:true catches scroll
+    // on any ancestor (the settings-page-body scroller included).
+    useEffect(() => {
+        if (!open) return;
+        const reposition = () => {
+            if (!triggerRef.current) return;
+            const rect = triggerRef.current.getBoundingClientRect();
+            setPopupPos({
+                top: rect.bottom + 4,
+                right: window.innerWidth - rect.right,
+            });
+        };
+        window.addEventListener('resize', reposition);
+        window.addEventListener('scroll', reposition, true);
+        return () => {
+            window.removeEventListener('resize', reposition);
+            window.removeEventListener('scroll', reposition, true);
+        };
+    }, [open]);
+
     if (!shouldRenderMenu(connector)) return null;
 
     const stop = (e: React.MouseEvent) => {
         // Prevent the tile from toggling open when the menu trigger is clicked.
         e.stopPropagation();
         e.preventDefault();
+    };
+
+    const handleTriggerClick = (e: React.MouseEvent) => {
+        stop(e);
+        if (!open && triggerRef.current) {
+            const rect = triggerRef.current.getBoundingClientRect();
+            // Anchor popup below-right of trigger; right-align to viewport right edge.
+            setPopupPos({
+                top: rect.bottom + 4,
+                right: window.innerWidth - rect.right,
+            });
+        }
+        setOpen((v) => !v);
     };
 
     const runAction = async (action: () => Promise<unknown>) => {
@@ -93,28 +135,30 @@ export function ConnectorTileMenu({ connector, onChanged }: Props) {
 
     return (
         <div
-            ref={wrapperRef}
             className="connector-tile-menu"
             onClick={stop}
             onKeyDown={stop as unknown as React.KeyboardEventHandler<HTMLDivElement>}
         >
             <button
+                ref={triggerRef}
                 type="button"
                 className="connector-tile-menu-trigger"
                 aria-haspopup="menu"
                 aria-expanded={open}
                 aria-label="Connector actions"
-                onClick={(e) => {
-                    stop(e);
-                    setOpen((v) => !v);
-                }}
+                onClick={handleTriggerClick}
                 disabled={busy}
             >
                 <MoreHorizontal size={14} />
             </button>
 
-            {open && (
-                <div role="menu" className="connector-tile-menu-popup">
+            {open && popupPos && (
+                <div
+                    ref={popupRef}
+                    role="menu"
+                    className="connector-tile-menu-popup"
+                    style={{ position: 'fixed', top: popupPos.top, right: popupPos.right }}
+                >
                     {connector.enabled ? (
                         <button
                             role="menuitem"

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.css
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.css
@@ -499,10 +499,9 @@
 }
 
 .connector-tile-menu-popup {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
-    z-index: 100;
+    /* position/top/right set via inline style (position:fixed) so the popup
+       escapes overflow:hidden on .connector-tile */
+    z-index: 1000;
     min-width: 160px;
     background: var(--bg-primary);
     border: 1px solid var(--border-color, var(--border-light));

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.css
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.css
@@ -544,6 +544,135 @@
     margin: 4px 0;
 }
 
+/* ── Custom-agent MCP section (#1020) ─────────────────────────────── */
+
+/*
+ * Read-only section below the managed connectors list. Each tile shows one
+ * MCP server from a custom agent's local mcp_servers.json. No toggle, no
+ * overflow menu — the user edits the JSON directly to change these.
+ */
+.agent-mcps-section {
+    margin-top: 20px;
+}
+
+.agent-mcps-section-header {
+    font-size: 10px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+}
+
+.agent-mcp-tile {
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    background: var(--bg-secondary);
+    overflow: hidden;
+    transition: border-color var(--duration) var(--ease);
+}
+.agent-mcp-tile:hover,
+.agent-mcp-tile--open {
+    border-color: var(--border);
+}
+
+.agent-mcp-tile-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px 14px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    font-family: var(--font-sans);
+    color: var(--text-primary);
+}
+.agent-mcp-tile-header:hover {
+    background: var(--bg-hover, rgba(0,0,0,0.03));
+}
+[data-theme="dark"] .agent-mcp-tile-header:hover {
+    background: rgba(255,255,255,0.04);
+}
+
+.agent-mcp-server-name {
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.agent-mcp-agent-label {
+    font-size: 11px;
+    font-family: var(--font-sans);
+    color: var(--text-muted);
+    flex: 1;
+}
+
+.agent-mcp-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-family: var(--font-sans);
+}
+.agent-mcp-status.enabled  { color: var(--accent-green); }
+.agent-mcp-status.disabled {
+    color: var(--text-muted);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 999px;
+    padding: 1px 8px;
+}
+
+.agent-mcp-readonly-badge {
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 999px;
+    padding: 1px 6px;
+    flex-shrink: 0;
+}
+
+.agent-mcp-chevron {
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.agent-mcp-detail {
+    border-top: 1px solid var(--border-light);
+    padding: 12px 16px;
+}
+
+.agent-mcp-command-row {
+    font-size: 12px;
+    font-family: var(--font-mono);
+    color: var(--text-secondary);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-sm);
+    padding: 6px 10px;
+    margin-bottom: 8px;
+    word-break: break-all;
+}
+
+.agent-mcp-config-path {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    margin-bottom: 4px;
+    word-break: break-all;
+}
+
+.agent-mcp-config-hint {
+    font-size: 11px;
+    font-family: var(--font-sans);
+    color: var(--text-muted);
+    font-style: italic;
+}
+
 .connector-tile-menu-error {
     padding: 6px 10px;
     color: var(--text-danger, #d04a3a);

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.css
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.css
@@ -83,6 +83,23 @@
 }
 .connector-status.ok { color: var(--accent-green); }
 .connector-status.idle { color: var(--text-muted); }
+/*
+ * "Disabled" pill (#1004) — distinct from .idle.
+ *
+ * .idle ("Not configured") is cool gray: the connector has never been
+ * touched. .disabled is a warm orange-tinted muted: the connector IS
+ * configured (credentials + grants live) but the user has paused it.
+ * Different colour communicates "you can re-enable this with one click"
+ * rather than "you need to set this up from scratch".
+ */
+.connector-status.disabled {
+    color: var(--text-muted);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 999px;
+    padding: 1px 8px;
+    font-size: 11px;
+}
 
 .connector-tile-chevron {
     margin-left: auto;
@@ -409,4 +426,129 @@
 @keyframes spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }
+}
+
+/* ── Per-MCP enable/disable toggle (#1004) ───────────────────────── */
+
+/*
+ * Toggle row inside the connector detail body. Sits above the
+ * credentials section so it's the first interaction the user sees on
+ * a configured MCP — flipping the connector off without losing any
+ * state.
+ */
+.connector-toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
+    margin-bottom: 10px;
+}
+
+.connector-toggle-label {
+    flex: 1;
+    font-size: 12px;
+    font-family: var(--font-sans);
+    color: var(--text-primary);
+}
+
+.connector-toggle-help {
+    margin: -4px 0 10px 14px;
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+/* ── Per-tile overflow menu (#1004) ──────────────────────────────── */
+
+.connector-tile-menu {
+    position: relative;
+    flex-shrink: 0;
+    /*
+     * The menu wrapper lives inside the tile-header <button>. We need
+     * pointer events to reach the trigger button without bubbling up
+     * to the parent (the trigger calls stopPropagation() on click but
+     * keyboard-driven activation also has to work).
+     */
+    display: inline-flex;
+    align-items: center;
+}
+
+.connector-tile-menu-trigger {
+    background: transparent;
+    border: none;
+    padding: 4px;
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 0;
+}
+.connector-tile-menu-trigger:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+.connector-tile-menu-trigger:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 1px;
+}
+.connector-tile-menu-trigger:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.connector-tile-menu-popup {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 100;
+    min-width: 160px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color, var(--border-light));
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    /* Don't inherit the parent <button>'s cursor/text-align. */
+    text-align: left;
+}
+
+.connector-tile-menu-item {
+    background: transparent;
+    border: none;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-family: var(--font-sans);
+    color: var(--text-primary);
+    text-align: left;
+    border-radius: 3px;
+    cursor: pointer;
+    line-height: 1.4;
+}
+.connector-tile-menu-item:hover {
+    background: var(--bg-secondary);
+}
+.connector-tile-menu-item:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.connector-tile-menu-item--danger {
+    color: var(--text-danger, #d04a3a);
+}
+
+.connector-tile-menu-divider {
+    height: 1px;
+    background: var(--border-light);
+    margin: 4px 0;
+}
+
+.connector-tile-menu-error {
+    padding: 6px 10px;
+    color: var(--text-danger, #d04a3a);
+    font-size: 11px;
+    border-top: 1px solid var(--border-light);
+    margin-top: 4px;
 }

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -44,6 +44,7 @@ import * as api from '../services/api';
 import { useChatStore } from '../stores/chatStore';
 import { useConnectorsSSE } from '../hooks/useConnectorsSSE';
 import type { ConnectorRow } from '../types';
+import { ConnectorTileMenu } from './ConnectorTileMenu';
 import './ConnectorsSection.css';
 
 // ── ConnectorsSection ────────────────────────────────────────────────────────
@@ -148,6 +149,25 @@ function ConnectorTile({
     onToggle: () => void;
     onChanged: () => void;
 }) {
+    // Three exclusive status states for the tile header pill (#1004):
+    //   - configured + enabled   → "Configured" / account_id (green ok)
+    //   - configured + disabled  → "Disabled"               (warm muted)
+    //   - not configured         → "Not configured"         (cool muted)
+    const renderStatus = () => {
+        if (!connector.configured) {
+            return <span className="connector-status idle">Not configured</span>;
+        }
+        if (connector.type === 'mcp_server' && connector.enabled === false) {
+            return <span className="connector-status disabled">Disabled</span>;
+        }
+        return (
+            <span className="connector-status ok">
+                <CheckCircle2 size={12} />
+                {connector.account_id ?? 'Configured'}
+            </span>
+        );
+    };
+
     return (
         <div className={`connector-tile${expanded ? ' connector-tile--open' : ''}`}>
             <button
@@ -157,14 +177,8 @@ function ConnectorTile({
             >
                 <span className="connector-tile-name">{connector.display_name}</span>
                 <span className="connector-tile-type">{connector.type === 'oauth_pkce' ? 'OAuth' : 'MCP'}</span>
-                {connector.configured ? (
-                    <span className="connector-status ok">
-                        <CheckCircle2 size={12} />
-                        {connector.account_id ?? 'Configured'}
-                    </span>
-                ) : (
-                    <span className="connector-status idle">Not configured</span>
-                )}
+                {renderStatus()}
+                <ConnectorTileMenu connector={connector} onChanged={onChanged} />
                 <span className="connector-tile-chevron">
                     {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
                 </span>
@@ -452,6 +466,29 @@ function MCPServerConfigureBody({
         }
     };
 
+    // Per-MCP enable/disable toggle (#1004). The toggle row appears only
+    // for already-configured MCP connectors — toggling on a never-
+    // configured connector has no meaning. Detail-view toggle and the
+    // tile-header overflow menu both call the same enableConnector /
+    // disableConnector helpers, so the SSE refresh keeps both surfaces
+    // in sync.
+    const handleToggleEnabled = async () => {
+        setBusy(true);
+        setErr(null);
+        try {
+            if (connector.enabled) {
+                await api.disableConnector(connector.id);
+            } else {
+                await api.enableConnector(connector.id);
+            }
+            onChanged();
+        } catch (e) {
+            setErr(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(false);
+        }
+    };
+
     return (
         <div className="configure-body">
             {connector.description && (
@@ -461,6 +498,31 @@ function MCPServerConfigureBody({
                 <div className="configure-error">
                     <AlertCircle size={12} /> {err}
                 </div>
+            )}
+            {connector.configured && (
+                <div className="connector-toggle-row">
+                    <span className="connector-toggle-label">Active</span>
+                    <span className="toggle-switch">
+                        <input
+                            type="checkbox"
+                            checked={connector.enabled !== false}
+                            onChange={() => void handleToggleEnabled()}
+                            disabled={busy}
+                            aria-label={
+                                connector.enabled
+                                    ? 'Disable this MCP server'
+                                    : 'Enable this MCP server'
+                            }
+                        />
+                        <span className="toggle-track" />
+                    </span>
+                </div>
+            )}
+            {connector.configured && connector.enabled === false && (
+                <p className="connector-toggle-help">
+                    Credentials and per-agent grants are preserved.
+                    Re-enable to make this server's tools available again.
+                </p>
             )}
             {connector.mcp_env_keys.map((key) => (
                 <div key={key} className="mcp-key-row">

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -43,7 +43,7 @@ function scopeLabel(scope: string): string {
 import * as api from '../services/api';
 import { useChatStore } from '../stores/chatStore';
 import { useConnectorsSSE } from '../hooks/useConnectorsSSE';
-import type { ConnectorRow } from '../types';
+import type { AgentMcpServer, ConnectorRow } from '../types';
 import { ConnectorTileMenu } from './ConnectorTileMenu';
 import './ConnectorsSection.css';
 
@@ -51,14 +51,19 @@ import './ConnectorsSection.css';
 
 export function ConnectorsSection() {
     const [connectors, setConnectors] = useState<ConnectorRow[]>([]);
+    const [agentMcps, setAgentMcps] = useState<AgentMcpServer[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [expanded, setExpanded] = useState<string | null>(null);
 
     const load = useCallback(async () => {
         try {
-            const { connectors: rows } = await api.listConnectors();
+            const [{ connectors: rows }, { agent_mcps: mcps }] = await Promise.all([
+                api.listConnectors(),
+                api.listAgentMcps(),
+            ]);
             setConnectors(rows);
+            setAgentMcps(mcps);
             setError(null);
         } catch (e) {
             setError(e instanceof Error ? e.message : String(e));
@@ -120,17 +125,26 @@ export function ConnectorsSection() {
                     <Loader2 size={16} className="spin" />
                 </div>
             ) : (
-                <div className="connectors-list">
-                    {connectors.map((c) => (
-                        <ConnectorTile
-                            key={c.id}
-                            connector={c}
-                            expanded={expanded === c.id}
-                            onToggle={() => toggle(c.id)}
-                            onChanged={() => void onChanged(c.id)}
+                <>
+                    <div className="connectors-list">
+                        {connectors.map((c) => (
+                            <ConnectorTile
+                                key={c.id}
+                                connector={c}
+                                expanded={expanded === c.id}
+                                onToggle={() => toggle(c.id)}
+                                onChanged={() => void onChanged(c.id)}
+                            />
+                        ))}
+                    </div>
+                    {agentMcps.length > 0 && (
+                        <AgentMcpsSection
+                            servers={agentMcps}
+                            expanded={expanded}
+                            onToggle={toggle}
                         />
-                    ))}
-                </div>
+                    )}
+                </>
             )}
         </section>
     );
@@ -658,6 +672,93 @@ function AgentGrantCard({
         </div>
     );
 }
+
+// ── AgentMcpsSection ─────────────────────────────────────────────────────────
+
+/**
+ * Read-only section listing MCP servers declared by custom Python agents
+ * (#1020). These are controlled by the agent's local mcp_servers.json;
+ * the user edits that file directly — no toggle or disconnect action here.
+ */
+function AgentMcpsSection({
+    servers,
+    expanded,
+    onToggle,
+}: {
+    servers: AgentMcpServer[];
+    expanded: string | null;
+    onToggle: (key: string) => void;
+}) {
+    return (
+        <div className="agent-mcps-section">
+            <div className="agent-mcps-section-header">Custom agent servers</div>
+            <div className="connectors-list">
+                {servers.map((s) => {
+                    const key = `${s.agent_id}::${s.server_name}`;
+                    return (
+                        <AgentMcpTile
+                            key={key}
+                            server={s}
+                            expanded={expanded === key}
+                            onToggle={() => onToggle(key)}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function AgentMcpTile({
+    server,
+    expanded,
+    onToggle,
+}: {
+    server: AgentMcpServer;
+    expanded: boolean;
+    onToggle: () => void;
+}) {
+    const cmdDisplay = [server.command, ...server.args].join(' ');
+
+    return (
+        <div className={`agent-mcp-tile${expanded ? ' agent-mcp-tile--open' : ''}`}>
+            <button
+                type="button"
+                className="agent-mcp-tile-header"
+                onClick={onToggle}
+                aria-expanded={expanded}
+            >
+                <span className="agent-mcp-server-name">{server.server_name}</span>
+                <span className="agent-mcp-agent-label">via {server.agent_name}</span>
+                {server.disabled ? (
+                    <span className="agent-mcp-status disabled">Disabled</span>
+                ) : (
+                    <span className="agent-mcp-status enabled">
+                        <CheckCircle2 size={11} /> Active
+                    </span>
+                )}
+                <span className="agent-mcp-readonly-badge">read-only</span>
+                <span className="agent-mcp-chevron">
+                    {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                </span>
+            </button>
+
+            {expanded && (
+                <div className="agent-mcp-detail">
+                    {cmdDisplay && (
+                        <div className="agent-mcp-command-row">{cmdDisplay}</div>
+                    )}
+                    <div className="agent-mcp-config-path">{server.config_path}</div>
+                    <div className="agent-mcp-config-hint">
+                        Edit the agent's <code>mcp_servers.json</code> to change this server.
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ── ConnectorAgentGrants ─────────────────────────────────────────────────────
 
 function ConnectorAgentGrants({ connectorId }: { connectorId: string }) {
     const { agents } = useChatStore();

--- a/src/gaia/apps/webui/src/hooks/useConnectorsSSE.ts
+++ b/src/gaia/apps/webui/src/hooks/useConnectorsSSE.ts
@@ -11,6 +11,8 @@
  *   - ``connector.configured``        ({connector_id, account_id})
  *   - ``connector.disconnected``      ({connector_id})
  *   - ``connector.tested``            ({connector_id, ok, detail})
+ *   - ``connector.enabled``           ({connector_id})
+ *   - ``connector.disabled``          ({connector_id})
  *   - ``connector.oauth.completed``   ({connector_id, account_email})
  *   - ``connector.oauth.error``       ({connector_id, error})
  *   - ``connector.grant.changed``     ({connector_id, agent_id, scopes})
@@ -40,6 +42,8 @@ interface SseEnvelope {
 export type ConnectorChangeReason =
     | 'configured'
     | 'disconnected'
+    | 'enabled'
+    | 'disabled'
     | 'oauth_completed'
     | 'oauth_error'
     | 'tested'
@@ -77,6 +81,10 @@ function reasonFor(eventType: string): ConnectorChangeReason | null {
             return 'oauth_error';
         case 'connector.tested':
             return 'tested';
+        case 'connector.enabled':
+            return 'enabled';
+        case 'connector.disabled':
+            return 'disabled';
         case 'connector.grant.changed':
             return 'grant_changed';
         default:

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -151,6 +151,33 @@ export async function disconnectConnector(connectorId: string): Promise<void> {
     await apiFetch<unknown>('DELETE', `/connectors/${connectorId}`, undefined, UI_HEADER);
 }
 
+/**
+ * Enable a previously-disabled MCP connector (#1004).
+ *
+ * Returns the updated ConnectorRow with `enabled: true`. The backend
+ * triggers a live reload of every cached chat session's MCPClientManager
+ * so the connector's tools materialize without restarting GAIA.
+ *
+ * Throws when called against a non-MCP connector (server returns 400).
+ */
+export async function enableConnector(connectorId: string): Promise<ConnectorRow> {
+    return apiFetch('POST', `/connectors/${connectorId}/enable`, {}, UI_HEADER);
+}
+
+/**
+ * Disable a configured MCP connector without clearing credentials (#1004).
+ *
+ * Credentials, the env-block ``$keyring`` references, and per-agent grants
+ * are preserved. The backend triggers a live reload so the connector's
+ * tools disappear from active agents' tool lists. Re-enable with
+ * ``enableConnector`` to make tools available again.
+ *
+ * Throws when called against a non-MCP connector (server returns 400).
+ */
+export async function disableConnector(connectorId: string): Promise<ConnectorRow> {
+    return apiFetch('POST', `/connectors/${connectorId}/disable`, {}, UI_HEADER);
+}
+
 export async function listConnectorGrants(connectorId: string): Promise<{
     grants: Record<string, string[]>;
 }> {

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -114,7 +114,7 @@ export async function listAgents(): Promise<{ agents: AgentInfo[]; total: number
 
 // -- Connections (issue #915) ---------------------------------------------------
 
-import type { ConnectorInfo, ConnectorRow } from '../types';
+import type { AgentMcpServer, ConnectorInfo, ConnectorRow } from '../types';
 
 // New framework endpoints (T-8b) — /api/connectors
 const UI_HEADER = { 'x-gaia-ui': '1' };
@@ -176,6 +176,17 @@ export async function enableConnector(connectorId: string): Promise<ConnectorRow
  */
 export async function disableConnector(connectorId: string): Promise<ConnectorRow> {
     return apiFetch('POST', `/connectors/${connectorId}/disable`, {}, UI_HEADER);
+}
+
+/**
+ * List MCP servers declared by custom Python agents (#1020).
+ *
+ * Returns a flat sorted list (enabled first, alphabetical) of server entries
+ * from each custom agent's local mcp_servers.json. These are read-only — the
+ * UI renders them without a toggle or disconnect action.
+ */
+export async function listAgentMcps(): Promise<{ agent_mcps: AgentMcpServer[] }> {
+    return apiFetch('GET', '/connectors/agent-mcps');
 }
 
 export async function listConnectorGrants(connectorId: string): Promise<{

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -100,6 +100,17 @@ export interface ConnectorRow {
      * Populated only when ``configurable === false``; null otherwise.
      */
     config_error: string | null;
+    /**
+     * Whether the connector is currently enabled (#1004).
+     *
+     * Meaningful only for ``type === 'mcp_server'`` — when ``false``, the
+     * connector retains its credentials and per-agent grants but is
+     * suppressed from agent tool lists. The backend defaults this to
+     * ``true`` for OAuth tiles and for not-yet-configured MCP tiles, so
+     * the UI never renders a "Disabled" pill where the concept doesn't
+     * apply.
+     */
+    enabled: boolean;
     account_id: string | null;
     scopes: string[];
     last_tested_at: string | null;

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -142,6 +142,20 @@ export interface ConnectorConfigField {
     help_md: string;
 }
 
+/**
+ * One MCP server entry declared by a custom Python agent (#1020).
+ * Read-only — controlled by the agent's local mcp_servers.json.
+ */
+export interface AgentMcpServer {
+    agent_id: string;
+    agent_name: string;
+    config_path: string;
+    server_name: string;
+    command: string;
+    args: string[];
+    disabled: boolean;
+}
+
 export interface InferenceStats {
     tokens_per_second: number;
     time_to_first_token: number;

--- a/src/gaia/connectors/catalog/mcp_servers.py
+++ b/src/gaia/connectors/catalog/mcp_servers.py
@@ -7,10 +7,14 @@ Curated, tested MCP servers exposed as ``ConnectorSpec`` objects in the global
 ``REGISTRY``. Importing this module also imports ``gaia.connectors.mcp_server``
 so the handler is registered before any dispatch call.
 
-Scope: this catalog ships only entries that have explicit test coverage or are
-trivial enough (no API key required) to verify on the fly. Untested entries
-that previously shipped have been removed in favor of the user-supplied custom
-MCP path (see ``gaia connectors mcp add``).
+Scope: the catalog lists only MCP servers that are consumed by the built-in
+agents through the connectors framework (i.e. at least one built-in agent
+declares ``REQUIRED_CONNECTORS`` pointing at the entry). Servers with no
+built-in consumers were removed: ``mcp-filesystem`` and ``mcp-fetch`` are
+gone because the File Agent and Web Agent use Python-native tool mixins rather
+than the MCP protocol. Custom agents that want file/web MCP access supply
+their own ``mcp_servers.json`` — discoverable via the Settings "Custom agent
+servers" section (#1020, #1021).
 """
 
 import gaia.connectors.mcp_server  # noqa: F401  # pylint: disable=unused-import
@@ -20,27 +24,6 @@ from gaia.connectors.spec import ConfigField, ConnectorSpec
 # ---------------------------------------------------------------------------
 # Curated catalog
 # ---------------------------------------------------------------------------
-
-_FILESYSTEM = ConnectorSpec(
-    id="mcp-filesystem",
-    display_name="File System",
-    icon="📁",
-    category="system",
-    tier=1,
-    type="mcp_server",
-    description="Secure file read/write/search with configurable access controls.",
-    mcp_command="npx",
-    mcp_args=("-y", "@modelcontextprotocol/server-filesystem", "~"),
-    config_schema=(
-        ConfigField(
-            key="allowed_directories",
-            label="Allowed directories",
-            kind="text",
-            placeholder="~/Documents,~/Downloads",
-            help_md="Comma-separated list of paths the server may access.",
-        ),
-    ),
-)
 
 _GITHUB = ConnectorSpec(
     id="mcp-github",
@@ -64,18 +47,6 @@ _GITHUB = ConnectorSpec(
             secret=True,
         ),
     ),
-)
-
-_FETCH = ConnectorSpec(
-    id="mcp-fetch",
-    display_name="Web Fetch",
-    icon="🌐",
-    category="web",
-    tier=1,
-    type="mcp_server",
-    description="Fetch web content and convert it to Markdown.",
-    mcp_command="npx",
-    mcp_args=("-y", "@modelcontextprotocol/server-fetch"),
 )
 
 _MEMORY = ConnectorSpec(
@@ -107,9 +78,7 @@ _GIT = ConnectorSpec(
 # ---------------------------------------------------------------------------
 
 _ALL_SPECS = (
-    _FILESYSTEM,
     _GITHUB,
-    _FETCH,
     _MEMORY,
     _GIT,
 )

--- a/src/gaia/connectors/mcp_server.py
+++ b/src/gaia/connectors/mcp_server.py
@@ -134,6 +134,17 @@ class McpServerHandler:
     def __init__(self, reload_callback: Optional[Callable[[], None]] = None) -> None:
         self._reload = reload_callback
 
+    def set_reload_callback(self, callback: Optional[Callable[[], None]]) -> None:
+        """Attach (or replace) the reload callback after construction.
+
+        The handler singleton is registered at module-import time, well before
+        the FastAPI app's ``MCPClientManager`` exists. The lifespan startup
+        hook calls this setter to wire ``manager.reload`` so a subsequent
+        ``configure`` / ``disconnect`` / ``set_enabled`` makes new tools
+        materialize without restarting GAIA (#1004).
+        """
+        self._reload = callback
+
     # ------------------------------------------------------------------
     # ConnectorHandler Protocol implementation
     # ------------------------------------------------------------------
@@ -263,6 +274,45 @@ class McpServerHandler:
 
         if self._reload is not None:
             self._reload()
+
+    async def set_enabled(self, connector_id: str, enabled: bool) -> None:
+        """
+        Flip the ``disabled`` flag on an existing entry in ``mcp_servers.json``.
+
+        Unlike ``configure``/``disconnect`` this method touches **only** the
+        ``disabled`` field — keyring entries, env block ``$keyring`` references,
+        command, args, and per-agent grants are all preserved. The reload
+        callback fires so live agents pick up the change without a restart.
+
+        Raises ``ConnectorsError`` if ``connector_id`` is not present in
+        ``mcp_servers.json`` (the toggle is meaningful only for already-
+        configured connectors).
+        """
+        servers = _read_mcp_servers_json()
+        if connector_id not in servers:
+            raise ConnectorsError(
+                f"set_enabled({connector_id!r}, enabled={enabled}): "
+                f"connector is not configured. Configure it first via "
+                f"Settings → Connectors or `gaia connectors configure {connector_id}`."
+            )
+
+        servers[connector_id]["disabled"] = not enabled
+        _write_mcp_servers_json(servers)
+
+        logger.info(
+            "mcp_server: %s connector_id=%s",
+            "enabled" if enabled else "disabled",
+            connector_id,
+        )
+
+        if self._reload is not None:
+            self._reload()
+        else:
+            logger.warning(
+                "McpServerHandler.set_enabled: reload_callback not set; "
+                "the toggle has been persisted but the running agent's tool list "
+                "will not reflect the change until GAIA is restarted."
+            )
 
     async def test(self, spec: ConnectorSpec) -> Dict[str, Any]:
         """

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -462,6 +462,51 @@ def _store_agent(
         )
 
 
+def reload_all_session_agents_mcp() -> int:
+    """
+    Call ``reload()`` on every cached agent's ``MCPClientManager`` (#1004).
+
+    Each `ChatAgent` instance owns its own per-instance `MCPClientManager`
+    (see `MCPClientMixin.__init__`); there is no process-wide singleton.
+    When a user toggles a connector via Settings → Connectors, the active
+    chat sessions need to pick up the new ``mcp_servers.json`` state on
+    their next turn — otherwise tools materialize/disappear only after
+    GAIA restart.
+
+    Wired as the ``McpServerHandler.reload_callback`` from the FastAPI
+    lifespan. Returns the count of managers reloaded for diagnostics.
+    """
+    count = 0
+    failed = 0
+    with _agent_cache_lock:
+        entries = list(_agent_cache.items())
+
+    for session_id, entry in entries:
+        agent = entry.get("agent")
+        manager = getattr(agent, "_mcp_manager", None)
+        if manager is None:
+            continue
+        try:
+            manager.reload()
+            count += 1
+        except (
+            Exception
+        ) as e:  # noqa: BLE001 — defensive: one bad session must not break others
+            failed += 1
+            logger.warning(
+                "reload_all_session_agents_mcp: reload() failed for session %s (%s)",
+                session_id[:8],
+                e,
+            )
+
+    logger.info(
+        "reload_all_session_agents_mcp: reloaded %d session manager(s), %d failed",
+        count,
+        failed,
+    )
+    return count
+
+
 def _index_rag_with_progress(
     agent, fpath_list, sse_handler, *, rebuild_per_doc=False, label="document(s)"
 ):

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -428,6 +428,78 @@ async def debug_state() -> Dict[str, Any]:
     }
 
 
+@router.get("/agent-mcps")
+async def list_agent_mcps(request: Request) -> Dict[str, Any]:
+    """Return MCP servers declared by custom-Python agents (#1020).
+
+    Scans each registered custom agent's ``mcp_servers.json`` (if present) and
+    returns a flat sorted list of server entries.  Servers are sorted: enabled
+    first (alphabetical), then disabled (alphabetical).
+
+    These entries are read-only — they are controlled by each agent's local
+    config file, not the global connectors framework.  The UI renders them in a
+    separate "Custom agent servers" section with no toggle or disconnect action.
+    """
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None:
+        # Registry not yet initialised (e.g. test client without lifespan).
+        return {"agent_mcps": []}
+
+    servers: List[Dict[str, Any]] = []
+
+    for reg in registry.list():
+        if reg.source != "custom_python" or reg.agent_dir is None:
+            continue
+        config_path = reg.agent_dir / "mcp_servers.json"
+        if not config_path.exists():
+            continue
+        try:
+            with open(config_path, "r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+            if not isinstance(raw, dict):
+                raise ValueError(
+                    f"top-level JSON must be an object, got {type(raw).__name__}"
+                )
+            mcp_servers_data = raw.get("mcpServers", raw.get("servers", {}))
+            if not isinstance(mcp_servers_data, dict):
+                raise ValueError("'mcpServers' must be an object")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "agent-mcps: failed to read %s for agent %r: %s",
+                config_path,
+                reg.id,
+                exc,
+            )
+            continue
+
+        for server_name, server_cfg in mcp_servers_data.items():
+            if not isinstance(server_cfg, dict):
+                logger.warning(
+                    "agent-mcps: skipping non-object server %r in %s",
+                    server_name,
+                    config_path,
+                )
+                continue
+            raw_args = server_cfg.get("args", [])
+            args = [str(a) for a in raw_args] if isinstance(raw_args, list) else []
+            servers.append(
+                {
+                    "agent_id": reg.id,
+                    "agent_name": reg.name,
+                    "config_path": str(config_path),
+                    "server_name": server_name,
+                    "command": str(server_cfg.get("command", "")),
+                    "args": args,
+                    "disabled": bool(server_cfg.get("disabled", False)),
+                }
+            )
+
+    # Enabled (disabled=False) first, then disabled; alphabetical within each group.
+    servers.sort(key=lambda s: (s["disabled"], s["server_name"].lower()))
+
+    return {"agent_mcps": servers}
+
+
 @router.get("/{connector_id}/grants")
 async def get_grants(connector_id: str) -> Dict[str, Any]:
     return {"grants": list_agent_grants(connector_id)}

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -63,8 +63,16 @@ from gaia.connectors.grants import (
     list_agent_grants,
     revoke_agent_grant,
 )
-from gaia.connectors.handler import configure, disconnect, health_check
-from gaia.connectors.mcp_server import is_mcp_server_configured
+from gaia.connectors.handler import (
+    _HANDLER_REGISTRY,
+    configure,
+    disconnect,
+    health_check,
+)
+from gaia.connectors.mcp_server import (
+    _read_mcp_servers_json,
+    is_mcp_server_configured,
+)
 from gaia.connectors.registry import REGISTRY
 from gaia.connectors.store import peek_connection
 
@@ -274,8 +282,28 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
             account_id = blob.get("account_email")
             scopes = list(blob.get("scopes", []))
 
-    elif spec.type == "mcp_server":
+    # ``enabled`` is meaningful only for ``mcp_server`` connectors. We
+    # default to ``True`` for both not-configured connectors AND OAuth so
+    # the UI doesn't render a "Disabled" pill where the concept doesn't
+    # apply.
+    enabled = True
+
+    if spec.type == "mcp_server":
         configured = is_mcp_server_configured(spec.id)
+        if configured:
+            try:
+                entry = _read_mcp_servers_json().get(spec.id, {})
+                enabled = not entry.get("disabled", False)
+            except ConnectorsError as e:
+                # Corrupt mcp_servers.json — log loudly so the user has
+                # a path to a fix, but don't crash the whole catalog
+                # list (one bad entry would make every tile unavailable).
+                logger.warning(
+                    "connectors-summary: cannot read mcp_servers.json for "
+                    "%s (%s); rendering tile with default enabled=true",
+                    spec.id,
+                    e,
+                )
 
     return {
         "id": spec.id,
@@ -292,6 +320,7 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
         "config_error": config_error,
         "account_id": account_id,
         "scopes": scopes,
+        "enabled": enabled,
         "mcp_env_keys": list(spec.mcp_env_keys),
         "default_scopes": list(spec.default_scopes),
         "available_scopes": list(spec.available_scopes),
@@ -341,6 +370,8 @@ async def connector_events() -> StreamingResponse:
       - ``connector.configured``        ({connector_id, account_id})
       - ``connector.disconnected``      ({connector_id})
       - ``connector.tested``            ({connector_id, ok, detail})
+      - ``connector.enabled``           ({connector_id})
+      - ``connector.disabled``          ({connector_id})
       - ``connector.oauth.completed``   ({connector_id, account_email})
       - ``connector.oauth.error``       ({connector_id, error})
       - ``connector.grant.changed``     ({connector_id, agent_id, scopes})
@@ -486,6 +517,67 @@ async def disconnect_connector(connector_id: str) -> Response:
 
     await _emitter.emit("connector.disconnected", {"connector_id": connector_id})
     return Response(status_code=204)
+
+
+async def _set_connector_enabled(connector_id: str, enabled: bool) -> Dict[str, Any]:
+    """Shared implementation for ``POST /{id}/enable`` and ``POST /{id}/disable``.
+
+    The toggle is meaningful only for ``mcp_server`` connectors that have
+    already been configured. Unknown ids → 404; non-MCP types → 400; not-yet-
+    configured ids → bubble up the handler's ``ConnectorsError`` as 500.
+
+    On success, emits ``connector.enabled`` or ``connector.disabled`` on the
+    SSE stream and returns the updated connector summary.
+    """
+    try:
+        spec = REGISTRY.get(connector_id)
+    except KeyError:
+        raise HTTPException(
+            status_code=404, detail=f"Unknown connector: {connector_id!r}"
+        )
+
+    if spec.type != "mcp_server":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Connector type {spec.type!r} does not support enable/disable. "
+                "Only mcp_server connectors can be toggled."
+            ),
+        )
+
+    if not is_mcp_server_configured(connector_id):
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Connector {connector_id!r} is not configured. "
+                "Configure it before toggling its enabled state."
+            ),
+        )
+
+    handler = _HANDLER_REGISTRY.get("mcp_server")
+    if handler is None:  # pragma: no cover — handler registers at import time
+        raise HTTPException(status_code=500, detail="MCP handler not registered")
+
+    try:
+        await handler.set_enabled(connector_id, enabled)
+    except ConnectorsError as e:
+        raise _raise_http_for(e) from e
+
+    event_name = "connector.enabled" if enabled else "connector.disabled"
+    await _emitter.emit(event_name, {"connector_id": connector_id})
+    return _connector_summary(connector_id)
+
+
+@router.post("/{connector_id}/enable", dependencies=[Depends(_require_ui_header)])
+async def enable_connector(connector_id: str) -> Dict[str, Any]:
+    """Enable a previously-disabled MCP connector. Tools materialize live."""
+    return await _set_connector_enabled(connector_id, True)
+
+
+@router.post("/{connector_id}/disable", dependencies=[Depends(_require_ui_header)])
+async def disable_connector(connector_id: str) -> Dict[str, Any]:
+    """Disable a configured MCP connector without clearing its credentials."""
+    return await _set_connector_enabled(connector_id, False)
 
 
 @router.post("/{connector_id}/authorize", dependencies=[Depends(_require_ui_header)])

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -332,6 +332,37 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
                 e,
             )
 
+        # ── Connectors live-reload (issue #1004) ────────────────────────
+        # Wire the McpServerHandler.reload_callback so a Settings →
+        # Connectors enable/disable/configure/disconnect from the UI
+        # broadcasts a reload to every cached chat-session agent's
+        # per-instance MCPClientManager. Without this, toggling an MCP
+        # only takes effect after GAIA restart.
+        try:
+            from gaia.connectors.handler import _HANDLER_REGISTRY
+            from gaia.ui._chat_helpers import reload_all_session_agents_mcp
+
+            mcp_handler = _HANDLER_REGISTRY.get("mcp_server")
+            if mcp_handler is not None:
+                mcp_handler.set_reload_callback(reload_all_session_agents_mcp)
+                logger.info(
+                    "connectors: McpServerHandler reload_callback wired to "
+                    "reload_all_session_agents_mcp"
+                )
+            else:
+                logger.warning(
+                    "connectors: McpServerHandler not registered; live "
+                    "reload of toggled connectors will be deferred until "
+                    "GAIA restart"
+                )
+        except Exception as e:  # noqa: BLE001 — defense in depth
+            logger.warning(
+                "connectors: failed to wire McpServerHandler reload_callback "
+                "(%s); live reload of toggled connectors will be deferred "
+                "until GAIA restart",
+                e,
+            )
+
         yield
 
         # Shutdown

--- a/tests/unit/connectors/test_agent_mcps_router.py
+++ b/tests/unit/connectors/test_agent_mcps_router.py
@@ -17,14 +17,12 @@ Coverage:
 from __future__ import annotations
 
 import json
-import types
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 from unittest.mock import MagicMock
 
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Minimal AgentRegistration stub so the test does not import the real module
@@ -187,7 +185,7 @@ class TestAgentMcpsRoute:
                 "mcpServers": {
                     "zebra": {"command": "z", "args": [], "disabled": False},
                     "alpha": {"command": "a", "args": [], "disabled": True},
-                    "beta":  {"command": "b", "args": [], "disabled": False},
+                    "beta": {"command": "b", "args": [], "disabled": False},
                     "omega": {"command": "o", "args": [], "disabled": True},
                 }
             },
@@ -202,9 +200,7 @@ class TestAgentMcpsRoute:
         # Enabled (beta, zebra) alphabetical first, then disabled (alpha, omega) alphabetical.
         assert names == ["beta", "zebra", "alpha", "omega"]
 
-    def test_malformed_json_skipped_other_agents_returned(
-        self, app_client, tmp_path
-    ):
+    def test_malformed_json_skipped_other_agents_returned(self, app_client, tmp_path):
         """Bad JSON for one agent does not prevent other agents from appearing."""
         client, app = app_client
 

--- a/tests/unit/connectors/test_agent_mcps_router.py
+++ b/tests/unit/connectors/test_agent_mcps_router.py
@@ -1,0 +1,290 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for GET /api/connectors/agent-mcps (#1020).
+
+Coverage:
+- Returns empty list when registry is not initialised
+- Built-in agents (agent_dir=None) are skipped
+- Custom agent with no mcp_servers.json is skipped
+- Valid mcp_servers.json entries are returned, sorted (enabled first, alphabetical)
+- Malformed JSON is skipped; other agents are still returned
+- Non-dict mcpServers value is skipped
+- Non-dict server entry is skipped (per-server guard)
+- Disabled flag is correctly reflected
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal AgentRegistration stub so the test does not import the real module
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Reg:
+    id: str
+    name: str
+    source: str
+    agent_dir: Optional[Path]
+    hidden: bool = False
+    models: List[str] = field(default_factory=list)
+    conversation_starters: List[str] = field(default_factory=list)
+    description: str = ""
+    required_connections: List = field(default_factory=list)
+    namespaced_agent_id: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_registry(*regs: _Reg):
+    """Return a duck-typed registry whose list() returns *regs*."""
+    m = MagicMock()
+    m.list.return_value = list(regs)
+    return m
+
+
+def _write_mcp_json(path: Path, content: dict) -> None:
+    path.write_text(json.dumps(content), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_client(monkeypatch):
+    """TestClient with a controllable app.state.agent_registry."""
+    pytest.importorskip("starlette")
+    from starlette.testclient import TestClient
+
+    from gaia.ui.server import create_app
+
+    app = create_app()
+    client = TestClient(app)
+    return client, app
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentMcpsRoute:
+    def test_no_registry_returns_empty(self, app_client):
+        """When app.state has no agent_registry, return empty list."""
+        client, app = app_client
+        # Default TestClient has no agent_registry set.
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        assert resp.json() == {"agent_mcps": []}
+
+    def test_builtin_agents_skipped(self, app_client, tmp_path):
+        """Built-in agents (agent_dir=None) never appear in the output."""
+        client, app = app_client
+        builtin = _Reg(id="chat", name="Chat", source="builtin", agent_dir=None)
+        app.state.agent_registry = _make_registry(builtin)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        assert resp.json()["agent_mcps"] == []
+
+    def test_custom_agent_without_config_skipped(self, app_client, tmp_path):
+        """Custom agent with no mcp_servers.json is silently skipped."""
+        client, app = app_client
+        agent_dir = tmp_path / "my-agent"
+        agent_dir.mkdir()
+        reg = _Reg(
+            id="my-agent", name="My Agent", source="custom_python", agent_dir=agent_dir
+        )
+        app.state.agent_registry = _make_registry(reg)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        assert resp.json()["agent_mcps"] == []
+
+    def test_returns_servers_from_valid_config(self, app_client, tmp_path):
+        """Servers from a well-formed mcp_servers.json are returned."""
+        client, app = app_client
+        agent_dir = tmp_path / "time-agent"
+        agent_dir.mkdir()
+        _write_mcp_json(
+            agent_dir / "mcp_servers.json",
+            {
+                "mcpServers": {
+                    "time": {
+                        "command": "uvx",
+                        "args": ["mcp-server-time"],
+                    }
+                }
+            },
+        )
+        reg = _Reg(
+            id="time-agent",
+            name="Time Agent",
+            source="custom_python",
+            agent_dir=agent_dir,
+        )
+        app.state.agent_registry = _make_registry(reg)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        data = resp.json()["agent_mcps"]
+        assert len(data) == 1
+        entry = data[0]
+        assert entry["agent_id"] == "time-agent"
+        assert entry["agent_name"] == "Time Agent"
+        assert entry["server_name"] == "time"
+        assert entry["command"] == "uvx"
+        assert entry["args"] == ["mcp-server-time"]
+        assert entry["disabled"] is False
+
+    def test_disabled_flag_reflected(self, app_client, tmp_path):
+        """Disabled flag in the JSON is surfaced in the response."""
+        client, app = app_client
+        agent_dir = tmp_path / "myagent"
+        agent_dir.mkdir()
+        _write_mcp_json(
+            agent_dir / "mcp_servers.json",
+            {
+                "mcpServers": {
+                    "paused": {
+                        "command": "python",
+                        "args": ["-m", "server"],
+                        "disabled": True,
+                    }
+                }
+            },
+        )
+        reg = _Reg(
+            id="myagent", name="My Agent", source="custom_python", agent_dir=agent_dir
+        )
+        app.state.agent_registry = _make_registry(reg)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        entry = resp.json()["agent_mcps"][0]
+        assert entry["disabled"] is True
+
+    def test_sort_enabled_first_then_alphabetical(self, app_client, tmp_path):
+        """Enabled servers come before disabled; each group is alphabetical."""
+        client, app = app_client
+        agent_dir = tmp_path / "multi"
+        agent_dir.mkdir()
+        _write_mcp_json(
+            agent_dir / "mcp_servers.json",
+            {
+                "mcpServers": {
+                    "zebra": {"command": "z", "args": [], "disabled": False},
+                    "alpha": {"command": "a", "args": [], "disabled": True},
+                    "beta":  {"command": "b", "args": [], "disabled": False},
+                    "omega": {"command": "o", "args": [], "disabled": True},
+                }
+            },
+        )
+        reg = _Reg(
+            id="multi", name="Multi", source="custom_python", agent_dir=agent_dir
+        )
+        app.state.agent_registry = _make_registry(reg)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        names = [e["server_name"] for e in resp.json()["agent_mcps"]]
+        # Enabled (beta, zebra) alphabetical first, then disabled (alpha, omega) alphabetical.
+        assert names == ["beta", "zebra", "alpha", "omega"]
+
+    def test_malformed_json_skipped_other_agents_returned(
+        self, app_client, tmp_path
+    ):
+        """Bad JSON for one agent does not prevent other agents from appearing."""
+        client, app = app_client
+
+        bad_dir = tmp_path / "bad"
+        bad_dir.mkdir()
+        (bad_dir / "mcp_servers.json").write_text("NOT JSON {{{", encoding="utf-8")
+
+        good_dir = tmp_path / "good"
+        good_dir.mkdir()
+        _write_mcp_json(
+            good_dir / "mcp_servers.json",
+            {"mcpServers": {"srv": {"command": "ok", "args": []}}},
+        )
+
+        app.state.agent_registry = _make_registry(
+            _Reg(id="bad", name="Bad", source="custom_python", agent_dir=bad_dir),
+            _Reg(id="good", name="Good", source="custom_python", agent_dir=good_dir),
+        )
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        data = resp.json()["agent_mcps"]
+        assert len(data) == 1
+        assert data[0]["agent_id"] == "good"
+
+    def test_non_dict_mcp_servers_value_skipped(self, app_client, tmp_path):
+        """If mcpServers is not a dict (e.g. null), the whole file is skipped."""
+        client, app = app_client
+        agent_dir = tmp_path / "null-mcp"
+        agent_dir.mkdir()
+        _write_mcp_json(
+            agent_dir / "mcp_servers.json",
+            {"mcpServers": None},
+        )
+        reg = _Reg(
+            id="null-mcp", name="NullMCP", source="custom_python", agent_dir=agent_dir
+        )
+        app.state.agent_registry = _make_registry(reg)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        assert resp.json()["agent_mcps"] == []
+
+    def test_non_dict_server_entry_skipped(self, app_client, tmp_path):
+        """A non-object server value is skipped; other servers in the same file pass."""
+        client, app = app_client
+        agent_dir = tmp_path / "mixed"
+        agent_dir.mkdir()
+        _write_mcp_json(
+            agent_dir / "mcp_servers.json",
+            {
+                "mcpServers": {
+                    "bad-entry": "should be an object",
+                    "good-entry": {"command": "ok", "args": []},
+                }
+            },
+        )
+        reg = _Reg(
+            id="mixed", name="Mixed", source="custom_python", agent_dir=agent_dir
+        )
+        app.state.agent_registry = _make_registry(reg)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        data = resp.json()["agent_mcps"]
+        assert len(data) == 1
+        assert data[0]["server_name"] == "good-entry"
+
+    def test_legacy_servers_key_also_accepted(self, app_client, tmp_path):
+        """Files using the legacy 'servers' key (without 'mcpServers') are read."""
+        client, app = app_client
+        agent_dir = tmp_path / "legacy"
+        agent_dir.mkdir()
+        _write_mcp_json(
+            agent_dir / "mcp_servers.json",
+            {"servers": {"legacy-srv": {"command": "old", "args": []}}},
+        )
+        reg = _Reg(
+            id="legacy", name="Legacy", source="custom_python", agent_dir=agent_dir
+        )
+        app.state.agent_registry = _make_registry(reg)
+        resp = client.get("/api/connectors/agent-mcps")
+        assert resp.status_code == 200
+        data = resp.json()["agent_mcps"]
+        assert len(data) == 1
+        assert data[0]["server_name"] == "legacy-srv"

--- a/tests/unit/connectors/test_catalog_ledger.py
+++ b/tests/unit/connectors/test_catalog_ledger.py
@@ -1,18 +1,19 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Catalog ledger test (#976).
+Catalog ledger test (#976, updated #1021).
 
 Replaces the previous "legacy ⊆ new" parity check. The MCP catalog has been
-intentionally reduced from 22 deployed entries down to 5 tested entries; the
-17 dropped entries are gone for cause (untested or redundant with another
-connector). This test asserts both ends of that ledger:
+intentionally reduced from 22 deployed entries down to 3 entries (#1021
+removed mcp-filesystem and mcp-fetch because no built-in agent consumes them
+through the connectors framework; custom agents supply their own
+mcp_servers.json instead). This test asserts both ends of that ledger:
 
-  * KEPT_IDS — exactly these 5 ids must remain in
+  * KEPT_IDS — exactly these 3 ids must remain in
     ``connectors.catalog.mcp_servers``. For each, field-by-field equivalence
     against the legacy ``mcp.py:_CATALOG`` row of the same name is asserted as
     a guard against silent drift during the migration.
-  * DELETED_IDS — these 17 ids must NOT be present. Regression guard against
+  * DELETED_IDS — these 19 ids must NOT be present. Regression guard against
     accidentally re-introducing untested catalog tiles.
 
 When ``src/gaia/ui/routers/mcp.py:_CATALOG`` is finally deleted (also part of
@@ -29,9 +30,7 @@ from gaia.connectors.registry import REGISTRY
 
 KEPT_IDS = frozenset(
     {
-        "mcp-filesystem",
         "mcp-github",
-        "mcp-fetch",
         "mcp-memory",
         "mcp-git",
     }
@@ -39,6 +38,12 @@ KEPT_IDS = frozenset(
 
 DELETED_IDS = frozenset(
     {
+        # Removed in #1021: no built-in agent consumes these via the connectors
+        # framework; the File/Web agents use Python-native tool mixins instead.
+        # Custom agents supply their own mcp_servers.json.
+        "mcp-filesystem",
+        "mcp-fetch",
+        # Removed in #976: untested / redundant entries.
         "mcp-playwright",
         "mcp-desktop-commander",
         "mcp-brave-search",

--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -15,7 +15,6 @@ share the ``revoke_all_grants_for`` helper.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
 from unittest.mock import patch
 

--- a/tests/unit/connectors/test_enable_disable.py
+++ b/tests/unit/connectors/test_enable_disable.py
@@ -15,7 +15,6 @@ These tests cover ``McpServerHandler.set_enabled`` and
 
 from __future__ import annotations
 
-import json
 import os
 import stat
 from typing import Dict

--- a/tests/unit/connectors/test_enable_disable.py
+++ b/tests/unit/connectors/test_enable_disable.py
@@ -1,0 +1,295 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Per-MCP enable/disable toggle (#1004).
+
+The ``disabled`` flag is already persisted per-entry in ``mcp_servers.json``
+(written today by ``McpServerHandler.configure``) and ``MCPClientManager``
+already skips disabled entries — so the runtime suppression path is in
+place. What's missing is an API to flip the flag without re-running the
+full ``configure`` round-trip (which would re-prompt for credentials).
+
+These tests cover ``McpServerHandler.set_enabled`` and
+``set_reload_callback`` — the two new methods this PR adds.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from typing import Dict
+from unittest.mock import patch
+
+import pytest
+
+from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.mcp_server import (
+    McpServerHandler,
+    _read_mcp_servers_json,
+)
+from gaia.connectors.spec import ConfigField, ConnectorSpec
+from gaia.connectors.store import SERVICE_NAME
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def fake_home(tmp_path, monkeypatch):
+    """Redirect ``~/.gaia/mcp_servers.json`` to a tempdir."""
+    monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
+    return tmp_path
+
+
+def _make_mcp_spec(
+    *,
+    spec_id: str = "mcp-github",
+    mcp_env_keys: tuple = ("GITHUB_TOKEN",),
+) -> ConnectorSpec:
+    return ConnectorSpec(
+        id=spec_id,
+        display_name="GitHub MCP",
+        icon="🐙",
+        category="dev-tools",
+        tier=1,
+        type="mcp_server",
+        description="GitHub MCP server",
+        mcp_command="npx",
+        mcp_args=("-y", "@modelcontextprotocol/server-github"),
+        mcp_env_keys=mcp_env_keys,
+        config_schema=tuple(
+            ConfigField(key=k, label=k, kind="secret", secret=True)
+            for k in mcp_env_keys
+        ),
+    )
+
+
+def _make_oauth_spec() -> ConnectorSpec:
+    return ConnectorSpec(
+        id="google",
+        display_name="Google",
+        icon="🔵",
+        category="cloud",
+        tier=1,
+        type="oauth_pkce",
+        description="Google OAuth",
+        oauth_provider_ref="google",
+    )
+
+
+@pytest.fixture
+async def configured_handler(tmp_path):
+    """Build a handler with one configured MCP entry and a mock reload callback."""
+    spec = _make_mcp_spec()
+    reload_calls: list[int] = []
+    handler = McpServerHandler(reload_callback=lambda: reload_calls.append(1))
+
+    # Pre-configure the entry. We patch keyring.set_password so the test
+    # doesn't touch the real OS keyring.
+    stored: Dict[tuple, str] = {}
+
+    def fake_set_password(service, username, value):
+        stored[(service, username)] = value
+
+    with patch(
+        "gaia.connectors.mcp_server.keyring.set_password",
+        side_effect=fake_set_password,
+    ):
+        await handler.configure(spec, {"GITHUB_TOKEN": "ghp_secret"})
+
+    # Drain the reload calls from configure() — tests should observe their own.
+    reload_calls.clear()
+    return handler, spec, reload_calls, stored
+
+
+# ---------------------------------------------------------------------------
+# A1.1 — set_enabled flips the disabled flag without touching anything else
+# ---------------------------------------------------------------------------
+
+
+class TestSetEnabledPersistence:
+    @pytest.mark.asyncio
+    async def test_disable_flips_flag_only(self, configured_handler, tmp_path):
+        handler, spec, _, _ = configured_handler
+
+        # Before disable: disabled flag is False (configure() default).
+        before = _read_mcp_servers_json()[spec.id]
+        assert before["disabled"] is False
+        before_env = dict(before["env"])
+        before_command = before["command"]
+        before_args = list(before["args"])
+
+        await handler.set_enabled(spec.id, False)
+
+        after = _read_mcp_servers_json()[spec.id]
+        assert after["disabled"] is True
+        # Env block (with $keyring refs), command, args all unchanged.
+        assert after["env"] == before_env
+        assert after["command"] == before_command
+        assert list(after["args"]) == before_args
+
+    @pytest.mark.asyncio
+    async def test_enable_flips_flag_back(self, configured_handler):
+        handler, spec, _, _ = configured_handler
+
+        await handler.set_enabled(spec.id, False)
+        await handler.set_enabled(spec.id, True)
+
+        after = _read_mcp_servers_json()[spec.id]
+        assert after["disabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_round_trip_preserves_keyring_refs(self, configured_handler):
+        """Disable → enable → disable must not mutate the env block."""
+        handler, spec, _, _ = configured_handler
+
+        original_env = dict(_read_mcp_servers_json()[spec.id]["env"])
+
+        await handler.set_enabled(spec.id, False)
+        await handler.set_enabled(spec.id, True)
+        await handler.set_enabled(spec.id, False)
+
+        final_env = dict(_read_mcp_servers_json()[spec.id]["env"])
+        assert final_env == original_env
+        # Specifically, the $keyring reference is preserved (no plaintext leak).
+        assert final_env["GITHUB_TOKEN"] == {
+            "$keyring": f"{SERVICE_NAME}:mcp-github:GITHUB_TOKEN"
+        }
+
+    @pytest.mark.asyncio
+    async def test_idempotent_re_disable_is_harmless(self, configured_handler):
+        handler, spec, _, _ = configured_handler
+
+        await handler.set_enabled(spec.id, False)
+        # Second disable on already-disabled entry is a no-op (or harmless write).
+        await handler.set_enabled(spec.id, False)
+
+        assert _read_mcp_servers_json()[spec.id]["disabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# A1.2 — File mode 0600 (mirror #976 hardening)
+# ---------------------------------------------------------------------------
+
+
+class TestFilePermissions:
+    @pytest.mark.asyncio
+    async def test_file_mode_0600_after_disable(self, configured_handler, tmp_path):
+        handler, spec, _, _ = configured_handler
+
+        await handler.set_enabled(spec.id, False)
+
+        path = tmp_path / ".gaia" / "mcp_servers.json"
+        st = os.stat(path)
+        # On Windows chmod is best-effort; only assert on Unix.
+        if hasattr(os, "geteuid"):
+            mode = stat.S_IMODE(st.st_mode)
+            assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# A1.3 — Type guard and unknown-id errors
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_unknown_id_raises_actionable_error(self, configured_handler):
+        handler, _, _, _ = configured_handler
+
+        with pytest.raises(ConnectorsError, match="not configured"):
+            await handler.set_enabled("mcp-nonexistent", False)
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_error_names_the_id(self, configured_handler):
+        handler, _, _, _ = configured_handler
+
+        with pytest.raises(ConnectorsError, match="mcp-totally-fake"):
+            await handler.set_enabled("mcp-totally-fake", False)
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_does_not_corrupt_file(self, configured_handler):
+        handler, spec, _, _ = configured_handler
+
+        before = _read_mcp_servers_json()
+        try:
+            await handler.set_enabled("mcp-bogus", False)
+        except ConnectorsError:
+            pass
+        after = _read_mcp_servers_json()
+        # The good entry is still present and unchanged.
+        assert after == before
+
+
+# ---------------------------------------------------------------------------
+# A1.4 — Reload callback wiring
+# ---------------------------------------------------------------------------
+
+
+class TestReloadCallback:
+    @pytest.mark.asyncio
+    async def test_reload_fires_once_per_call(self, configured_handler):
+        handler, spec, reload_calls, _ = configured_handler
+
+        await handler.set_enabled(spec.id, False)
+        assert len(reload_calls) == 1
+
+        await handler.set_enabled(spec.id, True)
+        assert len(reload_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_reload_not_called_when_unset(self, tmp_path):
+        """A handler without a reload callback still flips the flag and warns."""
+        spec = _make_mcp_spec()
+        handler = McpServerHandler()  # no callback
+
+        with patch("gaia.connectors.mcp_server.keyring.set_password"):
+            await handler.configure(spec, {"GITHUB_TOKEN": "tok"})
+
+        # No callback means no exception when disabling — just a warning.
+        await handler.set_enabled(spec.id, False)
+
+        assert _read_mcp_servers_json()[spec.id]["disabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_set_reload_callback_attaches_after_construction(self, tmp_path):
+        """The setter lets the FastAPI lifespan wire the callback post-import."""
+        spec = _make_mcp_spec()
+        handler = McpServerHandler()  # no callback at construction
+        reload_calls: list[int] = []
+
+        # Public setter (added in this PR) lets the lifespan attach a callback
+        # after both the handler singleton and the manager are initialized.
+        handler.set_reload_callback(lambda: reload_calls.append(1))
+
+        with patch("gaia.connectors.mcp_server.keyring.set_password"):
+            await handler.configure(spec, {"GITHUB_TOKEN": "tok"})
+
+        await handler.set_enabled(spec.id, False)
+
+        # configure() triggered one reload, set_enabled() triggered another.
+        assert len(reload_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# A1.5 — Sanity check that grants.json is untouched by toggle
+# ---------------------------------------------------------------------------
+
+
+class TestGrantsUnchanged:
+    @pytest.mark.asyncio
+    async def test_disable_does_not_revoke_grants(self, configured_handler, tmp_path):
+        """Toggling disabled state must NOT call revoke_all_grants_for —
+        that's disconnect's job (per #976), and inheriting our own grants
+        on re-enable is the whole point of the feature."""
+        handler, spec, _, _ = configured_handler
+
+        # ``revoke_all_grants_for`` is imported lazily inside ``disconnect()``
+        # to avoid a circular import — patch it at the source module.
+        with patch("gaia.connectors.grants.revoke_all_grants_for") as mock_revoke:
+            await handler.set_enabled(spec.id, False)
+            await handler.set_enabled(spec.id, True)
+
+            assert mock_revoke.call_count == 0, "set_enabled must not revoke grants"

--- a/tests/unit/connectors/test_handler_reload_wired.py
+++ b/tests/unit/connectors/test_handler_reload_wired.py
@@ -1,0 +1,170 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Reload-callback wiring at FastAPI lifespan startup (#1004).
+
+The ``McpServerHandler`` singleton is constructed at module import time
+(``handler.py:_HANDLER_REGISTRY``) — well before the FastAPI app's chat-
+session agent cache exists. The lifespan startup hook calls
+``handler.set_reload_callback(reload_all_session_agents_mcp)`` so that a
+subsequent ``configure`` / ``disconnect`` / ``set_enabled`` reaches every
+cached agent's per-instance ``MCPClientManager``.
+
+These tests check the wiring contract without spawning real MCP servers
+or chat agents — the wiring itself is what's worth pinning.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def reset_handler_callback():
+    """
+    Snapshot and restore the McpServerHandler reload callback around each
+    test, so a test that wires (or unwires) it doesn't leak into others.
+    """
+    from gaia.connectors.handler import _HANDLER_REGISTRY
+
+    handler = _HANDLER_REGISTRY.get("mcp_server")
+    if handler is None:
+        pytest.skip("McpServerHandler not registered")
+
+    original = getattr(handler, "_reload", None)
+    yield handler
+    handler._reload = original
+
+
+def test_lifespan_wires_reload_callback(ui_api_client, reset_handler_callback):
+    """After the FastAPI app starts, the handler's reload callback is set."""
+    handler = reset_handler_callback
+    # ui_api_client fixture has already triggered the lifespan startup hook
+    # by the time this test runs. The wired callback should be the helper
+    # from `_chat_helpers`.
+    assert handler._reload is not None, (
+        "Lifespan startup did not wire the McpServerHandler reload_callback. "
+        "Toggling a connector via /api/connectors/{id}/disable would not "
+        "take effect until GAIA restart."
+    )
+
+    # Sanity: the wired function comes from _chat_helpers (not some unrelated
+    # callable that happened to land there).
+    from gaia.ui._chat_helpers import reload_all_session_agents_mcp
+
+    assert handler._reload is reload_all_session_agents_mcp
+
+
+def test_set_enabled_invokes_session_reload(
+    ui_api_client, reset_handler_callback, monkeypatch, tmp_path
+):
+    """
+    End-to-end: hitting POST /api/connectors/.../disable triggers the
+    wired reload_all_session_agents_mcp helper.
+    """
+    handler = reset_handler_callback
+
+    # Replace the wired callback with a mock that just records the call.
+    mock_reload = MagicMock()
+    handler.set_reload_callback(mock_reload)
+
+    # Pre-write an mcp_servers.json entry so the route can find it. The
+    # lifespan-bound REGISTRY already contains the catalog entries.
+    import json
+
+    monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
+    gaia_dir = tmp_path / ".gaia"
+    gaia_dir.mkdir(parents=True, exist_ok=True)
+    (gaia_dir / "mcp_servers.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "mcp-github": {
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-github"],
+                        "env": {
+                            "GITHUB_TOKEN": {
+                                "$keyring": ("gaia.connections:mcp-github:GITHUB_TOKEN")
+                            }
+                        },
+                        "disabled": False,
+                    }
+                }
+            }
+        )
+    )
+
+    resp = ui_api_client.post(
+        "/api/connectors/mcp-github/disable",
+        headers={"x-gaia-ui": "1"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The wired callback fired exactly once.
+    assert mock_reload.call_count == 1
+
+
+def test_reload_helper_is_resilient_to_per_session_failures(monkeypatch):
+    """
+    `reload_all_session_agents_mcp` must NOT propagate an exception from
+    one bad session — otherwise toggling fails the request when only one
+    cached agent is in a bad state.
+    """
+    from gaia.ui import _chat_helpers
+
+    bad_agent = type(
+        "BadAgent",
+        (),
+        {
+            "_mcp_manager": type(
+                "BadManager",
+                (),
+                {"reload": lambda self: (_ for _ in ()).throw(RuntimeError("boom"))},
+            )()
+        },
+    )()
+    good_manager_calls: list[int] = []
+    good_agent = type(
+        "GoodAgent",
+        (),
+        {
+            "_mcp_manager": type(
+                "GoodManager",
+                (),
+                {"reload": lambda self: good_manager_calls.append(1)},
+            )()
+        },
+    )()
+
+    fake_cache = {
+        "session-bad": {"agent": bad_agent, "model_id": "m", "agent_type": "chat"},
+        "session-good": {"agent": good_agent, "model_id": "m", "agent_type": "chat"},
+    }
+    monkeypatch.setattr(_chat_helpers, "_agent_cache", fake_cache)
+
+    count = _chat_helpers.reload_all_session_agents_mcp()
+
+    # Good session was reloaded; bad session failed quietly.
+    assert good_manager_calls == [1]
+    assert count == 1
+
+
+def test_reload_helper_skips_agents_without_mcp_manager(monkeypatch):
+    """An agent without ``_mcp_manager`` (some custom registry agent) must
+    be silently skipped, not crash the broadcast."""
+    from gaia.ui import _chat_helpers
+
+    plain_agent = object()  # no _mcp_manager attribute
+    fake_cache = {
+        "session-plain": {
+            "agent": plain_agent,
+            "model_id": "m",
+            "agent_type": "chat",
+        },
+    }
+    monkeypatch.setattr(_chat_helpers, "_agent_cache", fake_cache)
+
+    count = _chat_helpers.reload_all_session_agents_mcp()
+    assert count == 0

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -331,3 +331,212 @@ class TestGrantsEndpoints:
             headers=UI_HEADER,
         )
         assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# POST /api/connectors/{connector_id}/enable | /disable  (#1004)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcp_spec_in_registry(isolated_registry):
+    """Add a configured MCP spec to the test registry for #1004 tests."""
+    from gaia.connectors.spec import ConfigField, ConnectorSpec
+
+    spec = ConnectorSpec(
+        id="mcp-github",
+        display_name="GitHub MCP",
+        icon="🐙",
+        category="dev-tools",
+        tier=1,
+        type="mcp_server",
+        description="GitHub MCP server",
+        mcp_command="npx",
+        mcp_args=("-y", "@modelcontextprotocol/server-github"),
+        mcp_env_keys=("GITHUB_TOKEN",),
+        config_schema=(
+            ConfigField(key="GITHUB_TOKEN", label="Token", kind="secret", secret=True),
+        ),
+    )
+    isolated_registry.register(spec)
+    return spec
+
+
+@pytest.fixture
+def configured_mcp(mcp_spec_in_registry, tmp_path, monkeypatch):
+    """Pre-write an mcp_servers.json entry so the toggle endpoints can find it."""
+    import json
+
+    monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
+
+    gaia_dir = tmp_path / ".gaia"
+    gaia_dir.mkdir(parents=True, exist_ok=True)
+    (gaia_dir / "mcp_servers.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "mcp-github": {
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-github"],
+                        "env": {
+                            "GITHUB_TOKEN": {
+                                "$keyring": "gaia.connections:mcp-github:GITHUB_TOKEN"
+                            }
+                        },
+                        "disabled": False,
+                    }
+                }
+            }
+        )
+    )
+    return mcp_spec_in_registry
+
+
+class TestEnableDisableCsrf:
+    def test_enable_without_header_is_403(self, ui_api_client):
+        resp = ui_api_client.post("/api/connectors/mcp-github/enable")
+        assert resp.status_code == 403
+
+    def test_disable_without_header_is_403(self, ui_api_client):
+        resp = ui_api_client.post("/api/connectors/mcp-github/disable")
+        assert resp.status_code == 403
+
+
+class TestEnableDisableTypeGuard:
+    def test_enable_on_oauth_returns_400(self, ui_api_client):
+        resp = ui_api_client.post("/api/connectors/google/enable", headers=UI_HEADER)
+        assert resp.status_code == 400
+        assert "oauth_pkce" in (resp.json().get("detail") or "")
+
+    def test_disable_on_oauth_returns_400(self, ui_api_client):
+        resp = ui_api_client.post("/api/connectors/google/disable", headers=UI_HEADER)
+        assert resp.status_code == 400
+
+
+class TestEnableDisableUnknown:
+    def test_enable_unknown_id_returns_404(self, ui_api_client):
+        resp = ui_api_client.post(
+            "/api/connectors/mcp-totally-fake/enable", headers=UI_HEADER
+        )
+        assert resp.status_code == 404
+
+    def test_disable_unconfigured_returns_404(
+        self, ui_api_client, mcp_spec_in_registry
+    ):
+        # Spec is in the registry but no mcp_servers.json entry yet.
+        resp = ui_api_client.post(
+            "/api/connectors/mcp-github/disable", headers=UI_HEADER
+        )
+        assert resp.status_code == 404
+        assert "not configured" in (resp.json().get("detail") or "")
+
+
+class TestEnableDisableHappyPath:
+    def test_disable_returns_summary_with_enabled_false(
+        self, ui_api_client, configured_mcp
+    ):
+        resp = ui_api_client.post(
+            "/api/connectors/mcp-github/disable", headers=UI_HEADER
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == "mcp-github"
+        assert body["enabled"] is False
+        assert body["configured"] is True
+
+    def test_enable_returns_summary_with_enabled_true(
+        self, ui_api_client, configured_mcp
+    ):
+        # First disable, then re-enable.
+        ui_api_client.post("/api/connectors/mcp-github/disable", headers=UI_HEADER)
+        resp = ui_api_client.post(
+            "/api/connectors/mcp-github/enable", headers=UI_HEADER
+        )
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is True
+
+    def test_round_trip_persists_in_summary(self, ui_api_client, configured_mcp):
+        # Toggle off → GET reflects it
+        ui_api_client.post("/api/connectors/mcp-github/disable", headers=UI_HEADER)
+        resp = ui_api_client.get("/api/connectors/mcp-github")
+        assert resp.json()["enabled"] is False
+
+        # Toggle back on → GET reflects that too
+        ui_api_client.post("/api/connectors/mcp-github/enable", headers=UI_HEADER)
+        resp = ui_api_client.get("/api/connectors/mcp-github")
+        assert resp.json()["enabled"] is True
+
+
+class TestEnableDisableSseEvents:
+    def test_disable_emits_sse_event(self, ui_api_client, configured_mcp):
+        from gaia.ui.routers.connectors import _emitter
+
+        captured: list[dict] = []
+        original_emit = _emitter.emit
+
+        async def capture(event_type, payload):
+            captured.append({"type": event_type, "payload": payload})
+            await original_emit(event_type, payload)
+
+        _emitter.emit = capture  # type: ignore[assignment]
+        try:
+            ui_api_client.post("/api/connectors/mcp-github/disable", headers=UI_HEADER)
+        finally:
+            _emitter.emit = original_emit  # type: ignore[assignment]
+
+        assert any(
+            e["type"] == "connector.disabled"
+            and e["payload"] == {"connector_id": "mcp-github"}
+            for e in captured
+        )
+
+    def test_enable_emits_sse_event(self, ui_api_client, configured_mcp):
+        from gaia.ui.routers.connectors import _emitter
+
+        captured: list[dict] = []
+        original_emit = _emitter.emit
+
+        async def capture(event_type, payload):
+            captured.append({"type": event_type, "payload": payload})
+            await original_emit(event_type, payload)
+
+        _emitter.emit = capture  # type: ignore[assignment]
+        try:
+            ui_api_client.post("/api/connectors/mcp-github/disable", headers=UI_HEADER)
+            ui_api_client.post("/api/connectors/mcp-github/enable", headers=UI_HEADER)
+        finally:
+            _emitter.emit = original_emit  # type: ignore[assignment]
+
+        assert any(
+            e["type"] == "connector.enabled"
+            and e["payload"] == {"connector_id": "mcp-github"}
+            for e in captured
+        )
+
+
+class TestEnabledFieldInSummary:
+    def test_unconfigured_mcp_summary_has_enabled_true_default(
+        self, ui_api_client, mcp_spec_in_registry
+    ):
+        """An MCP that's never been configured still reports enabled=true so
+        the UI doesn't render a 'Disabled' pill on a fresh tile."""
+        resp = ui_api_client.get("/api/connectors/mcp-github")
+        body = resp.json()
+        assert body["configured"] is False
+        assert body["enabled"] is True
+
+    def test_configured_mcp_summary_reflects_disabled_flag(
+        self, ui_api_client, configured_mcp
+    ):
+        # Initially enabled
+        resp = ui_api_client.get("/api/connectors/mcp-github")
+        assert resp.json()["enabled"] is True
+
+        # Disable, then re-fetch
+        ui_api_client.post("/api/connectors/mcp-github/disable", headers=UI_HEADER)
+        resp = ui_api_client.get("/api/connectors/mcp-github")
+        assert resp.json()["enabled"] is False
+
+    def test_oauth_summary_always_reports_enabled_true(self, ui_api_client):
+        resp = ui_api_client.get("/api/connectors/google")
+        assert resp.json()["enabled"] is True


### PR DESCRIPTION
Closes #1004. Part of #927. **Builds on PR #998 — please merge that first.**

Users can now temporarily disable a configured MCP connector without losing its credentials or per-agent grants. Concrete user flow: toggle off GitHub MCP during a sensitive code review → toggle back on without re-pasting the PAT or re-granting agents.

The `disabled` flag was already persisted in `mcp_servers.json` and `MCPClientManager.load_from_config()` already skipped disabled entries. This PR adds the API/UI/live-reload wiring to drive it.

## What lands

- **Toggle row** in the connector detail view (above credentials), only when configured. Shows helper text when off.
- **Tile-level overflow menu** (⋯) for one-click enable/disable/disconnect without drilling in.
- **Tile status pill** flips to a warm-muted "Disabled" state (distinct from cool-muted "Not configured" so users see at a glance these are different states).
- **`POST /api/connectors/{id}/enable`** and `/disable` (CSRF-guarded, 400 on non-MCP types, 404 on unconfigured ids).
- **Live reload** — the lifespan wires a broadcast helper that calls `manager.reload()` on every cached ChatAgent's per-instance `MCPClientManager`. Toggling takes effect without restarting GAIA.

## Test plan

- [ ] `python -m pytest tests/unit/connectors/test_enable_disable.py -v` — 12 handler tests pass
- [ ] `python -m pytest tests/unit/connectors/test_router_connectors.py::TestEnableDisable -v` — 8 router tests pass
- [ ] `python -m pytest tests/unit/connectors/test_handler_reload_wired.py -v` — 4 wiring tests pass
- [ ] Manual: configure `mcp-github` with a PAT → ChatAgent uses tools → click ⋯ on the GitHub tile → Disable → ChatAgent no longer sees GitHub tools (no restart) → Enable → tools return → restart GAIA → state persists.
- [ ] `cd src/gaia/apps/webui && npx tsc --noEmit && npm run build`
- [ ] `python util/lint.py --all`