### PR TITLE
fix(blender): unblock send_command hang against persistent-connection server (#1022)

### DIFF
--- a/src/gaia/mcp/blender_mcp_client.py
+++ b/src/gaia/mcp/blender_mcp_client.py
@@ -43,7 +43,7 @@ class MCPClient:
         # Return original message if no enhancement is available
         return error_message
 
-    def send_command(self, cmd_type, params=None, timeout: float = 30.0):
+    def send_command(self, cmd_type, params=None, timeout: float = 120.0):
         """Send a command to the Blender MCP server and return the parsed response.
 
         The Blender addon (src/gaia/mcp/blender_mcp_server.py) keeps the TCP
@@ -53,6 +53,12 @@ class MCPClient:
         FIN. Instead we read incrementally and break as soon as a complete
         JSON document can be parsed, mirroring the server's own framing in
         ``blender_mcp_server.py:128-166``.
+
+        ``timeout`` is the per-recv socket timeout (not cumulative) — long
+        Blender operations like ``bpy.ops.render.render(...)`` can take many
+        seconds without the server emitting any data, so the default is
+        deliberately generous. Pass a higher value for very long renders or
+        simulations.
 
         Regression-tested by ``tests/unit/mcp/test_blender_mcp_client.py``.
         Fixes issue #1022.
@@ -76,12 +82,26 @@ class MCPClient:
                 # response parses out of the buffer. The server keeps the
                 # connection open afterwards (see docstring above), so a
                 # chunk-until-EOF loop would deadlock here.
+                #
+                # Catch UnicodeDecodeError as well as JSONDecodeError: a
+                # multi-byte UTF-8 character (e.g. an emoji or non-ASCII
+                # object name in an error message) can be split across
+                # ``recv()`` boundaries, raising UnicodeDecodeError on the
+                # partial buffer. Treat both as "keep reading".
                 buffer = b""
                 parsed_response = None
                 while True:
-                    chunk = sock.recv(65536)
+                    try:
+                        chunk = sock.recv(65536)
+                    except ConnectionResetError as e:
+                        # RST instead of FIN — server crashed or closed
+                        # forcefully mid-response. Same user-facing
+                        # outcome: we don't have a complete response.
+                        raise MCPError(
+                            "Connection closed before a complete response was received"
+                        ) from e
                     if not chunk:
-                        # Server closed without sending a full JSON response.
+                        # FIN before a complete JSON response.
                         raise MCPError(
                             "Connection closed before a complete response was received"
                         )
@@ -89,7 +109,7 @@ class MCPClient:
                     try:
                         parsed_response = json.loads(buffer.decode("utf-8"))
                         break
-                    except json.JSONDecodeError:
+                    except (json.JSONDecodeError, UnicodeDecodeError):
                         continue
 
                 if parsed_response["status"] == "error":

--- a/src/gaia/mcp/blender_mcp_client.py
+++ b/src/gaia/mcp/blender_mcp_client.py
@@ -43,7 +43,20 @@ class MCPClient:
         # Return original message if no enhancement is available
         return error_message
 
-    def send_command(self, cmd_type, params=None):
+    def send_command(self, cmd_type, params=None, timeout: float = 30.0):
+        """Send a command to the Blender MCP server and return the parsed response.
+
+        The Blender addon (src/gaia/mcp/blender_mcp_server.py) keeps the TCP
+        connection open after responding so it can accept further commands on
+        the same socket. We therefore cannot rely on ``recv()`` returning empty
+        (FIN) to know the response is complete — the server will never send
+        FIN. Instead we read incrementally and break as soon as a complete
+        JSON document can be parsed, mirroring the server's own framing in
+        ``blender_mcp_server.py:128-166``.
+
+        Regression-tested by ``tests/unit/mcp/test_blender_mcp_client.py``.
+        Fixes issue #1022.
+        """
         if params is None:
             params = {}
 
@@ -55,20 +68,29 @@ class MCPClient:
         # Send command to server
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(timeout)
                 sock.connect((self.host, self.port))
                 sock.sendall(json.dumps(command).encode("utf-8"))
 
-                # Receive full response (may arrive in multiple recv chunks)
-                chunks = []
+                # Read incrementally; stop as soon as a complete JSON
+                # response parses out of the buffer. The server keeps the
+                # connection open afterwards (see docstring above), so a
+                # chunk-until-EOF loop would deadlock here.
+                buffer = b""
+                parsed_response = None
                 while True:
                     chunk = sock.recv(65536)
                     if not chunk:
+                        # Server closed without sending a full JSON response.
+                        raise MCPError(
+                            "Connection closed before a complete response was received"
+                        )
+                    buffer += chunk
+                    try:
+                        parsed_response = json.loads(buffer.decode("utf-8"))
                         break
-                    chunks.append(chunk)
-                response = b"".join(chunks).decode("utf-8")
-
-                # Parse the JSON response
-                parsed_response = json.loads(response)
+                    except json.JSONDecodeError:
+                        continue
 
                 if parsed_response["status"] == "error":
                     error_message = parsed_response.get("message", "Unknown error")
@@ -82,6 +104,14 @@ class MCPClient:
         except ConnectionRefusedError:
             error_msg = "Connection refused. Is the Blender MCP server running?"
             self.log.error(f"Connection error: {error_msg}")
+            raise MCPError(error_msg)
+        except socket.timeout:
+            error_msg = (
+                f"Timed out after {timeout}s waiting for response from Blender MCP "
+                f"server at {self.host}:{self.port}. The server may be unresponsive — "
+                "check Blender's console for errors."
+            )
+            self.log.error(error_msg)
             raise MCPError(error_msg)
         except MCPError:
             # Re-raise MCPError without wrapping it

--- a/src/gaia/mcp/blender_mcp_client.py
+++ b/src/gaia/mcp/blender_mcp_client.py
@@ -4,11 +4,17 @@
 # This Blender MCP client is a simplified and modified version of the BlenderMCP project from https://github.com/BlenderMCP/blender-mcp
 
 import json
-import logging
 import re
 import socket
 
 from gaia.logger import get_logger
+
+# Defensive bound on response buffer size. A misbehaving server that
+# trickles bytes in just under the per-recv timeout would otherwise grow
+# the buffer without bound. Real Blender responses are KB-range; 16 MB
+# leaves enormous headroom (e.g. for execute_code returning large stdout
+# from a Blender Python script) while preventing pathological growth.
+_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
 
 
 class MCPError(Exception):
@@ -22,8 +28,9 @@ class MCPClient:
     def __init__(self, host="localhost", port=9876):
         self.host = host
         self.port = port
-        self.log = self.__class__.log  # Use the class-level logger for instances
-        self.log.setLevel(logging.INFO)
+        # Use the class-level logger; do not mutate global log level here —
+        # the user's logging config decides verbosity.
+        self.log = self.__class__.log
 
     def _enhance_error_message(self, error_message):
         """Enhance error messages with more helpful information."""
@@ -90,13 +97,19 @@ class MCPClient:
                 # partial buffer. Treat both as "keep reading".
                 buffer = b""
                 parsed_response = None
+                decoder = json.JSONDecoder()
                 while True:
                     try:
                         chunk = sock.recv(65536)
-                    except ConnectionResetError as e:
-                        # RST instead of FIN — server crashed or closed
-                        # forcefully mid-response. Same user-facing
-                        # outcome: we don't have a complete response.
+                    except (
+                        ConnectionResetError,
+                        ConnectionAbortedError,
+                        BrokenPipeError,
+                    ) as e:
+                        # RST / abort / broken pipe instead of FIN —
+                        # server crashed or closed forcefully mid-response.
+                        # Same user-facing outcome: we don't have a complete
+                        # response.
                         raise MCPError(
                             "Connection closed before a complete response was received"
                         ) from e
@@ -106,10 +119,28 @@ class MCPClient:
                             "Connection closed before a complete response was received"
                         )
                     buffer += chunk
+                    if len(buffer) > _MAX_RESPONSE_BYTES:
+                        raise MCPError(
+                            f"Response exceeded {_MAX_RESPONSE_BYTES} bytes "
+                            "without a parseable JSON document — refusing to "
+                            "buffer further (possible server misbehaviour)."
+                        )
+                    # Two-step parse: a multi-byte UTF-8 character split
+                    # across recv() boundaries raises UnicodeDecodeError,
+                    # not JSONDecodeError, so decode and parse separately.
                     try:
-                        parsed_response = json.loads(buffer.decode("utf-8"))
+                        text = buffer.decode("utf-8")
+                    except UnicodeDecodeError:
+                        continue
+                    # raw_decode parses the first complete JSON value and
+                    # tolerates trailing data, so a hypothetically pipelined
+                    # ``{"a":1}{"b":2}`` would yield the first object instead
+                    # of looping until timeout. The current server sends one
+                    # response per command, but this is cheap future-proofing.
+                    try:
+                        parsed_response, _ = decoder.raw_decode(text)
                         break
-                    except (json.JSONDecodeError, UnicodeDecodeError):
+                    except json.JSONDecodeError:
                         continue
 
                 if parsed_response["status"] == "error":
@@ -141,9 +172,18 @@ class MCPClient:
             self.log.error(error_msg)
             raise MCPError(error_msg)
 
-    def execute_code(self, code):
+    def execute_code(self, code, timeout: float = 600.0):
+        """Execute arbitrary Python code inside Blender.
+
+        Defaults to a 10-minute per-recv timeout (vs. 120s for other
+        commands) because ``execute_code`` is the path used for
+        rendering, simulations, and complex geometry generation —
+        operations that can legitimately sit silent for many seconds
+        between any output. Pass a higher ``timeout`` for very long
+        renders.
+        """
         self.log.debug("Executing code in Blender")
-        return self.send_command("execute_code", {"code": code})
+        return self.send_command("execute_code", {"code": code}, timeout=timeout)
 
     def get_scene_info(self):
         self.log.debug("Getting scene info")

--- a/tests/unit/mcp/test_blender_mcp_client.py
+++ b/tests/unit/mcp/test_blender_mcp_client.py
@@ -1,0 +1,163 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Socket-level tests for the Blender MCP client.
+
+Uses a fake persistent-connection server (no real Blender required) to
+verify that ``send_command`` does not deadlock against a server that
+keeps the connection open after responding — matching the real Blender
+addon's behaviour.
+
+Regression test for issue #1022: the client looped on ``recv()`` until
+the server sent FIN, but the Blender addon never closes the connection
+on its own, leading to a mutual-recv deadlock.
+"""
+
+import json
+import socket
+import threading
+import time
+
+import pytest
+
+from gaia.mcp.blender_mcp_client import MCPClient, MCPError
+
+
+class _PersistentServer:
+    """Fake server mimicking the Blender addon's connection model.
+
+    Accepts a single connection, reads one JSON command, sends a JSON
+    response via ``sendall``, and then *keeps the socket open* — the
+    same behaviour as ``SimpleBlenderMCPServer._handle_client`` in
+    ``src/gaia/mcp/blender_mcp_server.py``. A correctly-implemented
+    client must therefore stop reading as soon as it has parsed a
+    complete JSON response, rather than waiting for FIN.
+    """
+
+    def __init__(self, response: dict):
+        self.response = response
+        self.host = "127.0.0.1"
+        self.port = 0
+        self._sock = None
+        self._thread = None
+        self._stop = threading.Event()
+        self.received_command = None
+
+    def start(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((self.host, 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._sock.settimeout(2.0)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        try:
+            client, _ = self._sock.accept()
+        except socket.timeout:
+            return
+        client.settimeout(2.0)
+        try:
+            buffer = b""
+            while not self._stop.is_set():
+                try:
+                    chunk = client.recv(8192)
+                except socket.timeout:
+                    continue
+                if not chunk:
+                    break
+                buffer += chunk
+                try:
+                    self.received_command = json.loads(buffer.decode("utf-8"))
+                    break
+                except json.JSONDecodeError:
+                    continue
+            try:
+                client.sendall(json.dumps(self.response).encode("utf-8"))
+            except OSError:
+                return
+            # Crucially: do NOT close. Hold the socket open exactly like
+            # the real Blender addon, which is waiting for the next
+            # command on the same connection.
+            while not self._stop.is_set():
+                time.sleep(0.05)
+        finally:
+            try:
+                client.close()
+            except OSError:
+                pass
+
+    def stop(self):
+        self._stop.set()
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+
+@pytest.fixture
+def persistent_server():
+    server = _PersistentServer(
+        response={
+            "status": "success",
+            "result": {"object_count": 0, "message": "Scene cleared successfully"},
+        }
+    )
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def test_send_command_does_not_hang_with_persistent_server(persistent_server):
+    """Regression test for #1022.
+
+    The client must not loop on ``recv()`` waiting for a FIN that the
+    server never sends. We run the call inside a *daemon* thread so the
+    test fails fast (rather than hanging the suite) if the deadlock
+    comes back — daemon threads are abandoned when pytest exits, even
+    if blocked on ``recv()``.
+    """
+    client = MCPClient(host=persistent_server.host, port=persistent_server.port)
+    outcome: dict = {}
+
+    def _call():
+        try:
+            outcome["response"] = client.send_command("clear_scene")
+        except BaseException as exc:  # noqa: BLE001 — propagate to assertion
+            outcome["error"] = exc
+
+    worker = threading.Thread(target=_call, daemon=True)
+    worker.start()
+    worker.join(timeout=5.0)
+
+    if worker.is_alive():
+        pytest.fail(
+            "send_command hung against a persistent-connection server. "
+            "This is the #1022 regression — the client is waiting for "
+            "the server to send FIN, but the Blender addon keeps its "
+            "side of the connection open."
+        )
+    if "error" in outcome:
+        raise outcome["error"]
+
+    response = outcome["response"]
+    assert response["status"] == "success"
+    assert response["result"]["message"] == "Scene cleared successfully"
+    assert persistent_server.received_command == {
+        "type": "clear_scene",
+        "params": {},
+    }
+
+
+def test_send_command_raises_on_connection_refused():
+    """Connection-refused errors must surface as actionable MCPError."""
+    client = MCPClient(host="127.0.0.1", port=1)  # almost certainly nothing here
+    with pytest.raises(MCPError) as exc_info:
+        client.send_command("clear_scene")
+    assert "Connection refused" in str(exc_info.value)

--- a/tests/unit/mcp/test_blender_mcp_client.py
+++ b/tests/unit/mcp/test_blender_mcp_client.py
@@ -218,7 +218,11 @@ class _ChunkedServer:
                     break
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     continue
-            payload = json.dumps(self.response).encode("utf-8")
+            # ensure_ascii=False so non-ASCII content lands on the wire as
+            # raw multi-byte UTF-8, letting tests deliberately split the
+            # payload mid-codepoint to exercise the client's
+            # UnicodeDecodeError tolerance.
+            payload = json.dumps(self.response, ensure_ascii=False).encode("utf-8")
             try:
                 client.sendall(payload[: self.split_after])
                 time.sleep(self.gap_seconds)
@@ -247,12 +251,26 @@ class _ChunkedServer:
 def test_send_command_assembles_chunked_response():
     """The incremental-parse loop must reconstruct a JSON response that
     arrives across multiple recv() chunks (TCP segmentation)."""
+    response_dict = {
+        "status": "success",
+        "result": {"object_count": 0, "message": "Scene cleared 🧼"},
+    }
+    # Split halfway through the 4-byte UTF-8 encoding of the emoji to
+    # exercise the UnicodeDecodeError tolerance specifically. If we just
+    # picked an arbitrary offset it would land in pure ASCII (the bulk of
+    # the JSON) and never reach the multi-byte boundary, leaving that code
+    # path uncovered.
+    # Match the wire format _ChunkedServer will emit (ensure_ascii=False
+    # keeps the emoji as raw 4-byte UTF-8 instead of escaping to \uXXXX).
+    payload = json.dumps(response_dict, ensure_ascii=False).encode("utf-8")
+    emoji_bytes = "🧼".encode("utf-8")
+    assert len(emoji_bytes) == 4
+    emoji_start = payload.index(emoji_bytes)
+    mid_emoji = emoji_start + 2  # split inside the emoji, mid-codepoint
+
     server = _ChunkedServer(
-        response={
-            "status": "success",
-            "result": {"object_count": 0, "message": "Scene cleared 🧼"},
-        },
-        split_after=20,
+        response=response_dict,
+        split_after=mid_emoji,
         gap_seconds=0.05,
     )
     server.start()
@@ -277,10 +295,48 @@ def test_send_command_assembles_chunked_response():
 
         response = outcome["response"]
         assert response["status"] == "success"
-        # Non-ASCII payload exercises the UnicodeDecodeError tolerance:
-        # if split_after lands mid-emoji, the partial buffer would raise
-        # UnicodeDecodeError; the loop must keep reading instead of dying.
-        assert "🧼" in response["result"]["message"]
+        # The emoji must have been reconstructed across the mid-codepoint
+        # split — proves the UnicodeDecodeError tolerance is exercised.
+        assert response["result"]["message"] == "Scene cleared 🧼"
+    finally:
+        server.stop()
+
+
+def test_send_command_surfaces_enhanced_error_message():
+    """When the server returns ``{"status": "error", "message": ...}``,
+    the client must run the message through ``_enhance_error_message``
+    before raising — so a bare NameError ("name 'foo' is not defined")
+    becomes a more actionable message for the LLM/user."""
+    server = _PersistentServer(
+        response={
+            "status": "error",
+            "message": "name 'undefined_var' is not defined",
+        }
+    )
+    server.start()
+    try:
+        client = MCPClient(host=server.host, port=server.port)
+        outcome: dict = {}
+
+        def _call():
+            try:
+                client.send_command("execute_code", {"code": "undefined_var + 1"})
+            except BaseException as exc:  # noqa: BLE001
+                outcome["error"] = exc
+
+        worker = threading.Thread(target=_call, daemon=True)
+        worker.start()
+        worker.join(timeout=5.0)
+
+        if worker.is_alive():
+            pytest.fail("send_command hung against an error-response server")
+        assert "error" in outcome, "expected MCPError, got nothing"
+        err = outcome["error"]
+        assert isinstance(err, MCPError)
+        # _enhance_error_message rewrites NameError-shaped messages
+        # into a friendlier, actionable form.
+        assert "undefined_var" in str(err)
+        assert "Make sure to declare it before use" in str(err)
     finally:
         server.stop()
 

--- a/tests/unit/mcp/test_blender_mcp_client.py
+++ b/tests/unit/mcp/test_blender_mcp_client.py
@@ -157,7 +157,179 @@ def test_send_command_does_not_hang_with_persistent_server(persistent_server):
 
 def test_send_command_raises_on_connection_refused():
     """Connection-refused errors must surface as actionable MCPError."""
-    client = MCPClient(host="127.0.0.1", port=1)  # almost certainly nothing here
+    # Bind a socket to grab a free port, then close it; subsequent
+    # connect() to that port should reliably get ECONNREFUSED across
+    # platforms and CI sandboxes.
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    free_port = probe.getsockname()[1]
+    probe.close()
+
+    client = MCPClient(host="127.0.0.1", port=free_port)
     with pytest.raises(MCPError) as exc_info:
-        client.send_command("clear_scene")
+        client.send_command("clear_scene", timeout=2.0)
     assert "Connection refused" in str(exc_info.value)
+
+
+class _ChunkedServer:
+    """Like _PersistentServer but writes the response in two send() calls
+    with a small delay, to exercise the client's incremental-parse loop."""
+
+    def __init__(
+        self, response: dict, split_after: int = 30, gap_seconds: float = 0.05
+    ):
+        self.response = response
+        self.split_after = split_after
+        self.gap_seconds = gap_seconds
+        self.host = "127.0.0.1"
+        self.port = 0
+        self._sock = None
+        self._thread = None
+        self._stop = threading.Event()
+
+    def start(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((self.host, 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._sock.settimeout(2.0)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        try:
+            client, _ = self._sock.accept()
+        except socket.timeout:
+            return
+        client.settimeout(2.0)
+        try:
+            buffer = b""
+            while not self._stop.is_set():
+                try:
+                    chunk = client.recv(8192)
+                except socket.timeout:
+                    continue
+                if not chunk:
+                    break
+                buffer += chunk
+                try:
+                    json.loads(buffer.decode("utf-8"))
+                    break
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+            payload = json.dumps(self.response).encode("utf-8")
+            try:
+                client.sendall(payload[: self.split_after])
+                time.sleep(self.gap_seconds)
+                client.sendall(payload[self.split_after :])
+            except OSError:
+                return
+            # Hold the connection open like the real Blender addon.
+            while not self._stop.is_set():
+                time.sleep(0.05)
+        finally:
+            try:
+                client.close()
+            except OSError:
+                pass
+
+    def stop(self):
+        self._stop.set()
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+
+def test_send_command_assembles_chunked_response():
+    """The incremental-parse loop must reconstruct a JSON response that
+    arrives across multiple recv() chunks (TCP segmentation)."""
+    server = _ChunkedServer(
+        response={
+            "status": "success",
+            "result": {"object_count": 0, "message": "Scene cleared 🧼"},
+        },
+        split_after=20,
+        gap_seconds=0.05,
+    )
+    server.start()
+    try:
+        client = MCPClient(host=server.host, port=server.port)
+        outcome: dict = {}
+
+        def _call():
+            try:
+                outcome["response"] = client.send_command("clear_scene", timeout=5.0)
+            except BaseException as exc:  # noqa: BLE001
+                outcome["error"] = exc
+
+        worker = threading.Thread(target=_call, daemon=True)
+        worker.start()
+        worker.join(timeout=5.0)
+
+        if worker.is_alive():
+            pytest.fail("send_command hung against a chunked-response server")
+        if "error" in outcome:
+            raise outcome["error"]
+
+        response = outcome["response"]
+        assert response["status"] == "success"
+        # Non-ASCII payload exercises the UnicodeDecodeError tolerance:
+        # if split_after lands mid-emoji, the partial buffer would raise
+        # UnicodeDecodeError; the loop must keep reading instead of dying.
+        assert "🧼" in response["result"]["message"]
+    finally:
+        server.stop()
+
+
+def test_send_command_raises_on_premature_close():
+    """If the server closes before sending a full JSON response, the
+    client must surface a clear MCPError rather than returning garbage."""
+
+    class _PrematureCloseServer:
+        def __init__(self):
+            self.host = "127.0.0.1"
+            self.port = 0
+            self._sock = None
+            self._thread = None
+
+        def start(self):
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._sock.bind((self.host, 0))
+            self._sock.listen(1)
+            self.port = self._sock.getsockname()[1]
+            self._sock.settimeout(2.0)
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+
+        def _run(self):
+            try:
+                client, _ = self._sock.accept()
+            except socket.timeout:
+                return
+            try:
+                # Send a fragment that cannot parse as JSON, then close.
+                client.sendall(b'{"status": "succ')
+                client.close()
+            except OSError:
+                pass
+
+        def stop(self):
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+
+    server = _PrematureCloseServer()
+    server.start()
+    try:
+        client = MCPClient(host=server.host, port=server.port)
+        with pytest.raises(MCPError) as exc_info:
+            client.send_command("clear_scene", timeout=3.0)
+        assert "Connection closed" in str(exc_info.value)
+    finally:
+        server.stop()


### PR DESCRIPTION
## Why this matters

Before: on v0.17.6, running `gaia blender ...` against the Blender MCP addon hangs forever after the first tool call (e.g. `clear_scene`), and Ctrl-C does not interrupt it. Reported in #1022.

After: `send_command` reads the response incrementally and returns as soon as a complete JSON document parses out of the buffer — matching the framing the server already uses. A 30 s socket timeout also keeps Ctrl-C responsive.

The bug was a protocol mismatch between client and server: the client looped on `recv()` until FIN, but the Blender addon keeps the connection open to accept further commands on the same socket, so FIN never came. Both ends ended up blocked on `recv()` waiting for each other.

Adds `tests/unit/mcp/test_blender_mcp_client.py` — a socket-level regression test using a fake persistent-connection server. Runs in CI without a Blender install.

Fixes #1022. Plan for the broader Blender modernization is tracked in #1025.

## Test plan

- [x] \`pytest tests/unit/mcp/test_blender_mcp_client.py -v\` — passes in <1 s
- [x] \`pytest src/gaia/agents/blender/tests/test_mcp_client.py -v\` — still skips cleanly without a Blender server
- [x] \`python util/lint.py --black --isort\` — clean
- [ ] Manual smoke: \`gaia blender --example 1\` against a real Blender 4.5 + addon (delegated to issue reporter via #1022)