### PR TITLE
fix(agent): repair Windows-path tool args; gate SD override (#1023)

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -64,6 +64,49 @@ TOOLS_REQUIRING_CONFIRMATION = {
 }
 
 
+# Issue #1023: smaller LLMs (Gemma-4-E4B-class) sometimes emit Windows paths
+# in tool-call arguments with single backslashes (e.g. ``C:\Users\Klaus``)
+# where strict JSON requires the backslashes doubled.  ``json.loads`` rejects
+# any backslash NOT followed by one of: " \ / b f n r t u  -- so ``\U`` (and
+# the other dozen-or-so cases) errors with "Invalid \escape: ...".
+# ``_repair_invalid_json_escapes`` doubles only the offending backslashes,
+# leaving valid escapes (\n, \t, \uXXXX, etc.) untouched.  Idempotent.
+#
+# The pattern matches a backslash followed by one character (DOTALL so the
+# next char can also be a newline).  The replacement callback decides whether
+# to keep the pair (valid escape) or double the leading backslash (invalid).
+# Consuming the pair in a single match -- rather than just matching the lone
+# backslash -- keeps the function idempotent: running it twice on ``\\X``
+# does not produce ``\\\\X``.
+_JSON_BACKSLASH_PAIR_RE = re.compile(r"\\(.)", re.DOTALL)
+_VALID_JSON_ESCAPE_NEXT_CHARS = frozenset('"\\/bfnrtu')
+
+
+def _repair_invalid_json_escapes(s: str) -> str:
+    """Double any backslash that strict JSON would reject as an invalid escape.
+
+    Used as a one-shot recovery pass when ``json.loads`` raises on tool-call
+    arguments emitted by under-escaping LLMs.  Already-valid JSON is returned
+    unchanged (idempotent).
+    """
+
+    def _fix(match: "re.Match[str]") -> str:
+        nxt = match.group(1)
+        if nxt in _VALID_JSON_ESCAPE_NEXT_CHARS:
+            return match.group(0)
+        return "\\\\" + nxt
+
+    return _JSON_BACKSLASH_PAIR_RE.sub(_fix, s)
+
+
+# Capability tools whose post-call outcome (success / error) gates the
+# verbose-failure override in ``process_query``.  Currently a single-element
+# tuple, but kept as a tuple to mirror the prefix-match style used elsewhere
+# (``startswith``) and so future capability tools (e.g. ``generate_video``)
+# slot in without restructuring the guard logic.
+_SD_CAPABILITY_TOOLS = ("generate_image",)
+
+
 class Agent(abc.ABC):
     """
     Base Agent class that provides core functionality for domain-specific agents.
@@ -1041,13 +1084,36 @@ Do NOT wrap conversational replies in JSON.
             elif isinstance(arguments_raw, dict):
                 tool_args = arguments_raw
             elif isinstance(arguments_raw, (str, bytes, bytearray)):
+                args_str = (
+                    arguments_raw.decode("utf-8")
+                    if isinstance(arguments_raw, (bytes, bytearray))
+                    else arguments_raw
+                )
                 try:
-                    tool_args = json.loads(arguments_raw)
+                    tool_args = json.loads(args_str)
                 except json.JSONDecodeError as exc:
-                    raise ValueError(
-                        f"Malformed tool_call arguments for '{name}': {exc}. "
-                        f"Raw arguments: {str(arguments_raw)[:200]}"
-                    ) from exc
+                    # Issue #1023: Windows paths emitted with single
+                    # backslashes (``C:\Users\Klaus``) -> ``\U`` is invalid
+                    # JSON.  Repair invalid escapes and retry once before
+                    # surfacing the error to the recovery layer.
+                    repaired = _repair_invalid_json_escapes(args_str)
+                    if repaired == args_str:
+                        raise ValueError(
+                            f"Malformed tool_call arguments for '{name}': {exc}. "
+                            f"Raw arguments: {args_str[:200]}"
+                        ) from exc
+                    try:
+                        tool_args = json.loads(repaired)
+                    except json.JSONDecodeError as exc2:
+                        raise ValueError(
+                            f"Malformed tool_call arguments for '{name}': {exc2}. "
+                            f"Raw arguments: {args_str[:200]}"
+                        ) from exc2
+                    logger.debug(
+                        "[PARSE] repaired invalid backslash escape(s) in "
+                        "tool_call args for '%s'",
+                        name,
+                    )
             else:
                 # Unexpected shape (list / int / None-ish) — treat as malformed
                 # so the recovery layer in process_query nudges the model to
@@ -1903,6 +1969,12 @@ Do NOT wrap conversational replies in JSON.
         tool_call_log = (
             []
         )  # Full unbounded log of all tool calls this turn (for workflow guards)
+        # Issue #1023: track the latest outcome of any capability tool
+        # (currently ``generate_image``) so the verbose-failure override
+        # downstream fires only when the tool actually errored.  ``None``
+        # = not called yet, ``True`` = last call succeeded, ``False`` =
+        # last call returned an error.
+        capability_tool_last_succeeded: Optional[bool] = None
         query_result_cache: dict[str, int] = (
             {}
         )  # result_hash → call count (result-based dedup)
@@ -2014,6 +2086,15 @@ Do NOT wrap conversational replies in JSON.
 
                     # Stop progress indicator
                     self.console.stop_progress()
+
+                    # Issue #1023: record success/failure of capability tools
+                    # so the verbose-failure override downstream can fire
+                    # only when the tool actually errored.
+                    if any(tool_name.startswith(_s) for _s in _SD_CAPABILITY_TOOLS):
+                        capability_tool_last_succeeded = not (
+                            isinstance(tool_result, dict)
+                            and tool_result.get("status") in ("error", "denied")
+                        )
 
                     # Handle domain-specific post-processing
                     self._post_process_tool_result(tool_name, tool_args, tool_result)
@@ -2904,6 +2985,15 @@ Do NOT wrap conversational replies in JSON.
                 # Stop progress indicator
                 self.console.stop_progress()
 
+                # Issue #1023: record success/failure of capability tools so
+                # the verbose-failure override downstream fires only when the
+                # tool actually errored.
+                if any(tool_name.startswith(_s) for _s in _SD_CAPABILITY_TOOLS):
+                    capability_tool_last_succeeded = not (
+                        isinstance(tool_result, dict)
+                        and tool_result.get("status") in ("error", "denied")
+                    )
+
                 # Result-based dedup: if this tool (query family) returns the same result
                 # it returned in a prior call, inject a correction so the agent stops looping.
                 _QUERY_TOOLS = (
@@ -3271,9 +3361,8 @@ Do NOT wrap conversational replies in JSON.
                     r"i can.*create.*image",
                     r"when.*--sd",
                 ]
-                _SD_TOOLS = ("generate_image",)
                 has_tried_capability_tool = any(
-                    any(_tname.lower().startswith(_s) for _s in _SD_TOOLS)
+                    any(_tname.lower().startswith(_s) for _s in _SD_CAPABILITY_TOOLS)
                     for _tname, _ in tool_call_log
                 )
                 is_capability_claim = any(
@@ -3360,7 +3449,18 @@ Do NOT wrap conversational replies in JSON.
                 # Post-failure verbosity guard: when generate_image was called and
                 # failed, the LLM often apologises and explains "what it would have done"
                 # with prompt-engineering tips. Intercept and replace with a clean response.
-                if has_tried_capability_tool:
+                #
+                # Issue #1023: gate on the LATEST outcome of the capability tool.
+                # When generate_image succeeded and a *different* tool's parse
+                # error provoked a verbose apology, the override used to clobber
+                # the model's reply with a misleading "Image generation is not
+                # available" message even though the image was generated.  Now
+                # the override fires only when the most recent capability call
+                # actually returned an error.
+                if (
+                    has_tried_capability_tool
+                    and capability_tool_last_succeeded is False
+                ):
                     _SD_POST_FAILURE_VERBOSE = [
                         r"would have done",
                         r"what i would",

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -2089,8 +2089,13 @@ Do NOT wrap conversational replies in JSON.
 
                     # Issue #1023: record success/failure of capability tools
                     # so the verbose-failure override downstream can fire
-                    # only when the tool actually errored.
-                    if any(tool_name.startswith(_s) for _s in _SD_CAPABILITY_TOOLS):
+                    # only when the tool actually errored.  ``.lower()``
+                    # mirrors the defensive check at
+                    # ``has_tried_capability_tool`` so a model that emits
+                    # ``Generate_Image`` doesn't slip past the tracker.
+                    if any(
+                        tool_name.lower().startswith(_s) for _s in _SD_CAPABILITY_TOOLS
+                    ):
                         capability_tool_last_succeeded = not (
                             isinstance(tool_result, dict)
                             and tool_result.get("status") in ("error", "denied")
@@ -2987,8 +2992,10 @@ Do NOT wrap conversational replies in JSON.
 
                 # Issue #1023: record success/failure of capability tools so
                 # the verbose-failure override downstream fires only when the
-                # tool actually errored.
-                if any(tool_name.startswith(_s) for _s in _SD_CAPABILITY_TOOLS):
+                # tool actually errored.  ``.lower()`` mirrors the defensive
+                # check at ``has_tried_capability_tool`` so a model that emits
+                # ``Generate_Image`` doesn't slip past the tracker.
+                if any(tool_name.lower().startswith(_s) for _s in _SD_CAPABILITY_TOOLS):
                     capability_tool_last_succeeded = not (
                         isinstance(tool_result, dict)
                         and tool_result.get("status") in ("error", "denied")

--- a/tests/unit/agents/test_parse_error_recovery.py
+++ b/tests/unit/agents/test_parse_error_recovery.py
@@ -183,3 +183,175 @@ class TestProcessQueryRecoversOnContextOverflow:
             # No raw exception leaked
             assert "exceeds the available context size" not in text
             assert "Traceback" not in text
+
+
+class TestRepairInvalidJsonEscapes:
+    """Helper that doubles invalid JSON backslash escapes (e.g. Windows paths).
+
+    Issue #1023: smaller LLMs (Gemma-4-E4B-class) sometimes emit Windows paths
+    in tool-call arguments with single backslashes. Strict ``json.loads``
+    rejects ``\\U`` (and any other backslash followed by a non-escape char).
+    """
+
+    def test_doubles_backslash_before_invalid_escape_char(self):
+        """`C:\\Users\\K` (single-escaped) becomes parseable JSON after repair."""
+        from gaia.agents.base.agent import _repair_invalid_json_escapes
+
+        bad = r'{"path":"C:\Users\K"}'
+        # Sanity: input is genuinely invalid JSON without repair.
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(bad)
+        repaired = _repair_invalid_json_escapes(bad)
+        assert json.loads(repaired) == {"path": r"C:\Users\K"}
+
+    def test_preserves_valid_json_escape_sequences(self):
+        """Valid escapes (\\n \\t \\\\ \\" \\u00ff) must pass through unchanged."""
+        from gaia.agents.base.agent import _repair_invalid_json_escapes
+
+        valid = (
+            r'{"text":"line1\nline2\ttab","quote":"\"",'
+            r'"unicode":"ÿ","slash":"a\\b"}'
+        )
+        before = json.loads(valid)
+        repaired = _repair_invalid_json_escapes(valid)
+        assert json.loads(repaired) == before
+
+    def test_idempotent_on_already_repaired_string(self):
+        """Running repair twice gives the same result as running it once."""
+        from gaia.agents.base.agent import _repair_invalid_json_escapes
+
+        bad = r'{"a":"\X","b":"\W"}'
+        once = _repair_invalid_json_escapes(bad)
+        twice = _repair_invalid_json_escapes(once)
+        assert once == twice
+        # And the result actually parses.
+        assert json.loads(once) == {"a": r"\X", "b": r"\W"}
+
+
+class TestParseLLMResponseRecoversFromInvalidEscapes:
+    """Issue #1023: tool-call arguments with under-escaped Windows paths."""
+
+    def test_windows_path_with_single_escapes_parses_via_repair(self, agent):
+        """Reproduces #1023 step 2: ``C:\\Users\\Klaus\\img.png`` parses cleanly."""
+        # The arguments string the LLM emitted (under-escaped backslashes).
+        # ``r"..."`` keeps backslashes literal -- this is what the outer JSON
+        # decoder hands to the inner ``json.loads(arguments_raw)`` call.
+        malformed_inner = (
+            r'{"image_path":"C:\Users\Klaus\.gaia\cache\sd\images\img.png",'
+            r'"story_style":"dramatic"}'
+        )
+        # Sanity: confirm the input is genuinely invalid JSON without repair.
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(malformed_inner)
+
+        # Build the full LLM response envelope. ``json.dumps`` encodes the
+        # outer level correctly while keeping the inner string verbatim.
+        response = json.dumps(
+            {
+                "__tool_calls__": [
+                    {
+                        "function": {
+                            "name": "create_story_from_image",
+                            "arguments": malformed_inner,
+                        }
+                    }
+                ]
+            }
+        )
+
+        parsed = agent._parse_llm_response(response)
+        assert parsed["tool"] == "create_story_from_image"
+        assert parsed["tool_args"]["image_path"] == (
+            r"C:\Users\Klaus\.gaia\cache\sd\images\img.png"
+        )
+        assert parsed["tool_args"]["story_style"] == "dramatic"
+
+    def test_truly_malformed_args_still_raise_after_repair_attempt(self, agent):
+        """When repair cannot fix the JSON, ValueError still propagates."""
+        # Truncated/corrupt -- repair won't help, error must still surface.
+        broken = (
+            '{"__tool_calls__": [{"function": {"name": "x",'
+            ' "arguments": "{not-json:"}}]}'
+        )
+        with pytest.raises(ValueError, match="Malformed"):
+            agent._parse_llm_response(broken)
+
+
+class TestPostFailureOverrideSkippedAfterCapabilitySuccess:
+    """Issue #1023 step 3: the verbose-failure override at process_query
+    must NOT fire when the capability tool (``generate_image``) succeeded.
+
+    The original guard fired solely on ``has_tried_capability_tool`` --
+    "was generate_image called this turn?" -- with no check on whether the
+    call actually returned an error.  As a result, when generate_image
+    succeeded and a SUBSEQUENT tool's parse error provoked a verbose
+    apology, the override clobbered the model's reply with a misleading
+    "Image generation is not available" message.
+    """
+
+    def _stub_chat(self, agent, *responses):
+        responses = list(responses)
+        chat = MagicMock()
+
+        def _send(*_, **__):
+            r = responses.pop(0)
+            resp = MagicMock()
+            resp.text = r
+            resp.stats = {}
+            return resp
+
+        chat.send_messages = MagicMock(side_effect=_send)
+        agent.chat = chat
+        return chat
+
+    def test_override_skipped_when_generate_image_succeeded(self, agent):
+        """generate_image returned success -> verbose model reply is preserved."""
+        # Inject a fake generate_image into the agent's instance registry.
+        # _instance_tools is per-instance, so this does not pollute the global
+        # _TOOL_REGISTRY or other tests.
+        agent._instance_tools = {
+            "generate_image": {
+                "name": "generate_image",
+                "description": "stub",
+                "parameters": {
+                    "prompt": {"type": "string", "required": True},
+                },
+                "function": lambda prompt="": {
+                    "status": "success",
+                    "image_path": r"C:\Users\K\img.png",
+                    "model": "SDXL-Turbo",
+                },
+                "atomic": True,
+            }
+        }
+
+        # Step 1: model calls generate_image (succeeds).
+        step1 = json.dumps(
+            {"tool": "generate_image", "tool_args": {"prompt": "a forest"}}
+        )
+        # Step 2: malformed tool call -> parse fails -> recovery prompt added.
+        step2 = (
+            '{"__tool_calls__": [{"function":'
+            ' {"name": "make_story", "arguments": "{not-json:"}}]}'
+        )
+        # Step 3: model responds with phrasing that matches the verbose-failure
+        # regex (``r"i apologize for the confusion"``).  After the fix, this
+        # text passes through unchanged because generate_image SUCCEEDED.
+        step3 = json.dumps(
+            {
+                "answer": (
+                    "I apologize for the confusion. "
+                    "The image was generated successfully."
+                )
+            }
+        )
+        self._stub_chat(agent, step1, step2, step3)
+
+        result = agent.process_query("make me an image", max_steps=10)
+        # ``process_query`` returns ``{"status": ..., "result": <final_answer>, ...}``
+        text = result["result"]
+
+        # The hardcoded override message must NOT replace the model's reply.
+        assert "Image generation is not available" not in text
+        # And the model's actual answer must be visible.
+        assert "image was generated successfully" in text.lower()

--- a/tests/unit/agents/test_parse_error_recovery.py
+++ b/tests/unit/agents/test_parse_error_recovery.py
@@ -304,11 +304,21 @@ class TestPostFailureOverrideSkippedAfterCapabilitySuccess:
         agent.chat = chat
         return chat
 
-    def test_override_skipped_when_generate_image_succeeded(self, agent):
-        """generate_image returned success -> verbose model reply is preserved."""
-        # Inject a fake generate_image into the agent's instance registry.
-        # _instance_tools is per-instance, so this does not pollute the global
-        # _TOOL_REGISTRY or other tests.
+    def _register_generate_image(self, agent, *, status: str = "success") -> None:
+        """Inject a fake generate_image into the agent's instance registry.
+
+        ``_instance_tools`` is per-instance, so this does not pollute the
+        global ``_TOOL_REGISTRY`` or other tests.
+        """
+        result = (
+            {
+                "status": "success",
+                "image_path": r"C:\Users\K\img.png",
+                "model": "SDXL-Turbo",
+            }
+            if status == "success"
+            else {"status": "error", "error": "SD backend not available"}
+        )
         agent._instance_tools = {
             "generate_image": {
                 "name": "generate_image",
@@ -316,14 +326,14 @@ class TestPostFailureOverrideSkippedAfterCapabilitySuccess:
                 "parameters": {
                     "prompt": {"type": "string", "required": True},
                 },
-                "function": lambda prompt="": {
-                    "status": "success",
-                    "image_path": r"C:\Users\K\img.png",
-                    "model": "SDXL-Turbo",
-                },
+                "function": lambda prompt="", _r=result: _r,
                 "atomic": True,
             }
         }
+
+    def test_override_skipped_when_generate_image_succeeded(self, agent):
+        """generate_image returned success -> verbose model reply is preserved."""
+        self._register_generate_image(agent, status="success")
 
         # Step 1: model calls generate_image (succeeds).
         step1 = json.dumps(
@@ -355,3 +365,87 @@ class TestPostFailureOverrideSkippedAfterCapabilitySuccess:
         assert "Image generation is not available" not in text
         # And the model's actual answer must be visible.
         assert "image was generated successfully" in text.lower()
+
+    def test_override_still_fires_when_generate_image_failed(self, agent):
+        """Regression guard: legitimate failure path keeps the canonical message.
+
+        Pairs with the post-success test above.  Without this, the gate
+        could be (intentionally or accidentally) widened to skip the
+        override unconditionally and only the post-success test would
+        catch it -- leaving the legitimate "SD not enabled" UX broken.
+        """
+        self._register_generate_image(agent, status="error")
+
+        # Step 1: model calls generate_image (returns error).
+        step1 = json.dumps(
+            {"tool": "generate_image", "tool_args": {"prompt": "a forest"}}
+        )
+        # Step 2: model emits a verbose-apology answer matching the
+        # ``i apologize for the confusion`` pattern.  Because the
+        # capability tool actually FAILED, the override must replace
+        # this with the canonical "Image generation is not available"
+        # message -- preserving the pre-existing UX for the legitimate
+        # "SD not enabled" case.
+        step2 = json.dumps(
+            {
+                "answer": (
+                    "I apologize for the confusion. Let me explain what "
+                    "I would have done with prompt enhancement..."
+                )
+            }
+        )
+        self._stub_chat(agent, step1, step2)
+
+        result = agent.process_query("make me an image", max_steps=10)
+        text = result["result"]
+
+        # The override fired and replaced the verbose apology with the
+        # canonical "not available" message.
+        assert "Image generation is not available" in text
+
+    def test_override_fires_after_mixed_case_capability_failure(self, agent):
+        """The tracker must be case-insensitive (mirrors ``has_tried_capability_tool``).
+
+        Models occasionally emit tool names with non-canonical casing
+        (``Generate_Image``).  The dispatcher resolves these via
+        ``_resolve_tool_name`` for execution, but ``tool_call_log`` records
+        the un-normalized name -- so both the pre-existing
+        ``has_tried_capability_tool`` check and the new
+        ``capability_tool_last_succeeded`` tracker must apply ``.lower()``
+        for the gate to evaluate consistently.
+
+        The interesting failure mode is **mixed-case + tool error**:
+        without ``.lower()``, the tracker silently stays at ``None``, and
+        ``None is False`` is False, so the override DOESN'T fire even
+        though the capability tool legitimately errored.  The user would
+        then see a verbose model apology instead of the canonical "not
+        available" message.  This test pins that down.
+        """
+        # generate_image returns an error this time.
+        self._register_generate_image(agent, status="error")
+
+        # Step 1: model emits the tool name with mixed case.  The
+        # dispatcher resolves "Generate_Image" -> "generate_image" but
+        # ``tool_call_log`` records the original LLM-emitted casing.
+        step1 = json.dumps(
+            {"tool": "Generate_Image", "tool_args": {"prompt": "a forest"}}
+        )
+        # Step 2: verbose-apology answer that matches the failure-override
+        # regex.  With ``.lower()`` the tracker correctly registered Step
+        # 1's failure, so the gate fires and replaces this with the
+        # canonical "not available" message.
+        step2 = json.dumps(
+            {
+                "answer": (
+                    "I apologize for the confusion. Let me explain what "
+                    "I would have done with prompt enhancement..."
+                )
+            }
+        )
+        self._stub_chat(agent, step1, step2)
+
+        result = agent.process_query("make me an image", max_steps=10)
+        text = result["result"]
+
+        # Override fired despite the mixed-case tool name.
+        assert "Image generation is not available" in text

--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -15,7 +15,6 @@ share the ``revoke_all_grants_for`` helper.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
 from unittest.mock import patch
 


### PR DESCRIPTION
## Why this matters

`gaia sd <prompt>` on Windows would generate an image successfully in Step 1 but then return *"Image generation is not available — start GAIA with the `--sd` flag to enable it"* in Step 2 — telling the user to enable a feature that was already on, while silently dropping the story output.

Two stacked bugs:

- **Parse fragility** — the native tool_calls parser strictly required JSON-valid backslash escapes, but the LLM probabilistically emits `C:\Users\Klaus` (single-escape) which JSON rejects as `Invalid \escape: \U`. Now repaired before re-raise; idempotent and lossless on already-valid input.
- **Overaggressive verbose-failure override** — the post-failure guard fired whenever `generate_image` had been *called* this turn, even when it *succeeded*. Now gated on the latest capability call actually erroring.

## Test plan

- [ ] `pytest tests/unit/agents/test_parse_error_recovery.py` — 5 new tests + 6 pre-existing all pass
- [ ] `pytest tests/unit/agents/ tests/unit/test_sd_agent.py tests/unit/test_tool_call_priority.py` — 190 pass, no regressions
- [ ] Manual on Windows: `gaia sd "a forest" --logging-level DEBUG` — Step 2 parses the Windows path, story appears in the final answer (not the misleading "--sd" message)

Closes #1023