### PR TITLE
fix(mcp): make keyring a true optional dependency in _resolve_keyring_refs

### DIFF
--- a/src/gaia/mcp/client/mcp_client.py
+++ b/src/gaia/mcp/client/mcp_client.py
@@ -37,15 +37,29 @@ def _resolve_keyring_refs(env: Optional[Dict[str, Any]]) -> Dict[str, str]:
     """
     if not env:
         return {}
-    import keyring  # pylint: disable=import-outside-toplevel
 
-    from gaia.connectors.errors import ConnectorsError
-    from gaia.connectors.store import SERVICE_NAME
+    # Imports (keyring + connectors) are deferred to the branch that
+    # actually needs them. ``keyring`` is an optional dependency — if
+    # the env contains no ``$keyring`` references, plain values must
+    # pass through without forcing a keyring install.
+    keyring = None  # populated on first $keyring reference
+    SERVICE_NAME = None
+    ConnectorsError: type = Exception  # type: ignore[assignment]
 
     resolved: Dict[str, str] = {}
     missing: list[str] = []
     for key, value in env.items():
         if isinstance(value, dict) and "$keyring" in value:
+            if keyring is None:
+                # pylint: disable=import-outside-toplevel
+                import keyring as _keyring  # noqa: I001
+
+                from gaia.connectors.errors import ConnectorsError as _ConnectorsError
+                from gaia.connectors.store import SERVICE_NAME as _SERVICE_NAME
+
+                keyring = _keyring
+                ConnectorsError = _ConnectorsError
+                SERVICE_NAME = _SERVICE_NAME
             ref = value["$keyring"]
             service, _, username = ref.partition(":")
             if service != SERVICE_NAME:

--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -15,7 +15,6 @@ share the ``revoke_all_grants_for`` helper.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
 from unittest.mock import patch
 


### PR DESCRIPTION
## Why this matters

Before: \`tests/unit/mcp/client/test_mcp_client.py::test_from_config_accepts_env\` fails at import on any dev environment without the optional \`keyring\` package, even though that test only passes plain string env vars and never exercises the \`\$keyring\` path. The unconditional \`import keyring\` at the top of \`_resolve_keyring_refs\` made keyring a hard dependency in practice for *every* config-driven MCP server load.

After: imports for \`keyring\`, \`ConnectorsError\`, and \`SERVICE_NAME\` are deferred to the branch that actually needs them. Plain-env callers stay zero-dep on keyring; the security invariants and error handling for real \`\$keyring\` references are unchanged.

Caught while reviewing #1026 — pre-existing issue, not introduced by that PR.

## Test plan

- [x] \`pytest tests/unit/mcp/client/ -v\` — 25/25 pass (previously 24 pass + 1 fail)
- [x] \`python util/lint.py --black --isort\` — clean