### PR TITLE
fix(installer): drop bogus 'gaia chat init' from post-install banner (#1024)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,8 +657,8 @@ The documentation is organized in [`docs/docs.json`](docs/docs.json) with the fo
 Thanks for reporting this! The error you're seeing in `gaia chat` appears to be related to RAG initialization.
 
 Looking at src/gaia/rag/sdk.py:145, the initialization expects a model path. Could you confirm:
-1. Did you run `gaia chat init` first?
-2. What's the output of `gaia chat status`?
+1. Did you run `gaia init --profile chat` first?
+2. Could you share the output of `gaia diagnostics`?
 
 See docs/guides/chat.mdx for the full setup process. This might also be related to #123.
 ```

--- a/docs/guides/chat.mdx
+++ b/docs/guides/chat.mdx
@@ -129,6 +129,13 @@ RAG (Retrieval-Augmented Generation) enables chatting with PDF documents using s
     ```
   </Tab>
 
+  <Tab title="Watch Folder">
+    ```bash
+    # Auto-index every PDF in a folder, and any new ones dropped in later
+    gaia chat --watch ./docs
+    ```
+  </Tab>
+
   <Tab title="Voice Mode">
     <Note>
       **Prerequisites:** Voice mode requires the `talk` module:

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -505,6 +505,11 @@ gaia chat --index doc1.pdf doc2.pdf doc3.pdf
 gaia chat --index report.pdf --query "Summarize the report"
 ```
 
+```bash Watch Folder
+# Auto-index every PDF in a folder, and any new ones dropped in later
+gaia chat --watch ./docs
+```
+
 ```bash Custom Settings
 gaia chat \
   --model Qwen3.5-35B-A3B-GGUF \

--- a/docs/reference/features.mdx
+++ b/docs/reference/features.mdx
@@ -64,13 +64,16 @@ gaia chat --index manual.pdf
 # Multiple documents
 gaia chat --index doc1.pdf doc2.pdf
 
+# Watch a folder and auto-index any PDF dropped into it
+gaia chat --watch ./docs
+
 # Show detailed statistics
 gaia chat --show-stats
 ```
 
 **Key features:**
 - **Conversation History**: Maintains context across messages with configurable history length
-- **Document Q&A**: RAG support for querying PDF documents with --index option
+- **Document Q&A**: RAG support for querying PDF documents with `--index` (one-off) or `--watch` (auto-index a folder)
 - **Interactive Commands**: Built-in commands for session management and debugging
 - **Streaming Responses**: Real-time response streaming for better user experience
 - **Model Flexibility**: Support for different LLM models with automatic prompt formatting

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -1629,10 +1629,13 @@ class InitCommand:
                 )
             elif self.profile == "chat":
                 self.console.print(
-                    "    [cyan]gaia chat[/cyan]              Start interactive chat with RAG"
+                    "    [cyan]gaia chat[/cyan]                            Start interactive chat with RAG"
                 )
                 self.console.print(
-                    "    [cyan]gaia chat init[/cyan]         Setup document folder"
+                    "    [cyan]gaia chat --index report.pdf[/cyan]         Index a PDF for Q&A"
+                )
+                self.console.print(
+                    "    [cyan]gaia chat --watch ./docs[/cyan]             Auto-index a folder of docs"
                 )
             elif self.profile == "vlm":
                 self.console.print(
@@ -1683,9 +1686,14 @@ class InitCommand:
                 )
             elif self.profile == "chat":
                 self._print(
-                    "    gaia chat              # Start interactive chat with RAG"
+                    "    gaia chat                            # Start interactive chat with RAG"
                 )
-                self._print("    gaia chat init         # Setup document folder")
+                self._print(
+                    "    gaia chat --index report.pdf         # Index a PDF for Q&A"
+                )
+                self._print(
+                    "    gaia chat --watch ./docs             # Auto-index a folder of docs"
+                )
             elif self.profile == "vlm":
                 self._print(
                     "    gaia cache status      # Verify VLM model is available"

--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -15,7 +15,6 @@ share the ``revoke_all_grants_for`` helper.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
 from unittest.mock import patch
 


### PR DESCRIPTION
## Why this matters

Closes #1024.

**Before:** After `gaia init`, the post-install banner advertised `gaia chat init` as the way to "Setup document folder". That command never existed — the chat subparser only defines flags (`--query`, `--index`, `--watch`, …). Following the banner's own instructions printed `error: unrecognized arguments: init` and stopped the user cold (Windows 11 / PowerShell, but reproducible everywhere).

**After:** The banner shows three real, working commands that match the user's actual intent (bringing documents into RAG):

\`\`\`
gaia chat                            Start interactive chat with RAG
gaia chat --index report.pdf         Index a PDF for Q&A
gaia chat --watch ./docs             Auto-index a folder of docs
\`\`\`

Concrete filenames (`report.pdf`, `./docs`) instead of `<placeholder>` syntax — `<` is a reserved redirection operator in PowerShell and would have re-broken the same Windows users on a different parse error.

Also fixed a CLAUDE.md example that propagated the same fake `gaia chat init` / `gaia chat status` commands to anyone training agents off this repo (replaced with the real `gaia init --profile chat` and `gaia diagnostics`).

## Test plan

- [x] Reproduce: `python -c "import sys; sys.argv=['gaia','chat','init']; from gaia.cli import main; main()"` → still rejects (bug behavior confirmed)
- [x] `gaia chat --index report.pdf` and `gaia chat --watch ./docs` parse cleanly and dispatch to the chat agent
- [x] `_print_completion()` rendered in both rich and plain-text branches — output is shell-safe on PowerShell, cmd, bash, zsh
- [x] `python -m black --check src/gaia/installer/init_command.py` clean
- [x] `pytest tests/unit/test_webui_build.py tests/unit/installer/test_init_ctx_size.py` → 19 passed
- [ ] Reporter (@pleabargain) confirms `gaia init --profile chat` followed by the suggested commands works end-to-end on Windows 11 / PowerShell