### PR TITLE
fix(lint): remove unused os import in test_disconnect_clears_grants

### DIFF
--- a/tests/unit/connectors/test_disconnect_clears_grants.py
+++ b/tests/unit/connectors/test_disconnect_clears_grants.py
@@ -15,7 +15,6 @@ share the ``revoke_all_grants_for`` helper.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Dict
 from unittest.mock import patch
 


### PR DESCRIPTION
## Why this matters

Before: Code Quality CI fails on every PR with \`F401 'os' imported but unused\` at \`tests/unit/connectors/test_disconnect_clears_grants.py:18\`. Introduced incidentally by #998. Blocks #1026 and any subsequent PR from going green.

After: import removed, flake8 exits clean.

## Test plan

- [x] \`flake8 src/ tests/ --max-line-length=88 --extend-ignore=E203,W503,E501,F541,W291,W293,E402,F841,E722\` → 0 errors