### PR TITLE
docs(process): mandate eval runs + layman-led summaries

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -131,6 +131,18 @@ jobs:
 
             You are reviewing a GAIA pull request. Provide a thorough, professional code review following GAIA standards.
 
+            ## Output style: layman-first
+
+            The review must be readable by humans who do not parse diffs for a living. The same layman-first style mandated in CLAUDE.md (see "Issue Response Guidelines" → "Tone & Style" / "Response Length Guidelines") applies here.
+
+            - **Lead with a 1–2 sentence plain-English summary** of your findings before any code references, file paths, or framework jargon. A maintainer skimming the comment should know the verdict in 15 seconds without opening a file.
+            - **The Summary section uses product / user language, not implementation language.** Good: "This PR fixes the document Q&A timeout that hit Gemma 4 users on PDFs." Bad: "Refactors `_compose_system_prompt` to truncate the mixin docstring concatenation."
+            - **File and `file.py:line` references are still required for every blocking issue**, but they go AFTER the plain-English finding, not before it. Wrong: "src/gaia/agents/chat/agent.py:412 — system prompt is too long." Right: "The default system prompt grew long enough to crowd out user input on small-context models (src/gaia/agents/chat/agent.py:412)."
+            - **Hard length limits:** review summaries under ~400 words; each blocking-issue block under ~150 words; nits under ~50 words. Long walls of jargon get ignored — the value is in the verdict, not the volume.
+            - **Do not open with a code block or a file path.** Both signal "diff review" before the reader knows whether they did something wrong.
+
+            The existing review structure (Summary → Issues → Strengths → Verdict) is unchanged — these rules are additive style constraints on top of it, not a replacement.
+
             ## FIRST ACTIONS (Do these immediately, in this order)
             1. Read `pr-diff.txt` — ALL changes in the PR (this IS the review target)
             2. Read `pr-files.txt` — changed file list
@@ -394,6 +406,16 @@ jobs:
 
             You are GAIA's AI assistant helping with pull request discussions.
 
+            ## Output style: layman-first
+
+            Replies must be readable by humans who do not parse diffs for a living. The same layman-first style mandated in CLAUDE.md (see "Issue Response Guidelines") applies here.
+
+            - **Lead with a 1–2 sentence plain-English answer** to the user's question before any code references, file paths, or framework jargon. The reader should know the gist in 15 seconds.
+            - **Use product / user language**, not implementation language. "The agent is failing because it can't reach Lemonade" — not "The `LemonadeManager.discover()` probe is returning a `httpx.ConnectError` on the discovery handshake."
+            - **File and `file.py:line` references are still expected** when pointing at a problem, but they go AFTER the plain-English finding, not before it.
+            - **Cap length: under ~200 words per reply.** If the answer needs more, you are probably trying to answer multiple questions at once — split or ask which one matters most.
+            - **Do not lead with a code block or a file path.**
+
             ## FIRST ACTIONS
             1. Read `pr-diff.txt` to see what changed
             2. Read `pr-files.txt` to see which files changed
@@ -566,6 +588,16 @@ jobs:
             ---
 
             You are GAIA's helpful AI assistant responding to issues and PR conversations.
+
+            ## Output style: layman-first
+
+            Replies must be readable by humans who may not be GAIA core devs. The same layman-first style mandated in CLAUDE.md (see "Issue Response Guidelines" → "Tone & Style" and "Response Length Guidelines") applies here — those rules are authoritative; the bullets below are the operating summary.
+
+            - **Lead with a 1–2 sentence plain-English answer / diagnosis / framing** before any code references, file paths, or framework jargon. The issue author should know what you think in 15 seconds. Good: "Looks like RAG initialization didn't complete — what GAIA reports when it can't find a loaded embedding model." Bad: "Looking at `src/gaia/rag/sdk.py:145`, `RAGSDK.__init__` invokes `_load_embedder`..."
+            - **Use product / user language** — what feature is failing, what they should try — not implementation internals.
+            - **File and `file.py:line` references are still expected** when you've actually identified the location, but they go AFTER the plain-English diagnosis, not before it. Don't reference files you guessed at.
+            - **Hard length caps:** quick answers 2–4 sentences; how-to / bug / feature replies under ~200 words; complex discussions open with a 1–2 sentence layman framing before the technical detail.
+            - **Do not lead with a code block or a file path.**
 
             ## Context Detection
             This handler responds to:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -131,17 +131,9 @@ jobs:
 
             You are reviewing a GAIA pull request. Provide a thorough, professional code review following GAIA standards.
 
-            ## Output style: concise and direct
+            ## Output style
 
-            The same style mandated in CLAUDE.md (see "Issue Response Guidelines" → "Tone & Style" / "Response Length Guidelines") applies here. Be tight.
-
-            - **Lead with the verdict in 1–2 sentences** before any code references, file paths, or framework jargon. No labelled prefix ("In plain English:", "TL;DR:"). A maintainer should grasp the verdict in 15 seconds.
-            - **Summary uses product / user language**, not implementation language. Good: "This PR fixes the document Q&A timeout that hit Gemma 4 users on PDFs." Bad: "Refactors `_compose_system_prompt` to truncate the mixin docstring concatenation."
-            - **`file.py:line` references are required for every blocking issue**, but they go AFTER the finding, not before it. Wrong: "src/gaia/agents/chat/agent.py:412 — system prompt is too long." Right: "The default system prompt is too long for small-context models (src/gaia/agents/chat/agent.py:412)."
-            - **Length caps:** review summary under ~400 words; each blocking-issue block under ~150 words; nits under ~50 words. The value is in the verdict, not the volume.
-            - **Do not open with a code block or a file path.**
-
-            The existing review structure (Summary → Issues → Strengths → Verdict) is unchanged — these are additive style constraints, not a replacement.
+            CLAUDE.md "Issue Response Guidelines" sets the style — follow it. Lead with the verdict in 1–2 sentences; `file.py:line` references go AFTER the finding, not before; do not open with a labelled `In plain English:` preamble. Length caps: summary ≤400 words; each blocking-issue block ≤150; nits ≤50. The Summary → Issues → Strengths → Verdict structure stays as-is.
 
             ## FIRST ACTIONS (Do these immediately, in this order)
             1. Read `pr-diff.txt` — ALL changes in the PR (this IS the review target)
@@ -406,15 +398,9 @@ jobs:
 
             You are GAIA's AI assistant helping with pull request discussions.
 
-            ## Output style: concise and direct
+            ## Output style
 
-            The same style mandated in CLAUDE.md (see "Issue Response Guidelines") applies here. Be tight.
-
-            - **Lead with the answer in 1–2 sentences** before any code references, file paths, or framework jargon. No labelled prefix ("In plain English:", "TL;DR:"). The reader should grasp the gist in 15 seconds.
-            - **Use product / user language**, not implementation language. "The agent is failing because it can't reach Lemonade" — not "The `LemonadeManager.discover()` probe is returning a `httpx.ConnectError`."
-            - **`file.py:line` references are expected** when pointing at a problem, but they go AFTER the finding, not before it.
-            - **Length cap: under ~200 words per reply.** If you need more, you are answering multiple questions at once — split or ask which one matters most.
-            - **Do not lead with a code block or a file path.**
+            CLAUDE.md "Issue Response Guidelines" sets the style — follow it. Lead with the answer in 1–2 sentences; `file.py:line` references go AFTER the finding; do not open with a labelled `In plain English:` preamble. Length cap: ≤200 words per reply.
 
             ## FIRST ACTIONS
             1. Read `pr-diff.txt` to see what changed
@@ -589,15 +575,9 @@ jobs:
 
             You are GAIA's helpful AI assistant responding to issues and PR conversations.
 
-            ## Output style: concise and direct
+            ## Output style
 
-            CLAUDE.md "Issue Response Guidelines" → "Tone & Style" and "Response Length Guidelines" are authoritative; the bullets below are the operating summary.
-
-            - **Lead with the diagnosis / answer in 1–2 sentences** before any code references, file paths, or framework jargon. No labelled prefix ("In plain English:", "TL;DR:"). Good: "Looks like RAG initialization didn't complete — what GAIA reports when it can't find a loaded embedding model." Bad: "Looking at `src/gaia/rag/sdk.py:145`, `RAGSDK.__init__` invokes `_load_embedder`..."
-            - **Use product / user language** — what feature is failing, what to try — not implementation internals.
-            - **`file.py:line` references are expected** when you've actually identified the location, but they go AFTER the finding, not before it. Don't reference files you guessed at.
-            - **Length caps:** quick answers 2–4 sentences; how-to / bug / feature replies under ~200 words; complex discussions open with a 1–2 sentence framing of the conclusion before the technical detail.
-            - **Do not lead with a code block or a file path.**
+            CLAUDE.md "Issue Response Guidelines" sets the style — follow it. Lead with the diagnosis / answer in 1–2 sentences; `file.py:line` references go AFTER the finding (don't reference files you guessed at); do not open with a labelled `In plain English:` preamble. Length caps: quick answers 2–4 sentences; how-to / bug / feature replies ≤200 words.
 
             ## Context Detection
             This handler responds to:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -131,17 +131,17 @@ jobs:
 
             You are reviewing a GAIA pull request. Provide a thorough, professional code review following GAIA standards.
 
-            ## Output style: layman-first
+            ## Output style: concise and direct
 
-            The review must be readable by humans who do not parse diffs for a living. The same layman-first style mandated in CLAUDE.md (see "Issue Response Guidelines" → "Tone & Style" / "Response Length Guidelines") applies here.
+            The same style mandated in CLAUDE.md (see "Issue Response Guidelines" → "Tone & Style" / "Response Length Guidelines") applies here. Be tight.
 
-            - **Lead with a 1–2 sentence plain-English summary** of your findings before any code references, file paths, or framework jargon. A maintainer skimming the comment should know the verdict in 15 seconds without opening a file.
-            - **The Summary section uses product / user language, not implementation language.** Good: "This PR fixes the document Q&A timeout that hit Gemma 4 users on PDFs." Bad: "Refactors `_compose_system_prompt` to truncate the mixin docstring concatenation."
-            - **File and `file.py:line` references are still required for every blocking issue**, but they go AFTER the plain-English finding, not before it. Wrong: "src/gaia/agents/chat/agent.py:412 — system prompt is too long." Right: "The default system prompt grew long enough to crowd out user input on small-context models (src/gaia/agents/chat/agent.py:412)."
-            - **Hard length limits:** review summaries under ~400 words; each blocking-issue block under ~150 words; nits under ~50 words. Long walls of jargon get ignored — the value is in the verdict, not the volume.
-            - **Do not open with a code block or a file path.** Both signal "diff review" before the reader knows whether they did something wrong.
+            - **Lead with the verdict in 1–2 sentences** before any code references, file paths, or framework jargon. No labelled prefix ("In plain English:", "TL;DR:"). A maintainer should grasp the verdict in 15 seconds.
+            - **Summary uses product / user language**, not implementation language. Good: "This PR fixes the document Q&A timeout that hit Gemma 4 users on PDFs." Bad: "Refactors `_compose_system_prompt` to truncate the mixin docstring concatenation."
+            - **`file.py:line` references are required for every blocking issue**, but they go AFTER the finding, not before it. Wrong: "src/gaia/agents/chat/agent.py:412 — system prompt is too long." Right: "The default system prompt is too long for small-context models (src/gaia/agents/chat/agent.py:412)."
+            - **Length caps:** review summary under ~400 words; each blocking-issue block under ~150 words; nits under ~50 words. The value is in the verdict, not the volume.
+            - **Do not open with a code block or a file path.**
 
-            The existing review structure (Summary → Issues → Strengths → Verdict) is unchanged — these rules are additive style constraints on top of it, not a replacement.
+            The existing review structure (Summary → Issues → Strengths → Verdict) is unchanged — these are additive style constraints, not a replacement.
 
             ## FIRST ACTIONS (Do these immediately, in this order)
             1. Read `pr-diff.txt` — ALL changes in the PR (this IS the review target)
@@ -406,14 +406,14 @@ jobs:
 
             You are GAIA's AI assistant helping with pull request discussions.
 
-            ## Output style: layman-first
+            ## Output style: concise and direct
 
-            Replies must be readable by humans who do not parse diffs for a living. The same layman-first style mandated in CLAUDE.md (see "Issue Response Guidelines") applies here.
+            The same style mandated in CLAUDE.md (see "Issue Response Guidelines") applies here. Be tight.
 
-            - **Lead with a 1–2 sentence plain-English answer** to the user's question before any code references, file paths, or framework jargon. The reader should know the gist in 15 seconds.
-            - **Use product / user language**, not implementation language. "The agent is failing because it can't reach Lemonade" — not "The `LemonadeManager.discover()` probe is returning a `httpx.ConnectError` on the discovery handshake."
-            - **File and `file.py:line` references are still expected** when pointing at a problem, but they go AFTER the plain-English finding, not before it.
-            - **Cap length: under ~200 words per reply.** If the answer needs more, you are probably trying to answer multiple questions at once — split or ask which one matters most.
+            - **Lead with the answer in 1–2 sentences** before any code references, file paths, or framework jargon. No labelled prefix ("In plain English:", "TL;DR:"). The reader should grasp the gist in 15 seconds.
+            - **Use product / user language**, not implementation language. "The agent is failing because it can't reach Lemonade" — not "The `LemonadeManager.discover()` probe is returning a `httpx.ConnectError`."
+            - **`file.py:line` references are expected** when pointing at a problem, but they go AFTER the finding, not before it.
+            - **Length cap: under ~200 words per reply.** If you need more, you are answering multiple questions at once — split or ask which one matters most.
             - **Do not lead with a code block or a file path.**
 
             ## FIRST ACTIONS
@@ -589,14 +589,14 @@ jobs:
 
             You are GAIA's helpful AI assistant responding to issues and PR conversations.
 
-            ## Output style: layman-first
+            ## Output style: concise and direct
 
-            Replies must be readable by humans who may not be GAIA core devs. The same layman-first style mandated in CLAUDE.md (see "Issue Response Guidelines" → "Tone & Style" and "Response Length Guidelines") applies here — those rules are authoritative; the bullets below are the operating summary.
+            CLAUDE.md "Issue Response Guidelines" → "Tone & Style" and "Response Length Guidelines" are authoritative; the bullets below are the operating summary.
 
-            - **Lead with a 1–2 sentence plain-English answer / diagnosis / framing** before any code references, file paths, or framework jargon. The issue author should know what you think in 15 seconds. Good: "Looks like RAG initialization didn't complete — what GAIA reports when it can't find a loaded embedding model." Bad: "Looking at `src/gaia/rag/sdk.py:145`, `RAGSDK.__init__` invokes `_load_embedder`..."
-            - **Use product / user language** — what feature is failing, what they should try — not implementation internals.
-            - **File and `file.py:line` references are still expected** when you've actually identified the location, but they go AFTER the plain-English diagnosis, not before it. Don't reference files you guessed at.
-            - **Hard length caps:** quick answers 2–4 sentences; how-to / bug / feature replies under ~200 words; complex discussions open with a 1–2 sentence layman framing before the technical detail.
+            - **Lead with the diagnosis / answer in 1–2 sentences** before any code references, file paths, or framework jargon. No labelled prefix ("In plain English:", "TL;DR:"). Good: "Looks like RAG initialization didn't complete — what GAIA reports when it can't find a loaded embedding model." Bad: "Looking at `src/gaia/rag/sdk.py:145`, `RAGSDK.__init__` invokes `_load_embedder`..."
+            - **Use product / user language** — what feature is failing, what to try — not implementation internals.
+            - **`file.py:line` references are expected** when you've actually identified the location, but they go AFTER the finding, not before it. Don't reference files you guessed at.
+            - **Length caps:** quick answers 2–4 sentences; how-to / bug / feature replies under ~200 words; complex discussions open with a 1–2 sentence framing of the conclusion before the technical detail.
             - **Do not lead with a code block or a file path.**
 
             ## Context Detection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,16 @@ That's it. No "What changed" / "Files modified" / "Implementation notes" section
 
 **The "user-observable impact" test:** can a non-author understand the value in <30 seconds without reading the diff? If your description is "supports X protocol" or "refactors Y handler", you've described the *change* but not the *value*. Rewrite to "before: feature Z silently failed for users running model M; after: it works." Concrete observable behaviour beats abstract capability claims.
 
+**Layman-first lead (applies to PRs AND commit messages):**
+
+The **first paragraph of every PR description** AND the **first line of the body of every non-trivial commit message** must be a plain-English summary of the change. A non-engineer — an AMD product manager, a community user reading the changelog, a triager who has never touched this corner of the codebase — must be able to understand the *what* and the *why* in 15 seconds without parsing the diff or decoding framework jargon.
+
+The layman paragraph **leads**; technical detail **follows**. This supplements technical detail, it does not replace it. Cap the layman summary at ~3 sentences; if you need more, the change is bundling multiple things and you should ask whether to split it.
+
+For commit messages: the conventional-commits title (`fix(agents): trim ChatAgent prompt …`) is the technical handle. The **first line of the body** (after the blank line under the title) is the layman lead, and the technical detail follows in the same body. PR #1034's commit message is a reasonable model — its body opens with `"ChatAgent system prompt had grown to ~52K chars …"` which is technical-but-readable rather than framework-jargon-only.
+
+The same layman-first rule applies to bot reviews and issue comments — see [Issue Response Guidelines](#issue-response-guidelines) below.
+
 **Hard rules:**
 
 - **No section longer than ~5 lines of prose** before breaking into bullets or cutting.
@@ -67,6 +77,7 @@ That's it. No "What changed" / "Files modified" / "Implementation notes" section
 - ❌ A "What changed" bullet list when the title + commit message body already cover it
 - ❌ Naming files in the description ("modified `agent.py`") — the diff already shows that
 - ❌ Burying the user impact under a section labelled "Summary"; lead with the impact
+- ❌ Opening with "Refactors X handler" / "Migrates to Y protocol" / "Adopts Z abstraction" — implementation-language leads tell the reviewer *what changed* but not *why they should care*; lead with the user / reviewer impact instead
 
 **Title convention:** conventional commits style (`feat(scope):`, `fix(scope):`, `docs(scope):`, `ci(scope):`), under ~70 chars, descriptive of the *change*, not the *why* (the body carries the why).
 
@@ -223,6 +234,42 @@ gaia mcp status
 # Bad - avoid unless debugging
 python -m gaia.mcp.mcp_bridge
 ```
+
+### IMPORTANT: Run agent evals when changing LLM-affecting code paths — do NOT skip
+
+**Unit tests catch code paths; they don't catch LLM behavior.** When a change touches an LLM-affecting surface, you MUST run `gaia eval agent` against the relevant category and compare to the committed baseline before claiming the change is done. Skipping the eval is how regressions that pass every unit test still ship to users.
+
+**Changes that REQUIRE an eval run before merge:**
+
+- ChatAgent / DocumentQAAgent / FileIOAgent / ChatAgentLite system prompts (`_get_system_prompt()`) or any mixin prompt fragment
+- The base agent's `_compose_system_prompt`, prompt-assembly order, or `_format_tools_for_prompt`
+- Tool registration, tool docstrings, or the JSON tool schema sent to Lemonade
+- Error classification (`LemonadeError` subclasses, `_classify_chat_exception`, `_extract_lemonade_user_message`) or the agent-loop catchall
+- The default LLM model, tokenizer config, or the `is_tool_calling_model` mapping
+- Tool-call response parsing / native-tool-call sentinel handling
+
+**Claude API access is almost always already available** when you are running from a Claude Code session — the user's subscription provides Claude API usage by default. Do not assume otherwise, and do not skip the eval on the assumption that no key is configured. Check first:
+
+```bash
+echo "${ANTHROPIC_API_KEY:0:8}"   # prints the first 8 chars if set
+```
+
+If it's empty, ask the user to export the key from their subscription rather than skipping the eval. "I didn't run the eval because I assumed no key was available" is not acceptable.
+
+**How to run:**
+
+```bash
+# Terminal 1 — backend (needed by gaia eval agent)
+python -m gaia.ui.server --port 4200 --host 127.0.0.1
+
+# Terminal 2 — eval the affected category, compare to baseline
+gaia eval agent --category rag_quality --agent-type doc \
+  --compare tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/scorecard_rag_quality.json
+```
+
+**Interpreting regressions:** if a category drops, fix the prompt in the same session and re-run before you commit. If the regression is intentional (e.g. you deliberately removed a capability), regenerate the baseline with `--save-baseline` and call it out explicitly in the PR description — the reviewer needs to see the diff between baselines, not just the new score.
+
+**#1030 (the Gemma-4 RAG-PDF timeout) is the canonical example of what happens when this rule is skipped:** a prompt change passed every unit test, then broke document Q&A in production. #1033 tracks the systemic CI gaps that let it through.
 
 ### IMPORTANT: Run agent evals SERIALLY, never in parallel
 
@@ -600,9 +647,10 @@ The documentation is organized in [`docs/docs.json`](docs/docs.json) with the fo
 ### Response Quality Guidelines
 
 #### Tone & Style
+- **Layman-first:** every response leads with a one-sentence plain-English summary of what's wrong / what's needed / what you'd recommend. Technical detail follows. Do not lead with a code reference or framework jargon — the issue author may not be a GAIA core dev, and even if they are, the first sentence should not require a file open to parse.
 - **Professional but friendly:** Welcome contributors warmly while maintaining technical accuracy
 - **Concise:** Aim for 1-3 paragraphs for simple questions, expand for complex issues
-- **Specific:** Reference actual files with line numbers (e.g., `src/gaia/agents/base/agent.py:123`)
+- **Specific:** Reference actual files with line numbers (e.g., `src/gaia/agents/base/agent.py:123`) — but AFTER the plain-English finding, not before it
 - **Helpful:** Provide next steps, code examples, or links to documentation
 - **Honest:** If you don't know something, say so and suggest escalation to @kovtcharov-amd
 
@@ -639,28 +687,30 @@ The documentation is organized in [`docs/docs.json`](docs/docs.json) with the fo
 
 #### Response Length Guidelines
 
-- **Quick answers:** 1 paragraph + link to docs
-- **How-to questions:** 2-3 paragraphs + code example + links
-- **Bug reports:** Ask for reproduction steps (if missing), check similar issues, reference relevant code
-- **Feature requests:** 2-4 paragraphs discussing feasibility, existing patterns, AMD optimization opportunities
-- **Complex technical discussions:** Be thorough but use headers/bullets for readability
+- **Quick answers:** 2–4 sentences. One doc link if relevant. No code unless it directly answers the question.
+- **How-to questions:** One short paragraph of context, then the minimum viable code example, then one doc link. Cap at ~150 words.
+- **Bug reports:** Lead with "I think this is X" or "I need more info to tell" in plain English. Ask for specific reproduction steps. Reference `file.py:line` only if you have actually identified the location — never guess. Cap at ~200 words.
+- **Feature requests:** Lead with one sentence on whether the feature is in scope. Then 2–4 bullets on feasibility / existing patterns / next steps. Cap at ~200 words.
+- **Complex technical discussions:** Still allowed, but they must open with a 1–2 sentence layman framing before diving into the technical detail.
 
 **Never:**
 - Write walls of text without structure
 - Repeat information already in the issue
 - Provide generic advice not specific to GAIA
+- **Never lead with a code reference.** `Looking at src/gaia/foo.py:123, ...` makes the response feel like a diff review; users want to know whether they did something wrong before they see the line number.
 
 #### Examples
 
 **Good Response (Bug Report):**
 ```
-Thanks for reporting this! The error you're seeing in `gaia chat` appears to be related to RAG initialization.
+Looks like RAG initialization didn't complete — the symptom you're hitting is what happens
+when GAIA can't find a loaded embedding model. Two quick checks:
 
-Looking at src/gaia/rag/sdk.py:145, the initialization expects a model path. Could you confirm:
-1. Did you run `gaia chat init` first?
-2. What's the output of `gaia chat status`?
+1. Did you run `gaia init` after install?
+2. What does `gaia chat status` print?
 
-See docs/guides/chat.mdx for the full setup process. This might also be related to #123.
+If both look right, paste the output of `gaia chat --debug` and I can dig in further. Setup
+walkthrough lives at docs/guides/chat.mdx.
 ```
 
 **Bad Response (Too Generic):**
@@ -686,6 +736,18 @@ Would you be interested in contributing this? See CONTRIBUTING.md for how to get
 Looking at your code, the issue is on line 45 where you're using subprocess.call() with user input. Here's how an attacker could exploit it: [detailed exploit]. You should use shlex.quote() like this: [code example].
 ```
 *This is bad because it discusses exploit details publicly. Should escalate privately instead.*
+
+**Bad Response (Excessively Technical):**
+```
+The error originates in `src/gaia/rag/sdk.py:145` where `RAGSDK.__init__` invokes
+`_load_embedder` which raises if `self.config.embedding_model` cannot be resolved by
+the Lemonade `/api/v1/models` endpoint. The traceback at line 178 indicates that
+`httpx.ConnectError` was raised because the `LemonadeManager` discovery probe failed
+to bind on the canonical port (13305) due to an upstream proxy collision with `gaia mcp docker`.
+```
+*This is bad because it leads with file paths and framework internals; a user filing a bug
+shouldn't have to decode it. Lead with a plain-English diagnosis ("looks like RAG can't reach
+the Lemonade server"), then drop the file references for the contributor who follows up.*
 
 #### Community & Contributor Management
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,15 +50,15 @@ That's it. No "What changed" / "Files modified" / "Implementation notes" section
 
 **The "user-observable impact" test:** can a non-author understand the value in <30 seconds without reading the diff? If your description is "supports X protocol" or "refactors Y handler", you've described the *change* but not the *value*. Rewrite to "before: feature Z silently failed for users running model M; after: it works." Concrete observable behaviour beats abstract capability claims.
 
-**Layman-first lead (applies to PRs AND commit messages):**
+**Lead with the summary (PRs and commit messages):**
 
-The **first paragraph of every PR description** AND the **first line of the body of every non-trivial commit message** must be a plain-English summary of the change. A non-engineer — an AMD product manager, a community user reading the changelog, a triager who has never touched this corner of the codebase — must be able to understand the *what* and the *why* in 15 seconds without parsing the diff or decoding framework jargon.
+The first paragraph of every PR description AND the first line of every non-trivial commit-message body must summarize the change directly — what's different, why a reviewer should care, in ~3 sentences. No labelled prefix ("In plain English:", "Layman-first:") — just lead with the substance. If 3 sentences isn't enough, the change is doing more than one thing; ask whether to split.
 
-The layman paragraph **leads**; technical detail **follows**. This supplements technical detail, it does not replace it. Cap the layman summary at ~3 sentences; if you need more, the change is bundling multiple things and you should ask whether to split it.
+The summary leads; technical detail follows in the same body. Supplements technical detail, does not replace it.
 
-For commit messages: the conventional-commits title (`fix(agents): trim ChatAgent prompt …`) is the technical handle. The **first line of the body** (after the blank line under the title) is the layman lead, and the technical detail follows in the same body. PR #1034's commit message is a reasonable model — its body opens with `"ChatAgent system prompt had grown to ~52K chars …"` which is technical-but-readable rather than framework-jargon-only.
+For commit messages: the conventional-commits title (`fix(agents): trim ChatAgent prompt …`) is the technical handle; the first line of the body is the summary. PR #1034's commit body opens with `"ChatAgent system prompt had grown to ~52K chars …"` — direct, no preamble, technical-but-readable.
 
-The same layman-first rule applies to bot reviews and issue comments — see [Issue Response Guidelines](#issue-response-guidelines) below.
+The same rule applies to bot reviews and issue comments — see [Issue Response Guidelines](#issue-response-guidelines) below.
 
 **Hard rules:**
 
@@ -647,10 +647,10 @@ The documentation is organized in [`docs/docs.json`](docs/docs.json) with the fo
 ### Response Quality Guidelines
 
 #### Tone & Style
-- **Layman-first:** every response leads with a one-sentence plain-English summary of what's wrong / what's needed / what you'd recommend. Technical detail follows. Do not lead with a code reference or framework jargon — the issue author may not be a GAIA core dev, and even if they are, the first sentence should not require a file open to parse.
+- **Lead with the finding:** open every response with one sentence stating the diagnosis, the answer, or what you need from the author. No labelled prefix ("In plain English:", "TL;DR:") — just the finding.
 - **Professional but friendly:** Welcome contributors warmly while maintaining technical accuracy
-- **Concise:** Aim for 1-3 paragraphs for simple questions, expand for complex issues
-- **Specific:** Reference actual files with line numbers (e.g., `src/gaia/agents/base/agent.py:123`) — but AFTER the plain-English finding, not before it
+- **Concise:** 1–3 paragraphs for simple questions; expand only when the issue actually warrants it
+- **Specific:** Reference actual files with line numbers (e.g., `src/gaia/agents/base/agent.py:123`) — but AFTER the finding, not before it
 - **Helpful:** Provide next steps, code examples, or links to documentation
 - **Honest:** If you don't know something, say so and suggest escalation to @kovtcharov-amd
 
@@ -689,15 +689,15 @@ The documentation is organized in [`docs/docs.json`](docs/docs.json) with the fo
 
 - **Quick answers:** 2–4 sentences. One doc link if relevant. No code unless it directly answers the question.
 - **How-to questions:** One short paragraph of context, then the minimum viable code example, then one doc link. Cap at ~150 words.
-- **Bug reports:** Lead with "I think this is X" or "I need more info to tell" in plain English. Ask for specific reproduction steps. Reference `file.py:line` only if you have actually identified the location — never guess. Cap at ~200 words.
-- **Feature requests:** Lead with one sentence on whether the feature is in scope. Then 2–4 bullets on feasibility / existing patterns / next steps. Cap at ~200 words.
-- **Complex technical discussions:** Still allowed, but they must open with a 1–2 sentence layman framing before diving into the technical detail.
+- **Bug reports:** Open with "I think this is X" or "I need more info to tell." Ask for specific reproduction steps. Reference `file.py:line` only when you've actually identified the location — never guess. Cap at ~200 words.
+- **Feature requests:** Open with one sentence on whether the feature is in scope. Then 2–4 bullets on feasibility / existing patterns / next steps. Cap at ~200 words.
+- **Complex technical discussions:** Allowed, but open with a 1–2 sentence framing of the conclusion before diving into the technical detail.
 
 **Never:**
 - Write walls of text without structure
 - Repeat information already in the issue
 - Provide generic advice not specific to GAIA
-- **Never lead with a code reference.** `Looking at src/gaia/foo.py:123, ...` makes the response feel like a diff review; users want to know whether they did something wrong before they see the line number.
+- **Lead with a code reference.** `Looking at src/gaia/foo.py:123, ...` makes the response feel like a diff review; the reader wants the finding before the line number.
 
 #### Examples
 
@@ -746,8 +746,8 @@ the Lemonade `/api/v1/models` endpoint. The traceback at line 178 indicates that
 to bind on the canonical port (13305) due to an upstream proxy collision with `gaia mcp docker`.
 ```
 *This is bad because it leads with file paths and framework internals; a user filing a bug
-shouldn't have to decode it. Lead with a plain-English diagnosis ("looks like RAG can't reach
-the Lemonade server"), then drop the file references for the contributor who follows up.*
+shouldn't have to decode it. Lead with the diagnosis ("looks like RAG can't reach the
+Lemonade server"), then drop the file references for the contributor who follows up.*
 
 #### Community & Contributor Management
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ If *any* of those is uncertain, **do not commit** — surface the uncertainty to
 
 **Target shape (default — most PRs need only this):**
 
-1. **One-paragraph "Why this matters"** — the user-observable impact in plain English. Lead with the *before-state* (what was broken / missing) and the *after-state* (what now works). If a reviewer stops after this paragraph, they should know whether to merge.
-2. **Test plan** — checkbox list of how to verify. Specific commands beat vague prose.
+1. **One-paragraph "Why this matters"** — the user-observable impact, in concise direct prose (~3 sentences max). Lead with the *before-state* (what was broken / missing) and the *after-state* (what now works). No labelled prefix (`In plain English:`, `Layman-first:`); just lead with the substance. If a reviewer stops after this paragraph, they should know whether to merge.
+2. **Test plan** — checkbox list of how to verify. Specific commands beat vague prose. Only list items a reviewer can actually verify before merge.
 
 That's it. No "What changed" / "Files modified" / "Implementation notes" sections by default — the diff shows what changed; the commit messages explain how. The PR description's job is to sell the merge.
 
@@ -50,15 +50,7 @@ That's it. No "What changed" / "Files modified" / "Implementation notes" section
 
 **The "user-observable impact" test:** can a non-author understand the value in <30 seconds without reading the diff? If your description is "supports X protocol" or "refactors Y handler", you've described the *change* but not the *value*. Rewrite to "before: feature Z silently failed for users running model M; after: it works." Concrete observable behaviour beats abstract capability claims.
 
-**Lead with the summary (PRs and commit messages):**
-
-The first paragraph of every PR description AND the first line of every non-trivial commit-message body must summarize the change directly — what's different, why a reviewer should care, in ~3 sentences. No labelled prefix ("In plain English:", "Layman-first:") — just lead with the substance. If 3 sentences isn't enough, the change is doing more than one thing; ask whether to split.
-
-The summary leads; technical detail follows in the same body. Supplements technical detail, does not replace it.
-
-For commit messages: the conventional-commits title (`fix(agents): trim ChatAgent prompt …`) is the technical handle; the first line of the body is the summary. PR #1034's commit body opens with `"ChatAgent system prompt had grown to ~52K chars …"` — direct, no preamble, technical-but-readable.
-
-The same rule applies to bot reviews and issue comments — see [Issue Response Guidelines](#issue-response-guidelines) below.
+**Same rule for commit messages:** the conventional-commits title is the technical handle; the first line of the body is the summary (concise direct prose, no labelled prefix). PR #1034's body opens with `"ChatAgent system prompt had grown to ~52K chars …"` — direct, no preamble. The same rule applies to bot reviews and issue comments — see [Issue Response Guidelines](#issue-response-guidelines).
 
 **Hard rules:**
 
@@ -160,6 +152,37 @@ This self-review step is mandatory - never skip verification of your output.
 1. Check if similar functionality exists in `src/gaia/agents/base/`
 2. Check existing mixins in agent subdirectories (e.g., `chat/tools/`, `code/tools/`)
 3. Extract shared logic into base classes or mixins when patterns repeat
+
+### Code Comments — Short or Skip
+
+**Default to no comments.** Write one only when the *why* is non-obvious — a hidden constraint, a subtle invariant, a workaround for a specific bug. Never explain *what* the code does (identifiers should already do that).
+
+**Keep WHY comments to one short line.** Multi-paragraph "history of how we got here" blocks are noise — the diff, commit message, and linked issue carry the history. Inline comments are read at the speed of code, not the speed of a postmortem.
+
+**Don't reference the current task, fix, or callers inline.** Patterns like `"Pre-#1030 follow-up the non-streaming path skipped the check…"` or `"Added for the Y flow"` belong in the PR description and commit body. Inline they rot as soon as the code moves.
+
+**Bad** (verbose, history-tagged, will rot):
+
+```python
+# Pre-flight: ensure the model is loaded at the GAIA-expected ctx.
+# The streaming path already does this via
+# ``_stream_chat_completions_with_openai`` -> ``_ensure_model_loaded``.
+# Pre-#1030 follow-up the non-streaming path skipped the check, so
+# when something (e.g. the RAG SDK's embedder warm-up) unloaded the
+# LLM, the next non-streaming chat_completion let Lemonade auto-load
+# Gemma at its own default ctx (32K) — bypassing
+# MODELS[…].min_ctx_size and silently capping doc-Q&A at 32K.
+self._ensure_model_loaded()
+```
+
+**Good** (one line, names the invariant the call enforces):
+
+```python
+# Re-check ctx — embedder warm-up can quietly unload the chat model.
+self._ensure_model_loaded()
+```
+
+The PR / commit message is where multi-paragraph context lives. The code carries the one line a future reader needs to not break it.
 
 ### No Silent Fallbacks — Fail Loudly
 
@@ -647,7 +670,7 @@ The documentation is organized in [`docs/docs.json`](docs/docs.json) with the fo
 ### Response Quality Guidelines
 
 #### Tone & Style
-- **Lead with the finding:** open every response with one sentence stating the diagnosis, the answer, or what you need from the author. No labelled prefix ("In plain English:", "TL;DR:") — just the finding.
+- **Lead with the finding:** open every response with one sentence stating the diagnosis, the answer, or what you need from the author. No labelled "In plain English:" preamble — just the finding. (`TL;DR:` is fine if a long review genuinely warrants one; `In plain English:` reads as performative plain-talk and is forbidden.)
 - **Professional but friendly:** Welcome contributors warmly while maintaining technical accuracy
 - **Concise:** 1–3 paragraphs for simple questions; expand only when the issue actually warrants it
 - **Specific:** Reference actual files with line numbers (e.g., `src/gaia/agents/base/agent.py:123`) — but AFTER the finding, not before it


### PR DESCRIPTION
## Why this matters

Three process rules from the post-mortem on #1030 (the Gemma 4 RAG-PDF timeout fixed in #1034):

1. **Run the agent eval when you change anything that affects how the LLM behaves.** Don't skip it — the Claude Code subscription typically already provides API access. #1030 is the canonical example of a bug the eval would have caught in CI.
2. **Lead PR descriptions, commit messages, and bot reviews with the change itself, no labelled preamble.** Recent auto-review comments trended toward dense framework jargon non-engineers struggled to act on; the rule now demands the finding up front, then technical detail, with hard length caps.
3. **Keep code comments to one short line or skip them.** Multi-paragraph "history of how we got here" blocks belong in the PR / commit message, not inline. The new section quotes the verbose comment from the #1030 fix as the canonical Bad example.

No behaviour change, no code change. CLAUDE.md gets the three rules; the bot prompts in `.github/workflows/claude.yml` now defer to CLAUDE.md for style and only carry the length caps inline.

## Test plan

- [ ] `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude.yml'))"` — YAML still parses
- [ ] Read CLAUDE.md end-to-end and confirm the new rules read coherently with the existing rules; no contradictions
- [ ] Confirm the bot prompts still describe the same review structure (Summary → Issues → Strengths → Verdict) — the style rule is additive

## Merge order

CLAUDE.md's new "eval triggers" bullet references `_extract_lemonade_user_message` (introduced by #1034). #1036 should land **after** #1034 so that symbol resolves on main.

## Related

- #1030 — the bug that triggered this post-mortem
- #1034 — the bug fix
- #1033 — broader CI testing-gap follow-up
- #1037 — npm dependabot vulnerabilities investigation