### PR TITLE
fix(webui): restore flex layout on top navbar right container

### DIFF
--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -1323,7 +1323,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                         </>
                     )}
                 </div>
-                <div className="chat-header-right">
+                <div className="task-header-right">
                     <span
                         className={`model-badge ${!systemStatus?.model_loaded ? 'no-model' : ''}`}
                         title={


### PR DESCRIPTION
The action icons in the top navbar were stacking vertically instead of laying out in a horizontal row at all viewport widths. The right-side container (`<div className="chat-header-right">`) referenced a CSS class that didn't exist — `.task-header-right` is the correctly defined rule providing `display: flex`. Renaming the one JSX className restores the horizontal layout without touching any other file.

## Test plan

- [ ] Build passes: `cd src/gaia/apps/webui && npm run build` exits 0
- [ ] New class in bundle: `grep -c "task-header-right" dist/assets/index-*.js` → 1
- [ ] Old typo absent: `grep -c "chat-header-right" dist/assets/index-*.js` → 0
- [ ] At 1841×611 (the screenshot from the issue): model badge + 7 icons render in a single horizontal row
- [ ] At ≤768px: model badge hidden by existing responsive rule; icons remain on one row

Fixes #1059