### PR TITLE
fix(ci): make refresh-context7 fail loudly on unexpected status

### DIFF
--- a/.claude/skills/gaia-release/SKILL.md
+++ b/.claude/skills/gaia-release/SKILL.md
@@ -330,6 +330,10 @@ Show the user the run URL, the **release PR number** (`#$RELEASE_PR`), and the *
 
 5. **After approval**, PyPI + npm + GitHub Release jobs run in parallel. Watch to completion.
 
+6. **`refresh-context7` is the terminal job and may legitimately fail — that is not a release failure.** This job runs *after* PyPI, npm, GitHub Release, and the desktop installers are already published. Context7's API rejects refresh requests inside a short cooldown window (observed: ~3–6 days between releases), and the response is HTTP 400. If the job is red, the release is still live. Open the job log, read the `Response body:` block between the `::stop-commands::` markers, and either accept the cooldown reason or file a follow-up about a new rejection cause. Do **not** delete or re-tag — see the recovery guidance in the Notes section below.
+
+7. **Never add `set -x` or `curl -v` to the `refresh-context7` step** to "debug" a failure. GHA only masks the verbatim secret value; `curl -v` prints the `Authorization: Bearer <token>` header, which is a transformed form that GHA's masking does not catch. Read the captured response body instead — it carries the same diagnostic signal without the leak risk.
+
 ---
 
 ## Phase 6 — Post-release verification + announcement

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -510,15 +510,32 @@ jobs:
     steps:
       - name: Refresh Context7
         run: |
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+          # Fail loudly on unexpected status; 429 is the only tolerated non-2xx.
+          BODY_FILE=$(mktemp)
+          HTTP_STATUS=$(curl -s -o "$BODY_FILE" -w "%{http_code}" \
             -X POST https://context7.com/api/v1/refresh \
             -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{"libraryName": "/amd/gaia"}')
+          BODY=$(cat "$BODY_FILE")
+          rm -f "$BODY_FILE"
           if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "202" ]; then
             echo "Context7 refresh triggered (HTTP $HTTP_STATUS)"
           elif [ "$HTTP_STATUS" = "429" ]; then
-            echo "::warning::Context7 rate limited — refresh skipped"
+            echo "::warning::Context7 rate limited (HTTP 429) — refresh skipped"
+            # Body is third-party content; bracket with stop-commands so any
+            # ::cmd:: lines inside cannot inject GHA workflow commands.
+            TOKEN=$(uuidgen)
+            echo "::stop-commands::$TOKEN"
+            echo "Response body:"
+            echo "$BODY"
+            echo "::$TOKEN::"
           else
-            echo "::warning::Context7 refresh returned HTTP $HTTP_STATUS"
+            echo "::error::Context7 refresh failed (HTTP $HTTP_STATUS) — see body below"
+            TOKEN=$(uuidgen)
+            echo "::stop-commands::$TOKEN"
+            echo "Response body:"
+            echo "$BODY"
+            echo "::$TOKEN::"
+            exit 1
           fi

--- a/tests/integration/test_context7_refresh.sh
+++ b/tests/integration/test_context7_refresh.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Verifies refresh-context7 exit codes for each HTTP status class.
+# Mirrors the decision tree in .github/workflows/publish.yml (job: refresh-context7).
+# Update this script in lockstep with that step when the status-code policy changes.
+set -u
+
+run() {
+  HTTP_STATUS="$1" bash -c '
+    if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "202" ]; then
+      echo "ok"; exit 0
+    elif [ "$HTTP_STATUS" = "429" ]; then
+      echo "::warning::rate limited"; exit 0
+    else
+      echo "::error::Context7 refresh returned HTTP $HTTP_STATUS"; exit 1
+    fi'
+  echo "rc=$?"
+}
+
+expect() {
+  output="$(run "$1")"
+  rc_line="$(echo "$output" | tail -1)"
+  if [ "$rc_line" != "rc=$2" ]; then
+    echo "FAIL $1: expected rc=$2 got $rc_line"
+    echo "$output"
+    exit 1
+  fi
+  # Optional 3rd arg: substring that must appear in the output (e.g. "::error::").
+  # Exit code alone doesn't catch a regression that silently downgrades an
+  # ::error:: to a plain echo, so the annotation check is the AC2/AC4 anchor.
+  if [ -n "${3:-}" ] && ! printf '%s\n' "$output" | grep -qF "$3"; then
+    echo "FAIL $1: expected annotation '$3' missing"
+    echo "$output"
+    exit 1
+  fi
+  echo "PASS $1 -> $rc_line${3:+ (annotation matched: $3)}"
+}
+
+expect 200 0
+expect 202 0
+expect 400 1 "::error::"   # the bug — must now fail loudly with annotation
+expect 429 0 "::warning::" # tolerated transient — must still annotate
+expect 500 1 "::error::"
+expect 000 1 "::error::"   # curl network-error sentinel; only reachable if -e is off (harness only)


### PR DESCRIPTION
Three of the last four releases shipped with a green publish run that hid a real failure: Context7's doc-index refresh returned HTTP 400 on v0.17.5, v0.17.6, and v0.18.1, and the workflow logged `::warning::` and exited 0 without even capturing the response body. After this PR the `refresh-context7` step prints the body, fails the run on any unexpected status, and keeps HTTP 429 (genuine rate limit) as a tolerated `::warning::`. Because the step is the terminal leaf of the publish DAG, a red run here surfaces the problem without rolling back anything already on PyPI / npm / GitHub Releases.

**Expected behavior change for release managers:** the *next* release within Context7's cooldown window (~3–6 days based on observed pattern) WILL turn this job red — that is the fix, not a regression. The release is still live; read the captured body and file a follow-up. The same PR also adds a runbook paragraph at `.claude/skills/gaia-release/SKILL.md` (Phase 5, steps 6–7) so this is documented before it happens.

The body is third-party content, so it's bracketed with `::stop-commands::$(uuidgen)` / `::$TOKEN::` to prevent any `::cmd::` lines inside Context7's response from being interpreted as GHA workflow commands.

Closes #1063

## Test plan

- [x] `bash tests/integration/test_context7_refresh.sh` — six `PASS` lines, four with annotation assertions
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` — YAML parses
- [ ] Reviewer: confirm no other workflow file references `refresh-context7` (`grep -rn refresh-context7 .github/`)
- [ ] Next release tag run: `refresh-context7` log shows the captured body wrapped in `::stop-commands::` markers on any non-2xx response; job is red on non-2xx/429; green on 200/202