### PR TITLE
feat(agent-hub): Agent Hub UI + platform plan + hub skeleton

### DIFF
--- a/docs/plans/agent-hub-ui.mdx
+++ b/docs/plans/agent-hub-ui.mdx
@@ -1,0 +1,245 @@
+---
+title: "Agent Hub Platform"
+description: "End-to-end agent hub: packaging, distribution, discovery, and installation for GAIA agents"
+icon: "grid-2x2"
+---
+
+# Agent Hub Platform
+
+<Note>
+**Milestone:** v0.29 | **Status:** In Progress | **Priority:** High
+</Note>
+
+---
+
+## Overview
+
+The Agent Hub is a centralized platform for discovering, installing, and managing GAIA agents. It covers the full lifecycle: manifest format, versioning, Python wheel + C++ binary packaging, R2 cloud distribution, install/update/rollback API, Agent Hub UI (Installed/Available tabs with hardware compatibility checks), developer workflow (init/test/pack/publish), security tiers, and 5-interface standard (TUI, CLI, pipe, API server, MCP server) per agent package.
+
+## Key Design Decisions
+
+1. **Production agents live in `hub/agents/`.** All production agents (chat, doc, file, data, web, email, jira, blender, etc.) are standalone packages in `hub/agents/python/` and `hub/agents/cpp/`. They `import gaia` from the **published PyPI package** (`amd-gaia`), not from the source tree. Third-party contributors follow the identical pattern. `src/gaia/agents/` retains only the framework: base classes, shared tool mixins, and the registry.
+
+2. **`pip install amd-gaia` ships the framework only.** The core wheel provides `Agent`, `@tool`, `MCPAgent`, `AgentConsole`, LLM clients, RAG, MCP, etc. Production agents are separate wheels (`gaia-agent-chat`, `gaia-agent-doc`, etc.) published to the Hub. A meta-package `amd-gaia[agents]` installs all AMD production agents for convenience.
+
+3. **Manifest file is `gaia-agent.yaml`.** Every agent has a manifest declaring its metadata, version (starting at `0.1.0`), system requirements, permissions, interface modes, and Hub display info.
+
+4. **C++ agents get a Python backend subprocess launcher** so they work in both Electron and web contexts via JSON-RPC over stdio.
+
+5. **Per-agent manifest files on R2** (not a single global catalog). A lightweight `index.json` is rebuilt from per-agent manifests by a Cloudflare Worker on publish.
+
+6. **5-interface standard per agent:** TUI, CLI, pipe, REST API server, MCP stdio server — following the pattern from the gaia-bash C++ agent (PR #985).
+
+---
+
+## Phase 0: Restructure — `hub/agents/` Directory
+
+### Directory structure
+
+```
+hub/
+├── agents/
+│   ├── python/
+│   │   ├── chat/
+│   │   │   ├── gaia-agent.yaml          # manifest (v0.1.0)
+│   │   │   ├── pyproject.toml           # depends on amd-gaia
+│   │   │   ├── gaia_agent_chat/
+│   │   │   │   ├── __init__.py
+│   │   │   │   └── agent.py             # from gaia.agents.base import Agent
+│   │   │   ├── tests/
+│   │   │   └── README.md
+│   │   ├── doc/
+│   │   ├── file/
+│   │   ├── data/
+│   │   ├── web/
+│   │   ├── email/
+│   │   ├── jira/
+│   │   ├── blender/
+│   │   ├── docker/
+│   │   ├── summarize/
+│   │   ├── sd/
+│   │   ├── emr/
+│   │   └── routing/
+│   └── cpp/
+│       ├── bash/
+│       ├── health/
+│       └── wifi/
+└── README.md
+```
+
+### What stays in `src/gaia/agents/`
+
+Only the **framework** — the building blocks every agent imports:
+
+```
+src/gaia/agents/
+├── base/          # Agent, MCPAgent, ApiAgent, @tool, AgentConsole, errors
+├── tools/         # shared tool mixins (FileSearchTools, etc.)
+├── registry.py    # AgentRegistry
+├── builder/       # BuilderAgent (scaffolding tool)
+└── __init__.py
+```
+
+### Migration strategy
+
+1. Move agent code from `src/gaia/agents/<name>/` to `hub/agents/python/<name>/gaia_agent_<name>/`
+2. Rewrite imports — agents import from the installed `amd-gaia` package
+3. Add `pyproject.toml` per agent with `dependencies = ["amd-gaia>={min_gaia_version}"]`
+4. Add `gaia-agent.yaml` per agent — every agent starts at `version: 0.1.0`
+5. Update `setup.py` to remove agent packages from the core wheel
+6. Add `amd-gaia[agents]` extras that installs all production agent wheels
+7. Update registry — builtin agents discovered via `gaia-agent.yaml` scan, not hardcoded
+
+---
+
+## Phase 1: Agent Manifest + Registry Enhancement
+
+### `gaia-agent.yaml` manifest format
+
+```yaml
+id: chat
+name: Chat
+version: 0.1.0
+description: "General conversation — fast, personality-first"
+author: AMD
+license: MIT
+
+# Hub display
+category: conversation
+tags: [chat, general, personality]
+icon: message-circle
+avatar: avatar.png
+screenshots: []
+readme: README.md
+conversation_starters:
+  - "What can you help me with?"
+
+# Technical
+language: python
+min_gaia_version: "0.18.0"
+models: [Qwen3.5-35B-A3B-GGUF]
+tools_count: 0
+security_tier: verified
+
+# System requirements
+requirements:
+  min_memory_gb: 8
+  min_disk_gb: 2
+  min_context_size: 32768
+  platforms: [win-x64, linux-x64, darwin-arm64]
+  npu: optional
+  gpu_vram_gb: 0
+
+# Python-specific
+python:
+  entry_module: gaia_agent_chat.agent
+  entry_class: ChatAgent
+  dependencies: []
+
+# Permissions
+permissions:
+  - filesystem:read
+  - network:none
+
+# Interface modes
+interfaces:
+  tui: true
+  cli: true
+  pipe: true
+  api_server: true
+  mcp_server: true
+```
+
+### Registry reads `gaia-agent.yaml`
+
+The registry scans `~/.gaia/agents/*/gaia-agent.yaml` directly. Each manifest provides `python.entry_module` and `python.entry_class`. Uses `importlib.util.spec_from_file_location()` with `submodule_search_locations` for thread-safe loading.
+
+### C++ subprocess launcher
+
+`NativeAgentLauncher` in `src/gaia/hub/native_launcher.py` — spawns C++ agents as subprocesses with JSON-RPC over stdio, enabling native agents in web context (not just Electron).
+
+---
+
+## Phase 2: Versioning + Packaging
+
+- **Python wheels:** `gaia agent pack` reads `gaia-agent.yaml`, generates `pyproject.toml`, builds `.whl`
+- **C++ binaries:** Static linking via vcpkg, CI matrix for win-x64/linux-x64/darwin-arm64
+- **Version bumping:** `gaia agent version patch|minor|major`
+- **Install isolation:** `uv pip install --target ~/.gaia/agents/{id}/site-packages/`
+
+---
+
+## Phase 3: R2 Distribution
+
+- **Bucket structure:** Per-agent manifests at `agents/{id}/manifest.json`, versioned artifacts, lightweight `index.json`
+- **Cloudflare Worker:** Auth per publisher, version immutability, server-side SHA-256, index rebuild
+- **`gaia agent publish`:** validate → test → pack → upload
+- **Deprecation:** `gaia agent deprecate <id> --message "..."`
+- **Security tiers:** verified (AMD), community (publisher-signed), experimental (opt-in)
+- **Native trust:** Confirmation prompt for non-verified C++ agents
+
+---
+
+## Phase 4: Backend Install/Catalog API
+
+- **`GET /api/agents/catalog`** — R2 index + local registry merge + per-agent compatibility check
+- **`POST /api/agents/install`** — system check → download → verify → install → hot-register
+- **`DELETE /api/agents/{id}`** — uninstall
+- **`POST /api/agents/{id}/rollback`** — restore from `.backup/`
+- **Progress polling:** `GET /api/agents/{id}/install-status`
+- **Compatibility:** Platform, RAM, disk, GPU/NPU, context size checks with green/yellow/red UI indicators
+
+---
+
+## Phase 5: Frontend — Hub as Splash Page
+
+- **Tabs:** Installed (with update badges) / Available (with install buttons + download size + compatibility)
+- **Card states:** installed, available, update_available, installing
+- **Install progress:** Polling-based progress bar on card
+- **Offline:** Cached catalog with banner
+- **Unified `AgentInfo` TypeScript type** with status, version, compatibility, security_tier fields
+
+---
+
+## Phase 6: CLI Commands
+
+```bash
+gaia agent list | search | info               # Discovery
+gaia agent install | update | uninstall        # Management
+gaia agent rollback | update --all             # Recovery
+gaia agent run <id> [--prompt | --api | --mcp] # Execution
+gaia agent init | test | version | pack        # Development
+gaia agent publish | login                     # Distribution
+```
+
+---
+
+## Phase 7: Developer Experience
+
+- **`gaia agent init <name> --language python|cpp`** — proper package structure with `gaia-agent.yaml`
+- **`gaia agent test --lint`** (CI-safe) and **`--live`** (requires LLM)
+- **Full workflow:** init → develop → test → version → pack → publish
+
+---
+
+## Milestone: v0.29 — Agent Hub Platform
+
+| Issue | Phase | Priority |
+|-------|-------|----------|
+| #1102 | Phase 0: Restructure hub/agents/ | P0 |
+| #1091 | Phase 1: gaia-agent.yaml manifest | P0 |
+| #1098 | Phase 7: gaia agent init scaffolding | P0 |
+| #264 | Phase 6: Agent Hub CLI | P0 |
+| #1101 | Phase 1: API/MCP interface standard | P1 |
+| #1093 | Phase 2: Python wheel packaging | P1 |
+| #1094 | Phase 2: C++ binary packaging + CI | P1 |
+| #1099 | Phase 7: gaia agent test quality gates | P1 |
+| #465 | Phase 4: Agent Lifecycle Manager | P1 |
+| #1095 | Phase 3: R2 bucket + Worker API | P2 |
+| #1096 | Phase 4: Backend catalog/install API | P2 |
+| #1097 | Phase 5: Frontend install flow | P2 |
+| #1100 | Phase 3: Security tiers + trust | P2 |
+| #1092 | Phase 1: C++ subprocess launcher | P2 |
+| #468 | Phase 4: Progressive install executor | P2 |
+| #285 | Phase 1: Scope skills for agents | P2 |
+| #546 | Phase 0: Port example agents | P2 |

--- a/docs/plans/agent-hub.mdx
+++ b/docs/plans/agent-hub.mdx
@@ -282,7 +282,7 @@ Arena sessions run on **AMD Strix Halo Developer Cloud**, a separate infrastruct
 | Create profile | No | Yes |
 | Earn badges | No | Yes |
 
-Authentication uses [AMD AI Developer Program](https://www.amd.com/en/developer/ai-dev-program.html) SSO. Membership is free and open to all.
+Authentication uses [AMD AI Developer Program](https://www.amd.com/en/developer.html) SSO. Membership is free and open to all.
 
 ---
 

--- a/hub/README.md
+++ b/hub/README.md
@@ -1,0 +1,21 @@
+# GAIA Agent Hub
+
+Production agents for the GAIA Agent Hub. Each agent is a standalone package that depends on the published `amd-gaia` PyPI package.
+
+## Structure
+
+```
+hub/
+├── agents/
+│   ├── python/         # Python agents (packaged as wheels)
+│   └── cpp/            # C++ agents (compiled binaries)
+└── README.md
+```
+
+## Creating a new agent
+
+```bash
+gaia agent init my-agent --language python
+```
+
+See [docs/plans/agent-hub-ui.mdx](../docs/plans/agent-hub-ui.mdx) for the full Agent Hub platform plan.

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -186,7 +186,7 @@ class AgentRegistration:
     id: str
     name: str
     description: str
-    source: Literal["builtin", "custom_python"]
+    source: Literal["builtin", "custom_python", "native"]
     conversation_starters: List[str]
     factory: Callable[..., Any]  # returns Agent instance
     agent_dir: Optional[Path]
@@ -210,6 +210,14 @@ class AgentRegistration:
     # malicious custom agent from claiming a built-in's AGENT_ID to inherit
     # a previously-granted scope. Always non-empty.
     namespaced_agent_id: str = ""
+    # Agent Hub metadata — used by the Agent UI to render rich discovery cards.
+    # Hardcoded for builtins (lazy-import factories must not instantiate agents);
+    # custom agents declare via class attributes (AGENT_CATEGORY, etc.).
+    category: str = "general"
+    tags: List[str] = field(default_factory=list)
+    icon: str = ""  # lucide icon name (e.g. "message-circle", "zap")
+    tools_count: int = 0
+    language: str = "python"  # "python" | "cpp"
 
 
 class AgentRegistry:
@@ -277,6 +285,9 @@ class AgentRegistry:
         else:
             logger.info("registry: No custom agent directory found at %s", agents_dir)
 
+        # 3. Discover native (C++/binary) agents from agent-manifest.json
+        self._discover_native_agents()
+
         agent_ids = list(self._agents.keys())
         logger.info(
             "registry: Agent discovery complete. %d agents registered: %s",
@@ -317,6 +328,10 @@ class AgentRegistry:
                 models=[],
                 required_connections=[],
                 namespaced_agent_id="builtin:chat",
+                category="conversation",
+                tags=["chat", "general", "personality"],
+                icon="message-circle",
+                tools_count=0,
             )
         )
         logger.info(
@@ -349,6 +364,10 @@ class AgentRegistry:
                 models=[],
                 required_connections=[],
                 namespaced_agent_id="builtin:doc",
+                category="documents",
+                tags=["rag", "files", "search", "mcp"],
+                icon="file-text",
+                tools_count=15,
             )
         )
         logger.info("registry: Registered built-in agent: doc (ChatAgent, profile=doc)")
@@ -380,6 +399,10 @@ class AgentRegistry:
                 models=[],
                 required_connections=[],
                 namespaced_agent_id="builtin:file",
+                category="productivity",
+                tags=["files", "search", "filesystem", "shell"],
+                icon="folder-search",
+                tools_count=10,
             )
         )
         logger.info(
@@ -413,6 +436,10 @@ class AgentRegistry:
                 models=[],
                 required_connections=[],
                 namespaced_agent_id="builtin:data",
+                category="productivity",
+                tags=["data", "csv", "excel", "analysis"],
+                icon="table",
+                tools_count=10,
             )
         )
         logger.info(
@@ -446,6 +473,10 @@ class AgentRegistry:
                 models=[],
                 required_connections=[],
                 namespaced_agent_id="builtin:web",
+                category="research",
+                tags=["web", "search", "browser", "download"],
+                icon="globe",
+                tools_count=10,
             )
         )
         logger.info("registry: Registered built-in agent: web (ChatAgent, profile=web)")
@@ -520,6 +551,40 @@ class AgentRegistry:
             },
         ]
 
+        # Hub metadata for lite variants — mirrors their full-size counterparts.
+        _LITE_HUB_META = {
+            "chat-lite": {
+                "category": "conversation",
+                "tags": ["chat", "general", "lightweight"],
+                "icon": "message-circle",
+                "tools_count": 0,
+            },
+            "doc-lite": {
+                "category": "documents",
+                "tags": ["rag", "files", "lightweight"],
+                "icon": "file-text",
+                "tools_count": 15,
+            },
+            "file-lite": {
+                "category": "productivity",
+                "tags": ["files", "search", "lightweight"],
+                "icon": "folder-search",
+                "tools_count": 10,
+            },
+            "data-lite": {
+                "category": "productivity",
+                "tags": ["data", "csv", "lightweight"],
+                "icon": "table",
+                "tools_count": 10,
+            },
+            "web-lite": {
+                "category": "research",
+                "tags": ["web", "search", "lightweight"],
+                "icon": "globe",
+                "tools_count": 10,
+            },
+        }
+
         for agent_def in _LITE_AGENTS:
             aid = agent_def["id"]
             profile = agent_def["profile"]
@@ -540,6 +605,7 @@ class AgentRegistry:
 
                 return factory
 
+            hub = _LITE_HUB_META.get(aid, {})
             self._register(
                 AgentRegistration(
                     id=aid,
@@ -555,6 +621,10 @@ class AgentRegistry:
                     min_memory_gb=_LITE_MIN_MEMORY_GB,
                     required_connections=[],
                     namespaced_agent_id=f"builtin:{aid}",
+                    category=hub.get("category", "general"),
+                    tags=hub.get("tags", []),
+                    icon=hub.get("icon", ""),
+                    tools_count=hub.get("tools_count", 0),
                 )
             )
             logger.info(
@@ -585,6 +655,10 @@ class AgentRegistry:
                 min_memory_gb=_LITE_MIN_MEMORY_GB,
                 required_connections=[],
                 namespaced_agent_id="builtin:gaia-lite",
+                category="documents",
+                tags=["lightweight", "fast", "rag"],
+                icon="zap",
+                tools_count=15,
             )
         )
         logger.info(
@@ -642,6 +716,10 @@ class AgentRegistry:
                     # canonical objects so the registry stays consistent.
                     required_connections=list(ConnectorsDemoAgent.REQUIRED_CONNECTORS),
                     namespaced_agent_id="builtin:connectors-demo",
+                    category="productivity",
+                    tags=["google", "gmail", "github", "calendar"],
+                    icon="plug",
+                    tools_count=4,
                 )
             )
             logger.info(
@@ -681,6 +759,10 @@ class AgentRegistry:
                     models=[],
                     required_connections=list(EmailTriageAgent.REQUIRED_CONNECTORS),
                     namespaced_agent_id="builtin:email",
+                    category="productivity",
+                    tags=["email", "gmail", "calendar", "triage"],
+                    icon="mail",
+                    tools_count=6,
                 )
             )
             logger.info("registry: Registered built-in agent: email (EmailTriageAgent)")
@@ -716,12 +798,119 @@ class AgentRegistry:
                     hidden=True,
                     required_connections=[],
                     namespaced_agent_id="builtin:builder",
+                    category="infrastructure",
+                    tags=["scaffold", "create"],
+                    icon="wrench",
+                    tools_count=1,
                 )
             )
             logger.info("registry: Registered built-in agent: builder (BuilderAgent)")
         except ImportError:
             logger.debug(
                 "registry: BuilderAgent not available, skipping built-in registration"
+            )
+
+    # ------------------------------------------------------------------
+    # Native (C++/binary) agent discovery
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _noop_factory(**_kwargs):
+        """Placeholder factory for native agents that cannot be created in-process."""
+        raise RuntimeError(
+            "Native agents require the Electron Agent Process Manager "
+            "(JSON-RPC over stdio). They cannot be started from the web backend."
+        )
+
+    def _discover_native_agents(self) -> None:
+        """Register native agents from ``agent-manifest.json``.
+
+        The Electron desktop app seeds ``~/.gaia/agent-manifest.json`` with
+        metadata for C++/.NET/native binary agents managed by the Agent
+        Process Manager.  We read this manifest so ``GET /api/agents``
+        returns a unified list of all agents — Python and native alike.
+        Native agents cannot be instantiated in-process; their factory
+        raises at call time.
+        """
+        manifest_locations = [
+            Path.home() / ".gaia" / "agent-manifest.json",
+            Path.home() / ".gaia" / "agents" / "agent-manifest.json",
+        ]
+        manifest_path = None
+        for candidate in manifest_locations:
+            if candidate.exists():
+                manifest_path = candidate
+                break
+
+        if manifest_path is None:
+            logger.debug(
+                "registry: No agent-manifest.json found, skipping native agents"
+            )
+            return
+
+        import json
+
+        try:
+            with open(manifest_path, encoding="utf-8") as f:
+                manifest = json.load(f)
+        except Exception as e:
+            logger.warning(
+                "registry: Failed to read agent-manifest.json at %s: %s",
+                manifest_path,
+                e,
+            )
+            return
+
+        if not isinstance(manifest, dict):
+            logger.warning("registry: agent-manifest.json is not an object, skipping")
+            return
+
+        agents_list = manifest.get("agents", [])
+        if not isinstance(agents_list, list):
+            logger.warning(
+                "registry: agent-manifest.json 'agents' is not a list, skipping"
+            )
+            return
+
+        registered = 0
+        for entry in agents_list:
+            if not isinstance(entry, dict) or "id" not in entry or "name" not in entry:
+                continue
+            agent_id = entry["id"]
+            # Skip if a Python agent already claimed this ID.
+            if agent_id in self._agents:
+                logger.debug(
+                    "registry: native agent %s skipped — ID already registered",
+                    agent_id,
+                )
+                continue
+            categories = entry.get("categories", [])
+            self._register(
+                AgentRegistration(
+                    id=agent_id,
+                    name=entry["name"],
+                    description=entry.get("description", ""),
+                    source="native",
+                    conversation_starters=[],
+                    factory=self._noop_factory,
+                    agent_dir=Path.home() / ".gaia" / "agents" / agent_id,
+                    models=[],
+                    hidden=False,
+                    namespaced_agent_id=f"native:{agent_id}",
+                    category=categories[0] if categories else "general",
+                    tags=list(categories),
+                    icon=entry.get("icon", ""),
+                    tools_count=entry.get("toolsCount", 0),
+                    language=entry.get("language", "cpp"),
+                )
+            )
+            registered += 1
+
+        if registered:
+            logger.info(
+                "registry: Registered %d native agent(s) from %s",
+                registered,
+                manifest_path,
             )
 
     # ------------------------------------------------------------------
@@ -805,6 +994,12 @@ class AgentRegistry:
         agent_name = agent_class.AGENT_NAME
         agent_desc = getattr(agent_class, "AGENT_DESCRIPTION", "")
         starters = getattr(agent_class, "CONVERSATION_STARTERS", [])
+
+        # Agent Hub metadata — optional class attributes for rich card display.
+        agent_category = getattr(agent_class, "AGENT_CATEGORY", "custom")
+        agent_icon = getattr(agent_class, "AGENT_ICON", "")
+        agent_tags = list(getattr(agent_class, "AGENT_TAGS", []) or [])
+        agent_tools_count = getattr(agent_class, "AGENT_TOOLS_COUNT", 0)
 
         # T-X2 (issue #915, plan amendment A9): block custom agents from
         # claiming a built-in's reserved AGENT_ID. Without this, a custom
@@ -916,6 +1111,10 @@ class AgentRegistry:
                 models=models,
                 required_connections=required_connections,
                 namespaced_agent_id=namespaced_id,
+                category=agent_category,
+                tags=agent_tags,
+                icon=agent_icon,
+                tools_count=agent_tools_count,
             )
         )
         logger.info(

--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -66,7 +66,9 @@ function App() {
         showDocLibrary,
         showFileBrowser,
         showSettings,
+        setShowSettings,
         showMemoryDashboard,
+        setShowMemoryDashboard,
         sidebarOpen,
         toggleSidebar,
         setSidebarOpen,
@@ -514,6 +516,7 @@ function App() {
 
             <Sidebar
                 onNewTask={handleNewTask}
+                onHome={() => { setCurrentSession(null); setShowSettings(false); setShowMemoryDashboard(false); window.history.replaceState(null, '', window.location.pathname); }}
                 tunnelActive={tunnelActive}
                 tunnelLoading={tunnelLoading}
                 onMobileToggle={handleMobileToggle}

--- a/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
+++ b/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
@@ -6,6 +6,8 @@ import { Wrench, Cpu, Shield, X, HardDrive } from 'lucide-react';
 import { getAgentIcon } from './agentIcons';
 import type { AgentInfo } from '../types';
 
+const isElectron = typeof window !== 'undefined' && !!(window as any).electronAPI;
+
 interface AgentDetailModalProps {
     agent: AgentInfo;
     onClose: () => void;
@@ -18,6 +20,9 @@ export function AgentDetailModal({ agent, onClose, onStartChat }: AgentDetailMod
     const starters = agent.conversation_starters ?? [];
     const models = agent.models ?? [];
     const toolsCount = agent.tools_count ?? 0;
+    const isNative = agent.source === 'native';
+    const canStart = !isNative || isElectron;
+    const DetailIcon = getAgentIcon(agent.icon);
 
     // Close on Escape
     const handleKey = useCallback((e: KeyboardEvent) => {
@@ -31,27 +36,33 @@ export function AgentDetailModal({ agent, onClose, onStartChat }: AgentDetailMod
 
     return (
         <div className="agent-detail-overlay" onClick={onClose}>
-            <div className="agent-detail-modal" onClick={(e) => e.stopPropagation()}>
+            <div
+                className="agent-detail-modal"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="agent-detail-title"
+                onClick={(e) => e.stopPropagation()}
+            >
                 {/* Header */}
                 <div className="agent-detail-header">
                     <div className="agent-detail-icon">
-                        {(() => { const Icon = getAgentIcon(agent.icon); return <Icon size={24} />; })()}
+                        <DetailIcon size={24} />
                     </div>
                     <div className="agent-detail-title-area">
-                        <h2 className="agent-detail-name">{agent.name}</h2>
+                        <h2 id="agent-detail-title" className="agent-detail-name">{agent.name}</h2>
                         <div className="agent-hub-card-badges">
                             {agent.source === 'builtin' && <span className="agent-badge agent-badge-builtin">Built-in</span>}
                             {agent.source === 'native' && <span className="agent-badge agent-badge-native">Native</span>}
                             {agent.source === 'custom_python' && <span className="agent-badge agent-badge-custom">Custom</span>}
-                            {agent.category && agent.category !== 'general' && (
-                                <span className="agent-badge agent-badge-category">{agent.category}</span>
-                            )}
                             {agent.language && agent.language !== 'python' && (
                                 <span className="agent-badge agent-badge-native">{agent.language.toUpperCase()}</span>
                             )}
+                            {agent.category && agent.category !== 'general' && (
+                                <span className="agent-badge agent-badge-category">{agent.category}</span>
+                            )}
                         </div>
                     </div>
-                    <button className="agent-detail-close" onClick={onClose}>
+                    <button className="agent-detail-close" onClick={onClose} aria-label="Close">
                         <X size={18} />
                     </button>
                 </div>
@@ -112,7 +123,7 @@ export function AgentDetailModal({ agent, onClose, onStartChat }: AgentDetailMod
                         <div className="agent-detail-section-title">Access Rights</div>
                         {connections.length > 0 ? (
                             <div className="agent-detail-permissions">
-                                {connections.map((c: any, i: number) => (
+                                {connections.map((c, i) => (
                                     <div key={i} className="agent-detail-permission">
                                         <Shield size={14} />
                                         <span>{c.connector_id}</span>
@@ -146,6 +157,8 @@ export function AgentDetailModal({ agent, onClose, onStartChat }: AgentDetailMod
                                     <button
                                         key={s}
                                         className="agent-detail-starter-chip"
+                                        disabled={!canStart}
+                                        title={!canStart ? 'Available in GAIA Desktop' : undefined}
                                         onClick={() => { onStartChat(agent.id, s); onClose(); }}
                                     >
                                         {s}

--- a/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
+++ b/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
@@ -1,0 +1,161 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useCallback } from 'react';
+import { Wrench, Cpu, Shield, X, HardDrive } from 'lucide-react';
+import { getAgentIcon } from './agentIcons';
+import type { AgentInfo } from '../types';
+
+interface AgentDetailModalProps {
+    agent: AgentInfo;
+    onClose: () => void;
+    onStartChat: (id: string, prompt?: string) => void;
+}
+
+export function AgentDetailModal({ agent, onClose, onStartChat }: AgentDetailModalProps) {
+    const connections = agent.required_connections ?? [];
+    const tags = agent.tags ?? [];
+    const starters = agent.conversation_starters ?? [];
+    const models = agent.models ?? [];
+    const toolsCount = agent.tools_count ?? 0;
+
+    // Close on Escape
+    const handleKey = useCallback((e: KeyboardEvent) => {
+        if (e.key === 'Escape') onClose();
+    }, [onClose]);
+
+    useEffect(() => {
+        document.addEventListener('keydown', handleKey);
+        return () => document.removeEventListener('keydown', handleKey);
+    }, [handleKey]);
+
+    return (
+        <div className="agent-detail-overlay" onClick={onClose}>
+            <div className="agent-detail-modal" onClick={(e) => e.stopPropagation()}>
+                {/* Header */}
+                <div className="agent-detail-header">
+                    <div className="agent-detail-icon">
+                        {(() => { const Icon = getAgentIcon(agent.icon); return <Icon size={24} />; })()}
+                    </div>
+                    <div className="agent-detail-title-area">
+                        <h2 className="agent-detail-name">{agent.name}</h2>
+                        <div className="agent-hub-card-badges">
+                            {agent.source === 'builtin' && <span className="agent-badge agent-badge-builtin">Built-in</span>}
+                            {agent.source === 'native' && <span className="agent-badge agent-badge-native">Native</span>}
+                            {agent.source === 'custom_python' && <span className="agent-badge agent-badge-custom">Custom</span>}
+                            {agent.category && agent.category !== 'general' && (
+                                <span className="agent-badge agent-badge-category">{agent.category}</span>
+                            )}
+                            {agent.language && agent.language !== 'python' && (
+                                <span className="agent-badge agent-badge-native">{agent.language.toUpperCase()}</span>
+                            )}
+                        </div>
+                    </div>
+                    <button className="agent-detail-close" onClick={onClose}>
+                        <X size={18} />
+                    </button>
+                </div>
+
+                {/* Body */}
+                <div className="agent-detail-body">
+                    {/* Description */}
+                    <div className="agent-detail-section">
+                        <div className="agent-detail-section-title">About</div>
+                        <p className="agent-detail-desc">{agent.description || 'No description available.'}</p>
+                    </div>
+
+                    {/* Technical metadata */}
+                    <div className="agent-detail-section">
+                        <div className="agent-detail-section-title">Details</div>
+                        <div className="agent-detail-meta-grid">
+                            {models.length > 0 && (
+                                <div className="agent-detail-meta-item">
+                                    <Cpu size={14} />
+                                    <div>
+                                        <div className="agent-detail-meta-label">Model</div>
+                                        <div className="agent-detail-meta-value">{models[0]}</div>
+                                    </div>
+                                </div>
+                            )}
+                            {toolsCount > 0 && (
+                                <div className="agent-detail-meta-item">
+                                    <Wrench size={14} />
+                                    <div>
+                                        <div className="agent-detail-meta-label">Tools</div>
+                                        <div className="agent-detail-meta-value">{toolsCount}</div>
+                                    </div>
+                                </div>
+                            )}
+                            {agent.min_memory_gb != null && (
+                                <div className="agent-detail-meta-item">
+                                    <HardDrive size={14} />
+                                    <div>
+                                        <div className="agent-detail-meta-label">Min Memory</div>
+                                        <div className="agent-detail-meta-value">{agent.min_memory_gb} GB</div>
+                                    </div>
+                                </div>
+                            )}
+                            {models.length > 1 && (
+                                <div className="agent-detail-meta-item">
+                                    <Cpu size={14} />
+                                    <div>
+                                        <div className="agent-detail-meta-label">Fallback</div>
+                                        <div className="agent-detail-meta-value">{models[1]}</div>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Access rights */}
+                    <div className="agent-detail-section">
+                        <div className="agent-detail-section-title">Access Rights</div>
+                        {connections.length > 0 ? (
+                            <div className="agent-detail-permissions">
+                                {connections.map((c: any, i: number) => (
+                                    <div key={i} className="agent-detail-permission">
+                                        <Shield size={14} />
+                                        <span>{c.connector_id}</span>
+                                        {c.reason && <span style={{ color: 'var(--text-muted)', fontSize: 12 }}> — {c.reason}</span>}
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="agent-detail-no-permissions">No special permissions required.</p>
+                        )}
+                    </div>
+
+                    {/* Tags */}
+                    {tags.length > 0 && (
+                        <div className="agent-detail-section">
+                            <div className="agent-detail-section-title">Tags</div>
+                            <div className="agent-detail-tags">
+                                {tags.map((tag) => (
+                                    <span key={tag} className="agent-detail-tag">{tag}</span>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Conversation starters */}
+                    {starters.length > 0 && (
+                        <div className="agent-detail-section">
+                            <div className="agent-detail-section-title">Try asking</div>
+                            <div className="agent-detail-starters">
+                                {starters.map((s) => (
+                                    <button
+                                        key={s}
+                                        className="agent-detail-starter-chip"
+                                        onClick={() => { onStartChat(agent.id, s); onClose(); }}
+                                    >
+                                        {s}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -5,7 +5,6 @@
 
 .agent-hub {
     width: 100%;
-    max-width: 820px;
     margin: 0 auto;
 }
 
@@ -83,14 +82,8 @@
 
 .agent-hub-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: 14px;
-}
-
-@media (max-width: 768px) {
-    .agent-hub-grid {
-        grid-template-columns: 1fr;
-    }
 }
 
 .agent-hub-empty {

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -5,7 +5,7 @@
 
 .agent-hub {
     width: 100%;
-    max-width: 960px;
+    max-width: 820px;
     margin: 0 auto;
 }
 
@@ -83,13 +83,13 @@
 
 .agent-hub-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px;
 }
 
-@media (max-width: 1200px) {
+@media (min-width: 1400px) {
     .agent-hub-grid {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, 1fr);
     }
 }
 
@@ -115,7 +115,7 @@
     background: var(--bg-card);
     border: 1px solid var(--border);
     border-radius: var(--radius-lg);
-    padding: 20px;
+    padding: 16px;
     cursor: pointer;
     transition: all 200ms ease;
     position: relative;

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -1,0 +1,580 @@
+/* Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+   SPDX-License-Identifier: MIT */
+
+/* ── Agent Hub Grid ─────────────────────────────────────────────────────── */
+
+.agent-hub {
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.agent-hub-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
+.agent-hub-title {
+    font-family: var(--font-sans);
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+/* Search + filter bar — only shown when 6+ agents */
+.agent-hub-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.agent-hub-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    font-size: 13px;
+    transition: border-color 200ms ease;
+}
+
+.agent-hub-search:focus-within {
+    border-color: var(--amd-red);
+}
+
+.agent-hub-search input {
+    border: none;
+    background: none;
+    outline: none;
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    width: 160px;
+}
+
+.agent-hub-search input::placeholder {
+    color: var(--text-muted);
+}
+
+.agent-hub-filter {
+    padding: 6px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    cursor: pointer;
+    transition: border-color 200ms ease;
+}
+
+.agent-hub-filter:hover {
+    border-color: var(--text-secondary);
+}
+
+/* ── Card Grid ──────────────────────────────────────────────────────────── */
+
+.agent-hub-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+}
+
+@media (max-width: 1200px) {
+    .agent-hub-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .agent-hub-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.agent-hub-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+/* ── Agent Hub Card ─────────────────────────────────────────────────────── */
+
+.agent-hub-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 20px;
+    cursor: pointer;
+    transition: all 200ms ease;
+    position: relative;
+    opacity: 0;
+    animation: hubCardReveal 400ms ease forwards;
+}
+
+@keyframes hubCardReveal {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.agent-hub-card:nth-child(1) { animation-delay: 0ms; }
+.agent-hub-card:nth-child(2) { animation-delay: 80ms; }
+.agent-hub-card:nth-child(3) { animation-delay: 160ms; }
+.agent-hub-card:nth-child(4) { animation-delay: 240ms; }
+.agent-hub-card:nth-child(5) { animation-delay: 320ms; }
+.agent-hub-card:nth-child(6) { animation-delay: 400ms; }
+.agent-hub-card:nth-child(n+7) { animation-delay: 480ms; }
+
+.agent-hub-card:hover {
+    border-color: var(--text-secondary);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+
+.agent-hub-card.active {
+    border-left: 3px solid var(--amd-red);
+    border-color: var(--amd-red);
+    box-shadow: 0 0 0 1px rgba(237, 28, 36, 0.1);
+}
+
+.agent-hub-card.disabled {
+    opacity: 0.55;
+    cursor: default;
+}
+
+.agent-hub-card.disabled:hover {
+    transform: none;
+    box-shadow: none;
+}
+
+/* Card header */
+.agent-hub-card-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 10px;
+}
+
+.agent-hub-card-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-md);
+    background: var(--amd-red-dim);
+    color: var(--amd-red);
+    flex-shrink: 0;
+}
+
+.agent-hub-card-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.agent-hub-card-name {
+    font-family: var(--font-sans);
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-hub-card-badges {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+/* Card description */
+.agent-hub-card-desc {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.45;
+    margin-bottom: 12px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* Card metadata row */
+.agent-hub-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 12px;
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.agent-hub-card-meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.agent-hub-card-meta-item svg {
+    opacity: 0.7;
+}
+
+/* Conversation starter preview */
+.agent-hub-card-starter {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-style: italic;
+    padding: 8px 0;
+    border-top: 1px solid var(--border);
+    margin-bottom: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-hub-card-starter::before {
+    content: '\201C';
+}
+
+.agent-hub-card-starter::after {
+    content: '\201D';
+}
+
+/* Card actions */
+.agent-hub-card-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: auto;
+}
+
+.agent-hub-card-actions .btn-start-chat {
+    flex: 1;
+    padding: 7px 14px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--amd-red);
+    color: #fff;
+    font-family: var(--font-sans);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 200ms ease;
+}
+
+.agent-hub-card-actions .btn-start-chat:hover {
+    background: var(--amd-red-dark);
+}
+
+.agent-hub-card-actions .btn-start-chat:disabled {
+    background: var(--text-muted);
+    cursor: not-allowed;
+}
+
+.agent-hub-card-actions .btn-details {
+    padding: 7px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 200ms ease;
+}
+
+.agent-hub-card-actions .btn-details:hover {
+    border-color: var(--text-secondary);
+    color: var(--text-primary);
+}
+
+/* ── Badges ─────────────────────────────────────────────────────────────── */
+
+.agent-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+}
+
+.agent-badge-builtin {
+    background: var(--amd-red-dim);
+    color: var(--amd-red);
+}
+
+.agent-badge-custom {
+    background: rgba(59, 158, 255, 0.1);
+    color: var(--accent-blue);
+}
+
+.agent-badge-native {
+    background: rgba(6, 182, 212, 0.1);
+    color: var(--accent-cyan);
+}
+
+.agent-badge-category {
+    background: rgba(232, 168, 48, 0.1);
+    color: var(--accent-gold);
+}
+
+/* ── Create Agent CTA Card ──────────────────────────────────────────────── */
+
+.agent-hub-card.create-new {
+    border-style: dashed;
+    border-width: 2px;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    min-height: 200px;
+    background: transparent;
+}
+
+.agent-hub-card.create-new:hover {
+    border-color: var(--amd-red);
+    background: var(--amd-red-dim2);
+}
+
+.agent-hub-card.create-new .create-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--amd-red-dim);
+    color: var(--amd-red);
+    margin-bottom: 12px;
+}
+
+.agent-hub-card.create-new .create-title {
+    font-family: var(--font-sans);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+}
+
+.agent-hub-card.create-new .create-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+/* ── Detail Modal ───────────────────────────────────────────────────────── */
+
+.agent-detail-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    animation: fadeIn 200ms ease;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.agent-detail-modal {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    width: 90%;
+    max-width: 560px;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: var(--shadow-lg);
+    animation: modalSlide 250ms ease;
+}
+
+@keyframes modalSlide {
+    from { opacity: 0; transform: translateY(16px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.agent-detail-header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 24px 24px 16px;
+    border-bottom: 1px solid var(--border);
+}
+
+.agent-detail-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: var(--radius-md);
+    background: var(--amd-red-dim);
+    color: var(--amd-red);
+    flex-shrink: 0;
+}
+
+.agent-detail-title-area {
+    flex: 1;
+}
+
+.agent-detail-name {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 4px;
+}
+
+.agent-detail-close {
+    padding: 6px;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: all 200ms ease;
+}
+
+.agent-detail-close:hover {
+    color: var(--text-primary);
+    background: var(--bg-card);
+}
+
+.agent-detail-body {
+    padding: 20px 24px 24px;
+}
+
+.agent-detail-section {
+    margin-bottom: 20px;
+}
+
+.agent-detail-section:last-child {
+    margin-bottom: 0;
+}
+
+.agent-detail-section-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 8px;
+}
+
+.agent-detail-desc {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.55;
+}
+
+.agent-detail-meta-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
+.agent-detail-meta-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--bg-card);
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.agent-detail-meta-item svg {
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.agent-detail-meta-label {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.agent-detail-meta-value {
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+/* Conversation starter chips */
+.agent-detail-starters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.agent-detail-starter-chip {
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: var(--bg-card);
+    font-size: 12px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 200ms ease;
+}
+
+.agent-detail-starter-chip:hover {
+    border-color: var(--amd-red);
+    color: var(--amd-red);
+    background: var(--amd-red-dim2);
+}
+
+/* Tags list */
+.agent-detail-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.agent-detail-tag {
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: var(--bg-tertiary);
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+/* Permissions list */
+.agent-detail-permissions {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.agent-detail-permission {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: var(--bg-card);
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.agent-detail-no-permissions {
+    font-size: 13px;
+    color: var(--text-muted);
+    font-style: italic;
+}

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -87,12 +87,6 @@
     gap: 14px;
 }
 
-@media (min-width: 1400px) {
-    .agent-hub-grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
-}
-
 @media (max-width: 768px) {
     .agent-hub-grid {
         grid-template-columns: 1fr;

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -143,9 +143,8 @@
 }
 
 .agent-hub-card.active {
-    border-left: 3px solid var(--amd-red);
     border-color: var(--amd-red);
-    box-shadow: 0 0 0 1px rgba(237, 28, 36, 0.1);
+    box-shadow: inset 3px 0 0 var(--amd-red), 0 0 0 1px var(--amd-red-dim);
 }
 
 .agent-hub-card.disabled {

--- a/src/gaia/apps/webui/src/components/AgentHubCard.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubCard.tsx
@@ -1,0 +1,117 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { Cpu, Wrench, Shield } from 'lucide-react';
+import { getAgentIcon } from './agentIcons';
+import type { AgentInfo } from '../types';
+
+function sourceBadge(source: string) {
+    if (source === 'builtin') return <span className="agent-badge agent-badge-builtin">Built-in</span>;
+    if (source === 'native') return <span className="agent-badge agent-badge-native">Native</span>;
+    return <span className="agent-badge agent-badge-custom">Custom</span>;
+}
+
+interface AgentHubCardProps {
+    agent: AgentInfo;
+    isActive: boolean;
+    isElectron: boolean;
+    onSelect: (id: string) => void;
+    onStartChat: (id: string) => void;
+    onViewDetails: (agent: AgentInfo) => void;
+}
+
+export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartChat, onViewDetails }: AgentHubCardProps) {
+    const isNative = agent.source === 'native';
+    const canStart = !isNative || isElectron;
+    const model = agent.models?.[0];
+    const toolsCount = agent.tools_count ?? 0;
+    const starter = agent.conversation_starters?.[0];
+    const connections = agent.required_connections ?? [];
+    const Icon = getAgentIcon(agent.icon);
+
+    const cardClass = [
+        'agent-hub-card',
+        isActive && 'active',
+        !canStart && 'disabled',
+    ].filter(Boolean).join(' ');
+
+    return (
+        <div
+            className={cardClass}
+            role="button"
+            tabIndex={canStart ? 0 : -1}
+            onClick={() => canStart && onSelect(agent.id)}
+            onKeyDown={(e) => { if (canStart && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onSelect(agent.id); } }}
+        >
+            {/* Header */}
+            <div className="agent-hub-card-header">
+                <div className="agent-hub-card-icon">
+                    <Icon size={18} />
+                </div>
+                <div className="agent-hub-card-info">
+                    <h3 className="agent-hub-card-name">{agent.name}</h3>
+                    <div className="agent-hub-card-badges">
+                        {sourceBadge(agent.source)}
+                        {agent.language && agent.language !== 'python' && (
+                            <span className="agent-badge agent-badge-native">{agent.language.toUpperCase()}</span>
+                        )}
+                        {agent.category && agent.category !== 'general' && (
+                            <span className="agent-badge agent-badge-category">{agent.category}</span>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Description */}
+            <p className="agent-hub-card-desc">{agent.description || 'Custom agent'}</p>
+
+            {/* Metadata */}
+            <div className="agent-hub-card-meta">
+                {model && (
+                    <span className="agent-hub-card-meta-item">
+                        <Cpu size={12} />
+                        {model}
+                    </span>
+                )}
+                {toolsCount > 0 && (
+                    <span className="agent-hub-card-meta-item">
+                        <Wrench size={12} />
+                        {toolsCount} tools
+                    </span>
+                )}
+                {connections.length > 0 ? (
+                    <span className="agent-hub-card-meta-item">
+                        <Shield size={12} />
+                        {connections.map((c: any) => c.connector_id).join(', ')}
+                    </span>
+                ) : (
+                    <span className="agent-hub-card-meta-item">
+                        <Shield size={12} />
+                        No special permissions
+                    </span>
+                )}
+            </div>
+
+            {/* Starter preview */}
+            {starter && <div className="agent-hub-card-starter">{starter}</div>}
+
+            {/* Actions */}
+            <div className="agent-hub-card-actions">
+                <button
+                    className="btn-start-chat"
+                    disabled={!canStart}
+                    title={!canStart ? 'Available in GAIA Desktop' : `Start chat with ${agent.name}`}
+                    onClick={(e) => { e.stopPropagation(); onStartChat(agent.id); }}
+                >
+                    Start Chat
+                </button>
+                <button
+                    className="btn-details"
+                    onClick={(e) => { e.stopPropagation(); onViewDetails(agent); }}
+                >
+                    Details
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/AgentHubCard.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubCard.tsx
@@ -82,7 +82,7 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
                 {connections.length > 0 ? (
                     <span className="agent-hub-card-meta-item">
                         <Shield size={12} />
-                        {connections.map((c: any) => c.connector_id).join(', ')}
+                        {connections.map((c) => c.connector_id).join(', ')}
                     </span>
                 ) : (
                     <span className="agent-hub-card-meta-item">

--- a/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
@@ -73,6 +73,7 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
                             <input
                                 type="text"
                                 placeholder="Search agents..."
+                                aria-label="Search agents"
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
                             />
@@ -80,6 +81,7 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
                         {categories.length > 0 && (
                             <select
                                 className="agent-hub-filter"
+                                aria-label="Filter by category"
                                 value={categoryFilter}
                                 onChange={(e) => setCategoryFilter(e.target.value)}
                             >

--- a/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
@@ -109,7 +109,13 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
                     />
                 ))}
                 {onCreateAgent && (
-                    <div className="agent-hub-card create-new" onClick={onCreateAgent}>
+                    <div
+                        className="agent-hub-card create-new"
+                        role="button"
+                        tabIndex={0}
+                        onClick={onCreateAgent}
+                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCreateAgent(); } }}
+                    >
                         <div className="create-icon"><Plus size={22} /></div>
                         <div className="create-title">Build a Custom Agent</div>
                         <div className="create-desc">Create a new agent through conversation</div>

--- a/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
@@ -1,0 +1,129 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { useState, useMemo } from 'react';
+import { Plus, Search } from 'lucide-react';
+import type { AgentInfo } from '../types';
+import { AgentHubCard } from './AgentHubCard';
+import { AgentDetailModal } from './AgentDetailModal';
+import './AgentHub.css';
+
+interface AgentHubGridProps {
+    agents: AgentInfo[];
+    activeAgentId: string;
+    onSelect: (id: string) => void;
+    onStartChat: (id: string, prompt?: string) => void;
+    onCreateAgent?: () => void;
+}
+
+// Detect Electron context once
+const isElectron = typeof window !== 'undefined' && !!(window as any).electronAPI;
+
+/** Sort: builtin first, then custom, then native. Alphabetical within groups. */
+function sortAgents(agents: AgentInfo[]): AgentInfo[] {
+    const order: Record<string, number> = { builtin: 0, custom_python: 1, native: 2 };
+    return [...agents].sort((a, b) => {
+        const oa = order[a.source] ?? 1;
+        const ob = order[b.source] ?? 1;
+        if (oa !== ob) return oa - ob;
+        return a.name.localeCompare(b.name);
+    });
+}
+
+export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onCreateAgent }: AgentHubGridProps) {
+    const [search, setSearch] = useState('');
+    const [categoryFilter, setCategoryFilter] = useState('all');
+    const [detailAgent, setDetailAgent] = useState<AgentInfo | null>(null);
+
+    const showControls = agents.length > 6;
+
+    // Unique categories for the filter dropdown
+    const categories = useMemo(() => {
+        const cats = new Set<string>();
+        agents.forEach((a) => { if (a.category && a.category !== 'general') cats.add(a.category); });
+        return Array.from(cats).sort();
+    }, [agents]);
+
+    // Filter + sort
+    const filtered = useMemo(() => {
+        let list = agents;
+        if (search) {
+            const q = search.toLowerCase();
+            list = list.filter((a) =>
+                a.name.toLowerCase().includes(q) ||
+                a.description.toLowerCase().includes(q) ||
+                (a.tags ?? []).some((t) => t.toLowerCase().includes(q)) ||
+                (a.category ?? '').toLowerCase().includes(q)
+            );
+        }
+        if (categoryFilter !== 'all') {
+            list = list.filter((a) => a.category === categoryFilter);
+        }
+        return sortAgents(list);
+    }, [agents, search, categoryFilter]);
+
+    return (
+        <div className="agent-hub">
+            <div className="agent-hub-header">
+                <span className="agent-hub-title">Choose Your Agent</span>
+                {showControls && (
+                    <div className="agent-hub-controls">
+                        <div className="agent-hub-search">
+                            <Search size={14} />
+                            <input
+                                type="text"
+                                placeholder="Search agents..."
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                            />
+                        </div>
+                        {categories.length > 0 && (
+                            <select
+                                className="agent-hub-filter"
+                                value={categoryFilter}
+                                onChange={(e) => setCategoryFilter(e.target.value)}
+                            >
+                                <option value="all">All categories</option>
+                                {categories.map((c) => (
+                                    <option key={c} value={c}>{c}</option>
+                                ))}
+                            </select>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            <div className="agent-hub-grid">
+                {filtered.length === 0 && (
+                    <div className="agent-hub-empty">No agents match your search.</div>
+                )}
+                {filtered.map((agent) => (
+                    <AgentHubCard
+                        key={agent.id}
+                        agent={agent}
+                        isActive={agent.id === activeAgentId}
+                        isElectron={isElectron}
+                        onSelect={onSelect}
+                        onStartChat={(id) => onStartChat(id)}
+                        onViewDetails={setDetailAgent}
+                    />
+                ))}
+                {onCreateAgent && (
+                    <div className="agent-hub-card create-new" onClick={onCreateAgent}>
+                        <div className="create-icon"><Plus size={22} /></div>
+                        <div className="create-title">Build a Custom Agent</div>
+                        <div className="create-desc">Create a new agent through conversation</div>
+                    </div>
+                )}
+            </div>
+
+            {detailAgent && (
+                <AgentDetailModal
+                    agent={detailAgent}
+                    onClose={() => setDetailAgent(null)}
+                    onStartChat={onStartChat}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/Sidebar.css
+++ b/src/gaia/apps/webui/src/components/Sidebar.css
@@ -40,6 +40,13 @@
     overflow: hidden;
     flex-shrink: 1;
     min-width: 0;
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    color: inherit;
+    font: inherit;
 }
 
 .brand-icon {

--- a/src/gaia/apps/webui/src/components/Sidebar.tsx
+++ b/src/gaia/apps/webui/src/components/Sidebar.tsx
@@ -27,6 +27,7 @@ function copySessionLink(e: React.MouseEvent, sessionId: string) {
 
 interface SidebarProps {
     onNewTask: () => void;
+    onHome?: () => void;
     tunnelActive?: boolean;
     tunnelLoading?: boolean;
     onMobileToggle?: () => void;
@@ -101,7 +102,7 @@ function SessionItem({ session: s, isActive, isPendingDelete, isDeleting, onSele
     );
 }
 
-export function Sidebar({ onNewTask, tunnelActive, tunnelLoading, onMobileToggle }: SidebarProps) {
+export function Sidebar({ onNewTask, onHome, tunnelActive, tunnelLoading, onMobileToggle }: SidebarProps) {
     const {
         sessions, currentSessionId, setCurrentSession, removeSession, addSession,
         setMessages, theme, toggleTheme, setShowSettings, setShowMemoryDashboard,
@@ -349,7 +350,7 @@ export function Sidebar({ onNewTask, tunnelActive, tunnelLoading, onMobileToggle
             aria-label="Task sidebar"
         >
             <div className="sidebar-top">
-                <div className="sidebar-brand">
+                <button className="sidebar-brand" onClick={onHome} title="Agent Hub" aria-label="Go to Agent Hub">
                     <div className="brand-icon" aria-hidden="true">
                         <img src={gaiaRobot} alt="" width={28} height={28} />
                     </div>
@@ -358,7 +359,7 @@ export function Sidebar({ onNewTask, tunnelActive, tunnelLoading, onMobileToggle
                         <span className="brand-version">v{__APP_VERSION__}</span>
                         <span className="beta-badge">BETA</span>
                     </div>
-                </div>
+                </button>
                 <div className="sidebar-top-actions">
                     <button className="new-task-btn" onClick={onNewTask} title="New Task" aria-label="New Task">
                         <Plus size={18} />

--- a/src/gaia/apps/webui/src/components/WelcomeScreen.css
+++ b/src/gaia/apps/webui/src/components/WelcomeScreen.css
@@ -34,7 +34,8 @@
 }
 
 .welcome-inner {
-    max-width: 680px;
+    max-width: 1200px;
+    width: 100%;
     text-align: center;
     position: relative;
     z-index: 1;

--- a/src/gaia/apps/webui/src/components/WelcomeScreen.css
+++ b/src/gaia/apps/webui/src/components/WelcomeScreen.css
@@ -4,7 +4,7 @@
 .welcome {
     flex: 1;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     padding: 40px 40px 24px;
     overflow-y: auto;

--- a/src/gaia/apps/webui/src/components/WelcomeScreen.css
+++ b/src/gaia/apps/webui/src/components/WelcomeScreen.css
@@ -342,55 +342,6 @@
     line-height: 1.6;
 }
 
-/* ── Agent pills ─────────────────────────────────────────────── */
-.agent-pills {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 8px;
-    margin-bottom: 24px;
-    opacity: 0;
-}
-
-.content-revealed .agent-pills {
-    animation: fadeInUp 500ms var(--ease) 420ms forwards;
-}
-
-.agent-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    height: 32px;
-    padding: 0 14px;
-    font-size: 12px;
-    font-family: var(--font-sans);
-    font-weight: 500;
-    color: var(--text-secondary);
-    background: transparent;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-full);
-    cursor: pointer;
-    transition: all 0.2s var(--ease);
-    white-space: nowrap;
-}
-
-.agent-pill:hover {
-    border-color: var(--text-muted);
-    color: var(--text-primary);
-}
-
-.agent-pill.active {
-    background: #ed1c24;
-    border-color: #ed1c24;
-    color: #fff;
-}
-
-.agent-pill.active:hover {
-    background: #d41920;
-    border-color: #d41920;
-    color: #fff;
-}
-
 /* ── First-run setup hint ─────────────────────────────────────── */
 .welcome-setup-hint {
     display: flex;

--- a/src/gaia/apps/webui/src/components/WelcomeScreen.tsx
+++ b/src/gaia/apps/webui/src/components/WelcomeScreen.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Lock, Zap, FileText, DollarSign, Terminal, Bot, Plus } from 'lucide-react';
+import { Lock, Zap, FileText, DollarSign, Terminal } from 'lucide-react';
 import { useChatStore } from '../stores/chatStore';
+import { AgentHubGrid } from './AgentHubGrid';
 import './WelcomeScreen.css';
 
 interface WelcomeScreenProps {
@@ -157,20 +158,18 @@ export function WelcomeScreen({ onNewTask, onSendPrompt, onCreateAgent }: Welcom
                         expandedDesc="No API keys, no subscriptions, no hidden costs. Fully open-source." />
                 </div>
 
-                {agents.length > 1 && (
-                    <div className="agent-pills">
-                        {agents.map((agent) => (
-                            <button
-                                key={agent.id}
-                                className={`agent-pill${agent.id === activeAgentId ? ' active' : ''}`}
-                                onClick={() => setActiveAgentId(agent.id)}
-                                title={agent.description || agent.name}
-                            >
-                                <Bot size={14} />
-                                <span>{agent.name}</span>
-                            </button>
-                        ))}
-                    </div>
+                {agents.length > 0 && (
+                    <AgentHubGrid
+                        agents={agents}
+                        activeAgentId={activeAgentId}
+                        onSelect={setActiveAgentId}
+                        onStartChat={(id, prompt) => {
+                            setActiveAgentId(id);
+                            if (prompt) onSendPrompt(prompt);
+                            else onNewTask();
+                        }}
+                        onCreateAgent={onCreateAgent}
+                    />
                 )}
 
                 {/* First-run setup hints. Size hint is sourced from the
@@ -206,12 +205,6 @@ export function WelcomeScreen({ onNewTask, onSendPrompt, onCreateAgent }: Welcom
                     <button className="btn-primary start-btn" onClick={onNewTask} disabled={isInitializing}>
                         Start a New Task
                     </button>
-                    {onCreateAgent && (
-                        <button className="build-agent-btn" onClick={onCreateAgent} disabled={isInitializing}>
-                            <Plus size={14} />
-                            Build a Custom Agent
-                        </button>
-                    )}
                 </div>
 
                 <div className="suggestions">

--- a/src/gaia/apps/webui/src/components/agentIcons.ts
+++ b/src/gaia/apps/webui/src/components/agentIcons.ts
@@ -1,0 +1,34 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shared icon map for Agent Hub components.
+ * Maps lucide icon names (from agent metadata) to components.
+ */
+
+import {
+    Bot, MessageCircle, Zap, Plug, Wrench, Cpu, Hammer,
+    Shield, Code, FileText, FolderSearch, Table, Globe, Mail,
+    type LucideIcon,
+} from 'lucide-react';
+
+export const AGENT_ICON_MAP: Record<string, LucideIcon> = {
+    'message-circle': MessageCircle,
+    'file-text': FileText,
+    'folder-search': FolderSearch,
+    'table': Table,
+    'globe': Globe,
+    'mail': Mail,
+    'zap': Zap,
+    'plug': Plug,
+    'wrench': Wrench,
+    'cpu': Cpu,
+    'hammer': Hammer,
+    'shield': Shield,
+    'code': Code,
+    'bot': Bot,
+};
+
+export function getAgentIcon(name?: string): LucideIcon {
+    return (name && AGENT_ICON_MAP[name]) || Bot;
+}

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -36,6 +36,12 @@ export interface AgentInfo {
      * are `custom:<sha256-prefix>:<id>`. Pass this to the grants endpoint.
      */
     namespaced_agent_id?: string;
+    /** Agent Hub metadata — used to render rich discovery cards. */
+    category?: string;
+    tags?: string[];
+    icon?: string;
+    tools_count?: number;
+    language?: string;
 }
 
 /**

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -174,7 +174,7 @@ class AgentInfo(BaseModel):
     id: str
     name: str
     description: str
-    source: Literal["builtin", "custom_python"]
+    source: Literal["builtin", "custom_python", "native"]
     conversation_starters: List[str] = Field(default_factory=list)
     models: List[str] = Field(default_factory=list)
     # Minimum free system memory (GB) the agent recommends before loading its
@@ -192,6 +192,12 @@ class AgentInfo(BaseModel):
     # agents use ``custom:<sha256-prefix>:<id>``. The CLI and UI consent
     # dialog use this when calling ``grant_agent`` / ``revoke_agent_grant``.
     namespaced_agent_id: str = ""
+    # Agent Hub metadata — used by the frontend to render rich discovery cards.
+    category: str = "general"
+    tags: List[str] = Field(default_factory=list)
+    icon: str = ""  # lucide icon name
+    tools_count: int = 0
+    language: str = "python"  # "python" | "cpp"
 
 
 class AgentListResponse(BaseModel):

--- a/src/gaia/ui/routers/agents.py
+++ b/src/gaia/ui/routers/agents.py
@@ -80,6 +80,24 @@ def _require_tunnel_inactive(request: Request) -> None:
 
 
 def _reg_to_info(reg) -> AgentInfo:
+    # required_connections may contain ConnectorRequirement objects (with
+    # .connector_id/.scopes/.reason) or plain strings (legacy shorthand
+    # used by connectors-demo). Normalise both into dicts for the API
+    # response, keyed as "connector_id" to match the TypeScript
+    # ConnectorRequirement interface.
+    connections = []
+    for cr in reg.required_connections:
+        if isinstance(cr, str):
+            connections.append({"connector_id": cr, "scopes": [], "reason": ""})
+        else:
+            connections.append(
+                {
+                    "connector_id": cr.connector_id,
+                    "scopes": list(cr.scopes),
+                    "reason": cr.reason,
+                }
+            )
+
     return AgentInfo(
         id=reg.id,
         name=reg.name,
@@ -88,17 +106,13 @@ def _reg_to_info(reg) -> AgentInfo:
         conversation_starters=reg.conversation_starters,
         models=reg.models,
         min_memory_gb=reg.min_memory_gb,
-        # T-X2 (issue #915): surface declared connection requirements so the
-        # AgentUI consent dialog can render the prompt at agent-selection time.
-        required_connections=[
-            {
-                "connector_id": cr.connector_id,
-                "scopes": list(cr.scopes),
-                "reason": cr.reason,
-            }
-            for cr in reg.required_connections
-        ],
+        required_connections=connections,
         namespaced_agent_id=reg.namespaced_agent_id,
+        category=reg.category,
+        tags=reg.tags,
+        icon=reg.icon,
+        tools_count=reg.tools_count,
+        language=reg.language,
     )
 
 

--- a/tests/unit/test_agent_hub_api.py
+++ b/tests/unit/test_agent_hub_api.py
@@ -121,9 +121,7 @@ class TestNativeAgentDiscovery:
             ],
         }
         (tmp_path / ".gaia").mkdir(exist_ok=True)
-        (tmp_path / ".gaia" / "agent-manifest.json").write_text(
-            json.dumps(manifest)
-        )
+        (tmp_path / ".gaia" / "agent-manifest.json").write_text(json.dumps(manifest))
 
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         registry = AgentRegistry()

--- a/tests/unit/test_agent_hub_api.py
+++ b/tests/unit/test_agent_hub_api.py
@@ -105,7 +105,7 @@ class TestBuiltinAgentHubMetadata:
 class TestNativeAgentDiscovery:
     """Verify native agent discovery from agent-manifest.json."""
 
-    def test_discover_native_agents_from_manifest(self, tmp_path):
+    def test_discover_native_agents_from_manifest(self, tmp_path, monkeypatch):
         manifest = {
             "manifest_version": 1,
             "agents": [
@@ -120,28 +120,14 @@ class TestNativeAgentDiscovery:
                 },
             ],
         }
-        manifest_path = tmp_path / "agent-manifest.json"
-        manifest_path.write_text(json.dumps(manifest))
+        (tmp_path / ".gaia").mkdir(exist_ok=True)
+        (tmp_path / ".gaia" / "agent-manifest.json").write_text(
+            json.dumps(manifest)
+        )
 
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         registry = AgentRegistry()
-        # Patch the manifest location search
-        with patch.object(
-            AgentRegistry,
-            "_discover_native_agents",
-            wraps=registry._discover_native_agents,
-        ):
-            # Directly call with patched path
-            original = Path.home
-            try:
-                Path.home = staticmethod(lambda: tmp_path)
-                # Create the expected path structure
-                (tmp_path / ".gaia").mkdir(exist_ok=True)
-                manifest_dest = tmp_path / ".gaia" / "agent-manifest.json"
-                manifest_dest.write_text(json.dumps(manifest))
-
-                registry._discover_native_agents()
-            finally:
-                Path.home = original
+        registry._discover_native_agents()
 
         reg = registry.get("health-agent")
         assert reg is not None
@@ -152,14 +138,10 @@ class TestNativeAgentDiscovery:
         assert "system" in reg.tags
         assert reg.namespaced_agent_id == "native:health-agent"
 
-    def test_no_manifest_file_is_noop(self, tmp_path):
+    def test_no_manifest_file_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
         registry = AgentRegistry()
-        original = Path.home
-        try:
-            Path.home = staticmethod(lambda: tmp_path)
-            registry._discover_native_agents()
-        finally:
-            Path.home = original
+        registry._discover_native_agents()
         assert len(registry.list()) == 0
 
     def test_native_factory_raises(self):

--- a/tests/unit/test_agent_hub_api.py
+++ b/tests/unit/test_agent_hub_api.py
@@ -1,0 +1,209 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for Agent Hub metadata in the /api/agents endpoint."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gaia.agents.registry import AgentRegistration, AgentRegistry
+
+
+class TestAgentRegistrationHubMetadata:
+    """Verify that AgentRegistration carries Hub metadata fields."""
+
+    def test_default_hub_fields(self):
+        reg = AgentRegistration(
+            id="test",
+            name="Test Agent",
+            description="A test agent",
+            source="builtin",
+            conversation_starters=[],
+            factory=lambda **kw: None,
+            agent_dir=None,
+            models=[],
+        )
+        assert reg.category == "general"
+        assert reg.tags == []
+        assert reg.icon == ""
+        assert reg.tools_count == 0
+        assert reg.language == "python"
+
+    def test_custom_hub_fields(self):
+        reg = AgentRegistration(
+            id="my-agent",
+            name="My Agent",
+            description="Does things",
+            source="custom_python",
+            conversation_starters=["Hello"],
+            factory=lambda **kw: None,
+            agent_dir=None,
+            models=["Qwen3.5-35B"],
+            category="productivity",
+            tags=["email", "calendar"],
+            icon="mail",
+            tools_count=5,
+            language="python",
+        )
+        assert reg.category == "productivity"
+        assert reg.tags == ["email", "calendar"]
+        assert reg.icon == "mail"
+        assert reg.tools_count == 5
+
+    def test_native_source_type(self):
+        reg = AgentRegistration(
+            id="native-agent",
+            name="Native Agent",
+            description="C++ agent",
+            source="native",
+            conversation_starters=[],
+            factory=lambda **kw: None,
+            agent_dir=None,
+            models=[],
+            language="cpp",
+        )
+        assert reg.source == "native"
+        assert reg.language == "cpp"
+
+
+class TestBuiltinAgentHubMetadata:
+    """Verify builtin agents have Hub metadata populated."""
+
+    @pytest.fixture()
+    def registry(self):
+        r = AgentRegistry()
+        r._register_builtin_agents()
+        return r
+
+    def test_chat_agent_metadata(self, registry):
+        reg = registry.get("chat")
+        assert reg is not None
+        assert reg.category == "conversation"
+        assert "chat" in reg.tags
+        assert reg.icon == "message-circle"
+        assert reg.language == "python"
+
+    def test_gaia_lite_metadata(self, registry):
+        reg = registry.get("gaia-lite")
+        assert reg is not None
+        assert reg.category == "documents"
+        assert "lightweight" in reg.tags
+        assert reg.icon == "zap"
+        assert reg.tools_count > 0
+
+    def test_builder_metadata(self, registry):
+        reg = registry.get("builder")
+        if reg is None:
+            pytest.skip("BuilderAgent not available")
+        assert reg.category == "infrastructure"
+        assert reg.icon == "wrench"
+        assert reg.tools_count == 1
+
+
+class TestNativeAgentDiscovery:
+    """Verify native agent discovery from agent-manifest.json."""
+
+    def test_discover_native_agents_from_manifest(self, tmp_path):
+        manifest = {
+            "manifest_version": 1,
+            "agents": [
+                {
+                    "id": "health-agent",
+                    "name": "Health Agent",
+                    "description": "Monitors system health",
+                    "version": "1.0.0",
+                    "language": "cpp",
+                    "toolsCount": 3,
+                    "categories": ["monitoring", "system"],
+                },
+            ],
+        }
+        manifest_path = tmp_path / "agent-manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        registry = AgentRegistry()
+        # Patch the manifest location search
+        with patch.object(
+            AgentRegistry,
+            "_discover_native_agents",
+            wraps=registry._discover_native_agents,
+        ):
+            # Directly call with patched path
+            import gaia.agents.registry as reg_mod
+
+            original = Path.home
+            try:
+                Path.home = staticmethod(lambda: tmp_path)
+                # Create the expected path structure
+                (tmp_path / ".gaia").mkdir(exist_ok=True)
+                manifest_dest = tmp_path / ".gaia" / "agent-manifest.json"
+                manifest_dest.write_text(json.dumps(manifest))
+
+                registry._discover_native_agents()
+            finally:
+                Path.home = original
+
+        reg = registry.get("health-agent")
+        assert reg is not None
+        assert reg.source == "native"
+        assert reg.language == "cpp"
+        assert reg.tools_count == 3
+        assert reg.category == "monitoring"
+        assert "system" in reg.tags
+        assert reg.namespaced_agent_id == "native:health-agent"
+
+    def test_no_manifest_file_is_noop(self, tmp_path):
+        registry = AgentRegistry()
+        original = Path.home
+        try:
+            Path.home = staticmethod(lambda: tmp_path)
+            registry._discover_native_agents()
+        finally:
+            Path.home = original
+        assert len(registry.list()) == 0
+
+    def test_native_factory_raises(self):
+        with pytest.raises(RuntimeError, match="Native agents require"):
+            AgentRegistry._noop_factory()
+
+
+class TestAgentInfoApiModel:
+    """Verify the Pydantic AgentInfo model includes Hub fields."""
+
+    def test_hub_fields_serialize(self):
+        from gaia.ui.models import AgentInfo
+
+        info = AgentInfo(
+            id="test",
+            name="Test",
+            description="desc",
+            source="builtin",
+            category="documents",
+            tags=["rag"],
+            icon="message-circle",
+            tools_count=10,
+            language="python",
+        )
+        data = info.model_dump()
+        assert data["category"] == "documents"
+        assert data["tags"] == ["rag"]
+        assert data["icon"] == "message-circle"
+        assert data["tools_count"] == 10
+        assert data["language"] == "python"
+
+    def test_native_source_type(self):
+        from gaia.ui.models import AgentInfo
+
+        info = AgentInfo(
+            id="native",
+            name="Native",
+            description="desc",
+            source="native",
+            language="cpp",
+        )
+        assert info.source == "native"
+        assert info.language == "cpp"

--- a/tests/unit/test_agent_hub_api.py
+++ b/tests/unit/test_agent_hub_api.py
@@ -4,9 +4,7 @@
 """Tests for Agent Hub metadata in the /api/agents endpoint."""
 
 import json
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -133,8 +131,6 @@ class TestNativeAgentDiscovery:
             wraps=registry._discover_native_agents,
         ):
             # Directly call with patched path
-            import gaia.agents.registry as reg_mod
-
             original = Path.home
             try:
                 Path.home = staticmethod(lambda: tmp_path)

--- a/util/check_doc_links.py
+++ b/util/check_doc_links.py
@@ -56,6 +56,9 @@ SKIP_DOMAINS = {
     "your-domain",
     "grafana.internal",
     "marketplace.visualstudio.com",  # Blocks automated requests with 404
+    "dl.acm.org",  # Blocks automated requests with CAPTCHAs
+    "platform.openai.com",  # Rate-limits CI bots
+    "www.npmjs.com",  # Returns 403 to automated requests
 }
 
 # URL patterns to skip
@@ -67,6 +70,7 @@ SKIP_PATTERNS = [
     r"\{[{%]",  # Template variables like {{ var }}
     r"^\$\{",  # JS template literals
     r"^url$",  # Placeholder "url" in markdown syntax examples
+    r"`$",  # Trailing backtick from inline code extraction (e.g. `https://...`)
     r"github\.com/amd/gaia/compare/",  # Release compare URLs (tags may not exist yet)
     r"github\.com/amd/gaia/(blob|tree)/main/",  # Same-repo links (may 404 during PRs before merge)
     r"https?://(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)",  # RFC1918 private IPs (example URLs in docs)


### PR DESCRIPTION
The Agent UI Welcome Screen showed agents as tiny name-only pills — users couldn't see what an agent does, what model it uses, or what permissions it needs before selecting one.

Now: rich agent cards on the Welcome Screen with icon, description, model chip, tool count, access rights, conversation starter preview, and Start Chat / Details actions. Backend enriched with category, tags, icon, tools_count, and language. Native (C++) agent manifest ingestion from `agent-manifest.json`. Hub skeleton (`hub/agents/python/`, `hub/agents/cpp/`) established for standalone agent packages that depend on the published `amd-gaia` PyPI package. Full platform plan (Phase 0–7) documented at `docs/plans/agent-hub-ui.mdx`.

<img width="1440" height="864" alt="image" src="https://github.com/user-attachments/assets/fd15d9f9-0ce1-4dc1-b720-f5d8c7788cf4" />

## Test plan

- [ ] `PYTHONPATH=src python -m pytest tests/unit/test_agent_hub_api.py -xvs` — 11 tests pass
- [ ] `cd src/gaia/apps/webui && npm run build` — no TS errors
- [ ] `python util/lint.py --black --isort` — passes
- [ ] Dev server: agent cards render with metadata on Welcome Screen
- [ ] Clicking card selects agent, updates suggestion chips
- [ ] "Start Chat" creates session with selected agent
- [ ] "Details" opens modal with full agent info
- [ ] "Build Custom Agent" CTA card triggers builder flow
- [ ] GAIA logo navigates back to Agent Hub from any view
- [ ] Responsive layout adapts columns to available width