### PR TITLE
fix(agent-ui): list custom agents from disk

### DIFF
--- a/src/gaia/apps/webui/src/components/CustomAgentsSection.tsx
+++ b/src/gaia/apps/webui/src/components/CustomAgentsSection.tsx
@@ -24,7 +24,7 @@ import * as api from '../services/api';
 import { useChatStore } from '../stores/chatStore';
 import { getApiBase } from '../utils/apiBase';
 import { log } from '../utils/logger';
-import type { AgentInfo } from '../types';
+import type { DiskAgentInfo } from '../types';
 
 // Export/import hit the REST backend directly (not the apiFetch wrapper)
 // because they deal with binary zip payloads, not JSON.
@@ -37,9 +37,10 @@ type Status =
     | { kind: 'error'; message: string };
 
 export function CustomAgentsSection() {
-    const { agents, setAgents } = useChatStore();
+    const { setAgents } = useChatStore();
 
     const [status, setStatus] = useState<Status>({ kind: 'idle' });
+    const [diskAgents, setDiskAgents] = useState<DiskAgentInfo[]>([]);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const statusClearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const errorBannerRef = useRef<HTMLDivElement>(null);
@@ -66,17 +67,23 @@ export function CustomAgentsSection() {
 
     const refreshAgents = useCallback(async () => {
         try {
-            const data = await api.listAgents();
-            setAgents(data.agents || []);
+            const [registered, disk] = await Promise.all([
+                api.listAgents(),
+                api.listDiskAgents(),
+            ]);
+            setAgents(registered.agents || []);
+            setDiskAgents(disk.agents || []);
         } catch (err) {
-            log.api.warn('Failed to refresh agents after import', err);
+            log.api.warn('Failed to refresh custom agents', err);
         }
     }, [setAgents]);
 
-    // Custom agents = anything not built-in. The backend marks built-in
-    // agents with source === "builtin"; anything else (user-created,
-    // imported bundles) belongs in this list.
-    const customAgents: AgentInfo[] = agents.filter((a) => a.source !== 'builtin');
+    useEffect(() => {
+        void refreshAgents();
+    }, [refreshAgents]);
+
+    const customAgents = diskAgents;
+    const hasExportableAgents = customAgents.length > 0;
 
     // ── Export ───────────────────────────────────────────────────────
     const handleExport = useCallback(async () => {
@@ -222,9 +229,11 @@ export function CustomAgentsSection() {
                         <div key={agent.id} className="status-row">
                             <span className="status-label">{agent.name}</span>
                             <div className="status-value-wrap">
-                                <span className="status-value ok">{agent.id}</span>
-                                {agent.source && agent.source !== 'builtin' && (
+                                <span className={`status-value ${agent.registered ? 'ok' : 'warn'}`}>{agent.id}</span>
+                                {agent.registered ? agent.source && (
                                     <span className="status-hint"><code>{agent.source}</code></span>
+                                ) : (
+                                    <span className="status-hint">Not loaded</span>
                                 )}
                             </div>
                         </div>
@@ -236,8 +245,8 @@ export function CustomAgentsSection() {
                 <button
                     className="btn-model-save"
                     onClick={handleExport}
-                    disabled={isWorking || customAgents.length === 0}
-                    title={customAgents.length === 0 ? 'No custom agents to export' : undefined}
+                    disabled={isWorking || !hasExportableAgents}
+                    title={!hasExportableAgents ? 'No custom agents to export' : undefined}
                 >
                     {isWorking && status.message.startsWith('Export') ? (
                         <><Loader2 size={13} className="btn-spinner" /> Exporting…</>

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -3,7 +3,7 @@
 
 /** API client for GAIA Agent UI backend. */
 
-import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPServerStatus, AgentMCPServerStatus, AgentInfo } from '../types';
+import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPServerStatus, AgentMCPServerStatus, AgentInfo, DiskAgentInfo } from '../types';
 import { getApiBase } from '../utils/apiBase';
 import { log } from '../utils/logger';
 
@@ -110,6 +110,10 @@ export async function downloadModel(modelName: string, force = false): Promise<{
 
 export async function listAgents(): Promise<{ agents: AgentInfo[]; total: number }> {
     return apiFetch('GET', '/agents');
+}
+
+export async function listDiskAgents(): Promise<{ agents: DiskAgentInfo[]; total: number }> {
+    return apiFetch('GET', '/agents/disk', undefined, { 'x-gaia-ui': '1' });
 }
 
 // -- Connections (issue #915) ---------------------------------------------------

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -38,6 +38,14 @@ export interface AgentInfo {
     namespaced_agent_id?: string;
 }
 
+export interface DiskAgentInfo {
+    id: string;
+    name: string;
+    registered: boolean;
+    registered_agent_id?: string | null;
+    source?: string | null;
+}
+
 /**
  * Issue #915 — declarative scope claim on an agent.
  */

--- a/src/gaia/installer/export_import.py
+++ b/src/gaia/installer/export_import.py
@@ -101,6 +101,26 @@ def _is_custom_agent_dir(path: Path) -> bool:
     return path.is_dir() and (path / "agent.py").is_file()
 
 
+def list_exportable_custom_agent_dirs() -> List[Path]:
+    """Return custom agent directories that would be included in an export."""
+    agents_root = _agents_root()
+    if not agents_root.exists():
+        return []
+
+    agent_dirs: List[Path] = []
+    for d in sorted(agents_root.iterdir(), key=lambda p: p.name):
+        if _is_custom_agent_dir(d):
+            agent_dirs.append(d)
+        elif d.is_dir() and (d / "agent.yaml").is_file():
+            log.warning(
+                "export: skipping legacy YAML-only agent directory %s "
+                "(YAML manifest agents were removed in v0.17.5; convert to "
+                "agent.py — see https://amd-gaia.ai/docs/guides/custom-agent)",
+                d,
+            )
+    return agent_dirs
+
+
 def _validate_agent_id(agent_id: str) -> None:
     """Raise ValueError if the agent id is unsafe or malformed."""
     if not isinstance(agent_id, str) or not agent_id.strip():
@@ -139,22 +159,7 @@ def export_custom_agents(output_path: Path) -> ExportResult:
         ValueError: If there are no custom agents to export.
     """
     output_path = Path(output_path)
-    agents_root = _agents_root()
-
-    if not agents_root.exists():
-        raise ValueError("No custom agents found to export")
-
-    agent_dirs: List[Path] = []
-    for d in sorted(agents_root.iterdir(), key=lambda p: p.name):
-        if _is_custom_agent_dir(d):
-            agent_dirs.append(d)
-        elif d.is_dir() and (d / "agent.yaml").is_file():
-            log.warning(
-                "export: skipping legacy YAML-only agent directory %s "
-                "(YAML manifest agents were removed in v0.17.5; convert to "
-                "agent.py — see https://amd-gaia.ai/docs/guides/custom-agent)",
-                d,
-            )
+    agent_dirs = list_exportable_custom_agent_dirs()
     if not agent_dirs:
         raise ValueError("No custom agents found to export")
 

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -201,6 +201,23 @@ class AgentListResponse(BaseModel):
     total: int
 
 
+class DiskAgentInfo(BaseModel):
+    """Information about an agent present under ~/.gaia/agents."""
+
+    id: str
+    name: str
+    registered: bool
+    registered_agent_id: Optional[str] = None
+    source: Optional[str] = None
+
+
+class DiskAgentListResponse(BaseModel):
+    """List of custom agents found on disk."""
+
+    agents: List[DiskAgentInfo]
+    total: int
+
+
 # ── Sessions ────────────────────────────────────────────────────────────────
 
 

--- a/src/gaia/ui/routers/agents.py
+++ b/src/gaia/ui/routers/agents.py
@@ -25,7 +25,7 @@ from fastapi.responses import FileResponse
 
 from gaia.logger import get_logger
 
-from ..models import AgentInfo, AgentListResponse
+from ..models import AgentInfo, AgentListResponse, DiskAgentInfo, DiskAgentListResponse
 
 logger = get_logger(__name__)
 
@@ -111,6 +111,39 @@ async def list_agents(request: Request):
         agents=[_reg_to_info(r) for r in registrations],
         total=len(registrations),
     )
+
+
+@router.get(
+    "/api/agents/disk",
+    response_model=DiskAgentListResponse,
+    dependencies=[Depends(_require_localhost), Depends(_require_ui_header)],
+)
+async def list_disk_agents(request: Request):
+    """List custom agents present on disk using the export scanner."""
+    from gaia.installer.export_import import list_exportable_custom_agent_dirs
+
+    registry = _registry(request)
+    registered_by_dir = {}
+    for reg in registry.list():
+        agent_dir = getattr(reg, "agent_dir", None)
+        if agent_dir is not None:
+            registered_by_dir[Path(agent_dir).resolve()] = reg
+
+    agents: list[DiskAgentInfo] = []
+    for agent_dir in list_exportable_custom_agent_dirs():
+        resolved_dir = agent_dir.resolve()
+        reg = registered_by_dir.get(resolved_dir)
+        agents.append(
+            DiskAgentInfo(
+                id=agent_dir.name,
+                name=reg.name if reg else agent_dir.name,
+                registered=reg is not None,
+                registered_agent_id=reg.id if reg else None,
+                source=reg.source if reg else None,
+            )
+        )
+
+    return DiskAgentListResponse(agents=agents, total=len(agents))
 
 
 @router.get("/api/agents/{agent_id:path}", response_model=AgentInfo)

--- a/tests/unit/chat/ui/test_agents_router.py
+++ b/tests/unit/chat/ui/test_agents_router.py
@@ -4,6 +4,7 @@
 """Unit tests for the /api/agents endpoints."""
 
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -159,6 +160,81 @@ class TestAgentsRouterWithoutRegistry:
         client = TestClient(app)
         resp = client.get("/api/agents")
         assert resp.status_code == 503
+
+
+class TestListDiskAgents:
+    def test_lists_exportable_agent_missing_from_registry(
+        self, app_with_registry, tmp_path
+    ):
+        from gaia.ui.routers.agents import _require_localhost
+
+        agent_dir = tmp_path / ".gaia" / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "agent.py").write_text("class NotImportedYet: pass\n")
+
+        app_with_registry.dependency_overrides[_require_localhost] = lambda: None
+        try:
+            with patch("gaia.installer.export_import.Path.home", return_value=tmp_path):
+                client = TestClient(app_with_registry)
+                resp = client.get("/api/agents/disk", headers={"X-Gaia-UI": "1"})
+        finally:
+            app_with_registry.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "agents": [
+                {
+                    "id": "test-agent",
+                    "name": "test-agent",
+                    "registered": False,
+                    "registered_agent_id": None,
+                    "source": None,
+                }
+            ],
+            "total": 1,
+        }
+
+    def test_marks_disk_agent_registered_by_directory(self, tmp_path):
+        from gaia.ui.routers.agents import _require_localhost
+
+        agent_dir = tmp_path / ".gaia" / "agents" / "disk-dir"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "agent.py").write_text("class AlreadyLoaded: pass\n")
+
+        app = create_app(db_path=":memory:")
+        registry = MagicMock(spec=AgentRegistry)
+        registry.list.return_value = [
+            AgentRegistration(
+                id="runtime-id",
+                name="Runtime Agent",
+                description="Loaded from disk",
+                source="custom_python",
+                conversation_starters=[],
+                factory=lambda **kw: None,
+                agent_dir=agent_dir,
+                models=[],
+            )
+        ]
+        app.state.agent_registry = registry
+        app.dependency_overrides[_require_localhost] = lambda: None
+
+        try:
+            with patch("gaia.installer.export_import.Path.home", return_value=tmp_path):
+                client = TestClient(app)
+                resp = client.get("/api/agents/disk", headers={"X-Gaia-UI": "1"})
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        assert resp.json()["agents"] == [
+            {
+                "id": "disk-dir",
+                "name": "Runtime Agent",
+                "registered": True,
+                "registered_agent_id": "runtime-id",
+                "source": "custom_python",
+            }
+        ]
 
 
 class TestExportImportSecurityGuards:

--- a/tests/unit/chat/ui/test_agents_router.py
+++ b/tests/unit/chat/ui/test_agents_router.py
@@ -3,8 +3,7 @@
 
 """Unit tests for the /api/agents endpoints."""
 
-from unittest.mock import MagicMock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient


### PR DESCRIPTION
Settings → Custom Agents now uses the same disk inventory as `gaia agent export`, so agents present under `~/.gaia/agents/` no longer disappear just because the runtime registry has not loaded them. Registered agents still show their runtime source, while exportable-but-unloaded agents remain visible and exportable instead of making the section look empty.

Test plan:
- [x] `PYTHONPATH=src uv run --python /usr/bin/python3 --with pytest --with fastapi --with httpx --with pydantic --with python-multipart --with pyyaml --with requests --with rich --with openai --with psutil --with keyring --with aiohttp --with python-dotenv pytest tests/unit/chat/ui/test_agents_router.py -q`
- [x] `npm --prefix src/gaia/apps/webui run build`

Fixes #1087