### PR TITLE
fix(llm): normalize LEMONADE_BASE_URL env var to include /api/v1 suffix

### DIFF
--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -61,7 +61,7 @@ def _get_lemonade_config() -> tuple:
     Get Lemonade host, port, and base_url from environment or defaults.
 
     Parses LEMONADE_BASE_URL env var if set, otherwise uses defaults.
-    The base_url is expected to include /api/v1 suffix per documentation.
+    Normalizes the URL to include /api/v1 suffix if omitted.
 
     Returns:
         Tuple of (host, port, base_url)
@@ -69,6 +69,9 @@ def _get_lemonade_config() -> tuple:
     from urllib.parse import urlparse
 
     base_url = os.getenv("LEMONADE_BASE_URL", DEFAULT_LEMONADE_URL)
+    # Normalize: ensure base_url includes /api/v1 suffix (users often omit it)
+    if not base_url.rstrip("/").endswith(f"/api/{LEMONADE_API_VERSION}"):
+        base_url = f"{base_url.rstrip('/')}/api/{LEMONADE_API_VERSION}"
     # Parse the URL to extract host and port for backwards compatibility
     parsed = urlparse(base_url)
     host = parsed.hostname or DEFAULT_HOST

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -450,5 +450,45 @@ class TestLemonadeManagerContextMessage(unittest.TestCase):
                 mock_print_context.assert_not_called()
 
 
+class TestGetLemonadeConfigNormalization(unittest.TestCase):
+    """Verify _get_lemonade_config normalizes LEMONADE_BASE_URL to include /api/v1."""
+
+    def test_env_url_without_api_suffix_is_normalized(self):
+        """LEMONADE_BASE_URL without /api/v1 should be normalized (issue #1158)."""
+        from gaia.llm.lemonade_client import _get_lemonade_config
+
+        with patch.dict(os.environ, {"LEMONADE_BASE_URL": "http://remote:13305"}):
+            _host, _port, base_url = _get_lemonade_config()
+            self.assertEqual(base_url, "http://remote:13305/api/v1")
+
+    def test_env_url_with_api_suffix_unchanged(self):
+        """LEMONADE_BASE_URL already containing /api/v1 should not be doubled."""
+        from gaia.llm.lemonade_client import _get_lemonade_config
+
+        with patch.dict(
+            os.environ, {"LEMONADE_BASE_URL": "http://remote:13305/api/v1"}
+        ):
+            _host, _port, base_url = _get_lemonade_config()
+            self.assertEqual(base_url, "http://remote:13305/api/v1")
+
+    def test_env_url_with_trailing_slash_normalized(self):
+        """Trailing slash should be stripped before appending /api/v1."""
+        from gaia.llm.lemonade_client import _get_lemonade_config
+
+        with patch.dict(os.environ, {"LEMONADE_BASE_URL": "http://remote:13305/"}):
+            _host, _port, base_url = _get_lemonade_config()
+            self.assertEqual(base_url, "http://remote:13305/api/v1")
+
+    def test_env_url_host_and_port_extracted(self):
+        """Host and port should be correctly parsed from the normalized URL."""
+        from gaia.llm.lemonade_client import _get_lemonade_config
+
+        with patch.dict(os.environ, {"LEMONADE_BASE_URL": "http://myhost:9000"}):
+            host, port, base_url = _get_lemonade_config()
+            self.assertEqual(host, "myhost")
+            self.assertEqual(port, 9000)
+            self.assertEqual(base_url, "http://myhost:9000/api/v1")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`LEMONADE_BASE_URL=http://host:13305` (without `/api/v1`) caused `gaia init` to fail with "Remote Lemonade Server is not reachable" because `_get_lemonade_config()` returned the raw env var while the explicit `base_url=` parameter path normalized it. Now both paths apply the same normalization, so `http://host:13305` and `http://host:13305/api/v1` both work.

Closes #1158

## Test plan

- [ ] `python -m pytest tests/unit/test_llm.py::TestGetLemonadeConfigNormalization -xvs` — 4 new tests pass
- [ ] `python util/lint.py --all` passes
- [ ] `export LEMONADE_BASE_URL=http://<remote>:13305 && gaia init` connects successfully