### PR TITLE
feat(agent-hub): discover installed agent entry points

### DIFF
--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -5,6 +5,7 @@
 import dataclasses
 import hashlib
 import importlib
+import importlib.metadata
 import importlib.util
 import inspect
 import os
@@ -23,6 +24,8 @@ from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
+
+AGENT_ENTRY_POINT_GROUP = "gaia.agents"
 
 # KNOWN_TOOLS maps tool name -> (module_path, class_name) for lazy import.
 # Consumed by BuilderAgent's template (src/gaia/agents/builder/template.py) to
@@ -285,7 +288,10 @@ class AgentRegistry:
         else:
             logger.info("registry: No custom agent directory found at %s", agents_dir)
 
-        # 3. Discover native (C++/binary) agents from agent-manifest.json
+        # 3. Discover installed Python agents exposed by standalone wheels
+        self._discover_entry_point_agents()
+
+        # 4. Discover native (C++/binary) agents from agent-manifest.json
         self._discover_native_agents()
 
         agent_ids = list(self._agents.keys())
@@ -835,6 +841,59 @@ class AgentRegistry:
             logger.debug(
                 "registry: BuilderAgent not available, skipping built-in registration"
             )
+
+    # ------------------------------------------------------------------
+    # Installed Python agent discovery
+    # ------------------------------------------------------------------
+
+    def _discover_entry_point_agents(self) -> None:
+        """Register installed Python agents from the ``gaia.agents`` group."""
+        entry_points = importlib.metadata.entry_points()
+        if hasattr(entry_points, "select"):
+            agent_entry_points = entry_points.select(group=AGENT_ENTRY_POINT_GROUP)
+        else:
+            agent_entry_points = entry_points.get(AGENT_ENTRY_POINT_GROUP, [])
+
+        registered = 0
+        for entry_point in agent_entry_points:
+            try:
+                registration = self._load_entry_point_registration(entry_point)
+            except Exception as exc:
+                logger.warning(
+                    "registry: Failed to load agent entry point %s: %s",
+                    entry_point.name,
+                    exc,
+                )
+                continue
+
+            if registration.id in self._agents:
+                logger.warning(
+                    "registry: entry point agent %s skipped — ID already registered",
+                    registration.id,
+                )
+                continue
+
+            self._register(registration)
+            registered += 1
+
+        if registered:
+            logger.info("registry: Registered %d entry point agent(s)", registered)
+
+    def _load_entry_point_registration(self, entry_point) -> AgentRegistration:
+        loaded = entry_point.load()
+        registration = loaded() if callable(loaded) else loaded
+        if not isinstance(registration, AgentRegistration):
+            raise TypeError(
+                f"{AGENT_ENTRY_POINT_GROUP} entry point {entry_point.name!r} "
+                "must load an AgentRegistration or a zero-argument callable "
+                "returning one"
+            )
+        if not registration.namespaced_agent_id:
+            registration = dataclasses.replace(
+                registration,
+                namespaced_agent_id=f"installed:{registration.id}",
+            )
+        return registration
 
     # ------------------------------------------------------------------
     # Native (C++/binary) agent discovery

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -890,19 +890,13 @@ class AgentRegistry:
                 "must load an AgentRegistration or a zero-argument callable "
                 "returning one"
             )
-        if (
-            registration.namespaced_agent_id != f"installed:{registration.id}"
-            or registration.source != "installed"
-        ):
-            registration = dataclasses.replace(
-                registration,
-                namespaced_agent_id=f"installed:{registration.id}",
-                source="installed",
-            )
+        namespaced_id = f"installed:{registration.id}"
         registration = dataclasses.replace(
             registration,
+            namespaced_agent_id=namespaced_id,
+            source="installed",
             factory=_wrap_factory_with_namespaced_id(
-                registration.factory, registration.namespaced_agent_id
+                registration.factory, namespaced_id
             ),
         )
         return registration

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -896,6 +896,12 @@ class AgentRegistry:
             )
         if registration.source != "installed":
             registration = dataclasses.replace(registration, source="installed")
+        registration = dataclasses.replace(
+            registration,
+            factory=_wrap_factory_with_namespaced_id(
+                registration.factory, registration.namespaced_agent_id
+            ),
+        )
         return registration
 
     # ------------------------------------------------------------------

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -849,10 +849,12 @@ class AgentRegistry:
     def _discover_entry_point_agents(self) -> None:
         """Register installed Python agents from the ``gaia.agents`` group."""
         entry_points = importlib.metadata.entry_points()
-        if hasattr(entry_points, "select"):
-            agent_entry_points = entry_points.select(group=AGENT_ENTRY_POINT_GROUP)
+        select_entry_points = getattr(entry_points, "select", None)
+        if callable(select_entry_points):
+            agent_entry_points = select_entry_points(group=AGENT_ENTRY_POINT_GROUP)
         else:
-            agent_entry_points = entry_points.get(AGENT_ENTRY_POINT_GROUP, [])
+            entry_points_for_group = getattr(entry_points, "get")
+            agent_entry_points = entry_points_for_group(AGENT_ENTRY_POINT_GROUP, [])
 
         registered = 0
         for entry_point in agent_entry_points:

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -848,13 +848,9 @@ class AgentRegistry:
 
     def _discover_entry_point_agents(self) -> None:
         """Register installed Python agents from the ``gaia.agents`` group."""
-        entry_points = importlib.metadata.entry_points()
-        select_entry_points = getattr(entry_points, "select", None)
-        if callable(select_entry_points):
-            agent_entry_points = select_entry_points(group=AGENT_ENTRY_POINT_GROUP)
-        else:
-            entry_points_for_group = getattr(entry_points, "get")
-            agent_entry_points = entry_points_for_group(AGENT_ENTRY_POINT_GROUP, [])
+        agent_entry_points = importlib.metadata.entry_points(
+            group=AGENT_ENTRY_POINT_GROUP
+        )
 
         registered = 0
         for entry_point in agent_entry_points:
@@ -865,6 +861,7 @@ class AgentRegistry:
                     "registry: Failed to load agent entry point %s: %s",
                     entry_point.name,
                     exc,
+                    exc_info=True,
                 )
                 continue
 
@@ -881,7 +878,9 @@ class AgentRegistry:
         if registered:
             logger.info("registry: Registered %d entry point agent(s)", registered)
 
-    def _load_entry_point_registration(self, entry_point) -> AgentRegistration:
+    def _load_entry_point_registration(
+        self, entry_point: importlib.metadata.EntryPoint
+    ) -> AgentRegistration:
         loaded = entry_point.load()
         registration = loaded() if callable(loaded) else loaded
         if not isinstance(registration, AgentRegistration):

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -189,7 +189,7 @@ class AgentRegistration:
     id: str
     name: str
     description: str
-    source: Literal["builtin", "custom_python", "native"]
+    source: Literal["builtin", "custom_python", "native", "installed"]
     conversation_starters: List[str]
     factory: Callable[..., Any]  # returns Agent instance
     agent_dir: Optional[Path]
@@ -894,6 +894,8 @@ class AgentRegistry:
                 registration,
                 namespaced_agent_id=f"installed:{registration.id}",
             )
+        if registration.source != "installed":
+            registration = dataclasses.replace(registration, source="installed")
         return registration
 
     # ------------------------------------------------------------------

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -209,9 +209,10 @@ class AgentRegistration:
     # T-X2 (issue #915, plan amendment A9):
     # ``namespaced_agent_id`` is the grant-ledger key for this agent. Built-in
     # agents use ``builtin:<id>``; custom agents under ``~/.gaia/agents/``
-    # use ``custom:<sha256-of-agent.py>:<id>``. This namespacing prevents a
-    # malicious custom agent from claiming a built-in's AGENT_ID to inherit
-    # a previously-granted scope. Always non-empty.
+    # use ``custom:<sha256-of-agent.py>:<id>``; installed wheel agents use
+    # ``installed:<id>``. This namespacing prevents a malicious custom or
+    # installed agent from claiming a built-in's AGENT_ID to inherit a
+    # previously-granted scope. Always non-empty.
     namespaced_agent_id: str = ""
     # Agent Hub metadata — used by the Agent UI to render rich discovery cards.
     # Hardcoded for builtins (lazy-import factories must not instantiate agents);
@@ -889,13 +890,15 @@ class AgentRegistry:
                 "must load an AgentRegistration or a zero-argument callable "
                 "returning one"
             )
-        if not registration.namespaced_agent_id:
+        if (
+            registration.namespaced_agent_id != f"installed:{registration.id}"
+            or registration.source != "installed"
+        ):
             registration = dataclasses.replace(
                 registration,
                 namespaced_agent_id=f"installed:{registration.id}",
+                source="installed",
             )
-        if registration.source != "installed":
-            registration = dataclasses.replace(registration, source="installed")
         registration = dataclasses.replace(
             registration,
             factory=_wrap_factory_with_namespaced_id(

--- a/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
+++ b/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
@@ -54,6 +54,7 @@ export function AgentDetailModal({ agent, onClose, onStartChat }: AgentDetailMod
                             {agent.source === 'builtin' && <span className="agent-badge agent-badge-builtin">Built-in</span>}
                             {agent.source === 'native' && <span className="agent-badge agent-badge-native">Native</span>}
                             {agent.source === 'custom_python' && <span className="agent-badge agent-badge-custom">Custom</span>}
+                            {agent.source === 'installed' && <span className="agent-badge agent-badge-installed">Installed</span>}
                             {agent.language && agent.language !== 'python' && (
                                 <span className="agent-badge agent-badge-native">{agent.language.toUpperCase()}</span>
                             )}

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -315,6 +315,11 @@
     color: var(--accent-cyan);
 }
 
+.agent-badge-installed {
+    background: rgba(232, 168, 48, 0.1);
+    color: var(--accent-gold);
+}
+
 .agent-badge-category {
     background: rgba(232, 168, 48, 0.1);
     color: var(--accent-gold);

--- a/src/gaia/apps/webui/src/components/AgentHubCard.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubCard.tsx
@@ -8,6 +8,7 @@ import type { AgentInfo } from '../types';
 function sourceBadge(source: string) {
     if (source === 'builtin') return <span className="agent-badge agent-badge-builtin">Built-in</span>;
     if (source === 'native') return <span className="agent-badge agent-badge-native">Native</span>;
+    if (source === 'installed') return <span className="agent-badge agent-badge-installed">Installed</span>;
     return <span className="agent-badge agent-badge-custom">Custom</span>;
 }
 

--- a/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
@@ -19,9 +19,9 @@ interface AgentHubGridProps {
 // Detect Electron context once
 const isElectron = typeof window !== 'undefined' && !!(window as any).electronAPI;
 
-/** Sort: builtin first, then custom, then native. Alphabetical within groups. */
+/** Sort: builtin first, then custom, installed, and native. Alphabetical within groups. */
 function sortAgents(agents: AgentInfo[]): AgentInfo[] {
-    const order: Record<string, number> = { builtin: 0, custom_python: 1, native: 2 };
+    const order: Record<string, number> = { builtin: 0, custom_python: 1, installed: 2, native: 3 };
     return [...agents].sort((a, b) => {
         const oa = order[a.source] ?? 1;
         const ob = order[b.source] ?? 1;

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -33,7 +33,9 @@ export interface AgentInfo {
     required_connections?: ConnectorRequirement[];
     /**
      * Opaque grant-ledger key. Built-ins are `builtin:<id>`, custom agents
-     * are `custom:<sha256-prefix>:<id>`. Pass this to the grants endpoint.
+     * are `custom:<sha256-prefix>:<id>`, installed agents are
+     * `installed:<id>`, and native agents are `native:<id>`. Pass this to
+     * the grants endpoint.
      */
     namespaced_agent_id?: string;
     /** Agent Hub metadata — used to render rich discovery cards. */

--- a/src/gaia/connectors/grants.py
+++ b/src/gaia/connectors/grants.py
@@ -11,9 +11,10 @@ Schema::
       }
     }
 
-Where ``namespaced_agent_id`` is ``builtin:<id>`` for built-in agents and
+Where ``namespaced_agent_id`` is ``builtin:<id>`` for built-in agents,
 ``custom:<sha256-prefix>:<id>`` for custom agents under
-``~/.gaia/agents/`` (per plan amendment A9).
+``~/.gaia/agents/`` (per plan amendment A9), ``installed:<id>`` for
+wheel-installed agents, and ``native:<id>`` for binary agents.
 
 Atomicity guarantees:
 

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -174,7 +174,7 @@ class AgentInfo(BaseModel):
     id: str
     name: str
     description: str
-    source: Literal["builtin", "custom_python", "native"]
+    source: Literal["builtin", "custom_python", "native", "installed"]
     conversation_starters: List[str] = Field(default_factory=list)
     models: List[str] = Field(default_factory=list)
     # Minimum free system memory (GB) the agent recommends before loading its

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -413,7 +413,7 @@ class TestEntryPointDiscovery:
             id="hub-chat",
             name="Hub Chat",
             description="Standalone hub agent",
-            source="custom_python",
+            source="installed",
             conversation_starters=["Hello"],
             factory=lambda **kw: "created",
             agent_dir=None,
@@ -437,6 +437,7 @@ class TestEntryPointDiscovery:
         reg = registry.get("hub-chat")
         assert reg is not None
         assert reg.name == "Hub Chat"
+        assert reg.source == "installed"
         assert reg.namespaced_agent_id == "installed:hub-chat"
         assert registry.create_agent("hub-chat") == "created"
 
@@ -456,7 +457,7 @@ class TestEntryPointDiscovery:
             id="chat",
             name="Replacement Chat",
             description="Should not replace existing registrations",
-            source="custom_python",
+            source="installed",
             conversation_starters=[],
             factory=lambda **kw: "replacement",
             agent_dir=None,
@@ -486,7 +487,8 @@ class TestEntryPointDiscovery:
         )
 
         registry = AgentRegistry()
-        registry._discover_entry_point_agents()
+        with caplog.at_level("WARNING", logger="gaia.agents.registry"):
+            registry._discover_entry_point_agents()
 
         assert registry.get("broken-agent") is None
         assert "Failed to load agent entry point broken-agent" in caplog.text
@@ -496,7 +498,7 @@ class TestEntryPointDiscovery:
             id="hub-chat",
             name="Hub Chat",
             description="Standalone hub agent",
-            source="custom_python",
+            source="installed",
             conversation_starters=[],
             factory=lambda **kw: "created",
             agent_dir=None,

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -12,6 +12,7 @@ import platform
 import sys
 import textwrap
 import warnings
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -396,6 +397,85 @@ class TestDirectoryDiscovery:
         # Should not raise, just skip
         registry._load_from_dir(agent_dir)
         assert len(registry.list()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Installed wheel entry point discovery
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointDiscovery:
+    def _entry_point(self, name, loaded):
+        return SimpleNamespace(name=name, load=lambda: loaded)
+
+    def test_discovers_agent_registration_entry_point(self, monkeypatch):
+        registration = AgentRegistration(
+            id="hub-chat",
+            name="Hub Chat",
+            description="Standalone hub agent",
+            source="custom_python",
+            conversation_starters=["Hello"],
+            factory=lambda **kw: "created",
+            agent_dir=None,
+            models=["Qwen3.5-35B-A3B-GGUF"],
+            category="conversation",
+            tags=["hub"],
+            icon="message-circle",
+            tools_count=1,
+        )
+        entry_point = self._entry_point("hub-chat", lambda: registration)
+        entry_points = SimpleNamespace(select=lambda group: [entry_point])
+        monkeypatch.setattr(
+            registry_module.importlib.metadata,
+            "entry_points",
+            lambda: entry_points,
+        )
+
+        registry = AgentRegistry()
+        registry._discover_entry_point_agents()
+
+        reg = registry.get("hub-chat")
+        assert reg is not None
+        assert reg.name == "Hub Chat"
+        assert reg.namespaced_agent_id == "installed:hub-chat"
+        assert registry.create_agent("hub-chat") == "created"
+
+    def test_entry_point_does_not_override_existing_agent(self, monkeypatch):
+        existing = AgentRegistration(
+            id="chat",
+            name="Existing Chat",
+            description="Existing registration",
+            source="builtin",
+            conversation_starters=[],
+            factory=lambda **kw: "existing",
+            agent_dir=None,
+            models=[],
+            namespaced_agent_id="builtin:chat",
+        )
+        replacement = AgentRegistration(
+            id="chat",
+            name="Replacement Chat",
+            description="Should not replace existing registrations",
+            source="custom_python",
+            conversation_starters=[],
+            factory=lambda **kw: "replacement",
+            agent_dir=None,
+            models=[],
+        )
+        entry_point = self._entry_point("chat", lambda: replacement)
+        entry_points = SimpleNamespace(select=lambda group: [entry_point])
+        monkeypatch.setattr(
+            registry_module.importlib.metadata,
+            "entry_points",
+            lambda: entry_points,
+        )
+
+        registry = AgentRegistry()
+        registry._register(existing)
+        registry._discover_entry_point_agents()
+
+        assert registry.get("chat").name == "Existing Chat"
+        assert registry.create_agent("chat") == "existing"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -408,6 +408,11 @@ class TestEntryPointDiscovery:
     def _entry_point(self, name, loaded):
         return SimpleNamespace(name=name, load=lambda: loaded)
 
+    def _entry_points(self, entry_point):
+        return lambda group: (
+            [entry_point] if group == registry_module.AGENT_ENTRY_POINT_GROUP else []
+        )
+
     def test_discovers_agent_registration_entry_point(self, monkeypatch):
         registration = AgentRegistration(
             id="hub-chat",
@@ -427,7 +432,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: [entry_point],
+            self._entry_points(entry_point),
         )
 
         registry = AgentRegistry()
@@ -468,7 +473,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: [entry_point],
+            self._entry_points(entry_point),
         )
 
         registry = AgentRegistry()
@@ -483,7 +488,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: [entry_point],
+            self._entry_points(entry_point),
         )
 
         registry = AgentRegistry()
@@ -509,7 +514,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: [entry_point],
+            self._entry_points(entry_point),
         )
 
         registry = AgentRegistry()
@@ -532,7 +537,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: [entry_point],
+            self._entry_points(entry_point),
         )
 
         registry = AgentRegistry()
@@ -555,7 +560,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: [entry_point],
+            self._entry_points(entry_point),
         )
 
         registry = AgentRegistry()

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -493,9 +493,7 @@ class TestEntryPointDiscovery:
         assert registry.get("broken-agent") is None
         assert "Failed to load agent entry point broken-agent" in caplog.text
 
-    def test_entry_point_namespaced_agent_id_is_coerced_to_installed(
-        self, monkeypatch
-    ):
+    def test_entry_point_namespaced_agent_id_is_coerced_to_installed(self, monkeypatch):
         registration = AgentRegistration(
             id="hub-chat",
             name="Hub Chat",

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -424,11 +424,10 @@ class TestEntryPointDiscovery:
             tools_count=1,
         )
         entry_point = self._entry_point("hub-chat", lambda: registration)
-        entry_points = SimpleNamespace(select=lambda group: [entry_point])
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: entry_points.select(group=group),
+            lambda group: [entry_point],
         )
 
         registry = AgentRegistry()
@@ -516,6 +515,29 @@ class TestEntryPointDiscovery:
         registry._discover_entry_point_agents()
 
         assert registry.get("hub-chat").namespaced_agent_id == "wheel:hub-chat"
+
+    def test_entry_point_source_is_coerced_to_installed(self, monkeypatch):
+        registration = AgentRegistration(
+            id="hub-chat",
+            name="Hub Chat",
+            description="Standalone hub agent",
+            source="builtin",
+            conversation_starters=[],
+            factory=lambda **kw: "created",
+            agent_dir=None,
+            models=[],
+        )
+        entry_point = self._entry_point("hub-chat", lambda: registration)
+        monkeypatch.setattr(
+            registry_module.importlib.metadata,
+            "entry_points",
+            lambda group: [entry_point],
+        )
+
+        registry = AgentRegistry()
+        registry._discover_entry_point_agents()
+
+        assert registry.get("hub-chat").source == "installed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -440,6 +440,32 @@ class TestEntryPointDiscovery:
         assert reg.namespaced_agent_id == "installed:hub-chat"
         assert registry.create_agent("hub-chat") == "created"
 
+    def test_discovers_legacy_dict_entry_points(self, monkeypatch):
+        registration = AgentRegistration(
+            id="legacy-hub-chat",
+            name="Legacy Hub Chat",
+            description="Standalone hub agent from legacy metadata",
+            source="custom_python",
+            conversation_starters=[],
+            factory=lambda **kw: "legacy-created",
+            agent_dir=None,
+            models=[],
+        )
+        entry_point = self._entry_point("legacy-hub-chat", lambda: registration)
+        monkeypatch.setattr(
+            registry_module.importlib.metadata,
+            "entry_points",
+            lambda: {registry_module.AGENT_ENTRY_POINT_GROUP: [entry_point]},
+        )
+
+        registry = AgentRegistry()
+        registry._discover_entry_point_agents()
+
+        reg = registry.get("legacy-hub-chat")
+        assert reg is not None
+        assert reg.namespaced_agent_id == "installed:legacy-hub-chat"
+        assert registry.create_agent("legacy-hub-chat") == "legacy-created"
+
     def test_entry_point_does_not_override_existing_agent(self, monkeypatch):
         existing = AgentRegistration(
             id="chat",

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -415,7 +415,7 @@ class TestEntryPointDiscovery:
             description="Standalone hub agent",
             source="installed",
             conversation_starters=["Hello"],
-            factory=lambda **kw: "created",
+            factory=lambda **kw: SimpleNamespace(kind="created"),
             agent_dir=None,
             models=["Qwen3.5-35B-A3B-GGUF"],
             category="conversation",
@@ -438,7 +438,9 @@ class TestEntryPointDiscovery:
         assert reg.name == "Hub Chat"
         assert reg.source == "installed"
         assert reg.namespaced_agent_id == "installed:hub-chat"
-        assert registry.create_agent("hub-chat") == "created"
+        agent = registry.create_agent("hub-chat")
+        assert agent.kind == "created"
+        assert agent._gaia_namespaced_agent_id == "installed:hub-chat"
 
     def test_entry_point_does_not_override_existing_agent(self, monkeypatch):
         existing = AgentRegistration(

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -428,7 +428,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda: entry_points,
+            lambda group: entry_points.select(group=group),
         )
 
         registry = AgentRegistry()
@@ -439,32 +439,6 @@ class TestEntryPointDiscovery:
         assert reg.name == "Hub Chat"
         assert reg.namespaced_agent_id == "installed:hub-chat"
         assert registry.create_agent("hub-chat") == "created"
-
-    def test_discovers_legacy_dict_entry_points(self, monkeypatch):
-        registration = AgentRegistration(
-            id="legacy-hub-chat",
-            name="Legacy Hub Chat",
-            description="Standalone hub agent from legacy metadata",
-            source="custom_python",
-            conversation_starters=[],
-            factory=lambda **kw: "legacy-created",
-            agent_dir=None,
-            models=[],
-        )
-        entry_point = self._entry_point("legacy-hub-chat", lambda: registration)
-        monkeypatch.setattr(
-            registry_module.importlib.metadata,
-            "entry_points",
-            lambda: {registry_module.AGENT_ENTRY_POINT_GROUP: [entry_point]},
-        )
-
-        registry = AgentRegistry()
-        registry._discover_entry_point_agents()
-
-        reg = registry.get("legacy-hub-chat")
-        assert reg is not None
-        assert reg.namespaced_agent_id == "installed:legacy-hub-chat"
-        assert registry.create_agent("legacy-hub-chat") == "legacy-created"
 
     def test_entry_point_does_not_override_existing_agent(self, monkeypatch):
         existing = AgentRegistration(
@@ -493,7 +467,7 @@ class TestEntryPointDiscovery:
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda: entry_points,
+            lambda group: entry_points.select(group=group),
         )
 
         registry = AgentRegistry()
@@ -502,6 +476,44 @@ class TestEntryPointDiscovery:
 
         assert registry.get("chat").name == "Existing Chat"
         assert registry.create_agent("chat") == "existing"
+
+    def test_bad_entry_point_is_skipped_with_warning(self, monkeypatch, caplog):
+        entry_point = self._entry_point("broken-agent", object())
+        monkeypatch.setattr(
+            registry_module.importlib.metadata,
+            "entry_points",
+            lambda group: [entry_point],
+        )
+
+        registry = AgentRegistry()
+        registry._discover_entry_point_agents()
+
+        assert registry.get("broken-agent") is None
+        assert "Failed to load agent entry point broken-agent" in caplog.text
+
+    def test_preserves_existing_namespaced_agent_id(self, monkeypatch):
+        registration = AgentRegistration(
+            id="hub-chat",
+            name="Hub Chat",
+            description="Standalone hub agent",
+            source="custom_python",
+            conversation_starters=[],
+            factory=lambda **kw: "created",
+            agent_dir=None,
+            models=[],
+            namespaced_agent_id="wheel:hub-chat",
+        )
+        entry_point = self._entry_point("hub-chat", lambda: registration)
+        monkeypatch.setattr(
+            registry_module.importlib.metadata,
+            "entry_points",
+            lambda group: [entry_point],
+        )
+
+        registry = AgentRegistry()
+        registry._discover_entry_point_agents()
+
+        assert registry.get("hub-chat").namespaced_agent_id == "wheel:hub-chat"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -465,11 +465,10 @@ class TestEntryPointDiscovery:
             models=[],
         )
         entry_point = self._entry_point("chat", lambda: replacement)
-        entry_points = SimpleNamespace(select=lambda group: [entry_point])
         monkeypatch.setattr(
             registry_module.importlib.metadata,
             "entry_points",
-            lambda group: entry_points.select(group=group),
+            lambda group: [entry_point],
         )
 
         registry = AgentRegistry()
@@ -494,7 +493,9 @@ class TestEntryPointDiscovery:
         assert registry.get("broken-agent") is None
         assert "Failed to load agent entry point broken-agent" in caplog.text
 
-    def test_preserves_existing_namespaced_agent_id(self, monkeypatch):
+    def test_entry_point_namespaced_agent_id_is_coerced_to_installed(
+        self, monkeypatch
+    ):
         registration = AgentRegistration(
             id="hub-chat",
             name="Hub Chat",
@@ -504,7 +505,7 @@ class TestEntryPointDiscovery:
             factory=lambda **kw: "created",
             agent_dir=None,
             models=[],
-            namespaced_agent_id="wheel:hub-chat",
+            namespaced_agent_id="builtin:chat",
         )
         entry_point = self._entry_point("hub-chat", lambda: registration)
         monkeypatch.setattr(
@@ -516,7 +517,7 @@ class TestEntryPointDiscovery:
         registry = AgentRegistry()
         registry._discover_entry_point_agents()
 
-        assert registry.get("hub-chat").namespaced_agent_id == "wheel:hub-chat"
+        assert registry.get("hub-chat").namespaced_agent_id == "installed:hub-chat"
 
     def test_entry_point_source_is_coerced_to_installed(self, monkeypatch):
         registration = AgentRegistration(
@@ -540,6 +541,29 @@ class TestEntryPointDiscovery:
         registry._discover_entry_point_agents()
 
         assert registry.get("hub-chat").source == "installed"
+
+    def test_discovers_direct_agent_registration_entry_point(self, monkeypatch):
+        registration = AgentRegistration(
+            id="direct-agent",
+            name="Direct",
+            description="Loaded directly, not via callable",
+            source="installed",
+            conversation_starters=[],
+            factory=lambda **kw: SimpleNamespace(kind="direct"),
+            agent_dir=None,
+            models=[],
+        )
+        entry_point = self._entry_point("direct-agent", registration)
+        monkeypatch.setattr(
+            registry_module.importlib.metadata,
+            "entry_points",
+            lambda group: [entry_point],
+        )
+
+        registry = AgentRegistry()
+        registry._discover_entry_point_agents()
+
+        assert registry.get("direct-agent") is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `gaia.agents` entry point discovery so standalone Python agent wheels can register with `AgentRegistry`.
- Keeps existing built-in, custom directory, and native manifest discovery behavior unchanged.

## Root Cause
- Agent Hub Phase 0 needs installed wheel discovery, but the registry only scanned built-ins, `~/.gaia/agents/`, and native manifests.

## Changes
- Register `AgentRegistration` objects exposed through the `gaia.agents` entry point group.
- Skip entry point IDs already claimed by earlier discovery stages.
- Add unit coverage for successful entry point registration and duplicate-ID protection.

## Validation
- `uv run --python .venv/bin/python pytest tests/unit/agents/test_registry.py -q`
- `uv run --python .venv/bin/python python util/lint.py --imports`
- `uv run --python .venv/bin/python python util/lint.py --black --isort`

## Notes
- Refs #1102; this is a scoped registry prerequisite, not the full production-agent source-tree move.
- Initial push to `amd/gaia` failed with 403, so this PR is opened from the authenticated fork.
