### PR TITLE
fix(security): apply write guardrails to four unprotected file tools

### DIFF
--- a/src/gaia/agents/code/tools/file_io.py
+++ b/src/gaia/agents/code/tools/file_io.py
@@ -193,6 +193,9 @@ class FileIOToolsMixin:
         ) -> Dict[str, Any]:
             """Write Python code to a file.
 
+            Includes security guardrails: path validation, blocked directory enforcement,
+            sensitive file protection, size limits, backup creation, and audit logging.
+
             Args:
                 file_path: Path where to write the file
                 content: Python code content
@@ -220,12 +223,24 @@ class FileIOToolsMixin:
                             "syntax_errors": validation.get("errors", []),
                         }
 
-                # Security check
-                if not self.path_validator.is_path_allowed(file_path):
-                    return {
-                        "status": "error",
-                        "error": f"Access denied: {file_path} is not in allowed paths",
-                    }
+                content_size = len(content.encode("utf-8"))
+
+                # Security: validate write access (path, blocklist, size)
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    is_allowed, reason = path_validator.validate_write(
+                        str(file_path), content_size=content_size
+                    )
+                    if not is_allowed:
+                        path_validator.audit_write(
+                            "write", str(file_path), content_size, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
+
+                    # Backup existing file before overwrite
+                    backup_path = None
+                    if os.path.exists(file_path):
+                        backup_path = path_validator.create_backup(str(file_path))
 
                 # Create parent directories if needed
                 if create_dirs and os.path.dirname(file_path):
@@ -235,13 +250,28 @@ class FileIOToolsMixin:
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(content)
 
-                return {
+                # Audit successful write
+                if path_validator is not None:
+                    detail = f"backup={backup_path}" if backup_path else ""
+                    path_validator.audit_write(
+                        "write", str(file_path), content_size, "success", detail
+                    )
+
+                result = {
                     "status": "success",
                     "file_path": file_path,
-                    "bytes_written": len(content.encode("utf-8")),
+                    "bytes_written": content_size,
                     "line_count": len(content.splitlines()),
                 }
+                if path_validator is not None and backup_path:
+                    result["backup_path"] = backup_path
+                return result
             except Exception as e:
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    path_validator.audit_write(
+                        "write", file_path, 0, "error", str(e)
+                    )
                 return {"status": "error", "error": str(e)}
 
         @tool
@@ -254,6 +284,9 @@ class FileIOToolsMixin:
         ) -> Dict[str, Any]:
             """Edit a Python file by replacing content.
 
+            Includes security guardrails: path validation, blocked directory enforcement,
+            sensitive file protection, size limits, backup creation, and audit logging.
+
             Args:
                 file_path: Path to the file to edit
                 old_content: Content to find and replace
@@ -265,12 +298,44 @@ class FileIOToolsMixin:
                 Dictionary with edit operation results
             """
             try:
-                # Security check
-                if not self.path_validator.is_path_allowed(file_path):
-                    return {
-                        "status": "error",
-                        "error": f"Access denied: {file_path} is not in allowed paths",
-                    }
+                # Security: validate write access
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    # Check blocklist
+                    is_blocked, reason = path_validator.is_write_blocked(
+                        str(file_path)
+                    )
+                    if is_blocked:
+                        path_validator.audit_write(
+                            "edit", str(file_path), 0, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
+
+                    # Check allowlist
+                    if not path_validator.is_path_allowed(str(file_path)):
+                        reason = (
+                            f"Access denied: {file_path} is not in allowed paths"
+                        )
+                        path_validator.audit_write(
+                            "edit", str(file_path), 0, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
+
+                    # Enforce size limit on replacement content
+                    new_size = len(new_content.encode("utf-8"))
+                    from gaia.security import MAX_WRITE_SIZE_BYTES
+
+                    if new_size > MAX_WRITE_SIZE_BYTES:
+                        reason = (
+                            f"Edit blocked: replacement content "
+                            f"({new_size / (1024 * 1024):.1f} MB) exceeds "
+                            f"maximum allowed size "
+                            f"({MAX_WRITE_SIZE_BYTES / (1024 * 1024):.0f} MB)"
+                        )
+                        path_validator.audit_write(
+                            "edit", str(file_path), new_size, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
 
                 # Read current content
                 if not os.path.exists(file_path):
@@ -323,23 +388,49 @@ class FileIOToolsMixin:
                         "would_change": current_content != modified_content,
                     }
 
-                # Create backup if requested
+                # Create backup via path_validator if available, else manual
+                backup_path = None
                 if backup:
-                    backup_path = f"{file_path}.bak"
-                    with open(backup_path, "w", encoding="utf-8") as f:
-                        f.write(current_content)
+                    if path_validator is not None:
+                        backup_path = path_validator.create_backup(str(file_path))
+                    else:
+                        backup_path = f"{file_path}.bak"
+                        with open(backup_path, "w", encoding="utf-8") as f:
+                            f.write(current_content)
 
                 # Write the modified content
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(modified_content)
+
+                # Audit successful edit
+                if path_validator is not None:
+                    detail = (
+                        f"replaced {len(old_content)} chars with "
+                        f"{len(new_content)} chars"
+                    )
+                    if backup_path:
+                        detail += f", backup={backup_path}"
+                    path_validator.audit_write(
+                        "edit",
+                        str(file_path),
+                        len(modified_content),
+                        "success",
+                        detail,
+                    )
 
                 return {
                     "status": "success",
                     "file_path": file_path,
                     "diff": diff,
                     "backup_created": backup,
+                    "backup_path": backup_path,
                 }
             except Exception as e:
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    path_validator.audit_write(
+                        "edit", file_path, 0, "error", str(e)
+                    )
                 return {"status": "error", "error": str(e)}
 
         @tool
@@ -491,6 +582,9 @@ class FileIOToolsMixin:
         ) -> Dict[str, Any]:
             """Write content to a markdown file.
 
+            Includes security guardrails: path validation, blocked directory enforcement,
+            sensitive file protection, size limits, backup creation, and audit logging.
+
             Args:
                 file_path: Path where to write the file
                 content: Markdown content
@@ -500,12 +594,24 @@ class FileIOToolsMixin:
                 Dictionary with write operation results
             """
             try:
-                # Security check
-                if not self.path_validator.is_path_allowed(file_path):
-                    return {
-                        "status": "error",
-                        "error": f"Access denied: {file_path} is not in allowed paths",
-                    }
+                content_size = len(content.encode("utf-8"))
+
+                # Security: validate write access (path, blocklist, size)
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    is_allowed, reason = path_validator.validate_write(
+                        str(file_path), content_size=content_size
+                    )
+                    if not is_allowed:
+                        path_validator.audit_write(
+                            "write", str(file_path), content_size, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
+
+                    # Backup existing file before overwrite
+                    backup_path = None
+                    if os.path.exists(file_path):
+                        backup_path = path_validator.create_backup(str(file_path))
 
                 # Create parent directories if needed
                 if create_dirs:
@@ -517,13 +623,28 @@ class FileIOToolsMixin:
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(content)
 
-                return {
+                # Audit successful write
+                if path_validator is not None:
+                    detail = f"backup={backup_path}" if backup_path else ""
+                    path_validator.audit_write(
+                        "write", str(file_path), content_size, "success", detail
+                    )
+
+                result = {
                     "status": "success",
                     "file_path": file_path,
-                    "bytes_written": len(content.encode("utf-8")),
+                    "bytes_written": content_size,
                     "line_count": len(content.splitlines()),
                 }
+                if path_validator is not None and backup_path:
+                    result["backup_path"] = backup_path
+                return result
             except Exception as e:
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    path_validator.audit_write(
+                        "write", file_path, 0, "error", str(e)
+                    )
                 return {"status": "error", "error": str(e)}
 
         @tool
@@ -862,6 +983,9 @@ class FileIOToolsMixin:
         ) -> Dict[str, Any]:
             """Replace a specific function in a Python file.
 
+            Includes security guardrails: path validation, blocked directory enforcement,
+            sensitive file protection, size limits, backup creation, and audit logging.
+
             Args:
                 file_path: Path to the Python file
                 function_name: Name of the function to replace
@@ -872,12 +996,44 @@ class FileIOToolsMixin:
                 Dictionary with replacement result
             """
             try:
-                # Security check
-                if not self.path_validator.is_path_allowed(file_path):
-                    return {
-                        "status": "error",
-                        "error": f"Access denied: {file_path} is not in allowed paths",
-                    }
+                # Security: validate write access
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    # Check blocklist
+                    is_blocked, reason = path_validator.is_write_blocked(
+                        str(file_path)
+                    )
+                    if is_blocked:
+                        path_validator.audit_write(
+                            "edit", str(file_path), 0, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
+
+                    # Check allowlist
+                    if not path_validator.is_path_allowed(str(file_path)):
+                        reason = (
+                            f"Access denied: {file_path} is not in allowed paths"
+                        )
+                        path_validator.audit_write(
+                            "edit", str(file_path), 0, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
+
+                    # Enforce size limit on replacement content
+                    new_size = len(new_implementation.encode("utf-8"))
+                    from gaia.security import MAX_WRITE_SIZE_BYTES
+
+                    if new_size > MAX_WRITE_SIZE_BYTES:
+                        reason = (
+                            f"Edit blocked: replacement content "
+                            f"({new_size / (1024 * 1024):.1f} MB) exceeds "
+                            f"maximum allowed size "
+                            f"({MAX_WRITE_SIZE_BYTES / (1024 * 1024):.0f} MB)"
+                        )
+                        path_validator.audit_write(
+                            "edit", str(file_path), new_size, "denied", reason
+                        )
+                        return {"status": "error", "error": reason}
 
                 if not os.path.exists(file_path):
                     return {"status": "error", "error": f"File not found: {file_path}"}
@@ -924,12 +1080,15 @@ class FileIOToolsMixin:
                                 end_line = i
                                 break
 
-                # Create backup if requested
+                # Create backup via path_validator if available, else manual
                 backup_path = None
                 if backup:
-                    backup_path = f"{file_path}.bak"
-                    with open(backup_path, "w", encoding="utf-8") as f:
-                        f.write(content)
+                    if path_validator is not None:
+                        backup_path = path_validator.create_backup(str(file_path))
+                    else:
+                        backup_path = f"{file_path}.bak"
+                        with open(backup_path, "w", encoding="utf-8") as f:
+                            f.write(content)
 
                 # Replace the function
                 new_lines = (
@@ -967,6 +1126,19 @@ class FileIOToolsMixin:
                     )
                 )
 
+                # Audit successful edit
+                if path_validator is not None:
+                    detail = f"replaced function '{function_name}'"
+                    if backup_path:
+                        detail += f", backup={backup_path}"
+                    path_validator.audit_write(
+                        "edit",
+                        str(file_path),
+                        len(modified_content),
+                        "success",
+                        detail,
+                    )
+
                 return {
                     "status": "success",
                     "file_path": file_path,
@@ -975,6 +1147,11 @@ class FileIOToolsMixin:
                     "diff": diff,
                 }
             except Exception as e:
+                path_validator = getattr(self, "path_validator", None)
+                if path_validator is not None:
+                    path_validator.audit_write(
+                        "edit", file_path, 0, "error", str(e)
+                    )
                 return {"status": "error", "error": str(e)}
 
         # Return the list of registered tools for tracking

--- a/tests/test_file_io_guardrails.py
+++ b/tests/test_file_io_guardrails.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python
+# Copyright(C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for write guardrails on file I/O tools.
+
+Validates that write_python_file, edit_python_file, write_markdown_file,
+and replace_function enforce the same security guardrails (validate_write /
+is_write_blocked + audit + backup) as write_file and edit_file.
+
+See: https://github.com/amd/gaia/issues/955
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+
+
+def _make_agent_with_mocked_validator():
+    """Create a CodeAgent with a mocked path_validator for guardrail testing."""
+    from gaia.agents.code.agent import CodeAgent
+
+    agent = CodeAgent(silent_mode=True, max_steps=5)
+    agent._register_tools()
+
+    # Build a mock PathValidator with all required methods
+    mock_pv = MagicMock()
+    mock_pv.is_path_allowed.return_value = True
+    mock_pv.is_write_blocked.return_value = (False, "")
+    mock_pv.validate_write.return_value = (True, "")
+    mock_pv.create_backup.return_value = "/tmp/backup"
+    mock_pv.audit_write = MagicMock()
+
+    agent.path_validator = mock_pv
+    return agent, mock_pv
+
+
+class TestWritePythonFileGuardrails(unittest.TestCase):
+    """write_python_file must use validate_write + audit + backup."""
+
+    def setUp(self):
+        self.agent, self.mock_pv = _make_agent_with_mocked_validator()
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        _TOOL_REGISTRY.clear()
+
+    def _get_tool(self):
+        return _TOOL_REGISTRY["write_python_file"]
+
+    def test_rejects_when_validate_write_denies(self):
+        """write_python_file should reject writes denied by validate_write."""
+        self.mock_pv.validate_write.return_value = (
+            False,
+            "Write blocked: /etc/passwd is in a blocked directory",
+        )
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/etc/passwd",
+            content="print('hello')",
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("blocked", result["error"])
+        self.mock_pv.audit_write.assert_called()
+        # Verify the audit recorded a denial
+        audit_calls = [
+            c for c in self.mock_pv.audit_write.call_args_list if c[0][3] == "denied"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+    def test_audits_successful_write(self):
+        """write_python_file should audit successful writes."""
+        path = os.path.join(self.test_dir, "test.py")
+        self.mock_pv.validate_write.return_value = (True, "")
+
+        tool_fn = self._get_tool()
+        result = tool_fn(file_path=path, content="x = 1\n")
+
+        self.assertEqual(result["status"], "success")
+        # Should have audited the success
+        audit_calls = [
+            c
+            for c in self.mock_pv.audit_write.call_args_list
+            if c[0][3] == "success"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+    def test_creates_backup_on_overwrite(self):
+        """write_python_file should create backup when overwriting existing file."""
+        path = os.path.join(self.test_dir, "existing.py")
+        with open(path, "w") as f:
+            f.write("old = True\n")
+
+        self.mock_pv.validate_write.return_value = (True, "")
+        self.mock_pv.create_backup.return_value = path + ".bak"
+
+        tool_fn = self._get_tool()
+        result = tool_fn(file_path=path, content="new = True\n")
+
+        self.assertEqual(result["status"], "success")
+        self.mock_pv.create_backup.assert_called_once_with(path)
+
+
+class TestEditPythonFileGuardrails(unittest.TestCase):
+    """edit_python_file must use is_write_blocked + size check + audit."""
+
+    def setUp(self):
+        self.agent, self.mock_pv = _make_agent_with_mocked_validator()
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        _TOOL_REGISTRY.clear()
+
+    def _get_tool(self):
+        return _TOOL_REGISTRY["edit_python_file"]
+
+    def test_rejects_blocked_path(self):
+        """edit_python_file should reject writes to blocked paths."""
+        self.mock_pv.is_write_blocked.return_value = (
+            True,
+            "Write blocked: path is in a blocked directory",
+        )
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/etc/shadow",
+            old_content="old",
+            new_content="new",
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("blocked", result["error"].lower())
+        audit_calls = [
+            c for c in self.mock_pv.audit_write.call_args_list if c[0][3] == "denied"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+    def test_rejects_disallowed_path(self):
+        """edit_python_file should reject paths not in allowlist."""
+        self.mock_pv.is_write_blocked.return_value = (False, "")
+        self.mock_pv.is_path_allowed.return_value = False
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/some/random/path.py",
+            old_content="old",
+            new_content="new",
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Access denied", result["error"])
+
+    @patch("gaia.security.MAX_WRITE_SIZE_BYTES", 10)
+    def test_rejects_oversized_content(self):
+        """edit_python_file should reject replacement content exceeding size limit."""
+        self.mock_pv.is_write_blocked.return_value = (False, "")
+        self.mock_pv.is_path_allowed.return_value = True
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/tmp/test.py",
+            old_content="x = 1",
+            new_content="x" * 100,  # exceeds 10-byte limit
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("exceeds", result["error"].lower())
+
+    def test_audits_successful_edit(self):
+        """edit_python_file should audit successful edits."""
+        path = os.path.join(self.test_dir, "test.py")
+        with open(path, "w") as f:
+            f.write("x = 1\n")
+
+        self.mock_pv.is_write_blocked.return_value = (False, "")
+        self.mock_pv.is_path_allowed.return_value = True
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path=path,
+            old_content="x = 1",
+            new_content="x = 2",
+        )
+
+        self.assertEqual(result["status"], "success")
+        audit_calls = [
+            c
+            for c in self.mock_pv.audit_write.call_args_list
+            if c[0][3] == "success"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+
+class TestWriteMarkdownFileGuardrails(unittest.TestCase):
+    """write_markdown_file must use validate_write + audit + backup."""
+
+    def setUp(self):
+        self.agent, self.mock_pv = _make_agent_with_mocked_validator()
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        _TOOL_REGISTRY.clear()
+
+    def _get_tool(self):
+        return _TOOL_REGISTRY["write_markdown_file"]
+
+    def test_rejects_when_validate_write_denies(self):
+        """write_markdown_file should reject writes denied by validate_write."""
+        self.mock_pv.validate_write.return_value = (
+            False,
+            "Write blocked: sensitive file",
+        )
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/etc/cron.d/evil.md",
+            content="# Evil markdown",
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("blocked", result["error"].lower())
+        audit_calls = [
+            c for c in self.mock_pv.audit_write.call_args_list if c[0][3] == "denied"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+    def test_audits_successful_write(self):
+        """write_markdown_file should audit successful writes."""
+        path = os.path.join(self.test_dir, "readme.md")
+        self.mock_pv.validate_write.return_value = (True, "")
+
+        tool_fn = self._get_tool()
+        result = tool_fn(file_path=path, content="# Hello\n")
+
+        self.assertEqual(result["status"], "success")
+        audit_calls = [
+            c
+            for c in self.mock_pv.audit_write.call_args_list
+            if c[0][3] == "success"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+    def test_creates_backup_on_overwrite(self):
+        """write_markdown_file should create backup when overwriting."""
+        path = os.path.join(self.test_dir, "existing.md")
+        with open(path, "w") as f:
+            f.write("# Old\n")
+
+        self.mock_pv.validate_write.return_value = (True, "")
+        self.mock_pv.create_backup.return_value = path + ".bak"
+
+        tool_fn = self._get_tool()
+        result = tool_fn(file_path=path, content="# New\n")
+
+        self.assertEqual(result["status"], "success")
+        self.mock_pv.create_backup.assert_called_once_with(path)
+
+
+class TestReplaceFunctionGuardrails(unittest.TestCase):
+    """replace_function must use is_write_blocked + size check + audit."""
+
+    def setUp(self):
+        self.agent, self.mock_pv = _make_agent_with_mocked_validator()
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        _TOOL_REGISTRY.clear()
+
+    def _get_tool(self):
+        return _TOOL_REGISTRY["replace_function"]
+
+    def test_rejects_blocked_path(self):
+        """replace_function should reject writes to blocked paths."""
+        self.mock_pv.is_write_blocked.return_value = (
+            True,
+            "Write blocked: path is in a blocked directory",
+        )
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/etc/some_config.py",
+            function_name="dangerous",
+            new_implementation="def dangerous(): pass",
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("blocked", result["error"].lower())
+        audit_calls = [
+            c for c in self.mock_pv.audit_write.call_args_list if c[0][3] == "denied"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+    def test_rejects_disallowed_path(self):
+        """replace_function should reject paths not in allowlist."""
+        self.mock_pv.is_write_blocked.return_value = (False, "")
+        self.mock_pv.is_path_allowed.return_value = False
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/some/random/file.py",
+            function_name="foo",
+            new_implementation="def foo(): pass",
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Access denied", result["error"])
+
+    @patch("gaia.security.MAX_WRITE_SIZE_BYTES", 10)
+    def test_rejects_oversized_implementation(self):
+        """replace_function should reject oversized new_implementation."""
+        self.mock_pv.is_write_blocked.return_value = (False, "")
+        self.mock_pv.is_path_allowed.return_value = True
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path="/tmp/test.py",
+            function_name="foo",
+            new_implementation="def foo():\n    " + "x" * 100,
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("exceeds", result["error"].lower())
+
+    def test_audits_successful_replacement(self):
+        """replace_function should audit successful function replacements."""
+        path = os.path.join(self.test_dir, "module.py")
+        with open(path, "w") as f:
+            f.write("def greet():\n    return 'hello'\n")
+
+        self.mock_pv.is_write_blocked.return_value = (False, "")
+        self.mock_pv.is_path_allowed.return_value = True
+
+        tool_fn = self._get_tool()
+        result = tool_fn(
+            file_path=path,
+            function_name="greet",
+            new_implementation="def greet():\n    return 'hi'",
+        )
+
+        self.assertEqual(result["status"], "success")
+        audit_calls = [
+            c
+            for c in self.mock_pv.audit_write.call_args_list
+            if c[0][3] == "success"
+        ]
+        self.assertGreater(len(audit_calls), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Four file I/O tools in `src/gaia/agents/code/tools/file_io.py` only had basic `is_path_allowed()` checks but were missing the full security guardrails that `write_file` and `edit_file` already enforce. This PR applies the same security patterns to all four tools.

Closes #955

## Affected Tools

### Write tools (`write_python_file`, `write_markdown_file`)
- Added `validate_write()` for combined path + blocklist + size validation
- Added backup creation via `path_validator.create_backup()` before overwriting
- Added audit logging for both denied and successful writes
- Changed from direct `self.path_validator` access to `getattr(self, "path_validator", None)` for safer access

### Edit tools (`edit_python_file`, `replace_function`)
- Added `is_write_blocked()` for blocklist enforcement
- Added `is_path_allowed()` check with proper audit logging on denial
- Added `MAX_WRITE_SIZE_BYTES` enforcement on replacement content
- Added backup creation via `path_validator.create_backup()` (replaces manual `.bak` file creation)
- Added audit logging for both denied and successful edits
- Changed from direct `self.path_validator` access to `getattr(self, "path_validator", None)` for safer access

## Testing

Added `tests/test_file_io_guardrails.py` with unit tests covering:
- `write_python_file` rejects blocked paths, audits writes, creates backups
- `edit_python_file` rejects blocked paths, enforces size limits, audits edits
- `write_markdown_file` rejects blocked paths, audits writes, creates backups
- `replace_function` rejects blocked paths, enforces size limits, audits edits

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.