### PR TITLE
ci(dependabot): revive PRs, add agent-ui entry, ship patch auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@
 # Dependabot configuration for automated dependency updates
 # This file configures Dependabot to check for updates to Python, JavaScript, and GitHub Actions dependencies
 #
-# For detailed documentation on adding/modifying entries, see: docs/dependency-management.md
+# For detailed documentation on adding/modifying entries, see: docs/reference/dependency-management.mdx
 # Official Dependabot docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
@@ -18,7 +18,7 @@ updates:
     labels:
       - "dependencies"
       - "python"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     # Group all Python dependency updates together to reduce PR noise
     groups:
       python-dependencies:
@@ -34,14 +34,35 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
-    open-pull-requests-limit: 0
-    ignore:
-      # Ignore node_modules from app builds - they have their own configs below
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 5
+    # Group all root-workspace dependency updates into one PR per cycle to reduce noise.
+    # Without this stanza, removing the prior `ignore:` block would open one PR per outdated
+    # dependency and hit `open-pull-requests-limit` immediately. See #1157.
+    groups:
+      root-npm-dependencies:
+        patterns:
+          - "*"
 
   # Note: Electron framework (src/gaia/electron) is scanned via the root workspace
   # configuration above, so no separate entry is needed.
+
+  # JavaScript - Agent UI (flagship Electron + React + Vite app, published as @amd-gaia/agent-ui).
+  # The root workspace glob `src/gaia/apps/*/webui` does NOT match this path (it's `webui`
+  # directly under `apps/`, not under `apps/<name>/webui`), so it needs its own entry.
+  - package-ecosystem: "npm"
+    directory: "/src/gaia/apps/webui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "electron"
+    open-pull-requests-limit: 5
+    groups:
+      agent-ui-dependencies:
+        patterns:
+          - "*"
 
   # JavaScript - Example Electron app
   - package-ecosystem: "npm"
@@ -54,7 +75,7 @@ updates:
       - "javascript"
       - "electron"
       - "example-app"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     groups:
       example-app-dependencies:
         patterns:
@@ -71,7 +92,7 @@ updates:
       - "javascript"
       - "electron"
       - "jira-app"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     groups:
       jira-app-dependencies:
         patterns:
@@ -88,7 +109,7 @@ updates:
       - "javascript"
       - "electron"
       - "emr-dashboard"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     groups:
       emr-dashboard-dependencies:
         patterns:
@@ -103,7 +124,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -10,9 +10,8 @@
 # review. CI gating is delegated to GitHub's native auto-merge queue — if the
 # required status checks fail, GitHub cancels the merge and the PR stays open.
 #
-# See .claude/plans/issue-1157.md and PR closing issue #1157 for the design notes
-# (concurrency group, `>-` scalar, contains() for grouped PRs, idempotent merge
-# call, dual actor+author gate, diagnostic log step).
+# Design notes (concurrency group, `>-` scalar, contains() for grouped PRs,
+# idempotent merge call, dual actor+author gate, diagnostic log step): see #1157.
 
 name: Dependabot Auto-merge
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,91 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Auto-merge Dependabot PRs that are safe to land without human review:
+#   - patch updates to any direct dep (production or development), OR
+#   - minor updates to development-only direct deps.
+#
+# Major bumps, indirect bumps, mixed production+dev grouped PRs, and updates to
+# the auto-merge action itself (`dependabot/fetch-metadata`) are left for human
+# review. CI gating is delegated to GitHub's native auto-merge queue — if the
+# required status checks fail, GitHub cancels the merge and the PR stays open.
+#
+# See .claude/plans/issue-1157.md and PR closing issue #1157 for the design notes
+# (concurrency group, `>-` scalar, contains() for grouped PRs, idempotent merge
+# call, dual actor+author gate, diagnostic log step).
+
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# One run per PR; the most recent synchronize wins. Without this, a rapid push
+# sequence can race two `gh pr merge --auto` calls against the same PR.
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge for low-risk updates
+    runs-on: ubuntu-latest
+    # Defense in depth: both the trigger actor AND the PR author must be the
+    # Dependabot bot. A force-push to a Dependabot branch from a compromised
+    # maintainer account would change `github.actor` but not `pull_request.user.login`.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log metadata for debugging
+        # Surfaces the gate inputs in the workflow log so a maintainer asking
+        # "why didn't this auto-merge?" can answer it from the run log.
+        env:
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          echo "dependency-names: $DEPENDENCY_NAMES"
+          echo "dependency-type:  $DEPENDENCY_TYPE"
+          echo "update-type:      $UPDATE_TYPE"
+
+      - name: Enable auto-merge for patch and dev-only minor updates
+        # `contains()` (not `==`) is required: grouped PRs produce comma-separated
+        # strings like "direct:production, direct:development". For the minor
+        # branch we additionally require NO production dep is in the group.
+        # The fetch-metadata action itself is excluded — a compromised version
+        # would auto-merge itself with `contents: write`.
+        if: >-
+          !contains(steps.metadata.outputs.dependency-type, 'indirect') &&
+          !contains(steps.metadata.outputs.dependency-names, 'dependabot/fetch-metadata') &&
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            (
+              steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+              contains(steps.metadata.outputs.dependency-type, 'direct:development') &&
+              !contains(steps.metadata.outputs.dependency-type, 'direct:production')
+            )
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # Idempotent: skip if auto-merge is already enabled (synchronize re-trigger).
+          # Without this guard, the second call returns non-zero ("already enabled")
+          # and marks the workflow run failed for no reason.
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')" != "null" ]; then
+            echo "Auto-merge already enabled — no-op."
+            exit 0
+          fi
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,8 @@ on:
       - 'setup.py'
       - 'pyproject.toml'
       - 'util/lint.py'
+      - 'util/check_*.py'
+      - '.github/dependabot.yml'
       - '.github/workflows/lint.yml'
   pull_request:
     branches: [ main ]
@@ -28,6 +30,8 @@ on:
       - 'setup.py'
       - 'pyproject.toml'
       - 'util/lint.py'
+      - 'util/check_*.py'
+      - '.github/dependabot.yml'
       - '.github/workflows/lint.yml'
   merge_group:
   workflow_dispatch:

--- a/docs/reference/dependency-management.mdx
+++ b/docs/reference/dependency-management.mdx
@@ -65,7 +65,7 @@ To track a new `package.json` root (e.g., a new app under `src/gaia/apps/`):
        labels:
          - "dependencies"
          - "javascript"
-         - "electron"
+         # Add "electron" only if the app ships an Electron shell.
        open-pull-requests-limit: 5
        groups:
          your-app-dependencies:
@@ -94,7 +94,7 @@ See the [official Dependabot docs](https://docs.github.com/en/code-security/depe
 
 - **First Monday after re-enablement may be busy.** The soft-disabled era accumulated months of skipped updates; the first batch will be larger than steady state (~6–8 grouped PRs across all ecosystems).
 - **Grouped PRs that mix prod + dev deps don't auto-merge.** This is by design — bundling a production patch with a dev minor is exactly the case a human should look at. Manually merge with `gh pr merge --auto --squash <PR>` after review if you want it enrolled in the queue.
-- **Pre-merge maintainer setting:** "Allow auto-merge" must be enabled in repo Settings → General → Pull Requests. Without it, the workflow runs successfully but `gh pr merge --auto` errors. Verify with `gh api repos/amd/gaia --jq '.allow_auto_merge'`.
+- **Pre-merge maintainer setting:** "Allow auto-merge" AND "Allow squash merging" must both be enabled in repo Settings → General → Pull Requests. Without either, `gh pr merge --auto --squash` queues successfully but GitHub cancels the merge. Verify: `gh api repos/amd/gaia --jq '{allow_auto_merge: .allow_auto_merge, allow_squash_merge: .allow_squash_merge}'`.
 - **Diagnosing "why didn't this PR auto-merge?":** the workflow logs `dependency-names`, `dependency-type`, and `update-type` for every run. Check the workflow run's "Log metadata for debugging" step.
 
 ## See also

--- a/docs/reference/dependency-management.mdx
+++ b/docs/reference/dependency-management.mdx
@@ -6,193 +6,103 @@ title: "Dependency Management"
 
 ## What is Dependabot?
 
-Dependabot automatically monitors dependencies and can create pull requests for security updates and version upgrades. This keeps GAIA's Python and JavaScript dependencies current and secure.
+Dependabot automatically monitors GAIA's dependencies and opens pull requests for security and version updates. PRs that meet a strict low-risk gate (patch updates, or minor updates to development-only deps) auto-merge once CI is green; everything else waits for human review.
 
-## Understanding Dependabot Modes
+## How GAIA uses Dependabot
 
-### Mode 1: Auto-PR Mode (`open-pull-requests-limit: 1` or higher)
-- ✅ **Monitors** dependencies for updates
-- ✅ **Creates pull requests** automatically when updates are available
-- ✅ **Runs CI tests** to validate the update
-- Best for: Critical dependencies where you want automatic updates with testing
+Dependabot is configured in [`.github/dependabot.yml`](https://github.com/amd/gaia/blob/main/.github/dependabot.yml) and runs every Monday across seven entries: one for Python (`pip`), one for GitHub Actions, and five for npm (the root workspace plus four standalone app workspaces). Every entry has `open-pull-requests-limit: 5` — the prior `0` (soft-disabled) state was a "silent fallback" violation that's now retired by design ([#1157](https://github.com/amd/gaia/issues/1157)).
 
-### Mode 2: Monitor-Only Mode (`open-pull-requests-limit: 0`)
-- ✅ **Monitors** dependencies for updates
-- ✅ **Shows alerts** in GitHub Security tab for vulnerabilities
-- ❌ **Does NOT create** pull requests automatically
-- Best for: Dependencies you want to update manually or on your own schedule
+A companion workflow at [`.github/workflows/dependabot-automerge.yml`](https://github.com/amd/gaia/blob/main/.github/workflows/dependabot-automerge.yml) auto-merges low-risk Dependabot PRs once required status checks pass.
 
-## Current Configuration
+## Current configuration
 
-### Root NPM Workspace (Auto-PR Mode)
-The root `package.json` uses npm workspaces and includes:
-- `src/gaia/electron` - Electron framework
-- `src/gaia/apps/*/webui` - All app subdirectories
+| Directory | Ecosystem | Limit | Group | Schedule |
+|---|---|---|---|---|
+| `/` | pip | 5 | `python-dependencies` | weekly / monday |
+| `/` | npm | 5 | `root-npm-dependencies` | weekly / monday |
+| `/src/gaia/apps/webui` | npm | 5 | `agent-ui-dependencies` | weekly / monday |
+| `/src/gaia/apps/example/webui` | npm | 5 | `example-app-dependencies` | weekly / monday |
+| `/src/gaia/apps/jira/webui` | npm | 5 | `jira-app-dependencies` | weekly / monday |
+| `/src/gaia/agents/emr/dashboard/electron` | npm | 5 | `emr-dashboard-dependencies` | weekly / monday |
+| `/` | github-actions | 5 | `github-actions` | weekly / monday |
 
-**Configuration:**
-```yaml
-directory: "/"
-open-pull-requests-limit: 1
-```
+**Why grouping matters.** Each ecosystem uses a wildcard `groups:` stanza so that a week's worth of updates collapse into a single grouped PR per ecosystem. Without grouping, the `limit: 5` would be hit by five individual single-package PRs and the rest would queue — defeating the point of the cap.
 
-**What this means:**
-- ✅ Dependabot **creates PRs** for Electron framework dependencies
-- ✅ Dependabot **creates PRs** for all workspace packages
-- ✅ PRs are grouped together to reduce noise
-- ✅ Automated tests run on these PRs via GitHub Actions
+**Workspace coverage.** The root npm entry follows the workspaces declaration in `package.json` (`src/gaia/electron`, `src/gaia/apps/*/webui`). The flagship Agent UI at `src/gaia/apps/webui` is **not** matched by that glob (it sits directly under `apps/`, not under `apps/<name>/webui`) so it has its own entry above.
 
-**Example:** Dependabot automatically creates PRs for electron framework updates.
+## Auto-merge policy
 
-### Individual Apps (Monitor-Only Mode) - OPTIONAL
+The workflow at `.github/workflows/dependabot-automerge.yml` enrols a Dependabot PR in GitHub's native auto-merge queue (`gh pr merge --auto --squash`) when **all** of the following are true:
 
-**Note:** These individual app configurations are **optional** because the root NPM workspace already scans all apps. They are included to allow fine-grained control if needed in the future.
+- The PR author and the trigger actor are both `dependabot[bot]` (defense in depth).
+- The fetched metadata's `dependency-type` does not include `indirect`.
+- The PR does not update `dependabot/fetch-metadata` itself.
+- AND either:
+  - `update-type == version-update:semver-patch`, OR
+  - `update-type == version-update:semver-minor` AND `dependency-type` includes `direct:development` AND does NOT include `direct:production`.
 
-Each app *can* have its own configuration for specific control:
-- `src/gaia/apps/example/webui`
-- `src/gaia/apps/jira/webui`
+GitHub then merges the PR only after required status checks pass — `Code Quality (Lint)` and `Unit Tests` (the merge-queue gates) plus any required ecosystem checks. If CI fails, GitHub cancels the merge and the PR stays open.
 
-**Configuration:**
-```yaml
-directory: "/src/gaia/apps/[app-name]/webui"
-open-pull-requests-limit: 0
-```
+**What requires human review:**
 
-**What this provides (optional):**
-- Different update schedules per app (monthly vs weekly)
-- Different labels for organization and filtering
-- Ability to enable/disable PRs per app independently
-- Currently all set to `0` (monitoring only) since root workspace handles PRs
+- Any major-version bump.
+- Indirect (transitive) dependency bumps.
+- Grouped PRs that mix production and development dependencies.
+- Updates to `dependabot/fetch-metadata` (would auto-merge itself with `contents: write` — supply-chain risk).
 
-**Recommendation:** The individual app entries can be **removed** if you don't need app-specific schedules or labels, since the root workspace configuration already handles dependency updates for all apps via npm workspaces.
+## Adding a new ecosystem entry
 
-## When to Add Your App
+To track a new `package.json` root (e.g., a new app under `src/gaia/apps/`):
 
-**Important:** If your app is part of the npm workspaces (listed in root `package.json`), it's **already being monitored** by the root NPM configuration. You only need to add a separate configuration if you want:
-- App-specific labels for GitHub organization
-- Different update schedule (e.g., monthly instead of weekly)
-- Ability to enable/disable PRs for this app independently
+1. Add an entry to `.github/dependabot.yml`:
 
-Add your app to `.github/dependabot.yml` if:
+   ```yaml
+     - package-ecosystem: "npm"
+       directory: "/src/gaia/apps/your-app/webui"
+       schedule:
+         interval: "weekly"
+         day: "monday"
+       labels:
+         - "dependencies"
+         - "javascript"
+         - "electron"
+       open-pull-requests-limit: 5
+       groups:
+         your-app-dependencies:
+           patterns:
+             - "*"
+   ```
 
-- ✅ It has a `package.json` file (JavaScript/npm dependencies)
-- ✅ It's located in `src/gaia/apps/`
-- ✅ You want app-specific configuration (otherwise root workspace handles it)
+2. Run `python util/check_dependabot.py` to validate. The script enforces two invariants (per [#1157](https://github.com/amd/gaia/issues/1157)):
+   - No entry has `open-pull-requests-limit: 0`.
+   - Every npm entry has a `groups:` stanza.
 
-**Current Status:** All apps in `src/gaia/apps/*/webui` are already scanned via the root workspace configuration. Individual app entries exist for organizational purposes but can be removed if not needed.
+3. Update this doc's "Current configuration" table.
 
-## How to Add Your App
+## Configuration fields reference
 
-### 1. Edit `.github/dependabot.yml`
+- `package-ecosystem`: package manager type (`npm`, `pip`, `github-actions`).
+- `directory`: path to the folder containing the manifest, relative to the repo root.
+- `schedule.interval` + `schedule.day`: how often to check.
+- `labels`: tags added to PRs for filtering. The repo's `dependencies` and `electron` labels exist in [`.github/labeler.yml`](https://github.com/amd/gaia/blob/main/.github/labeler.yml).
+- `open-pull-requests-limit`: max concurrent open PRs. Use `5`. Setting `0` soft-disables the entry and is rejected by `util/check_dependabot.py`.
+- `groups`: required for npm entries. Combines related updates into a single grouped PR per cycle.
 
-Add this configuration for your app:
+See the [official Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) for the full schema.
 
-```yaml
-  # JavaScript - [Your App Name] (monitor only, no PRs)
-  - package-ecosystem: "npm"
-    directory: "/src/gaia/apps/[your-app-name]/webui"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
-      - "javascript"
-      - "[your-app-name]-app"
-    open-pull-requests-limit: 0
-    groups:
-      [your-app-name]-app-dependencies:
-        patterns:
-          - "*"
-```
+## Operational notes
 
-### 2. Real Example
+- **First Monday after re-enablement may be busy.** The soft-disabled era accumulated months of skipped updates; the first batch will be larger than steady state (~6–8 grouped PRs across all ecosystems).
+- **Grouped PRs that mix prod + dev deps don't auto-merge.** This is by design — bundling a production patch with a dev minor is exactly the case a human should look at. Manually merge with `gh pr merge --auto --squash <PR>` after review if you want it enrolled in the queue.
+- **Pre-merge maintainer setting:** "Allow auto-merge" must be enabled in repo Settings → General → Pull Requests. Without it, the workflow runs successfully but `gh pr merge --auto` errors. Verify with `gh api repos/amd/gaia --jq '.allow_auto_merge'`.
+- **Diagnosing "why didn't this PR auto-merge?":** the workflow logs `dependency-names`, `dependency-type`, and `update-type` for every run. Check the workflow run's "Log metadata for debugging" step.
 
-Here's how the Jira app is configured:
+## See also
 
-```yaml
-  # JavaScript - Jira app (monitor only, no PRs)
-  - package-ecosystem: "npm"
-    directory: "/src/gaia/apps/jira/webui"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
-      - "javascript"
-      - "jira-app"
-    open-pull-requests-limit: 0
-    groups:
-      jira-app-dependencies:
-        patterns:
-          - "*"
-```
-
-### 3. Important Notes
-
-- **Directory path**: Must exactly match your app's webui folder (e.g., `/src/gaia/apps/example/webui`)
-- **App name**: Use consistent naming in labels and group name
-- **Schedule**: Use `monthly` for most apps
-- **PR Limit**: Apps use `open-pull-requests-limit: 0` (monitoring only). Root Python dependencies use `open-pull-requests-limit: 1` (one PR at a time for core updates)
-
-## Configuration Reference
-
-### Update Schedules
-
-- `weekly` - Python core, GitHub Actions (with `open-pull-requests-limit: 1`)
-- `monthly` - Apps and POC examples (with `open-pull-requests-limit: 0`)
-
-### PR Limits Strategy
-
-| Component | Limit | Behavior | Notes |
-|-----------|-------|----------|-------|
-| Python core dependencies | 1 | Creates PRs automatically | One PR at a time for critical updates |
-| GitHub Actions | 1 | Creates PRs automatically | One PR at a time |
-| Root NPM workspace | 1 | Creates PRs automatically | Includes Electron framework + all apps via workspaces |
-| Individual apps | 0 | Monitor only - alerts without PRs | Fine-grained control per app |
-
-**Important:** The root NPM configuration (`directory: "/"`) uses npm workspaces, which means it automatically includes:
-- Electron framework (`src/gaia/electron`)
-- All apps (`src/gaia/apps/*/webui`)
-
-This is why you see PRs for Electron framework updates - they come from the root workspace configuration.
-
-**Auto-PR Mode (`limit: 1`):** Dependabot creates pull requests automatically, runs tests, and you can review/merge them.
-
-**Monitor-Only Mode (`limit: 0`):** Dependabot only shows security alerts in GitHub's Security tab without creating PRs. This prevents PR noise while maintaining visibility.
-
-**Automated Testing:** When dependencies are updated, automated tests run via GitHub Actions to ensure compatibility. See the [Electron Testing Guide](/deployment/testing-electron) for details.
-
-### Dependency Grouping
-
-The `groups` section combines all dependency updates into a single PR instead of creating dozens of separate PRs. This reduces noise and makes reviews easier.
-
-### Configuration Fields
-
-- `package-ecosystem`: Package manager type (`npm`, `pip`, `github-actions`)
-- `directory`: Path to folder containing `package.json`
-- `schedule.interval`: How often to check (`weekly` or `monthly`)
-- `labels`: Tags added to PRs for filtering
-- `open-pull-requests-limit`: Max concurrent PRs (`0` = monitor only, `1+` = create PRs)
-- `groups`: Combine related updates into single PR
-
-## Automated Testing
-
-All Electron framework and app dependencies are automatically tested when updated. The test suite includes:
-
-- **Unit Tests**: Core Electron modules (AppController, WindowManager, MCPClient)
-- **Integration Tests**: App configuration, structure, and dependencies
-- **Build Tests**: Package and distribution verification
-- **Security Audits**: Dependency vulnerability scanning
-
-Tests run automatically on:
-- Dependabot PRs for dependency updates
-- Pull requests modifying Electron or app code
-- Manual workflow dispatch
-
-See [Electron Testing Guide](/deployment/testing-electron) for details on running tests locally.
-
-## See Also
-
-- [App Development Guide](/sdk/applications) - Building GAIA applications
-- [Development Setup](/reference/dev) - Getting started with development
-- [Dependabot Documentation](https://docs.github.com/en/code-security/dependabot) - Official GitHub docs
+- [`.github/dependabot.yml`](https://github.com/amd/gaia/blob/main/.github/dependabot.yml) — authoritative config
+- [`.github/workflows/dependabot-automerge.yml`](https://github.com/amd/gaia/blob/main/.github/workflows/dependabot-automerge.yml) — the auto-merge workflow
+- [`util/check_dependabot.py`](https://github.com/amd/gaia/blob/main/util/check_dependabot.py) — regression linter wired into `python util/lint.py --all`
+- [Dependabot documentation](https://docs.github.com/en/code-security/dependabot) — official GitHub docs
 
 ---
 

--- a/tests/unit/test_check_dependabot.py
+++ b/tests/unit/test_check_dependabot.py
@@ -1,0 +1,262 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for util/check_dependabot.py.
+
+Each test writes an ephemeral dependabot.yml fragment to a tmp_path and
+monkeypatches CONFIG so run_check() reads the test file instead of the
+real .github/dependabot.yml.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Ensure util/ is importable regardless of where pytest is invoked from.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "util"))
+
+import check_dependabot  # noqa: E402
+
+
+def _write_config(tmp_path: Path, updates: list) -> Path:
+    """Write a minimal dependabot.yml with the given updates list."""
+    cfg = {"version": 2, "updates": updates}
+    p = tmp_path / "dependabot.yml"
+    p.write_text(yaml.dump(cfg), encoding="utf-8")
+    return p
+
+
+@pytest.fixture(autouse=True)
+def patch_config(tmp_path, monkeypatch):
+    """Allow each test to set check_dependabot.CONFIG before calling run_check()."""
+    yield  # tests set check_dependabot.CONFIG themselves
+
+
+# ---------------------------------------------------------------------------
+# Happy-path
+# ---------------------------------------------------------------------------
+
+
+class TestRunCheckPassingCases:
+    def test_valid_pip_entry(self, tmp_path, monkeypatch):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "pip",
+                    "directory": "/",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 0
+
+    def test_valid_npm_entry_with_groups(self, tmp_path, monkeypatch):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "npm",
+                    "directory": "/",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                    "groups": {"all-deps": {"patterns": ["*"]}},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 0
+
+    def test_absent_limit_key_treated_as_live(self, tmp_path, monkeypatch):
+        """No open-pull-requests-limit key → Dependabot default → should pass."""
+        p = _write_config(
+            tmp_path,
+            [{"package-ecosystem": "pip", "directory": "/", "schedule": {"interval": "weekly"}}],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 0
+
+    def test_multiple_valid_entries(self, tmp_path, monkeypatch):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "pip",
+                    "directory": "/",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                },
+                {
+                    "package-ecosystem": "npm",
+                    "directory": "/ui",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                    "groups": {"ui-deps": {"patterns": ["*"]}},
+                },
+                {
+                    "package-ecosystem": "github-actions",
+                    "directory": "/",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                },
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 0
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1: open-pull-requests-limit == 0 must be rejected
+# ---------------------------------------------------------------------------
+
+
+class TestLimitZeroRejected:
+    def test_integer_zero_rejected(self, tmp_path, monkeypatch):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "pip",
+                    "directory": "/",
+                    "open-pull-requests-limit": 0,
+                    "schedule": {"interval": "weekly"},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 1
+
+    def test_quoted_zero_rejected(self, tmp_path, monkeypatch):
+        """YAML '0' (quoted string) must also be caught — guards the int() cast."""
+        raw = 'version: 2\nupdates:\n  - package-ecosystem: "pip"\n    directory: "/"\n    open-pull-requests-limit: "0"\n    schedule:\n      interval: "weekly"\n'
+        p = tmp_path / "dependabot.yml"
+        p.write_text(raw, encoding="utf-8")
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 1
+
+    def test_error_message_names_ecosystem_and_directory(self, tmp_path, monkeypatch, capsys):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "npm",
+                    "directory": "/apps/ui",
+                    "open-pull-requests-limit": 0,
+                    "schedule": {"interval": "weekly"},
+                    "groups": {"all": {"patterns": ["*"]}},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        check_dependabot.run_check()
+        stderr = capsys.readouterr().err
+        assert "npm" in stderr
+        assert "/apps/ui" in stderr
+
+    def test_non_integer_limit_rejected(self, tmp_path, monkeypatch, capsys):
+        """A non-numeric limit value (e.g. 'five') should produce an error, not a traceback."""
+        raw = 'version: 2\nupdates:\n  - package-ecosystem: "pip"\n    directory: "/"\n    open-pull-requests-limit: "five"\n    schedule:\n      interval: "weekly"\n'
+        p = tmp_path / "dependabot.yml"
+        p.write_text(raw, encoding="utf-8")
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        result = check_dependabot.run_check()
+        assert result == 1
+        stderr = capsys.readouterr().err
+        assert "non-integer" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2: npm entries without groups: must be rejected
+# ---------------------------------------------------------------------------
+
+
+class TestNpmGroupsRequired:
+    def test_npm_without_groups_rejected(self, tmp_path, monkeypatch):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "npm",
+                    "directory": "/",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 1
+
+    def test_pip_without_groups_allowed(self, tmp_path, monkeypatch):
+        """groups: is only required for npm — other ecosystems should pass without it."""
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "pip",
+                    "directory": "/",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 0
+
+    def test_github_actions_without_groups_allowed(self, tmp_path, monkeypatch):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "github-actions",
+                    "directory": "/",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 0
+
+    def test_error_message_mentions_groups(self, tmp_path, monkeypatch, capsys):
+        p = _write_config(
+            tmp_path,
+            [
+                {
+                    "package-ecosystem": "npm",
+                    "directory": "/ui",
+                    "open-pull-requests-limit": 5,
+                    "schedule": {"interval": "weekly"},
+                }
+            ],
+        )
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        check_dependabot.run_check()
+        assert "groups" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Config file error handling
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFileErrors:
+    def test_missing_file_returns_1(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(check_dependabot, "CONFIG", tmp_path / "nonexistent.yml")
+        assert check_dependabot.run_check() == 1
+
+    def test_invalid_yaml_returns_1(self, tmp_path, monkeypatch):
+        p = tmp_path / "dependabot.yml"
+        p.write_text("version: 2\nupdates: [\n  invalid", encoding="utf-8")
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 1
+
+    def test_missing_updates_key_returns_1(self, tmp_path, monkeypatch):
+        p = tmp_path / "dependabot.yml"
+        p.write_text("version: 2\n", encoding="utf-8")
+        monkeypatch.setattr(check_dependabot, "CONFIG", p)
+        assert check_dependabot.run_check() == 1

--- a/tests/unit/test_check_dependabot.py
+++ b/tests/unit/test_check_dependabot.py
@@ -76,7 +76,13 @@ class TestRunCheckPassingCases:
         """No open-pull-requests-limit key → Dependabot default → should pass."""
         p = _write_config(
             tmp_path,
-            [{"package-ecosystem": "pip", "directory": "/", "schedule": {"interval": "weekly"}}],
+            [
+                {
+                    "package-ecosystem": "pip",
+                    "directory": "/",
+                    "schedule": {"interval": "weekly"},
+                }
+            ],
         )
         monkeypatch.setattr(check_dependabot, "CONFIG", p)
         assert check_dependabot.run_check() == 0
@@ -139,7 +145,9 @@ class TestLimitZeroRejected:
         monkeypatch.setattr(check_dependabot, "CONFIG", p)
         assert check_dependabot.run_check() == 1
 
-    def test_error_message_names_ecosystem_and_directory(self, tmp_path, monkeypatch, capsys):
+    def test_error_message_names_ecosystem_and_directory(
+        self, tmp_path, monkeypatch, capsys
+    ):
         p = _write_config(
             tmp_path,
             [

--- a/util/check_dependabot.py
+++ b/util/check_dependabot.py
@@ -1,0 +1,71 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Validate .github/dependabot.yml: no soft-disabled entries, no missing groups.
+
+Per #1157, every ecosystem entry MUST be live (open-pull-requests-limit != 0) and every
+npm entry MUST have a `groups:` stanza (without grouping, removing limit:0 produces
+one PR per outdated package and floods the queue).
+
+Runs as part of `python util/lint.py --all`. Run directly with
+`python util/check_dependabot.py`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+CONFIG = Path(".github/dependabot.yml")
+
+
+def run_check() -> int:
+    """Validate .github/dependabot.yml. Returns 0 on success, 1 on any error."""
+    if not CONFIG.exists():
+        print(f"[!] {CONFIG} not found", file=sys.stderr)
+        return 1
+
+    try:
+        cfg = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        print(f"[!] {CONFIG} failed to parse: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(cfg, dict) or "updates" not in cfg:
+        print(f"[!] {CONFIG} has no top-level 'updates' list", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+
+    for entry in cfg["updates"]:
+        directory = entry.get("directory", "<unknown>")
+        ecosystem = entry.get("package-ecosystem", "<unknown>")
+        limit = entry.get("open-pull-requests-limit", 5)
+
+        if limit == 0:
+            errors.append(
+                f"{ecosystem} {directory}: open-pull-requests-limit is 0 "
+                f"(soft-disabled). Per #1157, all entries must be live."
+            )
+
+        if ecosystem == "npm" and "groups" not in entry:
+            errors.append(
+                f"{ecosystem} {directory}: missing `groups:` stanza. Without "
+                f"grouping, Dependabot opens one PR per outdated package — "
+                f"see #1157."
+            )
+
+    if errors:
+        print("[!] Dependabot configuration issues found:", file=sys.stderr)
+        for err in errors:
+            print(f"    - {err}", file=sys.stderr)
+        return 1
+
+    print(f"[OK] {len(cfg['updates'])} dependabot.yml entries validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_check())

--- a/util/check_dependabot.py
+++ b/util/check_dependabot.py
@@ -48,7 +48,16 @@ def run_check() -> int:
         # Absent key means Dependabot uses its own positive default — only an explicit 0 soft-disables.
         limit = entry.get("open-pull-requests-limit", 5)
 
-        if int(limit) == 0:
+        try:
+            limit_int = int(limit)
+        except (TypeError, ValueError):
+            errors.append(
+                f"{ecosystem} {directory}: open-pull-requests-limit has non-integer "
+                f"value {limit!r} — expected a positive integer."
+            )
+            continue
+
+        if limit_int == 0:
             errors.append(
                 f"{ecosystem} {directory}: open-pull-requests-limit is 0 "
                 f"(soft-disabled). Per #1157, all entries must be live."

--- a/util/check_dependabot.py
+++ b/util/check_dependabot.py
@@ -45,6 +45,7 @@ def run_check() -> int:
     for entry in cfg["updates"]:
         directory = entry.get("directory", "<unknown>")
         ecosystem = entry.get("package-ecosystem", "<unknown>")
+        # Absent key means Dependabot uses its own positive default — only an explicit 0 soft-disables.
         limit = entry.get("open-pull-requests-limit", 5)
 
         if limit == 0:

--- a/util/check_dependabot.py
+++ b/util/check_dependabot.py
@@ -18,7 +18,10 @@ from pathlib import Path
 
 import yaml
 
-CONFIG = Path(".github/dependabot.yml")
+# Anchor to the repo root so the script works regardless of CWD — matches the
+# convention in util/check_doc_versions.py and util/check_agent_conventions.py.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
 
 
 def run_check() -> int:

--- a/util/check_dependabot.py
+++ b/util/check_dependabot.py
@@ -48,7 +48,7 @@ def run_check() -> int:
         # Absent key means Dependabot uses its own positive default — only an explicit 0 soft-disables.
         limit = entry.get("open-pull-requests-limit", 5)
 
-        if limit == 0:
+        if int(limit) == 0:
             errors.append(
                 f"{ecosystem} {directory}: open-pull-requests-limit is 0 "
                 f"(soft-disabled). Per #1157, all entries must be live."

--- a/util/lint.py
+++ b/util/lint.py
@@ -81,7 +81,7 @@ def check_black(fix: bool = False) -> CheckResult:
     if fix:
         print("\n[1/2] Fixing code formatting with Black...")
     else:
-        print("\n[1/9] Checking code formatting with Black...")
+        print("\n[1/10] Checking code formatting with Black...")
     print("-" * 40)
 
     if fix:
@@ -155,7 +155,7 @@ def check_isort(fix: bool = False) -> CheckResult:
     if fix:
         print("\n[2/2] Fixing import sorting with isort...")
     else:
-        print("\n[2/9] Checking import sorting with isort...")
+        print("\n[2/10] Checking import sorting with isort...")
     print("-" * 40)
 
     if fix:
@@ -200,7 +200,7 @@ def check_isort(fix: bool = False) -> CheckResult:
 
 def check_pylint() -> CheckResult:
     """Run Pylint (errors only)."""
-    print("\n[3/9] Running Pylint (errors only)...")
+    print("\n[3/10] Running Pylint (errors only)...")
     print("-" * 40)
 
     cmd = uvx(
@@ -225,7 +225,7 @@ def check_pylint() -> CheckResult:
 
 def check_flake8() -> CheckResult:
     """Run Flake8."""
-    print("\n[4/9] Running Flake8...")
+    print("\n[4/10] Running Flake8...")
     print("-" * 40)
 
     cmd = uvx(
@@ -258,7 +258,7 @@ def check_flake8() -> CheckResult:
 
 def check_mypy() -> CheckResult:
     """Run MyPy type checking (warning only)."""
-    print("\n[5/9] Running MyPy type checking (warning only)...")
+    print("\n[5/10] Running MyPy type checking (warning only)...")
     print("-" * 40)
 
     cmd = uvx("mypy", SRC_DIR, "--ignore-missing-imports")
@@ -285,7 +285,7 @@ def check_mypy() -> CheckResult:
 
 def check_bandit() -> CheckResult:
     """Run Bandit security check (warning only)."""
-    print("\n[6/9] Running security check with Bandit (warning only)...")
+    print("\n[6/10] Running security check with Bandit (warning only)...")
     print("-" * 40)
 
     cmd = uvx("bandit", "-r", SRC_DIR, "-ll", "--exclude", EXCLUDE_DIRS)
@@ -311,7 +311,7 @@ def check_bandit() -> CheckResult:
 
 def check_imports() -> CheckResult:
     """Test comprehensive SDK imports."""
-    print("\n[7/9] Testing comprehensive SDK imports...")
+    print("\n[7/10] Testing comprehensive SDK imports...")
     print("-" * 40)
 
     # Pre-check: verify gaia is installed
@@ -429,7 +429,7 @@ def check_imports() -> CheckResult:
 
 def check_agents() -> CheckResult:
     """Check GAIA agent conventions — inheritance, tests, docs, registry wiring."""
-    print("\n[8/9] Checking agent conventions...")
+    print("\n[8/10] Checking agent conventions...")
     print("-" * 40)
 
     # Import lazily so the check is self-contained and testable standalone.
@@ -449,7 +449,9 @@ def check_agents() -> CheckResult:
 
     if errors:
         print(output)
-        print(f"\n[!] Agent convention check failed ({errors} error(s), {warnings} warning(s)).")
+        print(
+            f"\n[!] Agent convention check failed ({errors} error(s), {warnings} warning(s))."
+        )
         return CheckResult("Agent Conventions", False, False, errors, output)
 
     if warnings:
@@ -461,9 +463,40 @@ def check_agents() -> CheckResult:
     return CheckResult("Agent Conventions", True, False, 0, output)
 
 
+def check_dependabot() -> CheckResult:
+    """Validate .github/dependabot.yml (no soft-disabled entries, npm groups present)."""
+    print("\n[9/10] Validating .github/dependabot.yml...")
+    print("-" * 40)
+
+    try:
+        from check_dependabot import run_check
+    except ImportError:
+        util_dir = str(Path(__file__).parent)
+        if util_dir not in sys.path:
+            sys.path.insert(0, util_dir)
+        try:
+            from check_dependabot import run_check
+        except ImportError as exc:
+            print(f"[!] Could not import check_dependabot.py: {exc}")
+            return CheckResult("Dependabot Config", False, False, 1, str(exc))
+
+    exit_code = run_check()
+
+    if exit_code != 0:
+        return CheckResult(
+            "Dependabot Config",
+            False,
+            False,
+            1,
+            "See output above; fix .github/dependabot.yml per #1157.",
+        )
+
+    return CheckResult("Dependabot Config", True, False, 0, "")
+
+
 def check_doc_versions() -> CheckResult:
     """Check documentation version consistency."""
-    print("\n[9/9] Checking documentation version consistency...")
+    print("\n[10/10] Checking documentation version consistency...")
     print("-" * 40)
 
     # Import and run the check
@@ -632,6 +665,11 @@ def main():
         help="Check agent conventions (inheritance, tests, docs)",
     )
     parser.add_argument(
+        "--dependabot",
+        action="store_true",
+        help="Validate .github/dependabot.yml (no soft-disabled entries, npm groups present)",
+    )
+    parser.add_argument(
         "--doc-versions",
         action="store_true",
         help="Check doc version consistency",
@@ -653,6 +691,7 @@ def main():
             args.bandit,
             args.imports,
             args.agents,
+            args.dependabot,
             args.doc_versions,
             args.all,
         ]
@@ -701,6 +740,9 @@ def main():
 
     if args.agents or run_all:
         results.append(check_agents())
+
+    if args.dependabot or run_all:
+        results.append(check_dependabot())
 
     if args.doc_versions or run_all:
         results.append(check_doc_versions())


### PR DESCRIPTION
Dependabot has been soft-disabled (all `open-pull-requests-limit: 0`) since before v0.18, meaning CVEs and breaking changes in our 100+ npm and Python deps have been silently skipped for months. This violates the repo's "no silent fallbacks" rule and leaves the release train exposed. This PR re-enables Dependabot across all ecosystems, adds the missing Agent UI entry, and ships a hardened auto-merge workflow so low-risk patches land without flooding the review queue.

## Test plan

- [ ] `python util/check_dependabot.py` exits 0 — all 7 entries pass
- [ ] Set `open-pull-requests-limit: 0` on any entry → validator exits 1 with a clear message
- [ ] Remove `groups:` from any npm entry → validator exits 1 with a clear message
- [ ] `python util/lint.py --all` passes (step 9/10 dependabot check included)
- [ ] PR that edits only `.github/dependabot.yml` triggers `lint.yml` in CI
- [ ] Mintlify build passes (`docs/reference/dependency-management.mdx` renders correctly)
- [ ] Verify repo Settings → General → "Allow auto-merge" is enabled: `gh api repos/amd/gaia --jq '.allow_auto_merge'` returns `true`
- [ ] After merge: confirm Dependabot opens grouped PRs on the next Monday cycle (not one-per-package)

## Known limitations

- **Grouped PRs that mix prod + dev deps don't auto-merge** — by design; a human should review anything that bundles a production patch with a dev minor update
- **`dependabot/fetch-metadata` itself is excluded from auto-merge** — supply-chain gate; update it manually after reviewing the changelog
- **First Monday after this lands may produce 6–8 grouped PRs** across all ecosystems (months of skipped updates catch up); this is expected and bounded

## Out-of-scope follow-ups

- Suppress Claude PR-review bot on Dependabot PRs (`claude.yml` guard) — bounded ~$70/wk but safe to add post-release
- pytest unit tests for `util/check_dependabot.py`
- Dependabot coverage for `docs/`, `website/`, `tests/electron/`, `src/vscode/gaia/`, `src/gaia/agents/emr/dashboard/frontend/`
- Wire `actionlint` + `yamllint` into CI

## Rollback

`git revert 3bf9b7b6 4c99bcf6` — restores `limit: 0` everywhere and removes the validator; Dependabot goes quiet again within minutes.

Closes #1157