### PR TITLE
test(cli): smoke-test every subcommand and console script with --help

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -74,28 +74,6 @@ jobs:
           pytest tests/unit/test_packaging.py -v --tb=short
           echo "✅ Packaging integrity checks passed"
 
-      - name: Validate CLI commands (dry-run)
-        run: |
-          echo "=== Validating CLI Commands ==="
-          echo "Testing CLI help and argument parsing (no server required)"
-          echo ""
-          # Validate gaia init command parses correctly
-          gaia init --help
-          echo "✅ gaia init --help passed"
-
-          # Validate other core commands
-          gaia --help
-          echo "✅ gaia --help passed"
-
-          gaia chat --help
-          echo "✅ gaia chat --help passed"
-
-          gaia prompt --help
-          echo "✅ gaia prompt --help passed"
-
-          gaia sd --help
-          echo "✅ gaia sd --help passed"
-
       - name: Run unit tests
         env:
           # Skip memory init — Lemonade isn't available in this CI job; the
@@ -131,12 +109,8 @@ jobs:
         run: |
           echo ""
           echo "=== Test Coverage ==="
-          echo "CLI Validation (Dry-Run):"
-          echo "  - gaia init --help: Command parsing and argument validation"
-          echo "  - gaia --help: Main CLI entry point"
-          echo "  - gaia chat --help: Chat command validation"
-          echo "  - gaia prompt --help: Prompt command validation"
-          echo "  - gaia sd --help: Image generation command validation"
+          echo "CLI Smoke Tests (pytest, auto-discovered):"
+          echo "  - tests/unit/cli/test_cli_smoke.py: --help for every subcommand + console script"
           echo ""
           echo "Unit Tests:"
           echo "  - SDToolsMixin: Stable Diffusion image generation for agents"

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1081,7 +1081,13 @@ def _print_reliability_summary(scorecards, pass_threshold=0.90):
         print(f"[RELIABILITY] Report saved → {report_path}")
 
 
-def main():
+def build_parser():
+    """Build the root argparse parser for the gaia CLI.
+
+    Exposed so tests can introspect the subparser tree without executing
+    main(). Adding a new subcommand here automatically gets --help smoke
+    coverage via tests/unit/cli/test_cli_smoke.py.
+    """
     import argparse
 
     # Create the main parser
@@ -1089,9 +1095,6 @@ def main():
         description=f"Gaia CLI - Interact with Gaia AI agents. \n{version}",
         formatter_class=argparse.RawTextHelpFormatter,
     )
-
-    # Get logger instance
-    log = get_logger(__name__)
 
     # Add version argument
     parser.add_argument(
@@ -2618,6 +2621,14 @@ Examples:
     )
 
     _register_uninstall_subparser(subparsers, parent_parser)
+    return parser
+
+
+def main():
+    parser = build_parser()
+
+    # Get logger instance
+    log = get_logger(__name__)
 
     args = parser.parse_args()
 

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1082,7 +1082,7 @@ def _print_reliability_summary(scorecards, pass_threshold=0.90):
 
 
 def build_parser():
-    """Build the root argparse parser; exposed so tests can introspect the subparser tree."""
+    """Build and return the root argparse parser."""
     import argparse
 
     # Create the main parser

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1082,12 +1082,7 @@ def _print_reliability_summary(scorecards, pass_threshold=0.90):
 
 
 def build_parser():
-    """Build the root argparse parser for the gaia CLI.
-
-    Exposed so tests can introspect the subparser tree without executing
-    main(). Adding a new subcommand here automatically gets --help smoke
-    coverage via tests/unit/cli/test_cli_smoke.py.
-    """
+    """Build the root argparse parser; exposed so tests can introspect the subparser tree."""
     import argparse
 
     # Create the main parser
@@ -2626,8 +2621,6 @@ Examples:
 
 def main():
     parser = build_parser()
-
-    # Get logger instance
     log = get_logger(__name__)
 
     args = parser.parse_args()

--- a/tests/unit/cli/test_cli_smoke.py
+++ b/tests/unit/cli/test_cli_smoke.py
@@ -102,6 +102,17 @@ _CONSOLE_SCRIPTS = _discover_console_scripts()
 _GAIA_BINARIES = _all_gaia_binaries()
 
 
+# ---- Shared fixture ----
+
+
+@pytest.fixture(scope="module")
+def root_parser():
+    """Module-scoped argparse parser — built once, shared across all subcommand tests."""
+    from gaia.cli import build_parser
+
+    return build_parser()
+
+
 # ---- Subcommand smoke tests (in-process) ----
 
 
@@ -110,12 +121,12 @@ _GAIA_BINARIES = _all_gaia_binaries()
     _SUBCOMMANDS,
     ids=["-".join(c) for c in _SUBCOMMANDS],
 )
-def test_subcommand_help(cmd: tuple[str, ...], capsys: pytest.CaptureFixture) -> None:
+def test_subcommand_help(
+    cmd: tuple[str, ...], capsys: pytest.CaptureFixture, root_parser
+) -> None:
     """`gaia <cmd> --help` exits 0 and prints a usage line."""
-    from gaia.cli import build_parser
-
     with pytest.raises(SystemExit) as excinfo:
-        build_parser().parse_args([*cmd, "--help"])
+        root_parser.parse_args([*cmd, "--help"])
 
     assert (
         excinfo.value.code == 0
@@ -126,12 +137,10 @@ def test_subcommand_help(cmd: tuple[str, ...], capsys: pytest.CaptureFixture) ->
     ), f"gaia {' '.join(cmd)} --help stdout missing 'usage:':\n{captured.out[:2000]}"
 
 
-def test_root_help(capsys: pytest.CaptureFixture) -> None:
+def test_root_help(capsys: pytest.CaptureFixture, root_parser) -> None:
     """`gaia --help` exits 0 and prints a usage line."""
-    from gaia.cli import build_parser
-
     with pytest.raises(SystemExit) as excinfo:
-        build_parser().parse_args(["--help"])
+        root_parser.parse_args(["--help"])
     assert excinfo.value.code == 0
     captured = capsys.readouterr()
     assert "usage:" in captured.out.lower()

--- a/tests/unit/cli/test_cli_smoke.py
+++ b/tests/unit/cli/test_cli_smoke.py
@@ -1,0 +1,226 @@
+"""Smoke test every gaia subcommand and standalone console script with --help.
+
+Subcommands are auto-discovered from `gaia.cli.build_parser()` — adding a
+new subcommand without --help coverage will fail this test at collection time.
+
+Console scripts are auto-discovered from importlib.metadata's
+`console_scripts` group, filtered to `gaia-*` (excluding `gaia-cli` which is
+a documented alias of `gaia`).
+
+Three layers of coverage per console_scripts entry:
+  - In-process argparse `--help` for every subcommand (fast, ~50 cases)
+  - Subprocess `python -m <module> --help` for the standalone binaries
+    (uses the project's portable `[sys.executable, "-m", ...]` convention
+    from tests/test_eval.py — does not depend on PATH layout)
+  - `shutil.which()` per gaia* binary to verify the console_scripts shim
+    actually installed on PATH (closes the gap from removing the manual
+    `gaia --help` shell step in test_unit.yml)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata as md
+import shutil
+import subprocess
+import sys
+from typing import Iterator
+
+import pytest
+
+# ---- Discovery helpers ----
+
+
+def _iter_subcommands(
+    parser: argparse.ArgumentParser,
+    prefix: tuple[str, ...] = (),
+    seen: set[int] | None = None,
+) -> Iterator[tuple[str, ...]]:
+    """Recursively yield every subcommand path as a tuple of names.
+
+    Yields BOTH intermediate groups AND leaves so that `gaia mcp --help`
+    is covered in addition to `gaia mcp start --help`. Deduplicates by
+    parser id() to guard against future argparse aliases.
+    """
+    if seen is None:
+        seen = set()
+
+    if prefix:
+        yield prefix
+
+    subparsers_action = next(
+        (a for a in parser._actions if isinstance(a, argparse._SubParsersAction)),
+        None,
+    )
+    if subparsers_action is None:
+        return
+
+    for name, child in subparsers_action.choices.items():
+        if id(child) in seen:
+            continue
+        seen.add(id(child))
+        yield from _iter_subcommands(child, prefix + (name,), seen)
+
+
+def _discover_subcommands() -> list[tuple[str, ...]]:
+    """Return the full sorted list of subcommand paths discovered from build_parser()."""
+    from gaia.cli import build_parser  # deferred — runs cli.py module side-effects
+
+    return sorted(_iter_subcommands(build_parser()))
+
+
+def _discover_console_scripts() -> list[tuple[str, str]]:
+    """Return (name, module) for every `gaia-*` console_scripts entry.
+
+    Excludes `gaia` (covered by in-process subcommand walk) and `gaia-cli`
+    (a documented alias of `gaia` with no new signal).
+    """
+    eps = md.entry_points(group="console_scripts")
+    out = []
+    for ep in eps:
+        if not ep.name.startswith("gaia-"):
+            continue
+        if ep.name == "gaia-cli":
+            continue
+        module = ep.value.split(":")[0]
+        out.append((ep.name, module))
+    return sorted(out)
+
+
+def _all_gaia_binaries() -> list[str]:
+    """Every gaia* binary name from console_scripts (including `gaia` itself)."""
+    eps = md.entry_points(group="console_scripts")
+    return sorted(
+        ep.name for ep in eps if ep.name == "gaia" or ep.name.startswith("gaia-")
+    )
+
+
+# ---- Module-level discovery (collection-phase) ----
+
+_SUBCOMMANDS = _discover_subcommands()
+_CONSOLE_SCRIPTS = _discover_console_scripts()
+_GAIA_BINARIES = _all_gaia_binaries()
+
+
+# ---- Subcommand smoke tests (in-process) ----
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    _SUBCOMMANDS,
+    ids=["-".join(c) for c in _SUBCOMMANDS],
+)
+def test_subcommand_help(cmd: tuple[str, ...], capsys: pytest.CaptureFixture) -> None:
+    """`gaia <cmd> --help` exits 0 and prints a usage line."""
+    from gaia.cli import build_parser
+
+    with pytest.raises(SystemExit) as excinfo:
+        build_parser().parse_args([*cmd, "--help"])
+
+    assert (
+        excinfo.value.code == 0
+    ), f"gaia {' '.join(cmd)} --help exited {excinfo.value.code}"
+    captured = capsys.readouterr()
+    assert (
+        "usage:" in captured.out.lower()
+    ), f"gaia {' '.join(cmd)} --help stdout missing 'usage:':\n{captured.out[:2000]}"
+
+
+def test_root_help(capsys: pytest.CaptureFixture) -> None:
+    """`gaia --help` exits 0 and prints a usage line."""
+    from gaia.cli import build_parser
+
+    with pytest.raises(SystemExit) as excinfo:
+        build_parser().parse_args(["--help"])
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out.lower()
+
+
+def test_discovery_minimum_count() -> None:
+    """Sentinel: fail loudly if subcommand discovery returns fewer than expected.
+
+    With intermediate-group coverage, expect ~60 paths: ~52 leaves plus
+    ~8 intermediate groups (telegram, eval, mcp, cache, memory, agent,
+    connectors, connectors-grants). Threshold set at 55 — five paths may
+    disappear before the alert fires. Raise this if intentional growth
+    pushes the count up.
+    """
+    assert len(_SUBCOMMANDS) >= 55, (
+        f"Subcommand discovery returned only {len(_SUBCOMMANDS)} paths; expected >= 55. "
+        f"Did a recent refactor break parser-tree introspection?\n"
+        f"Discovered: {['-'.join(c) for c in _SUBCOMMANDS]}"
+    )
+
+
+# ---- Console-script smoke tests (subprocess) ----
+
+
+@pytest.mark.parametrize(
+    "name_and_module",
+    _CONSOLE_SCRIPTS,
+    ids=[name for name, _ in _CONSOLE_SCRIPTS],
+)
+def test_console_script_help(name_and_module: tuple[str, str]) -> None:
+    """`python -m <module> --help` exits 0 and prints a usage line.
+
+    Uses `[sys.executable, "-m", <module>]` rather than the bare binary
+    name to match the project subprocess convention (tests/test_eval.py)
+    and avoid PATH dependency. The PATH/shim wiring is verified separately
+    by `test_gaia_binary_on_path`.
+    """
+    name, module = name_and_module
+    result = subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0, (
+        f"python -m {module} --help (entry {name!r}) exited {result.returncode}\n"
+        f"stdout: {result.stdout[:2000]}\n"
+        f"stderr: {result.stderr[:2000]}"
+    )
+    assert (
+        "usage:" in result.stdout.lower()
+    ), f"python -m {module} --help stdout missing 'usage:':\n{result.stdout[:2000]}"
+
+
+def test_console_script_minimum_count() -> None:
+    """Sentinel: fail loudly if console_scripts discovery returned nothing.
+
+    `_discover_console_scripts()` returns [] when the package is not
+    installed (no metadata to read). Without this assert, the parametrize
+    above would silently generate 0 tests — a silent fallback.
+    """
+    assert len(_CONSOLE_SCRIPTS) >= 3, (
+        f"Console-script discovery returned only {len(_CONSOLE_SCRIPTS)} entries; "
+        f"expected >= 3 (gaia-mcp, gaia-emr, gaia-code). "
+        f"Is the package installed? Run `pip install -e .`\n"
+        f"Found: {_CONSOLE_SCRIPTS}"
+    )
+
+
+# ---- Binary-on-PATH check ----
+
+
+@pytest.mark.parametrize("binary", _GAIA_BINARIES)
+def test_gaia_binary_on_path(binary: str) -> None:
+    """Every `gaia*` console_scripts entry is reachable on PATH after `pip install`.
+
+    Replaces the manual `gaia init --help`, `gaia --help`, etc. shell
+    steps removed from test_unit.yml. Checks shim presence only — does
+    not run the binary — so it cannot fail for runtime reasons.
+    """
+    assert shutil.which(binary) is not None, (
+        f"Binary {binary!r} not found on PATH. The console_scripts shim "
+        f"from setup.py may not have been installed. Run `pip install -e .`"
+    )
+
+
+def test_gaia_binary_minimum_count() -> None:
+    """Sentinel: confirm `_all_gaia_binaries()` found at least `gaia` itself."""
+    assert "gaia" in _GAIA_BINARIES, (
+        f"`gaia` binary missing from console_scripts metadata. "
+        f"Found: {_GAIA_BINARIES}. Is the package installed?"
+    )

--- a/tests/unit/cli/test_cli_smoke.py
+++ b/tests/unit/cli/test_cli_smoke.py
@@ -1,21 +1,4 @@
-"""Smoke test every gaia subcommand and standalone console script with --help.
-
-Subcommands are auto-discovered from `gaia.cli.build_parser()` — adding a
-new subcommand without --help coverage will fail this test at collection time.
-
-Console scripts are auto-discovered from importlib.metadata's
-`console_scripts` group, filtered to `gaia-*` (excluding `gaia-cli` which is
-a documented alias of `gaia`).
-
-Three layers of coverage per console_scripts entry:
-  - In-process argparse `--help` for every subcommand (fast, ~50 cases)
-  - Subprocess `python -m <module> --help` for the standalone binaries
-    (uses the project's portable `[sys.executable, "-m", ...]` convention
-    from tests/test_eval.py — does not depend on PATH layout)
-  - `shutil.which()` per gaia* binary to verify the console_scripts shim
-    actually installed on PATH (closes the gap from removing the manual
-    `gaia --help` shell step in test_unit.yml)
-"""
+"""Smoke-test every gaia subcommand and standalone console script with --help."""
 
 from __future__ import annotations
 
@@ -36,12 +19,7 @@ def _iter_subcommands(
     prefix: tuple[str, ...] = (),
     seen: set[int] | None = None,
 ) -> Iterator[tuple[str, ...]]:
-    """Recursively yield every subcommand path as a tuple of names.
-
-    Yields BOTH intermediate groups AND leaves so that `gaia mcp --help`
-    is covered in addition to `gaia mcp start --help`. Deduplicates by
-    parser id() to guard against future argparse aliases.
-    """
+    """Recursively yield every subcommand path; deduplicates parser aliases by id()."""
     if seen is None:
         seen = set()
 
@@ -214,13 +192,12 @@ def test_console_script_minimum_count() -> None:
 
 
 @pytest.mark.parametrize("binary", _GAIA_BINARIES)
+@pytest.mark.skipif(
+    not _GAIA_BINARIES,
+    reason="package not installed; run `pip install -e .` to enable binary PATH checks",
+)
 def test_gaia_binary_on_path(binary: str) -> None:
-    """Every `gaia*` console_scripts entry is reachable on PATH after `pip install`.
-
-    Replaces the manual `gaia init --help`, `gaia --help`, etc. shell
-    steps removed from test_unit.yml. Checks shim presence only — does
-    not run the binary — so it cannot fail for runtime reasons.
-    """
+    """Every `gaia*` console_scripts shim is reachable on PATH after `pip install`."""
     assert shutil.which(binary) is not None, (
         f"Binary {binary!r} not found on PATH. The console_scripts shim "
         f"from setup.py may not have been installed. Run `pip install -e .`"


### PR DESCRIPTION
Before this PR, ~46 of ~50 `gaia` subcommands had zero `--help` CI coverage. A typo in a `default=` value or an `ImportError` in a lazy-loaded handler module would ship to PyPI with green CI. Five manual shell checks in `test_unit.yml` covered only `gaia init/chat/prompt/sd/--help`, leaving `connectors`, `mcp`, `memory`, `telegram`, `eval`, `agent`, and all three standalone binaries (`gaia-code`, `gaia-emr`, `gaia-mcp`) completely uncovered.

This PR adds 72 auto-discovered pytest tests that run in under 5 seconds, covering every subcommand path and every `console_scripts` entry — including the 3-level-deep `gaia connectors grants list`. Adding a new subcommand to `cli.py` automatically gets `--help` smoke coverage at collection time with no manual updates needed.

Follow-up: #1192 (split `build_parser` into per-subcommand factory functions — deferred to keep this PR scoped).

## Test plan

- `PYTHONPATH=src GAIA_MEMORY_DISABLED=1 python -m pytest tests/unit/cli/ -v --tb=short` — 69 pass locally (4 `test_gaia_binary_on_path` fail without full `pip install -e .`; all 73 pass in CI after `uv pip install --system -e ".[api]"`)
- `python util/lint.py --all` — all critical checks pass (black, isort, pylint, flake8)
- `python -c "from gaia.cli import build_parser; build_parser().parse_args(['chat', '--help'])"` — exits 0

Closes #878