### PR TITLE
fix(agents): unbreak BrowserAgent/AnalystAgent in Agent UI

### DIFF
--- a/src/gaia/agents/analyst/agent.py
+++ b/src/gaia/agents/analyst/agent.py
@@ -47,6 +47,11 @@ class AnalystAgent(
         self._path_validator = self.path_validator
         self._scratchpad = ScratchpadService(db_path=config.scratchpad_db_path)
 
+        # Agent has no MCP servers; the UI auto-calls get_mcp_status_report()
+        # on every chat send and MCPClientMixin.__init__ never runs because
+        # Agent.__init__ doesn't chain super().
+        self._mcp_manager = None
+
         super().__init__(
             use_claude=config.use_claude,
             use_chatgpt=config.use_chatgpt,

--- a/src/gaia/agents/browser/agent.py
+++ b/src/gaia/agents/browser/agent.py
@@ -49,6 +49,11 @@ class BrowserAgent(Agent, BrowserToolsMixin, MCPClientMixin):
             rate_limit=config.browser_rate_limit,
         )
 
+        # Agent has no MCP servers; the UI auto-calls get_mcp_status_report()
+        # on every chat send and MCPClientMixin.__init__ never runs because
+        # Agent.__init__ doesn't chain super().
+        self._mcp_manager = None
+
         super().__init__(
             use_claude=config.use_claude,
             use_chatgpt=config.use_chatgpt,

--- a/src/gaia/agents/chat/lite_agent.py
+++ b/src/gaia/agents/chat/lite_agent.py
@@ -32,6 +32,11 @@ class ChatAgentLite(
             config = ChatAgentLiteConfig()
         self.config = config
 
+        # Agent has no MCP servers; the UI auto-calls get_mcp_status_report()
+        # on every chat send and MCPClientMixin.__init__ never runs because
+        # Agent.__init__ doesn't chain super().
+        self._mcp_manager = None
+
         # Avoid initializing local Lemonade during unit tests
         super().__init__(
             use_claude=config.use_claude,

--- a/src/gaia/agents/docqa/agent.py
+++ b/src/gaia/agents/docqa/agent.py
@@ -46,6 +46,11 @@ class DocumentQAAgent(
             # Optional dependency not installed in test environments
             self.rag = None
 
+        # Agent has no MCP servers; the UI auto-calls get_mcp_status_report()
+        # on every chat send and MCPClientMixin.__init__ never runs because
+        # Agent.__init__ doesn't chain super().
+        self._mcp_manager = None
+
         super().__init__(
             use_claude=config.use_claude,
             use_chatgpt=config.use_chatgpt,

--- a/src/gaia/agents/fileio/agent.py
+++ b/src/gaia/agents/fileio/agent.py
@@ -35,6 +35,11 @@ class FileIOAgent(
             config = FileIOAgentConfig()
         self.config = config
 
+        # Agent has no MCP servers; the UI auto-calls get_mcp_status_report()
+        # on every chat send and MCPClientMixin.__init__ never runs because
+        # Agent.__init__ doesn't chain super().
+        self._mcp_manager = None
+
         super().__init__(
             use_claude=config.use_claude,
             use_chatgpt=config.use_chatgpt,

--- a/src/gaia/mcp/mixin.py
+++ b/src/gaia/mcp/mixin.py
@@ -20,16 +20,31 @@ class MCPClientMixin:
     This mixin allows any agent to connect to MCP servers and use their tools.
     MCP tools are automatically registered in the agent's _TOOL_REGISTRY.
 
-    Usage:
-        class MyAgent(Agent, MCPClientMixin):
-            def __init__(self, ...):
-                super().__init__(...)
-                self.connect_mcp_server("github", {
-                    "command": "npx",
-                    "args": ["-y", "@modelcontextprotocol/server-github"],
-                    "env": {"GITHUB_TOKEN": "ghp_xxx"}
-                })
+    Usage (MCP-enabled agent):
+        ``Agent.__init__`` does not chain ``super().__init__()``, so this
+        mixin's ``__init__`` is unreachable through the MRO. Set
+        ``self._mcp_manager`` before calling ``super().__init__(...)`` —
+        ``Agent.__init__`` runs ``_register_tools()`` which loads MCP tools.
+        See ``ChatAgent.__init__`` (``src/gaia/agents/chat/agent.py``) for
+        the canonical pattern.
+
+            class MyAgent(Agent, MCPClientMixin):
+                def __init__(self, ...):
+                    self._mcp_manager = MCPClientManager(config=MCPConfig())
+                    super().__init__(...)
+
+    Usage (MCP-disabled agent):
+        Inherit ``MCPClientMixin`` but rely on the class-level default below;
+        ``get_mcp_status_report()`` will return ``[]`` and other accessors
+        that hit ``_mcp_manager`` are not invoked.
     """
+
+    # Class-level default so ``self._mcp_manager`` always resolves to ``None``
+    # when ``MCPClientMixin.__init__`` is bypassed by a broken cooperative-MI
+    # chain (``Agent.__init__`` does not call ``super().__init__()``).
+    # Instance-level assignment in ``__init__`` below — or in subclasses that
+    # follow the MCP-enabled pattern above — overrides this default.
+    _mcp_manager: Optional[MCPClientManager] = None
 
     def __init__(
         self,

--- a/tests/integration/test_chat_ui_integration.py
+++ b/tests/integration/test_chat_ui_integration.py
@@ -2094,3 +2094,72 @@ class TestCustomAgentModelChoice:
             f"Issue #841: agent.model_id must reflect kwargs.setdefault value; "
             f"got {captured['agent_model_id']!r}"
         )
+
+
+# ── PR #1201 regression: get_mcp_status_report must not AttributeError ────────
+
+
+class TestSplitAgentsMcpStatusReport:
+    """Regression for the PR #1201 release blocker.
+
+    BrowserAgent and AnalystAgent (PR #1070) inherit MCPClientMixin after
+    Agent in MRO and do not pre-set ``_mcp_manager``. ``Agent.__init__`` does
+    not chain ``super().__init__()``, so ``MCPClientMixin.__init__`` never
+    runs and ``_mcp_manager`` is undefined. The UI auto-calls
+    ``agent.get_mcp_status_report()`` on every chat send
+    (``src/gaia/ui/_chat_helpers.py:1644``) → ``AttributeError``.
+
+    These tests prove the fix: ``/api/chat/send`` for the ``web`` and ``data``
+    agent_types completes without surfacing the ``_mcp_manager`` AttributeError.
+    """
+
+    def _run_send(self, tmp_path, monkeypatch, agent_type: str):
+        # Redirect HOME so AnalystAgent's default ~/.gaia/scratchpad.db lands
+        # under tmp_path instead of polluting the developer's real home.
+        # Both patches are needed: Path.home() in registry.discover() reads
+        # the cached value while ScratchpadService's os.path.expanduser
+        # reads $HOME from the environment.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch("gaia.agents.registry.Path.home", return_value=tmp_path):
+            app = create_app(db_path=":memory:")
+
+            with TestClient(app) as client:
+                # Create a session typed to the split agent.
+                sess_resp = client.post(
+                    "/api/sessions",
+                    json={"title": "1201-test", "agent_type": agent_type},
+                )
+                assert sess_resp.status_code == 200, sess_resp.text
+                sid = sess_resp.json()["id"]
+
+                with (
+                    patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+                    patch(
+                        "gaia.ui._chat_helpers._agent_registry",
+                        app.state.agent_registry,
+                    ),
+                ):
+                    return client.post(
+                        "/api/chat/send",
+                        json={
+                            "session_id": sid,
+                            "message": "hi",
+                            "stream": False,
+                        },
+                    )
+
+    def test_web_agent_does_not_raise_mcp_attribute_error(self, tmp_path, monkeypatch):
+        chat_resp = self._run_send(tmp_path, monkeypatch, "web")
+        assert chat_resp.status_code == 200, chat_resp.text
+        assert "_mcp_manager" not in chat_resp.text, (
+            f"PR #1201: BrowserAgent surfaced _mcp_manager AttributeError "
+            f"through /api/chat/send:\n{chat_resp.text}"
+        )
+
+    def test_data_agent_does_not_raise_mcp_attribute_error(self, tmp_path, monkeypatch):
+        chat_resp = self._run_send(tmp_path, monkeypatch, "data")
+        assert chat_resp.status_code == 200, chat_resp.text
+        assert "_mcp_manager" not in chat_resp.text, (
+            f"PR #1201: AnalystAgent surfaced _mcp_manager AttributeError "
+            f"through /api/chat/send:\n{chat_resp.text}"
+        )

--- a/tests/unit/test_agents_split.py
+++ b/tests/unit/test_agents_split.py
@@ -115,3 +115,41 @@ def test_browse_and_analyze_cli_list_tools(monkeypatch, tmp_path, capsys):
         assert "fetch_page" not in analyze_output
     finally:
         sys.argv = original_argv
+
+
+def test_get_mcp_status_report_does_not_raise(tmp_path):
+    """Regression: agents that inherit MCPClientMixin must survive
+    ``get_mcp_status_report()`` even when MCP is not initialised.
+
+    The Agent UI auto-calls this on every chat send
+    (src/gaia/ui/_chat_helpers.py:1644). Before the fix, any agent whose MRO
+    had ``MCPClientMixin`` after ``Agent`` raised
+    ``AttributeError: '<Agent>' object has no attribute '_mcp_manager'``
+    because ``Agent.__init__`` doesn't chain ``super().__init__()``.
+    """
+    from gaia.agents.analyst.agent import AnalystAgent, AnalystAgentConfig
+    from gaia.agents.browser.agent import BrowserAgent
+    from gaia.agents.chat.lite_agent import ChatAgentLite
+    from gaia.agents.docqa.agent import DocumentQAAgent
+    from gaia.agents.fileio.agent import FileIOAgent
+
+    agents = [
+        BrowserAgent(),
+        AnalystAgent(AnalystAgentConfig(scratchpad_db_path=str(tmp_path / "s.db"))),
+        DocumentQAAgent(),
+        FileIOAgent(),
+        ChatAgentLite(),
+    ]
+    try:
+        for agent in agents:
+            assert agent.get_mcp_status_report() == [], (
+                f"{type(agent).__name__}.get_mcp_status_report() must return [] "
+                f"when MCP is not initialised"
+            )
+            assert (
+                agent._mcp_manager is None
+            ), f"{type(agent).__name__}._mcp_manager must resolve to None"
+    finally:
+        for agent in agents:
+            if hasattr(agent, "close"):
+                agent.close()


### PR DESCRIPTION
Selecting **Browser Agent** or **Analyst Agent** in the Agent UI and sending any message failed instantly with `AttributeError: '<Agent>' object has no attribute '_mcp_manager'`. After this change, both agents run their tool loops normally — Browser fetches pages, Analyst creates and queries scratchpad tables — exactly as users expect after the [#1070](https://github.com/amd/gaia/pull/1070) split landed. This unblocks release [#1201](https://github.com/amd/gaia/pull/1201): without the fix, anyone selecting the two new agents in the UI sees "SOMETHING WENT WRONG" before any work happens. CLI paths never hit the bug, which is why it shipped — the only auto-invoked dereference is `agent.get_mcp_status_report()` in `src/gaia/ui/_chat_helpers.py:1644`, which fires on every `/api/chat/send`.

## Test plan

- [x] `python util/lint.py --black --isort --imports` clean
- [x] `pytest tests/unit/test_agents_split.py -xvs` — 6/6 pass, including new `test_get_mcp_status_report_does_not_raise` covering Browser, Analyst, DocumentQA, FileIO, ChatAgentLite
- [x] `pytest tests/integration/test_chat_ui_integration.py::TestSplitAgentsMcpStatusReport -xvs` — 2/2 pass (web and data agent_types via real `/api/chat/send`)
- [x] `gaia browse --no-lemonade-check --list-tools` and `gaia analyze --no-lemonade-check --list-tools` register tools correctly
- [x] Hands-on UI smoke: opened http://localhost:4200 in Chrome, selected Browser Agent → "List your tools" returned a clean response in 19.7s; selected Analyst Agent → same in 16.3s; Analyst created `scratch_q1` and ran SQL aggregates with results matching the input CSV exactly (Gadget = $18,000 winner, verified in SQLite)
- [x] `code-reviewer` agent: "safe to merge, no critical issues, no silent-fallback regressions, no security concerns"

## Why two layers

A class-level `_mcp_manager: Optional[MCPClientManager] = None` on `MCPClientMixin` protects every current and future agent that inherits the mixin without pre-setting the attribute. The explicit `self._mcp_manager = None` in each of the five affected agents documents intent at the point of use (matches the fallback shape already in `ChatAgent.__init__`). The combination means the bug can't regress without a test catching it: removing one layer still leaves the other.

The proper architectural fix — making `Agent.__init__` call `super().__init__()` so the cooperative-MI chain actually reaches `MCPClientMixin.__init__` — is deferred. It would require every mixin in every agent's MRO to also cooperate via `super()`, which is too wide a refactor for a release-blocker patch.