### PR TITLE
fix(tests): align mcp-harness expected error with #718 no-echo invariant

### DIFF
--- a/tests/installer/test_custom_agent_mcp_harness.py
+++ b/tests/installer/test_custom_agent_mcp_harness.py
@@ -196,7 +196,7 @@ def test_custom_agent_with_mcp_reports_diagnosable_connection_failure(
     ]
     assert agent.process_query("add 7 and 35") == {
         "status": "error",
-        "error": "Tool 'mcp_dummy_add_two_numbers' not found",
+        "error": "Unknown tool name. Use only tools listed in your AVAILABLE TOOLS section.",
     }
 
 


### PR DESCRIPTION
Build Installers on the merged [v0.19.0 release commit](https://github.com/amd/gaia/commit/6f8bba0689558027911c87e289140bef3337274c) fails on both `ubuntu-latest` and `windows-latest` legs of the **Custom agent MCP harness** matrix because [`tests/installer/test_custom_agent_mcp_harness.py:199`](https://github.com/amd/gaia/blob/main/tests/installer/test_custom_agent_mcp_harness.py#L199) still encodes the pre-#718 error wording. PR [#718](https://github.com/amd/gaia/pull/718) deliberately replaced `"Tool '<name>' not found"` with the generic `"Unknown tool name. Use only tools listed in your AVAILABLE TOOLS section."` to prevent small models from interpreting the echoed bad name as self-confirmation and looping on it — that's the "no-echo invariant on the candidate-list message" called out in v0.19.0's release notes. The test from [#1069](https://github.com/amd/gaia/pull/1069) missed the migration.

This is a one-line test update to the second assertion in `test_custom_agent_with_mcp_reports_diagnosable_connection_failure`. The test's "diagnosable connection failure" intent is preserved by the **first** assertion in the same function, which still verifies `get_mcp_status_report()` surfaces the transport-level error (`"MCP server process died (exit code: 17)"`) — that's the actual user-facing diagnostic for a dead MCP server.

This unblocks the v0.19.0 release ([#1201](https://github.com/amd/gaia/pull/1201)) — pre-tag verification requires a green Build Installers run on the merged commit, which currently fails because of this single assertion.

## Test plan

- [x] `python -m pytest tests/installer/test_custom_agent_mcp_harness.py -xvs` — 3/3 pass locally
- [x] Lint: change is a string-literal update; no formatter impact
- [ ] Build Installers run on this branch goes green