### PR TITLE
feat(cpp): add LLM usage stats to JSONL event output

### DIFF
--- a/cpp/examples/process_agent.cpp
+++ b/cpp/examples/process_agent.cpp
@@ -701,7 +701,8 @@ static void cleanupBalloonNotify() {
 // ---------------------------------------------------------------------------
 class ProcessConsole : public gaia::CleanConsole {
 public:
-    void printFinalAnswer(const std::string& answer) override {
+    void printFinalAnswer(const std::string& answer,
+                          const gaia::UsageStats& /*usage*/ = {}) override {
         if (answer.empty()) return;
 
         std::string cleanAnswer = answer;

--- a/cpp/include/gaia/agent.h
+++ b/cpp/include/gaia/agent.h
@@ -187,11 +187,16 @@ private:
 
     // ---- LLM Communication ----
 
-    /// Send messages to the LLM and get a response.
+    struct LlmResult {
+        std::string content;
+        UsageStats usage;
+    };
+
+    /// Send messages to the LLM and get a response with usage stats.
     /// Uses OpenAI-compatible chat completions API.
     /// @param cfg  Config snapshot from the current processQuery() call.
-    std::string callLlm(const std::vector<Message>& messages, const std::string& systemPrompt,
-                        const AgentConfig& cfg);
+    LlmResult callLlm(const std::vector<Message>& messages, const std::string& systemPrompt,
+                      const AgentConfig& cfg);
 
     // ---- Execution Helpers ----
 

--- a/cpp/include/gaia/clean_console.h
+++ b/cpp/include/gaia/clean_console.h
@@ -63,7 +63,8 @@ public:
     void printInfo(const std::string& message) override;
     void startProgress(const std::string& message) override;
     void stopProgress() override;
-    void printFinalAnswer(const std::string& answer) override;
+    void printFinalAnswer(const std::string& answer,
+                          const UsageStats& usage = {}) override;
     void printCompletion(int stepsTaken, int stepsLimit) override;
     void printDecisionMenu(const std::vector<Decision>& decisions) override;
     void printStreamToken(const std::string& token) override;

--- a/cpp/include/gaia/console.h
+++ b/cpp/include/gaia/console.h
@@ -50,7 +50,8 @@ public:
     virtual void stopProgress() = 0;
 
     // === Completion Methods ===
-    virtual void printFinalAnswer(const std::string& answer) = 0;
+    virtual void printFinalAnswer(const std::string& answer,
+                                  const UsageStats& usage = {}) = 0;
     virtual void printCompletion(int stepsTaken, int stepsLimit) = 0;
 
     // === Optional Methods (default no-op) ===
@@ -92,7 +93,8 @@ public:
     void printInfo(const std::string& message) override;
     void startProgress(const std::string& message) override;
     void stopProgress() override;
-    void printFinalAnswer(const std::string& answer) override;
+    void printFinalAnswer(const std::string& answer,
+                          const UsageStats& usage = {}) override;
     void printCompletion(int stepsTaken, int stepsLimit) override;
     void printHeader(const std::string& text) override;
     void printSeparator(int length = 50) override;
@@ -136,7 +138,8 @@ public:
     void printInfo(const std::string&) override {}
     void startProgress(const std::string&) override {}
     void stopProgress() override {}
-    void printFinalAnswer(const std::string& answer) override;
+    void printFinalAnswer(const std::string& answer,
+                          const UsageStats& usage = {}) override;
     void printCompletion(int, int) override {}
 
 private:

--- a/cpp/include/gaia/json_event_handler.h
+++ b/cpp/include/gaia/json_event_handler.h
@@ -53,7 +53,8 @@ public:
     void stopProgress() override;
 
     // === Completion ===
-    void printFinalAnswer(const std::string& answer) override;
+    void printFinalAnswer(const std::string& answer,
+                          const UsageStats& usage = {}) override;
     void printCompletion(int stepsTaken, int stepsLimit) override;
 
     // === Streaming ===

--- a/cpp/include/gaia/tui_console.h
+++ b/cpp/include/gaia/tui_console.h
@@ -63,7 +63,8 @@ public:
     void printInfo(const std::string& message) override;
     void startProgress(const std::string& message) override;
     void stopProgress() override;
-    void printFinalAnswer(const std::string& answer) override;
+    void printFinalAnswer(const std::string& answer,
+                          const UsageStats& usage = {}) override;
     void printCompletion(int stepsTaken, int stepsLimit) override;
     void printDecisionMenu(const std::vector<Decision>& decisions) override;
     void printStreamToken(const std::string& token) override;

--- a/cpp/include/gaia/types.h
+++ b/cpp/include/gaia/types.h
@@ -248,6 +248,26 @@ struct ToolInfo {
     std::optional<std::string> mcpToolName;
 };
 
+// ---- LLM Usage Statistics ----
+
+struct UsageStats {
+    int promptTokens = 0;
+    int completionTokens = 0;
+    int totalTokens = 0;
+
+    void operator+=(const UsageStats& other) {
+        promptTokens += other.promptTokens;
+        completionTokens += other.completionTokens;
+        totalTokens += other.totalTokens;
+    }
+
+    json toJson() const {
+        return {{"prompt_tokens", promptTokens},
+                {"completion_tokens", completionTokens},
+                {"total_tokens", totalTokens}};
+    }
+};
+
 // ---- Parsed LLM Response ----
 
 struct ParsedResponse {

--- a/cpp/src/agent.cpp
+++ b/cpp/src/agent.cpp
@@ -254,8 +254,21 @@ std::string Agent::composeSystemPrompt() const {
 
 // ---- LLM Communication ----
 
-std::string Agent::callLlm(const std::vector<Message>& messages, const std::string& sysPrompt,
-                           const AgentConfig& cfg) {
+namespace {
+UsageStats extractUsage(const json& responseJson) {
+    UsageStats usage;
+    if (responseJson.contains("usage") && responseJson["usage"].is_object()) {
+        const auto& u = responseJson["usage"];
+        usage.promptTokens = u.value("prompt_tokens", 0);
+        usage.completionTokens = u.value("completion_tokens", 0);
+        usage.totalTokens = u.value("total_tokens", 0);
+    }
+    return usage;
+}
+} // namespace
+
+Agent::LlmResult Agent::callLlm(const std::vector<Message>& messages, const std::string& sysPrompt,
+                                const AgentConfig& cfg) {
     // Build OpenAI-compatible request.
     // NOTE: n_ctx is intentionally omitted — context size is set at model load
     // time via LemonadeClient::loadModel() / ensureModelLoaded(), not per-request.
@@ -295,7 +308,14 @@ std::string Agent::callLlm(const std::vector<Message>& messages, const std::stri
 
         if (!accumulated.empty()) {
             console_->printStreamEnd();
-            return accumulated;
+            // Streaming responses may include usage in the final chunk;
+            // attempt to extract from the raw bytes.
+            UsageStats usage;
+            try {
+                const json responseJson = json::parse(rawResponse);
+                usage = extractUsage(responseJson);
+            } catch (...) {}
+            return {accumulated, usage};
         }
 
         // Fallback: server returned a non-streaming response despite "stream":true.
@@ -307,7 +327,8 @@ std::string Agent::callLlm(const std::vector<Message>& messages, const std::stri
                     const auto& choice = responseJson["choices"][0];
                     if (choice.contains("message") && choice["message"].contains("content")
                         && choice["message"]["content"].is_string()) {
-                        return choice["message"]["content"].get<std::string>();
+                        return {choice["message"]["content"].get<std::string>(),
+                                extractUsage(responseJson)};
                     }
                 }
             } catch (...) {}
@@ -316,7 +337,7 @@ std::string Agent::callLlm(const std::vector<Message>& messages, const std::stri
         throw std::runtime_error("Streaming response contained no tokens");
     }
 
-    // ---- Non-streaming path (unchanged) ----
+    // ---- Non-streaming path ----
     std::string responseBody = lemonade_.chatCompletions(requestBody);
 
     // Parse response
@@ -327,7 +348,8 @@ std::string Agent::callLlm(const std::vector<Message>& messages, const std::stri
             auto& choice = responseJson["choices"][0];
             if (choice.contains("message") && choice["message"].contains("content")
                 && choice["message"]["content"].is_string()) {
-                return choice["message"]["content"].get<std::string>();
+                return {choice["message"]["content"].get<std::string>(),
+                        extractUsage(responseJson)};
             }
         }
         // Include truncated response body in error for debugging
@@ -696,6 +718,7 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
     std::string lastError;
     std::vector<json> stepResults;
     std::vector<std::pair<std::string, json>> toolCallHistory; // (name, args) for loop detection
+    UsageStats totalUsage;
 
     while (stepsTaken < stepsLimit && finalAnswer.empty()) {
         // ---- Cancel check ----
@@ -729,9 +752,9 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
         // Call LLM (retry once on failure).
         // Skip progress spinner when streaming — tokens serve as live progress.
         if (!config_.streaming) console_->startProgress("Thinking");
-        std::string response;
+        LlmResult llmResult;
         try {
-            response = callLlm(messages, systemPrompt(), cfg);
+            llmResult = callLlm(messages, systemPrompt(), cfg);
         } catch (const std::exception& e) {
             if (!config_.streaming) console_->stopProgress();
             console_->printWarning(std::string("LLM call failed, retrying: ") + e.what());
@@ -739,7 +762,7 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
             // Retry once
             if (!config_.streaming) console_->startProgress("Retrying");
             try {
-                response = callLlm(messages, systemPrompt(), cfg);
+                llmResult = callLlm(messages, systemPrompt(), cfg);
             } catch (const std::exception& e2) {
                 if (!config_.streaming) console_->stopProgress();
                 console_->printError(std::string("LLM error: ") + e2.what());
@@ -748,6 +771,9 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
             }
         }
         if (!config_.streaming) console_->stopProgress();
+
+        const std::string& response = llmResult.content;
+        totalUsage += llmResult.usage;
 
         // Debug: show response
         if (cfg.showPrompts) {
@@ -775,7 +801,7 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
         // ---- Handle final answer ----
         if (parsed.answer.has_value()) {
             finalAnswer = parsed.answer.value();
-            if (!config_.streaming || config_.structuredEvents) console_->printFinalAnswer(finalAnswer);
+            if (!config_.streaming || config_.structuredEvents) console_->printFinalAnswer(finalAnswer, totalUsage);
             break;
         }
 
@@ -860,7 +886,7 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
         // No tool call and no answer — treat response as conversational
         if (!parsed.toolName.has_value() && !parsed.answer.has_value()) {
             finalAnswer = response;
-            if (!config_.streaming || config_.structuredEvents) console_->printFinalAnswer(finalAnswer);
+            if (!config_.streaming || config_.structuredEvents) console_->printFinalAnswer(finalAnswer, totalUsage);
             break;
         }
     }
@@ -899,11 +925,15 @@ json Agent::processQueryInternal(const std::vector<Message>& userMessages, int m
     }
     conversationHistory_ = messages;
 
-    return json{
+    json result = {
         {"result", finalAnswer},
         {"steps_taken", stepsTaken},
         {"steps_limit", stepsLimit}
     };
+    if (totalUsage.totalTokens > 0) {
+        result["usage"] = totalUsage.toJson();
+    }
+    return result;
 }
 
 } // namespace gaia

--- a/cpp/src/clean_console.cpp
+++ b/cpp/src/clean_console.cpp
@@ -207,7 +207,8 @@ void CleanConsole::startProgress(const std::string& /*message*/) {}
 
 void CleanConsole::stopProgress() {}
 
-void CleanConsole::printFinalAnswer(const std::string& answer) {
+void CleanConsole::printFinalAnswer(const std::string& answer,
+                                    const UsageStats& /*usage*/) {
     if (answer.empty()) return;
 
     // Extract clean text from the LLM's final response.

--- a/cpp/src/console.cpp
+++ b/cpp/src/console.cpp
@@ -106,7 +106,8 @@ void TerminalConsole::stopProgress() {
     std::cout << "\n";
 }
 
-void TerminalConsole::printFinalAnswer(const std::string& answer) {
+void TerminalConsole::printFinalAnswer(const std::string& answer,
+                                       const UsageStats& /*usage*/) {
     std::cout << "\n" << BOLD << GREEN << "Answer:" << RESET << "\n" << answer << "\n";
 }
 
@@ -139,7 +140,8 @@ void TerminalConsole::printStreamEnd() {
 
 // ---- SilentConsole ----
 
-void SilentConsole::printFinalAnswer(const std::string& answer) {
+void SilentConsole::printFinalAnswer(const std::string& answer,
+                                     const UsageStats& /*usage*/) {
     if (!silenceFinalAnswer_) {
         std::cout << answer << "\n";
     }

--- a/cpp/src/json_event_handler.cpp
+++ b/cpp/src/json_event_handler.cpp
@@ -165,11 +165,16 @@ void JsonEventOutputHandler::stopProgress() {
 // Completion
 // ---------------------------------------------------------------------------
 
-void JsonEventOutputHandler::printFinalAnswer(const std::string& answer) {
-    emit({{"type", "answer"},
-          {"content", answer},
-          {"steps", stepsTaken_},
-          {"tools_used", toolsUsed_}});
+void JsonEventOutputHandler::printFinalAnswer(const std::string& answer,
+                                               const UsageStats& usage) {
+    json event = {{"type", "answer"},
+                  {"content", answer},
+                  {"steps", stepsTaken_},
+                  {"tools_used", toolsUsed_}};
+    if (usage.totalTokens > 0) {
+        event["usage"] = usage.toJson();
+    }
+    emit(event);
 }
 
 void JsonEventOutputHandler::printCompletion(int stepsTaken, int stepsLimit) {

--- a/cpp/src/tui_console.cpp
+++ b/cpp/src/tui_console.cpp
@@ -148,7 +148,8 @@ void TuiConsole::stopProgress() {
 // OutputHandler: completion
 // ---------------------------------------------------------------------------
 
-void TuiConsole::printFinalAnswer(const std::string& answer) {
+void TuiConsole::printFinalAnswer(const std::string& answer,
+                                  const UsageStats& /*usage*/) {
     if (answer.empty()) return;
     addEntry(ChatEntry::Type::ASSISTANT, answer);
 }

--- a/cpp/tests/test_json_event_handler.cpp
+++ b/cpp/tests/test_json_event_handler.cpp
@@ -257,6 +257,44 @@ TEST(JsonEventHandlerTest, FinalAnswer) {
     EXPECT_EQ(ev["content"], "Your WiFi is working correctly.");
     EXPECT_EQ(ev["steps"], 2);
     EXPECT_EQ(ev["tools_used"], 1);
+    // No usage object when UsageStats is default (zero)
+    EXPECT_FALSE(ev.contains("usage"));
+}
+
+TEST(JsonEventHandlerTest, FinalAnswerWithUsage) {
+    JsonEventOutputHandler handler;
+
+    {
+        CoutCapture cap;
+        handler.printProcessingStart("test query", 10, "model");
+        handler.printStepHeader(1, 10);
+    }
+
+    UsageStats usage;
+    usage.promptTokens = 150;
+    usage.completionTokens = 45;
+    usage.totalTokens = 195;
+
+    CoutCapture cap;
+    handler.printFinalAnswer("The answer is 42.", usage);
+    auto ev = cap.first();
+    EXPECT_EQ(ev["type"], "answer");
+    EXPECT_EQ(ev["content"], "The answer is 42.");
+    EXPECT_EQ(ev["steps"], 1);
+    ASSERT_TRUE(ev.contains("usage"));
+    EXPECT_EQ(ev["usage"]["prompt_tokens"], 150);
+    EXPECT_EQ(ev["usage"]["completion_tokens"], 45);
+    EXPECT_EQ(ev["usage"]["total_tokens"], 195);
+}
+
+TEST(JsonEventHandlerTest, FinalAnswerZeroUsageOmitted) {
+    JsonEventOutputHandler handler;
+
+    CoutCapture cap;
+    handler.printFinalAnswer("Result", UsageStats{});
+    auto ev = cap.first();
+    EXPECT_EQ(ev["type"], "answer");
+    EXPECT_FALSE(ev.contains("usage"));
 }
 
 TEST(JsonEventHandlerTest, Completion) {


### PR DESCRIPTION
The `--json-events` answer event was missing token usage data, so the TUI/WebUI had no visibility into how many tokens each query consumed. Now the answer event includes a `usage` object with `prompt_tokens`, `completion_tokens`, and `total_tokens` — accumulated across all LLM calls in a multi-step query — so the frontend can render token consumption directly from the event stream.

## Test plan
- [ ] `tests_mock --gtest_filter="JsonEventHandlerTest.*"` — all 23 tests pass (2 new: `FinalAnswerWithUsage`, `FinalAnswerZeroUsageOmitted`)
- [ ] `gaia-bash.exe --json-events --query "what is 2+2?"` — verify `answer` event includes `usage` when Lemonade returns it
- [ ] `gaia-bash.exe --json-events --query "hello"` — verify `usage` key is omitted when server returns zero tokens (graceful degradation)

Closes #1205