### PR TITLE
docs: include rag and ui extras in quickstart

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -206,7 +206,7 @@ Choose your platform and installation type:
     ```
 
     <Tip>
-      **Optional extras:** `uv pip install "amd-gaia[talk,rag]"` for voice and document Q&A features.
+      **Optional extras:** `uv pip install "amd-gaia[talk,rag,ui]"` for voice, document Q&A, and Agent UI features.
     </Tip>
 
     ### Step 5: Verify Installation
@@ -269,9 +269,9 @@ Choose your platform and installation type:
     ```
 
     <Tip>
-      **Optional extras:** Add `[talk,rag]` for voice and document Q&A features:
+      **Optional extras:** Add `[talk,rag,ui]` for voice, document Q&A, and Agent UI features:
       ```bash
-      uv pip install "amd-gaia[talk,rag]" --extra-index-url https://download.pytorch.org/whl/cpu
+      uv pip install "amd-gaia[talk,rag,ui]" --extra-index-url https://download.pytorch.org/whl/cpu
       ```
     </Tip>
 
@@ -342,11 +342,11 @@ Choose your platform and installation type:
     ### Step 4: Install in Editable Mode
 
     ```powershell
-    uv pip install -e ".[dev]"
+    uv pip install -e ".[dev,rag,ui]"
     ```
 
     <Tip>
-      **With all extras:** `uv pip install -e ".[dev,talk,rag]"` for voice and document Q&A features.
+      **With voice extras:** `uv pip install -e ".[dev,talk,rag,ui]"` for voice in addition to document Q&A and Agent UI features.
     </Tip>
 
     ### Step 5: Verify Installation
@@ -413,13 +413,13 @@ Choose your platform and installation type:
     </Warning>
 
     ```bash
-    uv pip install -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu
+    uv pip install -e ".[dev,rag,ui]" --extra-index-url https://download.pytorch.org/whl/cpu
     ```
 
     <Tip>
-      **With all extras:** Add `[talk,rag]` for voice and document Q&A features:
+      **With voice extras:** Add `talk` for voice in addition to document Q&A and Agent UI features:
       ```bash
-      uv pip install -e ".[dev,talk,rag]" --extra-index-url https://download.pytorch.org/whl/cpu
+      uv pip install -e ".[dev,talk,rag,ui]" --extra-index-url https://download.pytorch.org/whl/cpu
       ```
     </Tip>
 


### PR DESCRIPTION
## Problem
The developer quickstart installs only `.[dev]`, which leaves the Agent Memory, Document Q&A, and Agent UI walkthroughs missing the RAG/UI dependencies called out in #1074. The PyPI optional-extras tips also omit the UI extra.

## Solution
- Install `.[dev,rag,ui]` in both editable/developer quickstart tabs.
- Include `ui` in the optional PyPI extras examples.
- Keep voice dependencies opt-in by showing `talk` only in the expanded voice extras commands.

Closes #1074

## Validation
- `git diff --check`

## Confidence
85/100 — docs/install-path fix, directly follows maintainer issue comment and existing `setup.py` extras.