### PR TITLE
docs(mcp): remove unsupported CLI config commands

### DIFF
--- a/docs/guides/mcp/client.mdx
+++ b/docs/guides/mcp/client.mdx
@@ -79,11 +79,7 @@ MCP server connected, tools auto-discovered, and the agent uses them naturally.
   </Step>
 
   <Step title="Add an MCP server">
-    Add the official [MCP Time Server](https://github.com/modelcontextprotocol/servers/tree/main/src/time):
-    ```bash
-    gaia mcp add time "uvx mcp-server-time"
-    ```
-    Or edit `~/.gaia/mcp_servers.json` directly:
+    Add the official [MCP Time Server](https://github.com/modelcontextprotocol/servers/tree/main/src/time) to `~/.gaia/mcp_servers.json`:
     ```json
     {
       "mcpServers": {
@@ -239,13 +235,11 @@ flowchart TB
     ```
   </Tab>
 
-  <Tab title="Via CLI">
+  <Tab title="Via config file">
+    Add the server to `~/.gaia/mcp_servers.json`, then use the CLI to inspect it:
     ```bash
-    # Add server to config
-    gaia mcp add filesystem "npx -y @modelcontextprotocol/server-filesystem /tmp"
-
-    # List configured servers
     gaia mcp list
+    gaia mcp tools filesystem
     ```
   </Tab>
 </Tabs>
@@ -337,12 +331,16 @@ This format is compatible with Claude Desktop and other Anthropic tools. The `mc
   </Step>
 
   <Step title="Add to config">
-    ```bash
-    gaia mcp add <name> "<command>"
-    ```
-    For example, to add the Memory server:
-    ```bash
-    gaia mcp add memory "npx -y @modelcontextprotocol/server-memory"
+    Add a new entry to `~/.gaia/mcp_servers.json` (or `./mcp_servers.json` for a project-specific config). For example, to add the Memory server:
+    ```json
+    {
+      "mcpServers": {
+        "memory": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-memory"]
+        }
+      }
+    }
     ```
   </Step>
 
@@ -400,20 +398,20 @@ For detailed API usage and patterns, see the [SDK Reference](/sdk/sdks/mcp).
 
 <AccordionGroup>
   <Accordion title="CLI Commands">
-    GAIA provides CLI commands for managing MCP server configurations without writing code.
+    GAIA provides CLI commands for inspecting configured MCP servers and testing connections.
 
     <Card title="MCP CLI Reference" icon="terminal" href="/reference/cli#mcp-client">
-      Complete documentation of all MCP CLI commands: `add`, `list`, `tools`, `test-client`, `remove`
+      Complete documentation of all MCP CLI commands: `list`, `tools`, `test-client`
     </Card>
 
     **Quick reference:**
     ```bash
-    gaia mcp add <name> "<command>"     # Add server to config
     gaia mcp list                        # List configured servers
     gaia mcp tools <name>                # List tools from server
     gaia mcp test-client <name>          # Test connection
-    gaia mcp remove <name>               # Remove server
     ```
+
+    To add or remove custom servers, edit the `mcpServers` entries in `~/.gaia/mcp_servers.json` or a project-local `./mcp_servers.json`.
 
     For detailed usage, parameters, and output examples, see the [CLI Reference](/reference/cli#mcp-client).
   </Accordion>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -970,34 +970,9 @@ curl http://localhost:8080/health
   Connect GAIA agents to external MCP servers
 </Card>
 
-Configure MCP servers that your agents can connect to. Servers are saved to `~/.gaia/mcp_servers.json` by default, or to a custom config file using `--config`.
+Inspect and test MCP servers that your agents can connect to. Server definitions are read from `~/.gaia/mcp_servers.json` by default, or from a custom config file using `--config`; add or remove custom servers by editing the `mcpServers` entries in that JSON file.
 
 ### Commands
-
-#### `gaia mcp add`
-
-Add an MCP server to configuration.
-
-```bash
-gaia mcp add <server-name> "<command>" [--config PATH]
-```
-
-**Arguments:**
-- `<server-name>` - Unique identifier for the server (e.g., "time", "memory")
-- `"<command>"` - Shell command to start the MCP server (must be quoted)
-
-**Options:**
-- `--config PATH` - Custom config file path (default: `~/.gaia/mcp_servers.json`)
-
-**Examples:**
-```bash
-# Add to user config (default)
-gaia mcp add time "uvx mcp-server-time"
-gaia mcp add memory "npx -y @modelcontextprotocol/server-memory"
-
-# Add to project config (can be committed to git)
-gaia mcp add time "uvx mcp-server-time" --config ./mcp_servers.json
-```
 
 #### `gaia mcp list`
 
@@ -1017,29 +992,6 @@ gaia mcp list
 
 # List from project config
 gaia mcp list --config ./mcp_servers.json
-```
-
-#### `gaia mcp remove`
-
-Remove an MCP server from configuration.
-
-```bash
-gaia mcp remove <server-name> [--config PATH]
-```
-
-**Arguments:**
-- `<server-name>` - Name of the server to remove
-
-**Options:**
-- `--config PATH` - Custom config file path (default: `~/.gaia/mcp_servers.json`)
-
-**Example:**
-```bash
-# Remove from user config
-gaia mcp remove time
-
-# Remove from project config
-gaia mcp remove memory --config ./mcp_servers.json
 ```
 
 #### `gaia mcp tools`
@@ -1067,17 +1019,14 @@ gaia mcp tools memory --config ./mcp_servers.json
 
 #### `gaia mcp test-client`
 
-Test connection to a configured MCP server.
+Test connection to a configured MCP server from the default config.
 
 ```bash
-gaia mcp test-client <server-name> [--config PATH]
+gaia mcp test-client <server-name>
 ```
 
 **Arguments:**
 - `<server-name>` - Name of the server to test
-
-**Options:**
-- `--config PATH` - Custom config file path (default: `~/.gaia/mcp_servers.json`)
 
 **Example:**
 ```bash


### PR DESCRIPTION
The MCP docs currently tell users to run `gaia mcp add` and `gaia mcp remove`, but those subcommands are not registered by the CLI. This updates the guide and CLI reference to show the supported flow: edit `mcpServers` in the config file, then use `gaia mcp list`, `tools`, and `test-client` to inspect or validate configured servers.

Test plan:
- [x] `python` assertions that the updated user-facing docs no longer mention `gaia mcp add`/`gaia mcp remove`
- [x] `git diff --check -- docs/guides/mcp/client.mdx docs/reference/cli.mdx`

Related issue: #1076
Confidence: 85 (docs)
