### PR TITLE
feat(connectors): per-agent MCP tool-visibility activations (#1005)

### DIFF
--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -121,17 +121,19 @@ gaia connectors status
 # Test health of a configured connector
 gaia connectors test github
 
-# Per-agent grants (OAuth only)
+# Per-agent grants (every connector type)
 gaia connectors grants grant google builtin:chat \
     --scopes https://www.googleapis.com/auth/gmail.readonly
 gaia connectors grants list google
 gaia connectors grants revoke google builtin:chat
 
-# Per-agent activations — gate which agents see this connector's tools
-gaia connectors activations activate github builtin:chat \
-    --scopes repo:read   # --scopes is only consulted when no prior grant exists
-gaia connectors activations list github
-gaia connectors activations deactivate github builtin:chat
+# Per-agent activations — gate which agents see this MCP server's tools.
+# Activations apply to mcp_server connectors only; OAuth connectors are
+# rejected with exit 3 (use per-scope grants above instead).
+gaia connectors activations activate mcp-github builtin:chat \
+    --scopes use   # --scopes is only consulted when no prior grant exists
+gaia connectors activations list mcp-github
+gaia connectors activations deactivate mcp-github builtin:chat
 
 # Disconnect
 gaia connectors disconnect google
@@ -186,17 +188,17 @@ The Agent UI consent dialog renders `reason` in plain language. After
 the user grants the scopes, subsequent `get_access_token_sync` calls
 return fresh tokens transparently.
 
-## Per-agent activation
+## Per-agent activation (MCP servers only)
 
 Activations are the second axis of the per-agent authorization model
-(issue #1005):
+(issue #1005) and apply to **`mcp_server` connectors only**:
 
 - **Grant** (`grants.json`) — agent X is *allowed* to use connector Y's
   credentials with scopes S. Gates **credential access**
-  (`get_access_token`).
-- **Activation** (`activations.json`) — agent X *currently has* connector
-  Y's tools surfaced in its toolset. Gates **tool visibility** (system
-  prompt / tool registry).
+  (`get_access_token`). Applies to every connector type.
+- **Activation** (`activations.json`) — agent X *currently has* MCP
+  connector Y's tools surfaced in its toolset. Gates **MCP tool
+  visibility** (`MCPClientManager.tools_for_agent`).
 
 A tool from an MCP connector is visible to an agent if and only if:
 
@@ -208,6 +210,19 @@ Activations default to **inactive** when absent — least-privilege opt-in.
 The ledger stores explicit `true`/`false` entries; an unknown pair returns
 `is_agent_active == False`.
 
+<Warning>
+**OAuth connectors do not accept activations.** Agents reach OAuth providers
+(Google, etc.) through native Python `@tool` functions that call
+`get_credential_sync` directly — there is no MCP tool surface to gate.
+Per-agent access for OAuth connectors is controlled entirely by the
+per-scope grant toggles above.
+
+Calling `activate()` / `deactivate()` for an OAuth connector raises
+`ConfigurationError`; the HTTP `PUT` / `DELETE` returns `400 Bad Request`;
+the CLI exits with code 3. The Agent UI hides the "Active for" section
+for OAuth tiles for the same reason.
+</Warning>
+
 **One-click activation:** activating an agent with no prior grant
 auto-creates a grant using the agent's declared `REQUIRED_CONNECTORS`
 scopes. This is the path Settings → Connectors → "Active for" takes when
@@ -216,18 +231,19 @@ the user ticks an agent that has never been granted access:
 ```python
 from gaia.connectors import activate, deactivate
 
-# Activate (auto-grants if no prior grant exists)
-activate("github", "builtin:chat", scopes_for_grant=["repo:read"])
+# Activate (auto-grants if no prior grant exists). mcp-github is the
+# catalog id for the GitHub MCP server; activations only accept
+# mcp_server connectors.
+activate("mcp-github", "builtin:chat", scopes_for_grant=["use"])
 
 # Deactivate (preserves grant — re-activate is one click)
-deactivate("github", "builtin:chat")
+deactivate("mcp-github", "builtin:chat")
 ```
 
 ```bash
-gaia connectors activations activate github builtin:chat \
-    --scopes repo:read
-gaia connectors activations list github
-gaia connectors activations deactivate github builtin:chat
+gaia connectors activations activate mcp-github builtin:chat --scopes use
+gaia connectors activations list mcp-github
+gaia connectors activations deactivate mcp-github builtin:chat
 ```
 
 The HTTP router exposes:
@@ -238,11 +254,14 @@ PUT    /api/connectors/{id}/activations/{agent_id}     # body: {"scopes": [...]}
 DELETE /api/connectors/{id}/activations/{agent_id}
 ```
 
-SSE event `connector.activation.changed` is emitted on every PUT / DELETE
-so the Agent UI tile refreshes within ~1 s when another caller (CLI,
-SDK) changes the state. Disconnecting a connector wipes both grants
-**and** activations for that connector — re-adding the same `connector_id`
-must not silently inherit the previous user's tool-visibility decisions.
+Both mutating routes reject non-`mcp_server` connectors with `400 Bad
+Request` (after the standard `X-Gaia-UI` CSRF check). SSE event
+`connector.activation.changed` is emitted on every successful PUT /
+DELETE so the Agent UI tile refreshes within ~1 s when another caller
+(CLI, SDK) changes the state. Disconnecting a connector wipes both
+grants **and** activations for that connector — re-adding the same
+`connector_id` must not silently inherit the previous user's
+tool-visibility decisions.
 
 ## Where things live
 

--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -127,6 +127,12 @@ gaia connectors grants grant google builtin:chat \
 gaia connectors grants list google
 gaia connectors grants revoke google builtin:chat
 
+# Per-agent activations — gate which agents see this connector's tools
+gaia connectors activations activate github builtin:chat \
+    --scopes repo:read   # --scopes is only consulted when no prior grant exists
+gaia connectors activations list github
+gaia connectors activations deactivate github builtin:chat
+
 # Disconnect
 gaia connectors disconnect google
 ```
@@ -180,12 +186,71 @@ The Agent UI consent dialog renders `reason` in plain language. After
 the user grants the scopes, subsequent `get_access_token_sync` calls
 return fresh tokens transparently.
 
+## Per-agent activation
+
+Activations are the second axis of the per-agent authorization model
+(issue #1005):
+
+- **Grant** (`grants.json`) — agent X is *allowed* to use connector Y's
+  credentials with scopes S. Gates **credential access**
+  (`get_access_token`).
+- **Activation** (`activations.json`) — agent X *currently has* connector
+  Y's tools surfaced in its toolset. Gates **tool visibility** (system
+  prompt / tool registry).
+
+A tool from an MCP connector is visible to an agent if and only if:
+
+```text
+grant exists for (connector_id, agent_id)  AND  is_agent_active(...)
+```
+
+Activations default to **inactive** when absent — least-privilege opt-in.
+The ledger stores explicit `true`/`false` entries; an unknown pair returns
+`is_agent_active == False`.
+
+**One-click activation:** activating an agent with no prior grant
+auto-creates a grant using the agent's declared `REQUIRED_CONNECTORS`
+scopes. This is the path Settings → Connectors → "Active for" takes when
+the user ticks an agent that has never been granted access:
+
+```python
+from gaia.connectors import activate, deactivate
+
+# Activate (auto-grants if no prior grant exists)
+activate("github", "builtin:chat", scopes_for_grant=["repo:read"])
+
+# Deactivate (preserves grant — re-activate is one click)
+deactivate("github", "builtin:chat")
+```
+
+```bash
+gaia connectors activations activate github builtin:chat \
+    --scopes repo:read
+gaia connectors activations list github
+gaia connectors activations deactivate github builtin:chat
+```
+
+The HTTP router exposes:
+
+```text
+GET    /api/connectors/{id}/activations
+PUT    /api/connectors/{id}/activations/{agent_id}     # body: {"scopes": [...]}?
+DELETE /api/connectors/{id}/activations/{agent_id}
+```
+
+SSE event `connector.activation.changed` is emitted on every PUT / DELETE
+so the Agent UI tile refreshes within ~1 s when another caller (CLI,
+SDK) changes the state. Disconnecting a connector wipes both grants
+**and** activations for that connector — re-adding the same `connector_id`
+must not silently inherit the previous user's tool-visibility decisions.
+
 ## Where things live
 
 | Path | Contents |
 |------|----------|
 | `~/.gaia/connectors/state.json` | Non-secret connector metadata (configured, account_id, scopes). Mode 0600. |
 | `~/.gaia/connectors/grants.json` | Per-agent scope grants. Mode 0600. |
+| `~/.gaia/connectors/activations.json` | Per-agent tool-visibility activations. Mode 0600. |
 | OS keychain `gaia.connections` | Encrypted refresh tokens + MCP API keys. |
 
 ## Adding a new OAuth provider

--- a/docs/security/connections.mdx
+++ b/docs/security/connections.mdx
@@ -18,22 +18,25 @@ Each connector occupies a dedicated keyring slot keyed by `gaia.connections:<con
 
 OAuth refresh tokens and MCP server API keys are AES-256 encrypted by the OS keyring at rest and decrypted in memory only when a tool call needs them.
 
-## Per-agent grant model
+## Per-agent grant + activation model
 
-Connecting a service (e.g. Google) does **not** give every agent access to it. Access is gated at two levels:
+Connecting a service (e.g. Google) does **not** give every agent access to it. Access is gated at three levels:
 
 1. **Connection** — you store a credential once in the keyring (OAuth refresh token or PAT).
-2. **Grant** — you explicitly allow a specific agent to use that credential for a specific scope.
+2. **Grant** — you explicitly allow a specific agent to use that credential for a specific scope. Gates **credential access** (`get_access_token`).
+3. **Activation** — you explicitly enable a specific agent to *see* the connector's tools in its system prompt. Gates **tool visibility**. Defaults to OFF — least-privilege opt-in.
 
 ```
 User → connects Google once
-User → grants chat-agent gmail.readonly
-User → grants my-research-agent gmail.readonly + drive.readonly
+User → grants chat-agent gmail.readonly         (credential access)
+User → activates chat-agent for google MCP      (tool visibility)
 ```
 
 An agent that calls `get_credential_sync("google", agent_id=..., required_scopes=["gmail.readonly"])` without a matching grant receives `AuthRequiredError(reason=AGENT_NOT_GRANTED)` and cannot proceed. No token is ever returned to an ungrantedn agent.
 
-Grants are stored in `~/.gaia/connectors/grants.json` — a flat file that is **not** a secret store. It contains agent IDs and scope names, not credentials.
+Without an activation, the connector's MCP tools never enter the agent's tool list — they don't bloat the system prompt, and the agent cannot select them even if it has a grant.
+
+Grants are stored in `~/.gaia/connectors/grants.json` and activations in `~/.gaia/connectors/activations.json` — both flat files that are **not** secret stores. They contain agent IDs and scope/boolean values, never credentials.
 
 ## Revocation
 
@@ -41,8 +44,9 @@ You can revoke access at any level:
 
 | Action | Effect |
 |---|---|
-| Settings → Connections → \<connector\> → **Disconnect** | Removes token from keyring; all agent calls fail with `NOT_CONNECTED` |
+| Settings → Connectors → \<connector\> → **Disconnect** | Removes token from keyring AND clears all grants AND all activations for that connector; all agent calls fail with `NOT_CONNECTED` |
 | `gaia connectors grants revoke <connector> <agent>` | Removes the per-agent grant; that agent's calls fail with `AGENT_NOT_GRANTED` |
+| `gaia connectors activations deactivate <connector> <agent>` | Removes the per-agent activation; that agent stops seeing the connector's tools but the grant survives so re-activation is one click |
 | Revoke the PAT/OAuth client at the provider | Invalidates the token at the source; GAIA's next API call surfaces the provider's error |
 
 ## Threat model
@@ -51,6 +55,7 @@ You can revoke access at any level:
 |---|---|
 | Malicious process reads `mcp_servers.json` | File contains only `$keyring:...` references, never raw tokens |
 | Malicious agent requests a credential it wasn't granted | `get_credential_sync` checks the grants ledger before returning; unapproved calls raise `AuthRequiredError` |
+| Connector re-added after disconnect silently inherits prior tool visibility | `disconnect` wipes both grants AND activations for that `connector_id`; re-adding requires explicit re-grant + re-activate |
 | Token leak via logging | Connector code never logs token values; credentials are redacted before any log statement |
 | Token exfiltration via a rogue custom agent | Custom agents run in the same process as GAIA — they are trusted code you install yourself, analogous to a browser extension |
 

--- a/docs/security/connections.mdx
+++ b/docs/security/connections.mdx
@@ -20,21 +20,23 @@ OAuth refresh tokens and MCP server API keys are AES-256 encrypted by the OS key
 
 ## Per-agent grant + activation model
 
-Connecting a service (e.g. Google) does **not** give every agent access to it. Access is gated at three levels:
+Connecting a service does **not** give every agent access to it. Access is gated at up to three levels depending on connector type:
 
 1. **Connection** — you store a credential once in the keyring (OAuth refresh token or PAT).
-2. **Grant** — you explicitly allow a specific agent to use that credential for a specific scope. Gates **credential access** (`get_access_token`).
-3. **Activation** — you explicitly enable a specific agent to *see* the connector's tools in its system prompt. Gates **tool visibility**. Defaults to OFF — least-privilege opt-in.
+2. **Grant** — you explicitly allow a specific agent to use that credential for a specific scope. Gates **credential access** (`get_access_token`). Applies to every connector type.
+3. **Activation** — you explicitly enable a specific agent to *see* an MCP server's tools in its system prompt. Gates **MCP tool visibility**. Defaults to OFF — least-privilege opt-in. **Applies to `mcp_server` connectors only.**
 
 ```
-User → connects Google once
-User → grants chat-agent gmail.readonly         (credential access)
-User → activates chat-agent for google MCP      (tool visibility)
+User → connects mcp-github once                   (credential)
+User → grants chat-agent the GitHub PAT scope     (credential access)
+User → activates chat-agent for mcp-github        (MCP tool visibility)
 ```
 
-An agent that calls `get_credential_sync("google", agent_id=..., required_scopes=["gmail.readonly"])` without a matching grant receives `AuthRequiredError(reason=AGENT_NOT_GRANTED)` and cannot proceed. No token is ever returned to an ungrantedn agent.
+OAuth connectors (e.g. Google) reach the provider through native Python `@tool` functions that call `get_credential_sync` directly — there is no MCP tool surface for activations to gate. Per-agent control for OAuth is handled entirely by the per-scope grant toggles. Calling `activate()` / `deactivate()` for an OAuth connector raises `ConfigurationError`; the HTTP route returns `400 Bad Request`; the CLI exits with code 3.
 
-Without an activation, the connector's MCP tools never enter the agent's tool list — they don't bloat the system prompt, and the agent cannot select them even if it has a grant.
+An agent that calls `get_credential_sync("google", agent_id=..., required_scopes=["gmail.readonly"])` without a matching grant receives `AuthRequiredError(reason=AGENT_NOT_GRANTED)` and cannot proceed. No token is ever returned to an ungranted agent.
+
+Without an activation, an MCP connector's tools never enter the agent's tool list — they don't bloat the system prompt, and the agent cannot select them even if it has a grant.
 
 Grants are stored in `~/.gaia/connectors/grants.json` and activations in `~/.gaia/connectors/activations.json` — both flat files that are **not** secret stores. They contain agent IDs and scope/boolean values, never credentials.
 
@@ -46,7 +48,7 @@ You can revoke access at any level:
 |---|---|
 | Settings → Connectors → \<connector\> → **Disconnect** | Removes token from keyring AND clears all grants AND all activations for that connector; all agent calls fail with `NOT_CONNECTED` |
 | `gaia connectors grants revoke <connector> <agent>` | Removes the per-agent grant; that agent's calls fail with `AGENT_NOT_GRANTED` |
-| `gaia connectors activations deactivate <connector> <agent>` | Removes the per-agent activation; that agent stops seeing the connector's tools but the grant survives so re-activation is one click |
+| `gaia connectors activations deactivate <mcp-server-connector> <agent>` | Removes the per-agent activation; that agent stops seeing the MCP server's tools but the grant survives so re-activation is one click. Only valid for `mcp_server` connectors |
 | Revoke the PAT/OAuth client at the provider | Invalidates the token at the source; GAIA's next API call surfaces the provider's error |
 
 ## Threat model

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -2207,6 +2207,36 @@ Do NOT wrap conversational replies in JSON.
         half = max_chars // 2 - 20
         return f"{content_str[:half]}\n...[truncated]...\n{content_str[-half:]}"
 
+    def _namespaced_agent_id(self) -> Optional[str]:
+        """Return the registry-assigned namespaced agent id, or None.
+
+        The registry wraps each factory with ``_wrap_factory_with_namespaced_id``
+        so production agent instances always carry ``_gaia_namespaced_agent_id``.
+        Tests that construct agents directly (without going through the registry)
+        fall back to bare ``AGENT_ID``; both keys may legitimately resolve to
+        ``None`` for ad-hoc agents that opt out of the activation/grant layer
+        entirely.
+        """
+        return getattr(self, "_gaia_namespaced_agent_id", None) or getattr(
+            self, "AGENT_ID", None
+        )
+
+    def _active_mcp_servers(self, manager) -> List[str]:
+        """Return MCP server names whose tools should be visible to this agent.
+
+        Per issue #1005, MCP tools are gated by the activations ledger
+        (``~/.gaia/connectors/activations.json``). When no namespaced agent
+        id is available (e.g. test agents constructed directly), every
+        connected server is returned — the activation filter only applies
+        to agents that participate in the registry's identity scheme.
+        """
+        if manager is None:
+            return []
+        ns_id = self._namespaced_agent_id()
+        if ns_id is None:
+            return list(manager.list_servers())
+        return list(manager.servers_for_agent(ns_id))
+
     def process_query(
         self,
         user_input: str,

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -120,6 +120,17 @@ class ChatAgentConfig:
     #   "full"  — all tools and prompt sections (backward-compatible default)
     prompt_profile: str = "full"
 
+    # Per-agent identity for the connectors activation filter (#1005).
+    # Must be set BEFORE ``Agent.__init__`` runs ``_register_tools``, because
+    # that's where ``_active_mcp_servers`` consults ``is_agent_active`` to
+    # decide which MCP servers' tools to surface. The registry's
+    # ``_wrap_factory_with_namespaced_id`` injects this via kwargs, and the
+    # UI's direct construction paths in ``_chat_helpers`` pass it explicitly.
+    # Leaving this ``None`` reproduces the pre-#1005 behaviour where the
+    # agent sees every connected MCP server unfiltered — keep it set for
+    # any built-in or registered Chat instance.
+    namespaced_agent_id: Optional[str] = None
+
 
 class ChatAgent(
     MemoryMixin,
@@ -163,6 +174,15 @@ class ChatAgent(
         # Use provided config or create default
         if config is None:
             config = ChatAgentConfig()
+
+        # Stamp the per-agent identity for the connectors activation filter
+        # (#1005) BEFORE ``super().__init__`` runs ``_register_tools``. The
+        # MCP-tool registration step in ``_register_tools`` consults
+        # ``_active_mcp_servers`` which reads this attribute; setting it
+        # after super().__init__ would be too late and the filter would
+        # silently fall back to "ad-hoc agent — show every MCP server".
+        if config.namespaced_agent_id:
+            self._gaia_namespaced_agent_id = config.namespaced_agent_id
 
         # Initialize path validator
         self.path_validator = PathValidator(config.allowed_paths)

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -1550,10 +1550,15 @@ No documents are currently indexed.
             try:
                 self._mcp_manager.load_from_config()
                 self._print_mcp_load_summary()
+                # Filter to servers explicitly activated for this agent
+                # (issue #1005). Falls back to the unfiltered list when the
+                # agent has no registry identity, preserving prior behaviour
+                # for ad-hoc test agents.
+                _active_servers = self._active_mcp_servers(self._mcp_manager)
                 # Preview total tool count before registering
                 _mcp_tool_count = sum(
                     len(_c.list_tools())
-                    for _srv in self._mcp_manager.list_servers()
+                    for _srv in _active_servers
                     if (_c := self._mcp_manager.get_client(_srv)) is not None
                 )
                 if _mcp_tool_count > _MCP_TOOL_LIMIT:
@@ -1565,7 +1570,7 @@ No documents are currently indexed.
                     )
                 else:
                     _before = len(_TOOL_REGISTRY)
-                    for _srv in self._mcp_manager.list_servers():
+                    for _srv in _active_servers:
                         _client = self._mcp_manager.get_client(_srv)
                         if _client:
                             self._register_mcp_tools(_client)

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -144,26 +144,37 @@ def _wrap_factory_with_namespaced_id(
 ) -> Callable[..., Any]:
     """
     Wrap a registration factory so the resulting Agent instance carries its
-    namespaced ID for ``Agent.process_query`` to read at runtime.
+    namespaced ID.
 
-    The base ``Agent.process_query`` reads ``_gaia_namespaced_agent_id`` (and
-    falls back to ``AGENT_ID``) when wrapping the call in the agent context
-    contextvar. Setting this attribute on the instance is what lets a
-    custom-installed agent get its proper ``custom:<sha256>:<id>`` namespace
-    instead of the bare ``AGENT_ID``.
+    Two things have to happen for the per-agent connectors activation filter
+    (#1005) to work correctly:
+
+    1. The agent class must see the namespaced id BEFORE its ``__init__``
+       calls ``_register_tools`` — that's where MCP tools get registered and
+       where ``_active_mcp_servers`` reads the id to decide which servers'
+       tools to surface. We pass it as a ``namespaced_agent_id`` kwarg so
+       config classes that declare the field (e.g. ``ChatAgentConfig``) can
+       stamp ``self._gaia_namespaced_agent_id`` at the top of ``__init__``.
+       Factories that filter kwargs by their config fields will pick this up
+       automatically; factories whose config does NOT declare the field
+       drop it harmlessly.
+    2. The instance attribute is also stamped after the factory returns as
+       belt-and-braces — covers agents whose config doesn't (yet) declare
+       the field, and ensures ``Agent.process_query`` sees the id at
+       runtime even if step 1 didn't apply.
     """
 
     def _factory(**kwargs):
+        # Inject for kwarg-aware factories (step 1).
+        kwargs.setdefault("namespaced_agent_id", namespaced_id)
         instance = factory(**kwargs)
-        # Attribute access — use setattr because subclasses may override
-        # __setattr__ to validate fields. We set on the instance, not the
-        # class, so two different registrations of the same class don't
-        # collide.
+        # Belt-and-braces post-init stamp (step 2). Use setattr so subclasses
+        # with custom ``__setattr__`` validation see a well-formed write,
+        # and tolerate __slots__-defined agents that can't accept the
+        # attribute (process_query will fall back to AGENT_ID).
         try:
             instance._gaia_namespaced_agent_id = namespaced_id
         except (AttributeError, TypeError):
-            # If the agent uses __slots__ without an entry for this field,
-            # we still proceed — process_query will fall back to AGENT_ID.
             pass
         return instance
 

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -763,20 +763,44 @@ function AgentMcpTile({
 function ConnectorAgentGrants({ connectorId }: { connectorId: string }) {
     const { agents } = useChatStore();
     const [grants, setGrants] = useState<Record<string, string[]>>({});
+    const [activations, setActivations] = useState<Record<string, boolean>>({});
     const [loading, setLoading] = useState(true);
 
     const load = useCallback(async () => {
         try {
-            const { grants: g } = await api.listConnectorGrants(connectorId);
+            const [{ grants: g }, { activations: acts }] = await Promise.all([
+                api.listConnectorGrants(connectorId),
+                api.listConnectorActivations(connectorId),
+            ]);
             setGrants(g);
+            setActivations(acts);
         } catch {
             setGrants({});
+            setActivations({});
         } finally {
             setLoading(false);
         }
     }, [connectorId]);
 
     useEffect(() => { void load(); }, [load]);
+
+    // Live updates: when grant or activation changes (either through this UI
+    // or another caller — CLI, SDK), pick the fresh state up.
+    useConnectorsSSE(
+        useCallback(
+            (event) => {
+                if (
+                    event.connectorId === connectorId &&
+                    (event.reason === 'grant_changed' ||
+                        event.reason === 'activation_changed' ||
+                        event.reason === 'disconnected')
+                ) {
+                    void load();
+                }
+            },
+            [connectorId, load],
+        ),
+    );
 
     if (loading) return null;
 
@@ -800,6 +824,121 @@ function ConnectorAgentGrants({ connectorId }: { connectorId: string }) {
                         onChanged={() => void load()}
                     />
                 ))
+            )}
+
+            {relevantAgents.length > 0 && (
+                <>
+                    <div className="grants-header grants-header--activations">
+                        Active for
+                    </div>
+                    <div className="grants-help">
+                        Activations gate which agents see this connector's tools.
+                        Activating without a prior grant auto-creates one.
+                    </div>
+                    {relevantAgents.map((agent) => (
+                        <AgentActivationCard
+                            key={`activation-${agent.namespaced_agent_id}`}
+                            agent={agent}
+                            connectorId={connectorId}
+                            active={Boolean(activations[agent.namespaced_agent_id!])}
+                            grantedScopes={grants[agent.namespaced_agent_id!] ?? []}
+                            onChanged={() => void load()}
+                        />
+                    ))}
+                </>
+            )}
+        </div>
+    );
+}
+
+// ── AgentActivationCard ──────────────────────────────────────────────────────
+
+/**
+ * One-row activation toggle for a single agent (issue #1005).
+ *
+ * Activation gates tool visibility: when ON, the connector's tools appear
+ * in the agent's prompt; when OFF (or absent), the tools are hidden even
+ * if the agent holds a grant. Activating without a prior grant auto-creates
+ * one using the agent's declared REQUIRED_CONNECTORS scopes.
+ */
+function AgentActivationCard({
+    agent,
+    connectorId,
+    active,
+    grantedScopes,
+    onChanged,
+}: {
+    agent: {
+        namespaced_agent_id?: string;
+        name: string;
+        required_connections?: Array<{ connector_id: string; scopes: string[]; reason: string }>;
+    };
+    connectorId: string;
+    active: boolean;
+    grantedScopes: string[];
+    onChanged: () => void;
+}) {
+    const req = agent.required_connections?.find((rc) => rc.connector_id === connectorId);
+    const agentId = agent.namespaced_agent_id;
+    if (!req || !agentId) return null;
+
+    const [localActive, setLocalActive] = useState(active);
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+
+    useEffect(() => {
+        setLocalActive(active);
+    }, [active]);
+
+    const toggle = async () => {
+        if (busy) return;
+        const next = !localActive;
+        setLocalActive(next); // optimistic
+        setBusy(true);
+        setErr(null);
+        try {
+            if (next) {
+                // Auto-grant uses the agent's declared REQUIRED_CONNECTORS
+                // scopes — but only if no grant is in place yet. The server
+                // ignores the body when a grant already exists.
+                const scopesForGrant =
+                    grantedScopes.length === 0 ? [...req.scopes] : undefined;
+                await api.activateConnectorAgent(connectorId, agentId, scopesForGrant);
+            } else {
+                await api.deactivateConnectorAgent(connectorId, agentId);
+            }
+            onChanged();
+        } catch (e) {
+            setLocalActive(active); // revert
+            setErr(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="grant-agent-card">
+            <div className="grant-agent-card-name">{agent.name}</div>
+            <div className="grant-scope-list">
+                <label className="grant-scope-item">
+                    <span className="grant-scope-label">
+                        {localActive ? 'Tools visible to this agent' : 'Tools hidden from this agent'}
+                    </span>
+                    <span className="toggle-switch">
+                        <input
+                            type="checkbox"
+                            checked={localActive}
+                            onChange={() => void toggle()}
+                            disabled={busy}
+                        />
+                        <span className="toggle-track" />
+                    </span>
+                </label>
+            </div>
+            {err && (
+                <div className="grant-scope-warning grant-scope-warning--error">
+                    <AlertCircle size={11} /> {err}
+                </div>
             )}
         </div>
     );

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -206,7 +206,10 @@ function ConnectorTile({
                         <MCPServerConfigureBody connector={connector} onChanged={onChanged} />
                     )}
                     {connector.configured && (
-                        <ConnectorAgentGrants connectorId={connector.id} />
+                        <ConnectorAgentGrants
+                            connectorId={connector.id}
+                            connectorType={connector.type}
+                        />
                     )}
                 </div>
             )}
@@ -760,7 +763,13 @@ function AgentMcpTile({
 
 // ── ConnectorAgentGrants ─────────────────────────────────────────────────────
 
-function ConnectorAgentGrants({ connectorId }: { connectorId: string }) {
+function ConnectorAgentGrants({
+    connectorId,
+    connectorType,
+}: {
+    connectorId: string;
+    connectorType: string;
+}) {
     const { agents } = useChatStore();
     const [grants, setGrants] = useState<Record<string, string[]>>({});
     const [activations, setActivations] = useState<Record<string, boolean>>({});
@@ -826,7 +835,11 @@ function ConnectorAgentGrants({ connectorId }: { connectorId: string }) {
                 ))
             )}
 
-            {relevantAgents.length > 0 && (
+            {/* Activations gate MCP tool visibility. OAuth connectors have no
+                MCP tool surface — their per-agent access is governed by the
+                per-scope grant toggles above — so showing this block for them
+                would be a switch that does nothing. (issue #1005) */}
+            {connectorType === 'mcp_server' && relevantAgents.length > 0 && (
                 <>
                     <div className="grants-header grants-header--activations">
                         Active for
@@ -856,10 +869,14 @@ function ConnectorAgentGrants({ connectorId }: { connectorId: string }) {
 /**
  * One-row activation toggle for a single agent (issue #1005).
  *
- * Activation gates tool visibility: when ON, the connector's tools appear
- * in the agent's prompt; when OFF (or absent), the tools are hidden even
- * if the agent holds a grant. Activating without a prior grant auto-creates
- * one using the agent's declared REQUIRED_CONNECTORS scopes.
+ * Activation gates MCP tool visibility: when ON, the MCP server's tools
+ * appear in the agent's prompt; when OFF (or absent), the tools are hidden
+ * even if the agent holds a grant. Activating without a prior grant
+ * auto-creates one using the agent's declared REQUIRED_CONNECTORS scopes.
+ *
+ * Rendered only for ``type === 'mcp_server'`` connectors — the parent
+ * (``ConnectorAgentGrants``) gates the entire ``Active for`` block on
+ * connector type because activations apply to MCP servers only.
  */
 function AgentActivationCard({
     agent,

--- a/src/gaia/apps/webui/src/hooks/useConnectorsSSE.ts
+++ b/src/gaia/apps/webui/src/hooks/useConnectorsSSE.ts
@@ -16,6 +16,7 @@
  *   - ``connector.oauth.completed``   ({connector_id, account_email})
  *   - ``connector.oauth.error``       ({connector_id, error})
  *   - ``connector.grant.changed``     ({connector_id, agent_id, scopes})
+ *   - ``connector.activation.changed`` ({connector_id, agent_id, active})
  *
  * For backwards compatibility, the legacy event names emitted by
  * ``src/gaia/connectors/flow.py`` (``connection.connected`` /
@@ -47,7 +48,8 @@ export type ConnectorChangeReason =
     | 'oauth_completed'
     | 'oauth_error'
     | 'tested'
-    | 'grant_changed';
+    | 'grant_changed'
+    | 'activation_changed';
 
 export interface ConnectorChangeEvent {
     /** Which connector changed, if the payload identified one. */
@@ -87,6 +89,8 @@ function reasonFor(eventType: string): ConnectorChangeReason | null {
             return 'disabled';
         case 'connector.grant.changed':
             return 'grant_changed';
+        case 'connector.activation.changed':
+            return 'activation_changed';
         default:
             return null;
     }

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -227,9 +227,11 @@ export async function revokeConnectorAgentGrant(
 /**
  * List per-agent activations for a connector (issue #1005).
  *
- * Activations gate tool visibility — an agent must be both granted (credential
- * access) AND activated (tool visibility) for the connector's tools to appear
- * in its system prompt.
+ * Activations gate MCP tool visibility — an agent must be both granted
+ * (credential access) AND activated (tool visibility) for an MCP server's
+ * tools to appear in its system prompt. This endpoint is type-agnostic for
+ * read convenience: OAuth connectors return ``{}`` because the mutating
+ * routes refuse to write to them.
  */
 export async function listConnectorActivations(connectorId: string): Promise<{
     activations: Record<string, boolean>;
@@ -245,9 +247,14 @@ interface ActivateConnectorResponse {
 }
 
 /**
- * Activate a connector for an agent. If no grant exists yet, ``scopes`` is
- * used to auto-create one (one-click convenience). Without ``scopes`` the
- * request returns 400 when no prior grant exists.
+ * Activate an MCP-server connector for an agent. If no grant exists yet,
+ * ``scopes`` is used to auto-create one (one-click convenience). Without
+ * ``scopes`` the request returns 400 when no prior grant exists.
+ *
+ * Only valid for ``mcp_server`` connectors — calling this for an OAuth
+ * provider returns ``400 Bad Request``. OAuth per-agent access is
+ * controlled by the grants endpoints above. The Agent UI hides the
+ * "Active for" section for OAuth tiles to surface this at the UI layer.
  */
 export async function activateConnectorAgent(
     connectorId: string,
@@ -262,6 +269,11 @@ export async function activateConnectorAgent(
     );
 }
 
+/**
+ * Deactivate an MCP-server connector for an agent. Non-destructive — the
+ * grant survives so a later re-activate is one click. Only valid for
+ * ``mcp_server`` connectors (see :func:`activateConnectorAgent`).
+ */
 export async function deactivateConnectorAgent(
     connectorId: string,
     agentId: string,

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -224,6 +224,56 @@ export async function revokeConnectorAgentGrant(
     );
 }
 
+/**
+ * List per-agent activations for a connector (issue #1005).
+ *
+ * Activations gate tool visibility — an agent must be both granted (credential
+ * access) AND activated (tool visibility) for the connector's tools to appear
+ * in its system prompt.
+ */
+export async function listConnectorActivations(connectorId: string): Promise<{
+    activations: Record<string, boolean>;
+}> {
+    return apiFetch('GET', `/connectors/${connectorId}/activations`);
+}
+
+interface ActivateConnectorResponse {
+    connector_id: string;
+    agent_id: string;
+    active: boolean;
+    auto_granted: boolean;
+}
+
+/**
+ * Activate a connector for an agent. If no grant exists yet, ``scopes`` is
+ * used to auto-create one (one-click convenience). Without ``scopes`` the
+ * request returns 400 when no prior grant exists.
+ */
+export async function activateConnectorAgent(
+    connectorId: string,
+    agentId: string,
+    scopes?: string[],
+): Promise<ActivateConnectorResponse> {
+    return apiFetch<ActivateConnectorResponse>(
+        'PUT',
+        `/connectors/${connectorId}/activations/${encodeURIComponent(agentId)}`,
+        scopes ? { scopes } : {},
+        UI_HEADER,
+    );
+}
+
+export async function deactivateConnectorAgent(
+    connectorId: string,
+    agentId: string,
+): Promise<void> {
+    await apiFetch<unknown>(
+        'DELETE',
+        `/connectors/${connectorId}/activations/${encodeURIComponent(agentId)}`,
+        undefined,
+        UI_HEADER,
+    );
+}
+
 export async function listConnections(): Promise<{ connections: ConnectorInfo[] }> {
     return apiFetch('GET', '/connections');
 }

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -130,6 +130,13 @@ export interface ConnectorRow {
     enabled: boolean;
     account_id: string | null;
     scopes: string[];
+    /**
+     * Per-agent activation snapshot (issue #1005). Keys are namespaced
+     * agent ids (``builtin:chat``, ``custom:<hash>:<id>``, …), values are
+     * ``true`` when the agent is explicitly activated. Absence means
+     * inactive — activations are opt-in.
+     */
+    activations: Record<string, boolean>;
     last_tested_at: string | null;
     mcp_env_keys: string[];
     default_scopes: string[];

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -131,10 +131,13 @@ export interface ConnectorRow {
     account_id: string | null;
     scopes: string[];
     /**
-     * Per-agent activation snapshot (issue #1005). Keys are namespaced
-     * agent ids (``builtin:chat``, ``custom:<hash>:<id>``, …), values are
-     * ``true`` when the agent is explicitly activated. Absence means
-     * inactive — activations are opt-in.
+     * Per-agent MCP-tool-visibility activation snapshot (issue #1005).
+     * Keys are namespaced agent ids (``builtin:chat``,
+     * ``custom:<hash>:<id>``, …), values are ``true`` when the agent is
+     * explicitly activated. Absence means inactive — activations are
+     * opt-in. Populated only for ``type === 'mcp_server'`` connectors;
+     * OAuth connectors always return ``{}`` because activation writes
+     * are rejected for them at the API layer.
      */
     activations: Record<string, boolean>;
     last_tested_at: string | null;

--- a/src/gaia/connectors/__init__.py
+++ b/src/gaia/connectors/__init__.py
@@ -65,14 +65,21 @@ from gaia.connectors.spec import ConfigField, ConnectorSpec
 # other subcommands to work on environments where keyring is not installed.
 _API_NAMES: frozenset[str] = frozenset(
     {
+        "activate",
+        "activate_agent",
         "cancel_flow",
         "complete_authorization",
+        "deactivate",
+        "deactivate_agent",
         "get_access_token",
         "get_access_token_sync",
         "get_connection",
         "grant_agent",
+        "is_agent_active",
+        "list_agent_activations",
         "list_agent_grants",
         "list_connections",
+        "load_activations",
         "load_grants",
         "revoke_agent_grant",
         "revoke_connection",

--- a/src/gaia/connectors/activations.py
+++ b/src/gaia/connectors/activations.py
@@ -3,14 +3,24 @@
 """
 Per-agent activations ledger at ``~/.gaia/connectors/activations.json``.
 
-Activations are the second axis of the connectors authorization model. The
-first axis is :mod:`gaia.connectors.grants` — "agent X is *allowed* to use
-connector Y's credentials." Activations answer a separate question: "agent X
-*currently has* connector Y's tools surfaced in its toolset."
+Activations are the second axis of the connectors authorization model, and
+they apply to **MCP-server connectors only**. The first axis is
+:mod:`gaia.connectors.grants` — "agent X is *allowed* to use connector Y's
+credentials" — and it applies to every connector type. Activations answer
+a narrower question: "agent X *currently has* MCP connector Y's tools
+surfaced in its toolset."
 
 A tool from an MCP connector is visible to an agent if and only if::
 
     grant exists for (connector_id, agent_id)  AND  is_agent_active(...)
+
+OAuth connectors (e.g. Google) have no MCP tool surface — agents reach them
+through native Python ``@tool`` functions that call ``get_credential_sync``
+directly — so this ledger does not apply to them. The orchestration layer
+(:func:`gaia.connectors.api.activate` / :func:`gaia.connectors.api.deactivate`)
+enforces that invariant by rejecting non-``mcp_server`` connector ids with
+``ConfigurationError``; this module itself stays type-agnostic so the ledger
+remains a pure key/value store.
 
 Activations default to **False** when absent — least-privilege opt-in. The
 ledger only stores explicit True/False entries; an unknown ``(connector_id,

--- a/src/gaia/connectors/activations.py
+++ b/src/gaia/connectors/activations.py
@@ -1,0 +1,297 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Per-agent activations ledger at ``~/.gaia/connectors/activations.json``.
+
+Activations are the second axis of the connectors authorization model. The
+first axis is :mod:`gaia.connectors.grants` — "agent X is *allowed* to use
+connector Y's credentials." Activations answer a separate question: "agent X
+*currently has* connector Y's tools surfaced in its toolset."
+
+A tool from an MCP connector is visible to an agent if and only if::
+
+    grant exists for (connector_id, agent_id)  AND  is_agent_active(...)
+
+Activations default to **False** when absent — least-privilege opt-in. The
+ledger only stores explicit True/False entries; an unknown ``(connector_id,
+agent_id)`` pair returns ``is_agent_active == False``.
+
+Schema::
+
+    {
+      "version": 1,
+      "activations": {
+        "<connector_id>": {
+          "<namespaced_agent_id>": true
+        }
+      }
+    }
+
+``version`` reserves a forward-compat lever for future schema evolution.
+
+Atomicity guarantees mirror :mod:`gaia.connectors.grants`:
+
+- Writes go to a unique tempfile via ``tempfile.mkstemp(dir=parent)``,
+  then ``os.replace(tmp, final)`` — POSIX atomic, Windows best-effort
+  via ``MoveFileEx(MOVEFILE_REPLACE_EXISTING)``.
+- Tempfile opened with mode ``0o600`` from creation (``O_EXCL``).
+- Per-process ``threading.Lock`` serializes load-modify-save under
+  concurrent callers (CLI worker + UI server + tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import tempfile
+import threading
+from pathlib import Path
+from typing import Dict, List
+
+from gaia.connectors.errors import ConnectorsError
+
+logger = logging.getLogger(__name__)
+
+
+# Module constant — resolved at import time. Tests use the function path
+# ``_activations_path()`` to pick up monkeypatched ``Path.home`` at call time.
+ACTIVATIONS_FILE = Path.home() / ".gaia" / "connectors" / "activations.json"
+
+
+SCHEMA_VERSION = 1
+
+
+# Per-process write lock. ``threading.Lock`` is sufficient for the CLI worker
+# thread + UI server thread + test driver case; async callers serialize on
+# the same lock through ``asyncio.to_thread``.
+_write_lock = threading.Lock()
+
+
+def _activations_path() -> Path:
+    """Resolve the activations path on each call so tests can monkeypatch
+    ``Path.home`` after import."""
+    return Path.home() / ".gaia" / "connectors" / "activations.json"
+
+
+def _ensure_parent(path: Path) -> None:
+    """Create the parent directory with mode 0700 if missing (POSIX)."""
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        try:
+            os.chmod(parent, 0o700)
+        except OSError as e:
+            logger.warning("activations: could not chmod %s: %s", parent, e)
+
+
+def _empty_ledger() -> Dict[str, object]:
+    return {"version": SCHEMA_VERSION, "activations": {}}
+
+
+def _load_activations_raw() -> Dict[str, object]:
+    """
+    Read and return the full ledger document (including ``version``).
+
+    Returns an empty ledger if the file does not exist.
+    Raises ``ConnectorsError`` on malformed JSON or wrong top-level shape,
+    with an actionable message naming the path and the ``rm`` recovery hint.
+    """
+    path = _activations_path()
+    if not path.exists():
+        return _empty_ledger()
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ConnectorsError(
+            f"Activations ledger at {path} is corrupted ({e.msg} at line "
+            f"{e.lineno}). Delete the file to reset every per-agent "
+            f"activation:\n"
+            f"  rm {path}\n"
+            "You will need to re-activate connectors from Settings → "
+            "Connectors → Active for, or via "
+            "`gaia connectors activations activate ...`."
+        ) from e
+    except OSError as e:
+        raise ConnectorsError(
+            f"Could not read activations ledger at {path}: {e}. Check "
+            "file permissions; the parent directory should be 0700 and "
+            "the file 0600."
+        ) from e
+    if not isinstance(data, dict):
+        raise ConnectorsError(
+            f"Activations ledger at {path} has the wrong shape (expected "
+            f"a JSON object). Delete with `rm {path}` to reset."
+        )
+    # Tolerate older / forward versions silently — readers must keep
+    # working even if a future version adds new fields.
+    activations = data.get("activations", {})
+    if not isinstance(activations, dict):
+        raise ConnectorsError(
+            f"Activations ledger at {path} has the wrong shape "
+            f"(expected an 'activations' object). Delete with "
+            f"`rm {path}` to reset."
+        )
+    return data
+
+
+def load_activations() -> Dict[str, Dict[str, bool]]:
+    """
+    Return ``{connector_id: {agent_id: bool}}``.
+
+    Returns an empty dict if no file exists. Raises ``ConnectorsError`` on
+    a corrupted ledger (same actionable-error template as grants).
+    """
+    data = _load_activations_raw()
+    activations = data.get("activations", {})
+    # Defensive copy — callers must not mutate our cached structure.
+    result: Dict[str, Dict[str, bool]] = {}
+    for connector_id, agents in activations.items():
+        if not isinstance(agents, dict):
+            # Skip malformed sub-entry rather than reject the whole file;
+            # the corrupted-file path above already covered the common
+            # cases. This guards against partial hand-edits.
+            continue
+        result[connector_id] = {
+            agent_id: bool(active) for agent_id, active in agents.items()
+        }
+    return result
+
+
+def _save_activations_locked(data: Dict[str, Dict[str, bool]]) -> None:
+    """
+    Write the activations ledger atomically. Caller MUST hold ``_write_lock``.
+
+    The on-disk shape always includes ``version`` so future readers can
+    detect schema migrations.
+    """
+    path = _activations_path()
+    _ensure_parent(path)
+
+    payload = {"version": SCHEMA_VERSION, "activations": data}
+    fd, tmp_path = tempfile.mkstemp(
+        dir=path.parent, prefix=".activations_", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, sort_keys=True, indent=2)
+        if sys.platform != "win32":
+            os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+        if sys.platform != "win32":
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def activate_agent(connector_id: str, agent_id: str) -> None:
+    """
+    Mark ``(connector_id, agent_id)`` active.
+
+    Idempotent — re-activating an already-active pair is a no-op write.
+    """
+    with _write_lock:
+        data = load_activations()
+        data.setdefault(connector_id, {})[agent_id] = True
+        _save_activations_locked(data)
+    logger.debug(
+        "activations: activated connector_id=%s agent_id=%s",
+        connector_id,
+        agent_id,
+    )
+
+
+def deactivate_agent(connector_id: str, agent_id: str) -> None:
+    """
+    Remove the active entry for ``(connector_id, agent_id)``. Idempotent.
+
+    Deactivation deletes the explicit entry rather than writing ``False``
+    so the absence-equals-inactive invariant remains the source of truth.
+    """
+    with _write_lock:
+        data = load_activations()
+        if connector_id in data and agent_id in data[connector_id]:
+            del data[connector_id][agent_id]
+            if not data[connector_id]:
+                del data[connector_id]
+            _save_activations_locked(data)
+            logger.debug(
+                "activations: deactivated connector_id=%s agent_id=%s",
+                connector_id,
+                agent_id,
+            )
+
+
+def revoke_all_activations_for(connector_id: str) -> List[str]:
+    """
+    Remove every agent activation for ``connector_id``.
+
+    Called on connector ``disconnect()`` to prevent silent inheritance when
+    a connector with the same id is later re-added — symmetric to
+    :func:`gaia.connectors.grants.revoke_all_grants_for`.
+
+    Returns the list of agent_ids whose activations were cleared.
+    """
+    with _write_lock:
+        data = load_activations()
+        if connector_id not in data:
+            return []
+        revoked = sorted(data[connector_id].keys())
+        del data[connector_id]
+        _save_activations_locked(data)
+        logger.info(
+            "activations: cleared all agent activations for connector_id=%s "
+            "(%d agents: %s)",
+            connector_id,
+            len(revoked),
+            revoked,
+        )
+        return revoked
+
+
+def list_agent_activations(connector_id: str) -> Dict[str, bool]:
+    """Return ``{agent_id: bool}`` for ``connector_id``, or empty dict."""
+    return dict(load_activations().get(connector_id, {}))
+
+
+def is_agent_active(connector_id: str, agent_id: str) -> bool:
+    """
+    Return True if ``agent_id`` is explicitly active for ``connector_id``.
+
+    Absence in the ledger returns False — activations are opt-in.
+    """
+    return bool(load_activations().get(connector_id, {}).get(agent_id, False))
+
+
+async def activate_agent_async(connector_id: str, agent_id: str) -> None:
+    """Async wrapper around :func:`activate_agent` for native-async callers."""
+    await asyncio.to_thread(activate_agent, connector_id, agent_id)
+
+
+async def deactivate_agent_async(connector_id: str, agent_id: str) -> None:
+    """Async wrapper around :func:`deactivate_agent`."""
+    await asyncio.to_thread(deactivate_agent, connector_id, agent_id)
+
+
+__all__ = [
+    "ACTIVATIONS_FILE",
+    "SCHEMA_VERSION",
+    "activate_agent",
+    "activate_agent_async",
+    "deactivate_agent",
+    "deactivate_agent_async",
+    "is_agent_active",
+    "list_agent_activations",
+    "load_activations",
+    "revoke_all_activations_for",
+]

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -232,6 +232,45 @@ def revoke_connection(provider: str) -> None:
     logger.info("api: revoked connection provider=%s", provider)
 
 
+def _require_mcp_server_for_activation(connector_id: str) -> None:
+    """Reject activation writes for non-MCP-server connectors (#1005).
+
+    Activations gate MCP tool visibility (see
+    ``MCPClientManager.tools_for_agent``). OAuth-only connectors have no
+    MCP tool surface — per-agent access is governed by the per-scope grant
+    ledger instead — so allowing a write here would create state nothing
+    reads. Enforced at the orchestration layer so all callers (HTTP, CLI,
+    SDK, future callers) get the same guarantee without duplicating the
+    spec lookup at every boundary.
+
+    Raises ``ConfigurationError`` with an actionable message. The router
+    catches this and translates to HTTP 400; the CLI surfaces it as a
+    non-zero exit with the message on stderr.
+    """
+    # Importing the catalog populates REGISTRY with the built-in specs.
+    # Other CLI handlers (``_handle_list`` / ``_handle_configure`` / etc.)
+    # do this explicitly; bare ``gaia connectors activations …`` did not
+    # need it before this guard existed. Doing the import here protects
+    # every caller — CLI, SDK, custom embedders — without each entry
+    # point having to remember. Idempotent: Python's module cache makes
+    # repeat imports a no-op, and tests that monkeypatch ``REGISTRY``
+    # with a fresh instance see their substitute (the catalog only ever
+    # mutates the original singleton bound at first-import time).
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+    from gaia.connectors.registry import REGISTRY
+
+    try:
+        spec = REGISTRY.get(connector_id)
+    except KeyError as e:
+        raise ConfigurationError(f"Unknown connector '{connector_id}'.") from e
+    if spec.type != "mcp_server":
+        raise ConfigurationError(
+            f"Activations apply to MCP-server connectors only; "
+            f"'{connector_id}' is type '{spec.type}'. Use per-agent grants "
+            f"to control access for OAuth connectors."
+        )
+
+
 def activate(
     connector_id: str,
     agent_id: str,
@@ -250,9 +289,13 @@ def activate(
     Returns True if a grant was auto-created, False otherwise (informative
     only — both paths complete the activation).
 
-    Activations gate **tool visibility**; grants gate **credential access**.
+    Activations gate **MCP tool visibility**; grants gate **credential access**.
+    Only ``mcp_server`` connectors accept activations — OAuth connectors
+    have no MCP tool surface and their access is controlled entirely by
+    grants. Calling this for an OAuth connector raises ``ConfigurationError``.
     See ``docs/sdk/infrastructure/connectors.mdx`` for the two-axis model.
     """
+    _require_mcp_server_for_activation(connector_id)
     existing_scopes = list_agent_grants(connector_id).get(agent_id)
     auto_granted = False
     if existing_scopes is None:
@@ -287,10 +330,14 @@ def deactivate(connector_id: str, agent_id: str) -> None:
     """
     Deactivate ``(connector_id, agent_id)``.
 
+    Only valid for ``mcp_server`` connectors — see :func:`activate` for
+    the rationale. OAuth connectors raise ``ConfigurationError``.
+
     Non-destructive — the grant survives so a later re-activate is one
     click without re-consent. To wipe both, call
     :func:`gaia.connectors.grants.revoke_agent_grant` separately.
     """
+    _require_mcp_server_for_activation(connector_id)
     deactivate_agent(connector_id, agent_id)
 
 

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -25,6 +25,13 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Optional
 
+from gaia.connectors.activations import (
+    activate_agent,
+    deactivate_agent,
+    is_agent_active,
+    list_agent_activations,
+    load_activations,
+)
 from gaia.connectors.context import current_agent_id
 from gaia.connectors.errors import (
     AuthRequiredError,
@@ -225,6 +232,68 @@ def revoke_connection(provider: str) -> None:
     logger.info("api: revoked connection provider=%s", provider)
 
 
+def activate(
+    connector_id: str,
+    agent_id: str,
+    *,
+    scopes_for_grant: Optional[List[str]] = None,
+) -> bool:
+    """
+    Activate ``(connector_id, agent_id)`` and auto-grant if needed.
+
+    The "one-click convenience" path from issue #1005: if no grant exists
+    for the pair, this creates one using ``scopes_for_grant`` and then
+    flips the activation bit. If ``scopes_for_grant`` is not provided AND
+    no grant exists, raises ``ConfigurationError`` so the caller can
+    surface an actionable message to the user.
+
+    Returns True if a grant was auto-created, False otherwise (informative
+    only — both paths complete the activation).
+
+    Activations gate **tool visibility**; grants gate **credential access**.
+    See ``docs/sdk/infrastructure/connectors.mdx`` for the two-axis model.
+    """
+    existing_scopes = list_agent_grants(connector_id).get(agent_id)
+    auto_granted = False
+    if existing_scopes is None:
+        if scopes_for_grant is None:
+            raise ConfigurationError(
+                f"Cannot activate connector '{connector_id}' for agent "
+                f"'{agent_id}': no grant exists and no scopes provided "
+                "for auto-grant. Either pass --scopes explicitly or "
+                "register the agent with a REQUIRED_CONNECTORS entry "
+                "for this connector."
+            )
+        grant_agent(connector_id, agent_id, list(scopes_for_grant))
+        auto_granted = True
+        logger.info(
+            "api: auto-granted scopes for activation connector_id=%s "
+            "agent_id=%s scopes=%d",
+            connector_id,
+            agent_id,
+            len(scopes_for_grant),
+        )
+    activate_agent(connector_id, agent_id)
+    logger.info(
+        "api: activated connector_id=%s agent_id=%s (auto_granted=%s)",
+        connector_id,
+        agent_id,
+        auto_granted,
+    )
+    return auto_granted
+
+
+def deactivate(connector_id: str, agent_id: str) -> None:
+    """
+    Deactivate ``(connector_id, agent_id)``.
+
+    Non-destructive — the grant survives so a later re-activate is one
+    click without re-consent. To wipe both, call
+    :func:`gaia.connectors.grants.revoke_agent_grant` separately.
+    """
+    deactivate_agent(connector_id, agent_id)
+
+
 def tripwire_check() -> None:
     """
     Iterate every known provider and call ``load_connection`` to fire
@@ -248,14 +317,21 @@ def tripwire_check() -> None:
 
 
 __all__ = [
+    "activate",
+    "activate_agent",
     "cancel_flow",
     "complete_authorization",
+    "deactivate",
+    "deactivate_agent",
     "get_access_token",
     "get_access_token_sync",
     "get_connection",
     "grant_agent",
+    "is_agent_active",
+    "list_agent_activations",
     "list_agent_grants",
     "list_connections",
+    "load_activations",
     "load_grants",
     "revoke_agent_grant",
     "revoke_connection",

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -1,7 +1,7 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-CLI for ``gaia connectors {list|connect|configure|test|disconnect|grants ...}``.
+CLI for ``gaia connectors {list|connect|configure|test|disconnect|grants|activations ...}``.
 
 Subcommands:
 - ``list``        → catalog entries with configured/not status
@@ -10,6 +10,7 @@ Subcommands:
 - ``test``        → health check for a configured connector
 - ``disconnect``  → remove credentials and reset connector state
 - ``grants list|grant|revoke`` → per-agent scope grants ledger
+- ``activations list|activate|deactivate`` → per-agent tool-visibility ledger
 """
 
 from __future__ import annotations
@@ -135,6 +136,51 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     p_gr.add_argument("connector_id")
     p_gr.add_argument("agent_id")
 
+    # activations (issue #1005)
+    p_acts = sub.add_parser(
+        "activations",
+        help="Manage per-agent tool-visibility activations",
+        description=(
+            "Activations gate which agents see a connector's tools in their "
+            "prompt. A tool is visible to an agent only if the agent both has "
+            "a grant (credential access) and an activation (tool visibility) "
+            "for the connector."
+        ),
+    )
+    a = p_acts.add_subparsers(dest="activations_action", metavar="<subcommand>")
+
+    p_al = a.add_parser("list", help="List agent activations for a connector")
+    p_al.add_argument(
+        "connector_id",
+        nargs="?",
+        help="Connector id (lists every connector when omitted)",
+    )
+    p_al.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit machine-readable JSON",
+    )
+
+    p_aa = a.add_parser("activate", help="Activate a connector for an agent")
+    p_aa.add_argument("connector_id")
+    p_aa.add_argument(
+        "agent_id",
+        help="Namespaced agent id, e.g. 'builtin:chat' or 'custom:abc:inbox'",
+    )
+    p_aa.add_argument(
+        "--scopes",
+        nargs="+",
+        help=(
+            "Scopes to auto-grant if no grant exists yet. Required when "
+            "the agent has no prior grant for this connector."
+        ),
+    )
+
+    p_ad = a.add_parser("deactivate", help="Deactivate a connector for an agent")
+    p_ad.add_argument("connector_id")
+    p_ad.add_argument("agent_id")
+
 
 def handle(args: argparse.Namespace) -> int:
     """Dispatch a parsed ``gaia connectors ...`` command. Returns exit code."""
@@ -158,6 +204,8 @@ def handle(args: argparse.Namespace) -> int:
             return _handle_disconnect(args)
         if action == "grants":
             return _handle_grants(args)
+        if action == "activations":
+            return _handle_activations(args)
     except ConfigurationError as e:
         sys.stderr.write(f"Configuration error: {e}\n")
         return 3
@@ -363,6 +411,62 @@ def _handle_grants(args: argparse.Namespace) -> int:
     sys.stderr.write(
         "gaia connectors grants: missing subcommand. "
         "Try 'gaia connectors grants --help'.\n"
+    )
+    return 2
+
+
+def _handle_activations(args: argparse.Namespace) -> int:
+    """Handle ``gaia connectors activations {list|activate|deactivate}``."""
+    from gaia.connectors.activations import (
+        deactivate_agent,
+        list_agent_activations,
+        load_activations,
+    )
+    from gaia.connectors.api import activate
+
+    sub = getattr(args, "activations_action", None)
+    if sub == "list":
+        connector_id = getattr(args, "connector_id", None)
+        if connector_id:
+            listing = {connector_id: list_agent_activations(connector_id)}
+        else:
+            listing = load_activations()
+
+        if getattr(args, "as_json", False):
+            sys.stdout.write(json.dumps(listing, indent=2, sort_keys=True) + "\n")
+            return 0
+
+        any_rows = False
+        for cid, agents in sorted(listing.items()):
+            for agent_id, active in sorted(agents.items()):
+                state = "active" if active else "inactive"
+                sys.stdout.write(f"{cid} {agent_id}: {state}\n")
+                any_rows = True
+        if not any_rows:
+            sys.stdout.write("No activations.\n")
+        return 0
+
+    if sub == "activate":
+        scopes = getattr(args, "scopes", None) or None
+        auto_granted = activate(
+            args.connector_id, args.agent_id, scopes_for_grant=scopes
+        )
+        if auto_granted:
+            sys.stdout.write(
+                f"Auto-granted scopes {', '.join(scopes or [])} "
+                f"to {args.agent_id} for {args.connector_id}.\n"
+            )
+        sys.stdout.write(f"Activated {args.connector_id} for {args.agent_id}.\n")
+        return 0
+
+    if sub == "deactivate":
+        deactivate_agent(args.connector_id, args.agent_id)
+        sys.stdout.write(f"Deactivated {args.connector_id} for {args.agent_id}.\n")
+        return 0
+
+    sys.stderr.write(
+        "gaia connectors activations: missing subcommand. "
+        "Try 'gaia connectors activations --help'.\n"
     )
     return 2
 

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -9,8 +9,8 @@ Subcommands:
 - ``configure``   → configure via the handler dispatcher (KEY=VALUE or --json)
 - ``test``        → health check for a configured connector
 - ``disconnect``  → remove credentials and reset connector state
-- ``grants list|grant|revoke`` → per-agent scope grants ledger
-- ``activations list|activate|deactivate`` → per-agent tool-visibility ledger
+- ``grants list|grant|revoke`` → per-agent scope grants ledger (every connector type)
+- ``activations list|activate|deactivate`` → per-agent MCP tool-visibility ledger (mcp_server only)
 """
 
 from __future__ import annotations
@@ -139,12 +139,15 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     # activations (issue #1005)
     p_acts = sub.add_parser(
         "activations",
-        help="Manage per-agent tool-visibility activations",
+        help="Manage per-agent MCP tool-visibility activations (mcp_server only)",
         description=(
-            "Activations gate which agents see a connector's tools in their "
-            "prompt. A tool is visible to an agent only if the agent both has "
-            "a grant (credential access) and an activation (tool visibility) "
-            "for the connector."
+            "Activations gate which agents see an MCP server's tools in "
+            "their prompt. A tool is visible to an agent only if the agent "
+            "both has a grant (credential access) and an activation (tool "
+            "visibility) for the connector. Activations apply to "
+            "mcp_server connectors only — OAuth connectors have no MCP "
+            "tool surface and are rejected with exit code 3 (use "
+            "'gaia connectors grants' to control OAuth access per agent)."
         ),
     )
     a = p_acts.add_subparsers(dest="activations_action", metavar="<subcommand>")
@@ -418,11 +421,10 @@ def _handle_grants(args: argparse.Namespace) -> int:
 def _handle_activations(args: argparse.Namespace) -> int:
     """Handle ``gaia connectors activations {list|activate|deactivate}``."""
     from gaia.connectors.activations import (
-        deactivate_agent,
         list_agent_activations,
         load_activations,
     )
-    from gaia.connectors.api import activate
+    from gaia.connectors.api import activate, deactivate
 
     sub = getattr(args, "activations_action", None)
     if sub == "list":
@@ -460,7 +462,10 @@ def _handle_activations(args: argparse.Namespace) -> int:
         return 0
 
     if sub == "deactivate":
-        deactivate_agent(args.connector_id, args.agent_id)
+        # Use the api wrapper so the MCP-only type guard fires uniformly
+        # across CLI/SDK/HTTP. The bare ``deactivate_agent`` ledger call
+        # would bypass it.
+        deactivate(args.connector_id, args.agent_id)
         sys.stdout.write(f"Deactivated {args.connector_id} for {args.agent_id}.\n")
         return 0
 

--- a/src/gaia/connectors/mcp_server.py
+++ b/src/gaia/connectors/mcp_server.py
@@ -263,12 +263,15 @@ class McpServerHandler:
             except keyring.errors.PasswordDeleteError:
                 pass  # already absent — idempotent
 
-        # Wipe per-agent grants. If the same connector_id is re-added later
-        # (custom MCP, repeat OAuth, etc.) the new connector must NOT inherit
-        # the previous user's consent without an explicit re-grant.
+        # Wipe per-agent grants AND activations. If the same connector_id is
+        # re-added later the new connector must NOT inherit the previous user's
+        # consent (grant) or tool visibility (activation) without explicit
+        # re-grant + re-activate.
+        from gaia.connectors.activations import revoke_all_activations_for
         from gaia.connectors.grants import revoke_all_grants_for
 
         revoke_all_grants_for(spec.id)
+        revoke_all_activations_for(spec.id)
 
         logger.info("mcp_server: disconnected connector_id=%s", spec.id)
 

--- a/src/gaia/connectors/oauth_pkce.py
+++ b/src/gaia/connectors/oauth_pkce.py
@@ -141,15 +141,18 @@ class OAuthPkceHandler:
         account_email = account_id or DEFAULT_ACCOUNT
         delete_connection(provider_id, account_email=account_email)
 
-        # Wipe per-agent grants AND activations for this connector_id. Local
-        # imports keep the module-level dependency graph identical to before.
-        # Activations are wiped alongside grants so that re-adding the same
-        # connector_id does NOT silently inherit prior tool visibility either
-        # (symmetric to the grant-inheritance security concern).
+        # Wipe per-agent grants for this connector_id. Local import keeps
+        # the module-level dependency graph identical to before.
         from gaia.connectors.activations import revoke_all_activations_for
         from gaia.connectors.grants import revoke_all_grants_for
 
         revoke_all_grants_for(spec.id)
+        # Defensive sweep: OAuth connectors never accept activation writes
+        # (rejected at the api layer — see ``_require_mcp_server_for_activation``),
+        # so this is a no-op today. Kept as a belt-and-braces guard against
+        # ledger entries that pre-date the type check or are written via
+        # future migration paths — re-adding the same connector_id must
+        # never silently inherit prior state.
         revoke_all_activations_for(spec.id)
 
         logger.info("oauth_pkce: disconnected connector_id=%s", spec.id)

--- a/src/gaia/connectors/oauth_pkce.py
+++ b/src/gaia/connectors/oauth_pkce.py
@@ -141,12 +141,16 @@ class OAuthPkceHandler:
         account_email = account_id or DEFAULT_ACCOUNT
         delete_connection(provider_id, account_email=account_email)
 
-        # Wipe per-agent grants for this connector_id. Local import keeps the
-        # module-level dependency graph identical to before (grants depends on
-        # nothing else here).
+        # Wipe per-agent grants AND activations for this connector_id. Local
+        # imports keep the module-level dependency graph identical to before.
+        # Activations are wiped alongside grants so that re-adding the same
+        # connector_id does NOT silently inherit prior tool visibility either
+        # (symmetric to the grant-inheritance security concern).
+        from gaia.connectors.activations import revoke_all_activations_for
         from gaia.connectors.grants import revoke_all_grants_for
 
         revoke_all_grants_for(spec.id)
+        revoke_all_activations_for(spec.id)
 
         logger.info("oauth_pkce: disconnected connector_id=%s", spec.id)
 

--- a/src/gaia/mcp/client/mcp_client_manager.py
+++ b/src/gaia/mcp/client/mcp_client_manager.py
@@ -129,6 +129,46 @@ class MCPClientManager:
         """
         return list(self._clients.keys())
 
+    def servers_for_agent(self, agent_id: Optional[str]) -> List[str]:
+        """Return server names whose tools are visible to *agent_id*.
+
+        Per issue #1005 (per-agent activation), an MCP server's tools are
+        only visible to an agent when ``is_agent_active(server_id, agent_id)``
+        is True. With ``agent_id=None`` (CLI/debug context with no agent
+        identity), the unfiltered list is returned — activations only
+        gate the agent-tool path.
+
+        Activation lookups are file-backed (``activations.json``) and
+        cached by the OS page cache; this method is safe to call in tight
+        loops at tool-registration time.
+        """
+        if agent_id is None:
+            return self.list_servers()
+        # Local import keeps the manager free of a hard dependency on the
+        # connectors package — callers that never use activations don't
+        # pay the import cost.
+        from gaia.connectors.activations import is_agent_active
+
+        return [name for name in self._clients if is_agent_active(name, agent_id)]
+
+    def tools_for_agent(self, agent_id: Optional[str]) -> Dict[str, List]:
+        """Return ``{server_name: [MCPTool, ...]}`` filtered by activation.
+
+        Returns every connected server's tool list when ``agent_id`` is
+        None (CLI/debug callers) so unrelated tooling that walks the full
+        registry keeps working. With a real ``agent_id`` the result is
+        filtered to servers that have been explicitly activated for the
+        pair via ``gaia.connectors.activations``.
+        """
+        names = self.servers_for_agent(agent_id)
+        result: Dict[str, List] = {}
+        for name in names:
+            client = self._clients.get(name)
+            if client is None:
+                continue
+            result[name] = list(client.list_tools())
+        return result
+
     def get_status_report(self) -> List[Dict]:
         """Return runtime connection status for all known servers.
 

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -37,6 +37,33 @@ from .sse_handler import (
 logger = logging.getLogger(__name__)
 
 
+def _stamp_builtin_chat_identity(config) -> None:
+    """Inject ``namespaced_agent_id="builtin:chat"`` into a ``ChatAgentConfig``
+    BEFORE ``ChatAgent(config)`` is constructed.
+
+    Must be applied to the *config*, not to the instance after construction.
+    The connectors activation filter (``Agent._active_mcp_servers`` →
+    ``MCPClientManager.servers_for_agent``) is consulted inside
+    ``ChatAgent.__init__`` → ``super().__init__`` → ``_register_tools``,
+    so the agent must already know its namespaced id by the time
+    ``_register_tools`` runs. A post-construction stamp on the instance
+    is too late — ``_register_tools`` has already loaded the unfiltered
+    MCP-tool set.
+
+    ``ChatAgent.__init__`` reads ``config.namespaced_agent_id`` at its top
+    and sets ``self._gaia_namespaced_agent_id`` from it before invoking
+    ``super().__init__``. This helper just centralises the
+    ``"builtin:chat"`` literal so every direct-construction site in this
+    module uses the same value and a fifth caller can't forget.
+
+    Idempotent — only sets the field if it is still its default ``None``,
+    so callers that already set a custom namespaced id (e.g. a future
+    custom-Chat wrapper) are not clobbered.
+    """
+    if getattr(config, "namespaced_agent_id", None) is None:
+        config.namespaced_agent_id = "builtin:chat"
+
+
 def _register_agent_memory_ops(agent) -> None:
     """Register LLM-powered memory operations from a ChatAgent with the memory router.
 
@@ -1075,6 +1102,7 @@ async def _get_chat_response(
                 debug=False,
                 **_session_kwargs,
             )
+            _stamp_builtin_chat_identity(config)
             agent = ChatAgent(config)
             _store_agent(session_id, model_id, document_ids, agent, agent_type)
             _register_agent_memory_ops(agent)
@@ -1111,6 +1139,7 @@ async def _get_chat_response(
                     debug=False,
                     **_session_kwargs,
                 )
+                _stamp_builtin_chat_identity(config)
                 agent = ChatAgent(config)
                 _store_agent(session_id, model_id, document_ids, agent, agent_type)
                 _register_agent_memory_ops(agent)
@@ -1461,6 +1490,7 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                         **_session_kwargs,
                     )
 
+                    _stamp_builtin_chat_identity(config)
                     t_construct = _time.monotonic()
                     agent = ChatAgent(config)
                     logger.info(
@@ -1566,6 +1596,7 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                                 session_id=session_id,
                             ),
                         )
+                        _stamp_builtin_chat_identity(config)
                         agent = ChatAgent(config)
                         agent.console = sse_handler
                         _register_agent_memory_ops(agent)

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -45,6 +45,11 @@ from pydantic import BaseModel, Field
 
 import gaia.connectors as connections
 import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+from gaia.connectors.activations import (
+    deactivate_agent,
+    list_agent_activations,
+)
+from gaia.connectors.api import activate as activate_connector_for_agent
 from gaia.connectors.errors import (
     AuthRequiredError,
     ConfigurationError,
@@ -108,6 +113,17 @@ class AuthorizeRequest(BaseModel):
 
 class GrantRequest(BaseModel):
     scopes: List[str] = Field(default_factory=list)
+
+
+class ActivationRequest(BaseModel):
+    """Body for ``PUT /api/connectors/{id}/activations/{agent_id}``.
+
+    ``scopes`` is optional: when present and no grant exists for the pair,
+    it is used to auto-create the grant (one-click convenience). When the
+    pair already has a grant the body is ignored — see issue #1005.
+    """
+
+    scopes: Optional[List[str]] = None
 
 
 class ConfigureRequest(BaseModel):
@@ -305,6 +321,11 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
                     e,
                 )
 
+    # Activations ledger snapshot (issue #1005). Read-only here; the
+    # frontend toggles each entry via PUT/DELETE
+    # /api/connectors/{id}/activations/{agent_id}.
+    activations = list_agent_activations(spec.id)
+
     return {
         "id": spec.id,
         "display_name": spec.display_name,
@@ -321,6 +342,7 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
         "account_id": account_id,
         "scopes": scopes,
         "enabled": enabled,
+        "activations": activations,
         "mcp_env_keys": list(spec.mcp_env_keys),
         "default_scopes": list(spec.default_scopes),
         "available_scopes": list(spec.available_scopes),
@@ -375,6 +397,7 @@ async def connector_events() -> StreamingResponse:
       - ``connector.oauth.completed``   ({connector_id, account_email})
       - ``connector.oauth.error``       ({connector_id, error})
       - ``connector.grant.changed``     ({connector_id, agent_id, scopes})
+      - ``connector.activation.changed`` ({connector_id, agent_id, active})
     """
     queue = await _emitter.subscribe()
 
@@ -503,6 +526,11 @@ async def list_agent_mcps(request: Request) -> Dict[str, Any]:
 @router.get("/{connector_id}/grants")
 async def get_grants(connector_id: str) -> Dict[str, Any]:
     return {"grants": list_agent_grants(connector_id)}
+
+
+@router.get("/{connector_id}/activations")
+async def get_activations(connector_id: str) -> Dict[str, Any]:
+    return {"activations": list_agent_activations(connector_id)}
 
 
 @router.get("/{connector_id}")
@@ -694,5 +722,76 @@ async def delete_grant(connector_id: str, agent_id: str) -> Response:
     await _emitter.emit(
         "connector.grant.changed",
         {"connector_id": connector_id, "agent_id": agent_id, "scopes": []},
+    )
+    return Response(status_code=204)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Activations endpoints (issue #1005)
+# ─────────────────────────────────────────────────────────────────
+
+
+@router.put(
+    "/{connector_id}/activations/{agent_id:path}",
+    dependencies=[Depends(_require_ui_header)],
+)
+async def put_activation(
+    connector_id: str, agent_id: str, body: ActivationRequest
+) -> Dict[str, Any]:
+    """Activate ``agent_id`` for ``connector_id``.
+
+    Auto-grants when no grant exists and ``body.scopes`` is provided.
+    Returns 400 if no grant exists and the body omits scopes — the
+    frontend must look up REQUIRED_CONNECTORS scopes for the agent and
+    pass them in.
+    """
+    try:
+        auto_granted = activate_connector_for_agent(
+            connector_id, agent_id, scopes_for_grant=body.scopes
+        )
+    except ConfigurationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except ConnectorsError as e:
+        raise _raise_http_for(e) from e
+
+    if auto_granted:
+        # Auto-grant fired — also surface the grant change so subscribed
+        # UIs refresh both panels.
+        await _emitter.emit(
+            "connector.grant.changed",
+            {
+                "connector_id": connector_id,
+                "agent_id": agent_id,
+                "scopes": list(body.scopes or []),
+            },
+        )
+    await _emitter.emit(
+        "connector.activation.changed",
+        {"connector_id": connector_id, "agent_id": agent_id, "active": True},
+    )
+    return {
+        "connector_id": connector_id,
+        "agent_id": agent_id,
+        "active": True,
+        "auto_granted": auto_granted,
+    }
+
+
+@router.delete(
+    "/{connector_id}/activations/{agent_id:path}",
+    status_code=204,
+    dependencies=[Depends(_require_ui_header)],
+)
+async def delete_activation(connector_id: str, agent_id: str) -> Response:
+    """Deactivate ``agent_id`` for ``connector_id``. Idempotent.
+
+    Non-destructive — the grant is preserved so a later re-activate is
+    one click. To wipe the grant call ``DELETE
+    /api/connectors/{id}/grants/{agent_id}`` instead.
+    """
+    deactivate_agent(connector_id, agent_id)
+    await _emitter.emit(
+        "connector.activation.changed",
+        {"connector_id": connector_id, "agent_id": agent_id, "active": False},
     )
     return Response(status_code=204)

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -102,6 +102,31 @@ def _require_ui_header(request: Request) -> None:
         raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
 
 
+def _require_mcp_server(connector_id: str) -> None:
+    """Reject activation writes for non-MCP-server connectors.
+
+    Activations gate MCP tool visibility via ``MCPClientManager.tools_for_agent``
+    (see issue #1005). OAuth-only connectors have no MCP tool surface — their
+    agent access is gated by per-scope grants, not by this ledger — so allowing
+    a write here would create a switch that does nothing.
+    """
+    try:
+        spec = REGISTRY.get(connector_id)
+    except KeyError:
+        raise HTTPException(
+            status_code=404, detail=f"Unknown connector: {connector_id!r}"
+        )
+    if spec.type != "mcp_server":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Activations apply to MCP-server connectors only; "
+                f"{connector_id!r} is type {spec.type!r}. Use per-agent grants "
+                "to control access for OAuth connectors."
+            ),
+        )
+
+
 # ─────────────────────────────────────────────────────────────────
 # Request / response models
 # ─────────────────────────────────────────────────────────────────
@@ -117,6 +142,8 @@ class GrantRequest(BaseModel):
 
 class ActivationRequest(BaseModel):
     """Body for ``PUT /api/connectors/{id}/activations/{agent_id}``.
+
+    Valid only for ``mcp_server`` connectors — see ``_require_mcp_server``.
 
     ``scopes`` is optional: when present and no grant exists for the pair,
     it is used to auto-create the grant (one-click convenience). When the
@@ -323,7 +350,10 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
 
     # Activations ledger snapshot (issue #1005). Read-only here; the
     # frontend toggles each entry via PUT/DELETE
-    # /api/connectors/{id}/activations/{agent_id}.
+    # /api/connectors/{id}/activations/{agent_id} — mutating routes
+    # accept ``mcp_server`` connectors only (see ``_require_mcp_server``).
+    # The dict is always returned (empty ``{}`` for OAuth) so the response
+    # shape stays uniform across connector types.
     activations = list_agent_activations(spec.id)
 
     return {
@@ -728,6 +758,12 @@ async def delete_grant(connector_id: str, agent_id: str) -> Response:
 
 # ─────────────────────────────────────────────────────────────────
 # Activations endpoints (issue #1005)
+#
+# Activations gate MCP tool visibility (``MCPClientManager.tools_for_agent``).
+# The PUT/DELETE routes accept ``mcp_server`` connectors only — OAuth
+# connectors have no MCP tool surface and are rejected with HTTP 400 via
+# ``_require_mcp_server``. The GET route is type-agnostic so frontends
+# that fetch indiscriminately keep working (returns ``{}`` for OAuth).
 # ─────────────────────────────────────────────────────────────────
 
 
@@ -745,6 +781,7 @@ async def put_activation(
     frontend must look up REQUIRED_CONNECTORS scopes for the agent and
     pass them in.
     """
+    _require_mcp_server(connector_id)
     try:
         auto_granted = activate_connector_for_agent(
             connector_id, agent_id, scopes_for_grant=body.scopes
@@ -789,6 +826,7 @@ async def delete_activation(connector_id: str, agent_id: str) -> Response:
     one click. To wipe the grant call ``DELETE
     /api/connectors/{id}/grants/{agent_id}`` instead.
     """
+    _require_mcp_server(connector_id)
     deactivate_agent(connector_id, agent_id)
     await _emitter.emit(
         "connector.activation.changed",

--- a/tests/unit/agents/test_tool_visibility_filter.py
+++ b/tests/unit/agents/test_tool_visibility_filter.py
@@ -1,0 +1,174 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Per-agent activation gates MCP tool visibility (issue #1005).
+
+Tests focus on the boundary between :class:`MCPClientManager` and the
+:class:`Agent` base class — specifically that ``servers_for_agent`` and
+``Agent._active_mcp_servers`` honour the activations ledger.
+
+End-to-end behaviour (ChatAgent registering tools to ``_TOOL_REGISTRY``)
+is covered by the multi-caller equivalence test in
+``tests/unit/connectors/test_e2e_smoke.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gaia.connectors.activations import activate_agent, deactivate_agent
+from gaia.mcp.client.mcp_client_manager import MCPClientManager
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
+    return tmp_path
+
+
+def _stub_manager_with_servers(*names: str) -> MCPClientManager:
+    """Build an MCPClientManager whose ``_clients`` map points at stubbed clients.
+
+    Bypasses the actual connect path because the activation filter is a
+    purely-in-memory concern — the only thing being tested here is which
+    server names cross the filter.
+    """
+    manager = MCPClientManager()
+    for name in names:
+        client = MagicMock()
+        client.list_tools.return_value = [MagicMock(name=f"tool-from-{name}")]
+        manager._clients[name] = client
+    return manager
+
+
+class TestServersForAgent:
+    def test_no_activations_yields_empty_list(self, fake_home):
+        manager = _stub_manager_with_servers("github", "filesystem")
+        # No activation entries yet — least-privilege default.
+        assert manager.servers_for_agent("builtin:chat") == []
+
+    def test_only_activated_servers_returned(self, fake_home):
+        manager = _stub_manager_with_servers("github", "filesystem", "fetch")
+        activate_agent("github", "builtin:chat")
+        activate_agent("fetch", "builtin:chat")
+        assert sorted(manager.servers_for_agent("builtin:chat")) == [
+            "fetch",
+            "github",
+        ]
+
+    def test_activation_for_different_agent_does_not_leak(self, fake_home):
+        manager = _stub_manager_with_servers("github")
+        activate_agent("github", "builtin:code")
+        # builtin:chat must NOT see github tools just because builtin:code
+        # is activated — activations are per-agent.
+        assert manager.servers_for_agent("builtin:chat") == []
+        assert manager.servers_for_agent("builtin:code") == ["github"]
+
+    def test_deactivate_removes_visibility(self, fake_home):
+        manager = _stub_manager_with_servers("github")
+        activate_agent("github", "builtin:chat")
+        assert manager.servers_for_agent("builtin:chat") == ["github"]
+        deactivate_agent("github", "builtin:chat")
+        assert manager.servers_for_agent("builtin:chat") == []
+
+    def test_none_agent_id_bypasses_filter(self, fake_home):
+        # CLI / debug callers with no agent context still see everything.
+        manager = _stub_manager_with_servers("github", "filesystem")
+        assert sorted(manager.servers_for_agent(None)) == [
+            "filesystem",
+            "github",
+        ]
+
+    def test_servers_not_in_manager_are_not_returned(self, fake_home):
+        # Activating an agent for a server that isn't connected is allowed
+        # (the user may activate before the connector is up); the filter
+        # only returns servers actually known to the manager.
+        manager = _stub_manager_with_servers("github")
+        activate_agent("filesystem", "builtin:chat")
+        activate_agent("github", "builtin:chat")
+        assert manager.servers_for_agent("builtin:chat") == ["github"]
+
+
+class TestToolsForAgent:
+    def test_tools_for_agent_returns_per_server_lists(self, fake_home):
+        manager = _stub_manager_with_servers("github", "filesystem")
+        activate_agent("github", "builtin:chat")
+        result = manager.tools_for_agent("builtin:chat")
+        assert set(result.keys()) == {"github"}
+        assert len(result["github"]) == 1
+
+    def test_tools_for_agent_empty_when_no_activation(self, fake_home):
+        manager = _stub_manager_with_servers("github")
+        assert manager.tools_for_agent("builtin:chat") == {}
+
+    def test_tools_for_agent_with_none_returns_all(self, fake_home):
+        manager = _stub_manager_with_servers("github", "filesystem")
+        result = manager.tools_for_agent(None)
+        assert set(result.keys()) == {"github", "filesystem"}
+
+
+class TestAgentBaseHelper:
+    """``Agent._active_mcp_servers`` is the integration point that ChatAgent
+    (and any future MCP-consuming agent) calls during ``_register_tools``."""
+
+    def test_none_manager_returns_empty(self, fake_home):
+        from gaia.agents.base.agent import Agent
+
+        # We don't instantiate Agent (too heavy); call the unbound method
+        # against a minimal SimpleNamespace stand-in that has the resolver.
+        class _Stub:
+            _gaia_namespaced_agent_id = "builtin:chat"
+            AGENT_ID = "chat"
+
+            _namespaced_agent_id = Agent._namespaced_agent_id
+            _active_mcp_servers = Agent._active_mcp_servers
+
+        assert _Stub()._active_mcp_servers(None) == []
+
+    def test_with_namespaced_id_applies_filter(self, fake_home):
+        from gaia.agents.base.agent import Agent
+
+        class _Stub:
+            _gaia_namespaced_agent_id = "builtin:chat"
+            AGENT_ID = "chat"
+
+            _namespaced_agent_id = Agent._namespaced_agent_id
+            _active_mcp_servers = Agent._active_mcp_servers
+
+        manager = _stub_manager_with_servers("github", "filesystem")
+        activate_agent("github", "builtin:chat")
+        servers = _Stub()._active_mcp_servers(manager)
+        assert servers == ["github"]
+
+    def test_no_namespaced_id_returns_all_servers(self, fake_home):
+        # Fallback path for ad-hoc agents constructed outside the registry.
+        from gaia.agents.base.agent import Agent
+
+        class _Stub:
+            _gaia_namespaced_agent_id = None
+            AGENT_ID = None
+
+            _namespaced_agent_id = Agent._namespaced_agent_id
+            _active_mcp_servers = Agent._active_mcp_servers
+
+        manager = _stub_manager_with_servers("github", "filesystem")
+        # No activations, but no agent id either — must NOT filter.
+        servers = _Stub()._active_mcp_servers(manager)
+        assert sorted(servers) == ["filesystem", "github"]
+
+    def test_falls_back_to_bare_agent_id_when_no_namespaced(self, fake_home):
+        from gaia.agents.base.agent import Agent
+
+        class _Stub:
+            _gaia_namespaced_agent_id = None
+            AGENT_ID = "chat"  # bare id — used as the activation key
+
+            _namespaced_agent_id = Agent._namespaced_agent_id
+            _active_mcp_servers = Agent._active_mcp_servers
+
+        manager = _stub_manager_with_servers("github")
+        activate_agent("github", "chat")
+        servers = _Stub()._active_mcp_servers(manager)
+        assert servers == ["github"]

--- a/tests/unit/chat/ui/test_chat_helpers.py
+++ b/tests/unit/chat/ui/test_chat_helpers.py
@@ -500,3 +500,128 @@ class TestStreamingRegisteredAgentDoesNotDoubleIndex:
             "miss. See src/gaia/ui/_chat_helpers.py comment at that call "
             "site for the full rationale."
         )
+
+
+# ── _stamp_builtin_chat_identity ─────────────────────────────────────────────
+#
+# Regression coverage for the activation-filter bypass discovered during #1005
+# UI verification: ``_chat_helpers`` constructs ``ChatAgent(config)`` directly
+# at four call sites (built-in Chat streaming/non-streaming + two fallback
+# branches). Without stamping the namespaced id, those instances appear to the
+# activation filter as ``_gaia_namespaced_agent_id is None``, and
+# ``Agent._active_mcp_servers`` falls back to "ad-hoc agent — show every MCP
+# server unfiltered". The activations.json ledger gets written but ignored,
+# so deactivating ``mcp-github`` for ``builtin:chat`` has no effect on what the
+# UI's Chat sees.
+
+
+class TestStampBuiltinChatIdentity:
+    """Tests for _stamp_builtin_chat_identity().
+
+    The stamp must hit the ChatAgentConfig BEFORE ChatAgent.__init__ runs,
+    because ``__init__`` calls ``_register_tools`` which reads the namespaced
+    id to decide which MCP servers' tools to surface. Stamping the instance
+    after construction is too late and reproduces the bypass bug.
+    """
+
+    def test_stamps_field_on_fresh_config(self):
+        from gaia.agents.chat.agent import ChatAgentConfig
+        from gaia.ui._chat_helpers import _stamp_builtin_chat_identity
+
+        config = ChatAgentConfig()
+        assert config.namespaced_agent_id is None
+        _stamp_builtin_chat_identity(config)
+        assert config.namespaced_agent_id == "builtin:chat"
+
+    def test_is_idempotent_no_overwrite_when_already_set(self):
+        # Callers that pre-fill the field with a custom id (e.g. a future
+        # custom-Chat wrapper) must NOT be clobbered.
+        from gaia.agents.chat.agent import ChatAgentConfig
+        from gaia.ui._chat_helpers import _stamp_builtin_chat_identity
+
+        config = ChatAgentConfig(namespaced_agent_id="custom:abc:chat")
+        _stamp_builtin_chat_identity(config)
+        assert config.namespaced_agent_id == "custom:abc:chat"
+
+    def test_chat_agent_init_propagates_config_to_instance_attr_before_super(
+        self,
+    ):
+        """``ChatAgent.__init__`` must propagate ``config.namespaced_agent_id``
+        to ``self._gaia_namespaced_agent_id`` BEFORE invoking
+        ``super().__init__`` (which calls ``_register_tools`` → loads MCP
+        servers with the activation filter). A post-super() stamp would be
+        too late and silently breaks #1005.
+
+        Asserted by source inspection — the full agent stack is too heavy
+        to instantiate in a unit test, but the prelude pattern is stable
+        enough to grep for. If someone reorders ChatAgent.__init__ and
+        moves the stamp past super(), this test fails before the
+        activation filter silently regresses at runtime.
+        """
+        from pathlib import Path as _Path
+
+        src = (
+            _Path(__file__).parents[4] / "src" / "gaia" / "agents" / "chat" / "agent.py"
+        ).read_text()
+        init_start = src.index("def __init__(self, config: Optional[ChatAgentConfig]")
+        super_init = src.index("super().__init__(", init_start)
+        prelude = src[init_start:super_init]
+        assert (
+            "self._gaia_namespaced_agent_id = config.namespaced_agent_id" in prelude
+        ), (
+            "ChatAgent.__init__ must set self._gaia_namespaced_agent_id "
+            "from config.namespaced_agent_id BEFORE super().__init__() — "
+            "otherwise _register_tools loads MCP tools without the "
+            "activation filter and #1005 silently breaks for every "
+            "UI Chat session."
+        )
+
+    def test_every_direct_ChatAgent_construction_is_pre_stamped(self):
+        """Every ``agent = ChatAgent(config)`` in _chat_helpers.py must be
+        PRECEDED by ``_stamp_builtin_chat_identity(config)`` (within the
+        last 5 non-blank lines).
+
+        Structural guard: a fifth direct construction site added without
+        the prior stamp would silently re-introduce the activation-filter
+        bypass. This catches it at PR time instead of user-bug-report
+        time.
+
+        Why "before, not after": ``_register_tools`` runs inside
+        ``ChatAgent.__init__``; the activation filter consults the
+        namespaced id at that point. Stamping the instance after
+        construction is too late — the unfiltered tool set has already
+        been registered.
+        """
+        import re
+        from pathlib import Path as _Path
+
+        src = (
+            _Path(__file__).parents[4] / "src" / "gaia" / "ui" / "_chat_helpers.py"
+        ).read_text()
+
+        lines = src.splitlines()
+        offenders = []
+        for i, line in enumerate(lines):
+            if re.search(r"\bagent\s*=\s*ChatAgent\(", line):
+                # Look BACKWARD up to 5 non-blank lines for the stamp call.
+                window = []
+                j = i - 1
+                while j >= 0 and len(window) < 5:
+                    if lines[j].strip():
+                        window.append(lines[j])
+                    j -= 1
+                if not any("_stamp_builtin_chat_identity(config)" in w for w in window):
+                    offenders.append(
+                        f"line {i + 1}: {line.strip()!r} — missing prior "
+                        f"_stamp_builtin_chat_identity(config)"
+                    )
+
+        assert not offenders, (
+            "Every direct ``agent = ChatAgent(config)`` in _chat_helpers.py "
+            "must be PRECEDED by ``_stamp_builtin_chat_identity(config)`` "
+            "(within the last 5 non-blank lines) so the per-agent "
+            "activation filter (#1005) fires correctly. Post-construction "
+            "stamping is too late — ChatAgent.__init__ runs "
+            "_register_tools immediately and the filter would silently "
+            "bypass. Offending sites:\n  - " + "\n  - ".join(offenders)
+        )

--- a/tests/unit/connectors/conftest.py
+++ b/tests/unit/connectors/conftest.py
@@ -71,4 +71,5 @@ def _autouse_isolate_home(tmp_path, monkeypatch):
     the explicit per-file ``fake_home`` fixtures.
     """
     monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
     monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)

--- a/tests/unit/connectors/test_activation_api.py
+++ b/tests/unit/connectors/test_activation_api.py
@@ -1,0 +1,100 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for the ``activate``/``deactivate`` orchestration in
+``gaia.connectors.api`` — the one-click convenience layer that combines
+grants + activations per issue #1005.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.connectors.activations import is_agent_active
+from gaia.connectors.api import activate, deactivate
+from gaia.connectors.errors import ConfigurationError
+from gaia.connectors.grants import grant_agent, list_agent_grants
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
+    return tmp_path
+
+
+class TestActivateWithExistingGrant:
+    def test_activate_with_existing_grant_does_not_touch_grant(self, fake_home):
+        grant_agent("github", "builtin:chat", ["repo:read"])
+        auto_granted = activate("github", "builtin:chat")
+        assert auto_granted is False
+        # Grant is preserved as-is.
+        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+        assert is_agent_active("github", "builtin:chat") is True
+
+    def test_activate_ignores_scopes_for_grant_when_grant_exists(self, fake_home):
+        # Existing grants are NOT overwritten — auto-grant only fires when
+        # no grant is present at all.
+        grant_agent("github", "builtin:chat", ["repo:read"])
+        activate("github", "builtin:chat", scopes_for_grant=["repo:write"])
+        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+
+
+class TestActivateAutoGrant:
+    def test_activate_without_grant_auto_grants_required_scopes(self, fake_home):
+        auto_granted = activate(
+            "github", "builtin:chat", scopes_for_grant=["repo:read", "repo:write"]
+        )
+        assert auto_granted is True
+        assert list_agent_grants("github") == {
+            "builtin:chat": ["repo:read", "repo:write"]
+        }
+        assert is_agent_active("github", "builtin:chat") is True
+
+    def test_activate_without_grant_or_scopes_raises_configuration_error(
+        self, fake_home
+    ):
+        with pytest.raises(ConfigurationError) as exc:
+            activate("github", "builtin:chat")
+        msg = str(exc.value)
+        assert "github" in msg
+        assert "builtin:chat" in msg
+        assert "scopes" in msg.lower()
+
+    def test_auto_grant_scopes_are_a_copy_not_a_reference(self, fake_home):
+        # Defensive: callers must not be able to mutate the stored grant
+        # through the list they passed in.
+        scopes = ["repo:read"]
+        activate("github", "builtin:chat", scopes_for_grant=scopes)
+        scopes.append("repo:write")
+        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+
+
+class TestDeactivatePreservesGrant:
+    def test_deactivate_preserves_grant(self, fake_home):
+        grant_agent("github", "builtin:chat", ["repo:read"])
+        activate("github", "builtin:chat")
+        deactivate("github", "builtin:chat")
+        # Grant survives — re-activate must be one click, no re-consent.
+        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+        assert is_agent_active("github", "builtin:chat") is False
+
+    def test_deactivate_without_prior_activation_is_idempotent(self, fake_home):
+        grant_agent("github", "builtin:chat", ["repo:read"])
+        # Has grant but never activated — deactivate must not raise.
+        deactivate("github", "builtin:chat")
+        assert is_agent_active("github", "builtin:chat") is False
+        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+
+
+class TestActivateIsIdempotent:
+    def test_double_activate_no_double_grant(self, fake_home):
+        activate("github", "builtin:chat", scopes_for_grant=["repo:read"])
+        # Second activate must NOT re-grant (existing grant blocks the
+        # auto-grant path).
+        auto_granted = activate(
+            "github", "builtin:chat", scopes_for_grant=["repo:write"]
+        )
+        assert auto_granted is False
+        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+        assert is_agent_active("github", "builtin:chat") is True

--- a/tests/unit/connectors/test_activation_api.py
+++ b/tests/unit/connectors/test_activation_api.py
@@ -4,6 +4,11 @@
 Tests for the ``activate``/``deactivate`` orchestration in
 ``gaia.connectors.api`` — the one-click convenience layer that combines
 grants + activations per issue #1005.
+
+Activations apply to MCP-server connectors only — OAuth connectors have
+no MCP tool surface to gate (see ``_require_mcp_server_for_activation``).
+Tests use ``mcp-github`` (an MCP server) for the success paths and
+``google`` (an OAuth provider) for the rejection paths.
 """
 
 from __future__ import annotations
@@ -23,78 +28,238 @@ def fake_home(tmp_path, monkeypatch):
     return tmp_path
 
 
+@pytest.fixture
+def mcp_test_spec(monkeypatch):
+    """Register a stub ``mcp_server`` spec so ``activate``/``deactivate``
+    pass the type guard without depending on the real catalog.
+
+    Tests that want to exercise the rejection path use a different fake
+    spec ``oauth-test`` registered in :func:`oauth_test_spec`.
+    """
+    from gaia.connectors.registry import ConnectorRegistry
+    from gaia.connectors.spec import ConnectorSpec
+
+    fresh = ConnectorRegistry()
+    fresh.register(
+        ConnectorSpec(
+            id="mcp-test",
+            display_name="MCP Test",
+            icon="M",
+            category="dev-tools",
+            tier=1,
+            type="mcp_server",
+            description="Stub MCP server for api tests",
+            mcp_command="true",
+            mcp_args=(),
+        )
+    )
+    fresh.register(
+        ConnectorSpec(
+            id="oauth-test",
+            display_name="OAuth Test",
+            icon="O",
+            category="productivity",
+            tier=1,
+            type="oauth_pkce",
+            description="Stub OAuth provider for api tests",
+            default_scopes=("openid",),
+            oauth_provider_ref="oauth-test",
+        )
+    )
+    monkeypatch.setattr("gaia.connectors.registry.REGISTRY", fresh)
+    return fresh
+
+
 class TestActivateWithExistingGrant:
-    def test_activate_with_existing_grant_does_not_touch_grant(self, fake_home):
-        grant_agent("github", "builtin:chat", ["repo:read"])
-        auto_granted = activate("github", "builtin:chat")
+    def test_activate_with_existing_grant_does_not_touch_grant(
+        self, fake_home, mcp_test_spec
+    ):
+        grant_agent("mcp-test", "builtin:chat", ["use"])
+        auto_granted = activate("mcp-test", "builtin:chat")
         assert auto_granted is False
         # Grant is preserved as-is.
-        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
-        assert is_agent_active("github", "builtin:chat") is True
+        assert list_agent_grants("mcp-test") == {"builtin:chat": ["use"]}
+        assert is_agent_active("mcp-test", "builtin:chat") is True
 
-    def test_activate_ignores_scopes_for_grant_when_grant_exists(self, fake_home):
+    def test_activate_ignores_scopes_for_grant_when_grant_exists(
+        self, fake_home, mcp_test_spec
+    ):
         # Existing grants are NOT overwritten — auto-grant only fires when
         # no grant is present at all.
-        grant_agent("github", "builtin:chat", ["repo:read"])
-        activate("github", "builtin:chat", scopes_for_grant=["repo:write"])
-        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+        grant_agent("mcp-test", "builtin:chat", ["use"])
+        activate("mcp-test", "builtin:chat", scopes_for_grant=["use:write"])
+        assert list_agent_grants("mcp-test") == {"builtin:chat": ["use"]}
 
 
 class TestActivateAutoGrant:
-    def test_activate_without_grant_auto_grants_required_scopes(self, fake_home):
+    def test_activate_without_grant_auto_grants_required_scopes(
+        self, fake_home, mcp_test_spec
+    ):
         auto_granted = activate(
-            "github", "builtin:chat", scopes_for_grant=["repo:read", "repo:write"]
+            "mcp-test", "builtin:chat", scopes_for_grant=["use", "use:write"]
         )
         assert auto_granted is True
-        assert list_agent_grants("github") == {
-            "builtin:chat": ["repo:read", "repo:write"]
-        }
-        assert is_agent_active("github", "builtin:chat") is True
+        assert list_agent_grants("mcp-test") == {"builtin:chat": ["use", "use:write"]}
+        assert is_agent_active("mcp-test", "builtin:chat") is True
 
     def test_activate_without_grant_or_scopes_raises_configuration_error(
-        self, fake_home
+        self, fake_home, mcp_test_spec
     ):
         with pytest.raises(ConfigurationError) as exc:
-            activate("github", "builtin:chat")
+            activate("mcp-test", "builtin:chat")
         msg = str(exc.value)
-        assert "github" in msg
+        assert "mcp-test" in msg
         assert "builtin:chat" in msg
         assert "scopes" in msg.lower()
 
-    def test_auto_grant_scopes_are_a_copy_not_a_reference(self, fake_home):
+    def test_auto_grant_scopes_are_a_copy_not_a_reference(
+        self, fake_home, mcp_test_spec
+    ):
         # Defensive: callers must not be able to mutate the stored grant
         # through the list they passed in.
-        scopes = ["repo:read"]
-        activate("github", "builtin:chat", scopes_for_grant=scopes)
-        scopes.append("repo:write")
-        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+        scopes = ["use"]
+        activate("mcp-test", "builtin:chat", scopes_for_grant=scopes)
+        scopes.append("use:write")
+        assert list_agent_grants("mcp-test") == {"builtin:chat": ["use"]}
 
 
 class TestDeactivatePreservesGrant:
-    def test_deactivate_preserves_grant(self, fake_home):
-        grant_agent("github", "builtin:chat", ["repo:read"])
-        activate("github", "builtin:chat")
-        deactivate("github", "builtin:chat")
+    def test_deactivate_preserves_grant(self, fake_home, mcp_test_spec):
+        grant_agent("mcp-test", "builtin:chat", ["use"])
+        activate("mcp-test", "builtin:chat")
+        deactivate("mcp-test", "builtin:chat")
         # Grant survives — re-activate must be one click, no re-consent.
-        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
-        assert is_agent_active("github", "builtin:chat") is False
+        assert list_agent_grants("mcp-test") == {"builtin:chat": ["use"]}
+        assert is_agent_active("mcp-test", "builtin:chat") is False
 
-    def test_deactivate_without_prior_activation_is_idempotent(self, fake_home):
-        grant_agent("github", "builtin:chat", ["repo:read"])
+    def test_deactivate_without_prior_activation_is_idempotent(
+        self, fake_home, mcp_test_spec
+    ):
+        grant_agent("mcp-test", "builtin:chat", ["use"])
         # Has grant but never activated — deactivate must not raise.
-        deactivate("github", "builtin:chat")
-        assert is_agent_active("github", "builtin:chat") is False
-        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
+        deactivate("mcp-test", "builtin:chat")
+        assert is_agent_active("mcp-test", "builtin:chat") is False
+        assert list_agent_grants("mcp-test") == {"builtin:chat": ["use"]}
 
 
 class TestActivateIsIdempotent:
-    def test_double_activate_no_double_grant(self, fake_home):
-        activate("github", "builtin:chat", scopes_for_grant=["repo:read"])
+    def test_double_activate_no_double_grant(self, fake_home, mcp_test_spec):
+        activate("mcp-test", "builtin:chat", scopes_for_grant=["use"])
         # Second activate must NOT re-grant (existing grant blocks the
         # auto-grant path).
         auto_granted = activate(
-            "github", "builtin:chat", scopes_for_grant=["repo:write"]
+            "mcp-test", "builtin:chat", scopes_for_grant=["use:write"]
         )
         assert auto_granted is False
-        assert list_agent_grants("github") == {"builtin:chat": ["repo:read"]}
-        assert is_agent_active("github", "builtin:chat") is True
+        assert list_agent_grants("mcp-test") == {"builtin:chat": ["use"]}
+        assert is_agent_active("mcp-test", "builtin:chat") is True
+
+
+class TestRejectNonMcpServer:
+    """#1005 follow-up — activations gate MCP tool visibility only.
+
+    Both ``activate`` and ``deactivate`` must reject OAuth connectors so
+    the CLI / SDK / HTTP surfaces all enforce the same invariant. The
+    HTTP router has its own pre-check (``_require_mcp_server``) for early
+    rejection + cleaner error semantics, but this is the canonical guard
+    every caller flows through.
+    """
+
+    def test_activate_oauth_connector_raises_configuration_error(
+        self, fake_home, mcp_test_spec
+    ):
+        with pytest.raises(ConfigurationError) as exc:
+            activate("oauth-test", "builtin:chat", scopes_for_grant=["openid"])
+        msg = str(exc.value)
+        assert "MCP-server" in msg
+        assert "oauth-test" in msg
+        # Nothing was written — both ledgers stay empty.
+        assert list_agent_grants("oauth-test") == {}
+        assert is_agent_active("oauth-test", "builtin:chat") is False
+
+    def test_deactivate_oauth_connector_raises_configuration_error(
+        self, fake_home, mcp_test_spec
+    ):
+        with pytest.raises(ConfigurationError) as exc:
+            deactivate("oauth-test", "builtin:chat")
+        assert "MCP-server" in str(exc.value)
+
+    def test_activate_unknown_connector_raises_configuration_error(
+        self, fake_home, mcp_test_spec
+    ):
+        with pytest.raises(ConfigurationError) as exc:
+            activate("does-not-exist", "builtin:chat", scopes_for_grant=["use"])
+        assert "does-not-exist" in str(exc.value)
+
+    def test_deactivate_unknown_connector_raises_configuration_error(
+        self, fake_home, mcp_test_spec
+    ):
+        with pytest.raises(ConfigurationError) as exc:
+            deactivate("does-not-exist", "builtin:chat")
+        assert "does-not-exist" in str(exc.value)
+
+
+class TestActivateColdStartLoadsCatalog:
+    """Regression: ``api.activate`` must populate ``REGISTRY`` from the
+    catalog on its own — callers cannot be required to ``import
+    gaia.connectors.catalog`` first.
+
+    Before the fix, a bare ``gaia connectors activations activate
+    mcp-github …`` from a fresh shell raised
+    ``ConfigurationError: Unknown connector 'mcp-github'`` because the CLI
+    handler for ``activations`` did not load the catalog (other handlers
+    like ``list``/``configure``/``test``/``disconnect`` do). The type
+    guard then read an empty registry and rejected every connector id.
+
+    Spawned in a subprocess to guarantee a pristine import cache — any
+    in-process check is contaminated by prior tests that have already
+    imported the catalog.
+    """
+
+    def _spawn(self, code: str) -> tuple[int, str, str]:
+        import os
+        import subprocess
+        import sys
+
+        env = os.environ.copy()
+        # Isolate ledger writes — otherwise the subprocess would mutate
+        # the developer's real ~/.gaia/ files.
+        env["HOME"] = env.get("PYTEST_CURRENT_HOME", env["HOME"])
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+
+    def test_activate_works_without_explicit_catalog_import(self, tmp_path):
+        # Subprocess: bare activate() call against a real catalog id with
+        # no prior ``import gaia.connectors.catalog``. Use ``mcp-github``
+        # because it's a real ``mcp_server`` entry that ships in the
+        # built-in catalog. Isolate ledger writes via HOME override.
+        code = (
+            f"import os; os.environ['HOME'] = {str(tmp_path)!r}\n"
+            "from gaia.connectors.api import activate\n"
+            # If activate() does not load the catalog itself, this raises
+            # ConfigurationError('Unknown connector mcp-github') and the
+            # process exits non-zero.
+            "activate('mcp-github', 'builtin:chat', "
+            "scopes_for_grant=['use'])\n"
+            "print('OK')\n"
+        )
+        rc, out, err = self._spawn(code)
+        assert rc == 0, f"activate failed cold: stderr={err!r}"
+        assert "OK" in out
+
+    def test_deactivate_works_without_explicit_catalog_import(self, tmp_path):
+        code = (
+            f"import os; os.environ['HOME'] = {str(tmp_path)!r}\n"
+            "from gaia.connectors.api import deactivate\n"
+            "deactivate('mcp-github', 'builtin:chat')\n"
+            "print('OK')\n"
+        )
+        rc, out, err = self._spawn(code)
+        assert rc == 0, f"deactivate failed cold: stderr={err!r}"
+        assert "OK" in out

--- a/tests/unit/connectors/test_activations.py
+++ b/tests/unit/connectors/test_activations.py
@@ -1,0 +1,239 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Per-agent activations ledger at ``~/.gaia/connectors/activations.json``
+(issue #1005).
+
+Coverage mirrors ``test_grants.py``:
+
+- ``activate_agent`` writes the file at the right path with mode 0600 and
+  parent dir 0700 (POSIX); skipped on Windows where POSIX modes do not apply.
+- Atomic write via ``tempfile.mkstemp`` + ``os.replace`` — no leftover
+  tempfiles after a successful write.
+- Round-trip through ``deactivate_agent`` and ``list_agent_activations``.
+- ``is_agent_active`` returns False for absent entries (least-privilege
+  opt-in) and True after activation.
+- A corrupted ledger raises ``ConnectorsError`` with an actionable message
+  naming the file path and the ``rm`` recovery command.
+- Concurrent activate calls do not corrupt the file (per-process lock).
+- Namespaced agent IDs (builtin vs custom with same bare id) are isolated.
+- Schema version is persisted and parsed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+from gaia.connectors.activations import (
+    ACTIVATIONS_FILE,
+    SCHEMA_VERSION,
+    activate_agent,
+    deactivate_agent,
+    is_agent_active,
+    list_agent_activations,
+    load_activations,
+    revoke_all_activations_for,
+)
+from gaia.connectors.errors import ConnectorsError
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
+    return tmp_path
+
+
+def _activations_path(home):
+    return home / ".gaia" / "connectors" / "activations.json"
+
+
+class TestPathAndMode:
+    def test_activate_creates_file_at_correct_path(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        assert _activations_path(fake_home).exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
+    def test_file_mode_0600(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        path = _activations_path(fake_home)
+        assert os.stat(path).st_mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes only")
+    def test_parent_dir_mode_0700(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        path = _activations_path(fake_home)
+        assert os.stat(path.parent).st_mode & 0o777 == 0o700
+
+    def test_activations_file_constant_matches_path_shape(self, fake_home):
+        assert "connectors" in str(ACTIVATIONS_FILE)
+        assert str(ACTIVATIONS_FILE).endswith("activations.json")
+
+
+class TestRoundTrip:
+    def test_activate_then_list(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        assert list_agent_activations("github") == {"builtin:chat": True}
+
+    def test_two_agents_independent(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        activate_agent("github", "custom:abc:inbox")
+        assert list_agent_activations("github") == {
+            "builtin:chat": True,
+            "custom:abc:inbox": True,
+        }
+
+    def test_deactivate_removes_only_target(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        activate_agent("github", "custom:abc:inbox")
+        deactivate_agent("github", "builtin:chat")
+        assert list_agent_activations("github") == {"custom:abc:inbox": True}
+
+    def test_deactivate_unknown_is_idempotent(self, fake_home):
+        deactivate_agent("github", "nobody")  # must not raise
+
+    def test_activate_is_idempotent(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        activate_agent("github", "builtin:chat")
+        assert list_agent_activations("github") == {"builtin:chat": True}
+
+    def test_load_activations_empty_when_no_file(self, fake_home):
+        assert load_activations() == {}
+
+    def test_deactivate_then_reactivate(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        deactivate_agent("github", "builtin:chat")
+        assert not is_agent_active("github", "builtin:chat")
+        activate_agent("github", "builtin:chat")
+        assert is_agent_active("github", "builtin:chat")
+
+
+class TestIsActive:
+    def test_absent_returns_false(self, fake_home):
+        # Least-privilege opt-in: absence means inactive.
+        assert is_agent_active("github", "builtin:chat") is False
+
+    def test_true_after_activate(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        assert is_agent_active("github", "builtin:chat") is True
+
+    def test_false_after_deactivate(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        deactivate_agent("github", "builtin:chat")
+        assert is_agent_active("github", "builtin:chat") is False
+
+    def test_unrelated_connector_unaffected(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        assert is_agent_active("filesystem", "builtin:chat") is False
+
+
+class TestRevokeAllForConnector:
+    def test_revoke_all_clears_every_agent(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        activate_agent("github", "builtin:code")
+        revoked = revoke_all_activations_for("github")
+        assert sorted(revoked) == ["builtin:chat", "builtin:code"]
+        assert list_agent_activations("github") == {}
+
+    def test_revoke_all_for_unknown_is_noop(self, fake_home):
+        assert revoke_all_activations_for("nonexistent") == []
+
+    def test_revoke_all_does_not_touch_other_connectors(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        activate_agent("filesystem", "builtin:chat")
+        revoke_all_activations_for("github")
+        assert list_agent_activations("filesystem") == {"builtin:chat": True}
+
+
+class TestAtomicity:
+    def test_atomic_replace_does_not_leave_tempfile(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        connectors_dir = _activations_path(fake_home).parent
+        leftovers = [p.name for p in connectors_dir.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == [], f"unexpected tempfile leftovers: {leftovers}"
+
+    def test_concurrent_activations_do_not_corrupt(self, fake_home):
+        async def driver():
+            await asyncio.gather(
+                *[
+                    asyncio.to_thread(activate_agent, "github", f"agent_{i}")
+                    for i in range(20)
+                ]
+            )
+
+        asyncio.run(driver())
+        listing = list_agent_activations("github")
+        assert len(listing) == 20
+        for i in range(20):
+            assert listing[f"agent_{i}"] is True
+
+
+class TestSchemaVersion:
+    def test_written_file_carries_version_field(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        path = _activations_path(fake_home)
+        on_disk = json.loads(path.read_text())
+        assert on_disk["version"] == SCHEMA_VERSION
+        assert on_disk["activations"] == {"github": {"builtin:chat": True}}
+
+    def test_loader_tolerates_unknown_future_version(self, fake_home):
+        # Forward-compat: a reader on schema v1 must keep working if a
+        # future writer bumps the version field and adds keys we ignore.
+        path = _activations_path(fake_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "activations": {"github": {"builtin:chat": True}},
+                    "future_field": "ignored",
+                }
+            )
+        )
+        assert list_agent_activations("github") == {"builtin:chat": True}
+
+
+class TestCorruptedFileRecovery:
+    def test_corrupted_activations_raises_actionable_error(self, fake_home):
+        path = _activations_path(fake_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ this is not valid json")
+
+        with pytest.raises(ConnectorsError) as exc:
+            load_activations()
+
+        msg = str(exc.value)
+        assert str(path) in msg
+        assert "rm" in msg.lower()
+
+    def test_wrong_top_level_shape_raises_actionable_error(self, fake_home):
+        path = _activations_path(fake_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(["this", "is", "a", "list"]))
+
+        with pytest.raises(ConnectorsError) as exc:
+            load_activations()
+        assert str(path) in str(exc.value)
+
+
+class TestNamespacedAgentIds:
+    def test_builtin_and_custom_with_same_aid_are_separate(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        activate_agent("github", "custom:abc:chat")
+        listing = list_agent_activations("github")
+        assert listing == {
+            "builtin:chat": True,
+            "custom:abc:chat": True,
+        }
+
+    def test_deactivate_one_does_not_affect_other(self, fake_home):
+        activate_agent("github", "builtin:chat")
+        activate_agent("github", "custom:abc:chat")
+        deactivate_agent("github", "custom:abc:chat")
+        listing = list_agent_activations("github")
+        assert "builtin:chat" in listing
+        assert "custom:abc:chat" not in listing

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -22,6 +22,7 @@ from gaia.connectors.providers import _registry
 def fake_home(tmp_path, monkeypatch):
     """Isolated grants/mcp_servers dirs per test."""
     monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
     monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
     monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "test.apps.example")
     _registry.clear()
@@ -137,4 +138,111 @@ class TestDisconnect:
 class TestMissingSubcommand:
     def test_no_subcommand_returns_exit_2(self):
         rc, _out, _err = _run("connectors")
+        assert rc == 2
+
+
+class TestActivations:
+    def test_activations_list_empty(self):
+        rc, out, _err = _run("connectors", "activations", "list", "google")
+        assert rc == 0
+        assert "No activations" in out
+
+    def test_activate_with_explicit_scopes_auto_grants(self):
+        rc, out, _err = _run(
+            "connectors",
+            "activations",
+            "activate",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "gmail.readonly",
+        )
+        assert rc == 0
+        assert "Auto-granted" in out
+        assert "Activated google for builtin:chat" in out
+
+        # The grant landed too — visible via the grants subcommand.
+        rc2, out2, _err2 = _run("connectors", "grants", "list", "google")
+        assert rc2 == 0
+        assert "builtin:chat" in out2
+        assert "gmail.readonly" in out2
+
+        # List shows the activation.
+        rc3, out3, _err3 = _run("connectors", "activations", "list", "google")
+        assert rc3 == 0
+        assert "builtin:chat: active" in out3
+
+    def test_activate_without_grant_or_scopes_returns_exit_3(self):
+        # ConfigurationError → exit code 3 per the shared error-class table.
+        rc, _out, err = _run(
+            "connectors", "activations", "activate", "google", "builtin:chat"
+        )
+        assert rc == 3
+        assert "Configuration error" in err
+
+    def test_activate_existing_grant_no_auto_grant_message(self):
+        _run(
+            "connectors",
+            "grants",
+            "grant",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "gmail.readonly",
+        )
+        rc, out, _err = _run(
+            "connectors", "activations", "activate", "google", "builtin:chat"
+        )
+        assert rc == 0
+        assert "Auto-granted" not in out
+        assert "Activated google for builtin:chat" in out
+
+    def test_deactivate_preserves_grant(self):
+        _run(
+            "connectors",
+            "activations",
+            "activate",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "gmail.readonly",
+        )
+        rc, out, _err = _run(
+            "connectors", "activations", "deactivate", "google", "builtin:chat"
+        )
+        assert rc == 0
+        assert "Deactivated" in out
+
+        # Grant survives.
+        rc2, out2, _err2 = _run("connectors", "grants", "list", "google")
+        assert "builtin:chat" in out2
+        assert "gmail.readonly" in out2
+
+        # No active rows.
+        rc3, out3, _err3 = _run("connectors", "activations", "list", "google")
+        assert "No activations" in out3 or "builtin:chat: active" not in out3
+
+    def test_deactivate_idempotent(self):
+        rc, _out, _err = _run(
+            "connectors", "activations", "deactivate", "google", "builtin:chat"
+        )
+        assert rc == 0
+
+    def test_activations_list_json(self):
+        _run(
+            "connectors",
+            "activations",
+            "activate",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "gmail.readonly",
+        )
+        rc, out, _err = _run("connectors", "activations", "list", "google", "--json")
+        assert rc == 0
+        listing = json.loads(out)
+        assert listing == {"google": {"builtin:chat": True}}
+
+    def test_activations_no_subcommand_returns_exit_2(self):
+        rc, _out, _err = _run("connectors", "activations")
         assert rc == 2

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -142,8 +142,13 @@ class TestMissingSubcommand:
 
 
 class TestActivations:
+    """Activations apply to MCP-server connectors only (#1005). All tests
+    here use ``mcp-github`` (a real MCP catalog entry); OAuth rejection
+    is covered by :class:`TestActivationsRejectOauth` below.
+    """
+
     def test_activations_list_empty(self):
-        rc, out, _err = _run("connectors", "activations", "list", "google")
+        rc, out, _err = _run("connectors", "activations", "list", "mcp-github")
         assert rc == 0
         assert "No activations" in out
 
@@ -152,30 +157,30 @@ class TestActivations:
             "connectors",
             "activations",
             "activate",
-            "google",
+            "mcp-github",
             "builtin:chat",
             "--scopes",
-            "gmail.readonly",
+            "use",
         )
         assert rc == 0
         assert "Auto-granted" in out
-        assert "Activated google for builtin:chat" in out
+        assert "Activated mcp-github for builtin:chat" in out
 
         # The grant landed too — visible via the grants subcommand.
-        rc2, out2, _err2 = _run("connectors", "grants", "list", "google")
+        rc2, out2, _err2 = _run("connectors", "grants", "list", "mcp-github")
         assert rc2 == 0
         assert "builtin:chat" in out2
-        assert "gmail.readonly" in out2
+        assert "use" in out2
 
         # List shows the activation.
-        rc3, out3, _err3 = _run("connectors", "activations", "list", "google")
+        rc3, out3, _err3 = _run("connectors", "activations", "list", "mcp-github")
         assert rc3 == 0
         assert "builtin:chat: active" in out3
 
     def test_activate_without_grant_or_scopes_returns_exit_3(self):
         # ConfigurationError → exit code 3 per the shared error-class table.
         rc, _out, err = _run(
-            "connectors", "activations", "activate", "google", "builtin:chat"
+            "connectors", "activations", "activate", "mcp-github", "builtin:chat"
         )
         assert rc == 3
         assert "Configuration error" in err
@@ -185,46 +190,46 @@ class TestActivations:
             "connectors",
             "grants",
             "grant",
-            "google",
+            "mcp-github",
             "builtin:chat",
             "--scopes",
-            "gmail.readonly",
+            "use",
         )
         rc, out, _err = _run(
-            "connectors", "activations", "activate", "google", "builtin:chat"
+            "connectors", "activations", "activate", "mcp-github", "builtin:chat"
         )
         assert rc == 0
         assert "Auto-granted" not in out
-        assert "Activated google for builtin:chat" in out
+        assert "Activated mcp-github for builtin:chat" in out
 
     def test_deactivate_preserves_grant(self):
         _run(
             "connectors",
             "activations",
             "activate",
-            "google",
+            "mcp-github",
             "builtin:chat",
             "--scopes",
-            "gmail.readonly",
+            "use",
         )
         rc, out, _err = _run(
-            "connectors", "activations", "deactivate", "google", "builtin:chat"
+            "connectors", "activations", "deactivate", "mcp-github", "builtin:chat"
         )
         assert rc == 0
         assert "Deactivated" in out
 
         # Grant survives.
-        rc2, out2, _err2 = _run("connectors", "grants", "list", "google")
+        rc2, out2, _err2 = _run("connectors", "grants", "list", "mcp-github")
         assert "builtin:chat" in out2
-        assert "gmail.readonly" in out2
+        assert "use" in out2
 
         # No active rows.
-        rc3, out3, _err3 = _run("connectors", "activations", "list", "google")
+        rc3, out3, _err3 = _run("connectors", "activations", "list", "mcp-github")
         assert "No activations" in out3 or "builtin:chat: active" not in out3
 
     def test_deactivate_idempotent(self):
         rc, _out, _err = _run(
-            "connectors", "activations", "deactivate", "google", "builtin:chat"
+            "connectors", "activations", "deactivate", "mcp-github", "builtin:chat"
         )
         assert rc == 0
 
@@ -233,16 +238,48 @@ class TestActivations:
             "connectors",
             "activations",
             "activate",
-            "google",
+            "mcp-github",
             "builtin:chat",
             "--scopes",
-            "gmail.readonly",
+            "use",
         )
-        rc, out, _err = _run("connectors", "activations", "list", "google", "--json")
+        rc, out, _err = _run(
+            "connectors", "activations", "list", "mcp-github", "--json"
+        )
         assert rc == 0
         listing = json.loads(out)
-        assert listing == {"google": {"builtin:chat": True}}
+        assert listing == {"mcp-github": {"builtin:chat": True}}
 
     def test_activations_no_subcommand_returns_exit_2(self):
         rc, _out, _err = _run("connectors", "activations")
         assert rc == 2
+
+
+class TestActivationsRejectOauth:
+    """#1005 follow-up — activations gate MCP tool visibility only.
+
+    OAuth connectors like ``google`` have no MCP tool surface — their
+    per-agent access is controlled by grants. The CLI must reject the
+    write with the standard ConfigurationError exit code (3) so users
+    don't end up with a ledger entry nothing reads.
+    """
+
+    def test_activate_on_oauth_connector_returns_exit_3(self):
+        rc, _out, err = _run(
+            "connectors",
+            "activations",
+            "activate",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "openid",
+        )
+        assert rc == 3
+        assert "MCP-server" in err
+
+    def test_deactivate_on_oauth_connector_returns_exit_3(self):
+        rc, _out, err = _run(
+            "connectors", "activations", "deactivate", "google", "builtin:chat"
+        )
+        assert rc == 3
+        assert "MCP-server" in err

--- a/tests/unit/connectors/test_disconnect_clears_activations.py
+++ b/tests/unit/connectors/test_disconnect_clears_activations.py
@@ -1,0 +1,173 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Per-agent activations must be wiped on connector disconnect (issue #1005).
+
+Symmetric to ``test_disconnect_clears_grants.py``: re-adding a connector
+with the same id later must NOT silently re-attach the previous user's
+tool-visibility decisions either.
+
+The cycle exercised: configure → grant → activate → disconnect → check
+that activations for that connector_id are empty. Both handler types
+share the ``revoke_all_activations_for`` helper.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+from gaia.connectors.activations import (
+    activate_agent,
+    list_agent_activations,
+    revoke_all_activations_for,
+)
+from gaia.connectors.grants import (
+    grant_agent,
+    list_agent_grants,
+)
+
+
+@pytest.fixture
+def home_in_tmp(tmp_path, monkeypatch):
+    """Redirect both grants.json and activations.json to a tempdir."""
+    connectors_dir = tmp_path / ".gaia" / "connectors"
+    connectors_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "gaia.connectors.grants._grants_path",
+        lambda: connectors_dir / "grants.json",
+    )
+    monkeypatch.setattr(
+        "gaia.connectors.activations._activations_path",
+        lambda: connectors_dir / "activations.json",
+    )
+    yield connectors_dir
+
+
+def test_revoke_all_activations_for_clears_every_agent(home_in_tmp):
+    activate_agent("mcp-test", "agent-A")
+    activate_agent("mcp-test", "agent-B")
+    activate_agent("mcp-other", "agent-A")
+
+    revoked = revoke_all_activations_for("mcp-test")
+    assert sorted(revoked) == ["agent-A", "agent-B"]
+
+    assert list_agent_activations("mcp-test") == {}
+    # Unrelated connector untouched.
+    assert list_agent_activations("mcp-other") == {"agent-A": True}
+
+
+def test_revoke_all_activations_for_unknown_id_is_noop(home_in_tmp):
+    activate_agent("mcp-test", "agent-A")
+    revoked = revoke_all_activations_for("nonexistent")
+    assert revoked == []
+    assert list_agent_activations("mcp-test") == {"agent-A": True}
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_disconnect_clears_activations(home_in_tmp, tmp_path):
+    """
+    End-to-end: configure → grant → activate → disconnect → assert both
+    grants and activations are empty. Re-configure with the same id and
+    assert they are still empty (no silent inheritance, either axis).
+    """
+    from gaia.connectors.mcp_server import McpServerHandler
+    from gaia.connectors.spec import ConfigField, ConnectorSpec
+
+    spec = ConnectorSpec(
+        id="mcp-disconnect-activation-test",
+        display_name="Disconnect Activations Test",
+        icon="🧪",
+        category="test",
+        tier=1,
+        type="mcp_server",
+        description="ephemeral test entry",
+        mcp_command="echo",
+        mcp_args=("hello",),
+        mcp_env_keys=("API_KEY",),
+        config_schema=(
+            ConfigField(
+                key="API_KEY",
+                label="API Key",
+                kind="secret",
+                secret=True,
+            ),
+        ),
+    )
+
+    with patch("gaia.connectors.mcp_server._mcp_servers_path") as mock_path:
+        mock_path.return_value = tmp_path / ".gaia" / "mcp_servers.json"
+
+        handler = McpServerHandler()
+        await handler.configure(spec, {"API_KEY": "secret-1"})
+
+        # Grant + activate two agents.
+        grant_agent(spec.id, "agent-A", ["use"])
+        grant_agent(spec.id, "agent-B", ["use"])
+        activate_agent(spec.id, "agent-A")
+        activate_agent(spec.id, "agent-B")
+        assert sorted(list_agent_activations(spec.id).keys()) == [
+            "agent-A",
+            "agent-B",
+        ]
+
+        # Disconnect must wipe both axes.
+        await handler.disconnect(spec)
+        assert list_agent_grants(spec.id) == {}
+        assert list_agent_activations(spec.id) == {}
+
+        # Re-configure with the same id.
+        await handler.configure(spec, {"API_KEY": "secret-2"})
+        assert list_agent_grants(spec.id) == {}, (
+            "Re-configuring a connector with the same id silently inherited "
+            "the previous user's grants — security bypass."
+        )
+        assert list_agent_activations(spec.id) == {}, (
+            "Re-configuring a connector with the same id silently inherited "
+            "the previous user's activations — security bypass."
+        )
+
+
+@pytest.mark.asyncio
+async def test_oauth_pkce_disconnect_clears_activations(home_in_tmp, monkeypatch):
+    """OAuth-pkce disconnect must wipe activations alongside grants."""
+    from gaia.connectors.oauth_pkce import OAuthPkceHandler
+
+    captured: Dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        "gaia.connectors.oauth_pkce.delete_connection",
+        lambda provider_id, account_email: captured.update(
+            provider_id=provider_id, account_email=account_email
+        ),
+    )
+
+    from gaia.connectors.spec import ConnectorSpec
+
+    spec = ConnectorSpec(
+        id="oauth-activation-test",
+        display_name="OAuth Activation Test",
+        icon="🧪",
+        category="test",
+        tier=1,
+        type="oauth_pkce",
+        description="ephemeral",
+        oauth_provider_ref="oauth-activation-test",
+    )
+
+    grant_agent(spec.id, "agent-A", ["scope.read"])
+    activate_agent(spec.id, "agent-A")
+    activate_agent(spec.id, "agent-B")
+
+    handler = OAuthPkceHandler()
+    await handler.disconnect(spec)
+
+    assert list_agent_grants(spec.id) == {}
+    assert list_agent_activations(spec.id) == {}
+    assert captured == {
+        "provider_id": "oauth-activation-test",
+        "account_email": "default",
+    }

--- a/tests/unit/connectors/test_e2e_smoke.py
+++ b/tests/unit/connectors/test_e2e_smoke.py
@@ -48,6 +48,7 @@ def _run(*argv) -> tuple[int, str, str]:
 def isolated_env(tmp_path, monkeypatch):
     """Isolate filesystem and env for every smoke test."""
     monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
     monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
     monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "test.apps.example")
     # Clear the OAuth provider cache (not the catalog registry).
@@ -237,3 +238,127 @@ class TestRouterSyncSmoke:
         assert (
             "https://www.googleapis.com/auth/gmail.readonly" in grants["builtin:chat"]
         )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Smoke: activations multi-caller equivalence (issue #1005)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestActivationsMultiCallerSmoke:
+    """Activations written by one surface must be visible to every other.
+
+    Mirrors the grants multi-caller test — issue #1005 promises the same
+    SDK / CLI / HTTP equivalence that PR #926 established for grants.
+    """
+
+    def test_cli_activate_visible_via_sdk_and_router(self, ui_api_client):
+        from gaia.connectors.activations import (
+            is_agent_active,
+            list_agent_activations,
+        )
+
+        # 1. CLI activate (auto-grants because no prior grant).
+        rc, _out, _err = _run(
+            "connectors",
+            "activations",
+            "activate",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "openid",
+        )
+        assert rc == 0
+
+        # 2. SDK sees the activation.
+        assert is_agent_active("google", "builtin:chat") is True
+        assert list_agent_activations("google") == {"builtin:chat": True}
+
+        # 3. HTTP router sees it too — both via the dedicated endpoint
+        # and as part of the connector summary (no-cache catalog read).
+        r = ui_api_client.get("/api/connectors/google/activations")
+        assert r.status_code == 200
+        assert r.json() == {"activations": {"builtin:chat": True}}
+
+        summary = ui_api_client.get("/api/connectors/google").json()
+        assert summary["activations"] == {"builtin:chat": True}
+
+    def test_router_activate_visible_via_sdk_and_cli(self, ui_api_client):
+        from gaia.connectors.activations import is_agent_active
+
+        # 1. HTTP PUT activates (auto-grant via the body's scopes).
+        r = ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={"scopes": ["openid"]},
+            headers={"x-gaia-ui": "1"},
+        )
+        assert r.status_code == 200
+
+        # 2. SDK sees it.
+        assert is_agent_active("google", "builtin:chat") is True
+
+        # 3. CLI sees it.
+        rc, out, _err = _run("connectors", "activations", "list", "google")
+        assert rc == 0
+        assert "builtin:chat: active" in out
+
+    def test_deactivate_clears_visibility_but_preserves_grant(self, ui_api_client):
+        from gaia.connectors.activations import is_agent_active
+        from gaia.connectors.grants import list_agent_grants
+
+        # Activate via CLI (auto-grants openid).
+        _run(
+            "connectors",
+            "activations",
+            "activate",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "openid",
+        )
+        assert is_agent_active("google", "builtin:chat") is True
+
+        # Deactivate via the router.
+        r = ui_api_client.delete(
+            "/api/connectors/google/activations/builtin:chat",
+            headers={"x-gaia-ui": "1"},
+        )
+        assert r.status_code == 204
+
+        # SDK + CLI both see the activation cleared, grant preserved.
+        assert is_agent_active("google", "builtin:chat") is False
+        assert list_agent_grants("google") == {"builtin:chat": ["openid"]}
+
+    def test_tools_for_agent_reflects_activation_state(self, ui_api_client):
+        """The MCP manager filter honours activations across all writers."""
+        from unittest.mock import MagicMock
+
+        from gaia.mcp.client.mcp_client_manager import MCPClientManager
+
+        manager = MCPClientManager()
+        manager._clients["google"] = MagicMock()
+        manager._clients["filesystem"] = MagicMock()
+        manager._clients["google"].list_tools.return_value = [MagicMock()]
+        manager._clients["filesystem"].list_tools.return_value = [MagicMock()]
+
+        # No activations yet — agent sees nothing.
+        assert manager.servers_for_agent("builtin:chat") == []
+
+        # Activate via CLI.
+        _run(
+            "connectors",
+            "activations",
+            "activate",
+            "google",
+            "builtin:chat",
+            "--scopes",
+            "openid",
+        )
+        assert manager.servers_for_agent("builtin:chat") == ["google"]
+
+        # Deactivate via router → manager filter updates.
+        ui_api_client.delete(
+            "/api/connectors/google/activations/builtin:chat",
+            headers={"x-gaia-ui": "1"},
+        )
+        assert manager.servers_for_agent("builtin:chat") == []

--- a/tests/unit/connectors/test_e2e_smoke.py
+++ b/tests/unit/connectors/test_e2e_smoke.py
@@ -258,29 +258,32 @@ class TestActivationsMultiCallerSmoke:
             list_agent_activations,
         )
 
-        # 1. CLI activate (auto-grants because no prior grant).
+        # 1. CLI activate (auto-grants because no prior grant). Uses
+        # ``mcp-github`` because activations are valid for MCP-server
+        # connectors only (#1005) — OAuth connectors like ``google`` are
+        # rejected by the activation API.
         rc, _out, _err = _run(
             "connectors",
             "activations",
             "activate",
-            "google",
+            "mcp-github",
             "builtin:chat",
             "--scopes",
-            "openid",
+            "use",
         )
         assert rc == 0
 
         # 2. SDK sees the activation.
-        assert is_agent_active("google", "builtin:chat") is True
-        assert list_agent_activations("google") == {"builtin:chat": True}
+        assert is_agent_active("mcp-github", "builtin:chat") is True
+        assert list_agent_activations("mcp-github") == {"builtin:chat": True}
 
         # 3. HTTP router sees it too — both via the dedicated endpoint
         # and as part of the connector summary (no-cache catalog read).
-        r = ui_api_client.get("/api/connectors/google/activations")
+        r = ui_api_client.get("/api/connectors/mcp-github/activations")
         assert r.status_code == 200
         assert r.json() == {"activations": {"builtin:chat": True}}
 
-        summary = ui_api_client.get("/api/connectors/google").json()
+        summary = ui_api_client.get("/api/connectors/mcp-github").json()
         assert summary["activations"] == {"builtin:chat": True}
 
     def test_router_activate_visible_via_sdk_and_cli(self, ui_api_client):
@@ -288,17 +291,17 @@ class TestActivationsMultiCallerSmoke:
 
         # 1. HTTP PUT activates (auto-grant via the body's scopes).
         r = ui_api_client.put(
-            "/api/connectors/google/activations/builtin:chat",
-            json={"scopes": ["openid"]},
+            "/api/connectors/mcp-github/activations/builtin:chat",
+            json={"scopes": ["use"]},
             headers={"x-gaia-ui": "1"},
         )
         assert r.status_code == 200
 
         # 2. SDK sees it.
-        assert is_agent_active("google", "builtin:chat") is True
+        assert is_agent_active("mcp-github", "builtin:chat") is True
 
         # 3. CLI sees it.
-        rc, out, _err = _run("connectors", "activations", "list", "google")
+        rc, out, _err = _run("connectors", "activations", "list", "mcp-github")
         assert rc == 0
         assert "builtin:chat: active" in out
 
@@ -306,28 +309,28 @@ class TestActivationsMultiCallerSmoke:
         from gaia.connectors.activations import is_agent_active
         from gaia.connectors.grants import list_agent_grants
 
-        # Activate via CLI (auto-grants openid).
+        # Activate via CLI (auto-grants ``use``).
         _run(
             "connectors",
             "activations",
             "activate",
-            "google",
+            "mcp-github",
             "builtin:chat",
             "--scopes",
-            "openid",
+            "use",
         )
-        assert is_agent_active("google", "builtin:chat") is True
+        assert is_agent_active("mcp-github", "builtin:chat") is True
 
         # Deactivate via the router.
         r = ui_api_client.delete(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-github/activations/builtin:chat",
             headers={"x-gaia-ui": "1"},
         )
         assert r.status_code == 204
 
         # SDK + CLI both see the activation cleared, grant preserved.
-        assert is_agent_active("google", "builtin:chat") is False
-        assert list_agent_grants("google") == {"builtin:chat": ["openid"]}
+        assert is_agent_active("mcp-github", "builtin:chat") is False
+        assert list_agent_grants("mcp-github") == {"builtin:chat": ["use"]}
 
     def test_tools_for_agent_reflects_activation_state(self, ui_api_client):
         """The MCP manager filter honours activations across all writers."""
@@ -336,9 +339,9 @@ class TestActivationsMultiCallerSmoke:
         from gaia.mcp.client.mcp_client_manager import MCPClientManager
 
         manager = MCPClientManager()
-        manager._clients["google"] = MagicMock()
+        manager._clients["mcp-github"] = MagicMock()
         manager._clients["filesystem"] = MagicMock()
-        manager._clients["google"].list_tools.return_value = [MagicMock()]
+        manager._clients["mcp-github"].list_tools.return_value = [MagicMock()]
         manager._clients["filesystem"].list_tools.return_value = [MagicMock()]
 
         # No activations yet — agent sees nothing.
@@ -349,16 +352,16 @@ class TestActivationsMultiCallerSmoke:
             "connectors",
             "activations",
             "activate",
-            "google",
+            "mcp-github",
             "builtin:chat",
             "--scopes",
-            "openid",
+            "use",
         )
-        assert manager.servers_for_agent("builtin:chat") == ["google"]
+        assert manager.servers_for_agent("builtin:chat") == ["mcp-github"]
 
         # Deactivate via router → manager filter updates.
         ui_api_client.delete(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-github/activations/builtin:chat",
             headers={"x-gaia-ui": "1"},
         )
         assert manager.servers_for_agent("builtin:chat") == []

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -29,26 +29,51 @@ UI_HEADER = {"x-gaia-ui": "1"}
 
 @pytest.fixture(autouse=True)
 def isolated_registry(monkeypatch, tmp_path):
-    """Each test gets a fresh REGISTRY and isolated grants/state dirs."""
+    """Each test gets a fresh REGISTRY and isolated grants/state dirs.
+
+    Registers two specs so tests can exercise both the OAuth path
+    (``google``) and the MCP-server path (``mcp-test``) without colliding.
+    Activations endpoints accept only ``mcp_server`` connectors (#1005),
+    so tests targeting that ledger should use ``mcp-test``.
+    """
     from gaia.connectors.registry import ConnectorRegistry
     from gaia.connectors.spec import ConnectorSpec
 
     fresh = ConnectorRegistry()
-    spec = ConnectorSpec(
-        id="google",
-        display_name="Google",
-        icon="G",
-        category="productivity",
-        tier=1,
-        type="oauth_pkce",
-        description="Google OAuth",
-        default_scopes=("openid",),
-        oauth_provider_ref="google",
+    fresh.register(
+        ConnectorSpec(
+            id="google",
+            display_name="Google",
+            icon="G",
+            category="productivity",
+            tier=1,
+            type="oauth_pkce",
+            description="Google OAuth",
+            default_scopes=("openid",),
+            oauth_provider_ref="google",
+        )
     )
-    fresh.register(spec)
+    fresh.register(
+        ConnectorSpec(
+            id="mcp-test",
+            display_name="MCP Test",
+            icon="M",
+            category="dev-tools",
+            tier=1,
+            type="mcp_server",
+            description="Stub MCP server for router tests",
+            mcp_command="true",
+            mcp_args=(),
+        )
+    )
 
     monkeypatch.setattr("gaia.ui.routers.connectors.REGISTRY", fresh)
     monkeypatch.setattr("gaia.connectors.handler.REGISTRY", fresh)
+    # ``connectors.api._require_mcp_server_for_activation`` imports REGISTRY
+    # lazily from its canonical home so the type guard applies to CLI/SDK
+    # callers too — patch the canonical name so all three surfaces share
+    # the same fresh catalog under test.
+    monkeypatch.setattr("gaia.connectors.registry.REGISTRY", fresh)
     monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
     monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
     monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
@@ -551,52 +576,52 @@ class TestEnabledFieldInSummary:
 class TestActivationsCsrf:
     def test_put_without_header_is_403(self, ui_api_client):
         resp = ui_api_client.put(
-            "/api/connectors/google/activations/builtin:chat",
-            json={"scopes": ["openid"]},
+            "/api/connectors/mcp-test/activations/builtin:chat",
+            json={"scopes": ["use"]},
         )
         assert resp.status_code == 403
 
     def test_delete_without_header_is_403(self, ui_api_client):
         resp = ui_api_client.delete(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-test/activations/builtin:chat",
         )
         assert resp.status_code == 403
 
 
 class TestActivationsEndpoints:
     def test_get_activations_returns_activations_key(self, ui_api_client):
-        resp = ui_api_client.get("/api/connectors/google/activations")
+        resp = ui_api_client.get("/api/connectors/mcp-test/activations")
         assert resp.status_code == 200
         assert resp.json() == {"activations": {}}
 
     def test_put_activation_with_existing_grant_succeeds(self, ui_api_client):
         # Grant first, then activate (the explicit two-step path).
         ui_api_client.put(
-            "/api/connectors/google/grants/builtin:chat",
-            json={"scopes": ["openid"]},
+            "/api/connectors/mcp-test/grants/builtin:chat",
+            json={"scopes": ["use"]},
             headers=UI_HEADER,
         )
         resp = ui_api_client.put(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-test/activations/builtin:chat",
             json={},
             headers=UI_HEADER,
         )
         assert resp.status_code == 200
         body = resp.json()
         assert body == {
-            "connector_id": "google",
+            "connector_id": "mcp-test",
             "agent_id": "builtin:chat",
             "active": True,
             "auto_granted": False,
         }
         # GET reflects the new active state.
-        listing = ui_api_client.get("/api/connectors/google/activations").json()
+        listing = ui_api_client.get("/api/connectors/mcp-test/activations").json()
         assert listing == {"activations": {"builtin:chat": True}}
 
     def test_put_activation_with_no_grant_and_scopes_auto_grants(self, ui_api_client):
         resp = ui_api_client.put(
-            "/api/connectors/google/activations/builtin:chat",
-            json={"scopes": ["openid", "email"]},
+            "/api/connectors/mcp-test/activations/builtin:chat",
+            json={"scopes": ["use", "read"]},
             headers=UI_HEADER,
         )
         assert resp.status_code == 200
@@ -604,66 +629,124 @@ class TestActivationsEndpoints:
         assert body["auto_granted"] is True
         assert body["active"] is True
         # Grant landed too.
-        grants = ui_api_client.get("/api/connectors/google/grants").json()
-        assert grants == {"grants": {"builtin:chat": ["openid", "email"]}}
+        grants = ui_api_client.get("/api/connectors/mcp-test/grants").json()
+        assert grants == {"grants": {"builtin:chat": ["use", "read"]}}
 
     def test_put_activation_with_no_grant_and_no_scopes_is_400(self, ui_api_client):
         resp = ui_api_client.put(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-test/activations/builtin:chat",
             json={},
             headers=UI_HEADER,
         )
         assert resp.status_code == 400
         detail = resp.json().get("detail", "")
-        assert "google" in detail
+        assert "mcp-test" in detail
         assert "builtin:chat" in detail
 
     def test_delete_activation_succeeds_idempotently(self, ui_api_client):
         # No prior activation — delete is still 204 (idempotent).
         resp = ui_api_client.delete(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-test/activations/builtin:chat",
             headers=UI_HEADER,
         )
         assert resp.status_code == 204
 
     def test_delete_activation_preserves_grant(self, ui_api_client):
         ui_api_client.put(
-            "/api/connectors/google/grants/builtin:chat",
-            json={"scopes": ["openid"]},
+            "/api/connectors/mcp-test/grants/builtin:chat",
+            json={"scopes": ["use"]},
             headers=UI_HEADER,
         )
         ui_api_client.put(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-test/activations/builtin:chat",
             json={},
             headers=UI_HEADER,
         )
         resp = ui_api_client.delete(
-            "/api/connectors/google/activations/builtin:chat",
+            "/api/connectors/mcp-test/activations/builtin:chat",
             headers=UI_HEADER,
         )
         assert resp.status_code == 204
         # Activation cleared, grant survives — re-activate must be one click.
-        grants = ui_api_client.get("/api/connectors/google/grants").json()
-        assert grants == {"grants": {"builtin:chat": ["openid"]}}
-        listing = ui_api_client.get("/api/connectors/google/activations").json()
+        grants = ui_api_client.get("/api/connectors/mcp-test/grants").json()
+        assert grants == {"grants": {"builtin:chat": ["use"]}}
+        listing = ui_api_client.get("/api/connectors/mcp-test/activations").json()
         assert listing == {"activations": {}}
 
     def test_connector_summary_exposes_activations(self, ui_api_client):
         ui_api_client.put(
+            "/api/connectors/mcp-test/activations/builtin:chat",
+            json={"scopes": ["use"]},
+            headers=UI_HEADER,
+        )
+        resp = ui_api_client.get("/api/connectors/mcp-test")
+        assert resp.status_code == 200
+        assert resp.json()["activations"] == {"builtin:chat": True}
+
+
+class TestActivationsRejectNonMcpServer:
+    """#1005 follow-up — activations gate MCP tool visibility only.
+
+    The router must reject PUT/DELETE for OAuth connectors so we don't
+    expose a UI switch that silently does nothing. CSRF still wins over
+    type-check (a 403 before a 400 is the safe ordering — type checks
+    leak catalog membership; CSRF doesn't).
+    """
+
+    def test_put_on_oauth_connector_is_400(self, ui_api_client):
+        resp = ui_api_client.put(
             "/api/connectors/google/activations/builtin:chat",
             json={"scopes": ["openid"]},
             headers=UI_HEADER,
         )
-        resp = ui_api_client.get("/api/connectors/google")
-        assert resp.status_code == 200
-        assert resp.json()["activations"] == {"builtin:chat": True}
+        assert resp.status_code == 400
+        detail = resp.json().get("detail", "")
+        assert "MCP-server" in detail
+        assert "google" in detail
+        # And nothing was written to the ledger.
+        listing = ui_api_client.get("/api/connectors/google/activations").json()
+        assert listing == {"activations": {}}
+
+    def test_delete_on_oauth_connector_is_400(self, ui_api_client):
+        resp = ui_api_client.delete(
+            "/api/connectors/google/activations/builtin:chat",
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 400
+        assert "MCP-server" in resp.json().get("detail", "")
+
+    def test_put_on_unknown_connector_is_404(self, ui_api_client):
+        resp = ui_api_client.put(
+            "/api/connectors/does-not-exist/activations/builtin:chat",
+            json={"scopes": ["use"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 404
+        assert "does-not-exist" in resp.json().get("detail", "")
+
+    def test_delete_on_unknown_connector_is_404(self, ui_api_client):
+        resp = ui_api_client.delete(
+            "/api/connectors/does-not-exist/activations/builtin:chat",
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 404
+
+    def test_csrf_takes_precedence_over_type_check_put(self, ui_api_client):
+        # Missing X-Gaia-UI header on an OAuth connector still returns 403,
+        # not 400 — never leak catalog membership / spec metadata to an
+        # unauthenticated caller.
+        resp = ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={"scopes": ["openid"]},
+        )
+        assert resp.status_code == 403
 
     def test_namespaced_agent_id_with_colon_is_routed_correctly(self, ui_api_client):
         # The agent_id path parameter uses ``:path`` so colons in namespaced
         # ids (``builtin:chat``, ``custom:abc:chat``) survive routing.
         resp = ui_api_client.put(
-            "/api/connectors/google/activations/custom:deadbeef:chat",
-            json={"scopes": ["openid"]},
+            "/api/connectors/mcp-test/activations/custom:deadbeef:chat",
+            json={"scopes": ["use"]},
             headers=UI_HEADER,
         )
         assert resp.status_code == 200

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -50,6 +50,7 @@ def isolated_registry(monkeypatch, tmp_path):
     monkeypatch.setattr("gaia.ui.routers.connectors.REGISTRY", fresh)
     monkeypatch.setattr("gaia.connectors.handler.REGISTRY", fresh)
     monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("gaia.connectors.activations.Path.home", lambda: tmp_path)
     monkeypatch.setattr("gaia.connectors.mcp_server.Path.home", lambda: tmp_path)
     yield fresh
 
@@ -540,3 +541,131 @@ class TestEnabledFieldInSummary:
     def test_oauth_summary_always_reports_enabled_true(self, ui_api_client):
         resp = ui_api_client.get("/api/connectors/google")
         assert resp.json()["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Activations endpoints (issue #1005)
+# ---------------------------------------------------------------------------
+
+
+class TestActivationsCsrf:
+    def test_put_without_header_is_403(self, ui_api_client):
+        resp = ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={"scopes": ["openid"]},
+        )
+        assert resp.status_code == 403
+
+    def test_delete_without_header_is_403(self, ui_api_client):
+        resp = ui_api_client.delete(
+            "/api/connectors/google/activations/builtin:chat",
+        )
+        assert resp.status_code == 403
+
+
+class TestActivationsEndpoints:
+    def test_get_activations_returns_activations_key(self, ui_api_client):
+        resp = ui_api_client.get("/api/connectors/google/activations")
+        assert resp.status_code == 200
+        assert resp.json() == {"activations": {}}
+
+    def test_put_activation_with_existing_grant_succeeds(self, ui_api_client):
+        # Grant first, then activate (the explicit two-step path).
+        ui_api_client.put(
+            "/api/connectors/google/grants/builtin:chat",
+            json={"scopes": ["openid"]},
+            headers=UI_HEADER,
+        )
+        resp = ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {
+            "connector_id": "google",
+            "agent_id": "builtin:chat",
+            "active": True,
+            "auto_granted": False,
+        }
+        # GET reflects the new active state.
+        listing = ui_api_client.get("/api/connectors/google/activations").json()
+        assert listing == {"activations": {"builtin:chat": True}}
+
+    def test_put_activation_with_no_grant_and_scopes_auto_grants(self, ui_api_client):
+        resp = ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={"scopes": ["openid", "email"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["auto_granted"] is True
+        assert body["active"] is True
+        # Grant landed too.
+        grants = ui_api_client.get("/api/connectors/google/grants").json()
+        assert grants == {"grants": {"builtin:chat": ["openid", "email"]}}
+
+    def test_put_activation_with_no_grant_and_no_scopes_is_400(self, ui_api_client):
+        resp = ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 400
+        detail = resp.json().get("detail", "")
+        assert "google" in detail
+        assert "builtin:chat" in detail
+
+    def test_delete_activation_succeeds_idempotently(self, ui_api_client):
+        # No prior activation — delete is still 204 (idempotent).
+        resp = ui_api_client.delete(
+            "/api/connectors/google/activations/builtin:chat",
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 204
+
+    def test_delete_activation_preserves_grant(self, ui_api_client):
+        ui_api_client.put(
+            "/api/connectors/google/grants/builtin:chat",
+            json={"scopes": ["openid"]},
+            headers=UI_HEADER,
+        )
+        ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={},
+            headers=UI_HEADER,
+        )
+        resp = ui_api_client.delete(
+            "/api/connectors/google/activations/builtin:chat",
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 204
+        # Activation cleared, grant survives — re-activate must be one click.
+        grants = ui_api_client.get("/api/connectors/google/grants").json()
+        assert grants == {"grants": {"builtin:chat": ["openid"]}}
+        listing = ui_api_client.get("/api/connectors/google/activations").json()
+        assert listing == {"activations": {}}
+
+    def test_connector_summary_exposes_activations(self, ui_api_client):
+        ui_api_client.put(
+            "/api/connectors/google/activations/builtin:chat",
+            json={"scopes": ["openid"]},
+            headers=UI_HEADER,
+        )
+        resp = ui_api_client.get("/api/connectors/google")
+        assert resp.status_code == 200
+        assert resp.json()["activations"] == {"builtin:chat": True}
+
+    def test_namespaced_agent_id_with_colon_is_routed_correctly(self, ui_api_client):
+        # The agent_id path parameter uses ``:path`` so colons in namespaced
+        # ids (``builtin:chat``, ``custom:abc:chat``) survive routing.
+        resp = ui_api_client.put(
+            "/api/connectors/google/activations/custom:deadbeef:chat",
+            json={"scopes": ["openid"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["agent_id"] == "custom:deadbeef:chat"


### PR DESCRIPTION
<!--
Thanks for contributing to GAIA! Every PR must reference a GitHub issue —
see CONTRIBUTING.md (https://github.com/amd/gaia/blob/main/CONTRIBUTING.md)
if you don't have one yet.
-->

## Summary

Per-agent MCP tool-visibility activations, layered on top of the PR #926 connectors framework. Users now have two independent axes of control: **grants** (credential access, already shipped) and **activations** (which MCP-server tools land in an agent's prompt). Activations default to OFF — explicit opt-in per `(connector, agent)`.

## Why

Today, every granted MCP connector's tools surface to every agent that holds a grant. A `ChatAgent` with several MCP servers granted sees ~30 extra tool descriptions in its system prompt — bloating context and degrading small-model tool selection. Issue #1005 asks for a separate signal between "this agent is *allowed* to use this connector" (grant) and "this agent currently *sees* its tools" (activation). Activation also gives users a least-privilege opt-in posture: a granted-but-inactive agent cannot select the tools at all, even if a prompt-injection tried to coax it into trying.

Activations apply to **MCP-server connectors only**. OAuth connectors (Google, etc.) reach providers through native Python `@tool` functions that call `get_credential_sync` directly — there is no MCP tool surface for activations to gate. Per-agent control of OAuth access stays on the per-scope grant toggles already shipped by #926. Calling `activate()` / `deactivate()` for an OAuth connector is rejected at every boundary (HTTP 400, SDK `ConfigurationError`, CLI exit 3); the UI hides the "Active for" section on OAuth tiles for the same reason.

## Linked issue

Closes #1005

## Changes

- **New module `src/gaia/connectors/activations.py`** — ledger at `~/.gaia/connectors/activations.json`, mode 0600, atomic-replace writes, per-process write lock, corruption recovery with actionable `rm` hint. Mirrors `grants.py` one-to-one in structure and rigour. Low-level API named `activate_agent` / `deactivate_agent` / `is_agent_active` / `list_agent_activations` / `revoke_all_activations_for` — matches the `grants.py` naming pattern (`grant_agent`, `revoke_agent_grant`).
- **Schema includes a `version` field** so future evolution has a forward-compat lever from day one:
  ```json
  {
    "version": 1,
    "activations": {
      "<connector_id>": {
        "<namespaced_agent_id>": true
      }
    }
  }
  ```
  Issue #1005 sketched `[agent_id]`-list values; this PR ships the object form so per-pair lookups are O(1) and a future `false` value can carry meaning if needed.
- **`src/gaia/connectors/api.py`** — public orchestration helpers `activate` / `deactivate`. `activate` auto-grants using the agent's declared `REQUIRED_CONNECTORS` scopes when no prior grant exists (one-click convenience). MCP-only type guard at this layer — every caller (HTTP, CLI, SDK) flows through it. Auto-imports the catalog so bare-CLI callers can't trip "Unknown connector 'mcp-github'" on a cold REGISTRY.
- **`src/gaia/mcp/client/mcp_client_manager.py`** — new `tools_for_agent(agent_id)` and `servers_for_agent(agent_id)`. Pure filter over the existing per-server tool catalogue. With `agent_id=None` (CLI/debug context) the unfiltered list is returned — activations only gate the agent-tool path.
- **`src/gaia/agents/base/agent.py`** — `_active_mcp_servers(manager)` helper consumed by ChatAgent's `_register_tools`. Built-in `@tool`-decorated functions bypass the filter entirely — activations are an MCP-connector concept, not a Python-decorator one.
- **`src/gaia/agents/chat/agent.py`** + **`src/gaia/agents/registry.py`** + **`src/gaia/ui/_chat_helpers.py`** — `ChatAgentConfig.namespaced_agent_id` plus an early-init stamp so `_register_tools` sees the correct identity. Necessary because the registry wrapper used to stamp `_gaia_namespaced_agent_id` *after* `__init__` returned — meaning the filter never actually fired for any UI Chat session. The wrapper now also injects via kwarg, and `_chat_helpers` stamps the config before each direct construction. Source-grep guard test catches any future direct `ChatAgent(config)` site that forgets the stamp.
- **HTTP routes** in `src/gaia/ui/routers/connectors.py` — `PUT/DELETE /api/connectors/{id}/activations/{agent_id:path}` (CSRF-guarded, type-checked, SSE-emitting). `GET /api/connectors/{id}/activations`. Existing connector summary gains an `activations: Dict[str, bool]` field.
- **CLI** in `src/gaia/connectors/cli.py` — `gaia connectors activations {list|activate|deactivate}` with `--scopes` for explicit auto-grant overrides and `--json` for machine-readable output. Same exit-code map as the rest of `gaia connectors` (0/1/2/3/5).
- **Disconnect wipes activations** alongside grants in `mcp_server.py` disconnect paths — re-adding a connector_id never silently inherits prior tool visibility.
- **Frontend** `src/gaia/apps/webui/src/components/ConnectorsSection.tsx` — new "Active for" subsection rendered only when `connector.type === 'mcp_server'`. New `AgentActivationCard` mirrors the existing scope-grant card with a single toggle. Optimistic update + rollback on error. Live updates via `useConnectorsSSE`.
- **Tests (24 new + several migrated)** — `tests/unit/connectors/test_activations.py` (file mode, atomicity, corruption, namespacing), `test_activation_api.py` (orchestration + rejection + cold-start regression), `test_disconnect_clears_activations.py` (wipe symmetry), router/CLI/E2E extensions, and `tests/unit/agents/test_tool_visibility_filter.py` (the canonical filter probe). Plus `tests/unit/chat/ui/test_chat_helpers.py::TestStampBuiltinChatIdentity` — four tests including a source-grep structural guard.
- **Docs** — new "Per-agent activation" section in `docs/sdk/infrastructure/connectors.mdx`; revocation table updated in `docs/security/connections.mdx`. Both explicitly call out the MCP-only scope of activations.

## Why this matters

- **Smaller prompts, better tool selection.** A `ChatAgent` with mcp-github granted + activated for it gets the 26 GitHub tools in its prompt; without activation, those 26 lines never enter the prompt. Small-model tool-call accuracy improves directly with prompt density reduction.
- **Real least-privilege.** A user can grant `mcp-github` to ChatAgent so the credential is available, but leave activation off so a routine "summarise this document" turn cannot reach a `mcp_github_create_pull_request` tool even if the model wanted to call it.
- **Activations default OFF.** Migration story is the strictest reading of the issue: no implicit "everything granted is now active" on upgrade. Users opt in per `(connector, agent)` from Settings → Connectors → "Active for".
- **Multi-caller equivalence preserved.** Whatever rigour PR #926 set for grants (SDK / CLI / HTTP all see the same ledger, atomic writes, mode 0600), this PR mirrors for activations. New `TestActivationsMultiCallerSmoke` proves it.

## Test plan

- [x] `python util/lint.py --all` — clean.
- [x] `python -m pytest tests/unit/connectors/ tests/unit/agents/test_tool_visibility_filter.py tests/unit/chat/ui/test_chat_helpers.py` — 480 passed, 3 skipped.
- [x] `cd src/gaia/apps/webui && ./node_modules/.bin/tsc --noEmit` — zero errors.
- [x] Manual CLI round-trip:
  ```bash
  gaia connectors activations deactivate mcp-github builtin:chat			        # clean up
  gaia connectors grants revoke mcp-github builtin:chat					    	# clean up
  gaia connectors activations list mcp-github                                     # empty
  gaia connectors activations activate mcp-github builtin:chat --scopes use       # auto-grants
  gaia connectors activations list mcp-github                                     # builtin:chat: active
  gaia connectors activations deactivate mcp-github builtin:chat
  gaia connectors activations list mcp-github                                     # inactive; grant survives
  ```
- [x] OAuth rejection:
  ```bash
  gaia connectors activations activate google builtin:connectors-demo --scopes openid
  # exit 3; stderr: "Configuration error: Activations apply to MCP-server connectors only…"
  ```
- [x] HTTP rejection: `PUT /api/connectors/google/activations/builtin:chat` → 400; CSRF still wins (no header → 403); unknown connector → 404.
- [x] End-to-end LLM-visible effect: with Lemonade + Gemma-4-E4B-it-GGUF, ChatAgent in the UI lists `mcp_github_*` tools when activated, says "I don't have any GitHub MCP tools" when not.
- [x] Disconnect-wipe: after granting + activating `mcp-github` for two agents and disconnecting via UI, both `~/.gaia/connectors/grants.json` and `~/.gaia/connectors/activations.json` are empty for `mcp-github`.
- [x] Agent eval (`gaia eval agent --category rag_quality --agent-type doc`) — 100% pass (7/7), avg score 9.4. The diff vs. the committed baseline reports +33%/+1.2 but the two scorecards share zero scenarios (baseline pre-dates the current scenario set), so the relevant signal is the absolute number — no regression introduced.

## Follow-ups (not in this PR — will file as separate issues)

- **SSE gap for non-router writes.** `connector.activation.changed` only fires from the HTTP router's PUT/DELETE handlers. CLI / SDK toggles write the same ledger but emit nothing, so an open Settings tab won't reflect CLI-driven state changes until the user navigates away/back. Two reasonable fixes: (a) have the CLI POST through the router instead of calling the SDK directly, or (b) add a file-watcher on `activations.json` that emits SSE on change.
- **"Active for" panel filters by `REQUIRED_CONNECTORS`.** The UI surfaces only agents that declare the connector in their `REQUIRED_CONNECTORS` class attribute. For `mcp-github` that's only `Connectors Demo` — `Chat` (`builtin:chat`) does not appear even though activations can be set for it via CLI/SDK and the runtime filter honours them. Worth widening the panel for MCP-consuming agents that load servers from `~/.gaia/mcp_servers.json`.
- **`tests/unit/test_file_tools.py` hangs.** Running the full unit suite (`pytest tests/unit/`) hangs on this file. Pre-existing — not introduced by this PR — but worth a separate bug.
- **Stale `.env.example` and `LEMONADE_BASE_URL`.** Both this repo's and a sibling checkout's `.env.example` still pin `LEMONADE_BASE_URL=http://localhost:8000/api/v1`, the pre-v10.1 port. Anyone copying `.env.example` → `.env` against Lemonade v10.1+ gets a silent connection-refused that surfaces as "Lemonade server is not running" — actionable error wording would help, but updating `.env.example` to `13305` (or removing the line so the built-in default applies) is the cleanest fix.
- **Misleading "Lemonade server is not running" warning.** `lemonade_manager.py:353` logs that exact string when `health_check` raises, without naming the URL it tried. Including `status.url` + `status.error` would have surfaced the wrong-port mismatch immediately.
- **Stale eval baseline.** `tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/scorecard_rag_quality.json` was captured against a now-removed scenario list. A refresh with `--save-baseline` would make future deltas meaningful.
- **`CONTRIBUTING.md` is silent on fork workflow.** Step 2 says "Branch off `main`" without mentioning that external contributors need to fork first (only AMD maintainers have direct push access). A one-line clarification would help the next external contributor avoid the same "Permission to amd/gaia.git denied" surprise.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #1005`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/connectors/ …`).
- [x] I have updated documentation if user-visible behavior changed — `docs/sdk/infrastructure/connectors.mdx` and `docs/security/connections.mdx` updated.
