### PR TITLE
Skip unreadable agent dirs during export

### DIFF
--- a/src/gaia/installer/export_import.py
+++ b/src/gaia/installer/export_import.py
@@ -98,7 +98,11 @@ def _is_custom_agent_dir(path: Path) -> bool:
     were removed in v0.17.5; such directories are intentionally excluded
     from export so we don't ship bundles that the importer would reject.
     """
-    return path.is_dir() and (path / "agent.py").is_file()
+    try:
+        return path.is_dir() and (path / "agent.py").is_file()
+    except OSError as exc:
+        log.debug("export: skipping unreadable path %s: %s", path, exc)
+        return False
 
 
 def list_exportable_custom_agent_dirs() -> List[Path]:

--- a/tests/unit/test_export_import.py
+++ b/tests/unit/test_export_import.py
@@ -21,6 +21,7 @@ from gaia.installer.export_import import (
     ImportResult,
     export_custom_agents,
     import_agent_bundle,
+    list_exportable_custom_agent_dirs,
 )
 
 # ---------------------------------------------------------------------------
@@ -117,6 +118,23 @@ def test_export_import_round_trip(tmp_path, fake_home, agents_root):
     assert (restored / "agent.py").is_file()
     assert (restored / "notes.txt").read_text() == "hello"
     assert (restored / "sub" / "helper.py").read_text() == "x = 1\n"
+
+
+def test_exportable_agent_dirs_skip_unreadable_entries(agents_root, monkeypatch):
+    valid_agent = _make_agent(agents_root, "valid-agent")
+    locked_agent = agents_root / "locked-agent"
+    locked_agent.mkdir()
+
+    original_is_file = Path.is_file
+
+    def flaky_is_file(self):
+        if self == locked_agent / "agent.py":
+            raise PermissionError("access denied")
+        return original_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", flaky_is_file)
+
+    assert list_exportable_custom_agent_dirs() == [valid_agent]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #830.

`_is_custom_agent_dir()` currently lets filesystem errors from the `agent.py` probe escape while scanning `~/.gaia/agents`. On Windows, that means one restricted sibling directory can break Export All for otherwise valid agents.

This catches `OSError` around the directory check, logs a debug skip reason, and treats unreadable entries as non-exportable. The regression test covers a valid custom agent next to an entry whose `agent.py` probe raises `PermissionError`.

Tested:
- `PYTHONPATH=src python -m pytest tests/unit/test_export_import.py -q`
- `python -m ruff check src/gaia/installer/export_import.py tests/unit/test_export_import.py`
- `python -m compileall -q src/gaia/installer/export_import.py tests/unit/test_export_import.py`
- `git diff --check`