### PR TITLE
ci(claude): upgrade Opus jobs from 4.7 to 4.8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -446,7 +446,7 @@ jobs:
 
           claude_args: |
             --max-turns 50
-            --model claude-opus-4-7
+            --model claude-opus-4-8
             --allowedTools Edit,Read,Write,Grep,Glob,Bash
 
   # Respond to new issues or @claude mentions in PR conversations (including forks)
@@ -654,7 +654,7 @@ jobs:
 
           claude_args: |
             --max-turns 50
-            --model claude-opus-4-7
+            --model claude-opus-4-8
             --allowedTools Edit,Read,Write,Grep,Glob,Bash
 
   # Auto-fix: attempt to implement a fix for bulletproof, easy bug reports
@@ -875,7 +875,7 @@ jobs:
 
           claude_args: |
             --max-turns 30
-            --model claude-opus-4-7
+            --model claude-opus-4-8
             --allowedTools Edit,Read,Write,Grep,Glob,Bash
 
   # Generate release notes when PyPi workflow completes successfully on a tag
@@ -1163,7 +1163,7 @@ jobs:
 
           claude_args: |
             --max-turns 30
-            --model claude-opus-4-7
+            --model claude-opus-4-8
             --allowedTools Edit,Read,Write,Grep,Glob,Bash
 
       - name: Verify and validate release notes


### PR DESCRIPTION
Opus 4.8 released today — 69.2% on SWE-Bench Pro (up from 4.7's 64.3%), 4x fewer unmentioned code flaws. Upgrades all four Opus-backed jobs (pr-comment, issue-handler, auto-fix, release-notes). Sonnet 4.6 stays on pr-review for cost.

## Test plan

- [ ] Merge, then comment `@claude` on any PR — `issue-handler` should respond using Opus 4.8
- [ ] Open a bug issue with `bug` label — `auto-fix` triage should run on Opus 4.8