### PR TITLE
feat(ci): add post-publish smoke test to validate PyPI install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -416,12 +416,14 @@ jobs:
         run: |
           for attempt in 1 2 3 4 5; do
             echo "Attempt $attempt: pip install amd-gaia==$TAG_VERSION"
-            if pip install "amd-gaia==$TAG_VERSION"; then
+            if pip install --no-cache-dir "amd-gaia==$TAG_VERSION"; then
               echo "Installed amd-gaia==$TAG_VERSION successfully"
               exit 0
             fi
-            echo "PyPI package not available yet, waiting 30s..."
-            sleep 30
+            if [ "$attempt" -lt 5 ]; then
+              echo "PyPI package not available yet, waiting 30s..."
+              sleep 30
+            fi
           done
           echo "ERROR: Failed to install amd-gaia==$TAG_VERSION after 5 attempts"
           exit 1
@@ -432,7 +434,7 @@ jobs:
         run: |
           VERSION_OUTPUT=$(gaia --version)
           echo "gaia --version: $VERSION_OUTPUT"
-          if ! echo "$VERSION_OUTPUT" | grep -q "$TAG_VERSION"; then
+          if ! echo "$VERSION_OUTPUT" | grep -qF "$TAG_VERSION"; then
             echo "ERROR: version output does not contain $TAG_VERSION"
             exit 1
           fi
@@ -459,10 +461,10 @@ jobs:
 
   github-release:
     name: GitHub Release
-    needs: [validate, publish-pypi, publish-npm, build-desktop-installers]
+    needs: [validate, post-publish-smoke, publish-npm, build-desktop-installers]
     if: >-
       !cancelled() &&
-      needs.publish-pypi.result == 'success' &&
+      needs.post-publish-smoke.result == 'success' &&
       needs.publish-npm.result == 'success' &&
       needs.build-desktop-installers.result == 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@
 #   validate → build (pypi + npm + desktop installers, parallel)
 #     → approve (single manual gate)
 #       → publish (pypi + npm, parallel)
+#         → post-publish smoke test (PyPI install verification)
 #         → github release (sigstore + desktop installers)
 #
 # Environment setup (one-time, in GitHub repo settings):
@@ -395,6 +396,63 @@ jobs:
           echo ""
           echo "Install with:"
           echo "  npm install -g @amd-gaia/agent-ui@$TAG_VERSION"
+
+  # ── Post-publish: smoke-test the PyPI package ───────────────────────
+
+  post-publish-smoke:
+    name: Post-Publish Smoke Test
+    needs: [validate, publish-pypi]
+    if: needs.publish-pypi.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install from PyPI (with retry for propagation delay)
+        env:
+          TAG_VERSION: ${{ needs.validate.outputs.tag_version }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            echo "Attempt $attempt: pip install amd-gaia==$TAG_VERSION"
+            if pip install "amd-gaia==$TAG_VERSION"; then
+              echo "Installed amd-gaia==$TAG_VERSION successfully"
+              exit 0
+            fi
+            echo "PyPI package not available yet, waiting 30s..."
+            sleep 30
+          done
+          echo "ERROR: Failed to install amd-gaia==$TAG_VERSION after 5 attempts"
+          exit 1
+
+      - name: Verify gaia --version
+        env:
+          TAG_VERSION: ${{ needs.validate.outputs.tag_version }}
+        run: |
+          VERSION_OUTPUT=$(gaia --version)
+          echo "gaia --version: $VERSION_OUTPUT"
+          if ! echo "$VERSION_OUTPUT" | grep -q "$TAG_VERSION"; then
+            echo "ERROR: version output does not contain $TAG_VERSION"
+            exit 1
+          fi
+
+      - name: Verify CLI entry points
+        run: |
+          gaia --help
+          gaia-code --help
+          gaia-mcp --help
+
+      - name: Verify Python import
+        env:
+          TAG_VERSION: ${{ needs.validate.outputs.tag_version }}
+        run: |
+          IMPORT_VERSION=$(python -c "import gaia; print(gaia.__version__)")
+          echo "gaia.__version__: $IMPORT_VERSION"
+          if [ "$IMPORT_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: gaia.__version__ ($IMPORT_VERSION) != tag ($TAG_VERSION)"
+            exit 1
+          fi
 
   # ── Stage 5: GitHub Release ─────────────────────────────────────────
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -442,15 +442,16 @@ jobs:
           gaia --help
           gaia-code --help
           gaia-mcp --help
+          gaia-emr --help
 
       - name: Verify Python import
         env:
           TAG_VERSION: ${{ needs.validate.outputs.tag_version }}
         run: |
-          IMPORT_VERSION=$(python -c "import gaia; print(gaia.__version__)")
-          echo "gaia.__version__: $IMPORT_VERSION"
+          IMPORT_VERSION=$(python -c "from importlib.metadata import version; print(version('amd-gaia'))")
+          echo "amd-gaia version: $IMPORT_VERSION"
           if [ "$IMPORT_VERSION" != "$TAG_VERSION" ]; then
-            echo "ERROR: gaia.__version__ ($IMPORT_VERSION) != tag ($TAG_VERSION)"
+            echo "ERROR: installed version ($IMPORT_VERSION) != tag ($TAG_VERSION)"
             exit 1
           fi
 


### PR DESCRIPTION
After `publish.yml` publishes to PyPI, there's no verification that the package actually installs and works — a broken wheel can reach users undetected. This adds a `post-publish-smoke` job that installs `amd-gaia` from PyPI on a fresh runner and verifies all CLI entry points and the Python import work with the correct version.

## Test plan

- [ ] Review the new `post-publish-smoke` job in `.github/workflows/publish.yml`
- [ ] Confirm `needs: [validate, publish-pypi]` and `if: needs.publish-pypi.result == 'success'` are correct
- [ ] Confirm retry loop handles PyPI propagation delay (5 attempts × 30s)
- [ ] Confirm no `continue-on-error: true` — failure is loud
- [ ] Verify the job runs in parallel with `github-release` (not blocking it)

Closes #1156