### PR TITLE
fix(tests): make test_jira.py collectable, add xdist/rerunfailures deps, add shared fixture

### DIFF
--- a/.claude/agents/jira-specialist.md
+++ b/.claude/agents/jira-specialist.md
@@ -13,7 +13,7 @@ You own the GAIA Jira integration: the `JiraAgent`, its JQL templates, the stand
 - Editing the Jira standalone app under `src/gaia/apps/jira/`
 - Adding JQL generation, field mapping, bulk-update, or sprint-planning tools
 - Wiring or debugging Atlassian MCP servers
-- Writing or updating `tests/test_jira.py`
+- Writing or updating `scripts/jira_smoke.py`
 
 ## When NOT to use
 
@@ -28,7 +28,7 @@ You own the GAIA Jira integration: the `JiraAgent`, its JQL templates, the stand
 | `src/gaia/agents/jira/agent.py` | `JiraAgent` implementation |
 | `src/gaia/agents/jira/jql_templates.py` | JQL template library |
 | `src/gaia/apps/jira/` | Standalone Jira app (webui + app.py) |
-| `tests/test_jira.py` | Jira agent tests |
+| `scripts/jira_smoke.py` | Jira agent smoke tests (manual, not pytest) |
 | `docs/guides/jira.mdx` | User guide |
 
 ## CLI

--- a/docs/guides/jira.mdx
+++ b/docs/guides/jira.mdx
@@ -702,25 +702,25 @@ else:
 Run the test suite:
 
 ```bash
-python tests/test_jira.py
+python scripts/jira_smoke.py
 ```
 
 Run with specific options - choose tests interactively:
 
 ```bash
-python tests/test_jira.py --interactive
+python scripts/jira_smoke.py --interactive
 ```
 
 Show debug output:
 
 ```bash
-python tests/test_jira.py --debug
+python scripts/jira_smoke.py --debug
 ```
 
 Display LLM prompts:
 
 ```bash
-python tests/test_jira.py --show-prompts
+python scripts/jira_smoke.py --show-prompts
 ```
 
 ## Limitations

--- a/scripts/jira_smoke.py
+++ b/scripts/jira_smoke.py
@@ -2,55 +2,24 @@
 # Copyright(C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Integration Test Suite for GAIA Jira Agent.
+Manual smoke-test script for the GAIA Jira Agent.
 
-This test suite validates all Jira agent functionality with REAL API calls:
-- Natural language query processing
-- JQL generation and execution
-- Issue creation, search, and updates
-- Multi-criteria queries
-- Error handling and recovery
-- Base agent framework integration
+NOT a pytest test suite — this file uses its own argparse CLI and makes REAL
+Jira API calls (no mocks). It was moved out of tests/ so that ``pytest
+--collect-only`` no longer picks it up with 0 items (see issue #877 Part B).
 
-NO MOCKS - All tests use real Jira API calls.
-Requires ATLASSIAN_SITE_URL, ATLASSIAN_API_KEY, ATLASSIAN_USER_EMAIL environment variables.
+Requires ATLASSIAN_SITE_URL, ATLASSIAN_API_KEY, ATLASSIAN_USER_EMAIL env vars.
 
 Usage:
-    # Run all tests
-    python tests/test_jira.py
-
-    # Run specific test
-    python tests/test_jira.py --test test_basic_fetch_queries
-
-    # Enable debug mode (debug logging, does NOT include prompt display)
-    python tests/test_jira.py --debug
-
-    # Show prompts sent to LLM (separate from debug mode)
-    python tests/test_jira.py --show-prompts
-
-    # Both debug and prompts
-    python tests/test_jira.py --debug --show-prompts
-
-    # Interactive mode - select tests from menu
-    python tests/test_jira.py --interactive
-
-    # Step mode - pause after each test
-    python tests/test_jira.py --step
-
-    # Export results to CSV
-    python tests/test_jira.py --csv results.csv
-
-    # Use Claude API instead of local LLM
-    python tests/test_jira.py --use-claude
-
-    # Use ChatGPT/OpenAI API
-    python tests/test_jira.py --use-chatgpt
-
-    # Use local LLM (default behavior - no flag needed)
-    python tests/test_jira.py
-
-    # Combine flags
-    python tests/test_jira.py --show-prompts --step --csv --use-claude
+    python scripts/jira_smoke.py                          # all tests
+    python scripts/jira_smoke.py --test test_basic_fetch   # one test
+    python scripts/jira_smoke.py --debug                   # debug logging
+    python scripts/jira_smoke.py --show-prompts            # show LLM prompts
+    python scripts/jira_smoke.py --interactive             # menu selection
+    python scripts/jira_smoke.py --step                    # pause between tests
+    python scripts/jira_smoke.py --csv results.csv         # export CSV
+    python scripts/jira_smoke.py --use-claude              # Claude API backend
+    python scripts/jira_smoke.py --use-chatgpt             # OpenAI API backend
 """
 
 import asyncio

--- a/scripts/jira_smoke.py
+++ b/scripts/jira_smoke.py
@@ -12,7 +12,7 @@ Requires ATLASSIAN_SITE_URL, ATLASSIAN_API_KEY, ATLASSIAN_USER_EMAIL env vars.
 
 Usage:
     python scripts/jira_smoke.py                          # all tests
-    python scripts/jira_smoke.py --test test_basic_fetch   # one test
+    python scripts/jira_smoke.py --test test_basic_fetch_queries  # one test
     python scripts/jira_smoke.py --debug                   # debug logging
     python scripts/jira_smoke.py --show-prompts            # show LLM prompts
     python scripts/jira_smoke.py --interactive             # menu selection
@@ -2986,7 +2986,7 @@ class JiraIntegrationTests:
                             break
 
             for method in sorted(failed_methods):
-                print(f"  python tests/test_jira.py --test {method}")
+                print(f"  python scripts/jira_smoke.py --test {method}")
 
         # Detailed results
         print(f"\n📋 DETAILED RESULTS:")

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,8 @@ setup(
             "pytest-benchmark",
             "pytest-mock",
             "pytest-asyncio",
+            "pytest-xdist",
+            "pytest-rerunfailures",
             "pyfakefs",
             "memory_profiler",
             "matplotlib",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ Current fixtures:
 - in_memory_keyring: Session-scoped fixture installing an in-memory keyring backend
   (used by tests/unit/connectors/ to avoid SecretService prerequisite on Linux CI)
 - ui_api_client: Function-scoped TestClient against gaia.ui.server.create_app()
+- mock_lemonade_client: Shared mock for LemonadeClient (requires pytest-mock)
 
 Current options:
 - --hybrid: Run tests with hybrid configuration (cloud + local models)
@@ -79,6 +80,12 @@ def require_lemonade(lemonade_available):
     """
     if not lemonade_available:
         pytest.skip("Lemonade server not available - skipping integration test")
+
+
+@pytest.fixture
+def mock_lemonade_client(mocker):
+    """Shared mock for LemonadeClient — avoids duplicating patch targets across test files."""
+    return mocker.patch("gaia.llm.lemonade_client.LemonadeClient")
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
`pytest --collect-only tests/test_jira.py` was reporting 0 items because the file is a standalone argparse smoke-test script (real Jira API calls, own CLI flags, bool-returning methods) — not a pytest suite. Meanwhile, `pytest-xdist` and `pytest-rerunfailures` were missing from dev deps, and every test file that needed a `LemonadeClient` mock was duplicating the same patch target.

Closes #877 Parts B, C, D (Part A shipped in #1190).

## Test plan

- [ ] `pytest --collect-only tests/test_jira.py` → "file or directory not found" (no longer in tests/)
- [ ] `python scripts/jira_smoke.py --help` still works (file moved, not deleted)
- [ ] `grep -E "pytest-xdist|pytest-rerunfailures" setup.py` shows both deps
- [ ] `grep mock_lemonade_client tests/conftest.py` shows the shared fixture
- [ ] `pytest --collect-only tests/conftest.py` parses without errors