### PR TITLE
ci(coverage): add Codecov integration with 60% project gate

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,24 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+
+ignore:
+  - "tests/"
+  - "docs/"
+  - "scripts/"
+  - "workshop/"
+  - "src/gaia/eval/"
+  - "src/gaia/apps/webui/"
+  - "setup.py"

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -89,13 +89,13 @@ jobs:
             --cov=src/gaia --cov-report=term-missing --cov-report=xml:coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        if: always()
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run DatabaseMixin integration tests
         env:

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -85,7 +85,17 @@ jobs:
           echo "=== Running Unit Tests ==="
           echo "These are fast tests for core SDK components"
           echo ""
-          pytest tests/unit/ -v --tb=short --cov=src/gaia --cov-report=term-missing
+          pytest tests/unit/ -v --tb=short \
+            --cov=src/gaia --cov-report=term-missing --cov-report=xml:coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          flags: unit
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run DatabaseMixin integration tests
         env:

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,7 @@ setup(
         ],
         "dev": [
             "pytest",
+            "pytest-cov",
             "pytest-benchmark",
             "pytest-mock",
             "pytest-asyncio",


### PR DESCRIPTION
Unit tests already ran pytest-cov but the data was never uploaded — no visibility into coverage trends, no PR gates. Now every unit-test run generates `coverage.xml` and uploads it to Codecov (py3.12 leg only to avoid duplicate reports), with a 60% project target and 70% patch target so regressions surface before merge.

**Note:** `CODECOV_TOKEN` must be added to the repo's Actions secrets (Settings → Secrets → Actions) for the upload step to authenticate. Without it the upload silently no-ops (`fail_ci_if_error: false`).

## Test plan
- [ ] Verify `CODECOV_TOKEN` secret is configured in repo settings
- [ ] Merge and confirm the Codecov upload step runs on the next push to main
- [ ] Open a test PR touching `src/gaia/` and verify Codecov posts a coverage status check

Closes #879