### PR TITLE
ci(security): add dependency review scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# CodeQL static analysis (SAST) for the Python codebase.
+# Catches security issues (injection, path traversal, crypto misuse, etc.)
+# that unit tests and linting don't cover.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+  schedule:
+    # Weekly scan — Sundays at 04:17 UTC
+    - cron: '17 4 * * 0'
+  workflow_dispatch:
+
+# Cancel in-progress runs when a new run is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,22 +1,17 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-# CodeQL static analysis (SAST) for the Python codebase.
-# Catches security issues (injection, path traversal, crypto misuse, etc.)
-# that unit tests and linting don't cover.
+# Dependency review (SCA) — flags known-vulnerable or restrictively-licensed
+# dependencies introduced by a PR.  SAST is already handled by GitHub's
+# default CodeQL setup (enabled at the repo level).
 
-name: CodeQL
+name: Dependency Review
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
-  schedule:
-    # Weekly scan — Sundays at 04:17 UTC
-    - cron: '17 4 * * 0'
   workflow_dispatch:
 
 # Cancel in-progress runs when a new run is triggered
@@ -26,27 +21,21 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
+  pull-requests: write
 
 jobs:
-  analyze:
-    name: Analyze (Python)
+  dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
         with:
-          languages: python
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:python"
+          fail-on-severity: high
+          deny-licenses: GPL-3.0, AGPL-3.0
+          comment-summary-in-pr: always

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0
-          comment-summary-in-pr: always
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
The repo has GitHub's default CodeQL setup enabled for Python SAST, but nothing catches known-vulnerable or restrictively-licensed dependencies introduced by PRs. This adds `actions/dependency-review-action` to flag high-severity CVEs and GPL-3.0/AGPL-3.0 licenses before merge, closing the SCA gap identified in #884.

## Test plan
- [ ] Workflow runs on this PR (check the Checks tab for "Dependency Review")
- [ ] PR comment summary appears from the action
- [ ] YAML follows repo conventions (compare with `lint.yml` / `test_security.yml`)

Closes #884