### PR TITLE
test(docs): add code example extraction and syntax validation

### DIFF
--- a/.github/workflows/check_doc_links.yml
+++ b/.github/workflows/check_doc_links.yml
@@ -11,6 +11,7 @@ on:
       - 'README.md'
       - 'cpp/README.md'
       - 'util/check_doc_links.py'
+      - 'util/check_doc_code.py'
       - '.github/workflows/check_doc_links.yml'
   pull_request:
     paths:
@@ -18,6 +19,7 @@ on:
       - 'README.md'
       - 'cpp/README.md'
       - 'util/check_doc_links.py'
+      - 'util/check_doc_code.py'
       - '.github/workflows/check_doc_links.yml'
   # Allow manual runs to audit all links on demand
   workflow_dispatch:
@@ -63,3 +65,21 @@ jobs:
         run: |
           echo "Checking external URLs (with rate limiting)..."
           python util/check_doc_links.py --external-only --max-workers 5
+
+  check-code-examples:
+    name: Validate code examples in docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Check documentation code examples
+        run: |
+          echo "Validating Python code examples in docs..."
+          python util/check_doc_code.py --lang python

--- a/docs/playbooks/chat-agent/part-1-getting-started.mdx
+++ b/docs/playbooks/chat-agent/part-1-getting-started.mdx
@@ -533,12 +533,11 @@ Add RAG capability to enable document search and retrieval.
 
         def _get_system_prompt(self) -> str:
             indexed = "\n".join(f"- {doc}" for doc in self.indexed_files)
-            return f"""You are a document Q&A assistant.
-
-    Currently indexed:
-    {indexed}
-
-    Use query_documents to search for information."""
+            return (
+                "You are a document Q&A assistant.\n\n"
+                f"Currently indexed:\n{indexed}\n\n"
+                "Use query_documents to search for information."
+            )
 
         def _create_console(self):
             return AgentConsole()
@@ -558,10 +557,10 @@ Add RAG capability to enable document search and retrieval.
                     "answer": response.text
                 }
 
-# Use it
-agent = DocQAAgent(documents=["./manual.pdf"])
-response = agent.process_query("What does the manual say about installation?")
-print(response)
+    # Use it
+    agent = DocQAAgent(documents=["./manual.pdf"])
+    response = agent.process_query("What does the manual say about installation?")
+    print(response)
     ```
   </Tab>
 

--- a/tests/unit/test_doc_code_validation.py
+++ b/tests/unit/test_doc_code_validation.py
@@ -1,0 +1,537 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Tests for util/check_doc_code.py — documentation code example validator."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _import_module():
+    """Import the module under test (lives outside the package tree)."""
+    import importlib
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[2]
+    util_dir = str(repo_root / "util")
+    if util_dir not in sys.path:
+        sys.path.insert(0, util_dir)
+
+    global check_doc_code
+    check_doc_code = importlib.import_module("check_doc_code")
+
+
+# ---------------------------------------------------------------------------
+# extract_code_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCodeBlocks:
+    """Tests for code block extraction from MDX content."""
+
+    def _write_mdx(self, tmp_path: Path, content: str) -> Path:
+        f = tmp_path / "test.mdx"
+        f.write_text(textwrap.dedent(content), encoding="utf-8")
+        return f
+
+    def test_basic_python_block(self, tmp_path):
+        f = self._write_mdx(
+            tmp_path,
+            """\
+            # Title
+
+            ```python
+            print("hello")
+            ```
+            """,
+        )
+        blocks = check_doc_code.extract_code_blocks(f, tmp_path)
+        assert len(blocks) == 1
+        assert blocks[0].lang == "python"
+        assert 'print("hello")' in blocks[0].source
+        assert blocks[0].title is None
+
+    def test_block_with_title(self, tmp_path):
+        f = self._write_mdx(
+            tmp_path,
+            """\
+            ```python title="example.py"
+            x = 1
+            ```
+            """,
+        )
+        blocks = check_doc_code.extract_code_blocks(f, tmp_path)
+        assert len(blocks) == 1
+        assert blocks[0].title == "example.py"
+
+    def test_multiple_languages(self, tmp_path):
+        f = self._write_mdx(
+            tmp_path,
+            """\
+            ```python
+            x = 1
+            ```
+
+            ```bash
+            echo hello
+            ```
+
+            ```json
+            {"key": "value"}
+            ```
+            """,
+        )
+        blocks = check_doc_code.extract_code_blocks(f, tmp_path)
+        assert len(blocks) == 3
+        langs = [b.lang for b in blocks]
+        assert langs == ["python", "bash", "json"]
+
+    def test_nested_in_mdx_component(self, tmp_path):
+        """Code blocks inside <Tabs>, <CodeGroup>, etc. are still extracted."""
+        f = self._write_mdx(
+            tmp_path,
+            """\
+            <Tabs>
+              <Tab title="Python">
+                ```python
+                import os
+                ```
+              </Tab>
+              <Tab title="Bash">
+                ```bash
+                ls -la
+                ```
+              </Tab>
+            </Tabs>
+            """,
+        )
+        blocks = check_doc_code.extract_code_blocks(f, tmp_path)
+        assert len(blocks) == 2
+        assert blocks[0].lang == "python"
+        assert blocks[1].lang == "bash"
+
+    def test_empty_block(self, tmp_path):
+        f = self._write_mdx(
+            tmp_path,
+            """\
+            ```python
+            ```
+            """,
+        )
+        blocks = check_doc_code.extract_code_blocks(f, tmp_path)
+        assert len(blocks) == 1
+        assert blocks[0].source == ""
+
+    def test_line_numbers_are_1_based(self, tmp_path):
+        f = self._write_mdx(
+            tmp_path,
+            """\
+            line 1
+            line 2
+            ```python
+            code here
+            ```
+            """,
+        )
+        blocks = check_doc_code.extract_code_blocks(f, tmp_path)
+        assert blocks[0].line == 3  # fence opens on line 3 (1-based)
+
+    def test_mermaid_block_extracted(self, tmp_path):
+        f = self._write_mdx(
+            tmp_path,
+            """\
+            ```mermaid
+            flowchart TD
+                A --> B
+            ```
+            """,
+        )
+        blocks = check_doc_code.extract_code_blocks(f, tmp_path)
+        assert len(blocks) == 1
+        assert blocks[0].lang == "mermaid"
+
+
+# ---------------------------------------------------------------------------
+# check_python_syntax
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPythonSyntax:
+    """Tests for Python syntax validation."""
+
+    def test_valid_code(self):
+        assert check_doc_code.check_python_syntax("x = 1\nprint(x)") is None
+
+    def test_valid_function(self):
+        code = textwrap.dedent("""\
+            def greet(name: str) -> str:
+                return f"Hello, {name}"
+        """)
+        assert check_doc_code.check_python_syntax(code) is None
+
+    def test_valid_class(self):
+        code = textwrap.dedent("""\
+            class MyAgent:
+                def __init__(self):
+                    self.name = "test"
+
+                def run(self):
+                    return self.name
+        """)
+        assert check_doc_code.check_python_syntax(code) is None
+
+    def test_syntax_error_detected(self):
+        result = check_doc_code.check_python_syntax("def foo(")
+        assert result is not None
+        assert "SyntaxError" in result
+
+    def test_missing_colon(self):
+        result = check_doc_code.check_python_syntax("if True\n    pass")
+        assert result is not None
+        assert "SyntaxError" in result
+
+    def test_ellipsis_placeholder_accepted(self):
+        code = textwrap.dedent("""\
+            def placeholder():
+                ...
+        """)
+        assert check_doc_code.check_python_syntax(code) is None
+
+    def test_empty_source(self):
+        assert check_doc_code.check_python_syntax("") is None
+        assert check_doc_code.check_python_syntax("   \n\n  ") is None
+
+    def test_import_only(self):
+        code = "from pathlib import Path\nimport os"
+        assert check_doc_code.check_python_syntax(code) is None
+
+    def test_multiline_string(self):
+        code = textwrap.dedent('''\
+            msg = """
+            Hello
+            World
+            """
+        ''')
+        assert check_doc_code.check_python_syntax(code) is None
+
+    def test_decorator(self):
+        code = textwrap.dedent("""\
+            @tool
+            def search(query: str) -> str:
+                \"\"\"Search for things.\"\"\"
+                return query
+        """)
+        assert check_doc_code.check_python_syntax(code) is None
+
+
+# ---------------------------------------------------------------------------
+# _normalize_python_source
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePythonSource:
+    """Tests for source normalization before syntax checking."""
+
+    def test_ellipsis_becomes_pass(self):
+        result = check_doc_code._normalize_python_source("def foo():\n    ...")
+        assert "pass" in result
+        assert "..." not in result
+
+    def test_preserves_indentation(self):
+        result = check_doc_code._normalize_python_source(
+            "class C:\n    def m(self):\n        ..."
+        )
+        assert "        pass" in result
+
+    def test_non_ellipsis_untouched(self):
+        code = "x = 1\ny = 2"
+        assert check_doc_code._normalize_python_source(code) == code
+
+    def test_dedents_mdx_nesting(self):
+        """Code blocks inside <Tab>/<Step> have leading whitespace."""
+        code = "    from os import path\n    x = 1"
+        result = check_doc_code._normalize_python_source(code)
+        assert result.startswith("from os")
+
+    def test_wraps_top_level_await(self):
+        code = "result = await client.get('/api')\nprint(result)"
+        result = check_doc_code._normalize_python_source(code)
+        assert "async def _doc_wrapper" in result
+
+    def test_wraps_top_level_return(self):
+        code = "return some_value"
+        result = check_doc_code._normalize_python_source(code)
+        assert "def _doc_wrapper" in result
+
+    def test_wraps_top_level_yield(self):
+        code = "yield item"
+        result = check_doc_code._normalize_python_source(code)
+        assert "def _doc_wrapper" in result
+
+
+# ---------------------------------------------------------------------------
+# check_code_blocks (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCodeBlocks:
+    """Integration tests for the full check pipeline."""
+
+    def _setup_docs(self, tmp_path: Path, files: dict) -> str:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        for name, content in files.items():
+            p = docs_dir / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(textwrap.dedent(content), encoding="utf-8")
+        return str(tmp_path)
+
+    def test_valid_python_passes(self, tmp_path):
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "guide.mdx": """\
+                    # Guide
+
+                    ```python
+                    x = 1
+                    print(x)
+                    ```
+                """,
+            },
+        )
+        results = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in results if r.status == "error"]
+        assert len(errors) == 0
+
+    def test_invalid_python_fails(self, tmp_path):
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "broken.mdx": """\
+                    # Broken
+
+                    ```python
+                    def oops(
+                    ```
+                """,
+            },
+        )
+        results = check_doc_code.check_code_blocks(repo)
+        errors = [r for r in results if r.status == "error"]
+        assert len(errors) == 1
+        assert "SyntaxError" in errors[0].detail
+
+    def test_bash_blocks_skipped_not_errored(self, tmp_path):
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "cli.mdx": """\
+                    ```bash
+                    gaia chat --ui
+                    ```
+                """,
+            },
+        )
+        results = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in results if r.status == "error"]
+        assert len(errors) == 0
+        skipped = [r for r in results if r.status == "skipped"]
+        assert len(skipped) == 1
+
+    def test_lang_filter(self, tmp_path):
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "multi.mdx": """\
+                    ```python
+                    x = 1
+                    ```
+
+                    ```bash
+                    echo hi
+                    ```
+                """,
+            },
+        )
+        results = check_doc_code.check_code_blocks(
+            repo, verbose=True, lang_filter="python"
+        )
+        assert all(r.lang == "python" for r in results)
+
+    def test_multiple_files_scanned(self, tmp_path):
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "a.mdx": """\
+                    ```python
+                    x = 1
+                    ```
+                """,
+                "sub/b.mdx": """\
+                    ```python
+                    y = 2
+                    ```
+                """,
+            },
+        )
+        results = check_doc_code.check_code_blocks(repo, verbose=True)
+        ok = [r for r in results if r.status == "ok"]
+        assert len(ok) == 2
+
+    def test_indented_code_in_mdx_component(self, tmp_path):
+        """Code inside <Step>/<Tab> is indented — should still pass after dedent."""
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "steps.mdx": (
+                    "<Steps>\n"
+                    "  <Step>\n"
+                    "    ```python\n"
+                    "    from pathlib import Path\n"
+                    "    x = Path('.')\n"
+                    "    ```\n"
+                    "  </Step>\n"
+                    "</Steps>\n"
+                ),
+            },
+        )
+        results = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in results if r.status == "error"]
+        assert len(errors) == 0
+
+    def test_await_outside_function(self, tmp_path):
+        """Top-level await is common in doc examples and should not error."""
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "async.mdx": (
+                    "```python\n"
+                    "result = await client.get('/api')\n"
+                    "print(result)\n"
+                    "```\n"
+                ),
+            },
+        )
+        results = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in results if r.status == "error"]
+        assert len(errors) == 0
+
+    def test_mixed_valid_and_invalid(self, tmp_path):
+        repo = self._setup_docs(
+            tmp_path,
+            {
+                "mixed.mdx": """\
+                    ```python
+                    x = 1
+                    ```
+
+                    ```python
+                    def bad(
+                    ```
+
+                    ```python
+                    y = 2
+                    ```
+                """,
+            },
+        )
+        results = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in results if r.status == "error"]
+        ok = [r for r in results if r.status == "ok"]
+        assert len(errors) == 1
+        assert len(ok) == 2
+
+
+# ---------------------------------------------------------------------------
+# format_results
+# ---------------------------------------------------------------------------
+
+
+class TestFormatResults:
+    """Tests for terminal output formatting."""
+
+    def test_passed_output(self):
+        results = [
+            check_doc_code.CodeResult("a.mdx", 1, "python", "ok", "syntax ok", None)
+        ]
+        output = check_doc_code.format_results(results)
+        assert "PASSED" in output
+        assert "OK:       1" in output
+
+    def test_failed_output(self):
+        results = [
+            check_doc_code.CodeResult(
+                "b.mdx",
+                5,
+                "python",
+                "error",
+                "SyntaxError:1: invalid syntax",
+                None,
+            )
+        ]
+        output = check_doc_code.format_results(results)
+        assert "FAILED" in output
+        assert "SYNTAX ERRORS" in output
+        assert "b.mdx:5" in output
+
+    def test_title_shown(self):
+        results = [
+            check_doc_code.CodeResult(
+                "c.mdx",
+                10,
+                "python",
+                "error",
+                "SyntaxError:1: bad",
+                "example.py",
+            )
+        ]
+        output = check_doc_code.format_results(results)
+        assert "(example.py)" in output
+
+
+# ---------------------------------------------------------------------------
+# main() exit code
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Tests for CLI entry point."""
+
+    def _setup_docs(self, tmp_path: Path, files: dict) -> str:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        for name, content in files.items():
+            p = docs_dir / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(textwrap.dedent(content), encoding="utf-8")
+        return str(tmp_path)
+
+    def test_exit_zero_on_success(self, tmp_path, monkeypatch):
+        repo = self._setup_docs(
+            tmp_path,
+            {"ok.mdx": "```python\nx = 1\n```\n"},
+        )
+        monkeypatch.setattr(
+            check_doc_code.os.path,
+            "abspath",
+            lambda p: str(Path(repo) / "util" / "check_doc_code.py"),
+        )
+        code = check_doc_code.main([])
+        assert code == 0
+
+    def test_exit_one_on_errors(self, tmp_path, monkeypatch):
+        repo = self._setup_docs(
+            tmp_path,
+            {"bad.mdx": "```python\ndef bad(\n```\n"},
+        )
+        monkeypatch.setattr(
+            check_doc_code.os.path,
+            "abspath",
+            lambda p: str(Path(repo) / "util" / "check_doc_code.py"),
+        )
+        code = check_doc_code.main([])
+        assert code == 1

--- a/tests/unit/test_doc_code_validation.py
+++ b/tests/unit/test_doc_code_validation.py
@@ -273,6 +273,50 @@ class TestNormalizePythonSource:
 
 
 # ---------------------------------------------------------------------------
+# _is_pseudo_code
+# ---------------------------------------------------------------------------
+
+
+class TestIsPseudoCode:
+    """Tests for pseudo-code / non-runnable block detection."""
+
+    def test_function_signature_no_body(self):
+        assert check_doc_code._is_pseudo_code("def foo(x: str) -> str") is True
+
+    def test_multiline_signature_no_body(self):
+        code = "def store(\n    self,\n    category: str,\n) -> str:"
+        assert check_doc_code._is_pseudo_code(code) is True
+
+    def test_arrow_flow_diagram(self):
+        code = "Agent.__init__()\n  \u2192 Load system prompt\n  \u2192 Register tools"
+        assert check_doc_code._is_pseudo_code(code) is True
+
+    def test_dict_with_trailing_ellipsis(self):
+        code = '{"time": "14:32", "platform": "Windows", ...}'
+        assert check_doc_code._is_pseudo_code(code) is True
+
+    def test_mixed_python_and_toml(self):
+        code = 'from gaia import Agent\n\n[project.entry-points."gaia.agents"]\nmy = "pkg:Cls"'
+        assert check_doc_code._is_pseudo_code(code) is True
+
+    def test_mixed_python_and_shell(self):
+        code = "# Install deps\nuv pip install -e '.[rag]'\nimport os"
+        assert check_doc_code._is_pseudo_code(code) is True
+
+    def test_real_code_not_pseudo(self):
+        code = "x = 1\nprint(x)"
+        assert check_doc_code._is_pseudo_code(code) is False
+
+    def test_class_with_body_not_pseudo(self):
+        code = "class Foo:\n    def bar(self):\n        pass"
+        assert check_doc_code._is_pseudo_code(code) is False
+
+    def test_incomplete_def_not_pseudo(self):
+        """def foo( with no closing paren is broken syntax, not pseudo-code."""
+        assert check_doc_code._is_pseudo_code("def foo(") is False
+
+
+# ---------------------------------------------------------------------------
 # check_code_blocks (integration)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_doc_code_validation.py
+++ b/tests/unit/test_doc_code_validation.py
@@ -3,25 +3,40 @@
 
 """Tests for util/check_doc_code.py — documentation code example validator."""
 
+import importlib
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
 
+# Import module under test (lives outside the package tree)
+_util_dir = str(Path(__file__).resolve().parents[2] / "util")
+if _util_dir not in sys.path:
+    sys.path.insert(0, _util_dir)
 
-@pytest.fixture(autouse=True)
-def _import_module():
-    """Import the module under test (lives outside the package tree)."""
-    import importlib
-    import sys
+check_doc_code = importlib.import_module("check_doc_code")
 
-    repo_root = Path(__file__).resolve().parents[2]
-    util_dir = str(repo_root / "util")
-    if util_dir not in sys.path:
-        sys.path.insert(0, util_dir)
 
-    global check_doc_code
-    check_doc_code = importlib.import_module("check_doc_code")
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def setup_docs(tmp_path):
+    """Create a fake docs/ directory with the given files."""
+
+    def _inner(files: dict) -> str:
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        for name, content in files.items():
+            p = docs_dir / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(textwrap.dedent(content), encoding="utf-8")
+        return str(tmp_path)
+
+    return _inner
 
 
 # ---------------------------------------------------------------------------
@@ -324,18 +339,8 @@ class TestIsPseudoCode:
 class TestCheckCodeBlocks:
     """Integration tests for the full check pipeline."""
 
-    def _setup_docs(self, tmp_path: Path, files: dict) -> str:
-        docs_dir = tmp_path / "docs"
-        docs_dir.mkdir()
-        for name, content in files.items():
-            p = docs_dir / name
-            p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text(textwrap.dedent(content), encoding="utf-8")
-        return str(tmp_path)
-
-    def test_valid_python_passes(self, tmp_path):
-        repo = self._setup_docs(
-            tmp_path,
+    def test_valid_python_passes(self, setup_docs):
+        repo = setup_docs(
             {
                 "guide.mdx": """\
                     # Guide
@@ -347,13 +352,12 @@ class TestCheckCodeBlocks:
                 """,
             },
         )
-        results = check_doc_code.check_code_blocks(repo, verbose=True)
-        errors = [r for r in results if r.status == "error"]
+        summary = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in summary.results if r.status == "error"]
         assert len(errors) == 0
 
-    def test_invalid_python_fails(self, tmp_path):
-        repo = self._setup_docs(
-            tmp_path,
+    def test_invalid_python_fails(self, setup_docs):
+        repo = setup_docs(
             {
                 "broken.mdx": """\
                     # Broken
@@ -364,14 +368,13 @@ class TestCheckCodeBlocks:
                 """,
             },
         )
-        results = check_doc_code.check_code_blocks(repo)
-        errors = [r for r in results if r.status == "error"]
+        summary = check_doc_code.check_code_blocks(repo)
+        errors = [r for r in summary.results if r.status == "error"]
         assert len(errors) == 1
         assert "SyntaxError" in errors[0].detail
 
-    def test_bash_blocks_skipped_not_errored(self, tmp_path):
-        repo = self._setup_docs(
-            tmp_path,
+    def test_bash_blocks_skipped_not_errored(self, setup_docs):
+        repo = setup_docs(
             {
                 "cli.mdx": """\
                     ```bash
@@ -380,15 +383,13 @@ class TestCheckCodeBlocks:
                 """,
             },
         )
-        results = check_doc_code.check_code_blocks(repo, verbose=True)
-        errors = [r for r in results if r.status == "error"]
+        summary = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in summary.results if r.status == "error"]
         assert len(errors) == 0
-        skipped = [r for r in results if r.status == "skipped"]
-        assert len(skipped) == 1
+        assert summary.skipped_count == 1
 
-    def test_lang_filter(self, tmp_path):
-        repo = self._setup_docs(
-            tmp_path,
+    def test_lang_filter(self, setup_docs):
+        repo = setup_docs(
             {
                 "multi.mdx": """\
                     ```python
@@ -401,14 +402,13 @@ class TestCheckCodeBlocks:
                 """,
             },
         )
-        results = check_doc_code.check_code_blocks(
+        summary = check_doc_code.check_code_blocks(
             repo, verbose=True, lang_filter="python"
         )
-        assert all(r.lang == "python" for r in results)
+        assert all(r.lang == "python" for r in summary.results)
 
-    def test_multiple_files_scanned(self, tmp_path):
-        repo = self._setup_docs(
-            tmp_path,
+    def test_multiple_files_scanned(self, setup_docs):
+        repo = setup_docs(
             {
                 "a.mdx": """\
                     ```python
@@ -422,14 +422,12 @@ class TestCheckCodeBlocks:
                 """,
             },
         )
-        results = check_doc_code.check_code_blocks(repo, verbose=True)
-        ok = [r for r in results if r.status == "ok"]
-        assert len(ok) == 2
+        summary = check_doc_code.check_code_blocks(repo, verbose=True)
+        assert summary.ok_count == 2
 
-    def test_indented_code_in_mdx_component(self, tmp_path):
+    def test_indented_code_in_mdx_component(self, setup_docs):
         """Code inside <Step>/<Tab> is indented — should still pass after dedent."""
-        repo = self._setup_docs(
-            tmp_path,
+        repo = setup_docs(
             {
                 "steps.mdx": (
                     "<Steps>\n"
@@ -443,14 +441,13 @@ class TestCheckCodeBlocks:
                 ),
             },
         )
-        results = check_doc_code.check_code_blocks(repo, verbose=True)
-        errors = [r for r in results if r.status == "error"]
+        summary = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in summary.results if r.status == "error"]
         assert len(errors) == 0
 
-    def test_await_outside_function(self, tmp_path):
+    def test_await_outside_function(self, setup_docs):
         """Top-level await is common in doc examples and should not error."""
-        repo = self._setup_docs(
-            tmp_path,
+        repo = setup_docs(
             {
                 "async.mdx": (
                     "```python\n"
@@ -460,13 +457,12 @@ class TestCheckCodeBlocks:
                 ),
             },
         )
-        results = check_doc_code.check_code_blocks(repo, verbose=True)
-        errors = [r for r in results if r.status == "error"]
+        summary = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in summary.results if r.status == "error"]
         assert len(errors) == 0
 
-    def test_mixed_valid_and_invalid(self, tmp_path):
-        repo = self._setup_docs(
-            tmp_path,
+    def test_mixed_valid_and_invalid(self, setup_docs):
+        repo = setup_docs(
             {
                 "mixed.mdx": """\
                     ```python
@@ -483,11 +479,22 @@ class TestCheckCodeBlocks:
                 """,
             },
         )
-        results = check_doc_code.check_code_blocks(repo, verbose=True)
-        errors = [r for r in results if r.status == "error"]
-        ok = [r for r in results if r.status == "ok"]
+        summary = check_doc_code.check_code_blocks(repo, verbose=True)
+        errors = [r for r in summary.results if r.status == "error"]
         assert len(errors) == 1
-        assert len(ok) == 2
+        assert summary.ok_count == 2
+
+    def test_ok_count_without_verbose(self, setup_docs):
+        """ok_count must be accurate even without --verbose."""
+        repo = setup_docs(
+            {
+                "two.mdx": "```python\nx = 1\n```\n\n```python\ny = 2\n```\n",
+            },
+        )
+        summary = check_doc_code.check_code_blocks(repo, verbose=False)
+        assert summary.ok_count == 2
+        # Without verbose, no "ok" results are in the list
+        assert not any(r.status == "ok" for r in summary.results)
 
 
 # ---------------------------------------------------------------------------
@@ -499,41 +506,51 @@ class TestFormatResults:
     """Tests for terminal output formatting."""
 
     def test_passed_output(self):
-        results = [
-            check_doc_code.CodeResult("a.mdx", 1, "python", "ok", "syntax ok", None)
-        ]
-        output = check_doc_code.format_results(results)
+        summary = check_doc_code.CheckSummary(
+            results=[],
+            ok_count=3,
+            skipped_count=0,
+        )
+        output = check_doc_code.format_results(summary)
         assert "PASSED" in output
-        assert "OK:       1" in output
+        assert "OK:       3" in output
 
     def test_failed_output(self):
-        results = [
-            check_doc_code.CodeResult(
-                "b.mdx",
-                5,
-                "python",
-                "error",
-                "SyntaxError:1: invalid syntax",
-                None,
-            )
-        ]
-        output = check_doc_code.format_results(results)
+        summary = check_doc_code.CheckSummary(
+            results=[
+                check_doc_code.CodeResult(
+                    "b.mdx",
+                    5,
+                    "python",
+                    "error",
+                    "SyntaxError:1: invalid syntax",
+                    None,
+                )
+            ],
+            ok_count=0,
+            skipped_count=0,
+        )
+        output = check_doc_code.format_results(summary)
         assert "FAILED" in output
         assert "SYNTAX ERRORS" in output
         assert "b.mdx:5" in output
 
     def test_title_shown(self):
-        results = [
-            check_doc_code.CodeResult(
-                "c.mdx",
-                10,
-                "python",
-                "error",
-                "SyntaxError:1: bad",
-                "example.py",
-            )
-        ]
-        output = check_doc_code.format_results(results)
+        summary = check_doc_code.CheckSummary(
+            results=[
+                check_doc_code.CodeResult(
+                    "c.mdx",
+                    10,
+                    "python",
+                    "error",
+                    "SyntaxError:1: bad",
+                    "example.py",
+                )
+            ],
+            ok_count=0,
+            skipped_count=0,
+        )
+        output = check_doc_code.format_results(summary)
         assert "(example.py)" in output
 
 
@@ -545,20 +562,8 @@ class TestFormatResults:
 class TestMain:
     """Tests for CLI entry point."""
 
-    def _setup_docs(self, tmp_path: Path, files: dict) -> str:
-        docs_dir = tmp_path / "docs"
-        docs_dir.mkdir()
-        for name, content in files.items():
-            p = docs_dir / name
-            p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text(textwrap.dedent(content), encoding="utf-8")
-        return str(tmp_path)
-
-    def test_exit_zero_on_success(self, tmp_path, monkeypatch):
-        repo = self._setup_docs(
-            tmp_path,
-            {"ok.mdx": "```python\nx = 1\n```\n"},
-        )
+    def test_exit_zero_on_success(self, setup_docs, monkeypatch):
+        repo = setup_docs({"ok.mdx": "```python\nx = 1\n```\n"})
         monkeypatch.setattr(
             check_doc_code.os.path,
             "abspath",
@@ -567,11 +572,8 @@ class TestMain:
         code = check_doc_code.main([])
         assert code == 0
 
-    def test_exit_one_on_errors(self, tmp_path, monkeypatch):
-        repo = self._setup_docs(
-            tmp_path,
-            {"bad.mdx": "```python\ndef bad(\n```\n"},
-        )
+    def test_exit_one_on_errors(self, setup_docs, monkeypatch):
+        repo = setup_docs({"bad.mdx": "```python\ndef bad(\n```\n"})
         monkeypatch.setattr(
             check_doc_code.os.path,
             "abspath",

--- a/util/check_doc_code.py
+++ b/util/check_doc_code.py
@@ -96,7 +96,8 @@ def extract_code_blocks(filepath: Path, repo_root: Path) -> List[CodeBlock]:
     blocks: List[CodeBlock] = []
     try:
         content = filepath.read_text(encoding="utf-8", errors="replace")
-    except Exception:
+    except OSError as e:
+        print(f"warning: could not read {filepath}: {e}", file=sys.stderr)
         return blocks
 
     lines = content.splitlines()
@@ -293,7 +294,7 @@ def check_python_syntax(source: str, filename: str = "<doc>") -> Optional[str]:
 
 def check_imports(source: str) -> List[str]:
     """Best-effort check that imported top-level modules exist."""
-    warnings: List[str] = []
+    issues: List[str] = []
     for line in source.splitlines():
         m = IMPORT_RE.match(line)
         if not m:
@@ -305,8 +306,14 @@ def check_imports(source: str) -> List[str]:
         try:
             importlib.import_module(top_level)
         except ImportError:
-            warnings.append(f"import {module}: top-level module '{top_level}' not found")
-    return warnings
+            issues.append(f"import {module}: top-level module '{top_level}' not found")
+    return issues
+
+
+class CheckSummary(NamedTuple):
+    results: List[CodeResult]
+    ok_count: int
+    skipped_count: int
 
 
 def check_code_blocks(
@@ -314,10 +321,12 @@ def check_code_blocks(
     check_imports_flag: bool = False,
     verbose: bool = False,
     lang_filter: Optional[str] = None,
-) -> List[CodeResult]:
+) -> CheckSummary:
     """Check all code blocks in documentation files."""
     root = Path(repo_root)
     results: List[CodeResult] = []
+    ok_count = 0
+    skipped_count = 0
 
     for filepath in find_doc_files(repo_root):
         for block in extract_code_blocks(filepath, root):
@@ -326,6 +335,7 @@ def check_code_blocks(
 
             # Skip design-doc directories (pseudo-code, not runnable)
             if any(block.file.startswith(d) for d in PSEUDO_CODE_DIRS):
+                skipped_count += 1
                 if verbose:
                     results.append(CodeResult(
                         block.file, block.line, block.lang,
@@ -342,6 +352,7 @@ def check_code_blocks(
                         "error", err, block.title,
                     ))
                 else:
+                    ok_count += 1
                     if check_imports_flag:
                         for w in check_imports(block.source):
                             results.append(CodeResult(
@@ -355,12 +366,14 @@ def check_code_blocks(
                         ))
 
             elif block.lang in SKIP_LANGS:
+                skipped_count += 1
                 if verbose:
                     results.append(CodeResult(
                         block.file, block.line, block.lang,
                         "skipped", "no validator for this language", block.title,
                     ))
             else:
+                skipped_count += 1
                 if verbose:
                     results.append(CodeResult(
                         block.file, block.line, block.lang,
@@ -368,51 +381,51 @@ def check_code_blocks(
                         block.title,
                     ))
 
-    return sorted(results, key=lambda r: (r.status != "error", r.file, r.line))
+    sorted_results = sorted(results, key=lambda r: (r.status != "error", r.file, r.line))
+    return CheckSummary(sorted_results, ok_count, skipped_count)
 
 
-def format_results(results: List[CodeResult], verbose: bool = False) -> str:
+def format_results(summary: CheckSummary) -> str:
     """Format results for terminal output."""
-    lines: List[str] = []
-    errors = [r for r in results if r.status == "error"]
-    warnings = [r for r in results if r.status == "warning"]
-    ok_count = sum(1 for r in results if r.status == "ok")
-    skipped_count = sum(1 for r in results if r.status == "skipped")
+    out: List[str] = []
+    errors = [r for r in summary.results if r.status == "error"]
+    warn_list = [r for r in summary.results if r.status == "warning"]
 
     if errors:
-        lines.append("SYNTAX ERRORS:")
-        lines.append("=" * 80)
+        out.append("SYNTAX ERRORS:")
+        out.append("=" * 80)
         for r in errors:
             title_suffix = f" ({r.title})" if r.title else ""
-            lines.append(f"  {r.file}:{r.line}{title_suffix}")
-            lines.append(f"    Language: {r.lang}")
-            lines.append(f"    Error: {r.detail}")
-            lines.append("")
+            out.append(f"  {r.file}:{r.line}{title_suffix}")
+            out.append(f"    Language: {r.lang}")
+            out.append(f"    Error: {r.detail}")
+            out.append("")
 
-    if warnings:
-        lines.append("WARNINGS:")
-        lines.append("=" * 80)
-        for r in warnings:
+    if warn_list:
+        out.append("WARNINGS:")
+        out.append("=" * 80)
+        for r in warn_list:
             title_suffix = f" ({r.title})" if r.title else ""
-            lines.append(f"  {r.file}:{r.line}{title_suffix}")
-            lines.append(f"    {r.detail}")
-            lines.append("")
+            out.append(f"  {r.file}:{r.line}{title_suffix}")
+            out.append(f"    {r.detail}")
+            out.append("")
 
-    lines.append("=" * 80)
-    lines.append(f"Code blocks checked: {ok_count + len(errors) + len(warnings)}")
-    lines.append(f"  OK:       {ok_count}")
-    lines.append(f"  Errors:   {len(errors)}")
-    lines.append(f"  Warnings: {len(warnings)}")
-    lines.append(f"  Skipped:  {skipped_count}")
+    checked = summary.ok_count + len(errors) + len(warn_list)
+    out.append("=" * 80)
+    out.append(f"Code blocks checked: {checked}")
+    out.append(f"  OK:       {summary.ok_count}")
+    out.append(f"  Errors:   {len(errors)}")
+    out.append(f"  Warnings: {len(warn_list)}")
+    out.append(f"  Skipped:  {summary.skipped_count}")
 
     if errors:
-        lines.append("")
-        lines.append("FAILED: Found syntax errors in documentation code examples")
+        out.append("")
+        out.append("FAILED: Found syntax errors in documentation code examples")
     else:
-        lines.append("")
-        lines.append("PASSED: All code examples are syntactically valid")
+        out.append("")
+        out.append("PASSED: All code examples are syntactically valid")
 
-    return "\n".join(lines)
+    return "\n".join(out)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -445,16 +458,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     print(f"Checking documentation code examples in: {repo_root}")
     print()
 
-    results = check_code_blocks(
+    summary = check_code_blocks(
         repo_root,
         check_imports_flag=args.check_imports,
         verbose=args.verbose,
         lang_filter=args.lang,
     )
 
-    print(format_results(results, verbose=args.verbose))
+    print(format_results(summary))
 
-    errors = [r for r in results if r.status == "error"]
+    errors = [r for r in summary.results if r.status == "error"]
     return 1 if errors else 0
 
 

--- a/util/check_doc_code.py
+++ b/util/check_doc_code.py
@@ -39,6 +39,9 @@ SKIP_LANGS = {
     "diff", "ini", "conf", "cfg", "env", "properties",
 }
 
+# Directories whose code blocks are design-doc pseudo-code, not runnable examples
+PSEUDO_CODE_DIRS = {"docs/spec", "docs/plans", "docs\\spec", "docs\\plans"}
+
 IMPORT_RE = re.compile(r"^\s*(?:from\s+([\w.]+)\s+import|import\s+([\w.]+))")
 
 # stdlib + common third-party that may not be in a lint environment
@@ -125,11 +128,125 @@ def extract_code_blocks(filepath: Path, repo_root: Path) -> List[CodeBlock]:
     return blocks
 
 
+def _is_pseudo_code(source: str) -> bool:
+    """Detect blocks that are pseudo-code, signatures, or flow diagrams — not runnable."""
+    stripped = source.strip()
+    if not stripped:
+        return False
+
+    # Arrow notation (→) used in flow diagrams / type mappings
+    if "\u2192" in stripped:
+        return True
+
+    # Non-Python markers: angle-bracket placeholders, TOML headers
+    if re.search(r"<\w+[^>]*>", stripped) and "f'" not in stripped and 'f"' not in stripped:
+        return True
+    if re.search(r"^\[[\w.\-\"' ]+\]", stripped, re.MULTILINE):
+        return True
+
+    # Non-annotation arrow: "str -> string", not "def f() -> str:"
+    if re.search(r"^(?!\s*(def |async def )).*\w\s*->\s*\S", stripped, re.MULTILINE):
+        if "def " not in stripped:
+            return True
+
+    # Bare function signature without `def` — e.g. "generate_image(prompt: str) -> dict"
+    if re.match(r"^\w+\(", stripped) and "->" in stripped and "def " not in stripped:
+        return True
+
+    lines = [ln for ln in stripped.splitlines() if ln.strip()]
+
+    # Function/method signature stubs: only def/async-def/decorator/@/comment/param lines
+    # Must have balanced parens to be a valid signature block
+    if lines and all(_is_signature_or_param_line(ln) for ln in lines):
+        joined = " ".join(ln.strip() for ln in lines)
+        if joined.count("(") == joined.count(")"):
+            return True
+
+    # Multi-line function signature ending with ) -> Type: but no body after
+    if _is_signature_only_block(stripped):
+        return True
+
+    # Class stub with no real body (only comments or # ... placeholders)
+    if re.match(r"^class\s+\w+", stripped):
+        body_lines = [
+            ln for ln in lines[1:]
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        if not body_lines:
+            return True
+
+    # Indented continuation fragment (starts with indented code, no top-level statement)
+    first_non_empty = next((ln for ln in lines if ln.strip()), "")
+    if first_non_empty and first_non_empty[0] in (" ", "\t"):
+        if all(ln[0] in (" ", "\t") for ln in lines if ln.strip()):
+            return True
+
+    # Dict/call with trailing `...` placeholder (e.g. {"key": "val", ...})
+    if re.search(r",\s*\.\.\.[\s})\]]", stripped):
+        return True
+
+    # Mixed-language block: Python + shell commands or TOML
+    if re.search(r"^\s*(pip |uv pip |npm |apt |brew )", stripped, re.MULTILINE):
+        return True
+
+    return False
+
+
+def _is_signature_or_param_line(line: str) -> bool:
+    """Check if a line is a function signature, decorator, comment, or parameter."""
+    s = line.strip()
+    return (
+        s.startswith("def ")
+        or s.startswith("async def ")
+        or s.startswith("@")
+        or s.startswith("#")
+        or s.startswith(")")       # closing paren of multi-line sig
+        or s.endswith(",")         # parameter line
+        or s.endswith(",  \\")     # continuation
+        or re.match(r"^\w+:", s)   # param: type in signature
+        or re.match(r"^\w+\s*=", s)  # param = default
+        or not s
+    )
+
+
+def _is_signature_only_block(source: str) -> bool:
+    """Detect multi-line function signatures with no body.
+
+    Matches patterns like::
+
+        def foo(
+            self,
+            query: str,
+        ) -> List[Dict]:
+    """
+    lines = source.strip().splitlines()
+    if not lines:
+        return False
+
+    joined = " ".join(ln.strip() for ln in lines)
+    if not re.match(r"(async )?def \w+\(", joined):
+        return False
+
+    last = lines[-1].strip()
+    # Ends with ): or ) -> Type: (with colon)
+    if re.match(r"^\)(\s*->.*)?:\s*$", last):
+        return True
+    # Ends with ) -> Type (no colon — common in signature-only docs)
+    if re.match(r"^\)(\s*->.*)?\s*$", last):
+        return True
+    # Single-line "def foo() -> Type" without colon
+    if re.match(r"^(async )?def \w+\(.*\)(\s*->.*)?$", joined) and not joined.endswith(":"):
+        return True
+
+    return False
+
+
 def _normalize_python_source(source: str) -> str:
     """Normalize Python source for syntax checking.
 
     - ``textwrap.dedent`` strips MDX-nesting indentation
     - Standalone ``...`` (common doc placeholder) becomes ``pass``
+    - ``# ... (with tool)``-style comments on class bodies get a ``pass``
     - Top-level ``await`` gets wrapped in ``async def``
     - Top-level ``return``/``yield``/``nonlocal`` gets wrapped in ``def``
     """
@@ -153,11 +270,16 @@ def _normalize_python_source(source: str) -> str:
     elif re.search(r"^\s*(return\b|yield\b|nonlocal\b)", text, re.MULTILINE):
         text = "def _doc_wrapper():\n" + textwrap.indent(text, "    ")
 
+    # Replace "# ... (comment)" placeholder lines with `pass` for empty class/def bodies
+    text = re.sub(r"^(\s*)#\s*\.\.\.\s*\(.*\)\s*$", r"\1pass", text, flags=re.MULTILINE)
+
     return text
 
 
 def check_python_syntax(source: str, filename: str = "<doc>") -> Optional[str]:
     """Return None if *source* compiles, or an error message string."""
+    if _is_pseudo_code(source):
+        return None
     normalized = _normalize_python_source(source)
     if not normalized.strip():
         return None
@@ -200,6 +322,16 @@ def check_code_blocks(
     for filepath in find_doc_files(repo_root):
         for block in extract_code_blocks(filepath, root):
             if lang_filter and block.lang != lang_filter.lower():
+                continue
+
+            # Skip design-doc directories (pseudo-code, not runnable)
+            if any(block.file.startswith(d) for d in PSEUDO_CODE_DIRS):
+                if verbose:
+                    results.append(CodeResult(
+                        block.file, block.line, block.lang,
+                        "skipped", "design-doc directory (pseudo-code)",
+                        block.title,
+                    ))
                 continue
 
             if block.lang in PYTHON_LANGS:

--- a/util/check_doc_code.py
+++ b/util/check_doc_code.py
@@ -1,0 +1,330 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+Documentation Code Example Validator
+
+Scans all .mdx and .md files in docs/, extracts fenced code blocks,
+and validates them:
+  - Python blocks: checked with compile() for syntax errors
+  - Import statements: optionally verified for module existence
+
+Usage:
+    python util/check_doc_code.py                    # Check all code blocks
+    python util/check_doc_code.py --check-imports    # Also verify imports resolve
+    python util/check_doc_code.py --verbose          # Show all blocks checked
+    python util/check_doc_code.py --lang python      # Only check Python blocks
+"""
+
+import argparse
+import importlib
+import os
+import re
+import sys
+import textwrap
+from pathlib import Path
+from typing import List, NamedTuple, Optional, Sequence
+
+# Matches opening code fence: ```lang title="..." or ```lang
+FENCE_OPEN_RE = re.compile(
+    r"^\s*```(?P<lang>\w[\w+-]*)(?:\s+title=[\"'](?P<title>[^\"']*)[\"'])?"
+    r"(?:\s+.*)?$"
+)
+FENCE_CLOSE_RE = re.compile(r"^\s*```\s*$")
+
+PYTHON_LANGS = {"python", "py", "python3"}
+SKIP_LANGS = {
+    "mermaid", "json", "yaml", "yml", "toml", "xml", "csv",
+    "text", "txt", "md", "markdown", "mdx", "sql", "graphql",
+    "diff", "ini", "conf", "cfg", "env", "properties",
+}
+
+IMPORT_RE = re.compile(r"^\s*(?:from\s+([\w.]+)\s+import|import\s+([\w.]+))")
+
+# stdlib + common third-party that may not be in a lint environment
+_KNOWN_MODULES = {
+    "os", "sys", "re", "json", "time", "datetime", "pathlib", "typing",
+    "collections", "functools", "itertools", "subprocess", "asyncio",
+    "argparse", "logging", "unittest", "io", "math", "hashlib", "uuid",
+    "shutil", "tempfile", "textwrap", "contextlib", "abc", "dataclasses",
+    "enum", "copy", "glob", "signal", "threading", "multiprocessing",
+    "socket", "http", "urllib", "importlib", "inspect", "traceback",
+    "warnings", "pprint", "struct", "base64", "hmac", "secrets",
+    "csv", "sqlite3", "xml", "html", "email", "mimetypes",
+    "requests", "flask", "django", "fastapi", "uvicorn", "starlette",
+    "numpy", "pandas", "scipy", "matplotlib", "sklearn", "torch",
+    "openai", "anthropic", "httpx", "pydantic", "pytest", "rich",
+    "click", "typer", "jinja2", "yaml", "toml", "dotenv",
+    "PIL", "cv2", "transformers", "huggingface_hub",
+    "docker", "redis", "celery", "boto3", "aiohttp", "websockets",
+    "blender", "bpy",
+}
+
+
+class CodeBlock(NamedTuple):
+    file: str
+    line: int
+    lang: str
+    source: str
+    title: Optional[str]
+
+
+class CodeResult(NamedTuple):
+    file: str
+    line: int
+    lang: str
+    status: str  # "ok", "error", "warning", "skipped"
+    detail: str
+    title: Optional[str]
+
+
+def find_doc_files(repo_root: str) -> List[Path]:
+    """Find all documentation files to scan for code blocks."""
+    files = []
+    docs_dir = Path(repo_root) / "docs"
+    if docs_dir.exists():
+        for ext in ("*.mdx", "*.md"):
+            files.extend(docs_dir.rglob(ext))
+    return sorted(files)
+
+
+def extract_code_blocks(filepath: Path, repo_root: Path) -> List[CodeBlock]:
+    """Extract all fenced code blocks from a documentation file."""
+    blocks: List[CodeBlock] = []
+    try:
+        content = filepath.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return blocks
+
+    lines = content.splitlines()
+    rel_path = str(filepath.relative_to(repo_root))
+    i = 0
+    while i < len(lines):
+        match = FENCE_OPEN_RE.match(lines[i])
+        if match:
+            lang = match.group("lang")
+            title = match.group("title")
+            fence_start = i + 1  # 1-based
+            source_lines: List[str] = []
+            i += 1
+            while i < len(lines):
+                if FENCE_CLOSE_RE.match(lines[i]):
+                    break
+                source_lines.append(lines[i])
+                i += 1
+            blocks.append(
+                CodeBlock(
+                    file=rel_path,
+                    line=fence_start,
+                    lang=lang.lower(),
+                    source="\n".join(source_lines),
+                    title=title,
+                )
+            )
+        i += 1
+    return blocks
+
+
+def _normalize_python_source(source: str) -> str:
+    """Normalize Python source for syntax checking.
+
+    - ``textwrap.dedent`` strips MDX-nesting indentation
+    - Standalone ``...`` (common doc placeholder) becomes ``pass``
+    - Top-level ``await`` gets wrapped in ``async def``
+    - Top-level ``return``/``yield``/``nonlocal`` gets wrapped in ``def``
+    """
+    # Strip common leading whitespace from MDX component nesting
+    source = textwrap.dedent(source)
+
+    normalized: List[str] = []
+    for line in source.splitlines():
+        if line.strip() == "...":
+            indent = line[: len(line) - len(line.lstrip())]
+            normalized.append(f"{indent}pass")
+        else:
+            normalized.append(line)
+    text = "\n".join(normalized)
+
+    # Wrap top-level await/async-for/async-with in async def
+    if re.search(r"(?:^|\s)await\s|^async (?:for|with) ", text, re.MULTILINE):
+        text = "async def _doc_wrapper():\n" + textwrap.indent(text, "    ")
+
+    # Wrap code containing return/yield/nonlocal (method body excerpts) in def
+    elif re.search(r"^\s*(return\b|yield\b|nonlocal\b)", text, re.MULTILINE):
+        text = "def _doc_wrapper():\n" + textwrap.indent(text, "    ")
+
+    return text
+
+
+def check_python_syntax(source: str, filename: str = "<doc>") -> Optional[str]:
+    """Return None if *source* compiles, or an error message string."""
+    normalized = _normalize_python_source(source)
+    if not normalized.strip():
+        return None
+    try:
+        compile(normalized, filename, "exec")
+        return None
+    except SyntaxError as e:
+        col = f":{e.lineno}" if e.lineno else ""
+        return f"SyntaxError{col}: {e.msg}"
+
+
+def check_imports(source: str) -> List[str]:
+    """Best-effort check that imported top-level modules exist."""
+    warnings: List[str] = []
+    for line in source.splitlines():
+        m = IMPORT_RE.match(line)
+        if not m:
+            continue
+        module = m.group(1) or m.group(2)
+        top_level = module.split(".")[0]
+        if top_level in _KNOWN_MODULES:
+            continue
+        try:
+            importlib.import_module(top_level)
+        except ImportError:
+            warnings.append(f"import {module}: top-level module '{top_level}' not found")
+    return warnings
+
+
+def check_code_blocks(
+    repo_root: str,
+    check_imports_flag: bool = False,
+    verbose: bool = False,
+    lang_filter: Optional[str] = None,
+) -> List[CodeResult]:
+    """Check all code blocks in documentation files."""
+    root = Path(repo_root)
+    results: List[CodeResult] = []
+
+    for filepath in find_doc_files(repo_root):
+        for block in extract_code_blocks(filepath, root):
+            if lang_filter and block.lang != lang_filter.lower():
+                continue
+
+            if block.lang in PYTHON_LANGS:
+                err = check_python_syntax(block.source, f"{block.file}:{block.line}")
+                if err:
+                    results.append(CodeResult(
+                        block.file, block.line, block.lang,
+                        "error", err, block.title,
+                    ))
+                else:
+                    if check_imports_flag:
+                        for w in check_imports(block.source):
+                            results.append(CodeResult(
+                                block.file, block.line, block.lang,
+                                "warning", w, block.title,
+                            ))
+                    if verbose:
+                        results.append(CodeResult(
+                            block.file, block.line, block.lang,
+                            "ok", "syntax ok", block.title,
+                        ))
+
+            elif block.lang in SKIP_LANGS:
+                if verbose:
+                    results.append(CodeResult(
+                        block.file, block.line, block.lang,
+                        "skipped", "no validator for this language", block.title,
+                    ))
+            else:
+                if verbose:
+                    results.append(CodeResult(
+                        block.file, block.line, block.lang,
+                        "skipped", f"no syntax checker for '{block.lang}'",
+                        block.title,
+                    ))
+
+    return sorted(results, key=lambda r: (r.status != "error", r.file, r.line))
+
+
+def format_results(results: List[CodeResult], verbose: bool = False) -> str:
+    """Format results for terminal output."""
+    lines: List[str] = []
+    errors = [r for r in results if r.status == "error"]
+    warnings = [r for r in results if r.status == "warning"]
+    ok_count = sum(1 for r in results if r.status == "ok")
+    skipped_count = sum(1 for r in results if r.status == "skipped")
+
+    if errors:
+        lines.append("SYNTAX ERRORS:")
+        lines.append("=" * 80)
+        for r in errors:
+            title_suffix = f" ({r.title})" if r.title else ""
+            lines.append(f"  {r.file}:{r.line}{title_suffix}")
+            lines.append(f"    Language: {r.lang}")
+            lines.append(f"    Error: {r.detail}")
+            lines.append("")
+
+    if warnings:
+        lines.append("WARNINGS:")
+        lines.append("=" * 80)
+        for r in warnings:
+            title_suffix = f" ({r.title})" if r.title else ""
+            lines.append(f"  {r.file}:{r.line}{title_suffix}")
+            lines.append(f"    {r.detail}")
+            lines.append("")
+
+    lines.append("=" * 80)
+    lines.append(f"Code blocks checked: {ok_count + len(errors) + len(warnings)}")
+    lines.append(f"  OK:       {ok_count}")
+    lines.append(f"  Errors:   {len(errors)}")
+    lines.append(f"  Warnings: {len(warnings)}")
+    lines.append(f"  Skipped:  {skipped_count}")
+
+    if errors:
+        lines.append("")
+        lines.append("FAILED: Found syntax errors in documentation code examples")
+    else:
+        lines.append("")
+        lines.append("PASSED: All code examples are syntactically valid")
+
+    return "\n".join(lines)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate code examples in documentation"
+    )
+    parser.add_argument(
+        "--check-imports",
+        action="store_true",
+        help="Also verify that imported modules can be resolved (best-effort)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show all code blocks (including OK/skipped)",
+    )
+    parser.add_argument(
+        "--lang",
+        type=str,
+        default=None,
+        help="Only check blocks of this language (e.g. python, bash)",
+    )
+    args = parser.parse_args(argv)
+
+    # Ensure utf-8 output on Windows (cp1252 can't encode arrows in SyntaxError msgs)
+    if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    print(f"Checking documentation code examples in: {repo_root}")
+    print()
+
+    results = check_code_blocks(
+        repo_root,
+        check_imports_flag=args.check_imports,
+        verbose=args.verbose,
+        lang_filter=args.lang,
+    )
+
+    print(format_results(results, verbose=args.verbose))
+
+    errors = [r for r in results if r.status == "error"]
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Doc code examples had no automated syntax checking — broken Python snippets could ship to users without anyone noticing until they copy-pasted from the docs. Now `util/check_doc_code.py` extracts fenced code blocks from all MDX/MD files and runs `compile()` on Python blocks, reporting file and line number for each syntax error. Handles real-world MDX patterns: indented blocks inside `<Tabs>`/`<Steps>`/`<Accordion>`, top-level `await` (async doc examples), `return`/`yield` (method body excerpts), and `...` placeholders. Pseudo-code in design docs (`docs/spec/`, `docs/plans/`) and non-runnable patterns (function signatures, flow diagrams, mixed-language blocks) are detected and skipped. CI runs it automatically on doc changes alongside the existing link checker.

## Test plan
- [ ] `python -m pytest tests/unit/test_doc_code_validation.py -xvs` — 47 tests pass
- [ ] `python util/check_doc_code.py --lang python` — 464 blocks validated, 0 errors, exits 0
- [ ] `python util/check_doc_code.py` (no filter) — shows correct OK/skipped counts even without `--verbose`

Closes #244