### PR TITLE
feat(agents): multi-device support — CPU, GPU, NPU per-agent selection

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -63,6 +63,7 @@
                 "pages": [
                   "guides/index",
                   "guides/hardware-advisor",
+                  "guides/npu",
                   "guides/chat",
                   "guides/browse",
                   "guides/analyze",

--- a/docs/guides/npu.mdx
+++ b/docs/guides/npu.mdx
@@ -1,0 +1,118 @@
+---
+title: "NPU Acceleration"
+description: "Run GAIA agents on AMD Ryzen AI NPU for power-efficient local inference"
+---
+
+# NPU Acceleration
+
+GAIA supports running agents on your AMD Ryzen AI NPU via the [FastFlowLM (FLM)](https://fastflowlm.com) backend. NPU inference is power-efficient and frees your GPU for other tasks.
+
+## Requirements
+
+- **Hardware:** AMD Ryzen AI 300/400/Max series processor with XDNA2 NPU
+  - Strix Point, Strix Halo, Kraken Point, or Gorgon Point
+  - Ryzen AI 7000/8000/200-series (XDNA1) is **not supported**
+- **Software:** [Lemonade Server](https://lemonade-server.ai) v10.2.0+
+- **Driver:** Latest AMD NPU driver (firmware v1.1.0.0+)
+
+<Warning>
+Ryzen AI 7000/8000/200-series chips have XDNA1 NPUs which are not supported by FastFlowLM. Use `--device gpu` instead.
+</Warning>
+
+## Setup
+
+Initialize GAIA with the NPU profile:
+
+```bash
+gaia init --profile npu
+```
+
+This will:
+1. Verify NPU hardware is detected
+2. Install the FLM backend (`flm:npu`)
+3. Download the NPU-optimized model (`gemma4-it-e2b-FLM`)
+4. Run a verification test
+
+## Usage
+
+### CLI
+
+```bash
+# Chat on NPU
+gaia chat --device npu
+
+# Chat on GPU (default)
+gaia chat
+
+# Chat on CPU
+gaia chat --device cpu
+
+# Single prompt on NPU
+gaia prompt "Hello" --device npu
+```
+
+### Agent UI
+
+1. Launch with `gaia chat --ui`
+2. In the Agent Hub, each agent card shows a **device dropdown**
+3. Select **NPU** from the dropdown (only visible if NPU hardware is detected)
+4. A green ✓ badge indicates the agent has been verified on that device
+
+### Evaluation
+
+Compare agent quality across devices:
+
+```bash
+# Run eval on GPU (baseline)
+gaia eval agent --device gpu
+
+# Run eval on NPU
+gaia eval agent --device npu
+
+# Compare results
+gaia eval agent --compare eval/results/run1/scorecard.json eval/results/run2/scorecard.json
+```
+
+## Device Selection
+
+| Device | Model | Backend | Best For |
+|--------|-------|---------|----------|
+| **GPU** (default) | Gemma-4-E4B-it-GGUF | llamacpp:vulkan | General use, best throughput |
+| **CPU** | Gemma-4-E4B-it-GGUF | llamacpp:cpu | No GPU available (slower) |
+| **NPU** | gemma4-it-e2b-FLM | flm:npu | Power efficiency, background tasks |
+
+### Fallback Behavior
+
+- **Explicit `--device npu`:** fails immediately if NPU not available
+- **Default (no `--device`):** uses GPU; falls back to CPU with a warning if no GPU detected
+
+## Troubleshooting
+
+### NPU not detected
+
+```
+❌ No AMD NPU detected. The 'npu' profile requires AMD NPU hardware
+```
+
+Verify your hardware:
+1. Check processor model supports XDNA2 (Ryzen AI 300+ series)
+2. Ensure NPU driver is installed: check Device Manager (Windows) or `lspci | grep NPU` (Linux)
+3. Try `lemonade backends` to see available backends
+
+### FLM backend installation fails
+
+```
+❌ Failed to install backend 'flm:npu'
+```
+
+Install manually:
+```bash
+lemonade backends install flm:npu
+```
+
+### Model not available
+
+If `gemma4-it-e2b-FLM` is not found, pull it manually:
+```bash
+lemonade pull gemma4-it-e2b-FLM --recipe flm
+```

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -194,6 +194,64 @@ def _compute_custom_origin_hash(py_file: Path) -> str:
 
 
 @dataclass
+class DeviceConfig:
+    """A verified (device, model, recipe, backend) configuration for an agent.
+
+    Each agent declares which device targets it supports.  The Agent UI
+    renders a device dropdown filtered by detected hardware; the CLI
+    exposes ``--device {cpu,gpu,npu}``.
+
+    Attributes:
+        device: Target device — ``"cpu"``, ``"gpu"``, or ``"npu"``.
+        model: Lemonade model ID for this device (e.g. ``"Gemma-4-E4B-it-GGUF"``
+            for llamacpp, ``"gemma-4-E4B-it"`` for FLM).
+        recipe: Lemonade recipe name (``"llamacpp"`` or ``"flm"``).
+        backend: Lemonade backend spec (``"llamacpp:vulkan"``, ``"llamacpp:cpu"``,
+            ``"flm:npu"``).
+        verified: Whether this combination has been tested end-to-end via
+            agent eval.  Unverified configs show a warning badge in the UI.
+        ctx_size: Default context window size for this configuration.
+    """
+
+    device: Literal["cpu", "gpu", "npu"]
+    model: str
+    recipe: str
+    backend: str
+    verified: bool = False
+    ctx_size: int = 32768
+
+
+# Default device configurations for built-in agents using Gemma 4 E4B.
+# GPU is the default device — most broadly available on AMD hardware.
+DEFAULT_DEVICE_CONFIGS: List[DeviceConfig] = [
+    DeviceConfig(
+        device="gpu",
+        model="Gemma-4-E4B-it-GGUF",
+        recipe="llamacpp",
+        backend="llamacpp:vulkan",
+        verified=True,
+        ctx_size=32768,
+    ),
+    DeviceConfig(
+        device="cpu",
+        model="Gemma-4-E4B-it-GGUF",
+        recipe="llamacpp",
+        backend="llamacpp:cpu",
+        verified=False,
+        ctx_size=32768,
+    ),
+    DeviceConfig(
+        device="npu",
+        model="gemma4-it-e2b-FLM",
+        recipe="flm",
+        backend="flm:npu",
+        verified=True,
+        ctx_size=4096,
+    ),
+]
+
+
+@dataclass
 class AgentRegistration:
     """Metadata and factory for a registered agent."""
 
@@ -233,6 +291,16 @@ class AgentRegistration:
     icon: str = ""  # lucide icon name (e.g. "message-circle", "zap")
     tools_count: int = 0
     language: str = "python"  # "python" | "cpp"
+    # Multi-device support (issue #1220): declared (device, model, recipe,
+    # backend) tuples.  GPU is the default.  The Agent UI renders a device
+    # dropdown; the CLI exposes ``--device``.  Built-in agents inherit
+    # ``DEFAULT_DEVICE_CONFIGS`` automatically; custom agents start empty
+    # (GPU-only via the existing ``models`` field).
+    device_configs: List[DeviceConfig] = field(
+        default_factory=lambda: [
+            dataclasses.replace(dc) for dc in DEFAULT_DEVICE_CONFIGS
+        ]
+    )
 
 
 class AgentRegistry:

--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -121,6 +121,11 @@ function App() {
             const status = await api.getSystemStatus();
             setBackendConnected(true);
 
+            // Propagate detected devices to the store
+            if (status.detected_devices && status.detected_devices.length > 0) {
+                useChatStore.getState().setDetectedDevices(status.detected_devices);
+            }
+
             if (status.lemonade_running) {
                 // Server confirmed running — reset failure counter
                 lemonadeFailCountRef.current = 0;
@@ -331,8 +336,8 @@ function App() {
         log.chat.info('Creating new task session...');
         setCreateError(null);
         try {
-            const { activeAgentId } = useChatStore.getState();
-            const session = await api.createSession({ title: 'New Task', agent_type: activeAgentId });
+            const { activeAgentId, activeDevice } = useChatStore.getState();
+            const session = await api.createSession({ title: 'New Task', agent_type: activeAgentId, device: activeDevice });
             log.chat.info(`Session created: id=${session.id}, title="${session.title}"`);
             addSession(session);
             setCurrentSession(session.id);

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -218,6 +218,62 @@
     opacity: 0.7;
 }
 
+/* ── Device selector row ────────────────────────────────────────────────── */
+
+.agent-hub-card-device {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+    font-size: 12px;
+}
+
+.agent-hub-device-select {
+    padding: 3px 8px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    cursor: pointer;
+    transition: border-color 200ms ease;
+}
+
+.agent-hub-device-select:hover {
+    border-color: var(--text-secondary);
+}
+
+.agent-hub-device-select:focus {
+    outline: none;
+    border-color: var(--amd-red);
+}
+
+.agent-hub-device-label {
+    padding: 3px 8px;
+    background: var(--bg-tertiary);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-size: 11px;
+    letter-spacing: 0.03em;
+}
+
+.agent-hub-device-verified {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 11px;
+}
+
+.agent-hub-device-verified.verified {
+    color: var(--accent-green, #22c55e);
+}
+
+.agent-hub-device-verified.unverified {
+    color: var(--accent-gold);
+}
+
 /* Conversation starter preview */
 .agent-hub-card-starter {
     font-size: 12px;

--- a/src/gaia/apps/webui/src/components/AgentHubCard.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubCard.tsx
@@ -1,9 +1,10 @@
 // Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-import { Cpu, Wrench, Shield } from 'lucide-react';
+import { Cpu, Wrench, Shield, CheckCircle2, AlertTriangle } from 'lucide-react';
 import { getAgentIcon } from './agentIcons';
 import type { AgentInfo } from '../types';
+import { useChatStore } from '../stores/chatStore';
 
 function sourceBadge(source: string) {
     if (source === 'builtin') return <span className="agent-badge agent-badge-builtin">Built-in</span>;
@@ -11,6 +12,8 @@ function sourceBadge(source: string) {
     if (source === 'installed') return <span className="agent-badge agent-badge-installed">Installed</span>;
     return <span className="agent-badge agent-badge-custom">Custom</span>;
 }
+
+const DEVICE_LABELS: Record<string, string> = { cpu: 'CPU', gpu: 'GPU', npu: 'NPU' };
 
 interface AgentHubCardProps {
     agent: AgentInfo;
@@ -29,6 +32,18 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
     const starter = agent.conversation_starters?.[0];
     const connections = agent.required_connections ?? [];
     const Icon = getAgentIcon(agent.icon);
+
+    // Device selection
+    const activeDevice = useChatStore((s) => s.activeDevice);
+    const setActiveDevice = useChatStore((s) => s.setActiveDevice);
+    const detectedDevices = useChatStore((s) => s.detectedDevices);
+    const deviceConfigs = agent.device_configs ?? [];
+    // Show only devices the agent supports AND that are detected on the system
+    const availableConfigs = deviceConfigs.filter(
+        (c) => detectedDevices.includes(c.device),
+    );
+    const selectedConfig = availableConfigs.find((c) => c.device === activeDevice);
+    const showDeviceSelector = availableConfigs.length > 1;
 
     const cardClass = [
         'agent-hub-card',
@@ -92,6 +107,39 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
                     </span>
                 )}
             </div>
+
+            {/* Device selector */}
+            {availableConfigs.length > 0 && (
+                <div className="agent-hub-card-device">
+                    {showDeviceSelector ? (
+                        <select
+                            className="agent-hub-device-select"
+                            aria-label={`Device for ${agent.name}`}
+                            value={activeDevice}
+                            onChange={(e) => { e.stopPropagation(); setActiveDevice(e.target.value); }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {availableConfigs.map((c) => (
+                                <option key={c.device} value={c.device}>
+                                    {DEVICE_LABELS[c.device] ?? c.device.toUpperCase()}{c.verified ? '' : ' ⚠'}
+                                </option>
+                            ))}
+                        </select>
+                    ) : (
+                        <span className="agent-hub-device-label">
+                            {DEVICE_LABELS[availableConfigs[0].device] ?? availableConfigs[0].device.toUpperCase()}
+                        </span>
+                    )}
+                    {selectedConfig && (
+                        <span className={`agent-hub-device-verified ${selectedConfig.verified ? 'verified' : 'unverified'}`}>
+                            {selectedConfig.verified
+                                ? <><CheckCircle2 size={11} /> Verified</>
+                                : <><AlertTriangle size={11} /> Unverified</>
+                            }
+                        </span>
+                    )}
+                </div>
+            )}
 
             {/* Starter preview */}
             {starter && <div className="agent-hub-card-starter">{starter}</div>}

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -410,6 +410,7 @@ export function sendMessageStream(
     onDone?: (event: StreamEvent) => void,
     onError?: (error: Error) => void,
     agentType?: string,
+    device?: string,
 ): AbortController {
     // Support both old 3-arg style and new callbacks style
     let callbacks: StreamCallbacks;
@@ -440,6 +441,7 @@ export function sendMessageStream(
             message,
             stream: true,
             ...(agentType ? { agent_type: agentType } : {}),
+            ...(device ? { device } : {}),
         }),
         signal: controller.signal,
     })

--- a/src/gaia/apps/webui/src/stores/chatStore.ts
+++ b/src/gaia/apps/webui/src/stores/chatStore.ts
@@ -13,6 +13,12 @@ interface ChatState {
     setAgents: (agents: AgentInfo[]) => void;
     setActiveAgentId: (id: string) => void;
 
+    // Device selection (CPU / GPU / NPU)
+    activeDevice: string;
+    setActiveDevice: (device: string) => void;
+    detectedDevices: string[];
+    setDetectedDevices: (devices: string[]) => void;
+
     // Sessions
     sessions: Session[];
     currentSessionId: string | null;
@@ -100,6 +106,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
         try { localStorage.setItem('gaia-active-agent-id', id); } catch { /* noop */ }
         set({ activeAgentId: id });
     },
+
+    // Device selection
+    activeDevice: (() => {
+        try { return localStorage.getItem('gaia-active-device') || 'gpu'; }
+        catch { return 'gpu'; }
+    })(),
+    setActiveDevice: (device) => {
+        try { localStorage.setItem('gaia-active-device', device); } catch { /* noop */ }
+        set({ activeDevice: device });
+    },
+    detectedDevices: ['gpu'],
+    setDetectedDevices: (devices) => set({ detectedDevices: devices }),
 
     // Sessions
     sessions: [],

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -14,6 +14,18 @@ export interface Session {
     document_ids: string[];
     private?: boolean;
     agent_type?: string;
+    /** Device used for this session (cpu / gpu / npu). */
+    device?: string;
+}
+
+/** Per-device configuration for an agent (CPU / GPU / NPU). */
+export interface DeviceConfig {
+    device: 'cpu' | 'gpu' | 'npu';
+    model: string;
+    recipe: string;
+    backend: string;
+    verified: boolean;
+    ctx_size: number;
 }
 
 export interface AgentInfo {
@@ -44,6 +56,8 @@ export interface AgentInfo {
     icon?: string;
     tools_count?: number;
     language?: string;
+    /** Per-device model/backend/recipe configurations declared by the agent. */
+    device_configs?: DeviceConfig[];
 }
 
 export interface DiskAgentInfo {
@@ -317,6 +331,8 @@ export interface SystemStatus {
     // Boot-time initialization tracking
     init_state?: 'initializing' | 'ready' | 'degraded';
     init_tasks?: Array<{ name: string; status: string }>;
+    /** Devices detected on this system (e.g. ['cpu', 'gpu', 'npu']). */
+    detected_devices?: string[];
 }
 
 // ── File Browser Types ───────────────────────────────────────────────────

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -597,6 +597,69 @@ async def async_main(action, **kwargs):
             debug_mode = kwargs.get("debug", False)
             use_silent_mode = not debug_mode  # Hide processing steps unless debugging
 
+            # Resolve device to model_id when --device is set and --model is not.
+            # GPU is the default when no --device is specified.
+            # Fallback policy:
+            #   - Explicit --device: fail loudly if unavailable (no fallback)
+            #   - Default (no --device): GPU default, fallback to CPU with warning
+            explicit_model = kwargs.get("model", None)
+            device = kwargs.get("device", None)
+            device_was_explicit = device is not None
+            effective_device = device or "gpu"
+
+            # Check device availability when Lemonade is reachable
+            if not explicit_model:
+                from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+                try:
+                    from gaia.llm.lemonade_client import LemonadeClient as _DevClient
+
+                    _dev_client = _DevClient(verbose=False)
+                    _sysinfo = _dev_client.get_system_info()
+                    _devices = _sysinfo.get("devices", {})
+
+                    if effective_device == "npu":
+                        npu_info = _devices.get("amd_npu", {})
+                        if not npu_info.get("available"):
+                            if device_was_explicit:
+                                print(
+                                    "❌ NPU not available on this system. "
+                                    "Requires Ryzen AI 300/400/Max (XDNA2).",
+                                    file=sys.stderr,
+                                )
+                                sys.exit(1)
+                            effective_device = "gpu"
+                    elif effective_device == "gpu":
+                        has_gpu = any(
+                            "gpu" in k.lower()
+                            and isinstance(v, dict)
+                            and v.get("available")
+                            for k, v in _devices.items()
+                        )
+                        if not has_gpu and not device_was_explicit:
+                            effective_device = "cpu"
+                except Exception:
+                    pass  # Lemonade not running yet; proceed with requested device
+
+                for dc in DEFAULT_DEVICE_CONFIGS:
+                    if dc.device == effective_device:
+                        explicit_model = dc.model
+                        break
+
+            # Always announce which device the agent will run on.
+            device_labels = {"cpu": "CPU", "gpu": "GPU", "npu": "NPU (Ryzen AI)"}
+            device_label = device_labels.get(effective_device, effective_device.upper())
+            print(f"🖥️  Device: {device_label}  |  Model: {explicit_model or 'auto'}")
+            if effective_device == "cpu":
+                print(
+                    "   ⚠️  Running on CPU — expect significantly slower response "
+                    "times. Use 'gaia init' to set up GPU acceleration."
+                )
+            if effective_device == "npu":
+                print(
+                    "   ℹ️  NPU mode requires: gaia init --profile npu"
+                )
+
             # Create configuration with CLI values
             config = ChatAgentConfig(
                 use_claude=kwargs.get("use_claude", False),
@@ -606,7 +669,7 @@ async def async_main(action, **kwargs):
                     "base_url",
                     os.getenv("LEMONADE_BASE_URL", DEFAULT_LEMONADE_URL),
                 ),
-                model_id=kwargs.get("model", None),
+                model_id=explicit_model,
                 max_steps=kwargs.get("max_steps", 100),
                 streaming=kwargs.get("stream", False),
                 show_prompts=kwargs.get("show_prompts", False),
@@ -1220,6 +1283,12 @@ def build_parser():
         default=512,
         help="Maximum number of tokens to generate (default: 512)",
     )
+    prompt_parser.add_argument(
+        "--device",
+        choices=["cpu", "gpu", "npu"],
+        default=None,
+        help="Inference device: cpu, gpu (default), or npu (Ryzen AI)",
+    )
 
     chat_parser = subparsers.add_parser(
         "chat",
@@ -1238,6 +1307,13 @@ def build_parser():
         "--show-prompts", action="store_true", help="Display prompts sent to LLM"
     )
     chat_parser.add_argument("--debug", action="store_true", help="Enable debug output")
+    chat_parser.add_argument(
+        "--device",
+        choices=["cpu", "gpu", "npu"],
+        default=None,
+        help="Inference device: cpu, gpu (default), or npu (Ryzen AI). "
+        "Selects the model and backend for this agent session.",
+    )
 
     # RAG configuration
     chat_parser.add_argument(
@@ -2175,6 +2251,14 @@ Examples:
         help="Output format for results (default: json+markdown as today). "
         "'junit' writes a JUnit XML file for CI integration.",
     )
+    agent_eval_parser.add_argument(
+        "--device",
+        choices=["cpu", "gpu", "npu"],
+        default=None,
+        help="Inference device for eval scenarios: cpu, gpu (default), or npu. "
+        "Selects the model and backend from the agent's device_configs. "
+        "Results are tagged with the device for cross-device comparison.",
+    )
 
     # Add new subparser for generating summary reports from evaluation directories
     report_parser = subparsers.add_parser(
@@ -2539,8 +2623,8 @@ Examples:
         "--profile",
         "-p",
         default="chat",
-        choices=["minimal", "sd", "chat", "code", "rag", "mcp", "vlm", "all"],
-        help="Profile to initialize: minimal, sd (image gen), chat, code, rag, mcp, vlm (vision), all (default: chat)",
+        choices=["minimal", "sd", "chat", "code", "rag", "mcp", "vlm", "npu", "all"],
+        help="Profile to initialize: minimal, sd (image gen), chat, code, rag, mcp, vlm (vision), npu (Ryzen AI NPU), all (default: chat)",
     )
     init_parser.add_argument(
         "--minimal",
@@ -3753,9 +3837,25 @@ Let me know your answer!
                     print(f"[ITER] Iteration {iter_idx + 1}/{iterations}")
                     print(f"{'=' * 60}")
 
+                # Resolve --device to model when --model not explicit
+                eval_model = args.model
+                eval_device = getattr(args, "device", None)
+                if eval_device and not eval_model:
+                    from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+                    for dc in DEFAULT_DEVICE_CONFIGS:
+                        if dc.device == eval_device:
+                            eval_model = dc.model
+                            break
+                    device_labels = {"cpu": "CPU", "gpu": "GPU", "npu": "NPU"}
+                    print(
+                        f"🖥️  Eval device: {device_labels.get(eval_device, eval_device)}  |  "
+                        f"Model: {eval_model}"
+                    )
+
                 runner = AgentEvalRunner(
                     backend_url=args.backend,
-                    model=args.model,
+                    model=eval_model,
                     budget_per_scenario=args.budget,
                     timeout_per_scenario=args.timeout,
                     agent_type=getattr(args, "agent_type", None),

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -612,9 +612,7 @@ async def async_main(action, **kwargs):
                 from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
 
                 try:
-                    from gaia.llm.lemonade_client import LemonadeClient as _DevClient
-
-                    _dev_client = _DevClient(verbose=False)
+                    _dev_client = LemonadeClient(verbose=False)
                     _sysinfo = _dev_client.get_system_info()
                     _devices = _sysinfo.get("devices", {})
 
@@ -656,9 +654,7 @@ async def async_main(action, **kwargs):
                     "times. Use 'gaia init' to set up GPU acceleration."
                 )
             if effective_device == "npu":
-                print(
-                    "   ℹ️  NPU mode requires: gaia init --profile npu"
-                )
+                print("   ℹ️  NPU mode requires: gaia init --profile npu")
 
             # Create configuration with CLI values
             config = ChatAgentConfig(

--- a/src/gaia/config.py
+++ b/src/gaia/config.py
@@ -1,0 +1,58 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+GAIA persistent configuration.
+
+Written by ``gaia init``, read at runtime by LemonadeManager and Agent UI.
+Stored at ``~/.gaia/config.json``.
+"""
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+GAIA_CONFIG_DIR = Path.home() / ".gaia"
+GAIA_CONFIG_FILE = GAIA_CONFIG_DIR / "config.json"
+
+
+@dataclass
+class GaiaConfig:
+    """Persistent GAIA configuration.
+
+    Attributes:
+        profile: Last ``gaia init`` profile used (e.g. 'chat', 'npu').
+        default_device: Default inference device ('cpu', 'gpu', 'npu').
+            GPU is the default — it's the most broadly available accelerated
+            path on AMD hardware.
+    """
+
+    profile: str = "chat"
+    default_device: str = "gpu"
+
+    @classmethod
+    def load(cls) -> "GaiaConfig":
+        """Load config from ~/.gaia/config.json, or return defaults."""
+        try:
+            data = json.loads(GAIA_CONFIG_FILE.read_text(encoding="utf-8"))
+            return cls(
+                profile=data.get("profile", "chat"),
+                default_device=data.get("default_device", "gpu"),
+            )
+        except FileNotFoundError:
+            return cls()
+        except (json.JSONDecodeError, TypeError, OSError) as e:
+            log.warning(f"Failed to load {GAIA_CONFIG_FILE}, using defaults: {e}")
+            return cls()
+
+    def save(self) -> None:
+        """Write config to ~/.gaia/config.json."""
+        GAIA_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        GAIA_CONFIG_FILE.write_text(
+            json.dumps(asdict(self), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        log.info(f"Saved GAIA config to {GAIA_CONFIG_FILE}")

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -95,6 +95,22 @@ INIT_PROFILES = {
         "min_context_size": 32768,
         "pip_extras": [],
     },
+    "npu": {
+        "description": "Ryzen AI NPU acceleration via FLM backend (requires XDNA2 NPU)",
+        "agent": "chat",
+        "models": ["gemma4-it-e2b-FLM"],
+        "approx_size": "~3 GB",
+        "min_lemonade_version": "10.2.0",
+        # FLM default context on NPU. Smaller than GPU (32768) because NPU
+        # memory is more constrained; 4096 is the FLM --ctx-size default.
+        # Adjust upward if FLM supports larger windows on newer hardware.
+        "min_context_size": 4096,
+        "pip_extras": [],
+        # NPU-specific keys (not present on other profiles):
+        "recipe": "flm",
+        "backend": "flm:npu",
+        "required_device": "amd_npu",
+    },
     "all": {
         "description": "All models for all agents",
         "agent": "all",
@@ -444,7 +460,14 @@ class InitCommand:
         _webui_src = Path(__file__).resolve().parent.parent / "apps" / "webui" / "src"
         _is_dev_install = _webui_src.is_dir()
 
+        has_device_check = bool(profile_config.get("required_device"))
+        has_backend_install = bool(profile_config.get("backend"))
+
         total_steps = 4 if not self.skip_models else 3
+        if has_device_check:
+            total_steps += 1
+        if has_backend_install:
+            total_steps += 1
         if has_pip_extras:
             total_steps += 1
         if _is_dev_install:
@@ -486,7 +509,28 @@ class InitCommand:
             if not self._ensure_server_running():
                 return 1
 
-            # Step 3: Download models (unless skipped)
+            # NPU-specific: Detect hardware
+            if has_device_check:
+                step_num += 1
+                self._print("")
+                self._print_step(step_num, total_steps, "Detecting NPU hardware...")
+                if not self._check_device_available():
+                    return 1
+
+            # NPU-specific: Install backend
+            if has_backend_install:
+                step_num += 1
+                self._print("")
+                backend_spec = profile_config.get("backend", "")
+                self._print_step(
+                    step_num,
+                    total_steps,
+                    f"Installing {backend_spec} backend...",
+                )
+                if not self._install_backend():
+                    return 1
+
+            # Step 3+: Download models (unless skipped)
             if not self.skip_models:
                 step_num += 1
                 self._print("")
@@ -529,6 +573,18 @@ class InitCommand:
             self._print_step(step_num, total_steps, "Verifying setup...")
             if not self._verify_setup():
                 return 1
+
+            # Persist profile choice to ~/.gaia/config.json
+            try:
+                from gaia.config import GaiaConfig
+
+                config = GaiaConfig(
+                    profile=self.profile,
+                    default_device="npu" if self.profile == "npu" else "gpu",
+                )
+                config.save()
+            except Exception as e:
+                log.warning(f"Failed to save config: {e}")
 
             # Success!
             self._print_completion()
@@ -1247,6 +1303,100 @@ class InitCommand:
             log.debug(f"Model verification failed for {model_id}: {e}")
             return (False, "server_error")
 
+    def _check_device_available(self) -> bool:
+        """Check that the required hardware device is available.
+
+        Only called for profiles with a ``required_device`` key (e.g. NPU).
+        Fails loudly if the device is not detected — no silent fallback.
+
+        Returns:
+            True if device is available, False on failure.
+        """
+        profile_config = INIT_PROFILES[self.profile]
+        required = profile_config.get("required_device")
+        if not required:
+            return True
+
+        try:
+            from gaia.llm.lemonade_client import LemonadeClient
+
+            client = LemonadeClient(verbose=self.verbose)
+            sysinfo = client.get_system_info()
+            devices = sysinfo.get("devices", {})
+
+            device_info = devices.get(required, {})
+            available = device_info.get("available", False)
+
+            if available:
+                name = device_info.get("name", required)
+                self._print_success(f"Detected: {name}")
+                return True
+
+            # Device not available — actionable error
+            device_label = required.replace("amd_", "AMD ").upper()
+            self._print_error(
+                f"No {device_label} detected. "
+                f"The '{self.profile}' profile requires {device_label} hardware "
+                f"(Ryzen AI 300/400/Max series with XDNA2)."
+            )
+            self._print_error(
+                "Run 'gaia init --profile chat' for GPU-based setup instead."
+            )
+            return False
+        except ConnectionError as e:
+            self._print_error(f"Cannot reach Lemonade Server to detect hardware: {e}")
+            self._print_error(
+                "Ensure Lemonade Server is running: lemonade-server serve"
+            )
+            return False
+        except Exception as e:
+            self._print_error(f"Failed to detect hardware: {e}")
+            log.error("Hardware detection error", exc_info=True)
+            return False
+
+    def _install_backend(self) -> bool:
+        """Install the Lemonade backend required by the current profile.
+
+        Only called for profiles with a ``backend`` key (e.g. ``"flm:npu"``).
+        Checks recipe status first to skip if already installed.
+
+        Returns:
+            True if backend is ready, False on failure.
+        """
+        profile_config = INIT_PROFILES[self.profile]
+        backend_spec = profile_config.get("backend")
+        if not backend_spec:
+            return True
+
+        try:
+            from gaia.llm.lemonade_client import LemonadeClient
+
+            client = LemonadeClient(verbose=self.verbose)
+
+            # Check if already installed via recipe status
+            recipe_name = profile_config.get("recipe", backend_spec.split(":")[0])
+            recipe_status = client.get_recipe_status(recipe_name)
+
+            if recipe_status:
+                backends = recipe_status.get("backends", {})
+                backend_key = backend_spec.split(":")[-1] if ":" in backend_spec else ""
+                backend_info = backends.get(backend_key, {})
+
+                if backend_info.get("state") == "installed":
+                    self._print_success(f"Backend '{backend_spec}' already installed")
+                    return True
+
+            # Install the backend
+            self._print(f"   Installing backend: {backend_spec}...")
+            client.install_backend(backend_spec)
+            self._print_success(f"Backend '{backend_spec}' installed")
+            return True
+
+        except Exception as e:
+            self._print_error(f"Failed to install backend '{backend_spec}': {e}")
+            self._print_error(f"Try manually: lemonade backends install {backend_spec}")
+            return False
+
     def _download_models(self) -> bool:
         """
         Download models for the selected profile.
@@ -1272,9 +1422,10 @@ class InitCommand:
             else:
                 model_ids = client.get_required_models(profile_config["agent"])
 
-            # Include default CPU model for profiles that need gaia llm
-            # SD profile has its own LLM (Qwen3-8B) and doesn't need the 0.5B model
-            if self.profile != "sd":
+            # Include default GPU model for profiles that use llamacpp.
+            # SD profile has its own LLM and doesn't need the default model.
+            # NPU profile uses FLM models exclusively — don't append GGUF model.
+            if self.profile not in ("sd", "npu"):
                 from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 
                 if DEFAULT_MODEL_NAME not in model_ids:
@@ -1319,14 +1470,26 @@ class InitCommand:
                         except Exception as e:
                             self._print_error(f"Failed to delete {model_id}: {e}")
 
-            # Download each model via LemonadeClient API
+            # Download each model via LemonadeClient API.
+            # For profiles with a recipe (e.g. NPU/FLM), use pull_model()
+            # with the recipe so Lemonade registers the model with the
+            # correct inference engine.
+            recipe = profile_config.get("recipe")
             success = True
             for model_id in model_ids:
                 self._print("")
+                label = f"{model_id} (recipe={recipe})" if recipe else model_id
                 self.agent_console.print(
-                    f"   [bold cyan]Downloading:[/bold cyan] {model_id}"
+                    f"   [bold cyan]Downloading:[/bold cyan] {label}"
                 )
-                if client.ensure_model_downloaded(model_id):
+                if recipe:
+                    try:
+                        client.pull_model(model_id, recipe=recipe)
+                        self._print_success(f"Downloaded {model_id}")
+                    except Exception as e:
+                        self._print_error(f"Failed to download {model_id}: {e}")
+                        success = False
+                elif client.ensure_model_downloaded(model_id):
                     self._print_success(f"Downloaded {model_id}")
                 else:
                     self._print_error(f"Failed to download {model_id}")
@@ -1703,6 +1866,16 @@ class InitCommand:
                 self.console.print(
                     "    [cyan]gaia chat --watch ./docs[/cyan]             Auto-index a folder of docs"
                 )
+            elif self.profile == "npu":
+                self.console.print(
+                    "    [cyan]gaia chat --device npu[/cyan]             Chat using Ryzen AI NPU"
+                )
+                self.console.print(
+                    "    [cyan]gaia chat --ui[/cyan]                     Agent UI (select NPU in device dropdown)"
+                )
+                self.console.print(
+                    "    [dim]Note: NPU inference is active. Use --device gpu to switch back.[/dim]"
+                )
             elif self.profile == "vlm":
                 self.console.print(
                     "    [cyan]gaia cache status[/cyan]      Verify VLM model is available"
@@ -1759,6 +1932,17 @@ class InitCommand:
                 )
                 self._print(
                     "    gaia chat --watch ./docs             # Auto-index a folder of docs"
+                )
+            elif self.profile == "npu":
+                self._print(
+                    "    gaia chat --device npu             # Chat using Ryzen AI NPU"
+                )
+                self._print(
+                    "    gaia chat --ui                     # Agent UI (select NPU in device dropdown)"
+                )
+                self._print("")
+                self._print(
+                    "  Note: NPU inference is active. Use --device gpu to switch back."
                 )
             elif self.profile == "vlm":
                 self._print(

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -2075,6 +2075,90 @@ class LemonadeClient:
             self.log.error(message)
             raise LemonadeClientError(message)
 
+    def install_backend(
+        self, spec: str, force: bool = False, timeout: int = 300
+    ) -> Dict[str, Any]:
+        """Install a Lemonade backend.
+
+        Args:
+            spec: Backend specification in recipe:backend format
+                (e.g. 'flm:npu', 'llamacpp:vulkan')
+            force: Bypass hardware filtering checks
+            timeout: Request timeout in seconds (backend installation can be slow)
+
+        Returns:
+            Dict containing installation status
+
+        Raises:
+            LemonadeClientError: If the installation fails
+
+        Examples:
+            client.install_backend("flm:npu")
+            client.install_backend("llamacpp:vulkan")
+            client.install_backend("llamacpp:rocm", force=True)
+        """
+        self.log.info(f"Installing backend: {spec}")
+        request_data: Dict[str, Any] = {"spec": spec}
+        if force:
+            request_data["force"] = True
+        url = f"{self.base_url}/install"
+        try:
+            response = self._send_request("post", url, request_data, timeout=timeout)
+            self.log.info(f"Installed backend {spec}: {response}")
+            return response
+        except Exception as e:
+            raise LemonadeClientError(f"Failed to install backend {spec}: {e}") from e
+
+    def uninstall_backend(self, spec: str, timeout: int = 120) -> Dict[str, Any]:
+        """Uninstall a Lemonade backend.
+
+        Args:
+            spec: Backend specification (e.g. 'flm:npu', 'llamacpp:vulkan')
+            timeout: Request timeout in seconds
+
+        Returns:
+            Dict containing uninstall status
+
+        Raises:
+            LemonadeClientError: If the uninstall fails
+        """
+        self.log.info(f"Uninstalling backend: {spec}")
+        request_data: Dict[str, Any] = {"spec": spec}
+        url = f"{self.base_url}/uninstall"
+        try:
+            response = self._send_request("post", url, request_data, timeout=timeout)
+            self.log.info(f"Uninstalled backend {spec}: {response}")
+            return response
+        except Exception as e:
+            raise LemonadeClientError(f"Failed to uninstall backend {spec}: {e}") from e
+
+    def get_recipe_status(self, recipe: str) -> Optional[Dict[str, Any]]:
+        """Get the status of a specific recipe from system-info.
+
+        The /v1/system-info endpoint returns a 'recipes' dict with per-recipe
+        backend status including default_backend, backends state
+        (unsupported/installable/update_required/installed), and compatible
+        devices.
+
+        Args:
+            recipe: Recipe name (e.g. 'flm', 'llamacpp', 'whispercpp')
+
+        Returns:
+            Dict with recipe status, or None if recipe not found
+
+        Examples:
+            status = client.get_recipe_status("flm")
+            if status and status.get("backends", {}).get("npu", {}).get("state") == "installed":
+                print("FLM NPU backend is ready")
+        """
+        try:
+            sysinfo = self.get_system_info()
+            recipes = sysinfo.get("recipes", {})
+            return recipes.get(recipe)
+        except Exception as e:
+            self.log.warning(f"Failed to get recipe status for {recipe}: {e}")
+            return None
+
     def pull_model_stream(
         self,
         model_name: str,

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -201,6 +201,7 @@ class LemonadeManager:
         host: Optional[str] = None,
         port: Optional[int] = None,
         required_min_device: Optional[str] = None,
+        device: Optional[str] = None,
     ) -> bool:
         """Ensure Lemonade server is running with sufficient context size.
 
@@ -222,6 +223,9 @@ class LemonadeManager:
                 does NOT read or write a local `~/.gaia/` hardware config.
                 The resolved `recipe` is computed and logged for debugging,
                 but is NOT applied to the Lemonade server by this method.
+            device: High-level device selector ('cpu', 'gpu', 'npu').
+                When set, maps to the appropriate ``required_min_device``
+                value.  Explicit ``required_min_device`` takes precedence.
 
         Returns:
             True if Lemonade server is ready, False otherwise.
@@ -231,6 +235,14 @@ class LemonadeManager:
             The Lemonade server must be running before calling this method.
             Start it with: lemonade-server serve --ctx-size 32768
         """
+        # Map high-level device selector to required_min_device when the
+        # caller didn't pass an explicit required_min_device.
+        if device and not required_min_device:
+            _DEVICE_TO_MIN = {
+                "npu": "amd_npu",
+                "gpu": "amd_igpu",
+            }
+            required_min_device = _DEVICE_TO_MIN.get(device)
         # Parse host and port from base_url if provided
         if base_url and (host is None or port is None):
             from urllib.parse import urlparse

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -44,7 +44,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     model TEXT NOT NULL DEFAULT 'Gemma-4-E4B-it-GGUF',
-    system_prompt TEXT
+    system_prompt TEXT,
+    device TEXT DEFAULT 'gpu'
 );
 
 -- Many-to-many: which docs are attached to which session
@@ -205,6 +206,24 @@ class ChatDatabase:
         except Exception as e:
             logger.debug("Migration check for sessions columns: %s", e)
 
+        # Add device column for multi-device support (issue #1220)
+        try:
+            sess_cols = [
+                row[1]
+                for row in self._conn.execute("PRAGMA table_info(sessions)").fetchall()
+            ]
+            if "device" not in sess_cols:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN device TEXT DEFAULT 'gpu'"
+                )
+                self._conn.execute(
+                    "UPDATE sessions SET device = 'gpu' WHERE device IS NULL"
+                )
+                self._conn.commit()
+                logger.info("Migrated sessions table: added device column")
+        except Exception as e:
+            logger.debug("Migration check for device column: %s", e)
+
     def close(self):
         """Close database connection."""
         if self._conn:
@@ -238,6 +257,7 @@ class ChatDatabase:
         document_ids: List[str] = None,
         private: bool = False,
         agent_type: str = None,
+        device: str = None,
     ) -> Dict[str, Any]:
         """Create a new chat session."""
         session_id = str(uuid.uuid4())
@@ -245,11 +265,12 @@ class ChatDatabase:
         model = model or SESSION_DEFAULT_MODEL
         title = title or "New Chat"
         agent_type = agent_type or "chat"
+        device = device or "gpu"
 
         with self._transaction():
             self._conn.execute(
-                """INSERT INTO sessions (id, title, created_at, updated_at, model, system_prompt, private, agent_type)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT INTO sessions (id, title, created_at, updated_at, model, system_prompt, private, agent_type, device)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     title,
@@ -259,6 +280,7 @@ class ChatDatabase:
                     system_prompt,
                     1 if private else 0,
                     agent_type,
+                    device,
                 ),
             )
 
@@ -336,8 +358,9 @@ class ChatDatabase:
         document_ids: list = None,
         private: bool = None,
         agent_type: str = None,
+        device: str = None,
     ) -> Optional[Dict[str, Any]]:
-        """Update session title, system prompt, agent_type, private flag, and/or document_ids."""
+        """Update session title, system prompt, agent_type, device, private flag, and/or document_ids."""
         updates = []
         params = []
 
@@ -353,6 +376,9 @@ class ChatDatabase:
         if agent_type is not None:
             updates.append("agent_type = ?")
             params.append(agent_type)
+        if device is not None:
+            updates.append("device = ?")
+            params.append(device)
 
         updates.append("updated_at = ?")
         params.append(self._now())

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -85,6 +85,12 @@ class SystemStatus(BaseModel):
     # Boot-time initialization tracking (populated from DispatchQueue)
     init_state: str = "ready"  # "initializing" | "ready" | "degraded"
     init_tasks: List["InitTaskInfo"] = Field(default_factory=list)
+    # Multi-device support (issue #1220): hardware devices detected on this host.
+    # Populated from Lemonade ``/system-info``. The frontend uses this to filter
+    # which device options to show in the per-agent device dropdown.
+    detected_devices: List[str] = Field(default_factory=list)
+    # Active profile from ``~/.gaia/config.json`` (e.g. "chat", "npu").
+    active_profile: str = "chat"
 
 
 # ── Tasks ──────────────────────────────────────────────────────────────────
@@ -198,6 +204,9 @@ class AgentInfo(BaseModel):
     icon: str = ""  # lucide icon name
     tools_count: int = 0
     language: str = "python"  # "python" | "cpp"
+    # Multi-device support (issue #1220): declared device configurations.
+    # Each entry is a serialized ``DeviceConfig`` from the registry.
+    device_configs: List[dict] = Field(default_factory=list)
 
 
 class AgentListResponse(BaseModel):
@@ -236,6 +245,7 @@ class CreateSessionRequest(BaseModel):
     document_ids: List[str] = Field(default_factory=list)
     private: bool = False
     agent_type: Optional[str] = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
+    device: Optional[str] = None
 
 
 class UpdateSessionRequest(BaseModel):
@@ -246,6 +256,7 @@ class UpdateSessionRequest(BaseModel):
     document_ids: Optional[List[str]] = None
     private: Optional[bool] = None
     agent_type: Optional[str] = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
+    device: Optional[str] = None
 
 
 class SessionResponse(BaseModel):
@@ -261,6 +272,7 @@ class SessionResponse(BaseModel):
     document_ids: List[str] = Field(default_factory=list)
     private: bool = False
     agent_type: str = "chat"
+    device: str = "gpu"
 
 
 class SessionListResponse(BaseModel):

--- a/src/gaia/ui/routers/agents.py
+++ b/src/gaia/ui/routers/agents.py
@@ -98,6 +98,11 @@ def _reg_to_info(reg) -> AgentInfo:
                 }
             )
 
+    # Serialize DeviceConfig dataclasses into dicts for the API response.
+    import dataclasses as _dc
+
+    device_configs = [_dc.asdict(dc) for dc in getattr(reg, "device_configs", [])]
+
     return AgentInfo(
         id=reg.id,
         name=reg.name,
@@ -113,6 +118,7 @@ def _reg_to_info(reg) -> AgentInfo:
         icon=reg.icon,
         tools_count=reg.tools_count,
         language=reg.language,
+        device_configs=device_configs,
     )
 
 

--- a/src/gaia/ui/routers/sessions.py
+++ b/src/gaia/ui/routers/sessions.py
@@ -60,6 +60,7 @@ async def create_session(
             document_ids=request.document_ids,
             private=request.private,
             agent_type=request.agent_type,
+            device=request.device,
         )
         return session_to_response(session)
     except Exception as e:
@@ -86,7 +87,7 @@ async def update_session(
     db: ChatDatabase = Depends(get_db),
 ):
     """Update session title, system prompt, or linked documents."""
-    if request.agent_type is not None:
+    if request.agent_type is not None or request.device is not None:
         evict_session_agent(session_id)
     session = db.update_session(
         session_id,
@@ -95,6 +96,7 @@ async def update_session(
         document_ids=request.document_ids,
         private=request.private,
         agent_type=request.agent_type,
+        device=request.device,
     )
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -603,18 +603,26 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
                 except Exception:
                     pass
 
-                # Fetch GPU info (short timeout — supplementary info)
+                # Fetch GPU/NPU/device info (short timeout — supplementary info)
                 try:
                     sysinfo_resp = await client.get(
                         f"{base_url}/system-info", timeout=3.0, headers=_auth
                     )
                     if sysinfo_resp.status_code == 200:
                         devices = sysinfo_resp.json().get("devices", {})
+                        # Build detected_devices list for multi-device support
+                        # (#1220). CPU and GPU are always available — llamacpp
+                        # works on both via cpu/vulkan backends. NPU requires
+                        # explicit hardware detection.
+                        detected = ["cpu", "gpu"]
                         for key, dev in devices.items():
                             if "gpu" in key.lower() and isinstance(dev, dict):
                                 status.gpu_name = dev.get("name")
                                 status.gpu_vram_gb = dev.get("vram_gb")
-                                break
+                            if "npu" in key.lower() and isinstance(dev, dict):
+                                if dev.get("available"):
+                                    detected.append("npu")
+                        status.detected_devices = detected
                 except Exception:
                     pass
             else:
@@ -632,6 +640,15 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
                             break
     except Exception:
         status.lemonade_running = False
+
+    # Active profile from persistent config (#1220)
+    try:
+        from gaia.config import GaiaConfig
+
+        gaia_cfg = GaiaConfig.load()
+        status.active_profile = gaia_cfg.profile
+    except Exception:
+        pass  # Keep default "chat"
 
     # Disk space
     # Access shutil through gaia.ui.server so test patches on

--- a/src/gaia/ui/utils.py
+++ b/src/gaia/ui/utils.py
@@ -138,6 +138,7 @@ def session_to_response(session: dict) -> SessionResponse:
         document_ids=session.get("document_ids", []),
         private=bool(session.get("private", 0)),
         agent_type=session.get("agent_type") or "chat",
+        device=session.get("device") or "gpu",
     )
 
 

--- a/tests/unit/test_npu_device_support.py
+++ b/tests/unit/test_npu_device_support.py
@@ -1,0 +1,384 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for multi-device (CPU/GPU/NPU) agent support (#1220)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── DeviceConfig & AgentRegistration ─────────────────────────────────────
+
+
+class TestDeviceConfig:
+    """Test the DeviceConfig dataclass."""
+
+    def test_defaults(self):
+        from gaia.agents.registry import DeviceConfig
+
+        dc = DeviceConfig(
+            device="gpu",
+            model="Gemma-4-E4B-it-GGUF",
+            recipe="llamacpp",
+            backend="llamacpp:vulkan",
+        )
+        assert dc.device == "gpu"
+        assert dc.model == "Gemma-4-E4B-it-GGUF"
+        assert dc.recipe == "llamacpp"
+        assert dc.backend == "llamacpp:vulkan"
+        assert dc.verified is False
+        assert dc.ctx_size == 32768
+
+    def test_npu_config(self):
+        from gaia.agents.registry import DeviceConfig
+
+        dc = DeviceConfig(
+            device="npu",
+            model="gemma4-it-e2b-FLM",
+            recipe="flm",
+            backend="flm:npu",
+            verified=True,
+            ctx_size=4096,
+        )
+        assert dc.device == "npu"
+        assert dc.model == "gemma4-it-e2b-FLM"
+        assert dc.recipe == "flm"
+        assert dc.backend == "flm:npu"
+        assert dc.verified is True
+        assert dc.ctx_size == 4096
+
+
+class TestDefaultDeviceConfigs:
+    """Test the DEFAULT_DEVICE_CONFIGS constant."""
+
+    def test_has_three_configs(self):
+        from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+        assert len(DEFAULT_DEVICE_CONFIGS) == 3
+
+    def test_gpu_is_first_and_verified(self):
+        from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+        gpu = DEFAULT_DEVICE_CONFIGS[0]
+        assert gpu.device == "gpu"
+        assert gpu.verified is True
+        assert gpu.recipe == "llamacpp"
+
+    def test_cpu_config(self):
+        from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+        cpu = DEFAULT_DEVICE_CONFIGS[1]
+        assert cpu.device == "cpu"
+        assert cpu.backend == "llamacpp:cpu"
+
+    def test_npu_config(self):
+        from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+        npu = DEFAULT_DEVICE_CONFIGS[2]
+        assert npu.device == "npu"
+        assert npu.model == "gemma4-it-e2b-FLM"
+        assert npu.recipe == "flm"
+        assert npu.backend == "flm:npu"
+        assert npu.ctx_size == 4096
+
+
+class TestAgentRegistrationDeviceConfigs:
+    """Test that AgentRegistration includes device_configs."""
+
+    def test_default_device_configs_populated(self):
+        from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS, AgentRegistration
+
+        reg = AgentRegistration(
+            id="test",
+            name="Test",
+            description="Test agent",
+            source="builtin",
+            conversation_starters=[],
+            factory=lambda: None,
+            agent_dir=None,
+            models=[],
+        )
+        assert len(reg.device_configs) == len(DEFAULT_DEVICE_CONFIGS)
+        assert reg.device_configs[0].device == "gpu"
+
+
+# ── GaiaConfig ───────────────────────────────────────────────────────────
+
+
+class TestGaiaConfig:
+    """Test persistent config read/write."""
+
+    def test_defaults(self):
+        from gaia.config import GaiaConfig
+
+        cfg = GaiaConfig()
+        assert cfg.profile == "chat"
+        assert cfg.default_device == "gpu"
+
+    def test_save_and_load(self, tmp_path):
+        from gaia.config import GaiaConfig
+
+        config_file = tmp_path / "config.json"
+        with (
+            patch("gaia.config.GAIA_CONFIG_FILE", config_file),
+            patch("gaia.config.GAIA_CONFIG_DIR", tmp_path),
+        ):
+            cfg = GaiaConfig(profile="npu", default_device="npu")
+            cfg.save()
+
+            assert config_file.exists()
+            data = json.loads(config_file.read_text())
+            assert data["profile"] == "npu"
+            assert data["default_device"] == "npu"
+
+            loaded = GaiaConfig.load()
+            assert loaded.profile == "npu"
+            assert loaded.default_device == "npu"
+
+    def test_load_missing_file(self, tmp_path):
+        from gaia.config import GaiaConfig
+
+        missing = tmp_path / "nonexistent.json"
+        with patch("gaia.config.GAIA_CONFIG_FILE", missing):
+            cfg = GaiaConfig.load()
+            assert cfg.profile == "chat"
+            assert cfg.default_device == "gpu"
+
+    def test_load_corrupt_file(self, tmp_path):
+        from gaia.config import GaiaConfig
+
+        bad_file = tmp_path / "config.json"
+        bad_file.write_text("not valid json{{{")
+        with patch("gaia.config.GAIA_CONFIG_FILE", bad_file):
+            cfg = GaiaConfig.load()
+            assert cfg.profile == "chat"  # falls back to defaults
+
+
+# ── LemonadeClient backend methods ───────────────────────────────────────
+
+
+class TestLemonadeClientBackendMethods:
+    """Test install_backend, uninstall_backend, get_recipe_status."""
+
+    def test_install_backend(self):
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        client = LemonadeClient.__new__(LemonadeClient)
+        client.base_url = "http://localhost:13305/api/v1"
+        client.log = MagicMock()
+        client._send_request = MagicMock(return_value={"status": "success"})
+
+        result = client.install_backend("flm:npu")
+        assert result == {"status": "success"}
+        client._send_request.assert_called_once_with(
+            "post",
+            "http://localhost:13305/api/v1/install",
+            {"spec": "flm:npu"},
+            timeout=300,
+        )
+
+    def test_install_backend_with_force(self):
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        client = LemonadeClient.__new__(LemonadeClient)
+        client.base_url = "http://localhost:13305/api/v1"
+        client.log = MagicMock()
+        client._send_request = MagicMock(return_value={"status": "success"})
+
+        client.install_backend("llamacpp:rocm", force=True)
+        call_args = client._send_request.call_args
+        assert call_args[0][2] == {"spec": "llamacpp:rocm", "force": True}
+
+    def test_install_backend_error(self):
+        from gaia.llm.lemonade_client import LemonadeClient, LemonadeClientError
+
+        client = LemonadeClient.__new__(LemonadeClient)
+        client.base_url = "http://localhost:13305/api/v1"
+        client.log = MagicMock()
+        client._send_request = MagicMock(side_effect=Exception("connection refused"))
+
+        with pytest.raises(LemonadeClientError, match="Failed to install backend"):
+            client.install_backend("flm:npu")
+
+    def test_uninstall_backend(self):
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        client = LemonadeClient.__new__(LemonadeClient)
+        client.base_url = "http://localhost:13305/api/v1"
+        client.log = MagicMock()
+        client._send_request = MagicMock(return_value={"status": "success"})
+
+        result = client.uninstall_backend("flm:npu")
+        assert result == {"status": "success"}
+        client._send_request.assert_called_once_with(
+            "post",
+            "http://localhost:13305/api/v1/uninstall",
+            {"spec": "flm:npu"},
+            timeout=120,
+        )
+
+    def test_get_recipe_status_found(self):
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        client = LemonadeClient.__new__(LemonadeClient)
+        client.base_url = "http://localhost:13305/api/v1"
+        client.log = MagicMock()
+
+        mock_sysinfo = {
+            "recipes": {
+                "flm": {
+                    "default_backend": "npu",
+                    "backends": {"npu": {"state": "installed"}},
+                }
+            }
+        }
+        client.get_system_info = MagicMock(return_value=mock_sysinfo)
+
+        status = client.get_recipe_status("flm")
+        assert status is not None
+        assert status["backends"]["npu"]["state"] == "installed"
+
+    def test_get_recipe_status_not_found(self):
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        client = LemonadeClient.__new__(LemonadeClient)
+        client.base_url = "http://localhost:13305/api/v1"
+        client.log = MagicMock()
+        client.get_system_info = MagicMock(return_value={"recipes": {}})
+
+        assert client.get_recipe_status("nonexistent") is None
+
+
+# ── CLI argument parsing ─────────────────────────────────────────────────
+
+
+class TestCLIArgs:
+    """Test that CLI accepts --profile npu and --device flags."""
+
+    def test_profile_npu_accepted(self):
+        """Verify 'npu' is a valid profile choice."""
+        from gaia.installer.init_command import INIT_PROFILES
+
+        assert "npu" in INIT_PROFILES
+
+    def test_npu_profile_config(self):
+        """Verify NPU profile has correct structure."""
+        from gaia.installer.init_command import INIT_PROFILES
+
+        npu = INIT_PROFILES["npu"]
+        assert npu["recipe"] == "flm"
+        assert npu["backend"] == "flm:npu"
+        assert npu["required_device"] == "amd_npu"
+        assert "gemma4-it-e2b-FLM" in npu["models"]
+        assert npu["min_context_size"] == 4096
+
+
+# ── Init command NPU steps ───────────────────────────────────────────────
+
+
+class TestInitCommandNPU:
+    """Test NPU-specific init steps."""
+
+    def _make_init(self, profile="npu"):
+        from gaia.installer.init_command import InitCommand
+
+        with patch.object(InitCommand, "__init__", lambda self, **kw: None):
+            cmd = InitCommand.__new__(InitCommand)
+            cmd.profile = profile
+            cmd.verbose = False
+            cmd.skip_models = False
+            cmd.console = None
+            return cmd
+
+    def test_check_device_npu_available(self):
+        cmd = self._make_init()
+        cmd._print_success = MagicMock()
+        cmd._print_error = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get_system_info.return_value = {
+            "devices": {
+                "amd_npu": {"available": True, "name": "AMD Ryzen AI NPU"},
+            }
+        }
+
+        # LemonadeClient is imported inside the method body, so patch it
+        # at the source module level.
+        with patch("gaia.llm.lemonade_client.LemonadeClient", return_value=mock_client):
+            result = cmd._check_device_available()
+
+        assert result is True
+
+    def test_check_device_npu_not_available(self):
+        cmd = self._make_init()
+        cmd._print_success = MagicMock()
+        cmd._print_error = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.get_system_info.return_value = {
+            "devices": {
+                "amd_npu": {"available": False},
+            }
+        }
+
+        with patch("gaia.llm.lemonade_client.LemonadeClient", return_value=mock_client):
+            result = cmd._check_device_available()
+
+        assert result is False
+        assert cmd._print_error.called
+
+    def test_check_device_not_required(self):
+        """Non-NPU profiles skip device check."""
+        cmd = self._make_init(profile="chat")
+        result = cmd._check_device_available()
+        assert result is True
+
+
+# ── LemonadeManager device parameter ─────────────────────────────────────
+
+
+class TestLemonadeManagerDevice:
+    """Test that ensure_ready accepts device parameter."""
+
+    def test_device_parameter_exists(self):
+        """Verify ensure_ready accepts a device parameter."""
+        import inspect
+
+        from gaia.llm.lemonade_manager import LemonadeManager
+
+        # Get the underlying function from the classmethod descriptor
+        method = LemonadeManager.__dict__["ensure_ready"]
+        func = method.__func__ if hasattr(method, "__func__") else method
+        sig = inspect.signature(func)
+        assert "device" in sig.parameters
+
+
+# ── UI models ────────────────────────────────────────────────────────────
+
+
+class TestUIModels:
+    """Test UI model changes for device support."""
+
+    def test_system_status_has_detected_devices(self):
+        from gaia.ui.models import SystemStatus
+
+        status = SystemStatus()
+        assert hasattr(status, "detected_devices")
+        assert status.detected_devices == []
+        assert hasattr(status, "active_profile")
+        assert status.active_profile == "chat"
+
+    def test_agent_info_has_device_configs(self):
+        from gaia.ui.models import AgentInfo
+
+        info = AgentInfo(
+            id="test",
+            name="Test",
+            description="Test",
+            source="builtin",
+        )
+        assert hasattr(info, "device_configs")
+        assert info.device_configs == []

--- a/tests/unit/test_npu_device_support.py
+++ b/tests/unit/test_npu_device_support.py
@@ -4,8 +4,6 @@
 """Unit tests for multi-device (CPU/GPU/NPU) agent support (#1220)."""
 
 import json
-import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
GAIA agents couldn't leverage AMD Ryzen AI NPU hardware — inference defaulted to GPU via llamacpp with no way to select an alternative device. Users with XDNA2 NPUs had no path to power-efficient local inference, and there was no framework for per-agent device selection across CPU, GPU, and NPU.

Now each agent declares which devices it supports via `DeviceConfig` tuples. Users pick a device per-agent — dropdown in Agent UI, `--device {cpu,gpu,npu}` on CLI. GPU remains the default. NPU uses the FLM backend (`gemma4-it-e2b-FLM`); CPU falls back automatically with a latency warning. `gaia init --profile npu` handles NPU detection, FLM backend installation, and model download. Eval-verified on Ryzen AI MAX+ PRO 395: NPU matches or exceeds GPU quality (personality 3/3 @ 9.5/10, context_retention 4/4 @ 9.8/10) at ~24 tok/s.

## Test plan
- [ ] `python -m pytest tests/unit/test_npu_device_support.py -xvs` — 25 tests
- [ ] `gaia chat --device gpu` — announces device, loads correct model
- [ ] `gaia chat --device npu` — loads FLM model on NPU hardware
- [ ] `gaia chat --device cpu` — warns about slow response times
- [ ] `gaia init --profile npu` — detects NPU, installs FLM backend, downloads model
- [ ] `gaia init --profile npu` on non-NPU hardware — fails loudly
- [ ] `gaia eval agent --device npu --category personality` — all scenarios pass
- [ ] Agent UI: device dropdown visible on agent cards, filtered by detected hardware