### PR TITLE
fix(security): resolve symlink write-guard bypass on Python 3.10

### DIFF
--- a/src/gaia/security.py
+++ b/src/gaia/security.py
@@ -410,8 +410,11 @@ class PathValidator:
             Tuple of (is_blocked, reason). If blocked, reason explains why.
         """
         try:
-            real_path = Path(os.path.realpath(path)).resolve()
-            real_path_str = str(real_path)
+            # Use os.path.realpath exclusively for symlink resolution — do NOT
+            # chain Path.resolve(), which re-resolves on Python <3.12 via a
+            # separate code path and can disagree with realpath.
+            real_path_str = os.path.realpath(path)
+            real_path = Path(real_path_str)
             # Apply macOS /private normalization so /etc, /var/run, etc. match
             # the BLOCKED_DIRECTORIES entries (they're stored unprefixed).
             norm_path = os.path.normpath(_normalize_macos_symlinks(real_path_str))

--- a/tests/unit/test_security_edge_cases.py
+++ b/tests/unit/test_security_edge_cases.py
@@ -344,12 +344,10 @@ class TestIsWriteBlockedException:
         assert is_blocked is True
         assert "unable to validate" in reason.lower()
 
-    def test_exception_from_path_resolve_returns_blocked(self, validator):
-        """When Path.resolve() raises, is_write_blocked returns (True, reason)."""
+    def test_exception_from_path_construction_returns_blocked(self, validator):
+        """When path construction raises, is_write_blocked returns (True, reason)."""
         with patch("os.path.realpath", return_value="/tmp/test.txt"):
-            with patch.object(
-                Path, "resolve", side_effect=RuntimeError("Resolve failed")
-            ):
+            with patch("os.path.normpath", side_effect=RuntimeError("Normpath failed")):
                 is_blocked, reason = validator.is_write_blocked("/tmp/test.txt")
 
         assert is_blocked is True


### PR DESCRIPTION
Symlinks pointing into blocked directories (`.ssh`, `C:\Windows`, `/etc`, …) were not detected by `is_write_blocked()` on Python <3.12 — the write guardrail returned `False` when it should have returned `True`. The Python 3.10/3.11 version matrix (#1247) surfaced this via `test_symlink_to_blocked_directory_is_blocked`. On 3.12+ the test passed by accident because `Path.resolve()` internally delegates to `os.path.realpath`; on older versions it uses a separate resolver that can disagree after symlink traversal.

The fix drops the redundant `.resolve()` call so `os.path.realpath` is the single source of truth for symlink resolution across all supported Python versions.

## Test plan
- [ ] `python -m pytest tests/unit/test_security_edge_cases.py tests/unit/test_file_write_guardrails.py -xvs` — all 132 pass, 6 skipped (platform-specific)
- [ ] CI matrix passes on Python 3.10, 3.11, 3.12, 3.13