### PR TITLE
fix(webui): use dynamic API base for memoryApi to support random back…

### DIFF
--- a/src/gaia/apps/webui/src/services/memoryApi.ts
+++ b/src/gaia/apps/webui/src/services/memoryApi.ts
@@ -3,7 +3,9 @@
 
 /** API client for the GAIA memory dashboard endpoints. */
 
-const API_BASE = '/api';
+import { getApiBase } from '../utils/apiBase';
+
+const API_BASE = getApiBase();
 
 async function memFetch<T>(method: string, path: string, body?: unknown): Promise<T> {
     const url = `${API_BASE}${path}`;


### PR DESCRIPTION
<!--
Thanks for contributing to GAIA! Every PR must reference a GitHub issue —
see CONTRIBUTING.md (https://github.com/amd/gaia/blob/main/CONTRIBUTING.md)
if you don't have one yet.
-->

## Summary

Fixes the Memory Dashboard toggle — `memoryApi.ts` was using a hardcoded `/api` path instead of the dynamic `getApiBase()`, causing PUT requests to fail when the Electron app runs.

## Why

`memoryApi.ts` was the only API client that didn't use `getApiBase()` from `utils/apiBase.ts`. In the packaged Electron app, the frontend loads via `file://` and the backend binds a random port. The hardcoded `/api` path caused `PUT /api/memory/settings` to resolve incorrectly, resulting in "Failed to update setting" errors. All other API clients (`api.ts`, `useConnectorsSSE.ts`, `CustomAgentsSection.tsx`) already use `getApiBase()` correctly.

## Linked issue

<!--
Required. Use a closing keyword so the issue auto-closes on merge.
Example:  Closes #1258
If this PR only partially addresses an issue, use `Refs #123` instead.
-->

Closes #1258 <!-- replace N with the issue number, e.g. Closes #123 -->

## Changes

- `src/gaia/apps/webui/src/services/memoryApi.ts` — replaced hardcoded `'/api'` with `getApiBase()` import so the memory API client resolves the correct backend URL (random port in Electron, same-origin in dev/pip).
-

## Test plan

<!--
How can a reviewer verify this works? Specific commands beat vague prose.
Mix automated and manual checks as needed.
-->

- [ ] Open GAIA desktop app → open Memory Dashboard (brain icon in sidebar)
- [ ] Click the Memory toggle → confirm Beta confirmation modal appears
- [ ] Click "Enable Memory" → confirm toast "Memory enabled" and toggle switches to "On"
- [ ] Verify `GET /api/memory/settings` returns `{"memory_enabled":true,...}`
- [ ] Repeat for MCP Memory Access and System Discovery toggles

## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described **why** this change is being made, not just what changed.
- [ ] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [ ] I have updated documentation if user-visible behavior changed (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
