### PR TITLE
feat(eval): email-triage throughput benchmark + reusable eval stats/metrics (#1233)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1409,6 +1409,48 @@ gaia eval agent --scenario-dir ~/my-project/eval-scenarios
 
 ---
 
+### Email Throughput Benchmark
+
+Measure end-to-end email-triage throughput (tokens/sec), time-to-first-token, and pipeline latency for an on-device model. Direct-drives the email agent over the committed synthetic corpus and harvests metrics from the agent's per-step stats. The committed bar is **≥10 tok/s** (snappy-UX stretch ~30 tok/s); the benchmark is **non-gating** — a miss is reported, not failed.
+
+```bash
+gaia eval benchmark [OPTIONS]
+```
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--model` | str | `Gemma-4-E4B-it-GGUF` | Lemonade model id to benchmark |
+| `--limit` | int | `50` | Target message count steered to the triage call (effective = min(limit, corpus size)) |
+| `--experiments` | int | `1` | Repeat count per model; >1 prints a variance report |
+| `--mbox-path` | str | stub fixture | MBOX corpus to triage |
+| `--ground-truth` | str | fixture's | Ground-truth JSON for quality scoring |
+| `--backend` | str | agent default | Lemonade base URL |
+| `--output-dir` | str | — | Write `scorecard.json` / `summary.md` / `variance.json` |
+| `--compare` | path | — | Compare throughput against a saved baseline (non-gating) |
+| `--save-baseline` | flag | off | Save this run's scorecard as the throughput baseline |
+
+<CodeGroup>
+```bash Benchmark the primary model
+gaia eval benchmark --model Gemma-4-E4B-it-GGUF --limit 50
+```
+
+```bash Repeat for variance + save a baseline
+gaia eval benchmark --experiments 3 --save-baseline
+```
+
+```bash Compare against a saved baseline
+gaia eval benchmark --compare eval/results/bench_baseline.json
+```
+</CodeGroup>
+
+<Note>
+  Runs from a GAIA repo checkout (it drives the synthetic corpus in `tests/fixtures/email/`) and needs Lemonade serving the target model. Run at most one `gaia eval` process at a time against a single Lemonade server.
+</Note>
+
+---
+
 ### Visualize Command
 
 Launch interactive web-based visualizer for comparing evaluation results.

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -3866,8 +3866,7 @@ Let me know your answer!
 
         # Email-triage throughput benchmark: gaia eval benchmark (#1233)
         if getattr(args, "eval_command", None) == "benchmark":
-            import tempfile as _tempfile
-            from pathlib import Path as _Path
+            import tempfile
 
             from gaia.eval.benchmark import (
                 THROUGHPUT_BAR_TPS,
@@ -3882,7 +3881,7 @@ Let me know your answer!
             mbox_path = args.mbox_path or str(fixtures / "_stub_inbox.mbox")
             gt_path = args.ground_truth or str(fixtures / "ground_truth.json")
             ground_truth = (
-                load_ground_truth(gt_path) if _Path(gt_path).exists() else None
+                load_ground_truth(gt_path) if Path(gt_path).exists() else None
             )
             if ground_truth is None:
                 print(
@@ -3890,7 +3889,7 @@ Let me know your answer!
                     "quality scoring skipped"
                 )
 
-            with _tempfile.TemporaryDirectory(prefix="gaia-bench-") as tmp:
+            with tempfile.TemporaryDirectory(prefix="gaia-bench-") as tmp:
                 results = run_benchmark(
                     args.model,
                     mbox_path=mbox_path,
@@ -3898,7 +3897,7 @@ Let me know your answer!
                     experiments=args.experiments,
                     base_url=args.backend,
                     ground_truth=ground_truth,
-                    db_path=str(_Path(tmp) / "state.db"),
+                    db_path=str(Path(tmp) / "state.db"),
                 )
 
             run_id = f"bench-{args.model.replace('/', '-').lower()}"
@@ -3940,7 +3939,7 @@ Let me know your answer!
             if args.output_dir:
                 from gaia.eval.scorecard import write_summary_md
 
-                outdir = _Path(args.output_dir)
+                outdir = Path(args.output_dir)
                 outdir.mkdir(parents=True, exist_ok=True)
                 (outdir / "scorecard.json").write_text(
                     json.dumps(summary["scorecard"], indent=2, ensure_ascii=False),
@@ -3968,11 +3967,11 @@ Let me know your answer!
                 print(f"[BASELINE] saved throughput baseline → {baseline_path}")
 
             if args.compare:
-                cmp_path = _Path(args.compare)
+                cmp_path = Path(args.compare)
                 if not cmp_path.exists():
                     print(f"[ERROR] baseline not found: {cmp_path}")
                     sys.exit(1)
-                base = json.loads(cmp_path.read_text())
+                base = json.loads(cmp_path.read_text(encoding="utf-8"))
                 base_tps = base.get("performance", {}).get("avg_tokens_per_second")
                 if isinstance(base_tps, (int, float)) and isinstance(tps, (int, float)):
                     print(

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -2176,6 +2176,74 @@ Examples:
         "'junit' writes a JUnit XML file for CI integration.",
     )
 
+    # Email-triage throughput benchmark subcommand: gaia eval benchmark [OPTIONS] (#1233)
+    benchmark_eval_parser = eval_subparsers.add_parser(
+        "benchmark",
+        help="Email-triage throughput benchmark (TTFT / tok-per-sec / latency)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Benchmark the primary on-device model over the committed corpus
+  gaia eval benchmark --model Gemma-4-E4B-it-GGUF --limit 50
+
+  # Repeat 3 times for variance + compare against a saved baseline
+  gaia eval benchmark --experiments 3 --compare eval/results/bench_baseline.json
+
+  # Save this run as the throughput baseline
+  gaia eval benchmark --save-baseline
+        """,
+    )
+    benchmark_eval_parser.add_argument(
+        "--model",
+        default="Gemma-4-E4B-it-GGUF",
+        help="Lemonade model id to benchmark (default: Gemma-4-E4B-it-GGUF).",
+    )
+    benchmark_eval_parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Target message count steered to the agent's triage call "
+        "(default: 50). The committed stub corpus is smaller, so the "
+        "effective count is min(limit, corpus size).",
+    )
+    benchmark_eval_parser.add_argument(
+        "--experiments",
+        type=int,
+        default=1,
+        help="Repeat count per model for variance analysis (default: 1).",
+    )
+    benchmark_eval_parser.add_argument(
+        "--mbox-path",
+        default=None,
+        help="MBOX corpus to triage (default: the committed stub fixture).",
+    )
+    benchmark_eval_parser.add_argument(
+        "--ground-truth",
+        default=None,
+        help="Ground-truth JSON for quality scoring (default: the fixture's).",
+    )
+    benchmark_eval_parser.add_argument(
+        "--backend",
+        default=None,
+        help="Lemonade base URL (default: the agent's configured base URL).",
+    )
+    benchmark_eval_parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory to write scorecard.json / summary.md (optional).",
+    )
+    benchmark_eval_parser.add_argument(
+        "--compare",
+        metavar="PATH",
+        default=None,
+        help="Compare this run's throughput against a saved baseline scorecard.",
+    )
+    benchmark_eval_parser.add_argument(
+        "--save-baseline",
+        action="store_true",
+        help="Save this run's scorecard as the throughput baseline.",
+    )
+
     # Add new subparser for generating summary reports from evaluation directories
     report_parser = subparsers.add_parser(
         "report",
@@ -3794,6 +3862,125 @@ Let me know your answer!
                     encoding="utf-8",
                 )
                 print(f"[BASELINE] Saved baseline → {baseline_path}")
+            return
+
+        # Email-triage throughput benchmark: gaia eval benchmark (#1233)
+        if getattr(args, "eval_command", None) == "benchmark":
+            import tempfile as _tempfile
+            from pathlib import Path as _Path
+
+            from gaia.eval.benchmark import (
+                THROUGHPUT_BAR_TPS,
+                THROUGHPUT_STRETCH_TPS,
+                load_ground_truth,
+                run_benchmark,
+                summarize_benchmark,
+            )
+            from gaia.eval.runner import REPO_ROOT, RESULTS_DIR
+
+            fixtures = REPO_ROOT / "tests" / "fixtures" / "email"
+            mbox_path = args.mbox_path or str(fixtures / "_stub_inbox.mbox")
+            gt_path = args.ground_truth or str(fixtures / "ground_truth.json")
+            ground_truth = (
+                load_ground_truth(gt_path) if _Path(gt_path).exists() else None
+            )
+            if ground_truth is None:
+                print(
+                    f"[WARN] ground truth not found at {gt_path}; "
+                    "quality scoring skipped"
+                )
+
+            with _tempfile.TemporaryDirectory(prefix="gaia-bench-") as tmp:
+                results = run_benchmark(
+                    args.model,
+                    mbox_path=mbox_path,
+                    limit=args.limit,
+                    experiments=args.experiments,
+                    base_url=args.backend,
+                    ground_truth=ground_truth,
+                    db_path=str(_Path(tmp) / "state.db"),
+                )
+
+            run_id = f"bench-{args.model.replace('/', '-').lower()}"
+            summary = summarize_benchmark(results, run_id=run_id)
+            perf = summary["scorecard"]["performance"]
+            tps = perf.get("avg_tokens_per_second")
+            ttft = perf.get("avg_time_to_first_token")
+            bar_ok = isinstance(tps, (int, float)) and tps >= THROUGHPUT_BAR_TPS
+
+            print(f"\n{'=' * 60}")
+            print(f"  Email-Triage Throughput Benchmark — {args.model}")
+            print(f"{'=' * 60}")
+            print(
+                f"  Experiments:  {args.experiments}  " f"(limit {args.limit} emails)"
+            )
+            print(
+                f"  Throughput:   {tps} tok/s  "
+                f"(bar ≥{THROUGHPUT_BAR_TPS}, stretch {THROUGHPUT_STRETCH_TPS})"
+            )
+            print(f"  TTFT:         {ttft} s")
+            if results and isinstance(results[0].get("quality"), dict):
+                print(f"  Category acc: {results[0]['quality']['category_accuracy']}")
+            print(
+                f"  Committed bar (≥{THROUGHPUT_BAR_TPS} tok/s): "
+                f"{'PASS' if bar_ok else 'MISS'} (non-gating demo)"
+            )
+            print(f"{'=' * 60}\n")
+
+            # Variance report across repeated experiments.
+            if args.experiments > 1:
+                from gaia.eval.statistics import (
+                    compare_runs_by_model,
+                    print_comparison_report,
+                )
+
+                for report in compare_runs_by_model(results).values():
+                    print_comparison_report(report)
+
+            if args.output_dir:
+                from gaia.eval.scorecard import write_summary_md
+
+                outdir = _Path(args.output_dir)
+                outdir.mkdir(parents=True, exist_ok=True)
+                (outdir / "scorecard.json").write_text(
+                    json.dumps(summary["scorecard"], indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
+                (outdir / "summary.md").write_text(
+                    write_summary_md(summary["scorecard"]), encoding="utf-8"
+                )
+                (outdir / "variance.json").write_text(
+                    json.dumps(summary["variance"], indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
+                print(
+                    f"[OUT] wrote scorecard.json / summary.md / variance.json "
+                    f"→ {outdir}"
+                )
+
+            if getattr(args, "save_baseline", False):
+                RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+                baseline_path = RESULTS_DIR / "bench_baseline.json"
+                baseline_path.write_text(
+                    json.dumps(summary["scorecard"], indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
+                print(f"[BASELINE] saved throughput baseline → {baseline_path}")
+
+            if args.compare:
+                cmp_path = _Path(args.compare)
+                if not cmp_path.exists():
+                    print(f"[ERROR] baseline not found: {cmp_path}")
+                    sys.exit(1)
+                base = json.loads(cmp_path.read_text())
+                base_tps = base.get("performance", {}).get("avg_tokens_per_second")
+                if isinstance(base_tps, (int, float)) and isinstance(tps, (int, float)):
+                    print(
+                        f"[COMPARE] throughput {tps} vs baseline {base_tps} "
+                        f"tok/s (Δ{round(tps - base_tps, 1):+})  [non-gating]"
+                    )
+                else:
+                    print("[COMPARE] insufficient throughput data to compare")
             return
 
         # Bare "gaia eval" without subcommand - show help

--- a/src/gaia/eval/benchmark.py
+++ b/src/gaia/eval/benchmark.py
@@ -1,0 +1,343 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Email-triage throughput benchmark (issue #1233).
+
+Direct-drives the ``EmailTriageAgent`` over the committed synthetic corpus via
+the documented eval injection seam (``EmailAgentConfig(gmail_backend=...)``),
+harvests latency/throughput via :mod:`gaia.eval.performance`, scores quality via
+:mod:`gaia.eval.quality_metrics`, and emits per-run result dicts whose
+``performance_summary`` matches the contract that
+:func:`gaia.eval.scorecard.build_scorecard` already aggregates — so the existing
+scorecard / summary / JUnit renderers are reused unchanged. Variance across
+repeated runs is computed with :mod:`gaia.eval.statistics`.
+
+This is a read-only harness over an unchanged agent: it changes no LLM-affecting
+product path.
+
+Fail-loud contract: tool-result envelopes that *look* like JSON but don't parse
+raise an actionable ``ValueError`` (the upstream fork swallowed these). Genuine
+non-envelope tool output is skipped — that is not an error, just "not the
+message we're looking for".
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from gaia.eval import performance, quality_metrics
+
+# Committed throughput bar for #1233 (non-gating for the demo).
+THROUGHPUT_BAR_TPS = 10.0
+# Snappy-UX stretch target (printed, never asserted).
+THROUGHPUT_STRETCH_TPS = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Envelope parsing (fail-loud)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_agent_result(agent_result: object) -> dict[str, Any]:
+    """Coerce a ``process_query`` return into a dict, failing loud on garbage."""
+    if isinstance(agent_result, dict):
+        return agent_result
+    if isinstance(agent_result, str):
+        try:
+            parsed = json.loads(agent_result)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError(
+                f"agent result is a string but not valid JSON: {exc}; "
+                f"snippet: {agent_result[:200]!r}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"agent result JSON decoded to {type(parsed).__name__}, expected object"
+            )
+        return parsed
+    raise TypeError(
+        f"unsupported agent_result type {type(agent_result).__name__}; "
+        "expected dict or JSON string"
+    )
+
+
+def _maybe_parse_tool_envelope(content: object) -> dict | None:
+    """Parse a tool message's content as a JSON envelope.
+
+    Returns the parsed dict, or ``None`` when the content is plainly not an
+    envelope (empty, or not starting with ``{``/``[``). Raises ``ValueError``
+    when the content *looks* like JSON but fails to parse — a malformed tool
+    envelope is a real defect and must surface, not be swallowed.
+    """
+    if isinstance(content, dict):
+        return content
+    if isinstance(content, list):
+        text = "".join(b.get("text", "") for b in content if isinstance(b, dict))
+    elif isinstance(content, str):
+        text = content
+    else:
+        return None
+
+    stripped = text.strip()
+    if not stripped or stripped[0] not in "{[":
+        return None  # not an envelope — skip, not an error
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError(
+            f"malformed tool-result JSON envelope: {exc}; "
+            f"payload snippet: {stripped[:200]!r}"
+        ) from exc
+
+
+def _extract_triage_results(conversation: list) -> tuple[list[dict], str]:
+    """Find the triage tool result in the conversation.
+
+    Returns ``(results, error)``. Raises ``ValueError`` on a malformed envelope
+    (via :func:`_maybe_parse_tool_envelope`).
+    """
+    for msg in conversation:
+        if msg.get("role") != "tool" or not msg.get("content"):
+            continue
+        envelope = _maybe_parse_tool_envelope(msg["content"])
+        if not isinstance(envelope, dict):
+            continue
+        data = envelope.get("data")
+        if envelope.get("ok") and isinstance(data, dict) and "results" in data:
+            return data["results"], ""
+        if envelope.get("ok") is False and "error" in envelope:
+            return [], str(envelope["error"])
+    return [], ""
+
+
+def _extract_tools_called(agent_result: dict) -> list[str]:
+    """Ordered, de-duplicated list of tool names used in the conversation."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for msg in agent_result.get("conversation", []):
+        role = msg.get("role")
+        name = ""
+        if role == "assistant" and isinstance(msg.get("content"), dict):
+            name = msg["content"].get("tool", "")
+        elif role == "tool":
+            name = msg.get("name", "")
+        if name and name not in seen:
+            seen.add(name)
+            ordered.append(name)
+    return ordered
+
+
+# ---------------------------------------------------------------------------
+# Result assembly (pure — offline-testable)
+# ---------------------------------------------------------------------------
+
+
+def build_result(
+    agent_result: object,
+    *,
+    run_id: str,
+    timestamp: str,
+    model_id: str,
+    total_duration_ms: int,
+    ground_truth: dict[str, dict] | None = None,
+    is_cold_start: bool = False,
+) -> dict[str, Any]:
+    """Assemble a single benchmark result dict from a ``process_query`` return.
+
+    Pure and offline-testable (no Lemonade): feed a canned ``agent_result``.
+    The output is ``build_scorecard``-compatible (``status`` / ``category`` /
+    ``performance_summary`` / ``cost_estimate``) and carries the perf RunResult
+    plus an optional ``quality`` block when ``ground_truth`` is provided.
+    """
+    result_dict = _normalize_agent_result(agent_result)
+    conversation = result_dict.get("conversation", [])
+
+    triage_results, tool_error = _extract_triage_results(conversation)
+    predicted_categories = {
+        r.get("id", ""): r.get("category", "") for r in triage_results if r.get("id")
+    }
+    category_counts: dict[str, int] = {}
+    for cat in predicted_categories.values():
+        if cat:
+            category_counts[cat] = category_counts.get(cat, 0) + 1
+
+    perf_run = performance.extract_from_agent_result(
+        result_dict,
+        run_id=run_id,
+        timestamp=timestamp,
+        model_id=model_id,
+        mode="full",
+        total_duration_ms=total_duration_ms,
+        category_counts=category_counts,
+        total_emails=len(triage_results),
+        is_cold_start=is_cold_start,
+    )
+
+    out = performance.run_to_dict(perf_run)
+    out["tools_called"] = _extract_tools_called(result_dict)
+    out["performance_summary"] = performance.to_performance_summary(perf_run)
+    out["cost_estimate"] = {
+        "estimated_usd": quality_metrics.compute_cost(
+            perf_run.total_input_tokens,
+            perf_run.total_output_tokens,
+            model=model_id,
+        )
+    }
+    out["meets_throughput_bar"] = perf_run.avg_tokens_per_second >= THROUGHPUT_BAR_TPS
+
+    # build_scorecard-compatible fields. category groups the scorecard by model.
+    out["category"] = model_id
+    if tool_error:
+        out["status"] = "ERRORED"
+        out["error"] = tool_error
+    elif triage_results:
+        out["status"] = "PASS"
+    else:
+        out["status"] = "FAIL"
+        out["error"] = "no triage results found in agent conversation"
+
+    if ground_truth is not None:
+        predicted_spam = {
+            r.get("id", ""): bool(r.get("is_spam", False))
+            for r in triage_results
+            if r.get("id")
+        }
+        predicted_phishing = {
+            r.get("id", ""): bool(r.get("is_phishing", False))
+            for r in triage_results
+            if r.get("id")
+        }
+        out["quality"] = {
+            "category_accuracy": quality_metrics.category_accuracy(
+                predicted_categories, ground_truth
+            ),
+            "spam": quality_metrics.confusion_for_flag(
+                predicted_spam, ground_truth, "is_spam"
+            ).to_dict(),
+            "phishing": quality_metrics.confusion_for_flag(
+                predicted_phishing, ground_truth, "is_phishing"
+            ).to_dict(),
+            # Needs-attention axis (one candidate FP/FN gate for #1278).
+            "needs_attention": quality_metrics.confusion_for_categories(
+                predicted_categories, ground_truth, {"urgent", "actionable"}
+            ).to_dict(),
+        }
+
+    return out
+
+
+def summarize_benchmark(results: list[dict], *, run_id: str) -> dict[str, Any]:
+    """Aggregate per-run results into a scorecard + per-model variance report.
+
+    Reuses :func:`gaia.eval.scorecard.build_scorecard` (perf section) and
+    :func:`gaia.eval.statistics.compare_runs_by_model` (variance) — no new
+    aggregation logic.
+    """
+    from gaia.eval.scorecard import build_scorecard
+    from gaia.eval.statistics import compare_runs_by_model
+    from gaia.eval.statistics import to_dict as variance_to_dict
+
+    scorecard = build_scorecard(
+        run_id, results, {"benchmark": "email_triage_throughput"}
+    )
+    variance = {
+        model: variance_to_dict(report)
+        for model, report in compare_runs_by_model(results).items()
+    }
+    return {"scorecard": scorecard, "variance": variance}
+
+
+# ---------------------------------------------------------------------------
+# Live driver (integration — needs Lemonade)
+# ---------------------------------------------------------------------------
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def run_benchmark(
+    model_id: str,
+    *,
+    mbox_path: str,
+    limit: int = 50,
+    experiments: int = 1,
+    base_url: str | None = None,
+    ground_truth: dict[str, dict] | None = None,
+    db_path: str | None = None,
+    agent_factory: Callable[[], Any] | None = None,
+    run_id_prefix: str = "bench",
+) -> list[dict[str, Any]]:
+    """Run the throughput benchmark ``experiments`` times and return result dicts.
+
+    Direct-drives ``EmailTriageAgent.process_query`` over a ``FakeGmailBackend``
+    loaded from ``mbox_path``. ``agent_factory`` overrides agent construction
+    (used by tests to inject a stub — keeps the unit path Lemonade-free); when
+    omitted a real agent is built lazily so importing this module stays cheap.
+    """
+    model_slug = model_id.replace("/", "-").lower()
+    # Steer the agent to triage_inbox (whose envelope carries per-email
+    # ``results``) rather than pre_scan_inbox, so throughput AND quality are
+    # both harvestable and the run is deterministic across model whims.
+    prompt = (
+        f"Call triage_inbox for up to {limit} messages in my inbox, "
+        "then give me a short summary."
+    )
+    results: list[dict[str, Any]] = []
+
+    for exp in range(1, experiments + 1):
+        if agent_factory is not None:
+            agent = agent_factory()
+        else:
+            # Lazy import: keep `import gaia.eval.benchmark` free of the agent stack.
+            from gaia.agents.email.agent import EmailTriageAgent
+            from gaia.agents.email.config import EmailAgentConfig
+
+            try:
+                from tests.fixtures.email.fake_gmail import FakeGmailBackend
+            except ImportError as exc:
+                raise RuntimeError(
+                    "The email throughput benchmark must run from a GAIA repo "
+                    "checkout — it drives the synthetic corpus in "
+                    "tests/fixtures/email and is not available in a packaged "
+                    f"install. Original import error: {exc}"
+                ) from exc
+
+            config = EmailAgentConfig(
+                model_id=model_id,
+                base_url=base_url,
+                gmail_backend=FakeGmailBackend(mbox_path),
+                db_path=db_path,
+                show_stats=True,
+                silent_mode=True,
+            )
+            agent = EmailTriageAgent(config=config)
+
+        run_id = f"{run_id_prefix}-{model_slug}-exp{exp}"
+        start = time.monotonic()
+        agent_result = agent.process_query(prompt)
+        total_duration_ms = int((time.monotonic() - start) * 1000)
+
+        results.append(
+            build_result(
+                agent_result,
+                run_id=run_id,
+                timestamp=_utc_now_iso(),
+                model_id=model_id,
+                total_duration_ms=total_duration_ms,
+                ground_truth=ground_truth,
+                is_cold_start=(exp == 1),
+            )
+        )
+
+    return results
+
+
+def load_ground_truth(path: str | Path) -> dict[str, dict]:
+    """Load a ground-truth JSON file (loud on missing/invalid)."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)

--- a/src/gaia/eval/performance.py
+++ b/src/gaia/eval/performance.py
@@ -1,0 +1,327 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Performance metric extraction for GAIA eval benchmarks.
+
+Harvests per-step latency/throughput/token metrics from the agent's
+``conversation`` trace. The base ``Agent`` appends a system message of the
+shape ``{"role": "system", "content": {"type": "stats",
+"performance_stats": {...}}}`` after each LLM call
+(see ``gaia.agents.base.agent``). ``performance_stats`` is whatever Lemonade's
+``/stats`` endpoint returns; confirmed live keys (Gemma-4):
+
+    input_tokens, output_tokens, prompt_tokens,
+    time_to_first_token (seconds), tokens_per_second, decode_token_times
+
+``total_tokens`` and per-step ``duration`` are NOT in ``/stats`` — they are
+tolerated (token total falls back to input+output; run-level wall-clock
+duration is supplied by the caller). This module is **domain-free**: it knows
+nothing about email triage. Per-email classification (categories, confidence)
+is extracted by the domain caller (e.g. ``gaia.eval.benchmark``) and passed in
+via ``category_counts`` / ``total_emails``.
+
+Sibling module ``gaia.perf_analysis`` covers the same TTFT/TPS vocabulary via
+llama.cpp *log scraping*; this module is the *structured-stats* path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class StepResult:
+    """A single LLM call in the agent loop with its token/latency cost."""
+
+    step_number: int
+    action: str  # "llm_call", "planning", "final_answer"
+    tool_name: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0  # tokens in <thinking> blocks (estimated)
+    total_tokens: int = 0
+    duration_ms: int = 0
+    time_to_first_token_ms: float = 0.0  # TTFT: prompt-send → first token
+    tokens_per_second: float = 0.0  # TPS: inference throughput
+    status: str = "ok"
+
+
+@dataclass
+class RunResult:
+    """Run-level performance aggregate (domain-free).
+
+    ``category_counts`` / ``total_emails`` are generic and supplied by the
+    domain caller; this module never inspects classification output.
+    """
+
+    run_id: str
+    timestamp: str
+    model: str
+    mode: str = ""
+    step_results: list[StepResult] = field(default_factory=list)
+    total_emails: int = 0
+    total_duration_ms: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_reasoning_tokens: int = 0
+    total_tokens: int = 0
+    avg_time_to_first_token_ms: float = 0.0
+    avg_tokens_per_second: float = 0.0
+    category_counts: dict[str, int] = field(default_factory=dict)
+    is_cold_start: bool = False
+    status: str = "ok"
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_reasoning_tokens(text: str) -> int:
+    """Estimate reasoning tokens from ``<thinking>`` blocks in assistant text.
+
+    Lemonade's /stats endpoint does not report reasoning tokens separately, so
+    we approximate by counting characters inside ``<thinking>...</thinking>``
+    blocks at a 1-token ≈ 4-character (BPE) ratio. Returns 0 if no blocks found.
+    """
+    thinking_blocks = re.findall(r"<thinking>(.*?)</thinking>", text, re.DOTALL)
+    if not thinking_blocks:
+        return 0
+    total_chars = sum(len(b.strip()) for b in thinking_blocks)
+    return max(1, total_chars // 4)
+
+
+def _last_assistant_text(conversation: list, stats_msg: dict) -> str:
+    """Return the last assistant message text before a system stats message."""
+    try:
+        idx = conversation.index(stats_msg)
+    except ValueError:
+        return ""
+    for i in range(idx - 1, -1, -1):
+        msg = conversation[i]
+        if msg.get("role") == "assistant":
+            text = msg.get("content", "")
+            if isinstance(text, str):
+                return text
+            if isinstance(text, list):
+                return "".join(b.get("text", "") for b in text if isinstance(b, dict))
+    return ""
+
+
+def extract_step_stats(conversation: list) -> tuple[list[StepResult], int]:
+    """Extract per-step ``StepResult`` objects and total reasoning tokens.
+
+    Walks the conversation for ``{"type": "stats"}`` system messages emitted by
+    the base agent after each LLM call. Returns
+    ``(step_results, total_reasoning_tokens)``.
+    """
+    step_results: list[StepResult] = []
+    step_num = 0
+    total_reasoning_tokens = 0
+    last_tool_name = ""
+
+    for msg in conversation:
+        role = msg.get("role", "")
+
+        # Track the tool name from the most recent tool result.
+        if role == "tool" and msg.get("name"):
+            last_tool_name = msg["name"]
+
+        # A new assistant turn = new LLM call with no tool attributed yet.
+        if role == "assistant":
+            last_tool_name = ""
+            assistant_text = msg.get("content", "")
+            if isinstance(assistant_text, str) and assistant_text:
+                reasoning = _extract_reasoning_tokens(assistant_text)
+                if reasoning > 0:
+                    total_reasoning_tokens += reasoning
+
+        # Per-step stats live in system entries with a dict content.
+        if role == "system" and isinstance(msg.get("content"), dict):
+            content = msg["content"]
+            if content.get("type") == "stats" and "performance_stats" in content:
+                stats = content["performance_stats"]
+                step_num += 1
+                raw_ttft = stats.get("time_to_first_token")
+                ttft_ms = float(raw_ttft) * 1000 if raw_ttft else 0.0
+                in_tok = stats.get("input_tokens", 0) or 0
+                out_tok = stats.get("output_tokens", 0) or 0
+                step_results.append(
+                    StepResult(
+                        step_number=step_num,
+                        action="llm_call",
+                        tool_name=last_tool_name,
+                        input_tokens=in_tok,
+                        output_tokens=out_tok,
+                        reasoning_tokens=_extract_reasoning_tokens(
+                            _last_assistant_text(conversation, msg)
+                        ),
+                        total_tokens=(
+                            stats.get("total_tokens", 0) or (in_tok + out_tok)
+                        ),
+                        # /stats has no per-step "duration"; tolerated as 0.
+                        duration_ms=int((stats.get("duration", 0) or 0) * 1000),
+                        time_to_first_token_ms=ttft_ms,
+                        tokens_per_second=float(stats.get("tokens_per_second", 0) or 0),
+                    )
+                )
+
+    return step_results, total_reasoning_tokens
+
+
+# ---------------------------------------------------------------------------
+# Main extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_from_agent_result(
+    agent_result: dict[str, Any],
+    *,
+    run_id: str,
+    timestamp: str,
+    model_id: str,
+    mode: str = "full",
+    total_duration_ms: int = 0,
+    category_counts: dict[str, int] | None = None,
+    total_emails: int = 0,
+    is_cold_start: bool = False,
+) -> RunResult:
+    """Build a perf ``RunResult`` from a ``process_query()`` result dict.
+
+    Domain metrics (``category_counts`` / ``total_emails``) are supplied by the
+    caller — this function only harvests latency/throughput/token stats.
+
+    Args:
+        agent_result: dict returned by ``agent.process_query()`` (must carry a
+            ``conversation`` list; may carry top-level ``input_tokens`` etc.).
+        run_id / timestamp / model_id / mode: run identity.
+        total_duration_ms: wall-clock duration measured by the caller.
+        category_counts / total_emails: domain classification rollup (optional).
+        is_cold_start: whether this was the first run of the model.
+    """
+    conversation = agent_result.get("conversation", [])
+    step_results, total_reasoning_tokens = extract_step_stats(conversation)
+
+    # Prefer top-level aggregates if present, else sum from steps.
+    input_tokens = agent_result.get("input_tokens") or sum(
+        s.input_tokens for s in step_results
+    )
+    output_tokens = agent_result.get("output_tokens") or sum(
+        s.output_tokens for s in step_results
+    )
+    total_tokens = agent_result.get("total_tokens") or (input_tokens + output_tokens)
+
+    ttft_vals = [
+        s.time_to_first_token_ms for s in step_results if s.time_to_first_token_ms > 0
+    ]
+    tps_vals = [s.tokens_per_second for s in step_results if s.tokens_per_second > 0]
+    avg_ttft = sum(ttft_vals) / len(ttft_vals) if ttft_vals else 0.0
+    avg_tps = sum(tps_vals) / len(tps_vals) if tps_vals else 0.0
+
+    return RunResult(
+        run_id=run_id,
+        timestamp=timestamp,
+        model=model_id,
+        mode=mode,
+        step_results=step_results,
+        total_emails=total_emails,
+        total_duration_ms=total_duration_ms,
+        total_input_tokens=input_tokens,
+        total_output_tokens=output_tokens,
+        total_reasoning_tokens=total_reasoning_tokens,
+        total_tokens=total_tokens,
+        avg_time_to_first_token_ms=round(avg_ttft, 1),
+        avg_tokens_per_second=round(avg_tps, 1),
+        category_counts=dict(category_counts or {}),
+        is_cold_start=is_cold_start,
+        status="ok",
+    )
+
+
+def to_performance_summary(run: RunResult) -> dict[str, Any]:
+    """Render a ``RunResult`` into the per-scenario ``performance_summary`` dict
+    that ``gaia.eval.scorecard.build_scorecard`` aggregates.
+
+    Throughput/TTFT come straight from the harvested steps; pipeline latency is
+    the caller-measured wall clock. ``flags`` carries gating-vs-reported notes.
+    """
+    return {
+        "avg_tokens_per_second": run.avg_tokens_per_second,
+        "avg_time_to_first_token": round(run.avg_time_to_first_token_ms / 1000.0, 4),
+        "avg_time_to_first_token_ms": run.avg_time_to_first_token_ms,
+        "total_input_tokens": run.total_input_tokens,
+        "total_output_tokens": run.total_output_tokens,
+        "total_tokens": run.total_tokens,
+        "total_duration_ms": run.total_duration_ms,
+        "total_emails": run.total_emails,
+        "steps": len(run.step_results),
+        "flags": [],
+    }
+
+
+def run_to_dict(run: RunResult) -> dict[str, Any]:
+    """Serialize a ``RunResult`` (with its steps) to a JSON-serializable dict."""
+    return {
+        "run_id": run.run_id,
+        "timestamp": run.timestamp,
+        "model": run.model,
+        "mode": run.mode,
+        "total_emails": run.total_emails,
+        "total_duration_ms": run.total_duration_ms,
+        "total_input_tokens": run.total_input_tokens,
+        "total_output_tokens": run.total_output_tokens,
+        "total_reasoning_tokens": run.total_reasoning_tokens,
+        "total_tokens": run.total_tokens,
+        "avg_time_to_first_token_ms": run.avg_time_to_first_token_ms,
+        "avg_tokens_per_second": run.avg_tokens_per_second,
+        "category_counts": run.category_counts,
+        "is_cold_start": run.is_cold_start,
+        "status": run.status,
+        "error": run.error,
+        "step_results": [
+            {
+                "step_number": s.step_number,
+                "action": s.action,
+                "tool_name": s.tool_name,
+                "input_tokens": s.input_tokens,
+                "output_tokens": s.output_tokens,
+                "reasoning_tokens": s.reasoning_tokens,
+                "total_tokens": s.total_tokens,
+                "duration_ms": s.duration_ms,
+                "time_to_first_token_ms": s.time_to_first_token_ms,
+                "tokens_per_second": s.tokens_per_second,
+                "status": s.status,
+            }
+            for s in run.step_results
+        ],
+    }
+
+
+def extract_from_trace_json(
+    trace_path: str,
+    *,
+    run_id: str,
+    timestamp: str,
+    model_id: str,
+    mode: str = "full",
+    total_duration_ms: int = 0,
+) -> RunResult:
+    """Load a ``--trace`` JSON file and extract a perf ``RunResult``.
+
+    Convenience wrapper for post-hoc perf analysis of any saved agent run.
+    Raises ``FileNotFoundError`` / ``json.JSONDecodeError`` loudly on bad input.
+    """
+    with open(trace_path, "r", encoding="utf-8") as f:
+        agent_result = json.load(f)
+    return extract_from_agent_result(
+        agent_result,
+        run_id=run_id,
+        timestamp=timestamp,
+        model_id=model_id,
+        mode=mode,
+        total_duration_ms=total_duration_ms,
+    )

--- a/src/gaia/eval/quality_metrics.py
+++ b/src/gaia/eval/quality_metrics.py
@@ -1,0 +1,233 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Quality metrics for GAIA classification-style eval benchmarks.
+
+Provides corpus-agnostic scoring primitives:
+  * ``category_accuracy`` — exact-match accuracy of predicted vs ground-truth
+    category (the lifted ``_compute_quality`` semantics).
+  * ``binary_confusion`` + axis helpers — true/false positive/negative counts
+    with FP-rate, FN-rate, precision, recall, F1 for any binary axis.
+  * ``compute_cost`` — token cost via ``gaia.eval.config.MODEL_PRICING``.
+
+**FP/FN axis is a policy choice, intentionally not baked in.** Email triage has
+two independent binary axes — a spam/phishing axis (the corpus tracks
+``is_spam`` / ``is_phishing`` booleans) and a "needs-attention" axis (category
+∈ {urgent, actionable}). #1278's bars (FP<5% / FN<2%) are coherest on the
+attention axis (missing an important mail is worse than a false alarm), but the
+corpus natively supports the spam axis too. This module exposes neutral
+primitives for *all* axes; which axis (and threshold) gates CI is decided when
+#1278 is closed. Ground truth is always passed in as an argument, so #1230's
+future corpus is a drop-in swap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from gaia.eval.config import MODEL_PRICING
+
+# Categories whose ground-truth entries are real labels (skip metadata rows).
+_METADATA_KEYS = {"_meta", "_comment", "_metadata"}
+
+
+@dataclass
+class Confusion:
+    """2x2 confusion counts for a single binary axis, with derived rates."""
+
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    tn: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.tp + self.fp + self.fn + self.tn
+
+    @property
+    def false_positive_rate(self) -> float:
+        """FP / (FP + TN) — fraction of true negatives wrongly flagged."""
+        denom = self.fp + self.tn
+        return round(self.fp / denom, 4) if denom else 0.0
+
+    @property
+    def false_negative_rate(self) -> float:
+        """FN / (FN + TP) — fraction of true positives missed (= 1 - recall)."""
+        denom = self.fn + self.tp
+        return round(self.fn / denom, 4) if denom else 0.0
+
+    @property
+    def precision(self) -> float:
+        denom = self.tp + self.fp
+        return round(self.tp / denom, 4) if denom else 0.0
+
+    @property
+    def recall(self) -> float:
+        denom = self.tp + self.fn
+        return round(self.tp / denom, 4) if denom else 0.0
+
+    @property
+    def f1(self) -> float:
+        p, r = self.precision, self.recall
+        return round(2 * p * r / (p + r), 4) if (p + r) else 0.0
+
+    @property
+    def accuracy(self) -> float:
+        return round((self.tp + self.tn) / self.total, 4) if self.total else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tp": self.tp,
+            "fp": self.fp,
+            "fn": self.fn,
+            "tn": self.tn,
+            "false_positive_rate": self.false_positive_rate,
+            "false_negative_rate": self.false_negative_rate,
+            "precision": self.precision,
+            "recall": self.recall,
+            "f1": self.f1,
+            "accuracy": self.accuracy,
+        }
+
+
+def _labelled_ids(ground_truth: dict[str, dict]) -> list[str]:
+    """Ground-truth ids that carry a real ``category`` label (skip metadata)."""
+    return [
+        gid
+        for gid, entry in ground_truth.items()
+        if gid not in _METADATA_KEYS
+        and isinstance(entry, dict)
+        and entry.get("category") is not None
+    ]
+
+
+def category_accuracy(
+    predictions: dict[str, str], ground_truth: dict[str, dict]
+) -> float:
+    """Exact-match category accuracy over ids present in both inputs.
+
+    Case-insensitive comparison. Returns 0.0 if no ids overlap. Only counts
+    ground-truth rows that carry a ``category`` (metadata rows are skipped).
+    """
+    matched = 0
+    correct = 0
+    for gid in _labelled_ids(ground_truth):
+        if gid not in predictions:
+            continue
+        matched += 1
+        expected = str(ground_truth[gid]["category"]).strip().lower()
+        actual = str(predictions[gid]).strip().lower()
+        if actual == expected:
+            correct += 1
+    return round(correct / matched, 4) if matched else 0.0
+
+
+def binary_confusion(predictions: dict[str, bool], truth: dict[str, bool]) -> Confusion:
+    """Confusion counts over ids present in both ``predictions`` and ``truth``."""
+    c = Confusion()
+    for gid, pred_pos in predictions.items():
+        if gid not in truth:
+            continue
+        true_pos = bool(truth[gid])
+        pred_pos = bool(pred_pos)
+        if pred_pos and true_pos:
+            c.tp += 1
+        elif pred_pos and not true_pos:
+            c.fp += 1
+        elif not pred_pos and true_pos:
+            c.fn += 1
+        else:
+            c.tn += 1
+    return c
+
+
+def confusion_for_flag(
+    predictions: dict[str, bool], ground_truth: dict[str, dict], flag: str
+) -> Confusion:
+    """Binary confusion for a boolean ground-truth flag (e.g. ``is_spam``).
+
+    ``predictions`` maps email-id → the agent's predicted boolean for ``flag``.
+    """
+    truth = {
+        gid: bool(entry.get(flag, False))
+        for gid, entry in ground_truth.items()
+        if gid not in _METADATA_KEYS and isinstance(entry, dict)
+    }
+    return binary_confusion(predictions, truth)
+
+
+def confusion_for_categories(
+    predicted_categories: dict[str, str],
+    ground_truth: dict[str, dict],
+    positive_categories: set[str],
+) -> Confusion:
+    """One-vs-rest confusion treating ``positive_categories`` as the positive
+    class (e.g. ``{"urgent", "actionable"}`` for a needs-attention axis)."""
+    positives = {c.strip().lower() for c in positive_categories}
+    predictions = {
+        gid: cat.strip().lower() in positives
+        for gid, cat in predicted_categories.items()
+    }
+    truth = {
+        gid: str(entry.get("category", "")).strip().lower() in positives
+        for gid, entry in ground_truth.items()
+        if gid not in _METADATA_KEYS
+        and isinstance(entry, dict)
+        and entry.get("category") is not None
+    }
+    return binary_confusion(predictions, truth)
+
+
+def per_category_confusion(
+    predicted_categories: dict[str, str], ground_truth: dict[str, dict]
+) -> dict[str, Confusion]:
+    """One-vs-rest confusion for every category present in the ground truth."""
+    cats = {
+        str(entry["category"]).strip().lower()
+        for gid, entry in ground_truth.items()
+        if gid not in _METADATA_KEYS
+        and isinstance(entry, dict)
+        and entry.get("category") is not None
+    }
+    return {
+        cat: confusion_for_categories(predicted_categories, ground_truth, {cat})
+        for cat in sorted(cats)
+    }
+
+
+def compute_cost(
+    total_input_tokens: int,
+    total_output_tokens: int,
+    *,
+    model: str | None = None,
+    cost_per_1m_input: float | None = None,
+    cost_per_1m_output: float | None = None,
+) -> float:
+    """Token cost in USD.
+
+    Explicit ``cost_per_1m_*`` overrides win. Otherwise the model is looked up
+    by exact id in ``MODEL_PRICING`` (cloud judge models). Local models
+    (Lemonade-served Gemma/Qwen/etc.) are absent from the table and therefore
+    cost ``0.0`` — local inference has no per-token API cost. This is defined
+    behavior, not a fallback: the ``"default"`` pricing row is intentionally
+    NOT applied to unrecognized models so local runs never get mis-billed.
+    """
+    if cost_per_1m_input is None or cost_per_1m_output is None:
+        pricing = MODEL_PRICING.get(model or "")
+        in_rate = (
+            cost_per_1m_input
+            if cost_per_1m_input is not None
+            else (pricing["input_per_mtok"] if pricing else 0.0)
+        )
+        out_rate = (
+            cost_per_1m_output
+            if cost_per_1m_output is not None
+            else (pricing["output_per_mtok"] if pricing else 0.0)
+        )
+    else:
+        in_rate, out_rate = cost_per_1m_input, cost_per_1m_output
+
+    input_cost = total_input_tokens * in_rate / 1_000_000
+    output_cost = total_output_tokens * out_rate / 1_000_000
+    return round(input_cost + output_cost, 6)

--- a/src/gaia/eval/statistics.py
+++ b/src/gaia/eval/statistics.py
@@ -1,0 +1,732 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Statistical analysis primitives for GAIA eval benchmarks.
+
+Stdlib-only (no numpy/scipy). Provides:
+  * ``compute_variance`` — mean/stdev/min/max/CV% + extended percentiles,
+    IQR, MAD, and skewness for a list of values.
+  * ``compare_runs`` / ``compare_runs_by_model`` — run-to-run deltas and
+    variance summaries across repeated benchmark runs.
+  * ``mann_whitney_u`` / ``cliffs_delta`` / ``bootstrap_ci`` — non-parametric
+    significance + effect-size tests for cross-model comparison.
+
+The run-comparison helpers operate on plain ``list[dict]`` run-result records
+(keys such as ``total_duration_ms``, ``total_tokens``, ``category_counts``,
+``batch_results``); they never import benchmark or agent code, so they are
+reusable by any eval that emits the same record shape.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunDelta:
+    """+/- delta between two consecutive runs."""
+
+    run_id_a: str  # earlier run
+    run_id_b: str  # later run
+    delta_duration_ms: int  # B - A
+    delta_input_tokens: int
+    delta_output_tokens: int
+    delta_reasoning_tokens: int
+    delta_total_tokens: int
+    delta_total_emails: int
+    delta_avg_ttft_ms: float = 0.0  # B - A, avg TTFT in milliseconds
+    delta_avg_tps: float = 0.0  # B - A, avg tokens per second
+    category_deltas: dict[str, int] = field(default_factory=dict)
+    # Per-category: count in B - count in A
+
+
+@dataclass
+class BatchDelta:
+    """+/- delta for a specific batch between two runs."""
+
+    batch_number: int
+    run_id_a: str
+    run_id_b: str
+    delta_duration_ms: int
+    delta_input_tokens: int
+    delta_output_tokens: int
+    delta_reasoning_tokens: int
+    delta_avg_ttft_ms: float = 0.0
+    delta_avg_tps: float = 0.0
+    delta_email_count: int = 0
+
+
+@dataclass
+class VarianceSummary:
+    """Statistical summary across multiple runs."""
+
+    metric: str  # e.g., "total_duration_ms", "total_tokens"
+    mean: float
+    stdev: float
+    min_val: float
+    max_val: float
+    cv_pct: float  # coefficient of variation (%)
+    values: list[float] = field(default_factory=list)
+    # Extended percentiles and robust statistics (multi-model support).
+    median: float = 0.0
+    p25: float = 0.0
+    p75: float = 0.0
+    p95: float = 0.0
+    p99: float = 0.0
+    iqr: float = 0.0  # interquartile range (p75 - p25)
+    mad: float = 0.0  # median absolute deviation
+    skewness: float = 0.0
+    n: int = 0  # total runs included
+    filtered_n: int = 0  # runs after filtering (e.g., cold-start excluded)
+
+
+@dataclass
+class ComparisonReport:
+    """Full comparison report across multiple benchmark runs."""
+
+    runs_compared: int
+    run_deltas: list[RunDelta] = field(default_factory=list)
+    batch_deltas: list[BatchDelta] = field(default_factory=list)
+    variance_summaries: list[VarianceSummary] = field(default_factory=list)
+    category_stability: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Statistics helpers
+# ---------------------------------------------------------------------------
+
+
+def _mean(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _stdev(values: list[float], mean_val: float) -> float:
+    if len(values) < 2:
+        return 0.0
+    variance = sum((v - mean_val) ** 2 for v in values) / (len(values) - 1)
+    return math.sqrt(variance)
+
+
+def _cv_pct(_values: list[float], mean_val: float, stdev_val: float) -> float:
+    if mean_val == 0:
+        return 0.0
+    return abs(stdev_val / mean_val) * 100
+
+
+# ---------------------------------------------------------------------------
+# Extended percentile / robust statistic helpers
+# ---------------------------------------------------------------------------
+
+
+def _percentile(values: list[float], p: float) -> float:
+    """Compute the p-th percentile (0-100) using linear interpolation."""
+    if not values:
+        return 0.0
+    s = sorted(values)
+    n = len(s)
+    if n == 1:
+        return s[0]
+    # Linear interpolation (same as numpy default).
+    k = (p / 100.0) * (n - 1)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return s[int(k)]
+    d0 = s[f] * (c - k)
+    d1 = s[c] * (k - f)
+    return d0 + d1
+
+
+def _median(values: list[float]) -> float:
+    return _percentile(values, 50)
+
+
+def _mad(values: list[float]) -> float:
+    """Median Absolute Deviation."""
+    if not values:
+        return 0.0
+    med = _median(values)
+    return _median([abs(v - med) for v in values])
+
+
+def _skewness(values: list[float]) -> float:
+    """Fisher-Pearson skewness coefficient."""
+    n = len(values)
+    if n < 3:
+        return 0.0
+    m = _mean(values)
+    s = _stdev(values, m)
+    if s == 0:
+        return 0.0
+    m3 = sum((v - m) ** 3 for v in values) / n
+    return m3 / (s**3)
+
+
+def compute_variance(values: list[float], *, metric_name: str = "") -> VarianceSummary:
+    """Compute mean/stdev/min/max/CV% + extended percentiles for a list of values."""
+    if not values:
+        return VarianceSummary(
+            metric=metric_name,
+            mean=0.0,
+            stdev=0.0,
+            min_val=0.0,
+            max_val=0.0,
+            cv_pct=0.0,
+        )
+    m = _mean(values)
+    s = _stdev(values, m)
+    p25 = _percentile(values, 25)
+    p75 = _percentile(values, 75)
+    return VarianceSummary(
+        metric=metric_name,
+        mean=round(m, 2),
+        stdev=round(s, 2),
+        min_val=min(values),
+        max_val=max(values),
+        cv_pct=round(_cv_pct(values, m, s), 2),
+        values=values,
+        median=round(_percentile(values, 50), 2),
+        p25=round(p25, 2),
+        p75=round(p75, 2),
+        p95=round(_percentile(values, 95), 2),
+        p99=round(_percentile(values, 99), 2),
+        iqr=round(p75 - p25, 2),
+        mad=round(_mad(values), 2),
+        skewness=round(_skewness(values), 4),
+        n=len(values),
+        filtered_n=len(values),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run-to-run deltas
+# ---------------------------------------------------------------------------
+
+
+def _compute_run_delta(run_a: dict, run_b: dict) -> RunDelta:
+    """Compute +/- deltas between two run result dicts."""
+    cat_a = run_a.get("category_counts", {})
+    cat_b = run_b.get("category_counts", {})
+    all_cats = set(cat_a.keys()) | set(cat_b.keys())
+
+    category_deltas = {}
+    for cat in sorted(all_cats):
+        category_deltas[cat] = cat_b.get(cat, 0) - cat_a.get(cat, 0)
+
+    return RunDelta(
+        run_id_a=run_a.get("run_id", "unknown"),
+        run_id_b=run_b.get("run_id", "unknown"),
+        delta_duration_ms=run_b.get("total_duration_ms", 0)
+        - run_a.get("total_duration_ms", 0),
+        delta_input_tokens=run_b.get("total_input_tokens", 0)
+        - run_a.get("total_input_tokens", 0),
+        delta_output_tokens=run_b.get("total_output_tokens", 0)
+        - run_a.get("total_output_tokens", 0),
+        delta_reasoning_tokens=run_b.get("total_reasoning_tokens", 0)
+        - run_a.get("total_reasoning_tokens", 0),
+        delta_total_tokens=run_b.get("total_tokens", 0) - run_a.get("total_tokens", 0),
+        delta_total_emails=run_b.get("total_emails", 0) - run_a.get("total_emails", 0),
+        delta_avg_ttft_ms=run_b.get("avg_time_to_first_token_ms", 0)
+        - run_a.get("avg_time_to_first_token_ms", 0),
+        delta_avg_tps=run_b.get("avg_tokens_per_second", 0)
+        - run_a.get("avg_tokens_per_second", 0),
+        category_deltas=category_deltas,
+    )
+
+
+def _compute_batch_deltas(run_a: dict, run_b: dict) -> list[BatchDelta]:
+    """Compute per-batch deltas between two runs."""
+    deltas = []
+    batches_a = {b["batch_number"]: b for b in run_a.get("batch_results", [])}
+    batches_b = {b["batch_number"]: b for b in run_b.get("batch_results", [])}
+    all_batch_nums = set(batches_a.keys()) | set(batches_b.keys())
+
+    for batch_num in sorted(all_batch_nums):
+        ba = batches_a.get(batch_num, {})
+        bb = batches_b.get(batch_num, {})
+        deltas.append(
+            BatchDelta(
+                batch_number=batch_num,
+                run_id_a=run_a.get("run_id", "unknown"),
+                run_id_b=run_b.get("run_id", "unknown"),
+                delta_duration_ms=bb.get("duration_ms", 0) - ba.get("duration_ms", 0),
+                delta_input_tokens=bb.get("total_input_tokens", 0)
+                - ba.get("total_input_tokens", 0),
+                delta_output_tokens=bb.get("total_output_tokens", 0)
+                - ba.get("total_output_tokens", 0),
+                delta_reasoning_tokens=bb.get("total_reasoning_tokens", 0)
+                - ba.get("total_reasoning_tokens", 0),
+                delta_avg_ttft_ms=bb.get("avg_time_to_first_token_ms", 0)
+                - ba.get("avg_time_to_first_token_ms", 0),
+                delta_avg_tps=bb.get("avg_tokens_per_second", 0)
+                - ba.get("avg_tokens_per_second", 0),
+                delta_email_count=len(bb.get("email_results", []))
+                - len(ba.get("email_results", [])),
+            )
+        )
+    return deltas
+
+
+# ---------------------------------------------------------------------------
+# Category stability analysis
+# ---------------------------------------------------------------------------
+
+
+def _compute_category_stability(runs: list[dict]) -> dict[str, dict[str, Any]]:
+    """Track how category counts vary across runs."""
+    all_cats: set[str] = set()
+    for run in runs:
+        all_cats.update(run.get("category_counts", {}).keys())
+
+    stability = {}
+    for cat in sorted(all_cats):
+        counts = [run.get("category_counts", {}).get(cat, 0) for run in runs]
+        m = _mean(counts)
+        s = _stdev(counts, m)
+        stability[cat] = {
+            "mean": round(m, 2),
+            "stdev": round(s, 2),
+            "min": min(counts) if counts else 0,
+            "max": max(counts) if counts else 0,
+            "cv_pct": round(_cv_pct(counts, m, s), 2),
+            "counts_per_run": counts,
+        }
+    return stability
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compare_runs(runs: list[dict]) -> ComparisonReport:
+    """Compare multiple benchmark runs and compute variance + deltas.
+
+    Args:
+        runs: List of run result dicts (from JSON/JSONL output).
+
+    Returns:
+        ComparisonReport with run deltas, batch deltas, and variance summaries.
+    """
+    if len(runs) < 2:
+        # Single run — compute variance summaries with single values.
+        report = ComparisonReport(runs_compared=len(runs))
+        if runs:
+            run = runs[0]
+            # Duration metrics: ms → seconds.
+            for metric_key in [
+                "total_duration_ms",
+                "avg_duration_per_email_ms",
+            ]:
+                val = run.get(metric_key, 0) / 1_000
+                report.variance_summaries.append(
+                    VarianceSummary(
+                        metric=metric_key.replace("_ms", "_s"),
+                        mean=val,
+                        stdev=0.0,
+                        min_val=val,
+                        max_val=val,
+                        cv_pct=0.0,
+                        values=[val],
+                    )
+                )
+            for metric_key in [
+                "total_input_tokens",
+                "total_output_tokens",
+                "total_reasoning_tokens",
+                "total_tokens",
+                "total_emails",
+                "avg_input_tokens_per_email",
+                "avg_output_tokens_per_email",
+                "avg_total_tokens_per_email",
+            ]:
+                val = run.get(metric_key, 0)
+                report.variance_summaries.append(
+                    VarianceSummary(
+                        metric=metric_key,
+                        mean=val,
+                        stdev=0.0,
+                        min_val=val,
+                        max_val=val,
+                        cv_pct=0.0,
+                        values=[val],
+                    )
+                )
+            report.category_stability = _compute_category_stability(runs)
+            # Single-run LLM escalation %.
+            total = 0
+            confident = 0
+            for batch in run.get("batch_results", []):
+                for email in batch.get("email_results", []):
+                    total += 1
+                    if email.get("confident", False):
+                        confident += 1
+            pct = (total - confident) / max(total, 1) * 100 if total > 0 else 0.0
+            report.variance_summaries.append(
+                VarianceSummary(
+                    metric="llm_escalation_pct",
+                    mean=pct,
+                    stdev=0.0,
+                    min_val=pct,
+                    max_val=pct,
+                    cv_pct=0.0,
+                    values=[pct],
+                )
+            )
+        return report
+
+    # Compute run-to-run deltas.
+    run_deltas = []
+    batch_deltas = []
+    for i in range(1, len(runs)):
+        run_deltas.append(_compute_run_delta(runs[i - 1], runs[i]))
+        batch_deltas.extend(_compute_batch_deltas(runs[i - 1], runs[i]))
+
+    # Compute variance summaries across all runs.
+    variance_summaries = []
+
+    # Duration metrics: convert ms → seconds before computing variance.
+    duration_keys = ["total_duration_ms", "avg_duration_per_email_ms"]
+    for key in duration_keys:
+        values_ms = [run.get(key, 0) for run in runs]
+        values_s = [v / 1_000 for v in values_ms]
+        display_key = key.replace("_ms", "_s")
+        variance_summaries.append(compute_variance(values_s, metric_name=display_key))
+
+    # Non-duration metrics: pass through as-is.
+    for metric_key in [
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_reasoning_tokens",
+        "total_tokens",
+        "total_emails",
+        "avg_input_tokens_per_email",
+        "avg_output_tokens_per_email",
+        "avg_total_tokens_per_email",
+        "avg_time_to_first_token_ms",
+        "avg_tokens_per_second",
+    ]:
+        values = [run.get(metric_key, 0) for run in runs]
+        variance_summaries.append(compute_variance(values, metric_name=metric_key))
+
+    # Category stability.
+    category_stability = _compute_category_stability(runs)
+
+    # LLM escalation % variance.
+    escalation_pcts = []
+    for run in runs:
+        total = 0
+        confident = 0
+        for batch in run.get("batch_results", []):
+            for email in batch.get("email_results", []):
+                total += 1
+                if email.get("confident", False):
+                    confident += 1
+        pct = (total - confident) / max(total, 1) * 100 if total > 0 else 0.0
+        escalation_pcts.append(pct)
+    if escalation_pcts:
+        variance_summaries.append(
+            compute_variance(escalation_pcts, metric_name="llm_escalation_pct")
+        )
+
+    return ComparisonReport(
+        runs_compared=len(runs),
+        run_deltas=run_deltas,
+        batch_deltas=batch_deltas,
+        variance_summaries=variance_summaries,
+        category_stability=category_stability,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Human-readable report
+# ---------------------------------------------------------------------------
+
+
+def print_comparison_report(report: ComparisonReport) -> None:
+    """Print a human-readable comparison report to stdout."""
+    print(f"\n{'='*70}")
+    print("  GAIA Eval Benchmark — Variance Analysis")
+    print(f"{'='*70}")
+    print(f"  Runs compared: {report.runs_compared}")
+
+    if report.run_deltas:
+        print("\n  Run-to-Run Deltas (+/- values):")
+        print(f"  {'─'*66}")
+        for delta in report.run_deltas:
+            sign_dur = "+" if delta.delta_duration_ms >= 0 else ""
+            sign_tok = "+" if delta.delta_total_tokens >= 0 else ""
+            print(f"  {delta.run_id_a[-14:]} → {delta.run_id_b[-14:]}")
+            print(f"    Duration: {sign_dur}{delta.delta_duration_ms}ms")
+            print(f"    Tokens:   {sign_tok}{delta.delta_total_tokens}")
+            sign_ttft = "+" if delta.delta_avg_ttft_ms >= 0 else ""
+            sign_tps = "+" if delta.delta_avg_tps >= 0 else ""
+            print(f"    TTFT:     {sign_ttft}{delta.delta_avg_ttft_ms:.1f}ms")
+            print(f"    TPS:      {sign_tps}{delta.delta_avg_tps:.1f}")
+            if delta.category_deltas:
+                for cat, d in sorted(delta.category_deltas.items()):
+                    sign = "+" if d >= 0 else ""
+                    print(f"    {cat}: {sign}{d}")
+            print(f"  {'─'*66}")
+
+    if report.variance_summaries:
+        print("\n  Variance Summary (across all runs):")
+        print(f"  {'─'*66}")
+        for vs in report.variance_summaries:
+            line = (
+                f"  {vs.metric:<30s}: μ={vs.mean:>10.2f}  "
+                f"σ={vs.stdev:>10.2f}  "
+                f"min={vs.min_val:>8.2f}  "
+                f"max={vs.max_val:>8.2f}  "
+                f"CV={vs.cv_pct:>5.1f}%"
+            )
+            # Extended stats on a second line if n >= 2.
+            if vs.n >= 2 and vs.median != 0:
+                line += (
+                    f"\n  {'':>30s}  median={vs.median:>8.2f}  "
+                    f"IQR={vs.iqr:>8.2f}  "
+                    f"MAD={vs.mad:>8.2f}  "
+                    f"skew={vs.skewness:>6.2f}"
+                )
+            print(line)
+
+    if report.category_stability:
+        print("\n  Category Stability:")
+        print(f"  {'─'*66}")
+        for cat, stats in sorted(report.category_stability.items()):
+            print(
+                f"  {cat:<16s}: μ={stats['mean']:.1f}  "
+                f"σ={stats['stdev']:.1f}  "
+                f"range=[{stats['min']}, {stats['max']}]  "
+                f"CV={stats['cv_pct']:.1f}%"
+            )
+
+    print(f"{'='*70}\n")
+
+
+def to_dict(report: ComparisonReport) -> dict[str, Any]:
+    """Serialize a ComparisonReport to a JSON-serializable dict."""
+    return {
+        "runs_compared": report.runs_compared,
+        "run_deltas": [
+            {
+                "run_id_a": d.run_id_a,
+                "run_id_b": d.run_id_b,
+                "delta_duration_ms": d.delta_duration_ms,
+                "delta_input_tokens": d.delta_input_tokens,
+                "delta_output_tokens": d.delta_output_tokens,
+                "delta_reasoning_tokens": d.delta_reasoning_tokens,
+                "delta_total_tokens": d.delta_total_tokens,
+                "delta_total_emails": d.delta_total_emails,
+                "delta_avg_ttft_ms": round(d.delta_avg_ttft_ms, 1),
+                "delta_avg_tps": round(d.delta_avg_tps, 1),
+                "category_deltas": d.category_deltas,
+            }
+            for d in report.run_deltas
+        ],
+        "batch_deltas": [
+            {
+                "batch_number": d.batch_number,
+                "run_id_a": d.run_id_a,
+                "run_id_b": d.run_id_b,
+                "delta_duration_ms": d.delta_duration_ms,
+                "delta_input_tokens": d.delta_input_tokens,
+                "delta_output_tokens": d.delta_output_tokens,
+                "delta_reasoning_tokens": d.delta_reasoning_tokens,
+                "delta_avg_ttft_ms": round(d.delta_avg_ttft_ms, 1),
+                "delta_avg_tps": round(d.delta_avg_tps, 1),
+                "delta_email_count": d.delta_email_count,
+            }
+            for d in report.batch_deltas
+        ],
+        "variance_summaries": [
+            {
+                "metric": vs.metric,
+                "mean": vs.mean,
+                "stdev": vs.stdev,
+                "min": vs.min_val,
+                "max": vs.max_val,
+                "cv_pct": vs.cv_pct,
+                "median": vs.median,
+                "p25": vs.p25,
+                "p75": vs.p75,
+                "p95": vs.p95,
+                "p99": vs.p99,
+                "iqr": vs.iqr,
+                "mad": vs.mad,
+                "skewness": vs.skewness,
+                "n": vs.n,
+                "filtered_n": vs.filtered_n,
+            }
+            for vs in report.variance_summaries
+        ],
+        "category_stability": report.category_stability,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cross-model grouping
+# ---------------------------------------------------------------------------
+
+
+def compare_runs_by_model(runs: list[dict]) -> dict[str, ComparisonReport]:
+    """Group runs by model_id and compute per-model variance reports.
+
+    Args:
+        runs: List of run result dicts (from JSON/JSONL output).
+
+    Returns:
+        Dict mapping model_id -> ComparisonReport for that model.
+    """
+    groups: dict[str, list[dict]] = {}
+    for run in runs:
+        model_id = run.get("model", "unknown")
+        groups.setdefault(model_id, []).append(run)
+
+    return {model: compare_runs(group) for model, group in groups.items()}
+
+
+# ---------------------------------------------------------------------------
+# Statistical tests (stdlib-only, no scipy dependency)
+# ---------------------------------------------------------------------------
+
+
+def mann_whitney_u(values_a: list[float], values_b: list[float]) -> tuple[float, float]:
+    """Mann-Whitney U test for cross-model comparison.
+
+    Returns (U_statistic, approximate_p_value).
+    Uses normal approximation with continuity correction and tie handling.
+    Requires at least 2 samples per group.
+    """
+    n1 = len(values_a)
+    n2 = len(values_b)
+    if n1 < 2 or n2 < 2:
+        return (0.0, 1.0)
+
+    # Rank all values together.
+    combined = [(v, 0) for v in values_a] + [(v, 1) for v in values_b]
+    combined.sort(key=lambda x: x[0])
+
+    # Assign ranks (handle ties with average rank).
+    ranks_a: list[float] = []
+    ranks_b: list[float] = []
+    i = 0
+    while i < len(combined):
+        j = i
+        while j < len(combined) and combined[j][0] == combined[i][0]:
+            j += 1
+        # Average rank for tied values.
+        avg_rank = (i + 1 + j) / 2.0
+        for k in range(i, j):
+            if combined[k][1] == 0:
+                ranks_a.append(avg_rank)
+            else:
+                ranks_b.append(avg_rank)
+        i = j
+
+    R1 = sum(ranks_a)
+    U1 = R1 - n1 * (n1 + 1) / 2.0
+    U2 = n1 * n2 - U1
+    U = min(U1, U2)
+
+    # Normal approximation for p-value.
+    mean_u = n1 * n2 / 2.0
+    std_u = math.sqrt(n1 * n2 * (n1 + n2 + 1) / 12.0)
+    if std_u == 0:
+        return (U, 1.0)
+
+    # Continuity correction.
+    z = (U - mean_u + 0.5) / std_u if U < mean_u else (U - mean_u - 0.5) / std_u
+    # Approximate two-tailed p-value using error function approximation.
+    p_value = 2.0 * (1.0 - _normal_cdf(abs(z)))
+    return (U, max(0.0, min(1.0, p_value)))
+
+
+def _normal_cdf(x: float) -> float:
+    """Approximation of the standard normal CDF."""
+    # Abramowitz and Stegun approximation (error < 7.5e-8).
+    a1 = 0.254829592
+    a2 = -0.284496736
+    a3 = 1.421413741
+    a4 = -1.453152027
+    a5 = 1.061405429
+    p = 0.3275911
+    sign = 1 if x >= 0 else -1
+    x = abs(x) / math.sqrt(2)
+    t = 1.0 / (1.0 + p * x)
+    y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * math.exp(-x * x)
+    return 0.5 * (1.0 + sign * y)
+
+
+def cliffs_delta(values_a: list[float], values_b: list[float]) -> float:
+    """Cliff's delta effect size for cross-model comparison.
+
+    Returns a value in [-1, 1]:
+    - |d| < 0.147: negligible
+    - 0.147 <= |d| < 0.33: small
+    - 0.33 <= |d| < 0.474: medium
+    - |d| >= 0.474: large
+    """
+    if not values_a or not values_b:
+        return 0.0
+
+    n1 = len(values_a)
+    n2 = len(values_b)
+    greater = 0
+    ties = 0
+    for a in values_a:
+        for b in values_b:
+            if a > b:
+                greater += 1
+            elif a == b:
+                ties += 1
+
+    return (2.0 * greater + ties) / (n1 * n2) - 1.0
+
+
+def bootstrap_ci(
+    values_a: list[float],
+    values_b: list[float],
+    *,
+    n_bootstrap: int = 1000,
+    confidence: float = 0.95,
+    statistic: str = "mean_diff",
+) -> tuple[float, float]:
+    """Bootstrap confidence interval for the difference between two samples.
+
+    Args:
+        values_a: First sample.
+        values_b: Second sample.
+        n_bootstrap: Number of bootstrap resamples.
+        confidence: Confidence level (default 0.95).
+        statistic: "mean_diff" or "median_diff".
+
+    Returns:
+        (lower_bound, upper_bound) of the confidence interval.
+    """
+    if len(values_a) < 2 or len(values_b) < 2:
+        return (0.0, 0.0)
+
+    boot_stats: list[float] = []
+    rng = random.Random(42)  # Reproducible.
+    for _ in range(n_bootstrap):
+        resample_a = [rng.choice(values_a) for _ in range(len(values_a))]
+        resample_b = [rng.choice(values_b) for _ in range(len(values_b))]
+        if statistic == "median_diff":
+            boot_stats.append(_median(resample_a) - _median(resample_b))
+        else:
+            boot_stats.append(_mean(resample_a) - _mean(resample_b))
+
+    alpha = (1.0 - confidence) / 2.0
+    lower = _percentile(boot_stats, alpha * 100)
+    upper = _percentile(boot_stats, (1.0 - alpha) * 100)
+    return (round(lower, 4), round(upper, 4))

--- a/tests/integration/test_email_bench_throughput.py
+++ b/tests/integration/test_email_bench_throughput.py
@@ -1,0 +1,79 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Integration test for the email-triage throughput benchmark (#1233).
+
+Skipped automatically when Lemonade is not running (via ``require_lemonade``).
+Direct-drives ``EmailTriageAgent`` over the committed synthetic stub corpus and
+asserts that perf metrics are harvested end-to-end. The committed >10 tok/s bar
+is *non-gating for the demo* (#1233): a miss is surfaced via ``xfail`` (visible
+in CI) rather than a hard failure, since throughput is hardware-dependent.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytestmark = pytest.mark.integration
+
+from gaia.eval.benchmark import (  # noqa: E402
+    THROUGHPUT_BAR_TPS,
+    load_ground_truth,
+    run_benchmark,
+    summarize_benchmark,
+)
+
+FIXTURES_DIR = _REPO_ROOT / "tests" / "fixtures" / "email"
+STUB_INBOX = FIXTURES_DIR / "_stub_inbox.mbox"
+GROUND_TRUTH = FIXTURES_DIR / "ground_truth.json"
+
+MODEL = "Gemma-4-E4B-it-GGUF"
+
+
+def test_throughput_benchmark_end_to_end(require_lemonade, tmp_path):
+    """Run one benchmark pass and assert perf metrics are harvested."""
+    ground_truth = load_ground_truth(GROUND_TRUTH)
+
+    results = run_benchmark(
+        MODEL,
+        mbox_path=str(STUB_INBOX),
+        limit=10,
+        experiments=1,
+        ground_truth=ground_truth,
+        db_path=str(tmp_path / "state.db"),
+    )
+
+    assert len(results) == 1
+    r = results[0]
+    assert r["status"] == "PASS", f"benchmark did not complete: {r.get('error')}"
+    assert r["total_emails"] > 0
+    assert "quality" in r  # ground truth was supplied
+
+    summary = summarize_benchmark(results, run_id="itest-bench")
+    perf = summary["scorecard"]["performance"]
+    tps = perf["avg_tokens_per_second"]
+    ttft = perf["avg_time_to_first_token"]
+    print(
+        f"\nThroughput benchmark ({MODEL}):\n"
+        f"  tokens/sec: {tps}\n"
+        f"  TTFT (s):   {ttft}\n"
+        f"  category accuracy: {r['quality']['category_accuracy']}\n"
+    )
+
+    # Perf must actually be harvested from /stats (the core deliverable).
+    assert isinstance(tps, (int, float)) and tps > 0, "no throughput harvested"
+    assert isinstance(ttft, (int, float)) and ttft > 0, "no TTFT harvested"
+
+    # Committed bar is non-gating for the demo — xfail (visible) on a miss.
+    if tps < THROUGHPUT_BAR_TPS:
+        pytest.xfail(
+            f"throughput {tps} tok/s below committed bar {THROUGHPUT_BAR_TPS} "
+            "tok/s (non-gating demo; hardware-dependent)"
+        )

--- a/tests/unit/eval/test_benchmark.py
+++ b/tests/unit/eval/test_benchmark.py
@@ -1,0 +1,218 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.eval.benchmark (offline — no Lemonade)."""
+
+import json
+
+import pytest
+
+from gaia.eval.benchmark import (
+    _extract_tools_called,
+    _extract_triage_results,
+    _maybe_parse_tool_envelope,
+    _normalize_agent_result,
+    build_result,
+    run_benchmark,
+    summarize_benchmark,
+)
+
+GT = {
+    "_meta": {"note": "skip me"},
+    "a": {"category": "urgent", "is_spam": False, "is_phishing": False},
+    "b": {"category": "low priority", "is_spam": True, "is_phishing": False},
+}
+
+TRIAGE_ENVELOPE = {
+    "ok": True,
+    "data": {
+        "results": [
+            {
+                "id": "a",
+                "category": "urgent",
+                "confident": True,
+                "is_spam": False,
+                "is_phishing": False,
+            },
+            {
+                "id": "b",
+                "category": "low priority",
+                "confident": True,
+                "is_spam": True,
+                "is_phishing": False,
+            },
+        ]
+    },
+}
+
+
+def _agent_result():
+    return {
+        "input_tokens": 1000,
+        "output_tokens": 200,
+        "total_tokens": 1200,
+        "conversation": [
+            {"role": "user", "content": "Triage my inbox (50 emails)"},
+            {
+                "role": "assistant",
+                "content": {"tool": "triage_inbox", "tool_input": {}},
+            },
+            {
+                "role": "tool",
+                "name": "triage_inbox",
+                "content": json.dumps(TRIAGE_ENVELOPE),
+            },
+            {"role": "assistant", "content": "Done."},
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "performance_stats": {
+                        "input_tokens": 1000,
+                        "output_tokens": 200,
+                        "time_to_first_token": 0.1,
+                        "tokens_per_second": 50.0,
+                    },
+                },
+            },
+        ],
+    }
+
+
+class TestFailLoud:
+    """The upstream fork swallowed malformed tool JSON; we must raise."""
+
+    def test_malformed_envelope_raises(self):
+        with pytest.raises(ValueError, match="malformed tool-result JSON envelope"):
+            _maybe_parse_tool_envelope('{"ok": true, "data": {')  # truncated JSON
+
+    def test_extract_triage_raises_on_malformed(self):
+        convo = [
+            {"role": "tool", "name": "triage_inbox", "content": '{"ok": true, "data'}
+        ]
+        with pytest.raises(ValueError):
+            _extract_triage_results(convo)
+
+    def test_build_result_propagates_raise(self):
+        ar = _agent_result()
+        ar["conversation"][2]["content"] = '{"ok": true, "data": ['  # corrupt
+        with pytest.raises(ValueError):
+            build_result(
+                ar, run_id="r", timestamp="t", model_id="m", total_duration_ms=1
+            )
+
+    def test_non_envelope_tool_output_is_skipped_not_raised(self):
+        # plain-text tool output is "not the message we want", not an error
+        assert _maybe_parse_tool_envelope("done, archived 3 messages") is None
+        assert _maybe_parse_tool_envelope("") is None
+
+
+class TestNormalizeAgentResult:
+    def test_dict_passthrough(self):
+        d = {"conversation": []}
+        assert _normalize_agent_result(d) is d
+
+    def test_json_string_parsed(self):
+        assert _normalize_agent_result('{"x": 1}') == {"x": 1}
+
+    def test_bad_string_raises(self):
+        with pytest.raises(ValueError):
+            _normalize_agent_result("not json {")
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(TypeError):
+            _normalize_agent_result(42)
+
+
+class TestExtractToolsCalled:
+    def test_dedupes_in_order(self):
+        assert _extract_tools_called(_agent_result()) == ["triage_inbox"]
+
+
+class TestBuildResult:
+    def test_scorecard_compatible_and_perf(self):
+        out = build_result(
+            _agent_result(),
+            run_id="r1",
+            timestamp="t",
+            model_id="Gemma-4-E4B-it-GGUF",
+            total_duration_ms=2000,
+            ground_truth=GT,
+        )
+        assert out["status"] == "PASS"
+        assert out["category"] == "Gemma-4-E4B-it-GGUF"
+        assert out["performance_summary"]["avg_tokens_per_second"] == 50.0
+        assert out["performance_summary"]["avg_time_to_first_token"] == 0.1
+        assert out["cost_estimate"]["estimated_usd"] == 0.0  # local model
+        assert out["meets_throughput_bar"] is True  # 50 >= 10
+        assert out["category_counts"] == {"urgent": 1, "low priority": 1}
+        assert out["total_emails"] == 2
+        # quality block computed against ground truth
+        assert out["quality"]["category_accuracy"] == 1.0
+        assert "spam" in out["quality"] and "needs_attention" in out["quality"]
+
+    def test_no_triage_results_is_fail(self):
+        ar = {"conversation": [{"role": "assistant", "content": "I refuse."}]}
+        out = build_result(
+            ar, run_id="r", timestamp="t", model_id="m", total_duration_ms=1
+        )
+        assert out["status"] == "FAIL"
+        assert "error" in out
+
+    def test_tool_error_envelope_is_errored(self):
+        ar = {
+            "conversation": [
+                {
+                    "role": "tool",
+                    "name": "triage_inbox",
+                    "content": json.dumps({"ok": False, "error": "backend down"}),
+                }
+            ]
+        }
+        out = build_result(
+            ar, run_id="r", timestamp="t", model_id="m", total_duration_ms=1
+        )
+        assert out["status"] == "ERRORED"
+        assert out["error"] == "backend down"
+
+
+class TestRunBenchmarkOffline:
+    def test_injected_agent_factory_runs_without_lemonade(self):
+        class _StubAgent:
+            def process_query(self, prompt):
+                return _agent_result()
+
+        results = run_benchmark(
+            "Gemma-4-E4B-it-GGUF",
+            mbox_path="ignored-when-factory-injected",
+            limit=2,
+            experiments=2,
+            ground_truth=GT,
+            agent_factory=_StubAgent,
+        )
+        assert len(results) == 2
+        assert all(r["status"] == "PASS" for r in results)
+        assert results[0]["is_cold_start"] is True
+        assert results[1]["is_cold_start"] is False
+
+
+class TestSummarizeBenchmark:
+    def test_scorecard_perf_section_populated(self):
+        results = [
+            build_result(
+                _agent_result(),
+                run_id=f"r{i}",
+                timestamp="t",
+                model_id="Gemma-4-E4B-it-GGUF",
+                total_duration_ms=2000,
+            )
+            for i in range(3)
+        ]
+        summary = summarize_benchmark(results, run_id="bench-run")
+        perf = summary["scorecard"]["performance"]
+        assert perf["avg_tokens_per_second"] == 50.0
+        assert perf["scenarios_with_data"] == 3
+        assert "Gemma-4-E4B-it-GGUF" in summary["variance"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/eval/test_performance_extractor.py
+++ b/tests/unit/eval/test_performance_extractor.py
@@ -1,0 +1,174 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.eval.performance (perf extractor — no Lemonade)."""
+
+import json
+
+import pytest
+
+from gaia.eval.performance import (
+    RunResult,
+    extract_from_agent_result,
+    extract_from_trace_json,
+    extract_step_stats,
+    run_to_dict,
+    to_performance_summary,
+)
+
+
+def _agent_result():
+    """A synthetic process_query() result mimicking agent.py:3745-3753 stats."""
+    return {
+        "input_tokens": 1200,
+        "output_tokens": 300,
+        "total_tokens": 1500,
+        "conversation": [
+            {"role": "system", "content": "You are an email triage agent."},
+            {"role": "user", "content": "Triage my inbox"},
+            {
+                "role": "assistant",
+                "content": "<thinking>let me plan</thinking> I'll triage now.",
+            },
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 1,
+                    "performance_stats": {
+                        "input_tokens": 800,
+                        "output_tokens": 150,
+                        "time_to_first_token": 0.09,  # seconds
+                        "tokens_per_second": 120.0,
+                    },
+                },
+            },
+            {"role": "tool", "name": "triage_inbox", "content": "{}"},
+            {"role": "assistant", "content": "Done."},
+            {
+                "role": "system",
+                "content": {
+                    "type": "stats",
+                    "step": 2,
+                    "performance_stats": {
+                        "input_tokens": 400,
+                        "output_tokens": 150,
+                        "time_to_first_token": 0.11,
+                        "tokens_per_second": 100.0,
+                    },
+                },
+            },
+        ],
+    }
+
+
+class TestExtractStepStats:
+    def test_two_steps_with_field_map(self):
+        steps, reasoning = extract_step_stats(_agent_result()["conversation"])
+        assert len(steps) == 2
+        s0 = steps[0]
+        assert s0.input_tokens == 800
+        assert s0.output_tokens == 150
+        assert s0.time_to_first_token_ms == 90.0  # 0.09s × 1000
+        assert s0.tokens_per_second == 120.0
+        assert s0.total_tokens == 950  # no total_tokens key → input+output fallback
+        assert s0.duration_ms == 0  # /stats has no per-step duration
+        # "<thinking>let me plan</thinking>" → 11 chars // 4 = 2 reasoning tokens
+        assert reasoning == 2
+
+    def test_no_stats_messages(self):
+        steps, reasoning = extract_step_stats(
+            [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}]
+        )
+        assert steps == []
+        assert reasoning == 0
+
+
+class TestExtractFromAgentResult:
+    def test_aggregates_and_averages(self):
+        run = extract_from_agent_result(
+            _agent_result(),
+            run_id="r1",
+            timestamp="2026-05-29T00:00:00Z",
+            model_id="Gemma-4-E4B-it-GGUF",
+            mode="full",
+            total_duration_ms=4200,
+            category_counts={"urgent": 1},
+            total_emails=1,
+        )
+        assert isinstance(run, RunResult)
+        assert len(run.step_results) == 2
+        assert run.total_input_tokens == 1200  # top-level preferred
+        assert run.total_output_tokens == 300
+        assert run.total_tokens == 1500
+        assert run.avg_time_to_first_token_ms == 100.0  # (90+110)/2
+        assert run.avg_tokens_per_second == 110.0  # (120+100)/2
+        assert run.total_duration_ms == 4200
+        assert run.category_counts == {"urgent": 1}
+        assert run.total_emails == 1
+        assert run.status == "ok"
+
+    def test_sums_from_steps_when_no_top_level_tokens(self):
+        ar = _agent_result()
+        del ar["input_tokens"]
+        del ar["output_tokens"]
+        del ar["total_tokens"]
+        run = extract_from_agent_result(ar, run_id="r2", timestamp="t", model_id="m")
+        assert run.total_input_tokens == 1200  # 800 + 400
+        assert run.total_output_tokens == 300  # 150 + 150
+
+    def test_empty_conversation_is_ok_with_zero_steps(self):
+        run = extract_from_agent_result(
+            {"conversation": []}, run_id="r3", timestamp="t", model_id="m"
+        )
+        assert run.step_results == []
+        assert run.avg_tokens_per_second == 0.0
+        assert run.status == "ok"
+
+
+class TestPerformanceSummary:
+    def test_scorecard_contract_keys(self):
+        run = extract_from_agent_result(
+            _agent_result(),
+            run_id="r",
+            timestamp="t",
+            model_id="m",
+            total_duration_ms=4200,
+        )
+        summary = to_performance_summary(run)
+        for key in (
+            "avg_tokens_per_second",
+            "avg_time_to_first_token",
+            "total_input_tokens",
+            "total_output_tokens",
+            "flags",
+        ):
+            assert key in summary
+        assert summary["avg_time_to_first_token"] == 0.1  # 100ms → 0.1s
+        assert summary["avg_tokens_per_second"] == 110.0
+
+    def test_run_to_dict_json_serializable(self):
+        run = extract_from_agent_result(
+            _agent_result(), run_id="r", timestamp="t", model_id="m"
+        )
+        json.dumps(run_to_dict(run))  # must not raise
+
+
+class TestExtractFromTraceJson:
+    def test_round_trips_a_trace_file(self, tmp_path):
+        trace = tmp_path / "trace.json"
+        trace.write_text(json.dumps(_agent_result()))
+        run = extract_from_trace_json(
+            str(trace), run_id="r", timestamp="t", model_id="m"
+        )
+        assert len(run.step_results) == 2
+        assert run.avg_tokens_per_second == 110.0
+
+    def test_missing_file_raises_loudly(self):
+        with pytest.raises(FileNotFoundError):
+            extract_from_trace_json(
+                "/nonexistent/trace.json", run_id="r", timestamp="t", model_id="m"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/eval/test_quality_metrics.py
+++ b/tests/unit/eval/test_quality_metrics.py
@@ -1,0 +1,130 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.eval.quality_metrics (pure — no Lemonade)."""
+
+import pytest
+
+from gaia.eval.quality_metrics import (
+    binary_confusion,
+    category_accuracy,
+    compute_cost,
+    confusion_for_categories,
+    confusion_for_flag,
+    per_category_confusion,
+)
+
+GT = {
+    "_meta": {"note": "metadata row — must be skipped"},
+    "a": {"category": "urgent", "is_spam": False, "is_phishing": False},
+    "b": {"category": "low priority", "is_spam": True, "is_phishing": False},
+    "c": {"category": "informational", "is_spam": False, "is_phishing": False},
+    "d": {"category": "actionable", "is_spam": False, "is_phishing": True},
+}
+
+
+class TestCategoryAccuracy:
+    def test_partial_match(self):
+        preds = {"a": "urgent", "b": "low priority", "c": "urgent", "d": "actionable"}
+        assert category_accuracy(preds, GT) == 0.75  # c wrong, 3/4
+
+    def test_case_insensitive(self):
+        assert category_accuracy({"a": "URGENT"}, GT) == 1.0
+
+    def test_skips_metadata_and_unmatched(self):
+        # only "a" overlaps; _meta never counts
+        assert category_accuracy({"a": "urgent", "z": "urgent"}, GT) == 1.0
+
+    def test_no_overlap_is_zero(self):
+        assert category_accuracy({"z": "urgent"}, GT) == 0.0
+
+
+class TestBinaryConfusion:
+    def test_one_each_quadrant(self):
+        pred = {"a": True, "b": False, "c": True, "d": False}
+        truth = {"a": True, "b": True, "c": False, "d": False}
+        c = binary_confusion(pred, truth)
+        assert (c.tp, c.fp, c.fn, c.tn) == (1, 1, 1, 1)
+        assert c.false_positive_rate == 0.5
+        assert c.false_negative_rate == 0.5
+        assert c.precision == 0.5
+        assert c.recall == 0.5
+        assert c.f1 == 0.5
+        assert c.accuracy == 0.5
+
+    def test_zero_denominator_rates_are_zero(self):
+        # all true-negative → no positives anywhere
+        c = binary_confusion({"a": False}, {"a": False})
+        assert c.false_positive_rate == 0.0
+        assert c.false_negative_rate == 0.0
+
+
+class TestSpamAxis:
+    def test_perfect_spam_detection(self):
+        pred = {"a": False, "b": True, "c": False, "d": False}  # only b is spam
+        c = confusion_for_flag(pred, GT, "is_spam")
+        assert (c.tp, c.fp, c.fn, c.tn) == (1, 0, 0, 3)
+        assert c.false_negative_rate == 0.0
+
+    def test_missed_spam_is_false_negative(self):
+        pred = {"a": False, "b": False, "c": False, "d": False}  # missed b
+        c = confusion_for_flag(pred, GT, "is_spam")
+        assert c.fn == 1
+        assert c.false_negative_rate == 1.0  # 1 of 1 actual spam missed
+
+
+class TestAttentionAxis:
+    def test_needs_attention_one_vs_rest(self):
+        preds = {
+            "a": "urgent",
+            "b": "low priority",
+            "c": "informational",
+            "d": "actionable",
+        }
+        c = confusion_for_categories(preds, GT, {"urgent", "actionable"})
+        assert (c.tp, c.fp, c.fn, c.tn) == (2, 0, 0, 2)
+
+    def test_false_positive_when_junk_flagged_important(self):
+        preds = {"a": "urgent", "b": "urgent", "c": "informational", "d": "actionable"}
+        c = confusion_for_categories(preds, GT, {"urgent", "actionable"})
+        assert c.fp == 1  # b (low priority) wrongly treated as needs-attention
+
+
+class TestPerCategoryConfusion:
+    def test_one_entry_per_category(self):
+        preds = {
+            "a": "urgent",
+            "b": "low priority",
+            "c": "informational",
+            "d": "actionable",
+        }
+        by_cat = per_category_confusion(preds, GT)
+        assert set(by_cat.keys()) == {
+            "urgent",
+            "low priority",
+            "informational",
+            "actionable",
+        }
+        assert by_cat["urgent"].tp == 1
+
+
+class TestComputeCost:
+    def test_local_model_is_free(self):
+        assert compute_cost(1_000_000, 1_000_000, model="Gemma-4-E4B-it-GGUF") == 0.0
+
+    def test_unknown_model_no_default_billing(self):
+        # the MODEL_PRICING "default" row must NOT apply to local models
+        assert compute_cost(5_000_000, 5_000_000, model=None) == 0.0
+
+    def test_cloud_model_is_priced(self):
+        # sonnet: $3/Mtok in, $15/Mtok out
+        assert compute_cost(1_000_000, 1_000_000, model="claude-sonnet-4-6") == 18.0
+
+    def test_explicit_override_wins(self):
+        assert (
+            compute_cost(1_000_000, 0, cost_per_1m_input=2.0, cost_per_1m_output=8.0)
+            == 2.0
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/eval/test_statistics.py
+++ b/tests/unit/eval/test_statistics.py
@@ -1,0 +1,149 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.eval.statistics (pure stdlib, no Lemonade)."""
+
+import json
+
+import pytest
+
+from gaia.eval.statistics import (
+    bootstrap_ci,
+    cliffs_delta,
+    compare_runs,
+    compare_runs_by_model,
+    compute_variance,
+    mann_whitney_u,
+    to_dict,
+)
+
+
+class TestComputeVariance:
+    def test_known_values(self):
+        vs = compute_variance([10, 12, 14, 16, 18], metric_name="demo")
+        assert vs.metric == "demo"
+        assert vs.mean == 14.0
+        assert vs.stdev == 3.16  # sample stdev sqrt(10) rounded
+        assert vs.min_val == 10
+        assert vs.max_val == 18
+        assert vs.cv_pct == 22.59
+        assert vs.median == 14.0
+        assert vs.p25 == 12.0
+        assert vs.p75 == 16.0
+        assert vs.iqr == 4.0
+        assert vs.n == 5
+
+    def test_empty_returns_zeros(self):
+        vs = compute_variance([], metric_name="empty")
+        assert vs.mean == 0.0
+        assert vs.stdev == 0.0
+        assert vs.n == 0
+
+    def test_single_value_zero_variance(self):
+        vs = compute_variance([42.0], metric_name="one")
+        assert vs.mean == 42.0
+        assert vs.stdev == 0.0
+        assert vs.cv_pct == 0.0
+        assert vs.n == 1
+
+
+class TestMannWhitneyU:
+    def test_fully_separated_groups(self):
+        u, p = mann_whitney_u([1, 2, 3], [10, 11, 12])
+        assert u == 0.0  # no overlap → U statistic is 0
+        assert p < 0.15  # normal approx for n=3 each
+
+    def test_too_few_samples_is_nonsignificant(self):
+        u, p = mann_whitney_u([1], [2])
+        assert u == 0.0
+        assert p == 1.0
+
+
+class TestCliffsDelta:
+    def test_a_entirely_below_b_is_minus_one(self):
+        assert cliffs_delta([1, 2, 3], [10, 11, 12]) == -1.0
+
+    def test_a_entirely_above_b_is_plus_one(self):
+        assert cliffs_delta([10, 11, 12], [1, 2, 3]) == 1.0
+
+    def test_identical_is_zero(self):
+        # all ties → (0 greater + 9 ties)/9 - 1 = 0
+        assert cliffs_delta([5, 5, 5], [5, 5, 5]) == 0.0
+
+
+class TestBootstrapCI:
+    def test_deterministic_and_reproducible(self):
+        a = [1.0, 2.0, 3.0, 4.0]
+        b = [10.0, 11.0, 12.0, 13.0]
+        ci1 = bootstrap_ci(a, b)
+        ci2 = bootstrap_ci(a, b)
+        assert ci1 == ci2  # seeded → reproducible
+        lower, upper = ci1
+        assert lower <= upper
+        assert upper < 0  # mean(a) - mean(b) is strongly negative
+
+    def test_too_few_samples_returns_zero_interval(self):
+        assert bootstrap_ci([1.0], [2.0]) == (0.0, 0.0)
+
+
+def _run(run_id, model, dur_ms, tokens, cats):
+    return {
+        "run_id": run_id,
+        "model": model,
+        "total_duration_ms": dur_ms,
+        "total_tokens": tokens,
+        "total_input_tokens": int(tokens * 0.8),
+        "total_output_tokens": int(tokens * 0.2),
+        "total_emails": sum(cats.values()),
+        "category_counts": cats,
+        "avg_tokens_per_second": 50.0,
+        "avg_time_to_first_token_ms": 100.0,
+    }
+
+
+class TestCompareRuns:
+    def test_two_run_deltas(self):
+        runs = [
+            _run("a", "M", 1000, 500, {"urgent": 2, "low priority": 8}),
+            _run("b", "M", 1200, 600, {"urgent": 3, "low priority": 7}),
+        ]
+        report = compare_runs(runs)
+        assert report.runs_compared == 2
+        assert len(report.run_deltas) == 1
+        d = report.run_deltas[0]
+        assert d.delta_duration_ms == 200
+        assert d.delta_total_tokens == 100
+        assert d.category_deltas == {"urgent": 1, "low priority": -1}
+        assert report.variance_summaries  # non-empty
+
+    def test_single_run_zero_variance(self):
+        report = compare_runs([_run("solo", "M", 800, 400, {"urgent": 1})])
+        assert report.runs_compared == 1
+        assert report.run_deltas == []
+        assert all(vs.stdev == 0.0 for vs in report.variance_summaries)
+
+    def test_to_dict_is_json_serializable(self):
+        runs = [
+            _run("a", "M", 1000, 500, {"urgent": 2}),
+            _run("b", "M", 1100, 520, {"urgent": 3}),
+        ]
+        out = to_dict(compare_runs(runs))
+        # Must round-trip through json with no errors.
+        json.dumps(out)
+        assert out["runs_compared"] == 2
+
+
+class TestCompareRunsByModel:
+    def test_groups_by_model(self):
+        runs = [
+            _run("a1", "X", 1000, 500, {"urgent": 1}),
+            _run("a2", "X", 1050, 510, {"urgent": 2}),
+            _run("b1", "Y", 900, 450, {"urgent": 1}),
+        ]
+        by_model = compare_runs_by_model(runs)
+        assert set(by_model.keys()) == {"X", "Y"}
+        assert by_model["X"].runs_compared == 2
+        assert by_model["Y"].runs_compared == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Why this matters

Before, GAIA had no way to measure on-device email-triage throughput, and the eval framework carried no reusable statistics or performance-extraction primitives — so "is the agent fast enough on Ryzen AI?" couldn't be answered with a number. Now `gaia eval benchmark` direct-drives the email agent over the committed synthetic corpus and reports **TTFT, tokens/sec, and pipeline latency** through the existing scorecard. On `Gemma-4-E4B` it measures ~62–69 tok/s — well above the committed **≥10 tok/s** bar (non-gating for the demo; ~30 tok/s stretch).

Closes #1233.

The benchmark rides on four dependency-light eval modules that are reusable beyond email (they're the foundation for #1277 perf-metrics and #1278 quality-metrics next):

- **`statistics.py`** — variance/CV/percentiles, Mann-Whitney U, Cliff's delta, bootstrap CI (stdlib-only); the rigor layer for cross-run/cross-model comparison.
- **`performance.py`** — domain-free per-step TTFT/throughput/token extraction from the agent conversation; emits the scorecard `performance_summary` shape so aggregation/rendering is reused, not reinvented.
- **`quality_metrics.py`** — category accuracy + spam/phishing/needs-attention confusion (FP/FN) + token cost via `MODEL_PRICING` (local models are correctly free).
- **`benchmark.py`** — the orchestrator; malformed tool-result envelopes now **raise loudly** instead of being silently swallowed (the upstream pattern this was lifted from used `except: pass`), while genuine non-envelope tool output is still skipped.

## Test plan

- [ ] `python -m pytest tests/unit/eval/ -k "statistics or performance_extractor or quality_metrics or benchmark" -v` — 52 unit tests, no Lemonade required (includes fail-loud `pytest.raises` coverage).
- [ ] With Lemonade serving `Gemma-4-E4B-it-GGUF`: `python -m pytest tests/integration/test_email_bench_throughput.py -v -s` — end-to-end; asserts perf is harvested (>0 tok/s) and xfails (visible, non-gating) on a sub-bar number.
- [ ] `gaia eval benchmark --model Gemma-4-E4B-it-GGUF --limit 50` — prints a throughput number ≥10 tok/s plus a scorecard Performance section.
- [ ] `python util/lint.py --black --flake8` clean on the changed files.
