### PR TITLE
fix(ui): return 409 for overlapping chat turns

### DIFF
--- a/src/gaia/ui/routers/chat.py
+++ b/src/gaia/ui/routers/chat.py
@@ -86,22 +86,16 @@ async def send_message(
     sid = request.session_id
     session_lock = session_locks.setdefault(sid, asyncio.Lock())
 
-    # Acquire session lock — if a previous request is stuck (hung LLM
-    # connection, crashed stream), force-release and proceed rather than
-    # leaving the user permanently stuck with "request already in progress".
-    try:
-        await asyncio.wait_for(session_lock.acquire(), timeout=5.0)
-    except asyncio.TimeoutError:
-        logger.warning(
-            "Force-releasing stuck session lock for %s "
-            "(previous request likely hung)",
-            sid,
+    # Reject overlapping turns for the same session. Force-releasing an
+    # asyncio.Lock held by another coroutine is unsafe because the lock
+    # has no ownership tracking.
+    if session_lock.locked():
+        raise HTTPException(
+            status_code=409,
+            detail="A chat request is already in progress for this session. "
+            "Please wait for it to finish.",
         )
-        try:
-            session_lock.release()
-        except RuntimeError:
-            pass  # Lock wasn't held — race condition, safe to ignore
-        await session_lock.acquire()
+    await session_lock.acquire()
 
     # ── Global concurrency gate ──────────────────────────────────────
     # Queue rather than immediately reject: wait up to 60 s for a slot.

--- a/tests/unit/chat/ui/test_chat_concurrency.py
+++ b/tests/unit/chat/ui/test_chat_concurrency.py
@@ -39,11 +39,13 @@ def session_id(client):
     return resp.json()["id"]
 
 
-class TestSessionLockForceRelease:
-    """Tests for per-session lock force-release on stuck requests."""
+class TestSessionLockConflict:
+    """Tests for same-session conflict handling."""
 
-    def test_concurrent_request_force_releases_stuck_lock(self, app, session_id):
-        """When a session lock is stuck, a second request force-releases it and proceeds."""
+    def test_concurrent_request_returns_409_if_session_lock_is_held(
+        self, app, session_id
+    ):
+        """When a session lock is held, a second request should get 409."""
         # Pre-acquire the session lock to simulate a stuck request
         lock = asyncio.Lock()
 
@@ -63,14 +65,15 @@ class TestSessionLockForceRelease:
                 "/api/chat/send",
                 json={
                     "session_id": session_id,
-                    "message": "should succeed after force-release",
+                    "message": "should conflict while another turn is active",
                     "stream": False,
                 },
             )
-        # Should succeed (200) instead of deadlocking with 409
-        assert resp.status_code == 200
+        assert resp.status_code == 409
+        assert "already in progress" in resp.json()["detail"]
 
         # Cleanup
+        lock.release()
         loop.close()
 
     def test_different_sessions_not_blocked(self, client, db):


### PR DESCRIPTION
## Summary

- return `409` when a second `/api/chat/send` request arrives for a session that already has an active turn
- remove the unsafe force-release path for held session locks
- update the chat concurrency unit test to assert the conflict behavior we already expect in stress coverage

## Why

The old code would wait 5 seconds, call `release()` on the per-session `asyncio.Lock`, and then continue. That is not safe because `asyncio.Lock` does not track ownership. A slow but healthy request could still be holding the lock when a second request force-unlocked it, which opened the door to overlapping turns mutating the same session.

This change keeps the contract simple: one active turn per session, and the second request gets a `409` instead of barging through.

Closes #1303.

## Testing

- `uv run pytest tests/unit/chat/ui/test_chat_concurrency.py -q`
- `uv run python -m compileall src/gaia/ui/routers/chat.py tests/unit/chat/ui/test_chat_concurrency.py`
