### PR TITLE
ci: rag_quality eval dry-run (DO NOT MERGE — diagnostic)

### DIFF
--- a/.github/workflows/eval_rag_dryrun.yml
+++ b/.github/workflows/eval_rag_dryrun.yml
@@ -59,11 +59,23 @@ jobs:
           # The eval shells out to the `claude` CLI as the user-simulator and
           # judge (runner.py preflight hard-requires it; anthropic SDK alone is
           # not enough). ANTHROPIC_API_KEY (job env) provides headless auth.
-          npm install -g @anthropic-ai/claude-code
-          $prefix = (npm config get prefix).Trim()
-          $env:PATH = "$prefix;$env:PATH"
-          Add-Content -Path $env:GITHUB_PATH -Value $prefix
-          Write-Host "claude on PATH at: $prefix"
+          # stx runners have no npm, so use the native installer.
+          irm https://claude.ai/install.ps1 | iex
+
+          $candidates = @(
+            "$env:USERPROFILE\.local\bin",
+            "$env:LOCALAPPDATA\Programs\claude",
+            "$env:LOCALAPPDATA\claude"
+          )
+          $bin = $candidates | Where-Object { Test-Path "$_\claude.exe" } | Select-Object -First 1
+          if (-not $bin) {
+            $found = Get-ChildItem -Path $env:USERPROFILE, $env:LOCALAPPDATA -Recurse -Filter claude.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($found) { $bin = $found.DirectoryName }
+          }
+          if (-not $bin) { throw "claude.exe not found after install" }
+          $env:PATH = "$bin;$env:PATH"
+          Add-Content -Path $env:GITHUB_PATH -Value $bin
+          Write-Host "claude on PATH at: $bin"
           claude --version
 
       - name: Run rag_quality eval end-to-end (Lemonade + :4200 backend + Claude judge)

--- a/.github/workflows/eval_rag_dryrun.yml
+++ b/.github/workflows/eval_rag_dryrun.yml
@@ -53,6 +53,19 @@ jobs:
       - name: Install Lemonade Server
         uses: ./.github/actions/install-lemonade
 
+      - name: Install Claude Code CLI (eval user-simulator + judge)
+        shell: powershell
+        run: |
+          # The eval shells out to the `claude` CLI as the user-simulator and
+          # judge (runner.py preflight hard-requires it; anthropic SDK alone is
+          # not enough). ANTHROPIC_API_KEY (job env) provides headless auth.
+          npm install -g @anthropic-ai/claude-code
+          $prefix = (npm config get prefix).Trim()
+          $env:PATH = "$prefix;$env:PATH"
+          Add-Content -Path $env:GITHUB_PATH -Value $prefix
+          Write-Host "claude on PATH at: $prefix"
+          claude --version
+
       - name: Run rag_quality eval end-to-end (Lemonade + :4200 backend + Claude judge)
         shell: powershell
         run: |
@@ -130,7 +143,7 @@ jobs:
             Write-Host "[OK] backend ready"
 
             # `--compare <one path>` is diff-only and reads the saved baseline
-            # at eval/results/baseline.json — it does NOT run the eval. So:
+            # at eval/results/baseline.json -- it does NOT run the eval. So:
             # seed the committed baseline there, RUN the eval, then COMPARE.
             Write-Host "=== Seeding baseline -> eval/results/baseline.json ==="
             New-Item -ItemType Directory -Force -Path eval/results | Out-Null

--- a/.github/workflows/eval_rag_dryrun.yml
+++ b/.github/workflows/eval_rag_dryrun.yml
@@ -41,10 +41,13 @@ jobs:
         uses: ./.github/actions/setup-venv
         with:
           python-version: '3.12'
+          # -e (editable) is REQUIRED: the eval resolves REPO_ROOT via
+          # Path(__file__)...parent, so a non-editable install points
+          # eval/{scenarios,corpus,results} into .venv\Lib (non-existent).
           # ui  -> fastapi/uvicorn for the :4200 backend
           # rag -> retrieval deps for the doc agent
           # eval-> anthropic (Claude judge) + reportlab/pypdf/sklearn
-          install-package: '.[dev,ui,rag,eval]'
+          install-package: '-e .[dev,ui,rag,eval]'
           extra-index-url: 'https://download.pytorch.org/whl/cpu'
 
       - name: Install Lemonade Server
@@ -126,12 +129,28 @@ jobs:
             if (-not $ready) { throw "Agent UI backend failed to become ready on :4200" }
             Write-Host "[OK] backend ready"
 
-            Write-Host "=== Running rag_quality eval (compare to committed baseline) ==="
-            & $gaia eval agent --category rag_quality `
-              --compare tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/scorecard_rag_quality.json
+            # `--compare <one path>` is diff-only and reads the saved baseline
+            # at eval/results/baseline.json — it does NOT run the eval. So:
+            # seed the committed baseline there, RUN the eval, then COMPARE.
+            Write-Host "=== Seeding baseline -> eval/results/baseline.json ==="
+            New-Item -ItemType Directory -Force -Path eval/results | Out-Null
+            Copy-Item tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/scorecard_rag_quality.json `
+              eval/results/baseline.json -Force
+
+            Write-Host "=== Running rag_quality eval (8 scenarios) ==="
+            & $gaia eval agent --category rag_quality
+            Write-Host "eval run exit code: $LASTEXITCODE"
+
+            $sc = Get-ChildItem eval/results/eval-*/scorecard.json -ErrorAction SilentlyContinue |
+              Sort-Object LastWriteTime | Select-Object -Last 1
+            if (-not $sc) { throw "no scorecard produced - eval run did not complete" }
+            Write-Host "scorecard: $($sc.FullName)"
+
+            Write-Host "=== Comparing run vs baseline ==="
+            & $gaia eval agent --compare eval/results/baseline.json $sc.FullName
             $code = $LASTEXITCODE
-            Write-Host "eval exit code: $code"
-            if ($code -ne 0) { throw "rag_quality eval failed (exit $code)" }
+            Write-Host "compare exit code: $code"
+            if ($code -ne 0) { throw "rag_quality eval regressed vs baseline (compare exit $code)" }
             Write-Host "[OK] rag_quality eval passed vs baseline"
           }
           finally {

--- a/.github/workflows/eval_rag_dryrun.yml
+++ b/.github/workflows/eval_rag_dryrun.yml
@@ -1,7 +1,7 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# TEMPORARY DIAGNOSTIC — DO NOT MERGE.
+# TEMPORARY DIAGNOSTIC - DO NOT MERGE.
 #
 # Proves the `rag_quality` eval runs green end-to-end on the `stx`
 # self-hosted runner *before* we rewrite the real test_eval_rag.yml
@@ -20,7 +20,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
-# Own group — must NOT share `lemonade-eval` with test_eval_rag.yml, whose
+# Own group - must NOT share `lemonade-eval` with test_eval_rag.yml, whose
 # runs queue forever for the non-existent runner and would block this one.
 concurrency:
   group: eval-rag-dryrun-${{ github.event.pull_request.number }}
@@ -116,7 +116,7 @@ jobs:
             for ($i = 0; $i -lt 90 -and -not $ready; $i++) {
               Start-Sleep -Seconds 2
               if ($backend.HasExited) {
-                throw "Agent UI backend exited early (code $($backend.ExitCode)) — see log above"
+                throw "Agent UI backend exited early (code $($backend.ExitCode)) - see log above"
               }
               try {
                 Invoke-RestMethod -Uri "http://localhost:4200/api/health" -TimeoutSec 5 | Out-Null

--- a/.github/workflows/eval_rag_dryrun.yml
+++ b/.github/workflows/eval_rag_dryrun.yml
@@ -20,9 +20,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+# Own group — must NOT share `lemonade-eval` with test_eval_rag.yml, whose
+# runs queue forever for the non-existent runner and would block this one.
 concurrency:
-  group: lemonade-eval
-  cancel-in-progress: false
+  group: eval-rag-dryrun-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   dryrun:

--- a/.github/workflows/eval_rag_dryrun.yml
+++ b/.github/workflows/eval_rag_dryrun.yml
@@ -41,7 +41,10 @@ jobs:
         uses: ./.github/actions/setup-venv
         with:
           python-version: '3.12'
-          install-package: '.[dev,rag]'
+          # ui  -> fastapi/uvicorn for the :4200 backend
+          # rag -> retrieval deps for the doc agent
+          # eval-> anthropic (Claude judge) + reportlab/pypdf/sklearn
+          install-package: '.[dev,ui,rag,eval]'
           extra-index-url: 'https://download.pytorch.org/whl/cpu'
 
       - name: Install Lemonade Server
@@ -112,6 +115,9 @@ jobs:
             $ready = $false
             for ($i = 0; $i -lt 90 -and -not $ready; $i++) {
               Start-Sleep -Seconds 2
+              if ($backend.HasExited) {
+                throw "Agent UI backend exited early (code $($backend.ExitCode)) — see log above"
+              }
               try {
                 Invoke-RestMethod -Uri "http://localhost:4200/api/health" -TimeoutSec 5 | Out-Null
                 $ready = $true

--- a/.github/workflows/eval_rag_dryrun.yml
+++ b/.github/workflows/eval_rag_dryrun.yml
@@ -1,0 +1,140 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# TEMPORARY DIAGNOSTIC — DO NOT MERGE.
+#
+# Proves the `rag_quality` eval runs green end-to-end on the `stx`
+# self-hosted runner *before* we rewrite the real test_eval_rag.yml
+# (which is wedged on the non-existent `lemonade-eval` runner label and
+# never starts Lemonade or the :4200 backend the eval needs).
+#
+# Stack exercised here, mirroring test_rag.yml:
+#   Lemonade (:13305) -> GAIA Agent UI backend (:4200) -> Gemma-4-E4B
+#   (model under test) with Claude (claude-sonnet-4-6) as the judge.
+#
+# Runs ONLY on a PR carrying the `eval-dryrun` label, so the file is inert
+# if it ever lingers. Delete this workflow once the dry-run is green.
+name: Eval RAG Dry-Run (diagnostic)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: lemonade-eval
+  cancel-in-progress: false
+
+jobs:
+  dryrun:
+    name: RAG Quality Eval Dry-Run (stx)
+    if: contains(github.event.pull_request.labels.*.name, 'eval-dryrun')
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    timeout-minutes: 90
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          python-version: '3.12'
+          install-package: '.[dev,rag]'
+          extra-index-url: 'https://download.pytorch.org/whl/cpu'
+
+      - name: Install Lemonade Server
+        uses: ./.github/actions/install-lemonade
+
+      - name: Run rag_quality eval end-to-end (Lemonade + :4200 backend + Claude judge)
+        shell: powershell
+        run: |
+          [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+          $env:PYTHONIOENCODING = "utf-8"
+          $env:PYTHONUTF8 = "1"
+          chcp 65001 | Out-Null
+
+          # GAIA defaults Lemonade to :13305 (DEFAULT_PORT); be explicit so the
+          # backend's LemonadeManager attaches to the server we start below.
+          $env:LEMONADE_BASE_URL = "http://localhost:13305"
+
+          $py = ".\.venv\Scripts\python.exe"
+          $gaia = ".\.venv\Scripts\gaia.exe"
+          $backend = $null
+          $serverJob = $null
+
+          try {
+            Write-Host "=== Starting Lemonade Server (:13305) ==="
+            $serverJob = Start-Job -ScriptBlock {
+              # Issue #612 workaround: disable Vulkan coopmat optimization.
+              $env:GGML_VK_DISABLE_COOPMAT = "1"
+              & lemonade-server serve --host localhost --port 13305 --no-tray 2>&1
+            }
+
+            $ready = $false
+            for ($i = 0; $i -lt 60 -and -not $ready; $i++) {
+              Start-Sleep -Seconds 2
+              try {
+                Invoke-RestMethod -Uri "http://localhost:13305/api/v1/health" -TimeoutSec 5 | Out-Null
+                $ready = $true
+              } catch {}
+            }
+            if (-not $ready) { throw "Lemonade Server failed to become ready on :13305" }
+            Write-Host "[OK] Lemonade ready"
+
+            # Ensure the model-under-test and the RAG embedder are present.
+            # (Both are already cached on stx; this just guarantees it.)
+            foreach ($m in @("Gemma-4-E4B-it-GGUF", "nomic-embed-text-v2-moe-GGUF")) {
+              Write-Host "Pulling $m ..."
+              try {
+                $body = @{ model_name = $m } | ConvertTo-Json
+                Invoke-RestMethod -Uri "http://localhost:13305/api/v1/pull" -Method POST `
+                  -ContentType "application/json" -Body $body -TimeoutSec 1200 | Out-Null
+                Write-Host "  [OK] $m"
+              } catch { Write-Host "  [WARN] pull $m`: $($_.Exception.Message)" }
+            }
+
+            # Preload the embedder (RAG indexing needs it immediately). The LLM
+            # is loaded by the agent itself at GAIA's expected ctx_size.
+            try {
+              $body = @{ model_name = "nomic-embed-text-v2-moe-GGUF" } | ConvertTo-Json
+              Invoke-RestMethod -Uri "http://localhost:13305/api/v1/load" -Method POST `
+                -ContentType "application/json" -Body $body -TimeoutSec 120 | Out-Null
+              Write-Host "[OK] embedder loaded"
+            } catch { Write-Host "[WARN] embedder load: $($_.Exception.Message)" }
+
+            Write-Host "=== Starting GAIA Agent UI backend (:4200) ==="
+            $backend = Start-Process -FilePath $py `
+              -ArgumentList "-m gaia.ui.server --port 4200" `
+              -PassThru -NoNewWindow
+
+            $ready = $false
+            for ($i = 0; $i -lt 90 -and -not $ready; $i++) {
+              Start-Sleep -Seconds 2
+              try {
+                Invoke-RestMethod -Uri "http://localhost:4200/api/health" -TimeoutSec 5 | Out-Null
+                $ready = $true
+              } catch {}
+            }
+            if (-not $ready) { throw "Agent UI backend failed to become ready on :4200" }
+            Write-Host "[OK] backend ready"
+
+            Write-Host "=== Running rag_quality eval (compare to committed baseline) ==="
+            & $gaia eval agent --category rag_quality `
+              --compare tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/scorecard_rag_quality.json
+            $code = $LASTEXITCODE
+            Write-Host "eval exit code: $code"
+            if ($code -ne 0) { throw "rag_quality eval failed (exit $code)" }
+            Write-Host "[OK] rag_quality eval passed vs baseline"
+          }
+          finally {
+            Write-Host "=== Cleanup ==="
+            if ($backend -and -not $backend.HasExited) {
+              Stop-Process -Id $backend.Id -Force -ErrorAction SilentlyContinue
+            }
+            if ($serverJob) {
+              Stop-Job $serverJob -ErrorAction SilentlyContinue
+              Remove-Job $serverJob -Force -ErrorAction SilentlyContinue
+            }
+            Get-Process llama-server -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+            Get-Process lemonade-server -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+          }


### PR DESCRIPTION
**Diagnostic — DO NOT MERGE. Throwaway branch, will be deleted.**

Proves the `rag_quality` eval runs green end-to-end on the `stx` self-hosted runner — Lemonade (:13305) + Gemma-4-E4B + the :4200 Agent UI backend + Claude judge — *before* rewriting the real `test_eval_rag.yml`.

Context: `test_eval_rag.yml` has never executed in 139 runs. Its `runs-on: [self-hosted, lemonade-eval]` targets a runner label that never existed (every sibling workflow uses `stx`/`stx-test`), and it never starts Lemonade or the :4200 backend the eval needs. This validates the corrected stack so the real fix lands green.

Triggered by the `eval-dryrun` label.