### PR TITLE
feat(connectors): emit connector.activation.changed for CLI/SDK activation writes (#1226)

### DIFF
--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -255,13 +255,20 @@ DELETE /api/connectors/{id}/activations/{agent_id}
 ```
 
 Both mutating routes reject non-`mcp_server` connectors with `400 Bad
-Request` (after the standard `X-Gaia-UI` CSRF check). SSE event
-`connector.activation.changed` is emitted on every successful PUT /
-DELETE so the Agent UI tile refreshes within ~1 s when another caller
-(CLI, SDK) changes the state. Disconnecting a connector wipes both
-grants **and** activations for that connector — re-adding the same
-`connector_id` must not silently inherit the previous user's
-tool-visibility decisions.
+Request` (after the standard `X-Gaia-UI` CSRF check).
+
+Every activation change emits the SSE event `connector.activation.changed`
+(`{connector_id, agent_id, active}`) so an open Agent UI Settings tab
+refreshes the "Active for" state without a manual reload. The emit is
+centralized in `api.activate` / `api.deactivate`, so HTTP, SDK, and CLI
+callers all notify through one path. Because the CLI runs in a separate
+process from the UI server, the server also runs a background watcher on
+`activations.json` that emits the same event (within ~1 s) when an
+out-of-process writer changes the ledger.
+
+Disconnecting a connector wipes both grants **and** activations for that
+connector — re-adding the same `connector_id` must not silently inherit
+the previous user's tool-visibility decisions.
 
 ## Where things live
 

--- a/src/gaia/connectors/activation_watcher.py
+++ b/src/gaia/connectors/activation_watcher.py
@@ -1,0 +1,164 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Background watcher that emits ``connector.activation.changed`` for
+out-of-process activation writes (#1226).
+
+The HTTP router and any SDK code running inside the UI-server process emit the
+event in-process via ``gaia.connectors.api.activate`` / ``deactivate``. But the
+``gaia connectors activations`` CLI runs as a *separate* process and writes the
+same ``~/.gaia/connectors/activations.json`` ledger directly, so its change
+never reaches the server's SSE clients. This watcher closes that gap: the
+long-running server polls the ledger and emits one event per changed
+``(connector_id, agent_id)`` pair, so an open Agent UI Settings tab updates
+live without a manual refresh.
+
+In-process writes are de-duplicated: ``api`` calls :func:`note_local_write`
+after each write to advance the watcher snapshot, so the next poll sees no diff
+and the event fires exactly once. Writes are atomic (``os.replace`` under a
+per-process lock in :mod:`gaia.connectors.activations`), so each poll reads only
+fully-committed state — there is no torn-read race.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from gaia.connectors import activations
+from gaia.connectors.events import emit
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_POLL_INTERVAL = 1.0
+
+# {connector_id: {agent_id: active_bool}}
+Ledger = Dict[str, Dict[str, bool]]
+
+
+def _safe_load() -> Ledger:
+    try:
+        return activations.load_activations()
+    except Exception:
+        logger.warning(
+            "activation-watcher: could not read activations ledger", exc_info=True
+        )
+        return {}
+
+
+def diff_ledgers(old: Ledger, new: Ledger) -> List[Tuple[str, str, bool]]:
+    """Return ``(connector_id, agent_id, active)`` for every changed pair.
+
+    Absence means inactive (the ledger deletes entries on deactivate), so a
+    pair present in ``old`` but missing in ``new`` yields ``active=False``.
+    """
+    changes: List[Tuple[str, str, bool]] = []
+    for connector_id in set(old) | set(new):
+        old_agents = old.get(connector_id, {})
+        new_agents = new.get(connector_id, {})
+        for agent_id in set(old_agents) | set(new_agents):
+            before = bool(old_agents.get(agent_id, False))
+            after = bool(new_agents.get(agent_id, False))
+            if before != after:
+                changes.append((connector_id, agent_id, after))
+    return changes
+
+
+class ActivationWatcher:
+    """Polls the activations ledger and emits change events."""
+
+    def __init__(self, poll_interval: float = _DEFAULT_POLL_INTERVAL) -> None:
+        self._poll_interval = poll_interval
+        self._snapshot: Ledger = {}
+        self._task: Optional[asyncio.Task] = None
+
+    def start(self) -> None:
+        """Seed the snapshot and launch the polling task on the running loop."""
+        self._snapshot = _safe_load()
+        self._task = asyncio.create_task(
+            self._run(), name="connector-activation-watcher"
+        )
+        logger.info("activation-watcher: started (poll=%.1fs)", self._poll_interval)
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+        logger.info("activation-watcher: stopped")
+
+    def note_local_write(self, connector_id: str, agent_id: str, active: bool) -> None:
+        """Advance the snapshot for one pair after an in-process write.
+
+        Called after an in-process ledger write so the watcher does not
+        re-emit an event the in-process path already sent. Only the written
+        pair is advanced — a concurrent out-of-process change to a *different*
+        pair is still detected on the next poll.
+        """
+        if active:
+            self._snapshot.setdefault(connector_id, {})[agent_id] = True
+        elif connector_id in self._snapshot:
+            self._snapshot[connector_id].pop(agent_id, None)
+            if not self._snapshot[connector_id]:
+                del self._snapshot[connector_id]
+
+    async def _run(self) -> None:
+        # CancelledError subclasses BaseException (not Exception) on 3.8+, so the
+        # broad ``except Exception`` below never swallows task cancellation.
+        while True:
+            await asyncio.sleep(self._poll_interval)
+            try:
+                await self.poll_once()
+            except Exception:
+                logger.warning("activation-watcher: poll failed", exc_info=True)
+
+    async def poll_once(self) -> List[Tuple[str, str, bool]]:
+        """Emit events for any changes since the last snapshot; return them."""
+        new = _safe_load()
+        changes = diff_ledgers(self._snapshot, new)
+        self._snapshot = new
+        for connector_id, agent_id, active in changes:
+            await emit(
+                "connector.activation.changed",
+                {
+                    "connector_id": connector_id,
+                    "agent_id": agent_id,
+                    "active": active,
+                },
+            )
+        return changes
+
+
+# Module-level singleton managed by the UI-server lifespan.
+_watcher: Optional[ActivationWatcher] = None
+
+
+def start_watcher(poll_interval: float = _DEFAULT_POLL_INTERVAL) -> ActivationWatcher:
+    """Create, start, and register the singleton watcher. Server lifespan only."""
+    global _watcher
+    _watcher = ActivationWatcher(poll_interval)
+    _watcher.start()
+    return _watcher
+
+
+async def stop_watcher() -> None:
+    """Stop and clear the singleton watcher (server shutdown)."""
+    global _watcher
+    if _watcher is not None:
+        await _watcher.stop()
+        _watcher = None
+
+
+def note_local_write(connector_id: str, agent_id: str, active: bool) -> None:
+    """Advance the running watcher's snapshot after an in-process write.
+
+    No-op unless a watcher is running (e.g. in the CLI process, where the
+    server-side watcher in another process is what reaches the UI).
+    """
+    if _watcher is not None:
+        _watcher.note_local_write(connector_id, agent_id, active)

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -25,6 +25,7 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Optional
 
+from gaia.connectors.activation_watcher import note_local_write
 from gaia.connectors.activations import (
     activate_agent,
     deactivate_agent,
@@ -37,6 +38,7 @@ from gaia.connectors.errors import (
     AuthRequiredError,
     ConfigurationError,
 )
+from gaia.connectors.events import emit_change
 from gaia.connectors.flow import (
     cancel_flow,
     complete_authorization,
@@ -317,6 +319,11 @@ def activate(
             len(scopes_for_grant),
         )
     activate_agent(connector_id, agent_id)
+    emit_change(
+        "connector.activation.changed",
+        {"connector_id": connector_id, "agent_id": agent_id, "active": True},
+    )
+    note_local_write(connector_id, agent_id, True)
     logger.info(
         "api: activated connector_id=%s agent_id=%s (auto_granted=%s)",
         connector_id,
@@ -339,6 +346,11 @@ def deactivate(connector_id: str, agent_id: str) -> None:
     """
     _require_mcp_server_for_activation(connector_id)
     deactivate_agent(connector_id, agent_id)
+    emit_change(
+        "connector.activation.changed",
+        {"connector_id": connector_id, "agent_id": agent_id, "active": False},
+    )
+    note_local_write(connector_id, agent_id, False)
 
 
 def tripwire_check() -> None:

--- a/src/gaia/connectors/events.py
+++ b/src/gaia/connectors/events.py
@@ -14,6 +14,7 @@ duck-typed throughout. The router does not need to inherit anything.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Optional, Protocol, runtime_checkable
 
@@ -56,3 +57,36 @@ async def emit(event_type: str, payload: dict) -> None:
     """Emit an event through the currently-registered emitter."""
     if _active_emitter is not None:
         await _active_emitter.emit(event_type, payload)
+
+
+def _log_emit_result(task: "asyncio.Task") -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("connections-event emit task failed: %r", exc)
+
+
+def emit_change(event_type: str, payload: dict) -> None:
+    """Fire-and-forget synchronous wrapper around :func:`emit`.
+
+    Lets synchronous callers (``api.py``, the CLI) trigger an event without
+    being async themselves. Inside the UI server (a running event loop) the
+    coroutine is scheduled on that loop and fanned out to SSE subscribers; in a
+    bare process (the CLI) it is run to completion against the registered
+    emitter — the no-op logging emitter unless an SSE one was registered.
+    Failures are logged, never silently swallowed.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None:
+        task = loop.create_task(emit(event_type, payload))
+        task.add_done_callback(_log_emit_result)
+    else:
+        try:
+            asyncio.run(emit(event_type, payload))
+        except Exception:  # defensive: a notification must not break the write
+            logger.exception("emit_change failed for %s", event_type)

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -45,11 +45,9 @@ from pydantic import BaseModel, Field
 
 import gaia.connectors as connections
 import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
-from gaia.connectors.activations import (
-    deactivate_agent,
-    list_agent_activations,
-)
+from gaia.connectors.activations import list_agent_activations
 from gaia.connectors.api import activate as activate_connector_for_agent
+from gaia.connectors.api import deactivate as deactivate_connector_for_agent
 from gaia.connectors.errors import (
     AuthRequiredError,
     ConfigurationError,
@@ -802,10 +800,8 @@ async def put_activation(
                 "scopes": list(body.scopes or []),
             },
         )
-    await _emitter.emit(
-        "connector.activation.changed",
-        {"connector_id": connector_id, "agent_id": agent_id, "active": True},
-    )
+    # ``connector.activation.changed`` is emitted by ``api.activate`` so CLI,
+    # SDK, and HTTP callers all notify through one path (#1226).
     return {
         "connector_id": connector_id,
         "agent_id": agent_id,
@@ -826,10 +822,10 @@ async def delete_activation(connector_id: str, agent_id: str) -> Response:
     one click. To wipe the grant call ``DELETE
     /api/connectors/{id}/grants/{agent_id}`` instead.
     """
+    # Route through ``api.deactivate`` so the MCP-only guard and the
+    # ``connector.activation.changed`` emit fire on one path for all callers
+    # (#1226). Previously this called the bare ledger function and emitted
+    # inline, bypassing the guard.
     _require_mcp_server(connector_id)
-    deactivate_agent(connector_id, agent_id)
-    await _emitter.emit(
-        "connector.activation.changed",
-        {"connector_id": connector_id, "agent_id": agent_id, "active": False},
-    )
+    deactivate_connector_for_agent(connector_id, agent_id)
     return Response(status_code=204)

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -345,6 +345,15 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
         await monitor.start()
         logger.info("Document file monitor started (30s polling interval)")
 
+        # ── Connector activation watcher (issue #1226) ──────────────────
+        # CLI/SDK activation writes land in the activations ledger from a
+        # separate process; poll it and emit connector.activation.changed so
+        # an open Settings tab reflects them live without a manual refresh.
+        from gaia.connectors.activation_watcher import start_watcher
+
+        start_watcher()
+        logger.info("Connector activation watcher started")
+
         # ── Connections (issue #915) ────────────────────────────────────
         # Eager tripwire sweep so a rotated OAuth client_id surfaces in
         # the server logs at boot (and clears stale entries) BEFORE any
@@ -405,6 +414,10 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
         await queue.shutdown()
         await monitor.stop()
         logger.info("Document file monitor stopped")
+        from gaia.connectors.activation_watcher import stop_watcher
+
+        await stop_watcher()
+        logger.info("Connector activation watcher stopped")
         db.close()
         logger.info("Database connection closed")
         memory_router_mod.close_store()

--- a/tests/unit/connectors/test_activation_api.py
+++ b/tests/unit/connectors/test_activation_api.py
@@ -70,6 +70,27 @@ def mcp_test_spec(monkeypatch):
     return fresh
 
 
+class _RecordingEmitter:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event_type, payload):
+        self.events.append((event_type, dict(payload)))
+
+
+@pytest.fixture
+def recording_emitter():
+    """Capture events published through the connectors event bus (#1226)."""
+    from gaia.connectors import events
+
+    rec = _RecordingEmitter()
+    events.set_emitter(rec)
+    try:
+        yield rec
+    finally:
+        events.reset_emitter()
+
+
 class TestActivateWithExistingGrant:
     def test_activate_with_existing_grant_does_not_touch_grant(
         self, fake_home, mcp_test_spec
@@ -263,3 +284,49 @@ class TestActivateColdStartLoadsCatalog:
         rc, out, err = self._spawn(code)
         assert rc == 0, f"deactivate failed cold: stderr={err!r}"
         assert "OK" in out
+
+
+class TestActivationEmitsSseEvent:
+    """#1226 — CLI/SDK callers flow through ``api.activate``/``deactivate``,
+    which must emit ``connector.activation.changed`` with the same payload the
+    HTTP PUT/DELETE handlers used to emit inline. This is the mockable
+    ``CLI → SSE`` path: the CLI calls these functions directly.
+    """
+
+    _EVENT = "connector.activation.changed"
+
+    def test_activate_emits_changed_event_active_true(
+        self, fake_home, mcp_test_spec, recording_emitter
+    ):
+        activate("mcp-test", "builtin:chat", scopes_for_grant=["use"])
+        assert (
+            self._EVENT,
+            {"connector_id": "mcp-test", "agent_id": "builtin:chat", "active": True},
+        ) in recording_emitter.events
+
+    def test_deactivate_emits_changed_event_active_false(
+        self, fake_home, mcp_test_spec, recording_emitter
+    ):
+        grant_agent("mcp-test", "builtin:chat", ["use"])
+        activate("mcp-test", "builtin:chat")
+        recording_emitter.events.clear()
+        deactivate("mcp-test", "builtin:chat")
+        assert (
+            self._EVENT,
+            {"connector_id": "mcp-test", "agent_id": "builtin:chat", "active": False},
+        ) in recording_emitter.events
+
+    def test_failed_activate_emits_nothing(
+        self, fake_home, mcp_test_spec, recording_emitter
+    ):
+        # No grant + no scopes raises before any write — and before any emit.
+        with pytest.raises(ConfigurationError):
+            activate("mcp-test", "builtin:chat")
+        assert recording_emitter.events == []
+
+    def test_rejected_oauth_activate_emits_nothing(
+        self, fake_home, mcp_test_spec, recording_emitter
+    ):
+        with pytest.raises(ConfigurationError):
+            activate("oauth-test", "builtin:chat", scopes_for_grant=["openid"])
+        assert recording_emitter.events == []

--- a/tests/unit/connectors/test_activation_watcher.py
+++ b/tests/unit/connectors/test_activation_watcher.py
@@ -1,0 +1,113 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the activation file-watcher (#1226).
+
+The watcher closes the cross-process gap: a ``gaia connectors activations``
+CLI write lands in ``~/.gaia/connectors/activations.json`` from a separate
+process, and the long-running UI server polls that ledger to emit
+``connector.activation.changed`` to its SSE clients. The autouse ``_autouse_
+isolate_home`` fixture in ``conftest.py`` already redirects the ledger path to
+a per-test ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.connectors import activations, events
+from gaia.connectors.activation_watcher import ActivationWatcher, diff_ledgers
+
+
+class _RecordingEmitter:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, event_type, payload):
+        self.events.append((event_type, dict(payload)))
+
+
+@pytest.fixture
+def recording_emitter():
+    rec = _RecordingEmitter()
+    events.set_emitter(rec)
+    try:
+        yield rec
+    finally:
+        events.reset_emitter()
+
+
+class TestDiffLedgers:
+    def test_activation_added(self):
+        assert diff_ledgers({}, {"mcp-x": {"a": True}}) == [("mcp-x", "a", True)]
+
+    def test_deactivation_removed(self):
+        # Deactivate deletes the entry; absence => inactive.
+        assert diff_ledgers({"mcp-x": {"a": True}}, {}) == [("mcp-x", "a", False)]
+
+    def test_no_change_returns_empty(self):
+        assert diff_ledgers({"mcp-x": {"a": True}}, {"mcp-x": {"a": True}}) == []
+
+    def test_multiple_changes(self):
+        old = {"mcp-x": {"a": True}}
+        new = {"mcp-x": {"b": True}}
+        assert sorted(diff_ledgers(old, new)) == [
+            ("mcp-x", "a", False),
+            ("mcp-x", "b", True),
+        ]
+
+
+class TestPollOnce:
+    async def test_emits_on_external_activation(self, recording_emitter):
+        watcher = ActivationWatcher()  # seeded with empty snapshot
+        activations.activate_agent("mcp-x", "builtin:chat")
+
+        changes = await watcher.poll_once()
+
+        assert ("mcp-x", "builtin:chat", True) in changes
+        assert (
+            "connector.activation.changed",
+            {"connector_id": "mcp-x", "agent_id": "builtin:chat", "active": True},
+        ) in recording_emitter.events
+
+    async def test_emits_on_external_deactivation(self, recording_emitter):
+        activations.activate_agent("mcp-x", "builtin:chat")
+        watcher = ActivationWatcher()
+        # snapshot now includes the activation
+        watcher.note_local_write("mcp-x", "builtin:chat", True)
+        recording_emitter.events.clear()
+
+        activations.deactivate_agent("mcp-x", "builtin:chat")
+        changes = await watcher.poll_once()
+
+        assert ("mcp-x", "builtin:chat", False) in changes
+        assert (
+            "connector.activation.changed",
+            {"connector_id": "mcp-x", "agent_id": "builtin:chat", "active": False},
+        ) in recording_emitter.events
+
+    async def test_no_change_emits_nothing(self, recording_emitter):
+        watcher = ActivationWatcher()
+        assert await watcher.poll_once() == []
+        assert recording_emitter.events == []
+
+    async def test_note_local_write_suppresses_duplicate(self, recording_emitter):
+        # Simulates an in-process write that already emitted: advancing the
+        # snapshot must make the next poll a no-op (no double event).
+        watcher = ActivationWatcher()
+        activations.activate_agent("mcp-x", "builtin:chat")
+        watcher.note_local_write("mcp-x", "builtin:chat", True)
+
+        assert await watcher.poll_once() == []
+        assert recording_emitter.events == []
+
+    async def test_note_local_write_does_not_mask_other_pair(self, recording_emitter):
+        # An in-process write to one pair must not swallow a concurrent
+        # out-of-process change to a *different* pair.
+        watcher = ActivationWatcher()
+        activations.activate_agent("mcp-x", "builtin:chat")  # in-process write
+        watcher.note_local_write("mcp-x", "builtin:chat", True)
+        activations.activate_agent("mcp-x", "builtin:code")  # external write
+
+        changes = await watcher.poll_once()
+
+        assert changes == [("mcp-x", "builtin:code", True)]


### PR DESCRIPTION


<!--
Thanks for contributing to GAIA! Every PR must reference a GitHub issue —
see CONTRIBUTING.md (https://github.com/amd/gaia/blob/main/CONTRIBUTING.md)
if you don't have one yet.
-->

## Summary

CLI and SDK activation toggles now drive the same live `connector.activation.changed` SSE update that the HTTP router already emitted, so the Agent UI's "Active for" panel reflects them without a manual refresh.

## Why

Activation writes from `gaia connectors activations activate/deactivate` (CLI) and direct SDK calls landed in `~/.gaia/connectors/activations.json` **silently** — only the HTTP `PUT/DELETE` handlers emitted `connector.activation.changed`. With the Agent UI Settings tab open, a CLI-driven toggle took effect on disk but the panel kept showing stale state until the user navigated away and back to force a refetch, making CLI ↔ UI workflows confusing. This was filed as an explicit follow-up on #1219.

## Linked issue

Closes #1226

## Changes

- **Centralized the emit (`src/gaia/connectors/api.py`).** `activate()` / `deactivate()` now emit `connector.activation.changed` (`{connector_id, agent_id, active}`) after the ledger write, so HTTP, SDK, and any in-process caller all notify through one path — mirroring how #1219 centralized the MCP-only guard in `api.py`.
- **New `emit_change()` helper (`src/gaia/connectors/events.py`).** A sync, loop-aware fire-and-forget wrapper so synchronous callers (`api`, CLI) can publish without being async. Inside the server loop it schedules on that loop and fans out to SSE subscribers; in a bare process it runs against the registered emitter (the no-op logging emitter). Failures are logged, never swallowed.
- **Server-side ledger watcher (`src/gaia/connectors/activation_watcher.py`, new).** The CLI runs in a separate process from the UI server, where the SSE bus lives. A background watcher polls `activations.json`, diffs against a snapshot, and emits one event per changed `(connector, agent)` pair (~1 s) so cross-process CLI/SDK writes reach connected UI clients. In-process writes call `note_local_write(...)` to advance the snapshot per-pair, so they don't double-emit — and a concurrent change to a *different* pair is still caught.
- **Watcher lifecycle (`src/gaia/ui/server.py`).** Started/stopped in the FastAPI lifespan, mirroring the existing `DocumentMonitor`.
- **Router cleanup + guard fix (`src/gaia/ui/routers/connectors.py`).** Removed the now-duplicate inline emits from `PUT/DELETE`; `DELETE` now routes through `api.deactivate` instead of the bare ledger call, closing a pre-existing MCP-only-guard bypass on that route.
- **Tests.** New `tests/unit/connectors/test_activation_watcher.py` (diff, poll-emit, dedup, don't-mask-other-pair) and extended `tests/unit/connectors/test_activation_api.py` (CLI→SSE path: emits on success, nothing on failure/rejection).
- **Docs (`docs/sdk/infrastructure/connectors.mdx`).** Updated the activation SSE section to describe the centralized emit + watcher. No frontend changes — `useConnectorsSSE.ts` already consumes `connector.activation.changed`.

## Test plan

- [x] `python util/lint.py --all` — all quality checks pass (Black, isort, Pylint, Flake8 green; pre-existing MyPy/Bandit/agent-convention warnings only, none in touched files).
- [x] `python -m pytest tests/unit/connectors/test_activation_api.py tests/unit/connectors/test_activation_watcher.py tests/unit/connectors/test_router_connectors.py` — 77 passed.
- [x] `python -m pytest tests/unit/connectors/` — 436 passed, 3 skipped.
- [x] Manual cross-process live update: start the UI server, open Settings → Connectors → expand an MCP connector's "Active for"; in a second terminal run `gaia connectors activations activate mcp-github builtin:connectors-demo --scopes use` → panel flips to active with no refresh; `gaia connectors activations deactivate mcp-github builtin:connectors-demo` → flips back live.

## Follow-ups (not in this PR — gaps found while doing this work)

- **`DispatchQueue` worker logs after the test stream closes (pre-existing).** Any UI test that boots a `TestClient` prints repeated `--- Logging error --- ValueError: I/O operation on closed file` blocks pointing at `src/gaia/ui/server.py:267` (`_import_modules` logging the faiss-load line). Root cause: `DispatchQueue.shutdown` (`src/gaia/ui/dispatch.py:104-105`) calls `self._executor.shutdown(wait=False)`, so a boot-init worker thread (the slow `faiss` import) is still running and logs after pytest closed the captured stream. Cosmetic (tests pass, exit 0) and reproduces on `main` with this PR stashed. **Suggested fix:** have `shutdown` drain in-flight boot jobs with a bounded wait, e.g. `await loop.run_in_executor(None, lambda: self._executor.shutdown(wait=True, cancel_futures=True))` under a timeout, so no worker logs post-teardown.
- **`StarletteDeprecationWarning: Using httpx with starlette.testclient is deprecated; install httpx2` (pre-existing, repo-wide).** Emitted by any test using the shared `ui_api_client` `TestClient` fixture (origin `tests/conftest.py:355`); pytest dedupes it to a single "1 warning" line. Not introduced here (reproduces on `main` with this PR stashed). **Suggested fix:** bump to `httpx2` per Starlette's guidance, or add a scoped `filterwarnings` entry in `pyproject.toml`.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #1226`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have updated documentation if user-visible behavior changed (see [CONTRIBUTING.md](../CONTRIBUTING.md)).