### PR TITLE
feat(connectors): surface MCP-consuming agents in the "Active for" panel (#1227)

### DIFF
--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -188,6 +188,16 @@ The Agent UI consent dialog renders `reason` in plain language. After
 the user grants the scopes, subsequent `get_access_token_sync` calls
 return fresh tokens transparently.
 
+If instead your agent loads MCP servers dynamically at runtime (from
+`~/.gaia/mcp_servers.json`) rather than declaring specific connectors, set
+`CONSUMES_MCP_SERVERS = True` so the Settings → Connectors "Active for"
+panel lists it for every `mcp_server` connector:
+
+```python
+class MyAgent(Agent):
+    CONSUMES_MCP_SERVERS: ClassVar[bool] = True
+```
+
 ## Per-agent activation (MCP servers only)
 
 Activations are the second axis of the per-agent authorization model
@@ -245,6 +255,21 @@ gaia connectors activations activate mcp-github builtin:chat --scopes use
 gaia connectors activations list mcp-github
 gaia connectors activations deactivate mcp-github builtin:chat
 ```
+
+### Which agents appear in the "Active for" panel
+
+For an `mcp_server` connector the panel lists agents from **two** sources:
+
+1. Agents that declare the connector in `REQUIRED_CONNECTORS` (static).
+2. Agents that set `CONSUMES_MCP_SERVERS = True` — they load MCP servers
+   dynamically at runtime (from `~/.gaia/mcp_servers.json`) and gate the
+   tools through this same activation ledger, so they can use **any** MCP
+   connector once activated. `builtin:chat` is the canonical example.
+
+Category (2) agents declare no scopes of their own, so one-click activation
+auto-grants the canonical `use` scope. The registry surfaces the flag on
+each agent as `consumes_mcp_servers`. OAuth connectors have no activatable
+agents — the panel is hidden for them entirely.
 
 The HTTP router exposes:
 

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -168,11 +168,7 @@ class Agent(abc.ABC):
     # Empty list = no external connections required (the default for built-ins).
     REQUIRED_CONNECTORS: ClassVar[List[ConnectorRequirement]] = []
 
-    # Whether this agent loads MCP servers dynamically at runtime (from
-    # ``~/.gaia/mcp_servers.json``) and gates their tools through the per-agent
-    # activation ledger. Such agents declare no static ``REQUIRED_CONNECTORS``
-    # for those servers, so the registry surfaces this flag to let the Settings
-    # "Active for" panel list them as activatable for MCP-server connectors.
+    # Registry reads this to include dynamic MCP consumers in the Settings "Active for" panel.
     CONSUMES_MCP_SERVERS: ClassVar[bool] = False
 
     # Declarative per-agent hardware requirement.  Agents that need a

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -168,6 +168,13 @@ class Agent(abc.ABC):
     # Empty list = no external connections required (the default for built-ins).
     REQUIRED_CONNECTORS: ClassVar[List[ConnectorRequirement]] = []
 
+    # Whether this agent loads MCP servers dynamically at runtime (from
+    # ``~/.gaia/mcp_servers.json``) and gates their tools through the per-agent
+    # activation ledger. Such agents declare no static ``REQUIRED_CONNECTORS``
+    # for those servers, so the registry surfaces this flag to let the Settings
+    # "Active for" panel list them as activatable for MCP-server connectors.
+    CONSUMES_MCP_SERVERS: ClassVar[bool] = False
+
     # Declarative per-agent hardware requirement.  Agents that need a
     # minimum tier (e.g., NPU) should set this ClassVar to a
     # `HardwareRequirement` instance. Example:

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -164,9 +164,7 @@ class ChatAgent(
     - MCP server integration
     """
 
-    # Loads MCP servers dynamically from ``~/.gaia/mcp_servers.json`` and gates
-    # their tools through the activation ledger, so it can use any MCP-server
-    # connector once activated without a static REQUIRED_CONNECTORS declaration.
+    # Dynamic MCP loader — registry exposes this for the Settings "Active for" panel.
     CONSUMES_MCP_SERVERS: ClassVar[bool] = True
 
     def __init__(self, config: Optional[ChatAgentConfig] = None):

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -9,7 +9,7 @@ import platform
 import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 try:
     from watchdog.observers import Observer
@@ -163,6 +163,11 @@ class ChatAgent(
     - Session persistence with auto-save
     - MCP server integration
     """
+
+    # Loads MCP servers dynamically from ``~/.gaia/mcp_servers.json`` and gates
+    # their tools through the activation ledger, so it can use any MCP-server
+    # connector once activated without a static REQUIRED_CONNECTORS declaration.
+    CONSUMES_MCP_SERVERS: ClassVar[bool] = True
 
     def __init__(self, config: Optional[ChatAgentConfig] = None):
         """

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -275,6 +275,12 @@ class AgentRegistration:
     # the CLI ``gaia connectors grants`` command can render the prompt
     # without re-importing the agent module.
     required_connections: List[ConnectorRequirement] = field(default_factory=list)
+    # ``consumes_mcp_servers`` is the agent class's ``CONSUMES_MCP_SERVERS``
+    # ClassVar surfaced into the registry. True for agents that load MCP
+    # servers dynamically at runtime (e.g. ChatAgent); lets the Settings
+    # "Active for" panel list them as activatable for MCP-server connectors
+    # even though they declare no static ``REQUIRED_CONNECTORS`` for those.
+    consumes_mcp_servers: bool = False
     # T-X2 (issue #915, plan amendment A9):
     # ``namespaced_agent_id`` is the grant-ledger key for this agent. Built-in
     # agents use ``builtin:<id>``; custom agents under ``~/.gaia/agents/``
@@ -413,6 +419,10 @@ class AgentRegistry:
                 agent_dir=None,
                 models=[],
                 required_connections=[],
+                # Hardcoded to mirror ``ChatAgent.CONSUMES_MCP_SERVERS`` — the
+                # lazy factory must not import the chat module at discovery
+                # time. A guard test keeps the two in sync.
+                consumes_mcp_servers=True,
                 namespaced_agent_id="builtin:chat",
                 category="conversation",
                 tags=["chat", "general", "personality"],
@@ -1185,6 +1195,7 @@ class AgentRegistry:
         required_connections = list(
             getattr(agent_class, "REQUIRED_CONNECTORS", []) or []
         )
+        consumes_mcp_servers = bool(getattr(agent_class, "CONSUMES_MCP_SERVERS", False))
         origin_hash = _compute_custom_origin_hash(py_file)
         namespaced_id = f"custom:{origin_hash}:{agent_id}"
 
@@ -1280,6 +1291,7 @@ class AgentRegistry:
                 agent_dir=agent_dir,
                 models=models,
                 required_connections=required_connections,
+                consumes_mcp_servers=consumes_mcp_servers,
                 namespaced_agent_id=namespaced_id,
                 category=agent_category,
                 tags=agent_tags,

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -47,6 +47,11 @@ import type { AgentMcpServer, ConnectorRow } from '../types';
 import { ConnectorTileMenu } from './ConnectorTileMenu';
 import './ConnectorsSection.css';
 
+// Canonical scope for MCP-server grants. Agents that consume MCP servers
+// dynamically declare no scopes of their own, so one-click activation
+// auto-grants this when no prior grant exists.
+const MCP_DEFAULT_GRANT_SCOPES = ['use'];
+
 // ── ConnectorsSection ────────────────────────────────────────────────────────
 
 export function ConnectorsSection() {
@@ -814,9 +819,25 @@ function ConnectorAgentGrants({
     if (loading) return null;
 
     // Every agent that declares a requirement for this connector — granted or not.
+    // Drives the per-agent (credential) grants section below.
     const relevantAgents = agents.filter(
         (a) => a.namespaced_agent_id && a.required_connections?.some((rc) => rc.connector_id === connectorId),
     );
+
+    // Activation eligibility is wider than grant eligibility: for MCP-server
+    // connectors, agents that load MCP servers dynamically (consumes_mcp_servers)
+    // can use this connector's tools once activated even without a static
+    // requirement declaration. OAuth connectors have no MCP tool surface, so
+    // there are no activatable agents for them.
+    const activatableAgents =
+        connectorType === 'mcp_server'
+            ? agents.filter(
+                  (a) =>
+                      a.namespaced_agent_id &&
+                      (a.consumes_mcp_servers ||
+                          a.required_connections?.some((rc) => rc.connector_id === connectorId)),
+              )
+            : [];
 
     return (
         <div className="connection-grants">
@@ -839,7 +860,7 @@ function ConnectorAgentGrants({
                 MCP tool surface — their per-agent access is governed by the
                 per-scope grant toggles above — so showing this block for them
                 would be a switch that does nothing. (issue #1005) */}
-            {connectorType === 'mcp_server' && relevantAgents.length > 0 && (
+            {activatableAgents.length > 0 && (
                 <>
                     <div className="grants-header grants-header--activations">
                         Active for
@@ -848,7 +869,7 @@ function ConnectorAgentGrants({
                         Activations gate which agents see this connector's tools.
                         Activating without a prior grant auto-creates one.
                     </div>
-                    {relevantAgents.map((agent) => (
+                    {activatableAgents.map((agent) => (
                         <AgentActivationCard
                             key={`activation-${agent.namespaced_agent_id}`}
                             agent={agent}
@@ -872,7 +893,9 @@ function ConnectorAgentGrants({
  * Activation gates MCP tool visibility: when ON, the MCP server's tools
  * appear in the agent's prompt; when OFF (or absent), the tools are hidden
  * even if the agent holds a grant. Activating without a prior grant
- * auto-creates one using the agent's declared REQUIRED_CONNECTORS scopes.
+ * auto-creates one using the agent's declared REQUIRED_CONNECTORS scopes, or
+ * the canonical MCP scope for agents that consume MCP servers dynamically and
+ * declare no static requirement.
  *
  * Rendered only for ``type === 'mcp_server'`` connectors — the parent
  * (``ConnectorAgentGrants``) gates the entire ``Active for`` block on
@@ -897,7 +920,9 @@ function AgentActivationCard({
 }) {
     const req = agent.required_connections?.find((rc) => rc.connector_id === connectorId);
     const agentId = agent.namespaced_agent_id;
-    if (!req || !agentId) return null;
+    // A dynamic MCP consumer has no ``req`` for this connector but is still
+    // activatable — only the namespaced id is required.
+    if (!agentId) return null;
 
     const [localActive, setLocalActive] = useState(active);
     const [busy, setBusy] = useState(false);
@@ -915,11 +940,16 @@ function AgentActivationCard({
         setErr(null);
         try {
             if (next) {
-                // Auto-grant uses the agent's declared REQUIRED_CONNECTORS
-                // scopes — but only if no grant is in place yet. The server
-                // ignores the body when a grant already exists.
+                // Auto-grant only when no grant is in place yet (the server
+                // ignores the body when a grant already exists). Use the
+                // agent's declared REQUIRED_CONNECTORS scopes, falling back to
+                // the canonical MCP scope for dynamic consumers that declare none.
                 const scopesForGrant =
-                    grantedScopes.length === 0 ? [...req.scopes] : undefined;
+                    grantedScopes.length === 0
+                        ? req
+                            ? [...req.scopes]
+                            : [...MCP_DEFAULT_GRANT_SCOPES]
+                        : undefined;
                 await api.activateConnectorAgent(connectorId, agentId, scopesForGrant);
             } else {
                 await api.deactivateConnectorAgent(connectorId, agentId);

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -44,6 +44,14 @@ export interface AgentInfo {
      */
     required_connections?: ConnectorRequirement[];
     /**
+     * True when the agent loads MCP servers dynamically at runtime (e.g. the
+     * chat agent) and gates their tools through the activation ledger. The
+     * Settings → Connectors "Active for" panel lists such agents as
+     * activatable for `mcp_server` connectors even without a matching
+     * `required_connections` entry.
+     */
+    consumes_mcp_servers?: boolean;
+    /**
      * Opaque grant-ledger key. Built-ins are `builtin:<id>`, custom agents
      * are `custom:<sha256-prefix>:<id>`, installed agents are
      * `installed:<id>`, and native agents are `native:<id>`. Pass this to

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -194,6 +194,11 @@ class AgentInfo(BaseModel):
     # Each entry is a serialized ``ConnectorRequirement``:
     # {connector_id: str, scopes: list[str], reason: str}.
     required_connections: List[dict] = Field(default_factory=list)
+    # True when the agent loads MCP servers dynamically at runtime (e.g. the
+    # chat agent) and gates their tools through the activation ledger. The
+    # Settings "Active for" panel lists such agents as activatable for
+    # MCP-server connectors even without a static ``required_connections`` entry.
+    consumes_mcp_servers: bool = False
     # T-X2: opaque grant-ledger key. Built-ins use ``builtin:<id>``; custom
     # agents use ``custom:<sha256-prefix>:<id>``. The CLI and UI consent
     # dialog use this when calling ``grant_agent`` / ``revoke_agent_grant``.

--- a/src/gaia/ui/routers/agents.py
+++ b/src/gaia/ui/routers/agents.py
@@ -112,6 +112,7 @@ def _reg_to_info(reg) -> AgentInfo:
         models=reg.models,
         min_memory_gb=reg.min_memory_gb,
         required_connections=connections,
+        consumes_mcp_servers=getattr(reg, "consumes_mcp_servers", False),
         namespaced_agent_id=reg.namespaced_agent_id,
         category=reg.category,
         tags=reg.tags,

--- a/tests/unit/test_agent_hub_api.py
+++ b/tests/unit/test_agent_hub_api.py
@@ -183,3 +183,24 @@ class TestAgentInfoApiModel:
         )
         assert info.source == "native"
         assert info.language == "cpp"
+
+
+class TestConsumesMcpServersExposure:
+    """The /api/agents serializer surfaces ``consumes_mcp_servers`` so the
+    Settings "Active for" panel can list dynamic MCP consumers."""
+
+    def test_reg_to_info_exposes_flag_for_chat(self):
+        from gaia.ui.routers.agents import _reg_to_info
+
+        registry = AgentRegistry()
+        registry._register_builtin_agents()
+        info = _reg_to_info(registry.get("chat"))
+        assert info.consumes_mcp_servers is True
+
+    def test_reg_to_info_defaults_false_for_non_consumer(self):
+        from gaia.ui.routers.agents import _reg_to_info
+
+        registry = AgentRegistry()
+        registry._register_builtin_agents()
+        info = _reg_to_info(registry.get("doc"))
+        assert info.consumes_mcp_servers is False

--- a/tests/unit/test_agent_required_connectors.py
+++ b/tests/unit/test_agent_required_connectors.py
@@ -108,6 +108,101 @@ class TestBuiltinPath:
         assert _RESERVED_BUILTIN_IDS <= registered
 
 
+CUSTOM_MCP_CONSUMER_TEMPLATE = textwrap.dedent("""
+    from typing import ClassVar
+    from gaia.agents.base.agent import Agent
+
+
+    class DynamicMcpAgent(Agent):
+        AGENT_ID = "{agent_id}"
+        AGENT_NAME = "Dynamic MCP"
+        AGENT_DESCRIPTION = "test fixture"
+        CONVERSATION_STARTERS = []
+        CONSUMES_MCP_SERVERS: ClassVar[bool] = True
+
+        def __init__(self, **kwargs):
+            pass
+
+        def _register_tools(self):
+            pass
+
+        def get_system_prompt(self) -> str:
+            return "fake"
+
+        def step(self, *a, **k):
+            return {{}}
+    """)
+
+
+class TestConsumesMcpServers:
+    """``CONSUMES_MCP_SERVERS`` widens the Settings "Active for" panel beyond
+    static ``REQUIRED_CONNECTORS`` declarants to agents that load MCP servers
+    dynamically (e.g. the chat agent)."""
+
+    def test_base_default_is_false(self):
+        assert Agent.CONSUMES_MCP_SERVERS is False
+        assert isinstance(Agent.CONSUMES_MCP_SERVERS, bool)
+
+    def test_builtin_chat_consumes_mcp_servers(self):
+        registry = AgentRegistry()
+        registry._register_builtin_agents()
+        chat = registry.get("chat")
+        assert chat is not None
+        assert chat.consumes_mcp_servers is True
+
+    def test_builtin_chat_registration_matches_class(self):
+        # The lazy factory cannot import the chat module at discovery time, so
+        # the registration hardcodes the flag. Guard it against the class-level
+        # source of truth drifting apart.
+        from gaia.agents.chat.agent import ChatAgent
+
+        registry = AgentRegistry()
+        registry._register_builtin_agents()
+        chat = registry.get("chat")
+        assert ChatAgent.CONSUMES_MCP_SERVERS is True
+        assert chat.consumes_mcp_servers == ChatAgent.CONSUMES_MCP_SERVERS
+
+    def test_other_builtins_do_not_consume_mcp_servers(self):
+        registry = AgentRegistry()
+        registry._register_builtin_agents()
+        for reg in registry.list():
+            if reg.id == "chat":
+                continue
+            assert reg.consumes_mcp_servers is False, (
+                f"Built-in agent {reg.id} unexpectedly sets "
+                "consumes_mcp_servers=True"
+            )
+
+    def test_custom_agent_flag_round_trips(self, tmp_path, monkeypatch):
+        agent_dir = tmp_path / ".gaia" / "agents" / "dyn-mcp"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "agent.py").write_text(
+            CUSTOM_MCP_CONSUMER_TEMPLATE.format(agent_id="dyn_mcp")
+        )
+        monkeypatch.setattr("gaia.agents.registry.Path.home", lambda: tmp_path)
+
+        registry = AgentRegistry()
+        registry.discover()
+        reg = registry.get("dyn_mcp")
+        assert reg is not None
+        assert reg.consumes_mcp_servers is True
+
+    def test_custom_agent_defaults_false(self, tmp_path, monkeypatch):
+        # The REQUIRED_CONNECTORS fixture does not set the flag — it must
+        # default to False (least privilege; the panel won't list it for
+        # connectors it doesn't declare).
+        agent_dir = tmp_path / ".gaia" / "agents" / "inbox-zero"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "agent.py").write_text(
+            CUSTOM_AGENT_TEMPLATE.format(agent_id="inbox_zero")
+        )
+        monkeypatch.setattr("gaia.agents.registry.Path.home", lambda: tmp_path)
+
+        registry = AgentRegistry()
+        registry.discover()
+        assert registry.get("inbox_zero").consumes_mcp_servers is False
+
+
 class TestCustomAgentPath:
     def test_required_connections_round_trip(self, tmp_path, monkeypatch):
         agents_root = tmp_path / ".gaia" / "agents"
@@ -240,6 +335,18 @@ class TestAgentInfoSerialization:
         )
         assert info.required_connections == []
         assert info.namespaced_agent_id == ""
+        assert info.consumes_mcp_servers is False
+
+    def test_consumes_mcp_servers_round_trips(self):
+        info = AgentInfo(
+            id="chat",
+            name="Chat",
+            description="x",
+            source="builtin",
+            consumes_mcp_servers=True,
+        )
+        round_tripped = AgentInfo.model_validate_json(info.model_dump_json())
+        assert round_tripped.consumes_mcp_servers is True
 
     def test_invalid_source_rejected(self):
         with pytest.raises(ValidationError):


### PR DESCRIPTION


<!--
Thanks for contributing to GAIA! Every PR must reference a GitHub issue —
see CONTRIBUTING.md (https://github.com/amd/gaia/blob/main/CONTRIBUTING.md)
if you don't have one yet.
-->

## Summary

Widens the Settings → Connectors **"Active for"** panel so it lists agents that consume MCP servers *dynamically* (like the chat agent), not only agents that statically declare `REQUIRED_CONNECTORS`. The chat agent now appears as an activatable target for MCP-only connectors loaded from `~/.gaia/mcp_servers.json`.


## Why

Before this change, the "Active for" panel only listed agents whose class declared the connector in `REQUIRED_CONNECTORS`. The chat agent (`builtin:chat`) declares none for MCP servers — it loads them at runtime and already gates their tools through the activation ledger (`_active_mcp_servers` → `MCPClientManager.servers_for_agent` → `is_agent_active`). So a user could activate `builtin:chat` for an MCP connector via the CLI/SDK and it worked, but the Settings UI never showed the chat agent as eligible — a UI-only user had no way to toggle it. The runtime was correct; the panel just couldn't see these agents.

This PR closes that surfacing gap by adding a `CONSUMES_MCP_SERVERS` capability flag that flows from the agent class through the registry and API to the frontend, exactly the way `REQUIRED_CONNECTORS` already does. No activation, ledger, or SSE logic changes — those already work end-to-end (#1005, #1226).

Follow-up to #1219, which introduced per-agent MCP tool-visibility activations.


## Linked issue

Closes #1227


## Changes

- **New capability flag, surfaced like `REQUIRED_CONNECTORS`:** `Agent.CONSUMES_MCP_SERVERS` ClassVar (`False` by default), set `True` on `ChatAgent`. The registry carries it as `AgentRegistration.consumes_mcp_servers` — hardcoded for the built-in chat (its lazy factory must not import the chat module at discovery time; a guard test keeps the two in sync) and read via class introspection on the custom-agent discovery path, so builder-scaffolded MCP agents surface automatically too.
- **API exposure:** `AgentInfo.consumes_mcp_servers` (Pydantic) + the `/api/agents` serializer (`_reg_to_info`), and the matching TypeScript `AgentInfo` field.
- **Frontend:** `ConnectorsSection.tsx` computes a separate, wider `activatableAgents` set for the "Active for" block (an agent is eligible if it declares the connector **or** sets `consumes_mcp_servers`); the "Per-agent grants" credential section is unchanged. `AgentActivationCard` no longer bails when an agent has no static requirement, and its one-click auto-grant falls back to the canonical MCP `use` scope for dynamic consumers (named constant, not a magic string).
- **Docs:** `docs/sdk/infrastructure/connectors.mdx` documents the new `CONSUMES_MCP_SERVERS` flag in the agent-author guide and adds a "Which agents appear in the Active for panel" section covering both inclusion patterns.
- **Tests:** base default, chat flag, class↔registration consistency guard, "no other built-in consumes MCP", custom-agent round-trip (`True` and default `False`), `AgentInfo` round-trip, and `_reg_to_info` exposure for a consumer vs a non-consumer.


## Test plan

- [x] `python util/lint.py --all` — Black/isort clean, no new critical errors.
- [x] `pytest tests/unit/test_agent_required_connectors.py tests/unit/test_agent_hub_api.py -q` — 30 passed.
- [x] `pytest tests/unit/connectors/ -q` — 429 passed, 3 skipped (no regressions).
- [x] `cd src/gaia/apps/webui && npm run build` — `tsc && vite build` clean.
- [x] **Manual golden path:** add an MCP server to `~/.gaia/mcp_servers.json` and configure it as an MCP connector → `gaia chat --ui` → Settings → Connectors → open the MCP tile. Confirm **Chat** now appears under "Active for"; toggle it ON. Verify `gaia connectors activations list <connector_id>` shows `builtin:chat: active` and the toggle survives a page reload (SSE refresh). Toggle OFF and confirm deactivation. Confirm an OAuth connector still shows **no** "Active for" section.


## Checklist

- [x] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have updated documentation if user-visible behavior changed (see [CONTRIBUTING.md](../CONTRIBUTING.md)).