### PR TITLE
ci(eval): disable RAG eval gate on PRs pending rebuild

### DIFF
--- a/.github/workflows/test_eval_rag.yml
+++ b/.github/workflows/test_eval_rag.yml
@@ -1,11 +1,14 @@
 name: Eval RAG Quality
 
-# DISABLED on PRs pending rebuild -- see #1315.
+# FULLY DISABLED pending rebuild -- see #1315.
 # This gate has never executed successfully: it targeted a runner label
 # that never existed plus several more blocking bugs, and overflows the
-# 90-min budget even once fixed. `workflow_dispatch` is kept so the
-# rebuild work (#1315) can run it manually; restore the `pull_request`
-# trigger only with a working, time-bounded config.
+# 90-min budget even once fixed. `workflow_dispatch` below is only a
+# placeholder so the YAML stays valid -- a manual dispatch runs nothing
+# useful, because the job `if:` conditions gate on `github.event.pull_request`
+# (null on dispatch) and the job body is still broken. The working
+# reference config lives on branch `ci/eval-rag-dryrun`; rebuild and
+# re-enable (job conditions + `pull_request` trigger) are tracked in #1315.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/test_eval_rag.yml
+++ b/.github/workflows/test_eval_rag.yml
@@ -1,13 +1,13 @@
 name: Eval RAG Quality
 
+# DISABLED on PRs pending rebuild -- see #1315.
+# This gate has never executed successfully: it targeted a runner label
+# that never existed plus several more blocking bugs, and overflows the
+# 90-min budget even once fixed. `workflow_dispatch` is kept so the
+# rebuild work (#1315) can run it manually; restore the `pull_request`
+# trigger only with a working, time-bounded config.
 on:
-  pull_request:
-    paths:
-      - 'src/gaia/agents/**'
-      - 'src/gaia/llm/**'
-      - 'src/gaia/rag/**'
-      - 'src/gaia/eval/**'
-      - 'eval/scenarios/**'
+  workflow_dispatch:
 
 concurrency:
   group: lemonade-eval


### PR DESCRIPTION
## Why this matters

The `Eval RAG Quality` gate (`test_eval_rag.yml`, from #1040) has never executed successfully — it targets a self-hosted runner label that doesn't exist, so every internal PR touching the watched paths spawns an eval job that queues forever, cluttering checks and adding merge friction. This neuters the `pull_request` trigger (keeping `workflow_dispatch` so the rebuild work can still run it manually), so PRs stop hanging on it.

The workflow has also been turned off via the Actions toggle for immediate relief; this PR makes the disable explicit and discoverable in code, and points to the rebuild plan.

Full diagnosis — 7 individually-fatal plumbing bugs plus a performance ceiling that overflows the 90-min budget even once fixed — and the path to a working, time-bounded gate are tracked in **#1315**.

## Test plan
- [ ] `test_eval_rag.yml` no longer triggers on `pull_request` (now `workflow_dispatch`-only).
- [ ] Open PRs stop showing a perpetually-pending `Run RAG Quality Eval` check.

Part of #1315.
