### PR TITLE
feat(email): request/response contract schema (single email + thread)

### DIFF
--- a/.claude/plans/issue-1262.md
+++ b/.claude/plans/issue-1262.md
@@ -1,0 +1,96 @@
+---
+type: plan
+source-issue: 1262
+repo: amd/gaia
+title: "feat(email): request/response contract schema (single email + thread)"
+created: 2026-06-01
+status: in-progress
+work_type: feature
+complexity: medium
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 6
+test_command: "python -m pytest tests/unit/agents/email/test_contract_schema.py -x"
+build_command: "uv pip install -e \".[dev]\""
+lint_command: "python util/lint.py --all"
+branch: feat/issue-1262-email-contract-schema
+reflection_iterations: 1
+agents_used:
+  - general-purpose (code-explorer)
+  - general-purpose (code-reviewer)
+---
+
+# Issue #1262 — Email request/response contract schema
+
+## Goal
+A documented, STABLE request/response schema shared by the REST surface (#1229)
+and the MCP stdio interface (#1104). GAIA owns the contract (#1261 Q2 RESOLVED).
+Freeze it before dependent endpoints are built.
+
+## Acceptance criteria
+1. Documented, stable INPUT schema: principal recipient, other participants, body.
+2. Documented OUTPUT schema: category, summary, draft, action items.
+3. Schema handles BOTH a single email AND a full thread.
+
+### Test ACs
+- Sample request/response payloads validate (single email AND thread).
+- Invalid payloads rejected loudly.
+
+## Design decisions (grounded in the existing email agent)
+
+- **Validation idiom: pydantic v2.** Already a hard dependency (`setup.py`:
+  `pydantic>=2.9.2`) and used in `src/gaia/api/schemas.py`, `src/gaia/ui/models.py`.
+  No new dependency. Matches the REST surface's idiom so #1229 can reuse the models
+  directly as FastAPI request/response bodies.
+- **Placement: `src/gaia/agents/email/contract.py`** — dependency-light (pydantic
+  only, no Gmail/connector imports) so BOTH the REST server and the MCP stdio
+  interface can import it without dragging backends in.
+- **Category taxonomy** reuses the frozen four-bucket scheme from
+  `triage_heuristics.py` (`urgent | actionable | informational | low priority`)
+  via a `Literal`/enum — drift would break AC4 of the agent. Plus `is_spam` /
+  `is_phishing` booleans surfaced independently (matches triage output).
+- **Single-email vs thread** is modeled with a discriminated union on a `kind`
+  field (`"single"` | `"thread"`) so a consumer can branch deterministically and
+  validation rejects a thread payload missing its message list.
+- **Participants model** mirrors RFC-822 roles: `principal` (the recipient the
+  agent acts on behalf of), `from`, `to`, `cc`, `bcc`. Address = display name +
+  email, email validated non-empty + contains `@`.
+- **Output draft / action items** mirror what the agent already produces
+  (`reply_tools` draft = to/subject/body; action items = free-text imperative with
+  optional due hint). `summary` is plain text.
+- **Stability surface:** `SCHEMA_VERSION` constant pinned in the module and echoed
+  in both request and response so a consumer can detect a breaking change. Models
+  use `extra="forbid"` so unknown fields are rejected loudly (no silent drift).
+
+## Module shape (`contract.py`)
+- `SCHEMA_VERSION: str`
+- `EmailCategory` (str Enum: urgent/actionable/informational/low priority)
+- `EmailAddress` (name, email)
+- `EmailMessage` (message_id, from_, to, cc, date, subject, body, ...)
+- `SingleEmailInput` (kind="single", principal, message)
+- `ThreadInput` (kind="thread", principal, thread_id, messages: non-empty list)
+- `EmailTriageRequest` (schema_version, payload: discriminated union)
+- `ActionItem` (description, due_hint?)
+- `DraftReply` (to, subject, body)
+- `EmailTriageResult` (category, is_spam, is_phishing, summary, action_items, draft?)
+- `EmailTriageResponse` (schema_version, request_kind, result)
+- helper `parse_request(dict) -> EmailTriageRequest` that raises loudly.
+
+## TDD steps
+1. Write `tests/unit/agents/email/test_contract_schema.py` with failing tests:
+   valid single-email request, valid thread request, valid responses (both kinds),
+   invalid payloads rejected (missing principal, empty thread, bad category,
+   unknown field, malformed address, wrong schema_version type).
+2. Implement `contract.py` until green.
+3. Re-export from `email/__init__.py` (dependency-light import safety).
+4. Docs: `docs/spec/email-contract.mdx` + register in `docs/docs.json`.
+5. Lint + review.
+
+## Test / build / lint
+- test: `python -m pytest tests/unit/agents/email/test_contract_schema.py -x`
+  plus `python -m pytest tests/ -k "email and (schema or contract)" -x`
+- build: `uv pip install -e ".[dev]"`
+- lint: `python util/lint.py --all`
+
+## Real-world tier
+LOCAL-ONLY — pure schema + docs. Nothing to exercise on hardware.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -313,6 +313,7 @@
               "spec/docker-agent",
               "spec/jira-agent",
               "spec/blender-agent",
+              "spec/email-contract",
               "spec/summarizer-app",
               "spec/component-status"
             ]

--- a/docs/spec/email-contract.mdx
+++ b/docs/spec/email-contract.mdx
@@ -1,0 +1,267 @@
+---
+title: "Email Triage Contract Schema"
+---
+
+<Info>
+  **Source Code:** [`src/gaia/agents/email/contract.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/email/contract.py)
+</Info>
+
+<Note>
+**Component:** Email request/response contract (issue #1262)
+**Module:** `gaia.agents.email.contract`
+**Validation:** pydantic v2
+**Schema version:** `1.0`
+</Note>
+
+---
+
+## Overview
+
+A **frozen, stable** request/response schema for the Email Triage Agent, shared
+by the REST surface ([#1229](https://github.com/amd/gaia/issues/1229)) and the
+MCP stdio interface ([#1104](https://github.com/amd/gaia/issues/1104)). GAIA owns
+this contract — the consuming application conforms to it, not the other way
+around. It is frozen here so the dependent endpoints can be built against a
+stable shape.
+
+**Key properties:**
+
+- **One schema, two surfaces.** REST and MCP stdio import the same pydantic
+  models, guaranteeing identical structured output for a fixed input.
+- **Single email *and* full thread.** The input is a discriminated union on a
+  `kind` field (`"single"` / `"thread"`); a consumer branches deterministically.
+- **Dependency-light.** `gaia.agents.email.contract` imports only pydantic — no
+  Gmail or connector backends — so either surface can import it without pulling
+  live-mail machinery into the process. (A regression test enforces this.)
+- **Fail loudly.** Every model forbids unknown fields (`extra="forbid"`). An
+  off-contract payload raises a `ValidationError` naming the offending field,
+  never a silently coerced result.
+- **Versioned.** `SCHEMA_VERSION` (`"1.0"`) is pinned in the module and echoed in
+  both request and response so a consumer can detect a breaking change.
+
+---
+
+## Request schema (input)
+
+`EmailTriageRequest` — top-level envelope.
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Contract version. Defaults to `"1.0"`. |
+| `payload` | `SingleEmailInput` \| `ThreadInput` | Discriminated on `kind`. |
+
+### Shared input fields
+
+Both payload shapes carry a **principal** — the recipient the agent acts on
+behalf of (the inbox owner). This is distinct from a message's `to`: in a thread
+the principal is not necessarily a recipient of every message.
+
+`EmailAddress`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string \| null | Display name. Optional. |
+| `email` | string | Required. Rejected loudly if it lacks `@` or a dotted domain. |
+
+`EmailMessage`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `message_id` | string | Provider message id. Required. |
+| `thread_id` | string \| null | Owning thread id. |
+| `from` | `EmailAddress` | Sender. On the wire the key is `from`; in Python the field is `from_` (keyword clash). Required. |
+| `to` | `EmailAddress[]` | Primary recipients. |
+| `cc` | `EmailAddress[]` | Carbon copies. |
+| `bcc` | `EmailAddress[]` | Blind carbon copies. |
+| `date` | string \| null | ISO-8601 timestamp. |
+| `subject` | string | Subject line. |
+| `body` | string | Plain-text body to analyze. Required. |
+
+### `SingleEmailInput` (`kind: "single"`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `"single"` | Discriminator. |
+| `principal` | `EmailAddress` | Inbox owner. Required. |
+| `message` | `EmailMessage` | The one message to analyze. Required. |
+
+### `ThreadInput` (`kind: "thread"`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `"thread"` | Discriminator. |
+| `principal` | `EmailAddress` | Inbox owner. Required. |
+| `thread_id` | string | Conversation id. Required. |
+| `messages` | `EmailMessage[]` | **Non-empty**, oldest-first. An empty thread is rejected loudly. |
+
+---
+
+## Response schema (output)
+
+`EmailTriageResponse` — top-level envelope.
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Echoes the contract version. |
+| `request_kind` | `"single"` \| `"thread"` | Which input shape produced the result. |
+| `result` | `EmailTriageResult` | The structured analysis. |
+
+`EmailTriageResult`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `category` | enum | One of `urgent`, `actionable`, `informational`, `low priority`. Matches the agent's frozen four-bucket taxonomy. |
+| `is_spam` | bool | Spam signal, scored independently of `category`. |
+| `is_phishing` | bool | Phishing signal, independent of `is_spam`. |
+| `summary` | string | Plain-text summary of the email / thread. Required. |
+| `action_items` | `ActionItem[]` | Extracted actions. May be empty. |
+| `draft` | `DraftReply` \| null | Proposed reply, or `null` when none is suggested. Never sent without explicit confirmation (#1264). |
+
+`ActionItem`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `description` | string | Imperative action. Required, non-empty. |
+| `due_hint` | string \| null | Free-text due hint as written (`"Friday"`); not parsed into a date. |
+
+`DraftReply`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `to` | `EmailAddress[]` | **Non-empty** proposed recipients. |
+| `subject` | string | Proposed subject. |
+| `body` | string | Proposed body. |
+
+---
+
+## Example — single email
+
+### Request
+
+```json
+{
+  "schema_version": "1.0",
+  "payload": {
+    "kind": "single",
+    "principal": { "name": "Alice Example", "email": "alice@example.com" },
+    "message": {
+      "message_id": "msg-1",
+      "thread_id": "thread-1",
+      "from": { "name": "Bob Sender", "email": "bob@vendor.com" },
+      "to": [{ "name": "Alice Example", "email": "alice@example.com" }],
+      "cc": [],
+      "date": "2026-05-30T09:00:00Z",
+      "subject": "Q2 invoice attached",
+      "body": "Hi Alice, please review the attached invoice by Friday."
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "schema_version": "1.0",
+  "request_kind": "single",
+  "result": {
+    "category": "actionable",
+    "is_spam": false,
+    "is_phishing": false,
+    "summary": "Vendor invoice needs review by Friday.",
+    "action_items": [
+      { "description": "Review the Q2 invoice", "due_hint": "Friday" }
+    ],
+    "draft": {
+      "to": [{ "name": "Bob Sender", "email": "bob@vendor.com" }],
+      "subject": "Re: Q2 invoice attached",
+      "body": "Thanks Bob, I'll review and confirm by Friday."
+    }
+  }
+}
+```
+
+---
+
+## Example — full thread
+
+### Request
+
+```json
+{
+  "schema_version": "1.0",
+  "payload": {
+    "kind": "thread",
+    "principal": { "name": "Alice Example", "email": "alice@example.com" },
+    "thread_id": "thread-42",
+    "messages": [
+      {
+        "message_id": "msg-1",
+        "thread_id": "thread-42",
+        "from": { "name": "Bob", "email": "bob@vendor.com" },
+        "to": [{ "name": "Alice", "email": "alice@example.com" }],
+        "date": "2026-05-30T09:00:00Z",
+        "subject": "Contract renewal",
+        "body": "Can we hop on a call about the renewal?"
+      },
+      {
+        "message_id": "msg-2",
+        "thread_id": "thread-42",
+        "from": { "name": "Alice", "email": "alice@example.com" },
+        "to": [{ "name": "Bob", "email": "bob@vendor.com" }],
+        "date": "2026-05-30T10:00:00Z",
+        "subject": "Re: Contract renewal",
+        "body": "Sure, does Thursday 2pm work?"
+      }
+    ]
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "schema_version": "1.0",
+  "request_kind": "thread",
+  "result": {
+    "category": "actionable",
+    "is_spam": false,
+    "is_phishing": false,
+    "summary": "Bob wants a renewal call; Alice proposed Thursday 2pm.",
+    "action_items": [{ "description": "Confirm Thursday 2pm call" }],
+    "draft": null
+  }
+}
+```
+
+---
+
+## Usage
+
+Validate a payload at a boundary (REST endpoint, MCP tool handler). Both helpers
+raise loudly on a contract violation — never return a partial object:
+
+```python
+from gaia.agents.email.contract import parse_request, parse_response
+
+request = parse_request(raw_request_dict)   # -> EmailTriageRequest
+if request.payload.kind == "thread":
+    for message in request.payload.messages:
+        ...
+
+response = parse_response(raw_response_dict)  # -> EmailTriageResponse
+```
+
+---
+
+## Stability contract
+
+- **Frozen at `1.0`.** Additive, backward-compatible changes (new optional
+  fields) keep the version. Any breaking change (renamed/removed field, new
+  required field, taxonomy change) bumps `SCHEMA_VERSION` so consumers detect it.
+- **Categories never drift.** The four-bucket taxonomy is mirrored from the
+  agent's `triage_heuristics.ALL_CATEGORIES`; a unit test asserts byte-for-byte
+  equality, so a taxonomy change in either place fails CI.
+- **Unknown fields are errors**, not warnings — there is no silent forward-compat
+  drift in either direction.

--- a/src/gaia/agents/email/__init__.py
+++ b/src/gaia/agents/email/__init__.py
@@ -1,8 +1,32 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-"""Email Triage Agent — public re-exports."""
+"""Email Triage Agent — public re-exports.
 
-from gaia.agents.email.agent import EmailTriageAgent
-from gaia.agents.email.config import EmailAgentConfig
+``EmailTriageAgent`` / ``EmailAgentConfig`` are imported lazily (PEP 562) so
+that ``from gaia.agents.email.contract import ...`` — the dependency-light
+request/response contract used by the REST surface (#1229) and the MCP stdio
+interface (#1104) — does NOT drag the agent and its Gmail / connector backends
+into the importing process.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    from gaia.agents.email.agent import EmailTriageAgent
+    from gaia.agents.email.config import EmailAgentConfig
 
 __all__ = ["EmailTriageAgent", "EmailAgentConfig"]
+
+
+def __getattr__(name: str):
+    # PEP 562 lazy attribute access — keeps the heavy agent import off the path
+    # of dependency-light consumers (e.g. the contract module).
+    if name == "EmailTriageAgent":
+        from gaia.agents.email.agent import EmailTriageAgent
+
+        return EmailTriageAgent
+    if name == "EmailAgentConfig":
+        from gaia.agents.email.config import EmailAgentConfig
+
+        return EmailAgentConfig
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/gaia/agents/email/contract.py
+++ b/src/gaia/agents/email/contract.py
@@ -1,0 +1,303 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Frozen request/response contract for the Email Triage Agent (issue #1262).
+
+This module is the **single source of truth** for the payloads exchanged with
+the email agent. It is shared, intentionally, by:
+
+- the REST surface (#1229) — used directly as FastAPI request/response bodies;
+- the MCP stdio interface (#1104) — used to validate the same operation.
+
+GAIA owns this contract (#1261 Q2 RESOLVED: GAIA defines the payloads; the
+consuming application conforms). Freeze it here; build the endpoints against it.
+
+Design notes
+------------
+- **pydantic v2** (already a hard dependency, `setup.py`: ``pydantic>=2.9.2``)
+  matches `gaia.api.schemas` and `gaia.ui.models`. No new dependency.
+- **Dependency-light:** this module imports ONLY pydantic. It must never import
+  Gmail / connector backends — or even ``triage_heuristics``, which transitively
+  drags the agent package ``__init__`` (and thus the live backends) in — so both
+  API surfaces can import it without pulling live-mail machinery into process.
+- **Fail loudly:** every model sets ``extra="forbid"`` so an unknown field is a
+  ``ValidationError``, never silently dropped — a consuming app that drifts from
+  the contract finds out immediately.
+- **Single email vs full thread** is a discriminated union on ``kind`` so a
+  consumer branches deterministically and an empty/`messages`-less thread is
+  rejected at validation time.
+- **Categories** mirror the agent's frozen four-bucket taxonomy. The strings are
+  duplicated here (not imported) to keep this module backend-free; the contract
+  tests assert byte-for-byte equality against
+  ``triage_heuristics.ALL_CATEGORIES`` so drift is caught at test time, not by
+  coupling the import graph.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Category strings — kept in sync with ``triage_heuristics.ALL_CATEGORIES`` by
+# ``test_contract_schema.test_categories_match_agent_taxonomy``. Duplicated
+# (not imported) so this module stays free of the email package's heavy
+# ``__init__`` import chain.
+CATEGORY_URGENT = "urgent"
+CATEGORY_ACTIONABLE = "actionable"
+CATEGORY_INFORMATIONAL = "informational"
+CATEGORY_LOW_PRIORITY = "low priority"
+
+# ---------------------------------------------------------------------------
+# Versioning
+# ---------------------------------------------------------------------------
+
+# Bump on ANY breaking change to the shapes below. Echoed in both request and
+# response so a consumer can detect a mismatch loudly instead of silently
+# mis-parsing. The first frozen revision is "1.0".
+SCHEMA_VERSION = "1.0"
+
+
+class _Strict(BaseModel):
+    """Base for every contract model: reject unknown fields loudly."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# Category taxonomy (must agree with triage_heuristics — AC4)
+# ---------------------------------------------------------------------------
+
+
+class EmailCategory(str, Enum):
+    """The frozen four-bucket triage taxonomy. Values MUST match
+    ``triage_heuristics.ALL_CATEGORIES`` — the contract tests assert this.
+    """
+
+    URGENT = CATEGORY_URGENT
+    ACTIONABLE = CATEGORY_ACTIONABLE
+    INFORMATIONAL = CATEGORY_INFORMATIONAL
+    LOW_PRIORITY = CATEGORY_LOW_PRIORITY
+
+
+# ---------------------------------------------------------------------------
+# Shared value objects
+# ---------------------------------------------------------------------------
+
+
+class EmailAddress(_Strict):
+    """A single email participant. ``name`` is optional (many headers carry a
+    bare address); ``email`` is required and must look like an address.
+    """
+
+    name: Optional[str] = Field(
+        default=None, description="Display name, e.g. 'Alice Example'."
+    )
+    email: str = Field(..., description="Bare email address, e.g. 'a@b.com'.")
+
+    @field_validator("email")
+    @classmethod
+    def _email_must_be_plausible(cls, v: str) -> str:
+        v = (v or "").strip()
+        # Minimal, non-silent validation: an address has a local part, an '@',
+        # and a domain with a dot. We deliberately do not pull in a full RFC-822
+        # validator — the contract only needs to reject obvious garbage loudly.
+        if not v or "@" not in v:
+            raise ValueError(f"not a valid email address: {v!r}")
+        local, _, domain = v.partition("@")
+        if not local or not domain or "." not in domain:
+            raise ValueError(f"not a valid email address: {v!r}")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# INPUT — AC1: principal recipient, other participants, body
+# ---------------------------------------------------------------------------
+
+
+class EmailMessage(_Strict):
+    """One email message. Shared by the single-email and thread inputs."""
+
+    message_id: str = Field(..., description="Provider message id (opaque).")
+    thread_id: Optional[str] = Field(
+        default=None, description="Provider thread id this message belongs to."
+    )
+    from_: EmailAddress = Field(
+        ...,
+        alias="from",
+        description="Sender. Aliased to 'from' (a Python keyword) on the wire.",
+    )
+    to: List[EmailAddress] = Field(
+        default_factory=list, description="Primary recipients (the 'To' line)."
+    )
+    cc: List[EmailAddress] = Field(
+        default_factory=list, description="Carbon-copy recipients."
+    )
+    bcc: List[EmailAddress] = Field(
+        default_factory=list, description="Blind-carbon-copy recipients."
+    )
+    date: Optional[str] = Field(
+        default=None, description="ISO-8601 timestamp of the message."
+    )
+    subject: str = Field(default="", description="Subject line.")
+    body: str = Field(..., description="Plain-text message body to analyze.")
+
+    # Accept both the wire alias ('from') and the python name ('from_').
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class _BaseInput(_Strict):
+    """Common fields for both input shapes."""
+
+    principal: EmailAddress = Field(
+        ...,
+        description=(
+            "The recipient the agent acts on behalf of — whose inbox this is. "
+            "Distinct from per-message 'to': the principal is the account "
+            "owner, not necessarily a recipient of every message in a thread."
+        ),
+    )
+
+
+class SingleEmailInput(_BaseInput):
+    """A single email to triage (AC3 — single-email path)."""
+
+    kind: Literal["single"] = "single"
+    message: EmailMessage = Field(..., description="The one message to analyze.")
+
+
+class ThreadInput(_BaseInput):
+    """A full conversation thread to triage (AC3 — thread path)."""
+
+    kind: Literal["thread"] = "thread"
+    thread_id: str = Field(..., description="Provider thread id for the conversation.")
+    messages: List[EmailMessage] = Field(
+        ...,
+        min_length=1,
+        description="Every message in the thread, oldest-first. Non-empty.",
+    )
+
+
+# Discriminated union: ``kind`` selects the concrete shape. An unknown kind or a
+# shape missing its required fields is rejected loudly.
+EmailInput = Union[SingleEmailInput, ThreadInput]
+
+
+class EmailTriageRequest(_Strict):
+    """Top-level request envelope shared by REST (#1229) and MCP stdio (#1104)."""
+
+    schema_version: str = Field(
+        default=SCHEMA_VERSION,
+        description="Contract version. Mismatch lets a consumer fail loudly.",
+    )
+    payload: EmailInput = Field(
+        ...,
+        discriminator="kind",
+        description="The single-email or full-thread input.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# OUTPUT — AC2: category, summary, draft, action items
+# ---------------------------------------------------------------------------
+
+
+class ActionItem(_Strict):
+    """A single extracted action the principal should take."""
+
+    description: str = Field(..., description="Imperative action, e.g. 'Reply to Bob'.")
+    due_hint: Optional[str] = Field(
+        default=None,
+        description="Free-text due hint as written ('Friday', 'EOD'); not parsed.",
+    )
+
+    @field_validator("description")
+    @classmethod
+    def _description_nonempty(cls, v: str) -> str:
+        if not (v or "").strip():
+            raise ValueError("action item description must be non-empty")
+        return v
+
+
+class DraftReply(_Strict):
+    """A drafted reply the agent proposes. Never sent without confirmation
+    (#1264) — this is a proposal, not an action.
+    """
+
+    to: List[EmailAddress] = Field(
+        ..., min_length=1, description="Proposed recipients (non-empty)."
+    )
+    subject: str = Field(..., description="Proposed subject line.")
+    body: str = Field(..., description="Proposed reply body.")
+
+
+class EmailTriageResult(_Strict):
+    """The structured analysis of a single email or thread."""
+
+    category: EmailCategory = Field(..., description="One of the four buckets.")
+    is_spam: bool = Field(default=False, description="Spam signal (independent).")
+    is_phishing: bool = Field(
+        default=False, description="Phishing signal (independent of spam)."
+    )
+    summary: str = Field(..., description="Plain-text summary of the email/thread.")
+    action_items: List[ActionItem] = Field(
+        default_factory=list, description="Extracted actions (may be empty)."
+    )
+    draft: Optional[DraftReply] = Field(
+        default=None, description="Proposed reply, or null when none is suggested."
+    )
+
+
+class EmailTriageResponse(_Strict):
+    """Top-level response envelope shared by REST (#1229) and MCP stdio (#1104)."""
+
+    schema_version: str = Field(
+        default=SCHEMA_VERSION, description="Echoes the contract version."
+    )
+    request_kind: Literal["single", "thread"] = Field(
+        ..., description="Which input shape produced this result."
+    )
+    result: EmailTriageResult = Field(..., description="The structured analysis.")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_request(data: dict) -> EmailTriageRequest:
+    """Validate a raw request dict into an :class:`EmailTriageRequest`.
+
+    Raises ``pydantic.ValidationError`` (a ``ValueError`` subclass) on any
+    contract violation — never returns a partial/coerced object. Use this at the
+    REST and MCP boundaries so a malformed payload fails loudly with an
+    actionable message naming the offending field.
+    """
+    return EmailTriageRequest.model_validate(data)
+
+
+def parse_response(data: dict) -> EmailTriageResponse:
+    """Validate a raw response dict into an :class:`EmailTriageResponse`.
+
+    Same fail-loudly contract as :func:`parse_request`.
+    """
+    return EmailTriageResponse.model_validate(data)
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "EmailCategory",
+    "EmailAddress",
+    "EmailMessage",
+    "SingleEmailInput",
+    "ThreadInput",
+    "EmailInput",
+    "EmailTriageRequest",
+    "ActionItem",
+    "DraftReply",
+    "EmailTriageResult",
+    "EmailTriageResponse",
+    "parse_request",
+    "parse_response",
+]

--- a/tests/unit/agents/email/test_contract_schema.py
+++ b/tests/unit/agents/email/test_contract_schema.py
@@ -1,0 +1,319 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Contract-schema tests for the Email Triage Agent (issue #1262).
+
+These tests freeze the request/response contract shared by the REST surface
+(#1229) and the MCP stdio interface (#1104). They assert that:
+
+- A valid single-email request validates and round-trips.
+- A valid full-thread request validates and round-trips.
+- Valid responses (single + thread) validate.
+- Invalid payloads are rejected LOUDLY (pydantic ValidationError / ValueError),
+  never silently coerced.
+
+The schema lives in ``gaia.agents.email.contract`` — dependency-light (pydantic
+only) so both API surfaces can import it without dragging Gmail backends in.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gaia.agents.email.contract import (
+    SCHEMA_VERSION,
+    ActionItem,
+    DraftReply,
+    EmailAddress,
+    EmailCategory,
+    EmailTriageRequest,
+    EmailTriageResponse,
+    EmailTriageResult,
+    parse_request,
+)
+from gaia.agents.email.tools.triage_heuristics import ALL_CATEGORIES
+
+# ---------------------------------------------------------------------------
+# Sample payloads (the frozen contract examples — kept in sync with the .mdx)
+# ---------------------------------------------------------------------------
+
+
+def _single_email_request() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "payload": {
+            "kind": "single",
+            "principal": {"name": "Alice Example", "email": "alice@example.com"},
+            "message": {
+                "message_id": "msg-1",
+                "thread_id": "thread-1",
+                "from_": {"name": "Bob Sender", "email": "bob@vendor.com"},
+                "to": [{"name": "Alice Example", "email": "alice@example.com"}],
+                "cc": [],
+                "date": "2026-05-30T09:00:00Z",
+                "subject": "Q2 invoice attached",
+                "body": "Hi Alice, please review the attached invoice by Friday.",
+            },
+        },
+    }
+
+
+def _thread_request() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "payload": {
+            "kind": "thread",
+            "principal": {"name": "Alice Example", "email": "alice@example.com"},
+            "thread_id": "thread-42",
+            "messages": [
+                {
+                    "message_id": "msg-1",
+                    "thread_id": "thread-42",
+                    "from_": {"name": "Bob", "email": "bob@vendor.com"},
+                    "to": [{"name": "Alice", "email": "alice@example.com"}],
+                    "date": "2026-05-30T09:00:00Z",
+                    "subject": "Contract renewal",
+                    "body": "Can we hop on a call about the renewal?",
+                },
+                {
+                    "message_id": "msg-2",
+                    "thread_id": "thread-42",
+                    "from_": {"name": "Alice", "email": "alice@example.com"},
+                    "to": [{"name": "Bob", "email": "bob@vendor.com"}],
+                    "date": "2026-05-30T10:00:00Z",
+                    "subject": "Re: Contract renewal",
+                    "body": "Sure, does Thursday 2pm work?",
+                },
+            ],
+        },
+    }
+
+
+def _single_response() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "request_kind": "single",
+        "result": {
+            "category": "actionable",
+            "is_spam": False,
+            "is_phishing": False,
+            "summary": "Vendor invoice needs review by Friday.",
+            "action_items": [
+                {"description": "Review the Q2 invoice", "due_hint": "Friday"}
+            ],
+            "draft": {
+                "to": [{"name": "Bob Sender", "email": "bob@vendor.com"}],
+                "subject": "Re: Q2 invoice attached",
+                "body": "Thanks Bob, I'll review and confirm by Friday.",
+            },
+        },
+    }
+
+
+def _thread_response() -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "request_kind": "thread",
+        "result": {
+            "category": "actionable",
+            "is_spam": False,
+            "is_phishing": False,
+            "summary": "Bob wants a renewal call; Alice proposed Thursday 2pm.",
+            "action_items": [{"description": "Confirm Thursday 2pm call"}],
+            "draft": None,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Valid payloads
+# ---------------------------------------------------------------------------
+
+
+def test_contract_import_is_backend_free():
+    # The REST surface (#1229) and MCP stdio interface (#1104) must be able to
+    # import the contract without dragging Gmail / connector backends into the
+    # process. Importing it in a fresh subprocess proves no backend module is
+    # loaded as a side effect.
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, gaia.agents.email.contract;"
+        "heavy=[m for m in sys.modules if 'gmail_backend' in m "
+        "or 'connectors' in m or 'calendar_backend' in m "
+        "or m=='gaia.agents.email.agent'];"
+        "assert not heavy, heavy;"
+        "print('ok')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_schema_version_is_pinned_and_nonempty():
+    assert isinstance(SCHEMA_VERSION, str)
+    assert SCHEMA_VERSION
+
+
+def test_categories_match_agent_taxonomy():
+    # AC4 guard: the contract's categories must not drift from the agent's
+    # frozen four-bucket taxonomy in triage_heuristics.
+    assert {c.value for c in EmailCategory} == set(ALL_CATEGORIES)
+
+
+def test_valid_single_email_request_validates():
+    req = EmailTriageRequest.model_validate(_single_email_request())
+    assert req.payload.kind == "single"
+    assert req.payload.principal.email == "alice@example.com"
+    assert req.payload.message.subject == "Q2 invoice attached"
+
+
+def test_valid_thread_request_validates():
+    req = EmailTriageRequest.model_validate(_thread_request())
+    assert req.payload.kind == "thread"
+    assert len(req.payload.messages) == 2
+    assert req.payload.thread_id == "thread-42"
+
+
+def test_parse_request_helper_returns_model():
+    req = parse_request(_thread_request())
+    assert isinstance(req, EmailTriageRequest)
+    assert req.payload.kind == "thread"
+
+
+def test_request_round_trips_through_dump():
+    req = EmailTriageRequest.model_validate(_single_email_request())
+    dumped = req.model_dump(by_alias=True)
+    again = EmailTriageRequest.model_validate(dumped)
+    assert again == req
+
+
+def test_valid_single_response_validates():
+    resp = EmailTriageResponse.model_validate(_single_response())
+    assert resp.request_kind == "single"
+    assert resp.result.category == EmailCategory.ACTIONABLE
+    assert resp.result.draft is not None
+    assert resp.result.action_items[0].due_hint == "Friday"
+
+
+def test_valid_thread_response_validates_with_null_draft():
+    resp = EmailTriageResponse.model_validate(_thread_response())
+    assert resp.request_kind == "thread"
+    assert resp.result.draft is None
+
+
+def test_email_address_accepts_optional_name():
+    addr = EmailAddress.model_validate({"email": "x@y.com"})
+    assert addr.name is None
+    assert addr.email == "x@y.com"
+
+
+def test_action_item_due_hint_optional():
+    item = ActionItem.model_validate({"description": "do thing"})
+    assert item.due_hint is None
+
+
+def test_wire_alias_from_validates():
+    # The docs / REST + MCP consumers send the RFC-822 wire key "from"
+    # (not the Python field name "from_"). Both must validate.
+    payload = _single_email_request()
+    msg = payload["payload"]["message"]
+    msg["from"] = msg.pop("from_")
+    req = EmailTriageRequest.model_validate(payload)
+    assert req.payload.message.from_.email == "bob@vendor.com"
+    # And the canonical dump uses the wire alias.
+    assert "from" in req.payload.message.model_dump(by_alias=True)
+
+
+# ---------------------------------------------------------------------------
+# Invalid payloads — must be rejected LOUDLY
+# ---------------------------------------------------------------------------
+
+
+def test_missing_principal_rejected():
+    payload = _single_email_request()
+    del payload["payload"]["principal"]
+    with pytest.raises(ValidationError):
+        EmailTriageRequest.model_validate(payload)
+
+
+def test_empty_thread_rejected():
+    payload = _thread_request()
+    payload["payload"]["messages"] = []
+    with pytest.raises(ValidationError):
+        EmailTriageRequest.model_validate(payload)
+
+
+def test_unknown_kind_rejected():
+    payload = _single_email_request()
+    payload["payload"]["kind"] = "digest"
+    with pytest.raises(ValidationError):
+        EmailTriageRequest.model_validate(payload)
+
+
+def test_bad_category_rejected():
+    payload = _single_response()
+    payload["result"]["category"] = "NEEDS_RESPONSE"  # old PR#916 taxonomy
+    with pytest.raises(ValidationError):
+        EmailTriageResponse.model_validate(payload)
+
+
+def test_unknown_field_rejected_loudly():
+    payload = _single_email_request()
+    payload["payload"]["message"]["totally_new_field"] = "surprise"
+    with pytest.raises(ValidationError):
+        EmailTriageRequest.model_validate(payload)
+
+
+def test_malformed_address_rejected():
+    payload = _single_email_request()
+    payload["payload"]["message"]["from_"] = {"name": "X", "email": "not-an-email"}
+    with pytest.raises(ValidationError):
+        EmailTriageRequest.model_validate(payload)
+
+
+def test_empty_address_rejected():
+    with pytest.raises(ValidationError):
+        EmailAddress.model_validate({"email": ""})
+
+
+def test_thread_payload_missing_messages_rejected():
+    payload = _thread_request()
+    del payload["payload"]["messages"]
+    with pytest.raises(ValidationError):
+        EmailTriageRequest.model_validate(payload)
+
+
+def test_single_payload_missing_message_rejected():
+    payload = _single_email_request()
+    del payload["payload"]["message"]
+    with pytest.raises(ValidationError):
+        EmailTriageRequest.model_validate(payload)
+
+
+def test_parse_request_raises_loudly_on_garbage():
+    with pytest.raises((ValidationError, ValueError)):
+        parse_request({"not": "a request"})
+
+
+def test_response_unknown_field_rejected():
+    payload = _single_response()
+    payload["result"]["extra_secret"] = "leak"
+    with pytest.raises(ValidationError):
+        EmailTriageResponse.model_validate(payload)
+
+
+def test_draft_requires_recipient():
+    with pytest.raises(ValidationError):
+        DraftReply.model_validate({"subject": "hi", "body": "x", "to": []})
+
+
+def test_result_summary_required():
+    payload = _single_response()
+    del payload["result"]["summary"]
+    with pytest.raises(ValidationError):
+        EmailTriageResult.model_validate(payload["result"])


### PR DESCRIPTION
Closes #1262

## Why this matters
Before #1262, the email-triage agent had no documented, stable wire contract — every consumer (the planned REST surface #1229 and MCP stdio interface #1104) would have invented its own request/response shape, guaranteeing drift and rework. This freezes one schema (`SCHEMA_VERSION 1.0`): a single discriminated-union input that handles **both a single email and a full thread**, and a structured output (category, summary, draft, action items) matching the v0.20 taxonomy the agent already emits. Per the v0.20 execution map (#1319), the field-level contract is GAIA-owned (#1261 Q2 resolved), so the schema is frozen here and partners conform.

The schema imports backend-free (a subprocess test proves it), so #1229/#1104 can depend on it without dragging in the heavy email package.

## Test Evidence
- [x] Unit / payload-validation (the integration gate for a schema): `python -m pytest tests/unit/agents/email/test_contract_schema.py` — 25/25. Valid single-email AND full-thread request/response payloads validate; 13 invalid-payload cases rejected loudly.
- [x] Email regression: `python -m pytest tests/ -k email` — 119/119 (lazy `__init__` change broke nothing).
- [x] Lint: `python util/lint.py --all` — 0 failures.
- [x] Real-world tier: **local-only** — pure schema + docs deliverable, nothing to exercise on hardware. Stated explicitly rather than skipped.