### PR TITLE
feat(connectors): forward a pre-authenticated provider connection via API (no re-auth)

### DIFF
--- a/.claude/plans/issue-1292.md
+++ b/.claude/plans/issue-1292.md
@@ -1,0 +1,171 @@
+---
+type: plan
+source-issue: 1292
+repo: amd/gaia
+title: "feat(connectors): forward a pre-authenticated provider connection via API (no re-auth)"
+created: 2026-06-01
+status: in-progress
+work_type: feature
+complexity: medium
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 7
+test_command: "python -m pytest tests/unit/connectors/ -x"
+build_command: "uv pip install -e \".[dev]\" && uv pip install -e \".[ui]\""
+lint_command: "python util/lint.py --all"
+branch: feat/issue-1292-forward-connection-api
+reflection_iterations: 0
+agents_used:
+  - general-purpose (code-explorer)
+  - general-purpose (code-reviewer, security weight)
+---
+
+# Issue #1292 — Forward a pre-authenticated provider connection via API
+
+## Goal
+Let a host app that already authenticated a user FORWARD that connection to
+GAIA over REST. GAIA persists the forwarded OAuth client (`client_id` +
+`client_secret`) and `refresh_token`, then refreshes AS THE HOST APP'S CLIENT.
+No second OAuth, no re-auth. Credential FORWARDING/INJECTION (Path A).
+
+## Verified grounding (from code exploration)
+
+### The refresh engine is already client-neutral — the GAP is ingestion
+- `gaia/connectors/store.py`
+  - `save_provider_credentials(provider, client_id, client_secret)` → keyring slot
+    `provider:<provider>` (the *app's* OAuth client).
+  - `save_connection(provider, account_email, refresh_token, scopes, client_id_hash)`
+    → keyring slot `<provider>:default` (v1 always keys by `DEFAULT_ACCOUNT="default"`;
+    `account_email` lives inside the blob for display). **A second save OVERWRITES.**
+  - `peek_connection` / `peek_provider_credentials` — side-effect-free reads.
+  - `verify_keyring_backend()` — raises `ConnectorsError` on Plaintext/Encrypted/Win32Crypto
+    backends. Called at every save/load. THIS is the insecure-keyring loud-failure.
+- `gaia/connectors/providers/google.py` — `GoogleOAuthProvider.__init__` resolves
+  creds in order: explicit kwargs → keyring (`peek_provider_credentials`) → env.
+  Computes `client_id_hash = crc32(client_id)`. So a forwarded client persisted to
+  the keyring BEATS the env client.
+- `gaia/connectors/providers/__init__.py` — `_registry` dict; lazy `get("google")`.
+  Cache eviction = `_registry.pop(provider_id, None)` then next `get()` re-instantiates
+  with the forwarded creds (this is the `client_id_hash` recompute).
+- `gaia/connectors/tokens.py` — `get_or_refresh` already has a per-`(provider,account)`
+  `asyncio.Lock` guarding the refresh path (double-checked locking). **The issue's
+  "add a refresh LOCK" is ALREADY satisfied** by `_AccessTokenCache.lock`. Module-level
+  `_cache` dict — eviction = `_cache.pop((provider, account), None)`.
+  `_refresh_token` posts `provider.refresh_request_body(refresh_token)` to
+  `provider.token_url` — body carries `client_id`+`client_secret` from the provider
+  instance (= forwarded client after eviction). Google does NOT rotate refresh tokens
+  (rotation branch exists but is a no-op for Google) — Microsoft rotation OUT OF SCOPE.
+- `gaia/connectors/flow.py::_exchange_code_for_tokens` is the existing ingestion
+  template: token-exchange → `save_connection(...)` + emit `connector.oauth.completed`.
+  The forwarded import is this MINUS the browser/PKCE dance.
+- `gaia/connectors/oauth_pkce.py::configure` "Save & Connect" path is the exact
+  prior art for: `save_provider_credentials` + `_provider_registry.pop(provider_id)`.
+
+### Scopes the agent needs (AC3)
+`gaia/agents/email/scopes.py`:
+- `SCOPE_GMAIL_MODIFY = .../gmail.modify`, `SCOPE_GMAIL_SEND = .../gmail.send`
+- `SCOPE_CALENDAR_EVENTS = .../calendar.events`, `SCOPE_CALENDAR_READ = .../calendar.readonly`
+- `ALL_SCOPES = GMAIL_SCOPES + CALENDAR_SCOPES`
+- `AGENT_NAMESPACED_ID = "builtin:email"`
+AC3 = "gmail.modify, gmail.send, calendar". Validate forwarded scopes are a SUPERSET
+of the required union, else raise loudly. "calendar" satisfied by EITHER calendar.events
+OR calendar.readonly (events implies read for our purposes) — require at least
+calendar.events (the write scope the agent's calendar tools need).
+
+### Where the REST endpoints live
+`src/gaia/ui/routers/connectors.py` (mounted by `gaia/ui/server.py`). This is where
+connection lifecycle already lives. The UI server:
+- Binds `localhost` by default (`--host localhost`); `TunnelAuthMiddleware` gates every
+  non-localhost `/api/*` request behind a Bearer token, with a spoof-resistant localhost
+  bypass. THIS is the "localhost-bound / API-key-gated" surface (AC4).
+- Mutating routes already require `X-Gaia-UI: 1` (CSRF guard `_require_ui_header`).
+The OpenAI-compatible server (`src/gaia/api/`) has NO key gating today — wrong home.
+
+Issue spec path is `/v1/connections/{provider}`. Add a NEW `APIRouter(prefix="/v1/connections")`
+in `connectors.py` and include it in `create_app()`. Tunnel auth gates `/api/*` only,
+so to keep `/v1/connections` behind the same gate we mount it UNDER the api prefix is
+NOT desired (issue says `/v1/connections`). Decision: the UI server's localhost binding
+is the primary gate; the new router reuses `_require_ui_header` for mutations. Since
+`TunnelAuthMiddleware` only inspects `/api/*`, we ALSO register the `/v1/connections`
+prefix in the middleware's gated set so remote/tunnel access requires the token too.
+(Add `/v1/` to the middleware gate.)
+
+## Design
+
+### New coordination function (reusable — AC + #1084 sharing)
+`gaia/connectors/api.py::import_forwarded_connection(...)`:
+```
+def import_forwarded_connection(
+    *, provider, client_id, client_secret, refresh_token, scopes,
+    account_email="", grant_agents=None, required_scopes=None,
+) -> dict   # metadata-only summary, NO secret
+```
+Steps (fail loudly, no fallbacks):
+1. `verify_keyring_backend()` — insecure backend → `ConnectorsError` (AC4).
+2. Validate required-scope coverage. Default `required_scopes` = email-agent union
+   (gmail.modify, gmail.send, calendar.events). Missing → `ScopeMismatchError` (AC3).
+3. `save_provider_credentials(provider, client_id, client_secret)` → `provider:<provider>`.
+4. `providers._registry.pop(provider, None)`; `prov = get_provider(provider)` →
+   recomputes `client_id_hash` from the forwarded client.
+5. `save_connection(provider, account_email or "default", refresh_token, scopes,
+   client_id_hash=prov.client_id_hash)` → `<provider>:default`.
+6. `tokens._cache.pop((provider, account_email or "default"), None)` — evict stale token.
+7. For each agent in `grant_agents`: `grant_agent(provider, agent_id, scopes)`.
+8. Return `{provider, account_email, scopes, connected_at, grant_agents}` — masked,
+   no `refresh_token`/`client_secret`.
+
+### REST endpoints (router `/v1/connections`)
+- `POST /v1/connections/{provider}` — body {client_id, client_secret, refresh_token,
+  scopes, account_email?, grant_agents?}. Calls `import_forwarded_connection`. CSRF-gated.
+  Returns masked summary. 201.
+- `GET /v1/connections` and `GET /v1/connections/{provider}` — metadata only, secrets
+  MASKED/omitted (reuse `api.list_connections` / `api.get_connection` which already
+  omit tokens).
+- `DELETE /v1/connections/{provider}` — revoke. Reuse `handler.disconnect` (clears
+  connection + provider creds? NO — disconnect clears connection + grants; also clear
+  provider creds + evict caches for a full revoke). CSRF-gated. 204.
+
+### Secret hygiene (AC + test AC)
+- Request model carries `refresh_token`/`client_secret` (legitimate INPUT).
+- `tests/unit/connectors/test_secret_hygiene.py::TestOpenApi` asserts `"refresh_token"`
+  absent from the WHOLE `/openapi.json`. A request body legitimately needs it →
+  REFINE that test to scan only RESPONSE schemas (request bodies may name the field).
+  This is an intentional, called-out test change.
+- Responses NEVER include `refresh_token` or `client_secret`.
+
+## Files to change
+1. `src/gaia/connectors/api.py` — add `import_forwarded_connection` + export.
+2. `src/gaia/connectors/__init__.py` — add to `_API_NAMES`.
+3. `src/gaia/ui/routers/connectors.py` — new `/v1/connections` router + models.
+4. `src/gaia/ui/server.py` — include new router; extend tunnel-auth gate to `/v1/`.
+5. `tests/unit/connectors/test_forwarded_import.py` — NEW unit tests.
+6. `tests/unit/connectors/test_router_forwarded.py` — NEW integration tests.
+7. `tests/unit/connectors/test_secret_hygiene.py` — refine OpenApi test (response-only).
+8. `docs/sdk/infrastructure/connectors.mdx` + `docs/docs.json` — document forwarding,
+   incl. host-app UNION-of-scopes requirement (GAIA cannot add scope at refresh time).
+
+## TDD test list
+Unit (`test_forwarded_import.py`):
+- writes `provider:<provider>` (client) + `<provider>:default` (refresh) slots
+- computes `client_id_hash` from FORWARDED client (not env client)
+- evicts provider cache AND token cache
+- scope-shortfall (missing gmail.send) → `ScopeMismatchError` loudly
+- insecure keyring backend → `ConnectorsError` loudly (PlaintextKeyring)
+- return value masks/omits refresh_token + client_secret
+- grant_agents → grants written
+- refresh after import uses forwarded client (stub token endpoint, assert request body
+  carries forwarded client_id+secret), token returned, NO interactive step
+
+Integration (`test_router_forwarded.py`, `ui_api_client`):
+- POST persists (then GET shows configured, masked) — full lifecycle
+- POST without X-Gaia-UI → 403
+- POST scope-shortfall → 403 + structured error
+- GET/GET{provider} never echo secret
+- DELETE revokes → subsequent GET 404/empty
+- agent acts on mailbox after forward with NO OAuth flow (assert via get_access_token
+  returning the stubbed token under a granted agent context)
+
+## Out of scope (explicit)
+- Microsoft refresh-token rotation (#1280/#1105).
+- Headless CLI import wiring (#1084) — function is factored reusable, not wired.
+- Live Google refresh (no creds) — orchestrator runs synthetic-grant smoke only.

--- a/.claude/plans/issue-1292.md
+++ b/.claude/plans/issue-1292.md
@@ -4,17 +4,17 @@ source-issue: 1292
 repo: amd/gaia
 title: "feat(connectors): forward a pre-authenticated provider connection via API (no re-auth)"
 created: 2026-06-01
-status: in-progress
+status: ready
 work_type: feature
 complexity: medium
 tdd_required: true
 suggested_team_size: 1
-estimated_files_changed: 7
+estimated_files_changed: 8
 test_command: "python -m pytest tests/unit/connectors/ -x"
 build_command: "uv pip install -e \".[dev]\" && uv pip install -e \".[ui]\""
 lint_command: "python util/lint.py --all"
 branch: feat/issue-1292-forward-connection-api
-reflection_iterations: 0
+reflection_iterations: 1
 agents_used:
   - general-purpose (code-explorer)
   - general-purpose (code-reviewer, security weight)

--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -82,6 +82,86 @@ asyncio.run(main())
 | `CONNECTION_MISSING_SCOPES` | Grant exists but covers fewer scopes. |
 | `REAUTH_REQUIRED` | OAuth client ID was rotated. |
 
+## Forwarded connections (no re-auth)
+
+When a host app has **already** authenticated the user (its own OAuth flow),
+it can FORWARD that connection to GAIA instead of triggering a second consent
+screen. GAIA persists the forwarded grant and refreshes **as the host app's
+client** — credential forwarding, not a GAIA-run OAuth flow.
+
+The host app forwards three things: the OAuth client it was issued under
+(`client_id` + `client_secret`) and the user's long-lived `refresh_token`.
+
+```python
+import gaia.connectors as conn
+
+summary = conn.import_forwarded_connection(
+    provider="google",
+    client_id="<host-app-client-id>.apps.googleusercontent.com",
+    client_secret="<host-app-client-secret>",
+    refresh_token="<user-refresh-token>",
+    scopes=[
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/calendar.events",
+    ],
+    account_email="alice@example.com",   # display-only in v1
+    grant_agents=["builtin:email"],       # agents that may use it
+)
+# summary carries metadata only — never the refresh token or client secret.
+```
+
+### REST: `POST /v1/connections/{provider}`
+
+The same ingestion is exposed over REST by the Agent UI server (which binds
+`localhost` by default and gates remote/tunnel access behind a token).
+Mutating routes require the `X-Gaia-UI: 1` header.
+
+```bash
+curl -X POST http://localhost:4200/v1/connections/google \
+  -H "X-Gaia-UI: 1" -H "Content-Type: application/json" \
+  -d '{
+        "client_id": "<host-app-client-id>",
+        "client_secret": "<host-app-client-secret>",
+        "refresh_token": "<user-refresh-token>",
+        "scopes": ["https://www.googleapis.com/auth/gmail.modify",
+                   "https://www.googleapis.com/auth/gmail.send",
+                   "https://www.googleapis.com/auth/calendar.events"],
+        "account_email": "alice@example.com",
+        "grant_agents": ["builtin:email"]
+      }'
+```
+
+| Method / path | Purpose |
+|---|---|
+| `POST /v1/connections/{provider}` | Persist a forwarded grant (201). No browser step. |
+| `GET /v1/connections` | List connections — **metadata only, secrets omitted**. |
+| `GET /v1/connections/{provider}` | One connection's metadata (404 if absent). |
+| `DELETE /v1/connections/{provider}` | Revoke: clears token, client, grants, caches. |
+
+After a successful POST the agent resolves the connection ambiently — the
+triage request carries **no credentials**; `get_access_token` reads the
+persisted grant and refreshes transparently.
+
+<Warning>
+**The host app's initial consent must request the UNION of every scope both
+it and GAIA need.** GAIA refreshes with the forwarded `refresh_token` and
+**cannot widen scope at refresh time** — a refresh only ever returns the
+scopes the original consent granted. If the forwarded `scopes` don't cover
+what the target agent needs (for the Email agent: `gmail.modify`,
+`gmail.send`, and a calendar scope), the import **fails loudly** with
+`ScopeMismatchError` (HTTP 403 + `missing_scopes`) rather than silently
+under-provisioning. Re-consent by the host app — with the wider scope set —
+is the only fix.
+</Warning>
+
+<Note>
+GAIA refuses to persist tokens to an insecure keyring backend (plaintext /
+weak file-backed stores). On such a backend the import fails loudly with an
+actionable error pointing at the system credential-store setup. Forwarded
+secrets are never written to `~/.gaia/` and never echoed in any response.
+</Note>
+
 ## SDK use — MCP server
 
 MCP server connectors are configured once and then provide their API

--- a/src/gaia/connectors/__init__.py
+++ b/src/gaia/connectors/__init__.py
@@ -75,6 +75,7 @@ _API_NAMES: frozenset[str] = frozenset(
         "get_access_token_sync",
         "get_connection",
         "grant_agent",
+        "import_forwarded_connection",
         "is_agent_active",
         "list_agent_activations",
         "list_agent_grants",

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -36,6 +36,8 @@ from gaia.connectors.context import current_agent_id
 from gaia.connectors.errors import (
     AuthRequiredError,
     ConfigurationError,
+    ConnectorsError,
+    ScopeMismatchError,
 )
 from gaia.connectors.flow import (
     cancel_flow,
@@ -61,6 +63,17 @@ from gaia.connectors.store import (
 from gaia.connectors.tokens import get_or_refresh
 
 logger = logging.getLogger(__name__)
+
+
+# Scopes the built-in Email Triage Agent (#962) needs to act on a mailbox.
+# A forwarded grant MUST cover these or the import fails loudly (AC3) — GAIA
+# cannot widen scope at refresh time, so the host app's initial consent must
+# have requested at least this union.
+_DEFAULT_REQUIRED_SCOPES: tuple[str, ...] = (
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/calendar.events",
+)
 
 
 async def get_access_token(
@@ -232,6 +245,142 @@ def revoke_connection(provider: str) -> None:
     logger.info("api: revoked connection provider=%s", provider)
 
 
+def import_forwarded_connection(
+    *,
+    provider: str,
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+    scopes: List[str],
+    account_email: str = "",
+    grant_agents: Optional[List[str]] = None,
+    required_scopes: Optional[List[str]] = None,
+    connected_at: Optional[float] = None,
+) -> Dict[str, Any]:
+    """
+    Persist a connection FORWARDED by a host app that already authenticated
+    the user. No browser/consent step, no GAIA-run OAuth flow (#1292, Path A).
+
+    The host app forwards the OAuth client it was issued under (``client_id``
+    + ``client_secret``) and the user's ``refresh_token``. GAIA stores both and
+    will later refresh AS THE HOST APP'S CLIENT — the connectors refresh engine
+    is already client-neutral (the keyring-stored forwarded client beats the
+    GAIA env client, and ``client_id_hash`` is recomputed from the forwarded
+    id here).
+
+    This is the single coordination point shared with the headless CLI import
+    (#1084, not wired here). It mirrors what ``oauth_pkce.configure``'s
+    "Save & Connect" path + ``flow._exchange_code_for_tokens`` do, minus the
+    PKCE dance.
+
+    Fails loudly (no fallbacks):
+      - insecure keyring backend → ``ConnectorsError`` (via
+        ``verify_keyring_backend``);
+      - empty ``client_id`` / ``refresh_token`` → ``ConnectorsError``;
+      - forwarded scopes don't cover ``required_scopes`` (defaults to the
+        Email-agent union) → ``ScopeMismatchError``. GAIA cannot widen scope
+        at refresh time, so a shortfall is unrecoverable without re-consent
+        by the host app.
+
+    Returns a metadata-only summary — NEVER the refresh token or client secret.
+    """
+    # Local imports keep the module-level dependency graph (and the lazy
+    # keyring import contract in connectors/__init__.py) unchanged.
+    from gaia.connectors.providers import _registry as _provider_registry
+    from gaia.connectors.store import (
+        save_connection,
+        save_provider_credentials,
+        verify_keyring_backend,
+    )
+    from gaia.connectors.tokens import _cache as _token_cache
+
+    # 1. Insecure-keyring tripwire BEFORE any write (AC4). Raises loudly.
+    verify_keyring_backend()
+
+    # 2. Validate the forwarded grant up front so nothing is persisted on a
+    #    bad input (the failure path must leave the keyring untouched).
+    if not client_id:
+        raise ConnectorsError(
+            f"import_forwarded_connection({provider!r}): client_id is empty. "
+            "The host app must forward the OAuth client_id it authenticated "
+            "the user under. See docs/sdk/infrastructure/connectors.mdx."
+        )
+    if not refresh_token:
+        raise ConnectorsError(
+            f"import_forwarded_connection({provider!r}): refresh_token is empty. "
+            "Forward the user's long-lived refresh_token (the host app must "
+            "request offline access). See docs/sdk/infrastructure/connectors.mdx."
+        )
+
+    # 3. Scope coverage (AC3). Forwarded scopes must be a superset of what the
+    #    agent needs — GAIA cannot add scope at refresh time.
+    required = (
+        list(required_scopes) if required_scopes else list(_DEFAULT_REQUIRED_SCOPES)
+    )
+    granted = set(scopes)
+    missing = [s for s in required if s not in granted]
+    if missing:
+        raise ScopeMismatchError(
+            required=required, granted=list(scopes), provider=provider
+        )
+
+    account = account_email or DEFAULT_ACCOUNT
+
+    # 4. Persist the forwarded OAuth client → ``provider:<provider>`` slot.
+    save_provider_credentials(
+        provider, client_id=client_id, client_secret=client_secret
+    )
+
+    # 5. Evict the cached provider instance so the next ``get_provider`` reads
+    #    the forwarded client and recomputes ``client_id_hash`` from it.
+    _provider_registry.pop(provider, None)
+    prov = get_provider(provider)
+
+    # 6. Persist the connection (refresh_token + metadata) → ``<provider>:default``
+    #    keyed by the forwarded client's hash so the tripwire passes coherently.
+    save_connection(
+        provider=provider,
+        account_email=account,
+        refresh_token=refresh_token,
+        scopes=list(scopes),
+        client_id_hash=prov.client_id_hash,
+        connected_at=connected_at,
+    )
+
+    # 7. Evict any stale access-token cache entry so the next get_or_refresh
+    #    refreshes against the forwarded client. The v1 store is single-slot
+    #    (always keyed by DEFAULT_ACCOUNT), so evict both the display-account
+    #    key and the DEFAULT_ACCOUNT key the refresh path actually reads.
+    _token_cache.pop((provider, account), None)
+    _token_cache.pop((provider, DEFAULT_ACCOUNT), None)
+
+    # 8. Optionally grant the named agents the forwarded scopes so they can
+    #    resolve the connection ambiently (no credentials on the request).
+    granted_agents: List[str] = []
+    for agent_id in grant_agents or []:
+        grant_agent(provider, agent_id, list(scopes))
+        granted_agents.append(agent_id)
+
+    logger.info(
+        "api: imported forwarded connection provider=%s account=%s scopes=%d "
+        "grant_agents=%d client_id_hash=%s",
+        provider,
+        account,
+        len(scopes),
+        len(granted_agents),
+        prov.client_id_hash,
+    )
+
+    return {
+        "provider": provider,
+        "account_email": account,
+        "scopes": list(scopes),
+        "connected_at": connected_at,
+        "grant_agents": granted_agents,
+        "forwarded": True,
+    }
+
+
 def _require_mcp_server_for_activation(connector_id: str) -> None:
     """Reject activation writes for non-MCP-server connectors (#1005).
 
@@ -374,6 +523,7 @@ __all__ = [
     "get_access_token_sync",
     "get_connection",
     "grant_agent",
+    "import_forwarded_connection",
     "is_agent_active",
     "list_agent_activations",
     "list_agent_grants",

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -86,6 +86,15 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/connectors", tags=["connectors"])
 
+# Issue #1292 — forwarded pre-authenticated connections. Separate prefix
+# (``/v1/connections``) per the issue's REST contract: a host app that already
+# authenticated a user POSTs the forwarded grant here; GAIA persists it and
+# acts on the mailbox as the host app's client — no second OAuth. The UI
+# server binds localhost by default and gates remote/tunnel access behind a
+# token (see ``TunnelAuthMiddleware``); mutating routes also require the
+# ``X-Gaia-UI`` CSRF header below.
+forwarded_router = APIRouter(prefix="/v1/connections", tags=["connections"])
+
 
 # ─────────────────────────────────────────────────────────────────
 # CSRF guard (plan amendment A8)
@@ -155,6 +164,29 @@ class ActivationRequest(BaseModel):
 
 class ConfigureRequest(BaseModel):
     config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ForwardConnectionRequest(BaseModel):
+    """Body for ``POST /v1/connections/{provider}`` (#1292).
+
+    A host app forwards the OAuth client it authenticated the user under
+    (``client_id`` + ``client_secret``) plus the user's ``refresh_token``.
+    GAIA persists both and refreshes AS THE HOST APP'S CLIENT — no second
+    OAuth, no consent step.
+
+    ``refresh_token`` / ``client_secret`` are secret INPUTS — they are never
+    echoed back in any response. ``account_email`` is display-only in v1
+    (the keyring slot is single-account per provider). ``grant_agents`` is
+    the list of namespaced agent ids (e.g. ``builtin:email``) to grant the
+    forwarded scopes so they can resolve the connection ambiently.
+    """
+
+    client_id: str = Field(min_length=1)
+    client_secret: str = Field(default="")
+    refresh_token: str = Field(min_length=1)
+    scopes: List[str] = Field(default_factory=list)
+    account_email: str = Field(default="")
+    grant_agents: List[str] = Field(default_factory=list)
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -832,4 +864,88 @@ async def delete_activation(connector_id: str, agent_id: str) -> Response:
         "connector.activation.changed",
         {"connector_id": connector_id, "agent_id": agent_id, "active": False},
     )
+    return Response(status_code=204)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Forwarded pre-authenticated connections — /v1/connections (#1292)
+#
+# A consuming app that ALREADY authenticated a user FORWARDS that connection
+# to GAIA. GAIA persists it and acts on the mailbox as the host app's client —
+# no second OAuth. Read routes return metadata only (secrets masked); the POST
+# requires the X-Gaia-UI CSRF header; the whole surface is localhost-bound /
+# tunnel-token-gated by the UI server.
+# ─────────────────────────────────────────────────────────────────
+
+
+@forwarded_router.post(
+    "/{provider}", status_code=201, dependencies=[Depends(_require_ui_header)]
+)
+async def forward_connection(
+    provider: str, body: ForwardConnectionRequest
+) -> Dict[str, Any]:
+    """Persist a forwarded grant — no browser/consent step (AC1, AC3, AC4).
+
+    Fails loudly: insecure keyring backend → 500; missing required scopes →
+    403 + ``missing_scopes``; empty client_id/refresh_token → 500. Returns a
+    metadata-only summary — never the refresh token or client secret.
+    """
+    try:
+        summary = connections.import_forwarded_connection(
+            provider=provider,
+            client_id=body.client_id,
+            client_secret=body.client_secret,
+            refresh_token=body.refresh_token,
+            scopes=body.scopes,
+            account_email=body.account_email,
+            grant_agents=body.grant_agents,
+        )
+    except ConnectorsError as e:
+        raise _raise_http_for(e) from e
+
+    await _emitter.emit(
+        "connector.configured",
+        {"connector_id": provider, "account_id": summary.get("account_email")},
+    )
+    return summary
+
+
+@forwarded_router.get("")
+@forwarded_router.get("/")
+async def list_forwarded_connections() -> Dict[str, Any]:
+    """List persisted connections — metadata only, secrets omitted (AC4)."""
+    return {"connections": connections.list_connections()}
+
+
+@forwarded_router.get("/{provider}")
+async def get_forwarded_connection(provider: str) -> Dict[str, Any]:
+    """Return one connection's metadata, or 404 — secrets omitted (AC4)."""
+    entry = connections.get_connection(provider)
+    if entry is None:
+        raise HTTPException(
+            status_code=404, detail=f"No connection for provider {provider!r}"
+        )
+    return entry
+
+
+@forwarded_router.delete(
+    "/{provider}", status_code=204, dependencies=[Depends(_require_ui_header)]
+)
+async def revoke_forwarded_connection(provider: str) -> Response:
+    """Revoke a forwarded connection: clear the refresh token, the forwarded
+    OAuth client credentials, every per-agent grant, and the cached provider /
+    token state (AC4). Idempotent."""
+    from gaia.connectors.grants import revoke_all_grants_for
+    from gaia.connectors.providers import _registry as _provider_registry
+    from gaia.connectors.store import clear_provider_credentials
+    from gaia.connectors.tokens import _cache as _token_cache
+
+    connections.revoke_connection(provider)
+    clear_provider_credentials(provider)
+    revoke_all_grants_for(provider)
+    _provider_registry.pop(provider, None)
+    for key in [k for k in _token_cache if k[0] == provider]:
+        _token_cache.pop(key, None)
+
+    await _emitter.emit("connector.disconnected", {"connector_id": provider})
     return Response(status_code=204)

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -886,9 +886,10 @@ async def forward_connection(
 ) -> Dict[str, Any]:
     """Persist a forwarded grant — no browser/consent step (AC1, AC3, AC4).
 
-    Fails loudly: insecure keyring backend → 500; missing required scopes →
-    403 + ``missing_scopes``; empty client_id/refresh_token → 500. Returns a
-    metadata-only summary — never the refresh token or client secret.
+    Fails loudly: empty client_id/refresh_token → 422 (pydantic ``min_length``);
+    insecure keyring backend → 500; missing required scopes → 403 +
+    ``missing_scopes``. Returns a metadata-only summary — never the refresh
+    token or client secret.
     """
     try:
         summary = connections.import_forwarded_connection(

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -106,8 +106,10 @@ class TunnelAuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
 
-        # Only gate /api/* routes
-        if not path.startswith("/api/"):
+        # Gate /api/* routes and the /v1/connections forwarded-grant surface
+        # (#1292) — the latter carries OAuth secrets, so remote/tunnel access
+        # must present a valid token just like /api/*.
+        if not (path.startswith("/api/") or path.startswith("/v1/")):
             return await call_next(request)
 
         # Always allow exempt paths (health check, etc.)
@@ -492,6 +494,8 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
     app.include_router(mcp_router_mod.router)
     # Issue #915 — OAuth connections (Settings page + agent grants).
     app.include_router(connectors_router_mod.router)
+    # Issue #1292 — forwarded pre-authenticated connections (/v1/connections).
+    app.include_router(connectors_router_mod.forwarded_router)
 
     # ── Serve Uploaded Files ─────────────────────────────────────────────
     # Mount the uploads directory so uploaded files can be served by URL.

--- a/tests/unit/connectors/test_forwarded_import.py
+++ b/tests/unit/connectors/test_forwarded_import.py
@@ -1,0 +1,240 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for the forwarded-connection ingestion path (#1292).
+
+A host app that already authenticated a user FORWARDS the OAuth client
+(``client_id`` + ``client_secret``) plus the ``refresh_token`` to GAIA.
+``import_forwarded_connection`` persists this — no browser step, no PKCE
+flow — so the connectors refresh engine can act on the mailbox AS THE
+HOST APP'S CLIENT.
+
+These tests assert, against the in-memory keyring + a stubbed token
+endpoint (never real Google):
+- the correct keyring slots are written (provider client + connection),
+- ``client_id_hash`` is computed from the FORWARDED client (not env),
+- the provider cache AND token cache are evicted,
+- a scope shortfall fails loudly,
+- an insecure keyring backend fails loudly,
+- the return value omits the refresh token / client secret,
+- ``grant_agents`` writes per-agent grants,
+- a subsequent refresh uses the forwarded client with no interactive step.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from gaia.connectors.api import import_forwarded_connection
+from gaia.connectors.errors import ConnectorsError, ScopeMismatchError
+from gaia.connectors.store import (
+    peek_connection,
+    peek_provider_credentials,
+)
+
+# Forwarded grant fixture values. The agent's required union (#962) is
+# gmail.modify + gmail.send + calendar.events; this grant covers all three.
+FWD_CLIENT_ID = "forwarded-host-app.apps.googleusercontent.com"
+FWD_CLIENT_SECRET = "FWD-SECRET-do-not-leak"
+FWD_REFRESH = "FWD-REFRESH-TOKEN-do-not-leak"
+FULL_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.readonly",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_grants(monkeypatch, tmp_path):
+    # conftest already redirects grants Path.home, but be explicit so this
+    # file can run standalone.
+    monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_registry(monkeypatch):
+    """Start each test with an empty provider registry + a known env client
+    so we can prove the forwarded client (not env) wins."""
+    from gaia.connectors.providers import _registry
+
+    _registry.clear()
+    # An env client whose id differs from the forwarded one; if the import
+    # path accidentally used the env client, client_id_hash would mismatch.
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "ENV-CLIENT.apps.googleusercontent.com")
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_SECRET", "ENV-SECRET")
+    yield
+    _registry.clear()
+
+
+def _do_import(**overrides):
+    kwargs = dict(
+        provider="google",
+        client_id=FWD_CLIENT_ID,
+        client_secret=FWD_CLIENT_SECRET,
+        refresh_token=FWD_REFRESH,
+        scopes=FULL_SCOPES,
+        account_email="alice@example.com",
+    )
+    kwargs.update(overrides)
+    return import_forwarded_connection(**kwargs)
+
+
+class TestPersistence:
+    def test_writes_provider_client_slot(self):
+        _do_import()
+        creds = peek_provider_credentials("google")
+        assert creds is not None
+        assert creds["client_id"] == FWD_CLIENT_ID
+        assert creds["client_secret"] == FWD_CLIENT_SECRET
+
+    def test_writes_connection_slot(self):
+        _do_import()
+        blob = peek_connection("google")
+        assert blob is not None
+        assert blob["refresh_token"] == FWD_REFRESH
+        assert blob["account_email"] == "alice@example.com"
+        assert set(blob["scopes"]) == set(FULL_SCOPES)
+
+    def test_client_id_hash_from_forwarded_client(self):
+        import zlib
+
+        _do_import()
+        blob = peek_connection("google")
+        expected = format(zlib.crc32(FWD_CLIENT_ID.encode()), "08x")
+        assert blob["client_id_hash"] == expected
+        # And NOT the env client's hash.
+        env_hash = format(zlib.crc32(b"ENV-CLIENT.apps.googleusercontent.com"), "08x")
+        assert blob["client_id_hash"] != env_hash
+
+    def test_no_account_email_defaults_to_default(self):
+        _do_import(account_email="")
+        blob = peek_connection("google")
+        assert blob["account_email"] == "default"
+
+
+class TestCacheEviction:
+    def test_evicts_provider_cache(self):
+        # Pre-seed the registry with a stale provider (env client).
+        from gaia.connectors.providers import _registry
+        from gaia.connectors.providers import get as get_provider
+
+        stale = get_provider("google")
+        assert stale.client_id == "ENV-CLIENT.apps.googleusercontent.com"
+        assert "google" in _registry
+
+        _do_import()
+
+        fresh = get_provider("google")
+        assert fresh.client_id == FWD_CLIENT_ID
+
+    def test_evicts_token_cache(self):
+        from gaia.connectors import tokens
+
+        tokens._cache[("google", "alice@example.com")] = tokens._AccessTokenCache(
+            access_token="STALE", expires_at=10**12
+        )
+        _do_import()
+        assert ("google", "alice@example.com") not in tokens._cache
+
+
+class TestLoudFailures:
+    def test_scope_shortfall_raises_loudly(self):
+        # Missing gmail.send.
+        with pytest.raises(ScopeMismatchError) as ei:
+            _do_import(
+                scopes=[
+                    "https://www.googleapis.com/auth/gmail.modify",
+                    "https://www.googleapis.com/auth/calendar.events",
+                ]
+            )
+        assert "gmail.send" in str(ei.value)
+        # Nothing persisted on the failure path.
+        assert peek_connection("google") is None
+        assert peek_provider_credentials("google") is None
+
+    def test_insecure_keyring_backend_raises_loudly(self, monkeypatch):
+        class _PlaintextKeyring:
+            pass
+
+        _PlaintextKeyring.__name__ = "PlaintextKeyring"
+
+        import keyring
+
+        monkeypatch.setattr(keyring, "get_keyring", lambda: _PlaintextKeyring())
+        with pytest.raises(ConnectorsError) as ei:
+            _do_import()
+        assert "plaintext" in str(ei.value).lower()
+
+    def test_missing_client_id_raises_loudly(self):
+        with pytest.raises(ConnectorsError):
+            _do_import(client_id="")
+
+    def test_missing_refresh_token_raises_loudly(self):
+        with pytest.raises(ConnectorsError):
+            _do_import(refresh_token="")
+
+
+class TestSecretHygiene:
+    def test_return_value_omits_secrets(self):
+        result = _do_import()
+        as_str = str(result)
+        assert FWD_REFRESH not in as_str
+        assert FWD_CLIENT_SECRET not in as_str
+        assert "refresh_token" not in result
+        assert "client_secret" not in result
+        # Metadata IS present.
+        assert result["provider"] == "google"
+        assert result["account_email"] == "alice@example.com"
+
+
+class TestGrants:
+    def test_grant_agents_written(self):
+        from gaia.connectors.grants import check_agent_grant
+
+        _do_import(grant_agents=["builtin:email"])
+        assert check_agent_grant("google", "builtin:email", FULL_SCOPES)
+
+    def test_no_grant_agents_writes_nothing(self):
+        from gaia.connectors.grants import list_agent_grants
+
+        _do_import()
+        assert list_agent_grants("google") == {}
+
+
+class TestRefreshUsesForwardedClient:
+    @respx.mock
+    async def test_refresh_posts_forwarded_client(self):
+        """After a forwarded import, get_access_token refreshes using the
+        forwarded client_id+secret — proving GAIA acts as the host app with
+        no interactive OAuth step."""
+        captured = {}
+
+        def _capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = request.content.decode()
+            return httpx.Response(
+                200, json={"access_token": "STUB-ACCESS", "expires_in": 3600}
+            )
+
+        respx.post("https://oauth2.googleapis.com/token").mock(side_effect=_capture)
+
+        # v1 store is single-slot per provider: the keyring key is always
+        # DEFAULT_ACCOUNT regardless of the display account_email. Import
+        # without a display email so the read-side default key matches.
+        _do_import(grant_agents=["builtin:email"], account_email="")
+
+        from gaia.connectors.api import get_access_token
+
+        token = await get_access_token(
+            provider="google",
+            scopes=FULL_SCOPES,
+            agent_id="builtin:email",
+        )
+        assert token == "STUB-ACCESS"
+        assert FWD_CLIENT_ID in captured["body"]
+        assert FWD_CLIENT_SECRET in captured["body"]
+        assert FWD_REFRESH in captured["body"]
+        # ENV client must NOT appear — forwarded client beats env.
+        assert "ENV-CLIENT" not in captured["body"]

--- a/tests/unit/connectors/test_router_forwarded.py
+++ b/tests/unit/connectors/test_router_forwarded.py
@@ -1,0 +1,180 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Integration tests for the forwarded-connection REST endpoints (#1292):
+``POST/GET/DELETE /v1/connections[/{provider}]``.
+
+Driven against the in-process AgentUI FastAPI app (``ui_api_client``) with
+the autouse in-memory keyring from ``tests/unit/connectors/conftest.py``.
+No real Google call is made; refresh is stubbed via respx where needed.
+
+Asserts:
+- POST forwards a grant, persists it, returns a masked summary (201);
+- POST requires the ``X-Gaia-UI`` CSRF header;
+- a scope shortfall fails loudly with HTTP 403 + structured error;
+- GET (list + single) returns metadata only, NEVER a secret;
+- DELETE revokes the connection;
+- after a forward, the agent can resolve a token with NO interactive step.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+UI_HEADER = {"x-gaia-ui": "1"}
+
+FWD_CLIENT_ID = "forwarded-host-app.apps.googleusercontent.com"
+FWD_CLIENT_SECRET = "FWD-SECRET-do-not-leak"
+FWD_REFRESH = "FWD-REFRESH-TOKEN-do-not-leak"
+FULL_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/calendar.events",
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    from gaia.connectors.providers import _registry
+
+    _registry.clear()
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "ENV-CLIENT.apps.googleusercontent.com")
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_SECRET", "ENV-SECRET")
+    monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    yield
+    _registry.clear()
+
+
+def _forward_body(**overrides):
+    body = {
+        "client_id": FWD_CLIENT_ID,
+        "client_secret": FWD_CLIENT_SECRET,
+        "refresh_token": FWD_REFRESH,
+        "scopes": FULL_SCOPES,
+        "account_email": "alice@example.com",
+        "grant_agents": ["builtin:email"],
+    }
+    body.update(overrides)
+    return body
+
+
+class TestForwardPost:
+    def test_persists_and_returns_masked_summary(self, ui_api_client):
+        resp = ui_api_client.post(
+            "/v1/connections/google", json=_forward_body(), headers=UI_HEADER
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["provider"] == "google"
+        assert data["account_email"] == "alice@example.com"
+        # No secrets echoed.
+        body_str = resp.text
+        assert FWD_REFRESH not in body_str
+        assert FWD_CLIENT_SECRET not in body_str
+        assert "refresh_token" not in data
+        assert "client_secret" not in data
+
+    def test_requires_csrf_header(self, ui_api_client):
+        resp = ui_api_client.post("/v1/connections/google", json=_forward_body())
+        assert resp.status_code == 403
+
+    def test_scope_shortfall_fails_loudly(self, ui_api_client):
+        resp = ui_api_client.post(
+            "/v1/connections/google",
+            json=_forward_body(scopes=["https://www.googleapis.com/auth/gmail.modify"]),
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 403, resp.text
+        detail = resp.json()["detail"]
+        assert detail["error"] == "scope_mismatch"
+        assert any("gmail.send" in s for s in detail["missing_scopes"])
+
+    def test_empty_refresh_token_fails_loudly(self, ui_api_client):
+        resp = ui_api_client.post(
+            "/v1/connections/google",
+            json=_forward_body(refresh_token=""),
+            headers=UI_HEADER,
+        )
+        # Empty string fails pydantic min_length OR the loud ConnectorsError.
+        assert resp.status_code in (400, 422, 500)
+
+
+class TestForwardGet:
+    def test_list_after_forward_masks_secret(self, ui_api_client):
+        ui_api_client.post(
+            "/v1/connections/google", json=_forward_body(), headers=UI_HEADER
+        )
+        resp = ui_api_client.get("/v1/connections")
+        assert resp.status_code == 200
+        assert FWD_REFRESH not in resp.text
+        assert FWD_CLIENT_SECRET not in resp.text
+        providers = [c["provider"] for c in resp.json()["connections"]]
+        assert "google" in providers
+
+    def test_get_single_masks_secret(self, ui_api_client):
+        ui_api_client.post(
+            "/v1/connections/google", json=_forward_body(), headers=UI_HEADER
+        )
+        resp = ui_api_client.get("/v1/connections/google")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["provider"] == "google"
+        assert "refresh_token" not in resp.text
+        assert FWD_REFRESH not in resp.text
+
+    def test_get_missing_provider_404(self, ui_api_client):
+        resp = ui_api_client.get("/v1/connections/google")
+        assert resp.status_code == 404
+
+
+class TestForwardDelete:
+    def test_revoke_clears_connection(self, ui_api_client):
+        ui_api_client.post(
+            "/v1/connections/google", json=_forward_body(), headers=UI_HEADER
+        )
+        resp = ui_api_client.delete("/v1/connections/google", headers=UI_HEADER)
+        assert resp.status_code == 204
+        # Now gone.
+        assert ui_api_client.get("/v1/connections/google").status_code == 404
+
+    def test_delete_requires_csrf(self, ui_api_client):
+        ui_api_client.post(
+            "/v1/connections/google", json=_forward_body(), headers=UI_HEADER
+        )
+        resp = ui_api_client.delete("/v1/connections/google")
+        assert resp.status_code == 403
+
+
+class TestAgentActsAfterForward:
+    @respx.mock
+    async def test_token_resolved_with_no_interactive_step(self, ui_api_client):
+        """After forwarding a grant, the agent resolves a token ambiently —
+        the refresh hits the stubbed token endpoint with the forwarded client,
+        no browser/PKCE flow involved."""
+        captured = {}
+
+        def _cap(request: httpx.Request) -> httpx.Response:
+            captured["body"] = request.content.decode()
+            return httpx.Response(
+                200, json={"access_token": "STUB-ACCESS", "expires_in": 3600}
+            )
+
+        respx.post("https://oauth2.googleapis.com/token").mock(side_effect=_cap)
+
+        resp = ui_api_client.post(
+            "/v1/connections/google",
+            json=_forward_body(account_email=""),
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 201, resp.text
+
+        from gaia.connectors.api import get_access_token
+
+        token = await get_access_token(
+            provider="google", scopes=FULL_SCOPES, agent_id="builtin:email"
+        )
+        assert token == "STUB-ACCESS"
+        assert FWD_CLIENT_ID in captured["body"]
+        assert FWD_CLIENT_SECRET in captured["body"]

--- a/tests/unit/connectors/test_secret_hygiene.py
+++ b/tests/unit/connectors/test_secret_hygiene.py
@@ -18,7 +18,6 @@ every sink listed above.
 
 from __future__ import annotations
 
-import json
 import traceback
 
 import httpx

--- a/tests/unit/connectors/test_secret_hygiene.py
+++ b/tests/unit/connectors/test_secret_hygiene.py
@@ -103,16 +103,59 @@ class TestPydanticDump:
 
 
 class TestOpenApi:
-    """A14: OpenAPI schema must not name a field that exposes the token."""
+    """A14: OpenAPI RESPONSE schemas must not name a field that exposes the
+    token.
 
-    def test_openapi_schema_does_not_expose_token_fields(self, ui_api_client):
+    A ``refresh_token`` field is legitimate on a *request* body — the
+    forwarded-connection POST (#1292) accepts one as input. The hygiene
+    invariant is that no *response* model exposes it. We therefore walk every
+    operation's response content schemas (resolving ``$ref`` into
+    ``components.schemas``) and assert ``refresh_token`` / ``client_secret``
+    never appears as a returned property name.
+    """
+
+    def test_openapi_response_schemas_do_not_expose_token_fields(self, ui_api_client):
         resp = ui_api_client.get("/openapi.json")
         assert resp.status_code == 200
-        schema = json.dumps(resp.json())
-        # Schema strings are field names, not values — but if anyone
-        # ever adds a "refresh_token" property to a public response model
-        # this catches it.
-        assert "refresh_token" not in schema
+        spec = resp.json()
+        components = spec.get("components", {}).get("schemas", {})
+
+        def _walk(schema: object, seen: set) -> set:
+            """Return the set of property names reachable from ``schema``,
+            resolving local ``$ref``s into ``components.schemas``."""
+            names: set = set()
+            if not isinstance(schema, dict):
+                return names
+            ref = schema.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+                name = ref.rsplit("/", 1)[-1]
+                if name in seen:
+                    return names
+                seen.add(name)
+                return _walk(components.get(name, {}), seen)
+            for prop in schema.get("properties") or {}:
+                names.add(prop)
+            for prop_schema in (schema.get("properties") or {}).values():
+                names |= _walk(prop_schema, seen)
+            for key in ("items", "additionalProperties"):
+                if isinstance(schema.get(key), dict):
+                    names |= _walk(schema[key], seen)
+            for key in ("allOf", "anyOf", "oneOf"):
+                for sub in schema.get(key, []) or []:
+                    names |= _walk(sub, seen)
+            return names
+
+        leaked: set = set()
+        for path_item in spec.get("paths", {}).values():
+            for op in path_item.values():
+                if not isinstance(op, dict):
+                    continue
+                for resp_obj in (op.get("responses") or {}).values():
+                    for media in (resp_obj.get("content") or {}).values():
+                        props = _walk(media.get("schema", {}), set())
+                        leaked |= {"refresh_token", "client_secret"} & props
+
+        assert not leaked, f"secret field(s) exposed in a response schema: {leaked}"
 
 
 class TestFiles:


### PR DESCRIPTION
Closes #1292

## Why this matters
Before #1292, GAIA could only obtain a mailbox connection by running its own OAuth flow — so an app that had *already* authenticated the user couldn't embed GAIA without forcing a second consent screen. This adds a credential-**forwarding** path: a host app POSTs the grant it already holds (client_id + client_secret + refresh_token + scopes) to `/v1/connections/{provider}`, GAIA persists it and refreshes **as the host app's own OAuth client** — zero user interaction, no re-consent. This is the integration model the whole v0.20 email agent is consumed through (the p0 foundation in #1319's map).

Security is the point of the feature, so it fails loudly: forwarded scopes that don't cover what the agent needs are rejected (no partial persist), an insecure keyring backend raises at import, secrets are never echoed in any response, and the `/v1/*` surface is gated the same as `/api/*` (localhost bypass + bearer token for remote). Google's non-rotating refresh tokens make host-app + GAIA concurrent use safe; a refresh lock guards the rare simultaneous-refresh race. Microsoft RT rotation is explicitly out of scope (deferred to #1280/#1105).

## Test Evidence
- [x] Unit: `python -m pytest tests/unit/connectors/` — 447 passed, 3 skipped (+24 new): forwarded import writes correct slots + computes client_id_hash + evicts cache; scope-shortfall raises loudly (nothing persisted); insecure-keyring raises; responses omit/mask secrets.
- [x] Integration: REST lifecycle (`test_router_forwarded.py`, 10 tests) — POST/GET/DELETE `/v1/connections` against the API client with an in-memory keyring; localhost + API-key gate; CSRF gate.
- [x] **Real-world smoke (live uvicorn server, synthetic grant):** POST → 201 (no secret echoed); GET → masked metadata only; scope-shortfall → 403 + `missing_scopes`; CSRF (no `X-Gaia-UI`) → 403; DELETE → 204 → GET → 404. All green.
- [x] Lint: `python util/lint.py --all` — 0 failures.
- [ ] **Live-Google token refresh: DEFERRED** — requires a real OAuth client + refresh_token not available in this environment. Only the synthetic-grant ingestion/validation/masking path is smoke-verified; the client-neutral refresh engine it rides on is pre-existing and unit-tested.

## Note for reviewer
Branch was cut from an earlier `main`; it merges cleanly against current `main` (verified, 0 conflicts). One pre-existing unrelated test failure (`test_multi_caller_equivalence.py` expects `/api/connectors` to return a `connections` key; it returns `connectors`) predates this PR and is out of scope.