### PR TITLE
fix(installer): resolve repo root correctly in scripts under installer/

### DIFF
--- a/installer/scripts/build-ui-installer.ps1
+++ b/installer/scripts/build-ui-installer.ps1
@@ -35,7 +35,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$REPO_ROOT = (Resolve-Path "$PSScriptRoot\..").Path
+$REPO_ROOT = (Resolve-Path "$PSScriptRoot\..\..").Path
 $WEBUI_DIR = "$REPO_ROOT\src\gaia\apps\webui"
 $ELECTRON_DIR = "$REPO_ROOT\src\gaia\electron"
 

--- a/installer/scripts/start-agent-ui.ps1
+++ b/installer/scripts/start-agent-ui.ps1
@@ -36,8 +36,8 @@ $RunBackend = -not $FrontendOnly
 $RunFrontend = -not $BackendOnly
 
 # ── Resolve project root ─────────────────────────────────────────────
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$ProjectRoot = Split-Path -Parent $ScriptDir
+# installer/scripts/ -> installer/ -> repo root
+$ProjectRoot = (Resolve-Path "$PSScriptRoot\..\..").Path
 $WebUIDir = Join-Path $ProjectRoot "src\gaia\apps\webui"
 
 Write-Host "=========================================="


### PR DESCRIPTION
## Summary
Fix repo-root resolution in the two PowerShell scripts under `installer/scripts/` - both climbed one parent directory too few after the R097 rename in #731, causing downstream paths (`$WebUIDir`, `$WEBUI_DIR`) to point one level short at `installer/src/...` instead of the real `<repo>/src/...`.

## Why
On a fresh Windows checkout:
- `start-agent-ui.ps1 -FrontendOnly` invokes `npm install` / `npm run dev` against the non-existent `installer\src\gaia\apps\webui` instead of `src\gaia\apps\webui`.
- `build-ui-installer.ps1` runs its `npm ci`, `npm run build`, `electron-forge package`/`make` against the same wrong tree, silently producing a broken installer or failing prerequisite checks at lines 77, 97, 106-108, 132, 149, 158, 166.

Both files live at `installer/scripts/`, so the correct traversal is `$PSScriptRoot\..\..` (two levels up -> repo root), not `$PSScriptRoot\..` (one level -> `installer/`).

**Scope note:** The bash counterparts (`start-agent-ui.sh`, `build-ui-installer.sh`) have the identical off-by-one bug on Linux/macOS. They are deliberately out of scope for this PR (separate platform) and will be addressed in a follow-up.

## Linked issue
Closes #1325

## Changes
- `installer/scripts/start-agent-ui.ps1`: replace the two-line `Split-Path -Parent` chain (plus the intermediate `$ScriptDir` variable) with `(Resolve-Path "$PSScriptRoot\..\..").Path`. `$ProjectRoot` name is preserved.
- `installer/scripts/build-ui-installer.ps1`: change `$REPO_ROOT = (Resolve-Path "$PSScriptRoot\..").Path` to use `..\..` (same one-character fix). `$WEBUI_DIR` / `$ELECTRON_DIR` derive from it, so they get corrected transitively.

## Test plan
Automated (cross-platform, no Windows required):
- [ ] PowerShell parser: `[System.Management.Automation.Language.Parser]::ParseFile(...)` returns no errors for both files.
- [ ] Path resolution sanity check - write a temp script containing the fixed line and confirm it resolves to the repo root:
  ```powershell
  `$PSScriptRoot = "`$PWD/installer/scripts"
  `$RepoRoot = (Resolve-Path "`$PSScriptRoot\..\..").Path
  Test-Path (Join-Path `$RepoRoot "src/gaia/apps/webui/package.json")  # expect True
  ```
- [ ] `git diff` is scope-clean: only the two `.ps1` files, 3 insertions / 3 deletions.

Manual (Windows reviewer, optional):
- [ ] On a fresh clone, run `.\installer\scripts\start-agent-ui.ps1 -FrontendOnly` and confirm `npm install` runs in the correct directory and `npm run dev` starts.
- [ ] Run `.\installer\scripts\build-ui-installer.ps1 -Mode browser` and confirm the build completes against the real `src\gaia\apps\webui`.


## Checklist
- [x] I have linked a GitHub issue above (Closes #1325).
- [x] I have described **why** this change is being made, not just what changed.
- [ ] I have run linting and tests locally. (N/A for PowerShell: python util/lint.py and pytest tests/unit/ don't cover .ps1. Lint equivalents ran: AST parse + path resolution test above.)
- [ ] I have updated documentation if user-visible behavior changed. (N/A - bug fix; behavior now matches documented path expectations.)