### PR TITLE
docs(release): generate value-prop-first release notes from the gaia-release skill

### DIFF
--- a/.claude/skills/gaia-release/SKILL.md
+++ b/.claude/skills/gaia-release/SKILL.md
@@ -53,7 +53,7 @@ These map to [CLAUDE.md](CLAUDE.md). Re-read them whenever this skill runs.
 
 - **No Claude attribution anywhere** — not in PR titles, PR bodies, commit messages (no `Co-Authored-By: Claude ...` trailer), release notes, code comments, or the Discord announcement.
 - **No silent fallbacks** — if a validator fails, a step times out, or a workflow run isn't found, stop with an actionable error. Do not retry blindly. Do not "proceed anyway."
-- **Match house style for release notes** — factual, not opinionated. No "finally", "silently", "no more crashes", "we're excited to announce". Read the **last 2–3 release notes** before drafting. Patch releases do **not** include a `pip install` block. Use the `Why upgrade:` framing with a short bullet list, then `## What's New`, then `## Bug Fixes`, then `## Full Changelog`.
+- **Match house style for release notes** — see *Generation parameters* in Phase 1. In short: value-prop first, **local agents are the headline** (not the SDK), one agent/command per highlight, plain language, engaging but factual, and **no emoji, no fluff** ("finally", "silently", "no more crashes", "we're excited to announce", "blazing", "Here's the good stuff"). Read the **last 2–3 release notes** before drafting. Patch releases do **not** include a `pip install` block. Use the `Why upgrade:` framing with a short bullet list, then `## What's New`, then `## Bug Fixes`, then `## Full Changelog`.
 - **Match the previous release PR body shape exactly** — read the most recent merged `Release vX.Y.Z` PR (e.g. `gh pr list --repo amd/gaia --state merged --search "Release v in:title" --limit 3`). Open with `# GAIA vX.Y.Z Release Notes` (no MDX frontmatter in the PR body), end with a `Release checklist` section. Style drift here costs review cycles.
 - **Bulletproof commits only** — every change made by this skill must satisfy the four criteria in CLAUDE.md (validated, critiqued, scope-clean, no half-finished work) before being committed.
 - **Pushing tags is irreversible.** Always confirm the SHA the tag will point to and the green status of the pre-tag verification run before `git push origin v<version>`.
@@ -117,9 +117,11 @@ These map to [CLAUDE.md](CLAUDE.md). Re-read them whenever this skill runs.
 
    ## What's New
 
-   ### <Feature title>
+   ### <What the user can now do> — `<gaia command>`
 
-   <Two short paragraphs: what changed, why it matters, link the PR(s) inline.>
+   <Lead with the outcome and why it matters, in plain language that makes the reader
+   want to try it. Then one line on how to run it, PR linked inline. One agent or
+   command per entry — add another `### ` block for the next one.>
 
    ---
 
@@ -138,6 +140,40 @@ These map to [CLAUDE.md](CLAUDE.md). Re-read them whenever this skill runs.
 
    Full Changelog: [v<previous>...v<version>](https://github.com/amd/gaia/compare/v<previous>...v<version>)
    ```
+
+   **Generation parameters (apply to every entry — this is the point of the skill).**
+   GAIA's notes have historically read dry and engineering-first: they say *what
+   changed* but not *why a user should care or want to try it*. Generate against these
+   every time:
+
+   - **Value-prop first.** Open each entry with what the user can now do and why it
+     matters — the outcome, not the implementation. "Triage your inbox in one command"
+     before "added EmailAgent with IMAP polling".
+   - **Local agents are the headline.** Lead with the agents that solve real problems
+     (`gaia browse`, `gaia analyze`, email triage, …); SDK / infra / refactors are
+     supporting detail. People come for the agents, not the SDK.
+   - **One agent or command per highlight.** `gaia browse` and `gaia analyze` each get
+     their own `### ` entry with its own one-line utility — never lumped together.
+   - **Plain, human language.** Write like you're telling a colleague what they can do
+     now. Short sentences; plain words over jargon.
+   - **Engaging, still factual.** Make the reader want to try it without overselling —
+     no invented benchmarks, no "fastest ever". The pull comes from a clear, real
+     capability, not adjectives.
+   - **No fluff, no emoji.** Banned: emoji in headings or body, "we're excited to
+     announce", "finally", "blazing(-fast)", "Here's the good stuff", "no more
+     crashes", "silently", "game-changer".
+
+   **Example — one highlight, done right:**
+
+   > **Bad** (dry, implementation-first, no reason to care):
+   > ### EmailAgent
+   > Adds an EmailAgent with IMAP polling and a rules engine for classification.
+
+   > **Good** (value-first, plain, makes you want to try it):
+   > ### Triage your inbox from the terminal — `gaia email`
+   > Point GAIA at your inbox and it sorts the noise from what needs you: drafts
+   > replies to routine mail, flags what's urgent, leaves the rest. Runs locally, so
+   > your mail never leaves your machine. Try it: `gaia email triage`.
 
 4. **Update [docs/docs.json](docs/docs.json):**
    - Add `releases/v<version>` to the Releases tab.
@@ -355,7 +391,7 @@ Show the user the run URL, the **release PR number** (`#$RELEASE_PR`), and the *
    ```
    Required artifacts: `.whl`, `.tar.gz`, `.deb`, `.AppImage`, `.dmg`, `.exe`, and the `latest*.yml` files for the Electron auto-updater. If any are missing, the corresponding build job didn't run or didn't upload — investigate.
 
-3. **Draft the Discord announcement** using the template below. Read the just-shipped release notes (`docs/releases/v<version>.mdx`) to populate the highlight list — one bullet per "What's New" entry plus any Bug Fix worth surfacing, written in the same voice as the notes (factual, no marketing).
+3. **Draft the Discord announcement** using the template below. Read the just-shipped release notes (`docs/releases/v<version>.mdx`) to populate the highlight list — one bullet per "What's New" entry plus any Bug Fix worth surfacing, written in the same voice as the notes — apply the same *Generation parameters* (value-prop first, plain, engaging, no fluff/emoji).
 
    **Template (copy verbatim, fill the bracketed fields):**
 


### PR DESCRIPTION
## Why this matters

GAIA's release notes read dry and engineering-first — they describe *what changed*, not *why a user should care or want to try it*. We ship genuinely useful local agents and then sell them poorly: Agent UI launched with no demo, and per-release the agents that are the actual product get buried under SDK/infra detail.

This upgrades the `gaia-release` Claude Code skill so it **generates** value-prop-first notes the first time, instead of validating tone after the fact. No new validator, no LLM judge, no extra tests — the fix is better generation guidance where the notes are written.

What the skill now enforces when drafting:
- **Value-prop first** — lead with what the user can now do and why, not the implementation.
- **Local agents are the headline** — agents that solve real problems come first; SDK/infra is supporting detail.
- **One agent/command per highlight** — `gaia browse` and `gaia analyze` each stand alone with their own utility line.
- **Plain language, engaging but factual, no emoji/fluff** — banned-phrase list promoted from prose to an explicit rule.
- A **bad/good worked example** (email triage) gives the model a concrete target.
- The Phase 6 Discord announcement reuses the same parameters, so it stops reading dry too.

## Test plan

- [ ] Read `.claude/skills/gaia-release/SKILL.md` Phase 1 "Generation parameters" block and the bad/good example for accuracy and house-style fit.
- [ ] On the next release, run the skill and confirm the drafted `## What's New` is per-agent and value-prop-first.
