### PR TITLE
fix(installer): resolve repo root correctly in bash scripts under installer/

### DIFF
--- a/installer/scripts/build-ui-installer.sh
+++ b/installer/scripts/build-ui-installer.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WEBUI_DIR="$REPO_ROOT/src/gaia/apps/webui"
 ELECTRON_DIR="$REPO_ROOT/src/gaia/electron"
 

--- a/installer/scripts/start-agent-ui.sh
+++ b/installer/scripts/start-agent-ui.sh
@@ -47,7 +47,7 @@ done
 
 # ── Resolve project root ─────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WEBUI_DIR="$PROJECT_ROOT/src/gaia/apps/webui"
 
 echo "=========================================="


### PR DESCRIPTION
## Why this matters

On a fresh Linux/macOS checkout, `start-agent-ui.sh --frontend-only` and `build-ui-installer.sh` were running `npm`/`electron-forge` against the non-existent `installer/src/gaia/apps/webui` instead of the real `src/gaia/apps/webui`, silently producing a broken installer or failing prerequisite checks. These are the bash counterparts to the two PowerShell scripts fixed in #1326 — flagged in that PR's review as having the identical off-by-one bug, deliberately deferred to this follow-up. Both scripts live at `installer/scripts/`, so the correct traversal is `$SCRIPT_DIR/../..` (two levels up to repo root), not `$SCRIPT_DIR/..` (one level, stopping at `installer/`).

Follow-up to #1326.

## Test plan
- [x] `bash -n` parses both scripts with no errors.
- [x] Path resolution: `cd "$SCRIPT_DIR/../.."` from `installer/scripts/` resolves to repo root, and `src/gaia/apps/webui/package.json` is found there.
- [x] `git diff` is scope-clean: only the two `.sh` files, 2 insertions / 2 deletions.
- [ ] Manual (Linux reviewer, optional): `./installer/scripts/start-agent-ui.sh --frontend-only` runs `npm` in the correct directory; `./installer/scripts/build-ui-installer.sh --browser` builds against the real `src/gaia/apps/webui`.