### PR TITLE
chore(lint): fix pre-existing flake8/isort on v0.20-email-triage-agent

### DIFF
--- a/src/gaia/governance/checkpoint_bridge.py
+++ b/src/gaia/governance/checkpoint_bridge.py
@@ -10,7 +10,6 @@ can run with no external dependencies.
 from __future__ import annotations
 
 from threading import Lock
-
 from typing import cast
 
 from .exceptions import CheckpointNotFoundError, InvalidResolutionError

--- a/tests/integration/test_pptx_rag_e2e.py
+++ b/tests/integration/test_pptx_rag_e2e.py
@@ -13,8 +13,6 @@ Skips when Lemonade is not reachable.
 
 from __future__ import annotations
 
-import os
-import tempfile
 import time
 from pathlib import Path
 from urllib.error import URLError

--- a/tests/unit/eval/test_audit.py
+++ b/tests/unit/eval/test_audit.py
@@ -9,8 +9,6 @@ Tests the deterministic architecture audit helpers that inspect
 
 import textwrap
 
-import pytest
-
 from gaia.eval.audit import (
     audit_agent_persistence,
     audit_chat_helpers,


### PR DESCRIPTION
Unblocks the v0.20 milestone branch's whole-tree lint gate. Three pre-existing lint failures on `v0.20-email-triage-agent` were causing the Code Quality CI to fail for any PR rebased onto it (e.g. the email-corpus PR #1322), even when the PR's own changes were clean:

- `tests/integration/test_pptx_rag_e2e.py` — removed unused `os`, `tempfile` (F401)
- `tests/unit/eval/test_audit.py` — removed unused `pytest` (F401)
- `src/gaia/governance/checkpoint_bridge.py` — fixed import ordering (isort)

5 deletions, no behavioral change.

## Test Evidence
- [x] `flake8 src/gaia tests` — clean (was 3 errors)
- [x] `isort --check-only src/gaia tests` — clean (was 1 error)