### PR TITLE
fix(agents): wire multi-device selection end-to-end and validate at runtime

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -248,6 +248,7 @@ Do NOT wrap conversational replies in JSON.
         max_consecutive_repeats: int = 4,
         min_context_size: int = 32768,
         skip_lemonade: bool = False,
+        device: Optional[str] = None,
     ):
         """
         Initialize the Agent with LLM client.
@@ -272,9 +273,14 @@ Do NOT wrap conversational replies in JSON.
             min_context_size: Minimum context size required for this agent (default: 32768).
             skip_lemonade: If True, skip Lemonade server initialization (default: False).
                           Use this when connecting to a different OpenAI-compatible backend.
+            device: Runtime device selector ('cpu', 'gpu', 'npu') chosen by the
+                          user (Agent UI dropdown / CLI --device). Validated against
+                          detected hardware at startup via LemonadeManager.ensure_ready;
+                          an unavailable device fails loudly (default: None = no check).
 
         Note: Uses local LLM server by default unless use_claude or use_chatgpt is True.
         """
+        self.device = device
         self.error_history = []  # Store error history for learning
         self.conversation_history = (
             []
@@ -312,6 +318,7 @@ Do NOT wrap conversational replies in JSON.
                 quiet=silent_mode,
                 base_url=base_url,
                 required_min_device=required_min_device,
+                device=device,
             )
 
         # Initialize state management

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -55,11 +55,7 @@ class ChatAgentConfig:
     max_steps: int = 10
     streaming: bool = False  # Use --streaming to enable
 
-    # Multi-device support (issue #1220). ``device`` is the runtime device the
-    # user selected ('cpu'/'gpu'/'npu'); it is validated against detected
-    # hardware at startup (fails loudly if absent). ``min_context_size`` lets a
-    # device config override the default 32K window — NPU's FLM build runs at
-    # 4K, so loading it at 32K would fail.
+    # NPU's FLM build runs at 4K, so a device config can override the 32K ctx.
     device: Optional[str] = None
     min_context_size: Optional[int] = None
 
@@ -363,7 +359,9 @@ class ChatAgent(
             debug=config.debug,
             device=config.device,
             min_context_size=(
-                config.min_context_size if config.min_context_size else 32768
+                config.min_context_size
+                if config.min_context_size is not None
+                else 32768
             ),
         )
 

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -55,6 +55,14 @@ class ChatAgentConfig:
     max_steps: int = 10
     streaming: bool = False  # Use --streaming to enable
 
+    # Multi-device support (issue #1220). ``device`` is the runtime device the
+    # user selected ('cpu'/'gpu'/'npu'); it is validated against detected
+    # hardware at startup (fails loudly if absent). ``min_context_size`` lets a
+    # device config override the default 32K window — NPU's FLM build runs at
+    # 4K, so loading it at 32K would fail.
+    device: Optional[str] = None
+    min_context_size: Optional[int] = None
+
     # Debug/output settings
     debug: bool = False
     debug_prompts: bool = False  # Backward compatibility
@@ -353,6 +361,10 @@ class ChatAgent(
             show_stats=config.show_stats,
             silent_mode=config.silent_mode,
             debug=config.debug,
+            device=config.device,
+            min_context_size=(
+                config.min_context_size if config.min_context_size else 32768
+            ),
         )
 
         # Index initial documents (only if RAG is available)

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -622,7 +622,9 @@ async def async_main(action, **kwargs):
                             if device_was_explicit:
                                 print(
                                     "❌ NPU not available on this system. "
-                                    "Requires Ryzen AI 300/400/Max (XDNA2).",
+                                    "Requires Ryzen AI 300/400/Max (XDNA2). "
+                                    "Run `gaia init --profile npu` to set it up, "
+                                    "or choose --device gpu.",
                                     file=sys.stderr,
                                 )
                                 sys.exit(1)
@@ -635,9 +637,32 @@ async def async_main(action, **kwargs):
                             for k, v in _devices.items()
                         )
                         if not has_gpu and not device_was_explicit:
+                            # Default GPU target unavailable — announce the
+                            # *reason* for the CPU fallback so it doesn't read
+                            # like a deliberate user choice.
+                            print(
+                                "No GPU detected; falling back to CPU (slower). "
+                                "Run `gaia init` to set up GPU acceleration."
+                            )
                             effective_device = "cpu"
-                except Exception:
-                    pass  # Lemonade not running yet; proceed with requested device
+                except LemonadeClientError as _probe_err:
+                    # Only treat "server not reachable yet" (connection refused /
+                    # timeout) as a soft pass — LemonadeClient surfaces those as
+                    # "Request failed: <reason>" with no HTTP status. A reachable
+                    # but broken server (HTTP 4xx/5xx, 401 auth) must NOT silently
+                    # let an explicit --device proceed; surface it so the user
+                    # sees the real failure. The agent runtime re-validates the
+                    # device regardless (LemonadeManager.ensure_ready).
+                    _probe_msg = str(_probe_err)
+                    _unreachable = (
+                        _probe_msg.startswith("Request failed:")
+                        and "with status" not in _probe_msg
+                    )
+                    if not _unreachable:
+                        raise
+                    log.debug(
+                        "Device probe: Lemonade not reachable yet (%s)", _probe_err
+                    )
 
                 for dc in DEFAULT_DEVICE_CONFIGS:
                     if dc.device == effective_device:
@@ -666,6 +691,7 @@ async def async_main(action, **kwargs):
                     os.getenv("LEMONADE_BASE_URL", DEFAULT_LEMONADE_URL),
                 ),
                 model_id=explicit_model,
+                device=effective_device,
                 max_steps=kwargs.get("max_steps", 100),
                 streaming=kwargs.get("stream", False),
                 show_prompts=kwargs.get("show_prompts", False),

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -647,16 +647,29 @@ async def async_main(action, **kwargs):
                             effective_device = "cpu"
                 except LemonadeClientError as _probe_err:
                     # Only treat "server not reachable yet" (connection refused /
-                    # timeout) as a soft pass — LemonadeClient surfaces those as
-                    # "Request failed: <reason>" with no HTTP status. A reachable
-                    # but broken server (HTTP 4xx/5xx, 401 auth) must NOT silently
-                    # let an explicit --device proceed; surface it so the user
-                    # sees the real failure. The agent runtime re-validates the
-                    # device regardless (LemonadeManager.ensure_ready).
-                    _probe_msg = str(_probe_err)
-                    _unreachable = (
-                        _probe_msg.startswith("Request failed:")
-                        and "with status" not in _probe_msg
+                    # timeout) as a soft pass. A reachable but broken server
+                    # (HTTP 4xx/5xx, 401 auth) must NOT silently let an explicit
+                    # --device proceed; surface it so the user sees the real
+                    # failure. The agent runtime re-validates the device
+                    # regardless (LemonadeManager.ensure_ready).
+                    #
+                    # Prefer the original requests exception preserved in the
+                    # cause chain over message-string matching — the client
+                    # wraps RequestException without an HTTP status, but the
+                    # exact wrapper text can change independently of this guard.
+                    import requests
+
+                    _cause = _probe_err.__cause__ or _probe_err.__context__
+                    _unreachable = isinstance(
+                        _cause,
+                        (
+                            requests.exceptions.ConnectionError,
+                            requests.exceptions.Timeout,
+                        ),
+                    ) or (
+                        # Fallback for wrappers that don't preserve __cause__.
+                        str(_probe_err).startswith("Request failed:")
+                        and "with status" not in str(_probe_err)
                     )
                     if not _unreachable:
                         raise

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -38,6 +38,55 @@ _RECIPE_BY_DEVICE = {
 # Device capability priority (high -> low)
 _DEVICE_PRIORITY = ["amd_npu", "amd_igpu", "amd_dgpu", "cpu"]
 
+# Map the high-level device selector ('cpu'/'gpu'/'npu') exposed to users
+# (Agent UI dropdown, CLI ``--device``) to the minimum detected-device tier
+# required to satisfy it.  A GPU requirement is met by EITHER integrated or
+# discrete Radeon graphics, so it maps to the lowest GPU tier (``amd_dgpu``):
+# ``_DEVICE_PRIORITY`` orders igpu above dgpu and the satisfaction check is
+# ``detected_idx <= req_idx``, so requiring ``amd_dgpu`` accepts an iGPU-only
+# box too.  Mapping ``gpu`` to ``amd_igpu`` (the old value) would wrongly
+# reject a discrete-Radeon-only host.
+_DEVICE_TO_MIN = {
+    "cpu": "cpu",
+    "gpu": "amd_dgpu",
+    "npu": "amd_npu",
+}
+
+# User-facing remedy for each device when the host can't satisfy it.
+_DEVICE_REMEDY = {
+    "npu": (
+        "NPU not available on this host; run `gaia init --profile npu` to set "
+        "up NPU acceleration, or choose --device gpu"
+    ),
+    "gpu": (
+        "No AMD GPU available on this host; run `gaia init` to set up GPU "
+        "acceleration, or choose --device cpu"
+    ),
+    "cpu": "CPU is unavailable on this host",
+}
+
+
+def _format_device_error(
+    device: Optional[str], required_min_device: Optional[str], detected
+) -> str:
+    """Build an actionable message for an unmet hardware requirement.
+
+    Names the requested device and the concrete remedy when a high-level
+    ``device`` selector was supplied; falls back to the raw tier comparison
+    for callers that passed only ``required_min_device`` (e.g. a static
+    ``REQUIRED_HARDWARE`` floor).
+    """
+    detected_list = sorted(str(d) for d in detected)
+    if device and device in _DEVICE_REMEDY:
+        return (
+            f"Requested device '{device}' is not available on this host "
+            f"(detected: {detected_list}). {_DEVICE_REMEDY[device]}."
+        )
+    return (
+        f"Hardware requirement not met: required={required_min_device}, "
+        f"detected={detected_list}"
+    )
+
 
 class HardwareRequirementError(Exception):
     """Raised when an agent's hardware requirement is not met by the host."""
@@ -238,10 +287,6 @@ class LemonadeManager:
         # Map high-level device selector to required_min_device when the
         # caller didn't pass an explicit required_min_device.
         if device and not required_min_device:
-            _DEVICE_TO_MIN = {
-                "npu": "amd_npu",
-                "gpu": "amd_igpu",
-            }
             required_min_device = _DEVICE_TO_MIN.get(device)
         # Parse host and port from base_url if provided
         if base_url and (host is None or port is None):
@@ -479,9 +524,12 @@ class LemonadeManager:
                                 f"Hardware requirement satisfied: {highest} -> recipe={recipe}"
                             )
                         else:
-                            # Not satisfied: raise actionable error
+                            # Not satisfied: raise actionable error naming the
+                            # requested device and the concrete remedy.
                             raise HardwareRequirementError(
-                                f"Hardware requirement not met: required={required_min_device}, detected={sorted(list(detected))}"
+                                _format_device_error(
+                                    device, required_min_device, detected
+                                )
                             )
                     except HardwareRequirementError:
                         raise

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -334,10 +334,25 @@ class LemonadeManager:
         except HardwareRequirementError:
             raise
         except Exception as e:
-            # Server not reachable / transient — can't validate now. Don't
-            # mislabel it as a hardware shortfall; the unreachable server is
-            # surfaced by the init path below (or the subsequent model load).
-            cls._log.debug("Skipping device validation (not reachable yet): %s", e)
+            # A server that's merely unreachable (connection refused / timeout)
+            # is expected and soft — don't mislabel it as missing hardware; the
+            # down server is surfaced by the init path (or the model load).
+            # Anything else (e.g. a malformed system-info response, a bug in
+            # _validate_device_requirement) is logged at WARNING so it stays
+            # visible instead of silently skipping validation.
+            msg = str(e)
+            is_conn = (
+                "Request failed:" in msg
+                or "refused" in msg.lower()
+                or "timeout" in msg.lower()
+                or "timed out" in msg.lower()
+            )
+            if is_conn:
+                cls._log.debug("Skipping device validation (not reachable yet): %s", e)
+            else:
+                cls._log.warning(
+                    "Skipping device validation (unexpected probe error): %s", e
+                )
             return
         cls._validated_min_devices.add(required_min_device)
 

--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -141,6 +141,13 @@ class LemonadeManager:
     _last_recheck_time: float = 0.0
     _RECHECK_INTERVAL: float = 30.0  # seconds between re-checks
 
+    # Device tiers (``amd_npu``/``amd_dgpu``/``cpu``/…) already validated OK on
+    # this host. Hardware is static per process, so once a tier passes we never
+    # re-probe it — but a NEWLY requested tier (e.g. the user switching the UI
+    # device dropdown to NPU after the manager warmed up on GPU) is still
+    # validated, which the ``_initialized`` fast-path would otherwise skip.
+    _validated_min_devices: set = set()
+
     @classmethod
     def is_lemonade_installed(cls) -> bool:
         """Check if Lemonade server is installed."""
@@ -242,6 +249,99 @@ class LemonadeManager:
         print("", file=sys.stderr)
 
     @classmethod
+    def _validate_device_requirement(cls, client, required_min_device, device):
+        """Raise ``HardwareRequirementError`` if *required_min_device* isn't met.
+
+        Resolves detected devices via ``client.get_system_info()`` and compares
+        capability tiers. Raises only on a *genuine* hardware shortfall — any
+        failure reaching the server (connection refused, timeout) propagates
+        unchanged so the caller can treat it as "not reachable yet" rather than
+        mislabelling a down server as missing hardware.
+        """
+        sys_info = client.get_system_info()
+        devices = sys_info.get("devices", {})
+        detected = set()
+        # devices may be a dict or a list; handle both
+        if isinstance(devices, dict):
+            detected = set(devices.keys())
+        elif isinstance(devices, list):
+            if all(isinstance(x, str) for x in devices):
+                detected = set(devices)
+            else:
+                for item in devices:
+                    if isinstance(item, dict):
+                        # Prefer explicit device_type when available.
+                        for k in ("device_type", "type", "id", "name"):
+                            if k in item:
+                                detected.add(str(item[k]))
+                                break
+        # Find highest-capability detected device
+        highest = None
+        for dev in _DEVICE_PRIORITY:
+            if dev in detected:
+                highest = dev
+                break
+        if highest is None:
+            # assume CPU-only host if nothing reported
+            highest = "cpu"
+
+        # Check capability ordering: lower index == higher capability
+        req_idx = (
+            _DEVICE_PRIORITY.index(required_min_device)
+            if required_min_device in _DEVICE_PRIORITY
+            else len(_DEVICE_PRIORITY) - 1
+        )
+        detected_idx = (
+            _DEVICE_PRIORITY.index(highest)
+            if highest in _DEVICE_PRIORITY
+            else len(_DEVICE_PRIORITY) - 1
+        )
+        if detected_idx <= req_idx:
+            recipe = _RECIPE_BY_DEVICE.get(highest, _RECIPE_BY_DEVICE.get("cpu"))
+            cls._log.debug(
+                f"Hardware requirement satisfied: {highest} -> recipe={recipe}"
+            )
+        else:
+            raise HardwareRequirementError(
+                _format_device_error(device, required_min_device, detected)
+            )
+
+    @classmethod
+    def _maybe_validate_device(
+        cls, required_min_device, device, base_url, host, port, quiet
+    ):
+        """Validate the requested device on EVERY ensure_ready call.
+
+        The ``_initialized`` singleton fast-path skips the full init block, so
+        without this a device switch after the manager is already warm (the UI
+        dropdown case) would never be checked. Memoised per tier so a passing
+        device is probed at most once per process. Caller must hold ``_lock``.
+        """
+        if not required_min_device:
+            return
+        if required_min_device in cls._validated_min_devices:
+            return
+        try:
+            if base_url:
+                probe = LemonadeClient(
+                    base_url=base_url, keep_alive=True, verbose=not quiet
+                )
+            else:
+                probe = LemonadeClient(
+                    host=host, port=port, keep_alive=True, verbose=not quiet
+                )
+            cls._validate_device_requirement(probe, required_min_device, device)
+        except HardwareRequirementError:
+            raise
+        except Exception as e:
+            # Server not reachable / transient — can't validate now. Don't
+            # mislabel it as a hardware shortfall; the unreachable server is
+            # surfaced by the init path below (or the subsequent model load).
+            cls._log.debug("Skipping device validation (not reachable yet): %s", e)
+            return
+        cls._validated_min_devices.add(required_min_device)
+
+    @classmethod
     def ensure_ready(
         cls,
         min_context_size: int = DEFAULT_CONTEXT_SIZE,
@@ -298,6 +398,15 @@ class LemonadeManager:
             if port is None:
                 port = parsed.port
         with cls._lock:
+            # Validate the requested device first — runs on every call (not just
+            # first init) so a UI device switch after the manager is warm is
+            # still checked. Memoised per tier, so this is at most one probe per
+            # distinct device per process. Raises HardwareRequirementError when
+            # the device is genuinely absent.
+            cls._maybe_validate_device(
+                required_min_device, device, base_url, host, port, quiet
+            )
+
             # If already initialized, just verify context size
             if cls._initialized:
                 if cls._context_size >= min_context_size:
@@ -471,74 +580,9 @@ class LemonadeManager:
                     f"(context: {cls._context_size} tokens)"
                 )
 
-                # If a caller requested a minimum device tier, resolve
-                # detected devices and ensure the requirement is met.
-                if required_min_device:
-                    try:
-                        sys_info = client.get_system_info()
-                        devices = sys_info.get("devices", {})
-                        detected = set()
-                        # devices may be a dict or a list; handle both
-                        if isinstance(devices, dict):
-                            detected = set(devices.keys())
-                        elif isinstance(devices, list):
-                            # list of strings or list of dicts
-                            if all(isinstance(x, str) for x in devices):
-                                detected = set(devices)
-                            else:
-                                for item in devices:
-                                    if isinstance(item, dict):
-                                        # try common keys
-                                        # Prefer explicit device_type when available.
-                                        for k in ("device_type", "type", "id", "name"):
-                                            if k in item:
-                                                detected.add(str(item[k]))
-                                                break
-                        # Find highest-capability detected device
-                        highest = None
-                        for dev in _DEVICE_PRIORITY:
-                            if dev in detected:
-                                highest = dev
-                                break
-                        if highest is None:
-                            # assume CPU-only host if nothing reported
-                            highest = "cpu"
-
-                        # Check capability ordering: lower index == higher capability
-                        req_idx = (
-                            _DEVICE_PRIORITY.index(required_min_device)
-                            if required_min_device in _DEVICE_PRIORITY
-                            else len(_DEVICE_PRIORITY) - 1
-                        )
-                        detected_idx = (
-                            _DEVICE_PRIORITY.index(highest)
-                            if highest in _DEVICE_PRIORITY
-                            else len(_DEVICE_PRIORITY) - 1
-                        )
-                        if detected_idx <= req_idx:
-                            # Satisfied: determine recipe (allow-listed)
-                            recipe = _RECIPE_BY_DEVICE.get(
-                                highest, _RECIPE_BY_DEVICE.get("cpu")
-                            )
-                            cls._log.debug(
-                                f"Hardware requirement satisfied: {highest} -> recipe={recipe}"
-                            )
-                        else:
-                            # Not satisfied: raise actionable error naming the
-                            # requested device and the concrete remedy.
-                            raise HardwareRequirementError(
-                                _format_device_error(
-                                    device, required_min_device, detected
-                                )
-                            )
-                    except HardwareRequirementError:
-                        raise
-                    except Exception as e:
-                        # Propagate as a HardwareRequirementError so callers
-                        # cannot silently ignore device-resolution failures.
-                        raise HardwareRequirementError(
-                            f"Failed to resolve hardware devices: {e}"
-                        ) from e
+                # Device requirement is validated up-front by
+                # ``_maybe_validate_device`` (runs on every call, before this
+                # init block), so there is nothing to re-check here.
 
                 # Only warn if:
                 # 1. Context size is non-zero (0 means no model loaded or model still loading)
@@ -769,4 +813,5 @@ class LemonadeManager:
             cls._base_url = None
             cls._context_size = 0
             cls._last_recheck_time = 0.0
+            cls._validated_min_devices = set()
             cls._log.debug("LemonadeManager state reset")

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -444,10 +444,10 @@ def _build_create_kwargs(
     Note: if registry.resolve_model() already promoted model_id before this
     call, it is forwarded as-is via branch 2 (resolve_model result ≠ default).
 
-    ``device``/``min_context_size`` (issue #1220) flow through to the agent's
-    config so the requested device is validated at runtime. Agent factories
-    filter unknown kwargs via ``dataclasses.fields``, so this is safe for
-    agents whose config doesn't declare them.
+    ``device``/``min_context_size`` flow through to the agent's config so the
+    requested device is validated at runtime. Agent factories filter unknown
+    kwargs via ``dataclasses.fields``, so this is safe for agents whose config
+    doesn't declare them.
     """
     suffix = " (streaming)" if streaming else ""
     kwargs: dict = {"silent_mode": not streaming, "debug": False}
@@ -487,16 +487,15 @@ def _effective_model(agent, fallback: str | None) -> str | None:
     return effective if effective is not None else fallback
 
 
-def _resolve_device_model(
+def resolve_device_model(
     agent_type: str, device: str | None, registry=None
 ) -> tuple[str | None, int | None]:
     """Resolve the (model, ctx_size) an agent should use on *device*.
 
-    Multi-device agents declare a ``DeviceConfig`` per device (issue #1220).
-    The Agent UI device dropdown writes ``session["device"]``; without this
-    lookup every agent-build site resolved the model from ``session["model"]``
-    only, so selecting "NPU" silently rebuilt the agent on the GPU model
-    (release blocker B1).
+    The Agent UI device dropdown writes ``session["device"]``; resolving the
+    model here is what makes selecting "NPU" actually switch models instead of
+    rebuilding on the GPU model. Public (no underscore) because the sessions
+    router also calls it to rewrite the session model on a device switch.
 
     Looks up the registered agent's ``device_configs`` and returns the model
     and context size of the entry matching *device*.  Falls back to the
@@ -521,6 +520,38 @@ def _resolve_device_model(
         if getattr(dc, "device", None) == device:
             return dc.model, getattr(dc, "ctx_size", None)
     return None, None
+
+
+def _apply_device_model(
+    session: dict,
+    agent_type: str,
+    model_id: str | None,
+    custom_model: str | None,
+    registry=None,
+) -> tuple[str | None, int | None]:
+    """Apply the session's device choice to the model + context window.
+
+    Returns ``(model_id, device_ctx)``. The device config drives the model when
+    the current model is the generic default (so built-in Gemma agents switch
+    correctly) OR the user picked a non-GPU device explicitly (a pinned model
+    can't run there) — so an agent that declares its own model isn't clobbered
+    on the default GPU. Skipped when the user pinned a ``custom_model``.
+    """
+    device = session.get("device")
+    if custom_model or not device:
+        return model_id, None
+    dev_model, dev_ctx = resolve_device_model(agent_type, device, registry)
+    if not dev_model:
+        return model_id, None
+    is_default_model = model_id in (None, _DB_DEFAULT_MODEL)
+    device_is_explicit = device != "gpu"
+    if dev_model == model_id or is_default_model or device_is_explicit:
+        if dev_model != model_id:
+            logger.info(
+                "chat: device=%s -> model %s (was %s)", device, dev_model, model_id
+            )
+        return dev_model, dev_ctx
+    return model_id, None
 
 
 def get_cached_mcp_status() -> list[dict]:
@@ -1108,31 +1139,11 @@ async def _get_chat_response(
                 )
                 model_id = preferred
 
-        # ── Multi-device: the selected device dictates the model + ctx (B1) ────
-        # The UI device dropdown writes ``session["device"]``; without this the
-        # agent was always (re)built on the GPU model regardless of the choice.
-        # Skipped when the user pinned a custom model override. We only let the
-        # device config drive the model when the current model is the generic
-        # default (so built-in Gemma agents switch correctly) OR the user picked
-        # a non-GPU device explicitly (a pinned preference can't run there) — so
-        # an agent that declares its own model isn't clobbered on the default GPU.
+        # The UI device dropdown drives the model + ctx window.
         device = session.get("device")
-        device_ctx = None
-        if not custom_model:
-            dev_model, dev_ctx = _resolve_device_model(agent_type, device, registry)
-            if dev_model:
-                is_default_model = model_id in (None, _DB_DEFAULT_MODEL)
-                device_is_explicit = bool(device) and device != "gpu"
-                if dev_model == model_id or is_default_model or device_is_explicit:
-                    if dev_model != model_id:
-                        logger.info(
-                            "chat: device=%s -> model %s (was %s)",
-                            device,
-                            dev_model,
-                            model_id,
-                        )
-                    model_id = dev_model
-                    device_ctx = dev_ctx
+        model_id, device_ctx = _apply_device_model(
+            session, agent_type, model_id, custom_model, registry
+        )
 
         # ── Agent cache ──────────────────────────────────────────────────────
         cached_agent = _get_cached_agent(session_id, model_id, agent_type)
@@ -1495,31 +1506,11 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                 )
                 model_id = preferred
 
-        # ── Multi-device: the selected device dictates the model + ctx (B1) ────
-        # The UI device dropdown writes ``session["device"]``; without this the
-        # agent was always (re)built on the GPU model regardless of the choice.
-        # Skipped when the user pinned a custom model override. We only let the
-        # device config drive the model when the current model is the generic
-        # default (so built-in Gemma agents switch correctly) OR the user picked
-        # a non-GPU device explicitly (a pinned preference can't run there) — so
-        # an agent that declares its own model isn't clobbered on the default GPU.
+        # The UI device dropdown drives the model + ctx window.
         device = session.get("device")
-        device_ctx = None
-        if not custom_model:
-            dev_model, dev_ctx = _resolve_device_model(agent_type, device, registry)
-            if dev_model:
-                is_default_model = model_id in (None, _DB_DEFAULT_MODEL)
-                device_is_explicit = bool(device) and device != "gpu"
-                if dev_model == model_id or is_default_model or device_is_explicit:
-                    if dev_model != model_id:
-                        logger.info(
-                            "chat: device=%s -> model %s (was %s) (streaming)",
-                            device,
-                            dev_model,
-                            model_id,
-                        )
-                    model_id = dev_model
-                    device_ctx = dev_ctx
+        model_id, device_ctx = _apply_device_model(
+            session, agent_type, model_id, custom_model, registry
+        )
 
         # Move ALL slow work into the background thread so the SSE generator
         # can yield the thinking event immediately.

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -431,6 +431,8 @@ def _build_create_kwargs(
     custom_model: str | None,
     model_id: str | None,
     streaming: bool = False,
+    device: str | None = None,
+    min_context_size: int | None = None,
 ) -> dict:
     """Return the kwargs dict for registry.create_agent().
 
@@ -441,11 +443,20 @@ def _build_create_kwargs(
 
     Note: if registry.resolve_model() already promoted model_id before this
     call, it is forwarded as-is via branch 2 (resolve_model result ≠ default).
+
+    ``device``/``min_context_size`` (issue #1220) flow through to the agent's
+    config so the requested device is validated at runtime. Agent factories
+    filter unknown kwargs via ``dataclasses.fields``, so this is safe for
+    agents whose config doesn't declare them.
     """
     suffix = " (streaming)" if streaming else ""
     kwargs: dict = {"silent_mode": not streaming, "debug": False}
     if streaming:
         kwargs["streaming"] = True
+    if device is not None:
+        kwargs["device"] = device
+    if min_context_size is not None:
+        kwargs["min_context_size"] = min_context_size
 
     if custom_model:
         kwargs["model_id"] = custom_model
@@ -474,6 +485,42 @@ def _effective_model(agent, fallback: str | None) -> str | None:
     """
     effective = getattr(agent, "model_id", None)
     return effective if effective is not None else fallback
+
+
+def _resolve_device_model(
+    agent_type: str, device: str | None, registry=None
+) -> tuple[str | None, int | None]:
+    """Resolve the (model, ctx_size) an agent should use on *device*.
+
+    Multi-device agents declare a ``DeviceConfig`` per device (issue #1220).
+    The Agent UI device dropdown writes ``session["device"]``; without this
+    lookup every agent-build site resolved the model from ``session["model"]``
+    only, so selecting "NPU" silently rebuilt the agent on the GPU model
+    (release blocker B1).
+
+    Looks up the registered agent's ``device_configs`` and returns the model
+    and context size of the entry matching *device*.  Falls back to the
+    built-in ``DEFAULT_DEVICE_CONFIGS`` when the agent isn't registered or
+    declares none (e.g. the direct-construction ``chat`` path).  Returns
+    ``(None, None)`` when *device* is falsy or no entry matches, so callers
+    leave the existing model untouched.
+    """
+    if not device:
+        return None, None
+    registry = registry if registry is not None else _agent_registry
+    device_configs = None
+    if registry is not None:
+        reg = registry.get(agent_type)
+        if reg is not None:
+            device_configs = getattr(reg, "device_configs", None)
+    if not device_configs:
+        from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+        device_configs = DEFAULT_DEVICE_CONFIGS
+    for dc in device_configs:
+        if getattr(dc, "device", None) == device:
+            return dc.model, getattr(dc, "ctx_size", None)
+    return None, None
 
 
 def get_cached_mcp_status() -> list[dict]:
@@ -1061,6 +1108,32 @@ async def _get_chat_response(
                 )
                 model_id = preferred
 
+        # ── Multi-device: the selected device dictates the model + ctx (B1) ────
+        # The UI device dropdown writes ``session["device"]``; without this the
+        # agent was always (re)built on the GPU model regardless of the choice.
+        # Skipped when the user pinned a custom model override. We only let the
+        # device config drive the model when the current model is the generic
+        # default (so built-in Gemma agents switch correctly) OR the user picked
+        # a non-GPU device explicitly (a pinned preference can't run there) — so
+        # an agent that declares its own model isn't clobbered on the default GPU.
+        device = session.get("device")
+        device_ctx = None
+        if not custom_model:
+            dev_model, dev_ctx = _resolve_device_model(agent_type, device, registry)
+            if dev_model:
+                is_default_model = model_id in (None, _DB_DEFAULT_MODEL)
+                device_is_explicit = bool(device) and device != "gpu"
+                if dev_model == model_id or is_default_model or device_is_explicit:
+                    if dev_model != model_id:
+                        logger.info(
+                            "chat: device=%s -> model %s (was %s)",
+                            device,
+                            dev_model,
+                            model_id,
+                        )
+                    model_id = dev_model
+                    device_ctx = dev_ctx
+
         # ── Agent cache ──────────────────────────────────────────────────────
         cached_agent = _get_cached_agent(session_id, model_id, agent_type)
 
@@ -1100,6 +1173,8 @@ async def _get_chat_response(
                 max_steps=10,
                 silent_mode=True,
                 debug=False,
+                device=device,
+                min_context_size=device_ctx,
                 **_session_kwargs,
             )
             _stamp_builtin_chat_identity(config)
@@ -1166,7 +1241,10 @@ async def _get_chat_response(
                 agent = registry.create_agent(
                     agent_type,
                     **_build_create_kwargs(
-                        custom_model=custom_model, model_id=model_id
+                        custom_model=custom_model,
+                        model_id=model_id,
+                        device=device,
+                        min_context_size=device_ctx,
                     ),
                     **_session_agent_kwargs(
                         rag_file_paths=rag_file_paths,
@@ -1417,6 +1495,32 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                 )
                 model_id = preferred
 
+        # ── Multi-device: the selected device dictates the model + ctx (B1) ────
+        # The UI device dropdown writes ``session["device"]``; without this the
+        # agent was always (re)built on the GPU model regardless of the choice.
+        # Skipped when the user pinned a custom model override. We only let the
+        # device config drive the model when the current model is the generic
+        # default (so built-in Gemma agents switch correctly) OR the user picked
+        # a non-GPU device explicitly (a pinned preference can't run there) — so
+        # an agent that declares its own model isn't clobbered on the default GPU.
+        device = session.get("device")
+        device_ctx = None
+        if not custom_model:
+            dev_model, dev_ctx = _resolve_device_model(agent_type, device, registry)
+            if dev_model:
+                is_default_model = model_id in (None, _DB_DEFAULT_MODEL)
+                device_is_explicit = bool(device) and device != "gpu"
+                if dev_model == model_id or is_default_model or device_is_explicit:
+                    if dev_model != model_id:
+                        logger.info(
+                            "chat: device=%s -> model %s (was %s) (streaming)",
+                            device,
+                            dev_model,
+                            model_id,
+                        )
+                    model_id = dev_model
+                    device_ctx = dev_ctx
+
         # Move ALL slow work into the background thread so the SSE generator
         # can yield the thinking event immediately.
         result_holder = {"answer": "", "error": None}
@@ -1487,6 +1591,8 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                         streaming=True,
                         silent_mode=False,
                         debug=False,
+                        device=device,
+                        min_context_size=device_ctx,
                         **_session_kwargs,
                     )
 
@@ -1589,6 +1695,8 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                             streaming=True,
                             silent_mode=False,
                             debug=False,
+                            device=device,
+                            min_context_size=device_ctx,
                             **_session_agent_kwargs(
                                 rag_file_paths=[],
                                 library_paths=library_paths,
@@ -1630,6 +1738,8 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                                 custom_model=custom_model,
                                 model_id=model_id,
                                 streaming=True,
+                                device=device,
+                                min_context_size=device_ctx,
                             ),
                             **_session_agent_kwargs(
                                 rag_file_paths=[],

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -359,14 +359,18 @@ class ChatDatabase:
         private: bool | None = None,
         agent_type: str | None = None,
         device: str | None = None,
+        model: str | None = None,
     ) -> Optional[Dict[str, Any]]:
-        """Update session title, system prompt, agent_type, device, private flag, and/or document_ids."""
+        """Update session title, system prompt, agent_type, device, model, private flag, and/or document_ids."""
         updates: list[str] = []
         params: list[Any] = []
 
         if title is not None:
             updates.append("title = ?")
             params.append(title)
+        if model is not None:
+            updates.append("model = ?")
+            params.append(model)
         if system_prompt is not None:
             updates.append("system_prompt = ?")
             params.append(system_prompt)

--- a/src/gaia/ui/routers/sessions.py
+++ b/src/gaia/ui/routers/sessions.py
@@ -11,8 +11,8 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from .._chat_helpers import evict_session_agent
-from ..database import ChatDatabase
+from .._chat_helpers import _resolve_device_model, evict_session_agent
+from ..database import SESSION_DEFAULT_MODEL, ChatDatabase
 from ..dependencies import get_db
 from ..models import (
     AttachDocumentRequest,
@@ -89,6 +89,25 @@ async def update_session(
     """Update session title, system prompt, or linked documents."""
     if request.agent_type is not None or request.device is not None:
         evict_session_agent(session_id)
+
+    # On a device switch, rewrite the session's model to that device's
+    # registered model so the agent rebuilt after eviction loads the right
+    # model (release blocker B1) and the model dropdown reflects reality.
+    # Only rewrite when the device model differs and the session isn't pinned
+    # to a non-default model on the default GPU device — mirrors the runtime
+    # guard in ``_chat_helpers`` so an agent's own model isn't clobbered.
+    device_model = None
+    if request.device is not None:
+        existing = db.get_session(session_id)
+        agent_type = request.agent_type or (existing or {}).get("agent_type") or "chat"
+        resolved, _ = _resolve_device_model(agent_type, request.device)
+        if resolved:
+            current_model = (existing or {}).get("model")
+            is_default_model = current_model in (None, SESSION_DEFAULT_MODEL)
+            device_is_explicit = request.device != "gpu"
+            if resolved != current_model and (is_default_model or device_is_explicit):
+                device_model = resolved
+
     session = db.update_session(
         session_id,
         title=request.title,
@@ -97,6 +116,7 @@ async def update_session(
         private=request.private,
         agent_type=request.agent_type,
         device=request.device,
+        model=device_model,
     )
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/src/gaia/ui/routers/sessions.py
+++ b/src/gaia/ui/routers/sessions.py
@@ -11,7 +11,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from .._chat_helpers import _resolve_device_model, evict_session_agent
+from .._chat_helpers import evict_session_agent, resolve_device_model
 from ..database import SESSION_DEFAULT_MODEL, ChatDatabase
 from ..dependencies import get_db
 from ..models import (
@@ -92,15 +92,15 @@ async def update_session(
 
     # On a device switch, rewrite the session's model to that device's
     # registered model so the agent rebuilt after eviction loads the right
-    # model (release blocker B1) and the model dropdown reflects reality.
-    # Only rewrite when the device model differs and the session isn't pinned
-    # to a non-default model on the default GPU device — mirrors the runtime
-    # guard in ``_chat_helpers`` so an agent's own model isn't clobbered.
+    # model and the model dropdown reflects reality. Only rewrite when the
+    # device model differs and the session isn't pinned to a non-default model
+    # on the default GPU device — mirrors the runtime guard in ``_chat_helpers``
+    # so an agent's own model isn't clobbered.
     device_model = None
     if request.device is not None:
         existing = db.get_session(session_id)
         agent_type = request.agent_type or (existing or {}).get("agent_type") or "chat"
-        resolved, _ = _resolve_device_model(agent_type, request.device)
+        resolved, _ = resolve_device_model(agent_type, request.device)
         if resolved:
             current_model = (existing or {}).get("model")
             is_default_model = current_model in (None, SESSION_DEFAULT_MODEL)

--- a/tests/fixtures/hardware/dgpu_only.json
+++ b/tests/fixtures/hardware/dgpu_only.json
@@ -1,0 +1,6 @@
+{
+  "devices": {
+    "amd_dgpu": { "memory_mb": 16384, "name": "AMD Radeon RX 7900 XTX" },
+    "cpu": { "cores": 16 }
+  }
+}

--- a/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
+++ b/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
@@ -340,6 +340,76 @@ class TestPostConstructionPreflight:
         )
 
 
+class TestDeviceModelOverride:
+    """B1: the selected device dictates the model passed to create_agent.
+
+    Pre-fix the device dropdown was a silent no-op — the agent was always
+    (re)built on the session model (GPU) regardless of the chosen device.
+    """
+
+    def test_npu_device_switches_model_and_threads_device(self):
+        registry, captured = _make_registry()
+        db = _make_db(custom_model=None)
+        session = _make_session(model=_DB_DEFAULT)
+        session["device"] = "npu"
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        kwargs = captured["kwargs"]
+        assert kwargs.get("model_id") == "gemma4-it-e2b-FLM"
+        assert kwargs.get("device") == "npu"
+        assert kwargs.get("min_context_size") == 4096
+
+    def test_explicit_npu_overrides_session_pinned_model(self):
+        """A non-GPU device wins even over a session-pinned model (it can't run there)."""
+        registry, captured = _make_registry()
+        db = _make_db(custom_model=None)
+        session = _make_session(model="UserChose-GGUF")
+        session["device"] = "npu"
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured["kwargs"].get("model_id") == "gemma4-it-e2b-FLM"
+
+    def test_gpu_device_does_not_clobber_pinned_model(self):
+        """On the default GPU device, an agent's own model preference is kept."""
+        registry, captured = _make_registry()
+        db = _make_db(custom_model=None)
+        session = _make_session(model="UserChose-GGUF")
+        session["device"] = "gpu"
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured["kwargs"].get("model_id") == "UserChose-GGUF"
+
+    def test_custom_model_override_beats_device(self):
+        """An explicit custom_model setting still wins over the device model."""
+        registry, captured = _make_registry()
+        db = _make_db(custom_model="UserPicked-GGUF")
+        session = _make_session(model=_DB_DEFAULT)
+        session["device"] = "npu"
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured["kwargs"].get("model_id") == "UserPicked-GGUF"
+
+
 class TestBuiltinChatAgentUnchanged:
     """Pin AC4: built-in ChatAgent (agent_type='chat') behavior is unchanged."""
 

--- a/tests/unit/chat/ui/test_database.py
+++ b/tests/unit/chat/ui/test_database.py
@@ -84,6 +84,16 @@ class TestSessions:
         result = db.update_session(session["id"])
         assert result["title"] == "Keep"
 
+    def test_update_session_model(self, db):
+        # Multi-device (#1220): a device switch rewrites the session model so
+        # the rebuilt agent loads the device's model (release blocker B1).
+        session = db.create_session(model="Gemma-4-E4B-it-GGUF")
+        updated = db.update_session(
+            session["id"], device="npu", model="gemma4-it-e2b-FLM"
+        )
+        assert updated["device"] == "npu"
+        assert updated["model"] == "gemma4-it-e2b-FLM"
+
     def test_update_session_not_found(self, db):
         result = db.update_session("nonexistent", title="Nope")
         assert result is None

--- a/tests/unit/test_multi_device_wiring.py
+++ b/tests/unit/test_multi_device_wiring.py
@@ -124,6 +124,71 @@ class TestUnavailableDeviceRaises:
         assert "gaia init" in msg
 
 
+class TestDeviceValidatedAfterWarmInit:
+    """B2: validation must run even when the manager is already initialized.
+
+    The ``_initialized`` singleton fast-path used to skip device validation, so
+    a UI device switch after the server warmed up on GPU silently bypassed the
+    check. Validation now runs on every call (memoised per tier).
+    """
+
+    def test_device_switch_validated_when_already_initialized(self, monkeypatch):
+        from gaia.llm.lemonade_manager import (
+            HardwareRequirementError,
+            LemonadeManager,
+        )
+
+        _patch_lemonade(monkeypatch, "cpu_only.json")
+        # Warm up the singleton with a plain (no-device) call.
+        assert LemonadeManager.ensure_ready(min_context_size=4096) is True
+        assert LemonadeManager._initialized is True
+        # A device switch to NPU on a CPU-only host must STILL raise.
+        with pytest.raises(HardwareRequirementError):
+            LemonadeManager.ensure_ready(device="npu")
+
+    def test_passing_device_is_memoized(self, monkeypatch):
+        from gaia.llm.lemonade_client import LemonadeClient
+        from gaia.llm.lemonade_manager import LemonadeManager
+
+        calls = {"n": 0}
+        data = _load_fixture("npu_igpu.json")
+
+        def _counting_sysinfo(self):
+            calls["n"] += 1
+            return data
+
+        monkeypatch.setattr(
+            LemonadeClient, "get_status", lambda self: _make_status(), raising=False
+        )
+        monkeypatch.setattr(
+            LemonadeClient, "get_system_info", _counting_sysinfo, raising=False
+        )
+        assert LemonadeManager.ensure_ready(device="npu") is True
+        after_first = calls["n"]
+        assert after_first >= 1
+        # A second build on the SAME device must not re-probe hardware.
+        assert LemonadeManager.ensure_ready(device="npu") is True
+        assert calls["n"] == after_first
+
+    def test_unreachable_server_does_not_become_hardware_error(self, monkeypatch):
+        from gaia.llm.lemonade_client import LemonadeClient, LemonadeClientError
+        from gaia.llm.lemonade_manager import LemonadeManager
+
+        def _down_status(self):
+            return _make_status(running=False)
+
+        def _down_sysinfo(self):
+            raise LemonadeClientError("Request failed: connection refused")
+
+        monkeypatch.setattr(LemonadeClient, "get_status", _down_status, raising=False)
+        monkeypatch.setattr(
+            LemonadeClient, "get_system_info", _down_sysinfo, raising=False
+        )
+        # Server down + device requested must NOT raise a hardware error — it
+        # returns False (not ready), same as the no-device down-server path.
+        assert LemonadeManager.ensure_ready(device="npu") is False
+
+
 class TestFormatDeviceError:
     def test_named_device_includes_remedy(self):
         from gaia.llm.lemonade_manager import _format_device_error

--- a/tests/unit/test_multi_device_wiring.py
+++ b/tests/unit/test_multi_device_wiring.py
@@ -272,42 +272,42 @@ class TestChatAgentConfigDeviceField:
 
 
 class TestResolveDeviceModelUI:
-    """``_resolve_device_model`` is the heart of the UI dropdown fix."""
+    """``resolve_device_model`` is the heart of the UI dropdown fix."""
 
     def test_npu_resolves_to_flm_model_and_4k_ctx(self):
-        from gaia.ui._chat_helpers import _resolve_device_model
+        from gaia.ui._chat_helpers import resolve_device_model
 
-        model, ctx = _resolve_device_model("chat", "npu", None)
+        model, ctx = resolve_device_model("chat", "npu", None)
         assert model == "gemma4-it-e2b-FLM"
         assert ctx == 4096
 
     def test_gpu_resolves_to_gguf_model_and_32k_ctx(self):
-        from gaia.ui._chat_helpers import _resolve_device_model
+        from gaia.ui._chat_helpers import resolve_device_model
 
-        model, ctx = _resolve_device_model("chat", "gpu", None)
+        model, ctx = resolve_device_model("chat", "gpu", None)
         assert model == "Gemma-4-E4B-it-GGUF"
         assert ctx == 32768
 
     def test_cpu_resolves_to_gguf_model(self):
-        from gaia.ui._chat_helpers import _resolve_device_model
+        from gaia.ui._chat_helpers import resolve_device_model
 
-        model, _ = _resolve_device_model("chat", "cpu", None)
+        model, _ = resolve_device_model("chat", "cpu", None)
         assert model == "Gemma-4-E4B-it-GGUF"
 
     def test_no_device_returns_none(self):
-        from gaia.ui._chat_helpers import _resolve_device_model
+        from gaia.ui._chat_helpers import resolve_device_model
 
-        assert _resolve_device_model("chat", None, None) == (None, None)
+        assert resolve_device_model("chat", None, None) == (None, None)
 
     def test_unknown_device_returns_none(self):
-        from gaia.ui._chat_helpers import _resolve_device_model
+        from gaia.ui._chat_helpers import resolve_device_model
 
-        assert _resolve_device_model("chat", "quantum", None) == (None, None)
+        assert resolve_device_model("chat", "quantum", None) == (None, None)
 
     def test_registered_agent_device_configs_used(self):
         """A registry entry's own device_configs take precedence over defaults."""
         from gaia.agents.registry import DeviceConfig
-        from gaia.ui._chat_helpers import _resolve_device_model
+        from gaia.ui._chat_helpers import resolve_device_model
 
         custom = SimpleNamespace(
             device_configs=[
@@ -321,7 +321,7 @@ class TestResolveDeviceModelUI:
             ]
         )
         registry = SimpleNamespace(get=lambda _id: custom)
-        model, ctx = _resolve_device_model("my-agent", "npu", registry)
+        model, ctx = resolve_device_model("my-agent", "npu", registry)
         assert model == "custom-npu-model"
         assert ctx == 2048
 
@@ -345,3 +345,46 @@ class TestCliDeviceModelMapping:
 
         model = next(dc.model for dc in DEFAULT_DEVICE_CONFIGS if dc.device == device)
         assert model == expected_model
+
+
+# ── B1: sessions router rewrites the model on a device switch (HTTP layer) ────
+
+
+class TestSessionsRouterDeviceRewrite:
+    """PUT /api/sessions/{id} with a device must rewrite the persisted model."""
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from gaia.ui.server import create_app
+
+        # No `with` — avoids running the lifespan (which would touch Lemonade);
+        # the device rewrite path needs only the DB + DEFAULT_DEVICE_CONFIGS.
+        return TestClient(create_app(db_path=":memory:"))
+
+    def test_switch_to_npu_rewrites_model(self, client):
+        created = client.post(
+            "/api/sessions", json={"model": "Gemma-4-E4B-it-GGUF"}
+        ).json()
+        resp = client.put(f"/api/sessions/{created['id']}", json={"device": "npu"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["device"] == "npu"
+        assert body["model"] == "gemma4-it-e2b-FLM"
+
+    def test_switch_to_gpu_keeps_default_model(self, client):
+        created = client.post("/api/sessions", json={}).json()
+        resp = client.put(f"/api/sessions/{created['id']}", json={"device": "gpu"})
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "Gemma-4-E4B-it-GGUF"
+
+    def test_title_only_update_leaves_model_untouched(self, client):
+        created = client.post(
+            "/api/sessions", json={"model": "Gemma-4-E4B-it-GGUF"}
+        ).json()
+        resp = client.put(f"/api/sessions/{created['id']}", json={"title": "Renamed"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == "Renamed"
+        assert body["model"] == "Gemma-4-E4B-it-GGUF"

--- a/tests/unit/test_multi_device_wiring.py
+++ b/tests/unit/test_multi_device_wiring.py
@@ -1,0 +1,282 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for end-to-end multi-device wiring (v0.20.0 blockers B1/B2/H1).
+
+Covers:
+  * MEDIUM — ``gpu`` selector accepts integrated OR discrete Radeon.
+  * B2 — the runtime device selection is validated and fails loudly with an
+    actionable error; ``device`` is threaded base Agent → ensure_ready.
+  * B1 — the UI/CLI device → model resolution (DeviceConfig lookup).
+"""
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "fixtures", "hardware")
+
+
+def _load_fixture(name: str):
+    with open(os.path.join(FIXTURES_DIR, name), "r") as f:
+        return json.load(f)
+
+
+def _make_status(running=True, context_size=32768, loaded_models=None):
+    if loaded_models is None:
+        loaded_models = [{"id": "gemma", "labels": []}]
+    return SimpleNamespace(
+        running=running, context_size=context_size, loaded_models=loaded_models
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_manager():
+    from gaia.llm.lemonade_manager import LemonadeManager
+
+    LemonadeManager.reset()
+    yield
+    LemonadeManager.reset()
+
+
+def _patch_lemonade(monkeypatch, fixture_file: str):
+    from gaia.llm.lemonade_client import LemonadeClient
+
+    data = _load_fixture(fixture_file)
+    monkeypatch.setattr(
+        LemonadeClient, "get_status", lambda self: _make_status(), raising=False
+    )
+    monkeypatch.setattr(
+        LemonadeClient, "get_system_info", lambda self: data, raising=False
+    )
+
+
+# ── MEDIUM: gpu selector accepts igpu OR dgpu ────────────────────────────────
+
+
+class TestDeviceToMinMapping:
+    """``_DEVICE_TO_MIN`` maps the high-level selector to the right tier."""
+
+    def test_mapping_values(self):
+        from gaia.llm.lemonade_manager import _DEVICE_TO_MIN
+
+        assert _DEVICE_TO_MIN["cpu"] == "cpu"
+        assert _DEVICE_TO_MIN["npu"] == "amd_npu"
+        # gpu must map to the LOWEST GPU tier so a dGPU-only box validates.
+        assert _DEVICE_TO_MIN["gpu"] == "amd_dgpu"
+
+
+class TestGpuSelectorAcceptsBothGpuTiers:
+    """A 'gpu' request is satisfied by integrated OR discrete Radeon."""
+
+    def test_gpu_satisfied_on_igpu_only(self, monkeypatch):
+        from gaia.llm.lemonade_manager import LemonadeManager
+
+        _patch_lemonade(monkeypatch, "igpu_only.json")
+        assert LemonadeManager.ensure_ready(device="gpu") is True
+
+    def test_gpu_satisfied_on_dgpu_only(self, monkeypatch):
+        from gaia.llm.lemonade_manager import LemonadeManager
+
+        _patch_lemonade(monkeypatch, "dgpu_only.json")
+        # Pre-fix this raised because gpu mapped to amd_igpu and a dGPU box
+        # reports only amd_dgpu (lower capability tier).
+        assert LemonadeManager.ensure_ready(device="gpu") is True
+
+    def test_cpu_always_satisfied(self, monkeypatch):
+        from gaia.llm.lemonade_manager import LemonadeManager
+
+        _patch_lemonade(monkeypatch, "cpu_only.json")
+        assert LemonadeManager.ensure_ready(device="cpu") is True
+
+
+# ── B2: unavailable device fails loudly with an actionable error ──────────────
+
+
+class TestUnavailableDeviceRaises:
+    def test_npu_request_on_cpu_only_raises_actionable(self, monkeypatch):
+        from gaia.llm.lemonade_manager import (
+            HardwareRequirementError,
+            LemonadeManager,
+        )
+
+        _patch_lemonade(monkeypatch, "cpu_only.json")
+        with pytest.raises(HardwareRequirementError) as exc:
+            LemonadeManager.ensure_ready(device="npu")
+        msg = str(exc.value)
+        # Names the device and a concrete remedy (per CLAUDE.md fail-loudly rule).
+        assert "npu" in msg.lower()
+        assert "gaia init --profile npu" in msg
+
+    def test_gpu_request_on_cpu_only_raises_actionable(self, monkeypatch):
+        from gaia.llm.lemonade_manager import (
+            HardwareRequirementError,
+            LemonadeManager,
+        )
+
+        _patch_lemonade(monkeypatch, "cpu_only.json")
+        with pytest.raises(HardwareRequirementError) as exc:
+            LemonadeManager.ensure_ready(device="gpu")
+        msg = str(exc.value)
+        assert "gpu" in msg.lower()
+        assert "gaia init" in msg
+
+
+class TestFormatDeviceError:
+    def test_named_device_includes_remedy(self):
+        from gaia.llm.lemonade_manager import _format_device_error
+
+        msg = _format_device_error("npu", "amd_npu", ["cpu"])
+        assert "npu" in msg.lower()
+        assert "gaia init --profile npu" in msg
+
+    def test_no_device_falls_back_to_raw(self):
+        from gaia.llm.lemonade_manager import _format_device_error
+
+        msg = _format_device_error(None, "amd_npu", ["cpu"])
+        assert "required=amd_npu" in msg
+
+
+# ── B2: device threaded base Agent → ensure_ready ────────────────────────────
+
+
+class TestAgentThreadsDevice:
+    def test_device_kwarg_forwarded_to_ensure_ready(self, monkeypatch):
+        from gaia.agents.base.agent import Agent
+
+        calls = {}
+
+        def fake_ensure_ready(*args, **kwargs):
+            calls["kwargs"] = kwargs
+            return True
+
+        monkeypatch.setattr(
+            "gaia.llm.lemonade_manager.LemonadeManager.ensure_ready",
+            fake_ensure_ready,
+            raising=False,
+        )
+
+        class MinimalAgent(Agent):
+            def _register_tools(self):
+                return None
+
+        agent = MinimalAgent(skip_lemonade=False, device="npu")
+        assert calls["kwargs"].get("device") == "npu"
+        assert agent.device == "npu"
+
+    def test_device_defaults_to_none(self, monkeypatch):
+        from gaia.agents.base.agent import Agent
+
+        calls = {}
+        monkeypatch.setattr(
+            "gaia.llm.lemonade_manager.LemonadeManager.ensure_ready",
+            lambda *a, **k: calls.update(kwargs=k) or True,
+            raising=False,
+        )
+
+        class MinimalAgent(Agent):
+            def _register_tools(self):
+                return None
+
+        MinimalAgent(skip_lemonade=False)
+        assert calls["kwargs"].get("device") is None
+
+
+# ── B2: ChatAgentConfig carries device + min_context_size ─────────────────────
+
+
+class TestChatAgentConfigDeviceField:
+    def test_config_has_device_and_ctx(self):
+        from gaia.agents.chat.agent import ChatAgentConfig
+
+        cfg = ChatAgentConfig(device="npu", min_context_size=4096)
+        assert cfg.device == "npu"
+        assert cfg.min_context_size == 4096
+
+    def test_config_device_defaults_none(self):
+        from gaia.agents.chat.agent import ChatAgentConfig
+
+        cfg = ChatAgentConfig()
+        assert cfg.device is None
+        assert cfg.min_context_size is None
+
+
+# ── B1: UI device → model resolution ─────────────────────────────────────────
+
+
+class TestResolveDeviceModelUI:
+    """``_resolve_device_model`` is the heart of the UI dropdown fix."""
+
+    def test_npu_resolves_to_flm_model_and_4k_ctx(self):
+        from gaia.ui._chat_helpers import _resolve_device_model
+
+        model, ctx = _resolve_device_model("chat", "npu", None)
+        assert model == "gemma4-it-e2b-FLM"
+        assert ctx == 4096
+
+    def test_gpu_resolves_to_gguf_model_and_32k_ctx(self):
+        from gaia.ui._chat_helpers import _resolve_device_model
+
+        model, ctx = _resolve_device_model("chat", "gpu", None)
+        assert model == "Gemma-4-E4B-it-GGUF"
+        assert ctx == 32768
+
+    def test_cpu_resolves_to_gguf_model(self):
+        from gaia.ui._chat_helpers import _resolve_device_model
+
+        model, _ = _resolve_device_model("chat", "cpu", None)
+        assert model == "Gemma-4-E4B-it-GGUF"
+
+    def test_no_device_returns_none(self):
+        from gaia.ui._chat_helpers import _resolve_device_model
+
+        assert _resolve_device_model("chat", None, None) == (None, None)
+
+    def test_unknown_device_returns_none(self):
+        from gaia.ui._chat_helpers import _resolve_device_model
+
+        assert _resolve_device_model("chat", "quantum", None) == (None, None)
+
+    def test_registered_agent_device_configs_used(self):
+        """A registry entry's own device_configs take precedence over defaults."""
+        from gaia.agents.registry import DeviceConfig
+        from gaia.ui._chat_helpers import _resolve_device_model
+
+        custom = SimpleNamespace(
+            device_configs=[
+                DeviceConfig(
+                    device="npu",
+                    model="custom-npu-model",
+                    recipe="flm",
+                    backend="flm:npu",
+                    ctx_size=2048,
+                )
+            ]
+        )
+        registry = SimpleNamespace(get=lambda _id: custom)
+        model, ctx = _resolve_device_model("my-agent", "npu", registry)
+        assert model == "custom-npu-model"
+        assert ctx == 2048
+
+
+# ── B1: CLI device → model mapping (shared DEFAULT_DEVICE_CONFIGS source) ─────
+
+
+class TestCliDeviceModelMapping:
+    """The CLI resolves device → model from DEFAULT_DEVICE_CONFIGS."""
+
+    @pytest.mark.parametrize(
+        "device,expected_model",
+        [
+            ("gpu", "Gemma-4-E4B-it-GGUF"),
+            ("cpu", "Gemma-4-E4B-it-GGUF"),
+            ("npu", "gemma4-it-e2b-FLM"),
+        ],
+    )
+    def test_default_device_config_models(self, device, expected_model):
+        from gaia.agents.registry import DEFAULT_DEVICE_CONFIGS
+
+        model = next(dc.model for dc in DEFAULT_DEVICE_CONFIGS if dc.device == device)
+        assert model == expected_model


### PR DESCRIPTION
## Why this matters

Multi-device support shipped in #1252 but the device selector never actually changed anything. Before: picking **NPU** in the Agent UI dropdown (or passing `--device npu`) silently rebuilt the agent on the **GPU** model — the choice was a no-op, and a request for hardware the host didn't have ran somewhere else without warning. After: selecting a device switches the model (and context window) to that device's registered config, and an unavailable device fails loudly with an actionable remedy instead of degrading silently.

This addresses the v0.20.0 release-review blockers **B1**, **B2**, and **H1**, plus one medium GPU-tier bug:

- **B1 — UI dropdown was a silent no-op.** The UI wrote `session.device` and evicted the agent, but every build site resolved the model from `session["model"]`, never the device's `DeviceConfig.model`. Now the device's model/ctx drive the rebuilt agent, and a device switch rewrites the session model so eviction/recreation picks it up. A guard keeps an agent's own pinned model from being clobbered on the default GPU device.
- **B2 — runtime never validated the chosen device.** `ChatAgentConfig` gained a `device` field that threads through the base `Agent` into `LemonadeManager.ensure_ready(device=...)`. An NPU request on a host without an NPU now raises an actionable `HardwareRequirementError` ("NPU not available… run `gaia init --profile npu`, or choose --device gpu") instead of silently running elsewhere.
- **H1 — CLI swallowed all device-probe errors.** `except Exception: pass` is narrowed to only treat genuine "server not reachable yet" (connection refused / timeout) as a soft pass; a reachable-but-broken Lemonade (HTTP 5xx, 401) now surfaces. The default GPU→CPU fallback says *why* ("No GPU detected; falling back to CPU (slower). Run `gaia init`…").
- **Medium — `gpu` rejected discrete Radeon.** `_DEVICE_TO_MIN` mapped `gpu`→`amd_igpu`, so an explicit GPU requirement misvalidated on a dGPU-only box. It now maps to the lowest GPU tier (`amd_dgpu`), accepting integrated **or** discrete graphics.

> **NPU quality eval is out of scope here and must be run by a maintainer on Ryzen AI hardware before tag:**
> `gaia eval agent --device npu --category context_retention,rag_quality`
> NPU runs a 2B FLM model at 4K ctx vs GPU's 4B at 32K, so a quality delta is expected and needs hardware to measure — it can't run in CI.

## Test plan

- [x] `python util/lint.py --black --isort --flake8` — all pass
- [x] `python -m pytest tests/unit/ -k "device or chat or agent"` — 1519 passed (2 failures are pre-existing on `main` and unrelated: a Windows-only `read_text()`/cp1252 quirk over an existing ❌ emoji, and an unrelated memory-reconcile test)
- [x] New `tests/unit/test_multi_device_wiring.py` — device→model resolution (UI + CLI), `gpu` accepts igpu **and** dgpu, unavailable device raises an actionable error, `device` threaded base Agent → `ensure_ready`
- [x] New cases in `tests/unit/chat/ui/test_chat_helpers_model_resolution.py` — full `_get_chat_response` flow: NPU switches the model + threads `device`/`min_context_size`; explicit non-GPU device overrides a pinned model; default GPU does **not** clobber a pinned model; `custom_model` still wins
- [x] `tests/unit/chat/ui/test_database.py` — `update_session(model=...)` device-switch rewrite
- [ ] Maintainer: NPU quality eval on Ryzen AI hardware (see note above)
