### PR TITLE
refactor(agents): isolate tool registries for all tool agents

### DIFF
--- a/installer/scripts/build-ui-installer.sh
+++ b/installer/scripts/build-ui-installer.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WEBUI_DIR="$REPO_ROOT/src/gaia/apps/webui"
 ELECTRON_DIR="$REPO_ROOT/src/gaia/electron"
 

--- a/installer/scripts/start-agent-ui.sh
+++ b/installer/scripts/start-agent-ui.sh
@@ -47,7 +47,7 @@ done
 
 # ── Resolve project root ─────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WEBUI_DIR="$PROJECT_ROOT/src/gaia/apps/webui"
 
 echo "=========================================="

--- a/src/gaia/agents/blender/agent.py
+++ b/src/gaia/agents/blender/agent.py
@@ -432,6 +432,9 @@ Examples of colored requests:
                 self.error_history.append(str(e))
                 return {"status": "error", "error": str(e)}
 
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()
+
     def _post_process_tool_result(
         self,
         tool_name: str,

--- a/src/gaia/agents/code/agent.py
+++ b/src/gaia/agents/code/agent.py
@@ -213,6 +213,9 @@ class CodeAgent(
         self.register_validation_tools()  # ValidationToolsMixin (Testing and validation)
         self.register_code_index_tools()  # CodeIndexToolsMixin (Semantic code search)
 
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()
+
     def process_query(
         self, user_input: str, workspace_root=None, progress_callback=None, **kwargs
     ):  # pylint: disable=arguments-differ,unused-argument

--- a/src/gaia/agents/docker/agent.py
+++ b/src/gaia/agents/docker/agent.py
@@ -218,6 +218,9 @@ Step 3: Build with build_image
             """
             return self._run_container(image, port, name)
 
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()
+
     def _analyze_directory(self, path: str) -> Dict[str, Any]:
         """Analyze directory to determine application type and structure."""
         logger.debug(f"Analyzing directory: {path}")

--- a/src/gaia/agents/docqa/agent.py
+++ b/src/gaia/agents/docqa/agent.py
@@ -74,5 +74,8 @@ class DocumentQAAgent(
 
             get_logger(__name__).debug("DocumentQAAgent: optional tools skipped: %s", e)
 
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()
+
     def _get_system_prompt(self) -> str:
         return "You are DocumentQAAgent. Use indexed documents to answer user queries accurately and cite sources."

--- a/src/gaia/agents/emr/agent.py
+++ b/src/gaia/agents/emr/agent.py
@@ -1314,6 +1314,9 @@ Use the available tools to search and retrieve patient information."""
                 }
             return {"success": False, "error": "Failed to extract patient data"}
 
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()
+
     def get_stats(self) -> Dict[str, Any]:
         """
         Get statistics about intake form processing.

--- a/src/gaia/agents/fileio/agent.py
+++ b/src/gaia/agents/fileio/agent.py
@@ -61,5 +61,8 @@ class FileIOAgent(
 
             get_logger(__name__).debug("FileIOAgent: optional tools skipped: %s", e)
 
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()
+
     def _get_system_prompt(self) -> str:
         return "You are FileIOAgent. Perform file operations safely and ask for confirmation before destructive actions."

--- a/src/gaia/agents/jira/agent.py
+++ b/src/gaia/agents/jira/agent.py
@@ -381,6 +381,9 @@ JQL RULES:
                 issue_key, summary, description, priority, status
             )
 
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()
+
     def _get_jira_credentials(self) -> tuple[str, str, str]:
         """Get Jira credentials from environment.
 

--- a/src/gaia/agents/sd/agent.py
+++ b/src/gaia/agents/sd/agent.py
@@ -220,3 +220,6 @@ RULES:
                 "image_path": str(path),
                 "story_file": story_path,
             }
+
+        # Isolate this agent's tools from other agents in the same process.
+        self._snapshot_tools()

--- a/src/gaia/agents/summarize/agent.py
+++ b/src/gaia/agents/summarize/agent.py
@@ -199,6 +199,8 @@ class SummarizerAgent(Agent):
 
     def _register_tools(self) -> None:
         """Register tools for the agent. No tools needed for summarizer."""
+        # Isolate this agent's (empty) tool set from other agents in-process.
+        self._snapshot_tools()
 
     def _prepare_chat(self, input_type: str) -> None:
         """Clear prior chat context and set system prompt for the given input type."""

--- a/util/check_agent_conventions.py
+++ b/util/check_agent_conventions.py
@@ -11,7 +11,9 @@ Hard checks (block CI on failure):
 - Defines at least one class inheriting from something named ``Agent`` / ``*Agent`` / ``*Mixin``
 - The agent class implements ``_get_system_prompt`` and ``_register_tools``
   (or inherits them transitively from a known base)
-- ``_register_tools`` contains ``_TOOL_REGISTRY.clear()`` (when defined locally)
+- ``_register_tools`` isolates its tool registry when defined locally — either
+  the modern ``self._snapshot_tools()`` (preferred) or the older
+  ``_TOOL_REGISTRY.clear()``/``.pop()``
 - Copyright header + SPDX line present
 - ``KNOWN_TOOLS`` entries in registry.py resolve to importable classes
 
@@ -68,7 +70,11 @@ def _method_names(cls: ast.ClassDef) -> set:
 
 
 def _manages_registry_state(cls: ast.ClassDef) -> bool:
-    """True if _register_* locally manages registry state (.clear() or .pop())."""
+    """True if _register_* locally isolates the tool registry.
+
+    Accepts the modern per-instance ``self._snapshot_tools()`` (preferred) or
+    the older global ``_TOOL_REGISTRY.clear()``/``.pop()`` patterns.
+    """
     has_register_tools = False
     for node in cls.body:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -79,7 +85,8 @@ def _manages_registry_state(cls: ast.ClassDef) -> bool:
             has_register_tools = True
         src = ast.unparse(node)
         if (
-            "_TOOL_REGISTRY.clear" in src
+            "_snapshot_tools" in src  # modern per-instance isolation (preferred)
+            or "_TOOL_REGISTRY.clear" in src
             or "_TOOL_REGISTRY.pop" in src
             or "_TOOL_REGISTRY[" in src  # explicit manipulation
         ):
@@ -149,9 +156,10 @@ def _check_agent_file(
 
         if not _manages_registry_state(cls):
             warnings.append(
-                f"{rel}: class {cls.name}._register_tools does not call "
-                "_TOOL_REGISTRY.clear() or .pop() — tools may leak across "
-                "agent instances; confirm this is intentional"
+                f"{rel}: class {cls.name}._register_tools does not isolate its "
+                "tool registry (call self._snapshot_tools(), or "
+                "_TOOL_REGISTRY.clear()/.pop()) — tools may leak across agent "
+                "instances; confirm this is intentional"
             )
 
     # ── Soft: tests exist ─────────────────────────────────────────────────


### PR DESCRIPTION
## Why this matters

Before: nine agents (blender, code, docker, docqa, emr, fileio, jira, sd, summarize) overrode `_register_tools` without isolating their tool set, so they shared the process-global `_TOOL_REGISTRY`. Constructing two of these agents in one process — e.g. routing between agents, or the Agent UI swapping agent types in a single backend — let the second agent's tools leak into the first agent's system prompt and execution path, advertising and exposing tools it never registered. After: each agent calls `self._snapshot_tools()`, the per-instance freeze already used by chat, connectors_demo, builder, analyst, and browser, so every agent sees only its own tools.

This also fixes the convention checker, which previously recognized only the older destructive `_TOOL_REGISTRY.clear()/.pop()` and flagged agents using the modern `_snapshot_tools()` with false-positive "tools may leak" warnings. It now accepts `_snapshot_tools()` as the preferred isolation. Combined, convention-checker warnings drop from 25 to 13 (the remaining 13 are unrelated missing-test / CLAUDE.md-mention notices).

Single-agent behavior is unchanged: `_snapshot_tools()` freezes a copy of the registry at construction, which in a one-agent-per-process run equals the previous global fallback — same tools advertised, same execution. The only behavioral difference is multi-agent-in-one-process isolation.

## Test plan

- [x] `python util/check_agent_conventions.py` → 0 errors, 13 warnings (was 25); all 12 registry-isolation warnings cleared
- [x] `python -m pytest tests/unit/agents/test_registry.py` → 47 passed
- [x] All 9 modified agent modules import cleanly
- [x] `python util/lint.py --black --isort` → PASS
- [x] Isolation verified end-to-end: agent A (built first) does not see agent B's tool after B registers in the same process
- [x] Confirmed no changed agent registers tools after `_register_tools()` returns: an AST sweep shows every `register_*_tools()` call lives inside `_register_tools` (before the snapshot), and none of the 9 reference `connect_mcp_server` / `load_mcp_servers_from_config` / `register_mcp` / `register_memory_tools`. Agents that do support runtime MCP (e.g. chat in the UI) re-invoke `_register_tools()` each turn, which re-snapshots.