### PR TITLE
docs(spec): Agent Hub restructure spec (#1102)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -403,6 +403,8 @@
             "group": "Ecosystem",
             "pages": [
               "plans/agent-hub",
+              "plans/agent-hub-ui",
+              "spec/agent-hub-restructure",
               "plans/skill-format",
               "plans/oem-bundling"
             ]

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -1,0 +1,195 @@
+---
+title: "Agent Hub Restructure"
+description: "Migration of production agents from the core wheel into standalone hub/agents/ packages"
+icon: "folder-tree"
+---
+
+<Note>
+**Tracking issue:** [#1102](https://github.com/amd/gaia/issues/1102) · **Milestone:** Agent Hub Platform [OSS] · **Status:** In Progress
+</Note>
+
+## Problem
+
+Production agents (chat, code, jira, blender, etc.) currently live inside `src/gaia/agents/` and ship as part of the core `amd-gaia` wheel. This couples every agent to the framework's release cycle, prevents independent versioning, and gives third-party contributors no pattern to follow — their agents would have to live inside the AMD source tree.
+
+## Goal
+
+Move production agents to `hub/agents/` as **standalone packages** that depend on the published `amd-gaia` PyPI package — not the source tree. The core wheel ships only the framework. Third-party contributors follow the identical pattern AMD uses for its own agents.
+
+```
+Before:                          After:
+src/gaia/agents/                 src/gaia/agents/        ← framework only
+├── base/        (framework)     ├── base/
+├── tools/       (framework)     ├── tools/              ← + promoted shared mixins
+├── registry.py  (framework)     ├── registry.py
+├── builder/     (framework)     ├── builder/
+├── chat/        (agent) ──┐     └── __init__.py
+├── code/        (agent)   │
+├── jira/        (agent)   │     hub/agents/
+└── ...          (agent) ──┘     ├── python/
+                                 │   ├── chat/           ← standalone package
+                                 │   │   ├── gaia-agent.yaml
+                                 │   │   ├── pyproject.toml   (depends on amd-gaia)
+                                 │   │   ├── gaia_agent_chat/
+                                 │   │   ├── tests/
+                                 │   │   └── README.md
+                                 │   └── ...
+                                 └── cpp/
+                                     └── ...
+```
+
+## Key Decisions
+
+1. **Framework-only core wheel.** `pip install amd-gaia` provides `Agent`, `@tool`, `MCPAgent`, `AgentConsole`, registry, LLM clients, RAG, MCP. No production agents.
+2. **Agents are separate wheels.** `gaia-agent-chat`, `gaia-agent-jira`, `gaia-agent-code`, etc. — installable via `gaia agent install <id>`, `pip install gaia-agent-{id}`, or `amd-gaia[agents]` for all of them. One wheel per **codebase**, not per registry ID: the `chat` package ships multiple prompt profiles (`doc`, `file`, `data`, `web`) and model presets (lite variants) selectable via config — they are not separate wheels (see [#1162](https://github.com/amd/gaia/issues/1162)).
+3. **Shared tool mixins promoted to framework.** RAG, FileIO, Shell, CodeIndex mixins move into `src/gaia/agents/tools/` so agents don't depend on each other for tools.
+4. **Entry-point discovery.** Agents register via the `gaia.agent` entry point group. The registry discovers installed agent wheels at startup — no hardcoded agent list.
+5. **Framework-provided generic server.** `src/gaia/agents/base/server.py` wraps any Agent into an OpenAI-compatible REST API + MCP stdio server. Agents don't implement server logic.
+
+## Pre-requisite: Promote shared tool mixins
+
+The current codebase has cross-agent tool dependencies that block independent packaging:
+
+| Mixin | Currently in | Used by | New location |
+|-------|-------------|---------|--------------|
+| `RAGToolsMixin` | `agents/chat/tools/rag_tools.py` | ChatAgent, DocQAAgent | `agents/tools/rag_tools.py` |
+| `FileIOToolsMixin` | `agents/code/tools/file_io.py` | ChatAgent, CodeAgent, DocQA, FileIO | `agents/tools/file_io_tools.py` |
+| `ShellToolsMixin` | `agents/chat/tools/shell_tools.py` | ChatAgent, FileIOAgent | `agents/tools/shell_tools.py` |
+| `CodeIndexToolsMixin` | `agents/code_index/tools/mixin.py` | CodeAgent | `agents/tools/code_index_tools.py` |
+
+After promotion, every `KNOWN_TOOLS` entry in `registry.py` points to `gaia.agents.tools.*`. No agent-specific tool paths remain. Old paths get deprecated re-exports for backward compatibility.
+
+## Package Format
+
+### `gaia-agent.yaml`
+
+```yaml
+id: chat
+name: Chat
+version: 0.1.0                      # independent of framework version
+description: "General conversation — fast, personality-first"
+author: AMD
+license: MIT
+
+category: conversation
+tags: [chat, general, personality]
+icon: message-circle
+tools_count: 0
+
+language: python
+min_gaia_version: "0.18.0"
+models: [Qwen3.5-35B-A3B-GGUF]
+
+requirements:
+  min_memory_gb: 8
+  platforms: [win-x64, linux-x64, darwin-arm64]
+
+interfaces:
+  tui: true
+  cli: true
+  pipe: true
+  api_server: true
+  mcp_server: true
+```
+
+### `pyproject.toml`
+
+```toml
+[project]
+name = "gaia-agent-chat"
+version = "0.1.0"
+dependencies = ["amd-gaia>=0.18.0"]
+
+[project.entry-points."gaia.agent"]
+chat = "gaia_agent_chat.agent:ChatAgent"
+```
+
+Agents with cross-agent dependencies (e.g. RoutingAgent uses CodeAgent) declare them as package dependencies: `dependencies = ["amd-gaia>=0.18.0", "gaia-agent-code>=0.1.0"]`.
+
+## Implementation Steps
+
+<Steps>
+<Step title="Promote shared tool mixins">
+Move RAG, FileIO, Shell, CodeIndex mixins to `src/gaia/agents/tools/`. Update all imports and `KNOWN_TOOLS`. Add deprecated re-exports. Run full test suite — no behavior change.
+</Step>
+<Step title="Create agent package skeletons">
+For each of the 16 agents, create `hub/agents/python/{id}/` with `gaia-agent.yaml`, `pyproject.toml`, `gaia_agent_{id}/` package dir, `tests/`, and `README.md`.
+</Step>
+<Step title="Move first agent (summarize)">
+Start with `summarize` — simplest, fewest dependencies. Proves the pattern end-to-end before bulk migration.
+</Step>
+<Step title="Move remaining agents in batches">
+Migrate the other 15 agents. Rewrite internal imports (`gaia.agents.{name}` → `gaia_agent_{name}`). Framework imports stay. Cross-agent deps become package deps.
+</Step>
+<Step title="Strip the core wheel">
+Remove agent packages from `setup.py`. Remove `gaia-emr`/`gaia-code` console scripts. Add `amd-gaia[agents]` and per-agent extras.
+</Step>
+<Step title="Update the registry">
+`_register_builtin_agents()` keeps only `builder`. Add `_discover_installed_agents()` using the `gaia.agent` entry point group.
+</Step>
+<Step title="Update CLI / UI / API callsites">
+Replace ~16 direct agent imports in `cli.py`, `ui/_chat_helpers.py`, `ui/agent_loop.py`, and apps with `registry.create_agent(id)`.
+</Step>
+<Step title="Add framework generic server">
+`src/gaia/agents/base/server.py` wraps any Agent into REST API + MCP server. Enables `gaia agent run <id> --api` and `--mcp`.
+</Step>
+<Step title="Add CI/CD workflow">
+`.github/workflows/build_agents.yml` — matrix-builds all agent wheels + C++ binaries, runs `gaia agent test --lint`, publishes to R2 + PyPI on tag.
+</Step>
+<Step title="Relocate tests">
+Move agent-specific tests to `hub/agents/python/{id}/tests/`. Framework tests stay in `tests/`.
+</Step>
+</Steps>
+
+## Cross-Agent Dependencies
+
+The exploration found these agent-to-agent couplings that must be resolved:
+
+| Dependency | Resolution |
+|-----------|-----------|
+| RoutingAgent → CodeAgent | `gaia-agent-routing` declares `gaia-agent-code` dependency |
+| ChatAgent → FileIOToolsMixin (from code) | Resolved by mixin promotion (Step 1) |
+| DocQAAgent → RAG + FileIO mixins | Resolved by mixin promotion (Step 1) |
+| FileIOAgent → Shell + FileIO mixins | Resolved by mixin promotion (Step 1) |
+| code/cli.py → RoutingAgent, CodeAgent | Internal to code package, no external visibility |
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| 252 import references across the codebase break | Promote mixins first (Step 1), then migrate one agent at a time |
+| `pip install amd-gaia` no longer ships agents (breaking change) | `amd-gaia[agents]` extras preserves the "everything" install; document migration |
+| Editable dev workflow friction | `pip install -e hub/agents/python/{id}/` registers via entry points |
+| Registry can't find agents | Entry-point discovery + `~/.gaia/agents/` scan; fail loudly if an agent's `min_gaia_version` is unmet |
+
+## Verification
+
+```bash
+# Step 1 — mixin promotion, no regressions
+python -m pytest tests/ -x
+
+# Step 3 — first agent works as standalone package
+pip install -e hub/agents/python/summarize/
+gaia agent run summarize --prompt "Summarize this text"
+python -m pytest hub/agents/python/summarize/tests/ -xvs
+
+# Step 5 — core wheel is framework-only
+pip install -e ".[dev]"        # framework
+pip install -e ".[agents]"     # framework + all agents
+
+# Step 8 — generic server
+gaia agent run chat --api --port 8080
+curl http://localhost:8080/v1/chat/completions \
+  -d '{"messages":[{"role":"user","content":"hello"}]}'
+
+# Full integration
+gaia agent list
+gaia agent run chat --prompt "hello"
+```
+
+## Related
+
+- [Agent Hub UI](/plans/agent-hub-ui) — the display + distribution platform plan
+- [Agent Hub](/plans/agent-hub) — original hub vision
+- [#1091](https://github.com/amd/gaia/issues/1091) — `gaia-agent.yaml` manifest parser (unblocked by this restructure)
+- [#1162](https://github.com/amd/gaia/issues/1162) — consolidate regular/lite agent variants


### PR DESCRIPTION
Production agents currently ship inside the core `amd-gaia` wheel under `src/gaia/agents/`, coupling every agent to the framework's release cycle and giving third-party contributors no pattern to follow. This spec defines moving them to `hub/agents/` as standalone packages that depend on the published `amd-gaia` PyPI package — the same pattern external contributors will use.

This PR adds the **design spec only** (no code yet) so the architecture gets reviewed before the high-risk migration of 16 agents begins. Implementation follows in subsequent PRs, one step at a time.

## What the spec covers

- **Framework-only core wheel** — `pip install amd-gaia` ships `Agent`, `@tool`, registry, LLM/RAG/MCP; agents become separate wheels
- **Shared tool mixin promotion** — RAG, FileIO, Shell, CodeIndex mixins move to `src/gaia/agents/tools/` so agents stop depending on each other for tools (verified: these 4 are the only agent-specific entries in `KNOWN_TOOLS`)
- **Package format** — `gaia-agent.yaml` manifest + `pyproject.toml` with `gaia.agent` entry points
- **Entry-point discovery** — registry discovers installed agent wheels, no hardcoded list
- **One wheel per codebase** — `chat` package ships `doc`/`file`/`data`/`web` profiles + lite presets via config, not separate wheels (aligns with #1162)
- **10-step implementation plan** with risk-ordered execution (mixins first, then one agent, then bulk)
- **Cross-agent dependency resolution** (e.g. RoutingAgent→CodeAgent becomes a package dependency)

## Test plan

- [ ] Review the spec for architectural soundness before implementation
- [ ] Mintlify renders `docs/spec/agent-hub-restructure.mdx` correctly
- [ ] Spec is reachable in the Ecosystem nav group

Tracking: #1102