### PR TITLE
fix(email): reset batch-organize counter across process_query calls

### DIFF
--- a/.claude/plans/issue-1106.md
+++ b/.claude/plans/issue-1106.md
@@ -1,0 +1,77 @@
+---
+type: plan
+source-issue: 1106
+repo: amd/gaia
+title: "Reset batch-organize counter across process_query calls"
+created: 2026-06-02
+status: complete
+work_type: code-refactor
+complexity: trivial
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 2
+test_command: "python -m pytest tests/unit/agents/test_email_agent.py tests/unit/agents/test_email_agent_confirmation.py tests/unit/agents/test_email_agent_prompt_injection.py -q"
+build_command: "uv pip install -e .[dev]"
+lint_command: "python util/lint.py --black --isort"
+branch: tmi/issue-1106-batch-counter-reset
+reflection_iterations: 1
+agents_used:
+  - planning
+  - execution
+  - validation
+---
+
+# Issue #1106 — Reset batch-organize counter across `process_query` calls
+
+## Problem
+
+`EmailTriageAgent`'s I3 batch-organize counter (`_organize_op_count`,
+`_organize_distinct_senders`) is only zeroed by `_reset_organize_counter()`, and
+that method was only ever called from `_register_tools()` — which runs ONCE at
+construction. The second `process_query()` on the same agent instance therefore
+inherited the prior turn's counts, so the single-batch-confirm-after-threshold
+logic (`_organize_batch_threshold_exceeded`) misfired on the 2nd+ run.
+
+The in-code comment in `__init__` already *claimed* the counter was "Reset per
+process_query() call" — the intended design — but nothing wired it to
+`process_query`. The reset *method* had a unit test (`test_reset_zeroes_counters`)
+but nothing asserted reset *across* `process_query` calls.
+
+## Fix (minimal, surgical)
+
+Override `process_query` on `EmailTriageAgent` to call
+`self._reset_organize_counter()` at the start of every turn, then delegate to
+`super().process_query(...)`. `EmailTriageAgent` does not inherit `MemoryMixin`,
+so this override sits directly above the base `Agent.process_query`.
+
+Only the two batch-organize fields are reset; `_session_preferences` (which must
+persist across queries within one instance) is untouched — `_reset_organize_counter`
+never references it.
+
+The base `Agent.process_query` / `_process_query_impl` were NOT modified (out of
+lane; would alter every agent). The construction-time reset in `_register_tools`
+is left as-is (harmless; `__init__` already zeroes the fields).
+
+## TDD
+
+1. RED — added `test_counter_resets_across_process_query_calls` to
+   `TestI3BatchThreshold`. Stubs `_process_query_impl` (no live LLM) to capture
+   the counter value seen on entry and to simulate a turn that trips the batch
+   threshold (6 ops / 4 senders). Asserted both turns START from a zeroed
+   counter. Failed `[0, 6] == [0, 0]` before the fix.
+2. GREEN — added the `process_query` override; test passes.
+3. Full email suite (146 tests) green; black + isort clean.
+
+## Acceptance criteria
+
+- [x] Batch-organize counter resets at the start of every `process_query` call.
+- [x] Test asserts the counter starts at zero each `process_query`, the
+      single confirmation fires only after the threshold within one run, and the
+      next `process_query` starts fresh.
+
+## Lane boundary
+
+Owned: `src/gaia/agents/email/agent.py` + its unit tests
+(`tests/unit/agents/test_email_agent_prompt_injection.py`). Did NOT touch
+`src/gaia/api/`, `src/gaia/connectors/`, `read_tools.py`, `reply_tools.py`,
+`calendar_tools.py`, or the base `Agent`.

--- a/src/gaia/agents/email/agent.py
+++ b/src/gaia/agents/email/agent.py
@@ -244,6 +244,13 @@ class EmailTriageAgent(
     def _get_system_prompt(self) -> str:
         return _SYSTEM_PROMPT
 
+    def process_query(self, *args, **kwargs):
+        # Zero the batch-organize counter per turn so a long-lived instance
+        # can't carry a prior turn's count into the batch-confirm threshold.
+        # Only the batch counter resets here; session preferences persist.
+        self._reset_organize_counter()
+        return super().process_query(*args, **kwargs)
+
     def _register_tools(self) -> None:
         # Mirror BuilderAgent / ConnectorsDemoAgent: clear the
         # module-level registry before registering this agent's tools so

--- a/tests/unit/agents/test_email_agent_prompt_injection.py
+++ b/tests/unit/agents/test_email_agent_prompt_injection.py
@@ -150,6 +150,45 @@ class TestI3BatchThreshold:
         assert agent._organize_op_count == 0
         assert agent._organize_distinct_senders == set()
 
+    def test_counter_resets_across_process_query_calls(self, agent):
+        """Issue #1106 — cold-run correctness.
+
+        The batch-organize counter must be zeroed at the START of every
+        ``process_query`` call, not just once at construction. Otherwise a
+        long-lived agent instance carries stale per-turn state into the next
+        turn and the batch-confirm threshold misfires.
+
+        We don't run the LLM loop: ``_process_query_impl`` is stubbed to
+        record the counter value it observes on entry and to simulate the
+        organize mutations that a real turn would accumulate. The first turn
+        pushes the counter well past the batch threshold; the second turn
+        must still see a zeroed counter on entry.
+        """
+        seen_op_counts: list[int] = []
+        seen_sender_sets: list[set[str]] = []
+
+        def fake_impl(user_input, max_steps=None, trace=False, filename=None):
+            # Capture the per-turn state the agent loop would actually see.
+            seen_op_counts.append(agent._organize_op_count)
+            seen_sender_sets.append(set(agent._organize_distinct_senders))
+            # Simulate a turn that trips the batch threshold (6 ops / 4 senders).
+            for sender in ("a", "b", "c", "d"):
+                agent._record_organize_op(f"m-{sender}", sender)
+            agent._record_organize_op("m-extra-1", "a")
+            agent._record_organize_op("m-extra-2", "b")
+            assert agent._organize_batch_threshold_exceeded() is True
+            return {"status": "completed", "result": "ok"}
+
+        with patch.object(agent, "_process_query_impl", side_effect=fake_impl):
+            agent.process_query("triage my inbox")
+            # After turn 1 the within-run mutations are still on the instance.
+            assert agent._organize_op_count > agent.ORGANIZE_BATCH_OP_THRESHOLD
+            agent.process_query("triage my inbox again")
+
+        # Both turns must have STARTED from a zeroed counter.
+        assert seen_op_counts == [0, 0]
+        assert seen_sender_sets == [set(), set()]
+
 
 # ---------------------------------------------------------------------------
 # I4 — attack-scenario fixtures from the stub mbox


### PR DESCRIPTION
Closes #1106

A reused `EmailTriageAgent` carried its batch-organize counter across `process_query` calls, so the "confirm before archiving 20+ emails" safety gate keyed off stale counts on the 2nd+ query in a session — it could fire when it shouldn't, or stay silent when it should prompt. Now the counter resets at the start of every `process_query`, so each turn's batch-confirmation logic is correct in isolation. This matters because the Agent UI and API server reuse one long-lived agent instance across turns.

## Test plan
- [x] New unit test asserts the counter starts at zero on a 2nd `process_query` and the batch-confirm fires only after the threshold *within one run* (`tests/unit/agents/test_email_agent_prompt_injection.py::TestI3BatchThreshold`)
- [x] Full email-agent unit suite: 184 passed, 0 regressions
- [x] `python util/lint.py --black --isort` clean
- [ ] Live two-turn check against a connected Gmail (pending OAuth creds) — logic is fully unit-covered; this run is confirmatory only

Targets the `tmi/infallible-payne-e3c628` integration branch (not main).