### PR TITLE
feat(connectors): configure OAuth creds via CLI flags (no Agent UI)

### DIFF
--- a/.claude/plans/issue-1084.md
+++ b/.claude/plans/issue-1084.md
@@ -1,0 +1,78 @@
+---
+type: plan
+source-issue: 1084
+repo: amd/gaia
+title: "Email connector requires Agent UI for OAuth config; gaia connectors configure google accepts no flags"
+created: 2026-06-02
+status: complete
+work_type: code-feature
+complexity: standard
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 3
+test_command: ".venv/bin/python -m pytest tests/unit/test_email_cli.py tests/unit/connectors/ -q"
+build_command: "uv pip install -e .[dev]"
+lint_command: "python util/lint.py --black --isort"
+branch: tmi/issue-1084-connector-cli-flags
+reflection_iterations: 0
+agents_used: [planning, execution, validation]
+---
+
+# Issue #1084 — Self-contained CLI OAuth-client config for the Google connector
+
+## Problem
+`gaia connectors configure google` only takes a generic `--set KEY=VALUE` / `--json`
+dispatcher. There is no `--client-id` / `--client-secret`, so new users onboarding the
+email connector are bounced to the Agent UI (or told env vars are a "Power users" path).
+The CLI's most prominently named connector command cannot configure the thing it names.
+
+## Resolution
+Add first-class `--client-id` / `--client-secret` flags to `gaia connectors configure`.
+When supplied, persist the OAuth *client* credentials to the keyring via the existing
+`store.save_provider_credentials(...)` — the exact store `GoogleOAuthProvider.__init__`
+reads from (`store.peek_provider_credentials("google")`). This completes OAuth *config*
+(client id/secret) without the Agent UI, leaving the actual interactive login to a
+separate `gaia connectors connect google` step (the live OAuth flow excluded from this
+issue's AC).
+
+### Why persist-only (no auto `connect`)
+`OAuthPkceHandler.configure` always calls `start_authorization` after saving creds, which
+launches a browser + a loopback callback server. That is the live-network OAuth step the
+AC explicitly excludes ("Mock/avoid live network"). So the `--client-id/--client-secret`
+path in the CLI persists credentials and prints the next-step hint, rather than routing
+through the handler's flow-starting `configure`. The generic `--set`/`--json` dispatcher
+path is unchanged (still goes through `handler.configure`).
+
+### Fail-loudly
+`--client-id` requires `--client-secret` and vice-versa (Google rejects token requests
+that omit the secret even for Desktop PKCE clients). Supplying one without the other is a
+usage error (exit 2). Mixing `--client-id` with `--set`/`--json` is rejected (exit 2) to
+avoid ambiguous double-writes.
+
+## Files (lane: cli.py + handler.py + email.mdx + tests)
+- `src/gaia/connectors/cli.py` — add `--client-id` / `--client-secret` to the `configure`
+  subparser; branch `_handle_configure` to a credential-persist path when they are set.
+- `src/gaia/connectors/handler.py` — (likely no change needed; persistence goes through
+  `store.save_provider_credentials`. Kept in lane in case a thin helper is cleaner.)
+- `docs/guides/email.mdx` — add a "Configure via CLI (no Agent UI)" subsection under the
+  CLI tab of "Connect your Google account", surfacing the runbook link.
+- `tests/unit/connectors/test_cli.py` — FAILING-first tests: invoking `configure google
+  --client-id X --client-secret Y` persists creds to the store the provider resolves from
+  (assert via `peek_provider_credentials` / a real provider re-read on the in-memory
+  keyring), no network call; one-flag-only is a usage error; mixing with `--set` errors.
+
+## Lane boundary
+OWN: cli.py, handler.py, email.mdx, tests. Do NOT touch providers/ or catalog/ (issue
+#1105 owns Microsoft provider there). Persistence is wired via the existing store API.
+
+## TDD
+1. RED: add tests in `test_cli.py` for the new flags → fail (argparse rejects unknown flag).
+2. GREEN: add flags + persist branch → tests pass.
+3. Docs: email.mdx CLI-config subsection + runbook link.
+
+## Live real-world recipe (for the orchestrator, NOT part of unit AC)
+Requires a real Google Cloud OAuth *Desktop-app* client id + secret and an interactive
+browser login:
+1. `gaia connectors configure google --client-id <REAL_ID> --client-secret <REAL_SECRET>`
+2. `gaia connectors connect google` → open the printed URL, complete consent in a browser.
+3. `gaia connectors test google` → expect `OK token_valid`.

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -36,7 +36,21 @@ There are two ways to connect Google depending on how you use GAIA.
     If you have an existing Google connection that predates GAIA v0.23, click **Reconnect** to grant the additional Gmail and Calendar scopes.
   </Tab>
   <Tab title="CLI (developer flow)">
-    The CLI connector flow is intended for developers and headless environments where a browser window cannot open automatically.
+    The CLI connector flow is fully self-contained — you do **not** need to open the Agent UI to set your OAuth client credentials. It is intended for developers and headless environments.
+
+    First, create an OAuth **Desktop-app** client in the Google Cloud Console and note its Client ID and Client Secret. See the [Google OAuth client runbook](https://github.com/amd/gaia/blob/main/docs/runbooks/google-oauth-client.md) for step-by-step instructions.
+
+    **Step 1 — Configure the OAuth client credentials** (persists them to your OS keyring, encrypted at rest):
+
+    ```bash
+    gaia connectors configure google \
+      --client-id <YOUR_CLIENT_ID>.apps.googleusercontent.com \
+      --client-secret <YOUR_CLIENT_SECRET>
+    ```
+
+    Both flags are required together — Google rejects token requests that omit the secret even for Desktop-app PKCE clients.
+
+    **Step 2 — Sign in and authorize:**
 
     ```bash
     gaia connectors connect google
@@ -48,6 +62,10 @@ There are two ways to connect Google depending on how you use GAIA.
     - `calendar.events`, `calendar.readonly`
 
     If you connected Google before GAIA v0.23, run `gaia connectors connect google --force` to trigger a fresh consent screen with the updated scope list.
+
+    <Note>
+      Power users can skip Step 1 by exporting `GAIA_GOOGLE_CLIENT_ID` and `GAIA_GOOGLE_CLIENT_SECRET` before launching GAIA — but `gaia connectors configure google` is the recommended path, since it stores the credentials securely and reuses them across connect/disconnect cycles.
+    </Note>
   </Tab>
 </Tabs>
 

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -77,12 +77,26 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="OAuth scopes to request (connector-specific)",
     )
 
-    # configure (generic dispatcher)
+    # configure (generic dispatcher + OAuth-client convenience flags)
     p_cfg = sub.add_parser(
         "configure",
         help="Configure a connector (MCP API keys, OAuth client creds, etc.)",
     )
     p_cfg.add_argument("connector_id", help="Connector id")
+    p_cfg.add_argument(
+        "--client-id",
+        dest="client_id",
+        help=(
+            "OAuth client id for an oauth_pkce connector (e.g. the Google "
+            "Desktop-app client). Persists to the keyring; requires --client-secret. "
+            "Run 'gaia connectors connect <id>' afterward to complete login."
+        ),
+    )
+    p_cfg.add_argument(
+        "--client-secret",
+        dest="client_secret",
+        help="OAuth client secret (paired with --client-id; stored encrypted in the keyring)",
+    )
     p_cfg.add_argument(
         "--set",
         action="append",
@@ -309,6 +323,16 @@ def _handle_configure(args: argparse.Namespace) -> int:
     import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
     from gaia.connectors.handler import configure
 
+    client_id = getattr(args, "client_id", None)
+    client_secret = getattr(args, "client_secret", None)
+
+    # OAuth-client convenience path (#1084): --client-id / --client-secret
+    # persist the application's OAuth client creds to the same keyring slot the
+    # provider reads from, completing OAuth *config* without the Agent UI. The
+    # interactive browser login stays a separate `gaia connectors connect`.
+    if client_id is not None or client_secret is not None:
+        return _handle_configure_client_credentials(args, client_id, client_secret)
+
     config: dict = {}
     if getattr(args, "config_json", None):
         try:
@@ -339,6 +363,80 @@ def _handle_configure(args: argparse.Namespace) -> int:
     sys.stdout.write(f"Configured {args.connector_id}.\n")
     if result.get("authorization_url"):
         sys.stdout.write(f"Complete OAuth flow at:\n  {result['authorization_url']}\n")
+    return 0
+
+
+def _handle_configure_client_credentials(
+    args: argparse.Namespace,
+    client_id: str | None,
+    client_secret: str | None,
+) -> int:
+    """Persist an oauth_pkce connector's OAuth *client* credentials (#1084).
+
+    Writes ``client_id`` / ``client_secret`` to the keyring slot the provider
+    resolves from (``store.peek_provider_credentials``) and evicts the cached
+    provider so the next construction re-reads them. Does NOT start the PKCE
+    flow — the browser login stays a separate ``gaia connectors connect``.
+
+    Both flags are required together: Google rejects token requests that omit
+    the secret even for Desktop PKCE clients, so a half-configured client would
+    fail loudly later instead of here. Mixing with ``--set`` / ``--json`` is a
+    usage error to avoid an ambiguous double-write.
+    """
+    if not client_id:
+        sys.stderr.write(
+            "gaia connectors configure: --client-secret requires --client-id.\n"
+        )
+        return 2
+    if not client_secret:
+        sys.stderr.write(
+            "gaia connectors configure: --client-id requires --client-secret "
+            "(Google requires the secret even for Desktop-app PKCE clients).\n"
+        )
+        return 2
+    if getattr(args, "config_pairs", None) or getattr(args, "config_json", None):
+        sys.stderr.write(
+            "gaia connectors configure: --client-id/--client-secret cannot be "
+            "combined with --set/--json. Use one configuration style at a time.\n"
+        )
+        return 2
+
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+    from gaia.connectors.providers import _registry as _provider_registry
+    from gaia.connectors.registry import REGISTRY
+    from gaia.connectors.store import save_provider_credentials
+
+    try:
+        spec = REGISTRY.get(args.connector_id)
+    except KeyError:
+        sys.stderr.write(
+            f"gaia connectors configure: unknown connector {args.connector_id!r}\n"
+        )
+        return 1
+
+    if spec.type != "oauth_pkce":
+        sys.stderr.write(
+            f"gaia connectors configure: --client-id/--client-secret apply only to "
+            f"oauth_pkce connectors; {args.connector_id!r} is type {spec.type!r}.\n"
+        )
+        return 2
+
+    provider_id = spec.oauth_provider_ref or spec.id
+    save_provider_credentials(
+        provider_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    # Evict any cached provider instance so the next get_provider() re-reads the
+    # freshly persisted creds instead of a stale id/secret.
+    _provider_registry.pop(provider_id, None)
+
+    sys.stdout.write(
+        f"Configured {args.connector_id}. OAuth client credentials saved to the "
+        "keyring.\n"
+        f"Next: run 'gaia connectors connect {args.connector_id}' to sign in and "
+        "authorize.\n"
+    )
     return 0
 
 

--- a/tests/unit/connectors/test_cli.py
+++ b/tests/unit/connectors/test_cli.py
@@ -128,6 +128,159 @@ class TestGrants:
         assert "No grants" in out
 
 
+class TestConfigure:
+    """``gaia connectors configure google --client-id … --client-secret …`` (#1084).
+
+    The flags persist the OAuth *client* credentials to the same keyring slot the
+    Google provider resolves from (``store.peek_provider_credentials("google")``),
+    completing OAuth config WITHOUT the Agent UI and WITHOUT any live OAuth/network
+    step. The actual browser login stays a separate ``gaia connectors connect``.
+    """
+
+    def test_client_id_secret_persist_to_provider_store(self, monkeypatch):
+        # No env creds — the persisted keyring blob must be the sole source the
+        # provider reads from afterward.
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_SECRET", raising=False)
+
+        rc, out, _err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-id",
+            "cli-id.apps.googleusercontent.com",
+            "--client-secret",
+            "GOCSPX-cli",
+        )
+        assert rc == 0
+        assert "Configured google" in out
+
+        # Landed in the exact store the provider resolves from.
+        from gaia.connectors.store import peek_provider_credentials
+
+        creds = peek_provider_credentials("google")
+        assert creds == {
+            "client_id": "cli-id.apps.googleusercontent.com",
+            "client_secret": "GOCSPX-cli",
+        }
+
+        # And the provider actually picks them up on next construction.
+        from gaia.connectors.providers import get as get_provider
+
+        prov = get_provider("google")
+        assert prov.client_id == "cli-id.apps.googleusercontent.com"
+        assert prov.client_secret == "GOCSPX-cli"
+
+    def test_client_id_secret_does_not_start_oauth_flow(self, monkeypatch):
+        # AC: no live OAuth/network. The credential-persist path must NOT invoke
+        # the PKCE flow starter (which opens a browser + loopback server).
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_ID", raising=False)
+        called = {"start": False}
+
+        def _boom(*_a, **_k):
+            called["start"] = True
+            raise AssertionError("start_authorization must not run on configure")
+
+        monkeypatch.setattr("gaia.connectors.flow.start_authorization", _boom)
+
+        rc, _out, _err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-id",
+            "id.apps.googleusercontent.com",
+            "--client-secret",
+            "GOCSPX-x",
+        )
+        assert rc == 0
+        assert called["start"] is False
+
+    def test_secret_not_echoed_to_stdout(self, monkeypatch):
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_ID", raising=False)
+        rc, out, _err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-id",
+            "id.apps.googleusercontent.com",
+            "--client-secret",
+            "GOCSPX-super-secret",
+        )
+        assert rc == 0
+        assert "GOCSPX-super-secret" not in out
+
+    def test_client_id_without_secret_is_usage_error(self):
+        rc, _out, err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-id",
+            "id.apps.googleusercontent.com",
+        )
+        assert rc == 2
+        assert "client-secret" in err
+
+    def test_client_secret_without_id_is_usage_error(self):
+        rc, _out, err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-secret",
+            "GOCSPX-x",
+        )
+        assert rc == 2
+        assert "client-id" in err
+
+    def test_keyring_failure_surfaces_as_connectors_error(self, monkeypatch):
+        # Fail-loudly: a keyring write failure must propagate as a
+        # ConnectorsError (exit 5), never a silent success.
+        from gaia.connectors.errors import ConnectorsError
+
+        def _boom(*_a, **_k):
+            raise ConnectorsError("Keyring set_password failed: backend locked")
+
+        monkeypatch.setattr("gaia.connectors.store.save_provider_credentials", _boom)
+        rc, _out, err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-id",
+            "id.apps.googleusercontent.com",
+            "--client-secret",
+            "GOCSPX-x",
+        )
+        assert rc == 5
+        assert "Connectors error" in err
+
+    def test_unknown_connector_returns_exit_1(self):
+        rc, _out, err = _run(
+            "connectors",
+            "configure",
+            "does-not-exist",
+            "--client-id",
+            "id.apps.googleusercontent.com",
+            "--client-secret",
+            "GOCSPX-x",
+        )
+        assert rc == 1
+        assert "unknown connector" in err
+
+    def test_client_id_with_set_is_usage_error(self):
+        rc, _out, err = _run(
+            "connectors",
+            "configure",
+            "google",
+            "--client-id",
+            "id.apps.googleusercontent.com",
+            "--client-secret",
+            "GOCSPX-x",
+            "--set",
+            "FOO=bar",
+        )
+        assert rc == 2
+        assert "--set" in err or "--json" in err
+
+
 class TestDisconnect:
     def test_disconnect_idempotent(self):
         rc, _out, _err = _run("connectors", "disconnect", "google")


### PR DESCRIPTION
Closes #1084

Before: connecting an email account required launching the Agent UI — `gaia connectors configure google` accepted no credential flags, so headless / CLI-only / server users were stuck. After: `gaia connectors configure google --client-id <id> --client-secret <secret>` persists OAuth creds to the same keyring the Google provider reads from, so the whole connect flow runs from the terminal. The email guide now documents the CLI onboarding path.

## Test plan
- [x] 8 new unit tests (`tests/unit/connectors/test_cli.py::TestConfigure`): creds persist to the store the provider re-reads; secret never echoed to stdout; fail-loudly on half-specified / mismatched flags; no live OAuth in the configure path
- [x] `tests/unit/connectors/test_cli.py tests/unit/test_email_cli.py` → 29 passed on the integration base
- [x] `python util/lint.py --black --isort` clean
- [ ] Live: `configure google --client-id … --client-secret …` → `connect google` → `test google` (pending a real Google Cloud Desktop OAuth client + interactive login)

Targets the `tmi/infallible-payne-e3c628` integration branch (not main).