### PR TITLE
feat(connectors): Microsoft OAuth provider for MS Graph (consumers tenant)

### DIFF
--- a/.claude/plans/issue-1105.md
+++ b/.claude/plans/issue-1105.md
@@ -4,7 +4,7 @@ source-issue: 1105
 repo: amd/gaia
 title: "Microsoft OAuth provider for MS Graph (consumers tenant, PKCE)"
 created: 2026-06-02
-status: in-progress
+status: complete
 work_type: code-feature
 complexity: standard
 tdd_required: true
@@ -14,7 +14,7 @@ test_command: ".venv/bin/python -m pytest tests/unit/connectors/ -q"
 build_command: "uv pip install -e .[dev]"
 lint_command: "python util/lint.py --black --isort"
 branch: tmi/issue-1105-ms-oauth-provider
-reflection_iterations: 0
+reflection_iterations: 1
 agents_used: [planning, execution, validation]
 ---
 

--- a/.claude/plans/issue-1105.md
+++ b/.claude/plans/issue-1105.md
@@ -1,0 +1,90 @@
+---
+type: plan
+source-issue: 1105
+repo: amd/gaia
+title: "Microsoft OAuth provider for MS Graph (consumers tenant, PKCE)"
+created: 2026-06-02
+status: in-progress
+work_type: code-feature
+complexity: standard
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 5
+test_command: ".venv/bin/python -m pytest tests/unit/connectors/ -q"
+build_command: "uv pip install -e .[dev]"
+lint_command: "python util/lint.py --black --isort"
+branch: tmi/issue-1105-ms-oauth-provider
+reflection_iterations: 0
+agents_used: [planning, execution, validation]
+---
+
+# Issue #1105 — Microsoft OAuth provider for MS Graph
+
+## Goal
+Add Microsoft as a second OAuth-PKCE provider alongside Google, scoped to the
+`consumers` tenant (personal Outlook.com / Hotmail / Live accounts). This is the
+FOUNDATION for #1275 (Outlook mailbox) and #1276 (Outlook calendar): the provider
++ catalog must be reusable so those later leads only add agent tools, not OAuth.
+
+## Acceptance criteria
+- `MicrosoftOAuthProvider` (MS identity platform v2.0, PKCE, tenant `consumers`).
+- `catalog/microsoft.py` declaring Mail.Read, Mail.Send, Calendars.ReadWrite.
+- Microsoft tile surfaces in Settings → Connectors (driven by REGISTRY.all()).
+- Unit tests (mock all network): authorization-URL construction, token-exchange
+  request shape, scope matching, tenant=`consumers`, refresh-body shape.
+
+## Key protocol facts (verified against learn.microsoft.com 2026-01 revision)
+- authorize: https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize
+- token:     https://login.microsoftonline.com/consumers/oauth2/v2.0/token
+- **Public/native PKCE client MUST NOT send client_secret** (differs from Google,
+  which requires one). So client_secret is optional, env/keyring only — NOT a
+  required setup field. token_request_body / refresh_request_body omit it unless
+  one is explicitly configured (confidential-app edge case).
+- refresh_token only returned if `offline_access` scope requested →
+  `offline_access` MUST be in provider.default_scopes + catalog default/available
+  so the SHARED flow.py (which hard-requires refresh_token) succeeds unmodified.
+- id_token (account email) only returned if `openid` scope requested → include
+  `openid` so flow._decode_email_from_id_token can populate account_email.
+- response_mode=query is correct for the loopback /callback GET; set it
+  explicitly via authorization_params() so MS never defaults to fragment.
+- scopes are space-delimited (same join as Google).
+
+## Lane boundary (parallel-lead collision avoidance)
+- OWN (new): providers/microsoft.py, catalog/microsoft.py, docs/connectors/microsoft.mdx,
+  tests/unit/connectors/test_microsoft_provider.py.
+- OWN (edit): providers/__init__.py (lazy-register microsoft branch),
+  catalog/__init__.py (import microsoft module + add to __all__).
+- DO NOT TOUCH: connectors/cli.py, connectors/handler.py (#1084 owns CLI flags),
+  providers/google.py, catalog/google.py (reference only), flow.py (shared).
+
+## TDD steps
+1. RED: write tests/unit/connectors/test_microsoft_provider.py asserting:
+   endpoints (consumers tenant in both URLs), client_id read at instantiation
+   (env GAIA_MICROSOFT_CLIENT_ID) not import, ConfigurationError naming the env
+   vars when missing, lazy registry registration, Protocol compliance,
+   client_id_hash CRC32, authorization_url has PKCE+state+response_type+
+   response_mode=query, token_request_body has code/code_verifier/redirect_uri/
+   grant_type and NO client_secret for public client, refresh_request_body shape,
+   catalog declares the three required scopes + offline_access + openid, catalog
+   default_scopes triggers refresh + id_token, no import side effects.
+2. GREEN: implement providers/microsoft.py mirroring google.py (env var fallback
+   GAIA_MICROSOFT_CLIENT_ID/_SECRET, keyring peek, no import side effects), add
+   catalog/microsoft.py (ConnectorSpec id="microsoft", oauth_provider_ref="microsoft",
+   setup form = Client ID only, secret optional), register lazy branch in
+   providers/__init__.py, wire catalog/__init__.py, add docs/connectors/microsoft.mdx
+   (docs_url test requires the mdx to exist for amd-gaia.ai URLs).
+3. Refactor + full connectors suite green + lint.
+
+## Integration seam for #1275 / #1276
+- Both call the SAME generic surface they'd use for Google: the connector id is
+  "microsoft"; agents declare REQUIRED_CONNECTORS=[ConnectorRequirement(
+  connector_id="microsoft", scopes=[...])]; get a token via the oauth_pkce
+  handler's get_credential (Authorization: Bearer <access_token> against
+  https://graph.microsoft.com/v1.0/...). No Microsoft-specific code leaks into
+  the agents — they only need the MS Graph scope URLs, all of which are in
+  catalog available_scopes.
+
+## Validation
+- .venv/bin/python -m pytest tests/unit/connectors/ -q  (no live OAuth)
+- .venv/bin/python util/lint.py --black --isort
+- self-review diff for PKCE correctness + no secret logging.

--- a/docs/connectors/index.mdx
+++ b/docs/connectors/index.mdx
@@ -40,6 +40,9 @@ never writes a token to a plaintext file.
   <Card title="Google" icon="google" href="/connectors/google">
     Gmail, Calendar, Drive, and other Google Workspace APIs via OAuth.
   </Card>
+  <Card title="Microsoft" icon="microsoft" href="/connectors/microsoft">
+    Outlook mail, calendar, and OneDrive via Microsoft Graph (OAuth).
+  </Card>
   <Card title="GitHub" icon="github" href="/connectors/github">
     Repos, PRs, issues, and Actions via the official GitHub MCP server.
   </Card>
@@ -54,7 +57,6 @@ priorities at [issue #937](https://github.com/amd/gaia/issues/937).
 In the meantime, the **Configure** form for each connector includes
 inline help with where to obtain the required token or API key.
 
-- **Microsoft 365** — `mcp-outlook`
 - **Calendars** — `mcp-google-calendar`
 - **Email** — `mcp-gmail`, `mcp-sendgrid`
 - **Productivity** — `mcp-notion`, `mcp-linear`, `mcp-jira`,

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -1,0 +1,134 @@
+---
+title: "Microsoft"
+icon: "microsoft"
+description: "Connect GAIA to Outlook mail, calendar, and OneDrive via Microsoft Graph."
+---
+
+<Info>
+  **Connector ID:** `microsoft` · **Type:** `oauth_pkce` · **Catalog entry:** [`src/gaia/connectors/catalog/microsoft.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/catalog/microsoft.py)
+</Info>
+
+GAIA connects to your **personal** Microsoft account — Outlook.com, Hotmail,
+or Live — using the Microsoft identity platform v2.0 with PKCE. Work and
+school (Microsoft Entra ID) accounts are not supported in this release.
+
+## What you'll need
+
+Microsoft requires every app — including GAIA running locally — to identify
+itself with an **App registration** that you create once in the Azure portal.
+For a single-developer machine it takes a few minutes and is free.
+
+You will register one app and paste a single value into the GAIA Agent UI: an
+**Application (client) ID**. Unlike Google, the standard desktop flow needs
+**no client secret** — Microsoft forbids secrets for public (desktop) clients.
+GAIA stores the Client ID encrypted in your OS keyring.
+
+## Step 1 — Register an app in Azure
+
+1. Go to the [Azure portal → App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).
+2. Click **New registration**.
+3. **Name**: `GAIA Personal` (or whatever you like).
+4. **Supported account types**: choose **Personal Microsoft accounts only**.
+   <Tooltip tip="This maps to the 'consumers' tenant GAIA uses. Picking a work/school option would target a tenant GAIA does not authenticate against in this release.">Why this option?</Tooltip>
+5. Click **Register**. The **Overview** page shows the **Application (client)
+   ID** — copy it for Step 3.
+
+## Step 2 — Add the loopback redirect URI
+
+GAIA runs a temporary loopback web server on `127.0.0.1` to receive the OAuth
+callback, so it needs a localhost redirect URI of the public-client type.
+
+1. In your app, go to **Authentication → Add a platform**.
+2. Pick **Mobile and desktop applications**.
+3. Check (or add) the redirect URI **`http://localhost`**.
+   <Tooltip tip="GAIA picks an ephemeral port at connect time, e.g. http://127.0.0.1:54321/callback. Microsoft treats http://localhost as a special public-client redirect that matches any port, so you only register the base.">Why just http://localhost?</Tooltip>
+4. Click **Configure** / **Save**.
+
+You do **not** need to create a client secret for the standard flow.
+
+## Step 3 — Paste the Client ID into GAIA
+
+1. Launch the Agent UI: `gaia chat --ui`.
+2. Click **Settings** (gear) → **Connections**.
+3. Click the **Microsoft** tile to expand it.
+4. Paste the **Application (client) ID** from Step 1. Leave the **Client
+   Secret** field blank.
+5. Click **Save & Connect**.
+
+GAIA will:
+
+1. Store the Client ID in your OS keyring (macOS Keychain on Mac,
+   gnome-keyring/kwallet on Linux, Credential Locker on Windows).
+2. Open Microsoft's consent screen in your default browser.
+3. Receive the callback on a temporary loopback server.
+4. Exchange the auth code for a refresh token (also stored in the keyring).
+   The refresh token is issued because GAIA requests the `offline_access`
+   scope.
+
+The tile flips to **Connected as you@outlook.com** once the flow completes.
+
+## Step 4 — Grant scopes to specific agents
+
+Connecting Microsoft doesn't automatically give every agent access to your
+mailbox. Each agent must be granted the specific Graph scopes it needs:
+
+```bash
+# Grant an agent read-only Outlook mail access
+gaia connectors grants grant microsoft builtin:chat \
+  --scopes https://graph.microsoft.com/Mail.Read
+```
+
+The scopes a connection can request are listed in the spec at
+[`src/gaia/connectors/catalog/microsoft.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/catalog/microsoft.py):
+
+| Scope | Grants |
+| --- | --- |
+| `https://graph.microsoft.com/Mail.Read` | Read your email |
+| `https://graph.microsoft.com/Mail.Send` | Send email on your behalf |
+| `https://graph.microsoft.com/Mail.ReadWrite` | Read, organize, and manage your email |
+| `https://graph.microsoft.com/Calendars.Read` | Read your calendar events |
+| `https://graph.microsoft.com/Calendars.ReadWrite` | Manage your calendar events |
+
+## Common issues
+
+### `AADSTS50011: redirect URI mismatch`
+
+The redirect URI in your app registration doesn't include `http://localhost`,
+or you added it under the wrong platform. Re-check Step 2 — it must be a
+**Mobile and desktop applications** platform redirect, not **Web**.
+
+### `AADSTS700016` / `unauthorized_client`
+
+The Client ID is wrong, or the app was registered for the wrong account type.
+Confirm you copied the **Application (client) ID** from the Overview page and
+chose **Personal Microsoft accounts only** in Step 1.
+
+### `AADSTS65001` / consent required
+
+You declined consent, or the agent is requesting a scope you didn't approve.
+Reconnect from the UI and accept the consent prompt; then grant the agent the
+scope (Step 4).
+
+### Token endpoint returned no `refresh_token`
+
+GAIA always requests `offline_access`, which is what makes Microsoft issue a
+refresh token. If you see this, disconnect and reconnect from the UI to
+restart the flow with the full default scope set.
+
+## Revoking access
+
+Two places — both work:
+
+- **From GAIA**: Settings → Connections → Microsoft → **Disconnect**. Removes
+  the refresh token from the keyring; the next API call errors with
+  `NOT_CONNECTED`.
+- **From Microsoft**: <a href="https://account.live.com/consent/Manage"
+  target="_blank">account.live.com/consent/Manage</a> → find your app →
+  **Remove these permissions**.
+
+## See also
+
+- [Connectors overview](/connectors)
+- [Microsoft identity platform — auth code + PKCE](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-auth-code-flow)
+- [Microsoft Graph permissions reference](https://learn.microsoft.com/graph/permissions-reference)
+- [Connectors security model](/security/connections)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,6 +89,7 @@
                 "pages": [
                   "connectors/index",
                   "connectors/google",
+                  "connectors/microsoft",
                   "connectors/github",
                   "security/connections"
                 ]

--- a/src/gaia/connectors/catalog/__init__.py
+++ b/src/gaia/connectors/catalog/__init__.py
@@ -19,5 +19,6 @@ things, then add an import here.
 
 from gaia.connectors.catalog import google  # noqa: F401
 from gaia.connectors.catalog import mcp_servers  # noqa: F401
+from gaia.connectors.catalog import microsoft  # noqa: F401
 
-__all__ = ["google", "mcp_servers"]
+__all__ = ["google", "mcp_servers", "microsoft"]

--- a/src/gaia/connectors/catalog/microsoft.py
+++ b/src/gaia/connectors/catalog/microsoft.py
@@ -1,0 +1,106 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Microsoft connector catalog entry (#1105).
+
+Registers the Microsoft OAuth-PKCE ConnectorSpec into the global REGISTRY and
+imports ``oauth_pkce`` so its handler is registered into ``_HANDLER_REGISTRY``.
+The AgentUI tile grid is driven by ``REGISTRY.all()``, so registering this spec
+is all that is needed for a Microsoft tile to appear in Settings → Connectors —
+no frontend change required (the tile renders from the catalog, exactly like
+Google).
+
+Foundation for the Outlook mailbox (#1275) and calendar (#1276) agents. Those
+leads add agent tools that request a Bearer token for these Graph scopes via
+the generic ``oauth_pkce`` handler — no Microsoft-specific OAuth code in the
+agents.
+
+Tenant is ``consumers`` (personal Outlook.com / Hotmail / Live). ``openid`` and
+``offline_access`` are in ``default_scopes`` because the shared OAuth flow
+requires an id_token (account email) and a refresh token respectively.
+"""
+
+import gaia.connectors.oauth_pkce  # noqa: F401  # pylint: disable=unused-import
+from gaia.connectors.registry import REGISTRY
+from gaia.connectors.spec import ConfigField, ConnectorSpec
+
+MICROSOFT_SPEC = ConnectorSpec(
+    id="microsoft",
+    display_name="Microsoft",
+    icon="https://learn.microsoft.com/favicon.ico",
+    category="productivity",
+    tier=1,
+    type="oauth_pkce",
+    description=(
+        "Connect GAIA to your personal Microsoft account for Outlook mail, "
+        "calendar, OneDrive, and more via Microsoft Graph."
+    ),
+    instructions_md=(
+        "Sign in with your personal Microsoft account (Outlook.com, Hotmail, "
+        "or Live) to allow GAIA to access your Outlook mail and calendar. You "
+        "can revoke access at any time from your "
+        "[Microsoft account privacy page](https://account.live.com/consent/Manage)."
+    ),
+    product_url="https://www.microsoft.com/microsoft-365",
+    docs_url="https://amd-gaia.ai/docs/connectors/microsoft",
+    # openid + offline_access are mandatory for the shared flow (id_token +
+    # refresh_token). User.Read gives a basic profile for the success page.
+    default_scopes=(
+        "openid",
+        "offline_access",
+        "https://graph.microsoft.com/User.Read",
+    ),
+    available_scopes=(
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "https://graph.microsoft.com/User.Read",
+        # Outlook mailbox (#1275).
+        "https://graph.microsoft.com/Mail.Read",
+        "https://graph.microsoft.com/Mail.Send",
+        # Mail.ReadWrite anticipates the triage agent's organize/flag/move
+        # tools (mirrors why google.py lists gmail.modify) so the per-agent
+        # grant ledger will accept the token request when #1275 lands.
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        # Outlook calendar (#1276).
+        "https://graph.microsoft.com/Calendars.Read",
+        "https://graph.microsoft.com/Calendars.ReadWrite",
+    ),
+    oauth_provider_ref="microsoft",
+    # First-time setup form. Microsoft public-client PKCE flows take ONLY a
+    # Client ID — Microsoft forbids a client_secret for public/native clients.
+    # The optional secret field exists solely for the rare confidential
+    # web-app registration; it is not required and is stored encrypted in the
+    # OS keyring. Power users may instead export GAIA_MICROSOFT_CLIENT_ID
+    # (and, only for a confidential app, GAIA_MICROSOFT_CLIENT_SECRET).
+    oauth_setup_fields=(
+        ConfigField(
+            key="client_id",
+            label="Application (client) ID",
+            kind="text",
+            help_md=(
+                "From the Azure portal → App registrations → your app → "
+                "Overview. Register the app with the "
+                "'Personal Microsoft accounts only' audience and a "
+                "http://localhost redirect URI of type 'Mobile and desktop "
+                "applications'. Looks like a GUID, e.g. "
+                "11112222-bbbb-3333-cccc-4444dddd5555."
+            ),
+        ),
+        ConfigField(
+            key="client_secret",
+            label="Client Secret (confidential apps only)",
+            kind="secret",
+            required=False,
+            help_md=(
+                "Leave blank for the standard public-client (desktop) flow — "
+                "Microsoft forbids a secret there. Only set this if you "
+                "registered a confidential web app. Stored encrypted in your "
+                "OS keyring."
+            ),
+        ),
+    ),
+)
+
+REGISTRY.register(MICROSOFT_SPEC)

--- a/src/gaia/connectors/providers/__init__.py
+++ b/src/gaia/connectors/providers/__init__.py
@@ -45,9 +45,16 @@ def get(provider_id: str) -> OAuthProvider:
         register(provider)
         return provider
 
+    if provider_id == "microsoft":
+        from gaia.connectors.providers.microsoft import MicrosoftOAuthProvider
+
+        provider = MicrosoftOAuthProvider()
+        register(provider)
+        return provider
+
     raise KeyError(
         f"Unknown OAuth provider '{provider_id}'. Known: "
-        f"{sorted(set(_registry) | {'google'})}"
+        f"{sorted(set(_registry) | {'google', 'microsoft'})}"
     )
 
 

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -1,0 +1,189 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Microsoft identity platform (v2.0) OAuth provider for ``gaia.connectors``.
+
+Foundation for the Outlook mailbox (#1275) and calendar (#1276) agents:
+unlocks MS Graph (mail, calendar, OneDrive, Teams, SharePoint) for any agent
+through the same generic ``oauth_pkce`` handler that already drives Google.
+
+NO module-level side effects: instantiating the provider reads
+``GAIA_MICROSOFT_CLIENT_ID`` and computes ``client_id_hash``. Importing this
+module registers nothing — registration is lazy on first ``get("microsoft")``
+(see ``providers/__init__.py``), matching ``GoogleOAuthProvider``.
+
+Tenant is ``consumers`` — personal Microsoft accounts (Outlook.com / Hotmail /
+Live). Work/school (Entra ID) tenants are out of scope for v1.
+
+Public-client PKCE: per the Microsoft identity platform docs, public clients
+(native/desktop, single-page apps) MUST NOT send a ``client_secret`` when
+redeeming an authorization code. This is the key difference from Google, which
+*requires* a secret even for installed apps. So the setup form asks only for a
+Client ID; ``token_request_body`` / ``refresh_request_body`` omit the secret
+unless one is explicitly configured (a confidential web-app edge case).
+
+The shared ``flow.py`` requires a refresh token (Microsoft returns one only
+when ``offline_access`` is requested) and decodes the account email from the
+id_token (returned only when ``openid`` is requested). Both scopes are in
+``default_scopes`` so a first connect succeeds without any flow.py change.
+"""
+
+from __future__ import annotations
+
+import os
+import zlib
+from typing import Iterable, Sequence
+from urllib.parse import urlencode
+
+from gaia.connectors.errors import ConfigurationError
+
+# Personal-account tenant. Pinned in both endpoint URLs.
+_TENANT = "consumers"
+
+# Plain-language descriptions for the AgentUI consent dialog, mirroring the
+# Google provider's SCOPE_DESCRIPTIONS. The router/CLI render these strings;
+# agents declare the Graph scope URLs in REQUIRED_CONNECTORS.
+SCOPE_DESCRIPTIONS: dict[str, str] = {
+    "https://graph.microsoft.com/Mail.Read": "Read your email",
+    "https://graph.microsoft.com/Mail.Send": "Send email on your behalf",
+    "https://graph.microsoft.com/Mail.ReadWrite": (
+        "Read, organize, and manage your email"
+    ),
+    "https://graph.microsoft.com/Calendars.Read": "Read your calendar events",
+    "https://graph.microsoft.com/Calendars.ReadWrite": "Manage your calendar events",
+    "https://graph.microsoft.com/Files.Read": "Read your OneDrive files",
+    "https://graph.microsoft.com/User.Read": "See your basic profile",
+    "openid": "Verify your identity",
+    "profile": "See your basic profile",
+    "email": "See your email address",
+    "offline_access": "Maintain access to data you've granted it access to",
+}
+
+
+class MicrosoftOAuthProvider:
+    """
+    Concrete provider for the Microsoft identity platform (``consumers``
+    tenant). Implements the ``OAuthProvider`` Protocol structurally — no
+    inheritance, matching ``GoogleOAuthProvider``.
+
+    Reads ``GAIA_MICROSOFT_CLIENT_ID`` at instantiation time, NOT at import
+    time. ``client_id_hash`` is a non-cryptographic CRC32 fingerprint used
+    only for log correlation / the ``store.load_connection`` tripwire compare.
+    """
+
+    provider_id: str = "microsoft"
+    auth_url: str = f"https://login.microsoftonline.com/{_TENANT}/oauth2/v2.0/authorize"
+    token_url: str = f"https://login.microsoftonline.com/{_TENANT}/oauth2/v2.0/token"
+    # offline_access => refresh token; openid => id_token (account email).
+    # The shared flow depends on both; keep them in the default set so a bare
+    # connect (no explicit scopes) still works end-to-end.
+    default_scopes: Sequence[str] = (
+        "openid",
+        "offline_access",
+        "https://graph.microsoft.com/User.Read",
+    )
+
+    def __init__(self, client_id: str | None = None, client_secret: str | None = None):
+        # Resolution order matches GoogleOAuthProvider (user-friendliness
+        # first):
+        #   1. Explicit kwargs (tests / library callers).
+        #   2. Keyring credentials saved via the AgentUI setup form.
+        #   3. Env vars (GAIA_MICROSOFT_CLIENT_ID / _SECRET) for CI / scripted
+        #      setups. Never required for new users.
+        if client_id is None or client_secret is None:
+            # Lazy import to avoid a connectors -> providers -> store cycle at
+            # module load time.
+            from gaia.connectors.store import peek_provider_credentials
+
+            stored = peek_provider_credentials("microsoft") or {}
+        else:
+            stored = {}
+
+        resolved_id = (
+            client_id
+            if client_id is not None
+            else stored.get("client_id")
+            or os.environ.get("GAIA_MICROSOFT_CLIENT_ID", "")
+        )
+        if not resolved_id:
+            raise ConfigurationError(
+                "Microsoft OAuth client is not configured. Open Settings → "
+                "Connections → Microsoft in the AgentUI and paste the "
+                "Application (client) ID from your Azure App registration "
+                "(personal-accounts / 'consumers' audience, with a "
+                "http://localhost redirect URI). (Power users may also set the "
+                "GAIA_MICROSOFT_CLIENT_ID env var — and, only for a "
+                "confidential web-app registration, GAIA_MICROSOFT_CLIENT_SECRET "
+                "— before launching GAIA.) See "
+                "docs/runbooks/microsoft-oauth-client.md."
+            )
+        self.client_id: str = resolved_id
+        # CRC32 fingerprint for log correlation / tripwire comparison only.
+        # Non-cryptographic by design — not used for security.
+        self.client_id_hash: str = format(zlib.crc32(resolved_id.encode()), "08x")
+        # Public PKCE clients send NO secret. Empty string => omitted from the
+        # token/refresh bodies. A non-empty value is the confidential-app
+        # opt-in (operator set GAIA_MICROSOFT_CLIENT_SECRET / saved one).
+        self.client_secret: str = (
+            client_secret
+            if client_secret is not None
+            else stored.get("client_secret")
+            or os.environ.get("GAIA_MICROSOFT_CLIENT_SECRET", "")
+        )
+
+    def authorization_params(self) -> dict:
+        """
+        Microsoft-specific extras for the authorization URL.
+
+        ``response_mode=query`` — the loopback ``/callback`` handler reads the
+        code from the query string (``?code=...``). Microsoft defaults to
+        ``fragment`` in some hybrid-flow cases, and browsers do not forward the
+        fragment to the loopback server, so we pin ``query`` explicitly.
+
+        Note: unlike Google, Microsoft does NOT need ``access_type=offline`` /
+        ``prompt=consent`` to issue a refresh token — the ``offline_access``
+        scope alone does that, and it is in ``default_scopes``.
+        """
+        return {"response_mode": "query"}
+
+    def authorization_url(
+        self,
+        redirect_uri: str,
+        challenge: str,
+        state: str,
+        scopes: Iterable[str],
+    ) -> str:
+        params = {
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+            "scope": " ".join(scopes),
+        }
+        params.update(self.authorization_params())
+        return f"{self.auth_url}?{urlencode(params)}"
+
+    def token_request_body(self, code: str, verifier: str, redirect_uri: str) -> dict:
+        body: dict = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "redirect_uri": redirect_uri,
+            "client_id": self.client_id,
+        }
+        # Public client: omit unless a confidential-app secret is configured.
+        if self.client_secret:
+            body["client_secret"] = self.client_secret
+        return body
+
+    def refresh_request_body(self, refresh_token: str) -> dict:
+        body: dict = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.client_id,
+        }
+        if self.client_secret:
+            body["client_secret"] = self.client_secret
+        return body

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -1,0 +1,274 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for the Microsoft OAuth provider (#1105) — the foundation for the
+Outlook mailbox (#1275) and Outlook calendar (#1276) agents.
+
+All network/OAuth is mocked; there are NO live calls. Coverage mirrors the
+Google provider tests in ``test_providers.py`` plus the Microsoft-specific
+invariants that the later mail/calendar leads depend on:
+
+- Tenant is ``consumers`` (personal Outlook.com/Hotmail/Live) — pinned in
+  BOTH the authorize and token endpoint URLs.
+- Public/native PKCE client: ``token_request_body`` / ``refresh_request_body``
+  carry NO ``client_secret`` unless one is explicitly configured (Microsoft
+  forbids secrets for public clients — unlike Google, which requires one).
+- ``default_scopes`` include ``offline_access`` (so the shared flow obtains a
+  refresh token) and ``openid`` (so the shared flow can decode the account
+  email from the id_token) — without these the shared ``flow.py`` would raise.
+- The catalog declares Mail.Read, Mail.Send, Calendars.ReadWrite so the grant
+  ledger accepts those scopes for the future Outlook agents.
+"""
+
+from __future__ import annotations
+
+import importlib
+import zlib
+
+import pytest
+
+from gaia.connectors import providers
+from gaia.connectors.errors import ConfigurationError
+from gaia.connectors.providers.base import OAuthProvider
+
+CONSUMERS_AUTH_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize"
+CONSUMERS_TOKEN_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token"
+
+MAIL_READ = "https://graph.microsoft.com/Mail.Read"
+MAIL_SEND = "https://graph.microsoft.com/Mail.Send"
+CALENDARS_RW = "https://graph.microsoft.com/Calendars.ReadWrite"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Clear the providers registry between tests so lazy registration is observable."""
+    saved = dict(providers._registry)  # type: ignore[attr-defined]
+    providers._registry.clear()  # type: ignore[attr-defined]
+    yield
+    providers._registry.clear()  # type: ignore[attr-defined]
+    providers._registry.update(saved)  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def _ms_env(monkeypatch):
+    monkeypatch.setenv(
+        "GAIA_MICROSOFT_CLIENT_ID", "11112222-bbbb-3333-cccc-4444dddd5555"
+    )
+    monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+    return "11112222-bbbb-3333-cccc-4444dddd5555"
+
+
+class TestRegistry:
+    def test_lazy_microsoft_registration(self, _ms_env):
+        # When the registry is empty for "microsoft", get() instantiates and
+        # registers MicrosoftOAuthProvider on demand — SDK/CLI/UI consumers do
+        # not need explicit setup, exactly as for Google.
+        prov = providers.get("microsoft")
+        assert prov.provider_id == "microsoft"
+        # Second call returns the SAME cached instance.
+        assert providers.get("microsoft") is prov
+
+    def test_unknown_provider_message_lists_microsoft(self, monkeypatch):
+        # After registering microsoft, the "unknown provider" message should
+        # include it so the error is actionable.
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "id")
+        providers.get("microsoft")
+        with pytest.raises(KeyError) as exc:
+            providers.get("definitely-not-a-provider")
+        assert "microsoft" in str(exc.value)
+
+    def test_lazy_missing_creds_raises_configuration_error(self, monkeypatch):
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+        with pytest.raises(ConfigurationError) as exc:
+            providers.get("microsoft")
+        msg = str(exc.value)
+        # Actionable error names the env vars and points at the setup form.
+        assert "GAIA_MICROSOFT_CLIENT_ID" in msg
+        assert "Settings" in msg
+        assert "Connections" in msg
+
+    def test_microsoft_loads_from_keyring_without_env(self, monkeypatch):
+        from gaia.connectors.store import save_provider_credentials
+
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+        save_provider_credentials(
+            "microsoft",
+            client_id="from-keyring-client-id",
+            client_secret="",
+        )
+        prov = providers.get("microsoft")
+        assert prov.client_id == "from-keyring-client-id"
+
+
+class TestProtocol:
+    def test_microsoft_satisfies_oauth_provider_protocol(self, _ms_env):
+        prov = providers.get("microsoft")
+        # runtime_checkable structural Protocol.
+        assert isinstance(prov, OAuthProvider)
+
+
+class TestEndpointsAndTenant:
+    def test_endpoints_pin_consumers_tenant(self, _ms_env):
+        prov = providers.get("microsoft")
+        assert prov.auth_url == CONSUMERS_AUTH_URL
+        assert prov.token_url == CONSUMERS_TOKEN_URL
+        # The personal-account tenant must be in both URLs.
+        assert "/consumers/" in prov.auth_url
+        assert "/consumers/" in prov.token_url
+
+    def test_client_id_hash_is_stable_crc32(self, monkeypatch):
+        client_id = "11112222-bbbb-3333-cccc-4444dddd5555"
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", client_id)
+        prov = providers.get("microsoft")
+        expected = format(zlib.crc32(client_id.encode()), "08x")
+        assert prov.client_id_hash == expected
+
+
+class TestDefaultScopes:
+    def test_default_scopes_include_offline_access_and_openid(self, _ms_env):
+        # offline_access => refresh_token is returned by the token endpoint;
+        # openid => id_token is returned so the shared flow can decode the
+        # account email. The shared flow.py REQUIRES a refresh_token, so a
+        # Microsoft connect without offline_access would raise — pin it here.
+        prov = providers.get("microsoft")
+        assert "offline_access" in prov.default_scopes
+        assert "openid" in prov.default_scopes
+
+
+class TestAuthorizationUrl:
+    def test_authorization_url_has_pkce_state_and_query_response_mode(self, _ms_env):
+        prov = providers.get("microsoft")
+        url = prov.authorization_url(
+            redirect_uri="http://127.0.0.1:54321/callback",
+            challenge="abcCHAL",
+            state="state-nonce",
+            scopes=[MAIL_READ, "offline_access", "openid"],
+        )
+        assert url.startswith(prov.auth_url)
+        assert "code_challenge=abcCHAL" in url
+        assert "code_challenge_method=S256" in url
+        assert "state=state-nonce" in url
+        assert "response_type=code" in url
+        assert "client_id=11112222-bbbb-3333-cccc-4444dddd5555" in url
+        # Loopback /callback handler reads ?code=... from the query string;
+        # MS defaults to fragment in some hybrid cases, so pin query mode.
+        assert "response_mode=query" in url
+
+    def test_authorization_url_space_delimits_scopes(self, _ms_env):
+        from urllib.parse import parse_qs, urlparse
+
+        prov = providers.get("microsoft")
+        url = prov.authorization_url(
+            redirect_uri="http://127.0.0.1:1/callback",
+            challenge="c",
+            state="s",
+            scopes=[MAIL_READ, MAIL_SEND, "offline_access"],
+        )
+        scope_value = parse_qs(urlparse(url).query)["scope"][0]
+        # Scopes are space-separated per the MS v2.0 spec.
+        assert scope_value == f"{MAIL_READ} {MAIL_SEND} offline_access"
+
+
+class TestTokenRequestBody:
+    def test_public_client_token_body_has_no_client_secret(self, _ms_env):
+        # Microsoft forbids client_secret for public/native PKCE clients
+        # (unlike Google, which requires it). With no secret configured the
+        # body must omit it entirely.
+        prov = providers.get("microsoft")
+        body = prov.token_request_body(
+            code="auth-code-x",
+            verifier="VERIFIER-VAL",
+            redirect_uri="http://127.0.0.1:54321/callback",
+        )
+        assert body["code"] == "auth-code-x"
+        assert body["code_verifier"] == "VERIFIER-VAL"
+        assert body["redirect_uri"] == "http://127.0.0.1:54321/callback"
+        assert body["grant_type"] == "authorization_code"
+        assert body["client_id"] == "11112222-bbbb-3333-cccc-4444dddd5555"
+        assert "client_secret" not in body
+
+    def test_refresh_body_has_no_client_secret(self, _ms_env):
+        prov = providers.get("microsoft")
+        body = prov.refresh_request_body("refresh-tok")
+        assert body["grant_type"] == "refresh_token"
+        assert body["refresh_token"] == "refresh-tok"
+        assert body["client_id"] == "11112222-bbbb-3333-cccc-4444dddd5555"
+        assert "client_secret" not in body
+
+    def test_confidential_client_includes_secret_when_configured(self, monkeypatch):
+        # Edge case: a confidential web-app registration where the operator
+        # set GAIA_MICROSOFT_CLIENT_SECRET. Then the secret IS sent. This is
+        # opt-in, never the default public-client posture.
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "conf-client")
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_SECRET", "super-secret")
+        prov = providers.get("microsoft")
+        token_body = prov.token_request_body(
+            code="c", verifier="v", redirect_uri="http://127.0.0.1:1/callback"
+        )
+        refresh_body = prov.refresh_request_body("r")
+        assert token_body["client_secret"] == "super-secret"
+        assert refresh_body["client_secret"] == "super-secret"
+
+
+class TestAuthorizationParams:
+    def test_authorization_params_pins_query_response_mode(self, _ms_env):
+        prov = providers.get("microsoft")
+        params = prov.authorization_params()
+        assert params.get("response_mode") == "query"
+
+
+class TestCatalog:
+    def test_catalog_declares_required_graph_scopes(self):
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+
+        for scope in (MAIL_READ, MAIL_SEND, CALENDARS_RW):
+            assert scope in MICROSOFT_SPEC.available_scopes, scope
+
+    def test_catalog_default_scopes_enable_refresh_and_account(self):
+        # The shared flow requires a refresh_token and decodes the account
+        # email from the id_token; both depend on these two scopes being in
+        # the default set used by a first connect.
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+
+        assert "offline_access" in MICROSOFT_SPEC.default_scopes
+        assert "openid" in MICROSOFT_SPEC.default_scopes
+
+    def test_catalog_is_oauth_pkce_pointing_at_microsoft_provider(self):
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+
+        assert MICROSOFT_SPEC.id == "microsoft"
+        assert MICROSOFT_SPEC.type == "oauth_pkce"
+        assert MICROSOFT_SPEC.oauth_provider_ref == "microsoft"
+
+    def test_catalog_setup_form_requires_client_id_only(self):
+        # Public PKCE client: the user pastes only a Client ID. A client
+        # secret must NOT be a required setup field (MS forbids secrets for
+        # public clients). Any secret field, if present, must be optional.
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+
+        fields = {f.key: f for f in MICROSOFT_SPEC.oauth_setup_fields}
+        assert "client_id" in fields
+        assert fields["client_id"].required is True
+        if "client_secret" in fields:
+            assert fields["client_secret"].required is False
+
+    def test_catalog_registered_in_global_registry(self):
+        import gaia.connectors.catalog  # noqa: F401  populate REGISTRY
+        from gaia.connectors.registry import REGISTRY
+
+        assert "microsoft" in REGISTRY
+        spec = REGISTRY.get("microsoft")
+        assert spec.display_name == "Microsoft"
+
+
+class TestNoImportSideEffects:
+    def test_importing_microsoft_module_does_not_register(self, monkeypatch):
+        # Mirror A-Crit-3 from the Google work: providers/microsoft.py must
+        # have NO side effects on import — registration is lazy via get().
+        from gaia.connectors.providers import microsoft as ms_mod
+
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        importlib.reload(ms_mod)
+        assert "microsoft" not in providers._registry  # type: ignore[attr-defined]

--- a/tests/unit/connectors/test_providers.py
+++ b/tests/unit/connectors/test_providers.py
@@ -72,8 +72,10 @@ class TestConnectorRequirement:
 
 class TestRegistry:
     def test_get_unknown_provider_raises_keyerror(self):
+        # "microsoft" is a known lazy-registered provider since #1105; use an
+        # id that is genuinely absent from the registry's lazy-init branches.
         with pytest.raises(KeyError):
-            providers.get("microsoft")
+            providers.get("definitely-not-a-provider")
 
     def test_register_then_get_round_trip(self):
         class FakeProvider:


### PR DESCRIPTION
Closes #1105

Before: GAIA could only connect Google accounts — no path to personal Outlook.com / Hotmail / Live mail or calendar. After: a `MicrosoftOAuthProvider` (Microsoft identity v2.0, PKCE, `consumers` tenant) ships with a Microsoft tile in Settings → Connectors and MS Graph scopes (Mail.Read / Mail.Send / Calendars.ReadWrite). This is the foundation **#1275** (Outlook mailbox) and **#1276** (Outlook calendar) build on — they consume the same provider-agnostic token surface, with no Microsoft-specific code.

For reviewers: unlike Google, Microsoft forbids a `client_secret` for public PKCE clients, so setup takes only a Client ID; `offline_access`+`openid` are in the default scopes so the shared connect flow still gets a refresh token + id_token.

## Test plan
- [x] 20 unit tests (`tests/unit/connectors/test_microsoft_provider.py`), all OAuth/network mocked: PKCE S256 auth-URL, token/refresh body shape, scope matching, tenant=`consumers`, lazy registration, ConfigurationError on missing creds, no import side-effects
- [x] `test_microsoft_provider.py test_providers.py test_secret_hygiene.py` → 44 passed on the integration base
- [x] no secret/token logging in the new modules; `python util/lint.py --black --isort` clean
- [ ] Live: Azure app registration (consumers, redirect `http://localhost`, no secret) → connect → real Graph `me/messages` call (pending Azure client id + interactive login)

Targets the `tmi/infallible-payne-e3c628` integration branch (not main).