### PR TITLE
feat(email): reversible batch archive (20+ emails in one action)

### DIFF
--- a/.claude/plans/issue-1270.md
+++ b/.claude/plans/issue-1270.md
@@ -1,0 +1,66 @@
+---
+type: plan
+source-issue: 1270
+repo: amd/gaia
+title: "feat(email): batch archive (20+ emails in one action)"
+created: 2026-06-02
+status: in-progress
+work_type: code-feature
+complexity: standard
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 3
+test_command: ".venv/bin/python -m pytest tests/unit/agents/email/ tests/unit/agents/test_email_agent_tools.py tests/unit/agents/test_email_agent_soft_delete.py -q"
+build_command: "uv pip install -e .[dev]"
+lint_command: "python util/lint.py --black --isort"
+branch: tmi/issue-1270-batch-archive
+reflection_iterations: 0
+agents_used: [planning, execution, validation]
+---
+
+# Issue 1270 — Batch archive (20+ emails in one action)
+
+## Acceptance criteria
+1. Archives a large selection (20+ emails) in a single action.
+2. Test asserts 20+ archived in one action AND the operation is reversible
+   within the undo window.
+
+## Verified current state
+- `archive_message_batch` (organize_tools.py ~L593) already archives N messages
+  in one tool call, recording one `email_actions` row per message with a shared
+  `batch_id` and a `prior_labels` payload. AC #1 is met by the existing tool.
+  - Batch threshold (`_check_threshold`) is evaluated ONCE at the top of the
+    batch (counter starts at 0 on a fresh agent → passes), then the per-message
+    counter is bumped AFTER. So a single 20+ batch on a fresh agent does not trip
+    the threshold. Confirmed.
+- GAP (AC #2): there is NO undo path for `archive`. `restore_message_impl`
+  (delete_tools.py — OUT OF LANE) explicitly raises for any `action_type` other
+  than `trash`. The `prior_labels` recorded by archive are never consumed. So a
+  batch archive is currently NOT reversible.
+
+## Plan
+TDD. In lane: `organize_tools.py`, `action_store.py`, tests only.
+
+1. FAILING test under `tests/unit/agents/email/test_batch_archive.py`:
+   - Build a ≥20-message fixture inbox (inject Gmail-API-shape messages into a
+     `FakeGmailBackend`, all labelled `INBOX`).
+   - Archive all in ONE `archive_message_batch` call; assert `total >= 20`,
+     all succeeded, all out of INBOX, all rows share one `batch_id`.
+   - Undo via a new `undo_archive_batch(batch_id)` tool within the window;
+     assert every message is back in INBOX and every row is marked undone.
+   - Assert undo OUTSIDE the window fails loudly (rows forced stale).
+2. Minimal fix to close the gap (in lane):
+   - `action_store.fetch_batch_undoable(db, *, batch_id, window_seconds)` →
+     list of in-window, not-yet-undone rows for the batch (mirrors
+     `fetch_undoable`).
+   - `organize_tools.undo_archive_batch_impl` + `undo_archive_batch` tool:
+     for each undoable `archive` row in the batch, re-add INBOX (restore
+     `prior_labels`), mark the row undone. Fail loudly if the batch has no
+     undoable rows (expired/unknown).
+3. Green + lint.
+
+## Risks
+- Must not touch `delete_tools.py` / `restore_message` (out of lane). New
+  archive-undo lives in organize_tools.py — its rightful owner.
+- Undo must restore the FULL prior label set, not just re-add INBOX, so a
+  message that also carried e.g. STARRED keeps it. Use `prior_labels`.

--- a/src/gaia/agents/email/action_store.py
+++ b/src/gaia/agents/email/action_store.py
@@ -149,6 +149,42 @@ def fetch_undoable(
     }
 
 
+def fetch_batch_undoable(
+    db, *, batch_id: str, window_seconds: int
+) -> list[Dict[str, Any]]:
+    """Return every action row in ``batch_id`` that is still undoable.
+
+    A row is undoable when it has not been undone and is inside the window.
+    Stale or already-undone rows are filtered out — this is the bulk
+    analogue of ``fetch_undoable`` for the batch-undo follow-up (#1270).
+    Returns ``[]`` for an unknown batch.
+    """
+    rows = db.query(
+        "SELECT * FROM email_actions WHERE batch_id = :b ORDER BY created_at",
+        {"b": batch_id},
+    )
+    cutoff = time.time() - window_seconds
+    out: list[Dict[str, Any]] = []
+    for row in rows or ():
+        if row["undone_at"] is not None:
+            continue
+        if row["created_at"] < cutoff:
+            continue
+        payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+        out.append(
+            {
+                "action_id": row["action_id"],
+                "action_type": row["action_type"],
+                "message_id": row["message_id"],
+                "thread_id": row["thread_id"],
+                "payload": payload,
+                "batch_id": row["batch_id"],
+                "created_at": row["created_at"],
+            }
+        )
+    return out
+
+
 def mark_undone(db, *, action_id: str) -> None:
     """Mark an action as undone. Idempotent — re-marking is a no-op.
 
@@ -220,6 +256,7 @@ __all__ = [
     "BODY_PREVIEW_MAX_CHARS",
     "EMAIL_ACTIONS_DDL",
     "EMAIL_DRAFTS_DDL",
+    "fetch_batch_undoable",
     "fetch_draft",
     "fetch_undoable",
     "init_schema",

--- a/src/gaia/agents/email/tools/organize_tools.py
+++ b/src/gaia/agents/email/tools/organize_tools.py
@@ -173,6 +173,54 @@ def move_to_label_impl(
         return {"action_id": action_id, "message_id": message_id, "label_id": label_id}
 
 
+def undo_archive_batch_impl(
+    gmail,
+    db,
+    *,
+    batch_id: str,
+    window_seconds: int,
+    debug: bool = False,
+) -> Dict[str, Any]:
+    """Reverse a batch archive within the undo window.
+
+    Re-adds the labels that ``archive`` removed (INBOX, plus any other
+    label the message carried before) for every still-undoable ``archive``
+    row sharing ``batch_id``, then marks each row undone.
+
+    Raises ``RuntimeError`` if the batch has no undoable rows — the window
+    expired, every row was already undone, or the batch_id is unknown. We
+    fail loudly rather than silently no-op so the caller surfaces it.
+    """
+    with log_tool_call("undo_archive_batch", {"batch_id": batch_id}, debug=debug) as st:
+        rows = action_store.fetch_batch_undoable(
+            db, batch_id=batch_id, window_seconds=window_seconds
+        )
+        if not rows:
+            raise RuntimeError(
+                f"undo window has expired ({window_seconds} s) or batch_id "
+                f"{batch_id!r} has no undoable archive actions. Use Gmail to "
+                "move the messages back to the inbox manually."
+            )
+        restored: List[Dict[str, Any]] = []
+        for row in rows:
+            if row["action_type"] != "archive":
+                # batch_id is archive-only today; skip anything else rather
+                # than mis-restore an unrelated action recorded under the
+                # same id by a future caller.
+                continue
+            mid = row["message_id"]
+            prior_labels = set(row["payload"].get("prior_labels") or [])
+            current = set(gmail.get_message(mid).get("labelIds", []))
+            # Archive only ever removes labels (INBOX); re-add whatever the
+            # message carried before that it no longer has.
+            for lab in prior_labels - current:
+                gmail.add_label(mid, lab)
+            action_store.mark_undone(db, action_id=row["action_id"])
+            restored.append({"message_id": mid, "action_id": row["action_id"]})
+        st["result_summary"] = {"restored": len(restored)}
+        return {"batch_id": batch_id, "restored": len(restored), "messages": restored}
+
+
 # ---------------------------------------------------------------------------
 # Mixin
 # ---------------------------------------------------------------------------
@@ -297,6 +345,7 @@ class OrganizeToolsMixin:
         gmail = self._gmail
         db = self
         debug_flag = bool(getattr(self.config, "debug", False))
+        window = int(getattr(self.config, "undo_window_seconds", 30))
         agent = self  # for batch-threshold counter access
 
         def _check_threshold() -> Optional[str]:
@@ -628,6 +677,26 @@ class OrganizeToolsMixin:
                         "succeeded": result["succeeded"],
                         "failed": result["failed"],
                     }
+                )
+            except ConnectorsError as exc:
+                return _envelope_err(str(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def undo_archive_batch(batch_id: str) -> str:
+            """Undo a batch archive by its batch_id, restoring every message
+            to the inbox within the undo window. Reverses archive_message_batch."""
+            try:
+                return _envelope_ok(
+                    undo_archive_batch_impl(
+                        gmail,
+                        db,
+                        batch_id=batch_id,
+                        window_seconds=window,
+                        debug=debug_flag,
+                    )
                 )
             except ConnectorsError as exc:
                 return _envelope_err(str(exc))

--- a/tests/unit/agents/email/test_batch_archive.py
+++ b/tests/unit/agents/email/test_batch_archive.py
@@ -1,0 +1,285 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Issue #1270 — batch archive of 20+ emails in a single action, reversible
+within the undo window.
+
+These tests pin two acceptance criteria:
+
+1. ``archive_message_batch`` archives 20+ selected messages in ONE tool
+   call (one shared ``batch_id``, one row per message, all out of INBOX).
+2. The batch is reversible within the undo window via
+   ``undo_archive_batch`` — every message returns to its prior label set
+   (INBOX restored) and every action row is marked undone. Outside the
+   window the undo fails loudly rather than silently no-op'ing.
+
+Everything runs against the in-memory ``FakeGmailBackend`` + an
+``EmailTriageAgent`` whose ``AgentSDK`` is mocked — no Lemonade, no eval.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Make tests.fixtures importable.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from gaia.agents.email import action_store  # noqa: E402
+from tests.fixtures.email.fake_gmail import (  # noqa: E402
+    FakeCalendarBackend,
+    FakeGmailBackend,
+)
+
+# Number of messages in the batch. Must be >= 20 per the AC.
+_BATCH_SIZE = 25
+
+
+def _make_inbox_message(idx: int, *, extra_labels=None) -> dict:
+    """Build a minimal Gmail-API-shape INBOX message."""
+    labels = ["INBOX", "UNREAD"]
+    if extra_labels:
+        labels.extend(extra_labels)
+    return {
+        "id": f"msg-{idx:03d}",
+        "threadId": f"thread-{idx:03d}",
+        "labelIds": labels,
+        "snippet": f"snippet {idx}",
+        "internalDate": str(1_700_000_000_000 + idx),
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": f"sender{idx}@example.com"},
+                {"name": "Subject", "value": f"Bulk message {idx}"},
+                {"name": "Message-ID", "value": f"<bulk-{idx}@example.com>"},
+            ],
+            "body": {"size": 0, "data": ""},
+        },
+        "sizeEstimate": 100,
+    }
+
+
+@pytest.fixture
+def bulk_gmail():
+    """A fake Gmail backend pre-loaded with ``_BATCH_SIZE`` INBOX messages.
+
+    One message also carries STARRED so the undo path is forced to restore
+    the FULL prior label set, not merely re-add INBOX.
+    """
+    gmail = FakeGmailBackend()
+    for i in range(_BATCH_SIZE):
+        extra = ["STARRED"] if i == 0 else None
+        gmail.add_message(_make_inbox_message(i, extra_labels=extra))
+    return gmail
+
+
+@pytest.fixture
+def fake_calendar():
+    return FakeCalendarBackend()
+
+
+def _make_email_agent(gmail, calendar, tmp_path):
+    """EmailTriageAgent with backends injected and AgentSDK mocked."""
+    from unittest.mock import MagicMock, patch
+
+    from gaia.agents.email.agent import EmailTriageAgent
+    from gaia.agents.email.config import EmailAgentConfig
+
+    cfg = EmailAgentConfig(
+        gmail_backend=gmail,
+        calendar_backend=calendar,
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+    )
+    with (
+        patch("gaia.llm.lemonade_manager.LemonadeManager.ensure_ready"),
+        patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+    ):
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent
+
+
+def _tool(name):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    return _TOOL_REGISTRY[name]["function"]
+
+
+class TestBatchArchive20Plus:
+    def test_archives_20_plus_in_one_action(self, bulk_gmail, fake_calendar, tmp_path):
+        """AC #1: a single ``archive_message_batch`` call archives 20+
+        messages — one shared batch_id, all removed from INBOX.
+        """
+        agent = _make_email_agent(bulk_gmail, fake_calendar, tmp_path)
+        try:
+            ids = list(bulk_gmail._messages.keys())
+            assert len(ids) >= 20
+
+            result = json.loads(_tool("archive_message_batch")(ids))
+            assert result["ok"] is True
+            data = result["data"]
+            assert data["total"] == len(ids)
+            assert len(data["succeeded"]) == len(ids)
+            assert data["failed"] == []
+
+            # One shared batch_id across every recorded row.
+            assert data["batch_id"]
+            all_rows = agent.query("SELECT batch_id FROM email_actions")
+            batch_ids = {r["batch_id"] for r in all_rows}
+            assert batch_ids == {data["batch_id"]}
+            assert len(all_rows) == len(ids)
+
+            # Every message is out of INBOX.
+            for mid in ids:
+                post = bulk_gmail.get_message(mid)
+                assert "INBOX" not in post["labelIds"], f"{mid} still in INBOX"
+        finally:
+            agent.close_db()
+
+    def test_batch_archive_reversible_within_undo_window(
+        self, bulk_gmail, fake_calendar, tmp_path
+    ):
+        """AC #2: ``undo_archive_batch`` restores all 20+ messages to their
+        prior label set within the window.
+        """
+        agent = _make_email_agent(bulk_gmail, fake_calendar, tmp_path)
+        try:
+            ids = list(bulk_gmail._messages.keys())
+            prior_labels = {
+                mid: list(bulk_gmail.get_message(mid)["labelIds"]) for mid in ids
+            }
+
+            archive_result = json.loads(_tool("archive_message_batch")(ids))
+            batch_id = archive_result["data"]["batch_id"]
+
+            # Sanity: all archived.
+            for mid in ids:
+                assert "INBOX" not in bulk_gmail.get_message(mid)["labelIds"]
+
+            undo_result = json.loads(_tool("undo_archive_batch")(batch_id))
+            assert undo_result["ok"] is True, undo_result
+            data = undo_result["data"]
+            assert data["restored"] == len(ids)
+
+            # Every message is back with its FULL prior label set restored —
+            # including the message that also carried STARRED.
+            for mid in ids:
+                post = bulk_gmail.get_message(mid)
+                assert "INBOX" in post["labelIds"], f"{mid} not restored to INBOX"
+                assert set(post["labelIds"]) == set(prior_labels[mid]), (
+                    f"{mid} prior labels not fully restored: "
+                    f"{post['labelIds']} != {prior_labels[mid]}"
+                )
+
+            # Every row in the batch is now marked undone.
+            rows = agent.query(
+                "SELECT undone_at FROM email_actions WHERE batch_id = :b",
+                {"b": batch_id},
+            )
+            assert len(rows) == len(ids)
+            assert all(r["undone_at"] is not None for r in rows)
+        finally:
+            agent.close_db()
+
+    def test_batch_archive_undo_fails_after_window(
+        self, bulk_gmail, fake_calendar, tmp_path
+    ):
+        """Outside the undo window the batch undo must fail loudly (no
+        silent no-op) and leave the messages archived.
+        """
+        agent = _make_email_agent(bulk_gmail, fake_calendar, tmp_path)
+        try:
+            ids = list(bulk_gmail._messages.keys())
+            archive_result = json.loads(_tool("archive_message_batch")(ids))
+            batch_id = archive_result["data"]["batch_id"]
+
+            # Force every row's created_at into the past (beyond the window).
+            agent.update(
+                "email_actions",
+                {"created_at": time.time() - 3600},
+                "batch_id = :b",
+                {"b": batch_id},
+            )
+
+            undo_result = json.loads(_tool("undo_archive_batch")(batch_id))
+            assert undo_result["ok"] is False
+            assert "undo window" in undo_result["error"].lower()
+
+            # Messages remain archived — undo did not partially fire.
+            for mid in ids:
+                assert "INBOX" not in bulk_gmail.get_message(mid)["labelIds"]
+        finally:
+            agent.close_db()
+
+
+class TestFetchBatchUndoable:
+    """``action_store.fetch_batch_undoable`` returns the in-window,
+    not-yet-undone rows for a batch and excludes stale / undone ones.
+    """
+
+    @pytest.fixture
+    def db(self):
+        from gaia.database.mixin import DatabaseMixin
+
+        class _DB(DatabaseMixin):
+            def __init__(self):
+                self.init_db(":memory:")
+
+        db = _DB()
+        action_store.init_schema(db)
+        yield db
+        db.close_db()
+
+    def test_returns_all_in_window_rows_for_batch(self, db):
+        for i in range(3):
+            action_store.record_action(
+                db,
+                action_type="archive",
+                message_id=f"m{i}",
+                payload={"prior_labels": ["INBOX"]},
+                batch_id="b1",
+            )
+        # A row in a different batch must not leak in.
+        action_store.record_action(
+            db, action_type="archive", message_id="other", batch_id="b2"
+        )
+        rows = action_store.fetch_batch_undoable(db, batch_id="b1", window_seconds=30)
+        assert {r["message_id"] for r in rows} == {"m0", "m1", "m2"}
+
+    def test_excludes_stale_and_undone_rows(self, db):
+        a_fresh = action_store.record_action(
+            db, action_type="archive", message_id="fresh", batch_id="b1"
+        )
+        a_stale = action_store.record_action(
+            db, action_type="archive", message_id="stale", batch_id="b1"
+        )
+        a_undone = action_store.record_action(
+            db, action_type="archive", message_id="undone", batch_id="b1"
+        )
+        db.update(
+            "email_actions",
+            {"created_at": time.time() - 3600},
+            "action_id = :id",
+            {"id": a_stale},
+        )
+        action_store.mark_undone(db, action_id=a_undone)
+
+        rows = action_store.fetch_batch_undoable(db, batch_id="b1", window_seconds=30)
+        ids = {r["action_id"] for r in rows}
+        assert a_fresh in ids
+        assert a_stale not in ids
+        assert a_undone not in ids
+
+    def test_unknown_batch_returns_empty(self, db):
+        assert (
+            action_store.fetch_batch_undoable(db, batch_id="nope", window_seconds=30)
+            == []
+        )

--- a/tests/unit/agents/test_email_agent.py
+++ b/tests/unit/agents/test_email_agent.py
@@ -134,6 +134,7 @@ class TestToolRegistry:
         "add_star_batch",
         "remove_star_batch",
         "archive_message_batch",
+        "undo_archive_batch",
         "label_message_batch",
         "move_to_label_batch",
         # Reply / send / forward


### PR DESCRIPTION
Closes #1270

Before: the agent could archive 20+ emails in one `archive_message_batch` call, but there was no way to undo it — the existing restore path rejects anything that isn't a trash action, so the recorded prior-labels were dead data. After: `undo_archive_batch(batch_id)` restores every message in the batch to the inbox (full prior label set) within the undo window, and fails loudly once the window expires rather than silently no-op'ing.

## Test plan
- [x] `test_archives_20_plus_in_one_action` (25 messages, one batch_id, all leave INBOX)
- [x] `test_batch_archive_reversible_within_undo_window` (incl. a STARRED message → full label-set restore)
- [x] `test_batch_archive_undo_fails_after_window` (fail-loud past window)
- [x] email suites → 199 passed; lint clean

Targets the `tmi/infallible-payne-e3c628` integration branch (not main).