### PR TITLE
feat(email): REST API surface for the agent (single email in, structured out)

### DIFF
--- a/.claude/plans/issue-1229.md
+++ b/.claude/plans/issue-1229.md
@@ -1,0 +1,111 @@
+---
+type: plan
+source-issue: 1229
+repo: amd/gaia
+title: "REST API surface for the email agent (single email in, structured results out)"
+created: 2026-06-02
+status: in-progress
+work_type: code-feature
+complexity: complex
+tdd_required: true
+suggested_team_size: 1
+estimated_files_changed: 4
+test_command: ".venv/bin/python -m pytest tests/test_api.py tests/unit/agents/email/ tests/integration/test_email_rest_api_e2e.py -q"
+build_command: "uv pip install -e .[dev]"
+lint_command: "python util/lint.py --black --isort"
+branch: tmi/issue-1229-email-rest-api
+reflection_iterations: 0
+agents_used: [planning, execution, validation]
+---
+
+# Issue #1229 — REST API surface for the email agent
+
+## Goal
+Expose the email agent over REST so a consuming app can:
+1. POST a single email (or thread) per the FROZEN #1262 contract and get a
+   structured triage result back (category, summary, draft, action items).
+2. Request a send, which is REJECTED with a 4xx unless an explicit confirmation
+   token is present — the send-confirmation gate (#1264) translated to the API
+   boundary. No silent auto-confirm.
+
+## Foundations (reuse, do NOT reinvent)
+- `src/gaia/agents/email/contract.py` — FROZEN pydantic v2 contract. Triage-only:
+  `EmailTriageRequest` (discriminated `single`/`thread` union) → `EmailTriageResponse`
+  (`EmailTriageResult`: category, is_spam, is_phishing, summary, action_items, draft).
+  There is NO send envelope in the contract — send is a separate concern.
+- `src/gaia/agents/email/tools/triage_heuristics.py::classify_category_heuristic` —
+  the agent's REAL deterministic categorizer. Imports cleanly without pulling Gmail/
+  connector backends. Used to derive category/is_spam/is_phishing deterministically.
+- `src/gaia/agents/email/agent.py::EmailTriageAgent` — conversational LLM agent.
+  Consume READ-ONLY (do not modify — #1106 owns it in parallel). Drives the e2e
+  pipeline via its read/triage/draft tools + `TOOLS_REQUIRING_CONFIRMATION` gate.
+- `src/gaia/api/openai_server.py` — module-level FastAPI `app`. Wire an APIRouter.
+- `tests/fixtures/email/fake_gmail.py::FakeGmailBackend` + `synthetic_inbox` fixture
+  — the deterministic backend for the e2e (Gmail-API-shaped, records `transport.calls`).
+
+## Architecture
+New module `src/gaia/api/email_routes.py`:
+- `EmailTriageService` — converts a contract `EmailInput` → a structured
+  `EmailTriageResult` deterministically:
+  - category/is_spam/is_phishing via `classify_category_heuristic` over the
+    message subject/from/(synthetic Gmail labels derived from is_spam? no —
+    we have no labelIds in the contract, so classify on subject+sender only;
+    that is exactly the heuristic's keyword path).
+  - summary: deterministic (subject + first sentence/snippet of body).
+  - action_items: deterministic extraction (imperative/“please …” lines).
+  - draft: a proposal ONLY (never sent here). The contract's `DraftReply`.
+  This is NOT an LLM call — it is the heuristic fast path, which is exactly
+  what the agent runs pre-LLM. Unit tier mocks any LLM; this path is deterministic.
+- `POST /v1/email/triage` — body=`EmailTriageRequest`, returns `EmailTriageResponse`.
+  FastAPI validates the request against the frozen model; an unknown field /
+  malformed payload → 422 (pydantic `extra="forbid"`). Response validated by the
+  declared `response_model`.
+- Send envelope models (LOCAL to email_routes.py — contract.py is frozen):
+  `EmailSendRequest { to, subject, body, confirmation_token: Optional[str] }`,
+  `EmailSendResponse { sent_id, to, subject, sent: True }`.
+- `POST /v1/email/send` — if `confirmation_token` is absent/empty/invalid →
+  HTTP 403 (or 400) with an actionable error naming the missing token. The
+  guard is the FIRST thing checked. Only a valid token reaches the backend
+  `send_message`. This mirrors `console.confirm_tool_execution() == False`
+  → boundary translation to 4xx.
+- Confirmation token: server issues a token from the triage/draft step
+  (`POST /v1/email/draft` returns a `confirmation_token` bound to the draft
+  payload hash). The send endpoint validates the token matches the payload.
+  Tokens are single-use, in-memory. A consuming app cannot send without first
+  obtaining a token AND echoing it — proving explicit confirmation.
+
+  Keep it MINIMAL: a token store seeded by the draft endpoint; send checks it.
+
+Wiring: `openai_server.py` imports and `app.include_router(email_router)`.
+Lane: only `src/gaia/api/` + tests. No edits to `agent.py`/`contract.py`/`connectors/`.
+
+## TDD order
+1. `tests/test_api.py` (TestClient, ImportError-guarded + skip like existing):
+   - triage single-email-in → 200 + contract-valid `EmailTriageResponse`
+     (parse_response round-trips; request_kind=="single"; category in taxonomy).
+   - triage thread-in → 200 + request_kind=="thread".
+   - malformed/unknown-field request → 422 (extra="forbid" fires).
+   - send WITHOUT confirmation_token → 4xx (assert no backend send happened).
+   - send WITH a valid token (issued by draft endpoint) → 200, backend send called.
+2. `tests/integration/test_email_rest_api_e2e.py` — FakeGmailBackend driven through
+   the agent's REAL tool impls: pre-scan → categorize → summarize → draft →
+   send-gate. Asserts each stage's contract; send blocked w/o confirm, allowed w/.
+   Deterministic stubs only; no live mail, no live Lemonade.
+3. Implement `email_routes.py`; wire into `openai_server.py`; green.
+
+## Acceptance criteria mapping
+- AC: consuming app invokes over REST → `/v1/email/triage` + TestClient tests.
+- AC: single email in → structured out → triage endpoint + contract round-trip.
+- AC: never sends without confirmation → `/v1/email/send` 4xx-without-token test.
+- AC test: TestClient single-in→struct-out, #1262 shape, 4xx on send w/o confirm.
+- AC test: e2e FakeGmail pre-scan→categorize→summarize→draft→send-gate, mocked LLM.
+
+## Risks
+- The contract is triage-only; the send/draft/confirmation-token envelope is NEW
+  and local to email_routes.py (NOT added to frozen contract.py). Documented.
+- fastapi is in `[api]`/`[ui]` extras, NOT `[dev]`. Tests MUST guard imports and
+  skip when fastapi is absent (matches existing test_api.py) so `[dev]`-only CI
+  stays green. Local verification installs `[api]`.
+- e2e must not modify agent.py. It constructs `EmailTriageAgent(EmailAgentConfig(
+  gmail_backend=FakeGmailBackend(...), base_url=local))` and calls the tool impls
+  directly (deterministic), not `process_query` (which needs an LLM).

--- a/src/gaia/api/email_routes.py
+++ b/src/gaia/api/email_routes.py
@@ -1,0 +1,576 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+REST surface for the Email Triage Agent (#1229).
+
+A consuming application invokes the email agent over HTTP through these
+endpoints, mounted on the existing OpenAI-compatible FastAPI app
+(``gaia.api.openai_server``):
+
+    POST /v1/email/triage  — single email or full thread in (the FROZEN
+                             #1262 contract), structured triage result out
+                             (category, summary, action items, optional
+                             draft proposal).
+    POST /v1/email/draft   — propose a reply and obtain a single-use
+                             confirmation token bound to the exact
+                             ``(to, subject, body)`` payload.
+    POST /v1/email/send    — send a reply. REJECTED with a 4xx unless a
+                             valid confirmation token for *this* payload is
+                             supplied. This is the send-confirmation gate
+                             (#1264) translated to the API boundary — the
+                             same rule the agent enforces via
+                             ``TOOLS_REQUIRING_CONFIRMATION`` /
+                             ``console.confirm_tool_execution``.
+
+Design commitments
+------------------
+- **Reuse the frozen contract.** ``/v1/email/triage`` takes and returns the
+  exact pydantic models from ``gaia.agents.email.contract`` — no parallel
+  schema. A consuming app that drifts from the contract gets a 422.
+- **Reuse the agent's real categorizer.** Category / spam / phishing come
+  from ``triage_heuristics.classify_category_heuristic`` — the same
+  deterministic fast-path the agent runs pre-LLM — not a reimplementation.
+- **Fail loudly, never auto-confirm.** A send without a valid, payload-bound
+  confirmation token raises a 403 with an actionable message. The token is
+  single-use and bound to the payload, so a stale token cannot authorize a
+  different message (no bait-and-switch).
+- **No live mail in tests.** The send backend is a FastAPI dependency
+  (:func:`get_send_backend`) so tests inject ``FakeGmailBackend`` via
+  ``app.dependency_overrides``; production resolves the live Gmail backend
+  and fails loudly if it is unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+import secrets
+import threading
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from gaia.agents.email.contract import (
+    ActionItem,
+    DraftReply,
+    EmailAddress,
+    EmailCategory,
+    EmailMessage,
+    EmailTriageRequest,
+    EmailTriageResponse,
+    EmailTriageResult,
+    SingleEmailInput,
+    ThreadInput,
+)
+from gaia.agents.email.tools.triage_heuristics import classify_category_heuristic
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/v1/email", tags=["email"])
+
+
+# ---------------------------------------------------------------------------
+# Deterministic triage service
+# ---------------------------------------------------------------------------
+
+# Phrases that mark a line as an action the principal must take. Deliberately
+# small and explicit — this is a deterministic extractor, not an LLM. The
+# agent's LLM path produces richer action items; this fast-path covers the
+# obvious imperative cues so the REST surface returns useful structure
+# without a model round-trip.
+_ACTION_CUES = (
+    "please ",
+    "can you ",
+    "could you ",
+    "kindly ",
+    "let me know",
+    "reply by",
+    "respond by",
+    "rsvp",
+    "action required",
+    "follow up",
+    "follow-up",
+    "review the",
+    "send me",
+    "send the",
+    "confirm ",
+)
+
+# Crude due-date hints surfaced verbatim (never parsed — the contract's
+# ``due_hint`` is explicitly free-text).
+_DUE_HINT_RE = re.compile(
+    r"\b(by\s+(?:eod|cob|tomorrow|today|monday|tuesday|wednesday|thursday|"
+    r"friday|saturday|sunday|next\s+\w+|\d{1,2}(?::\d{2})?\s*(?:am|pm)?))",
+    re.IGNORECASE,
+)
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+_MAX_SUMMARY_CHARS = 300
+
+
+def _split_sentences(text: str) -> List[str]:
+    text = re.sub(r"\s+", " ", (text or "").strip())
+    if not text:
+        return []
+    return [s.strip() for s in _SENTENCE_SPLIT_RE.split(text) if s.strip()]
+
+
+class EmailTriageService:
+    """Convert contract inputs (or raw Gmail-API messages) into a contract
+    :class:`EmailTriageResult` deterministically.
+
+    No LLM is invoked: category comes from the agent's heuristic
+    categorizer, and the summary / action items / draft proposal are derived
+    from the message text with explicit rules. This keeps the REST surface
+    fast, offline-testable, and aligned with the agent's pre-LLM fast path.
+    """
+
+    # -- Public: contract path ---------------------------------------------
+
+    def triage_request(self, request: EmailTriageRequest) -> EmailTriageResponse:
+        """Triage a contract request envelope into a contract response."""
+        payload = request.payload
+        if isinstance(payload, SingleEmailInput):
+            result = self._triage_single(payload)
+            kind = "single"
+        elif isinstance(payload, ThreadInput):
+            result = self._triage_thread(payload)
+            kind = "thread"
+        else:  # pragma: no cover - discriminated union guarantees one of the two
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unsupported payload kind: {getattr(payload, 'kind', '?')!r}",
+            )
+        return EmailTriageResponse(request_kind=kind, result=result)
+
+    def triage_gmail_message(
+        self, msg: dict, *, principal_email: str
+    ) -> EmailTriageResult:
+        """Triage a Gmail-API-shaped message (e.g. from ``get_message_impl``).
+
+        Used by the agent-pipeline e2e to assert the REST surface's
+        summarizer agrees with what the agent's read tools fetch.
+        """
+        from gaia.agents.email.gmail_backend import decode_message_body
+
+        payload = msg.get("payload") or {}
+        headers = {
+            (h.get("name") or "").lower(): h.get("value", "")
+            for h in payload.get("headers", [])
+        }
+        body, _attachments = decode_message_body(payload)
+        subject = headers.get("subject", "")
+        sender = headers.get("from", "")
+        label_ids = list(msg.get("labelIds", []))
+        principal = EmailAddress(email=principal_email)
+        return self._build_result(
+            subject=subject,
+            sender_raw=sender,
+            body=body,
+            label_ids=label_ids,
+            principal=principal,
+            reply_to=_parse_address(sender),
+        )
+
+    # -- Internal -----------------------------------------------------------
+
+    def _triage_single(self, payload: SingleEmailInput) -> EmailTriageResult:
+        msg = payload.message
+        return self._build_result(
+            subject=msg.subject,
+            sender_raw=_format_address(msg.from_),
+            body=msg.body,
+            label_ids=[],
+            principal=payload.principal,
+            reply_to=msg.from_,
+        )
+
+    def _triage_thread(self, payload: ThreadInput) -> EmailTriageResult:
+        # Summarize the whole thread; categorize on the LAST inbound message
+        # (the one awaiting the principal's attention), reply to its sender.
+        messages: List[EmailMessage] = payload.messages
+        last = messages[-1]
+        combined_body = "\n\n".join(
+            f"{_format_address(m.from_)}: {m.body}" for m in messages
+        )
+        result = self._build_result(
+            subject=last.subject,
+            sender_raw=_format_address(last.from_),
+            body=combined_body,
+            label_ids=[],
+            principal=payload.principal,
+            reply_to=last.from_,
+            summary_prefix=f"Thread of {len(messages)} messages. ",
+        )
+        return result
+
+    def _build_result(
+        self,
+        *,
+        subject: str,
+        sender_raw: str,
+        body: str,
+        label_ids: List[str],
+        principal: EmailAddress,
+        reply_to: Optional[EmailAddress],
+        summary_prefix: str = "",
+    ) -> EmailTriageResult:
+        heuristic = classify_category_heuristic(
+            subject=subject, sender=sender_raw, label_ids=label_ids
+        )
+        category = EmailCategory(heuristic.category)
+        summary = summary_prefix + self._summarize(subject, body)
+        action_items = self._extract_action_items(body)
+        draft = self._build_draft(
+            subject=subject,
+            reply_to=reply_to,
+            principal=principal,
+            is_spam=heuristic.is_spam,
+            is_phishing=heuristic.is_phishing,
+        )
+        return EmailTriageResult(
+            category=category,
+            is_spam=heuristic.is_spam,
+            is_phishing=heuristic.is_phishing,
+            summary=summary,
+            action_items=action_items,
+            draft=draft,
+        )
+
+    def _summarize(self, subject: str, body: str) -> str:
+        sentences = _split_sentences(body)
+        lead = " ".join(sentences[:2]) if sentences else ""
+        if subject and lead:
+            summary = f"{subject.strip()} — {lead}"
+        elif subject:
+            summary = subject.strip()
+        elif lead:
+            summary = lead
+        else:
+            summary = "(no content)"
+        if len(summary) > _MAX_SUMMARY_CHARS:
+            summary = summary[: _MAX_SUMMARY_CHARS - 1].rstrip() + "…"
+        return summary
+
+    def _extract_action_items(self, body: str) -> List[ActionItem]:
+        items: List[ActionItem] = []
+        seen: set[str] = set()
+        for sentence in _split_sentences(body):
+            low = sentence.lower()
+            if not any(cue in low for cue in _ACTION_CUES):
+                continue
+            normalized = sentence.strip()
+            key = normalized.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            due_match = _DUE_HINT_RE.search(sentence)
+            due_hint = due_match.group(1) if due_match else None
+            items.append(ActionItem(description=normalized, due_hint=due_hint))
+        return items
+
+    def _build_draft(
+        self,
+        *,
+        subject: str,
+        reply_to: Optional[EmailAddress],
+        principal: EmailAddress,
+        is_spam: bool,
+        is_phishing: bool,
+    ) -> Optional[DraftReply]:
+        # Never propose a reply to spam/phishing — surfacing a draft would
+        # nudge the user toward engaging with a hostile sender.
+        if is_spam or is_phishing or reply_to is None:
+            return None
+        # Don't propose replying to yourself (e.g. a thread whose last message
+        # the principal sent) — there is no one to reply to.
+        if reply_to.email.lower() == principal.email.lower():
+            return None
+        reply_subject = subject.strip()
+        if reply_subject and not reply_subject.lower().startswith("re:"):
+            reply_subject = f"Re: {reply_subject}"
+        elif not reply_subject:
+            reply_subject = "Re:"
+        return DraftReply(
+            to=[reply_to],
+            subject=reply_subject,
+            body="",  # proposal scaffold; the user/agent fills the body in
+        )
+
+
+def _format_address(addr: EmailAddress) -> str:
+    if addr.name:
+        return f"{addr.name} <{addr.email}>"
+    return addr.email
+
+
+def _parse_address(raw: str) -> Optional[EmailAddress]:
+    """Parse a raw ``From`` header (``"Alice <a@b.com>"``) into an
+    :class:`EmailAddress`. Returns None when no plausible address is found.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    m = re.search(r"<([^>]+)>", raw)
+    if m:
+        email = m.group(1).strip()
+        name = raw[: m.start()].strip().strip('"') or None
+    else:
+        email = raw
+        name = None
+    try:
+        return EmailAddress(name=name, email=email)
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Confirmation-token store (the send-confirmation gate)
+# ---------------------------------------------------------------------------
+
+
+def _payload_fingerprint(to: List[EmailAddress], subject: str, body: str) -> str:
+    """A stable fingerprint of the exact message a token authorizes.
+
+    Binding the token to the payload means a token issued for one message
+    cannot be replayed to send different content.
+    """
+    recipients = ",".join(sorted(a.email.lower() for a in to))
+    material = "\x1f".join([recipients, subject, body])
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+class ConfirmationStore:
+    """Single-use confirmation tokens bound to a message fingerprint.
+
+    A token is minted by the draft endpoint and consumed by the send
+    endpoint. Consuming a token removes it (single-use). The server-side
+    secret makes tokens unforgeable; the fingerprint makes them payload-
+    specific.
+    """
+
+    def __init__(self, secret: Optional[bytes] = None):
+        self._secret = secret or secrets.token_bytes(32)
+        self._lock = threading.Lock()
+        # token -> fingerprint it authorizes
+        self._tokens: dict[str, str] = {}
+
+    def issue(self, fingerprint: str) -> str:
+        token = hmac.new(
+            self._secret, (fingerprint + secrets.token_hex(8)).encode("utf-8"), "sha256"
+        ).hexdigest()
+        with self._lock:
+            self._tokens[token] = fingerprint
+        return token
+
+    def consume(self, token: str, fingerprint: str) -> bool:
+        """Validate and consume a token for ``fingerprint``.
+
+        Returns True only when the token was issued for exactly this
+        payload. The token is removed on a successful match (single-use).
+        A blank/unknown token, or a token issued for a different payload,
+        returns False and is NOT consumed.
+        """
+        if not token:
+            return False
+        with self._lock:
+            expected = self._tokens.get(token)
+            if expected is None:
+                return False
+            if not hmac.compare_digest(expected, fingerprint):
+                # Right token, wrong payload — do not consume; reject.
+                return False
+            del self._tokens[token]
+            return True
+
+
+# Process-wide store. Tokens live only for the life of the server process —
+# acceptable for a confirmation handshake (draft then send within a session).
+confirmation_store = ConfirmationStore()
+
+
+# ---------------------------------------------------------------------------
+# Send-backend dependency (injectable for tests; fail-loud in production)
+# ---------------------------------------------------------------------------
+
+
+def get_send_backend():
+    """Resolve the Gmail backend used by the send endpoint.
+
+    Production builds the live backend and fails loudly if Google
+    credentials are not connected — never silently no-ops a send. Tests
+    override this via ``app.dependency_overrides[get_send_backend]`` to
+    inject ``FakeGmailBackend`` so no live mail is touched.
+
+    IMPORTANT: this is invoked from the send handler *after* the
+    confirmation gate, NOT as a FastAPI ``Depends`` — a request that lacks a
+    valid confirmation token must be rejected with a 4xx regardless of
+    backend health, so the gate is always evaluated first. (Resolving the
+    backend as a ``Depends`` would let a backend-unavailable 503 preempt the
+    403, masking the missing-confirmation rejection.)
+    """
+    from gaia.agents.email.gmail_backend import LiveGmailBackend, _get_gmail_token
+
+    try:
+        return LiveGmailBackend(_get_gmail_token)
+    except Exception as exc:  # noqa: BLE001 - boundary translation, re-raised
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Email send backend unavailable: Google account is not "
+                "connected. Connect Google via the connectors flow before "
+                f"sending. ({type(exc).__name__}: {exc})"
+            ),
+        ) from exc
+
+
+# Module-level indirection the send handler calls after the gate. Tests swap
+# this (e.g. ``monkeypatch.setattr(email_routes, "resolve_send_backend",
+# lambda: FakeGmailBackend())``) to inject a fake without touching live mail.
+# Default is the fail-loud live resolver above.
+resolve_send_backend = get_send_backend
+
+
+# ---------------------------------------------------------------------------
+# Send / draft request & response models (LOCAL — contract.py is frozen and
+# triage-only; the send handshake is not part of the #1262 contract).
+# ---------------------------------------------------------------------------
+
+
+class _Strict(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class EmailDraftRequest(_Strict):
+    """Propose a reply and obtain a confirmation token for it."""
+
+    to: List[EmailAddress] = Field(..., min_length=1)
+    subject: str
+    body: str
+
+
+class EmailDraftResponse(_Strict):
+    """The proposed reply plus a single-use confirmation token bound to it."""
+
+    draft: DraftReply
+    confirmation_token: str = Field(
+        ...,
+        description=(
+            "Echo this back to POST /v1/email/send to authorize sending "
+            "exactly this payload. Single-use; bound to (to, subject, body)."
+        ),
+    )
+
+
+class EmailSendRequest(_Strict):
+    """Send a reply. Requires a valid confirmation token for this payload."""
+
+    to: List[EmailAddress] = Field(..., min_length=1)
+    subject: str
+    body: str
+    confirmation_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "Confirmation token from POST /v1/email/draft. A send without a "
+            "valid token for this exact payload is rejected (403)."
+        ),
+    )
+
+
+class EmailSendResponse(_Strict):
+    sent_id: str
+    to: List[EmailAddress]
+    subject: str
+    sent: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+_service = EmailTriageService()
+
+
+@router.post("/triage", response_model=EmailTriageResponse)
+async def triage_email(request: EmailTriageRequest) -> EmailTriageResponse:
+    """Triage a single email or a full thread.
+
+    Accepts the FROZEN #1262 ``EmailTriageRequest`` (a single-email or
+    thread payload, discriminated on ``kind``) and returns the structured
+    ``EmailTriageResponse`` — category, spam/phishing signals, a plain-text
+    summary, extracted action items, and an optional draft-reply proposal.
+    No mail is read or sent; this analyzes only the payload in the request.
+    """
+    return _service.triage_request(request)
+
+
+@router.post("/draft", response_model=EmailDraftResponse)
+async def draft_reply(request: EmailDraftRequest) -> EmailDraftResponse:
+    """Propose a reply and mint a confirmation token bound to its payload.
+
+    The returned token must be echoed to :func:`send_email` to authorize
+    sending exactly this ``(to, subject, body)``. This is the explicit
+    user-confirmation step — the consuming app surfaces the draft to the
+    user, and only a user-approved send echoes the token back.
+    """
+    fingerprint = _payload_fingerprint(request.to, request.subject, request.body)
+    token = confirmation_store.issue(fingerprint)
+    draft = DraftReply(to=request.to, subject=request.subject, body=request.body)
+    return EmailDraftResponse(draft=draft, confirmation_token=token)
+
+
+@router.post("/send", response_model=EmailSendResponse)
+async def send_email(request: EmailSendRequest) -> EmailSendResponse:
+    """Send a reply — gated on explicit confirmation (#1264).
+
+    The confirmation gate is enforced FIRST: a request without a valid,
+    payload-bound confirmation token is rejected with HTTP 403 before any
+    backend call (or even backend resolution). This mirrors the agent's
+    ``TOOLS_REQUIRING_CONFIRMATION`` guard, translated to the API boundary,
+    and guarantees the gate fires regardless of backend health. Never
+    auto-confirms.
+    """
+    fingerprint = _payload_fingerprint(request.to, request.subject, request.body)
+    if not confirmation_store.consume(request.confirmation_token or "", fingerprint):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Send rejected: missing or invalid confirmation token for this "
+                "message. Call POST /v1/email/draft to obtain a confirmation "
+                "token bound to this exact (to, subject, body), then echo it in "
+                "'confirmation_token'. Emails are never sent without explicit "
+                "confirmation."
+            ),
+        )
+
+    # Gate passed — resolve the backend now (AFTER the gate) and send. Gmail's
+    # send takes a single 'to' header string.
+    backend = resolve_send_backend()
+    to_header = ", ".join(_format_address(a) for a in request.to)
+    result = backend.send_message(
+        to=to_header, subject=request.subject, body=request.body
+    )
+    sent_id = result.get("id") or ""
+    if not sent_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Email backend did not return a message id for the send.",
+        )
+    logger.info("email send: id=%s to=%s", sent_id, to_header)
+    return EmailSendResponse(sent_id=sent_id, to=request.to, subject=request.subject)
+
+
+__all__ = [
+    "router",
+    "EmailTriageService",
+    "ConfirmationStore",
+    "confirmation_store",
+    "get_send_backend",
+    "EmailDraftRequest",
+    "EmailDraftResponse",
+    "EmailSendRequest",
+    "EmailSendResponse",
+]

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -28,6 +28,7 @@ from fastapi.responses import StreamingResponse
 from gaia.agents.base.api_agent import ApiAgent
 
 from .agent_registry import registry
+from .email_routes import router as email_router
 from .schemas import (
     ChatCompletionChoice,
     ChatCompletionRequest,
@@ -93,6 +94,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Email Triage Agent REST surface (#1229): POST /v1/email/{triage,draft,send}.
+app.include_router(email_router)
 
 
 # Raw request logging middleware (debug mode only)

--- a/tests/integration/test_email_rest_api_e2e.py
+++ b/tests/integration/test_email_rest_api_e2e.py
@@ -1,0 +1,231 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+End-to-end pipeline test for the email agent REST surface (#1229).
+
+Drives the agent's REAL tool implementations against ``FakeGmailBackend``
+(the synthetic-corpus seam, never live mail) through the full pipeline:
+
+    pre-scan  ->  categorize  ->  summarize  ->  draft  ->  send-gate
+
+and asserts each stage's contract. The LLM/agent reasoning is NOT invoked —
+the deterministic heuristic fast-path and the pure ``*_impl`` tool functions
+are exercised directly, so the run is deterministic and needs neither a live
+Lemonade server nor an Anthropic key.
+
+The final stage proves the confirmation gate (#1264): ``send_now`` is in
+``TOOLS_REQUIRING_CONFIRMATION`` and is refused when the console denies the
+confirmation, and allowed only once it is granted. The REST boundary
+translation of this gate is covered separately in ``tests/test_api.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make tests.fixtures.email importable: parents[1]=tests, [2]=repo-root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# EmailTriageService lives in gaia.api.email_routes, which imports FastAPI.
+# FastAPI ships in the [api]/[ui] extras, NOT [dev] — skip the whole module
+# (rather than error at collection) when it is unavailable, matching how the
+# rest of the API tests degrade on a [dev]-only runner.
+pytest.importorskip("fastapi")
+
+from gaia.agents.email import action_store  # noqa: E402
+from gaia.agents.email.agent import EmailTriageAgent  # noqa: E402
+from gaia.agents.email.config import EmailAgentConfig  # noqa: E402
+from gaia.agents.email.tools.read_tools import (  # noqa: E402
+    get_message_impl,
+    pre_scan_inbox_impl,
+    triage_inbox_impl,
+)
+from gaia.agents.email.tools.reply_tools import (  # noqa: E402
+    draft_reply_impl,
+    send_now_impl,
+)
+from gaia.agents.email.tools.triage_heuristics import ALL_CATEGORIES  # noqa: E402
+from gaia.api.email_routes import EmailTriageService  # noqa: E402
+from gaia.database.mixin import DatabaseMixin  # noqa: E402
+from tests.fixtures.email.fake_gmail import (  # noqa: E402
+    FakeCalendarBackend,
+    FakeGmailBackend,
+)
+
+
+@pytest.fixture
+def stub_inbox_path() -> Path:
+    p = _REPO_ROOT / "tests" / "fixtures" / "email" / "_stub_inbox.mbox"
+    assert p.exists(), p
+    return p
+
+
+@pytest.fixture
+def fake_gmail(stub_inbox_path) -> FakeGmailBackend:
+    return FakeGmailBackend(stub_inbox_path)
+
+
+@pytest.fixture
+def db():
+    """In-memory DatabaseMixin seeded with the email action-store schema —
+    the same fixture shape used by the unit-tier reply/send tests."""
+
+    class _DB(DatabaseMixin):
+        def __init__(self):
+            self.init_db(":memory:")
+
+    d = _DB()
+    action_store.init_schema(d)
+    yield d
+    d.close_db()
+
+
+@pytest.fixture
+def agent(fake_gmail, tmp_path):
+    """A real ``EmailTriageAgent`` over the fake backends, with the LLM side
+    (``AgentSDK``) patched so no Lemonade connection is made. Used to drive
+    the agent's actual ``_execute_tool`` confirmation guard."""
+    cfg = EmailAgentConfig(
+        gmail_backend=fake_gmail,
+        calendar_backend=FakeCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+        debug=False,
+    )
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        a = EmailTriageAgent(config=cfg)
+    yield a
+    a.close_db()
+
+
+class TestEmailPipelineE2E:
+    """The full FakeGmail -> pre-scan -> categorize -> summarize -> draft ->
+    send-gate pipeline, deterministic (no LLM)."""
+
+    def test_pre_scan_stage_returns_structured_buckets(self, fake_gmail):
+        out = pre_scan_inbox_impl(fake_gmail, max_messages=50)
+        # Pre-scan surfaces a structured, bucketed view the chat card renders.
+        assert isinstance(out, dict)
+        # Backend was actually consulted (not a stub).
+        methods = {c[0] for c in fake_gmail.transport.calls}
+        assert "list_messages" in methods
+
+    def test_categorize_stage_uses_frozen_taxonomy(self, fake_gmail):
+        out = triage_inbox_impl(fake_gmail, max_messages=50)
+        results = out["results"]
+        assert results, "stub inbox should yield messages"
+        for r in results:
+            assert r["category"] in ALL_CATEGORIES
+
+    def test_summarize_stage_produces_contract_result_per_message(self, fake_gmail):
+        """Feed each fetched message through the REST service's summarizer and
+        assert it yields a contract-valid EmailTriageResult."""
+        from gaia.agents.email.contract import EmailTriageResult
+
+        service = EmailTriageService()
+        listing = fake_gmail.list_messages(label_ids=["INBOX"], max_results=5)
+        assert listing["messages"]
+        for stub in listing["messages"]:
+            msg = get_message_impl(fake_gmail, message_id=stub["id"])
+            result = service.triage_gmail_message(
+                msg, principal_email="user@example.com"
+            )
+            assert isinstance(result, EmailTriageResult)
+            assert result.category.value in ALL_CATEGORIES
+            assert result.summary
+
+    def test_draft_stage_creates_proposal_without_sending(self, fake_gmail, db):
+        listing = fake_gmail.list_messages(label_ids=["INBOX"], max_results=1)
+        msg_id = listing["messages"][0]["id"]
+        out = draft_reply_impl(
+            fake_gmail, db, message_id=msg_id, body="Thanks, will do."
+        )
+        assert out["draft_id"]
+        # Draft created a draft, but did NOT send anything.
+        sent_calls = [c for c in fake_gmail.transport.calls if c[0] == "send_draft"]
+        assert sent_calls == []
+        assert any(c[0] == "create_draft" for c in fake_gmail.transport.calls)
+
+    def test_send_gate_blocks_without_confirmation_then_allows(self, agent, fake_gmail):
+        """Drive the agent's REAL confirmation guard end-to-end.
+
+        ``send_now`` is in ``TOOLS_REQUIRING_CONFIRMATION``, so
+        ``_execute_tool`` consults ``console.confirm_tool_execution`` before
+        running. When the console denies, the tool returns ``status:
+        denied`` and NOTHING is sent to Gmail. When it grants, the send
+        reaches the backend. This is the agent-side analogue of the REST
+        confirmation gate."""
+        from gaia.agents.base.agent import TOOLS_REQUIRING_CONFIRMATION
+
+        assert "send_now" in TOOLS_REQUIRING_CONFIRMATION
+
+        args = {
+            "to": "alice@example.com",
+            "subject": "Re: budget",
+            "body": "Approved.",
+        }
+
+        # DENIED: the console refuses -> the tool body never runs.
+        agent.console.confirm_tool_execution = lambda name, a: False
+        denied = agent._execute_tool("send_now", dict(args))
+        assert denied.get("status") == "denied"
+        assert not any(
+            c[0] == "send_message" for c in fake_gmail.transport.calls
+        ), "send must not reach Gmail while confirmation is denied"
+
+        # GRANTED: the console approves -> the send reaches the backend.
+        agent.console.confirm_tool_execution = lambda name, a: True
+        granted = agent._execute_tool("send_now", dict(args))
+        import json
+
+        # send_now returns the canonical {"ok": true, "data": {...}} envelope.
+        envelope = json.loads(granted)
+        assert envelope["ok"] is True
+        assert envelope["data"]["sent"] is True
+        assert any(c[0] == "send_message" for c in fake_gmail.transport.calls)
+
+    def test_full_pipeline_one_run(self, fake_gmail, db):
+        """Single run touching every stage in order, asserting each contract."""
+        from gaia.agents.email.contract import EmailTriageResult
+
+        service = EmailTriageService()
+
+        # 1. pre-scan
+        pre = pre_scan_inbox_impl(fake_gmail, max_messages=50)
+        assert isinstance(pre, dict)
+
+        # 2. categorize
+        triaged = triage_inbox_impl(fake_gmail, max_messages=50)
+        assert triaged["results"]
+        first_id = triaged["results"][0]["id"]
+
+        # 3. summarize (contract result for the first message)
+        msg = get_message_impl(fake_gmail, message_id=first_id)
+        result = service.triage_gmail_message(msg, principal_email="user@example.com")
+        assert isinstance(result, EmailTriageResult)
+
+        # 4. draft (proposal only)
+        drafted = draft_reply_impl(
+            fake_gmail, db, message_id=first_id, body="Acknowledged."
+        )
+        assert drafted["draft_id"]
+        assert not any(
+            c[0] in ("send_message", "send_draft") for c in fake_gmail.transport.calls
+        )
+
+        # 5. send-gate: allowed once granted (the gate was approved).
+        sent = send_now_impl(
+            fake_gmail,
+            db,
+            to=drafted["to"] or "alice@example.com",
+            subject=drafted["subject"],
+            body="Acknowledged.",
+        )
+        assert sent["sent"] is True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1144,5 +1144,336 @@ class TestErrorResponseFormat:
         assert "detail" in error_data
 
 
+# =============================================================================
+# EMAIL AGENT REST SURFACE (#1229) — TestClient, no external server / Lemonade
+# =============================================================================
+#
+# These exercise the /v1/email/* endpoints added by src/gaia/api/email_routes.py.
+# The triage endpoint accepts / returns the FROZEN #1262 contract
+# (gaia.agents.email.contract). The send endpoint enforces the confirmation
+# gate (#1264) at the API boundary: a send without a valid confirmation token
+# is rejected with a 4xx — never silently auto-confirmed.
+
+
+def _single_email_payload(
+    *,
+    subject: str = "Can you review the Q3 budget?",
+    body: str = "Hi, please review the attached Q3 budget and reply by Friday.",
+    sender_email: str = "alice@example.com",
+    principal_email: str = "me@example.com",
+):
+    """A contract-valid SingleEmailInput request envelope."""
+    return {
+        "payload": {
+            "kind": "single",
+            "principal": {"email": principal_email},
+            "message": {
+                "message_id": "m-1",
+                "from": {"name": "Alice", "email": sender_email},
+                "to": [{"email": principal_email}],
+                "subject": subject,
+                "body": body,
+            },
+        }
+    }
+
+
+def _thread_payload(*, principal_email: str = "me@example.com"):
+    """A contract-valid ThreadInput request envelope (two messages)."""
+    return {
+        "payload": {
+            "kind": "thread",
+            "principal": {"email": principal_email},
+            "thread_id": "t-1",
+            "messages": [
+                {
+                    "message_id": "m-1",
+                    "thread_id": "t-1",
+                    "from": {"email": "bob@example.com"},
+                    "to": [{"email": principal_email}],
+                    "subject": "Project kickoff",
+                    "body": "Let's kick off the project next week.",
+                },
+                {
+                    "message_id": "m-2",
+                    "thread_id": "t-1",
+                    "from": {"email": principal_email},
+                    "to": [{"email": "bob@example.com"}],
+                    "subject": "Re: Project kickoff",
+                    "body": "Sounds good, please send the agenda.",
+                },
+            ],
+        }
+    }
+
+
+class TestEmailTriageEndpoint:
+    """POST /v1/email/triage — single email / thread in, structured result out."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        if not API_AVAILABLE:
+            pytest.skip(f"API dependencies not available: {IMPORT_ERROR}")
+        self.client = TestClient(app)
+
+    def test_single_email_in_structured_out(self):
+        """A single email in returns a contract-valid structured result."""
+        from gaia.agents.email.contract import SCHEMA_VERSION, parse_response
+        from gaia.agents.email.tools.triage_heuristics import ALL_CATEGORIES
+
+        resp = self.client.post("/v1/email/triage", json=_single_email_payload())
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+
+        # Round-trips through the FROZEN contract (extra="forbid" — any drift
+        # from the #1262 shape raises here).
+        parsed = parse_response(data)
+        assert parsed.schema_version == SCHEMA_VERSION
+        assert parsed.request_kind == "single"
+        assert parsed.result.category.value in ALL_CATEGORIES
+        assert parsed.result.summary  # non-empty plain-text summary
+
+    def test_thread_in_structured_out(self):
+        """A full thread in returns request_kind == 'thread'."""
+        from gaia.agents.email.contract import parse_response
+
+        resp = self.client.post("/v1/email/triage", json=_thread_payload())
+        assert resp.status_code == 200, resp.text
+        parsed = parse_response(resp.json())
+        assert parsed.request_kind == "thread"
+        assert parsed.result.summary
+        # The thread's last message is from the principal, so there is no one
+        # to reply to — no draft is proposed.
+        assert parsed.result.draft is None
+
+    def test_single_email_proposes_draft_to_sender(self):
+        """An inbound email from someone else yields a draft addressed back
+        to that sender."""
+        from gaia.agents.email.contract import parse_response
+
+        resp = self.client.post(
+            "/v1/email/triage",
+            json=_single_email_payload(sender_email="bob@example.com"),
+        )
+        assert resp.status_code == 200, resp.text
+        parsed = parse_response(resp.json())
+        assert parsed.result.draft is not None
+        assert parsed.result.draft.to[0].email == "bob@example.com"
+        assert parsed.result.draft.subject.lower().startswith("re:")
+
+    def test_promotional_email_is_low_priority(self):
+        """The agent's real heuristic categorizer drives the result —
+        a promo subject lands in 'low priority' deterministically."""
+        from gaia.agents.email.contract import parse_response
+        from gaia.agents.email.tools.triage_heuristics import CATEGORY_LOW_PRIORITY
+
+        payload = _single_email_payload(
+            subject="50% off — sale ends tonight!",
+            body="Shop our biggest sale of the year.",
+            sender_email="deals@store.example.com",
+        )
+        resp = self.client.post("/v1/email/triage", json=payload)
+        assert resp.status_code == 200, resp.text
+        parsed = parse_response(resp.json())
+        assert parsed.result.category.value == CATEGORY_LOW_PRIORITY
+
+    def test_response_matches_contract_schema_shape(self):
+        """The response body has exactly the #1262 top-level keys."""
+        resp = self.client.post("/v1/email/triage", json=_single_email_payload())
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert set(data.keys()) == {"schema_version", "request_kind", "result"}
+        assert set(data["result"].keys()) >= {
+            "category",
+            "is_spam",
+            "is_phishing",
+            "summary",
+            "action_items",
+            "draft",
+        }
+
+    def test_unknown_field_rejected_422(self):
+        """extra='forbid' on the frozen contract → unknown field is a 422."""
+        payload = _single_email_payload()
+        payload["payload"]["message"]["totally_unknown_field"] = "x"
+        resp = self.client.post("/v1/email/triage", json=payload)
+        assert resp.status_code == 422
+
+    def test_empty_thread_rejected_422(self):
+        """A thread with no messages violates the contract (min_length=1)."""
+        payload = _thread_payload()
+        payload["payload"]["messages"] = []
+        resp = self.client.post("/v1/email/triage", json=payload)
+        assert resp.status_code == 422
+
+    def test_missing_payload_rejected_422(self):
+        resp = self.client.post("/v1/email/triage", json={})
+        assert resp.status_code == 422
+
+
+class TestEmailSendConfirmationGate:
+    """POST /v1/email/send — the send path MUST reject when confirmation is
+    absent (#1264). This is the security-critical acceptance criterion.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        if not API_AVAILABLE:
+            pytest.skip(f"API dependencies not available: {IMPORT_ERROR}")
+        # Inject an in-memory Gmail backend so the (authorized) send path
+        # never touches live mail. The gate-rejection cases never reach the
+        # backend — the confirmation check is enforced first.
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        from gaia.api import email_routes
+        from tests.fixtures.email.fake_gmail import FakeGmailBackend
+
+        self.fake_backend = FakeGmailBackend()
+        monkeypatch.setattr(
+            email_routes, "resolve_send_backend", lambda: self.fake_backend
+        )
+        self.client = TestClient(app)
+
+    def test_send_without_confirmation_token_is_4xx(self):
+        """No confirmation token → server-side rejection in the 4xx range."""
+        resp = self.client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: budget",
+                "body": "Looks good, approved.",
+            },
+        )
+        assert 400 <= resp.status_code < 500
+        # Actionable error names the missing confirmation.
+        assert "confirm" in resp.text.lower()
+
+    def test_send_with_empty_confirmation_token_is_4xx(self):
+        """An empty/blank token is not a confirmation."""
+        resp = self.client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: budget",
+                "body": "Looks good, approved.",
+                "confirmation_token": "",
+            },
+        )
+        # Exactly 403 (the gate), not an incidental 404 — the route exists.
+        assert resp.status_code == 403
+
+    def test_send_with_invalid_confirmation_token_is_4xx(self):
+        """A token that was never issued is rejected."""
+        resp = self.client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: budget",
+                "body": "Looks good, approved.",
+                "confirmation_token": "not-a-real-token",
+            },
+        )
+        assert resp.status_code == 403
+
+    def test_draft_then_send_with_valid_token_succeeds(self):
+        """The golden path: draft issues a confirmation token bound to the
+        exact payload; echoing it back authorizes the send."""
+        draft_resp = self.client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: budget",
+                "body": "Looks good, approved.",
+            },
+        )
+        assert draft_resp.status_code == 200, draft_resp.text
+        token = draft_resp.json()["confirmation_token"]
+        assert token
+
+        send_resp = self.client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: budget",
+                "body": "Looks good, approved.",
+                "confirmation_token": token,
+            },
+        )
+        assert send_resp.status_code == 200, send_resp.text
+        body = send_resp.json()
+        assert body["sent"] is True
+        assert body["sent_id"]
+
+    def test_token_does_not_authorize_a_different_payload(self):
+        """A token is bound to its payload — you cannot reuse it to send
+        different content (prevents bait-and-switch)."""
+        draft_resp = self.client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: budget",
+                "body": "Looks good, approved.",
+            },
+        )
+        token = draft_resp.json()["confirmation_token"]
+
+        # Same token, different body → rejected.
+        send_resp = self.client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "attacker@evil.example.com"}],
+                "subject": "Re: budget",
+                "body": "Wire $10,000 to account 12345.",
+                "confirmation_token": token,
+            },
+        )
+        assert send_resp.status_code == 403
+
+    def test_confirmation_token_is_single_use(self):
+        """A token authorizes exactly one send; a replay is rejected."""
+        payload = {
+            "to": [{"email": "alice@example.com"}],
+            "subject": "Re: budget",
+            "body": "Looks good, approved.",
+        }
+        token = self.client.post("/v1/email/draft", json=payload).json()[
+            "confirmation_token"
+        ]
+        first = self.client.post(
+            "/v1/email/send", json={**payload, "confirmation_token": token}
+        )
+        assert first.status_code == 200, first.text
+        # Replaying the consumed token must NOT send again.
+        replay = self.client.post(
+            "/v1/email/send", json={**payload, "confirmation_token": token}
+        )
+        assert replay.status_code == 403
+
+    def test_gate_fires_before_backend_resolution(self, monkeypatch):
+        """The confirmation gate is checked BEFORE the send backend is
+        resolved: a no-token send returns 403 even when the backend is
+        unavailable (would otherwise 503). The gate must never be masked by
+        backend health."""
+        from gaia.api import email_routes
+
+        def _boom():
+            raise AssertionError("backend resolved before the gate — gate bypassed")
+
+        monkeypatch.setattr(email_routes, "resolve_send_backend", _boom)
+        resp = self.client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: budget",
+                "body": "Looks good, approved.",
+            },
+        )
+        assert resp.status_code == 403
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #1229

Before: a host app had no way to invoke the email agent programmatically — the frozen #1262 contract existed but nothing served it. After: `POST /v1/email/triage` accepts a single email or a thread (per #1262) and returns structured results; `/v1/email/draft` issues a single-use, payload-bound confirmation token; `/v1/email/send` returns **403** without a valid token, and the gate fires *before* the backend is resolved — nothing can auto-send. This is the surface #1104 (MCP stdio) and #1263 (HTML spec) build on.

## Test plan
- [x] `TestEmailTriageEndpoint` — single-in → contract-shaped struct-out (single + thread)
- [x] `TestEmailSendConfirmationGate` — 403 on missing/empty/invalid/mismatched/replayed token, before backend resolution
- [x] `test_email_rest_api_e2e.py` — FakeGmail → pre-scan → categorize → summarize → draft → send-gate (LLM mocked)
- [x] 67 passed / 47 skipped (live-server fixtures); lint clean

Targets the `tmi/infallible-payne-e3c628` integration branch (not main). Did not touch `agent.py` (#1106) or the frozen `contract.py`.