### PR TITLE
docs(cli): fix Jira CLI card to reflect direct Atlassian REST API access

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -883,7 +883,7 @@ gaia talk -i guide.pdf --no-tts
 ### Jira Command
 
 <Card title="Jira / Atlassian" icon="ticket" href="/guides/jira">
-  Natural-language interface for Jira, Confluence, and Compass via the MCP bridge.
+  Natural-language interface for Jira, Confluence, and Compass using your Atlassian credentials (REST API).
 </Card>
 
 ```bash


### PR DESCRIPTION
## Why this matters

A review comment on the merged #1337 ([review](https://github.com/amd/gaia/pull/1337#pullrequestreview-4405945592)) flagged a docs-accuracy bug: the new Jira CLI card said `gaia jira` works "via the MCP bridge." That's wrong and could send users down a needless setup path. The code path (`handle_jira_command` → imports `gaia.apps.jira.app` directly, comment: *"no MCP needed"*) and the Jira guide (*"communicates directly with the Atlassian REST API — no intermediary services or MCP bridge required"*) both contradict the card. This aligns the card with the code and the guide.

The `--mcp-host` / `--mcp-port` flags are a real optional integration (they exist in the `jira` subparser), so they remain in the options table — only the high-level description changed.

## Test plan

- [ ] Card description at `docs/reference/cli.mdx` Jira section now reads "using your Atlassian credentials (REST API)" and matches `docs/guides/jira.mdx`.
- [ ] `gaia jira -h` still lists `--mcp-host`/`--mcp-port` (options table unchanged).