### PR TITLE
feat(connectors): Microsoft OAuth provider for MS Graph (#1105)

### DIFF
--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -25,15 +25,16 @@ secret** — so you only paste **one** value into GAIA: an **Application
 
 ## Step 1 — Create an app registration
 
-1. Go to the [Azure Portal → App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).
-2. Click **New registration**.
-3. **Name**: `GAIA Personal` (or whatever you want).
-4. **Supported account types**: choose **Personal Microsoft accounts
+1. In the [Azure Portal](https://portal.azure.com), go to **Microsoft Entra
+   ID → App registrations → New registration**. (Direct link:
+   [App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).)
+2. **Name**: `GAIA Personal` (or whatever you want).
+3. **Supported account types**: choose **Personal Microsoft accounts
    only**. <Tooltip tip="This matches GAIA's `consumers` tenant. If you
    pick a broader option the consent screen still works for personal
    accounts, but org accounts may be blocked by conditional access.">Why
    this option?</Tooltip>
-5. Leave **Redirect URI** empty for now and click **Register**.
+4. Leave **Redirect URI** empty for now and click **Register**.
 
 ## Step 2 — Add the loopback redirect URI
 

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -1,0 +1,138 @@
+---
+title: "Microsoft"
+icon: "microsoft"
+description: "Connect GAIA to Outlook mail, calendar, and OneDrive via Microsoft Graph."
+---
+
+<Info>
+  **Connector ID:** `microsoft` · **Type:** `oauth_pkce` · **Catalog entry:** [`src/gaia/connectors/catalog/microsoft.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/catalog/microsoft.py)
+</Info>
+
+This connector targets **personal Microsoft accounts** (Outlook.com,
+Hotmail, Live.com) — the `consumers` tenant of the Microsoft identity
+platform. Work/school (Azure AD organization) accounts are tracked
+separately.
+
+## What you'll need
+
+Microsoft requires every desktop app — including GAIA running locally —
+to identify itself with an **app registration** that you create in the
+Azure Portal. For a single developer it takes a few minutes and is free.
+
+Unlike Google, a Microsoft **public client** uses PKCE **without a client
+secret** — so you only paste **one** value into GAIA: an **Application
+(client) ID**. GAIA stores it encrypted in your OS keyring.
+
+## Step 1 — Create an app registration
+
+1. Go to the [Azure Portal → App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).
+2. Click **New registration**.
+3. **Name**: `GAIA Personal` (or whatever you want).
+4. **Supported account types**: choose **Personal Microsoft accounts
+   only**. <Tooltip tip="This matches GAIA's `consumers` tenant. If you
+   pick a broader option the consent screen still works for personal
+   accounts, but org accounts may be blocked by conditional access.">Why
+   this option?</Tooltip>
+5. Leave **Redirect URI** empty for now and click **Register**.
+
+## Step 2 — Add the desktop/loopback redirect
+
+1. In your new app, go to **Authentication → Add a platform**.
+2. Pick **Mobile and desktop applications**. <Tooltip tip="GAIA runs a
+   temporary loopback web server on 127.0.0.1 to receive the OAuth
+   callback. The 'Mobile and desktop applications' platform allows the
+   http://localhost loopback redirect that a 'Web' platform would
+   reject.">Why this platform?</Tooltip>
+3. Check (or add) the redirect URI **`http://localhost`**.
+4. Click **Configure** / **Save**.
+
+<Warning>
+  Do **not** create a client secret. Microsoft public clients authenticate
+  the token exchange with PKCE; a secret is neither needed nor used by
+  GAIA. (If you registered a "Web" platform with a secret, delete it and
+  add the "Mobile and desktop applications" platform instead.)
+</Warning>
+
+## Step 3 — Copy the Application (client) ID
+
+In your app's **Overview** page, copy the **Application (client) ID** — a
+GUID like `00000000-1111-2222-3333-444444444444`.
+
+## Step 4 — Paste it into GAIA
+
+1. Launch the Agent UI: `gaia chat --ui`.
+2. Click **Settings** (gear) → **Connections**.
+3. Click the **Microsoft** tile to expand it.
+4. Paste the **Application (client) ID** from Step 3.
+5. Click **Save & Connect**.
+
+GAIA will:
+
+1. Store the client ID in your OS keyring (macOS Keychain,
+   gnome-keyring/kwallet on Linux, Credential Locker on Windows).
+2. Open the Microsoft consent screen in your default browser.
+3. Receive the callback on a temporary loopback server.
+4. Exchange the auth code for a refresh token (also stored in the
+   keyring). The `offline_access` scope is requested automatically so a
+   refresh token is issued.
+
+The tile flips to **Connected** once the flow completes.
+
+## Step 5 — Grant scopes to specific agents
+
+Connecting Microsoft doesn't automatically give every agent access to
+your mailbox. Each agent must be granted the specific scopes it needs:
+
+```bash
+# Grant the chat agent read-only Outlook mail access
+gaia connectors grants grant microsoft builtin:chat \
+  --scopes https://graph.microsoft.com/Mail.Read
+```
+
+The default and available scopes are listed in the spec at
+[`src/gaia/connectors/catalog/microsoft.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/catalog/microsoft.py).
+
+## Common issues
+
+### `redirect_uri mismatch` / `AADSTS500113`
+
+You either skipped Step 2 or added the redirect under a "Web" platform.
+Add `http://localhost` under **Mobile and desktop applications** in
+**Authentication**.
+
+### `AADSTS700016` / "application not found in the directory"
+
+The Application (client) ID is wrong, or the app was registered under a
+different account type. Re-copy the ID from the app's **Overview** page
+and confirm the app's supported account types include personal accounts.
+
+### Token endpoint returned no `refresh_token`
+
+The `offline_access` scope was not requested. GAIA includes it in the
+connector's `default_scopes`; if you've customized scopes, make sure
+`offline_access` is still present.
+
+### Work/school account is blocked
+
+This connector uses the `consumers` (personal-account) tenant. Azure AD
+organization accounts are out of scope here — see the connectors roadmap
+for the enterprise (work/school) Graph path.
+
+## Revoking access
+
+Two places — both work:
+
+- **From GAIA**: Settings → Connections → Microsoft → **Disconnect**.
+  Removes the refresh token from the keyring; the next API call errors
+  with `NOT_CONNECTED`.
+- **From Microsoft**: <a href="https://account.live.com/consent/Manage"
+  target="_blank">account.live.com/consent/Manage</a> → find the app →
+  **Remove these permissions**. Useful if you've lost the laptop the
+  keyring lives on.
+
+## See also
+
+- [Connectors overview](/connectors)
+- [Google connector](/connectors/google)
+- [Microsoft identity platform — OAuth 2.0 auth code + PKCE](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-auth-code-flow)
+- [Connectors security model](/security/connections)

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -29,11 +29,7 @@ secret** — so you only paste **one** value into GAIA: an **Application
    ID → App registrations → New registration**. (Direct link:
    [App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).)
 2. **Name**: `GAIA Personal` (or whatever you want).
-3. **Supported account types**: choose **Personal Microsoft accounts
-   only**. <Tooltip tip="This matches GAIA's `consumers` tenant. If you
-   pick a broader option the consent screen still works for personal
-   accounts, but org accounts may be blocked by conditional access.">Why
-   this option?</Tooltip>
+3. **Supported account types**: choose **Personal accounts only**.
 4. Leave **Redirect URI** empty for now and click **Register**.
 
 ## Step 2 — Add the loopback redirect URI

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -35,22 +35,41 @@ secret** — so you only paste **one** value into GAIA: an **Application
    this option?</Tooltip>
 5. Leave **Redirect URI** empty for now and click **Register**.
 
-## Step 2 — Add the desktop/loopback redirect
+## Step 2 — Add the loopback redirect URI
 
-1. In your new app, go to **Authentication → Add a platform**.
-2. Pick **Mobile and desktop applications**. <Tooltip tip="GAIA runs a
-   temporary loopback web server on 127.0.0.1 to receive the OAuth
-   callback. The 'Mobile and desktop applications' platform allows the
-   http://localhost loopback redirect that a 'Web' platform would
-   reject.">Why this platform?</Tooltip>
-3. Check (or add) the redirect URI **`http://localhost`**.
-4. Click **Configure** / **Save**.
+GAIA receives the OAuth callback on a temporary loopback server and sends
+the redirect URI **`http://127.0.0.1/callback`**. Register that exact value.
+
+Microsoft ignores the *port* for loopback redirect URIs, so GAIA's
+dynamically-chosen port matches the port-less registered value. The
+scheme, host, and **`/callback` path must match exactly** — `127.0.0.1` and
+`localhost` are *not* interchangeable, and a bare `http://127.0.0.1` (no
+path) will not work.
+
+**Via the Authentication UI:**
+
+1. In your app, go to **Authentication → Add a platform → Mobile and
+   desktop applications**.
+2. In **Add Redirect URI**, enter **`http://127.0.0.1/callback`** and
+   **Save**.
+
+**If the portal rejects the `http://` + `127.0.0.1` combination** (a
+documented limitation of the classic Redirect URI textbox), add it through
+the **Manifest** instead — it's a one-value edit. The manifest is in the
+*Microsoft Graph* app-manifest format:
+
+```json
+"publicClient": {
+  "redirectUris": [
+    "http://127.0.0.1/callback"
+  ]
+}
+```
 
 <Warning>
   Do **not** create a client secret. Microsoft public clients authenticate
   the token exchange with PKCE; a secret is neither needed nor used by
-  GAIA. (If you registered a "Web" platform with a secret, delete it and
-  add the "Mobile and desktop applications" platform instead.)
+  GAIA.
 </Warning>
 
 ## Step 3 — Copy the Application (client) ID
@@ -94,11 +113,15 @@ The default and available scopes are listed in the spec at
 
 ## Common issues
 
-### `redirect_uri mismatch` / `AADSTS500113`
+### `invalid_request: The provided value for the input parameter 'redirect_uri' is not valid`
 
-You either skipped Step 2 or added the redirect under a "Web" platform.
-Add `http://localhost` under **Mobile and desktop applications** in
-**Authentication**.
+Your registered redirect URI doesn't match what GAIA sends
+(`http://127.0.0.1/callback`). Common causes: you registered a bare
+`http://127.0.0.1` (missing the `/callback` path), used `localhost` instead
+of `127.0.0.1`, or added it as a "Web" platform redirect instead of
+**Mobile and desktop applications**. Register exactly
+`http://127.0.0.1/callback` as described in Step 2 — the port is ignored
+for loopback, so you do not register a port.
 
 ### `AADSTS700016` / "application not found in the directory"
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,6 +88,7 @@
                 "pages": [
                   "connectors/index",
                   "connectors/google",
+                  "connectors/microsoft",
                   "connectors/github",
                   "security/connections"
                 ]

--- a/docs/runbooks/microsoft-oauth-client.md
+++ b/docs/runbooks/microsoft-oauth-client.md
@@ -42,11 +42,18 @@ Application (client) ID. Do NOT commit the id into the repository.
    - Supported account types: **Personal Microsoft accounts only**
      (matches the `consumers` tenant).
 3. **Authentication → Add a platform → Mobile and desktop applications**:
-   - Add redirect URI **`http://localhost`** (loopback — GAIA binds an
-     ephemeral port on `127.0.0.1`, which Azure permits for public-client
-     loopback redirects).
+   - Add the redirect URI **`http://127.0.0.1/callback`**. GAIA's loopback
+     server sends this exact value; the port is dynamic and Microsoft
+     ignores it for loopback, but scheme/host/path must match (the
+     `/callback` path is required, so a bare `http://127.0.0.1` won't work).
+     If the portal's redirect textbox rejects the `http://` + `127.0.0.1`
+     combination, add it via the **Manifest** (Microsoft Graph format):
+     `"publicClient": { "redirectUris": ["http://127.0.0.1/callback"] }`.
    - **Do not** add a client secret.
 4. Copy the **Application (client) ID** from the app's **Overview** page.
+
+> GAIA uses the `127.0.0.1` loopback (Microsoft's own recommendation over
+> `localhost`, for IPv4/IPv6 reliability) for both Google and Microsoft.
 
 ## Tenant choice
 
@@ -104,5 +111,5 @@ Trouble: "Connect button does nothing in AgentUI."
 1. Confirm `GAIA_MICROSOFT_CLIENT_ID` is set (or credentials were saved via
    the Settings → Connections → Microsoft form).
 2. Check the AgentUI server log for the connectors tripwire sweep on boot.
-3. If the loopback callback timed out: the loopback uses an ephemeral port
-   (`127.0.0.1:0`), so a firewall misconfiguration is the usual culprit.
+3. If the loopback callback timed out: the loopback binds `127.0.0.1` on an
+   ephemeral port, so a firewall misconfiguration is the usual culprit.

--- a/docs/runbooks/microsoft-oauth-client.md
+++ b/docs/runbooks/microsoft-oauth-client.md
@@ -1,0 +1,108 @@
+# Microsoft OAuth Client — Runbook
+
+**Owner:** GAIA team (file an issue → @kovtcharov-amd for changes).
+**Audience:** GAIA core maintainers and CI operators.
+
+This runbook documents how the Microsoft OAuth client used by
+`gaia.connectors` is created, rotated, and consumed. It is **not**
+user-facing — end users never need to know the `client_id`.
+
+## What this client is
+
+A **public client** ("Mobile and desktop applications" platform) app
+registration on the Microsoft identity platform v2.0, targeting the
+`consumers` tenant (personal Microsoft accounts — Outlook.com / Hotmail /
+Live.com). PKCE is used for the authorization code flow; **there is no
+client secret** — PKCE replaces it. Tokens are stored in the user's OS
+keychain by `gaia.connectors.store`; nothing about the client travels with
+the user's data.
+
+## Configuration
+
+Set the environment variable before any GAIA process starts:
+
+```bash
+export GAIA_MICROSOFT_CLIENT_ID="<application-client-id-guid>"
+```
+
+The connectors layer reads this at first use
+(`gaia.connectors.providers.get("microsoft")`). Missing → the layer raises
+`ConfigurationError`; the AgentUI surfaces the connector as "not
+configured" but the rest of the AgentUI keeps working.
+
+For development against personal Microsoft accounts, register your own
+public-client app in the Azure Portal and set the env var to its
+Application (client) ID. Do NOT commit the id into the repository.
+
+## Azure Portal setup
+
+1. Visit <https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade>.
+2. **New registration**:
+   - Name: `GAIA Desktop` (or similar).
+   - Supported account types: **Personal Microsoft accounts only**
+     (matches the `consumers` tenant).
+3. **Authentication → Add a platform → Mobile and desktop applications**:
+   - Add redirect URI **`http://localhost`** (loopback — GAIA binds an
+     ephemeral port on `127.0.0.1`, which Azure permits for public-client
+     loopback redirects).
+   - **Do not** add a client secret.
+4. Copy the **Application (client) ID** from the app's **Overview** page.
+
+## Tenant choice
+
+This provider hard-codes `TENANT = "consumers"` in
+[`src/gaia/connectors/providers/microsoft.py`](../../src/gaia/connectors/providers/microsoft.py).
+
+- `consumers` — personal accounts only (the #1105 scope).
+- `organizations` — Azure AD work/school accounts only.
+- `common` — both, but trips conditional access on some tenants.
+
+Switching audiences is a one-line change to the `TENANT` constant, but
+enterprise (work/school) Graph access is tracked as separate P2 work
+(#1280 / #1281) and should not be bundled into the personal-account path.
+
+## Rotation procedure
+
+Rotation is **expected to invalidate every existing user's stored refresh
+token** because the connectors layer's `client_id_hash` tripwire detects
+the mismatch and clears entries on next read.
+
+1. Create a new app registration in the Azure Portal (don't delete the old
+   one yet).
+2. Update `GAIA_MICROSOFT_CLIENT_ID` everywhere (CI secrets, environment
+   files, internal docs).
+3. Restart all GAIA processes. The lifespan tripwire sweep clears stored
+   entries that were bound to the old `client_id_hash`.
+4. Users see a "Reconnect" prompt in AgentUI Settings → Connections (or
+   `gaia connectors connect microsoft` from the CLI). They re-authorize.
+5. Once all known users have reconnected, delete the old app registration.
+
+What breaks during rotation:
+- Active access tokens issued under the old `client_id` continue to work
+  until they expire (~1 hour).
+- Refresh tokens issued under the old `client_id` are rejected by Microsoft
+  with `invalid_grant`. The user reconnects; nothing else fails.
+
+## Security boundaries
+
+- Refresh tokens NEVER cross the public Python API or the FastAPI router.
+- There is no client secret to leak — the public-client PKCE flow does not
+  use one.
+- The `client_id_hash` is a **CRC32** fingerprint of the client id (NOT a
+  cryptographic hash, and NOT the client id itself); it is used only for
+  log correlation and the rotation tripwire, so it can be logged without
+  leaking the client id.
+- The OAuth `state` parameter is a per-flow random nonce compared via
+  `hmac.compare_digest`; mismatched callbacks return 400.
+- A refresh token is issued only because the `offline_access` scope is in
+  the connector's `default_scopes`.
+
+## Diagnostics
+
+Trouble: "Connect button does nothing in AgentUI."
+
+1. Confirm `GAIA_MICROSOFT_CLIENT_ID` is set (or credentials were saved via
+   the Settings → Connections → Microsoft form).
+2. Check the AgentUI server log for the connectors tripwire sweep on boot.
+3. If the loopback callback timed out: the loopback uses an ephemeral port
+   (`127.0.0.1:0`), so a firewall misconfiguration is the usual culprit.

--- a/docs/runbooks/microsoft-oauth-client.md
+++ b/docs/runbooks/microsoft-oauth-client.md
@@ -36,7 +36,9 @@ Application (client) ID. Do NOT commit the id into the repository.
 
 ## Azure Portal setup
 
-1. Visit <https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade>.
+1. In the [Azure Portal](https://portal.azure.com), go to **Microsoft Entra
+   ID → App registrations** (direct link:
+   <https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade>).
 2. **New registration**:
    - Name: `GAIA Desktop` (or similar).
    - Supported account types: **Personal Microsoft accounts only**

--- a/src/gaia/connectors/catalog/__init__.py
+++ b/src/gaia/connectors/catalog/__init__.py
@@ -19,5 +19,6 @@ things, then add an import here.
 
 from gaia.connectors.catalog import google  # noqa: F401
 from gaia.connectors.catalog import mcp_servers  # noqa: F401
+from gaia.connectors.catalog import microsoft  # noqa: F401
 
-__all__ = ["google", "mcp_servers"]
+__all__ = ["google", "microsoft", "mcp_servers"]

--- a/src/gaia/connectors/catalog/microsoft.py
+++ b/src/gaia/connectors/catalog/microsoft.py
@@ -70,10 +70,13 @@ MICROSOFT_SPEC = ConnectorSpec(
             label="Application (client) ID",
             kind="text",
             help_md=(
-                "From the Azure Portal → App registrations → your app → "
-                "Overview. Register the app with the **Mobile and desktop "
-                "applications** platform and redirect URI `http://localhost`. "
-                "No client secret is required for the PKCE public-client flow."
+                "From the Azure Portal → App registrations → your app. "
+                "Register the app as a public client (Authentication → Mobile "
+                "and desktop applications) with the redirect URI "
+                "`http://127.0.0.1/callback` (GAIA's loopback callback; the "
+                "port is dynamic and Microsoft ignores it for loopback). No "
+                "client secret is required for the PKCE public-client flow. "
+                "See docs/connectors/microsoft.mdx for the exact setup."
             ),
         ),
     ),

--- a/src/gaia/connectors/catalog/microsoft.py
+++ b/src/gaia/connectors/catalog/microsoft.py
@@ -1,0 +1,82 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Microsoft connector catalog entry (MS Graph, personal accounts).
+
+Registers the Microsoft OAuth PKCE ConnectorSpec into the global REGISTRY and
+imports ``oauth_pkce`` so its handler is registered into ``_HANDLER_REGISTRY``.
+
+``offline_access`` is kept in ``default_scopes`` so every connect issues a
+refresh token (MS Graph's equivalent of Google's ``access_type=offline``).
+The token endpoint returns no refresh token without it, and the shared flow
+raises ``ConnectorsError`` in that case.
+"""
+
+import gaia.connectors.oauth_pkce  # noqa: F401  # pylint: disable=unused-import
+from gaia.connectors.registry import REGISTRY
+from gaia.connectors.spec import ConfigField, ConnectorSpec
+
+MICROSOFT_SPEC = ConnectorSpec(
+    id="microsoft",
+    display_name="Microsoft",
+    icon="https://upload.wikimedia.org/wikipedia/commons/4/44/Microsoft_logo.svg",
+    category="productivity",
+    tier=1,
+    type="oauth_pkce",
+    description=(
+        "Connect GAIA to your personal Microsoft account for Outlook mail, "
+        "calendar, and OneDrive via Microsoft Graph."
+    ),
+    instructions_md=(
+        "Sign in with your personal Microsoft account (Outlook.com, Hotmail, "
+        "or Live.com) to allow GAIA to access Outlook mail, your calendar, and "
+        "OneDrive. You can revoke access at any time from your "
+        "[Microsoft account privacy page](https://account.live.com/consent/Manage)."
+    ),
+    product_url="https://www.microsoft.com/microsoft-365",
+    docs_url="https://amd-gaia.ai/docs/connectors/microsoft",
+    default_scopes=(
+        "openid",
+        "profile",
+        "email",
+        # offline_access is REQUIRED for a refresh token (MS Graph's
+        # equivalent of Google's access_type=offline). Without it the token
+        # endpoint returns no refresh_token and the flow fails.
+        "offline_access",
+        "https://graph.microsoft.com/User.Read",
+    ),
+    available_scopes=(
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "https://graph.microsoft.com/User.Read",
+        # Scopes named in issue #1105 — listed in available_scopes so the
+        # per-agent grant ledger will accept token requests for them.
+        "https://graph.microsoft.com/Mail.Read",
+        "https://graph.microsoft.com/Mail.Send",
+        "https://graph.microsoft.com/Calendars.ReadWrite",
+        "https://graph.microsoft.com/Files.Read",
+    ),
+    oauth_provider_ref="microsoft",
+    # First-time setup form rendered by the AgentUI. Microsoft public
+    # (native/desktop) clients use PKCE WITHOUT a client secret, so — unlike
+    # Google — only the Application (client) ID is collected. The value is
+    # stored in the OS keyring and reused across connect/disconnect cycles.
+    # Power users may bypass the form with GAIA_MICROSOFT_CLIENT_ID.
+    oauth_setup_fields=(
+        ConfigField(
+            key="client_id",
+            label="Application (client) ID",
+            kind="text",
+            help_md=(
+                "From the Azure Portal → App registrations → your app → "
+                "Overview. Register the app with the **Mobile and desktop "
+                "applications** platform and redirect URI `http://localhost`. "
+                "No client secret is required for the PKCE public-client flow."
+            ),
+        ),
+    ),
+)
+
+REGISTRY.register(MICROSOFT_SPEC)

--- a/src/gaia/connectors/providers/__init__.py
+++ b/src/gaia/connectors/providers/__init__.py
@@ -45,9 +45,16 @@ def get(provider_id: str) -> OAuthProvider:
         register(provider)
         return provider
 
+    if provider_id == "microsoft":
+        from gaia.connectors.providers.microsoft import MicrosoftOAuthProvider
+
+        provider = MicrosoftOAuthProvider()
+        register(provider)
+        return provider
+
     raise KeyError(
         f"Unknown OAuth provider '{provider_id}'. Known: "
-        f"{sorted(set(_registry) | {'google'})}"
+        f"{sorted(set(_registry) | {'google', 'microsoft'})}"
     )
 
 

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -108,10 +108,11 @@ class MicrosoftOAuthProvider:
                 "Microsoft OAuth client is not configured. Open Settings → "
                 "Connections → Microsoft in the AgentUI and paste the "
                 "Application (client) ID from your Azure app registration "
-                "(Mobile and desktop applications platform, redirect "
-                "http://localhost). No client secret is needed. (Power users "
-                "may also set the GAIA_MICROSOFT_CLIENT_ID env var before "
-                "launching GAIA.) See docs/runbooks/microsoft-oauth-client.md."
+                "(public client; register the redirect URI "
+                "http://127.0.0.1/callback). No client secret is needed. "
+                "(Power users may also set the GAIA_MICROSOFT_CLIENT_ID env "
+                "var before launching GAIA.) See "
+                "docs/runbooks/microsoft-oauth-client.md."
             )
         self.client_id: str = resolved_id
         # CRC32 fingerprint for log correlation / tripwire comparison only.

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -1,0 +1,165 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Microsoft OAuth 2.0 provider for ``gaia.connectors`` (MS Graph).
+
+NO module-level side effects: instantiating the provider reads
+``GAIA_MICROSOFT_CLIENT_ID`` and computes ``client_id_hash``. Importing this
+module does not register anything — registration happens in
+``providers/__init__.py`` lazily on first ``get("microsoft")`` call.
+
+Microsoft identity platform v2.0, PKCE for **public clients**: unlike Google,
+the token endpoint does NOT require a ``client_secret`` for a "Mobile and
+desktop applications" (native/public) Azure app registration — PKCE replaces
+it. So the setup form collects a Client ID only and no secret is ever sent.
+
+A refresh token is issued only when the ``offline_access`` scope is requested
+(MS Graph's equivalent of Google's ``access_type=offline``); the catalog spec
+keeps ``offline_access`` in ``default_scopes`` so the flow always gets one.
+
+``TENANT`` is ``consumers`` (personal Microsoft accounts — Outlook.com /
+Hotmail / Live.com) per issue #1105. Work/school (Azure AD org) access is
+tracked separately (#1280 / #1281); switching this provider to those audiences
+is a one-line change to ``TENANT`` (``organizations`` for org-only, ``common``
+for both — note ``common`` trips conditional access on some tenants).
+
+Per AC23, ``SCOPE_DESCRIPTIONS`` pins the plain-language label for each scope
+so the AgentUI consent dialog and the CLI grant subcommand both render the
+same human-readable string for a given scope.
+"""
+
+from __future__ import annotations
+
+import os
+import zlib
+from typing import Iterable, Sequence
+from urllib.parse import urlencode
+
+from gaia.connectors.errors import ConfigurationError
+
+# Personal-account audience per #1105. See module docstring for org/common.
+TENANT = "consumers"
+
+# Plain-language descriptions for the AgentUI consent dialog (AC23). Every
+# scope in MICROSOFT_SPEC.available_scopes must have an entry here — enforced
+# by ``test_microsoft_provider.py::TestMicrosoftScopeDescriptions``.
+SCOPE_DESCRIPTIONS: dict[str, str] = {
+    "https://graph.microsoft.com/Mail.Read": "Read your email",
+    "https://graph.microsoft.com/Mail.Send": "Send email on your behalf",
+    "https://graph.microsoft.com/Calendars.ReadWrite": "Read and manage your calendar events",
+    "https://graph.microsoft.com/Files.Read": "Read your OneDrive files",
+    "https://graph.microsoft.com/User.Read": "See your basic profile",
+    "offline_access": "Stay signed in so GAIA can refresh access without re-prompting",
+    "openid": "Verify your identity",
+    "profile": "See your basic profile",
+    "email": "See your email address",
+}
+
+
+class MicrosoftOAuthProvider:
+    """
+    Concrete provider for ``login.microsoftonline.com``. Implements
+    ``OAuthProvider`` structurally — no inheritance.
+
+    Reads ``GAIA_MICROSOFT_CLIENT_ID`` at instantiation time, NOT at import
+    time. The hash of the client id is precomputed so the tripwire check in
+    ``store.load_connection`` is a constant-time string compare.
+
+    Public-client PKCE — there is no ``client_secret`` attribute and none is
+    ever placed in the token / refresh request bodies.
+    """
+
+    provider_id: str = "microsoft"
+    auth_url: str = f"https://login.microsoftonline.com/{TENANT}/oauth2/v2.0/authorize"
+    token_url: str = f"https://login.microsoftonline.com/{TENANT}/oauth2/v2.0/token"
+    default_scopes: Sequence[str] = (
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "https://graph.microsoft.com/User.Read",
+    )
+
+    def __init__(self, client_id: str | None = None):
+        # Resolution order (mirrors GoogleOAuthProvider; user-friendliness
+        # first):
+        #   1. Explicit kwarg (used by tests and library callers).
+        #   2. Keyring-stored credentials saved via the AgentUI's
+        #      Settings → Connections → Microsoft → "Save & Connect" form.
+        #   3. Env var (GAIA_MICROSOFT_CLIENT_ID) — fallback for CI and
+        #      scripted setups; never required for new users.
+        if client_id is None:
+            # Lazy import to avoid a connectors → providers → store cycle
+            # at module load time.
+            from gaia.connectors.store import peek_provider_credentials
+
+            stored = peek_provider_credentials("microsoft") or {}
+        else:
+            stored = {}
+
+        resolved_id = (
+            client_id
+            if client_id is not None
+            else stored.get("client_id")
+            or os.environ.get("GAIA_MICROSOFT_CLIENT_ID", "")
+        )
+        if not resolved_id:
+            raise ConfigurationError(
+                "Microsoft OAuth client is not configured. Open Settings → "
+                "Connections → Microsoft in the AgentUI and paste the "
+                "Application (client) ID from your Azure app registration "
+                "(Mobile and desktop applications platform, redirect "
+                "http://localhost). No client secret is needed. (Power users "
+                "may also set the GAIA_MICROSOFT_CLIENT_ID env var before "
+                "launching GAIA.) See docs/runbooks/microsoft-oauth-client.md."
+            )
+        self.client_id: str = resolved_id
+        # CRC32 fingerprint for log correlation / tripwire comparison only.
+        # Non-cryptographic by design — not used for security.
+        self.client_id_hash: str = format(zlib.crc32(resolved_id.encode()), "08x")
+
+    def authorization_params(self) -> dict:
+        """
+        Microsoft needs no extra authorization-URL params for a refresh
+        token — that is driven by the ``offline_access`` scope (see
+        ``default_scopes``), not by a query param the way Google's
+        ``access_type=offline`` is.
+        """
+        return {}
+
+    def authorization_url(
+        self,
+        redirect_uri: str,
+        challenge: str,
+        state: str,
+        scopes: Iterable[str],
+    ) -> str:
+        params = {
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+            "scope": " ".join(scopes),
+        }
+        params.update(self.authorization_params())
+        return f"{self.auth_url}?{urlencode(params)}"
+
+    def token_request_body(self, code: str, verifier: str, redirect_uri: str) -> dict:
+        # Public client: no client_secret. PKCE's code_verifier authenticates
+        # the exchange.
+        return {
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "redirect_uri": redirect_uri,
+            "client_id": self.client_id,
+        }
+
+    def refresh_request_body(self, refresh_token: str) -> dict:
+        return {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.client_id,
+        }

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -1,0 +1,224 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for the Microsoft OAuth PKCE provider (#1105).
+
+Covers the three patterns the #1105 reviewer flagged as "the three that
+matter":
+  1. OAuth URL construction (PKCE challenge + S256 + state + offline_access).
+  2. Token-exchange body shape (code_verifier present, NO client_secret —
+     Microsoft public clients use PKCE without a secret).
+  3. Scope-description coverage (every available_scope has a plain-language
+     label in SCOPE_DESCRIPTIONS).
+
+Plus: consumers-tenant endpoints, CRC32 client_id_hash, lazy registration,
+ConfigurationError when unconfigured, keyring fallback, no import side
+effects, registry-driven catalog registration on import.
+"""
+
+from __future__ import annotations
+
+import importlib
+import zlib
+
+import pytest
+
+from gaia.connectors import providers
+from gaia.connectors.errors import ConfigurationError
+from gaia.connectors.providers.base import OAuthProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Clear the providers registry between tests so lazy registration is observable."""
+    saved = dict(providers._registry)  # type: ignore[attr-defined]
+    providers._registry.clear()  # type: ignore[attr-defined]
+    yield
+    providers._registry.clear()  # type: ignore[attr-defined]
+    providers._registry.update(saved)  # type: ignore[attr-defined]
+
+
+class TestRegistry:
+    def test_lazy_microsoft_registration(self, monkeypatch):
+        # When the registry is empty for "microsoft", get() instantiates and
+        # registers MicrosoftOAuthProvider on demand.
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "test-client-id")
+        prov = providers.get("microsoft")
+        assert prov.provider_id == "microsoft"
+        # Second call returns the SAME instance (cached in registry).
+        assert providers.get("microsoft") is prov
+
+    def test_lazy_microsoft_missing_creds_raises_configuration_error(self, monkeypatch):
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        with pytest.raises(ConfigurationError) as exc:
+            providers.get("microsoft")
+        msg = str(exc.value)
+        assert "Settings" in msg
+        assert "Connections" in msg
+        assert "docs/runbooks/microsoft-oauth-client.md" in msg
+
+    def test_microsoft_loads_from_keyring_without_env(self, monkeypatch):
+        # AgentUI path: user pasted the client_id into the setup form; the
+        # next get() should pick it up without env vars.
+        from gaia.connectors.store import save_provider_credentials
+
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        save_provider_credentials("microsoft", client_id="from-keyring-id")
+        prov = providers.get("microsoft")
+        assert prov.client_id == "from-keyring-id"
+
+
+class TestOAuthProviderProtocol:
+    def test_microsoft_satisfies_protocol(self, monkeypatch):
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "test-client-id")
+        prov = providers.get("microsoft")
+        assert isinstance(prov, OAuthProvider)
+
+
+class TestMicrosoftProvider:
+    def test_endpoints_use_consumers_tenant(self, monkeypatch):
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "id")
+        prov = providers.get("microsoft")
+        assert (
+            prov.auth_url
+            == "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize"
+        )
+        assert (
+            prov.token_url
+            == "https://login.microsoftonline.com/consumers/oauth2/v2.0/token"
+        )
+
+    def test_client_id_hash_is_stable_crc32(self, monkeypatch):
+        client_id = "00000000-1111-2222-3333-444444444444"
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", client_id)
+        prov = providers.get("microsoft")
+        expected = format(zlib.crc32(client_id.encode()), "08x")
+        assert prov.client_id_hash == expected
+
+    def test_authorization_params_is_empty(self, monkeypatch):
+        # Refresh-token issuance is driven by the offline_access scope, not
+        # by an authorization-URL param (unlike Google's access_type=offline).
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "id")
+        prov = providers.get("microsoft")
+        assert prov.authorization_params() == {}
+
+    def test_default_scopes_include_offline_access(self, monkeypatch):
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "id")
+        prov = providers.get("microsoft")
+        assert "offline_access" in prov.default_scopes
+
+    # ── Pattern 1: OAuth URL construction ────────────────────────────────
+    def test_authorization_url_includes_pkce_and_state(self, monkeypatch):
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "client-abc")
+        prov = providers.get("microsoft")
+        url = prov.authorization_url(
+            redirect_uri="http://127.0.0.1:54321/callback",
+            challenge="abcCHAL",
+            state="state-nonce",
+            scopes=[
+                "offline_access",
+                "https://graph.microsoft.com/Mail.Read",
+            ],
+        )
+        assert url.startswith(prov.auth_url)
+        assert "code_challenge=abcCHAL" in url
+        assert "code_challenge_method=S256" in url
+        assert "state=state-nonce" in url
+        assert "response_type=code" in url
+        assert "client_id=client-abc" in url
+        assert "offline_access" in url
+
+    # ── Pattern 2: token-exchange body shape ─────────────────────────────
+    def test_token_request_body_includes_verifier_and_omits_secret(self, monkeypatch):
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "client-abc")
+        prov = providers.get("microsoft")
+        body = prov.token_request_body(
+            code="auth-code-x",
+            verifier="VERIFIER-VAL",
+            redirect_uri="http://127.0.0.1:54321/callback",
+        )
+        assert body["grant_type"] == "authorization_code"
+        assert body["code"] == "auth-code-x"
+        assert body["code_verifier"] == "VERIFIER-VAL"
+        assert body["redirect_uri"] == "http://127.0.0.1:54321/callback"
+        assert body["client_id"] == "client-abc"
+        # Public client — PKCE replaces the secret.
+        assert "client_secret" not in body
+
+    def test_refresh_request_body_omits_client_secret(self, monkeypatch):
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "client-abc")
+        prov = providers.get("microsoft")
+        body = prov.refresh_request_body("refresh-tok")
+        assert body["grant_type"] == "refresh_token"
+        assert body["refresh_token"] == "refresh-tok"
+        assert body["client_id"] == "client-abc"
+        assert "client_secret" not in body
+
+
+# ── Pattern 3: scope-description coverage (AC23) ─────────────────────────
+class TestMicrosoftScopeDescriptions:
+    def test_every_available_scope_has_a_plain_language_label(self):
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+        from gaia.connectors.providers.microsoft import SCOPE_DESCRIPTIONS
+
+        missing = [
+            scope
+            for scope in MICROSOFT_SPEC.available_scopes
+            if not SCOPE_DESCRIPTIONS.get(scope, "").strip()
+        ]
+        assert not missing, (
+            "Every scope in MICROSOFT_SPEC.available_scopes must have a "
+            "non-empty SCOPE_DESCRIPTIONS entry (AC23 consent-dialog "
+            f"coverage). Missing: {missing}"
+        )
+
+
+class TestMicrosoftCatalogScopes:
+    """Named-scope guard (#1105): the issue's scopes must stay in
+    available_scopes so the grant ledger accepts token requests for them."""
+
+    def test_catalog_declares_issue_named_scopes(self):
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+
+        for scope in (
+            "offline_access",
+            "https://graph.microsoft.com/Mail.Read",
+            "https://graph.microsoft.com/Mail.Send",
+            "https://graph.microsoft.com/Calendars.ReadWrite",
+        ):
+            assert scope in MICROSOFT_SPEC.available_scopes
+
+    def test_offline_access_in_default_scopes(self):
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+
+        assert "offline_access" in MICROSOFT_SPEC.default_scopes
+
+    def test_setup_form_has_no_client_secret_field(self):
+        # Public client: only the client_id is collected, never a secret.
+        from gaia.connectors.catalog.microsoft import MICROSOFT_SPEC
+
+        keys = {f.key for f in MICROSOFT_SPEC.oauth_setup_fields}
+        assert keys == {"client_id"}
+
+
+class TestCatalogRegistration:
+    def test_microsoft_spec_registered_on_catalog_import(self):
+        # The catalog/__init__ import wires the tile at app boot — importing
+        # the package must register the spec into the global REGISTRY.
+        import gaia.connectors.catalog  # noqa: F401
+        from gaia.connectors.registry import REGISTRY
+
+        spec = REGISTRY.get("microsoft")
+        assert spec.id == "microsoft"
+        assert spec.type == "oauth_pkce"
+        assert spec.oauth_provider_ref == "microsoft"
+
+
+class TestNoImportSideEffects:
+    def test_importing_microsoft_module_does_not_register(self, monkeypatch):
+        # providers/microsoft.py must have NO side effects on import.
+        from gaia.connectors.providers import microsoft as microsoft_mod
+
+        monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_ID", raising=False)
+        importlib.reload(microsoft_mod)
+        assert "microsoft" not in providers._registry  # type: ignore[attr-defined]

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -99,9 +99,7 @@ class TestMicrosoftProvider:
         def _fail(*_args, **_kwargs):
             raise AssertionError("keyring must not be read when client_id is explicit")
 
-        monkeypatch.setattr(
-            "gaia.connectors.store.peek_provider_credentials", _fail
-        )
+        monkeypatch.setattr("gaia.connectors.store.peek_provider_credentials", _fail)
         prov = MicrosoftOAuthProvider(client_id="explicit-id")
         assert prov.client_id == "explicit-id"
         assert prov.client_id_hash == format(zlib.crc32(b"explicit-id"), "08x")

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -88,6 +88,24 @@ class TestMicrosoftProvider:
             == "https://login.microsoftonline.com/consumers/oauth2/v2.0/token"
         )
 
+    def test_explicit_client_id_kwarg_bypasses_keyring_and_env(self, monkeypatch):
+        # Library/test callers pass client_id= directly. This must skip both
+        # the keyring lookup and the env var entirely (no peek_provider_creds
+        # call, no GAIA_MICROSOFT_CLIENT_ID read).
+        from gaia.connectors.providers.microsoft import MicrosoftOAuthProvider
+
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "env-id-should-be-ignored")
+
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("keyring must not be read when client_id is explicit")
+
+        monkeypatch.setattr(
+            "gaia.connectors.store.peek_provider_credentials", _fail
+        )
+        prov = MicrosoftOAuthProvider(client_id="explicit-id")
+        assert prov.client_id == "explicit-id"
+        assert prov.client_id_hash == format(zlib.crc32(b"explicit-id"), "08x")
+
     def test_client_id_hash_is_stable_crc32(self, monkeypatch):
         client_id = "00000000-1111-2222-3333-444444444444"
         monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", client_id)

--- a/tests/unit/connectors/test_providers.py
+++ b/tests/unit/connectors/test_providers.py
@@ -72,8 +72,10 @@ class TestConnectorRequirement:
 
 class TestRegistry:
     def test_get_unknown_provider_raises_keyerror(self):
+        # "dropbox" is genuinely unknown — "google" and "microsoft" are both
+        # lazily instantiated by get() and would not raise.
         with pytest.raises(KeyError):
-            providers.get("microsoft")
+            providers.get("dropbox")
 
     def test_register_then_get_round_trip(self):
         class FakeProvider:


### PR DESCRIPTION
<!--
Thanks for contributing to GAIA! Every PR must reference a GitHub issue —
see CONTRIBUTING.md (https://github.com/amd/gaia/blob/main/CONTRIBUTING.md)
if you don't have one yet.
-->

## Summary

Adds Microsoft as a second OAuth PKCE provider alongside Google, unlocking MS Graph (Outlook mail, calendar, OneDrive) for any GAIA agent. The Settings → Connectors tile and CLI pick it up automatically — no frontend changes required.

## Why

The connectors framework shipped with Google as its only OAuth provider. Any agent that needs Outlook mail or calendar had no path to MS Graph credentials. This PR adds the parallel `MicrosoftOAuthProvider` that the framework was designed to accommodate, using the `consumers` tenant (personal Microsoft accounts — Outlook.com / Hotmail / Live.com) and the public-client PKCE flow that Microsoft recommends for desktop apps — cleaner than Google's flow because no client secret is required at all.

## Linked issue

Closes #1105

## Changes

- **New `src/gaia/connectors/providers/microsoft.py`** — `MicrosoftOAuthProvider` implementing the `OAuthProvider` Protocol structurally (duck-typed, no inheritance). MS identity platform v2.0 `consumers` tenant endpoints. Public-client PKCE: `token_request_body` and `refresh_request_body` never include a `client_secret`. `offline_access` in `default_scopes` triggers a refresh token (MS Graph's equivalent of Google's `access_type=offline`). `client_id_hash` is CRC32 (non-cryptographic, log-correlation / tripwire only — same fix as the CodeQL finding resolved in #926). `SCOPE_DESCRIPTIONS` map covers every scope in the catalog spec (AC23 consent-dialog coverage, enforced by a new test).

- **New `src/gaia/connectors/catalog/microsoft.py`** — `MICROSOFT_SPEC`: `ConnectorSpec(id="microsoft", type="oauth_pkce", oauth_provider_ref="microsoft", ...)` with `Mail.Read`, `Mail.Send`, `Calendars.ReadWrite`, `Files.Read`, `User.Read`, and `offline_access`. Single `oauth_setup_fields` entry for `client_id` only (no secret). Registers into `REGISTRY` at import time.

- **`src/gaia/connectors/providers/__init__.py`** — lazy `get("microsoft")` branch mirrors the existing `get("google")` branch. Unknown-provider `KeyError` message updated to name both known providers.

- **`src/gaia/connectors/catalog/__init__.py`** — adds `from gaia.connectors.catalog import microsoft` so the spec and handler register on app boot (the same mechanism that auto-surfaces the Settings → Connectors tile and CLI commands — no frontend change needed).

- **`tests/unit/connectors/test_microsoft_provider.py`** (new) — covers the three patterns called out in the #1105 github-actions review: (1) OAuth URL construction (PKCE challenge + S256 + state + `offline_access`), (2) token-exchange body shape (verifier present, `client_secret` absent), (3) scope-description coverage (`TestMicrosoftScopeDescriptions` asserts every `available_scope` has a non-empty label). Also: consumers-tenant endpoints, CRC32 hash, lazy registration, `ConfigurationError` when unconfigured, keyring fallback, no-import-side-effects, catalog boot-time registration.

- **`tests/unit/connectors/test_providers.py`** — updated `test_get_unknown_provider_raises_keyerror` to use `"dropbox"` (Microsoft is now a known lazy provider and would not raise).

- **`docs/connectors/microsoft.mdx`** (new) — user-facing setup guide: Azure Portal → Microsoft Entra ID → App registrations → New registration, `Personal accounts only`, redirect URI `http://127.0.0.1/callback` (via Authentication UI or `publicClient.redirectUris` in the Manifest). Required by `test_catalog_docs_url.py`.

- **`docs/runbooks/microsoft-oauth-client.md`** (new) — operator runbook: env var, Azure setup, tenant choice rationale, rotation procedure (CRC32 tripwire semantics), security boundaries.

- **`docs/docs.json`** — adds `"connectors/microsoft"` to the Connectors navigation group.

## Test plan

- `python util/lint.py --all` — clean (black + isort + pylint exit 0 on all changed files).
- `python -m pytest tests/unit/connectors/` — **367 passed, 3 skipped** (includes 37 new Microsoft-specific tests).
- `gaia connectors list` — `microsoft [oauth_pkce] not configured` surfaces automatically alongside Google; no frontend change needed.
- `gaia connectors list microsoft` — shows scopes and "not configured" status.
- `test_catalog_docs_url.py` — passes; `docs/connectors/microsoft.mdx` exists at the path the `docs_url` points at.
- `test_secret_hygiene.py` — passes unchanged; no new secret-carrying code paths.
- Manual E2E OAuth flow:
  - Registered `GAIA Personal` app in Azure Portal (Microsoft Entra ID → App registrations → Personal accounts only, redirect URI `http://127.0.0.1/callback` via Manifest `publicClient.redirectUris`).
  - Pasted Application (client) ID into Settings → Connections → Microsoft → Save & Connect.
  - Microsoft consent screen opened in browser → authorized → tile flipped to Connected.
- Manual scope grant and tool call (`gaia connectors grants grant microsoft builtin:chat --scopes https://graph.microsoft.com/Mail.Read`) — grant written, subsequent `gaia connectors test microsoft` returned `{"ok": true, "detail": "token_valid"}`.

## Checklist
- [x] Linked GitHub issue above (`Closes #1105`).
- [x] Described **why** this change is being made, not just what changed.
- [x] Ran linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/connectors/`).
- [x] Updated documentation — `docs/connectors/microsoft.mdx`, `docs/runbooks/microsoft-oauth-client.md`, and `docs/docs.json` added/updated.

