### PR TITLE
fix(ui): unblock .pptx upload in Agent UI

### DIFF
--- a/src/gaia/apps/webui/src/components/UnsupportedFeature.tsx
+++ b/src/gaia/apps/webui/src/components/UnsupportedFeature.tsx
@@ -94,7 +94,7 @@ const UNSUPPORTED_FILE_CATEGORIES: FileTypeCategory[] = [
             'Save Word as PDF, then index the PDF',
             'Re-save legacy .xls workbooks as .xlsx — GAIA supports modern Excel files',
         ],
-        featureTitle: 'Support Microsoft Office (docx, xls) indexing',
+        featureTitle: 'Support Microsoft Office (doc, docx, ppt, xls) indexing',
     },
 ];
 

--- a/src/gaia/apps/webui/src/components/UnsupportedFeature.tsx
+++ b/src/gaia/apps/webui/src/components/UnsupportedFeature.tsx
@@ -84,16 +84,17 @@ const UNSUPPORTED_FILE_CATEGORIES: FileTypeCategory[] = [
     },
     {
         label: 'Microsoft Office',
-        extensions: new Set(['.doc', '.docx', '.ppt', '.pptx', '.xls']),
+        extensions: new Set(['.doc', '.docx', '.ppt', '.xls']),
         message:
-            'Word, PowerPoint, and legacy Excel (.xls) files are not yet ' +
-            'supported — GAIA does not currently ship parsers for these ' +
-            'formats.',
+            'Word, legacy PowerPoint (.ppt), and legacy Excel (.xls) files are ' +
+            'not yet supported — GAIA does not currently ship parsers for these ' +
+            'formats. Modern PowerPoint (.pptx) is supported.',
         alternatives: [
-            'Save as PDF from Word or PowerPoint, then index the PDF',
+            'Save modern PowerPoint as .pptx — GAIA indexes .pptx directly',
+            'Save Word as PDF, then index the PDF',
             'Re-save legacy .xls workbooks as .xlsx — GAIA supports modern Excel files',
         ],
-        featureTitle: 'Support Microsoft Office (docx, pptx, xls) indexing',
+        featureTitle: 'Support Microsoft Office (docx, xls) indexing',
     },
 ];
 
@@ -116,10 +117,11 @@ export function getUnsupportedCategory(extension: string): FileTypeCategory | nu
  * ``src/gaia/ui/utils.py``. Only list extensions that have a real extractor
  * in ``src/gaia/rag/sdk.py::_extract_text_from_file`` — listing one without
  * a backend handler causes the RAG pipeline to index binary garbage.
- * .doc/.docx/.ppt/.pptx and legacy .xls are intentionally excluded.
+ * .pptx IS supported (python-pptx ships with GAIA); .doc/.docx/.ppt and
+ * legacy .xls are intentionally excluded.
  */
 export const SUPPORTED_EXTENSIONS = new Set([
-    '.pdf', '.txt', '.md', '.csv', '.json', '.xlsx',
+    '.pdf', '.pptx', '.txt', '.md', '.csv', '.json', '.xlsx',
     '.html', '.htm', '.xml', '.svg',
     '.yaml', '.yml', '.py', '.js', '.ts', '.java', '.c', '.cpp',
     '.h', '.rs', '.go', '.rb', '.sh', '.bat', '.ps1', '.log',
@@ -260,7 +262,7 @@ export function UploadErrorToast({ filename, error, onDismiss, timeout = 15000 }
         Icon = AlertTriangle;
     } else if (isFileTypeError) {
         title = `File type not supported: ${ext}`;
-        detail = 'This file format cannot be indexed. Supported: PDF, TXT, MD, CSV, JSON, XLSX, HTML, XML, YAML, and 30+ code file formats.';
+        detail = 'This file format cannot be indexed. Supported: PDF, PPTX, TXT, MD, CSV, JSON, XLSX, HTML, XML, YAML, and 30+ code file formats.';
         issueUrl = featureRequestUrl(`Support ${ext} file indexing`);
         Icon = AlertTriangle;
     } else if (isConnectionError) {

--- a/src/gaia/apps/webui/src/components/__tests__/UnsupportedFeature.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/UnsupportedFeature.test.tsx
@@ -35,6 +35,16 @@ describe('getUnsupportedCategory', () => {
     it('returns "Microsoft Office" for .docx', () => {
         expect(getUnsupportedCategory('.docx')?.label).toBe('Microsoft Office');
     });
+
+    it('returns null for .pptx — PowerPoint indexing shipped in #1224', () => {
+        expect(getUnsupportedCategory('.pptx')).toBeNull();
+    });
+
+    it('keeps legacy Office formats (.ppt, .doc, .xls) blocked', () => {
+        expect(getUnsupportedCategory('.ppt')?.label).toBe('Microsoft Office');
+        expect(getUnsupportedCategory('.doc')?.label).toBe('Microsoft Office');
+        expect(getUnsupportedCategory('.xls')?.label).toBe('Microsoft Office');
+    });
 });
 
 describe('isExtensionSupported', () => {
@@ -44,6 +54,10 @@ describe('isExtensionSupported', () => {
 
     it('returns true for .py', () => {
         expect(isExtensionSupported('.py')).toBe(true);
+    });
+
+    it('returns true for .pptx — modern PowerPoint is indexable', () => {
+        expect(isExtensionSupported('.pptx')).toBe(true);
     });
 
     it('returns false for .exe', () => {

--- a/src/gaia/apps/webui/src/components/__tests__/UnsupportedFeature.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/UnsupportedFeature.test.tsx
@@ -36,7 +36,7 @@ describe('getUnsupportedCategory', () => {
         expect(getUnsupportedCategory('.docx')?.label).toBe('Microsoft Office');
     });
 
-    it('returns null for .pptx — PowerPoint indexing shipped in #1224', () => {
+    it('returns null for .pptx — PowerPoint indexing is supported', () => {
         expect(getUnsupportedCategory('.pptx')).toBeNull();
     });
 


### PR DESCRIPTION
The Agent UI hard-blocked PowerPoint uploads even though `.pptx` RAG shipped end-to-end in #1224 — the RAG backend *and* the FastAPI `ALLOWED_EXTENSIONS` already accept `.pptx`, but the React `UnsupportedFeature` gate still classified it as an unsupported "Microsoft Office" type and rejected it *before* upload. A headline feature was unreachable in the UI, and users were filing feature requests (#1072, #1291) for something that already worked. This drops `.pptx` from the frontend blocklist, adds it to the supported set (now matching the server allowlist exactly), and fixes the now-false rejection copy. `.doc/.docx/.ppt/.xls` stay blocked. No server change — the backend already accepts `.pptx`.

Closes #1363

## Test plan
- [x] `cd src/gaia/apps/webui && npm test` — Vitest 18/18 pass locally (new assertions verify `.pptx` is accepted and `.doc/.ppt/.xls` stay blocked). Note: the `test-webui-vitest` CI job doesn't currently trigger on diffs confined to `src/gaia/apps/webui` (pre-existing path-filter gap in `test_electron.yml`), so this was verified locally, not in CI.
- [x] `cd src/gaia/apps/webui && npm run build` — `tsc && vite build` clean
- [x] `code-reviewer` pass — no Critical/Advisory findings; independently confirmed the frontend `SUPPORTED_EXTENSIONS` now matches the server-side `ALLOWED_EXTENSIONS` and no consumer (`DocumentLibrary`, `FileBrowser`) breaks
- [x] Real-world (Agent UI on an AMD GPU box, Gemma-4-E4B): uploaded a `.pptx` through the Document Library → **accepted** (no "Microsoft Office not supported" toast) → indexed (1 chunk via nomic-embed) → Doc Agent answered questions grounded in slide body text (92.7% success rate), a table cell (14.5 Nm torque), and speaker notes (Bluejay-44 codename)