### PR TITLE
fix(ui): make Memory Dashboard and Settings mutually exclusive in chatStore

### DIFF
--- a/src/gaia/apps/webui/src/stores/chatStore.ts
+++ b/src/gaia/apps/webui/src/stores/chatStore.ts
@@ -259,8 +259,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
     pendingPrompt: null,
     setShowDocLibrary: (show) => set({ showDocLibrary: show }),
     setShowFileBrowser: (show) => set({ showFileBrowser: show }),
-    setShowSettings: (show) => set({ showSettings: show }),
-    setShowMemoryDashboard: (show) => set({ showMemoryDashboard: show }),
+    setShowSettings: (show) =>
+        set(show ? { showSettings: true, showMemoryDashboard: false } : { showSettings: false }),
+    setShowMemoryDashboard: (show) =>
+        set(show ? { showMemoryDashboard: true, showSettings: false } : { showMemoryDashboard: false }),
     toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
     setSidebarOpen: (open) => set({ sidebarOpen: open }),
     toggleSidebarCollapsed: () =>


### PR DESCRIPTION
## Why this matters

Clicking the **Memory Dashboard** button in the sidebar (or the Memory icon in the chat-toolbar) had no effect when the **Settings** page was currently open. The user had to close Settings first before Memory Dashboard would respond. The reverse direction "worked" but left a stale `showMemoryDashboard=true` in the store, so closing Settings via the back arrow could re-surface the Memory Dashboard from a previous session.

The Agent UI is not router-based. "Routing" between top-level views is a stateful ternary in `App.tsx:531-535` that gives `showSettings` unconditional priority over `showMemoryDashboard`, and the two store setters never cleared each other's flag.

## What changed

Single-source-of-truth fix in `src/gaia/apps/webui/src/stores/chatStore.ts:262-265`: the two setters are now mutually exclusive — opening one view always closes the other. This is better than patching all three call sites (sidebar × 2, chat-toolbar × 1) because future call sites cannot reintroduce the bug.

```diff
-    setShowSettings: (show) => set({ showSettings: show }),
-    setShowMemoryDashboard: (show) => set({ showMemoryDashboard: show }),
+    setShowSettings: (show) =>
+        set(show ? { showSettings: true, showMemoryDashboard: false } : { showSettings: false }),
+    setShowMemoryDashboard: (show) =>
+        set(show ? { showMemoryDashboard: true, showSettings: false } : { showMemoryDashboard: false }),
```

`onHome` in `App.tsx:524` still works correctly — it sets both flags to `false` explicitly, and the `false` path of each setter does not touch the other flag.

## Test plan

- [ ] Manual: open Settings from the sidebar, then click the Memory Dashboard button — Memory Dashboard renders (not Settings).
- [ ] Manual: open Memory Dashboard, then click Settings — Settings renders (no change there, but verify flag state is clean).
- [ ] Manual: from each view, hit the back arrow — return to the chat / welcome view, not to whatever was opened "behind" it.
- [ ] Add Playwright regression covering the "open Settings, click Memory Dashboard, verify Memory Dashboard is the rendered view" scenario and its symmetric counterpart.

## Notes

- Bug introduced by #606 (commit `74f637a4`) which added `MemoryDashboard` and the `showMemoryDashboard` flag without making the two flags mutually exclusive.
- Triage confirmed the fix location on the issue.

Fixes #1367
