### PR TITLE
docs(claude): human-first communication style in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,8 @@ GAIA (Generative AI Is Awesome) is AMD's open-source framework for running gener
 
 ## How You Communicate
 
-Applies to **every response** — interactive chat in a local session and GitHub issue/PR replies alike. The [Issue Response Guidelines](#issue-response-guidelines) add GitHub-specific detail; this is the general rule.
+Applies to **every response** — interactive chat in a local session and GitHub issue/PR replies alike. Lead with the finding (the [Issue Response Guidelines](#issue-response-guidelines) cover that and the GitHub-specific detail); the rules below add the conciseness bar that holds everywhere.
 
-- **Lead with the finding.** Open with the answer, the diagnosis, or what you need — in one sentence. No labelled `In plain English:` preamble.
 - **Write for the human reading it, not an engineer auditing the code.** Plain language; the shortest response that fully answers. If one line suffices, send one line.
 - **Cite `file.py:line`, symbols, module paths, or flags ONLY when the reader needs them to act** — never to show your work. Cut internal implementation detail (import paths, subparser/flag mechanics, class names) the reader doesn't need to make a decision.
 - **Don't pad.** Skip restating the question, "what I changed" walls the diff already shows, and exhaustive option dumps when one recommendation will do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,15 @@ GAIA (Generative AI Is Awesome) is AMD's open-source framework for running gener
 - SDK Reference: https://amd-gaia.ai/sdk
 - Guides: https://amd-gaia.ai/guides
 
+## How You Communicate
+
+Applies to **every response** — interactive chat in a local session and GitHub issue/PR replies alike. The [Issue Response Guidelines](#issue-response-guidelines) add GitHub-specific detail; this is the general rule.
+
+- **Lead with the finding.** Open with the answer, the diagnosis, or what you need — in one sentence. No labelled `In plain English:` preamble.
+- **Write for the human reading it, not an engineer auditing the code.** Plain language; the shortest response that fully answers. If one line suffices, send one line.
+- **Cite `file.py:line`, symbols, module paths, or flags ONLY when the reader needs them to act** — never to show your work. Cut internal implementation detail (import paths, subparser/flag mechanics, class names) the reader doesn't need to make a decision.
+- **Don't pad.** Skip restating the question, "what I changed" walls the diff already shows, and exhaustive option dumps when one recommendation will do.
+
 ## Version Control Guidelines
 
 ### Repository Structure


### PR DESCRIPTION
Local Claude Code sessions in this repo skew verbose and technical — leaking internal detail (import paths, symbol names, flag/subparser mechanics) into replies meant for a human. This adds a short **How You Communicate** section near the top of CLAUDE.md so every response — interactive and GitHub alike — leads with the finding, writes for the reader, and cites `file.py:line`/symbols only when they help the reader act, not to show work.

It mirrors the conciseness guidance going into the Claude AI Assistant workflow prompts (#1369), so the bot and local sessions follow one rule. Defers to the existing Issue Response Guidelines for GitHub-specific detail rather than duplicating it.

## Test plan

- [x] Section renders; internal anchor link to Issue Response Guidelines resolves
- [ ] Subjective: future local responses are shorter and lead with the finding
