### PR TITLE
ci(codecov): disable PR comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,9 @@
 codecov:
   require_ci_to_pass: true
 
+# Disable Codecov PR comments; coverage status checks still run.
+comment: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Why this matters

Codecov was auto-posting a coverage comment on every PR through its shared `codecov-commenter` bot user, adding noise to PR threads. Setting `comment: false` stops the bot from commenting. Coverage is still uploaded and the project (60%) and patch (70%) **status checks are unaffected** — reviewers can still see coverage in the checks and on the Codecov dashboard.

## Test plan

- [ ] On a follow-up PR, confirm no `codecov-commenter` comment is posted
- [ ] Confirm the Codecov project/patch status checks still appear and run