### PR TITLE
ci(test): authenticate HF model pulls in Linux CLI integration to stop 429 flakes

### DIFF
--- a/.github/workflows/test_gaia_cli_linux.yml
+++ b/.github/workflows/test_gaia_cli_linux.yml
@@ -77,6 +77,11 @@ jobs:
           echo "GAIA CLI installed successfully!"
 
       - name: Start Lemonade Server and Test Core Commands
+        env:
+          # Authenticate HF model pulls — unauthenticated requests get 429-throttled
+          # on shared CI runners, which kills Lemonade startup (matches the Windows job).
+          HUGGINGFACE_ACCESS_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
+          HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
         run: |
           echo "=== Starting Lemonade Server ==="
 


### PR DESCRIPTION
The Linux "Full Integration" CI job has been flaking on every release/PR — including the v0.20.0 release PR (#1334) and #1377. Root cause: it pulls `Qwen3-0.6B-GGUF` from HuggingFace **unauthenticated**, so shared GitHub runners hit `429 Too Many Requests`, Lemonade fails to start, and the whole job (summarizer/RAG/lemonade-client integration) fails. The Windows CLI, SD, and Agent SDK jobs already pass `HF_TOKEN` and never flake — this just brings the Linux job to parity.

After this, the Linux integration job authenticates its model pulls and stops 429-flaking.

## Test plan
- [ ] CI on this PR: **GAIA CLI Tests (Linux) → Test GAIA CLI on Linux (Full Integration)** reaches the model pull without a `429` and passes
- [ ] Confirm no secret leakage in logs (GitHub masks `secrets.*` automatically)
