### PR TITLE
fix(connectors): provider-aware forwarded-connection scope validation

### DIFF
--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -67,15 +67,22 @@ from gaia.connectors.tokens import get_or_refresh
 logger = logging.getLogger(__name__)
 
 
-# Scopes the built-in Email Triage Agent (#962) needs to act on a mailbox.
-# A forwarded grant MUST cover these or the import fails loudly (AC3) — GAIA
-# cannot widen scope at refresh time, so the host app's initial consent must
-# have requested at least this union.
-_DEFAULT_REQUIRED_SCOPES: tuple[str, ...] = (
-    "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/gmail.send",
-    "https://www.googleapis.com/auth/calendar.events",
-)
+# Per-provider minimum scopes a forwarded grant must cover when the caller
+# passes no explicit ``required_scopes``. Authoritative validation is the
+# caller's job (the UI router resolves the union from the granted agents'
+# ``REQUIRED_CONNECTORS``); this map is a defense-in-depth default so a
+# None-path forward never demands one provider's scopes of another. Unknown
+# providers default to no requirement — the use-time gate in
+# ``get_access_token`` still enforces per-agent scope coverage at the point an
+# agent actually requests a token.
+_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    # Built-in Email Triage Agent (#962) mailbox union.
+    "google": (
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/calendar.events",
+    ),
+}
 
 
 async def get_access_token(
@@ -279,10 +286,12 @@ def import_forwarded_connection(
       - insecure keyring backend → ``ConnectorsError`` (via
         ``verify_keyring_backend``);
       - empty ``client_id`` / ``refresh_token`` → ``ConnectorsError``;
-      - forwarded scopes don't cover ``required_scopes`` (defaults to the
-        Email-agent union) → ``ScopeMismatchError``. GAIA cannot widen scope
-        at refresh time, so a shortfall is unrecoverable without re-consent
-        by the host app.
+      - forwarded scopes don't cover ``required_scopes`` → ``ScopeMismatchError``.
+        ``required_scopes is None`` falls back to the per-provider default
+        (``_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER``, empty for unknown providers);
+        an explicit ``[]`` means "require nothing" at import time. GAIA cannot
+        widen scope at refresh time, so a shortfall is unrecoverable without
+        re-consent by the host app.
 
     Returns a metadata-only summary — NEVER the refresh token or client secret.
     """
@@ -315,10 +324,12 @@ def import_forwarded_connection(
         )
 
     # 3. Scope coverage (AC3). Forwarded scopes must be a superset of what the
-    #    agent needs — GAIA cannot add scope at refresh time.
-    required = (
-        list(required_scopes) if required_scopes else list(_DEFAULT_REQUIRED_SCOPES)
-    )
+    #    agent needs — GAIA cannot add scope at refresh time. ``is not None`` so
+    #    an explicit ``[]`` means "require nothing", not "use the default".
+    if required_scopes is not None:
+        required = list(required_scopes)
+    else:
+        required = list(_DEFAULT_REQUIRED_SCOPES_BY_PROVIDER.get(provider, ()))
     granted = set(scopes)
     missing = [s for s in required if s not in granted]
     if missing:

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -105,11 +105,17 @@ _pending: dict[str, _PendingFlow] = {}
 
 def _decode_email_from_id_token(id_token: str) -> Optional[str]:
     """
-    Extract the ``email`` claim from a Google id_token payload.
+    Extract the user's email from an id_token payload.
 
-    Best-effort — base64url-decode the middle segment, parse JSON, return
-    the ``email`` field. Production validation is deferred to the
-    userinfo endpoint; this is a quick path for the success page.
+    Best-effort — base64url-decode the middle segment, parse JSON, check
+    claims in priority order:
+      1. ``email`` — present in Google id_tokens and most OIDC providers.
+      2. ``preferred_username`` — Microsoft identity platform (personal
+         Outlook.com accounts and Azure AD work/school accounts).
+      3. ``upn`` — legacy Microsoft on-premises claim.
+
+    Production validation is deferred to the userinfo endpoint; this is a
+    quick path for display on the OAuth success page.
     """
     try:
         _, payload_b64, _ = id_token.split(".")
@@ -121,7 +127,9 @@ def _decode_email_from_id_token(id_token: str) -> Optional[str]:
         payload = json.loads(base64.urlsafe_b64decode(padded).decode("ascii"))
     except (ValueError, UnicodeDecodeError):
         return None
-    email = payload.get("email")
+    email = (
+        payload.get("email") or payload.get("preferred_username") or payload.get("upn")
+    )
     return email if isinstance(email, str) else None
 
 

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -878,7 +878,7 @@ async def delete_activation(connector_id: str, agent_id: str) -> Response:
     "/{provider}", status_code=201, dependencies=[Depends(_require_ui_header)]
 )
 async def forward_connection(
-    provider: str, body: ForwardConnectionRequest
+    request: Request, provider: str, body: ForwardConnectionRequest
 ) -> Dict[str, Any]:
     """Persist a forwarded grant — no browser/consent step (AC1, AC3, AC4).
 
@@ -886,7 +886,27 @@ async def forward_connection(
     insecure keyring backend → 500; missing required scopes → 403 +
     ``missing_scopes``. Returns a metadata-only summary — never the refresh
     token or client secret.
+
+    Required scopes are resolved from the granted agents' ``REQUIRED_CONNECTORS``
+    declarations (single source of truth). This means scope requirements
+    auto-tighten as agents add new ``ConnectorRequirement`` entries — no
+    duplication in the router.
     """
+    # Resolve required scopes from the granted agents' REQUIRED_CONNECTORS so
+    # the import-time check is driven by what agents actually need, not a
+    # hardcoded list in the connectors layer.
+    registry = getattr(request.app.state, "agent_registry", None)
+    required: set[str] = set()
+    if registry is not None and body.grant_agents:
+        by_nsid = {reg.namespaced_agent_id: reg for reg in registry.list()}
+        for nsid in body.grant_agents:
+            reg = by_nsid.get(nsid)
+            if reg is None:
+                continue
+            for cr in reg.required_connections:
+                if cr.connector_id == provider:
+                    required.update(cr.scopes)
+
     try:
         summary = connections.import_forwarded_connection(
             provider=provider,
@@ -896,6 +916,7 @@ async def forward_connection(
             scopes=body.scopes,
             account_email=body.account_email,
             grant_agents=body.grant_agents,
+            required_scopes=sorted(required),
         )
     except ConnectorsError as e:
         raise _raise_http_for(e) from e

--- a/tests/unit/connectors/test_flow.py
+++ b/tests/unit/connectors/test_flow.py
@@ -33,6 +33,7 @@ from gaia.connectors.errors import (
 )
 from gaia.connectors.flow import (
     _SUCCESS_HTML,
+    _decode_email_from_id_token,
     cancel_flow,
     complete_authorization,
     start_authorization,
@@ -273,3 +274,47 @@ class TestBrowserOpenNonBlocking:
         )
 
         await cancel_flow(results[0]["flow_id"])
+
+
+class TestDecodeEmailFromIdToken:
+    """Unit tests for _decode_email_from_id_token — the multi-provider claim
+    fallback added in the provider-aware forward-connection fix."""
+
+    # Pre-built tokens (header.base64url(payload).sig).
+    _GOOGLE_TOKEN = "header.eyJlbWFpbCI6ICJhbGljZUBnbWFpbC5jb20ifQ.sig"
+    _MS_PREFERRED_USERNAME = (
+        "header.eyJwcmVmZXJyZWRfdXNlcm5hbWUiOiAiYm9iQG91dGxvb2suY29tIn0.sig"
+    )
+    _BOTH_CLAIMS = (
+        "header"
+        ".eyJlbWFpbCI6ICJhbGljZUBnbWFpbC5jb20iLCAicHJlZmVycmVkX3VzZXJuYW1lIjogImJvYkBvdXRsb29rLmNvbSJ9"
+        ".sig"
+    )
+    _UPN_ONLY = "header.eyJ1cG4iOiAiY2Fyb2xAY29ycC5jb20ifQ.sig"
+    _NO_EMAIL = "header.eyJzdWIiOiAieHl6In0.sig"
+    _BAD_TOKEN = "not.a.jwt.at.all"
+
+    def test_google_email_claim(self):
+        assert _decode_email_from_id_token(self._GOOGLE_TOKEN) == "alice@gmail.com"
+
+    def test_microsoft_preferred_username_fallback(self):
+        assert (
+            _decode_email_from_id_token(self._MS_PREFERRED_USERNAME)
+            == "bob@outlook.com"
+        )
+
+    def test_email_takes_priority_over_preferred_username(self):
+        # When both claims present, ``email`` wins.
+        assert _decode_email_from_id_token(self._BOTH_CLAIMS) == "alice@gmail.com"
+
+    def test_upn_fallback(self):
+        assert _decode_email_from_id_token(self._UPN_ONLY) == "carol@corp.com"
+
+    def test_no_email_claim_returns_none(self):
+        assert _decode_email_from_id_token(self._NO_EMAIL) is None
+
+    def test_malformed_token_returns_none(self):
+        assert _decode_email_from_id_token(self._BAD_TOKEN) is None
+
+    def test_empty_string_returns_none(self):
+        assert _decode_email_from_id_token("") is None

--- a/tests/unit/connectors/test_forwarded_import.py
+++ b/tests/unit/connectors/test_forwarded_import.py
@@ -204,6 +204,82 @@ class TestGrants:
         assert list_agent_grants("google") == {}
 
 
+class TestProviderAwareScopeDefaults:
+    """Verify the fix for the provider-agnostic _DEFAULT_REQUIRED_SCOPES bug.
+
+    Before the fix, forwarding any provider with required_scopes=None fell
+    through to the Google-only default, so Microsoft (and every other non-Google
+    provider) was demanded Gmail scopes.  After the fix:
+      - Unknown providers default to an empty requirement (no import-time check).
+      - An explicit required_scopes=[] is honoured (not overridden by the default).
+      - Google's existing default is preserved for backward compat.
+    """
+
+    MS_SCOPES = [
+        "openid",
+        "offline_access",
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send",
+        "https://graph.microsoft.com/Calendars.ReadWrite",
+    ]
+
+    def test_non_google_provider_none_path_does_not_demand_google_scopes(
+        self, monkeypatch
+    ):
+        """Microsoft forward with required_scopes=None must NOT raise — there
+        is no Microsoft entry in _DEFAULT_REQUIRED_SCOPES_BY_PROVIDER so the
+        default is an empty list.  The forwarded Graph scopes need not include
+        any gmail.* URL.
+
+        We patch ``gaia.connectors.api.get_provider`` rather than injecting
+        into ``_registry`` because ``import_forwarded_connection`` pops the
+        registry entry (step 5) before re-calling ``get_provider`` to compute
+        the fresh ``client_id_hash``.  Patching the function avoids the pop.
+        """
+        import zlib
+        from unittest.mock import MagicMock
+
+        fake_ms = MagicMock()
+        fake_ms.client_id_hash = format(zlib.crc32(b"ms-client-id"), "08x")
+        monkeypatch.setattr("gaia.connectors.api.get_provider", lambda _: fake_ms)
+
+        result = import_forwarded_connection(
+            provider="microsoft",
+            client_id="ms-client-id",
+            client_secret="ms-secret",
+            refresh_token="ms-refresh",
+            scopes=self.MS_SCOPES,
+            account_email="user@outlook.com",
+            # required_scopes intentionally omitted → defaults to [] for microsoft
+        )
+        assert result["provider"] == "microsoft"
+        assert result["account_email"] == "user@outlook.com"
+
+    def test_explicit_empty_required_scopes_is_honoured(self):
+        """required_scopes=[] must mean "require nothing", not "use the
+        Google default".  Before the fix, [] was falsy so the Google default
+        fired and a Google forward with only openid would fail."""
+        # Even a minimal Google scope list is accepted when required_scopes=[].
+        _do_import(scopes=["openid"], required_scopes=[])
+
+    def test_explicit_nonempty_required_scopes_are_still_enforced(self):
+        """Passing an explicit required list tighter than the forwarded
+        scopes must still fail loudly."""
+        with pytest.raises(ScopeMismatchError):
+            _do_import(
+                scopes=["openid"],
+                required_scopes=["https://www.googleapis.com/auth/gmail.modify"],
+            )
+
+    def test_google_default_still_enforced_on_none_path(self):
+        """Regression: the Google None-path default must still gate a
+        shortfall.  This is the existing test_scope_shortfall_raises_loudly
+        re-asserted to prove the map entry is wired up."""
+        with pytest.raises(ScopeMismatchError) as ei:
+            _do_import(scopes=["https://www.googleapis.com/auth/gmail.modify"])
+        assert "gmail.send" in str(ei.value)
+
+
 class TestRefreshUsesForwardedClient:
     @respx.mock
     async def test_refresh_posts_forwarded_client(self):

--- a/tests/unit/connectors/test_router_forwarded.py
+++ b/tests/unit/connectors/test_router_forwarded.py
@@ -19,6 +19,10 @@ Asserts:
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from typing import List
+from unittest.mock import MagicMock
+
 import httpx
 import pytest
 import respx
@@ -28,10 +32,14 @@ UI_HEADER = {"x-gaia-ui": "1"}
 FWD_CLIENT_ID = "forwarded-host-app.apps.googleusercontent.com"
 FWD_CLIENT_SECRET = "FWD-SECRET-do-not-leak"
 FWD_REFRESH = "FWD-REFRESH-TOKEN-do-not-leak"
+# Includes all 4 scopes declared in EmailTriageAgent.REQUIRED_CONNECTORS (ALL_SCOPES).
+# The router now resolves required_scopes from the granted agents' REQUIRED_CONNECTORS,
+# so FULL_SCOPES must be a superset of that union for the forward to succeed.
 FULL_SCOPES = [
     "https://www.googleapis.com/auth/gmail.modify",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.readonly",
 ]
 
 
@@ -178,3 +186,189 @@ class TestAgentActsAfterForward:
         assert token == "STUB-ACCESS"
         assert FWD_CLIENT_ID in captured["body"]
         assert FWD_CLIENT_SECRET in captured["body"]
+
+
+# ─── Helpers for provider-aware scope tests ───────────────────────────────────
+
+MS_CLIENT_ID = "ms-app-client-id"
+MS_CLIENT_SECRET = "ms-secret"
+MS_REFRESH = "ms-refresh-token"
+MS_SCOPES = [
+    "openid",
+    "offline_access",
+    "https://graph.microsoft.com/Mail.ReadWrite",
+    "https://graph.microsoft.com/Mail.Send",
+    "https://graph.microsoft.com/Calendars.ReadWrite",
+]
+
+
+@pytest.fixture
+def ms_provider(monkeypatch):
+    """Inject a minimal fake Microsoft OAuth provider so the registry lookup
+    succeeds without real env vars."""
+    import zlib
+
+    fake = MagicMock()
+    fake.client_id = MS_CLIENT_ID
+    fake.client_id_hash = format(zlib.crc32(MS_CLIENT_ID.encode()), "08x")
+
+    from gaia.connectors.providers import _registry
+
+    _registry["microsoft"] = fake
+    monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", MS_CLIENT_ID)
+    yield fake
+    _registry.pop("microsoft", None)
+
+
+def _ms_forward_body(**overrides):
+    body = {
+        "client_id": MS_CLIENT_ID,
+        "client_secret": MS_CLIENT_SECRET,
+        "refresh_token": MS_REFRESH,
+        "scopes": MS_SCOPES,
+        "account_email": "user@outlook.com",
+        "grant_agents": [],
+    }
+    body.update(overrides)
+    return body
+
+
+def _make_fake_registry(provider: str, scopes: list[str], nsid: str = "builtin:test"):
+    """Return an object that mimics AgentRegistry.list() for the router's
+    scope-resolution code (``request.app.state.agent_registry``)."""
+    from gaia.connectors.providers.base import ConnectorRequirement
+
+    @dataclass
+    class FakeReg:
+        namespaced_agent_id: str
+        required_connections: List[ConnectorRequirement] = field(default_factory=list)
+
+    @dataclass
+    class FakeRegistry:
+        _regs: List[FakeReg]
+
+        def list(self):
+            return self._regs
+
+    cr = ConnectorRequirement(connector_id=provider, scopes=scopes)
+    return FakeRegistry(
+        _regs=[FakeReg(namespaced_agent_id=nsid, required_connections=[cr])]
+    )
+
+
+# ─── New test classes ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.skip(
+    reason=(
+        "Microsoft OAuth provider not in this branch — requires the Outlook backend "
+        "from PR #1358/#1275.  End-to-end Microsoft forward is validated against "
+        "strx-halo once that PR is merged into the integration branch."
+    )
+)
+class TestMicrosoftForward:
+    """Microsoft connections must forward without demanding Gmail scopes.
+
+    Skipped in this branch because the MicrosoftOAuthProvider is not yet
+    registered in ``gaia.connectors.providers`` here — it lives in PR #1358.
+    The unit-level proof (``TestProviderAwareScopeDefaults`` in
+    ``test_forwarded_import.py``) covers the scope-default logic without needing
+    the provider; this class covers the full HTTP path and should run after merge.
+    """
+
+    def test_microsoft_forward_returns_201(self, ui_api_client, ms_provider):
+        resp = ui_api_client.post(
+            "/v1/connections/microsoft",
+            json=_ms_forward_body(),
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["provider"] == "microsoft"
+        assert "refresh_token" not in data
+        assert "client_secret" not in data
+
+    def test_microsoft_listed_after_forward(self, ui_api_client, ms_provider):
+        ui_api_client.post(
+            "/v1/connections/microsoft",
+            json=_ms_forward_body(),
+            headers=UI_HEADER,
+        )
+        resp = ui_api_client.get("/v1/connections")
+        assert resp.status_code == 200
+        providers = [c["provider"] for c in resp.json()["connections"]]
+        assert "microsoft" in providers
+
+
+class TestRouterDrivenScopeResolution:
+    """The router must resolve required scopes from the granted agents'
+    REQUIRED_CONNECTORS.  When the forwarded scopes don't cover the agent's
+    declared requirements, the forward fails loudly with 403 scope_mismatch."""
+
+    def test_scope_mismatch_via_registry_fails_with_403(self, ui_api_client):
+        """Inject a registry whose builtin:test agent requires
+        gmail.modify for Google.  Forward Google scopes that exclude
+        gmail.modify → should raise scope_mismatch via the router resolution."""
+        fake_registry = _make_fake_registry(
+            provider="google",
+            scopes=["https://www.googleapis.com/auth/gmail.modify"],
+            nsid="builtin:test",
+        )
+        ui_api_client.app.state.agent_registry = fake_registry
+
+        resp = ui_api_client.post(
+            "/v1/connections/google",
+            json=_forward_body(
+                scopes=["openid"],  # does NOT include gmail.modify
+                grant_agents=["builtin:test"],
+            ),
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 403, resp.text
+        detail = resp.json()["detail"]
+        assert detail["error"] == "scope_mismatch"
+        assert any("gmail.modify" in s for s in detail["missing_scopes"])
+
+    def test_scope_satisfied_via_registry_returns_201(self, ui_api_client):
+        """When the forwarded scopes cover the agent's declared requirements,
+        the forward succeeds even though the default map would demand more."""
+        fake_registry = _make_fake_registry(
+            provider="google",
+            scopes=["https://www.googleapis.com/auth/gmail.modify"],
+            nsid="builtin:test",
+        )
+        ui_api_client.app.state.agent_registry = fake_registry
+
+        resp = ui_api_client.post(
+            "/v1/connections/google",
+            json=_forward_body(
+                scopes=[
+                    "https://www.googleapis.com/auth/gmail.modify",
+                    "openid",
+                ],
+                grant_agents=["builtin:test"],
+            ),
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 201, resp.text
+
+    def test_no_registry_no_grant_agents_accepts_any_scopes(self, ui_api_client):
+        """When app.state has no agent_registry AND grant_agents is empty,
+        required_scopes=[] is passed to api.py.  An explicit [] means
+        "require nothing at import time" — the forward succeeds regardless
+        of what scopes were provided.  Use-time gates (get_access_token)
+        still enforce coverage when an agent actually requests a token."""
+        # Ensure no registry on app.state.
+        if hasattr(ui_api_client.app.state, "agent_registry"):
+            del ui_api_client.app.state.agent_registry
+
+        resp = ui_api_client.post(
+            "/v1/connections/google",
+            json=_forward_body(
+                scopes=["openid"],
+                grant_agents=[],  # no agents → required resolves to []
+            ),
+            headers=UI_HEADER,
+        )
+        # required_scopes=[] → api.py honours empty list → 201.
+        assert resp.status_code == 201, resp.text


### PR DESCRIPTION
Forwarding a Microsoft (or any non-Google) OAuth connection to GAIA always 403'd with `scope_mismatch`, demanding Gmail scopes regardless of provider. This blocked the real-world Outlook testing milestone.

Two root defects in `import_forwarded_connection`:
1. `_DEFAULT_REQUIRED_SCOPES` applied Google-only scopes to every provider when `required_scopes` wasn't passed.
2. `if required_scopes` treated an explicit `[]` ("require nothing") identically to `None` ("use the default"), defeating any workaround.

The fix makes scope validation provider-aware at the connectors layer and agent-aware at the router layer — both unblocking Microsoft and tightening the contract for future providers.

## Test plan

- [ ] `pytest tests/unit/connectors/test_forwarded_import.py` — `TestProviderAwareScopeDefaults` covers non-Google None-path, explicit `[]`, explicit non-empty required, Google default preserved
- [ ] `pytest tests/unit/connectors/test_router_forwarded.py` (requires `[ui]` extras) — router-driven 403 and 201, no-registry-no-agents accepts any scopes
- [ ] `pytest tests/unit/connectors/test_flow.py` — `TestDecodeEmailFromIdToken` covers Google `email`, Microsoft `preferred_username`/`upn`, precedence, bad input
- [ ] Live: `POST /v1/connections/microsoft` with real Outlook refresh token → 201 (previously 403)
- [ ] Live: `POST /v1/connections/google` with `grant_agents=["builtin:email"]` → still 201 (no regression)
- [ ] `GET /v1/connections` → Microsoft entry listed with account email (not "default")

Follows #1292 (forwarded connection feature). Outlook triage E2E (#1275/#1358) is gated on the Outlook backend PR merging into this integration branch.