### PR TITLE
fix(ui): unload resident model before swapping in the chat load path (#1382)

### DIFF
--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1022,9 +1022,10 @@ def _maybe_load_expected_model(model_id: str, sse_handler=None) -> None:
         with model_load_lock:
             # Re-check after acquiring the lock: another thread may have
             # already loaded the expected model with sufficient context.
+            resident_chat_models = []
             resp2 = httpx.get(f"{base_url}/health", timeout=5.0, headers=_auth)
             if resp2.status_code == 200:
-                models2 = [
+                resident_chat_models = [
                     m
                     for m in resp2.json().get("all_models_loaded", [])
                     if m.get("type") in ("llm", "vlm")
@@ -1033,14 +1034,28 @@ def _maybe_load_expected_model(model_id: str, sse_handler=None) -> None:
                     (m.get("model_name") or "").lower() == expected_lower
                     and (m.get("recipe_options", {}).get("ctx_size") or 0)
                     >= DEFAULT_CONTEXT_SIZE
-                    for m in models2
+                    for m in resident_chat_models
                 ):
                     logger.debug(
                         "Expected model loaded with sufficient ctx by concurrent "
                         "thread; skipping load"
                     )
                     return
-            LemonadeClient(verbose=False).load_model(
+
+            client = LemonadeClient(verbose=False)
+            # Lemonade does not evict the resident model on a new /load, so
+            # loading a different model (or the same model at a larger ctx)
+            # leaves the previous one resident — a silent double-load that
+            # wastes memory and can degrade output. Unload the wrong/stale chat
+            # model first, mirroring gaia/rag/sdk.py before an embedder swap.
+            if resident_chat_models:
+                try:
+                    client.unload_model()
+                except Exception as unload_exc:
+                    logger.debug(
+                        "Pre-flight unload before reload failed: %s", unload_exc
+                    )
+            client.load_model(
                 model_id,
                 ctx_size=DEFAULT_CONTEXT_SIZE,
                 prompt=False,

--- a/tests/unit/test_chat_preflight.py
+++ b/tests/unit/test_chat_preflight.py
@@ -345,6 +345,62 @@ def test_concurrent_second_thread_skips_load():
 
 
 # ---------------------------------------------------------------------------
+# 11b. Wrong chat model resident → unload BEFORE load (issue #1382)
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_model_resident_unloads_before_load():
+    """Issue #1382: a different chat model resident (e.g. Gemma-4 preloaded at
+    boot) must be unloaded before loading the expected model. Lemonade does not
+    evict on /load, so without the unload both models stay resident — a
+    double-load that wastes memory and can degrade output (the slash-spew)."""
+    wrong = _health_ok([_model("llm", name="Gemma-4-E4B-it-GGUF")])
+
+    with (
+        patch(_LEMONADE_MANAGER) as mock_mgr,
+        patch(_HTTPX_GET, return_value=wrong),
+        patch(_LEMONADE_CLIENT) as mock_cls,
+    ):
+        mock_mgr.get_base_url.return_value = _BASE_URL
+        mock_instance = MagicMock()
+        mock_cls.return_value = mock_instance
+
+        _maybe_load_expected_model(_EXPECTED_LLM)
+
+        mock_instance.unload_model.assert_called_once()
+        mock_instance.load_model.assert_called_once()
+        order = [c[0] for c in mock_instance.method_calls]
+        assert order.index("unload_model") < order.index(
+            "load_model"
+        ), f"unload must precede load; got call order {order}"
+
+
+# ---------------------------------------------------------------------------
+# 11c. Nothing resident → load WITHOUT a wasteful unload
+# ---------------------------------------------------------------------------
+
+
+def test_no_resident_model_skips_unload():
+    """Fresh Lemonade (no chat model resident) → load_model is called but
+    unload_model is NOT (nothing to evict)."""
+    health = _health_ok([])
+
+    with (
+        patch(_LEMONADE_MANAGER) as mock_mgr,
+        patch(_HTTPX_GET, return_value=health),
+        patch(_LEMONADE_CLIENT) as mock_cls,
+    ):
+        mock_mgr.get_base_url.return_value = _BASE_URL
+        mock_instance = MagicMock()
+        mock_cls.return_value = mock_instance
+
+        _maybe_load_expected_model(_EXPECTED_LLM)
+
+        mock_instance.load_model.assert_called_once()
+        mock_instance.unload_model.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # 12. Re-check inside lock returns non-200 → load_model still called
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes the **resource leak** raised in #1382: the Agent UI preloads Gemma-4 at boot (`server.py`), then clicking **Build a Custom Agent** loads `Qwen3.5-35B-A3B` for the Builder. Lemonade doesn't evict the resident model on `/load`, so **both LLMs stay loaded at once** — kovtcharov-amd confirmed this in the thread ("Gemma4 and Qwen3.5-35B are both loaded … that should not be the case").

**Scope note:** this fixes the double-load only. It does **NOT** fix the repeated-`/` degenerate output also reported in #1382 — see the validation comment below; I could not reproduce that symptom and its cause is still unknown. #1382 should stay open for it.

**After:** `_maybe_load_expected_model` unloads the resident chat model before loading a different one (or the same one at a larger ctx), inside the existing `model_load_lock`. This mirrors `gaia/rag/sdk.py`, which already unloads before swapping because *"Lemonade skips reload if model already loaded"*. As a bonus it fixes a latent bug: the ctx-too-small reload path previously called `load_model` on an already-resident name, which Lemonade would skip.

Embedding models are left untouched (we only unload when a chat `llm`/`vlm` model is resident), so RAG's embedder + a chat model can still coexist.

## Test plan
- [x] `pytest tests/unit/test_chat_preflight.py` — 17 pass, incl. new `test_wrong_model_resident_unloads_before_load` and `test_no_resident_model_skips_unload`
- [x] Hardware A/B: old code → both models resident; this PR → only the target resident (see comment)
- [ ] `gaia eval agent` on the affected profile (LLM-affecting load path)
