### PR TITLE
fix(ui): render pre-scan card once + plumb mail_provider for Outlook routing

### DIFF
--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1174,6 +1174,10 @@ async def _get_chat_response(
                         allowed=allowed,
                         session_id=session_id,
                     ),
+                    # Forwarded only here (not via _session_agent_kwargs, which
+                    # also feeds the strict ChatAgentConfig). Non-email factories
+                    # drop it via dataclasses.fields filtering.
+                    mail_provider=session.get("mail_provider") or "google",
                 )
                 logger.info(
                     "chat: Invoking agent %s for session %s, model=%s",
@@ -1637,6 +1641,9 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                                 allowed=allowed,
                                 session_id=session_id,
                             ),
+                            # See the non-streaming path: email-only kwarg,
+                            # filtered out by non-email factories.
+                            mail_provider=session.get("mail_provider") or "google",
                         )
                         agent.console = sse_handler
                         logger.info(

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -45,7 +45,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     updated_at TEXT DEFAULT (datetime('now')),
     model TEXT NOT NULL DEFAULT 'Gemma-4-E4B-it-GGUF',
     system_prompt TEXT,
-    device TEXT DEFAULT 'gpu'
+    device TEXT DEFAULT 'gpu',
+    mail_provider TEXT DEFAULT 'google'
 );
 
 -- Many-to-many: which docs are attached to which session
@@ -224,6 +225,25 @@ class ChatDatabase:
         except Exception as e:
             logger.debug("Migration check for device column: %s", e)
 
+        # Add mail_provider column for per-session email-backend selection
+        # (Gmail vs Outlook). See EmailAgentConfig.mail_provider.
+        try:
+            sess_cols = [
+                row[1]
+                for row in self._conn.execute("PRAGMA table_info(sessions)").fetchall()
+            ]
+            if "mail_provider" not in sess_cols:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN mail_provider TEXT DEFAULT 'google'"
+                )
+                self._conn.execute(
+                    "UPDATE sessions SET mail_provider = 'google' WHERE mail_provider IS NULL"
+                )
+                self._conn.commit()
+                logger.info("Migrated sessions table: added mail_provider column")
+        except Exception as e:
+            logger.debug("Migration check for mail_provider column: %s", e)
+
     def close(self):
         """Close database connection."""
         if self._conn:
@@ -258,6 +278,7 @@ class ChatDatabase:
         private: bool = False,
         agent_type: str = None,
         device: str = None,
+        mail_provider: str = None,
     ) -> Dict[str, Any]:
         """Create a new chat session."""
         session_id = str(uuid.uuid4())
@@ -266,11 +287,12 @@ class ChatDatabase:
         title = title or "New Chat"
         agent_type = agent_type or "chat"
         device = device or "gpu"
+        mail_provider = mail_provider or "google"
 
         with self._transaction():
             self._conn.execute(
-                """INSERT INTO sessions (id, title, created_at, updated_at, model, system_prompt, private, agent_type, device)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT INTO sessions (id, title, created_at, updated_at, model, system_prompt, private, agent_type, device, mail_provider)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     title,
@@ -281,6 +303,7 @@ class ChatDatabase:
                     1 if private else 0,
                     agent_type,
                     device,
+                    mail_provider,
                 ),
             )
 
@@ -359,8 +382,9 @@ class ChatDatabase:
         private: bool = None,
         agent_type: str = None,
         device: str = None,
+        mail_provider: str = None,
     ) -> Optional[Dict[str, Any]]:
-        """Update session title, system prompt, agent_type, device, private flag, and/or document_ids."""
+        """Update session title, system prompt, agent_type, device, mail_provider, private flag, and/or document_ids."""
         updates = []
         params = []
 
@@ -379,6 +403,9 @@ class ChatDatabase:
         if device is not None:
             updates.append("device = ?")
             params.append(device)
+        if mail_provider is not None:
+            updates.append("mail_provider = ?")
+            params.append(mail_provider)
 
         updates.append("updated_at = ?")
         params.append(self._now())

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -246,6 +246,9 @@ class CreateSessionRequest(BaseModel):
     private: bool = False
     agent_type: Optional[str] = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
     device: Optional[str] = None
+    # Mailbox provider for email-backed agents. Gmail by default; "microsoft"
+    # routes the email agent to the Outlook backend (see EmailAgentConfig).
+    mail_provider: Optional[str] = Field(None, pattern=r"^(google|microsoft)$")
 
 
 class UpdateSessionRequest(BaseModel):
@@ -257,6 +260,7 @@ class UpdateSessionRequest(BaseModel):
     private: Optional[bool] = None
     agent_type: Optional[str] = Field(None, max_length=64, pattern=r"^[a-zA-Z0-9_-]+$")
     device: Optional[str] = None
+    mail_provider: Optional[str] = Field(None, pattern=r"^(google|microsoft)$")
 
 
 class SessionResponse(BaseModel):
@@ -273,6 +277,7 @@ class SessionResponse(BaseModel):
     private: bool = False
     agent_type: str = "chat"
     device: str = "gpu"
+    mail_provider: str = "google"
 
 
 class SessionListResponse(BaseModel):

--- a/src/gaia/ui/routers/sessions.py
+++ b/src/gaia/ui/routers/sessions.py
@@ -61,6 +61,7 @@ async def create_session(
             private=request.private,
             agent_type=request.agent_type,
             device=request.device,
+            mail_provider=request.mail_provider,
         )
         return session_to_response(session)
     except Exception as e:
@@ -87,7 +88,11 @@ async def update_session(
     db: ChatDatabase = Depends(get_db),
 ):
     """Update session title, system prompt, or linked documents."""
-    if request.agent_type is not None or request.device is not None:
+    if (
+        request.agent_type is not None
+        or request.device is not None
+        or request.mail_provider is not None
+    ):
         evict_session_agent(session_id)
     session = db.update_session(
         session_id,
@@ -97,6 +102,7 @@ async def update_session(
         private=request.private,
         agent_type=request.agent_type,
         device=request.device,
+        mail_provider=request.mail_provider,
     )
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -88,6 +88,52 @@ _RAG_RESULT_JSON_SUB_RE = re.compile(
 _TRAILING_CODE_FENCE_RE = re.compile(r"\n?```\s*$")
 
 
+def _strip_balanced_json_blobs(text: str, needle: "re.Pattern") -> str:
+    """Remove every top-level ``{...}`` JSON object whose body matches *needle*.
+
+    Brace- and string-aware: it walks the text tracking quote/escape state so a
+    ``{`` or ``}`` inside a JSON string never miscounts depth, and it only
+    removes *complete* balanced objects. This is why it is safe to run against
+    arbitrary LLM prose — an unbalanced or non-matching object is left intact.
+    """
+    if not text:
+        return text
+    out: List[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] != "{":
+            out.append(text[i])
+            i += 1
+            continue
+        depth, j, in_str, esc = 0, i, False, False
+        while j < n:
+            c = text[j]
+            if in_str:
+                if esc:
+                    esc = False
+                elif c == "\\":
+                    esc = True
+                elif c == '"':
+                    in_str = False
+            elif c == '"':
+                in_str = True
+            elif c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    j += 1
+                    break
+            j += 1
+        blob = text[i:j]
+        if depth == 0 and needle.search(blob):
+            i = j  # drop a complete, matching object
+            continue
+        out.append(blob)
+        i = j
+    return "".join(out)
+
+
 class SSEOutputHandler(OutputHandler):
     """
     OutputHandler that queues agent events as JSON for SSE streaming.
@@ -484,6 +530,33 @@ class SSEOutputHandler(OutputHandler):
         self._pending_render_payloads = []
         return "\n\n".join(blocks)
 
+    @classmethod
+    def _strip_echoed_render_cards(cls, answer: str) -> str:
+        """Drop any render-card copy the LLM reproduced in its prose.
+
+        The authoritative card is injected from ``_pending_render_payloads``;
+        small chat-tuned models sometimes also echo it (as a fenced
+        ```<lang>``` block or a bare envelope object), which would render the
+        card twice. Languages are derived from ``_RENDER_TOOL_TO_LANG`` so this
+        stays in sync as render tools are added.
+        """
+        if not answer:
+            return answer
+        langs = sorted(set(cls._RENDER_TOOL_TO_LANG.values()))
+        if not langs:
+            return answer
+        cache = cls.__dict__.get("_RENDER_ECHO_PATTERNS")
+        if cache is None or cache[0] != tuple(langs):
+            alt = "|".join(re.escape(lang) for lang in langs)
+            fence = re.compile(rf"```(?:{alt})\b[\s\S]*?```", re.IGNORECASE)
+            kind = re.compile(rf'"kind"\s*:\s*"(?:{alt})"')
+            cache = (tuple(langs), fence, kind)
+            cls._RENDER_ECHO_PATTERNS = cache
+        _, fence_re, kind_re = cache
+        answer = fence_re.sub("", answer)
+        answer = _strip_balanced_json_blobs(answer, kind_re)
+        return answer
+
     # === Completion Methods ===
 
     def print_final_answer(
@@ -510,6 +583,9 @@ class SSEOutputHandler(OutputHandler):
         # framing the LLM produced.
         rendered_fences = self._drain_render_payloads()
         if rendered_fences:
+            # The buffered card is authoritative — strip any copy the LLM
+            # echoed so the pre-scan card renders exactly once (#1000).
+            answer = self._strip_echoed_render_cards(answer).strip()
             answer = (rendered_fences + ("\n\n" + answer if answer else "")).strip()
         self._emit(
             {

--- a/src/gaia/ui/utils.py
+++ b/src/gaia/ui/utils.py
@@ -141,6 +141,7 @@ def session_to_response(session: dict) -> SessionResponse:
         private=bool(session.get("private", 0)),
         agent_type=session.get("agent_type") or "chat",
         device=session.get("device") or "gpu",
+        mail_provider=session.get("mail_provider") or "google",
     )
 
 

--- a/tests/unit/chat/ui/test_database.py
+++ b/tests/unit/chat/ui/test_database.py
@@ -110,6 +110,57 @@ class TestSessions:
         refreshed = db.get_session(session["id"])
         assert refreshed["updated_at"] >= original_updated
 
+    def test_create_session_default_mail_provider(self, db):
+        session = db.create_session()
+        assert session["mail_provider"] == "google"
+
+    def test_create_session_with_mail_provider(self, db):
+        session = db.create_session(mail_provider="microsoft")
+        assert session["mail_provider"] == "microsoft"
+        # Round-trips through a fresh read.
+        assert db.get_session(session["id"])["mail_provider"] == "microsoft"
+
+    def test_update_session_mail_provider(self, db):
+        session = db.create_session()  # defaults to google
+        updated = db.update_session(session["id"], mail_provider="microsoft")
+        assert updated["mail_provider"] == "microsoft"
+
+
+class TestMailProviderMigration:
+    """The mail_provider column must be added to pre-existing DBs that were
+    created before the email-provider selector landed (additive migration,
+    mirroring the device/agent_type precedent)."""
+
+    def test_migration_adds_mail_provider_column(self, tmp_path):
+        db_path = str(tmp_path / "old.db")
+        # Hand-roll a sessions table from before the mail_provider column.
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT, "
+            "created_at TEXT, updated_at TEXT, model TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, title, created_at, updated_at, model) "
+            "VALUES ('s1', 'Old', '2025-01-01', '2025-01-01', 'm')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Opening through ChatDatabase runs the additive migration.
+        database = ChatDatabase(db_path)
+        try:
+            cols = [
+                r[1]
+                for r in database._conn.execute(
+                    "PRAGMA table_info(sessions)"
+                ).fetchall()
+            ]
+            assert "mail_provider" in cols
+            # The pre-existing row defaults to google, never NULL.
+            assert database.get_session("s1")["mail_provider"] == "google"
+        finally:
+            database.close()
+
 
 class TestMessages:
     def test_add_and_get_messages(self, db):

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -829,6 +829,31 @@ class TestSessionEndpoints:
         resp = client.get("/api/sessions/nonexistent-uuid")
         assert resp.status_code == 404
 
+    def test_create_session_default_mail_provider(self, client):
+        data = client.post("/api/sessions", json={}).json()
+        assert data["mail_provider"] == "google"
+
+    def test_create_session_microsoft_mail_provider(self, client):
+        resp = client.post(
+            "/api/sessions",
+            json={"agent_type": "email", "mail_provider": "microsoft"},
+        )
+        assert resp.status_code == 200
+        sid = resp.json()["id"]
+        assert resp.json()["mail_provider"] == "microsoft"
+        # Persists across a fresh GET.
+        assert client.get(f"/api/sessions/{sid}").json()["mail_provider"] == "microsoft"
+
+    def test_create_session_invalid_mail_provider_rejected(self, client):
+        resp = client.post("/api/sessions", json={"mail_provider": "yahoo"})
+        assert resp.status_code == 422  # pattern validation fails loudly
+
+    def test_update_session_mail_provider(self, client):
+        sid = client.post("/api/sessions", json={}).json()["id"]
+        resp = client.put(f"/api/sessions/{sid}", json={"mail_provider": "microsoft"})
+        assert resp.status_code == 200
+        assert resp.json()["mail_provider"] == "microsoft"
+
     def test_update_session_title(self, client):
         create_resp = client.post("/api/sessions", json={"title": "Original"})
         session_id = create_resp.json()["id"]

--- a/tests/unit/chat/ui/test_sse_handler.py
+++ b/tests/unit/chat/ui/test_sse_handler.py
@@ -8,6 +8,7 @@ events queued for Server-Sent Events delivery to the frontend.
 """
 
 import queue
+import re
 import time
 
 import pytest
@@ -17,6 +18,7 @@ from gaia.ui.sse_handler import (
     SSEOutputHandler,
     _fix_double_escaped,
     _format_tool_args,
+    _strip_balanced_json_blobs,
     _summarize_tool_result,
     _tool_description,
 )
@@ -1830,6 +1832,60 @@ class TestStructuredRenderInjection:
         assert events[0]["content"].startswith("```email_pre_scan\n")
         assert events[0]["content"].rstrip().endswith("```")
 
+    # --- De-dup: explicit-tool path where the LLM also echoes the card ----
+
+    def test_echoed_fence_rendered_once(self, handler):
+        """Explicit-tool path: the model echoes the same fenced card the
+        handler already buffered. The card must appear exactly once."""
+        import json as _json
+
+        inner = self._make_envelope()["data"]
+        echoed = f"```email_pre_scan\n{_json.dumps(inner)}\n```"
+        handler.print_tool_usage("pre_scan_inbox")
+        _drain(handler)
+        handler.pretty_print_json(self._make_envelope(), title="Result")
+        _drain(handler)
+        handler.print_final_answer(f"Here is your inbox.\n\n{echoed}")
+        events = _drain(handler)
+        content = events[0]["content"]
+        # Exactly one fenced card (the authoritative buffered one).
+        assert content.count("```email_pre_scan") == 1
+        assert content.startswith("```email_pre_scan\n")
+        # The LLM prose survives.
+        assert "Here is your inbox." in content
+
+    def test_echoed_bare_envelope_stripped(self, handler):
+        """The model echoes the raw envelope object as prose (no fence). The
+        balanced-brace strip removes it so only the buffered card renders."""
+        import json as _json
+
+        echoed = _json.dumps(self._make_envelope())  # full {"ok":..,"data":..}
+        handler.print_tool_usage("pre_scan_inbox")
+        _drain(handler)
+        handler.pretty_print_json(self._make_envelope(), title="Result")
+        _drain(handler)
+        handler.print_final_answer(f"Summary below.\n\n{echoed}")
+        events = _drain(handler)
+        content = events[0]["content"]
+        assert content.count("```email_pre_scan") == 1
+        # The bare echo (a field unique to the envelope) is gone.
+        assert "informational_count" not in content.split("```", 3)[-1]
+        assert "Summary below." in content
+
+    def test_inline_path_fence_not_stripped(self, handler):
+        """Regression: inline single-step path has an EMPTY buffer, so the
+        strip must not run — the model's own legitimate fence renders once."""
+        import json as _json
+
+        inner = self._make_envelope()["data"]
+        legit = f"```email_pre_scan\n{_json.dumps(inner)}\n```"
+        assert handler._pending_render_payloads == []  # nothing buffered
+        handler.print_final_answer(f"{legit}\n\nDone.")
+        events = _drain(handler)
+        content = events[0]["content"]
+        assert content.count("```email_pre_scan") == 1
+        assert "Done." in content
+
     def test_other_tool_results_do_not_inject_fence(self, handler):
         """Only ``pre_scan_inbox`` triggers injection — other tools pass through."""
         handler.print_tool_usage("triage_inbox")
@@ -1882,3 +1938,37 @@ class TestStructuredRenderInjection:
         events = _drain(handler)
         assert events[0]["content"] == "Second turn — no card."
         assert "email_pre_scan" not in events[0]["content"]
+
+
+class TestStripBalancedJsonBlobs:
+    """Direct tests for the brace-/string-aware JSON blob remover."""
+
+    KIND_RE = re.compile(r'"kind"\s*:\s*"email_pre_scan"')
+
+    def test_removes_matching_object(self):
+        text = 'Before {"kind": "email_pre_scan", "n": 1} after'
+        out = _strip_balanced_json_blobs(text, self.KIND_RE)
+        assert "kind" not in out
+        assert "Before" in out and "after" in out
+
+    def test_removes_nested_matching_object(self):
+        text = 'x {"ok": true, "data": {"kind": "email_pre_scan", "n": 2}} y'
+        out = _strip_balanced_json_blobs(text, self.KIND_RE)
+        assert "email_pre_scan" not in out
+        assert out.startswith("x ") and out.endswith(" y")
+
+    def test_leaves_unrelated_objects(self):
+        text = 'Use {"foo": "bar"} and {"baz": 1} please'
+        out = _strip_balanced_json_blobs(text, self.KIND_RE)
+        assert out == text  # nothing matched the needle
+
+    def test_string_aware_does_not_miscount_braces(self):
+        # A '}' inside a JSON string must not end the object early.
+        text = '{"note": "a } brace", "kind": "email_pre_scan"} tail'
+        out = _strip_balanced_json_blobs(text, self.KIND_RE)
+        assert out.strip() == "tail"
+
+    def test_unbalanced_object_left_intact(self):
+        text = 'oops {"kind": "email_pre_scan", "n": 1 and no close'
+        out = _strip_balanced_json_blobs(text, self.KIND_RE)
+        assert out == text  # incomplete object is not removed


### PR DESCRIPTION
## Why this matters

Two bugs found during real-world email-triage testing on AMD hardware, both invisible to a green CI:

- **Before:** the Gmail pre-scan card rendered **twice** whenever the agent called `pre_scan_inbox` as an explicit tool — the buffered card plus the model's echoed copy. **After:** exactly one card, regardless of which path the model takes.
- **Before:** even though the Outlook backend exists and works, the UI session API had no way to select it, so every email session was Gmail-backed and Outlook triage was unreachable. **After:** a session created with `mail_provider="microsoft"` routes to the Outlook backend; invalid providers fail loudly (HTTP 422).

Resolves #1385 and #1386. Targets the `itomek/email-triage-agent` integration branch (not `main`).

## Test plan

- [ ] `PYTHONPATH=src python -m pytest tests/unit/chat/ui/test_sse_handler.py tests/unit/chat/ui/test_database.py tests/unit/chat/ui/test_server.py -q` → green (covers double-render once/inline-preserved, the balanced-JSON remover, DB round-trip + migration, and the session-API persistence + 422 validation)
- [ ] Start `python -m gaia.ui.server --port 4200`; create a session with `mail_provider="microsoft"` → GET round-trips `"microsoft"`; create a default session → `"google"`; drive a `pre_scan_inbox` explicit-tool turn and confirm the card renders once in the `answer` event
