### PR TITLE
fix(agents): raise step limit and centralize on one global default

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -96,6 +96,21 @@ gaia --ui --base-url https://your-server:13305/api/v1
   `gaia chat --ui` continues to work as an alias. The Agent UI requires an AMD Ryzen AI Max (Strix Halo) or an AMD Radeon GPU with ≥ 24 GB VRAM. If your device is not supported, a dismissible warning banner will appear in the UI.
 </Note>
 
+### Agent step limit
+
+Agents stop after a maximum number of reasoning/tool steps. The default is **50**, applied consistently across the CLI, the Agent UI, and background runs.
+
+- **Per-invocation:** pass `--max-steps <n>` to any agent command (e.g. `gaia browse --max-steps 80`). `gaia blender` uses `--steps <n>`.
+- **Fleet-wide:** set the `GAIA_AGENT_MAX_STEPS` environment variable to change the default for every agent at once, without per-command flags.
+
+```bash
+# Raise the limit for every agent in this shell
+export GAIA_AGENT_MAX_STEPS=80
+gaia browse "research the latest AMD Ryzen AI news"
+```
+
+A few agents intentionally override the default (e.g. the Code agent uses 100 for multi-file generation). An invalid `GAIA_AGENT_MAX_STEPS` value (non-integer or ≤ 0) fails fast with an actionable error rather than silently capping agents.
+
 ---
 
 ## Initialization

--- a/hub/agents/python/analyst/gaia_agent_analyst/agent.py
+++ b/hub/agents/python/analyst/gaia_agent_analyst/agent.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 """Structured-data analysis GAIA agent."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.tools import ScratchpadToolsMixin
 from gaia.mcp.mixin import MCPClientMixin
@@ -20,7 +20,7 @@ class AnalystAgentConfig:
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
     streaming: bool = False
     debug: bool = False
     debug_prompts: bool = False

--- a/hub/agents/python/analyst/tests/test_analyst_agent.py
+++ b/hub/agents/python/analyst/tests/test_analyst_agent.py
@@ -26,10 +26,12 @@ class TestAnalystAgentConfig(unittest.TestCase):
     def test_defaults(self):
         from gaia_agent_analyst import AnalystAgentConfig
 
+        from gaia.agents.base.agent import default_max_steps
+
         cfg = AnalystAgentConfig()
         self.assertFalse(cfg.use_claude)
         self.assertIsNone(cfg.model_id)
-        self.assertEqual(cfg.max_steps, 10)
+        self.assertEqual(cfg.max_steps, default_max_steps())
         self.assertTrue(cfg.scratchpad_db_path)
 
 

--- a/hub/agents/python/blender/gaia_agent_blender/agent.py
+++ b/hub/agents/python/blender/gaia_agent_blender/agent.py
@@ -30,7 +30,7 @@ class BlenderAgent(Agent):
         mcp: Optional[MCPClient] = None,
         model_id: str = None,
         base_url: str = "http://localhost:13305/api/v1",
-        max_steps: int = 5,
+        max_steps: Optional[int] = None,
         debug_prompts: bool = False,
         output_dir: str = None,
         streaming: bool = False,
@@ -526,10 +526,11 @@ Examples of colored requests:
         Returns:
             Dict containing the scene creation result
         """
-        # Same process as process_query but with more steps allowed if specified
+        # When the caller doesn't override, fall back to the agent's configured
+        # max_steps (the global default unless explicitly set at construction).
         return self.process_query(
             f"Create a complete 3D scene with the following description: {scene_description}",
-            max_steps=max_steps if max_steps is not None else self.max_steps * 2,
+            max_steps=max_steps,
             trace=trace,
             filename=filename,
         )

--- a/hub/agents/python/browser/gaia_agent_browser/agent.py
+++ b/hub/agents/python/browser/gaia_agent_browser/agent.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 """Browser-focused GAIA agent."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.tools import BrowserToolsMixin
 from gaia.mcp.mixin import MCPClientMixin
@@ -20,7 +20,7 @@ class BrowserAgentConfig:
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
     streaming: bool = False
     debug: bool = False
     debug_prompts: bool = False

--- a/hub/agents/python/code/gaia_agent_code/agent.py
+++ b/hub/agents/python/code/gaia_agent_code/agent.py
@@ -115,8 +115,10 @@ class CodeAgent(
         self.language = language
         self.project_type = project_type
 
-        # Default to more steps for complex workflows
-        if "max_steps" not in kwargs:
+        # Default to more steps for complex workflows. Treat an explicit None
+        # (the CLI's "use the default" sentinel) the same as omitted, so this
+        # override isn't silently dropped to the global default.
+        if kwargs.get("max_steps") is None:
             kwargs["max_steps"] = 100  # Increased for complex project generation
         # Use the coding model for better code understanding
         if "model_id" not in kwargs:

--- a/hub/agents/python/code/tests/test_code_agent.py
+++ b/hub/agents/python/code/tests/test_code_agent.py
@@ -68,6 +68,11 @@ class TestCodeAgent(unittest.TestCase):
         self.assertTrue(agent2.debug)
         self.assertTrue(agent2.show_prompts)
 
+        # Explicit max_steps=None is the CLI "use the default" sentinel and must
+        # NOT drop CodeAgent's 100-step override to the global default.
+        agent3 = CodeAgent(max_steps=None)
+        self.assertEqual(agent3.max_steps, 100)
+
     def test_system_prompt(self):
         """Test that system prompt is properly generated."""
         prompt = self.agent._get_system_prompt()

--- a/hub/agents/python/connectors-demo/gaia_agent_connectors_demo/agent.py
+++ b/hub/agents/python/connectors-demo/gaia_agent_connectors_demo/agent.py
@@ -36,13 +36,13 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, time
 from typing import Any, ClassVar, Dict, List, Optional
 
 import httpx
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.tools import tool
 from gaia.connectors.errors import ConnectorsError
@@ -295,7 +295,7 @@ class ConnectorsDemoAgentConfig:
 
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 6
+    max_steps: int = field(default_factory=default_max_steps)
     streaming: bool = False
     debug: bool = False
     show_stats: bool = False

--- a/hub/agents/python/docker/gaia_agent_docker/agent.py
+++ b/hub/agents/python/docker/gaia_agent_docker/agent.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict
 
+from gaia.agents.base.agent import default_max_steps
 from gaia.agents.base.console import AgentConsole, SilentConsole
 from gaia.agents.base.mcp_agent import MCPAgent
 from gaia.agents.base.tools import tool
@@ -22,7 +23,6 @@ from gaia.security import PathValidator
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "Qwen3.5-35B-A3B-GGUF"
-DEFAULT_MAX_STEPS = 10
 DEFAULT_PORT = 8080
 
 
@@ -45,7 +45,7 @@ class DockerAgent(MCPAgent):
 
         Args:
             **kwargs: Agent initialization parameters:
-                - max_steps: Maximum conversation steps (default: 10)
+                - max_steps: Maximum conversation steps (default: global default_max_steps())
                 - model_id: LLM model to use (default: Qwen3.5-35B-A3B-GGUF)
                 - silent_mode: Suppress console output (default: False)
                 - debug: Enable debug logging (default: False)
@@ -55,8 +55,10 @@ class DockerAgent(MCPAgent):
         if "model_id" not in kwargs:
             kwargs["model_id"] = DEFAULT_MODEL
 
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = DEFAULT_MAX_STEPS
+        # An explicit None (the CLI's "use the default" sentinel) counts as no
+        # override and falls through to the global default.
+        if kwargs.get("max_steps") is None:
+            kwargs["max_steps"] = default_max_steps()
 
         # Security: Configure allowed paths for file operations
         # If None, allow current directory and subdirectories

--- a/hub/agents/python/emr/gaia_agent_emr/agent.py
+++ b/hub/agents/python/emr/gaia_agent_emr/agent.py
@@ -130,8 +130,11 @@ class MedicalIntakeAgent(Agent, DatabaseMixin, FileWatcherMixin):
         # Signature: callback(filename, step_num, total_steps, step_name, status)
         self._progress_callback: Optional[callable] = None
 
-        # Set reasonable defaults for agent - higher max_steps for interactive use
-        kwargs.setdefault("max_steps", 50)
+        # Set reasonable defaults for agent - higher max_steps for interactive
+        # use. Treat an explicit None (the CLI "use the default" sentinel) the
+        # same as omitted so this override isn't dropped to the global default.
+        if kwargs.get("max_steps") is None:
+            kwargs["max_steps"] = 50
 
         super().__init__(**kwargs)
 

--- a/hub/agents/python/fileio/gaia_agent_fileio/agent.py
+++ b/hub/agents/python/fileio/gaia_agent_fileio/agent.py
@@ -1,9 +1,9 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.tools import (
     FileIOToolsMixin,
     FileSearchToolsMixin,
@@ -20,7 +20,7 @@ class FileIOAgentConfig:
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
 
 
 class FileIOAgent(

--- a/hub/agents/python/fileio/tests/test_fileio_agent.py
+++ b/hub/agents/python/fileio/tests/test_fileio_agent.py
@@ -24,11 +24,13 @@ class TestFileIOAgentConfig(unittest.TestCase):
     def test_defaults(self):
         from gaia_agent_fileio.agent import FileIOAgentConfig
 
+        from gaia.agents.base.agent import default_max_steps
+
         cfg = FileIOAgentConfig()
         self.assertFalse(cfg.use_claude)
         self.assertFalse(cfg.use_chatgpt)
         self.assertIsNone(cfg.model_id)
-        self.assertEqual(cfg.max_steps, 10)
+        self.assertEqual(cfg.max_steps, default_max_steps())
 
 
 class TestFileIOAgentInit(unittest.TestCase):

--- a/hub/agents/python/jira/gaia_agent_jira/agent.py
+++ b/hub/agents/python/jira/gaia_agent_jira/agent.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.base.console import AgentConsole, SilentConsole
 from gaia.agents.base.tools import tool
 
@@ -100,7 +100,7 @@ class JiraAgent(Agent):
                 - statuses: List of available status names
                 - priorities: List of available priority names
             **kwargs: Other agent initialization parameters:
-                - max_steps: Maximum conversation steps (default: 10)
+                - max_steps: Maximum conversation steps (default: global default_max_steps())
                 - model_id: LLM model to use (default: Qwen3.5-35B-A3B-GGUF)
                 - silent_mode: Suppress console output (default: False)
                 - debug: Enable debug logging (default: False)
@@ -119,9 +119,10 @@ class JiraAgent(Agent):
             }
             agent = JiraAgent(jira_config=config)
         """
-        # Increase max steps to allow for completion
-        if "max_steps" not in kwargs:
-            kwargs["max_steps"] = 10
+        # Use the global default unless the caller overrides it. An explicit
+        # None (the CLI's "use the default" sentinel) counts as no override.
+        if kwargs.get("max_steps") is None:
+            kwargs["max_steps"] = default_max_steps()
         # Use the larger coding model by default for reliable JSON parsing
         if "model_id" not in kwargs:
             kwargs["model_id"] = "Qwen3.5-35B-A3B-GGUF"

--- a/hub/agents/python/sd/gaia_agent_sd/agent.py
+++ b/hub/agents/python/sd/gaia_agent_sd/agent.py
@@ -9,10 +9,10 @@ and optimizes generation parameters based on the selected SD model.
 """
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.logger import get_logger
 from gaia.sd import SDToolsMixin
 from gaia.vlm import VLMToolsMixin
@@ -37,7 +37,7 @@ class SDAgentConfig:
     model_id: str = "Gemma-4-E4B-it-GGUF"  # Multimodal model for agentic reasoning
 
     # Execution settings
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
     streaming: bool = False
     ctx_size: int = 16384  # 16K context for multi-step planning with dynamic parameters
 

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -38,6 +38,40 @@ logger = logging.getLogger(__name__)
 CHUNK_TRUNCATION_THRESHOLD = 5000
 CHUNK_TRUNCATION_SIZE = 2500
 
+# Global default for how many reasoning/tool steps an agent may take before it
+# stops and reports progress. This is the single knob for the whole fleet:
+# change DEFAULT_MAX_STEPS here, or set GAIA_AGENT_MAX_STEPS=<n> at runtime to
+# override every agent at once. Agents that genuinely need more (e.g. CodeAgent
+# for multi-file generation) override it explicitly in their own config.
+DEFAULT_MAX_STEPS = 50
+
+
+def default_max_steps() -> int:
+    """Resolve the global default agent step limit.
+
+    Reads ``GAIA_AGENT_MAX_STEPS`` at call time (not import) so the env var can
+    be set after this module is imported and still take effect. Returns
+    ``DEFAULT_MAX_STEPS`` when the var is unset; raises on a present-but-invalid
+    value so a typo surfaces immediately instead of silently capping agents.
+    """
+    raw = os.environ.get("GAIA_AGENT_MAX_STEPS")
+    if raw is None or raw == "":
+        return DEFAULT_MAX_STEPS
+    try:
+        value = int(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"GAIA_AGENT_MAX_STEPS must be a positive integer, got {raw!r}. "
+            f"Unset it to use the default ({DEFAULT_MAX_STEPS})."
+        ) from e
+    if value <= 0:
+        raise ValueError(
+            f"GAIA_AGENT_MAX_STEPS must be a positive integer, got {value}. "
+            f"Unset it to use the default ({DEFAULT_MAX_STEPS})."
+        )
+    return value
+
+
 # Tools that require explicit user confirmation before execution.
 # Adding a tool name here causes _execute_tool() to call
 # console.confirm_tool_execution() and block until the user responds.
@@ -242,7 +276,7 @@ Do NOT wrap conversational replies in JSON.
         claude_model: str = "claude-sonnet-4-20250514",
         base_url: Optional[str] = None,
         model_id: str = None,
-        max_steps: int = 20,
+        max_steps: Optional[int] = None,
         debug_prompts: bool = False,
         show_prompts: bool = False,
         output_dir: str = None,
@@ -266,7 +300,9 @@ Do NOT wrap conversational replies in JSON.
             claude_model: Claude model to use when use_claude=True (default: "claude-sonnet-4-20250514")
             base_url: Base URL for local LLM server (default: reads from LEMONADE_BASE_URL env var, falls back to http://localhost:13305/api/v1)
             model_id: The ID of the model to use with LLM server (default for local)
-            max_steps: Maximum number of steps the agent can take before terminating
+            max_steps: Maximum number of steps the agent can take before terminating.
+                When None, falls back to the global default_max_steps() (env
+                GAIA_AGENT_MAX_STEPS, else DEFAULT_MAX_STEPS).
             debug_prompts: If True, includes prompts in the conversation history
             show_prompts: If True, displays prompts sent to LLM in console (default: False)
             output_dir: Directory for storing JSON output files (default: current directory)
@@ -292,7 +328,7 @@ Do NOT wrap conversational replies in JSON.
         self.conversation_history = (
             []
         )  # Store conversation history for session persistence
-        self.max_steps = max_steps
+        self.max_steps = max_steps if max_steps is not None else default_max_steps()
         self.debug_prompts = debug_prompts
         self.show_prompts = show_prompts  # Separate flag for displaying prompts
         self.output_dir = output_dir if output_dir else os.getcwd()

--- a/src/gaia/agents/builder/agent.py
+++ b/src/gaia/agents/builder/agent.py
@@ -13,11 +13,11 @@ import json
 import os
 import re
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.tools import tool
 from gaia.logger import get_logger
@@ -98,7 +98,7 @@ class BuilderAgentConfig:
 
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
     streaming: bool = False
     debug: bool = False
     show_stats: bool = False

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     Observer = None
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.memory import MemoryMixin
 from gaia.agents.base.tool_loader import ToolLoader
@@ -57,7 +57,7 @@ class ChatAgentConfig:
     model_id: Optional[str] = None  # None = use default model (Gemma)
 
     # Execution settings
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
     streaming: bool = False  # Use --streaming to enable
 
     # NPU's FLM build runs at 4K, so a device config can override the 32K ctx.

--- a/src/gaia/agents/chat/lite_agent.py
+++ b/src/gaia/agents/chat/lite_agent.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.tools import ScreenshotToolsMixin
 from gaia.mcp.mixin import MCPClientMixin
 from gaia.sd.mixin import SDToolsMixin
@@ -15,7 +15,7 @@ class ChatAgentLiteConfig:
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
 
 
 class ChatAgentLite(

--- a/src/gaia/agents/docqa/agent.py
+++ b/src/gaia/agents/docqa/agent.py
@@ -1,9 +1,9 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
-from gaia.agents.base.agent import Agent
+from gaia.agents.base.agent import Agent, default_max_steps
 from gaia.agents.chat.tools import FileToolsMixin
 from gaia.agents.tools import FileIOToolsMixin, FileSearchToolsMixin, RAGToolsMixin
 from gaia.mcp.mixin import MCPClientMixin
@@ -16,7 +16,7 @@ class DocumentQAAgentConfig:
     claude_model: str = "claude-sonnet-4-20250514"
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 10
+    max_steps: int = field(default_factory=default_max_steps)
     rag_documents: Optional[List[str]] = None
 
 

--- a/src/gaia/agents/email/config.py
+++ b/src/gaia/agents/email/config.py
@@ -16,9 +16,11 @@ API entirely.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 from urllib.parse import urlparse
+
+from gaia.agents.base.agent import default_max_steps
 
 
 class ConfigurationError(ValueError):
@@ -101,7 +103,7 @@ class EmailAgentConfig:
 
     base_url: Optional[str] = None
     model_id: Optional[str] = None
-    max_steps: int = 12
+    max_steps: int = field(default_factory=default_max_steps)
     streaming: bool = False
     debug: bool = False
     silent_mode: bool = False

--- a/src/gaia/agents/email/outlook_backend.py
+++ b/src/gaia/agents/email/outlook_backend.py
@@ -521,7 +521,7 @@ class LiveOutlookBackend:
         )
         return {"id": "", "to": to, "subject": subject}
 
-    def create_label(
+    def create_label(  # pylint: disable=unused-argument
         self, *, name: str, label_list_visibility: str = "labelShow"
     ) -> Dict[str, Any]:
         # Master categories require a ``color`` (preset enum); ``preset0`` is a

--- a/src/gaia/agents/email/outlook_calendar_backend.py
+++ b/src/gaia/agents/email/outlook_calendar_backend.py
@@ -237,7 +237,7 @@ class LiveOutlookCalendarBackend:
         data = self._get("/me/calendars")
         return data.get("value", [])
 
-    def list_events(
+    def list_events(  # pylint: disable=unused-argument
         self,
         *,
         calendar_id: str = "primary",
@@ -267,7 +267,7 @@ class LiveOutlookCalendarBackend:
         # exactly as a Google list response.
         return {"items": items}
 
-    def get_event(
+    def get_event(  # pylint: disable=unused-argument
         self, *, calendar_id: str = "primary", event_id: str
     ) -> Dict[str, Any]:
         # ``calendar_id`` is implicit in Graph's ``/me`` endpoints — kept in the
@@ -278,7 +278,7 @@ class LiveOutlookCalendarBackend:
 
     # -- Mutate APIs --------------------------------------------------------
 
-    def update_event_rsvp(
+    def update_event_rsvp(  # pylint: disable=unused-argument
         self,
         *,
         calendar_id: str = "primary",
@@ -301,7 +301,7 @@ class LiveOutlookCalendarBackend:
         self._post(f"/me/events/{event_id}/{action}", json_body={"sendResponse": True})
         return {"id": event_id, "responseStatus": response_status}
 
-    def create_event(
+    def create_event(  # pylint: disable=unused-argument
         self,
         *,
         calendar_id: str = "primary",

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -714,7 +714,9 @@ async def async_main(action, **kwargs):
                 ),
                 model_id=explicit_model,
                 device=effective_device,
-                max_steps=kwargs.get("max_steps", 100),
+                # None falls through to the global default (default_max_steps,
+                # honoring $GAIA_AGENT_MAX_STEPS) resolved in Agent.__init__.
+                max_steps=kwargs.get("max_steps"),
                 streaming=kwargs.get("stream", False),
                 show_prompts=kwargs.get("show_prompts", False),
                 show_stats=kwargs.get("show_stats", False),
@@ -815,7 +817,8 @@ async def async_main(action, **kwargs):
             claude_model=kwargs.get("claude_model", "claude-sonnet-4-20250514"),
             base_url=kwargs.get("base_url"),
             model_id=kwargs.get("model", None),
-            max_steps=kwargs.get("max_steps", 100),
+            # None → global default (default_max_steps / env) in Agent.
+            max_steps=kwargs.get("max_steps"),
             streaming=kwargs.get("stream", False),
             show_prompts=kwargs.get("show_prompts", False),
             show_stats=kwargs.get("show_stats", False),
@@ -1272,8 +1275,9 @@ def build_parser():
     parent_parser.add_argument(
         "--max-steps",
         type=int,
-        default=100,
-        help="Maximum conversation steps (default: 100)",
+        default=None,
+        help="Maximum conversation steps. Defaults to the global agent step "
+        "limit (50, or $GAIA_AGENT_MAX_STEPS if set).",
     )
     parent_parser.add_argument(
         "--list-tools",
@@ -1584,7 +1588,11 @@ def build_parser():
         help="Run a specific example (1-6), if not specified run interactive mode",
     )
     blender_parser.add_argument(
-        "--steps", type=int, default=5, help="Maximum number of steps per query"
+        "--steps",
+        type=int,
+        default=None,
+        help="Maximum number of steps per query. Defaults to the global agent "
+        "step limit (50, or $GAIA_AGENT_MAX_STEPS if set).",
     )
     blender_parser.add_argument(
         "--output-dir",

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1216,7 +1216,6 @@ async def _get_chat_response(
             )
             config = ChatAgentConfig(
                 model_id=model_id,
-                max_steps=10,
                 silent_mode=True,
                 debug=False,
                 device=device,
@@ -1603,7 +1602,6 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                     )
                     config = ChatAgentConfig(
                         model_id=model_id,
-                        max_steps=10,
                         streaming=True,
                         silent_mode=False,
                         debug=False,

--- a/src/gaia/ui/agent_loop.py
+++ b/src/gaia/ui/agent_loop.py
@@ -355,7 +355,6 @@ class AgentLoop:
                     allowed = _helpers._compute_allowed_paths(rag_paths + lib_paths)
                     config = ChatAgentConfig(
                         model_id=model_id,
-                        max_steps=int(os.environ.get("GAIA_AGENT_MAX_STEPS", "20")),
                         streaming=False,
                         silent_mode=True,
                         debug=False,

--- a/tests/unit/agents/test_default_max_steps.py
+++ b/tests/unit/agents/test_default_max_steps.py
@@ -1,0 +1,55 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the global agent step-limit knob.
+
+``default_max_steps()`` is the single source of truth for how many
+reasoning/tool steps an agent may take. Every agent config inherits it via
+``field(default_factory=default_max_steps)``, so these tests pin the
+resolution rules: the built-in default, the ``GAIA_AGENT_MAX_STEPS`` runtime
+override, and loud failure on a typo'd value (no silent capping).
+"""
+
+import os
+import unittest
+from unittest import mock
+
+from gaia.agents.base.agent import DEFAULT_MAX_STEPS, default_max_steps
+
+
+class TestDefaultMaxSteps(unittest.TestCase):
+    def test_unset_returns_builtin_default(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GAIA_AGENT_MAX_STEPS", None)
+            self.assertEqual(default_max_steps(), DEFAULT_MAX_STEPS)
+
+    def test_env_override_is_honored(self):
+        with mock.patch.dict(os.environ, {"GAIA_AGENT_MAX_STEPS": "123"}):
+            self.assertEqual(default_max_steps(), 123)
+
+    def test_empty_env_falls_back_to_default(self):
+        with mock.patch.dict(os.environ, {"GAIA_AGENT_MAX_STEPS": ""}):
+            self.assertEqual(default_max_steps(), DEFAULT_MAX_STEPS)
+
+    def test_non_integer_raises_loudly(self):
+        with mock.patch.dict(os.environ, {"GAIA_AGENT_MAX_STEPS": "lots"}):
+            with self.assertRaises(ValueError):
+                default_max_steps()
+
+    def test_non_positive_raises_loudly(self):
+        for bad in ("0", "-5"):
+            with mock.patch.dict(os.environ, {"GAIA_AGENT_MAX_STEPS": bad}):
+                with self.assertRaises(ValueError):
+                    default_max_steps()
+
+    def test_configs_inherit_the_override_at_construction(self):
+        from gaia.agents.chat.agent import ChatAgentConfig
+        from gaia.agents.docqa.agent import DocumentQAAgentConfig
+
+        with mock.patch.dict(os.environ, {"GAIA_AGENT_MAX_STEPS": "42"}):
+            self.assertEqual(ChatAgentConfig().max_steps, 42)
+            self.assertEqual(DocumentQAAgentConfig().max_steps, 42)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/agents/test_docqa_agent.py
+++ b/tests/unit/agents/test_docqa_agent.py
@@ -22,12 +22,13 @@ class TestDocumentQAAgentImport(unittest.TestCase):
 
 class TestDocumentQAAgentConfig(unittest.TestCase):
     def test_defaults(self):
+        from gaia.agents.base.agent import default_max_steps
         from gaia.agents.docqa.agent import DocumentQAAgentConfig
 
         cfg = DocumentQAAgentConfig()
         self.assertFalse(cfg.use_claude)
         self.assertIsNone(cfg.model_id)
-        self.assertEqual(cfg.max_steps, 10)
+        self.assertEqual(cfg.max_steps, default_max_steps())
         self.assertIsNone(cfg.rag_documents)
 
 


### PR DESCRIPTION
## Why this matters

Agents were running out of steps mid-task. The browser agent (and others) stopped at **10 steps** and told users to re-run with `--max-steps 60`, even on routine multi-step work. The cap was hardcoded low almost everywhere — `10` for most agents, `5`–`6` for a couple — and the Agent UI pinned `10` in four more places, while the CLI used `100` and background ticks `20`. So the limit was both too low *and* inconsistent depending on how you launched the agent.

After this change there's **one knob**: `default_max_steps()` in `base/agent.py` (default **50**, overridable at runtime with `GAIA_AGENT_MAX_STEPS=<n>`). Every agent config inherits it, as do the base `Agent`, the UI chat paths, and the autonomous-tick loop — so retuning the whole fleet is a one-line change or a single env var, no per-agent edits. Agents that genuinely need more keep their explicit override (CodeAgent=100, EMR=50), and a typo'd env value now fails loudly instead of silently capping.

## Test plan

- [x] `pytest tests/unit/agents/test_default_max_steps.py` — new helper tests (default, env override, empty, loud-failure on non-int/non-positive, configs inherit override)
- [x] `pytest tests/unit/agents/` — existing config-default tests updated to assert against the helper; all green (pre-existing context-overflow + Windows-encoding failures are unrelated, confirmed failing on `main`)
- [x] `python util/lint.py --black --isort` clean; `pyflakes` clean on all touched files
- [ ] Manual: launch the browser agent in the Agent UI and confirm it no longer stops at 10 steps; set `GAIA_AGENT_MAX_STEPS=5` and confirm every agent caps at 5
