### PR TITLE
fix(ui): kill orphaned backend before upgrade to free gaia.exe on Windows

### DIFF
--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -17,7 +17,7 @@ const { app, BrowserWindow, dialog, shell } = require("electron");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { spawn, spawnSync } = require("child_process");
+const { spawn } = require("child_process");
 const { pathToFileURL } = require("url");
 
 // ── Shared log path ───────────────────────────────────────────────────────────
@@ -57,6 +57,7 @@ const TrayManager = require("./services/tray-manager.cjs");
 const AgentProcessManager = require("./services/agent-process-manager.cjs");
 const NotificationService = require("./services/notification-service.cjs");
 const PortManager = require("./services/port-manager.cjs");
+const { isGaiaBackendProcess } = require("./services/backend-orphan.cjs");
 const { buildIndexQuery } = require("./services/index-query.cjs");
 const backendInstaller = require("./services/backend-installer.cjs");
 const installerProgressDialog = require("./services/backend-installer-progress-dialog.cjs");
@@ -225,6 +226,57 @@ let isQuitting = false;
 // ── Backend Process ────────────────────────────────────────────────────────
 
 /**
+ * Terminate a backend left running from a previous launch.
+ *
+ * The desktop app may be double-clicked multiple times or crash, leaving an
+ * orphaned `gaia chat --ui` process. On Windows that process keeps an open
+ * handle on `gaia.exe`, so the next upgrade's `uv pip install --refresh` fails
+ * with `os error 32` (file in use) — issue #1388. We MUST run this BEFORE the
+ * installer (`bootstrapBackend()`), not just before spawning the new backend,
+ * so the executable can be replaced.
+ *
+ * The PID is read from ~/.gaia/backend.pid and verified to be a GAIA backend
+ * (conservative match) before signalling, so we never kill unrelated user
+ * processes (issue #782 TOCTOU mitigation). Idempotent: the pidfile is removed
+ * after the first call, so later calls are no-ops.
+ */
+async function cleanupOrphanedBackend() {
+  try {
+    const pidFile = path.join(_GAIA_DIR, "backend.pid");
+    if (!fs.existsSync(pidFile)) return;
+    try {
+      const existingPid = parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+      if (!Number.isNaN(existingPid)) {
+        console.log(`[main] Found existing backend pidfile (${existingPid}) — verifying process identity`);
+
+        let isBackend = false;
+        try {
+          isBackend = isGaiaBackendProcess(existingPid);
+        } catch (err) {
+          console.warn(`[main] Could not verify pid ${existingPid}: ${err.message}`);
+        }
+
+        if (!isBackend) {
+          console.log(`[main] PID ${existingPid} does not appear to be a GAIA backend; skipping kill`);
+        } else {
+          try {
+            await portManager.killBackend(existingPid);
+            console.log(`[main] Cleaned up previous backend pid ${existingPid}`);
+          } catch (err) {
+            console.warn(`[main] Could not clean previous backend pid ${existingPid}: ${err.message}`);
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(`[main] Failed reading backend pidfile: ${err.message}`);
+    }
+    try { fs.unlinkSync(pidFile); } catch { /* ignore */ }
+  } catch (err) {
+    console.warn(`[main] PID cleanup check failed: ${err.message}`);
+  }
+}
+
+/**
  * Start the GAIA Python backend. Expects the backend installer to have
  * already ensured the venv is populated — callers should await
  * `bootstrapBackend()` first.
@@ -253,70 +305,10 @@ async function startBackend() {
     backendPort = DEFAULT_BACKEND_PORT;
   }
   healthCheckUrl = `http://localhost:${backendPort}/api/health`;
-  // Clean up any stale backend PID left from previous runs. The AppImage
-  // may be double-clicked multiple times or crash, leaving orphaned
-  // backend processes. We store a PID file under ~/.gaia/backend.pid and
-  // attempt to SIGTERM any still-running PID before starting a new backend.
-  try {
-    const pidFile = path.join(_GAIA_DIR, "backend.pid");
-    if (fs.existsSync(pidFile)) {
-      try {
-        const existingPid = parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
-        if (!Number.isNaN(existingPid)) {
-          console.log(`[main] Found existing backend pidfile (${existingPid}) — verifying process identity`);
-
-          // Verify the PID belongs to a GAIA backend before signalling it.
-          // Prefer a conservative match on the process command to avoid
-          // accidentally killing unrelated user processes (TOCTOU mitigation).
-          let isBackend = false;
-          try {
-            if (process.platform === "linux") {
-              const procCmd = `/proc/${existingPid}/cmdline`;
-              if (fs.existsSync(procCmd)) {
-                const raw = fs.readFileSync(procCmd, "utf8");
-                // /proc/<pid>/cmdline is NUL-separated; use a stricter match to
-                // avoid killing unrelated Python processes (Jupyter, LSP, etc.).
-                // Legitimate backend uses: `gaia chat --ui --ui-port <port>`
-                const looksLikeGaiaBackend = raw.includes("gaia") && (raw.includes("chat") || raw.includes("--ui-port"));
-                if (looksLikeGaiaBackend) {
-                  isBackend = true;
-                }
-              }
-            } else if (process.platform === "darwin") {
-              try {
-                const out = spawnSync("ps", ["-p", String(existingPid), "-o", "command="], { encoding: "utf8" });
-                const cmd = (out && out.stdout) ? out.stdout : "";
-                const looksLikeGaiaBackend = cmd.includes("gaia") && (cmd.includes("chat") || cmd.includes("--ui-port"));
-                if (looksLikeGaiaBackend) {
-                  isBackend = true;
-                }
-              } catch {
-                // fallthrough
-              }
-            }
-          } catch (err) {
-            console.warn(`[main] Could not verify pid ${existingPid}: ${err.message}`);
-          }
-
-          if (!isBackend) {
-            console.log(`[main] PID ${existingPid} does not appear to be a GAIA backend; skipping kill`);
-          } else {
-            try {
-              await portManager.killBackend(existingPid);
-              console.log(`[main] Cleaned up previous backend pid ${existingPid}`);
-            } catch (err) {
-              console.warn(`[main] Could not clean previous backend pid ${existingPid}: ${err.message}`);
-            }
-          }
-        }
-      } catch (err) {
-        console.warn(`[main] Failed reading backend pidfile: ${err.message}`);
-      }
-      try { fs.unlinkSync(pidFile); } catch { /* ignore */ }
-    }
-  } catch (err) {
-    console.warn(`[main] PID cleanup check failed: ${err.message}`);
-  }
+  // Defensively clean up any orphaned backend in case bootstrap was skipped
+  // on this path. cleanupOrphanedBackend() is idempotent and a no-op once the
+  // pidfile has already been consumed earlier in app startup.
+  await cleanupOrphanedBackend();
 
   console.log(`Starting backend: ${gaiaCmd} chat --ui --ui-port ${backendPort}`);
 
@@ -800,6 +792,12 @@ app.whenReady().then(async () => {
   } catch (err) {
     console.warn("[main] Agent seeding failed (non-fatal):", err);
   }
+
+  // Phase A0: kill any orphaned backend from a previous launch BEFORE the
+  // installer runs. On Windows a live `gaia chat --ui` holds an open handle on
+  // gaia.exe, so an upgrade's `uv pip install --refresh` fails with os error 32
+  // unless that process is gone first (issue #1388).
+  await cleanupOrphanedBackend();
 
   // Phase A: ensure the Python backend is installed BEFORE creating the
   // main window. The progress dialog owns the UI during this phase.

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -468,6 +468,16 @@ function runCommand(cmd, args, { env, stageLabel } = {}) {
   });
 }
 
+/**
+ * Detect the Windows "file in use" signature in command output. An upgrade's
+ * `uv pip install --refresh` can't replace gaia.exe while a previous GAIA
+ * process still holds it open — pip reports os error 32 (issue #1388).
+ */
+function isFileLockedError(output) {
+  if (!output) return false;
+  return /os error 32/i.test(output) || /being used by another process/i.test(output);
+}
+
 // ── Pre-checks ───────────────────────────────────────────────────────────────
 
 /**
@@ -1148,14 +1158,22 @@ async function installBackend(opts = {}) {
 
   const installResult = await runCommand("uv", pipArgs, { stageLabel: "pip" });
   if (installResult.code !== 0) {
+    // Windows: an upgrade can't replace gaia.exe while a previous GAIA
+    // process still holds it open (issue #1388). The orphan cleanup in
+    // main.cjs should have killed it first; if the lock persists, point the
+    // user at the live process rather than the generic manual-install hint.
+    const output = `${installResult.stdout || ""}\n${installResult.stderr || ""}`;
+    const suggestion = isFileLockedError(output)
+      ? "A running GAIA process is locking the install. Close GAIA completely (including any leftover gaia.exe in Task Manager), then relaunch."
+      : `Try installing manually:\n  uv pip install ${pipPackage} --python ${
+          IS_WINDOWS ? `${GAIA_VENV_DISPLAY}/Scripts/python.exe` : `${GAIA_VENV_DISPLAY}/bin/python`
+        }\nThen restart GAIA. See https://amd-gaia.ai/quickstart#cli-install`;
     throw new InstallError(
       `Failed to install ${pipPackage} (pip exit ${installResult.code}).`,
       {
         stage: STAGES.INSTALL_PACKAGE,
         code: installResult.code,
-        suggestion: `Try installing manually:\n  uv pip install ${pipPackage} --python ${
-          IS_WINDOWS ? `${GAIA_VENV_DISPLAY}/Scripts/python.exe` : `${GAIA_VENV_DISPLAY}/bin/python`
-        }\nThen restart GAIA. See https://amd-gaia.ai/quickstart#cli-install`,
+        suggestion,
       }
     );
   }
@@ -1439,6 +1457,7 @@ module.exports = {
   runPreChecks,
   checkDiskSpace,
   checkNetwork,
+  isFileLockedError,
 
   // State machine
   getState,

--- a/src/gaia/apps/webui/services/backend-orphan.cjs
+++ b/src/gaia/apps/webui/services/backend-orphan.cjs
@@ -36,6 +36,11 @@ function isGaiaBackendProcess(pid, deps = {}) {
   const spawnSync = deps.spawnSync || realSpawnSync;
   const platform = deps.platform || process.platform;
 
+  // Defense-in-depth: pid is interpolated into shell/CIM-filter args below.
+  // Production callers parseInt it, but reject anything non-integer here so a
+  // future caller can't inject through the PowerShell -Filter / ps -p args.
+  if (!Number.isInteger(pid)) return false;
+
   try {
     if (platform === "linux") {
       const procCmd = `/proc/${pid}/cmdline`;
@@ -48,6 +53,7 @@ function isGaiaBackendProcess(pid, deps = {}) {
     if (platform === "darwin") {
       const out = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
         encoding: "utf8",
+        timeout: 5000,
       });
       return commandLooksLikeBackend(out && out.stdout ? out.stdout : "");
     }
@@ -61,7 +67,8 @@ function isGaiaBackendProcess(pid, deps = {}) {
           "-Command",
           `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CommandLine`,
         ],
-        { encoding: "utf8" }
+        // timeout: a hung PowerShell on the recovery path must not block app startup.
+        { encoding: "utf8", timeout: 5000 }
       );
       return commandLooksLikeBackend(out && out.stdout ? out.stdout : "");
     }

--- a/src/gaia/apps/webui/services/backend-orphan.cjs
+++ b/src/gaia/apps/webui/services/backend-orphan.cjs
@@ -1,0 +1,76 @@
+// Identify orphaned GAIA backend processes left over from a previous launch.
+//
+// On Windows an orphaned `gaia chat --ui` process keeps an open handle on
+// `gaia.exe`, which makes the next `uv pip install --refresh` upgrade fail with
+// `os error 32` (file in use) — issue #1388. We must positively identify and
+// kill that process BEFORE the installer runs, so the executable can be
+// replaced.
+//
+// The check is deliberately conservative: it returns false whenever it cannot
+// positively confirm the process is a GAIA backend, so we never signal an
+// unrelated user process (issue #782 TOCTOU mitigation).
+
+const realFs = require("fs");
+const { spawnSync: realSpawnSync } = require("child_process");
+
+// Legitimate backend invocation is `gaia chat --ui --ui-port <port>`. Match on
+// "gaia" plus one of the backend-specific flags so unrelated Python/Node
+// processes (Jupyter, LSP, etc.) are never matched.
+function commandLooksLikeBackend(cmd) {
+  if (!cmd) return false;
+  return cmd.includes("gaia") && (cmd.includes("chat") || cmd.includes("--ui-port"));
+}
+
+/**
+ * Best-effort check that `pid` belongs to a GAIA backend process.
+ *
+ * @param {number} pid
+ * @param {object} [deps] injectable dependencies for testing
+ * @param {string} [deps.platform] process.platform override
+ * @param {object} [deps.fs] fs module override
+ * @param {Function} [deps.spawnSync] child_process.spawnSync override
+ * @returns {boolean}
+ */
+function isGaiaBackendProcess(pid, deps = {}) {
+  const fs = deps.fs || realFs;
+  const spawnSync = deps.spawnSync || realSpawnSync;
+  const platform = deps.platform || process.platform;
+
+  try {
+    if (platform === "linux") {
+      const procCmd = `/proc/${pid}/cmdline`;
+      if (!fs.existsSync(procCmd)) return false;
+      // /proc/<pid>/cmdline is NUL-separated.
+      const raw = fs.readFileSync(procCmd, "utf8");
+      return commandLooksLikeBackend(raw);
+    }
+
+    if (platform === "darwin") {
+      const out = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
+        encoding: "utf8",
+      });
+      return commandLooksLikeBackend(out && out.stdout ? out.stdout : "");
+    }
+
+    if (platform === "win32") {
+      const out = spawnSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CommandLine`,
+        ],
+        { encoding: "utf8" }
+      );
+      return commandLooksLikeBackend(out && out.stdout ? out.stdout : "");
+    }
+  } catch {
+    // Any probe failure → treat as "not a backend" so we don't kill blindly.
+    return false;
+  }
+
+  return false;
+}
+
+module.exports = { isGaiaBackendProcess, commandLooksLikeBackend };

--- a/tests/electron/backend-installer-lock.test.cjs
+++ b/tests/electron/backend-installer-lock.test.cjs
@@ -1,0 +1,29 @@
+// Tests for the Windows file-lock detection that produces an actionable
+// upgrade-failure message (issue #1388).
+
+const {
+  isFileLockedError,
+} = require("../../src/gaia/apps/webui/services/backend-installer.cjs");
+
+describe("isFileLockedError", () => {
+  test("detects the uv os-error-32 signature from issue #1388", () => {
+    const out =
+      "error: failed to remove file `C:\\Users\\x\\.gaia\\venv\\Lib\\site-packages\\../../Scripts/gaia.exe`: " +
+      "The process cannot access the file because it is being used by another process. (os error 32)";
+    expect(isFileLockedError(out)).toBe(true);
+  });
+
+  test("detects the plain 'being used by another process' phrasing", () => {
+    expect(
+      isFileLockedError("The file is being used by another process.")
+    ).toBe(true);
+  });
+
+  test("ignores unrelated pip failures", () => {
+    expect(
+      isFileLockedError("error: No solution found when resolving dependencies")
+    ).toBe(false);
+    expect(isFileLockedError("")).toBe(false);
+    expect(isFileLockedError(undefined)).toBe(false);
+  });
+});

--- a/tests/electron/backend-orphan.test.cjs
+++ b/tests/electron/backend-orphan.test.cjs
@@ -1,0 +1,99 @@
+// Tests for backend-orphan.cjs — the orphaned-backend identity probe that
+// guards the Windows upgrade lock fix (issue #1388).
+
+const {
+  isGaiaBackendProcess,
+  commandLooksLikeBackend,
+} = require("../../src/gaia/apps/webui/services/backend-orphan.cjs");
+
+describe("commandLooksLikeBackend", () => {
+  test("matches a real backend invocation", () => {
+    expect(
+      commandLooksLikeBackend("gaia chat --ui --ui-port 4321")
+    ).toBe(true);
+  });
+
+  test("matches gaia + --ui-port even without the chat token", () => {
+    expect(commandLooksLikeBackend("python gaia --ui-port 5000")).toBe(true);
+  });
+
+  test("rejects unrelated processes", () => {
+    expect(commandLooksLikeBackend("python -m jupyter lab")).toBe(false);
+    expect(commandLooksLikeBackend("gaia init --yes")).toBe(false);
+    expect(commandLooksLikeBackend("")).toBe(false);
+    expect(commandLooksLikeBackend(undefined)).toBe(false);
+  });
+});
+
+describe("isGaiaBackendProcess (win32)", () => {
+  const makeSpawnSync = (stdout) =>
+    jest.fn(() => ({ stdout, status: 0 }));
+
+  test("identifies a backend via the PowerShell CommandLine probe", () => {
+    const spawnSync = makeSpawnSync(
+      "C:\\Users\\me\\.gaia\\venv\\Scripts\\gaia.exe chat --ui --ui-port 4321\r\n"
+    );
+    const result = isGaiaBackendProcess(1234, {
+      platform: "win32",
+      spawnSync,
+    });
+    expect(result).toBe(true);
+    // Conservative probe: queries the specific PID, not a broad scan.
+    const [cmd, args] = spawnSync.mock.calls[0];
+    expect(cmd).toBe("powershell.exe");
+    expect(args.join(" ")).toContain("ProcessId=1234");
+  });
+
+  test("does not match an unrelated win32 process", () => {
+    const spawnSync = makeSpawnSync("C:\\Windows\\System32\\notepad.exe\r\n");
+    expect(
+      isGaiaBackendProcess(1234, { platform: "win32", spawnSync })
+    ).toBe(false);
+  });
+
+  test("returns false when the PID is gone (empty CommandLine)", () => {
+    const spawnSync = makeSpawnSync("");
+    expect(
+      isGaiaBackendProcess(9999, { platform: "win32", spawnSync })
+    ).toBe(false);
+  });
+
+  test("returns false (never throws) when the probe blows up", () => {
+    const spawnSync = jest.fn(() => {
+      throw new Error("powershell not found");
+    });
+    expect(
+      isGaiaBackendProcess(1234, { platform: "win32", spawnSync })
+    ).toBe(false);
+  });
+});
+
+describe("isGaiaBackendProcess (linux)", () => {
+  test("matches via /proc/<pid>/cmdline", () => {
+    const fs = {
+      existsSync: jest.fn(() => true),
+      readFileSync: jest.fn(() => "gaia\0chat\0--ui\0--ui-port\04321"),
+    };
+    expect(
+      isGaiaBackendProcess(1234, { platform: "linux", fs })
+    ).toBe(true);
+  });
+
+  test("returns false when /proc entry is missing", () => {
+    const fs = { existsSync: jest.fn(() => false), readFileSync: jest.fn() };
+    expect(
+      isGaiaBackendProcess(1234, { platform: "linux", fs })
+    ).toBe(false);
+  });
+});
+
+describe("isGaiaBackendProcess (darwin)", () => {
+  test("matches via ps command output", () => {
+    const spawnSync = jest.fn(() => ({
+      stdout: "gaia chat --ui --ui-port 4321\n",
+    }));
+    expect(
+      isGaiaBackendProcess(1234, { platform: "darwin", spawnSync })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why this matters

On Windows, GAIA could fail to open after an auto-upgrade. If a previous `gaia chat --ui` backend was still running (the app was double-clicked again or had crashed without cleanup), it kept an open handle on `gaia.exe`. The installer's `uv pip install --refresh` then couldn't replace the executable and aborted with `os error 32: The process cannot access the file because it is being used by another process` — the user saw an install-failed dialog instead of the app (issue #1388).

The orphan-cleanup logic that kills the leftover backend only ran inside `startBackend()`, **after** the installer had already tried (and failed) to refresh the package. It also had no Windows branch in its process-identity probe, so even with the right ordering it could not confirm the orphan was a GAIA backend and skipped the kill entirely. After this change the orphaned backend is identified and terminated **before** the upgrade runs, so the file lock is released and the upgrade completes.

## What changed

- Cleanup runs **before** `bootstrapBackend()` (the install/refresh step), not just before spawning the new backend.
- Added a Windows identity probe (PowerShell `Win32_Process` `CommandLine`), keeping the existing conservative match so unrelated user processes are never signalled (issue #782 TOCTOU mitigation).
- Defense-in-depth: the pip step now detects the `os error 32` lock signature and raises an actionable error ("close GAIA completely, including any leftover gaia.exe in Task Manager, then relaunch") instead of the generic manual-install hint.

## Test plan

- [x] `cd tests/electron && npx jest` — full suite green (577 tests), including new `backend-orphan.test.cjs` (win32/linux/darwin identity probe) and `backend-installer-lock.test.cjs` (os-error-32 detection).
- [ ] **Needs Windows to verify the live path:** launch GAIA, leave a backend running/orphaned, trigger an upgrade — confirm the orphaned `gaia.exe` is killed before the pip step and the upgrade completes.
- [ ] Confirm the PowerShell probe does not false-positive on unrelated processes and adds no noticeable startup latency.

Fixes #1388