### PR TITLE
feat(hub): gaia-agent.yaml manifest parser and validator (#1091)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "gaia.apps.summarize.templates",
         "gaia.eval",
         "gaia.installer",
+        "gaia.hub",
         "gaia.rag",
         "gaia.mcp",
         "gaia.mcp.client",

--- a/src/gaia/hub/__init__.py
+++ b/src/gaia/hub/__init__.py
@@ -1,0 +1,17 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GAIA Agent Hub — packaging, distribution, and discovery primitives.
+
+The Agent Hub turns every agent (builtin, custom, community) into a
+self-describing package.  This module owns the shared package format used
+across packaging (#1093), init scaffolding (#1098), and registry discovery.
+
+Public surface:
+    - :class:`gaia.hub.manifest.AgentManifest` — parsed ``gaia-agent.yaml``
+    - :func:`gaia.hub.manifest.parse` — load + validate a manifest file
+    - :class:`gaia.hub.manifest.ManifestError` — actionable validation error
+"""
+
+from gaia.hub.manifest import AgentManifest, ManifestError, parse
+
+__all__ = ["AgentManifest", "ManifestError", "parse"]

--- a/src/gaia/hub/manifest.py
+++ b/src/gaia/hub/manifest.py
@@ -1,0 +1,618 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Parser and validator for the ``gaia-agent.yaml`` package manifest.
+
+Every Agent Hub package — builtin, custom, or community — ships a
+``gaia-agent.yaml`` describing its identity, hub-display metadata, technical
+requirements, and declared permissions.  This module is the single source of
+truth for that format: :func:`parse` loads a file and returns a validated
+:class:`AgentManifest`, or raises :class:`ManifestError` with an actionable
+message naming what failed, what to do, and where to look.
+
+Validation follows the project's fail-loudly rule (see ``CLAUDE.md``): a
+malformed manifest never silently degrades to a partial/default object — it
+raises.  The only defaulting that happens is for *unspecified* optional fields,
+and security-relevant defaults choose the least-privileged value (an
+unspecified ``security_tier`` defaults to ``experimental``).
+
+Schema reference: ``docs/spec/agent-hub-restructure.mdx`` (Package Format →
+``gaia-agent.yaml``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import yaml
+
+from gaia.agents.registry import _RESERVED_BUILTIN_IDS
+
+# ---------------------------------------------------------------------------
+# Validation vocabulary
+# ---------------------------------------------------------------------------
+
+# Agent id: lowercase alphanumeric with internal hyphens, 1–52 chars, must
+# start and end with an alphanumeric.  Mirrors the npm-style slug used by the
+# hub URL scheme (``/agents/<id>``).
+_ID_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,50}[a-z0-9])?$")
+
+# Official SemVer 2.0.0 grammar (https://semver.org). Captures optional
+# pre-release and build-metadata suffixes so "1.2.3-rc.1+build.5" is valid.
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+# Permissions use domain-scoped syntax: ``<domain>:<action>`` (see the security
+# model plan, docs/plans/security-model.mdx — "domain-scoped syntax
+# (filesystem:read, network:write, etc.)").
+_PERMISSION_RE = re.compile(r"^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$")
+
+VALID_LANGUAGES = frozenset({"python", "cpp"})
+
+VALID_SECURITY_TIERS = frozenset({"verified", "community", "experimental"})
+
+# Least-privileged default for an unspecified tier — an unknown package is
+# treated as untrusted until a maintainer promotes it.
+DEFAULT_SECURITY_TIER = "experimental"
+
+# Recognized permission domains. The action half is free-form (lowercase
+# identifier) so agents can declare granular capabilities, but the domain must
+# be one we understand so a typo like ``filesytem:read`` fails loudly.
+KNOWN_PERMISSION_DOMAINS = frozenset(
+    {
+        "filesystem",
+        "network",
+        "shell",
+        "process",
+        "clipboard",
+        "screenshot",
+        "camera",
+        "microphone",
+        "system",
+        "env",
+        "notifications",
+    }
+)
+
+# Platform triples used by ``requirements.platforms`` and ``cpp.binaries``.
+VALID_PLATFORMS = frozenset(
+    {
+        "win-x64",
+        "win-arm64",
+        "linux-x64",
+        "linux-arm64",
+        "darwin-x64",
+        "darwin-arm64",
+    }
+)
+
+VALID_INTERFACES = frozenset({"tui", "cli", "pipe", "api_server", "mcp_server"})
+
+# Docs URL surfaced in error messages so the author knows where to look next.
+_SPEC_URL = "https://amd-gaia.ai/docs/spec/agent-hub-restructure"
+
+
+class ManifestError(ValueError):
+    """Raised when a ``gaia-agent.yaml`` is missing, malformed, or invalid.
+
+    The message always names three things (per CLAUDE.md): *what* failed,
+    *what* the author should do, and *where* to look (the manifest path and/or
+    the spec). Subclasses :class:`ValueError` so existing ``except ValueError``
+    callers keep working.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Sub-models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Requirements:
+    """System requirements block from ``requirements:``."""
+
+    min_memory_gb: Optional[float] = None
+    min_disk_gb: Optional[float] = None
+    min_context_size: Optional[int] = None
+    platforms: List[str] = field(default_factory=list)
+    npu: bool = False
+    gpu_vram_gb: Optional[float] = None
+
+
+@dataclass
+class PythonConfig:
+    """Python entry-point block from ``python:``."""
+
+    entry_module: Optional[str] = None
+    entry_class: Optional[str] = None
+    dependencies: List[str] = field(default_factory=list)
+
+
+@dataclass
+class CppConfig:
+    """Native (C++) binary block from ``cpp:``.
+
+    ``binaries`` maps a platform triple (e.g. ``win-x64``) to the relative
+    path of the executable shipped for that platform.
+    """
+
+    binaries: Dict[str, str] = field(default_factory=dict)
+    static_linked: bool = False
+
+
+@dataclass
+class Interfaces:
+    """Declared interface modes from ``interfaces:`` (follows PR #985)."""
+
+    tui: bool = False
+    cli: bool = False
+    pipe: bool = False
+    api_server: bool = False
+    mcp_server: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Top-level manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentManifest:
+    """A parsed, validated ``gaia-agent.yaml``.
+
+    Construct via :func:`parse` (file) or :meth:`from_dict` (already-loaded
+    mapping). Both validate eagerly and raise :class:`ManifestError` on the
+    first problem.
+    """
+
+    # Identity
+    id: str
+    name: str
+    version: str
+    description: str
+    author: str
+    license: str
+
+    # Technical
+    language: str
+
+    # Hub display
+    category: str = "general"
+    tags: List[str] = field(default_factory=list)
+    icon: str = ""
+    avatar: str = ""
+    screenshots: List[str] = field(default_factory=list)
+    readme: str = ""
+    conversation_starters: List[str] = field(default_factory=list)
+
+    # Technical (optional)
+    min_gaia_version: Optional[str] = None
+    models: List[str] = field(default_factory=list)
+    tools_count: int = 0
+    security_tier: str = DEFAULT_SECURITY_TIER
+
+    # Blocks
+    requirements: Requirements = field(default_factory=Requirements)
+    python: Optional[PythonConfig] = None
+    cpp: Optional[CppConfig] = None
+    permissions: List[str] = field(default_factory=list)
+    required_connections: List[str] = field(default_factory=list)
+    interfaces: Interfaces = field(default_factory=Interfaces)
+
+    # Provenance — set by :func:`parse`; not part of the YAML.
+    source_path: Optional[Path] = None
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_dict(
+        cls, data: Any, *, source: Optional[Union[str, Path]] = None
+    ) -> "AgentManifest":
+        """Build and validate an :class:`AgentManifest` from a mapping.
+
+        Args:
+            data: The parsed YAML mapping (``dict``).
+            source: Optional path to the originating file, used to make error
+                messages point at the right manifest.
+
+        Raises:
+            ManifestError: If *data* is not a mapping, a required field is
+                missing, or any field fails validation.
+        """
+        src = Path(source) if source is not None else None
+        where = f" in {src}" if src else ""
+
+        if not isinstance(data, dict):
+            raise ManifestError(
+                f"gaia-agent.yaml must be a YAML mapping (key: value){where}, "
+                f"got {type(data).__name__}. See {_SPEC_URL}."
+            )
+
+        # --- required scalar fields ---
+        required = ("id", "name", "version", "description", "author", "license")
+        missing = [k for k in required if not _nonempty_str(data.get(k))]
+        if missing:
+            raise ManifestError(
+                f"gaia-agent.yaml{where} is missing required field(s): "
+                f"{', '.join(missing)}. Add them as top-level string keys. "
+                f"See {_SPEC_URL}."
+            )
+
+        agent_id = data["id"]
+        _validate_id(agent_id, where)
+        _validate_semver(data["version"], "version", where)
+
+        language = data.get("language")
+        if not _nonempty_str(language):
+            raise ManifestError(
+                f"gaia-agent.yaml{where} is missing required field 'language'. "
+                f"Set it to one of: {_sorted(VALID_LANGUAGES)}. See {_SPEC_URL}."
+            )
+        if language not in VALID_LANGUAGES:
+            raise ManifestError(
+                f"gaia-agent.yaml{where}: language {language!r} is not supported. "
+                f"Use one of: {_sorted(VALID_LANGUAGES)}."
+            )
+
+        security_tier = data.get("security_tier", DEFAULT_SECURITY_TIER)
+        if security_tier not in VALID_SECURITY_TIERS:
+            raise ManifestError(
+                f"gaia-agent.yaml{where}: security_tier {security_tier!r} is "
+                f"invalid. Use one of: {_sorted(VALID_SECURITY_TIERS)}."
+            )
+
+        if data.get("min_gaia_version") is not None:
+            _validate_semver(data["min_gaia_version"], "min_gaia_version", where)
+
+        permissions = _validate_permissions(data.get("permissions"), where)
+        requirements = _parse_requirements(data.get("requirements"), where)
+        interfaces = _parse_interfaces(data.get("interfaces"), where)
+        python_cfg = _parse_python(data.get("python"), where)
+        cpp_cfg = _parse_cpp(data.get("cpp"), where)
+
+        # Language-specific section requirements. A C++ agent with no binary is
+        # unrunnable — fail loudly rather than register a dead package.
+        if language == "cpp" and (cpp_cfg is None or not cpp_cfg.binaries):
+            raise ManifestError(
+                f"gaia-agent.yaml{where}: language is 'cpp' but no 'cpp.binaries' "
+                f"are declared. Map at least one platform "
+                f"({_sorted(VALID_PLATFORMS)}) to a binary path."
+            )
+
+        return cls(
+            id=agent_id,
+            name=data["name"],
+            version=data["version"],
+            description=data["description"],
+            author=data["author"],
+            license=data["license"],
+            language=language,
+            category=data.get("category", "general") or "general",
+            tags=_str_list(data.get("tags"), "tags", where),
+            icon=data.get("icon", "") or "",
+            avatar=data.get("avatar", "") or "",
+            screenshots=_str_list(data.get("screenshots"), "screenshots", where),
+            readme=data.get("readme", "") or "",
+            conversation_starters=_str_list(
+                data.get("conversation_starters"), "conversation_starters", where
+            ),
+            min_gaia_version=data.get("min_gaia_version"),
+            models=_str_list(data.get("models"), "models", where),
+            tools_count=_parse_int(data.get("tools_count"), "tools_count", where, 0),
+            security_tier=security_tier,
+            requirements=requirements,
+            python=python_cfg,
+            cpp=cpp_cfg,
+            permissions=permissions,
+            required_connections=_str_list(
+                data.get("required_connections"), "required_connections", where
+            ),
+            interfaces=interfaces,
+            source_path=src,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def parse(path: Union[str, Path]) -> AgentManifest:
+    """Load and validate a ``gaia-agent.yaml`` file.
+
+    Args:
+        path: Path to the manifest file (or a directory containing one).
+
+    Returns:
+        A validated :class:`AgentManifest`.
+
+    Raises:
+        ManifestError: If the file is missing, unreadable, not valid YAML, or
+            fails schema validation. The message names the file and what to fix.
+    """
+    p = Path(path)
+    if p.is_dir():
+        p = p / "gaia-agent.yaml"
+
+    if not p.exists():
+        raise ManifestError(
+            f"Manifest not found: {p}. Every agent package needs a "
+            f"'gaia-agent.yaml' at its root. See {_SPEC_URL}."
+        )
+
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError as e:
+        raise ManifestError(f"Could not read manifest {p}: {e}") from e
+
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        raise ManifestError(
+            f"Invalid YAML in {p}: {e}. Fix the syntax and re-run. " f"See {_SPEC_URL}."
+        ) from e
+
+    if data is None:
+        raise ManifestError(
+            f"Manifest {p} is empty. It must declare at least the required "
+            f"identity fields (id, name, version, description, author, license). "
+            f"See {_SPEC_URL}."
+        )
+
+    return AgentManifest.from_dict(data, source=p)
+
+
+# ---------------------------------------------------------------------------
+# Field helpers
+# ---------------------------------------------------------------------------
+
+
+def _nonempty_str(value: Any) -> bool:
+    return isinstance(value, str) and value.strip() != ""
+
+
+def _sorted(values) -> str:
+    return ", ".join(sorted(values))
+
+
+def _validate_id(agent_id: Any, where: str) -> None:
+    if not isinstance(agent_id, str) or not _ID_RE.match(agent_id):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: id {agent_id!r} is invalid. Use 1–52 "
+            f"lowercase alphanumeric characters and internal hyphens "
+            f"(must start and end with a letter or digit), e.g. 'my-agent'."
+        )
+    if agent_id in _RESERVED_BUILTIN_IDS:
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: id {agent_id!r} is reserved for a built-in "
+            f"GAIA agent. Choose a different id. Reserved: "
+            f"{_sorted(_RESERVED_BUILTIN_IDS)}."
+        )
+
+
+def _validate_semver(value: Any, field_name: str, where: str) -> None:
+    if not isinstance(value, str) or not _SEMVER_RE.match(value):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} {value!r} is not valid SemVer. "
+            f"Use MAJOR.MINOR.PATCH (e.g. '0.1.0' or '1.2.3-rc.1'). "
+            f"See https://semver.org."
+        )
+
+
+def _validate_permissions(raw: Any, where: str) -> List[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: permissions must be a list of "
+            f"'<domain>:<action>' strings, got {type(raw).__name__}."
+        )
+    result: List[str] = []
+    for perm in raw:
+        if not isinstance(perm, str) or not _PERMISSION_RE.match(perm):
+            raise ManifestError(
+                f"gaia-agent.yaml{where}: permission {perm!r} has invalid syntax. "
+                f"Use '<domain>:<action>' (lowercase), e.g. 'filesystem:read'."
+            )
+        domain = perm.split(":", 1)[0]
+        if domain not in KNOWN_PERMISSION_DOMAINS:
+            raise ManifestError(
+                f"gaia-agent.yaml{where}: permission {perm!r} uses unknown domain "
+                f"{domain!r}. Valid domains: {_sorted(KNOWN_PERMISSION_DOMAINS)}."
+            )
+        result.append(perm)
+    return result
+
+
+def _str_list(raw: Any, field_name: str, where: str) -> List[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or not all(isinstance(x, str) for x in raw):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} must be a list of strings."
+        )
+    return list(raw)
+
+
+def _parse_int(raw: Any, field_name: str, where: str, default: int) -> int:
+    if raw is None:
+        return default
+    # bool is an int subclass; reject it so `tools_count: true` fails loudly.
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} must be an integer, got "
+            f"{type(raw).__name__}."
+        )
+    if raw < 0:
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} must be >= 0, got {raw}."
+        )
+    return raw
+
+
+def _parse_number(raw: Any, field_name: str, where: str) -> Optional[float]:
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} must be a number, got "
+            f"{type(raw).__name__}."
+        )
+    if raw < 0:
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} must be >= 0, got {raw}."
+        )
+    return float(raw)
+
+
+def _parse_bool(raw: Any, field_name: str, where: str, default: bool) -> bool:
+    if raw is None:
+        return default
+    if not isinstance(raw, bool):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} must be true or false, got "
+            f"{type(raw).__name__}."
+        )
+    return raw
+
+
+def _validate_platforms(raw: Any, field_name: str, where: str) -> List[str]:
+    platforms = _str_list(raw, field_name, where)
+    bad = [p for p in platforms if p not in VALID_PLATFORMS]
+    if bad:
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: {field_name} has unknown platform(s) "
+            f"{bad}. Valid platforms: {_sorted(VALID_PLATFORMS)}."
+        )
+    return platforms
+
+
+def _require_mapping(raw: Any, section: str, where: str) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: '{section}' must be a mapping, got "
+            f"{type(raw).__name__}."
+        )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Section parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_requirements(raw: Any, where: str) -> Requirements:
+    if raw is None:
+        return Requirements()
+    data = _require_mapping(raw, "requirements", where)
+    return Requirements(
+        min_memory_gb=_parse_number(
+            data.get("min_memory_gb"), "requirements.min_memory_gb", where
+        ),
+        min_disk_gb=_parse_number(
+            data.get("min_disk_gb"), "requirements.min_disk_gb", where
+        ),
+        min_context_size=(
+            None
+            if data.get("min_context_size") is None
+            else _parse_int(
+                data.get("min_context_size"),
+                "requirements.min_context_size",
+                where,
+                0,
+            )
+        ),
+        platforms=_validate_platforms(
+            data.get("platforms"), "requirements.platforms", where
+        ),
+        npu=_parse_bool(data.get("npu"), "requirements.npu", where, False),
+        gpu_vram_gb=_parse_number(
+            data.get("gpu_vram_gb"), "requirements.gpu_vram_gb", where
+        ),
+    )
+
+
+def _parse_interfaces(raw: Any, where: str) -> Interfaces:
+    if raw is None:
+        return Interfaces()
+    data = _require_mapping(raw, "interfaces", where)
+    unknown = set(data) - VALID_INTERFACES
+    if unknown:
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: interfaces has unknown key(s) "
+            f"{_sorted(unknown)}. Valid interfaces: {_sorted(VALID_INTERFACES)}."
+        )
+    return Interfaces(
+        tui=_parse_bool(data.get("tui"), "interfaces.tui", where, False),
+        cli=_parse_bool(data.get("cli"), "interfaces.cli", where, False),
+        pipe=_parse_bool(data.get("pipe"), "interfaces.pipe", where, False),
+        api_server=_parse_bool(
+            data.get("api_server"), "interfaces.api_server", where, False
+        ),
+        mcp_server=_parse_bool(
+            data.get("mcp_server"), "interfaces.mcp_server", where, False
+        ),
+    )
+
+
+def _parse_python(raw: Any, where: str) -> Optional[PythonConfig]:
+    if raw is None:
+        return None
+    data = _require_mapping(raw, "python", where)
+    entry_module = data.get("entry_module")
+    entry_class = data.get("entry_class")
+    if entry_module is not None and not _nonempty_str(entry_module):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: python.entry_module must be a non-empty "
+            f"string (e.g. 'gaia_agent_chat.agent')."
+        )
+    if entry_class is not None and not _nonempty_str(entry_class):
+        raise ManifestError(
+            f"gaia-agent.yaml{where}: python.entry_class must be a non-empty "
+            f"string (e.g. 'ChatAgent')."
+        )
+    return PythonConfig(
+        entry_module=entry_module,
+        entry_class=entry_class,
+        dependencies=_str_list(data.get("dependencies"), "python.dependencies", where),
+    )
+
+
+def _parse_cpp(raw: Any, where: str) -> Optional[CppConfig]:
+    if raw is None:
+        return None
+    data = _require_mapping(raw, "cpp", where)
+    binaries_raw = data.get("binaries")
+    binaries: Dict[str, str] = {}
+    if binaries_raw is not None:
+        if not isinstance(binaries_raw, dict):
+            raise ManifestError(
+                f"gaia-agent.yaml{where}: cpp.binaries must be a mapping of "
+                f"platform -> binary path, got {type(binaries_raw).__name__}."
+            )
+        for plat, bin_path in binaries_raw.items():
+            if plat not in VALID_PLATFORMS:
+                raise ManifestError(
+                    f"gaia-agent.yaml{where}: cpp.binaries has unknown platform "
+                    f"{plat!r}. Valid platforms: {_sorted(VALID_PLATFORMS)}."
+                )
+            if not _nonempty_str(bin_path):
+                raise ManifestError(
+                    f"gaia-agent.yaml{where}: cpp.binaries[{plat!r}] must be a "
+                    f"non-empty path string."
+                )
+            binaries[plat] = bin_path
+    return CppConfig(
+        binaries=binaries,
+        static_linked=_parse_bool(
+            data.get("static_linked"), "cpp.static_linked", where, False
+        ),
+    )

--- a/tests/unit/test_hub_manifest.py
+++ b/tests/unit/test_hub_manifest.py
@@ -1,0 +1,459 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the gaia-agent.yaml manifest parser/validator (#1091)."""
+
+import textwrap
+
+import pytest
+import yaml
+
+from gaia.hub import AgentManifest, ManifestError, parse
+from gaia.hub.manifest import DEFAULT_SECURITY_TIER
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+VALID_PYTHON_MANIFEST = {
+    "id": "my-agent",
+    "name": "My Agent",
+    "version": "0.1.0",
+    "description": "A test agent",
+    "author": "AMD",
+    "license": "MIT",
+    "category": "productivity",
+    "tags": ["test", "demo"],
+    "icon": "zap",
+    "tools_count": 3,
+    "language": "python",
+    "min_gaia_version": "0.18.0",
+    "models": ["Qwen3.5-35B-A3B-GGUF"],
+    "security_tier": "community",
+    "requirements": {
+        "min_memory_gb": 8,
+        "min_disk_gb": 2,
+        "min_context_size": 4096,
+        "platforms": ["win-x64", "linux-x64", "darwin-arm64"],
+        "npu": True,
+        "gpu_vram_gb": 6,
+    },
+    "python": {
+        "entry_module": "gaia_agent_my.agent",
+        "entry_class": "MyAgent",
+        "dependencies": ["amd-gaia>=0.18.0"],
+    },
+    "permissions": ["filesystem:read", "network:outbound"],
+    "required_connections": ["google"],
+    "interfaces": {
+        "tui": True,
+        "cli": True,
+        "pipe": True,
+        "api_server": True,
+        "mcp_server": False,
+    },
+}
+
+VALID_CPP_MANIFEST = {
+    "id": "fast-agent",
+    "name": "Fast Agent",
+    "version": "1.0.0",
+    "description": "A native agent",
+    "author": "AMD",
+    "license": "MIT",
+    "language": "cpp",
+    "cpp": {
+        "binaries": {
+            "win-x64": "bin/fast-agent.exe",
+            "linux-x64": "bin/fast-agent",
+        },
+        "static_linked": True,
+    },
+}
+
+
+def write_manifest(tmp_path, data, name="gaia-agent.yaml"):
+    p = tmp_path / name
+    p.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_valid_python_manifest_parses(tmp_path):
+    p = write_manifest(tmp_path, VALID_PYTHON_MANIFEST)
+    m = parse(p)
+    assert isinstance(m, AgentManifest)
+    assert m.id == "my-agent"
+    assert m.name == "My Agent"
+    assert m.version == "0.1.0"
+    assert m.language == "python"
+    assert m.security_tier == "community"
+    assert m.tools_count == 3
+    assert m.tags == ["test", "demo"]
+    assert m.models == ["Qwen3.5-35B-A3B-GGUF"]
+    assert m.permissions == ["filesystem:read", "network:outbound"]
+    assert m.required_connections == ["google"]
+    assert m.source_path == p
+
+
+def test_valid_python_manifest_blocks(tmp_path):
+    m = parse(write_manifest(tmp_path, VALID_PYTHON_MANIFEST))
+    assert m.python is not None
+    assert m.python.entry_module == "gaia_agent_my.agent"
+    assert m.python.entry_class == "MyAgent"
+    assert m.python.dependencies == ["amd-gaia>=0.18.0"]
+    assert m.requirements.min_memory_gb == 8
+    assert m.requirements.min_context_size == 4096
+    assert m.requirements.npu is True
+    assert m.requirements.platforms == ["win-x64", "linux-x64", "darwin-arm64"]
+    assert m.interfaces.tui is True
+    assert m.interfaces.mcp_server is False
+
+
+def test_valid_cpp_manifest_parses(tmp_path):
+    m = parse(write_manifest(tmp_path, VALID_CPP_MANIFEST))
+    assert m.language == "cpp"
+    assert m.cpp is not None
+    assert m.cpp.binaries["win-x64"] == "bin/fast-agent.exe"
+    assert m.cpp.static_linked is True
+    assert m.python is None
+
+
+def test_minimal_manifest_uses_safe_defaults(tmp_path):
+    minimal = {
+        "id": "minimal",
+        "name": "Minimal",
+        "version": "0.1.0",
+        "description": "x",
+        "author": "AMD",
+        "license": "MIT",
+        "language": "python",
+    }
+    m = parse(write_manifest(tmp_path, minimal))
+    # Unspecified security tier defaults to least-privileged.
+    assert m.security_tier == DEFAULT_SECURITY_TIER == "experimental"
+    assert m.category == "general"
+    assert m.tags == []
+    assert m.permissions == []
+    assert m.tools_count == 0
+    assert m.requirements.platforms == []
+    assert m.interfaces.cli is False
+
+
+def test_parse_accepts_directory(tmp_path):
+    write_manifest(tmp_path, VALID_PYTHON_MANIFEST)
+    m = parse(tmp_path)  # directory, not file
+    assert m.id == "my-agent"
+
+
+def test_from_dict_without_source():
+    m = AgentManifest.from_dict(dict(VALID_CPP_MANIFEST))
+    assert m.id == "fast-agent"
+    assert m.source_path is None
+
+
+def test_semver_prerelease_and_build_metadata():
+    data = dict(VALID_PYTHON_MANIFEST, version="1.2.3-rc.1+build.5")
+    m = AgentManifest.from_dict(data)
+    assert m.version == "1.2.3-rc.1+build.5"
+
+
+# ---------------------------------------------------------------------------
+# File-level failures
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_raises(tmp_path):
+    with pytest.raises(ManifestError, match="Manifest not found"):
+        parse(tmp_path / "nope.yaml")
+
+
+def test_empty_file_raises(tmp_path):
+    p = tmp_path / "gaia-agent.yaml"
+    p.write_text("", encoding="utf-8")
+    with pytest.raises(ManifestError, match="empty"):
+        parse(p)
+
+
+def test_invalid_yaml_raises(tmp_path):
+    p = tmp_path / "gaia-agent.yaml"
+    p.write_text("id: [unclosed\n", encoding="utf-8")
+    with pytest.raises(ManifestError, match="Invalid YAML"):
+        parse(p)
+
+
+def test_non_mapping_yaml_raises(tmp_path):
+    p = tmp_path / "gaia-agent.yaml"
+    p.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    with pytest.raises(ManifestError, match="must be a YAML mapping"):
+        parse(p)
+
+
+# ---------------------------------------------------------------------------
+# Required field validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "missing", ["id", "name", "version", "description", "author", "license"]
+)
+def test_missing_required_field_raises(missing):
+    data = dict(VALID_PYTHON_MANIFEST)
+    del data[missing]
+    with pytest.raises(ManifestError, match="missing required field"):
+        AgentManifest.from_dict(data)
+
+
+def test_missing_required_field_names_the_field():
+    data = dict(VALID_PYTHON_MANIFEST)
+    del data["author"]
+    with pytest.raises(ManifestError, match="author"):
+        AgentManifest.from_dict(data)
+
+
+def test_empty_string_required_field_raises():
+    data = dict(VALID_PYTHON_MANIFEST, name="   ")
+    with pytest.raises(ManifestError, match="missing required field"):
+        AgentManifest.from_dict(data)
+
+
+def test_missing_language_raises():
+    data = dict(VALID_PYTHON_MANIFEST)
+    del data["language"]
+    with pytest.raises(ManifestError, match="language"):
+        AgentManifest.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# SemVer validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["1.0", "v1.0.0", "1.0.0.0", "1", "abc", "01.2.3"])
+def test_invalid_semver_raises(bad):
+    data = dict(VALID_PYTHON_MANIFEST, version=bad)
+    with pytest.raises(ManifestError, match="SemVer"):
+        AgentManifest.from_dict(data)
+
+
+@pytest.mark.parametrize("good", ["0.0.1", "1.2.3", "10.20.30", "1.2.3-rc.1"])
+def test_valid_semver_accepted(good):
+    data = dict(VALID_PYTHON_MANIFEST, version=good)
+    assert AgentManifest.from_dict(data).version == good
+
+
+def test_invalid_min_gaia_version_raises():
+    data = dict(VALID_PYTHON_MANIFEST, min_gaia_version="not-a-version")
+    with pytest.raises(ManifestError, match="min_gaia_version"):
+        AgentManifest.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# ID validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "My-Agent",  # uppercase
+        "-leading",  # leading hyphen
+        "trailing-",  # trailing hyphen
+        "has_underscore",  # underscore not allowed
+        "has space",  # space
+        "a" * 60,  # too long
+        "",  # empty
+        "agent!",  # punctuation
+    ],
+)
+def test_invalid_id_raises(bad_id):
+    data = dict(VALID_PYTHON_MANIFEST, id=bad_id)
+    with pytest.raises(ManifestError, match="id"):
+        AgentManifest.from_dict(data)
+
+
+@pytest.mark.parametrize("good_id", ["a", "my-agent", "agent2", "a1-b2-c3"])
+def test_valid_id_accepted(good_id):
+    data = dict(VALID_PYTHON_MANIFEST, id=good_id)
+    assert AgentManifest.from_dict(data).id == good_id
+
+
+@pytest.mark.parametrize("reserved", ["chat", "builder", "gaia-lite", "email", "doc"])
+def test_reserved_id_rejected(reserved):
+    data = dict(VALID_PYTHON_MANIFEST, id=reserved)
+    with pytest.raises(ManifestError, match="reserved"):
+        AgentManifest.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# Enum-ish validation: language, security_tier
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_language_raises():
+    data = dict(VALID_PYTHON_MANIFEST, language="rust")
+    with pytest.raises(ManifestError, match="language"):
+        AgentManifest.from_dict(data)
+
+
+@pytest.mark.parametrize("tier", ["verified", "community", "experimental"])
+def test_valid_security_tier_accepted(tier):
+    data = dict(VALID_PYTHON_MANIFEST, security_tier=tier)
+    assert AgentManifest.from_dict(data).security_tier == tier
+
+
+def test_invalid_security_tier_raises():
+    data = dict(VALID_PYTHON_MANIFEST, security_tier="trusted")
+    with pytest.raises(ManifestError, match="security_tier"):
+        AgentManifest.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# Permission syntax validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_perm",
+    [
+        "filesystem",  # no action
+        "filesystem:",  # empty action
+        ":read",  # empty domain
+        "Filesystem:read",  # uppercase
+        "filesystem read",  # space, no colon
+        "filesystem:read:write",  # too many parts
+    ],
+)
+def test_invalid_permission_syntax_raises(bad_perm):
+    data = dict(VALID_PYTHON_MANIFEST, permissions=[bad_perm])
+    with pytest.raises(ManifestError, match="permission"):
+        AgentManifest.from_dict(data)
+
+
+def test_unknown_permission_domain_raises():
+    data = dict(VALID_PYTHON_MANIFEST, permissions=["filesytem:read"])  # typo
+    with pytest.raises(ManifestError, match="unknown domain"):
+        AgentManifest.from_dict(data)
+
+
+def test_permissions_not_a_list_raises():
+    data = dict(VALID_PYTHON_MANIFEST, permissions="filesystem:read")
+    with pytest.raises(ManifestError, match="permissions must be a list"):
+        AgentManifest.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    "good_perm",
+    ["filesystem:read", "network:outbound", "shell:exec", "clipboard:write"],
+)
+def test_valid_permission_accepted(good_perm):
+    data = dict(VALID_PYTHON_MANIFEST, permissions=[good_perm])
+    assert AgentManifest.from_dict(data).permissions == [good_perm]
+
+
+# ---------------------------------------------------------------------------
+# Requirements / interfaces / cpp section validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_platform_raises():
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["requirements"] = dict(data["requirements"], platforms=["solaris-sparc"])
+    with pytest.raises(ManifestError, match="unknown platform"):
+        AgentManifest.from_dict(data)
+
+
+def test_negative_memory_raises():
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["requirements"] = dict(data["requirements"], min_memory_gb=-1)
+    with pytest.raises(ManifestError, match="min_memory_gb"):
+        AgentManifest.from_dict(data)
+
+
+def test_bool_tools_count_raises():
+    data = dict(VALID_PYTHON_MANIFEST, tools_count=True)
+    with pytest.raises(ManifestError, match="tools_count"):
+        AgentManifest.from_dict(data)
+
+
+def test_unknown_interface_key_raises():
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["interfaces"] = {"tui": True, "websocket": True}
+    with pytest.raises(ManifestError, match="unknown key"):
+        AgentManifest.from_dict(data)
+
+
+def test_non_bool_interface_raises():
+    data = dict(VALID_PYTHON_MANIFEST)
+    data["interfaces"] = {"cli": "yes"}
+    with pytest.raises(ManifestError, match="interfaces.cli"):
+        AgentManifest.from_dict(data)
+
+
+def test_cpp_language_without_binaries_raises():
+    data = dict(VALID_CPP_MANIFEST)
+    del data["cpp"]
+    with pytest.raises(ManifestError, match="no 'cpp.binaries'"):
+        AgentManifest.from_dict(data)
+
+
+def test_cpp_empty_binaries_raises():
+    data = dict(VALID_CPP_MANIFEST, cpp={"binaries": {}, "static_linked": False})
+    with pytest.raises(ManifestError, match="no 'cpp.binaries'"):
+        AgentManifest.from_dict(data)
+
+
+def test_cpp_unknown_platform_binary_raises():
+    data = dict(
+        VALID_CPP_MANIFEST,
+        cpp={"binaries": {"bsd-x64": "bin/x"}},
+    )
+    with pytest.raises(ManifestError, match="unknown platform"):
+        AgentManifest.from_dict(data)
+
+
+def test_tags_not_list_of_strings_raises():
+    data = dict(VALID_PYTHON_MANIFEST, tags=[1, 2, 3])
+    with pytest.raises(ManifestError, match="tags must be a list of strings"):
+        AgentManifest.from_dict(data)
+
+
+def test_real_world_yaml_text(tmp_path):
+    """Exercise an end-to-end YAML matching the spec example."""
+    text = textwrap.dedent("""
+        id: chatty
+        name: Chatty
+        version: 0.1.0
+        description: "General conversation"
+        author: AMD
+        license: MIT
+
+        category: conversation
+        tags: [chat, general]
+        icon: message-circle
+        tools_count: 0
+
+        language: python
+        min_gaia_version: "0.18.0"
+        models: [Qwen3.5-35B-A3B-GGUF]
+
+        requirements:
+          min_memory_gb: 8
+          platforms: [win-x64, linux-x64, darwin-arm64]
+
+        interfaces:
+          tui: true
+          cli: true
+          pipe: true
+          api_server: true
+          mcp_server: true
+        """)
+    p = tmp_path / "gaia-agent.yaml"
+    p.write_text(text, encoding="utf-8")
+    m = parse(p)
+    assert m.id == "chatty"
+    assert m.requirements.min_memory_gb == 8
+    assert m.interfaces.mcp_server is True


### PR DESCRIPTION
## Why this matters

The Agent Hub turns every agent — builtin, custom, community — into a self-describing package, and every downstream piece (packaging #1093, init scaffolding #1098, registry discovery) needs to read and *trust* the same `gaia-agent.yaml`. Before this PR there was no parser, so each consumer would have re-implemented validation and drifted. This adds the single source of truth: `gaia.hub.manifest.parse()` loads a manifest and returns a validated `AgentManifest`, or raises `ManifestError` that names what failed, what to fix, and where to look — never a silently half-built object (per the fail-loudly rule).

Validation covers required identity fields, SemVer (`version` + `min_gaia_version`), the id slug regex, rejection of reserved built-in ids (reusing the registry's canonical list so a community package can't impersonate `chat`/`builder`/etc.), domain-scoped permission syntax (`filesystem:read`), the `python|cpp` and `verified|community|experimental` enums, platform triples, and the python vs cpp section variants (a `cpp` agent with no binary fails loudly).

Schema follows `docs/spec/agent-hub-restructure.mdx` (Package Format → `gaia-agent.yaml`).

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/test_hub_manifest.py -xvs` — 75 tests, all pass (happy paths for python + cpp variants, every validation failure raises a clear error, SemVer, reserved-id rejection, missing-field errors, permission syntax, platform/interface validation)
- [x] `python util/lint.py --black --isort` — passes
- [x] `python -c "from gaia.hub import AgentManifest, ManifestError, parse"` — imports clean; `gaia.hub` added to `setup.py` packages

Closes #1091.