### PR TITLE
fix(lint): clear pre-existing pylint/mypy debt blocking CI

### DIFF
--- a/src/gaia/agents/base/discovery.py
+++ b/src/gaia/agents/base/discovery.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse
 try:
     import winreg  # Windows only
 except ImportError:
-    winreg = None  # Linux / macOS
+    winreg = None  # type: ignore[assignment]  # Linux / macOS
 
 logger = logging.getLogger(__name__)
 

--- a/src/gaia/agents/base/goal_store.py
+++ b/src/gaia/agents/base/goal_store.py
@@ -337,7 +337,10 @@ class GoalStore:
             source,
             status,
         )
-        return self.get_goal(goal_id)
+        goal = self.get_goal(goal_id)
+        if goal is None:
+            raise RuntimeError(f"goal {goal_id} not found immediately after creation")
+        return goal
 
     def get_goal(self, goal_id: str) -> Optional[Goal]:
         """Return a goal by ID, with its tasks, or None if not found."""
@@ -449,7 +452,10 @@ class GoalStore:
             )
             conn.execute("UPDATE goals SET updated_at=? WHERE id=?", (now, goal_id))
             conn.commit()
-        return self.get_task(task_id)
+        task = self.get_task(task_id)
+        if task is None:
+            raise RuntimeError(f"task {task_id} not found immediately after creation")
+        return task
 
     def get_task(self, task_id: str) -> Optional[Task]:
         """Return a task by ID or None."""
@@ -533,7 +539,7 @@ class GoalStore:
             ).fetchone()
             if not row or row["total"] == 0:
                 return False
-            return row["total"] == row["done"]
+            return bool(row["total"] == row["done"])
 
     # ------------------------------------------------------------------
     # Stats / dashboard

--- a/src/gaia/agents/base/memory_store.py
+++ b/src/gaia/agents/base/memory_store.py
@@ -30,7 +30,7 @@ import sqlite3
 import threading
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
@@ -675,7 +675,7 @@ class MemoryStore:
         category: str,
         content: str,
         domain: str | None = None,
-        metadata: dict = None,
+        metadata: dict | None = None,
         confidence: float = 0.5,
         due_at: str | None = None,
         source: str = "tool",
@@ -877,7 +877,7 @@ class MemoryStore:
                         overlap,
                         existing_id,
                     )
-                    return existing_id
+                    return cast(str, existing_id)
         except sqlite3.OperationalError as e:
             logger.debug("[MemoryStore] FTS5 dedup search error: %s", e)
 
@@ -1223,7 +1223,7 @@ class MemoryStore:
         content: str | None = None,
         category: str | None = None,
         domain: str | None = None,
-        metadata: dict = None,
+        metadata: dict | None = None,
         context: str | None = None,
         sensitive: bool | None = None,
         entity: str | None = None,
@@ -1678,7 +1678,7 @@ class MemoryStore:
                 ORDER BY timestamp DESC
                 LIMIT ?
             """
-            params = (tool_name, limit)
+            params: tuple[Any, ...] = (tool_name, limit)
         else:
             sql = """
                 SELECT id, session_id, tool_name, args, result_summary,
@@ -2109,7 +2109,7 @@ class MemoryStore:
             error_map = {r[0]: r[1] for r in error_rows}
 
         # Build timeline for each day in range
-        all_days = set()
+        all_days: set[str] = set()
         all_days.update(conv_map.keys())
         all_days.update(tool_map.keys())
         all_days.update(knowledge_map.keys())

--- a/src/gaia/agents/email/contract.py
+++ b/src/gaia/agents/email/contract.py
@@ -36,7 +36,7 @@ Design notes
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -274,7 +274,7 @@ def parse_request(data: dict) -> EmailTriageRequest:
     REST and MCP boundaries so a malformed payload fails loudly with an
     actionable message naming the offending field.
     """
-    return EmailTriageRequest.model_validate(data)
+    return cast(EmailTriageRequest, EmailTriageRequest.model_validate(data))
 
 
 def parse_response(data: dict) -> EmailTriageResponse:
@@ -282,7 +282,7 @@ def parse_response(data: dict) -> EmailTriageResponse:
 
     Same fail-loudly contract as :func:`parse_request`.
     """
-    return EmailTriageResponse.model_validate(data)
+    return cast(EmailTriageResponse, EmailTriageResponse.model_validate(data))
 
 
 __all__ = [

--- a/src/gaia/agents/email/outlook_backend.py
+++ b/src/gaia/agents/email/outlook_backend.py
@@ -527,6 +527,7 @@ class LiveOutlookBackend:
         # Master categories require a ``color`` (preset enum); ``preset0`` is a
         # safe default. ``label_list_visibility`` has no Outlook analogue and is
         # ignored — kept in the signature for Protocol parity with Gmail.
+        # pylint: disable=unused-argument
         created = self._post(
             "/me/outlook/masterCategories",
             json_body={"displayName": name, "color": "preset0"},

--- a/src/gaia/agents/email/outlook_calendar_backend.py
+++ b/src/gaia/agents/email/outlook_calendar_backend.py
@@ -245,6 +245,9 @@ class LiveOutlookCalendarBackend:
         time_max: Optional[str] = None,
         max_results: int = 25,
     ) -> Dict[str, Any]:
+        # ``calendar_id`` is implicit in Graph's ``/me`` endpoints — kept in the
+        # signature for Protocol parity with the Google backend.
+        # pylint: disable=unused-argument
         # When BOTH bounds are present, use calendarView — it expands recurring
         # series into instances within the window (the analogue of Google's
         # ``singleEvents=true``). Otherwise list raw events ordered by start.
@@ -267,6 +270,9 @@ class LiveOutlookCalendarBackend:
     def get_event(
         self, *, calendar_id: str = "primary", event_id: str
     ) -> Dict[str, Any]:
+        # ``calendar_id`` is implicit in Graph's ``/me`` endpoints — kept in the
+        # signature for Protocol parity with the Google backend.
+        # pylint: disable=unused-argument
         data = self._get(f"/me/events/{event_id}")
         return graph_event_to_google(data)
 
@@ -281,8 +287,10 @@ class LiveOutlookCalendarBackend:
         response_status: str,
     ) -> Dict[str, Any]:
         # Graph RSVP is an action on the invitee's own copy of the event
-        # (the authenticated ``/me``), so ``attendee_email`` is unused here —
-        # kept in the signature for Protocol parity with the Google backend.
+        # (the authenticated ``/me``), so ``attendee_email`` and ``calendar_id``
+        # are unused here — kept in the signature for Protocol parity with the
+        # Google backend.
+        # pylint: disable=unused-argument
         action = _RSVP_ACTION.get((response_status or "").strip().lower())
         if action is None:
             raise ConnectorsError(
@@ -304,6 +312,9 @@ class LiveOutlookCalendarBackend:
         location: Optional[str] = None,
         description: Optional[str] = None,
     ) -> Dict[str, Any]:
+        # ``calendar_id`` is implicit in Graph's ``/me`` endpoints — kept in the
+        # signature for Protocol parity with the Google backend.
+        # pylint: disable=unused-argument
         body: Dict[str, Any] = {
             "subject": summary,
             "start": _graph_endpoint(start),

--- a/src/gaia/eval/quality_metrics.py
+++ b/src/gaia/eval/quality_metrics.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from gaia.eval.config import MODEL_PRICING
 
@@ -263,7 +263,7 @@ def categorization_export(
     predicted_categories: dict[str, str],
     ground_truth: dict[str, dict],
     *,
-    axis_positive_categories: set[str] = NEEDS_ATTENTION_CATEGORIES,
+    axis_positive_categories: Optional[set[str]] = None,
     axis_label: str = "needs_attention",
 ) -> dict[str, Any]:
     """Per-email categorization export with FP/FN flags on a binary axis.
@@ -279,6 +279,8 @@ def categorization_export(
     included (metadata rows are skipped). Raises ``ValueError`` if the positive
     set is empty — an axis with no positive class can't have FP/FN semantics.
     """
+    if axis_positive_categories is None:
+        axis_positive_categories = NEEDS_ATTENTION_CATEGORIES
     positives = {c.strip().lower() for c in axis_positive_categories}
     if not positives:
         raise ValueError(

--- a/src/gaia/mcp/servers/email_mcp.py
+++ b/src/gaia/mcp/servers/email_mcp.py
@@ -32,7 +32,7 @@ mail backend, and only on the authorized path.
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from gaia.agents.base.console import SilentConsole
 from gaia.agents.base.mcp_agent import MCPAgent
@@ -139,8 +139,16 @@ class _FakeSendBackend:
         self._seq = 0
 
     def send_message(
-        self, *, to: str, subject: str, body: str, headers: Dict[str, str] = None
+        self,
+        *,
+        to: str,
+        subject: str,
+        body: str,
+        headers: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
+        # Signature mirrors LiveGmailBackend.send_message; body/headers are part
+        # of that contract but unused by the in-process fake.
+        # pylint: disable=unused-argument
         self._seq += 1
         return {"id": f"mcp_fake_{self._seq}", "to": to, "subject": subject}
 

--- a/tests/fixtures/email/fake_gmail.py
+++ b/tests/fixtures/email/fake_gmail.py
@@ -31,7 +31,7 @@ from email.header import decode_header
 from email.message import Message
 from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, cast
 
 # ---------------------------------------------------------------------------
 # mbox → Gmail-API translator
@@ -139,10 +139,13 @@ def _walk_mime_to_payload(part: Message) -> Dict[str, Any]:
             "filename": filename,
             "headers": headers,
             "body": {"size": 0},
-            "parts": [_walk_mime_to_payload(p) for p in part.get_payload()],
+            "parts": [
+                _walk_mime_to_payload(p)
+                for p in cast(List[Message], part.get_payload())
+            ],
         }
 
-    raw = part.get_payload(decode=True) or b""
+    raw = cast(bytes, part.get_payload(decode=True) or b"")
     body: Dict[str, Any] = {"size": len(raw)}
     if mime_type.startswith("text/") or mime_type == "message/rfc822":
         body["data"] = _b64url(raw)
@@ -221,7 +224,7 @@ def _build_snippet(msg: Message) -> str:
     if msg.is_multipart():
         for part in msg.walk():
             if part.get_content_type() == "text/plain":
-                raw = part.get_payload(decode=True) or b""
+                raw = cast(bytes, part.get_payload(decode=True) or b"")
                 try:
                     text = raw.decode("utf-8", errors="replace")
                 except Exception:


### PR DESCRIPTION
## Why this matters

The **Code Quality (Lint)** gate is currently red on `main`: recently-merged email/Outlook/eval work landed pylint `W0613`/`W0102` errors and mypy violations that fail the "Run Code Quality Checks" job. Because that job runs on every PR, it's blocking **all open PRs** (including the Agent Hub milestone work) from going green — even though their own diffs are clean. This PR clears that debt with mechanical, behavior-preserving fixes so the gate passes again.

This is **not** a milestone issue — it's a pure CI unblock.

> Note: the Windows multiprocess pylint run (`jobs=0`) masks most of these locally; they only surface with `jobs=1`, which is what Linux CI effectively reports. Verified with `pylint src/gaia --jobs 1`.

## What changed (grouped by fix type)

**Pylint — unused-argument (W0613), interface-conformance stubs**
- `src/gaia/mcp/servers/email_mcp.py` — `_FakeSendBackend.send_message` mirrors `LiveGmailBackend`; `body`/`headers` kept for contract parity → targeted disable (+ `Optional` on the `headers` default).
- `src/gaia/agents/email/outlook_backend.py` — `create_label`'s `label_list_visibility` has no Outlook analogue.
- `src/gaia/agents/email/outlook_calendar_backend.py` — `calendar_id`/`attendee_email` are implicit in Graph's `/me` endpoints; kept for Protocol parity with the Google backend.

**Pylint — dangerous-default-value (W0102)**
- `src/gaia/eval/quality_metrics.py` — `categorization_export` mutable `set` default → `None` sentinel + in-body default.

**Mypy**
- `src/gaia/agents/email/contract.py` — `cast` pydantic `model_validate` results to the declared model types.
- `src/gaia/agents/base/memory_store.py` — `Optional` metadata defaults, cast dedup id to `str`, annotate the `params` tuple and `all_days` set.
- `src/gaia/agents/base/goal_store.py` — fail-loud guards so `create_goal`/`create_task` narrow to their non-Optional return contract (preserves the public signature); `bool()` the `is_complete` comparison.
- `src/gaia/agents/base/discovery.py` — `type: ignore[assignment]` on the non-Windows `winreg = None` shim (canonical conditional-import pattern).
- `tests/fixtures/email/fake_gmail.py` — narrow `email.message` payloads (cast to `bytes` / `Message` list).

## Test plan

- [x] `uvx pylint src/gaia --rcfile .pylintrc --disable <ci-set> --jobs 1` → no W0613/W0102 (only a pre-existing Windows-only `os.geteuid` E1101 false positive, which Linux CI never hits)
- [x] `uvx mypy src/gaia --ignore-missing-imports` → all listed errors resolved, no new errors at edit sites
- [x] `python util/lint.py --black --isort` → PASS
- [x] `PYTHONPATH=src python -m pytest tests/unit/ -k "email or memory or goal or quality or outlook or discovery or contract"` → 1201 passed; the single failure (`test_reconcile_returns_503_when_no_agent_and_faiss_missing`) is pre-existing and environment-specific (faiss is installed locally, so the "missing" simulation can't fire — fails identically on a clean tree)
- [x] Import sanity check on all 8 touched src modules → OK