### PR TITLE
feat(webui): Agent Hub Installed/Available tabs + install flow (#1097)

### DIFF
--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -78,6 +78,113 @@
     border-color: var(--text-secondary);
 }
 
+/* ── Tabs (Installed / Available) ───────────────────────────────────────── */
+
+.agent-hub-tabs {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.agent-hub-tab {
+    padding: 6px 14px;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: var(--radius-md);
+    border: 1px solid transparent;
+    transition: all 200ms ease;
+    white-space: nowrap;
+}
+
+.agent-hub-tab:hover {
+    color: var(--text-primary);
+    background: var(--bg-card);
+}
+
+.agent-hub-tab.active {
+    color: var(--amd-red);
+    background: var(--amd-red-dim);
+    border-color: var(--amd-red-dim);
+}
+
+/* ── Banners (offline / error) ──────────────────────────────────────────── */
+
+.agent-hub-banner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 14px;
+    border-radius: var(--radius-md);
+    font-size: 13px;
+    margin-bottom: 16px;
+}
+
+.agent-hub-banner svg {
+    flex-shrink: 0;
+}
+
+.agent-hub-banner-offline {
+    background: rgba(232, 168, 48, 0.1);
+    color: var(--accent-gold);
+    border: 1px solid rgba(232, 168, 48, 0.25);
+}
+
+.agent-hub-banner-error {
+    background: rgba(239, 68, 68, 0.08);
+    color: var(--accent-red, #ef4444);
+    border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.agent-hub-retry {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    margin-left: auto;
+    padding: 4px 10px;
+    border: 1px solid currentColor;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: inherit;
+    font-family: var(--font-sans);
+    font-size: 12px;
+    cursor: pointer;
+    transition: opacity 200ms ease;
+}
+
+.agent-hub-retry:hover {
+    opacity: 0.8;
+}
+
+/* ── Loading state ──────────────────────────────────────────────────────── */
+
+.agent-hub-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 40px 20px;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.agent-hub-spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--border);
+    border-top-color: var(--amd-red);
+    border-radius: 50%;
+    animation: agentHubSpin 700ms linear infinite;
+}
+
+@keyframes agentHubSpin {
+    to { transform: rotate(360deg); }
+}
+
 /* ── Card Grid ──────────────────────────────────────────────────────────── */
 
 .agent-hub-grid {
@@ -88,10 +195,18 @@
 
 .agent-hub-empty {
     grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
     text-align: center;
     padding: 40px 20px;
     color: var(--text-muted);
     font-size: 14px;
+}
+
+.agent-hub-empty p {
+    margin: 0;
 }
 
 /* ── Agent Hub Card ─────────────────────────────────────────────────────── */
@@ -343,6 +458,157 @@
     color: var(--text-primary);
 }
 
+/* ── Available-tab card (not a select target) ───────────────────────────── */
+
+.agent-hub-card.available-card {
+    cursor: default;
+}
+
+.agent-hub-card.available-card:hover {
+    border-color: var(--text-secondary);
+    box-shadow: var(--shadow-md);
+    transform: translateY(-2px);
+}
+
+/* ── Compatibility indicator dot ────────────────────────────────────────── */
+
+.agent-compat-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 4px;
+    cursor: help;
+}
+
+.agent-compat-compatible {
+    background: var(--accent-green, #22c55e);
+    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.15);
+}
+
+.agent-compat-warning {
+    background: var(--accent-gold);
+    box-shadow: 0 0 0 3px rgba(232, 168, 48, 0.15);
+}
+
+.agent-compat-incompatible {
+    background: var(--accent-red, #ef4444);
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}
+
+/* ── Install progress ───────────────────────────────────────────────────── */
+
+.agent-install-progress {
+    margin-bottom: 12px;
+}
+
+.agent-install-progress-head {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-bottom: 5px;
+}
+
+.agent-install-bar {
+    height: 6px;
+    width: 100%;
+    background: var(--bg-tertiary);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.agent-install-bar-fill {
+    height: 100%;
+    background: var(--amd-red);
+    border-radius: 3px;
+    transition: width 300ms ease;
+}
+
+.agent-install-error {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--accent-red, #ef4444);
+    margin-bottom: 12px;
+    line-height: 1.4;
+}
+
+.agent-install-error svg {
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+/* ── Install / uninstall / cancel buttons ───────────────────────────────── */
+
+.agent-hub-card-actions .btn-install {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 7px 14px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--amd-red);
+    color: #fff;
+    font-family: var(--font-sans);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 200ms ease;
+}
+
+.agent-hub-card-actions .btn-install:hover:not(:disabled) {
+    background: var(--amd-red-dark);
+}
+
+.agent-hub-card-actions .btn-install:disabled {
+    background: var(--text-muted);
+    cursor: not-allowed;
+}
+
+.agent-hub-card-actions .btn-install-cancel {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 7px 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-secondary);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 200ms ease;
+}
+
+.agent-hub-card-actions .btn-install-cancel:hover {
+    border-color: var(--accent-red, #ef4444);
+    color: var(--accent-red, #ef4444);
+}
+
+.agent-hub-card-actions .btn-uninstall {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 7px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 200ms ease;
+}
+
+.agent-hub-card-actions .btn-uninstall:hover {
+    border-color: var(--accent-red, #ef4444);
+    color: var(--accent-red, #ef4444);
+}
+
 /* ── Badges ─────────────────────────────────────────────────────────────── */
 
 .agent-badge {
@@ -379,6 +645,37 @@
 .agent-badge-category {
     background: rgba(232, 168, 48, 0.1);
     color: var(--accent-gold);
+}
+
+.agent-badge-update {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    background: rgba(232, 168, 48, 0.16);
+    color: var(--accent-gold);
+}
+
+.agent-badge-version {
+    background: var(--bg-tertiary);
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.agent-badge-tier-community {
+    background: rgba(59, 158, 255, 0.1);
+    color: var(--accent-blue);
+    text-transform: capitalize;
+}
+
+.agent-badge-tier-experimental {
+    background: rgba(168, 85, 247, 0.12);
+    color: var(--accent-purple, #a855f7);
+    text-transform: capitalize;
+}
+
+.agent-badge-deprecated {
+    background: rgba(239, 68, 68, 0.1);
+    color: var(--accent-red, #ef4444);
 }
 
 /* ── Create Agent CTA Card ──────────────────────────────────────────────── */

--- a/src/gaia/apps/webui/src/components/AgentHubCard.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubCard.tsx
@@ -1,10 +1,16 @@
 // Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-import { Cpu, Wrench, Shield, CheckCircle2, AlertTriangle } from 'lucide-react';
+import { Cpu, Wrench, Shield, CheckCircle2, AlertTriangle, Download, Trash2, ArrowUpCircle, X, RefreshCw } from 'lucide-react';
 import { getAgentIcon } from './agentIcons';
-import type { AgentInfo } from '../types';
+import type { AgentInfo, InstallStatus } from '../types';
 import { useChatStore } from '../stores/chatStore';
+import {
+    compatLevel,
+    compatLabel,
+    formatBytes,
+    isInstalling,
+} from '../utils/agentHub';
 
 function sourceBadge(source: string) {
     if (source === 'builtin') return <span className="agent-badge agent-badge-builtin">Built-in</span>;
@@ -15,16 +21,47 @@ function sourceBadge(source: string) {
 
 const DEVICE_LABELS: Record<string, string> = { cpu: 'CPU', gpu: 'GPU', npu: 'NPU' };
 
+const INSTALL_STAGE_LABEL: Record<string, string> = {
+    downloading: 'Downloading…',
+    verifying: 'Verifying…',
+    installing: 'Installing…',
+    installed: 'Installed',
+    failed: 'Failed',
+};
+
 interface AgentHubCardProps {
     agent: AgentInfo;
+    /** Which tab the card lives on — drives the action set. */
+    variant: 'installed' | 'available';
     isActive: boolean;
     isElectron: boolean;
     onSelect: (id: string) => void;
     onStartChat: (id: string) => void;
     onViewDetails: (agent: AgentInfo) => void;
+    /** Live install/update progress for this agent. */
+    installStatus?: InstallStatus | null;
+    /** Start an install / update. */
+    onInstall?: (id: string) => void;
+    /** Abort an in-flight install. */
+    onCancelInstall?: (id: string) => void;
+    /** Uninstall an installed agent. */
+    onUninstall?: (id: string) => void;
 }
 
-export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartChat, onViewDetails }: AgentHubCardProps) {
+export function AgentHubCard({
+    agent,
+    variant,
+    isActive,
+    isElectron,
+    onSelect,
+    onStartChat,
+    onViewDetails,
+    installStatus,
+    onInstall,
+    onCancelInstall,
+    onUninstall,
+}: AgentHubCardProps) {
+    const isAvailable = variant === 'available';
     const isNative = agent.source === 'native';
     const canStart = !isNative || isElectron;
     const model = agent.models?.[0];
@@ -33,31 +70,63 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
     const connections = agent.required_connections ?? [];
     const Icon = getAgentIcon(agent.icon);
 
-    // Device selection
+    const installing = isInstalling(installStatus);
+    const installFailed = installStatus?.state === 'failed';
+    const hasUpdate = agent.status === 'update_available';
+    const level = compatLevel(agent);
+    const incompatible = level === 'incompatible';
+
+    // Device selection (installed agents only)
     const activeDevice = useChatStore((s) => s.activeDevice);
     const setActiveDevice = useChatStore((s) => s.setActiveDevice);
     const detectedDevices = useChatStore((s) => s.detectedDevices);
     const deviceConfigs = agent.device_configs ?? [];
-    // Show only devices the agent supports AND that are detected on the system
-    const availableConfigs = deviceConfigs.filter(
-        (c) => detectedDevices.includes(c.device),
-    );
+    const availableConfigs = deviceConfigs.filter((c) => detectedDevices.includes(c.device));
     const selectedConfig = availableConfigs.find((c) => c.device === activeDevice);
     const showDeviceSelector = availableConfigs.length > 1;
 
+    // Installed-tab cards select-to-chat; available-tab cards do not.
+    const clickable = !isAvailable && canStart;
+
     const cardClass = [
         'agent-hub-card',
-        isActive && 'active',
-        !canStart && 'disabled',
+        isActive && !isAvailable && 'active',
+        !canStart && !isAvailable && 'disabled',
+        isAvailable && 'available-card',
     ].filter(Boolean).join(' ');
+
+    // Primary install/update button (used on both tabs while updating/installing).
+    const installButton = installing ? (
+        <button
+            className="btn-install-cancel"
+            onClick={(e) => { e.stopPropagation(); onCancelInstall?.(agent.id); }}
+        >
+            <X size={14} /> Cancel
+        </button>
+    ) : (
+        <button
+            className="btn-install"
+            disabled={incompatible}
+            title={incompatible
+                ? [compatLabel(level), ...(agent.compatibility?.reasons ?? [])].join(' ')
+                : `${hasUpdate ? 'Update' : 'Install'} ${agent.name}`}
+            onClick={(e) => { e.stopPropagation(); onInstall?.(agent.id); }}
+        >
+            {installFailed
+                ? <><RefreshCw size={14} /> Retry</>
+                : hasUpdate
+                    ? <><ArrowUpCircle size={14} /> Update</>
+                    : <><Download size={14} /> Install</>}
+        </button>
+    );
 
     return (
         <div
             className={cardClass}
-            role="button"
-            tabIndex={canStart ? 0 : -1}
-            onClick={() => canStart && onSelect(agent.id)}
-            onKeyDown={(e) => { if (canStart && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onSelect(agent.id); } }}
+            role={clickable ? 'button' : undefined}
+            tabIndex={clickable ? 0 : -1}
+            onClick={() => clickable && onSelect(agent.id)}
+            onKeyDown={(e) => { if (clickable && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onSelect(agent.id); } }}
         >
             {/* Header */}
             <div className="agent-hub-card-header">
@@ -67,7 +136,19 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
                 <div className="agent-hub-card-info">
                     <h3 className="agent-hub-card-name">{agent.name}</h3>
                     <div className="agent-hub-card-badges">
-                        {sourceBadge(agent.source)}
+                        {!isAvailable && sourceBadge(agent.source)}
+                        {hasUpdate && (
+                            <span className="agent-badge agent-badge-update">
+                                <ArrowUpCircle size={10} /> Update
+                            </span>
+                        )}
+                        {agent.version && !isAvailable && (
+                            <span className="agent-badge agent-badge-version">v{agent.version}</span>
+                        )}
+                        {agent.security_tier && agent.security_tier !== 'verified' && (
+                            <span className={`agent-badge agent-badge-tier-${agent.security_tier}`}>{agent.security_tier}</span>
+                        )}
+                        {agent.deprecated && <span className="agent-badge agent-badge-deprecated">Deprecated</span>}
                         {agent.language && agent.language !== 'python' && (
                             <span className="agent-badge agent-badge-native">{agent.language.toUpperCase()}</span>
                         )}
@@ -76,6 +157,14 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
                         )}
                     </div>
                 </div>
+                {/* Compatibility indicator (catalog cards) */}
+                {agent.compatibility && (
+                    <span
+                        className={`agent-compat-dot agent-compat-${level}`}
+                        title={[compatLabel(level), ...(agent.compatibility.reasons ?? [])].join('\n')}
+                        aria-label={compatLabel(level)}
+                    />
+                )}
             </div>
 
             {/* Description */}
@@ -95,7 +184,12 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
                         {toolsCount} tools
                     </span>
                 )}
-                {connections.length > 0 ? (
+                {isAvailable && agent.download_size_bytes != null ? (
+                    <span className="agent-hub-card-meta-item">
+                        <Download size={12} />
+                        {formatBytes(agent.download_size_bytes)}
+                    </span>
+                ) : connections.length > 0 ? (
                     <span className="agent-hub-card-meta-item">
                         <Shield size={12} />
                         {connections.map((c) => c.connector_id).join(', ')}
@@ -108,8 +202,8 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
                 )}
             </div>
 
-            {/* Device selector */}
-            {availableConfigs.length > 0 && (
+            {/* Device selector (installed agents only) */}
+            {!isAvailable && availableConfigs.length > 0 && (
                 <div className="agent-hub-card-device">
                     {showDeviceSelector ? (
                         <select
@@ -141,25 +235,68 @@ export function AgentHubCard({ agent, isActive, isElectron, onSelect, onStartCha
                 </div>
             )}
 
-            {/* Starter preview */}
-            {starter && <div className="agent-hub-card-starter">{starter}</div>}
+            {/* Starter preview (installed only) */}
+            {!isAvailable && starter && <div className="agent-hub-card-starter">{starter}</div>}
+
+            {/* Install / update progress */}
+            {installing && (
+                <div className="agent-install-progress">
+                    <div className="agent-install-progress-head">
+                        <span>{INSTALL_STAGE_LABEL[installStatus!.state] ?? 'Installing…'}</span>
+                        <span>{Math.round(installStatus!.progress)}%</span>
+                    </div>
+                    <div className="agent-install-bar" role="progressbar"
+                        aria-valuenow={Math.round(installStatus!.progress)} aria-valuemin={0} aria-valuemax={100}>
+                        <div className="agent-install-bar-fill" style={{ width: `${Math.max(2, installStatus!.progress)}%` }} />
+                    </div>
+                </div>
+            )}
+
+            {/* Install failure */}
+            {installFailed && (
+                <div className="agent-install-error" role="alert">
+                    <AlertTriangle size={12} />
+                    <span>{installStatus?.error || 'Install failed.'}</span>
+                </div>
+            )}
 
             {/* Actions */}
             <div className="agent-hub-card-actions">
-                <button
-                    className="btn-start-chat"
-                    disabled={!canStart}
-                    title={!canStart ? 'Available in GAIA Desktop' : `Start chat with ${agent.name}`}
-                    onClick={(e) => { e.stopPropagation(); onStartChat(agent.id); }}
-                >
-                    Start Chat
-                </button>
+                {isAvailable ? (
+                    installButton
+                ) : (
+                    <>
+                        <button
+                            className="btn-start-chat"
+                            disabled={!canStart}
+                            title={!canStart ? 'Available in GAIA Desktop' : `Start chat with ${agent.name}`}
+                            onClick={(e) => { e.stopPropagation(); onStartChat(agent.id); }}
+                        >
+                            Start Chat
+                        </button>
+                        {/* In-place update for installed agents with a pending update. */}
+                        {(hasUpdate || installing || installFailed) && (onInstall || onCancelInstall) && installButton}
+                    </>
+                )}
+
                 <button
                     className="btn-details"
                     onClick={(e) => { e.stopPropagation(); onViewDetails(agent); }}
                 >
                     Details
                 </button>
+
+                {/* Uninstall — only for installed agents that can be removed */}
+                {!isAvailable && onUninstall && agent.source === 'installed' && (
+                    <button
+                        className="btn-uninstall"
+                        title={`Uninstall ${agent.name}`}
+                        aria-label={`Uninstall ${agent.name}`}
+                        onClick={(e) => { e.stopPropagation(); onUninstall(agent.id); }}
+                    >
+                        <Trash2 size={14} />
+                    </button>
+                )}
             </div>
         </div>
     );

--- a/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
@@ -1,11 +1,20 @@
 // Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-import { useState, useMemo } from 'react';
-import { Plus, Search } from 'lucide-react';
-import type { AgentInfo } from '../types';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { Plus, Search, WifiOff, AlertTriangle, RotateCcw, Package } from 'lucide-react';
+import type { AgentInfo, InstallStatus } from '../types';
 import { AgentHubCard } from './AgentHubCard';
 import { AgentDetailModal } from './AgentDetailModal';
+import { useChatStore } from '../stores/chatStore';
+import * as api from '../services/api';
+import { log } from '../utils/logger';
+import {
+    mergeCatalogStatus,
+    splitAvailable,
+    countUpdates,
+    installedTabLabel,
+} from '../utils/agentHub';
 import './AgentHub.css';
 
 interface AgentHubGridProps {
@@ -19,6 +28,10 @@ interface AgentHubGridProps {
 // Detect Electron context once
 const isElectron = typeof window !== 'undefined' && !!(window as any).electronAPI;
 
+const POLL_INTERVAL_MS = 1200;
+
+type HubTab = 'installed' | 'available';
+
 /** Sort: builtin first, then custom, installed, and native. Alphabetical within groups. */
 function sortAgents(agents: AgentInfo[]): AgentInfo[] {
     const order: Record<string, number> = { builtin: 0, custom_python: 1, installed: 2, native: 3 };
@@ -30,42 +43,226 @@ function sortAgents(agents: AgentInfo[]): AgentInfo[] {
     });
 }
 
+function filterAgents(agents: AgentInfo[], search: string, categoryFilter: string): AgentInfo[] {
+    let list = agents;
+    if (search) {
+        const q = search.toLowerCase();
+        list = list.filter((a) =>
+            a.name.toLowerCase().includes(q) ||
+            a.description.toLowerCase().includes(q) ||
+            (a.tags ?? []).some((t) => t.toLowerCase().includes(q)) ||
+            (a.category ?? '').toLowerCase().includes(q)
+        );
+    }
+    if (categoryFilter !== 'all') {
+        list = list.filter((a) => a.category === categoryFilter);
+    }
+    return sortAgents(list);
+}
+
 export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onCreateAgent }: AgentHubGridProps) {
+    const [activeTab, setActiveTab] = useState<HubTab>('installed');
     const [search, setSearch] = useState('');
     const [categoryFilter, setCategoryFilter] = useState('all');
     const [detailAgent, setDetailAgent] = useState<AgentInfo | null>(null);
 
-    const showControls = agents.length > 6;
+    // Catalog state (issue #1096 backend)
+    const [catalog, setCatalog] = useState<AgentInfo[]>([]);
+    const [catalogOffline, setCatalogOffline] = useState(false);
+    const [catalogError, setCatalogError] = useState<string | null>(null);
+    const [catalogLoading, setCatalogLoading] = useState(false);
+    // True once a catalog fetch has been attempted (success OR failure). Gates
+    // the lazy auto-load to a single attempt so a persistent failure doesn't
+    // loop; the Retry button re-fetches explicitly.
+    const catalogAttemptedRef = useRef(false);
+    // True only after a successful catalog load (drives the Installed-tab merge).
+    const catalogLoadedRef = useRef(false);
 
-    // Unique categories for the filter dropdown
+    // Per-agent install progress, keyed by agent id.
+    const [installStates, setInstallStates] = useState<Record<string, InstallStatus>>({});
+    const pollTimers = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+
+    const activeDevice = useChatStore((s) => s.activeDevice);
+    const setAgents = useChatStore((s) => s.setAgents);
+
+    // ── Catalog fetch ──────────────────────────────────────────────────────
+    const fetchCatalog = useCallback(async () => {
+        catalogAttemptedRef.current = true;
+        setCatalogLoading(true);
+        setCatalogError(null);
+        try {
+            const res = await api.listCatalog();
+            setCatalog(res.agents || []);
+            setCatalogOffline(!!res.offline);
+            catalogLoadedRef.current = true;
+        } catch (err) {
+            // Fail loudly at the UI boundary — the Available tab shows the error
+            // with a Retry; the Installed tab still renders from the local list.
+            const msg = err instanceof Error ? err.message : 'Could not load the agent catalog.';
+            log.api.warn('[AgentHub] catalog fetch failed', err);
+            setCatalogError(msg);
+        } finally {
+            setCatalogLoading(false);
+        }
+    }, []);
+
+    // Lazily load the catalog the first time the Available tab is opened.
+    useEffect(() => {
+        if (activeTab === 'available' && !catalogAttemptedRef.current && !catalogLoading) {
+            fetchCatalog();
+        }
+    }, [activeTab, catalogLoading, fetchCatalog]);
+
+    // Refresh the locally-registered agent list (so installs/uninstalls reflect
+    // immediately rather than waiting for the 30s App poll).
+    const refreshAgents = useCallback(async () => {
+        try {
+            const data = await api.listAgents();
+            setAgents(data.agents || []);
+        } catch (err) {
+            log.api.warn('[AgentHub] agent list refresh failed', err);
+        }
+    }, [setAgents]);
+
+    // ── Install polling ────────────────────────────────────────────────────
+    const stopPolling = useCallback((id: string) => {
+        const t = pollTimers.current[id];
+        if (t) {
+            clearInterval(t);
+            delete pollTimers.current[id];
+        }
+    }, []);
+
+    const startPolling = useCallback((id: string) => {
+        stopPolling(id);
+        pollTimers.current[id] = setInterval(async () => {
+            try {
+                const status = await api.getInstallStatus(id);
+                setInstallStates((s) => ({ ...s, [id]: status }));
+                if (status.state === 'installed') {
+                    stopPolling(id);
+                    await fetchCatalog();
+                    await refreshAgents();
+                } else if (status.state === 'failed') {
+                    stopPolling(id);
+                }
+            } catch (err) {
+                stopPolling(id);
+                const msg = err instanceof Error ? err.message : 'Install status check failed.';
+                setInstallStates((s) => ({ ...s, [id]: { agent_id: id, state: 'failed', progress: 0, error: msg } }));
+            }
+        }, POLL_INTERVAL_MS);
+    }, [stopPolling, fetchCatalog, refreshAgents]);
+
+    // Cleanup all timers on unmount.
+    useEffect(() => () => {
+        Object.values(pollTimers.current).forEach(clearInterval);
+        pollTimers.current = {};
+    }, []);
+
+    const handleInstall = useCallback(async (id: string) => {
+        setInstallStates((s) => ({ ...s, [id]: { agent_id: id, state: 'downloading', progress: 0 } }));
+        try {
+            const status = await api.installAgent(id, activeDevice);
+            setInstallStates((s) => ({ ...s, [id]: status }));
+            if (status.state === 'installed') {
+                await fetchCatalog();
+                await refreshAgents();
+            } else if (status.state === 'failed') {
+                // leave the failed state for the Retry button
+            } else {
+                startPolling(id);
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Install failed.';
+            setInstallStates((s) => ({ ...s, [id]: { agent_id: id, state: 'failed', progress: 0, error: msg } }));
+        }
+    }, [activeDevice, startPolling, fetchCatalog, refreshAgents]);
+
+    const handleCancelInstall = useCallback(async (id: string) => {
+        stopPolling(id);
+        try {
+            // No dedicated cancel endpoint yet — uninstall cleans up the partial
+            // install. Surface failures rather than silently detaching the poll.
+            await api.uninstallAgent(id);
+            setInstallStates((s) => { const n = { ...s }; delete n[id]; return n; });
+            await fetchCatalog();
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Cancel failed.';
+            setInstallStates((s) => ({ ...s, [id]: { agent_id: id, state: 'failed', progress: 0, error: `Cancel failed: ${msg}` } }));
+        }
+    }, [stopPolling, fetchCatalog]);
+
+    const handleUninstall = useCallback(async (id: string) => {
+        const agent = agents.find((a) => a.id === id);
+        const name = agent?.name ?? id;
+        // eslint-disable-next-line no-alert
+        if (!window.confirm(`Uninstall ${name}? You can reinstall it from the Available tab.`)) return;
+        try {
+            await api.uninstallAgent(id);
+            await refreshAgents();
+            if (catalogLoadedRef.current) await fetchCatalog();
+        } catch (err) {
+            log.api.warn('[AgentHub] uninstall failed', err);
+            // eslint-disable-next-line no-alert
+            window.alert(err instanceof Error ? err.message : 'Uninstall failed.');
+        }
+    }, [agents, refreshAgents, fetchCatalog]);
+
+    // ── Derived lists ──────────────────────────────────────────────────────
+    // Installed tab: local agents merged with catalog status (update badges).
+    const installedAgents = useMemo(
+        () => mergeCatalogStatus(agents, catalog),
+        [agents, catalog],
+    );
+    const installedIds = useMemo(() => new Set(agents.map((a) => a.id)), [agents]);
+    const availableAgents = useMemo(
+        () => splitAvailable(catalog, installedIds),
+        [catalog, installedIds],
+    );
+    const updateCount = useMemo(() => countUpdates(installedAgents), [installedAgents]);
+
+    // Category dropdown options for the active tab's source list.
+    const sourceForFilter = activeTab === 'installed' ? installedAgents : availableAgents;
     const categories = useMemo(() => {
         const cats = new Set<string>();
-        agents.forEach((a) => { if (a.category && a.category !== 'general') cats.add(a.category); });
+        sourceForFilter.forEach((a) => { if (a.category && a.category !== 'general') cats.add(a.category); });
         return Array.from(cats).sort();
-    }, [agents]);
+    }, [sourceForFilter]);
 
-    // Filter + sort
-    const filtered = useMemo(() => {
-        let list = agents;
-        if (search) {
-            const q = search.toLowerCase();
-            list = list.filter((a) =>
-                a.name.toLowerCase().includes(q) ||
-                a.description.toLowerCase().includes(q) ||
-                (a.tags ?? []).some((t) => t.toLowerCase().includes(q)) ||
-                (a.category ?? '').toLowerCase().includes(q)
-            );
-        }
-        if (categoryFilter !== 'all') {
-            list = list.filter((a) => a.category === categoryFilter);
-        }
-        return sortAgents(list);
-    }, [agents, search, categoryFilter]);
+    const filteredInstalled = useMemo(
+        () => filterAgents(installedAgents, search, categoryFilter),
+        [installedAgents, search, categoryFilter],
+    );
+    const filteredAvailable = useMemo(
+        () => filterAgents(availableAgents, search, categoryFilter),
+        [availableAgents, search, categoryFilter],
+    );
+
+    // Search/filter bar: always shown on Available; shown on Installed when 6+.
+    const showControls = activeTab === 'available' || installedAgents.length > 6;
 
     return (
         <div className="agent-hub">
             <div className="agent-hub-header">
-                <span className="agent-hub-title">Choose Your Agent</span>
+                <div className="agent-hub-tabs" role="tablist" aria-label="Agent Hub tabs">
+                    <button
+                        role="tab"
+                        aria-selected={activeTab === 'installed'}
+                        className={`agent-hub-tab ${activeTab === 'installed' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('installed')}
+                    >
+                        {installedTabLabel(installedAgents.length, updateCount)}
+                    </button>
+                    <button
+                        role="tab"
+                        aria-selected={activeTab === 'available'}
+                        className={`agent-hub-tab ${activeTab === 'available' ? 'active' : ''}`}
+                        onClick={() => setActiveTab('available')}
+                    >
+                        Available{availableAgents.length > 0 ? ` (${availableAgents.length})` : ''}
+                    </button>
+                </div>
                 {showControls && (
                     <div className="agent-hub-controls">
                         <div className="agent-hub-search">
@@ -95,35 +292,102 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
                 )}
             </div>
 
-            <div className="agent-hub-grid">
-                {filtered.length === 0 && (
-                    <div className="agent-hub-empty">No agents match your search.</div>
-                )}
-                {filtered.map((agent) => (
-                    <AgentHubCard
-                        key={agent.id}
-                        agent={agent}
-                        isActive={agent.id === activeAgentId}
-                        isElectron={isElectron}
-                        onSelect={onSelect}
-                        onStartChat={(id) => onStartChat(id)}
-                        onViewDetails={setDetailAgent}
-                    />
-                ))}
-                {onCreateAgent && (
-                    <div
-                        className="agent-hub-card create-new"
-                        role="button"
-                        tabIndex={0}
-                        onClick={onCreateAgent}
-                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCreateAgent(); } }}
-                    >
-                        <div className="create-icon"><Plus size={22} /></div>
-                        <div className="create-title">Build a Custom Agent</div>
-                        <div className="create-desc">Create a new agent through conversation</div>
-                    </div>
-                )}
-            </div>
+            {/* Offline / stale-cache banner */}
+            {activeTab === 'available' && catalogOffline && (
+                <div className="agent-hub-banner agent-hub-banner-offline" role="status">
+                    <WifiOff size={14} />
+                    <span>Showing cached catalog — the Agent Hub is currently unreachable.</span>
+                </div>
+            )}
+
+            {/* ── Installed tab ── */}
+            {activeTab === 'installed' && (
+                <div className="agent-hub-grid">
+                    {filteredInstalled.length === 0 && !onCreateAgent && (
+                        <div className="agent-hub-empty">No agents match your search.</div>
+                    )}
+                    {filteredInstalled.map((agent) => (
+                        <AgentHubCard
+                            key={agent.id}
+                            agent={agent}
+                            variant="installed"
+                            isActive={agent.id === activeAgentId}
+                            isElectron={isElectron}
+                            onSelect={onSelect}
+                            onStartChat={(id) => onStartChat(id)}
+                            onViewDetails={setDetailAgent}
+                            installStatus={installStates[agent.id]}
+                            onInstall={handleInstall}
+                            onCancelInstall={handleCancelInstall}
+                            onUninstall={handleUninstall}
+                        />
+                    ))}
+                    {onCreateAgent && (
+                        <div
+                            className="agent-hub-card create-new"
+                            role="button"
+                            tabIndex={0}
+                            onClick={onCreateAgent}
+                            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCreateAgent(); } }}
+                        >
+                            <div className="create-icon"><Plus size={22} /></div>
+                            <div className="create-title">Build a Custom Agent</div>
+                            <div className="create-desc">Create a new agent through conversation</div>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {/* ── Available tab ── */}
+            {activeTab === 'available' && (
+                <>
+                    {catalogLoading && catalog.length === 0 && (
+                        <div className="agent-hub-loading">
+                            <div className="agent-hub-spinner" />
+                            <span>Loading catalog…</span>
+                        </div>
+                    )}
+                    {catalogError && catalog.length === 0 && !catalogLoading && (
+                        <div className="agent-hub-banner agent-hub-banner-error" role="alert">
+                            <AlertTriangle size={14} />
+                            <span>{catalogError}</span>
+                            <button className="agent-hub-retry" onClick={fetchCatalog}>
+                                <RotateCcw size={13} /> Retry
+                            </button>
+                        </div>
+                    )}
+                    {!catalogLoading && !catalogError && (
+                        <div className="agent-hub-grid">
+                            {filteredAvailable.length === 0 && (
+                                <div className="agent-hub-empty">
+                                    <Package size={28} strokeWidth={1.5} />
+                                    <p>{search || categoryFilter !== 'all'
+                                        ? 'No available agents match your search.'
+                                        : 'All catalog agents are installed.'}</p>
+                                </div>
+                            )}
+                            {filteredAvailable.map((agent) => {
+                                const status = installStates[agent.id];
+                                return (
+                                    <AgentHubCard
+                                        key={agent.id}
+                                        agent={agent}
+                                        variant="available"
+                                        isActive={false}
+                                        isElectron={isElectron}
+                                        onSelect={onSelect}
+                                        onStartChat={(id) => onStartChat(id)}
+                                        onViewDetails={setDetailAgent}
+                                        installStatus={status}
+                                        onInstall={handleInstall}
+                                        onCancelInstall={handleCancelInstall}
+                                    />
+                                );
+                            })}
+                        </div>
+                    )}
+                </>
+            )}
 
             {detailAgent && (
                 <AgentDetailModal

--- a/src/gaia/apps/webui/src/components/__tests__/AgentHubGrid.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/AgentHubGrid.test.tsx
@@ -1,0 +1,187 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AgentHubGrid } from '../AgentHubGrid';
+import type { AgentInfo, AgentCatalogResponse, InstallStatus } from '../../types';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+const mockedApi = vi.mocked(api);
+
+function agent(partial: Partial<AgentInfo> & { id: string }): AgentInfo {
+    return {
+        name: partial.id,
+        description: `${partial.id} description`,
+        source: 'builtin',
+        conversation_starters: [],
+        models: [],
+        ...partial,
+    };
+}
+
+const INSTALLED: AgentInfo[] = [
+    agent({ id: 'chat', name: 'Chat', source: 'builtin' }),
+    agent({ id: 'code', name: 'Code', source: 'builtin' }),
+];
+
+const CATALOG: AgentCatalogResponse = {
+    offline: false,
+    agents: [
+        agent({
+            id: 'weather',
+            name: 'Weather',
+            source: 'installed',
+            status: 'available',
+            download_size_bytes: 1.4 * 1024 * 1024 * 1024,
+            compatibility: { level: 'compatible' },
+        }),
+        agent({
+            id: 'mars',
+            name: 'Mars',
+            source: 'installed',
+            status: 'available',
+            download_size_bytes: 5 * 1024 * 1024,
+            compatibility: { level: 'incompatible', reasons: ['Requires NPU'] },
+        }),
+        // update for an installed agent
+        agent({ id: 'chat', name: 'Chat', status: 'update_available', version: '0.1.0', latest_version: '0.2.0' }),
+    ],
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.listCatalog.mockResolvedValue(CATALOG);
+    mockedApi.listAgents.mockResolvedValue({ agents: INSTALLED, total: INSTALLED.length });
+});
+
+describe('AgentHubGrid tabs', () => {
+    it('shows the Installed tab with a count and update suffix', async () => {
+        render(
+            <AgentHubGrid
+                agents={INSTALLED}
+                activeAgentId="chat"
+                onSelect={() => {}}
+                onStartChat={() => {}}
+            />,
+        );
+        // Default tab is Installed; both agents render.
+        expect(screen.getByText('Chat')).toBeInTheDocument();
+        expect(screen.getByText('Code')).toBeInTheDocument();
+        // The tab starts as "Installed (2)" before the catalog is fetched.
+        expect(screen.getByRole('tab', { name: /Installed \(2\)/ })).toBeInTheDocument();
+    });
+
+    it('loads the catalog and renders Available agents with Install buttons', async () => {
+        const user = userEvent.setup();
+        render(
+            <AgentHubGrid
+                agents={INSTALLED}
+                activeAgentId="chat"
+                onSelect={() => {}}
+                onStartChat={() => {}}
+            />,
+        );
+
+        await user.click(screen.getByRole('tab', { name: /Available/ }));
+
+        await waitFor(() => expect(mockedApi.listCatalog).toHaveBeenCalled());
+
+        // Available, not-installed agents show Install.
+        await screen.findByText('Weather');
+        expect(screen.getByText('Mars')).toBeInTheDocument();
+        const installButtons = screen.getAllByRole('button', { name: /Install/ });
+        expect(installButtons.length).toBeGreaterThanOrEqual(1);
+
+        // Download size is rendered.
+        expect(screen.getByText('1.4 GB')).toBeInTheDocument();
+    });
+
+    it('disables Install for incompatible agents', async () => {
+        const user = userEvent.setup();
+        render(
+            <AgentHubGrid
+                agents={INSTALLED}
+                activeAgentId="chat"
+                onSelect={() => {}}
+                onStartChat={() => {}}
+            />,
+        );
+        await user.click(screen.getByRole('tab', { name: /Available/ }));
+        await screen.findByText('Mars');
+
+        // The Mars card's Install button should be disabled (incompatible).
+        const marsCard = screen.getByText('Mars').closest('.agent-hub-card')!;
+        const installBtn = marsCard.querySelector('.btn-install') as HTMLButtonElement;
+        expect(installBtn).toBeTruthy();
+        expect(installBtn.disabled).toBe(true);
+    });
+
+    it('starts an install and shows a progress bar', async () => {
+        const user = userEvent.setup();
+        const installing: InstallStatus = { agent_id: 'weather', state: 'downloading', progress: 40 };
+        mockedApi.installAgent.mockResolvedValue(installing);
+        mockedApi.getInstallStatus.mockResolvedValue({ agent_id: 'weather', state: 'installing', progress: 80 });
+
+        render(
+            <AgentHubGrid
+                agents={INSTALLED}
+                activeAgentId="chat"
+                onSelect={() => {}}
+                onStartChat={() => {}}
+            />,
+        );
+        await user.click(screen.getByRole('tab', { name: /Available/ }));
+        await screen.findByText('Weather');
+
+        const weatherCard = screen.getByText('Weather').closest('.agent-hub-card')!;
+        const installBtn = weatherCard.querySelector('.btn-install') as HTMLButtonElement;
+        await user.click(installBtn);
+
+        await waitFor(() => expect(mockedApi.installAgent).toHaveBeenCalledWith('weather', expect.anything()));
+        // Progress bar appears with a Cancel button.
+        await waitFor(() => {
+            const card = screen.getByText('Weather').closest('.agent-hub-card')!;
+            expect(card.querySelector('.agent-install-bar')).toBeTruthy();
+        });
+    });
+
+    it('shows the offline banner when the catalog is cached', async () => {
+        const user = userEvent.setup();
+        mockedApi.listCatalog.mockResolvedValue({ ...CATALOG, offline: true });
+        render(
+            <AgentHubGrid
+                agents={INSTALLED}
+                activeAgentId="chat"
+                onSelect={() => {}}
+                onStartChat={() => {}}
+            />,
+        );
+        await user.click(screen.getByRole('tab', { name: /Available/ }));
+        await screen.findByText(/Showing cached catalog/);
+    });
+
+    it('shows an error with Retry when the catalog fails', async () => {
+        const user = userEvent.setup();
+        mockedApi.listCatalog.mockRejectedValueOnce(new Error('Catalog unavailable'));
+        render(
+            <AgentHubGrid
+                agents={INSTALLED}
+                activeAgentId="chat"
+                onSelect={() => {}}
+                onStartChat={() => {}}
+            />,
+        );
+        await user.click(screen.getByRole('tab', { name: /Available/ }));
+        await screen.findByText('Catalog unavailable');
+        expect(screen.getByRole('button', { name: /Retry/ })).toBeInTheDocument();
+
+        // Retry succeeds.
+        mockedApi.listCatalog.mockResolvedValue(CATALOG);
+        await user.click(screen.getByRole('button', { name: /Retry/ }));
+        await screen.findByText('Weather');
+    });
+});

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -3,7 +3,7 @@
 
 /** API client for GAIA Agent UI backend. */
 
-import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPServerStatus, AgentMCPServerStatus, AgentInfo, DiskAgentInfo } from '../types';
+import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPServerStatus, AgentMCPServerStatus, AgentInfo, DiskAgentInfo, AgentCatalogResponse, InstallStatus } from '../types';
 import { getApiBase } from '../utils/apiBase';
 import { log } from '../utils/logger';
 
@@ -114,6 +114,58 @@ export async function listAgents(): Promise<{ agents: AgentInfo[]; total: number
 
 export async function listDiskAgents(): Promise<{ agents: DiskAgentInfo[]; total: number }> {
     return apiFetch('GET', '/agents/disk', undefined, { 'x-gaia-ui': '1' });
+}
+
+// -- Agent Hub: catalog + install lifecycle (issue #1097, backend #1096) --------
+
+/**
+ * Fetch the merged Agent Hub catalog (R2 index + local registry + per-agent
+ * compatibility). Returns ``offline: true`` when the backend served a cached
+ * copy because the remote index was unreachable — the Hub renders a stale-cache
+ * banner instead of presenting old data as fresh.
+ */
+export async function listCatalog(): Promise<AgentCatalogResponse> {
+    return apiFetch('GET', '/agents/catalog', undefined, { 'x-gaia-ui': '1' });
+}
+
+/**
+ * Kick off an agent install (download → verify → install → hot-register).
+ * Returns the initial install status; poll ``getInstallStatus`` for progress.
+ * The optional ``device`` selects the per-device package variant when the
+ * agent ships more than one.
+ */
+export async function installAgent(agentId: string, device?: string): Promise<InstallStatus> {
+    return apiFetch(
+        'POST',
+        '/agents/install',
+        { id: agentId, ...(device ? { device } : {}) },
+        { 'x-gaia-ui': '1' },
+    );
+}
+
+/** Poll install progress for an in-flight install. */
+export async function getInstallStatus(agentId: string): Promise<InstallStatus> {
+    return apiFetch('GET', `/agents/${encodeURIComponent(agentId)}/install-status`);
+}
+
+/** Uninstall an installed agent (also used to abort an in-flight install). */
+export async function uninstallAgent(agentId: string): Promise<void> {
+    await apiFetch<unknown>(
+        'DELETE',
+        `/agents/${encodeURIComponent(agentId)}`,
+        undefined,
+        { 'x-gaia-ui': '1' },
+    );
+}
+
+/** Roll an agent back to the previous version from its ``.backup/`` snapshot. */
+export async function rollbackAgent(agentId: string): Promise<InstallStatus> {
+    return apiFetch(
+        'POST',
+        `/agents/${encodeURIComponent(agentId)}/rollback`,
+        {},
+        { 'x-gaia-ui': '1' },
+    );
 }
 
 // -- Connections (issue #915) ---------------------------------------------------

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -66,6 +66,88 @@ export interface AgentInfo {
     language?: string;
     /** Per-device model/backend/recipe configurations declared by the agent. */
     device_configs?: DeviceConfig[];
+
+    // ── Agent Hub catalog/install fields (issue #1097) ──────────────────────
+    // Populated by GET /api/agents/catalog (#1096). Locally-registered agents
+    // returned by GET /api/agents leave these undefined; the Hub merges catalog
+    // data in by id so installed cards can show versions and update badges.
+
+    /**
+     * Lifecycle status from the catalog. ``installed`` = present locally,
+     * ``available`` = downloadable from the Hub, ``update_available`` = a newer
+     * version exists than the installed one, ``installing`` = an install is in
+     * flight. Undefined for local-only agents (treated as ``installed``).
+     */
+    status?: AgentCardState;
+    /** Installed version (semver), when known. */
+    version?: string;
+    /** Latest version offered by the catalog — set when newer than ``version``. */
+    latest_version?: string;
+    /** Per-agent compatibility verdict from the backend's system check. */
+    compatibility?: AgentCompatibility;
+    /** Download size of the agent package in bytes (Available cards). */
+    download_size_bytes?: number;
+    /** Trust tier: AMD-verified, community-published, or experimental opt-in. */
+    security_tier?: 'verified' | 'community' | 'experimental';
+    /** Optional remote avatar image URL from the catalog. */
+    avatar_url?: string;
+    /** True when the publisher has deprecated this agent. */
+    deprecated?: boolean;
+}
+
+/** Derived card state for the Agent Hub (issue #1097). */
+export type AgentCardState =
+    | 'installed'
+    | 'available'
+    | 'update_available'
+    | 'installing';
+
+/**
+ * Per-agent compatibility verdict (issue #1096/#1097).
+ *
+ * ``level`` drives the green/yellow/red indicator: ``compatible`` (green),
+ * ``warning`` (yellow — runnable but a requirement is marginal), and
+ * ``incompatible`` (red — Install is disabled). ``reasons`` explains any
+ * non-green verdict for the tooltip.
+ */
+export interface AgentCompatibility {
+    level: 'compatible' | 'warning' | 'incompatible';
+    reasons?: string[];
+}
+
+/**
+ * Wire-level install state machine from the backend (issue #1096), distinct
+ * from the derived card-state enum. Polled via GET /api/agents/{id}/install-status.
+ */
+export type AgentInstallState =
+    | 'downloading'
+    | 'verifying'
+    | 'installing'
+    | 'installed'
+    | 'failed';
+
+/** Install progress snapshot returned by the install-status endpoint. */
+export interface InstallStatus {
+    agent_id: string;
+    state: AgentInstallState;
+    /** 0–100 overall progress. */
+    progress: number;
+    /** Populated only when ``state === 'failed'``. */
+    error?: string | null;
+}
+
+/**
+ * Response from GET /api/agents/catalog (issue #1096).
+ *
+ * ``offline`` is ``true`` when the backend served a cached copy because R2 was
+ * unreachable — the UI surfaces a "Showing cached catalog" banner rather than
+ * silently presenting stale data as fresh (CLAUDE.md: no silent fallbacks).
+ */
+export interface AgentCatalogResponse {
+    agents: AgentInfo[];
+    offline: boolean;
+    /** ISO timestamp the cached catalog was last refreshed (when offline). */
+    cached_at?: string | null;
 }
 
 export interface DiskAgentInfo {

--- a/src/gaia/apps/webui/src/utils/__tests__/agentHub.test.ts
+++ b/src/gaia/apps/webui/src/utils/__tests__/agentHub.test.ts
@@ -1,0 +1,134 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import {
+    formatBytes,
+    isInstalling,
+    compatLevel,
+    mergeCatalogStatus,
+    splitAvailable,
+    countUpdates,
+    installedTabLabel,
+} from '../agentHub';
+import type { AgentInfo } from '../../types';
+
+function agent(partial: Partial<AgentInfo> & { id: string }): AgentInfo {
+    return {
+        name: partial.id,
+        description: '',
+        source: 'installed',
+        conversation_starters: [],
+        models: [],
+        ...partial,
+    };
+}
+
+describe('formatBytes', () => {
+    it('returns an em dash for missing/zero/invalid sizes', () => {
+        expect(formatBytes(undefined)).toBe('—');
+        expect(formatBytes(null)).toBe('—');
+        expect(formatBytes(0)).toBe('—');
+        expect(formatBytes(-5)).toBe('—');
+        expect(formatBytes(NaN)).toBe('—');
+    });
+
+    it('formats bytes and KB without decimals', () => {
+        expect(formatBytes(512)).toBe('512 B');
+        expect(formatBytes(2048)).toBe('2 KB');
+    });
+
+    it('formats MB and GB with one decimal', () => {
+        expect(formatBytes(1.4 * 1024 * 1024 * 1024)).toBe('1.4 GB');
+        expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+    });
+});
+
+describe('isInstalling', () => {
+    it('is true for in-flight wire states', () => {
+        for (const state of ['downloading', 'verifying', 'installing'] as const) {
+            expect(isInstalling({ agent_id: 'x', state, progress: 10 })).toBe(true);
+        }
+    });
+
+    it('is false for terminal states and missing status', () => {
+        expect(isInstalling({ agent_id: 'x', state: 'installed', progress: 100 })).toBe(false);
+        expect(isInstalling({ agent_id: 'x', state: 'failed', progress: 0 })).toBe(false);
+        expect(isInstalling(undefined)).toBe(false);
+        expect(isInstalling(null)).toBe(false);
+    });
+});
+
+describe('compatLevel', () => {
+    it('defaults to compatible when no verdict', () => {
+        expect(compatLevel(agent({ id: 'x' }))).toBe('compatible');
+    });
+
+    it('reads the catalog verdict', () => {
+        expect(compatLevel(agent({ id: 'x', compatibility: { level: 'incompatible' } }))).toBe('incompatible');
+    });
+});
+
+describe('mergeCatalogStatus', () => {
+    it('marks installed agents with a newer catalog version as update_available', () => {
+        const installed = [agent({ id: 'chat', version: '0.1.0' })];
+        const catalog = [agent({ id: 'chat', status: 'update_available', version: '0.1.0', latest_version: '0.2.0' })];
+        const merged = mergeCatalogStatus(installed, catalog);
+        expect(merged[0].status).toBe('update_available');
+        expect(merged[0].latest_version).toBe('0.2.0');
+    });
+
+    it('marks matched-version agents as installed', () => {
+        const installed = [agent({ id: 'chat' })];
+        const catalog = [agent({ id: 'chat', status: 'installed', version: '0.2.0', latest_version: '0.2.0' })];
+        const merged = mergeCatalogStatus(installed, catalog);
+        expect(merged[0].status).toBe('installed');
+        expect(merged[0].version).toBe('0.2.0');
+    });
+
+    it('leaves agents absent from the catalog untouched', () => {
+        const installed = [agent({ id: 'local-only' })];
+        const merged = mergeCatalogStatus(installed, []);
+        expect(merged[0]).toEqual(installed[0]);
+    });
+});
+
+describe('splitAvailable', () => {
+    it('returns available agents not already installed', () => {
+        const catalog = [
+            agent({ id: 'new', status: 'available' }),
+            agent({ id: 'chat', status: 'available' }),
+            agent({ id: 'installed-elsewhere', status: 'installed' }),
+        ];
+        const result = splitAvailable(catalog, new Set(['chat']));
+        expect(result.map((a) => a.id)).toEqual(['new']);
+    });
+
+    it('excludes update_available agents (handled on the Installed tab)', () => {
+        const catalog = [agent({ id: 'chat', status: 'update_available' })];
+        const result = splitAvailable(catalog, new Set(['chat']));
+        expect(result).toEqual([]);
+    });
+});
+
+describe('countUpdates', () => {
+    it('counts update_available agents', () => {
+        const agents = [
+            agent({ id: 'a', status: 'update_available' }),
+            agent({ id: 'b', status: 'installed' }),
+            agent({ id: 'c', status: 'update_available' }),
+        ];
+        expect(countUpdates(agents)).toBe(2);
+    });
+});
+
+describe('installedTabLabel', () => {
+    it('omits the update suffix when none pending', () => {
+        expect(installedTabLabel(3, 0)).toBe('Installed (3)');
+    });
+
+    it('uses singular/plural for updates', () => {
+        expect(installedTabLabel(3, 1)).toBe('Installed (3) · 1 update');
+        expect(installedTabLabel(3, 2)).toBe('Installed (3) · 2 updates');
+    });
+});

--- a/src/gaia/apps/webui/src/utils/agentHub.ts
+++ b/src/gaia/apps/webui/src/utils/agentHub.ts
@@ -1,0 +1,108 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Pure helpers for the Agent Hub Installed/Available tabs and install flow
+ * (issue #1097). Kept side-effect-free so the tab/card logic is unit-testable
+ * without rendering React.
+ */
+
+import type { AgentInfo, InstallStatus } from '../types';
+
+/** Format a byte count as a compact human-readable size (e.g. "1.4 GB"). */
+export function formatBytes(bytes?: number | null): string {
+    if (bytes == null || !Number.isFinite(bytes) || bytes <= 0) return '—';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let value = bytes;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit++;
+    }
+    // No decimals for bytes/KB; one decimal for MB and up.
+    const digits = unit >= 2 ? 1 : 0;
+    return `${value.toFixed(digits)} ${units[unit]}`;
+}
+
+/** True when an install-status snapshot represents an in-flight install. */
+export function isInstalling(status?: InstallStatus | null): boolean {
+    if (!status) return false;
+    return status.state === 'downloading'
+        || status.state === 'verifying'
+        || status.state === 'installing';
+}
+
+/**
+ * Compatibility level for the indicator dot. Falls back to ``compatible`` when
+ * the catalog didn't supply a verdict (local-only agents are always runnable).
+ */
+export function compatLevel(
+    agent: AgentInfo,
+): 'compatible' | 'warning' | 'incompatible' {
+    return agent.compatibility?.level ?? 'compatible';
+}
+
+/** Human label for a compatibility level. */
+export function compatLabel(level: 'compatible' | 'warning' | 'incompatible'): string {
+    switch (level) {
+        case 'compatible': return 'Compatible with your system';
+        case 'warning': return 'May run with limitations';
+        case 'incompatible': return 'Not compatible with your system';
+    }
+}
+
+/**
+ * Merge catalog entries into the locally-registered agent list so installed
+ * cards can show versions and update badges. Matches by id; when the catalog
+ * marks an agent ``update_available`` (or reports a newer ``latest_version``),
+ * the merged entry carries that status forward.
+ */
+export function mergeCatalogStatus(
+    installed: AgentInfo[],
+    catalog: AgentInfo[],
+): AgentInfo[] {
+    const byId = new Map(catalog.map((a) => [a.id, a]));
+    return installed.map((agent) => {
+        const cat = byId.get(agent.id);
+        if (!cat) return agent;
+        const hasUpdate =
+            cat.status === 'update_available' ||
+            (!!cat.latest_version && !!cat.version && cat.latest_version !== cat.version);
+        return {
+            ...agent,
+            version: cat.version ?? agent.version,
+            latest_version: cat.latest_version,
+            compatibility: cat.compatibility ?? agent.compatibility,
+            security_tier: cat.security_tier ?? agent.security_tier,
+            deprecated: cat.deprecated ?? agent.deprecated,
+            status: hasUpdate ? 'update_available' : 'installed',
+        };
+    });
+}
+
+/**
+ * Agents shown on the Available tab: installable catalog entries not already
+ * present locally. Installed agents — including those with a pending update —
+ * are excluded here; updates are surfaced in place on the Installed tab.
+ */
+export function splitAvailable(
+    catalog: AgentInfo[],
+    installedIds: Set<string>,
+): AgentInfo[] {
+    return catalog.filter((a) => a.status === 'available' && !installedIds.has(a.id));
+}
+
+/** Count installed agents that have a pending update (for the tab label). */
+export function countUpdates(agents: AgentInfo[]): number {
+    return agents.filter((a) => a.status === 'update_available').length;
+}
+
+/**
+ * Tab label with count and optional update suffix, e.g.
+ * ``Installed (3) · 1 update`` / ``Installed (3) · 2 updates``.
+ */
+export function installedTabLabel(count: number, updates: number): string {
+    const base = `Installed (${count})`;
+    if (updates <= 0) return base;
+    return `${base} · ${updates} ${updates === 1 ? 'update' : 'updates'}`;
+}


### PR DESCRIPTION
## Why this matters

Before, the Agent Hub splash page could only list the agents already registered locally — there was no way to discover or install new ones, and no signal when an installed agent had an update or wasn't compatible with the user's hardware. After this change, the Hub has an **Installed / Available** tab split with the full install lifecycle: click **Install** on an Available card and watch a live progress bar (downloading → verifying → installing) that flips the agent into Installed when done, retries on failure, and shows green/yellow/red compatibility so users don't install something their machine can't run. If the catalog is unreachable, the Available tab shows a "Showing cached catalog" banner instead of silently presenting stale data, and the Installed tab keeps working from the local list.

Built against the documented **#1096** backend API shape (`GET /api/agents/catalog`, `POST /api/agents/install`, `GET /api/agents/{id}/install-status`, `DELETE /api/agents/{id}`, `POST /api/agents/{id}/rollback`). That backend isn't merged yet, so the catalog response is mocked in tests; the UI degrades gracefully (Installed tab renders from the local agent list) until it lands.

Isolated to `src/gaia/apps/webui/` — no Python touched.

### Notable threads
- **Card states** — `installed` (version badge, Start Chat, Uninstall), `available` (Install + download size), `update_available` (amber Update badge + in-place Update button on the Installed tab), `installing` (progress bar + Cancel), `failed` (error + Retry). State logic lives in pure helpers (`utils/agentHub.ts`) so it's unit-tested without rendering.
- **AgentInfo extension** — the hub-facing `AgentInfo` (`types/index.ts`) gains `status`/`version`/`latest_version`/`compatibility`/`security_tier`/`download_size_bytes`/`avatar_url`/`deprecated`. Fully merging the separate Electron native-manager `AgentInfo` (`types/agent.ts`) is **deferred** — it would require rewriting the native agent manager (`AgentManager`/`AgentCard`/`agentStore`) and is outside this issue's scope.
- **No silent fallbacks** — catalog failure surfaces a loud error + Retry at the UI boundary; the lazy auto-load fires once (no retry loop). Install/cancel errors are surfaced, not swallowed.

## Test plan
- [x] `cd src/gaia/apps/webui && npm install && npm run build` — no TS errors
- [x] `npm run test` — 39 passing (helper unit tests in `utils/__tests__/agentHub.test.ts` + component smoke tests in `components/__tests__/AgentHubGrid.test.tsx` covering tab counts, catalog load, Install→progress, incompatible-disabled, offline banner, error+Retry)
- [ ] Manual (once #1096 lands): open Hub → Available tab loads catalog → Install an agent → progress bar → moves to Installed; kill network → offline banner; install a known-incompatible agent → Install disabled with tooltip

Refs #1097 · plan: `docs/plans/agent-hub-ui.mdx` (Phase 5) · API: #1096