### PR TITLE
feat(hub): backend catalog + install/uninstall/rollback API (#1096)

### DIFF
--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -966,6 +966,15 @@ class AgentRegistry:
     # Installed Python agent discovery
     # ------------------------------------------------------------------
 
+    def discover_installed_agents(self) -> None:
+        """Re-scan entry points for installed agent wheels (public hot-reload hook).
+
+        Called by the Agent Hub installer after ``uv pip install --target`` so a
+        freshly installed agent appears in the live registry without a server
+        restart. Idempotent — already-registered ids are skipped.
+        """
+        self._discover_installed_agents()
+
     def _discover_installed_agents(self) -> None:
         """Register installed Python agents exposed by standalone wheels.
 

--- a/src/gaia/hub/catalog.py
+++ b/src/gaia/hub/catalog.py
@@ -1,0 +1,450 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Agent Hub catalog: fetch, cache, and merge with the local registry.
+
+The catalog is served by the Cloudflare R2 Worker (``workers/agent-hub/``, see
+#1095) as two JSON documents:
+
+* ``GET {hub}/index.json`` — the lightweight catalog: one entry per agent
+  summarising its latest published version (schema
+  ``workers/agent-hub/schemas/index.schema.json``).
+* ``GET {hub}/agents/<id>/manifest.json`` — the per-agent aggregate manifest
+  with every published version + artifact (sha256, R2 path, size).
+
+This module fetches ``index.json`` with a short in-memory TTL cache, persists a
+copy to ``~/.gaia/catalog-cache.json`` so the UI still renders when offline,
+and merges the remote catalog with the live :class:`AgentRegistry` to produce a
+unified per-agent view with a ``status`` of ``installed`` / ``available`` /
+``update_available``.
+
+Fail-loudly (CLAUDE.md): a network failure with *no* usable cache raises
+:class:`CatalogError` naming what to try. The only soft-degrade is the explicit
+offline path — and it is flagged (`offline=True`) rather than hidden.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Default hub origin. Overridable via GAIA_HUB_URL so dev/CI can point at a
+# local Worker (`wrangler dev`) or a file:// fixture host. No trailing slash.
+DEFAULT_HUB_URL = "https://hub.amd-gaia.ai"
+
+# In-memory cache TTL for index.json. The UI polls the catalog whenever the
+# discover panel opens; 5 minutes keeps it fresh without hammering R2.
+CACHE_TTL_SECONDS = 300
+
+# HTTP timeout for catalog fetches (seconds). Short — the catalog is small and
+# the offline cache covers a slow/absent network.
+_HTTP_TIMEOUT = 10
+
+# Fetcher signature: a callable taking a URL and returning the raw response
+# bytes, or raising on any transport/HTTP error. Injected in tests.
+Fetcher = Callable[[str], bytes]
+
+
+class CatalogError(RuntimeError):
+    """Raised when the catalog cannot be produced (no network and no cache).
+
+    The message names what failed, what to do, and where to look, per the
+    project's fail-loudly rule.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def get_hub_base_url() -> str:
+    """Return the hub origin, honouring ``GAIA_HUB_URL`` (no trailing slash)."""
+    return os.environ.get("GAIA_HUB_URL", DEFAULT_HUB_URL).rstrip("/")
+
+
+def default_cache_path() -> Path:
+    """Path of the on-disk offline catalog cache."""
+    return Path.home() / ".gaia" / "catalog-cache.json"
+
+
+def index_url(base_url: Optional[str] = None) -> str:
+    return f"{base_url or get_hub_base_url()}/index.json"
+
+
+def manifest_url(agent_id: str, base_url: Optional[str] = None) -> str:
+    return f"{base_url or get_hub_base_url()}/agents/{agent_id}/manifest.json"
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+
+def fetch_bytes(url: str, timeout: int = _HTTP_TIMEOUT) -> bytes:
+    """Default fetcher: GET *url* and return the raw body bytes.
+
+    Supports ``file://`` URLs so tests and offline mirrors can point
+    ``GAIA_HUB_URL`` at a local directory. Raises on any error (fail loudly).
+    """
+    if url.startswith("file://"):
+        from urllib.parse import urlparse
+        from urllib.request import url2pathname
+
+        local = Path(url2pathname(urlparse(url).path))
+        return local.read_bytes()
+
+    import requests
+
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.content
+
+
+def _fetch_json(url: str, fetcher: Fetcher) -> Any:
+    raw = fetcher(url)
+    return json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# Index validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_index(data: Any) -> List[Dict[str, Any]]:
+    """Validate the parsed ``index.json`` and return its ``agents`` list."""
+    if not isinstance(data, dict):
+        raise CatalogError(
+            "Hub index.json is malformed (expected a JSON object). The hub may "
+            "be misconfigured; check GAIA_HUB_URL or try again later."
+        )
+    agents = data.get("agents")
+    if not isinstance(agents, list):
+        raise CatalogError(
+            "Hub index.json is missing the 'agents' array. The hub may be "
+            "misconfigured; check GAIA_HUB_URL."
+        )
+    return [a for a in agents if isinstance(a, dict) and a.get("id")]
+
+
+# ---------------------------------------------------------------------------
+# In-memory TTL cache
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MemCache:
+    base_url: Optional[str] = None
+    raw: Optional[Dict[str, Any]] = None
+    fetched_at: float = 0.0
+
+
+_MEM = _MemCache()
+
+
+def clear_cache() -> None:
+    """Drop the in-memory catalog cache (test/maintenance hook)."""
+    global _MEM
+    _MEM = _MemCache()
+
+
+# ---------------------------------------------------------------------------
+# Disk cache
+# ---------------------------------------------------------------------------
+
+
+def _write_disk_cache(cache_path: Path, data: Dict[str, Any]) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except OSError as exc:
+        # Cache write failure must not break a successful live fetch; log it.
+        logger.warning("catalog: could not write cache %s: %s", cache_path, exc)
+
+
+def _read_disk_cache(cache_path: Path) -> Optional[Dict[str, Any]]:
+    if not cache_path.exists():
+        return None
+    try:
+        return json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("catalog: could not read cache %s: %s", cache_path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Catalog fetch
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CatalogResult:
+    """The fetched catalog plus provenance flags."""
+
+    agents: List[Dict[str, Any]]
+    offline: bool
+    source: str  # "memory" | "network" | "cache"
+    generated_at: Optional[str] = None
+
+
+def load_index(
+    *,
+    base_url: Optional[str] = None,
+    fetcher: Optional[Fetcher] = None,
+    cache_path: Optional[Path] = None,
+    force: bool = False,
+) -> CatalogResult:
+    """Fetch ``index.json`` with TTL + offline-cache fallback.
+
+    Order of resolution:
+
+    1. Fresh in-memory cache (within :data:`CACHE_TTL_SECONDS`) unless *force*.
+    2. Live network fetch → refreshes both caches, ``offline=False``.
+    3. On network/parse failure, the on-disk cache → ``offline=True``.
+    4. If none of the above yield data, raises :class:`CatalogError`.
+    """
+    base_url = (base_url or get_hub_base_url()).rstrip("/")
+    fetcher = fetcher or fetch_bytes
+    cache_path = Path(cache_path) if cache_path else default_cache_path()
+
+    now = time.monotonic()
+    if (
+        not force
+        and _MEM.raw is not None
+        and _MEM.base_url == base_url
+        and (now - _MEM.fetched_at) < CACHE_TTL_SECONDS
+    ):
+        data = _MEM.raw
+        return CatalogResult(
+            agents=_validate_index(data),
+            offline=False,
+            source="memory",
+            generated_at=data.get("generated_at"),
+        )
+
+    try:
+        data = _fetch_json(index_url(base_url), fetcher)
+        agents = _validate_index(data)
+    except CatalogError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - any transport/parse error → fallback
+        logger.warning("catalog: live fetch failed (%s); trying offline cache", exc)
+        cached = _read_disk_cache(cache_path)
+        if cached is None:
+            raise CatalogError(
+                "Could not reach the GAIA Agent Hub and no offline cache is "
+                f"available. Check your internet connection or GAIA_HUB_URL "
+                f"(currently {base_url}). Original error: {exc}"
+            ) from exc
+        return CatalogResult(
+            agents=_validate_index(cached),
+            offline=True,
+            source="cache",
+            generated_at=cached.get("generated_at"),
+        )
+
+    # Live fetch succeeded — refresh both caches.
+    _MEM.base_url = base_url
+    _MEM.raw = data
+    _MEM.fetched_at = now
+    _write_disk_cache(cache_path, data)
+    return CatalogResult(
+        agents=agents,
+        offline=False,
+        source="network",
+        generated_at=data.get("generated_at"),
+    )
+
+
+def fetch_manifest(
+    agent_id: str,
+    *,
+    base_url: Optional[str] = None,
+    fetcher: Optional[Fetcher] = None,
+) -> Dict[str, Any]:
+    """Fetch the per-agent aggregate manifest (``agents/<id>/manifest.json``)."""
+    fetcher = fetcher or fetch_bytes
+    data = _fetch_json(manifest_url(agent_id, base_url), fetcher)
+    if not isinstance(data, dict) or not data.get("versions"):
+        raise CatalogError(
+            f"Hub manifest for '{agent_id}' is malformed or has no published "
+            f"versions. Try again later or check GAIA_HUB_URL."
+        )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# SemVer comparison
+# ---------------------------------------------------------------------------
+
+
+def _parse_version(version: str):
+    """Parse ``MAJOR.MINOR.PATCH[-prerelease]`` into a sortable key.
+
+    A release sorts above its prereleases (1.0.0 > 1.0.0-rc.1), matching SemVer
+    precedence well enough for "is the catalog newer than what's installed".
+    """
+    core, _, pre = version.partition("-")
+    parts = []
+    for piece in core.split("."):
+        try:
+            parts.append(int(piece))
+        except ValueError:
+            parts.append(0)
+    while len(parts) < 3:
+        parts.append(0)
+    # Release (no prerelease) ranks higher: use 1 for release, 0 for prerelease.
+    return (parts[0], parts[1], parts[2], 1 if not pre else 0, pre)
+
+
+def compare_versions(a: str, b: str) -> int:
+    """Return -1/0/1 for *a* <, ==, > *b* by SemVer precedence."""
+    ka, kb = _parse_version(a), _parse_version(b)
+    if ka < kb:
+        return -1
+    if ka > kb:
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Merge with local registry
+# ---------------------------------------------------------------------------
+
+STATUS_INSTALLED = "installed"
+STATUS_AVAILABLE = "available"
+STATUS_UPDATE_AVAILABLE = "update_available"
+
+
+def merge_with_registry(
+    index_agents: List[Dict[str, Any]],
+    registry: Any,
+    installed_versions: Optional[Dict[str, str]] = None,
+) -> List[Dict[str, Any]]:
+    """Merge the remote catalog with the live registry into a unified list.
+
+    Args:
+        index_agents: The ``agents`` list from ``index.json``.
+        registry: The live :class:`AgentRegistry` (provides ``list()``).
+        installed_versions: Map of ``agent_id -> version`` for hub-installed
+            agents, read from install sentinels (see
+            :func:`gaia.hub.installer.list_installed`). Builtin/custom agents
+            present in the registry but absent here are treated as installed
+            with an unknown version.
+
+    Returns:
+        One dict per agent (union of registry + catalog), each carrying a
+        ``status`` and ``installed_version`` / ``latest_version``.
+    """
+    installed_versions = installed_versions or {}
+
+    registered = {}
+    if registry is not None:
+        for reg in registry.list():
+            registered[reg.id] = reg
+
+    by_id: Dict[str, Dict[str, Any]] = {}
+
+    # 1. Catalog entries (remote source of truth for latest_version).
+    for entry in index_agents:
+        agent_id = entry["id"]
+        latest = entry.get("latest_version")
+        reg = registered.get(agent_id)
+        installed_ver = installed_versions.get(agent_id)
+
+        if installed_ver:
+            if latest and compare_versions(latest, installed_ver) > 0:
+                status = STATUS_UPDATE_AVAILABLE
+            else:
+                status = STATUS_INSTALLED
+        elif reg is not None:
+            status = STATUS_INSTALLED
+        else:
+            status = STATUS_AVAILABLE
+
+        by_id[agent_id] = {
+            "id": agent_id,
+            "name": entry.get("name", agent_id),
+            "description": entry.get("description", ""),
+            "category": entry.get("category", "general"),
+            "icon": entry.get("icon", ""),
+            "language": entry.get("language", "python"),
+            "author": entry.get("author", ""),
+            "security_tier": entry.get("security_tier", "experimental"),
+            "download_size_bytes": entry.get("download_size_bytes", 0),
+            "requirements": entry.get("requirements", {"platforms": []}),
+            "deprecated": entry.get("deprecated", False),
+            "latest_version": latest,
+            "installed_version": installed_ver,
+            "status": status,
+            "source": (reg.source if reg is not None else "hub"),
+        }
+
+    # 2. Registry-only agents (builtins / custom not published to the hub).
+    for agent_id, reg in registered.items():
+        if agent_id in by_id:
+            continue
+        by_id[agent_id] = {
+            "id": agent_id,
+            "name": reg.name,
+            "description": reg.description,
+            "category": reg.category,
+            "icon": reg.icon,
+            "language": reg.language,
+            "author": "",
+            "security_tier": "verified" if reg.source == "builtin" else "experimental",
+            "download_size_bytes": 0,
+            "requirements": {"platforms": []},
+            "deprecated": False,
+            "latest_version": installed_versions.get(agent_id),
+            "installed_version": installed_versions.get(agent_id),
+            "status": STATUS_INSTALLED,
+            "source": reg.source,
+        }
+
+    return sorted(by_id.values(), key=lambda a: a["id"])
+
+
+@dataclass
+class UnifiedCatalog:
+    """The merged catalog returned by :func:`build_catalog`."""
+
+    agents: List[Dict[str, Any]] = field(default_factory=list)
+    offline: bool = False
+    generated_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agents": self.agents,
+            "offline": self.offline,
+            "generated_at": self.generated_at,
+            "total": len(self.agents),
+        }
+
+
+def build_catalog(
+    registry: Any,
+    *,
+    base_url: Optional[str] = None,
+    fetcher: Optional[Fetcher] = None,
+    cache_path: Optional[Path] = None,
+    installed_versions: Optional[Dict[str, str]] = None,
+    force: bool = False,
+) -> UnifiedCatalog:
+    """Fetch the catalog and merge it with the registry into a unified view."""
+    result = load_index(
+        base_url=base_url, fetcher=fetcher, cache_path=cache_path, force=force
+    )
+    merged = merge_with_registry(result.agents, registry, installed_versions)
+    return UnifiedCatalog(
+        agents=merged,
+        offline=result.offline,
+        generated_at=result.generated_at,
+    )

--- a/src/gaia/hub/compatibility.py
+++ b/src/gaia/hub/compatibility.py
@@ -1,0 +1,249 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""System-requirements checker for the Agent Hub install flow.
+
+Given an agent's declared ``requirements`` (the block from ``gaia-agent.yaml``
+/ the catalog index entry), this module reports whether the current machine can
+run it.  The result separates *blockers* (hard reasons the install must be
+refused — wrong platform, not enough disk for the download) from *warnings*
+(soft, recommended-but-not-required gaps — below the suggested RAM, no NPU
+detected).  ``compatible`` is true exactly when there are no blockers.
+
+The checker is the single place the install lifecycle (``installer.install``)
+and the catalog endpoint (``GET /api/agents/catalog``) consult, so the UI and
+the backend agree on what "compatible" means.
+
+Detection is best-effort but never silent: anything we cannot probe (GPU/NPU
+presence) becomes a *warning* that names what we could not verify — it never
+silently passes as if the requirement were met.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from gaia.hub.manifest import Requirements
+from gaia.hub.native_launcher import NativeAgentError, current_platform
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+_BYTES_PER_GB = 1024**3
+
+# Headroom multiplier applied to an artifact's download size to estimate the
+# on-disk install footprint (extraction + pip-resolved dependencies). A wheel
+# typically expands to several times its compressed size once dependencies are
+# installed; 3x is a deliberately conservative floor so we block *before* a
+# half-finished install fills the disk rather than after.
+_INSTALL_SIZE_HEADROOM = 3.0
+
+
+@dataclass
+class CompatibilityReport:
+    """Outcome of :func:`check_compatibility`.
+
+    ``compatible`` is ``True`` iff ``blockers`` is empty. ``warnings`` are
+    advisory — the install proceeds but the UI should surface them.
+    """
+
+    compatible: bool
+    platform_ok: bool
+    memory_ok: bool
+    disk_ok: bool
+    warnings: List[str] = field(default_factory=list)
+    blockers: List[str] = field(default_factory=list)
+    # Observed values, surfaced so the UI can render "needs 8 GB, have 6 GB".
+    detected_platform: Optional[str] = None
+    total_memory_gb: Optional[float] = None
+    free_disk_gb: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "compatible": self.compatible,
+            "platform_ok": self.platform_ok,
+            "memory_ok": self.memory_ok,
+            "disk_ok": self.disk_ok,
+            "warnings": list(self.warnings),
+            "blockers": list(self.blockers),
+            "detected_platform": self.detected_platform,
+            "total_memory_gb": self.total_memory_gb,
+            "free_disk_gb": self.free_disk_gb,
+        }
+
+
+def detect_platform() -> Optional[str]:
+    """Return the running platform triple (e.g. ``"win-x64"``) or ``None``.
+
+    Wraps :func:`gaia.hub.native_launcher.current_platform`, which *raises* on an
+    unsupported OS/arch; here an unsupported platform is reported as ``None`` so
+    the caller can turn it into a blocker rather than crashing the whole catalog
+    request.
+    """
+    try:
+        return current_platform()
+    except NativeAgentError as exc:
+        logger.debug("compatibility: unsupported platform: %s", exc)
+        return None
+
+
+def detect_total_memory_gb() -> Optional[float]:
+    """Total physical RAM in GB, or ``None`` if it cannot be determined."""
+    try:
+        import psutil
+
+        return psutil.virtual_memory().total / _BYTES_PER_GB
+    except Exception as exc:  # noqa: BLE001 - probe is best-effort
+        logger.debug("compatibility: could not read total memory: %s", exc)
+        return None
+
+
+def detect_free_disk_gb(path: Path) -> Optional[float]:
+    """Free disk space (GB) on the volume that will hold *path*.
+
+    Walks up to the first existing ancestor so the check works before the
+    install directory itself has been created.
+    """
+    probe = path
+    while not probe.exists() and probe.parent != probe:
+        probe = probe.parent
+    try:
+        return shutil.disk_usage(probe).free / _BYTES_PER_GB
+    except OSError as exc:
+        logger.debug("compatibility: could not read disk usage for %s: %s", probe, exc)
+        return None
+
+
+def _coerce_requirements(requirements: Any) -> Requirements:
+    """Accept either a :class:`Requirements` or a plain mapping (index entry)."""
+    if isinstance(requirements, Requirements):
+        return requirements
+    if requirements is None:
+        return Requirements()
+    if isinstance(requirements, dict):
+        return Requirements(
+            min_memory_gb=requirements.get("min_memory_gb"),
+            min_disk_gb=requirements.get("min_disk_gb"),
+            min_context_size=requirements.get("min_context_size"),
+            platforms=list(requirements.get("platforms") or []),
+            npu=bool(requirements.get("npu", False)),
+            gpu_vram_gb=requirements.get("gpu_vram_gb"),
+        )
+    raise TypeError(
+        "requirements must be a Requirements, a mapping, or None, got "
+        f"{type(requirements).__name__}"
+    )
+
+
+def check_compatibility(
+    requirements: Any,
+    *,
+    download_size_bytes: int = 0,
+    install_dir: Optional[Path] = None,
+) -> CompatibilityReport:
+    """Check whether the current machine satisfies *requirements*.
+
+    Args:
+        requirements: A :class:`Requirements` or the catalog index entry's
+            ``requirements`` mapping (must at least carry ``platforms``).
+        download_size_bytes: Size of the artifact to be downloaded; used with a
+            headroom multiplier to estimate required free disk when the manifest
+            declares no explicit ``min_disk_gb``.
+        install_dir: Where the agent will be installed; the disk check probes
+            this volume. Defaults to ``~/.gaia/agents``.
+
+    Returns:
+        A :class:`CompatibilityReport`. ``compatible`` is ``True`` only when no
+        blockers were found.
+    """
+    reqs = _coerce_requirements(requirements)
+    install_dir = install_dir or (Path.home() / ".gaia" / "agents")
+
+    warnings: List[str] = []
+    blockers: List[str] = []
+
+    # --- platform ---
+    detected = detect_platform()
+    if reqs.platforms:
+        if detected is None:
+            platform_ok = False
+            blockers.append(
+                "This OS/CPU architecture is unsupported. The agent supports: "
+                f"{', '.join(reqs.platforms)}."
+            )
+        elif detected not in reqs.platforms:
+            platform_ok = False
+            blockers.append(
+                f"Your platform ({detected}) is not supported by this agent. "
+                f"Supported platforms: {', '.join(reqs.platforms)}."
+            )
+        else:
+            platform_ok = True
+    else:
+        # No declared platforms — assume cross-platform.
+        platform_ok = True
+
+    # --- memory (advisory) ---
+    total_mem = detect_total_memory_gb()
+    memory_ok = True
+    if reqs.min_memory_gb:
+        if total_mem is None:
+            warnings.append(
+                f"Could not detect system memory; this agent recommends "
+                f"{reqs.min_memory_gb:g} GB."
+            )
+        elif total_mem < reqs.min_memory_gb:
+            memory_ok = False
+            warnings.append(
+                f"This agent recommends {reqs.min_memory_gb:g} GB RAM; your "
+                f"system has {total_mem:.1f} GB. It may run slowly or fail to "
+                f"load its model."
+            )
+
+    # --- disk (hard) ---
+    free_disk = detect_free_disk_gb(install_dir)
+    if reqs.min_disk_gb is not None:
+        required_disk_gb = float(reqs.min_disk_gb)
+    else:
+        required_disk_gb = (
+            download_size_bytes * _INSTALL_SIZE_HEADROOM
+        ) / _BYTES_PER_GB
+    disk_ok = True
+    if required_disk_gb > 0:
+        if free_disk is None:
+            warnings.append(
+                "Could not determine free disk space; install needs about "
+                f"{required_disk_gb:.1f} GB."
+            )
+        elif free_disk < required_disk_gb:
+            disk_ok = False
+            blockers.append(
+                f"Not enough disk space: install needs ~{required_disk_gb:.1f} GB "
+                f"but only {free_disk:.1f} GB is free on {install_dir}."
+            )
+
+    # --- NPU / GPU (best-effort, advisory) ---
+    if reqs.npu:
+        warnings.append(
+            "This agent requests an NPU. GAIA cannot verify NPU availability "
+            "here; ensure your Ryzen AI NPU driver is installed."
+        )
+    if reqs.gpu_vram_gb:
+        warnings.append(
+            f"This agent recommends {reqs.gpu_vram_gb:g} GB of GPU VRAM. GAIA "
+            "cannot verify GPU VRAM here."
+        )
+
+    return CompatibilityReport(
+        compatible=len(blockers) == 0,
+        platform_ok=platform_ok,
+        memory_ok=memory_ok,
+        disk_ok=disk_ok,
+        warnings=warnings,
+        blockers=blockers,
+        detected_platform=detected,
+        total_memory_gb=round(total_mem, 2) if total_mem is not None else None,
+        free_disk_gb=round(free_disk, 2) if free_disk is not None else None,
+    )

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -1,0 +1,773 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Agent Hub install lifecycle: download, verify, install, rollback, uninstall.
+
+This module owns what happens after a user clicks *Install* in the Agent Hub.
+It fetches the artifact named in the per-agent manifest (``manifest.json`` →
+``versions[v].artifact``), verifies its SHA-256 against the manifest, installs
+it under ``~/.gaia/agents/<id>/`` (``uv pip install --target`` for Python
+wheels, archive extraction for C++ binaries), records an ``.installed``
+sentinel, and hot-registers the agent into the live :class:`AgentRegistry` so it
+appears without a server restart.
+
+Safety properties (CLAUDE.md — fail loudly, no silent fallbacks):
+
+* **Checksum verified** before anything is written to the install dir — a
+  mismatch raises :class:`ChecksumError` and nothing is installed.
+* **Disk + platform checked** up front via
+  :func:`gaia.hub.compatibility.check_compatibility`; a hard blocker raises
+  before any download.
+* **One install per id** — a re-entrant install for the same agent raises
+  :class:`InstallInProgressError` (HTTP 409) instead of racing on the same dir.
+* **Backup before update** — updating an already-installed agent snapshots the
+  current install to ``.backup/<id>/`` first, so :func:`rollback` can restore it.
+* **Builtins are immutable** — :func:`uninstall` refuses reserved builtin ids.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import zipfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from gaia.agents.registry import _RESERVED_BUILTIN_IDS
+from gaia.hub import catalog as catalog_mod
+from gaia.hub.compatibility import check_compatibility
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Sentinel file written into each hub-installed agent dir. Its presence marks a
+# directory as hub-managed (vs. a hand-authored custom agent with agent.py).
+SENTINEL_NAME = ".installed"
+
+# Sub-directory under the install root holding pre-update snapshots for rollback.
+BACKUP_DIRNAME = ".backup"
+
+# Where Python wheels get installed (``uv pip install --target``).
+SITE_PACKAGES_DIRNAME = "site-packages"
+
+# Injectable pip runner: takes the full ``uv pip install`` argument list (after
+# ``uv pip install``) and runs it, raising InstallError on failure.
+PipRunner = Callable[[List[str]], None]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class InstallError(RuntimeError):
+    """Base class for install-lifecycle failures (actionable message)."""
+
+
+class ChecksumError(InstallError):
+    """Downloaded artifact's SHA-256 did not match the manifest."""
+
+
+class DiskSpaceError(InstallError):
+    """Not enough free disk space to install the agent."""
+
+
+class CompatibilityError(InstallError):
+    """The current machine does not satisfy the agent's requirements."""
+
+
+class InstallInProgressError(InstallError):
+    """An install for this agent id is already running (maps to HTTP 409)."""
+
+
+class NotInstalledError(InstallError):
+    """The agent is not installed (uninstall/rollback target missing)."""
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def default_install_root() -> Path:
+    return Path.home() / ".gaia" / "agents"
+
+
+def agent_install_dir(agent_id: str, install_root: Optional[Path] = None) -> Path:
+    return (install_root or default_install_root()) / agent_id
+
+
+def _backup_dir(agent_id: str, install_root: Optional[Path] = None) -> Path:
+    return (install_root or default_install_root()) / BACKUP_DIRNAME / agent_id
+
+
+def _sentinel_path(agent_id: str, install_root: Optional[Path] = None) -> Path:
+    return agent_install_dir(agent_id, install_root) / SENTINEL_NAME
+
+
+# ---------------------------------------------------------------------------
+# Installed-agent state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InstalledAgent:
+    """A hub-installed agent recorded by its ``.installed`` sentinel."""
+
+    id: str
+    version: str
+    language: str
+    installed_at: str
+    artifact_sha256: str = ""
+    path: Optional[Path] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "version": self.version,
+            "language": self.language,
+            "installed_at": self.installed_at,
+            "artifact_sha256": self.artifact_sha256,
+            "path": str(self.path) if self.path else None,
+        }
+
+
+def read_sentinel(
+    agent_id: str, install_root: Optional[Path] = None
+) -> Optional[InstalledAgent]:
+    """Return the :class:`InstalledAgent` for *agent_id*, or ``None``."""
+    path = _sentinel_path(agent_id, install_root)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("installer: unreadable sentinel %s: %s", path, exc)
+        return None
+    return InstalledAgent(
+        id=data.get("id", agent_id),
+        version=data.get("version", ""),
+        language=data.get("language", "python"),
+        installed_at=data.get("installed_at", ""),
+        artifact_sha256=data.get("artifact_sha256", ""),
+        path=agent_install_dir(agent_id, install_root),
+    )
+
+
+def list_installed(install_root: Optional[Path] = None) -> Dict[str, InstalledAgent]:
+    """Map ``agent_id -> InstalledAgent`` for every hub-installed agent."""
+    root = install_root or default_install_root()
+    result: Dict[str, InstalledAgent] = {}
+    if not root.exists():
+        return result
+    for child in sorted(root.iterdir()):
+        if not child.is_dir() or child.name == BACKUP_DIRNAME:
+            continue
+        if not (child / SENTINEL_NAME).exists():
+            continue
+        installed = read_sentinel(child.name, install_root)
+        if installed is not None:
+            result[child.name] = installed
+    return result
+
+
+def installed_versions(install_root: Optional[Path] = None) -> Dict[str, str]:
+    """Map ``agent_id -> version`` for hub-installed agents (catalog merge)."""
+    return {aid: ia.version for aid, ia in list_installed(install_root).items()}
+
+
+def is_builtin(agent_id: str) -> bool:
+    """Whether *agent_id* is a reserved builtin (immutable; never uninstalled)."""
+    return agent_id in _RESERVED_BUILTIN_IDS
+
+
+# ---------------------------------------------------------------------------
+# Concurrency guard (one install per id)
+# ---------------------------------------------------------------------------
+
+_GUARD_LOCK = threading.Lock()
+_IN_PROGRESS: set = set()
+
+
+@contextmanager
+def _install_slot(agent_id: str):
+    with _GUARD_LOCK:
+        if agent_id in _IN_PROGRESS:
+            raise InstallInProgressError(
+                f"An install for '{agent_id}' is already in progress. Wait for it "
+                f"to finish (poll GET /api/agents/{agent_id}/install-status)."
+            )
+        _IN_PROGRESS.add(agent_id)
+    try:
+        yield
+    finally:
+        with _GUARD_LOCK:
+            _IN_PROGRESS.discard(agent_id)
+
+
+def is_installing(agent_id: str) -> bool:
+    with _GUARD_LOCK:
+        return agent_id in _IN_PROGRESS
+
+
+# ---------------------------------------------------------------------------
+# Progress tracking (polling endpoint)
+# ---------------------------------------------------------------------------
+
+_PROGRESS_LOCK = threading.Lock()
+_PROGRESS: Dict[str, Dict[str, Any]] = {}
+
+
+def _set_progress(
+    agent_id: str,
+    *,
+    status: str,
+    phase: str,
+    percent: int,
+    version: Optional[str] = None,
+    error: Optional[str] = None,
+) -> None:
+    with _PROGRESS_LOCK:
+        _PROGRESS[agent_id] = {
+            "id": agent_id,
+            "status": status,
+            "phase": phase,
+            "percent": percent,
+            "version": version,
+            "error": error,
+        }
+
+
+def get_install_status(agent_id: str) -> Optional[Dict[str, Any]]:
+    """Return the latest install progress for *agent_id*, or ``None``."""
+    with _PROGRESS_LOCK:
+        state = _PROGRESS.get(agent_id)
+        return dict(state) if state is not None else None
+
+
+def clear_progress(agent_id: Optional[str] = None) -> None:
+    """Clear progress state (test/maintenance hook)."""
+    with _PROGRESS_LOCK:
+        if agent_id is None:
+            _PROGRESS.clear()
+        else:
+            _PROGRESS.pop(agent_id, None)
+
+
+# ---------------------------------------------------------------------------
+# Download + verify
+# ---------------------------------------------------------------------------
+
+
+def _download_and_verify(
+    url: str, expected_sha256: str, fetcher: catalog_mod.Fetcher
+) -> bytes:
+    data = fetcher(url)
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != (expected_sha256 or "").lower():
+        raise ChecksumError(
+            f"Artifact checksum mismatch for {url}: expected {expected_sha256}, "
+            f"got {actual}. The download is corrupt or tampered; nothing was "
+            f"installed. Try again, or report it if it persists."
+        )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Pip runner
+# ---------------------------------------------------------------------------
+
+
+def _default_run_pip(args: List[str]) -> None:
+    """Run ``uv pip install <args>``; raise InstallError on failure."""
+    cmd = ["uv", "pip", "install", *args]
+    try:
+        proc = subprocess.run(  # noqa: S603 - args are constructed, not shell
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise InstallError(
+            "Could not run 'uv' to install the agent's Python package. Install "
+            "uv (https://docs.astral.sh/uv/) or ensure it is on PATH."
+        ) from exc
+    if proc.returncode != 0:
+        raise InstallError(
+            f"'uv pip install' failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Artifact installation
+# ---------------------------------------------------------------------------
+
+
+def _install_python_artifact(
+    artifact_bytes: bytes,
+    filename: str,
+    install_dir: Path,
+    run_pip: PipRunner,
+) -> Path:
+    """Install a Python wheel/sdist into ``install_dir/site-packages``."""
+    site_packages = install_dir / SITE_PACKAGES_DIRNAME
+    site_packages.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="gaia-hub-") as tmp:
+        wheel_path = Path(tmp) / filename
+        wheel_path.write_bytes(artifact_bytes)
+        run_pip(["--target", str(site_packages), str(wheel_path)])
+    return site_packages
+
+
+def _install_cpp_artifact(
+    artifact_bytes: bytes, filename: str, install_dir: Path
+) -> Path:
+    """Extract a C++ agent archive into ``install_dir``."""
+    install_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="gaia-hub-") as tmp:
+        archive_path = Path(tmp) / filename
+        archive_path.write_bytes(artifact_bytes)
+        lower = filename.lower()
+        if lower.endswith(".zip"):
+            with zipfile.ZipFile(archive_path) as zf:
+                zf.extractall(install_dir)
+        elif lower.endswith((".tar.gz", ".tgz", ".tar")):
+            with tarfile.open(archive_path) as tf:
+                tf.extractall(install_dir)  # noqa: S202 - hub artifacts are trusted
+        else:
+            raise InstallError(
+                f"Unsupported C++ artifact format '{filename}'. Expected a .zip "
+                f"or .tar.gz archive."
+            )
+    return install_dir
+
+
+# ---------------------------------------------------------------------------
+# Version resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_version(manifest: Dict[str, Any], version: Optional[str]):
+    versions = manifest.get("versions") or {}
+    if not versions:
+        raise InstallError(
+            f"Hub manifest for '{manifest.get('id')}' has no published versions."
+        )
+    if version is None:
+        version = manifest.get("latest_version")
+        if not version or version not in versions:
+            version = max(versions, key=catalog_mod._parse_version)
+    if version not in versions:
+        raise InstallError(
+            f"Version '{version}' of '{manifest.get('id')}' is not published. "
+            f"Available: {', '.join(sorted(versions))}."
+        )
+    entry = versions[version]
+    artifact = entry.get("artifact") or {}
+    if not artifact.get("path") or not artifact.get("sha256"):
+        raise InstallError(
+            f"Hub manifest version '{version}' of '{manifest.get('id')}' is "
+            f"missing its artifact path or checksum."
+        )
+    return version, artifact
+
+
+# ---------------------------------------------------------------------------
+# Backup / restore
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_backup(agent_id: str, install_root: Path) -> None:
+    """Move the current install dir to ``.backup/<id>/`` before an update."""
+    install_dir = agent_install_dir(agent_id, install_root)
+    if not install_dir.exists():
+        return
+    backup = _backup_dir(agent_id, install_root)
+    if backup.exists():
+        shutil.rmtree(backup)
+    backup.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(install_dir), str(backup))
+    logger.info("installer: snapshotted %s -> %s", install_dir, backup)
+
+
+# ---------------------------------------------------------------------------
+# Hot-register
+# ---------------------------------------------------------------------------
+
+
+def _hot_register(agent_id: str, install_dir: Path, language: str, registry) -> bool:
+    """Register a freshly-installed Python agent into the live registry.
+
+    Adds the install's ``site-packages`` to ``sys.path`` so entry-point
+    discovery can find the new distribution, then asks the registry to rescan.
+    Returns whether the agent is now registered. Best-effort: a failure here
+    does not undo the on-disk install (the agent loads after a restart).
+    """
+    if language != "python":
+        logger.info(
+            "installer: %s is a native agent; it registers via the Electron "
+            "process manager, not in-process",
+            agent_id,
+        )
+        return False
+    if registry is None:
+        return False
+    site_packages = install_dir / SITE_PACKAGES_DIRNAME
+    try:
+        sp = str(site_packages)
+        if sp not in sys.path:
+            sys.path.insert(0, sp)
+        import importlib
+
+        importlib.invalidate_caches()
+        registry.discover_installed_agents()
+    except Exception as exc:  # noqa: BLE001 - secondary effect; log, don't fail
+        logger.warning("installer: hot-register failed for %s: %s", agent_id, exc)
+        return False
+    return registry.get(agent_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Public: install
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InstallResult:
+    """Outcome of a successful :func:`install`."""
+
+    id: str
+    version: str
+    language: str
+    path: Path
+    updated: bool
+    hot_registered: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "version": self.version,
+            "language": self.language,
+            "path": str(self.path),
+            "updated": self.updated,
+            "hot_registered": self.hot_registered,
+        }
+
+
+def install(
+    agent_id: str,
+    *,
+    version: Optional[str] = None,
+    manifest: Optional[Dict[str, Any]] = None,
+    base_url: Optional[str] = None,
+    fetcher: Optional[catalog_mod.Fetcher] = None,
+    run_pip: Optional[PipRunner] = None,
+    install_root: Optional[Path] = None,
+    registry: Any = None,
+    skip_compatibility_check: bool = False,
+) -> InstallResult:
+    """Download, verify, and install an agent from the hub.
+
+    Args:
+        agent_id: Hub agent id to install.
+        version: Specific version to install; defaults to the manifest's latest.
+        manifest: Pre-fetched per-agent manifest; fetched from the hub if absent.
+        base_url / fetcher: Hub origin + HTTP fetcher (injectable for tests).
+        run_pip: ``uv pip install`` runner (injectable for tests).
+        install_root: Install root; defaults to ``~/.gaia/agents``.
+        registry: Live :class:`AgentRegistry` to hot-register into.
+        skip_compatibility_check: Skip the platform/disk gate (tests/forced).
+
+    Raises:
+        InstallInProgressError, ChecksumError, DiskSpaceError,
+        CompatibilityError, InstallError.
+    """
+    fetcher = fetcher or catalog_mod.fetch_bytes
+    run_pip = run_pip or _default_run_pip
+    root = install_root or default_install_root()
+    base_url = (base_url or catalog_mod.get_hub_base_url()).rstrip("/")
+
+    with _install_slot(agent_id):
+        _set_progress(
+            agent_id, status="running", phase="resolving", percent=5, version=version
+        )
+        try:
+            if manifest is None:
+                manifest = catalog_mod.fetch_manifest(
+                    agent_id, base_url=base_url, fetcher=fetcher
+                )
+            language = manifest.get("language", "python")
+            resolved_version, artifact = _resolve_version(manifest, version)
+
+            # --- compatibility / disk gate ---
+            _set_progress(
+                agent_id,
+                status="running",
+                phase="checking",
+                percent=10,
+                version=resolved_version,
+            )
+            if not skip_compatibility_check:
+                report = check_compatibility(
+                    manifest.get("requirements"),
+                    download_size_bytes=artifact.get("size_bytes", 0),
+                    install_dir=root,
+                )
+                if not report.compatible:
+                    blockers = "; ".join(report.blockers)
+                    if not report.disk_ok:
+                        raise DiskSpaceError(blockers)
+                    raise CompatibilityError(blockers)
+
+            # --- download + verify ---
+            _set_progress(
+                agent_id,
+                status="running",
+                phase="downloading",
+                percent=30,
+                version=resolved_version,
+            )
+            artifact_url = f"{base_url}/{artifact['path']}"
+            artifact_bytes = _download_and_verify(
+                artifact_url, artifact["sha256"], fetcher
+            )
+
+            _set_progress(
+                agent_id,
+                status="running",
+                phase="installing",
+                percent=60,
+                version=resolved_version,
+            )
+
+            # --- backup before update ---
+            updated = read_sentinel(agent_id, root) is not None
+            if updated:
+                _snapshot_backup(agent_id, root)
+
+            install_dir = agent_install_dir(agent_id, root)
+            try:
+                install_dir.mkdir(parents=True, exist_ok=True)
+                if language == "python":
+                    _install_python_artifact(
+                        artifact_bytes, artifact["filename"], install_dir, run_pip
+                    )
+                else:
+                    _install_cpp_artifact(
+                        artifact_bytes, artifact["filename"], install_dir
+                    )
+                _write_agent_yaml(
+                    agent_id, resolved_version, install_dir, base_url, fetcher
+                )
+                _write_sentinel(
+                    agent_id,
+                    resolved_version,
+                    language,
+                    artifact["sha256"],
+                    install_dir,
+                )
+            except Exception:
+                # Install failed mid-write — restore the backup if we made one so
+                # the user is left with a working previous version, not a stub.
+                _restore_backup_if_present(agent_id, root)
+                raise
+
+            # --- hot-register ---
+            _set_progress(
+                agent_id,
+                status="running",
+                phase="registering",
+                percent=90,
+                version=resolved_version,
+            )
+            hot = _hot_register(agent_id, install_dir, language, registry)
+
+            # NOTE: the backup snapshot is intentionally retained after a
+            # successful update so rollback() can restore the prior version. It
+            # is overwritten by the next update's snapshot and cleared on
+            # uninstall.
+
+            _set_progress(
+                agent_id,
+                status="completed",
+                phase="completed",
+                percent=100,
+                version=resolved_version,
+            )
+            return InstallResult(
+                id=agent_id,
+                version=resolved_version,
+                language=language,
+                path=install_dir,
+                updated=updated,
+                hot_registered=hot,
+            )
+        except InstallInProgressError:
+            raise
+        except Exception as exc:
+            _set_progress(
+                agent_id,
+                status="failed",
+                phase="failed",
+                percent=0,
+                version=version,
+                error=str(exc),
+            )
+            raise
+
+
+def _write_sentinel(
+    agent_id: str,
+    version: str,
+    language: str,
+    sha256: str,
+    install_dir: Path,
+) -> None:
+    sentinel = InstalledAgent(
+        id=agent_id,
+        version=version,
+        language=language,
+        installed_at=datetime.now(timezone.utc).isoformat(),
+        artifact_sha256=sha256,
+        path=install_dir,
+    )
+    (install_dir / SENTINEL_NAME).write_text(
+        json.dumps(sentinel.to_dict(), indent=2), encoding="utf-8"
+    )
+
+
+def _write_agent_yaml(
+    agent_id: str,
+    version: str,
+    install_dir: Path,
+    base_url: str,
+    fetcher: catalog_mod.Fetcher,
+) -> None:
+    """Fetch the version's ``gaia-agent.yaml`` into the install dir.
+
+    Best-effort: the manifest already carries identity, so a missing yaml does
+    not fail the install — but we log it so a broken hub object is visible.
+    """
+    url = f"{base_url}/agents/{agent_id}/{version}/gaia-agent.yaml"
+    try:
+        data = fetcher(url)
+    except Exception as exc:  # noqa: BLE001 - optional asset
+        logger.warning("installer: could not fetch %s: %s", url, exc)
+        return
+    (install_dir / "gaia-agent.yaml").write_bytes(data)
+
+
+# ---------------------------------------------------------------------------
+# Public: uninstall
+# ---------------------------------------------------------------------------
+
+
+def uninstall(
+    agent_id: str,
+    *,
+    install_root: Optional[Path] = None,
+    registry: Any = None,
+) -> None:
+    """Remove a hub-installed agent. Refuses builtins.
+
+    Raises:
+        InstallError: If *agent_id* is a reserved builtin.
+        NotInstalledError: If the agent is not installed.
+    """
+    if is_builtin(agent_id):
+        raise InstallError(
+            f"'{agent_id}' is a built-in GAIA agent and cannot be uninstalled."
+        )
+    root = install_root or default_install_root()
+    install_dir = agent_install_dir(agent_id, root)
+    if read_sentinel(agent_id, root) is None:
+        raise NotInstalledError(
+            f"'{agent_id}' is not installed (no {SENTINEL_NAME} at {install_dir})."
+        )
+    shutil.rmtree(install_dir)
+    _discard_backup(agent_id, root)
+    if registry is not None:
+        _deregister(agent_id, registry)
+    logger.info("installer: uninstalled %s", agent_id)
+
+
+# ---------------------------------------------------------------------------
+# Public: rollback
+# ---------------------------------------------------------------------------
+
+
+def rollback(
+    agent_id: str,
+    *,
+    install_root: Optional[Path] = None,
+    registry: Any = None,
+) -> InstalledAgent:
+    """Restore the pre-update snapshot from ``.backup/<id>/``.
+
+    Raises:
+        InstallError: If there is no backup to restore.
+    """
+    root = install_root or default_install_root()
+    backup = _backup_dir(agent_id, root)
+    if not backup.exists():
+        raise InstallError(
+            f"No backup to roll back to for '{agent_id}'. A backup is only "
+            f"created when updating an already-installed agent."
+        )
+    install_dir = agent_install_dir(agent_id, root)
+    if install_dir.exists():
+        shutil.rmtree(install_dir)
+    shutil.move(str(backup), str(install_dir))
+    logger.info("installer: rolled back %s from backup", agent_id)
+
+    restored = read_sentinel(agent_id, root)
+    if restored is None:
+        raise InstallError(
+            f"Rollback for '{agent_id}' restored a directory with no "
+            f"{SENTINEL_NAME} sentinel; the backup is corrupt."
+        )
+    if registry is not None:
+        _hot_register(agent_id, install_dir, restored.language, registry)
+    return restored
+
+
+# ---------------------------------------------------------------------------
+# Backup helpers
+# ---------------------------------------------------------------------------
+
+
+def _discard_backup(agent_id: str, install_root: Path) -> None:
+    backup = _backup_dir(agent_id, install_root)
+    if backup.exists():
+        shutil.rmtree(backup, ignore_errors=True)
+
+
+def _restore_backup_if_present(agent_id: str, install_root: Path) -> None:
+    backup = _backup_dir(agent_id, install_root)
+    if not backup.exists():
+        return
+    install_dir = agent_install_dir(agent_id, install_root)
+    if install_dir.exists():
+        shutil.rmtree(install_dir, ignore_errors=True)
+    shutil.move(str(backup), str(install_dir))
+    logger.info("installer: restored %s from backup after failed install", agent_id)
+
+
+def _deregister(agent_id: str, registry: Any) -> None:
+    """Remove an agent from the live registry (best-effort)."""
+    try:
+        # pylint: disable=protected-access
+        with registry._lock:  # noqa: SLF001
+            registry._agents.pop(agent_id, None)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("installer: could not deregister %s: %s", agent_id, exc)

--- a/src/gaia/ui/routers/hub.py
+++ b/src/gaia/ui/routers/hub.py
@@ -1,0 +1,178 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Agent Hub endpoints: catalog, install, install-status, uninstall, rollback.
+
+These endpoints drive the Agent UI's discover/install panel. They are the HTTP
+surface over :mod:`gaia.hub.catalog` (remote catalog + local merge) and
+:mod:`gaia.hub.installer` (download/verify/install lifecycle).
+
+Like the rest of the local-first UI backend, the mutating endpoints are guarded
+to localhost + the ``X-Gaia-UI`` header (a lightweight CSRF guard — custom
+headers force a CORS preflight that drive-by POSTs cannot satisfy).
+
+NOTE on route ordering: this router MUST be included *before*
+``routers/agents.py`` in the app, because that router defines a greedy
+``GET /api/agents/{agent_id:path}`` that would otherwise swallow
+``/api/agents/catalog`` and ``/api/agents/{id}/install-status``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from gaia.hub import catalog as catalog_mod
+from gaia.hub import installer as installer_mod
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["hub"])
+
+_LOCALHOST_HOSTS = {"127.0.0.1", "::1", "localhost", ""}
+
+
+def _registry(request: Request):
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None:
+        raise HTTPException(status_code=503, detail="Agent registry not initialized")
+    return registry
+
+
+def _require_localhost(request: Request) -> None:
+    host = (request.client.host if request.client else "") or ""
+    if host not in _LOCALHOST_HOSTS:
+        raise HTTPException(
+            status_code=403, detail="endpoint only available on localhost"
+        )
+
+
+def _require_ui_header(request: Request) -> None:
+    if request.headers.get("x-gaia-ui") != "1":
+        raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
+
+
+class InstallRequest(BaseModel):
+    """Body for ``POST /api/agents/install``."""
+
+    id: str
+    version: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/agents/catalog")
+async def get_catalog(request: Request, refresh: bool = False):
+    """Unified agent catalog: remote hub merged with the local registry.
+
+    ``offline=true`` in the response means the live hub was unreachable and the
+    list came from the on-disk cache.
+    """
+    registry = _registry(request)
+    try:
+        unified = catalog_mod.build_catalog(
+            registry,
+            installed_versions=installer_mod.installed_versions(),
+            force=refresh,
+        )
+    except catalog_mod.CatalogError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return unified.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Install (async + polling)
+# ---------------------------------------------------------------------------
+
+
+def _run_install(agent_id: str, version: Optional[str], registry) -> None:
+    """Background install worker. Errors are recorded in install progress."""
+    try:
+        installer_mod.install(agent_id, version=version, registry=registry)
+    except installer_mod.InstallError as exc:
+        logger.warning("hub: install of %s failed: %s", agent_id, exc)
+    except Exception:  # noqa: BLE001 - record then swallow in the worker
+        logger.exception("hub: unexpected error installing %s", agent_id)
+
+
+@router.post(
+    "/api/agents/install",
+    status_code=202,
+    dependencies=[Depends(_require_localhost), Depends(_require_ui_header)],
+)
+async def install_agent(
+    request: Request, body: InstallRequest, background_tasks: BackgroundTasks
+):
+    """Start an install in the background; poll install-status for progress.
+
+    Returns 202 immediately. A duplicate request while an install for the same
+    id is running returns 409.
+    """
+    registry = _registry(request)
+    if installer_mod.is_installing(body.id):
+        raise HTTPException(
+            status_code=409,
+            detail=f"An install for '{body.id}' is already in progress.",
+        )
+    installer_mod.clear_progress(body.id)
+    installer_mod._set_progress(  # noqa: SLF001 - seed state for the poller
+        body.id, status="queued", phase="queued", percent=0, version=body.version
+    )
+    background_tasks.add_task(_run_install, body.id, body.version, registry)
+    return {"id": body.id, "status": "queued"}
+
+
+@router.get("/api/agents/{agent_id}/install-status")
+async def install_status(agent_id: str):
+    """Poll the progress of an in-flight or completed install."""
+    state = installer_mod.get_install_status(agent_id)
+    if state is None:
+        raise HTTPException(
+            status_code=404, detail=f"No install status for '{agent_id}'."
+        )
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+
+@router.delete(
+    "/api/agents/{agent_id}",
+    dependencies=[Depends(_require_localhost), Depends(_require_ui_header)],
+)
+async def uninstall_agent(agent_id: str, request: Request):
+    """Uninstall a hub-installed agent. Refuses builtins (400)."""
+    registry = _registry(request)
+    try:
+        installer_mod.uninstall(agent_id, registry=registry)
+    except installer_mod.NotInstalledError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except installer_mod.InstallError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"id": agent_id, "status": "uninstalled"}
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/api/agents/{agent_id}/rollback",
+    dependencies=[Depends(_require_localhost), Depends(_require_ui_header)],
+)
+async def rollback_agent(agent_id: str, request: Request):
+    """Roll an agent back to its pre-update snapshot in ``.backup/``."""
+    registry = _registry(request)
+    try:
+        restored = installer_mod.rollback(agent_id, registry=registry)
+    except installer_mod.InstallError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"id": agent_id, "status": "rolled_back", "version": restored.version}

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -55,6 +55,7 @@ from .routers import connectors as connectors_router_mod
 from .routers import documents as documents_router_mod
 from .routers import files as files_router_mod
 from .routers import goals as goals_router_mod
+from .routers import hub as hub_router_mod
 from .routers import mcp as mcp_router_mod
 from .routers import memory as memory_router_mod
 from .routers import sessions as sessions_router_mod
@@ -496,6 +497,10 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
 
     # ── Include Routers ──────────────────────────────────────────────────
     app.include_router(system_router_mod.router)
+    # Hub routes (catalog/install/...) MUST precede the agents router: that
+    # router has a greedy GET /api/agents/{agent_id:path} that would otherwise
+    # capture /api/agents/catalog and /api/agents/{id}/install-status.
+    app.include_router(hub_router_mod.router)
     app.include_router(agents_router_mod.router)
     app.include_router(sessions_router_mod.router)
     app.include_router(chat_router_mod.router)

--- a/tests/unit/test_hub_catalog.py
+++ b/tests/unit/test_hub_catalog.py
@@ -1,0 +1,210 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.hub.catalog — fetch, cache, and registry merge."""
+
+import json
+
+import pytest
+
+from gaia.hub import catalog
+from gaia.hub.catalog import (
+    CatalogError,
+    build_catalog,
+    compare_versions,
+    load_index,
+    merge_with_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_mem_cache():
+    catalog.clear_cache()
+    yield
+    catalog.clear_cache()
+
+
+def _index(*agents):
+    return {
+        "schema_version": 1,
+        "generated_at": "2026-06-03T00:00:00Z",
+        "agents": list(agents),
+    }
+
+
+def _entry(agent_id, version="1.0.0", **over):
+    e = {
+        "id": agent_id,
+        "name": agent_id.title(),
+        "description": f"{agent_id} agent",
+        "category": "general",
+        "latest_version": version,
+        "icon": "",
+        "language": "python",
+        "author": "AMD",
+        "security_tier": "community",
+        "download_size_bytes": 1000,
+        "requirements": {"platforms": []},
+        "deprecated": False,
+    }
+    e.update(over)
+    return e
+
+
+class _FakeReg:
+    def __init__(self, regs):
+        self._regs = regs
+
+    def list(self):
+        return self._regs
+
+
+class _Reg:
+    def __init__(self, agent_id, source="builtin"):
+        self.id = agent_id
+        self.name = agent_id.title()
+        self.description = ""
+        self.category = "general"
+        self.icon = ""
+        self.language = "python"
+        self.source = source
+
+
+# ---------------------------------------------------------------------------
+# Fetch + cache
+# ---------------------------------------------------------------------------
+
+
+def test_load_index_network_success_writes_cache(tmp_path):
+    cache = tmp_path / "catalog-cache.json"
+    payload = json.dumps(_index(_entry("demo"))).encode()
+
+    def fetcher(url):
+        assert url.endswith("/index.json")
+        return payload
+
+    result = load_index(
+        base_url="https://hub.test", fetcher=fetcher, cache_path=cache, force=True
+    )
+    assert result.offline is False
+    assert result.source == "network"
+    assert [a["id"] for a in result.agents] == ["demo"]
+    assert cache.exists()
+    assert json.loads(cache.read_text())["agents"][0]["id"] == "demo"
+
+
+def test_offline_fallback_uses_disk_cache(tmp_path):
+    cache = tmp_path / "catalog-cache.json"
+    cache.write_text(json.dumps(_index(_entry("cached"))))
+
+    def failing_fetcher(url):
+        raise ConnectionError("no network")
+
+    result = load_index(
+        base_url="https://hub.test",
+        fetcher=failing_fetcher,
+        cache_path=cache,
+        force=True,
+    )
+    assert result.offline is True
+    assert result.source == "cache"
+    assert result.agents[0]["id"] == "cached"
+
+
+def test_no_network_no_cache_raises(tmp_path):
+    def failing_fetcher(url):
+        raise ConnectionError("no network")
+
+    with pytest.raises(CatalogError):
+        load_index(
+            base_url="https://hub.test",
+            fetcher=failing_fetcher,
+            cache_path=tmp_path / "missing.json",
+            force=True,
+        )
+
+
+def test_malformed_index_raises(tmp_path):
+    def fetcher(url):
+        return b'{"no_agents": true}'
+
+    with pytest.raises(CatalogError):
+        load_index(
+            base_url="https://hub.test",
+            fetcher=fetcher,
+            cache_path=tmp_path / "c.json",
+            force=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# SemVer compare
+# ---------------------------------------------------------------------------
+
+
+def test_compare_versions():
+    assert compare_versions("1.0.1", "1.0.0") == 1
+    assert compare_versions("1.0.0", "1.0.1") == -1
+    assert compare_versions("2.0.0", "2.0.0") == 0
+    assert compare_versions("1.2.0", "1.10.0") == -1
+    # Release outranks its prerelease.
+    assert compare_versions("1.0.0", "1.0.0-rc.1") == 1
+
+
+# ---------------------------------------------------------------------------
+# Merge + status
+# ---------------------------------------------------------------------------
+
+
+def test_merge_status_available_when_not_installed():
+    merged = merge_with_registry([_entry("demo")], _FakeReg([]), {})
+    assert merged[0]["status"] == "available"
+    assert merged[0]["source"] == "hub"
+
+
+def test_merge_status_installed_at_latest():
+    merged = merge_with_registry(
+        [_entry("demo", version="1.0.0")], _FakeReg([]), {"demo": "1.0.0"}
+    )
+    assert merged[0]["status"] == "installed"
+    assert merged[0]["installed_version"] == "1.0.0"
+
+
+def test_merge_status_update_available():
+    merged = merge_with_registry(
+        [_entry("demo", version="2.0.0")], _FakeReg([]), {"demo": "1.0.0"}
+    )
+    assert merged[0]["status"] == "update_available"
+    assert merged[0]["latest_version"] == "2.0.0"
+
+
+def test_merge_builtin_registry_only_is_installed():
+    merged = merge_with_registry([], _FakeReg([_Reg("chat")]), {})
+    assert merged[0]["id"] == "chat"
+    assert merged[0]["status"] == "installed"
+    assert merged[0]["source"] == "builtin"
+
+
+def test_merge_registered_catalog_agent_is_installed():
+    # In the catalog AND registered (entry-point installed) but no sentinel
+    # version known -> still treated as installed, not available.
+    merged = merge_with_registry(
+        [_entry("demo")], _FakeReg([_Reg("demo", source="installed")]), {}
+    )
+    assert merged[0]["status"] == "installed"
+
+
+def test_build_catalog_merges(tmp_path):
+    payload = json.dumps(_index(_entry("demo", version="3.0.0"))).encode()
+
+    unified = build_catalog(
+        _FakeReg([_Reg("chat")]),
+        base_url="https://hub.test",
+        fetcher=lambda url: payload,
+        cache_path=tmp_path / "c.json",
+        installed_versions={"demo": "1.0.0"},
+        force=True,
+    )
+    by_id = {a["id"]: a for a in unified.agents}
+    assert by_id["demo"]["status"] == "update_available"
+    assert by_id["chat"]["status"] == "installed"
+    assert unified.offline is False

--- a/tests/unit/test_hub_compatibility.py
+++ b/tests/unit/test_hub_compatibility.py
@@ -1,0 +1,84 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.hub.compatibility — the system-requirements checker."""
+
+from gaia.hub import compatibility
+from gaia.hub.compatibility import check_compatibility
+
+
+def test_no_requirements_is_compatible():
+    report = check_compatibility({"platforms": []})
+    assert report.compatible is True
+    assert report.platform_ok is True
+    assert report.blockers == []
+
+
+def test_current_platform_passes():
+    current = compatibility.detect_platform()
+    report = check_compatibility({"platforms": [current]})
+    assert report.platform_ok is True
+    assert report.compatible is True
+
+
+def test_wrong_platform_is_blocker():
+    current = compatibility.detect_platform()
+    others = [
+        p
+        for p in ("win-x64", "linux-x64", "darwin-arm64", "linux-arm64")
+        if p != current
+    ]
+    report = check_compatibility({"platforms": others})
+    assert report.platform_ok is False
+    assert report.compatible is False
+    assert any("not supported" in b for b in report.blockers)
+
+
+def test_unsupported_platform_detected_none(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_platform", lambda: None)
+    report = check_compatibility({"platforms": ["win-x64"]})
+    assert report.platform_ok is False
+    assert report.compatible is False
+
+
+def test_low_memory_is_warning_not_blocker(monkeypatch):
+    # Plenty of disk, tiny RAM -> warn (advisory), still compatible.
+    monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 2.0)
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility({"platforms": [], "min_memory_gb": 16})
+    assert report.memory_ok is False
+    assert report.compatible is True  # not a hard blocker
+    assert any("RAM" in w for w in report.warnings)
+
+
+def test_insufficient_disk_is_blocker(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 0.5)
+    report = check_compatibility({"platforms": [], "min_disk_gb": 50})
+    assert report.disk_ok is False
+    assert report.compatible is False
+    assert any("disk" in b.lower() for b in report.blockers)
+
+
+def test_disk_estimated_from_download_size(monkeypatch):
+    # No explicit min_disk_gb: estimate from download size * headroom.
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 0.001)
+    huge = 5 * 1024**3  # 5 GB artifact -> ~15 GB estimate > 0.001 GB free
+    report = check_compatibility({"platforms": []}, download_size_bytes=huge)
+    assert report.disk_ok is False
+    assert report.compatible is False
+
+
+def test_npu_and_gpu_emit_warnings(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility({"platforms": [], "npu": True, "gpu_vram_gb": 8})
+    assert report.compatible is True
+    assert any("NPU" in w for w in report.warnings)
+    assert any("VRAM" in w for w in report.warnings)
+
+
+def test_report_to_dict_round_trips(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 100.0)
+    report = check_compatibility({"platforms": []})
+    d = report.to_dict()
+    assert set(
+        ["compatible", "platform_ok", "memory_ok", "disk_ok", "warnings", "blockers"]
+    ).issubset(d)

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -1,0 +1,323 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.hub.installer — install/uninstall/rollback lifecycle.
+
+All HTTP and pip work is mocked; no live network, no real ``uv``.
+"""
+
+import hashlib
+
+import pytest
+
+from gaia.hub import installer
+from gaia.hub.installer import (
+    ChecksumError,
+    DiskSpaceError,
+    InstallError,
+    InstallInProgressError,
+    NotInstalledError,
+    install,
+    list_installed,
+    read_sentinel,
+    rollback,
+    uninstall,
+)
+
+BASE = "https://hub.test"
+
+
+def _artifact_bytes(tag=b"wheel-bytes"):
+    return tag
+
+
+def _manifest(agent_id="demo", version="1.0.0", artifact_bytes=b"wheel-bytes", **reqs):
+    sha = hashlib.sha256(artifact_bytes).hexdigest()
+    path = f"agents/{agent_id}/{version}/{agent_id}-{version}.whl"
+    return {
+        "id": agent_id,
+        "language": "python",
+        "latest_version": version,
+        "requirements": {"platforms": [], **reqs},
+        "versions": {
+            version: {
+                "version": version,
+                "artifact": {
+                    "filename": f"{agent_id}-{version}-py3-none-any.whl",
+                    "path": path,
+                    "size_bytes": len(artifact_bytes),
+                    "sha256": sha,
+                    "content_type": "application/octet-stream",
+                },
+            }
+        },
+    }
+
+
+def _make_fetcher(manifest, agent_id="demo", artifact_bytes=b"wheel-bytes"):
+    version = manifest["latest_version"]
+    artifact_path = manifest["versions"][version]["artifact"]["path"]
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: demo\nname: Demo\n"
+        if url == f"{BASE}/{artifact_path}":
+            return artifact_bytes
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    return fetcher
+
+
+class _FakeRegistry:
+    def __init__(self):
+        self.discovered = 0
+        self._agents = {}
+        import threading
+
+        self._lock = threading.Lock()
+
+    def discover_installed_agents(self):
+        self.discovered += 1
+        self._agents["demo"] = object()
+
+    def get(self, agent_id):
+        return self._agents.get(agent_id)
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    installer.clear_progress()
+    installer._IN_PROGRESS.clear()  # noqa: SLF001
+    yield
+    installer.clear_progress()
+    installer._IN_PROGRESS.clear()  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_install_happy_path(tmp_path):
+    manifest = _manifest()
+    pip_calls = []
+    reg = _FakeRegistry()
+
+    result = install(
+        "demo",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_make_fetcher(manifest),
+        run_pip=lambda args: pip_calls.append(args),
+        install_root=tmp_path,
+        registry=reg,
+    )
+
+    assert result.version == "1.0.0"
+    assert result.updated is False
+    assert result.hot_registered is True
+    # sentinel written
+    sentinel = read_sentinel("demo", tmp_path)
+    assert sentinel is not None
+    assert sentinel.version == "1.0.0"
+    # gaia-agent.yaml copied
+    assert (tmp_path / "demo" / "gaia-agent.yaml").exists()
+    # uv pip install called targeting site-packages
+    assert pip_calls and "--target" in pip_calls[0]
+    # progress completed
+    status = installer.get_install_status("demo")
+    assert status["status"] == "completed"
+    assert status["percent"] == 100
+    # registry hot-registered
+    assert reg.discovered == 1
+    # list_installed reflects it
+    assert "demo" in list_installed(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Checksum mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_install_checksum_mismatch(tmp_path):
+    manifest = _manifest(artifact_bytes=b"correct")
+    # Fetcher returns DIFFERENT bytes than the manifest's sha256.
+    bad_fetcher = _make_fetcher(manifest, artifact_bytes=b"tampered")
+
+    with pytest.raises(ChecksumError):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=bad_fetcher,
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+    # Nothing installed.
+    assert read_sentinel("demo", tmp_path) is None
+    assert installer.get_install_status("demo")["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Disk-space block
+# ---------------------------------------------------------------------------
+
+
+def test_install_disk_space_block(tmp_path, monkeypatch):
+    from gaia.hub import compatibility
+
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 0.1)
+    manifest = _manifest(min_disk_gb=100)  # needs 100 GB, only 0.1 free
+
+    with pytest.raises(DiskSpaceError):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_make_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+    assert read_sentinel("demo", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Concurrency guard
+# ---------------------------------------------------------------------------
+
+
+def test_install_concurrency_guard(tmp_path):
+    manifest = _manifest()
+    with installer._install_slot("demo"):  # noqa: SLF001 - simulate in-flight
+        with pytest.raises(InstallInProgressError):
+            install(
+                "demo",
+                manifest=manifest,
+                base_url=BASE,
+                fetcher=_make_fetcher(manifest),
+                run_pip=lambda args: None,
+                install_root=tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Update creates backup; rollback restores
+# ---------------------------------------------------------------------------
+
+
+def test_update_then_rollback(tmp_path):
+    v1 = _manifest(version="1.0.0")
+    install(
+        "demo",
+        manifest=v1,
+        base_url=BASE,
+        fetcher=_make_fetcher(v1),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+    )
+    assert read_sentinel("demo", tmp_path).version == "1.0.0"
+
+    v2 = _manifest(version="2.0.0", artifact_bytes=b"wheel-v2")
+    result = install(
+        "demo",
+        manifest=v2,
+        base_url=BASE,
+        fetcher=_make_fetcher(v2, artifact_bytes=b"wheel-v2"),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+    )
+    assert result.updated is True
+    assert read_sentinel("demo", tmp_path).version == "2.0.0"
+
+    restored = rollback("demo", install_root=tmp_path)
+    assert restored.version == "1.0.0"
+    assert read_sentinel("demo", tmp_path).version == "1.0.0"
+
+
+def test_rollback_without_backup_raises(tmp_path):
+    with pytest.raises(InstallError):
+        rollback("demo", install_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_refuses_builtin(tmp_path):
+    with pytest.raises(InstallError):
+        uninstall("chat", install_root=tmp_path)
+
+
+def test_uninstall_not_installed_raises(tmp_path):
+    with pytest.raises(NotInstalledError):
+        uninstall("demo", install_root=tmp_path)
+
+
+def test_uninstall_removes_agent(tmp_path):
+    manifest = _manifest()
+    install(
+        "demo",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_make_fetcher(manifest),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+    )
+    assert (tmp_path / "demo").exists()
+    uninstall("demo", install_root=tmp_path)
+    assert not (tmp_path / "demo").exists()
+    assert read_sentinel("demo", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# C++ artifact extraction
+# ---------------------------------------------------------------------------
+
+
+def test_install_cpp_artifact_extracted(tmp_path):
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("bin/demo", "binary")
+    archive = buf.getvalue()
+    sha = hashlib.sha256(archive).hexdigest()
+    path = "agents/native/1.0.0/native.zip"
+    manifest = {
+        "id": "native",
+        "language": "cpp",
+        "latest_version": "1.0.0",
+        "requirements": {"platforms": []},
+        "versions": {
+            "1.0.0": {
+                "version": "1.0.0",
+                "artifact": {
+                    "filename": "native.zip",
+                    "path": path,
+                    "size_bytes": len(archive),
+                    "sha256": sha,
+                    "content_type": "application/zip",
+                },
+            }
+        },
+    }
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: native\n"
+        if url == f"{BASE}/{path}":
+            return archive
+        raise AssertionError(url)
+
+    result = install(
+        "native",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=fetcher,
+        install_root=tmp_path,
+    )
+    assert result.language == "cpp"
+    assert (tmp_path / "native" / "bin" / "demo").exists()
+    # Native agents do not hot-register in-process.
+    assert result.hot_registered is False

--- a/tests/unit/test_hub_router.py
+++ b/tests/unit/test_hub_router.py
@@ -1,0 +1,183 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the Agent Hub HTTP router (gaia.ui.routers.hub)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gaia.agents.registry import AgentRegistry
+from gaia.hub import catalog as catalog_mod
+from gaia.hub import installer as installer_mod
+from gaia.hub.catalog import UnifiedCatalog
+from gaia.hub.installer import InstalledAgent, InstallError, NotInstalledError
+from gaia.ui.routers import hub as hub_router
+from gaia.ui.server import create_app
+
+UI = {"X-Gaia-UI": "1"}
+
+
+@pytest.fixture
+def app():
+    app = create_app(db_path=":memory:")
+    app.state.agent_registry = MagicMock(spec=AgentRegistry)
+    # Bypass the localhost guard (TestClient host is "testclient").
+    app.dependency_overrides[hub_router._require_localhost] = lambda: None
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    installer_mod.clear_progress()
+    installer_mod._IN_PROGRESS.clear()  # noqa: SLF001
+    yield
+    installer_mod.clear_progress()
+    installer_mod._IN_PROGRESS.clear()  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_returns_merged_list(client, monkeypatch):
+    fake = UnifiedCatalog(
+        agents=[{"id": "demo", "status": "available"}],
+        offline=False,
+        generated_at="2026-06-03T00:00:00Z",
+    )
+    monkeypatch.setattr(catalog_mod, "build_catalog", lambda *a, **k: fake)
+    resp = client.get("/api/agents/catalog")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["agents"][0]["id"] == "demo"
+    assert body["offline"] is False
+
+
+def test_catalog_not_swallowed_by_agents_route(client, monkeypatch):
+    # Regression guard: /api/agents/catalog must hit the hub router, not the
+    # greedy GET /api/agents/{agent_id:path} in routers/agents.py.
+    monkeypatch.setattr(
+        catalog_mod,
+        "build_catalog",
+        lambda *a, **k: UnifiedCatalog(agents=[], offline=False),
+    )
+    resp = client.get("/api/agents/catalog")
+    assert resp.status_code == 200
+
+
+def test_catalog_offline_503_when_no_cache(client, monkeypatch):
+    def boom(*a, **k):
+        raise catalog_mod.CatalogError("no network and no cache")
+
+    monkeypatch.setattr(catalog_mod, "build_catalog", boom)
+    resp = client.get("/api/agents/catalog")
+    assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Install + status
+# ---------------------------------------------------------------------------
+
+
+def test_install_returns_202_and_schedules(client, monkeypatch):
+    called = {}
+
+    def fake_install(agent_id, **kwargs):
+        called["id"] = agent_id
+
+    monkeypatch.setattr(installer_mod, "install", fake_install)
+    resp = client.post("/api/agents/install", json={"id": "demo"}, headers=UI)
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "queued"
+    # BackgroundTasks run after the response in TestClient.
+    assert called.get("id") == "demo"
+
+
+def test_install_duplicate_returns_409(client, monkeypatch):
+    monkeypatch.setattr(installer_mod, "is_installing", lambda _id: True)
+    resp = client.post("/api/agents/install", json={"id": "demo"}, headers=UI)
+    assert resp.status_code == 409
+
+
+def test_install_requires_ui_header(client):
+    resp = client.post("/api/agents/install", json={"id": "demo"})
+    assert resp.status_code == 403
+
+
+def test_install_status_polling(client):
+    installer_mod._set_progress(  # noqa: SLF001
+        "demo", status="running", phase="downloading", percent=30
+    )
+    resp = client.get("/api/agents/demo/install-status")
+    assert resp.status_code == 200
+    assert resp.json()["phase"] == "downloading"
+
+
+def test_install_status_unknown_404(client):
+    resp = client.get("/api/agents/nope/install-status")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_success(client, monkeypatch):
+    monkeypatch.setattr(installer_mod, "uninstall", lambda *a, **k: None)
+    resp = client.delete("/api/agents/demo", headers=UI)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "uninstalled"
+
+
+def test_uninstall_builtin_refused(client):
+    # Real uninstall refuses builtins -> 400 (no mock needed).
+    resp = client.delete("/api/agents/chat", headers=UI)
+    assert resp.status_code == 400
+
+
+def test_uninstall_not_installed_404(client, monkeypatch):
+    def boom(*a, **k):
+        raise NotInstalledError("not installed")
+
+    monkeypatch.setattr(installer_mod, "uninstall", boom)
+    resp = client.delete("/api/agents/demo", headers=UI)
+    assert resp.status_code == 404
+
+
+def test_uninstall_requires_ui_header(client):
+    resp = client.delete("/api/agents/demo")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Rollback
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_success(client, monkeypatch):
+    restored = InstalledAgent(
+        id="demo", version="1.0.0", language="python", installed_at="now"
+    )
+    monkeypatch.setattr(installer_mod, "rollback", lambda *a, **k: restored)
+    resp = client.post("/api/agents/demo/rollback", headers=UI)
+    assert resp.status_code == 200
+    assert resp.json()["version"] == "1.0.0"
+
+
+def test_rollback_no_backup_400(client, monkeypatch):
+    def boom(*a, **k):
+        raise InstallError("no backup")
+
+    monkeypatch.setattr(installer_mod, "rollback", boom)
+    resp = client.post("/api/agents/demo/rollback", headers=UI)
+    assert resp.status_code == 400


### PR DESCRIPTION
## Why this matters

The Agent Hub had a publish path (R2 Worker, #1095) and a package format (#1093), but a running GAIA still had no way to *consume* it — no discovery, no install, no removal. This PR adds the backend lifecycle behind the Agent UI's discover panel: list community agents, install one with a checksum-verified download, watch its progress, uninstall it, and roll back a bad update. Everything is local-first — the hub origin is configurable via `GAIA_HUB_URL` and all I/O is injectable so nothing needs the live R2 bucket to be tested.

Closes part of #1096 (Phase 4A–4D). Spec: [`docs/spec/agent-hub-restructure.mdx`](docs/spec/agent-hub-restructure.mdx).

### What's here
- **`src/gaia/hub/catalog.py`** — fetches `index.json` (5-min TTL + offline fallback to `~/.gaia/catalog-cache.json`, flagged `offline=true`), merges with the live registry into a unified list with `installed` / `available` / `update_available` status.
- **`src/gaia/hub/compatibility.py`** — platform / RAM / disk / NPU / GPU checker that separates hard **blockers** (wrong platform, insufficient disk) from advisory **warnings** (below recommended RAM, unverifiable NPU).
- **`src/gaia/hub/installer.py`** — download + SHA-256 verify *before* writing, `uv pip install --target` (Python) / archive extract (C++), `.installed` sentinel, pre-update backup snapshot for rollback, one-install-per-id concurrency guard, hot-register into the live registry.
- **`src/gaia/ui/routers/hub.py`** — `GET /api/agents/catalog`, `POST /api/agents/install`, `GET /api/agents/{id}/install-status`, `DELETE /api/agents/{id}`, `POST /api/agents/{id}/rollback`. Registered **before** the agents router so its greedy `GET /api/agents/{id:path}` can't swallow `/catalog`.
- Minimal edits: a public `registry.discover_installed_agents()` hot-reload hook + the router registration in `server.py`.

Fail-loudly throughout: a checksum mismatch installs nothing; a hard blocker raises before any download; a duplicate install returns 409; no-network-no-cache raises rather than returning an empty catalog.

## Test plan
- [x] `PYTHONPATH=src python -m pytest tests/unit/test_hub_*.py -q` → 119 passed (44 new + existing manifest suite)
- [x] `tests/unit/chat/ui/test_agents_router.py` still green (route-ordering regression guard)
- [x] `python util/lint.py --pylint --black --isort --fix` → black/isort PASS; pylint clean on all new files (the one reported error is pre-existing in `lemonade_installer.py`, unrelated)
- New tests cover: catalog merge + status, offline fallback, no-cache error; compatibility pass/warn/block; install happy path + checksum mismatch + disk-space block + 409 concurrency; uninstall refuses builtins; update→rollback restores the prior version.