### PR TITLE
feat(agents): example reference agents for the Agent Hub (#546)

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -12,10 +12,27 @@ hub/
 └── README.md
 ```
 
+## New here? Start with the examples
+
+Minimal, heavily-commented reference agents live under
+[`agents/python/`](agents/python/) and are built to be copy-pasted as the
+starting point for your own agent:
+
+- [`hello-world/`](agents/python/hello-world/) — the smallest possible agent (no tools)
+- [`word-count/`](agents/python/word-count/) — registering a tool with `@tool`
+- [`doc-search/`](agents/python/doc-search/) — composing the framework `RAGToolsMixin`
+
+See [agents/python/README.md](agents/python/README.md) for the package format and a
+guided reading order.
+
 ## Creating a new agent
 
 ```bash
 gaia agent init my-agent --language python
 ```
 
-See [docs/plans/agent-hub-ui.mdx](../docs/plans/agent-hub-ui.mdx) for the full Agent Hub platform plan.
+…or copy one of the examples above. See
+[docs/plans/agent-hub-ui.mdx](../docs/plans/agent-hub-ui.mdx) for the full Agent
+Hub platform plan and
+[docs/spec/agent-hub-restructure.mdx](../docs/spec/agent-hub-restructure.mdx)
+for the package format.

--- a/hub/agents/python/README.md
+++ b/hub/agents/python/README.md
@@ -1,0 +1,56 @@
+# Python Agents
+
+Standalone Python agent packages for the GAIA Agent Hub. Each is a wheel that
+depends on the published `amd-gaia` framework — third-party contributors follow
+the exact same pattern AMD uses for its own agents.
+
+## New here? Start with the examples
+
+These reference agents are intentionally minimal, heavily commented, and built
+to be **copy-pasted** as the starting point for your own agent. Read them in
+order — each adds one concept:
+
+| Example | Teaches | Tools |
+|---------|---------|-------|
+| [`hello-world/`](hello-world/) | The smallest possible agent: subclass `Agent`, set a system prompt. | 0 |
+| [`word-count/`](word-count/) | Registering a tool with the `@tool` decorator. | 1 |
+| [`doc-search/`](doc-search/) | Composing a framework mixin (`RAGToolsMixin`) for document Q&A. | 10 |
+
+Each example's `README.md` explains the pattern; its `tests/` suite mocks the
+LLM so it runs with no Lemonade server.
+
+## Package layout
+
+Every agent package has the same shape (see any example above):
+
+```
+<id>/
+├── gaia-agent.yaml          # Hub manifest (id, category, models, interfaces)
+├── pyproject.toml           # gaia-agent-<id>, amd-gaia dep, gaia.agent entry point
+├── gaia_agent_<id>/
+│   ├── __init__.py          # build_registration() — advertises the agent
+│   └── agent.py             # the Agent subclass
+├── tests/
+│   └── test_<id>.py         # unit tests (LLM mocked; unique basename per package)
+└── README.md
+```
+
+## Install an agent for development
+
+```bash
+pip install -e hub/agents/python/<id>/          # registers via entry points
+pytest hub/agents/python/<id>/tests/ -x
+```
+
+The GAIA registry discovers installed agents automatically through the
+`gaia.agent` entry-point group — no hardcoded list.
+
+## Build your own
+
+```bash
+gaia agent init my-agent --language python
+```
+
+…or copy `hello-world/`, rename the package + class, and edit the prompt. See
+[docs/guides/custom-agent.mdx](../../../docs/guides/custom-agent.mdx) and the
+[Agent Hub restructure spec](../../../docs/spec/agent-hub-restructure.mdx).

--- a/hub/agents/python/doc-search/README.md
+++ b/hub/agents/python/doc-search/README.md
@@ -1,0 +1,60 @@
+# gaia-agent-doc-search
+
+A RAG (retrieval-augmented generation) agent built by **composing a framework
+tool mixin**. It inherits `RAGToolsMixin` to get a full set of document tools —
+index, query, list, summarize — for free, then answers questions over the
+user's documents.
+
+This is a *reference example* (`category: examples`,
+`security_tier: experimental`).
+
+## What it teaches
+
+`gaia_agent_doc_search/agent.py` demonstrates the most powerful pattern in
+GAIA: **you rarely write retrieval code yourself — you compose a mixin.**
+
+1. **Inherit the mixin:** `class DocSearchAgent(Agent, RAGToolsMixin):`.
+2. **Give the mixin its dependency:** `RAGToolsMixin` reads `self.rag`, so build
+   a `RAGSDK` in `__init__` before `super().__init__()`.
+3. **Activate the tools:** call `self.register_rag_tools()` in
+   `_register_tools()`.
+4. **Prompt the model** on how to use index/query/cite.
+
+The other framework mixins (file_io, shell, browser, scratchpad, …) follow the
+identical shape — see `KNOWN_TOOLS` in `gaia.agents.registry`.
+
+## Install
+
+```bash
+pip install -e hub/agents/python/doc-search   # editable, for development
+```
+
+Installing registers the `doc-search` agent via the `gaia.agent` entry-point
+group; the GAIA registry discovers it automatically.
+
+## Use
+
+```python
+from gaia.agents.registry import AgentRegistry
+
+registry = AgentRegistry()
+registry.discover()
+agent = registry.create_agent("doc-search")
+```
+
+## Develop / test
+
+```bash
+pip install -e "hub/agents/python/doc-search/[test]"
+pytest hub/agents/python/doc-search/tests/ -x
+```
+
+The tests mock the LLM **and** the RAG SDK, so they need no running Lemonade
+server and no embedding model.
+
+## Make your own
+
+Copy this directory and swap `RAGToolsMixin` for whichever framework mixin you
+need (or add several). See [docs/sdk/sdks/rag.mdx](../../../../docs/sdk/sdks/rag.mdx)
+for the RAG SDK and [docs/guides/custom-agent.mdx](../../../../docs/guides/custom-agent.mdx)
+for the full agent guide.

--- a/hub/agents/python/doc-search/gaia-agent.yaml
+++ b/hub/agents/python/doc-search/gaia-agent.yaml
@@ -1,0 +1,33 @@
+id: doc-search
+name: Doc Search
+version: 0.1.0
+description: "RAG reference agent — composes the framework RAGToolsMixin for document Q&A"
+author: AMD
+license: MIT
+
+category: examples
+security_tier: experimental
+tags: [example, reference, rag, documents, starter]
+icon: file-search
+tools_count: 10
+
+language: python
+min_gaia_version: "0.20.0"
+models: [Qwen3.5-35B-A3B-GGUF]
+
+python:
+  entry_module: gaia_agent_doc_search
+  entry_class: DocSearchAgent
+  dependencies:
+    - "amd-gaia>=0.20.0"
+
+requirements:
+  min_memory_gb: 8
+  platforms: [win-x64, linux-x64, darwin-arm64]
+
+interfaces:
+  tui: true
+  cli: true
+  pipe: true
+  api_server: true
+  mcp_server: true

--- a/hub/agents/python/doc-search/gaia_agent_doc_search/__init__.py
+++ b/hub/agents/python/doc-search/gaia_agent_doc_search/__init__.py
@@ -1,0 +1,64 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GAIA Doc Search agent — standalone hub package (reference example).
+
+A RAG agent built by *composing a framework tool mixin*: it inherits
+``RAGToolsMixin`` to get document indexing and retrieval tools for free. Use it
+as a copy-paste starting point for an agent that answers questions over the
+user's documents.
+
+Installing this package registers the ``doc-search`` agent in the GAIA registry
+via the ``gaia.agent`` entry-point group (see ``pyproject.toml``). The
+framework's ``AgentRegistry._discover_installed_agents`` calls
+:func:`build_registration` at discovery time; the agent module itself is
+imported lazily inside the factory so discovery stays cheap.
+"""
+
+# ``DocSearchAgent`` is re-exported lazily via ``__getattr__`` (below) so
+# importing this package at registry-discovery time does not pull in the agent
+# module; it is therefore intentionally absent from ``__all__``.
+__all__ = ["build_registration"]
+
+__version__ = "0.1.0"
+
+
+def __getattr__(name):
+    # Lazy re-export so ``import gaia_agent_doc_search`` (e.g. at registry
+    # discovery) does not pull in the agent module + its SDK deps.
+    if name == "DocSearchAgent":
+        from gaia_agent_doc_search.agent import DocSearchAgent
+
+        return DocSearchAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def build_registration():
+    """Return the :class:`AgentRegistration` for the doc-search agent."""
+    from gaia.agents.registry import AgentRegistration, class_factory
+
+    def factory(**kwargs):
+        from gaia_agent_doc_search.agent import DocSearchAgent
+
+        return class_factory(DocSearchAgent)(**kwargs)
+
+    return AgentRegistration(
+        id="doc-search",
+        name="Doc Search",
+        description=(
+            "RAG reference agent — composes the framework RAGToolsMixin for "
+            "document Q&A"
+        ),
+        source="installed",
+        conversation_starters=[
+            "Index the documents in ./docs and tell me what they cover",
+            "What does my report say about Q3 revenue?",
+        ],
+        factory=factory,
+        agent_dir=None,
+        models=["Qwen3.5-35B-A3B-GGUF"],
+        namespaced_agent_id="installed:doc-search",
+        category="examples",
+        tags=["example", "reference", "rag", "documents", "starter"],
+        icon="file-search",
+        tools_count=10,
+    )

--- a/hub/agents/python/doc-search/gaia_agent_doc_search/agent.py
+++ b/hub/agents/python/doc-search/gaia_agent_doc_search/agent.py
@@ -1,0 +1,80 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""DocSearchAgent — a RAG agent built by composing a framework tool mixin.
+
+This is a *reference example* that shows the most powerful pattern in GAIA:
+**you rarely write retrieval code yourself — you compose a mixin.** By
+inheriting :class:`gaia.agents.tools.RAGToolsMixin`, this agent gets a full set
+of document tools (index, query, list, summarize, …) for free.
+
+The pattern
+-----------
+1. Inherit ``Agent`` and the mixin(s) you want:
+   ``class DocSearchAgent(Agent, RAGToolsMixin):``
+2. Give the mixin the dependency it expects. ``RAGToolsMixin`` reads
+   ``self.rag``, so construct a :class:`gaia.rag.sdk.RAGSDK` in ``__init__``
+   *before* calling ``super().__init__()``.
+3. Activate the mixin's tools in ``_register_tools()`` by calling its
+   registration hook (``self.register_rag_tools()``).
+4. Write a system prompt that tells the model how to use those tools.
+
+Other framework mixins follow the same shape — see ``KNOWN_TOOLS`` in
+``gaia.agents.registry`` for the full list (file_io, shell, browser, …).
+"""
+
+from typing import Optional
+
+from gaia.agents.base import Agent
+from gaia.agents.tools import RAGToolsMixin
+
+_SYSTEM_PROMPT = """\
+You are GAIA's Doc Search agent. You answer questions using the user's own
+documents, retrieved with RAG (retrieval-augmented generation).
+
+How to work:
+- If the user points you at files or a directory, index them first
+  (index_document / index_directory).
+- To answer a question, call query_documents to retrieve the most relevant
+  chunks, then answer ONLY from what you retrieved.
+- Always cite the source file(s) you used. If retrieval returns nothing
+  relevant, say so — never invent an answer.
+- Use list_indexed_documents and rag_status when the user asks what you know.
+"""
+
+
+class DocSearchAgent(Agent, RAGToolsMixin):
+    """A document-Q&A agent composed from the framework ``RAGToolsMixin``."""
+
+    AGENT_ID = "doc-search"
+    AGENT_NAME = "Doc Search"
+    AGENT_DESCRIPTION = (
+        "RAG reference agent — composes the framework RAGToolsMixin for " "document Q&A"
+    )
+    CONVERSATION_STARTERS = [
+        "Index the documents in ./docs and tell me what they cover",
+        "What does my report say about Q3 revenue?",
+    ]
+
+    # RAG benefits from a stronger model than the trivial examples.
+    DEFAULT_MODEL = "Qwen3.5-35B-A3B-GGUF"
+
+    def __init__(self, model_id: Optional[str] = None, **kwargs):
+        from gaia.rag.sdk import RAGSDK, RAGConfig
+
+        model = model_id or self.DEFAULT_MODEL
+        # RAGToolsMixin reads ``self.rag`` — wire it up before super().__init__()
+        # so the tools have their dependency when _register_tools() runs.
+        self.rag = RAGSDK(RAGConfig(model=model))
+
+        self.response_mode = "conversational"
+        super().__init__(model_id=model, **kwargs)
+
+    def _get_system_prompt(self) -> str:
+        return _SYSTEM_PROMPT
+
+    def _register_tools(self) -> None:
+        # The mixin registers all RAG tools; we just turn them on.
+        self.register_rag_tools()
+        # Freeze this agent's tools so they don't leak into other agents
+        # running in the same process.
+        self._snapshot_tools()

--- a/hub/agents/python/doc-search/pyproject.toml
+++ b/hub/agents/python/doc-search/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaia-agent-doc-search"
+version = "0.1.0"
+description = "GAIA Doc Search agent — RAG reference implementation"
+authors = [{ name = "AMD" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = ["amd-gaia>=0.20.0"]
+
+[project.entry-points."gaia.agent"]
+doc-search = "gaia_agent_doc_search:build_registration"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.setuptools.packages.find]
+include = ["gaia_agent_doc_search*"]

--- a/hub/agents/python/doc-search/tests/test_doc_search.py
+++ b/hub/agents/python/doc-search/tests/test_doc_search.py
@@ -1,0 +1,43 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the Doc Search reference agent.
+
+These tests mock the LLM and the RAG SDK, so they run with no live Lemonade
+server and no embedding model. They verify the composition pattern: the agent
+inherits the framework ``RAGToolsMixin`` and activates its tools.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import gaia_agent_doc_search
+from gaia_agent_doc_search.agent import DocSearchAgent
+
+from gaia.agents.tools import RAGToolsMixin
+
+
+def test_build_registration_metadata():
+    reg = gaia_agent_doc_search.build_registration()
+    assert reg.id == "doc-search"
+    assert reg.category == "examples"
+    assert reg.tools_count == 10
+    assert reg.namespaced_agent_id == "installed:doc-search"
+    assert reg.models == ["Qwen3.5-35B-A3B-GGUF"]
+
+
+def test_agent_composes_rag_mixin():
+    """The example's whole point: it inherits the framework RAG mixin."""
+    assert issubclass(DocSearchAgent, RAGToolsMixin)
+
+
+def test_rag_tools_register():
+    """Constructing the agent (LLM + RAG mocked) registers RAG tools."""
+    with (
+        patch("gaia.rag.sdk.RAGSDK", return_value=MagicMock()),
+        patch("gaia.agents.base.agent.AgentSDK", return_value=MagicMock()),
+    ):
+        agent = DocSearchAgent(skip_lemonade=True)
+
+    # The mixin contributes a recognizable retrieval tool.
+    assert "query_documents" in agent._tools_registry
+    assert "index_document" in agent._tools_registry
+    assert "query_documents" in agent.system_prompt

--- a/hub/agents/python/hello-world/README.md
+++ b/hub/agents/python/hello-world/README.md
@@ -1,0 +1,55 @@
+# gaia-agent-hello-world
+
+The **smallest possible GAIA agent** — a conversational agent with a system
+prompt and no tools. Use it as a copy-paste starting point for your own
+conversational agent.
+
+This is a *reference example* (`category: examples`,
+`security_tier: experimental`). It is intentionally minimal.
+
+## What it teaches
+
+`gaia_agent_hello_world/agent.py` shows the four things every GAIA agent needs:
+
+1. Subclass `gaia.agents.base.Agent`.
+2. Set `response_mode = "conversational"` before `super().__init__()` so the
+   agent replies in plain text (not the planning JSON envelope).
+3. Implement `_get_system_prompt()` to give the agent its behavior.
+4. Implement `_register_tools()` — empty here, because a prompt alone is useful.
+
+`gaia_agent_hello_world/__init__.py` shows how the package advertises itself to
+the GAIA registry through the `gaia.agent` entry point via `build_registration()`.
+
+## Install
+
+```bash
+pip install -e hub/agents/python/hello-world   # editable, for development
+```
+
+Installing registers the `hello-world` agent via the `gaia.agent` entry-point
+group; the GAIA registry discovers it automatically.
+
+## Use
+
+```python
+from gaia.agents.registry import AgentRegistry
+
+registry = AgentRegistry()
+registry.discover()
+agent = registry.create_agent("hello-world")
+```
+
+## Develop / test
+
+```bash
+pip install -e "hub/agents/python/hello-world/[test]"
+pytest hub/agents/python/hello-world/tests/ -x
+```
+
+The tests mock the LLM and need no running Lemonade server.
+
+## Make your own
+
+Copy this directory, rename `gaia_agent_hello_world` → `gaia_agent_<your_id>`,
+update `pyproject.toml`, `gaia-agent.yaml`, and the class name, then edit
+`_SYSTEM_PROMPT`. See [docs/guides/custom-agent.mdx](../../../../docs/guides/custom-agent.mdx).

--- a/hub/agents/python/hello-world/gaia-agent.yaml
+++ b/hub/agents/python/hello-world/gaia-agent.yaml
@@ -1,0 +1,33 @@
+id: hello-world
+name: Hello World
+version: 0.1.0
+description: "Minimal conversational reference agent — the smallest possible GAIA agent"
+author: AMD
+license: MIT
+
+category: examples
+security_tier: experimental
+tags: [example, reference, conversation, starter]
+icon: sparkles
+tools_count: 0
+
+language: python
+min_gaia_version: "0.20.0"
+models: [Gemma-4-E4B-it-GGUF]
+
+python:
+  entry_module: gaia_agent_hello_world
+  entry_class: HelloWorldAgent
+  dependencies:
+    - "amd-gaia>=0.20.0"
+
+requirements:
+  min_memory_gb: 5
+  platforms: [win-x64, linux-x64, darwin-arm64]
+
+interfaces:
+  tui: true
+  cli: true
+  pipe: true
+  api_server: true
+  mcp_server: true

--- a/hub/agents/python/hello-world/gaia_agent_hello_world/__init__.py
+++ b/hub/agents/python/hello-world/gaia_agent_hello_world/__init__.py
@@ -1,0 +1,62 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GAIA Hello World agent — standalone hub package (reference example).
+
+The smallest possible GAIA agent: a system prompt and nothing else. Use it as
+a copy-paste starting point for a new conversational agent.
+
+Installing this package registers the ``hello-world`` agent in the GAIA
+registry via the ``gaia.agent`` entry-point group (see ``pyproject.toml``).
+The framework's ``AgentRegistry._discover_installed_agents`` calls
+:func:`build_registration` at discovery time; the agent module itself is
+imported lazily inside the factory so discovery stays cheap.
+"""
+
+# ``HelloWorldAgent`` is re-exported lazily via ``__getattr__`` (below) so
+# importing this package at registry-discovery time does not pull in the heavy
+# agent module; it is therefore intentionally absent from ``__all__``.
+__all__ = ["build_registration"]
+
+__version__ = "0.1.0"
+
+
+def __getattr__(name):
+    # Lazy re-export so ``import gaia_agent_hello_world`` (e.g. at registry
+    # discovery) does not pull in the agent module + its SDK deps.
+    if name == "HelloWorldAgent":
+        from gaia_agent_hello_world.agent import HelloWorldAgent
+
+        return HelloWorldAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def build_registration():
+    """Return the :class:`AgentRegistration` for the hello-world agent."""
+    from gaia.agents.registry import AgentRegistration, class_factory
+
+    def factory(**kwargs):
+        from gaia_agent_hello_world.agent import HelloWorldAgent
+
+        return class_factory(HelloWorldAgent)(**kwargs)
+
+    return AgentRegistration(
+        id="hello-world",
+        name="Hello World",
+        description=(
+            "Minimal conversational reference agent — the smallest possible "
+            "GAIA agent"
+        ),
+        source="installed",
+        conversation_starters=[
+            "Say hello",
+            "What can a GAIA agent do?",
+        ],
+        factory=factory,
+        agent_dir=None,
+        models=["Gemma-4-E4B-it-GGUF"],
+        namespaced_agent_id="installed:hello-world",
+        category="examples",
+        tags=["example", "reference", "conversation", "starter"],
+        icon="sparkles",
+        tools_count=0,
+    )

--- a/hub/agents/python/hello-world/gaia_agent_hello_world/agent.py
+++ b/hub/agents/python/hello-world/gaia_agent_hello_world/agent.py
@@ -1,0 +1,72 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""HelloWorldAgent — the smallest possible GAIA agent.
+
+This is a *reference example*: a conversational agent with a system prompt and
+no tools. It exists to show the minimum needed to build a GAIA agent that
+plugs into the registry, the CLI, the Agent UI, and the generic REST/MCP
+server.
+
+Anatomy of a GAIA agent
+-----------------------
+1. Subclass :class:`gaia.agents.base.Agent`.
+2. Set ``response_mode = "conversational"`` *before* ``super().__init__()`` so
+   the agent replies in plain text instead of the planning JSON envelope.
+3. Forward constructor kwargs to ``super().__init__()`` — the registry/UI host
+   injects things like ``model_id`` and ``base_url`` here.
+4. Implement :meth:`_get_system_prompt` to give the agent its personality.
+5. Implement :meth:`_register_tools` — empty for a no-tool agent.
+
+To make your own conversational agent, copy this file, rename the class, and
+edit ``_SYSTEM_PROMPT``.
+"""
+
+from typing import Optional
+
+from gaia.agents.base import Agent
+
+# The system prompt is the agent's entire behavior here. Keep it focused — a
+# good prompt describes the role, the tone, and any hard rules.
+_SYSTEM_PROMPT = """\
+You are GAIA's Hello World agent — a friendly greeter that demonstrates the
+smallest possible GAIA agent.
+
+Behavior:
+- Greet the user warmly and answer their question in 1-3 short sentences.
+- If asked what you are, explain that you are a minimal reference agent with
+  no tools, meant as a starting point for building new GAIA agents.
+- Keep replies concise and plain-spoken. Never invent capabilities you don't
+  have (you have no tools).
+"""
+
+
+class HelloWorldAgent(Agent):
+    """Minimal conversational agent with a system prompt and no tools."""
+
+    # Hub-display metadata (read by the registry when this class is the
+    # entry point target). The package's ``build_registration`` mirrors these.
+    AGENT_ID = "hello-world"
+    AGENT_NAME = "Hello World"
+    AGENT_DESCRIPTION = (
+        "Minimal conversational reference agent — the smallest possible " "GAIA agent"
+    )
+    CONVERSATION_STARTERS = [
+        "Say hello",
+        "What can a GAIA agent do?",
+    ]
+
+    # A small, fast default keeps the example responsive on modest hardware.
+    DEFAULT_MODEL = "Gemma-4-E4B-it-GGUF"
+
+    def __init__(self, model_id: Optional[str] = None, **kwargs):
+        # "conversational" must be set before super().__init__() so the base
+        # class composes a plain-text response format instead of the planning
+        # JSON envelope.
+        self.response_mode = "conversational"
+        super().__init__(model_id=model_id or self.DEFAULT_MODEL, **kwargs)
+
+    def _get_system_prompt(self) -> str:
+        return _SYSTEM_PROMPT
+
+    def _register_tools(self) -> None:
+        """No tools. A conversational agent can be useful with a prompt alone."""

--- a/hub/agents/python/hello-world/pyproject.toml
+++ b/hub/agents/python/hello-world/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaia-agent-hello-world"
+version = "0.1.0"
+description = "GAIA Hello World agent — minimal conversational reference implementation"
+authors = [{ name = "AMD" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = ["amd-gaia>=0.20.0"]
+
+[project.entry-points."gaia.agent"]
+hello-world = "gaia_agent_hello_world:build_registration"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.setuptools.packages.find]
+include = ["gaia_agent_hello_world*"]

--- a/hub/agents/python/hello-world/tests/test_hello_world.py
+++ b/hub/agents/python/hello-world/tests/test_hello_world.py
@@ -1,0 +1,62 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the Hello World reference agent.
+
+These tests mock the LLM and never contact a live Lemonade server, so they run
+anywhere ``amd-gaia`` is importable. They show the recommended pattern for
+testing a GAIA agent:
+
+- ``build_registration()`` metadata is pure data — assert it directly.
+- The agent class is constructed with the LLM client patched out and
+  ``skip_lemonade=True`` so no server is required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import gaia_agent_hello_world
+from gaia_agent_hello_world.agent import HelloWorldAgent
+
+
+def test_build_registration_metadata():
+    """The entry-point registration advertises the agent to the registry."""
+    reg = gaia_agent_hello_world.build_registration()
+
+    assert reg.id == "hello-world"
+    assert reg.name == "Hello World"
+    assert reg.category == "examples"
+    assert reg.tools_count == 0
+    assert reg.namespaced_agent_id == "installed:hello-world"
+    assert reg.models == ["Gemma-4-E4B-it-GGUF"]
+    assert reg.conversation_starters  # non-empty
+
+
+def test_factory_creates_agent_instance():
+    """The registration factory builds a real HelloWorldAgent."""
+    reg = gaia_agent_hello_world.build_registration()
+
+    with patch("gaia.agents.base.agent.AgentSDK", return_value=MagicMock()):
+        agent = reg.factory(skip_lemonade=True)
+
+    assert isinstance(agent, HelloWorldAgent)
+
+
+def test_system_prompt_and_no_tools():
+    """A no-tool conversational agent exposes its prompt and registers nothing."""
+    # The tool registry is a process-global dict; clear it so this assertion
+    # doesn't depend on which other agents were imported first in the session.
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    _TOOL_REGISTRY.clear()
+
+    with patch("gaia.agents.base.agent.AgentSDK", return_value=MagicMock()):
+        agent = HelloWorldAgent(skip_lemonade=True)
+
+    assert "Hello World agent" in agent.system_prompt
+    assert agent.response_mode == "conversational"
+    # No tools registered for this minimal example.
+    assert agent._tools_registry == {}
+
+
+def test_lazy_class_export():
+    """The class is importable via the package's lazy ``__getattr__``."""
+    assert gaia_agent_hello_world.HelloWorldAgent is HelloWorldAgent

--- a/hub/agents/python/word-count/README.md
+++ b/hub/agents/python/word-count/README.md
@@ -1,0 +1,55 @@
+# gaia-agent-word-count
+
+A GAIA agent with **exactly one tool**. It shows the tool pattern end-to-end:
+the LLM reads the request, decides to call `count_text`, the framework runs the
+Python function, and the LLM turns the result into a natural-language answer.
+
+This is a *reference example* (`category: examples`,
+`security_tier: experimental`).
+
+## What it teaches
+
+`gaia_agent_word_count/agent.py` demonstrates:
+
+1. **Registering a tool** with the `@tool` decorator inside `_register_tools()`.
+2. **The docstring is the schema** — the framework parses the wrapper's
+   docstring + signature to tell the model what the tool does.
+3. **Keep logic in a pure function** (`count_text_stats`) so it's unit-testable
+   without an LLM, with the `@tool` wrapper a thin adapter over it.
+4. **`self._snapshot_tools()`** at the end of `_register_tools()` isolates this
+   agent's tools from other agents in the same process.
+
+## Install
+
+```bash
+pip install -e hub/agents/python/word-count   # editable, for development
+```
+
+Installing registers the `word-count` agent via the `gaia.agent` entry-point
+group; the GAIA registry discovers it automatically.
+
+## Use
+
+```python
+from gaia.agents.registry import AgentRegistry
+
+registry = AgentRegistry()
+registry.discover()
+agent = registry.create_agent("word-count")
+```
+
+## Develop / test
+
+```bash
+pip install -e "hub/agents/python/word-count/[test]"
+pytest hub/agents/python/word-count/tests/ -x
+```
+
+The tests mock the LLM and need no running Lemonade server.
+
+## Make your own
+
+Copy this directory, rename the package and class, then replace `count_text`
+with your own `@tool` function. See
+[docs/sdk/core/tools.mdx](../../../../docs/sdk/core/tools.mdx) for the full
+tool reference.

--- a/hub/agents/python/word-count/gaia-agent.yaml
+++ b/hub/agents/python/word-count/gaia-agent.yaml
@@ -1,0 +1,33 @@
+id: word-count
+name: Word Count
+version: 0.1.0
+description: "Single-tool reference agent — demonstrates the @tool decorator"
+author: AMD
+license: MIT
+
+category: examples
+security_tier: experimental
+tags: [example, reference, tools, starter]
+icon: calculator
+tools_count: 1
+
+language: python
+min_gaia_version: "0.20.0"
+models: [Gemma-4-E4B-it-GGUF]
+
+python:
+  entry_module: gaia_agent_word_count
+  entry_class: WordCountAgent
+  dependencies:
+    - "amd-gaia>=0.20.0"
+
+requirements:
+  min_memory_gb: 5
+  platforms: [win-x64, linux-x64, darwin-arm64]
+
+interfaces:
+  tui: true
+  cli: true
+  pipe: true
+  api_server: true
+  mcp_server: true

--- a/hub/agents/python/word-count/gaia_agent_word_count/__init__.py
+++ b/hub/agents/python/word-count/gaia_agent_word_count/__init__.py
@@ -1,0 +1,60 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GAIA Word Count agent — standalone hub package (reference example).
+
+A single-tool agent: it shows how to register a tool with the ``@tool``
+decorator and let the LLM call it. Use it as a copy-paste starting point for a
+tool-using agent.
+
+Installing this package registers the ``word-count`` agent in the GAIA
+registry via the ``gaia.agent`` entry-point group (see ``pyproject.toml``).
+The framework's ``AgentRegistry._discover_installed_agents`` calls
+:func:`build_registration` at discovery time; the agent module itself is
+imported lazily inside the factory so discovery stays cheap.
+"""
+
+# ``WordCountAgent`` is re-exported lazily via ``__getattr__`` (below) so
+# importing this package at registry-discovery time does not pull in the agent
+# module; it is therefore intentionally absent from ``__all__``.
+__all__ = ["build_registration"]
+
+__version__ = "0.1.0"
+
+
+def __getattr__(name):
+    # Lazy re-export so ``import gaia_agent_word_count`` (e.g. at registry
+    # discovery) does not pull in the agent module + its SDK deps.
+    if name == "WordCountAgent":
+        from gaia_agent_word_count.agent import WordCountAgent
+
+        return WordCountAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def build_registration():
+    """Return the :class:`AgentRegistration` for the word-count agent."""
+    from gaia.agents.registry import AgentRegistration, class_factory
+
+    def factory(**kwargs):
+        from gaia_agent_word_count.agent import WordCountAgent
+
+        return class_factory(WordCountAgent)(**kwargs)
+
+    return AgentRegistration(
+        id="word-count",
+        name="Word Count",
+        description="Single-tool reference agent — demonstrates the @tool decorator",
+        source="installed",
+        conversation_starters=[
+            "Count the words in: the quick brown fox",
+            "How many sentences are in this paragraph?",
+        ],
+        factory=factory,
+        agent_dir=None,
+        models=["Gemma-4-E4B-it-GGUF"],
+        namespaced_agent_id="installed:word-count",
+        category="examples",
+        tags=["example", "reference", "tools", "starter"],
+        icon="calculator",
+        tools_count=1,
+    )

--- a/hub/agents/python/word-count/gaia_agent_word_count/agent.py
+++ b/hub/agents/python/word-count/gaia_agent_word_count/agent.py
@@ -1,0 +1,110 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""WordCountAgent — a GAIA agent with exactly one tool.
+
+This is a *reference example* that shows the tool pattern: the LLM reads the
+user's request, decides to call ``count_text``, the framework runs the Python
+function, and the LLM turns the result into a natural-language answer.
+
+Two ideas worth copying
+-----------------------
+1. **Keep tool logic in a module-level pure function** (:func:`count_text_stats`).
+   The ``@tool``-decorated wrapper inside :meth:`WordCountAgent._register_tools`
+   just calls it and serializes the result. This keeps the logic unit-testable
+   without constructing the Agent (which needs an LLM client).
+2. **The docstring IS the tool schema.** The framework parses the wrapper's
+   docstring and signature to tell the LLM what the tool does and what
+   arguments it takes — so write it for the model, not just for humans.
+
+To add a tool to your own agent: write a pure function, add an ``@tool``
+wrapper in ``_register_tools``, mention it in the system prompt, and call
+``self._snapshot_tools()`` at the end.
+"""
+
+import json
+import re
+from typing import Dict, Optional
+
+from gaia.agents.base import Agent
+from gaia.agents.base.tools import tool
+
+_SYSTEM_PROMPT = """\
+You are GAIA's Word Count agent. You answer questions about the size of a
+piece of text the user gives you.
+
+You have one tool:
+- count_text(text) — returns word, character, sentence, and line counts for
+  the given text as JSON.
+
+Behavior:
+- When the user gives you text to measure, call count_text with that exact
+  text. Do not estimate counts yourself.
+- Report the numbers the tool returns in a short, friendly sentence.
+- If the user asks something the tool can't answer, say so plainly.
+"""
+
+
+def count_text_stats(text: str) -> Dict[str, int]:
+    """Return word/character/sentence/line counts for ``text``.
+
+    Pure function so it can be unit-tested without an LLM or the Agent class.
+
+    Args:
+        text: The text to measure.
+
+    Returns:
+        A dict with ``words``, ``characters``, ``characters_no_spaces``,
+        ``sentences``, and ``lines``.
+    """
+    text = text or ""
+    words = len(text.split())
+    # A "sentence" ends in . ! or ? — count runs of those terminators so
+    # "Wow!!!" counts once. Empty text has zero sentences.
+    sentences = len(re.findall(r"[.!?]+", text)) if text.strip() else 0
+    lines = len(text.splitlines()) if text else 0
+    return {
+        "words": words,
+        "characters": len(text),
+        "characters_no_spaces": len(re.sub(r"\s", "", text)),
+        "sentences": sentences,
+        "lines": lines,
+    }
+
+
+class WordCountAgent(Agent):
+    """A minimal tool-using agent with a single ``count_text`` tool."""
+
+    AGENT_ID = "word-count"
+    AGENT_NAME = "Word Count"
+    AGENT_DESCRIPTION = "Single-tool reference agent — demonstrates the @tool decorator"
+    CONVERSATION_STARTERS = [
+        "Count the words in: the quick brown fox",
+        "How many sentences are in this paragraph?",
+    ]
+
+    DEFAULT_MODEL = "Gemma-4-E4B-it-GGUF"
+
+    def __init__(self, model_id: Optional[str] = None, **kwargs):
+        self.response_mode = "conversational"
+        super().__init__(model_id=model_id or self.DEFAULT_MODEL, **kwargs)
+
+    def _get_system_prompt(self) -> str:
+        return _SYSTEM_PROMPT
+
+    def _register_tools(self) -> None:
+        @tool
+        def count_text(text: str) -> str:
+            """Count the words, characters, sentences, and lines in some text.
+
+            Args:
+                text: The text to measure.
+
+            Returns:
+                A JSON string with keys ``words``, ``characters``,
+                ``characters_no_spaces``, ``sentences``, and ``lines``.
+            """
+            return json.dumps(count_text_stats(text))
+
+        # Freeze this agent's tools so they don't leak into other agents
+        # running in the same process.
+        self._snapshot_tools()

--- a/hub/agents/python/word-count/pyproject.toml
+++ b/hub/agents/python/word-count/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaia-agent-word-count"
+version = "0.1.0"
+description = "GAIA Word Count agent — single-tool reference implementation"
+authors = [{ name = "AMD" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = ["amd-gaia>=0.20.0"]
+
+[project.entry-points."gaia.agent"]
+word-count = "gaia_agent_word_count:build_registration"
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[tool.setuptools.packages.find]
+include = ["gaia_agent_word_count*"]

--- a/hub/agents/python/word-count/tests/test_word_count.py
+++ b/hub/agents/python/word-count/tests/test_word_count.py
@@ -1,0 +1,58 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the Word Count reference agent.
+
+These tests mock the LLM and never contact a live Lemonade server. They show
+the two layers worth testing in a tool-using agent:
+
+- The pure tool logic (``count_text_stats``) — tested directly, no LLM.
+- The agent wiring — the tool registers and the registration metadata is right.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import gaia_agent_word_count
+from gaia_agent_word_count.agent import WordCountAgent, count_text_stats
+
+
+def test_count_text_stats_basic():
+    stats = count_text_stats("The quick brown fox.")
+    assert stats["words"] == 4
+    assert stats["sentences"] == 1
+    assert stats["characters"] == len("The quick brown fox.")
+
+
+def test_count_text_stats_multiline_and_sentences():
+    stats = count_text_stats("Hello there!\nHow are you? I'm fine.")
+    assert stats["words"] == 7
+    assert stats["sentences"] == 3  # ! ? .
+    assert stats["lines"] == 2
+
+
+def test_count_text_stats_empty():
+    stats = count_text_stats("")
+    assert stats == {
+        "words": 0,
+        "characters": 0,
+        "characters_no_spaces": 0,
+        "sentences": 0,
+        "lines": 0,
+    }
+
+
+def test_build_registration_metadata():
+    reg = gaia_agent_word_count.build_registration()
+    assert reg.id == "word-count"
+    assert reg.category == "examples"
+    assert reg.tools_count == 1
+    assert reg.namespaced_agent_id == "installed:word-count"
+
+
+def test_tool_registers_on_agent():
+    """The @tool wrapper is snapshotted onto the instance."""
+    with patch("gaia.agents.base.agent.AgentSDK", return_value=MagicMock()):
+        agent = WordCountAgent(skip_lemonade=True)
+
+    assert "count_text" in agent._tools_registry
+    # The system prompt advertises the tool to the model.
+    assert "count_text" in agent.system_prompt


### PR DESCRIPTION
## Why this matters

Third-party contributors had no minimal starting point for building a GAIA agent. The only Python package under `hub/agents/python/` was `summarize` — a full production agent that's hard to learn from. These three small, heavily-commented reference agents give newcomers copy-paste templates, each isolating exactly one concept so they can be read in order.

| Example | Teaches | Tools |
|---------|---------|-------|
| `hello-world` | The smallest possible agent: subclass `Agent` + a system prompt | 0 |
| `word-count` | Registering a tool with the `@tool` decorator (logic in a pure function for easy testing) | 1 |
| `doc-search` | Composing a framework mixin (`RAGToolsMixin`) for document Q&A | 10 |

Each is a standalone hub package (`gaia-agent.yaml`, `pyproject.toml` with a `gaia.agent` entry point, package dir, `tests/`, `README.md`) following the format in [`docs/spec/agent-hub-restructure.mdx`](https://github.com/amd/gaia/blob/main/docs/spec/agent-hub-restructure.mdx). A new `hub/agents/python/README.md` points newcomers at the examples with a guided reading order.

This is **additive** — no `src/gaia` or existing-agent changes, so it doesn't conflict with the in-flight agent migration work.

## Test plan

- [ ] `pip install -e hub/agents/python/hello-world/ --no-deps` (repeat for `word-count`, `doc-search`)
- [ ] `python -m pytest hub/agents/python/hello-world/tests/ hub/agents/python/word-count/tests/ hub/agents/python/doc-search/tests/ -x` → 12 passed (LLM/RAG mocked, no live Lemonade server)
- [ ] Registry discovery: `AgentRegistry()._discover_installed_agents()` then `.get("hello-world")` / `"word-count"` / `"doc-search"` all resolve with `category="examples"`
- [ ] `python -m black --check` and `python -m isort --check` on the new files → clean

References #546 (delivers the Agent Hub reference-package interpretation; see the task scope note above).
