### PR TITLE
feat(hub): security tiers, deprecation, and native-agent trust (#1100)

### DIFF
--- a/docs/plans/agent-hub-ui.mdx
+++ b/docs/plans/agent-hub-ui.mdx
@@ -183,11 +183,30 @@ The registry scans `~/.gaia/agents/*/gaia-agent.yaml` directly. Each manifest pr
 ## Phase 4: Backend Install/Catalog API
 
 - **`GET /api/agents/catalog`** — R2 index + local registry merge + per-agent compatibility check
-- **`POST /api/agents/install`** — system check → download → verify → install → hot-register
+- **`POST /api/agents/install`** — system check → native-trust gate → download → verify → install → hot-register
 - **`DELETE /api/agents/{id}`** — uninstall
 - **`POST /api/agents/{id}/rollback`** — restore from `.backup/`
 - **Progress polling:** `GET /api/agents/{id}/install-status`
 - **Compatibility:** Platform, RAM, disk, GPU/NPU, context size checks with green/yellow/red UI indicators
+
+### Security tiers, native trust & deprecation (#1100)
+
+Implemented in `src/gaia/hub/installer.py`, `catalog.py`, and `ui/routers/hub.py`:
+
+- **Tiers surfaced in the catalog.** Each `GET /api/agents/catalog` entry carries
+  `security_tier` (`verified` | `community` | `experimental`) and a derived
+  `requires_trust` flag — `true` for non-verified **native (C++)** agents that run
+  unsandboxed.
+- **Native-agent trust gate.** `POST /api/agents/install` accepts `trust_native: bool`.
+  Installing a non-verified native agent without it is **refused with `403`** and an
+  actionable error; the Hub shows a *Trust & Install* confirmation that sets the flag.
+  The installer enforces the same rule (`TrustRequiredError`) as defense in depth.
+- **Deprecation.** Deprecated agents are recorded in the R2 manifest (Worker) and
+  **excluded from the default catalog listing** unless `include_deprecated=true`.
+  Installing one still works but logs a loud warning. The Hub renders a *Deprecated*
+  warning badge.
+- **Hub badges.** Verified = checkmark, community = shield, experimental = flask;
+  plus a tier filter dropdown on both Hub tabs.
 
 ---
 

--- a/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
+++ b/src/gaia/apps/webui/src/components/AgentDetailModal.tsx
@@ -2,11 +2,28 @@
 // SPDX-License-Identifier: MIT
 
 import { useEffect, useCallback } from 'react';
-import { Wrench, Cpu, Shield, X, HardDrive } from 'lucide-react';
+import { Wrench, Cpu, Shield, X, HardDrive, CheckCircle2, FlaskConical, AlertTriangle } from 'lucide-react';
 import { getAgentIcon } from './agentIcons';
 import type { AgentInfo } from '../types';
 
 const isElectron = typeof window !== 'undefined' && !!(window as any).electronAPI;
+
+const TIER_META: Record<string, { Icon: typeof Shield; label: string }> = {
+    verified: { Icon: CheckCircle2, label: 'Verified' },
+    community: { Icon: Shield, label: 'Community' },
+    experimental: { Icon: FlaskConical, label: 'Experimental' },
+};
+
+function tierBadge(tier?: string) {
+    const meta = tier ? TIER_META[tier] : undefined;
+    if (!meta) return null;
+    const { Icon, label } = meta;
+    return (
+        <span className={`agent-badge agent-badge-tier-${tier}`} title={`${label} security tier`}>
+            <Icon size={10} /> {label}
+        </span>
+    );
+}
 
 interface AgentDetailModalProps {
     agent: AgentInfo;
@@ -55,6 +72,12 @@ export function AgentDetailModal({ agent, onClose, onStartChat }: AgentDetailMod
                             {agent.source === 'native' && <span className="agent-badge agent-badge-native">Native</span>}
                             {agent.source === 'custom_python' && <span className="agent-badge agent-badge-custom">Custom</span>}
                             {agent.source === 'installed' && <span className="agent-badge agent-badge-installed">Installed</span>}
+                            {tierBadge(agent.security_tier)}
+                            {agent.deprecated && (
+                                <span className="agent-badge agent-badge-deprecated" title="Deprecated by the publisher — may be unmaintained">
+                                    <AlertTriangle size={10} /> Deprecated
+                                </span>
+                            )}
                             {agent.language && agent.language !== 'python' && (
                                 <span className="agent-badge agent-badge-native">{agent.language.toUpperCase()}</span>
                             )}

--- a/src/gaia/apps/webui/src/components/AgentHub.css
+++ b/src/gaia/apps/webui/src/components/AgentHub.css
@@ -661,16 +661,28 @@
     font-variant-numeric: tabular-nums;
 }
 
+.agent-badge-tier-verified,
+.agent-badge-tier-community,
+.agent-badge-tier-experimental,
+.agent-badge-deprecated {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.agent-badge-tier-verified {
+    background: rgba(34, 197, 94, 0.12);
+    color: var(--accent-green, #22c55e);
+}
+
 .agent-badge-tier-community {
     background: rgba(59, 158, 255, 0.1);
     color: var(--accent-blue);
-    text-transform: capitalize;
 }
 
 .agent-badge-tier-experimental {
     background: rgba(168, 85, 247, 0.12);
     color: var(--accent-purple, #a855f7);
-    text-transform: capitalize;
 }
 
 .agent-badge-deprecated {
@@ -921,4 +933,77 @@
     font-size: 13px;
     color: var(--text-muted);
     font-style: italic;
+}
+
+/* ── Install confirmation (native trust / deprecation) ──────────────────── */
+
+.install-confirm-modal {
+    max-width: 480px;
+}
+
+.install-confirm-icon {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--accent-red, #ef4444);
+}
+
+.install-confirm-subtitle {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin: 0;
+}
+
+.install-confirm-warnings {
+    list-style: none;
+    margin: 0 0 20px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.install-confirm-warning {
+    display: flex;
+    gap: 10px;
+    padding: 12px;
+    border-radius: var(--radius-md);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+}
+
+.install-confirm-warning-native_trust .install-confirm-warning-icon {
+    color: var(--accent-red, #ef4444);
+}
+
+.install-confirm-warning-deprecated .install-confirm-warning-icon {
+    color: var(--accent-gold);
+}
+
+.install-confirm-warning-icon {
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.install-confirm-warning-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 2px;
+}
+
+.install-confirm-warning-detail {
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text-secondary);
+}
+
+.install-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.install-confirm-proceed {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }

--- a/src/gaia/apps/webui/src/components/AgentHubCard.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubCard.tsx
@@ -1,7 +1,7 @@
 // Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-import { Cpu, Wrench, Shield, CheckCircle2, AlertTriangle, Download, Trash2, ArrowUpCircle, X, RefreshCw } from 'lucide-react';
+import { Cpu, Wrench, Shield, CheckCircle2, AlertTriangle, Download, Trash2, ArrowUpCircle, X, RefreshCw, FlaskConical } from 'lucide-react';
 import { getAgentIcon } from './agentIcons';
 import type { AgentInfo, InstallStatus } from '../types';
 import { useChatStore } from '../stores/chatStore';
@@ -17,6 +17,24 @@ function sourceBadge(source: string) {
     if (source === 'native') return <span className="agent-badge agent-badge-native">Native</span>;
     if (source === 'installed') return <span className="agent-badge agent-badge-installed">Installed</span>;
     return <span className="agent-badge agent-badge-custom">Custom</span>;
+}
+
+const TIER_META: Record<string, { Icon: typeof Shield; label: string }> = {
+    verified: { Icon: CheckCircle2, label: 'Verified' },
+    community: { Icon: Shield, label: 'Community' },
+    experimental: { Icon: FlaskConical, label: 'Experimental' },
+};
+
+/** Security-tier badge: checkmark (verified), shield (community), flask (experimental). */
+function tierBadge(tier?: string) {
+    const meta = tier ? TIER_META[tier] : undefined;
+    if (!meta) return null;
+    const { Icon, label } = meta;
+    return (
+        <span className={`agent-badge agent-badge-tier-${tier}`} title={`${label} security tier`}>
+            <Icon size={10} /> {label}
+        </span>
+    );
 }
 
 const DEVICE_LABELS: Record<string, string> = { cpu: 'CPU', gpu: 'GPU', npu: 'NPU' };
@@ -145,10 +163,12 @@ export function AgentHubCard({
                         {agent.version && !isAvailable && (
                             <span className="agent-badge agent-badge-version">v{agent.version}</span>
                         )}
-                        {agent.security_tier && agent.security_tier !== 'verified' && (
-                            <span className={`agent-badge agent-badge-tier-${agent.security_tier}`}>{agent.security_tier}</span>
+                        {tierBadge(agent.security_tier)}
+                        {agent.deprecated && (
+                            <span className="agent-badge agent-badge-deprecated" title="Deprecated by the publisher — may be unmaintained">
+                                <AlertTriangle size={10} /> Deprecated
+                            </span>
                         )}
-                        {agent.deprecated && <span className="agent-badge agent-badge-deprecated">Deprecated</span>}
                         {agent.language && agent.language !== 'python' && (
                             <span className="agent-badge agent-badge-native">{agent.language.toUpperCase()}</span>
                         )}

--- a/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubGrid.tsx
@@ -6,6 +6,7 @@ import { Plus, Search, WifiOff, AlertTriangle, RotateCcw, Package } from 'lucide
 import type { AgentInfo, InstallStatus } from '../types';
 import { AgentHubCard } from './AgentHubCard';
 import { AgentDetailModal } from './AgentDetailModal';
+import { InstallConfirmDialog, installWarnings, type InstallWarning } from './InstallConfirmDialog';
 import { useChatStore } from '../stores/chatStore';
 import * as api from '../services/api';
 import { log } from '../utils/logger';
@@ -43,7 +44,12 @@ function sortAgents(agents: AgentInfo[]): AgentInfo[] {
     });
 }
 
-function filterAgents(agents: AgentInfo[], search: string, categoryFilter: string): AgentInfo[] {
+function filterAgents(
+    agents: AgentInfo[],
+    search: string,
+    categoryFilter: string,
+    tierFilter: string,
+): AgentInfo[] {
     let list = agents;
     if (search) {
         const q = search.toLowerCase();
@@ -57,6 +63,9 @@ function filterAgents(agents: AgentInfo[], search: string, categoryFilter: strin
     if (categoryFilter !== 'all') {
         list = list.filter((a) => a.category === categoryFilter);
     }
+    if (tierFilter !== 'all') {
+        list = list.filter((a) => (a.security_tier ?? 'experimental') === tierFilter);
+    }
     return sortAgents(list);
 }
 
@@ -64,7 +73,11 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
     const [activeTab, setActiveTab] = useState<HubTab>('installed');
     const [search, setSearch] = useState('');
     const [categoryFilter, setCategoryFilter] = useState('all');
+    const [tierFilter, setTierFilter] = useState('all');
     const [detailAgent, setDetailAgent] = useState<AgentInfo | null>(null);
+    // Agent awaiting an install confirmation (native trust / deprecation), plus
+    // the warnings to display.
+    const [confirm, setConfirm] = useState<{ agent: AgentInfo; warnings: InstallWarning[] } | null>(null);
 
     // Catalog state (issue #1096 backend)
     const [catalog, setCatalog] = useState<AgentInfo[]>([]);
@@ -160,10 +173,12 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
         pollTimers.current = {};
     }, []);
 
-    const handleInstall = useCallback(async (id: string) => {
+    const doInstall = useCallback(async (id: string, trustNative: boolean) => {
         setInstallStates((s) => ({ ...s, [id]: { agent_id: id, state: 'downloading', progress: 0 } }));
         try {
-            const status = await api.installAgent(id, activeDevice);
+            const status = trustNative
+                ? await api.installAgent(id, activeDevice, true)
+                : await api.installAgent(id, activeDevice);
             setInstallStates((s) => ({ ...s, [id]: status }));
             if (status.state === 'installed') {
                 await fetchCatalog();
@@ -178,6 +193,26 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
             setInstallStates((s) => ({ ...s, [id]: { agent_id: id, state: 'failed', progress: 0, error: msg } }));
         }
     }, [activeDevice, startPolling, fetchCatalog, refreshAgents]);
+
+    // Install entry point used by the cards: gate native-trust / deprecated
+    // agents behind a confirmation before proceeding.
+    const handleInstall = useCallback((id: string) => {
+        const agent =
+            catalog.find((a) => a.id === id) ?? agents.find((a) => a.id === id);
+        const warnings = agent ? installWarnings(agent) : [];
+        if (agent && warnings.length > 0) {
+            setConfirm({ agent, warnings });
+            return;
+        }
+        void doInstall(id, false);
+    }, [catalog, agents, doInstall]);
+
+    const handleConfirmInstall = useCallback(() => {
+        if (!confirm) return;
+        const id = confirm.agent.id;
+        setConfirm(null);
+        void doInstall(id, true);
+    }, [confirm, doInstall]);
 
     const handleCancelInstall = useCallback(async (id: string) => {
         stopPolling(id);
@@ -231,13 +266,20 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
     }, [sourceForFilter]);
 
     const filteredInstalled = useMemo(
-        () => filterAgents(installedAgents, search, categoryFilter),
-        [installedAgents, search, categoryFilter],
+        () => filterAgents(installedAgents, search, categoryFilter, tierFilter),
+        [installedAgents, search, categoryFilter, tierFilter],
     );
     const filteredAvailable = useMemo(
-        () => filterAgents(availableAgents, search, categoryFilter),
-        [availableAgents, search, categoryFilter],
+        () => filterAgents(availableAgents, search, categoryFilter, tierFilter),
+        [availableAgents, search, categoryFilter, tierFilter],
     );
+
+    // Security tiers present in the active list (drives the tier dropdown).
+    const tiers = useMemo(() => {
+        const set = new Set<string>();
+        sourceForFilter.forEach((a) => { if (a.security_tier) set.add(a.security_tier); });
+        return Array.from(set).sort();
+    }, [sourceForFilter]);
 
     // Search/filter bar: always shown on Available; shown on Installed when 6+.
     const showControls = activeTab === 'available' || installedAgents.length > 6;
@@ -285,6 +327,21 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
                                 <option value="all">All categories</option>
                                 {categories.map((c) => (
                                     <option key={c} value={c}>{c}</option>
+                                ))}
+                            </select>
+                        )}
+                        {tiers.length > 1 && (
+                            <select
+                                className="agent-hub-filter"
+                                aria-label="Filter by security tier"
+                                value={tierFilter}
+                                onChange={(e) => setTierFilter(e.target.value)}
+                            >
+                                <option value="all">All tiers</option>
+                                {tiers.map((t) => (
+                                    <option key={t} value={t}>
+                                        {t.charAt(0).toUpperCase() + t.slice(1)}
+                                    </option>
                                 ))}
                             </select>
                         )}
@@ -394,6 +451,15 @@ export function AgentHubGrid({ agents, activeAgentId, onSelect, onStartChat, onC
                     agent={detailAgent}
                     onClose={() => setDetailAgent(null)}
                     onStartChat={onStartChat}
+                />
+            )}
+
+            {confirm && (
+                <InstallConfirmDialog
+                    agent={confirm.agent}
+                    warnings={confirm.warnings}
+                    onConfirm={handleConfirmInstall}
+                    onCancel={() => setConfirm(null)}
                 />
             )}
         </div>

--- a/src/gaia/apps/webui/src/components/InstallConfirmDialog.tsx
+++ b/src/gaia/apps/webui/src/components/InstallConfirmDialog.tsx
@@ -1,0 +1,127 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useCallback } from 'react';
+import { X, ShieldAlert, AlertTriangle, Download } from 'lucide-react';
+import type { AgentInfo } from '../types';
+
+export interface InstallWarning {
+    type: 'native_trust' | 'deprecated';
+    title: string;
+    detail: string;
+}
+
+/**
+ * Build the list of warnings that gate an install. Empty list ⇒ install can
+ * proceed without confirmation.
+ *
+ * - ``native_trust``: a non-verified native (C++) agent runs unsandboxed; the
+ *   backend refuses (403) unless the user opts in via ``trust_native``.
+ * - ``deprecated``: the publisher marked the agent deprecated; it may be
+ *   unmaintained or superseded.
+ */
+export function installWarnings(agent: AgentInfo): InstallWarning[] {
+    const warnings: InstallWarning[] = [];
+    const nativeUntrusted =
+        agent.requires_trust === true ||
+        (agent.language === 'cpp' && !!agent.security_tier && agent.security_tier !== 'verified');
+    if (nativeUntrusted) {
+        warnings.push({
+            type: 'native_trust',
+            title: 'Native agent — runs unsandboxed',
+            detail:
+                `${agent.name} ships a native (C++) binary in the ` +
+                `"${agent.security_tier ?? 'experimental'}" tier. It runs directly on your ` +
+                `machine without sandboxing. Only install it if you trust the publisher.`,
+        });
+    }
+    if (agent.deprecated) {
+        warnings.push({
+            type: 'deprecated',
+            title: 'Deprecated by the publisher',
+            detail:
+                `${agent.name} has been deprecated and may be unmaintained or superseded. ` +
+                `Install only if you specifically need this agent.`,
+        });
+    }
+    return warnings;
+}
+
+interface InstallConfirmDialogProps {
+    agent: AgentInfo;
+    warnings: InstallWarning[];
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+const WARNING_ICON: Record<InstallWarning['type'], typeof ShieldAlert> = {
+    native_trust: ShieldAlert,
+    deprecated: AlertTriangle,
+};
+
+/**
+ * Confirmation shown before installing an agent that carries install warnings
+ * (native-trust opt-in and/or deprecation). Confirming proceeds with
+ * ``trust_native`` so the backend accepts a non-verified native install.
+ */
+export function InstallConfirmDialog({ agent, warnings, onConfirm, onCancel }: InstallConfirmDialogProps) {
+    const handleKey = useCallback((e: KeyboardEvent) => {
+        if (e.key === 'Escape') onCancel();
+    }, [onCancel]);
+
+    useEffect(() => {
+        document.addEventListener('keydown', handleKey);
+        return () => document.removeEventListener('keydown', handleKey);
+    }, [handleKey]);
+
+    return (
+        <div className="agent-detail-overlay" onClick={onCancel}>
+            <div
+                className="agent-detail-modal install-confirm-modal"
+                role="alertdialog"
+                aria-modal="true"
+                aria-labelledby="install-confirm-title"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="agent-detail-header">
+                    <div className="agent-detail-icon install-confirm-icon">
+                        <ShieldAlert size={24} />
+                    </div>
+                    <div className="agent-detail-title-area">
+                        <h2 id="install-confirm-title" className="agent-detail-name">
+                            Install {agent.name}?
+                        </h2>
+                        <p className="install-confirm-subtitle">Review before installing</p>
+                    </div>
+                    <button className="agent-detail-close" onClick={onCancel} aria-label="Cancel">
+                        <X size={18} />
+                    </button>
+                </div>
+
+                <div className="agent-detail-body">
+                    <ul className="install-confirm-warnings">
+                        {warnings.map((w) => {
+                            const Icon = WARNING_ICON[w.type];
+                            return (
+                                <li key={w.type} className={`install-confirm-warning install-confirm-warning-${w.type}`}>
+                                    <Icon size={16} className="install-confirm-warning-icon" />
+                                    <div>
+                                        <div className="install-confirm-warning-title">{w.title}</div>
+                                        <div className="install-confirm-warning-detail">{w.detail}</div>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+
+                    <div className="install-confirm-actions">
+                        <button className="btn-secondary" onClick={onCancel}>Cancel</button>
+                        <button className="btn-install install-confirm-proceed" onClick={onConfirm}>
+                            <Download size={14} /> Trust &amp; Install
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/__tests__/AgentHubGrid.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/AgentHubGrid.test.tsx
@@ -149,6 +149,50 @@ describe('AgentHubGrid tabs', () => {
         });
     });
 
+    it('prompts for trust before installing a non-verified native agent', async () => {
+        const user = userEvent.setup();
+        const nativeCatalog: AgentCatalogResponse = {
+            offline: false,
+            agents: [
+                agent({
+                    id: 'edge',
+                    name: 'Edge Native',
+                    source: 'installed',
+                    status: 'available',
+                    language: 'cpp',
+                    security_tier: 'community',
+                    requires_trust: true,
+                    compatibility: { level: 'compatible' },
+                }),
+            ],
+        };
+        mockedApi.listCatalog.mockResolvedValue(nativeCatalog);
+        mockedApi.installAgent.mockResolvedValue({ agent_id: 'edge', state: 'downloading', progress: 10 });
+
+        render(
+            <AgentHubGrid
+                agents={INSTALLED}
+                activeAgentId="chat"
+                onSelect={() => {}}
+                onStartChat={() => {}}
+            />,
+        );
+        await user.click(screen.getByRole('tab', { name: /Available/ }));
+        await screen.findByText('Edge Native');
+
+        // Clicking Install opens the confirmation dialog (no install yet).
+        const card = screen.getByText('Edge Native').closest('.agent-hub-card')!;
+        await user.click(card.querySelector('.btn-install') as HTMLButtonElement);
+        await screen.findByRole('alertdialog');
+        expect(mockedApi.installAgent).not.toHaveBeenCalled();
+
+        // Confirming installs with trust_native.
+        await user.click(screen.getByRole('button', { name: /Trust & Install/ }));
+        await waitFor(() =>
+            expect(mockedApi.installAgent).toHaveBeenCalledWith('edge', expect.anything(), true),
+        );
+    });
+
     it('shows the offline banner when the catalog is cached', async () => {
         const user = userEvent.setup();
         mockedApi.listCatalog.mockResolvedValue({ ...CATALOG, offline: true });

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -132,13 +132,22 @@ export async function listCatalog(): Promise<AgentCatalogResponse> {
  * Kick off an agent install (download → verify → install → hot-register).
  * Returns the initial install status; poll ``getInstallStatus`` for progress.
  * The optional ``device`` selects the per-device package variant when the
- * agent ships more than one.
+ * agent ships more than one. ``trustNative`` must be set to install a
+ * non-verified native (C++) agent — the backend refuses (403) otherwise.
  */
-export async function installAgent(agentId: string, device?: string): Promise<InstallStatus> {
+export async function installAgent(
+    agentId: string,
+    device?: string,
+    trustNative?: boolean,
+): Promise<InstallStatus> {
     return apiFetch(
         'POST',
         '/agents/install',
-        { id: agentId, ...(device ? { device } : {}) },
+        {
+            id: agentId,
+            ...(device ? { device } : {}),
+            ...(trustNative ? { trust_native: true } : {}),
+        },
         { 'x-gaia-ui': '1' },
     );
 }

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -89,6 +89,12 @@ export interface AgentInfo {
     download_size_bytes?: number;
     /** Trust tier: AMD-verified, community-published, or experimental opt-in. */
     security_tier?: 'verified' | 'community' | 'experimental';
+    /**
+     * True when installing this agent needs an explicit native-trust opt-in —
+     * a non-verified native (C++) package that runs unsandboxed. The Hub shows
+     * a "Trust & Install" confirmation before sending ``trust_native``.
+     */
+    requires_trust?: boolean;
     /** Optional remote avatar image URL from the catalog. */
     avatar_url?: string;
     /** True when the publisher has deprecated this agent. */

--- a/src/gaia/hub/catalog.py
+++ b/src/gaia/hub/catalog.py
@@ -323,10 +323,21 @@ STATUS_AVAILABLE = "available"
 STATUS_UPDATE_AVAILABLE = "update_available"
 
 
+def _requires_trust(language: str, security_tier: str) -> bool:
+    """Whether a catalog entry needs an explicit native-trust opt-in to install.
+
+    Native (``cpp``) agents outside the ``verified`` tier ship an unsandboxed
+    binary from a non-AMD-audited publisher; the UI prompts before installing.
+    """
+    return language == "cpp" and security_tier != "verified"
+
+
 def merge_with_registry(
     index_agents: List[Dict[str, Any]],
     registry: Any,
     installed_versions: Optional[Dict[str, str]] = None,
+    *,
+    include_deprecated: bool = False,
 ) -> List[Dict[str, Any]]:
     """Merge the remote catalog with the live registry into a unified list.
 
@@ -338,10 +349,14 @@ def merge_with_registry(
             :func:`gaia.hub.installer.list_installed`). Builtin/custom agents
             present in the registry but absent here are treated as installed
             with an unknown version.
+        include_deprecated: When False (default), deprecated agents that are not
+            already installed are excluded from the listing. Installed agents are
+            always shown so a user can still see/manage what they have.
 
     Returns:
         One dict per agent (union of registry + catalog), each carrying a
-        ``status`` and ``installed_version`` / ``latest_version``.
+        ``status``, ``installed_version`` / ``latest_version``, and a
+        ``requires_trust`` flag.
     """
     installed_versions = installed_versions or {}
 
@@ -369,15 +384,18 @@ def merge_with_registry(
         else:
             status = STATUS_AVAILABLE
 
+        language = entry.get("language", "python")
+        security_tier = entry.get("security_tier", "experimental")
         by_id[agent_id] = {
             "id": agent_id,
             "name": entry.get("name", agent_id),
             "description": entry.get("description", ""),
             "category": entry.get("category", "general"),
             "icon": entry.get("icon", ""),
-            "language": entry.get("language", "python"),
+            "language": language,
             "author": entry.get("author", ""),
-            "security_tier": entry.get("security_tier", "experimental"),
+            "security_tier": security_tier,
+            "requires_trust": _requires_trust(language, security_tier),
             "download_size_bytes": entry.get("download_size_bytes", 0),
             "requirements": entry.get("requirements", {"platforms": []}),
             "deprecated": entry.get("deprecated", False),
@@ -391,6 +409,7 @@ def merge_with_registry(
     for agent_id, reg in registered.items():
         if agent_id in by_id:
             continue
+        reg_tier = "verified" if reg.source == "builtin" else "experimental"
         by_id[agent_id] = {
             "id": agent_id,
             "name": reg.name,
@@ -399,7 +418,8 @@ def merge_with_registry(
             "icon": reg.icon,
             "language": reg.language,
             "author": "",
-            "security_tier": "verified" if reg.source == "builtin" else "experimental",
+            "security_tier": reg_tier,
+            "requires_trust": _requires_trust(reg.language, reg_tier),
             "download_size_bytes": 0,
             "requirements": {"platforms": []},
             "deprecated": False,
@@ -407,6 +427,15 @@ def merge_with_registry(
             "installed_version": installed_versions.get(agent_id),
             "status": STATUS_INSTALLED,
             "source": reg.source,
+        }
+
+    # Hide deprecated, not-yet-installed agents from the default listing. They
+    # remain installable via include_deprecated (the UI confirms before install).
+    if not include_deprecated:
+        by_id = {
+            aid: a
+            for aid, a in by_id.items()
+            if not (a["deprecated"] and a["status"] == STATUS_AVAILABLE)
         }
 
     return sorted(by_id.values(), key=lambda a: a["id"])
@@ -437,12 +466,18 @@ def build_catalog(
     cache_path: Optional[Path] = None,
     installed_versions: Optional[Dict[str, str]] = None,
     force: bool = False,
+    include_deprecated: bool = False,
 ) -> UnifiedCatalog:
     """Fetch the catalog and merge it with the registry into a unified view."""
     result = load_index(
         base_url=base_url, fetcher=fetcher, cache_path=cache_path, force=force
     )
-    merged = merge_with_registry(result.agents, registry, installed_versions)
+    merged = merge_with_registry(
+        result.agents,
+        registry,
+        installed_versions,
+        include_deprecated=include_deprecated,
+    )
     return UnifiedCatalog(
         agents=merged,
         offline=result.offline,

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -58,6 +58,14 @@ BACKUP_DIRNAME = ".backup"
 # Where Python wheels get installed (``uv pip install --target``).
 SITE_PACKAGES_DIRNAME = "site-packages"
 
+# The only security tier whose native agents install without an explicit trust
+# opt-in. ``community`` / ``experimental`` C++ agents require ``trust_native``.
+VERIFIED_TIER = "verified"
+
+# Least-privileged default when a manifest omits its tier (mirrors the manifest
+# parser: an unknown package is treated as untrusted).
+DEFAULT_SECURITY_TIER = "experimental"
+
 # Injectable pip runner: takes the full ``uv pip install`` argument list (after
 # ``uv pip install``) and runs it, raising InstallError on failure.
 PipRunner = Callable[[List[str]], None]
@@ -86,6 +94,16 @@ class CompatibilityError(InstallError):
 
 class InstallInProgressError(InstallError):
     """An install for this agent id is already running (maps to HTTP 409)."""
+
+
+class TrustRequiredError(InstallError):
+    """A native (C++) non-verified agent needs explicit trust to install.
+
+    Native agents run as unsandboxed binaries on the user's machine, so a
+    ``community``/``experimental`` C++ package is only installed when the caller
+    explicitly opts in (``trust_native=True`` / the UI's *Trust & Install*
+    confirmation). Maps to HTTP 403 at the router boundary.
+    """
 
 
 class NotInstalledError(InstallError):
@@ -438,6 +456,43 @@ def _hot_register(agent_id: str, install_dir: Path, language: str, registry) -> 
 
 
 # ---------------------------------------------------------------------------
+# Security tier / native-agent trust
+# ---------------------------------------------------------------------------
+
+
+def requires_native_trust(manifest: Dict[str, Any]) -> bool:
+    """Whether installing *manifest* needs an explicit native-trust opt-in.
+
+    True for native (``language: cpp``) agents that are not in the ``verified``
+    tier — they ship an unsandboxed binary from a non-AMD-audited publisher.
+    """
+    language = manifest.get("language", "python")
+    tier = manifest.get("security_tier", DEFAULT_SECURITY_TIER)
+    return language == "cpp" and tier != VERIFIED_TIER
+
+
+def ensure_native_trust(
+    agent_id: str, manifest: Dict[str, Any], *, trust_native: bool
+) -> None:
+    """Raise :class:`TrustRequiredError` if native trust is needed but absent.
+
+    No-op for Python agents and ``verified`` native agents. Called both by the
+    router (synchronous 403) and :func:`install` (defense in depth).
+    """
+    if trust_native or not requires_native_trust(manifest):
+        return
+    tier = manifest.get("security_tier", DEFAULT_SECURITY_TIER)
+    raise TrustRequiredError(
+        f"'{agent_id}' is a native (C++) agent in the '{tier}' security tier. "
+        f"Native agents run as unsandboxed binaries on your machine, so this one "
+        f"is not installed automatically. Re-install with explicit trust "
+        f"(trust_native=true, or the UI's 'Trust & Install' confirmation) only if "
+        f"you trust its publisher. See "
+        f"https://amd-gaia.ai/docs/spec/agent-hub-restructure."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public: install
 # ---------------------------------------------------------------------------
 
@@ -475,6 +530,7 @@ def install(
     install_root: Optional[Path] = None,
     registry: Any = None,
     skip_compatibility_check: bool = False,
+    trust_native: bool = False,
 ) -> InstallResult:
     """Download, verify, and install an agent from the hub.
 
@@ -487,10 +543,12 @@ def install(
         install_root: Install root; defaults to ``~/.gaia/agents``.
         registry: Live :class:`AgentRegistry` to hot-register into.
         skip_compatibility_check: Skip the platform/disk gate (tests/forced).
+        trust_native: Explicit opt-in to install a non-verified native (C++)
+            agent. Required for ``community``/``experimental`` C++ packages.
 
     Raises:
         InstallInProgressError, ChecksumError, DiskSpaceError,
-        CompatibilityError, InstallError.
+        CompatibilityError, TrustRequiredError, InstallError.
     """
     fetcher = fetcher or catalog_mod.fetch_bytes
     run_pip = run_pip or _default_run_pip
@@ -507,6 +565,21 @@ def install(
                     agent_id, base_url=base_url, fetcher=fetcher
                 )
             language = manifest.get("language", "python")
+
+            # Native-agent trust gate — refuse non-verified C++ packages unless
+            # the caller explicitly opted in (defense in depth; the router also
+            # enforces this synchronously for a clean 403).
+            ensure_native_trust(agent_id, manifest, trust_native=trust_native)
+
+            # Deprecation is non-fatal but must be loud: a deprecated agent may
+            # be unmaintained or superseded.
+            if manifest.get("deprecated"):
+                logger.warning(
+                    "installer: '%s' is deprecated and may be unmaintained or "
+                    "superseded; installing anyway",
+                    agent_id,
+                )
+
             resolved_version, artifact = _resolve_version(manifest, version)
 
             # --- compatibility / disk gate ---

--- a/src/gaia/ui/routers/hub.py
+++ b/src/gaia/ui/routers/hub.py
@@ -59,6 +59,9 @@ class InstallRequest(BaseModel):
 
     id: str
     version: Optional[str] = None
+    # Explicit opt-in to install a non-verified native (C++) agent. The UI sets
+    # this after the user accepts the "Trust & Install" confirmation.
+    trust_native: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -67,11 +70,14 @@ class InstallRequest(BaseModel):
 
 
 @router.get("/api/agents/catalog")
-async def get_catalog(request: Request, refresh: bool = False):
+async def get_catalog(
+    request: Request, refresh: bool = False, include_deprecated: bool = False
+):
     """Unified agent catalog: remote hub merged with the local registry.
 
     ``offline=true`` in the response means the live hub was unreachable and the
-    list came from the on-disk cache.
+    list came from the on-disk cache. Deprecated, not-yet-installed agents are
+    hidden unless ``include_deprecated=true``.
     """
     registry = _registry(request)
     try:
@@ -79,6 +85,7 @@ async def get_catalog(request: Request, refresh: bool = False):
             registry,
             installed_versions=installer_mod.installed_versions(),
             force=refresh,
+            include_deprecated=include_deprecated,
         )
     except catalog_mod.CatalogError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
@@ -90,10 +97,23 @@ async def get_catalog(request: Request, refresh: bool = False):
 # ---------------------------------------------------------------------------
 
 
-def _run_install(agent_id: str, version: Optional[str], registry) -> None:
+def _run_install(
+    agent_id: str,
+    version: Optional[str],
+    registry,
+    *,
+    trust_native: bool,
+    manifest: Optional[dict],
+) -> None:
     """Background install worker. Errors are recorded in install progress."""
     try:
-        installer_mod.install(agent_id, version=version, registry=registry)
+        installer_mod.install(
+            agent_id,
+            version=version,
+            registry=registry,
+            trust_native=trust_native,
+            manifest=manifest,
+        )
     except installer_mod.InstallError as exc:
         logger.warning("hub: install of %s failed: %s", agent_id, exc)
     except Exception:  # noqa: BLE001 - record then swallow in the worker
@@ -119,11 +139,32 @@ async def install_agent(
             status_code=409,
             detail=f"An install for '{body.id}' is already in progress.",
         )
+
+    # Resolve the manifest up front so native-agent trust is enforced
+    # synchronously (a clean 403) instead of failing in the background task.
+    try:
+        manifest = catalog_mod.fetch_manifest(body.id)
+    except catalog_mod.CatalogError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    try:
+        installer_mod.ensure_native_trust(
+            body.id, manifest, trust_native=body.trust_native
+        )
+    except installer_mod.TrustRequiredError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
     installer_mod.clear_progress(body.id)
     installer_mod._set_progress(  # noqa: SLF001 - seed state for the poller
         body.id, status="queued", phase="queued", percent=0, version=body.version
     )
-    background_tasks.add_task(_run_install, body.id, body.version, registry)
+    background_tasks.add_task(
+        _run_install,
+        body.id,
+        body.version,
+        registry,
+        trust_native=body.trust_native,
+        manifest=manifest,
+    )
     return {"id": body.id, "status": "queued"}
 
 

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -316,6 +316,7 @@ def test_install_cpp_artifact_extracted(tmp_path):
         base_url=BASE,
         fetcher=fetcher,
         install_root=tmp_path,
+        trust_native=True,  # experimental native agent — explicit trust required
     )
     assert result.language == "cpp"
     assert (tmp_path / "native" / "bin" / "demo").exists()

--- a/tests/unit/test_hub_router.py
+++ b/tests/unit/test_hub_router.py
@@ -93,13 +93,61 @@ def test_install_returns_202_and_schedules(client, monkeypatch):
 
     def fake_install(agent_id, **kwargs):
         called["id"] = agent_id
+        called["trust_native"] = kwargs.get("trust_native")
 
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {"id": "demo", "language": "python"},
+    )
     monkeypatch.setattr(installer_mod, "install", fake_install)
-    resp = client.post("/api/agents/install", json={"id": "demo"}, headers=UI)
+    resp = client.post(
+        "/api/agents/install", json={"id": "demo", "trust_native": True}, headers=UI
+    )
     assert resp.status_code == 202
     assert resp.json()["status"] == "queued"
     # BackgroundTasks run after the response in TestClient.
     assert called.get("id") == "demo"
+    assert called.get("trust_native") is True
+
+
+def test_install_native_non_verified_refused_403(client, monkeypatch):
+    # A community native agent without trust_native is refused synchronously.
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {
+            "id": "native",
+            "language": "cpp",
+            "security_tier": "community",
+        },
+    )
+    resp = client.post("/api/agents/install", json={"id": "native"}, headers=UI)
+    assert resp.status_code == 403
+    assert "trust" in resp.json()["detail"].lower()
+
+
+def test_install_native_non_verified_allowed_with_trust(client, monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {
+            "id": "native",
+            "language": "cpp",
+            "security_tier": "community",
+        },
+    )
+    monkeypatch.setattr(
+        installer_mod, "install", lambda agent_id, **k: called.update(id=agent_id)
+    )
+    resp = client.post(
+        "/api/agents/install",
+        json={"id": "native", "trust_native": True},
+        headers=UI,
+    )
+    assert resp.status_code == 202
+    assert called.get("id") == "native"
 
 
 def test_install_duplicate_returns_409(client, monkeypatch):

--- a/tests/unit/test_hub_security.py
+++ b/tests/unit/test_hub_security.py
@@ -1,0 +1,273 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Security-tier, native-trust, and deprecation tests for the Agent Hub.
+
+Covers issue #1100 (Phase 3D/3E): non-verified native agents require an explicit
+trust opt-in to install, deprecated agents warn on install and are hidden from
+the default catalog listing, and the catalog surfaces ``security_tier`` and a
+``requires_trust`` flag. All HTTP/pip work is mocked.
+"""
+
+import hashlib
+import io
+import logging
+import zipfile
+
+import pytest
+
+from gaia.hub import catalog as catalog_mod
+from gaia.hub import installer
+from gaia.hub.installer import (
+    TrustRequiredError,
+    ensure_native_trust,
+    install,
+    read_sentinel,
+    requires_native_trust,
+)
+
+BASE = "https://hub.test"
+
+
+# ---------------------------------------------------------------------------
+# Manifest builders
+# ---------------------------------------------------------------------------
+
+
+def _python_manifest(agent_id="demo", version="1.0.0", **extra):
+    artifact_bytes = b"wheel-bytes"
+    sha = hashlib.sha256(artifact_bytes).hexdigest()
+    path = f"agents/{agent_id}/{version}/{agent_id}-{version}.whl"
+    return {
+        "id": agent_id,
+        "language": "python",
+        "latest_version": version,
+        "requirements": {"platforms": []},
+        "versions": {
+            version: {
+                "version": version,
+                "artifact": {
+                    "filename": f"{agent_id}-{version}-py3-none-any.whl",
+                    "path": path,
+                    "size_bytes": len(artifact_bytes),
+                    "sha256": sha,
+                    "content_type": "application/octet-stream",
+                },
+            }
+        },
+        **extra,
+    }
+
+
+def _python_fetcher(manifest):
+    version = manifest["latest_version"]
+    artifact_path = manifest["versions"][version]["artifact"]["path"]
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: demo\nname: Demo\n"
+        if url == f"{BASE}/{artifact_path}":
+            return b"wheel-bytes"
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    return fetcher
+
+
+def _native_manifest(agent_id="native", version="1.0.0", security_tier="experimental"):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("bin/native", "binary")
+    archive = buf.getvalue()
+    sha = hashlib.sha256(archive).hexdigest()
+    path = f"agents/{agent_id}/{version}/{agent_id}.zip"
+    manifest = {
+        "id": agent_id,
+        "language": "cpp",
+        "security_tier": security_tier,
+        "latest_version": version,
+        "requirements": {"platforms": []},
+        "versions": {
+            version: {
+                "version": version,
+                "artifact": {
+                    "filename": f"{agent_id}.zip",
+                    "path": path,
+                    "size_bytes": len(archive),
+                    "sha256": sha,
+                    "content_type": "application/zip",
+                },
+            }
+        },
+    }
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: native\n"
+        if url == f"{BASE}/{path}":
+            return archive
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    return manifest, fetcher
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    installer.clear_progress()
+    installer._IN_PROGRESS.clear()  # noqa: SLF001
+    yield
+    installer.clear_progress()
+    installer._IN_PROGRESS.clear()  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# requires_native_trust / ensure_native_trust
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "language,tier,expected",
+    [
+        ("cpp", "experimental", True),
+        ("cpp", "community", True),
+        ("cpp", "verified", False),
+        ("python", "experimental", False),
+        ("python", "community", False),
+    ],
+)
+def test_requires_native_trust_matrix(language, tier, expected):
+    manifest = {"language": language, "security_tier": tier}
+    assert requires_native_trust(manifest) is expected
+
+
+def test_ensure_native_trust_raises_without_optin():
+    manifest = {"language": "cpp", "security_tier": "community"}
+    with pytest.raises(TrustRequiredError):
+        ensure_native_trust("native", manifest, trust_native=False)
+
+
+def test_ensure_native_trust_allows_with_optin():
+    manifest = {"language": "cpp", "security_tier": "community"}
+    # Should not raise.
+    ensure_native_trust("native", manifest, trust_native=True)
+
+
+def test_ensure_native_trust_allows_verified_native_without_optin():
+    manifest = {"language": "cpp", "security_tier": "verified"}
+    ensure_native_trust("native", manifest, trust_native=False)
+
+
+# ---------------------------------------------------------------------------
+# install() enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_install_native_non_verified_refused_without_trust(tmp_path):
+    manifest, fetcher = _native_manifest(security_tier="experimental")
+    with pytest.raises(TrustRequiredError):
+        install(
+            "native",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=fetcher,
+            install_root=tmp_path,
+        )
+    # Nothing installed; progress recorded the failure.
+    assert read_sentinel("native", tmp_path) is None
+    assert installer.get_install_status("native")["status"] == "failed"
+
+
+def test_install_native_non_verified_succeeds_with_trust(tmp_path):
+    manifest, fetcher = _native_manifest(security_tier="community")
+    result = install(
+        "native",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=fetcher,
+        install_root=tmp_path,
+        trust_native=True,
+    )
+    assert result.language == "cpp"
+    assert (tmp_path / "native" / "bin" / "native").exists()
+
+
+def test_install_native_verified_succeeds_without_trust(tmp_path):
+    manifest, fetcher = _native_manifest(security_tier="verified")
+    result = install(
+        "native",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=fetcher,
+        install_root=tmp_path,
+    )
+    assert result.language == "cpp"
+
+
+# ---------------------------------------------------------------------------
+# Deprecation warning on install
+# ---------------------------------------------------------------------------
+
+
+def test_install_deprecated_agent_warns(tmp_path, caplog):
+    manifest = _python_manifest(deprecated=True)
+    with caplog.at_level(logging.WARNING, logger="gaia.hub.installer"):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_python_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+    # Install still succeeds, but a deprecation warning was emitted.
+    assert read_sentinel("demo", tmp_path) is not None
+    assert any("deprecated" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Catalog: requires_trust + deprecated filtering
+# ---------------------------------------------------------------------------
+
+
+def _index_entry(agent_id, **extra):
+    return {"id": agent_id, "name": agent_id, "latest_version": "1.0.0", **extra}
+
+
+def test_catalog_surfaces_security_tier_and_requires_trust():
+    agents = [
+        _index_entry("verified-cpp", language="cpp", security_tier="verified"),
+        _index_entry("community-cpp", language="cpp", security_tier="community"),
+        _index_entry(
+            "experimental-py", language="python", security_tier="experimental"
+        ),
+    ]
+    merged = catalog_mod.merge_with_registry(agents, registry=None)
+    by_id = {a["id"]: a for a in merged}
+    assert by_id["verified-cpp"]["security_tier"] == "verified"
+    assert by_id["verified-cpp"]["requires_trust"] is False
+    assert by_id["community-cpp"]["requires_trust"] is True
+    assert by_id["experimental-py"]["requires_trust"] is False
+
+
+def test_catalog_hides_deprecated_available_by_default():
+    agents = [
+        _index_entry("good", language="python", security_tier="verified"),
+        _index_entry(
+            "old", language="python", security_tier="community", deprecated=True
+        ),
+    ]
+    merged = catalog_mod.merge_with_registry(agents, registry=None)
+    ids = {a["id"] for a in merged}
+    assert "good" in ids
+    assert "old" not in ids  # deprecated + available ⇒ hidden
+
+
+def test_catalog_includes_deprecated_when_requested():
+    agents = [
+        _index_entry(
+            "old", language="python", security_tier="community", deprecated=True
+        ),
+    ]
+    merged = catalog_mod.merge_with_registry(
+        agents, registry=None, include_deprecated=True
+    )
+    assert {a["id"] for a in merged} == {"old"}
+    assert merged[0]["deprecated"] is True

--- a/workers/agent-hub/test/publish.test.ts
+++ b/workers/agent-hub/test/publish.test.ts
@@ -266,4 +266,53 @@ describe("POST /publish — input validation", () => {
     expect(res.status).toBe(413);
     expect(((await res.json()) as any).error.code).toBe("artifact_too_large");
   });
+
+  it("rejects an unknown security_tier on publish (400)", async () => {
+    const env = makeEnv();
+    const res = await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest({ security_tier: "gold" }),
+      artifact: "wheel-bytes",
+      filename: "gaia_agent_chat-0.1.0-py3-none-any.whl",
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error.code).toBe("invalid_manifest");
+    // Nothing written for a rejected publish.
+    expect(env.bucket.keys()).toEqual([]);
+  });
+});
+
+describe("POST /publish — security tier & deprecation", () => {
+  it("records the security_tier in the per-agent manifest and index", async () => {
+    const env = makeEnv();
+    await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest({ id: "exp", security_tier: "experimental" }),
+      artifact: "wheel",
+      filename: "gaia_agent_exp-0.1.0-py3-none-any.whl",
+    });
+    const manifest = (await (await env.bucket.get("agents/exp/manifest.json"))!.json()) as AgentManifest;
+    expect(manifest.security_tier).toBe("experimental");
+    const index = (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex;
+    expect(index.agents.find((a) => a.id === "exp")!.security_tier).toBe("experimental");
+  });
+
+  it("records deprecated state through to the index", async () => {
+    const env = makeEnv();
+    const deprecatedYaml = sampleManifest({ id: "old" }) + "deprecated: true\n";
+    const res = await publish(env, {
+      token: "tok_amd",
+      manifestYaml: deprecatedYaml,
+      artifact: "wheel",
+      filename: "gaia_agent_old-0.1.0-py3-none-any.whl",
+    });
+    expect(res.status).toBe(201);
+
+    const manifest = (await (await env.bucket.get("agents/old/manifest.json"))!.json()) as AgentManifest;
+    expect(manifest.deprecated).toBe(true);
+    expect(manifest.versions["0.1.0"].deprecated).toBe(true);
+
+    const index = (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex;
+    expect(index.agents.find((a) => a.id === "old")!.deprecated).toBe(true);
+  });
 });


### PR DESCRIPTION
## Why this matters

Before, a non-verified **native (C++)** agent — an unsandboxed binary from a non-AMD-audited publisher — would install with no gate. Now the install path refuses it unless the user explicitly trusts it, deprecated agents are hidden from the default catalog and warn loudly on install, and the Agent Hub surfaces every agent's trust tier at a glance. Users can see *what they're about to run* and consciously opt into anything risky.

Implements #1100 (Agent Hub Phase 3D/3E), per [`docs/spec/agent-hub-restructure.mdx`](docs/spec/agent-hub-restructure.mdx) and [`docs/plans/agent-hub-ui.mdx`](docs/plans/agent-hub-ui.mdx). Builds on the merged manifest tier field, installer/catalog/router (#1096), Hub cards (#1097), and Worker (#1095).

What changed, by why-a-reviewer-cares:
- **Native trust gate** — `POST /api/agents/install` takes `trust_native`; a non-verified C++ install without it returns **403** with an actionable message. The installer enforces the same rule (`TrustRequiredError`) so programmatic callers can't bypass it.
- **Deprecation lifecycle** — deprecated agents are excluded from the default catalog (still installable via `include_deprecated=true`) and log a loud warning on install.
- **Catalog surface** — each entry now carries `security_tier` + a derived `requires_trust` flag.
- **Hub UI** — tier badges (verified=check, community=shield, experimental=flask), a Deprecated badge, a *Trust & Install* confirmation dialog before native installs, and a tier-filter dropdown.
- **Worker** — already validated the 3 tiers and recorded deprecation; extended the vitest suite to cover unknown-tier rejection and deprecated round-trip at the publish boundary.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/test_hub_*.py` → 136 passed (incl. new `test_hub_security.py`)
- [x] `cd workers/agent-hub && npm test` → 35 passed (+4 new)
- [x] `cd src/gaia/apps/webui && npx vitest run` (hub specs) → 22 passed (incl. trust-dialog test)
- [x] `cd src/gaia/apps/webui && npm run build` → clean
- [x] `python util/lint.py --black --isort --pylint` → black/isort PASS; pylint clean on changed files (one pre-existing `os.geteuid` false-positive in `lemonade_installer.py` on Windows, untouched here)

Closes #1100.