### PR TITLE
feat(hub): gaia agent pack + dual-publish to R2 and PyPI (#1093, #1179)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -412,6 +412,55 @@ gaia agent test --live --timeout 90
 ```
 </CodeGroup>
 
+#### Distribution: `pack`, `publish`, `login`
+
+Build a distributable wheel from a Python agent package, then dual-publish it to the Agent Hub (R2, the source for the Hub UI) **and** PyPI (the source for `pip install`).
+
+```bash
+gaia agent login [--hub-token TOKEN | --hub] [--pypi-token TOKEN | --pypi]
+gaia agent pack [PATH] [--output DIR]
+gaia agent publish [PATH] [--output DIR] [--hub-url URL] [--skip-r2] [--skip-pypi]
+```
+
+**`pack`** runs `python -m build --wheel` against the package's `pyproject.toml`, writing `gaia_agent_<id>-<version>-py3-none-any.whl` to `dist/` and printing its SHA-256. Python agents only — native (C++) agents ship a CMake-built binary, not a wheel.
+
+**`publish`** packs the wheel and uploads it to both targets. R2 receives a multipart POST (`gaia-agent.yaml` + wheel) authenticated with a Bearer token; PyPI receives a `twine upload` authenticated with an API token. Both enforce version immutability — bump the version with `gaia agent version` before re-publishing.
+
+**`login`** stores publisher tokens in your OS keyring. Tokens may also be supplied via the `GAIA_HUB_TOKEN` and `PYPI_TOKEN` environment variables (useful in CI), which take precedence over the keyring.
+
+| Option | Applies to | Description |
+|--------|------------|-------------|
+| `PATH` | `pack`, `publish` | Agent package directory (positional, default: current dir) |
+| `--output, -o` | `pack`, `publish` | Output directory for the wheel (default: `<package>/dist`) |
+| `--hub-url` | `publish` | R2 Worker origin (default: `GAIA_HUB_URL` or `https://hub.amd-gaia.ai`) |
+| `--skip-r2` | `publish` | Publish to PyPI only |
+| `--skip-pypi` | `publish` | Publish to R2 only |
+| `--hub-token` / `--hub` | `login` | Store the R2 Hub token (pass a value, or `--hub` to be prompted) |
+| `--pypi-token` / `--pypi` | `login` | Store the PyPI token (pass a value, or `--pypi` to be prompted) |
+
+The packaging toolchain (`build`, `twine`) ships in the `publish` extra:
+
+```bash
+pip install "amd-gaia[publish]"
+```
+
+**Examples:**
+
+<CodeGroup>
+```bash Build a wheel
+gaia agent pack hub/agents/python/summarize/
+```
+
+```bash Store tokens, then dual-publish
+gaia agent login --hub --pypi          # prompts for each token
+gaia agent publish hub/agents/python/summarize/
+```
+
+```bash Publish to PyPI only
+gaia agent publish --skip-r2
+```
+</CodeGroup>
+
 #### Sharing: `export`, `import`
 
 Export every custom agent installed under `~/.gaia/agents/` into a single `.zip` bundle, and import a bundle produced on another machine.

--- a/setup.py
+++ b/setup.py
@@ -245,6 +245,24 @@ setup(
             "mypy",
             "bandit",
         ],
+        # Agent Hub packaging/publishing toolchain (issues #1093, #1179):
+        # 'gaia agent pack' shells out to 'python -m build', 'gaia agent publish'
+        # to 'twine upload'. Kept out of [dev] so the unit suite stays lean —
+        # install with 'pip install "amd-gaia[publish]"' to package an agent.
+        "publish": [
+            "build>=1.0.0",
+            "twine>=5.0.0",
+        ],
+        # Meta-package extras (issue #1179): install AMD production agents from
+        # PyPI. Each 'gaia-agent-<id>' is a standalone wheel; the set grows as
+        # agents migrate to hub/agents/ (spec Phase 2/3). Add an entry here when
+        # each agent's wheel is first published.
+        "agents": [
+            "gaia-agent-summarize",
+        ],
+        "agent-summarize": [
+            "gaia-agent-summarize",
+        ],
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/src/gaia/cli_agent.py
+++ b/src/gaia/cli_agent.py
@@ -142,6 +142,80 @@ def register_subparsers(agent_subparsers) -> None:
         help="Per-prompt timeout in seconds for --live mode (default: 60)",
     )
 
+    pack_p = agent_subparsers.add_parser(
+        "pack",
+        help="Build a distributable wheel from an agent package (python -m build)",
+    )
+    pack_p.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Agent package directory (default: current dir)",
+    )
+    pack_p.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output directory for the wheel (default: <package>/dist)",
+    )
+
+    publish_p = agent_subparsers.add_parser(
+        "publish",
+        help="Build + publish the wheel to R2 (Hub) and PyPI (dual-publish)",
+    )
+    publish_p.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Agent package directory (default: current dir)",
+    )
+    publish_p.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output directory for the built wheel (default: <package>/dist)",
+    )
+    publish_p.add_argument(
+        "--hub-url",
+        default=None,
+        help="R2 Worker origin (default: GAIA_HUB_URL or https://hub.amd-gaia.ai)",
+    )
+    publish_p.add_argument(
+        "--skip-r2",
+        action="store_true",
+        help="Publish to PyPI only (skip the R2 Hub upload)",
+    )
+    publish_p.add_argument(
+        "--skip-pypi",
+        action="store_true",
+        help="Publish to R2 only (skip the PyPI upload)",
+    )
+
+    login_p = agent_subparsers.add_parser(
+        "login",
+        help="Store publisher tokens (R2 Hub and/or PyPI) in the OS keyring",
+    )
+    login_p.add_argument(
+        "--hub-token",
+        default=None,
+        help="R2 Worker publish token (prompted securely if omitted with --hub)",
+    )
+    login_p.add_argument(
+        "--pypi-token",
+        default=None,
+        help="PyPI API token (prompted securely if omitted with --pypi)",
+    )
+    login_p.add_argument(
+        "--hub",
+        action="store_true",
+        help="Prompt for the R2 Hub token (use instead of --hub-token)",
+    )
+    login_p.add_argument(
+        "--pypi",
+        action="store_true",
+        help="Prompt for the PyPI token (use instead of --pypi-token)",
+    )
+
 
 def handle(args) -> bool:
     """Dispatch ``init`` / ``version`` / ``test`` actions.
@@ -155,6 +229,9 @@ def handle(args) -> bool:
         "init": cmd_init,
         "version": cmd_version,
         "test": cmd_test,
+        "pack": cmd_pack,
+        "publish": cmd_publish,
+        "login": cmd_login,
     }
     fn = dispatch.get(action)
     if fn is None:
@@ -665,6 +742,98 @@ def _query_with_timeout(agent, prompt: str, timeout: int):
     if thread.is_alive():
         return None, None, True
     return box.get("result"), box.get("error"), False
+
+
+# ---------------------------------------------------------------------------
+# pack / publish / login (distribution)
+# ---------------------------------------------------------------------------
+
+
+def cmd_pack(args) -> None:
+    """Build a distributable wheel from an agent package."""
+    from gaia.hub import packager
+
+    try:
+        result = packager.pack(args.path, output_dir=args.output)
+    except packager.PackagerError as exc:
+        raise AgentWorkflowError(str(exc)) from exc
+
+    print(f"Built wheel for agent '{result.agent_id}' v{result.version}")
+    print(f"  path:   {result.wheel_path}")
+    print(f"  size:   {result.size_bytes} bytes")
+    print(f"  sha256: {result.sha256}")
+    print("\nNext: 'gaia agent publish' to upload to the Hub (R2) and PyPI.")
+
+
+def cmd_publish(args) -> None:
+    """Build the wheel, then dual-publish it to R2 (Hub) and PyPI."""
+    from gaia.hub import packager, publisher
+
+    pkg_dir = Path(args.path).expanduser().resolve()
+    manifest_path = pkg_dir / "gaia-agent.yaml"
+
+    try:
+        pack_result = packager.pack(args.path, output_dir=args.output)
+    except packager.PackagerError as exc:
+        raise AgentWorkflowError(str(exc)) from exc
+
+    print(f"Built {pack_result.wheel_path.name} (sha256 {pack_result.sha256[:12]}…)")
+    print("Publishing…")
+    try:
+        result = publisher.publish(
+            pack_result,
+            manifest_path,
+            hub_url=args.hub_url,
+            skip_r2=args.skip_r2,
+            skip_pypi=args.skip_pypi,
+        )
+    except publisher.PublisherError as exc:
+        raise AgentWorkflowError(str(exc)) from exc
+
+    for target in (result.r2, result.pypi):
+        status = "skipped" if target.skipped else "PASS"
+        print(f"  [{status}] {target.target}: {target.detail}")
+    print(
+        f"\nPublished agent '{result.agent_id}' v{result.version} "
+        f"(R2 for the Hub UI, PyPI for 'pip install {pack_result.dist_name}')."
+    )
+
+
+def cmd_login(args) -> None:
+    """Store R2 Hub and/or PyPI publisher tokens in the OS keyring."""
+    import getpass
+
+    from gaia.hub import publisher
+
+    stored = []
+
+    hub_token = args.hub_token
+    if hub_token is None and args.hub:
+        hub_token = getpass.getpass("R2 Hub publish token: ")
+    if hub_token:
+        try:
+            publisher.store_token("hub", hub_token)
+        except publisher.PublisherError as exc:
+            raise AgentWorkflowError(str(exc)) from exc
+        stored.append("hub")
+
+    pypi_token = args.pypi_token
+    if pypi_token is None and args.pypi:
+        pypi_token = getpass.getpass("PyPI API token: ")
+    if pypi_token:
+        try:
+            publisher.store_token("pypi", pypi_token)
+        except publisher.PublisherError as exc:
+            raise AgentWorkflowError(str(exc)) from exc
+        stored.append("pypi")
+
+    if not stored:
+        raise AgentWorkflowError(
+            "no token provided. Pass --hub-token/--pypi-token (or --hub/--pypi "
+            "to be prompted). Tokens are stored in your OS keyring and read at "
+            "publish time."
+        )
+    print(f"Stored token(s) in the OS keyring: {', '.join(stored)}.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia/hub/packager.py
+++ b/src/gaia/hub/packager.py
@@ -1,0 +1,251 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Build a distributable Python wheel from a hub agent package.
+
+Phase 2 of the Agent Hub restructure (``docs/spec/agent-hub-restructure.mdx``):
+a community/AMD agent lives in ``hub/agents/python/<id>/`` with its own
+``pyproject.toml`` (declaring the ``gaia.agent`` entry point and an
+``amd-gaia>={min_gaia_version}`` dependency). :func:`pack` turns that source
+package into ``dist/gaia_agent_<id>-<version>-py3-none-any.whl`` via
+``python -m build --wheel`` and computes the artifact's SHA-256 so the publisher
+(and the R2 Worker) can verify integrity.
+
+Per ``CLAUDE.md`` (No Silent Fallbacks): every step either succeeds or raises a
+:class:`PackagerError` naming *what* failed, *what* to do, and *where* to look.
+There is no degraded "best-effort" wheel — a build failure is loud.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from gaia.hub import manifest as hub_manifest
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+# Read SHA-256 in 1 MiB chunks so a large native-deps wheel doesn't balloon RAM.
+_HASH_CHUNK = 1024 * 1024
+
+_SPEC_URL = "https://amd-gaia.ai/docs/spec/agent-hub-restructure"
+
+
+class PackagerError(Exception):
+    """Raised when a wheel cannot be built from an agent package.
+
+    The message always names *what* failed, *what* to do, and *where* to look,
+    per the project's fail-loudly rule.
+    """
+
+
+@dataclass
+class PackResult:
+    """The outcome of a successful :func:`pack`."""
+
+    wheel_path: Path
+    sha256: str
+    size_bytes: int
+    agent_id: str
+    version: str
+    dist_name: str
+
+    @property
+    def filename(self) -> str:
+        return self.wheel_path.name
+
+
+def _normalize_wheel_stem(dist_name: str) -> str:
+    """Return the wheel-escaped distribution name.
+
+    PEP 427 escapes runs of ``-_.`` in the distribution name to a single ``_``,
+    so ``gaia-agent-summarize`` becomes ``gaia_agent_summarize`` in the wheel
+    filename. We use this to locate the wheel ``python -m build`` produced.
+    """
+    return re.sub(r"[-_.]+", "_", dist_name).lower()
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the lowercase hex SHA-256 of *path* (streamed)."""
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(_HASH_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_pyproject_name(pyproject: Path) -> Optional[str]:
+    """Best-effort read of ``[project] name`` from a pyproject.toml.
+
+    Used only to locate the built wheel; the manifest id is authoritative for
+    everything else. Returns ``None`` if the field is absent so the caller can
+    fall back to the ``gaia-agent-<id>`` convention.
+    """
+    pattern = re.compile(r'^\s*name\s*=\s*["\']([^"\']+)["\']\s*$')
+    in_project = False
+    for line in pyproject.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project = stripped == "[project]"
+            continue
+        if in_project:
+            m = pattern.match(line)
+            if m:
+                return m.group(1)
+    return None
+
+
+def pack(
+    package_dir,
+    *,
+    output_dir=None,
+    runner=None,
+) -> PackResult:
+    """Build a wheel from the agent package at *package_dir*.
+
+    Args:
+        package_dir: Directory containing ``gaia-agent.yaml`` and
+            ``pyproject.toml`` (the agent package root).
+        output_dir: Where to write the wheel. Defaults to ``<package_dir>/dist``.
+        runner: Optional callable ``(cmd: list[str], cwd: Path) -> (rc, output)``
+            used to run the build (injected by tests). Defaults to a real
+            subprocess invocation of ``python -m build --wheel``.
+
+    Returns:
+        A :class:`PackResult` with the wheel path, its SHA-256, size, and the
+        agent's id/version.
+
+    Raises:
+        PackagerError: If the package is missing required files, is not a python
+            agent, the build tool is unavailable, the build fails, or no wheel
+            is produced.
+    """
+    pkg_dir = Path(package_dir).expanduser().resolve()
+    if not pkg_dir.is_dir():
+        raise PackagerError(
+            f"agent package directory not found: {pkg_dir}. Pass the path to a "
+            f"hub agent package (the directory containing gaia-agent.yaml)."
+        )
+
+    # The manifest is the source of truth for id/version and gates non-python
+    # packages. A C++ agent ships a binary, not a wheel — fail loudly.
+    try:
+        parsed = hub_manifest.parse(pkg_dir)
+    except hub_manifest.ManifestError as exc:
+        raise PackagerError(
+            f"cannot pack {pkg_dir}: its gaia-agent.yaml is invalid: {exc}"
+        ) from exc
+
+    if parsed.language != "python":
+        raise PackagerError(
+            f"'gaia agent pack' builds Python wheels, but {pkg_dir} is a "
+            f"{parsed.language!r} agent. Native (cpp) agents ship a binary built "
+            f"by CMake, not a wheel. See {_SPEC_URL}."
+        )
+
+    pyproject = pkg_dir / "pyproject.toml"
+    if not pyproject.exists():
+        raise PackagerError(
+            f"pyproject.toml not found at {pyproject}. A Python agent package "
+            f"needs one to declare its build backend, dependencies, and the "
+            f"'gaia.agent' entry point. See {_SPEC_URL}."
+        )
+
+    out_dir = (
+        Path(output_dir).expanduser().resolve()
+        if output_dir is not None
+        else pkg_dir / "dist"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    dist_name = _read_pyproject_name(pyproject) or f"gaia-agent-{parsed.id}"
+
+    # Snapshot existing wheels so we can identify exactly what this build adds —
+    # a stale wheel from a previous version must not be mistaken for the new one.
+    before = {p.name for p in out_dir.glob("*.whl")}
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "build",
+        "--wheel",
+        "--outdir",
+        str(out_dir),
+        str(pkg_dir),
+    ]
+    run = runner or _default_runner
+    log.debug("packager: building wheel: %s", " ".join(cmd))
+    rc, output = run(cmd, pkg_dir)
+    if rc != 0:
+        raise PackagerError(
+            f"wheel build failed for agent {parsed.id!r} (exit {rc}).\n"
+            f"{output.strip()}\n"
+            f"Ensure the build backend is installed ('pip install \"amd-gaia"
+            f"[publish]\"' or 'pip install build') and that pyproject.toml is "
+            f"valid, then re-run 'gaia agent pack'."
+        )
+
+    wheel = _locate_wheel(out_dir, before, dist_name, parsed.version)
+    sha256 = _sha256_file(wheel)
+    size = wheel.stat().st_size
+    log.debug("packager: built %s (%d bytes, sha256=%s)", wheel.name, size, sha256)
+    return PackResult(
+        wheel_path=wheel,
+        sha256=sha256,
+        size_bytes=size,
+        agent_id=parsed.id,
+        version=parsed.version,
+        dist_name=dist_name,
+    )
+
+
+def _locate_wheel(out_dir: Path, before: set, dist_name: str, version: str) -> Path:
+    """Return the wheel this build produced, failing loudly if ambiguous."""
+    new_wheels = [p for p in out_dir.glob("*.whl") if p.name not in before]
+    stem = _normalize_wheel_stem(dist_name)
+    expected_prefix = f"{stem}-{version}-"
+
+    # Prefer a freshly built wheel matching <normalized_name>-<version>.
+    matches = [p for p in new_wheels if p.name.lower().startswith(expected_prefix)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        names = ", ".join(sorted(p.name for p in matches))
+        raise PackagerError(
+            f"build produced multiple wheels matching {expected_prefix!r}: "
+            f"{names}. Clean {out_dir} and re-run 'gaia agent pack'."
+        )
+
+    # No new wheel matched the expected name — surface what *was* produced so
+    # the author can see a name/version mismatch between pyproject and manifest.
+    if new_wheels:
+        produced = ", ".join(sorted(p.name for p in new_wheels))
+        raise PackagerError(
+            f"build produced wheel(s) [{produced}] but none matched the expected "
+            f"name {expected_prefix!r} (from pyproject name {dist_name!r} and "
+            f"manifest version {version}). Make sure pyproject.toml 'name' and "
+            f"'version' agree with gaia-agent.yaml."
+        )
+    raise PackagerError(
+        f"'python -m build' reported success but no .whl appeared in {out_dir}. "
+        f"Check the build output and your pyproject.toml build backend."
+    )
+
+
+def _default_runner(cmd: List[str], cwd: Path):
+    """Run *cmd* in *cwd*; return ``(returncode, combined stdout+stderr)``."""
+    try:
+        proc = subprocess.run(
+            cmd, cwd=str(cwd), capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError as exc:
+        return 1, (
+            f"could not run {cmd[0]!r}: {exc}. Install the Python build "
+            f"frontend with 'pip install \"amd-gaia[publish]\"'."
+        )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")

--- a/src/gaia/hub/publisher.py
+++ b/src/gaia/hub/publisher.py
@@ -1,0 +1,370 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Dual-publish an agent wheel to R2 (Hub) and PyPI (pip).
+
+Phase 3 of the Agent Hub restructure (``docs/spec/agent-hub-restructure.mdx``,
+step 3F — dual distribution):
+
+* **R2** is the canonical source for the Hub UI/website. The wheel + its
+  ``gaia-agent.yaml`` are POSTed to the Cloudflare Worker's ``/publish``
+  endpoint (``workers/agent-hub/``) with a Bearer token. The Worker validates
+  the manifest, enforces publisher scope + version immutability, computes a
+  server-side SHA-256, and rebuilds ``index.json``.
+* **PyPI** is the canonical source for ``pip install gaia-agent-<id>``. The
+  wheel is uploaded with ``twine``; PyPI enforces version immutability natively.
+
+Tokens resolve from the environment first (``GAIA_HUB_TOKEN`` / ``PYPI_TOKEN``)
+then the OS keyring (``gaia agent login`` stores them there). Per ``CLAUDE.md``
+(No Silent Fallbacks): a missing token, a network failure, or a rejected upload
+raises a :class:`PublisherError` naming *what* failed, *what* to do, and *where*
+to look — there is no "publish to whichever one happens to work" degradation.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+# Keyring service + usernames for stored publisher tokens. Distinct from the
+# connectors' "gaia.connections" service so a Hub token can't be confused with
+# an OAuth refresh token.
+KEYRING_SERVICE = "gaia.hub"
+HUB_TOKEN_KEY = "hub-token"
+PYPI_TOKEN_KEY = "pypi-token"
+
+# Environment overrides (checked before the keyring) — handy for CI, where
+# secrets arrive as env vars, not an interactive keyring.
+HUB_TOKEN_ENV = "GAIA_HUB_TOKEN"
+PYPI_TOKEN_ENV = "PYPI_TOKEN"
+
+# PyPI token uploads always use the literal "__token__" username.
+PYPI_TOKEN_USERNAME = "__token__"
+
+_PUBLISH_TIMEOUT = 120  # seconds for the R2 multipart upload
+
+
+class PublisherError(Exception):
+    """Raised when a publish to R2 or PyPI cannot proceed or is rejected.
+
+    The message always names *what* failed, *what* to do, and *where* to look,
+    per the project's fail-loudly rule.
+    """
+
+
+@dataclass
+class TargetResult:
+    """Outcome of publishing to a single target (R2 or PyPI)."""
+
+    target: str  # "r2" | "pypi"
+    skipped: bool = False
+    detail: str = ""
+
+
+@dataclass
+class PublishResult:
+    """Combined outcome of a dual-publish."""
+
+    agent_id: str
+    version: str
+    r2: TargetResult
+    pypi: TargetResult
+
+
+# ---------------------------------------------------------------------------
+# Token storage (keyring + env)
+# ---------------------------------------------------------------------------
+
+
+def _keyring():
+    try:
+        import keyring  # local import: keyring is in [ui]/[dev], not core
+    except ImportError as exc:
+        raise PublisherError(
+            "the 'keyring' package is required to store/read publisher tokens. "
+            "Install it with 'pip install \"amd-gaia[dev]\"', or pass tokens via "
+            f"the {HUB_TOKEN_ENV} / {PYPI_TOKEN_ENV} environment variables."
+        ) from exc
+    return keyring
+
+
+def store_token(kind: str, token: str) -> None:
+    """Persist a publisher token in the OS keyring.
+
+    Args:
+        kind: ``"hub"`` (R2 Worker) or ``"pypi"``.
+        token: The secret to store.
+
+    Raises:
+        PublisherError: For an unknown *kind*, an empty *token*, or a keyring
+            backend failure.
+    """
+    if not token or not token.strip():
+        raise PublisherError(
+            f"refusing to store an empty {kind} token. Pass a non-empty token."
+        )
+    username = _username_for(kind)
+    try:
+        _keyring().set_password(KEYRING_SERVICE, username, token.strip())
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        raise PublisherError(
+            f"could not store the {kind} token in the OS keyring: {exc}. On a "
+            f"headless machine, set the {_env_for(kind)} environment variable "
+            f"instead."
+        ) from exc
+
+
+def _username_for(kind: str) -> str:
+    if kind == "hub":
+        return HUB_TOKEN_KEY
+    if kind == "pypi":
+        return PYPI_TOKEN_KEY
+    raise PublisherError(
+        f"unknown token kind {kind!r}. Use 'hub' (R2 Worker) or 'pypi'."
+    )
+
+
+def _env_for(kind: str) -> str:
+    return HUB_TOKEN_ENV if kind == "hub" else PYPI_TOKEN_ENV
+
+
+def get_hub_token() -> Optional[str]:
+    """Return the R2 Worker token from env or keyring (``None`` if unset)."""
+    return _resolve_token("hub")
+
+
+def get_pypi_token() -> Optional[str]:
+    """Return the PyPI API token from env or keyring (``None`` if unset)."""
+    return _resolve_token("pypi")
+
+
+def _resolve_token(kind: str) -> Optional[str]:
+    env_val = os.environ.get(_env_for(kind))
+    if env_val and env_val.strip():
+        return env_val.strip()
+    try:
+        stored = _keyring().get_password(KEYRING_SERVICE, _username_for(kind))
+    except PublisherError:
+        # keyring not installed — env was the only option and it's unset.
+        return None
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.warning("publisher: keyring read failed for %s token: %s", kind, exc)
+        return None
+    return stored.strip() if stored and stored.strip() else None
+
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+
+def publish(
+    pack_result,
+    manifest_path,
+    *,
+    hub_url: Optional[str] = None,
+    skip_r2: bool = False,
+    skip_pypi: bool = False,
+    twine_runner=None,
+) -> PublishResult:
+    """Dual-publish a built wheel to R2 and PyPI.
+
+    Args:
+        pack_result: A :class:`gaia.hub.packager.PackResult` (the wheel to ship).
+        manifest_path: Path to the agent's ``gaia-agent.yaml`` (uploaded to R2
+            so the Worker can validate + index the version).
+        hub_url: R2 Worker origin. Defaults to the configured hub base URL
+            (``GAIA_HUB_URL`` / ``https://hub.amd-gaia.ai``).
+        skip_r2: Publish to PyPI only.
+        skip_pypi: Publish to R2 only.
+        twine_runner: Optional ``(cmd, env) -> (rc, output)`` callable used to
+            run twine (injected by tests).
+
+    Returns:
+        A :class:`PublishResult` describing each target's outcome.
+
+    Raises:
+        PublisherError: For a missing token, a network/HTTP failure, or a
+            rejected upload (e.g. a version that already exists).
+    """
+    if skip_r2 and skip_pypi:
+        raise PublisherError(
+            "nothing to publish: both --skip-r2 and --skip-pypi were given. "
+            "Drop one so the wheel goes somewhere."
+        )
+
+    wheel = Path(pack_result.wheel_path)
+    if not wheel.exists():
+        raise PublisherError(
+            f"wheel not found: {wheel}. Run 'gaia agent pack' first (or the "
+            f"publish step rebuilds it)."
+        )
+    manifest = Path(manifest_path)
+    if not manifest.exists():
+        raise PublisherError(
+            f"gaia-agent.yaml not found: {manifest}. R2 needs the manifest to "
+            f"validate and index the published version."
+        )
+
+    r2 = (
+        TargetResult("r2", skipped=True, detail="skipped (--skip-r2)")
+        if skip_r2
+        else _publish_r2(wheel, manifest, hub_url)
+    )
+    pypi = (
+        TargetResult("pypi", skipped=True, detail="skipped (--skip-pypi)")
+        if skip_pypi
+        else _publish_pypi(wheel, twine_runner)
+    )
+    return PublishResult(
+        agent_id=pack_result.agent_id,
+        version=pack_result.version,
+        r2=r2,
+        pypi=pypi,
+    )
+
+
+def _hub_base_url(hub_url: Optional[str]) -> str:
+    if hub_url:
+        return hub_url.rstrip("/")
+    # Reuse the catalog's resolution so publish and install agree on the origin.
+    from gaia.hub.catalog import get_hub_base_url
+
+    return get_hub_base_url()
+
+
+def _publish_r2(wheel: Path, manifest: Path, hub_url: Optional[str]) -> TargetResult:
+    """POST the wheel + manifest to the Worker's ``/publish`` (Bearer auth)."""
+    token = get_hub_token()
+    if not token:
+        raise PublisherError(
+            "no Hub publish token found. Run 'gaia agent login --hub-token "
+            f"<token>' to store one, or set {HUB_TOKEN_ENV}. The Worker rejects "
+            "anonymous publishes with 401."
+        )
+
+    import requests  # local import: requests is a core dep
+
+    url = f"{_hub_base_url(hub_url)}/publish"
+    manifest_text = manifest.read_text(encoding="utf-8")
+    log.debug("publisher: POST %s (%s)", url, wheel.name)
+    try:
+        with wheel.open("rb") as fh:
+            resp = requests.post(
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+                files={
+                    "manifest": ("gaia-agent.yaml", manifest_text, "text/yaml"),
+                    "artifact": (
+                        wheel.name,
+                        fh,
+                        "application/octet-stream",
+                    ),
+                },
+                timeout=_PUBLISH_TIMEOUT,
+            )
+    except requests.RequestException as exc:
+        raise PublisherError(
+            f"could not reach the Hub publish endpoint at {url}: {exc}. Check "
+            f"your network and that GAIA_HUB_URL points at a running Worker."
+        ) from exc
+
+    if resp.status_code in (200, 201):
+        return TargetResult("r2", detail=f"published to {url}")
+
+    body = _short_body(resp)
+    if resp.status_code == 401:
+        raise PublisherError(
+            f"Hub rejected the publish token (401): {body}. Re-run 'gaia agent "
+            f"login --hub-token <token>' with a valid token."
+        )
+    if resp.status_code == 403:
+        raise PublisherError(
+            f"Hub rejected the publish: not authorized for this agent's author "
+            f"(403): {body}. The token's publisher scope must include the "
+            f"manifest 'author'."
+        )
+    if resp.status_code == 409:
+        raise PublisherError(
+            f"this version already exists on the Hub (409): {body}. Published "
+            f"versions are immutable — bump the version with 'gaia agent version "
+            f"<patch|minor|major>' and re-pack."
+        )
+    raise PublisherError(f"Hub publish failed ({resp.status_code}) at {url}: {body}.")
+
+
+def _short_body(resp, limit: int = 500) -> str:
+    try:
+        text = resp.text or ""
+    except Exception:  # pylint: disable=broad-exception-caught
+        return "<unreadable response body>"
+    text = text.strip()
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
+def _publish_pypi(wheel: Path, twine_runner) -> TargetResult:
+    """Upload the wheel to PyPI via twine (``__token__`` auth)."""
+    token = get_pypi_token()
+    if not token:
+        raise PublisherError(
+            "no PyPI token found. Run 'gaia agent login --pypi-token <token>' "
+            f"to store one, or set {PYPI_TOKEN_ENV}. Create a token at "
+            "https://pypi.org/manage/account/token/."
+        )
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "twine",
+        "upload",
+        "--non-interactive",
+        str(wheel),
+    ]
+    env = dict(os.environ)
+    env["TWINE_USERNAME"] = PYPI_TOKEN_USERNAME
+    env["TWINE_PASSWORD"] = token
+
+    run = twine_runner or _default_twine_runner
+    log.debug("publisher: twine upload %s", wheel.name)
+    rc, output = run(cmd, env)
+    if rc == 0:
+        return TargetResult("pypi", detail=f"uploaded {wheel.name} to PyPI")
+
+    lowered = (output or "").lower()
+    # PyPI rejects a re-upload of an existing file with 400 "File already
+    # exists" — surface that as the immutability message, not a generic failure.
+    if "already exists" in lowered or "this filename has already been used" in lowered:
+        raise PublisherError(
+            f"PyPI already has this version of {wheel.name}: published versions "
+            f"are immutable. Bump the version with 'gaia agent version "
+            f"<patch|minor|major>', re-pack, and publish again.\n{output.strip()}"
+        )
+    if "403" in lowered or "invalid or non-existent authentication" in lowered:
+        raise PublisherError(
+            f"PyPI rejected the upload token: {output.strip()}. Re-run 'gaia "
+            f"agent login --pypi-token <token>' with a valid API token."
+        )
+    raise PublisherError(
+        f"twine upload failed (exit {rc}) for {wheel.name}:\n{output.strip()}\n"
+        f"Ensure twine is installed ('pip install \"amd-gaia[publish]\"') and "
+        f"the token is valid."
+    )
+
+
+def _default_twine_runner(cmd: List[str], env: dict):
+    """Run twine; return ``(returncode, combined stdout+stderr)``."""
+    try:
+        proc = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:
+        return 1, (
+            f"could not run twine: {exc}. Install it with 'pip install "
+            f'"amd-gaia[publish]"\'.'
+        )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")

--- a/tests/unit/test_cli_agent.py
+++ b/tests/unit/test_cli_agent.py
@@ -297,3 +297,158 @@ def test_handle_returns_false_for_export():
 
 def test_handle_returns_true_for_init(tmp_path):
     assert cli_agent.handle(_init_args("demo-agent", tmp_path)) is True
+
+
+# ---------------------------------------------------------------------------
+# pack / publish / login (distribution)
+# ---------------------------------------------------------------------------
+
+
+def _pack_args(path, output=None):
+    return Namespace(agent_action="pack", path=str(path), output=output)
+
+
+def _publish_args(path, output=None, hub_url=None, skip_r2=False, skip_pypi=False):
+    return Namespace(
+        agent_action="publish",
+        path=str(path),
+        output=output,
+        hub_url=hub_url,
+        skip_r2=skip_r2,
+        skip_pypi=skip_pypi,
+    )
+
+
+def _login_args(hub_token=None, pypi_token=None, hub=False, pypi=False):
+    return Namespace(
+        agent_action="login",
+        hub_token=hub_token,
+        pypi_token=pypi_token,
+        hub=hub,
+        pypi=pypi,
+    )
+
+
+class _FakePackResult:
+    def __init__(self, tmp_path):
+        from pathlib import Path
+
+        self.wheel_path = Path(tmp_path) / "gaia_agent_demo-0.1.0-py3-none-any.whl"
+        self.wheel_path.write_bytes(b"wheel")
+        self.sha256 = "abc123def456"
+        self.size_bytes = 5
+        self.agent_id = "demo"
+        self.version = "0.1.0"
+        self.dist_name = "gaia-agent-demo"
+
+
+def test_cmd_pack_calls_packager(tmp_path, monkeypatch, capsys):
+    from gaia.hub import packager
+
+    called = {}
+    fake = _FakePackResult(tmp_path)
+
+    def _fake_pack(path, *, output_dir=None, **kw):
+        called["path"] = path
+        called["output_dir"] = output_dir
+        return fake
+
+    monkeypatch.setattr(packager, "pack", _fake_pack)
+    cli_agent.cmd_pack(_pack_args(tmp_path, output=None))
+    out = capsys.readouterr().out
+    assert "abc123def456" in out
+    assert called["path"] == str(tmp_path)
+
+
+def test_cmd_pack_wraps_packager_error(tmp_path, monkeypatch):
+    from gaia.hub import packager
+
+    def _boom(path, *, output_dir=None, **kw):
+        raise packager.PackagerError("build went boom")
+
+    monkeypatch.setattr(packager, "pack", _boom)
+    with pytest.raises(cli_agent.AgentWorkflowError, match="build went boom"):
+        cli_agent.cmd_pack(_pack_args(tmp_path))
+
+
+def test_cmd_publish_packs_then_publishes(tmp_path, monkeypatch, capsys):
+    from gaia.hub import packager, publisher
+
+    fake = _FakePackResult(tmp_path)
+    monkeypatch.setattr(packager, "pack", lambda p, *, output_dir=None, **k: fake)
+
+    captured = {}
+
+    def _fake_publish(pack_result, manifest_path, **kwargs):
+        captured["manifest"] = manifest_path
+        captured["kwargs"] = kwargs
+        return publisher.PublishResult(
+            agent_id="demo",
+            version="0.1.0",
+            r2=publisher.TargetResult("r2", detail="ok"),
+            pypi=publisher.TargetResult("pypi", detail="ok"),
+        )
+
+    monkeypatch.setattr(publisher, "publish", _fake_publish)
+    cli_agent.cmd_publish(_publish_args(tmp_path, hub_url="https://h"))
+    out = capsys.readouterr().out
+    assert "Published agent 'demo'" in out
+    assert captured["kwargs"]["hub_url"] == "https://h"
+    assert str(captured["manifest"]).endswith("gaia-agent.yaml")
+
+
+def test_cmd_publish_wraps_publisher_error(tmp_path, monkeypatch):
+    from gaia.hub import packager, publisher
+
+    fake = _FakePackResult(tmp_path)
+    monkeypatch.setattr(packager, "pack", lambda p, *, output_dir=None, **k: fake)
+
+    def _boom(*a, **k):
+        raise publisher.PublisherError("no token")
+
+    monkeypatch.setattr(publisher, "publish", _boom)
+    with pytest.raises(cli_agent.AgentWorkflowError, match="no token"):
+        cli_agent.cmd_publish(_publish_args(tmp_path))
+
+
+def test_cmd_login_stores_tokens(monkeypatch, capsys):
+    from gaia.hub import publisher
+
+    stored = {}
+    monkeypatch.setattr(
+        publisher, "store_token", lambda kind, token: stored.__setitem__(kind, token)
+    )
+    cli_agent.cmd_login(_login_args(hub_token="h-tok", pypi_token="p-tok"))
+    assert stored == {"hub": "h-tok", "pypi": "p-tok"}
+    assert "hub, pypi" in capsys.readouterr().out
+
+
+def test_cmd_login_no_token_raises(monkeypatch):
+    from gaia.hub import publisher
+
+    monkeypatch.setattr(publisher, "store_token", lambda kind, token: None)
+    with pytest.raises(cli_agent.AgentWorkflowError, match="no token provided"):
+        cli_agent.cmd_login(_login_args())
+
+
+def test_cmd_login_prompts_when_flag_set(monkeypatch):
+    import getpass
+
+    from gaia.hub import publisher
+
+    stored = {}
+    monkeypatch.setattr(
+        publisher, "store_token", lambda kind, token: stored.__setitem__(kind, token)
+    )
+    monkeypatch.setattr(getpass, "getpass", lambda prompt="": "prompted-secret")
+    cli_agent.cmd_login(_login_args(hub=True))
+    assert stored == {"hub": "prompted-secret"}
+
+
+def test_handle_dispatches_pack(tmp_path, monkeypatch):
+    from gaia.hub import packager
+
+    monkeypatch.setattr(
+        packager, "pack", lambda p, *, output_dir=None, **k: _FakePackResult(tmp_path)
+    )
+    assert cli_agent.handle(_pack_args(tmp_path)) is True

--- a/tests/unit/test_hub_packager.py
+++ b/tests/unit/test_hub_packager.py
@@ -1,0 +1,203 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``gaia.hub.packager`` (gaia agent pack).
+
+The Python build frontend (``python -m build``) is never invoked for real: a
+fake ``runner`` writes a placeholder wheel into the output dir so we can assert
+the produced path, checksum, and the fail-loudly error paths without a toolchain
+or network.
+"""
+
+import hashlib
+
+import pytest
+
+from gaia.hub import packager
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PYPROJECT = """\
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gaia-agent-demo-agent"
+version = "0.1.0"
+description = "Demo agent"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+dependencies = ["amd-gaia>=0.20.0"]
+
+[project.entry-points."gaia.agent"]
+demo-agent = "gaia_agent_demo_agent:build_registration"
+"""
+
+_MANIFEST = """\
+id: demo-agent
+name: Demo Agent
+version: 0.1.0
+description: "Demo agent for packaging tests"
+author: AMD
+license: MIT
+
+language: python
+min_gaia_version: "0.20.0"
+
+python:
+  entry_module: gaia_agent_demo_agent
+  entry_class: DemoAgent
+  dependencies:
+    - "amd-gaia>=0.20.0"
+"""
+
+_WHEEL_BYTES = b"PK\x03\x04 fake wheel payload for checksum test"
+_EXPECTED_WHEEL = "gaia_agent_demo_agent-0.1.0-py3-none-any.whl"
+
+
+def _make_package(tmp_path, *, language="python", with_pyproject=True):
+    pkg = tmp_path / "demo-agent"
+    code = pkg / "gaia_agent_demo_agent"
+    code.mkdir(parents=True)
+    (code / "__init__.py").write_text("", encoding="utf-8")
+    manifest = _MANIFEST
+    if language != "python":
+        manifest = manifest.replace("language: python", "language: cpp")
+        manifest += "\ncpp:\n  binaries:\n    linux-x64: build/demo-agent\n"
+    (pkg / "gaia-agent.yaml").write_text(manifest, encoding="utf-8")
+    if with_pyproject:
+        (pkg / "pyproject.toml").write_text(_PYPROJECT, encoding="utf-8")
+    return pkg
+
+
+def _wheel_writing_runner(filename=_EXPECTED_WHEEL, payload=_WHEEL_BYTES):
+    """Return a runner that drops *filename* into the build's --outdir."""
+
+    def _runner(cmd, cwd):
+        outdir = cmd[cmd.index("--outdir") + 1]
+        from pathlib import Path
+
+        Path(outdir).mkdir(parents=True, exist_ok=True)
+        (Path(outdir) / filename).write_bytes(payload)
+        return 0, "Successfully built " + filename
+
+    return _runner
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+def test_pack_produces_wheel_path_and_checksum(tmp_path):
+    pkg = _make_package(tmp_path)
+    result = packager.pack(pkg, runner=_wheel_writing_runner())
+
+    assert result.wheel_path.name == _EXPECTED_WHEEL
+    assert result.wheel_path.exists()
+    assert result.agent_id == "demo-agent"
+    assert result.version == "0.1.0"
+    assert result.dist_name == "gaia-agent-demo-agent"
+    assert result.size_bytes == len(_WHEEL_BYTES)
+    assert result.sha256 == hashlib.sha256(_WHEEL_BYTES).hexdigest()
+
+
+def test_pack_defaults_to_package_dist_dir(tmp_path):
+    pkg = _make_package(tmp_path)
+    result = packager.pack(pkg, runner=_wheel_writing_runner())
+    assert result.wheel_path.parent == (pkg / "dist")
+
+
+def test_pack_honours_output_dir(tmp_path):
+    pkg = _make_package(tmp_path)
+    out = tmp_path / "artifacts"
+    result = packager.pack(pkg, output_dir=out, runner=_wheel_writing_runner())
+    assert result.wheel_path.parent == out
+
+
+def test_pack_ignores_preexisting_stale_wheel(tmp_path):
+    pkg = _make_package(tmp_path)
+    dist = pkg / "dist"
+    dist.mkdir()
+    stale = dist / "gaia_agent_demo_agent-0.0.9-py3-none-any.whl"
+    stale.write_bytes(b"old")
+    result = packager.pack(pkg, runner=_wheel_writing_runner())
+    assert result.wheel_path.name == _EXPECTED_WHEEL
+    assert result.version == "0.1.0"
+
+
+# ---------------------------------------------------------------------------
+# Fail-loudly paths
+# ---------------------------------------------------------------------------
+
+
+def test_pack_missing_directory(tmp_path):
+    with pytest.raises(packager.PackagerError, match="not found"):
+        packager.pack(tmp_path / "nope")
+
+
+def test_pack_invalid_manifest(tmp_path):
+    pkg = tmp_path / "demo-agent"
+    pkg.mkdir()
+    (pkg / "gaia-agent.yaml").write_text("id: BAD ID!!!", encoding="utf-8")
+    with pytest.raises(packager.PackagerError, match="invalid"):
+        packager.pack(pkg)
+
+
+def test_pack_rejects_cpp_agent(tmp_path):
+    pkg = _make_package(tmp_path, language="cpp", with_pyproject=False)
+    with pytest.raises(packager.PackagerError, match="Python wheels"):
+        packager.pack(pkg)
+
+
+def test_pack_missing_pyproject(tmp_path):
+    pkg = _make_package(tmp_path, with_pyproject=False)
+    with pytest.raises(packager.PackagerError, match="pyproject.toml not found"):
+        packager.pack(pkg)
+
+
+def test_pack_build_failure_raises(tmp_path):
+    pkg = _make_package(tmp_path)
+
+    def _failing(cmd, cwd):
+        return 1, "ERROR: build backend exploded"
+
+    with pytest.raises(packager.PackagerError, match="build failed"):
+        packager.pack(pkg, runner=_failing)
+
+
+def test_pack_no_wheel_produced_raises(tmp_path):
+    pkg = _make_package(tmp_path)
+
+    def _noop(cmd, cwd):
+        return 0, "did nothing"
+
+    with pytest.raises(packager.PackagerError, match="no .whl"):
+        packager.pack(pkg, runner=_noop)
+
+
+def test_pack_wheel_name_mismatch_raises(tmp_path):
+    pkg = _make_package(tmp_path)
+    runner = _wheel_writing_runner(filename="something-else-9.9.9-py3-none-any.whl")
+    with pytest.raises(packager.PackagerError, match="none matched"):
+        packager.pack(pkg, runner=runner)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_wheel_stem():
+    assert packager._normalize_wheel_stem("gaia-agent-summarize") == (
+        "gaia_agent_summarize"
+    )
+    assert packager._normalize_wheel_stem("Gaia.Agent_Foo") == "gaia_agent_foo"
+
+
+def test_read_pyproject_name(tmp_path):
+    pp = tmp_path / "pyproject.toml"
+    pp.write_text(_PYPROJECT, encoding="utf-8")
+    assert packager._read_pyproject_name(pp) == "gaia-agent-demo-agent"

--- a/tests/unit/test_hub_publisher.py
+++ b/tests/unit/test_hub_publisher.py
@@ -1,0 +1,293 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``gaia.hub.publisher`` (dual-publish to R2 + PyPI).
+
+No real network or PyPI: the R2 upload mocks ``requests.post`` and the PyPI
+upload uses an injected ``twine_runner``. Token storage uses a fake in-memory
+keyring so the OS credential store is never touched.
+"""
+
+import pytest
+
+from gaia.hub import publisher
+from gaia.hub.packager import PackResult
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeKeyring:
+    """Minimal in-memory keyring backend."""
+
+    def __init__(self):
+        self.store = {}
+
+    def set_password(self, service, username, password):
+        self.store[(service, username)] = password
+
+    def get_password(self, service, username):
+        return self.store.get((service, username))
+
+
+class _FakeResponse:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch):
+    kr = _FakeKeyring()
+    monkeypatch.setattr(publisher, "_keyring", lambda: kr)
+    return kr
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv(publisher.HUB_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(publisher.PYPI_TOKEN_ENV, raising=False)
+
+
+@pytest.fixture
+def pack_result(tmp_path):
+    wheel = tmp_path / "gaia_agent_demo-0.1.0-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x03\x04 wheel")
+    return PackResult(
+        wheel_path=wheel,
+        sha256="deadbeef",
+        size_bytes=8,
+        agent_id="demo",
+        version="0.1.0",
+        dist_name="gaia-agent-demo",
+    )
+
+
+@pytest.fixture
+def manifest_file(tmp_path):
+    p = tmp_path / "gaia-agent.yaml"
+    p.write_text("id: demo\nversion: 0.1.0\nauthor: AMD\n", encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Token storage / resolution
+# ---------------------------------------------------------------------------
+
+
+def test_store_and_get_hub_token(fake_keyring, clean_env):
+    publisher.store_token("hub", "secret-hub")
+    assert publisher.get_hub_token() == "secret-hub"
+
+
+def test_store_and_get_pypi_token(fake_keyring, clean_env):
+    publisher.store_token("pypi", "pypi-abc")
+    assert publisher.get_pypi_token() == "pypi-abc"
+
+
+def test_env_overrides_keyring(fake_keyring, monkeypatch):
+    publisher.store_token("hub", "from-keyring")
+    monkeypatch.setenv(publisher.HUB_TOKEN_ENV, "from-env")
+    assert publisher.get_hub_token() == "from-env"
+
+
+def test_get_token_none_when_unset(fake_keyring, clean_env):
+    assert publisher.get_hub_token() is None
+    assert publisher.get_pypi_token() is None
+
+
+def test_store_empty_token_raises(fake_keyring):
+    with pytest.raises(publisher.PublisherError, match="empty"):
+        publisher.store_token("hub", "  ")
+
+
+def test_store_unknown_kind_raises(fake_keyring):
+    with pytest.raises(publisher.PublisherError, match="unknown token kind"):
+        publisher.store_token("bogus", "x")
+
+
+# ---------------------------------------------------------------------------
+# Dual publish — success
+# ---------------------------------------------------------------------------
+
+
+def test_publish_posts_to_r2_and_twine(
+    fake_keyring, clean_env, monkeypatch, pack_result, manifest_file
+):
+    publisher.store_token("hub", "hub-tok")
+    publisher.store_token("pypi", "pypi-tok")
+
+    posted = {}
+
+    def _fake_post(url, headers=None, files=None, timeout=None):
+        posted["url"] = url
+        posted["auth"] = headers["Authorization"]
+        posted["files"] = set(files)
+        return _FakeResponse(201, '{"published": {}}')
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    twine_calls = {}
+
+    def _fake_twine(cmd, env):
+        twine_calls["cmd"] = cmd
+        twine_calls["user"] = env["TWINE_USERNAME"]
+        twine_calls["pass"] = env["TWINE_PASSWORD"]
+        return 0, "Uploading… done"
+
+    result = publisher.publish(
+        pack_result,
+        manifest_file,
+        hub_url="https://hub.example",
+        twine_runner=_fake_twine,
+    )
+
+    assert posted["url"] == "https://hub.example/publish"
+    assert posted["auth"] == "Bearer hub-tok"
+    assert posted["files"] == {"manifest", "artifact"}
+    assert twine_calls["user"] == "__token__"
+    assert twine_calls["pass"] == "pypi-tok"
+    assert str(pack_result.wheel_path) in twine_calls["cmd"]
+
+    assert not result.r2.skipped
+    assert not result.pypi.skipped
+    assert result.agent_id == "demo"
+
+
+def test_publish_skip_pypi(
+    fake_keyring, clean_env, monkeypatch, pack_result, manifest_file
+):
+    publisher.store_token("hub", "hub-tok")
+    import requests
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: _FakeResponse(201, "{}"))
+
+    result = publisher.publish(
+        pack_result, manifest_file, hub_url="https://hub.example", skip_pypi=True
+    )
+    assert not result.r2.skipped
+    assert result.pypi.skipped
+
+
+def test_publish_skip_r2_uses_only_twine(
+    fake_keyring, clean_env, pack_result, manifest_file
+):
+    publisher.store_token("pypi", "pypi-tok")
+    result = publisher.publish(
+        pack_result,
+        manifest_file,
+        skip_r2=True,
+        twine_runner=lambda cmd, env: (0, "done"),
+    )
+    assert result.r2.skipped
+    assert not result.pypi.skipped
+
+
+def test_publish_both_skipped_raises(pack_result, manifest_file):
+    with pytest.raises(publisher.PublisherError, match="nothing to publish"):
+        publisher.publish(pack_result, manifest_file, skip_r2=True, skip_pypi=True)
+
+
+# ---------------------------------------------------------------------------
+# Missing tokens
+# ---------------------------------------------------------------------------
+
+
+def test_publish_r2_missing_token_raises(
+    fake_keyring, clean_env, pack_result, manifest_file
+):
+    with pytest.raises(publisher.PublisherError, match="no Hub publish token"):
+        publisher.publish(pack_result, manifest_file, skip_pypi=True)
+
+
+def test_publish_pypi_missing_token_raises(
+    fake_keyring, clean_env, pack_result, manifest_file
+):
+    with pytest.raises(publisher.PublisherError, match="no PyPI token"):
+        publisher.publish(pack_result, manifest_file, skip_r2=True)
+
+
+# ---------------------------------------------------------------------------
+# Version immutability / auth rejections
+# ---------------------------------------------------------------------------
+
+
+def test_publish_r2_version_exists_raises(
+    fake_keyring, clean_env, monkeypatch, pack_result, manifest_file
+):
+    publisher.store_token("hub", "hub-tok")
+    import requests
+
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *a, **k: _FakeResponse(409, "version_exists"),
+    )
+    with pytest.raises(publisher.PublisherError, match="already exists"):
+        publisher.publish(pack_result, manifest_file, skip_pypi=True)
+
+
+def test_publish_r2_unauthorized_raises(
+    fake_keyring, clean_env, monkeypatch, pack_result, manifest_file
+):
+    publisher.store_token("hub", "bad")
+    import requests
+
+    monkeypatch.setattr(
+        requests, "post", lambda *a, **k: _FakeResponse(401, "unauthorized")
+    )
+    with pytest.raises(publisher.PublisherError, match="rejected the publish token"):
+        publisher.publish(pack_result, manifest_file, skip_pypi=True)
+
+
+def test_publish_r2_network_error_raises(
+    fake_keyring, clean_env, monkeypatch, pack_result, manifest_file
+):
+    publisher.store_token("hub", "hub-tok")
+    import requests
+
+    def _boom(*a, **k):
+        raise requests.RequestException("connection refused")
+
+    monkeypatch.setattr(requests, "post", _boom)
+    with pytest.raises(publisher.PublisherError, match="could not reach"):
+        publisher.publish(pack_result, manifest_file, skip_pypi=True)
+
+
+def test_publish_pypi_already_exists_raises(
+    fake_keyring, clean_env, pack_result, manifest_file
+):
+    publisher.store_token("pypi", "pypi-tok")
+
+    def _twine(cmd, env):
+        return 1, "ERROR: File already exists for gaia-agent-demo"
+
+    with pytest.raises(publisher.PublisherError, match="immutable"):
+        publisher.publish(pack_result, manifest_file, skip_r2=True, twine_runner=_twine)
+
+
+def test_publish_pypi_generic_failure_raises(
+    fake_keyring, clean_env, pack_result, manifest_file
+):
+    publisher.store_token("pypi", "pypi-tok")
+
+    def _twine(cmd, env):
+        return 2, "something unexpected broke"
+
+    with pytest.raises(publisher.PublisherError, match="twine upload failed"):
+        publisher.publish(pack_result, manifest_file, skip_r2=True, twine_runner=_twine)
+
+
+def test_publish_missing_wheel_raises(fake_keyring, clean_env, manifest_file, tmp_path):
+    missing = PackResult(
+        wheel_path=tmp_path / "gone.whl",
+        sha256="x",
+        size_bytes=0,
+        agent_id="demo",
+        version="0.1.0",
+        dist_name="gaia-agent-demo",
+    )
+    with pytest.raises(publisher.PublisherError, match="wheel not found"):
+        publisher.publish(missing, manifest_file)


### PR DESCRIPTION
## Why this matters

Hub agents could be authored, versioned, and validated (`gaia agent init/version/test`) but there was **no way to ship one** — no command to turn a package into a wheel, and no path onto the Agent Hub or PyPI. Authors were stuck with a valid package and nowhere to send it.

This closes the loop. `gaia agent pack` builds a distributable wheel from any hub agent package, and `gaia agent publish` dual-publishes it to **R2** (canonical for the Hub UI/website) **and PyPI** (canonical for `pip install gaia-agent-<id>`) in one command. Both targets enforce version immutability, and every failure (missing token, build error, network, already-published version) surfaces as an actionable error rather than a silent no-op.

Implements #1093 (Phase 2 — wheel packaging) and #1179 (Phase 3F — dual distribution) from [`docs/spec/agent-hub-restructure.mdx`](docs/spec/agent-hub-restructure.mdx).

## What's here

- **`gaia agent pack`** — `python -m build --wheel` → `dist/gaia_agent_<id>-<version>-py3-none-any.whl` + SHA-256. Python agents only (C++ ships a CMake binary).
- **`gaia agent publish`** — packs, then POSTs the wheel + `gaia-agent.yaml` to the Worker `/publish` (Bearer auth) and `twine upload`s to PyPI. `--skip-r2` / `--skip-pypi` publish to one target.
- **`gaia agent login`** — stores Hub/PyPI tokens in the OS keyring; `GAIA_HUB_TOKEN` / `PYPI_TOKEN` env vars take precedence (CI-friendly).
- **`setup.py`** — new `publish` extra (`build`, `twine`) plus `agents` meta-extras.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/test_hub_packager.py tests/unit/test_hub_publisher.py tests/unit/test_cli_agent.py` → 66 pass (subprocess + HTTP mocked; covers wheel-path/checksum, dual-publish auth, missing-token, version-immutability, network errors)
- [x] Real smoke: `gaia agent pack hub/agents/python/summarize/` builds `gaia_agent_summarize-0.1.0-py3-none-any.whl` (14.5 KB) with `build` installed
- [x] `python util/lint.py --pylint --black --isort` → black/isort PASS; pylint clean for the new files (the one remaining error is a pre-existing Windows-only `os.geteuid` false positive in `lemonade_installer.py`, untouched here)
- [x] `tests/unit/test_amd_gaia_urls.py` passes (new spec URL keeps the `/docs/` prefix)

Refs #1093, #1179.