### PR TITLE
feat(hub): agent lifecycle (configure/health/status) + resumable parallel installs (#465, #468)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -412,6 +412,43 @@ gaia agent test --live --timeout 90
 ```
 </CodeGroup>
 
+#### Lifecycle: `configure`, `health`, `status`
+
+Manage an *installed* agent: set per-agent configuration, verify it loads, and inspect its state. Configuration is persisted under `~/.gaia/agents/<id>/config.json` and survives restarts.
+
+```bash
+gaia agent configure <id> [--model NAME] [--set KEY=VALUE ...] [--replace] [--show]
+gaia agent health <id>
+gaia agent status [<id>]
+```
+
+**`configure`** writes per-agent settings (e.g. a preferred model). `--set` values are JSON-decoded when possible (`--set temperature=0.2` stores a number, `--set verbose=true` a boolean), otherwise kept as strings. Settings merge into the existing config by default; pass `--replace` to overwrite it wholesale, or `--show` to print the current config without changing it.
+
+**`health`** verifies that an installed agent actually loads — its registration resolves and its entry point imports. It reports one of `healthy`, `degraded` (loads but something optional is off, e.g. a corrupt config), `error` (a required piece fails to load), or `not_installed`, and exits non-zero for `error` / `not_installed` so scripts can gate on it.
+
+**`status`** aggregates installed version, health, config summary, and source for one agent — or every discovered agent when `<id>` is omitted.
+
+| Option | Applies to | Description |
+|--------|------------|-------------|
+| `id` | all | Agent id (positional; optional for `status`, required otherwise) |
+| `--model` | `configure` | Preferred model, stored as the `model` setting |
+| `--set KEY=VALUE` | `configure` | Set an arbitrary setting (repeatable) |
+| `--replace` | `configure` | Replace the whole config instead of merging |
+| `--show` | `configure` | Print the current config and exit |
+
+**Examples:**
+
+<CodeGroup>
+```bash Set a model preference
+gaia agent configure chat --model Qwen3.5-35B-A3B-GGUF
+```
+
+```bash Check health and status
+gaia agent health chat
+gaia agent status            # every discovered agent
+```
+</CodeGroup>
+
 #### Distribution: `pack`, `publish`, `login`
 
 Build a distributable wheel from a Python agent package, then dual-publish it to the Agent Hub (R2, the source for the Hub UI) **and** PyPI (the source for `pip install`).

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -6164,7 +6164,10 @@ def handle_agent_command(args):
 
     if not hasattr(args, "agent_action") or args.agent_action is None:
         print("❌ Error: No agent action specified")
-        print("Available actions: init, version, test, export, import")
+        print(
+            "Available actions: init, version, test, configure, health, status, "
+            "export, import"
+        )
         print("Run 'gaia agent --help' for more information")
         sys.exit(1)
 

--- a/src/gaia/cli_agent.py
+++ b/src/gaia/cli_agent.py
@@ -191,6 +191,52 @@ def register_subparsers(agent_subparsers) -> None:
         help="Publish to R2 only (skip the PyPI upload)",
     )
 
+    configure_p = agent_subparsers.add_parser(
+        "configure",
+        help="Set per-agent config (model preference, settings) in ~/.gaia/agents/<id>",
+    )
+    configure_p.add_argument("id", help="Agent id to configure, e.g. 'chat'")
+    configure_p.add_argument(
+        "--model",
+        default=None,
+        help="Preferred model for this agent (stored as the 'model' setting)",
+    )
+    configure_p.add_argument(
+        "--set",
+        dest="settings",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Set an arbitrary setting (repeatable), e.g. --set temperature=0.2",
+    )
+    configure_p.add_argument(
+        "--replace",
+        action="store_true",
+        help="Replace the whole config instead of merging into the existing one",
+    )
+    configure_p.add_argument(
+        "--show",
+        action="store_true",
+        help="Print the current config and exit (no changes)",
+    )
+
+    health_p = agent_subparsers.add_parser(
+        "health",
+        help="Health check: does an installed agent load + its entry point resolve?",
+    )
+    health_p.add_argument("id", help="Agent id to health-check, e.g. 'chat'")
+
+    status_p = agent_subparsers.add_parser(
+        "status",
+        help="Show installed version, health, and config for one or all agents",
+    )
+    status_p.add_argument(
+        "id",
+        nargs="?",
+        default=None,
+        help="Agent id (omit to show every discovered agent)",
+    )
+
     login_p = agent_subparsers.add_parser(
         "login",
         help="Store publisher tokens (R2 Hub and/or PyPI) in the OS keyring",
@@ -232,6 +278,9 @@ def handle(args) -> bool:
         "pack": cmd_pack,
         "publish": cmd_publish,
         "login": cmd_login,
+        "configure": cmd_configure,
+        "health": cmd_health,
+        "status": cmd_status,
     }
     fn = dispatch.get(action)
     if fn is None:
@@ -834,6 +883,125 @@ def cmd_login(args) -> None:
             "publish time."
         )
     print(f"Stored token(s) in the OS keyring: {', '.join(stored)}.")
+
+
+# ---------------------------------------------------------------------------
+# configure / health / status (lifecycle — issue #465)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_setting(raw: str):
+    """Parse a ``KEY=VALUE`` pair, JSON-decoding the value when possible.
+
+    ``--set temperature=0.2`` stores a float; ``--set verbose=true`` a bool;
+    ``--set model=Qwen3.5-35B-A3B-GGUF`` a string. Anything that is not valid
+    JSON is kept as the raw string.
+    """
+    import json
+
+    if "=" not in raw:
+        raise AgentWorkflowError(
+            f"--set expects KEY=VALUE, got {raw!r}. Example: --set temperature=0.2."
+        )
+    key, _, value = raw.partition("=")
+    key = key.strip()
+    if not key:
+        raise AgentWorkflowError(f"--set has an empty key in {raw!r}.")
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        parsed = value
+    return key, parsed
+
+
+def cmd_configure(args) -> None:
+    """Set per-agent config under ~/.gaia/agents/<id>/config.json."""
+    from gaia.hub import lifecycle
+
+    if args.show:
+        try:
+            current = lifecycle.read_config(args.id)
+        except lifecycle.LifecycleError as exc:
+            raise AgentWorkflowError(str(exc)) from exc
+        if not current:
+            print(f"No config set for '{args.id}'.")
+        else:
+            import json
+
+            print(json.dumps(current, indent=2, sort_keys=True))
+        return
+
+    settings = {}
+    if args.model:
+        settings[lifecycle.CONFIG_MODEL_KEY] = args.model
+    for raw in args.settings:
+        key, value = _coerce_setting(raw)
+        settings[key] = value
+
+    if not settings:
+        raise AgentWorkflowError(
+            "nothing to configure. Pass --model <name> and/or --set KEY=VALUE, "
+            "or --show to view the current config."
+        )
+
+    try:
+        merged = lifecycle.configure(args.id, settings, merge=not args.replace)
+    except lifecycle.LifecycleError as exc:
+        raise AgentWorkflowError(str(exc)) from exc
+
+    import json
+
+    print(f"Updated config for '{args.id}':")
+    print(json.dumps(merged, indent=2, sort_keys=True))
+
+
+def cmd_health(args) -> None:
+    """Run a health check against an installed agent."""
+    from gaia.hub import lifecycle
+
+    registry = _build_registry()
+    result = lifecycle.health_check(args.id, registry=registry)
+    print(f"{args.id}: {result.state}")
+    if result.detail:
+        print(f"  {result.detail}")
+    for warning in result.warnings:
+        print(f"  warning: {warning}")
+    # error/not_installed are non-zero exits so scripts can gate on it.
+    if result.state in (lifecycle.HEALTH_ERROR, lifecycle.HEALTH_NOT_INSTALLED):
+        sys.exit(1)
+
+
+def cmd_status(args) -> None:
+    """Show installed version + health + config for one or all agents."""
+    from gaia.hub import lifecycle
+
+    registry = _build_registry()
+    if args.id:
+        statuses = {args.id: lifecycle.status(args.id, registry=registry)}
+    else:
+        statuses = lifecycle.status_all(registry=registry)
+
+    if not statuses:
+        print("No agents discovered.")
+        return
+
+    width = max(len(aid) for aid in statuses)
+    print(f"{'AGENT'.ljust(width)}  VERSION    HEALTH         SOURCE")
+    for aid, st in statuses.items():
+        version = st.installed_version or "-"
+        print(
+            f"{aid.ljust(width)}  {version.ljust(9)}  "
+            f"{st.health.ljust(13)}  {st.source or '-'}"
+        )
+
+
+def _build_registry():
+    """Build and populate an AgentRegistry for health/status commands."""
+    from gaia.agents.registry import AgentRegistry
+
+    registry = AgentRegistry()
+    registry.discover()
+    return registry
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -36,7 +36,7 @@ import tempfile
 import threading
 import zipfile
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -844,3 +844,256 @@ def _deregister(agent_id: str, registry: Any) -> None:
             registry._agents.pop(agent_id, None)
     except Exception as exc:  # noqa: BLE001
         logger.warning("installer: could not deregister %s: %s", agent_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Setup executor: progressive, resumable, parallel multi-agent install (#468)
+# ---------------------------------------------------------------------------
+#
+# ``run_setup`` installs several agents in one pass with three properties the
+# single-agent ``install`` does not provide on its own:
+#
+# * **Progressive** — steps run smallest-download-first so a minimal agent is
+#   usable while larger ones keep downloading.
+# * **Resumable** — every step transition is persisted to a JSON state file
+#   (``~/.gaia/setup_state.json``). A crashed/interrupted run re-reads it and
+#   skips already-``completed`` steps instead of re-downloading them.
+# * **Parallel** — downloads run with *bounded* concurrency (independent agents
+#   are safe to fetch at once); a failed step does not block the others.
+
+# Step lifecycle states for the resumable setup state file.
+STEP_PENDING = "pending"
+STEP_RUNNING = "running"
+STEP_COMPLETED = "completed"
+STEP_FAILED = "failed"
+
+# Default parallel-download bound. Conservative: enough to overlap a small fast
+# download with a large slow one without saturating a typical home connection.
+DEFAULT_MAX_PARALLEL = 2
+
+
+def default_setup_state_path(install_root: Optional[Path] = None) -> Path:
+    """Path of the resumable setup state file.
+
+    Lives next to the install root's parent (``~/.gaia/setup_state.json``) so it
+    survives across the per-agent install dirs it coordinates.
+    """
+    root = install_root or default_install_root()
+    return root.parent / "setup_state.json"
+
+
+@dataclass
+class SetupStep:
+    """One agent install within a :func:`run_setup` plan."""
+
+    agent_id: str
+    version: Optional[str] = None
+    size_bytes: int = 0
+    status: str = STEP_PENDING
+    error: Optional[str] = None
+    completed_at: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "version": self.version,
+            "size_bytes": self.size_bytes,
+            "status": self.status,
+            "error": self.error,
+            "completed_at": self.completed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SetupStep":
+        return cls(
+            agent_id=data["agent_id"],
+            version=data.get("version"),
+            size_bytes=data.get("size_bytes", 0),
+            status=data.get("status", STEP_PENDING),
+            error=data.get("error"),
+            completed_at=data.get("completed_at"),
+        )
+
+
+@dataclass
+class SetupResult:
+    """Outcome of :func:`run_setup`."""
+
+    steps: List[SetupStep] = field(default_factory=list)
+
+    @property
+    def completed(self) -> List[str]:
+        return [s.agent_id for s in self.steps if s.status == STEP_COMPLETED]
+
+    @property
+    def failed(self) -> List[str]:
+        return [s.agent_id for s in self.steps if s.status == STEP_FAILED]
+
+    @property
+    def all_ok(self) -> bool:
+        return all(s.status == STEP_COMPLETED for s in self.steps)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "steps": [s.to_dict() for s in self.steps],
+            "completed": self.completed,
+            "failed": self.failed,
+            "all_ok": self.all_ok,
+        }
+
+
+def _artifact_size(manifest: Dict[str, Any], version: Optional[str]) -> int:
+    """Best-effort download size for ordering (0 if it can't be resolved)."""
+    try:
+        _, artifact = _resolve_version(manifest, version)
+        return int(artifact.get("size_bytes", 0) or 0)
+    except InstallError:
+        return 0
+
+
+def read_setup_state(path: Path) -> Optional[Dict[str, Any]]:
+    """Read the resumable setup state file, or ``None`` if absent/corrupt."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("installer: unreadable setup state %s: %s", path, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _write_setup_state(path: Path, steps: List[SetupStep]) -> None:
+    payload = {
+        "status": (
+            STEP_COMPLETED
+            if all(s.status == STEP_COMPLETED for s in steps)
+            else STEP_RUNNING
+        ),
+        "steps": [s.to_dict() for s in steps],
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError as exc:
+        # A state-write failure must not abort an otherwise-fine install, but it
+        # does break resume — so it is logged loudly, not swallowed silently.
+        logger.warning("installer: could not write setup state %s: %s", path, exc)
+
+
+def run_setup(
+    manifests: Dict[str, Dict[str, Any]],
+    *,
+    versions: Optional[Dict[str, Optional[str]]] = None,
+    max_parallel: int = DEFAULT_MAX_PARALLEL,
+    resume: bool = True,
+    state_path: Optional[Path] = None,
+    install_root: Optional[Path] = None,
+    fetcher: Optional[catalog_mod.Fetcher] = None,
+    run_pip: Optional[PipRunner] = None,
+    registry: Any = None,
+    skip_compatibility_check: bool = False,
+    installer_fn: Optional[Callable[..., InstallResult]] = None,
+) -> SetupResult:
+    """Install several agents progressively, resumably, and in parallel.
+
+    Args:
+        manifests: ``{agent_id: manifest}`` for every agent to install. Passing
+            manifests in keeps this function offline-testable (no catalog fetch).
+        versions: Optional ``{agent_id: version}`` overrides (default: latest).
+        max_parallel: Bound on concurrent installs (must be >= 1).
+        resume: When True, completed steps recorded in *state_path* are skipped.
+        state_path: Resumable state file (default: ``~/.gaia/setup_state.json``).
+        install_root: Install root passed through to each :func:`install`.
+        fetcher / run_pip / registry / skip_compatibility_check: forwarded to
+            :func:`install`.
+        installer_fn: Injectable install callable (defaults to :func:`install`);
+            tests use it to assert the concurrency bound without real downloads.
+
+    Returns:
+        A :class:`SetupResult` listing each step's final status. A failed step
+        does not abort the others (independent agents stay independent).
+    """
+    if max_parallel < 1:
+        raise InstallError("max_parallel must be >= 1.")
+    versions = versions or {}
+    install_fn = installer_fn or install
+    state_path = state_path or default_setup_state_path(install_root)
+
+    # Build the plan: smallest download first so a minimal agent is usable while
+    # larger ones keep going (progressive capability unlock, #468).
+    steps = [
+        SetupStep(
+            agent_id=aid,
+            version=versions.get(aid),
+            size_bytes=_artifact_size(manifest, versions.get(aid)),
+        )
+        for aid, manifest in manifests.items()
+    ]
+    steps.sort(key=lambda s: (s.size_bytes, s.agent_id))
+
+    # Resume: mark steps already completed in a prior run so we skip them.
+    if resume:
+        prior = read_setup_state(state_path)
+        if prior:
+            done = {
+                s["agent_id"]
+                for s in prior.get("steps", [])
+                if s.get("status") == STEP_COMPLETED
+            }
+            for step in steps:
+                if step.agent_id in done:
+                    step.status = STEP_COMPLETED
+
+    _write_setup_state(state_path, steps)
+
+    state_lock = threading.Lock()
+
+    def _persist() -> None:
+        with state_lock:
+            _write_setup_state(state_path, steps)
+
+    def _run_step(step: SetupStep) -> None:
+        if step.status == STEP_COMPLETED:
+            logger.info("installer: setup skipping completed step %s", step.agent_id)
+            return
+        with state_lock:
+            step.status = STEP_RUNNING
+        _persist()
+        try:
+            install_fn(
+                step.agent_id,
+                version=step.version,
+                manifest=manifests[step.agent_id],
+                fetcher=fetcher,
+                run_pip=run_pip,
+                install_root=install_root,
+                registry=registry,
+                skip_compatibility_check=skip_compatibility_check,
+            )
+        except Exception as exc:  # noqa: BLE001 - recorded per-step; others go on
+            with state_lock:
+                step.status = STEP_FAILED
+                step.error = str(exc)
+            _persist()
+            logger.warning("installer: setup step %s failed: %s", step.agent_id, exc)
+            return
+        with state_lock:
+            step.status = STEP_COMPLETED
+            step.completed_at = datetime.now(timezone.utc).isoformat()
+        _persist()
+
+    pending = [s for s in steps if s.status != STEP_COMPLETED]
+    if pending:
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=max_parallel) as pool:
+            list(pool.map(_run_step, pending))
+
+    _persist()
+    return SetupResult(steps=steps)
+
+
+def get_setup_status(install_root: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """Return the latest persisted setup state (for the polling endpoint)."""
+    return read_setup_state(default_setup_state_path(install_root))

--- a/src/gaia/hub/lifecycle.py
+++ b/src/gaia/hub/lifecycle.py
@@ -1,0 +1,368 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Agent Hub lifecycle: per-agent configure, health check, and status.
+
+This module is the *post-install* half of the agent lifecycle manager (issue
+#465). The install/uninstall/rollback half ships in :mod:`gaia.hub.installer`
+(#1096); this module adds the three operations a user performs on an agent that
+is already installed:
+
+* :func:`configure` — persist per-agent settings (model preference, arbitrary
+  overrides) under ``~/.gaia/agents/<id>/config.json``. The config survives
+  restarts and is read by :func:`status` and the Agent UI.
+* :func:`health_check` — verify that an installed agent actually *loads*: its
+  registration resolves and its entry point / module imports. Distinguishes
+  ``healthy`` / ``degraded`` / ``error`` / ``not_installed`` so the UI can show
+  a working/degraded/broken badge instead of a silent failure at first use.
+* :func:`status` / :func:`status_all` — aggregate installed version + health +
+  config summary into one record per agent for the catalog/status panel.
+
+Fail-loudly (CLAUDE.md): :func:`configure` rejects a non-dict config and a
+reserved/empty id rather than silently writing junk. :func:`health_check` never
+swallows a load failure — it surfaces it as ``error`` with the underlying
+message instead of pretending the agent is fine.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from gaia.hub import installer as installer_mod
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Per-agent config file written alongside the install sentinel.
+CONFIG_NAME = "config.json"
+
+# Health states (issue #465). ``degraded`` = loads but missing something
+# optional; ``error`` = a required piece is broken; ``not_installed`` = nothing
+# to check.
+HEALTH_HEALTHY = "healthy"
+HEALTH_DEGRADED = "degraded"
+HEALTH_ERROR = "error"
+HEALTH_NOT_INSTALLED = "not_installed"
+
+# Top-level config keys we recognise explicitly (everything else is preserved
+# verbatim under the persisted dict — agents may declare their own settings).
+CONFIG_MODEL_KEY = "model"
+
+
+class LifecycleError(RuntimeError):
+    """Raised when a configure/health/status operation cannot proceed.
+
+    The message names *what* failed, *what* to do, and *where* to look, per the
+    project's fail-loudly rule.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def config_path(agent_id: str, install_root: Optional[Path] = None) -> Path:
+    """Path of the per-agent ``config.json`` (``~/.gaia/agents/<id>/config.json``)."""
+    return installer_mod.agent_install_dir(agent_id, install_root) / CONFIG_NAME
+
+
+# ---------------------------------------------------------------------------
+# Configure
+# ---------------------------------------------------------------------------
+
+
+def read_config(agent_id: str, install_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Return the persisted config for *agent_id* (``{}`` if none).
+
+    Raises:
+        LifecycleError: If the config file exists but is not valid JSON / not a
+            JSON object — a corrupt config is a loud failure, not an empty dict.
+    """
+    path = config_path(agent_id, install_root)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError(
+            f"config for '{agent_id}' at {path} is unreadable or corrupt: {exc}. "
+            f"Fix or delete the file, then re-run 'gaia agent configure {agent_id}'."
+        ) from exc
+    if not isinstance(data, dict):
+        raise LifecycleError(
+            f"config for '{agent_id}' at {path} must be a JSON object, got "
+            f"{type(data).__name__}. Delete the file and reconfigure."
+        )
+    return data
+
+
+def configure(
+    agent_id: str,
+    config: Dict[str, Any],
+    *,
+    install_root: Optional[Path] = None,
+    merge: bool = True,
+) -> Dict[str, Any]:
+    """Persist per-agent configuration under ``~/.gaia/agents/<id>/config.json``.
+
+    Args:
+        agent_id: Agent to configure (hub-installed, builtin, or custom).
+        config: Settings to store (e.g. ``{"model": "Qwen3.5-35B-A3B-GGUF"}``).
+        install_root: Override the install root (tests pass a tmp dir).
+        merge: When True (default) merge into the existing config; when False
+            replace it wholesale.
+
+    Returns:
+        The full persisted config dict (post-merge).
+
+    Raises:
+        LifecycleError: If *agent_id* is empty/reserved-invalid or *config* is
+            not a dict.
+    """
+    if not agent_id or not isinstance(agent_id, str):
+        raise LifecycleError("agent_id must be a non-empty string.")
+    if not isinstance(config, dict):
+        raise LifecycleError(
+            f"config for '{agent_id}' must be a dict of settings, got "
+            f"{type(config).__name__}."
+        )
+
+    existing = read_config(agent_id, install_root) if merge else {}
+    merged = {**existing, **config}
+
+    path = config_path(agent_id, install_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(merged, indent=2, sort_keys=True), encoding="utf-8")
+    logger.info("lifecycle: wrote config for %s -> %s", agent_id, path)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HealthStatus:
+    """Outcome of :func:`health_check`."""
+
+    id: str
+    state: str  # healthy | degraded | error | not_installed
+    detail: str = ""
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.state in (HEALTH_HEALTHY, HEALTH_DEGRADED)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "state": self.state,
+            "detail": self.detail,
+            "warnings": list(self.warnings),
+        }
+
+
+# A loader probe: given (agent_id, registry), import/resolve the agent so we
+# know it actually loads. Returns a list of non-fatal warnings (→ degraded) or
+# raises to signal a hard error. Injected in tests.
+LoaderProbe = Callable[[str, Any], List[str]]
+
+
+def _default_loader(agent_id: str, registry: Any) -> List[str]:
+    """Resolve an installed agent's entry point / module to prove it loads.
+
+    Built-ins are in-tree and always importable, so a registered builtin needs
+    no entry-point probe. For installed wheel agents we re-resolve the
+    ``gaia.agent`` / ``gaia.agents`` entry point named *agent_id* and ``.load()``
+    it — that is precisely "the entry point resolves". A failure raises.
+    """
+    if installer_mod.is_builtin(agent_id):
+        # Builtins ship in the core wheel; presence in the registry is proof.
+        if registry is not None and registry.get(agent_id) is None:
+            raise LifecycleError(
+                f"builtin agent '{agent_id}' is not present in the registry; "
+                f"the core install may be broken."
+            )
+        return []
+
+    import importlib
+
+    from gaia.agents.registry import AGENT_ENTRY_POINT_GROUPS
+
+    last_err: Optional[Exception] = None
+    for group in AGENT_ENTRY_POINT_GROUPS:
+        for ep in importlib.metadata.entry_points(group=group):
+            if ep.name != agent_id:
+                continue
+            try:
+                ep.load()
+                return []
+            except Exception as exc:  # noqa: BLE001 - re-raised as LifecycleError
+                last_err = exc
+    if last_err is not None:
+        raise LifecycleError(
+            f"agent '{agent_id}' is installed but its entry point failed to "
+            f"load: {last_err}. Re-install it ('gaia agent' / the Hub UI) or "
+            f"check its dependencies."
+        )
+    raise LifecycleError(
+        f"agent '{agent_id}' is installed on disk but exposes no "
+        f"'gaia.agent' entry point, so it cannot be loaded. The package may be "
+        f"incomplete; re-install it."
+    )
+
+
+def health_check(
+    agent_id: str,
+    *,
+    registry: Any = None,
+    install_root: Optional[Path] = None,
+    loader: Optional[LoaderProbe] = None,
+) -> HealthStatus:
+    """Check whether an installed agent is working.
+
+    Returns one of ``healthy`` / ``degraded`` / ``error`` / ``not_installed``:
+
+    * ``not_installed`` — no install sentinel, not a builtin, and not registered.
+    * ``error`` — installed but the entry point / module fails to load.
+    * ``degraded`` — loads, but something optional is off (e.g. a corrupt config
+      or an optional warning from the loader probe).
+    * ``healthy`` — loads cleanly with no warnings.
+    """
+    loader = loader or _default_loader
+
+    installed = installer_mod.read_sentinel(agent_id, install_root) is not None
+    is_builtin = installer_mod.is_builtin(agent_id)
+    registered = registry is not None and registry.get(agent_id) is not None
+
+    if not installed and not is_builtin and not registered:
+        return HealthStatus(
+            id=agent_id,
+            state=HEALTH_NOT_INSTALLED,
+            detail=f"'{agent_id}' is not installed.",
+        )
+
+    warnings: List[str] = []
+
+    # A corrupt config is non-fatal (the agent can run on defaults) but must be
+    # surfaced — it degrades, it doesn't silently pass.
+    try:
+        read_config(agent_id, install_root)
+    except LifecycleError as exc:
+        warnings.append(str(exc))
+
+    try:
+        warnings.extend(loader(agent_id, registry) or [])
+    except Exception as exc:  # noqa: BLE001 - any load failure → error state
+        return HealthStatus(
+            id=agent_id,
+            state=HEALTH_ERROR,
+            detail=str(exc),
+            warnings=warnings,
+        )
+
+    if warnings:
+        return HealthStatus(
+            id=agent_id,
+            state=HEALTH_DEGRADED,
+            detail=f"'{agent_id}' loads but has {len(warnings)} warning(s).",
+            warnings=warnings,
+        )
+    return HealthStatus(
+        id=agent_id, state=HEALTH_HEALTHY, detail=f"'{agent_id}' is healthy."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentStatus:
+    """Aggregated lifecycle status for one agent."""
+
+    id: str
+    installed: bool
+    installed_version: Optional[str]
+    health: str
+    config: Dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "installed": self.installed,
+            "installed_version": self.installed_version,
+            "health": self.health,
+            "config": dict(self.config),
+            "source": self.source,
+        }
+
+
+def status(
+    agent_id: str,
+    *,
+    registry: Any = None,
+    install_root: Optional[Path] = None,
+    loader: Optional[LoaderProbe] = None,
+) -> AgentStatus:
+    """Aggregate installed version, health, and config summary for one agent."""
+    sentinel = installer_mod.read_sentinel(agent_id, install_root)
+    is_builtin = installer_mod.is_builtin(agent_id)
+    reg = registry.get(agent_id) if registry is not None else None
+
+    installed = sentinel is not None or is_builtin or reg is not None
+    health = health_check(
+        agent_id, registry=registry, install_root=install_root, loader=loader
+    )
+
+    # Config read is best-effort here — a corrupt config already shows up as a
+    # health warning, so summarise empty rather than raise from status().
+    try:
+        config = read_config(agent_id, install_root)
+    except LifecycleError:
+        config = {}
+
+    # Hub-installed agents carry a SemVer in their sentinel; builtins/custom
+    # agents have no published version, so report None rather than guess.
+    version = sentinel.version if sentinel is not None else None
+
+    source = ""
+    if reg is not None:
+        source = reg.source
+    elif sentinel is not None:
+        source = "installed"
+    elif is_builtin:
+        source = "builtin"
+
+    return AgentStatus(
+        id=agent_id,
+        installed=installed,
+        installed_version=version,
+        health=health.state,
+        config=config,
+        source=source,
+    )
+
+
+def status_all(
+    *,
+    registry: Any = None,
+    install_root: Optional[Path] = None,
+    loader: Optional[LoaderProbe] = None,
+) -> Dict[str, AgentStatus]:
+    """Status for every discovered agent (hub-installed + registered)."""
+    ids = set(installer_mod.list_installed(install_root).keys())
+    if registry is not None:
+        for reg in registry.list():
+            ids.add(reg.id)
+    return {
+        aid: status(aid, registry=registry, install_root=install_root, loader=loader)
+        for aid in sorted(ids)
+    }

--- a/src/gaia/ui/routers/hub.py
+++ b/src/gaia/ui/routers/hub.py
@@ -18,13 +18,14 @@ NOTE on route ordering: this router MUST be included *before*
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from gaia.hub import catalog as catalog_mod
 from gaia.hub import installer as installer_mod
+from gaia.hub import lifecycle as lifecycle_mod
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -62,6 +63,22 @@ class InstallRequest(BaseModel):
     # Explicit opt-in to install a non-verified native (C++) agent. The UI sets
     # this after the user accepts the "Trust & Install" confirmation.
     trust_native: bool = False
+
+
+class ConfigRequest(BaseModel):
+    """Body for ``POST /api/agents/{id}/config``."""
+
+    config: Dict[str, Any]
+    # Replace the whole config instead of merging into the existing one.
+    replace: bool = False
+
+
+class SetupRequest(BaseModel):
+    """Body for ``POST /api/agents/setup`` (progressive multi-agent install)."""
+
+    ids: List[str]
+    max_parallel: int = installer_mod.DEFAULT_MAX_PARALLEL
+    resume: bool = True
 
 
 # ---------------------------------------------------------------------------
@@ -217,3 +234,101 @@ async def rollback_agent(agent_id: str, request: Request):
     except installer_mod.InstallError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"id": agent_id, "status": "rolled_back", "version": restored.version}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: configure / health / status (issue #465)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/agents/{agent_id}/config")
+async def get_agent_config(agent_id: str):
+    """Return the persisted per-agent config (``{}`` if none)."""
+    try:
+        config = lifecycle_mod.read_config(agent_id)
+    except lifecycle_mod.LifecycleError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"id": agent_id, "config": config}
+
+
+@router.post(
+    "/api/agents/{agent_id}/config",
+    dependencies=[Depends(_require_localhost), Depends(_require_ui_header)],
+)
+async def set_agent_config(agent_id: str, body: ConfigRequest):
+    """Persist per-agent config (model preference, settings). Merges by default."""
+    try:
+        merged = lifecycle_mod.configure(agent_id, body.config, merge=not body.replace)
+    except lifecycle_mod.LifecycleError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"id": agent_id, "config": merged}
+
+
+@router.get("/api/agents/{agent_id}/health")
+async def agent_health(agent_id: str, request: Request):
+    """Health check: does the installed agent load + its entry point resolve?"""
+    registry = _registry(request)
+    return lifecycle_mod.health_check(agent_id, registry=registry).to_dict()
+
+
+@router.get("/api/agents/{agent_id}/status")
+async def agent_status(agent_id: str, request: Request):
+    """Aggregated status: installed version, health, config summary."""
+    registry = _registry(request)
+    return lifecycle_mod.status(agent_id, registry=registry).to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Setup executor: progressive, resumable, parallel multi-agent install (#468)
+# ---------------------------------------------------------------------------
+
+
+def _run_setup(ids: List[str], registry, *, max_parallel: int, resume: bool) -> None:
+    """Background setup worker. Per-agent progress is in install-status."""
+    try:
+        manifests = {aid: catalog_mod.fetch_manifest(aid) for aid in ids}
+    except catalog_mod.CatalogError as exc:
+        logger.warning("hub: setup could not resolve manifests: %s", exc)
+        return
+    try:
+        installer_mod.run_setup(
+            manifests,
+            max_parallel=max_parallel,
+            resume=resume,
+            registry=registry,
+        )
+    except installer_mod.InstallError as exc:
+        logger.warning("hub: setup failed: %s", exc)
+    except Exception:  # noqa: BLE001 - record then swallow in the worker
+        logger.exception("hub: unexpected error during setup")
+
+
+@router.post(
+    "/api/agents/setup",
+    status_code=202,
+    dependencies=[Depends(_require_localhost), Depends(_require_ui_header)],
+)
+async def start_setup(
+    request: Request, body: SetupRequest, background_tasks: BackgroundTasks
+):
+    """Start a progressive multi-agent install; poll setup-status for progress."""
+    if not body.ids:
+        raise HTTPException(status_code=400, detail="No agent ids provided.")
+    registry = _registry(request)
+    background_tasks.add_task(
+        _run_setup,
+        body.ids,
+        registry,
+        max_parallel=body.max_parallel,
+        resume=body.resume,
+    )
+    return {"ids": body.ids, "status": "queued"}
+
+
+@router.get("/api/agents/setup-status")
+async def setup_status():
+    """Poll the resumable setup state (per-step progress for a multi-install)."""
+    state = installer_mod.get_setup_status()
+    if state is None:
+        raise HTTPException(status_code=404, detail="No setup in progress.")
+    return state

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -6,6 +6,7 @@ All HTTP and pip work is mocked; no live network, no real ``uv``.
 """
 
 import hashlib
+import json
 
 import pytest
 
@@ -322,3 +323,154 @@ def test_install_cpp_artifact_extracted(tmp_path):
     assert (tmp_path / "native" / "bin" / "demo").exists()
     # Native agents do not hot-register in-process.
     assert result.hot_registered is False
+
+
+# ---------------------------------------------------------------------------
+# Setup executor: progressive / resumable / parallel (#468)
+# ---------------------------------------------------------------------------
+
+
+def _sized_manifest(agent_id, size_bytes, version="1.0.0"):
+    """A manifest whose artifact declares a specific size (for ordering tests)."""
+    m = _manifest(agent_id=agent_id, version=version)
+    m["id"] = agent_id
+    m["versions"][version]["artifact"]["size_bytes"] = size_bytes
+    return m
+
+
+def test_run_setup_orders_smallest_first(tmp_path):
+    manifests = {
+        "big": _sized_manifest("big", 9000),
+        "small": _sized_manifest("small", 100),
+        "mid": _sized_manifest("mid", 500),
+    }
+    order = []
+
+    def fake_install(agent_id, **kwargs):
+        order.append(agent_id)
+        return None
+
+    result = installer.run_setup(
+        manifests,
+        max_parallel=1,  # serial so observed order == plan order
+        install_root=tmp_path,
+        state_path=tmp_path / "setup_state.json",
+        installer_fn=fake_install,
+    )
+    assert order == ["small", "mid", "big"]
+    assert result.all_ok
+    assert set(result.completed) == {"small", "mid", "big"}
+
+
+def test_run_setup_resume_skips_completed(tmp_path):
+    state_path = tmp_path / "setup_state.json"
+    # Prior run completed "a"; "b" is still pending.
+    state_path.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "steps": [
+                    {"agent_id": "a", "status": "completed"},
+                    {"agent_id": "b", "status": "pending"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifests = {"a": _sized_manifest("a", 100), "b": _sized_manifest("b", 200)}
+    installed = []
+
+    def fake_install(agent_id, **kwargs):
+        installed.append(agent_id)
+        return None
+
+    result = installer.run_setup(
+        manifests,
+        max_parallel=2,
+        resume=True,
+        install_root=tmp_path,
+        state_path=state_path,
+        installer_fn=fake_install,
+    )
+    # "a" was already completed → not re-installed; only "b" runs.
+    assert installed == ["b"]
+    assert result.all_ok
+
+
+def test_run_setup_respects_concurrency_bound(tmp_path):
+    import threading
+    import time
+
+    manifests = {f"agent{i}": _sized_manifest(f"agent{i}", i) for i in range(6)}
+
+    lock = threading.Lock()
+    state = {"active": 0, "peak": 0}
+
+    def fake_install(agent_id, **kwargs):
+        with lock:
+            state["active"] += 1
+            state["peak"] = max(state["peak"], state["active"])
+        time.sleep(0.02)  # hold the slot so overlap is observable
+        with lock:
+            state["active"] -= 1
+        return None
+
+    installer.run_setup(
+        manifests,
+        max_parallel=2,
+        install_root=tmp_path,
+        state_path=tmp_path / "setup_state.json",
+        installer_fn=fake_install,
+    )
+    assert state["peak"] <= 2
+
+
+def test_run_setup_failed_step_does_not_block_others(tmp_path):
+    manifests = {
+        "good": _sized_manifest("good", 100),
+        "bad": _sized_manifest("bad", 50),
+    }
+
+    def fake_install(agent_id, **kwargs):
+        if agent_id == "bad":
+            raise installer.InstallError("boom")
+        return None
+
+    result = installer.run_setup(
+        manifests,
+        max_parallel=2,
+        install_root=tmp_path,
+        state_path=tmp_path / "setup_state.json",
+        installer_fn=fake_install,
+    )
+    assert "good" in result.completed
+    assert "bad" in result.failed
+    assert not result.all_ok
+
+
+def test_run_setup_persists_state_file(tmp_path):
+    state_path = tmp_path / "setup_state.json"
+    manifests = {"a": _sized_manifest("a", 100)}
+
+    installer.run_setup(
+        manifests,
+        install_root=tmp_path,
+        state_path=state_path,
+        installer_fn=lambda agent_id, **kwargs: None,
+    )
+    assert state_path.exists()
+    saved = installer.read_setup_state(state_path)
+    assert saved["status"] == "completed"
+    assert saved["steps"][0]["agent_id"] == "a"
+    assert saved["steps"][0]["status"] == "completed"
+
+
+def test_run_setup_rejects_bad_concurrency(tmp_path):
+    with pytest.raises(InstallError):
+        installer.run_setup(
+            {"a": _sized_manifest("a", 1)},
+            max_parallel=0,
+            install_root=tmp_path,
+            state_path=tmp_path / "s.json",
+            installer_fn=lambda agent_id, **kwargs: None,
+        )

--- a/tests/unit/test_hub_lifecycle.py
+++ b/tests/unit/test_hub_lifecycle.py
@@ -1,0 +1,210 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.hub.lifecycle — configure / health / status (#465).
+
+No live network, no real agent imports: health probes are injected so the tests
+assert state transitions (healthy/degraded/error/not_installed) deterministically.
+"""
+
+import json
+
+import pytest
+
+from gaia.hub import installer, lifecycle
+from gaia.hub.lifecycle import (
+    HEALTH_DEGRADED,
+    HEALTH_ERROR,
+    HEALTH_HEALTHY,
+    HEALTH_NOT_INSTALLED,
+    LifecycleError,
+    configure,
+    health_check,
+    read_config,
+    status,
+    status_all,
+)
+
+
+def _install_sentinel(tmp_path, agent_id="demo", version="1.0.0"):
+    """Write a minimal install sentinel so the agent reads as installed."""
+    install_dir = installer.agent_install_dir(agent_id, tmp_path)
+    install_dir.mkdir(parents=True, exist_ok=True)
+    installer._write_sentinel(  # noqa: SLF001 - direct sentinel for test setup
+        agent_id, version, "python", "deadbeef", install_dir
+    )
+
+
+class _FakeRegistration:
+    def __init__(self, agent_id, source="installed"):
+        self.id = agent_id
+        self.source = source
+        self.name = agent_id
+        self.models = []
+
+
+class _FakeRegistry:
+    def __init__(self, agents=None):
+        self._agents = {a.id: a for a in (agents or [])}
+
+    def get(self, agent_id):
+        return self._agents.get(agent_id)
+
+    def list(self):
+        return list(self._agents.values())
+
+
+# ---------------------------------------------------------------------------
+# configure: persists + reloads + merges
+# ---------------------------------------------------------------------------
+
+
+def test_configure_persists_and_reloads(tmp_path):
+    merged = configure("demo", {"model": "Qwen3.5-35B-A3B-GGUF"}, install_root=tmp_path)
+    assert merged == {"model": "Qwen3.5-35B-A3B-GGUF"}
+
+    # Round-trips from disk.
+    reloaded = read_config("demo", install_root=tmp_path)
+    assert reloaded == {"model": "Qwen3.5-35B-A3B-GGUF"}
+
+    # File actually written under the agent dir.
+    path = lifecycle.config_path("demo", tmp_path)
+    assert path.exists()
+    assert json.loads(path.read_text())["model"] == "Qwen3.5-35B-A3B-GGUF"
+
+
+def test_configure_merges_by_default(tmp_path):
+    configure("demo", {"model": "m1", "temperature": 0.2}, install_root=tmp_path)
+    merged = configure("demo", {"model": "m2"}, install_root=tmp_path)
+    # model overwritten, temperature preserved.
+    assert merged == {"model": "m2", "temperature": 0.2}
+
+
+def test_configure_replace_drops_existing(tmp_path):
+    configure("demo", {"model": "m1", "temperature": 0.2}, install_root=tmp_path)
+    merged = configure("demo", {"model": "m2"}, install_root=tmp_path, merge=False)
+    assert merged == {"model": "m2"}
+
+
+def test_configure_rejects_non_dict(tmp_path):
+    with pytest.raises(LifecycleError):
+        configure("demo", ["not", "a", "dict"], install_root=tmp_path)
+
+
+def test_read_config_missing_returns_empty(tmp_path):
+    assert read_config("nope", install_root=tmp_path) == {}
+
+
+def test_read_config_corrupt_raises(tmp_path):
+    path = lifecycle.config_path("demo", tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not valid json", encoding="utf-8")
+    with pytest.raises(LifecycleError):
+        read_config("demo", install_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# health_check: healthy / degraded / error / not_installed
+# ---------------------------------------------------------------------------
+
+
+def test_health_not_installed(tmp_path):
+    result = health_check("ghost", registry=_FakeRegistry(), install_root=tmp_path)
+    assert result.state == HEALTH_NOT_INSTALLED
+    assert not result.ok
+
+
+def test_health_healthy(tmp_path):
+    _install_sentinel(tmp_path, "demo")
+    reg = _FakeRegistry([_FakeRegistration("demo")])
+    result = health_check(
+        "demo",
+        registry=reg,
+        install_root=tmp_path,
+        loader=lambda aid, registry: [],  # loads cleanly, no warnings
+    )
+    assert result.state == HEALTH_HEALTHY
+    assert result.ok
+
+
+def test_health_error_when_loader_raises(tmp_path):
+    _install_sentinel(tmp_path, "demo")
+    reg = _FakeRegistry([_FakeRegistration("demo")])
+
+    def broken_loader(aid, registry):
+        raise RuntimeError("entry point blew up")
+
+    result = health_check(
+        "demo", registry=reg, install_root=tmp_path, loader=broken_loader
+    )
+    assert result.state == HEALTH_ERROR
+    assert "entry point blew up" in result.detail
+
+
+def test_health_degraded_on_loader_warning(tmp_path):
+    _install_sentinel(tmp_path, "demo")
+    reg = _FakeRegistry([_FakeRegistration("demo")])
+    result = health_check(
+        "demo",
+        registry=reg,
+        install_root=tmp_path,
+        loader=lambda aid, registry: ["optional VLM model missing"],
+    )
+    assert result.state == HEALTH_DEGRADED
+    assert "optional VLM model missing" in result.warnings
+
+
+def test_health_degraded_on_corrupt_config(tmp_path):
+    _install_sentinel(tmp_path, "demo")
+    path = lifecycle.config_path("demo", tmp_path)
+    path.write_text("{broken", encoding="utf-8")
+    reg = _FakeRegistry([_FakeRegistration("demo")])
+    result = health_check(
+        "demo", registry=reg, install_root=tmp_path, loader=lambda aid, r: []
+    )
+    assert result.state == HEALTH_DEGRADED
+    assert any("corrupt" in w for w in result.warnings)
+
+
+def test_health_builtin_without_sentinel_is_checked(tmp_path):
+    # A builtin id (e.g. "chat") has no sentinel but must still be health-checked
+    # rather than reported not_installed.
+    reg = _FakeRegistry([_FakeRegistration("chat", source="builtin")])
+    result = health_check(
+        "chat", registry=reg, install_root=tmp_path, loader=lambda aid, r: []
+    )
+    assert result.state == HEALTH_HEALTHY
+
+
+# ---------------------------------------------------------------------------
+# status: aggregates version + health + config + source
+# ---------------------------------------------------------------------------
+
+
+def test_status_aggregates(tmp_path):
+    _install_sentinel(tmp_path, "demo", version="2.1.0")
+    configure("demo", {"model": "m1"}, install_root=tmp_path)
+    reg = _FakeRegistry([_FakeRegistration("demo")])
+
+    st = status("demo", registry=reg, install_root=tmp_path, loader=lambda aid, r: [])
+    assert st.installed is True
+    assert st.installed_version == "2.1.0"
+    assert st.health == HEALTH_HEALTHY
+    assert st.config == {"model": "m1"}
+    assert st.source == "installed"
+
+    d = st.to_dict()
+    assert d["installed_version"] == "2.1.0"
+    assert d["health"] == HEALTH_HEALTHY
+
+
+def test_status_all_covers_installed_and_registered(tmp_path):
+    _install_sentinel(tmp_path, "demo")
+    reg = _FakeRegistry(
+        [_FakeRegistration("demo"), _FakeRegistration("chat", source="builtin")]
+    )
+    all_status = status_all(
+        registry=reg, install_root=tmp_path, loader=lambda aid, r: []
+    )
+    assert set(all_status) == {"demo", "chat"}
+    assert all_status["demo"].installed_version is not None
+    assert all_status["chat"].installed_version is None  # builtin, no semver

--- a/tests/unit/test_hub_router.py
+++ b/tests/unit/test_hub_router.py
@@ -10,8 +10,10 @@ from fastapi.testclient import TestClient
 from gaia.agents.registry import AgentRegistry
 from gaia.hub import catalog as catalog_mod
 from gaia.hub import installer as installer_mod
+from gaia.hub import lifecycle as lifecycle_mod
 from gaia.hub.catalog import UnifiedCatalog
 from gaia.hub.installer import InstalledAgent, InstallError, NotInstalledError
+from gaia.hub.lifecycle import AgentStatus, HealthStatus
 from gaia.ui.routers import hub as hub_router
 from gaia.ui.server import create_app
 
@@ -229,3 +231,143 @@ def test_rollback_no_backup_400(client, monkeypatch):
     monkeypatch.setattr(installer_mod, "rollback", boom)
     resp = client.post("/api/agents/demo/rollback", headers=UI)
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: configure / health / status (#465)
+# ---------------------------------------------------------------------------
+
+
+def test_set_config_success(client, monkeypatch):
+    captured = {}
+
+    def fake_configure(agent_id, config, *, merge):
+        captured["id"] = agent_id
+        captured["config"] = config
+        captured["merge"] = merge
+        return config
+
+    monkeypatch.setattr(lifecycle_mod, "configure", fake_configure)
+    resp = client.post(
+        "/api/agents/demo/config",
+        json={"config": {"model": "m1"}},
+        headers=UI,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["config"] == {"model": "m1"}
+    assert captured["merge"] is True
+
+
+def test_set_config_replace_flag(client, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        lifecycle_mod,
+        "configure",
+        lambda agent_id, config, *, merge: captured.update(merge=merge) or config,
+    )
+    client.post(
+        "/api/agents/demo/config",
+        json={"config": {"model": "m1"}, "replace": True},
+        headers=UI,
+    )
+    assert captured["merge"] is False
+
+
+def test_set_config_requires_ui_header(client):
+    resp = client.post("/api/agents/demo/config", json={"config": {"a": 1}})
+    assert resp.status_code == 403
+
+
+def test_get_config(client, monkeypatch):
+    monkeypatch.setattr(lifecycle_mod, "read_config", lambda *a, **k: {"model": "m1"})
+    resp = client.get("/api/agents/demo/config")
+    assert resp.status_code == 200
+    assert resp.json()["config"] == {"model": "m1"}
+
+
+def test_health_endpoint(client, monkeypatch):
+    monkeypatch.setattr(
+        lifecycle_mod,
+        "health_check",
+        lambda *a, **k: HealthStatus(id="demo", state="healthy", detail="ok"),
+    )
+    resp = client.get("/api/agents/demo/health")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "healthy"
+
+
+def test_status_endpoint(client, monkeypatch):
+    monkeypatch.setattr(
+        lifecycle_mod,
+        "status",
+        lambda *a, **k: AgentStatus(
+            id="demo",
+            installed=True,
+            installed_version="1.2.3",
+            health="healthy",
+            config={"model": "m1"},
+            source="installed",
+        ),
+    )
+    resp = client.get("/api/agents/demo/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["installed_version"] == "1.2.3"
+    assert body["health"] == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# Setup executor (#468)
+# ---------------------------------------------------------------------------
+
+
+def test_setup_returns_202_and_schedules(client, monkeypatch):
+    called = {}
+    monkeypatch.setattr(catalog_mod, "fetch_manifest", lambda aid, *a, **k: {"id": aid})
+    monkeypatch.setattr(
+        installer_mod,
+        "run_setup",
+        lambda manifests, **k: called.update(ids=sorted(manifests)),
+    )
+    resp = client.post("/api/agents/setup", json={"ids": ["a", "b"]}, headers=UI)
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "queued"
+    assert called.get("ids") == ["a", "b"]
+
+
+def test_setup_empty_ids_400(client):
+    resp = client.post("/api/agents/setup", json={"ids": []}, headers=UI)
+    assert resp.status_code == 400
+
+
+def test_setup_requires_ui_header(client):
+    resp = client.post("/api/agents/setup", json={"ids": ["a"]})
+    assert resp.status_code == 403
+
+
+def test_setup_status_polling(client, monkeypatch):
+    monkeypatch.setattr(
+        installer_mod,
+        "get_setup_status",
+        lambda *a, **k: {"status": "running", "steps": []},
+    )
+    resp = client.get("/api/agents/setup-status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "running"
+
+
+def test_setup_status_unknown_404(client, monkeypatch):
+    monkeypatch.setattr(installer_mod, "get_setup_status", lambda *a, **k: None)
+    resp = client.get("/api/agents/setup-status")
+    assert resp.status_code == 404
+
+
+def test_setup_status_not_swallowed_by_agents_route(client, monkeypatch):
+    # Regression guard: /api/agents/setup-status must hit the hub router, not
+    # the greedy GET /api/agents/{agent_id:path} in routers/agents.py.
+    monkeypatch.setattr(
+        installer_mod, "get_setup_status", lambda *a, **k: {"status": "completed"}
+    )
+    resp = client.get("/api/agents/setup-status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "completed"


### PR DESCRIPTION
## Why this matters

Before this change a user could install a hub agent (#1096) but had no way to *configure* it, *verify* it actually loads, or *recover* an install interrupted halfway through. An agent that installed but failed to import silently broke at first use; installing several agents meant downloading them one-at-a-time with no resume after a crash. Now `gaia agent configure/health/status` (and the matching `/api/agents/{id}/...` endpoints) let you set a model preference, get a `healthy`/`degraded`/`error`/`not_installed` verdict, and read installed version + config at a glance — and a multi-agent install runs smallest-first, resumes from a state file, and downloads in parallel so a fast minimal agent is usable while a large one keeps going.

**Install / uninstall / rollback already shipped in #1096** — this PR adds only the *remainder* of #465 (lifecycle: configure/health/status) and #468 (setup executor: progressive/resumable/parallel), building on the existing `installer.py`, `catalog.py`, `compatibility.py`, and `routers/hub.py` rather than duplicating them. See `docs/spec/agent-hub-restructure.mdx` (Phase 4).

- **`gaia.hub.lifecycle`** (new): `configure()` persists per-agent settings to `~/.gaia/agents/<id>/config.json`; `health_check()` resolves the agent's entry point to tell working from broken; `status()`/`status_all()` aggregate version + health + config. Corrupt config and failed loads fail loudly, never silently.
- **`gaia.hub.installer.run_setup`** (new): progressive (smallest-download-first), resumable (skips steps already `completed` in `~/.gaia/setup_state.json`), bounded-parallel; a failed step doesn't block independent ones. Per-agent progress still flows through the existing install-status poller.
- **Endpoints** wired into `routers/hub.py`: `GET`/`POST /api/agents/{id}/config`, `GET /api/agents/{id}/health`, `GET /api/agents/{id}/status`, `POST /api/agents/setup`, `GET /api/agents/setup-status`.
- **CLI**: `gaia agent configure <id> [--model … | --set k=v | --show]`, `gaia agent health <id>`, `gaia agent status [<id>]`.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/test_hub_*.py` → 199 passed (new `test_hub_lifecycle.py`; extended `test_hub_installer.py` + `test_hub_router.py`). Covers: config persist/reload/merge/replace, corrupt-config rejection, health healthy/degraded/error/not_installed, status aggregation, resume-skips-completed, smallest-first ordering, concurrency-bound, failed-step-isolation, and the new endpoints incl. a `setup-status` route-ordering regression guard.
- [x] `python util/lint.py --pylint --black --isort --fix` → black + isort PASS; the one pylint error is pre-existing `os.geteuid` Windows-only noise in `installer/lemonade_installer.py` (untouched by this PR).
- [x] `gaia agent configure demo --model … --set temperature=0.2 --show` round-trips to `config.json`.

Refs #465, #468; spec `docs/spec/agent-hub-restructure.mdx`.