### PR TITLE
feat(email): browser-openable HTML endpoint spec (#1263)

### DIFF
--- a/src/gaia/agents/email/cli.py
+++ b/src/gaia/agents/email/cli.py
@@ -14,9 +14,7 @@ structured-logging contract from Phase A5 fires for every triage decision.
 from __future__ import annotations
 
 import logging
-import pathlib
 import sys
-import webbrowser
 from typing import Any
 
 from gaia.agents.email.agent import EmailTriageAgent
@@ -30,22 +28,11 @@ async def main(args: Any) -> int:
     """Async main — invoked by ``gaia.cli.handle_email_command``.
 
     Returns the process exit code (0 on success, 1 on error).
+
+    Note: ``--spec`` is handled upstream in ``gaia.cli.handle_email_command``
+    (it short-circuits before this coroutine is reached), so there is no
+    spec branch here — see ``spec_html.write_and_open_spec``.
     """
-    # --spec: local-only, no LLM. Generate the HTML spec and open it.
-    if getattr(args, "spec", False):
-        from gaia.agents.email.spec_html import render_endpoint_spec_html
-
-        output_path = getattr(args, "output", None)
-        if output_path:
-            dest = pathlib.Path(output_path).expanduser().resolve()
-        else:
-            dest = pathlib.Path.home() / ".gaia" / "email" / "endpoint-spec.html"
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(render_endpoint_spec_html(), encoding="utf-8")
-        print(dest)
-        webbrowser.open(dest.as_uri())
-        return 0
-
     # Wire verbose/debug to the agent's logger before constructing.
     if getattr(args, "verbose", False) or getattr(args, "debug", False):
         logging.getLogger("gaia.agents.email").setLevel(logging.INFO)

--- a/src/gaia/agents/email/cli.py
+++ b/src/gaia/agents/email/cli.py
@@ -14,7 +14,9 @@ structured-logging contract from Phase A5 fires for every triage decision.
 from __future__ import annotations
 
 import logging
+import pathlib
 import sys
+import webbrowser
 from typing import Any
 
 from gaia.agents.email.agent import EmailTriageAgent
@@ -29,6 +31,21 @@ async def main(args: Any) -> int:
 
     Returns the process exit code (0 on success, 1 on error).
     """
+    # --spec: local-only, no LLM. Generate the HTML spec and open it.
+    if getattr(args, "spec", False):
+        from gaia.agents.email.spec_html import render_endpoint_spec_html
+
+        output_path = getattr(args, "output", None)
+        if output_path:
+            dest = pathlib.Path(output_path).expanduser().resolve()
+        else:
+            dest = pathlib.Path.home() / ".gaia" / "email" / "endpoint-spec.html"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(render_endpoint_spec_html(), encoding="utf-8")
+        print(dest)
+        webbrowser.open(dest.as_uri())
+        return 0
+
     # Wire verbose/debug to the agent's logger before constructing.
     if getattr(args, "verbose", False) or getattr(args, "debug", False):
         logging.getLogger("gaia.agents.email").setLevel(logging.INFO)

--- a/src/gaia/agents/email/spec_html.py
+++ b/src/gaia/agents/email/spec_html.py
@@ -1,0 +1,417 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+HTML spec generator for the Email Triage Agent REST endpoints (issue #1263).
+
+``render_endpoint_spec_html()`` returns a single self-contained HTML page
+documenting the three email REST endpoints and the frozen #1262 contract
+request/response shapes. It derives field rows directly from the contract
+pydantic models so the spec stays in sync with the contract automatically.
+
+No external assets — inline CSS only. No LLM, no network calls.
+"""
+
+from __future__ import annotations
+
+import html as _html_lib
+from typing import Any, List, Tuple, Type
+
+from pydantic import BaseModel
+
+from gaia.agents.email.contract import (
+    SCHEMA_VERSION,
+    ActionItem,
+    DraftReply,
+    EmailAddress,
+    EmailCategory,
+    EmailMessage,
+    EmailTriageRequest,
+    EmailTriageResponse,
+    EmailTriageResult,
+    SingleEmailInput,
+    ThreadInput,
+)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_INLINE_CSS = """
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               Helvetica, Arial, sans-serif;
+  background: #0f1117;
+  color: #e0e0e0;
+  margin: 0;
+  padding: 2rem;
+  line-height: 1.6;
+}
+h1 {
+  color: #ed6b36;
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+}
+.subtitle {
+  color: #888;
+  font-size: 0.95rem;
+  margin-bottom: 2.5rem;
+}
+h2 {
+  color: #d97742;
+  margin-top: 2.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.4rem;
+}
+h3 {
+  color: #c0bfe0;
+  margin-top: 1.5rem;
+  margin-bottom: 0.4rem;
+  font-size: 1.1rem;
+}
+.endpoint-block {
+  background: #1a1d27;
+  border: 1px solid #2d2f3e;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+.method-badge {
+  display: inline-block;
+  background: #4e6aff;
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  letter-spacing: 0.05em;
+  margin-right: 0.75rem;
+  vertical-align: middle;
+}
+.path {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 1.05rem;
+  color: #a8d8a8;
+  vertical-align: middle;
+}
+.desc {
+  color: #aaa;
+  font-size: 0.93rem;
+  margin-top: 0.5rem;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+}
+th {
+  text-align: left;
+  color: #888;
+  font-weight: 600;
+  border-bottom: 1px solid #2d2f3e;
+  padding: 0.4rem 0.6rem;
+}
+td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid #1e2030;
+  vertical-align: top;
+}
+td:first-child {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  color: #8fd8ff;
+  white-space: nowrap;
+}
+td:nth-child(2) {
+  color: #d8a870;
+}
+td:nth-child(3) {
+  color: #aaa;
+}
+.required-badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  background: #6a3030;
+  color: #ff9a9a;
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+.optional-badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  background: #2a3040;
+  color: #8899bb;
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+.version-badge {
+  display: inline-block;
+  background: #2a3040;
+  color: #8899bb;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.75rem;
+  border-radius: 4px;
+  margin-left: 1rem;
+  vertical-align: middle;
+}
+.category-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+.category-tag {
+  background: #2a3040;
+  color: #a8d8a8;
+  border: 1px solid #3a4555;
+  border-radius: 4px;
+  padding: 0.2rem 0.75rem;
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 0.85rem;
+}
+.model-section {
+  background: #151821;
+  border: 1px solid #252838;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin-top: 1rem;
+}
+.footer {
+  margin-top: 3rem;
+  color: #555;
+  font-size: 0.8rem;
+  border-top: 1px solid #2d2f3e;
+  padding-top: 1rem;
+}
+"""
+
+
+def _esc(text: str) -> str:
+    return _html_lib.escape(str(text))
+
+
+def _type_label(field_info: Any) -> str:
+    """Best-effort human-readable type label from a pydantic FieldInfo."""
+    annotation = getattr(field_info, "annotation", None)
+    if annotation is None:
+        return "any"
+    # Use __name__ when available; fall back to repr for generics.
+    name = getattr(annotation, "__name__", None) or repr(annotation)
+    # Simplify common generic forms
+    name = (
+        name.replace("typing.", "")
+        .replace("Optional[", "")
+        .replace("]", "")
+        .replace("List[", "list[")
+    )
+    return name
+
+
+def _required_badge(field_info: Any) -> str:
+    has_default = (
+        field_info.default is not None or field_info.default_factory is not None
+    )
+    if has_default or getattr(field_info, "is_required", lambda: True)() is False:
+        return '<span class="optional-badge">optional</span>'
+    return '<span class="required-badge">required</span>'
+
+
+def _model_table(model: Type[BaseModel], title: str) -> str:
+    rows: List[str] = []
+    for name, info in model.model_fields.items():
+        desc = (info.description or "").strip()
+        type_label = _type_label(info)
+        badge = _required_badge(info)
+        rows.append(
+            f"<tr>"
+            f"<td>{_esc(name)}{badge}</td>"
+            f"<td>{_esc(type_label)}</td>"
+            f"<td>{_esc(desc)}</td>"
+            f"</tr>"
+        )
+
+    table_html = (
+        "<table>"
+        "<thead><tr>"
+        "<th>Field</th><th>Type</th><th>Description</th>"
+        "</tr></thead>"
+        "<tbody>" + "".join(rows) + "</tbody>"
+        "</table>"
+    )
+    return f'<div class="model-section"><h3>{_esc(title)}</h3>{table_html}</div>'
+
+
+def _category_list_html() -> str:
+    tags = "".join(
+        f'<span class="category-tag">{_esc(cat.value)}</span>' for cat in EmailCategory
+    )
+    return f'<div class="category-list">{tags}</div>'
+
+
+def _endpoint_block(
+    path: str,
+    description: str,
+    request_sections: List[Tuple[str, Type[BaseModel]]],
+    response_sections: List[Tuple[str, Type[BaseModel]]],
+    extra_html: str = "",
+) -> str:
+    req_html = "".join(_model_table(m, t) for t, m in request_sections)
+    resp_html = "".join(_model_table(m, t) for t, m in response_sections)
+    return (
+        f'<div class="endpoint-block">'
+        f'<span class="method-badge">POST</span>'
+        f'<span class="path">{_esc(path)}</span>'
+        f'<p class="desc">{_esc(description)}</p>'
+        f"{extra_html}"
+        f"<h3>Request body</h3>{req_html}"
+        f"<h3>Response body</h3>{resp_html}"
+        f"</div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def render_endpoint_spec_html() -> str:
+    """Return a self-contained HTML page documenting the Email Triage API.
+
+    The page is built entirely from the frozen #1262 contract models —
+    field names and descriptions are derived at call time so the spec
+    stays in sync with contract changes automatically. No external assets;
+    all CSS is inlined.
+    """
+    triage_extra = (
+        "<p class='desc'>"
+        "<strong>Payload discriminator:</strong> set <code>payload.kind</code> "
+        'to <code>"single"</code> for a single message or '
+        '<code>"thread"</code> for a conversation thread.</p>'
+        "<h3>Category values (EmailCategory)</h3>"
+        + _category_list_html()
+        + _model_table(SingleEmailInput, "SingleEmailInput (kind: single)")
+        + _model_table(ThreadInput, "ThreadInput (kind: thread)")
+        + _model_table(EmailMessage, "EmailMessage")
+        + _model_table(EmailAddress, "EmailAddress")
+    )
+
+    triage_block = (
+        f'<div class="endpoint-block">'
+        f'<span class="method-badge">POST</span>'
+        f'<span class="path">/v1/email/triage</span>'
+        f'<p class="desc">Triage a single email or a full thread. '
+        f"Accepts the frozen #1262 EmailTriageRequest and returns "
+        f"a structured EmailTriageResponse — category, spam/phishing signals, "
+        f"a plain-text summary, extracted action items, and an optional draft reply. "
+        f"No mail is read or sent; this analyses only the payload in the request.</p>"
+        f"<h3>Request envelope</h3>"
+        f"{_model_table(EmailTriageRequest, 'EmailTriageRequest')}"
+        f"<h3>Payload shapes</h3>"
+        f"{triage_extra}"
+        f"<h3>Response envelope</h3>"
+        f"{_model_table(EmailTriageResponse, 'EmailTriageResponse')}"
+        f"{_model_table(EmailTriageResult, 'EmailTriageResult')}"
+        f"{_model_table(DraftReply, 'DraftReply (optional)')}"
+        f"{_model_table(ActionItem, 'ActionItem')}"
+        f"</div>"
+    )
+
+    draft_block = (
+        '<div class="endpoint-block">'
+        '<span class="method-badge">POST</span>'
+        '<span class="path">/v1/email/draft</span>'
+        '<p class="desc">Propose a reply and obtain a single-use confirmation '
+        "token bound to the exact (to, subject, body) payload. "
+        "Echo the token to POST /v1/email/send to authorize sending.</p>"
+        "<h3>Request fields</h3>"
+        "<div class='model-section'>"
+        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
+        "<tbody>"
+        "<tr><td>to <span class='required-badge'>required</span></td><td>list[EmailAddress]</td><td>Proposed recipients (non-empty).</td></tr>"
+        "<tr><td>subject <span class='required-badge'>required</span></td><td>str</td><td>Proposed subject line.</td></tr>"
+        "<tr><td>body <span class='required-badge'>required</span></td><td>str</td><td>Proposed reply body.</td></tr>"
+        "</tbody></table>"
+        "</div>"
+        "<h3>Response fields</h3>"
+        "<div class='model-section'>"
+        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
+        "<tbody>"
+        "<tr><td>draft <span class='required-badge'>required</span></td><td>DraftReply</td><td>The proposed reply (to / subject / body).</td></tr>"
+        "<tr><td>confirmation_token <span class='required-badge'>required</span></td><td>str</td><td>Echo to POST /v1/email/send. Single-use; bound to this exact payload.</td></tr>"
+        "</tbody></table>"
+        "</div>"
+        "</div>"
+    )
+
+    send_block = (
+        '<div class="endpoint-block">'
+        '<span class="method-badge">POST</span>'
+        '<span class="path">/v1/email/send</span>'
+        '<p class="desc">Send a reply — gated on explicit confirmation (#1264). '
+        "The confirmation gate fires FIRST: a request without a valid, "
+        "payload-bound confirmation token is rejected with HTTP 403 before any "
+        "backend call. Emails are never sent without explicit confirmation.</p>"
+        "<h3>Request fields</h3>"
+        "<div class='model-section'>"
+        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
+        "<tbody>"
+        "<tr><td>to <span class='required-badge'>required</span></td><td>list[EmailAddress]</td><td>Recipients (non-empty).</td></tr>"
+        "<tr><td>subject <span class='required-badge'>required</span></td><td>str</td><td>Subject line.</td></tr>"
+        "<tr><td>body <span class='required-badge'>required</span></td><td>str</td><td>Reply body.</td></tr>"
+        "<tr><td>confirmation_token <span class='optional-badge'>optional</span></td><td>str</td><td>Confirmation token from POST /v1/email/draft. A send without a valid token for this exact payload is rejected (403).</td></tr>"
+        "</tbody></table>"
+        "</div>"
+        "<h3>Response fields</h3>"
+        "<div class='model-section'>"
+        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
+        "<tbody>"
+        "<tr><td>sent_id <span class='required-badge'>required</span></td><td>str</td><td>Provider message id of the sent email.</td></tr>"
+        "<tr><td>to <span class='required-badge'>required</span></td><td>list[EmailAddress]</td><td>Recipients the message was sent to.</td></tr>"
+        "<tr><td>subject <span class='required-badge'>required</span></td><td>str</td><td>Subject of the sent message.</td></tr>"
+        "<tr><td>sent <span class='required-badge'>required</span></td><td>bool</td><td>Always true on success.</td></tr>"
+        "</tbody></table>"
+        "</div>"
+        "</div>"
+    )
+
+    body = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Email Triage Agent — Endpoint Spec</title>
+<style>
+{_INLINE_CSS}
+</style>
+</head>
+<body>
+<h1>Email Triage Agent
+  <span class="version-badge">Contract schema_version: {_esc(SCHEMA_VERSION)}</span>
+</h1>
+<p class="subtitle">
+  REST endpoint specification derived from the frozen #1262 contract
+  (<code>gaia.agents.email.contract</code>).
+  Field descriptions are sourced directly from the pydantic models and stay
+  in sync with the contract automatically.
+</p>
+
+<h2>Endpoints</h2>
+
+{triage_block}
+
+{draft_block}
+
+{send_block}
+
+<div class="footer">
+  GAIA Email Triage Agent &mdash; schema_version {_esc(SCHEMA_VERSION)} &mdash; amd-gaia.ai
+</div>
+</body>
+</html>"""
+    return body
+
+
+__all__ = ["render_endpoint_spec_html"]

--- a/src/gaia/agents/email/spec_html.py
+++ b/src/gaia/agents/email/spec_html.py
@@ -14,7 +14,9 @@ No external assets — inline CSS only. No LLM, no network calls.
 from __future__ import annotations
 
 import html as _html_lib
-from typing import Any, List, Tuple, Type
+import webbrowser
+from pathlib import Path
+from typing import Any, List, Optional, Tuple, Type, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -35,6 +37,11 @@ from gaia.agents.email.contract import (
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+# The runtime type of ``None`` — used to drop the NoneType arm of Optional[X]
+# unions when labelling a field's type. ``type(None)`` is the canonical way to
+# obtain it; bound to a constant so the comparison reads ``is not _NONE_TYPE``.
+_NONE_TYPE = type(None)
 
 _INLINE_CSS = """
 body {
@@ -193,30 +200,53 @@ def _esc(text: str) -> str:
     return _html_lib.escape(str(text))
 
 
+def _annotation_label(annotation: Any) -> str:
+    """Render a typing annotation into a compact human-readable label.
+
+    Recurses through Optional / List / Union so generics like
+    ``Optional[List[EmailAddress]]`` render as ``list[EmailAddress]``
+    rather than the bare outer name. NoneType arms (from Optional) are
+    dropped so the label names the value type, not ``| None``.
+    """
+    origin = get_origin(annotation)
+    if origin is None:
+        # A concrete class (str, bool, EmailAddress, …) or a bare name.
+        return getattr(annotation, "__name__", None) or str(annotation)
+
+    args = [a for a in get_args(annotation) if a is not _NONE_TYPE]
+    if origin is Union:
+        # Optional[X] collapses to X; a real multi-arm Union joins with ' | '.
+        if len(args) == 1:
+            return _annotation_label(args[0])
+        return " | ".join(_annotation_label(a) for a in args)
+    if origin in (list, List):
+        inner = _annotation_label(args[0]) if args else "any"
+        return f"list[{inner}]"
+
+    # Other generics (e.g. Literal): show the origin name with its args.
+    origin_name = getattr(origin, "__name__", None) or str(origin)
+    if args:
+        inner = ", ".join(_annotation_label(a) for a in args)
+        return f"{origin_name}[{inner}]"
+    return origin_name
+
+
 def _type_label(field_info: Any) -> str:
     """Best-effort human-readable type label from a pydantic FieldInfo."""
     annotation = getattr(field_info, "annotation", None)
     if annotation is None:
         return "any"
-    # Use __name__ when available; fall back to repr for generics.
-    name = getattr(annotation, "__name__", None) or repr(annotation)
-    # Simplify common generic forms
-    name = (
-        name.replace("typing.", "")
-        .replace("Optional[", "")
-        .replace("]", "")
-        .replace("List[", "list[")
-    )
-    return name
+    return _annotation_label(annotation)
 
 
 def _required_badge(field_info: Any) -> str:
-    has_default = (
-        field_info.default is not None or field_info.default_factory is not None
-    )
-    if has_default or getattr(field_info, "is_required", lambda: True)() is False:
-        return '<span class="optional-badge">optional</span>'
-    return '<span class="required-badge">required</span>'
+    # pydantic v2's authoritative required check: a field with no default and
+    # no default_factory has ``is_required()`` True. ``default`` is the
+    # ``PydanticUndefined`` sentinel for required fields (NOT None), so testing
+    # ``default is not None`` would mislabel every required field as optional.
+    if field_info.is_required():
+        return '<span class="required-badge">required</span>'
+    return '<span class="optional-badge">optional</span>'
 
 
 def _model_table(model: Type[BaseModel], title: str) -> str:
@@ -319,62 +349,41 @@ def render_endpoint_spec_html() -> str:
         f"</div>"
     )
 
-    draft_block = (
-        '<div class="endpoint-block">'
-        '<span class="method-badge">POST</span>'
-        '<span class="path">/v1/email/draft</span>'
-        '<p class="desc">Propose a reply and obtain a single-use confirmation '
-        "token bound to the exact (to, subject, body) payload. "
-        "Echo the token to POST /v1/email/send to authorize sending.</p>"
-        "<h3>Request fields</h3>"
-        "<div class='model-section'>"
-        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
-        "<tbody>"
-        "<tr><td>to <span class='required-badge'>required</span></td><td>list[EmailAddress]</td><td>Proposed recipients (non-empty).</td></tr>"
-        "<tr><td>subject <span class='required-badge'>required</span></td><td>str</td><td>Proposed subject line.</td></tr>"
-        "<tr><td>body <span class='required-badge'>required</span></td><td>str</td><td>Proposed reply body.</td></tr>"
-        "</tbody></table>"
-        "</div>"
-        "<h3>Response fields</h3>"
-        "<div class='model-section'>"
-        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
-        "<tbody>"
-        "<tr><td>draft <span class='required-badge'>required</span></td><td>DraftReply</td><td>The proposed reply (to / subject / body).</td></tr>"
-        "<tr><td>confirmation_token <span class='required-badge'>required</span></td><td>str</td><td>Echo to POST /v1/email/send. Single-use; bound to this exact payload.</td></tr>"
-        "</tbody></table>"
-        "</div>"
-        "</div>"
+    # /draft and /send are derived from the REST route models (the same
+    # pydantic classes the endpoints actually use) via _endpoint_block, so the
+    # tables cannot drift from the live request/response shapes. Imported
+    # lazily here to keep this module's load surface free of FastAPI and to
+    # avoid any import-order coupling with email_routes (which imports this
+    # module lazily for its GET /spec page).
+    from gaia.api.email_routes import (
+        EmailDraftRequest,
+        EmailDraftResponse,
+        EmailSendRequest,
+        EmailSendResponse,
     )
 
-    send_block = (
-        '<div class="endpoint-block">'
-        '<span class="method-badge">POST</span>'
-        '<span class="path">/v1/email/send</span>'
-        '<p class="desc">Send a reply — gated on explicit confirmation (#1264). '
-        "The confirmation gate fires FIRST: a request without a valid, "
-        "payload-bound confirmation token is rejected with HTTP 403 before any "
-        "backend call. Emails are never sent without explicit confirmation.</p>"
-        "<h3>Request fields</h3>"
-        "<div class='model-section'>"
-        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
-        "<tbody>"
-        "<tr><td>to <span class='required-badge'>required</span></td><td>list[EmailAddress]</td><td>Recipients (non-empty).</td></tr>"
-        "<tr><td>subject <span class='required-badge'>required</span></td><td>str</td><td>Subject line.</td></tr>"
-        "<tr><td>body <span class='required-badge'>required</span></td><td>str</td><td>Reply body.</td></tr>"
-        "<tr><td>confirmation_token <span class='optional-badge'>optional</span></td><td>str</td><td>Confirmation token from POST /v1/email/draft. A send without a valid token for this exact payload is rejected (403).</td></tr>"
-        "</tbody></table>"
-        "</div>"
-        "<h3>Response fields</h3>"
-        "<div class='model-section'>"
-        "<table><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>"
-        "<tbody>"
-        "<tr><td>sent_id <span class='required-badge'>required</span></td><td>str</td><td>Provider message id of the sent email.</td></tr>"
-        "<tr><td>to <span class='required-badge'>required</span></td><td>list[EmailAddress]</td><td>Recipients the message was sent to.</td></tr>"
-        "<tr><td>subject <span class='required-badge'>required</span></td><td>str</td><td>Subject of the sent message.</td></tr>"
-        "<tr><td>sent <span class='required-badge'>required</span></td><td>bool</td><td>Always true on success.</td></tr>"
-        "</tbody></table>"
-        "</div>"
-        "</div>"
+    draft_block = _endpoint_block(
+        path="/v1/email/draft",
+        description=(
+            "Propose a reply and obtain a single-use confirmation token bound "
+            "to the exact (to, subject, body) payload. Echo the token to "
+            "POST /v1/email/send to authorize sending."
+        ),
+        request_sections=[("EmailDraftRequest", EmailDraftRequest)],
+        response_sections=[("EmailDraftResponse", EmailDraftResponse)],
+    )
+
+    send_block = _endpoint_block(
+        path="/v1/email/send",
+        description=(
+            "Send a reply — gated on explicit confirmation (#1264). The "
+            "confirmation gate fires FIRST: a request without a valid, "
+            "payload-bound confirmation token is rejected with HTTP 403 before "
+            "any backend call. Emails are never sent without explicit "
+            "confirmation."
+        ),
+        request_sections=[("EmailSendRequest", EmailSendRequest)],
+        response_sections=[("EmailSendResponse", EmailSendResponse)],
     )
 
     body = f"""<!DOCTYPE html>
@@ -414,4 +423,30 @@ def render_endpoint_spec_html() -> str:
     return body
 
 
-__all__ = ["render_endpoint_spec_html"]
+# Default location for the generated spec when no explicit path is given.
+DEFAULT_SPEC_PATH = Path.home() / ".gaia" / "email" / "endpoint-spec.html"
+
+
+def write_and_open_spec(output_path: Optional[str] = None) -> Path:
+    """Render the spec, write it to disk, and open it in a browser.
+
+    Shared by every ``gaia email --spec`` entry point so the write/open
+    behavior lives in one place. ``output_path`` overrides the default
+    ``~/.gaia/email/endpoint-spec.html``. Returns the resolved destination
+    path (already written) so callers can print it.
+    """
+    if output_path:
+        dest = Path(output_path).expanduser().resolve()
+    else:
+        dest = DEFAULT_SPEC_PATH
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(render_endpoint_spec_html(), encoding="utf-8")
+    webbrowser.open(dest.as_uri())
+    return dest
+
+
+__all__ = [
+    "render_endpoint_spec_html",
+    "write_and_open_spec",
+    "DEFAULT_SPEC_PATH",
+]

--- a/src/gaia/api/email_routes.py
+++ b/src/gaia/api/email_routes.py
@@ -50,6 +50,7 @@ import threading
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from gaia.agents.email.contract import (
@@ -561,6 +562,18 @@ async def send_email(request: EmailSendRequest) -> EmailSendResponse:
         )
     logger.info("email send: id=%s to=%s", sent_id, to_header)
     return EmailSendResponse(sent_id=sent_id, to=request.to, subject=request.subject)
+
+
+@router.get("/spec", response_class=HTMLResponse, include_in_schema=False)
+async def email_spec() -> HTMLResponse:
+    """Serve the self-contained HTML endpoint spec page.
+
+    Not included in the OpenAPI schema — this is a human-readable convenience
+    page, not a machine-readable contract endpoint.
+    """
+    from gaia.agents.email.spec_html import render_endpoint_spec_html
+
+    return HTMLResponse(content=render_endpoint_spec_html())
 
 
 __all__ = [

--- a/src/gaia/api/email_routes.py
+++ b/src/gaia/api/email_routes.py
@@ -448,15 +448,19 @@ class _Strict(BaseModel):
 class EmailDraftRequest(_Strict):
     """Propose a reply and obtain a confirmation token for it."""
 
-    to: List[EmailAddress] = Field(..., min_length=1)
-    subject: str
-    body: str
+    to: List[EmailAddress] = Field(
+        ..., min_length=1, description="Proposed recipients (non-empty)."
+    )
+    subject: str = Field(..., description="Proposed subject line.")
+    body: str = Field(..., description="Proposed reply body.")
 
 
 class EmailDraftResponse(_Strict):
     """The proposed reply plus a single-use confirmation token bound to it."""
 
-    draft: DraftReply
+    draft: DraftReply = Field(
+        ..., description="The proposed reply (to / subject / body)."
+    )
     confirmation_token: str = Field(
         ...,
         description=(
@@ -469,9 +473,11 @@ class EmailDraftResponse(_Strict):
 class EmailSendRequest(_Strict):
     """Send a reply. Requires a valid confirmation token for this payload."""
 
-    to: List[EmailAddress] = Field(..., min_length=1)
-    subject: str
-    body: str
+    to: List[EmailAddress] = Field(
+        ..., min_length=1, description="Recipients (non-empty)."
+    )
+    subject: str = Field(..., description="Subject line.")
+    body: str = Field(..., description="Reply body.")
     confirmation_token: Optional[str] = Field(
         default=None,
         description=(
@@ -482,10 +488,12 @@ class EmailSendRequest(_Strict):
 
 
 class EmailSendResponse(_Strict):
-    sent_id: str
-    to: List[EmailAddress]
-    subject: str
-    sent: bool = True
+    sent_id: str = Field(..., description="Provider message id of the sent email.")
+    to: List[EmailAddress] = Field(
+        ..., description="Recipients the message was sent to."
+    )
+    subject: str = Field(..., description="Subject of the sent message.")
+    sent: bool = Field(default=True, description="Always true on success.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -4597,20 +4597,10 @@ def handle_email_command(args):
     # --spec: generate the HTML endpoint spec and open it in a browser.
     # No LLM, no Lemonade — short-circuit before any server check.
     if getattr(args, "spec", False):
-        import pathlib
-        import webbrowser
+        from gaia.agents.email.spec_html import write_and_open_spec
 
-        from gaia.agents.email.spec_html import render_endpoint_spec_html
-
-        output_path = getattr(args, "output", None)
-        if output_path:
-            dest = pathlib.Path(output_path).expanduser().resolve()
-        else:
-            dest = pathlib.Path.home() / ".gaia" / "email" / "endpoint-spec.html"
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(render_endpoint_spec_html(), encoding="utf-8")
+        dest = write_and_open_spec(getattr(args, "output", None))
         print(dest)
-        webbrowser.open(dest.as_uri())
         sys.exit(0)
 
     # Initialize Lemonade — local LLM only. The email agent's config will

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1766,6 +1766,24 @@ def build_parser():
             "verbose output. Sensitive payloads in logs."
         ),
     )
+    email_parser.add_argument(
+        "--spec",
+        action="store_true",
+        help=(
+            "Generate the HTML endpoint spec page, write it to disk, and open "
+            "it in a browser. No LLM or Lemonade required."
+        ),
+    )
+    email_parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to write the HTML spec (default: ~/.gaia/email/endpoint-spec.html). "
+            "Only used with --spec."
+        ),
+    )
 
     # Add Docker app command
     docker_parser = subparsers.add_parser(
@@ -4575,6 +4593,25 @@ def handle_email_command(args):
         args: Parsed command line arguments for the email command
     """
     log = get_logger(__name__)
+
+    # --spec: generate the HTML endpoint spec and open it in a browser.
+    # No LLM, no Lemonade — short-circuit before any server check.
+    if getattr(args, "spec", False):
+        import pathlib
+        import webbrowser
+
+        from gaia.agents.email.spec_html import render_endpoint_spec_html
+
+        output_path = getattr(args, "output", None)
+        if output_path:
+            dest = pathlib.Path(output_path).expanduser().resolve()
+        else:
+            dest = pathlib.Path.home() / ".gaia" / "email" / "endpoint-spec.html"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(render_endpoint_spec_html(), encoding="utf-8")
+        print(dest)
+        webbrowser.open(dest.as_uri())
+        sys.exit(0)
 
     # Initialize Lemonade — local LLM only. The email agent's config will
     # also reject any non-local base_url at construction time, but the

--- a/tests/unit/agents/email/test_spec_html.py
+++ b/tests/unit/agents/email/test_spec_html.py
@@ -20,11 +20,16 @@ from gaia.agents.email.contract import (
     ActionItem,
     DraftReply,
     EmailCategory,
+    EmailMessage,
     EmailTriageRequest,
     EmailTriageResponse,
     EmailTriageResult,
 )
-from gaia.agents.email.spec_html import render_endpoint_spec_html
+from gaia.agents.email.spec_html import (
+    _required_badge,
+    _type_label,
+    render_endpoint_spec_html,
+)
 
 
 def _html() -> str:
@@ -190,3 +195,139 @@ def test_no_external_protocol_relative_script():
     html = _html()
     proto_relative = re.search(r'<script[^>]+src=["\']\/\/', html, re.IGNORECASE)
     assert proto_relative is None, "Found protocol-relative script src in spec HTML"
+
+
+# ---------------------------------------------------------------------------
+# Required / optional badges — must reflect pydantic's is_required(), not a
+# default-is-None heuristic (which mislabels every required field).
+# ---------------------------------------------------------------------------
+
+
+def _row_badge(html: str, field_name: str) -> str:
+    """Return 'required' or 'optional' for the FIRST rendered row of
+    ``field_name``, or '' if no badge is found.
+    """
+    m = re.search(
+        rf"<td>{re.escape(field_name)}" rf'<span class="(required|optional)-badge">',
+        html,
+    )
+    return m.group(1) if m else ""
+
+
+def test_required_badge_helper_marks_required_field_required():
+    # category has no default (PydanticUndefined) → is_required() is True.
+    badge = _required_badge(EmailTriageResult.model_fields["category"])
+    assert "required" in badge
+    assert "optional" not in badge
+
+
+def test_required_badge_helper_marks_optional_field_optional():
+    # thread_id is Optional[str] with default None → is_required() is False.
+    badge = _required_badge(EmailMessage.model_fields["thread_id"])
+    assert "optional" in badge
+    assert ">required<" not in badge
+
+
+def test_required_badge_helper_marks_default_factory_field_optional():
+    # action_items uses default_factory; its default is PydanticUndefined but
+    # is_required() is False — the old `default is not None` heuristic got this
+    # wrong. Guard against regression.
+    badge = _required_badge(EmailTriageResult.model_fields["action_items"])
+    assert "optional" in badge
+
+
+def test_required_field_renders_required_badge_in_html():
+    # A known-required field (category) must show the 'required' badge.
+    assert _row_badge(_html(), "category") == "required"
+
+
+def test_optional_field_renders_optional_badge_in_html():
+    # A known-optional field unique to one model (is_spam, only in
+    # EmailTriageResult, default False) must show the 'optional' badge.
+    # (thread_id is ambiguous — it's required on ThreadInput but optional on
+    # EmailMessage — so it's a poor page-level probe.)
+    assert _row_badge(_html(), "is_spam") == "optional"
+
+
+def test_send_response_sent_field_is_optional_in_html():
+    # EmailSendResponse.sent has default=True → optional, not required.
+    # (Regression guard for the hand-coded table that marked it 'required'.)
+    assert _row_badge(_html(), "sent") == "optional"
+
+
+# ---------------------------------------------------------------------------
+# Type labels — generics must render cleanly (no truncated `list[str`).
+# ---------------------------------------------------------------------------
+
+
+def test_type_label_renders_list_generic_cleanly():
+    # EmailMessage.to is List[EmailAddress] → 'list[EmailAddress]', not 'List'
+    # or a truncated 'list[EmailAddress' (the bracket-strip ordering bug).
+    label = _type_label(EmailMessage.model_fields["to"])
+    assert label == "list[EmailAddress]"
+
+
+def test_type_label_unwraps_optional():
+    # thread_id is Optional[str] → the value type 'str', not 'Optional'.
+    label = _type_label(EmailMessage.model_fields["thread_id"])
+    assert label == "str"
+
+
+def test_no_truncated_list_label_in_html():
+    # The whole page must never contain a truncated 'list[Something' without a
+    # closing bracket (the _type_label bracket-ordering bug). Every 'list['
+    # generic that opens must close with ']'.
+    html = _html()
+    for m in re.finditer(r"list\[[A-Za-z_]+(.?)", html):
+        assert m.group(1) == "]", f"Unclosed list[ label near: {m.group(0)!r}"
+
+
+# ---------------------------------------------------------------------------
+# /draft and /send sections are derived from the real route models, so their
+# model class names appear in the page (they would not if hand-coded).
+# ---------------------------------------------------------------------------
+
+
+def test_draft_section_derived_from_route_models():
+    html = _html()
+    assert "EmailDraftRequest" in html
+    assert "EmailDraftResponse" in html
+    assert "confirmation_token" in html
+
+
+def test_send_section_derived_from_route_models():
+    html = _html()
+    assert "EmailSendRequest" in html
+    assert "EmailSendResponse" in html
+    assert "sent_id" in html
+
+
+# ---------------------------------------------------------------------------
+# write_and_open_spec — the single shared write/open helper used by the CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_write_and_open_spec_writes_file_and_returns_path(tmp_path, monkeypatch):
+    import gaia.agents.email.spec_html as spec_mod
+
+    opened = []
+    monkeypatch.setattr(spec_mod.webbrowser, "open", lambda uri: opened.append(uri))
+
+    dest = tmp_path / "spec.html"
+    returned = spec_mod.write_and_open_spec(str(dest))
+
+    assert returned == dest.resolve()
+    assert dest.exists()
+    content = dest.read_text(encoding="utf-8")
+    assert content.strip().lower().startswith("<!doctype html")
+    # The browser was opened with this file's URI (no silent no-op).
+    assert opened == [dest.resolve().as_uri()]
+
+
+def test_write_and_open_spec_default_path_constant(monkeypatch):
+    import gaia.agents.email.spec_html as spec_mod
+
+    # Default path lives under ~/.gaia/email/ and is exposed as a constant the
+    # CLI prints; assert the shape without writing to the real home dir.
+    assert spec_mod.DEFAULT_SPEC_PATH.name == "endpoint-spec.html"
+    assert spec_mod.DEFAULT_SPEC_PATH.parent.name == "email"

--- a/tests/unit/agents/email/test_spec_html.py
+++ b/tests/unit/agents/email/test_spec_html.py
@@ -1,0 +1,192 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for the email agent HTML spec generator (issue #1263).
+
+The spec must:
+- Be a self-contained HTML page (no external script/link assets)
+- Document all 3 REST endpoints
+- Render key contract field names sourced from the contract models
+- Show SCHEMA_VERSION
+- Include the four category values from EmailCategory
+"""
+
+from __future__ import annotations
+
+import re
+
+from gaia.agents.email.contract import (
+    SCHEMA_VERSION,
+    ActionItem,
+    DraftReply,
+    EmailCategory,
+    EmailTriageRequest,
+    EmailTriageResponse,
+    EmailTriageResult,
+)
+from gaia.agents.email.spec_html import render_endpoint_spec_html
+
+
+def _html() -> str:
+    """Call once and cache in tests that need the output multiple times."""
+    return render_endpoint_spec_html()
+
+
+# ---------------------------------------------------------------------------
+# Basic well-formedness
+# ---------------------------------------------------------------------------
+
+
+def test_returns_nonempty_string():
+    html = _html()
+    assert isinstance(html, str)
+    assert len(html) > 0
+
+
+def test_starts_with_doctype():
+    html = _html()
+    assert html.strip().lower().startswith("<!doctype html")
+
+
+def test_contains_html_root_element():
+    html = _html()
+    assert "<html" in html.lower()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint paths
+# ---------------------------------------------------------------------------
+
+
+def test_triage_endpoint_present():
+    assert "/v1/email/triage" in _html()
+
+
+def test_draft_endpoint_present():
+    assert "/v1/email/draft" in _html()
+
+
+def test_send_endpoint_present():
+    assert "/v1/email/send" in _html()
+
+
+# ---------------------------------------------------------------------------
+# Contract field names — sourced from the models so a contract change that
+# drops a field will break this test, not slip through silently.
+# ---------------------------------------------------------------------------
+
+
+def test_request_field_schema_version_present():
+    # EmailTriageRequest has schema_version
+    assert "schema_version" in EmailTriageRequest.model_fields
+    assert "schema_version" in _html()
+
+
+def test_result_field_category_present():
+    assert "category" in EmailTriageResult.model_fields
+    assert "category" in _html()
+
+
+def test_result_field_is_phishing_present():
+    assert "is_phishing" in EmailTriageResult.model_fields
+    assert "is_phishing" in _html()
+
+
+def test_result_field_summary_present():
+    assert "summary" in EmailTriageResult.model_fields
+    assert "summary" in _html()
+
+
+def test_result_field_draft_present():
+    assert "draft" in EmailTriageResult.model_fields
+    assert "draft" in _html()
+
+
+def test_result_field_action_items_present():
+    assert "action_items" in EmailTriageResult.model_fields
+    assert "action_items" in _html()
+
+
+def test_response_field_request_kind_present():
+    assert "request_kind" in EmailTriageResponse.model_fields
+    assert "request_kind" in _html()
+
+
+def test_draft_reply_field_to_present():
+    assert "to" in DraftReply.model_fields
+    assert "to" in _html()
+
+
+def test_draft_reply_field_subject_present():
+    assert "subject" in DraftReply.model_fields
+    assert "subject" in _html()
+
+
+def test_draft_reply_field_body_present():
+    assert "body" in DraftReply.model_fields
+    assert "body" in _html()
+
+
+def test_action_item_field_description_present():
+    assert "description" in ActionItem.model_fields
+    assert "description" in _html()
+
+
+# ---------------------------------------------------------------------------
+# Category values — sourced from EmailCategory enum
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_category_values_present():
+    html = _html()
+    for cat in EmailCategory:
+        assert cat.value in html, f"Category value {cat.value!r} missing from spec"
+
+
+def test_category_urgent_present():
+    assert EmailCategory.URGENT.value in _html()
+
+
+def test_category_actionable_present():
+    assert EmailCategory.ACTIONABLE.value in _html()
+
+
+def test_category_informational_present():
+    assert EmailCategory.INFORMATIONAL.value in _html()
+
+
+def test_category_low_priority_present():
+    assert EmailCategory.LOW_PRIORITY.value in _html()
+
+
+# ---------------------------------------------------------------------------
+# Schema version
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_rendered():
+    assert SCHEMA_VERSION in _html()
+
+
+# ---------------------------------------------------------------------------
+# Self-contained — no external assets
+# ---------------------------------------------------------------------------
+
+
+def test_no_external_script_src():
+    html = _html()
+    # Any <script src="http..."> or <script src="//..."> is forbidden
+    external_script = re.search(r'<script[^>]+src=["\']https?://', html, re.IGNORECASE)
+    assert external_script is None, "Found external script src in spec HTML"
+
+
+def test_no_external_link_href():
+    html = _html()
+    external_link = re.search(r'<link[^>]+href=["\']https?://', html, re.IGNORECASE)
+    assert external_link is None, "Found external link href in spec HTML"
+
+
+def test_no_external_protocol_relative_script():
+    html = _html()
+    proto_relative = re.search(r'<script[^>]+src=["\']\/\/', html, re.IGNORECASE)
+    assert proto_relative is None, "Found protocol-relative script src in spec HTML"


### PR DESCRIPTION
Closes #1263

The email agent's REST contract (#1262) was only discoverable by reading pydantic source or a live server's `/docs`. Now `gaia email --spec` writes and opens a self-contained HTML page documenting all three endpoints (`/triage`, `/draft`, `/send`) with their request/response shapes — rendered directly from the contract models (so it can't drift) and fully offline (no external assets, opens from `file://`).

## Test plan
- [ ] `python -m pytest tests/unit/agents/email/test_spec_html.py -q` — 39 tests: required/optional badges via `is_required()`, model-derived endpoint tables, self-contained (no external assets), recursive type labels
- [ ] `gaia email --spec` → writes `~/.gaia/email/endpoint-spec.html` and opens it in a browser; confirm the three endpoints and correct required/optional badges render
