### PR TITLE
fix(deps): bump @remix-run/router to patch XSS in emr dashboard (#1420)

### DIFF
--- a/hub/agents/python/emr/gaia_agent_emr/dashboard/frontend/package-lock.json
+++ b/hub/agents/python/emr/gaia_agent_emr/dashboard/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.20.0"
+        "react-router-dom": "^6.30.4"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.1.tgz",
-      "integrity": "sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -1552,12 +1552,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.2.tgz",
-      "integrity": "sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.1"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1567,13 +1567,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.2.tgz",
-      "integrity": "sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.1",
-        "react-router": "6.30.2"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/hub/agents/python/emr/gaia_agent_emr/dashboard/frontend/package.json
+++ b/hub/agents/python/emr/gaia_agent_emr/dashboard/frontend/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.20.0"
+    "react-router-dom": "^6.30.4"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",


### PR DESCRIPTION
## Why this matters

The EMR dashboard frontend resolved `@remix-run/router@1.23.1` transitively through `react-router-dom@^6.20.0`, exposing it to the high-severity **XSS-via-open-redirect** advisory [GHSA-2w69-qvjg-hvjx](https://github.com/advisories/GHSA-2w69-qvjg-hvjx) (CVE-2026-22029). Before: a fresh install of the dashboard pulled in the vulnerable router. After: the `react-router-dom` floor is bumped to `^6.30.4`, which pins the patched `@remix-run/router@1.23.3`, clearing the advisory while staying on the 6.x line — **no major-version migration to react-router 7 required** (`react-router-dom@6.30.4` was released with the patched router after #1420 was filed, so the earlier "needs RR7" note no longer applies).

Scope is limited to the router bump: `package.json` floor + lockfile refresh only (13 lines changed, no package additions/removals). The sibling `electron/` dashboard does **not** pull in `@remix-run/router`, so it's untouched. The remaining vite/rollup/postcss/picomatch advisories in `npm audit` are pre-existing and out of scope for this fix.

## Test plan

- [x] `npm audit --audit-level=high` no longer reports `@remix-run/router` / `react-router` in `hub/agents/python/emr/gaia_agent_emr/dashboard/frontend/` (high count dropped 6→3, all remaining unrelated)
- [x] `npm run build` succeeds (vite build, 39 modules, clean)
- [x] Diff is scope-clean: only `react-router-dom` / `react-router` / `@remix-run/router` entries changed in the lockfile
- [x] Confirmed `electron/package-lock.json` has no `@remix-run/router` dependency

Closes #1420