### PR TITLE
feat(hub): publish agent wheels to PyPI (dual R2 + PyPI) (#1179)

### DIFF
--- a/.github/workflows/publish_agents.yml
+++ b/.github/workflows/publish_agents.yml
@@ -1,0 +1,161 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Publish the AMD production *Python* agent wheels (gaia-agent-<id>) to PyPI.
+# Issue #1179 (Agent Hub dual distribution): R2 is the canonical source for the
+# Hub UI; PyPI is the canonical source for `pip install gaia-agent-<id>` and the
+# `amd-gaia[agents]` meta-extra. The C++ agent binaries are handled separately
+# by build_agents.yml.
+#
+# Flow:
+#   discover (read setup.py[agents] -> matrix)
+#     -> build  (every push/PR: build each wheel + twine check, upload artifact)
+#       -> approve (tag only: single manual gate, "publish" environment)
+#         -> publish (tag only: gh-action-pypi-publish per agent, skip-existing)
+#
+# The build job runs on every push/PR touching an agent so a broken wheel is
+# caught in review. Publishing runs ONLY on a version tag (v*). Agent wheels
+# version independently (each gaia-agent.yaml/pyproject sets its own SemVer), so
+# `skip-existing: true` makes a release a no-op for any agent whose version did
+# not change — that is PyPI's native version immutability, not custom overwrite
+# logic (issue #1179).
+#
+# Secret: PYPI_API_TOKEN — a PyPI API token (account- or project-scoped) with
+# upload rights to every gaia-agent-* project. Store it as a *repository* (or
+# org) secret so the matrix publish jobs can read it; the manual gate is the
+# separate "publish" environment on approve-publish. The publisher CLI's local
+# env var is PYPI_TOKEN; the CI secret is intentionally separate.
+
+name: Publish Agent Wheels (PyPI)
+
+on:
+  # Tag pushes trigger the publish path. No `paths:` filter here — a release tag
+  # must always run even when the tagged commit didn't touch an agent (GitHub
+  # applies push `paths` filters to tag pushes too, which would skip publishing).
+  push:
+    tags:
+      - 'v*'
+  # PRs get the build/twine-check only (the publish jobs are gated on a v* tag).
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'hub/agents/python/**'
+      - 'setup.py'
+      - 'util/list_agent_packages.py'
+      - '.github/workflows/publish_agents.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+
+  # ── Discover: derive the agent matrix from setup.py[agents] ──────────
+  # Single source of truth — adding an agent to the meta-extra auto-includes
+  # it here. No hand-maintained second list to drift.
+  discover:
+    name: Discover Agent Packages
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - id: list
+        run: |
+          MATRIX=$(python util/list_agent_packages.py --format matrix)
+          echo "Production agent packages:"
+          echo "$MATRIX" | python -m json.tool
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  # ── Build: one wheel per agent, twine-checked ───────────────────────
+  build:
+    name: Build ${{ matrix.dist }}
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Build wheel + sdist
+        run: |
+          python -m pip install --upgrade build
+          rm -rf "${{ matrix.path }}/dist"
+          python -m build --outdir "${{ matrix.path }}/dist" "${{ matrix.path }}"
+      - name: Verify metadata declares the amd-gaia framework dependency
+        # Issue #1179: every agent wheel must depend on amd-gaia>={min_gaia_version}.
+        run: |
+          python - "${{ matrix.path }}/dist" "${{ matrix.dist }}" << 'PYEOF'
+          import glob, sys, zipfile
+          dist_dir, dist_name = sys.argv[1], sys.argv[2]
+          wheels = glob.glob(f"{dist_dir}/*.whl")
+          if not wheels:
+              sys.exit(f"ERROR: no wheel built in {dist_dir}")
+          z = zipfile.ZipFile(wheels[0])
+          meta_name = next(n for n in z.namelist() if n.endswith("METADATA"))
+          meta = z.read(meta_name).decode()
+          if not any(
+              line.startswith("Requires-Dist: amd-gaia")
+              for line in meta.splitlines()
+          ):
+              sys.exit(
+                  f"ERROR: {dist_name} wheel does not declare an 'amd-gaia' "
+                  f"dependency (Requires-Dist). Add it to its pyproject.toml."
+              )
+          print(f"{dist_name}: amd-gaia dependency present")
+          PYEOF
+      - name: Check with twine
+        run: |
+          python -m pip install --upgrade twine
+          twine check "${{ matrix.path }}"/dist/*
+      - name: Upload distribution
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent-dist-${{ matrix.id }}
+          path: ${{ matrix.path }}/dist/
+          if-no-files-found: error
+
+  # ── Approve: single manual gate, tag pushes only ────────────────────
+  approve-publish:
+    name: Approve Publishing
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') && !cancelled() && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    environment: publish
+    steps:
+      - run: echo "All agent wheels built. Publishing to PyPI approved."
+
+  # ── Publish: one PyPI upload per agent, tag pushes only ─────────────
+  publish:
+    name: Publish ${{ matrix.dist }}
+    needs: [discover, approve-publish]
+    if: startsWith(github.ref, 'refs/tags/v') && !cancelled() && needs.approve-publish.result == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    steps:
+      - name: Download built distribution
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-dist-${{ matrix.id }}
+          path: dist/
+      - name: Publish ${{ matrix.dist }} to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # PyPI's native version immutability: an unchanged agent version is a
+          # no-op, not a failure (issue #1179 — "no overwrite logic").
+          skip-existing: true
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -498,6 +498,33 @@ gaia agent publish --skip-r2
 ```
 </CodeGroup>
 
+##### Installing a published agent
+
+The two publish targets back two install paths, and both register the agent the
+same way — via the `gaia.agent` entry point, so the registry discovers it
+automatically:
+
+```bash From PyPI (pip)
+pip install gaia-agent-summarize          # one agent
+pip install "amd-gaia[agents]"            # every AMD production agent
+```
+
+The **Hub (R2)** path is the Agent UI's discover/install panel, which downloads
+the wheel from R2 into `~/.gaia/agents/<id>/` (`POST /api/agents/install`, backed
+by `gaia.hub.installer`). Use it when browsing the Hub UI; use `pip install` for
+scripted or headless setups.
+
+##### Automated PyPI publishing (CI)
+
+`.github/workflows/publish_agents.yml` builds every production agent wheel and
+publishes it to PyPI on a version tag (`v*`). Its matrix is derived from the
+`agents` extra in `setup.py` (via `util/list_agent_packages.py`), so adding an
+agent there is all it takes to start publishing it. The workflow uploads with
+[`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish)
+using the `PYPI_API_TOKEN` secret and `skip-existing: true`, so an unchanged
+agent version is a no-op rather than an error — PyPI enforces version
+immutability natively.
+
 #### Sharing: `export`, `import`
 
 Export every custom agent installed under `~/.gaia/agents/` into a single `.zip` bundle, and import a bundle produced on another machine.

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -155,7 +155,12 @@ Replace ~16 direct agent imports in `cli.py`, `ui/_chat_helpers.py`, `ui/agent_l
 `src/gaia/agents/base/server.py` wraps any Agent into REST API + MCP server. Enables `gaia agent run <id> --api` and `--mcp`.
 </Step>
 <Step title="Add CI/CD workflow">
-`.github/workflows/build_agents.yml` — matrix-builds all agent wheels + C++ binaries, runs `gaia agent test --lint`, publishes to R2 + PyPI on tag.
+`.github/workflows/build_agents.yml` matrix-builds the C++ agent binaries;
+`.github/workflows/publish_agents.yml` matrix-builds every Python agent wheel
+(matrix derived from `setup.py`'s `agents` extra via
+`util/list_agent_packages.py`) and publishes it to PyPI on a `v*` tag using
+`pypa/gh-action-pypi-publish` with `skip-existing: true` (PyPI-native version
+immutability). R2 publishing is handled at author time by `gaia agent publish`.
 </Step>
 <Step title="Relocate tests">
 Move agent-specific tests to `hub/agents/python/{id}/tests/`. Framework tests stay in `tests/`.

--- a/tests/unit/test_agent_pypi_publish.py
+++ b/tests/unit/test_agent_pypi_publish.py
@@ -1,0 +1,144 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Guards for the agent-wheel PyPI publish path (issue #1179).
+
+These tests do *not* touch the network or PyPI. They assert the static
+invariants that make dual distribution (R2 + PyPI) correct and drift-proof:
+
+* the production-agent list (``setup.py[agents]``) maps cleanly to packages
+  under ``hub/agents/python/<id>/`` (via ``util/list_agent_packages.py``);
+* every such wheel declares the ``gaia-agent-<id>`` name and an ``amd-gaia``
+  framework dependency (issue #1179 scope item 3);
+* the publish workflow derives its matrix from that same list, so a new agent
+  added to the extra is published automatically with no second list to sync.
+
+The live dual-publish logic is covered by ``test_hub_publisher.py``; the CLI
+wiring by ``test_cli_agent.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UTIL_DIR = REPO_ROOT / "util"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish_agents.yml"
+
+if str(UTIL_DIR) not in sys.path:
+    sys.path.insert(0, str(UTIL_DIR))
+
+import list_agent_packages as lap  # noqa: E402  (path set above)
+
+
+@pytest.fixture(scope="module")
+def packages():
+    return lap.list_agent_packages()
+
+
+def test_production_agent_list_nonempty(packages):
+    """setup.py[agents] resolves to at least the migrated agents."""
+    assert packages, "no production agent packages derived from setup.py[agents]"
+    ids = {p.agent_id for p in packages}
+    # Spot-check a couple that have already migrated; the helper enforces the
+    # full set exists on disk, so this just sanity-checks the mapping direction.
+    assert {"summarize", "analyst", "browser"} <= ids
+
+
+def test_dist_name_and_directory_convention(packages):
+    """Each entry follows gaia-agent-<id> and lives at hub/agents/python/<id>."""
+    for p in packages:
+        assert p.dist_name == f"gaia-agent-{p.agent_id}"
+        assert p.path == lap.PYTHON_AGENTS_DIR / p.agent_id
+        assert (p.path / "pyproject.toml").exists()
+
+
+def test_every_wheel_declares_amd_gaia_dependency(packages):
+    """Issue #1179 scope 3: each wheel depends on amd-gaia>={min_gaia_version}."""
+    for p in packages:
+        pyproject = (p.path / "pyproject.toml").read_text(encoding="utf-8")
+        assert (
+            "amd-gaia>=" in pyproject
+        ), f"{p.dist_name}: pyproject.toml is missing an 'amd-gaia>=' dependency"
+
+
+def test_pyproject_name_matches_dist(packages):
+    """The wheel's [project].name equals the published distribution name."""
+    for p in packages:
+        pyproject = (p.path / "pyproject.toml").read_text(encoding="utf-8")
+        assert (
+            f'name = "{p.dist_name}"' in pyproject
+        ), f"{p.path}/pyproject.toml [project].name != {p.dist_name}"
+
+
+def test_pyproject_declares_gaia_agent_entry_point(packages):
+    """Both install paths (R2 and pip) discover the agent via gaia.agent."""
+    for p in packages:
+        pyproject = (p.path / "pyproject.toml").read_text(encoding="utf-8")
+        assert (
+            'entry-points."gaia.agent"' in pyproject
+        ), f'{p.dist_name}: missing [project.entry-points."gaia.agent"]'
+
+
+def test_publish_workflow_exists_and_uses_pypi_action():
+    """The CI workflow publishes via gh-action-pypi-publish with the token secret."""
+    assert WORKFLOW.exists(), "publish_agents.yml workflow is missing"
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "pypa/gh-action-pypi-publish" in text
+    assert "secrets.PYPI_API_TOKEN" in text
+    # PyPI-native immutability rather than custom overwrite logic (#1179).
+    assert "skip-existing: true" in text
+    # Matrix is generated from the helper, not a hand-maintained second list.
+    assert "list_agent_packages.py --format matrix" in text
+
+
+def test_publish_workflow_only_publishes_on_tags():
+    """Publishing is gated on a v* tag; the build job runs on every push/PR."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "startsWith(github.ref, 'refs/tags/v')" in text
+
+
+def test_helper_matrix_format_matches_packages(packages):
+    """--format matrix emits exactly the resolved package set as GHA include[]."""
+    import json
+    import subprocess  # nosec B404 — fixed argv, no shell
+
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(UTIL_DIR / "list_agent_packages.py"),
+            "--format",
+            "matrix",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    matrix = json.loads(out.stdout)
+    assert "include" in matrix
+    assert [e["dist"] for e in matrix["include"]] == [p.dist_name for p in packages]
+    assert [e["id"] for e in matrix["include"]] == [p.agent_id for p in packages]
+
+
+def test_helper_rejects_missing_package(tmp_path):
+    """A dist in the extra with no on-disk package fails loudly (no silent skip)."""
+    fake_setup = tmp_path / "setup.py"
+    fake_setup.write_text(
+        'setup(\n    extras_require={"agents": ["gaia-agent-doesnotexist"]},\n)\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(lap.AgentListError, match="no package at"):
+        lap.list_agent_packages(setup_py=fake_setup)
+
+
+def test_helper_rejects_bad_naming(tmp_path):
+    """A dist not following gaia-agent-<id> fails loudly."""
+    fake_setup = tmp_path / "setup.py"
+    fake_setup.write_text(
+        'setup(\n    extras_require={"agents": ["totally-wrong-name"]},\n)\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(lap.AgentListError, match="naming convention"):
+        lap.list_agent_packages(setup_py=fake_setup)

--- a/util/list_agent_packages.py
+++ b/util/list_agent_packages.py
@@ -1,0 +1,163 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""List the AMD production agent packages that ship as ``gaia-agent-<id>`` wheels.
+
+Single source of truth = the ``agents`` entry of ``extras_require`` in
+``setup.py`` (the same list behind ``pip install "amd-gaia[agents]"``). This
+script reads that list *statically* (``ast``, never executing ``setup.py``),
+maps each ``gaia-agent-<id>`` distribution name to its package directory under
+``hub/agents/python/<id>/``, and verifies the directory exists.
+
+Consumers:
+
+* ``.github/workflows/publish_agents.yml`` calls ``--format matrix`` to generate
+  the build/publish matrix, so adding an agent to ``setup.py[agents]`` is all it
+  takes to start publishing its wheel — no second list to keep in sync.
+* ``tests/unit/test_agent_pypi_publish.py`` calls :func:`list_agent_packages`
+  to assert the published set, the on-disk packages, and their ``amd-gaia``
+  dependency all agree.
+
+Per ``CLAUDE.md`` (No Silent Fallbacks): a distribution listed in the extra with
+no matching ``hub/agents/python/<id>/`` directory, or a malformed ``setup.py``,
+raises rather than silently dropping the agent from the publish set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+# ``gaia-agent-chat`` -> id ``chat`` -> dir ``hub/agents/python/chat``.
+DIST_PREFIX = "gaia-agent-"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SETUP_PY = REPO_ROOT / "setup.py"
+PYTHON_AGENTS_DIR = REPO_ROOT / "hub" / "agents" / "python"
+
+
+class AgentListError(Exception):
+    """Raised when the production-agent list cannot be derived or is invalid."""
+
+
+@dataclass(frozen=True)
+class AgentPackage:
+    """A production agent wheel and where its source package lives."""
+
+    dist_name: str  # e.g. "gaia-agent-summarize"
+    agent_id: str  # e.g. "summarize"
+    path: Path  # e.g. <repo>/hub/agents/python/summarize
+
+    @property
+    def rel_path(self) -> str:
+        """Repo-relative POSIX path (stable across OSes, for CI matrices)."""
+        return self.path.relative_to(REPO_ROOT).as_posix()
+
+
+def _read_agents_extra(setup_py: Path) -> List[str]:
+    """Return the string list under ``extras_require["agents"]`` in *setup_py*.
+
+    Parses statically with :mod:`ast` — ``setup.py`` is never imported or run.
+    """
+    if not setup_py.exists():
+        raise AgentListError(
+            f"setup.py not found at {setup_py}. Run this from the gaia repo, or "
+            f"check the checkout."
+        )
+    tree = ast.parse(setup_py.read_text(encoding="utf-8"), filename=str(setup_py))
+
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.keyword) and node.arg == "extras_require"):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            raise AgentListError(
+                "setup.py: extras_require is not a dict literal — cannot derive "
+                "the production-agent list statically."
+            )
+        for key, value in zip(node.value.keys, node.value.values):
+            if isinstance(key, ast.Constant) and key.value == "agents":
+                try:
+                    dists = ast.literal_eval(value)
+                except ValueError as exc:
+                    raise AgentListError(
+                        f"setup.py: extras_require['agents'] is not a literal "
+                        f"list of strings: {exc}."
+                    ) from exc
+                if not isinstance(dists, list) or not all(
+                    isinstance(d, str) for d in dists
+                ):
+                    raise AgentListError(
+                        "setup.py: extras_require['agents'] must be a list of "
+                        "distribution-name strings."
+                    )
+                return dists
+        raise AgentListError(
+            "setup.py: extras_require has no 'agents' key. Add it (the meta "
+            "extra behind 'pip install \"amd-gaia[agents]\"')."
+        )
+    raise AgentListError(
+        "setup.py: no extras_require keyword found in the setup() call."
+    )
+
+
+def list_agent_packages(setup_py: Path = SETUP_PY) -> List[AgentPackage]:
+    """Return the production agent packages declared by ``setup.py[agents]``.
+
+    Raises:
+        AgentListError: For a malformed list, a distribution name that does not
+            start with ``gaia-agent-``, or a missing package directory.
+    """
+    packages: List[AgentPackage] = []
+    for dist in _read_agents_extra(setup_py):
+        if not dist.startswith(DIST_PREFIX):
+            raise AgentListError(
+                f"distribution {dist!r} in setup.py[agents] does not follow the "
+                f"'{DIST_PREFIX}<id>' naming convention required by issue #1179."
+            )
+        agent_id = dist[len(DIST_PREFIX) :]
+        path = PYTHON_AGENTS_DIR / agent_id
+        if not (path / "pyproject.toml").exists():
+            raise AgentListError(
+                f"{dist}: no package at {path}/pyproject.toml. Every entry in "
+                f"setup.py[agents] must have a wheel source under "
+                f"hub/agents/python/<id>/ (or remove it from the extra)."
+            )
+        packages.append(AgentPackage(dist_name=dist, agent_id=agent_id, path=path))
+    return packages
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=["ids", "paths", "matrix"],
+        default="ids",
+        help="ids: one agent id per line; paths: one repo-relative path per "
+        "line; matrix: a GitHub Actions matrix JSON object (default: ids)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        packages = list_agent_packages()
+    except AgentListError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.format == "ids":
+        print("\n".join(p.agent_id for p in packages))
+    elif args.format == "paths":
+        print("\n".join(p.rel_path for p in packages))
+    else:  # matrix
+        include = [
+            {"id": p.agent_id, "dist": p.dist_name, "path": p.rel_path}
+            for p in packages
+        ]
+        print(json.dumps({"include": include}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why this matters

`gaia agent publish` already dual-uploads each agent wheel to **R2** (the Hub UI source) and **PyPI** (the `pip install` source) at author time — but nothing published those wheels on a release. So `pip install gaia-agent-<id>` and `amd-gaia[agents]` had no automation behind them. This adds the missing CI half: on a `v*` tag, every production `gaia-agent-*` wheel is built and published to PyPI via `pypa/gh-action-pypi-publish` with `skip-existing: true`, so an unchanged agent version is a no-op (PyPI-native immutability — no custom overwrite logic). Closes the last open item of #1179.

The publish matrix is derived from `setup.py`'s `[agents]` extra through a new `util/list_agent_packages.py` helper, so the meta-package, the install docs, and the publish workflow all read one source of truth — adding an agent to the extra is enough to start publishing it (no second list to drift).

Scope note: the dual-publish `publisher.py`, the `gaia agent publish/login` CLI, `tests/unit/test_hub_publisher.py`, the `[agents]`/`[agent-*]` extras, and the `amd-gaia>=` wheel deps all landed earlier (#1415, #1102 wave). This PR adds only what was still missing for #1179: the release-tag PyPI workflow, the drift-proof matrix helper, guard tests, and the install/CI docs.

## Test plan

- [x] `python util/lint.py --black --isort` — clean
- [x] `pylint -E util/list_agent_packages.py tests/unit/test_agent_pypi_publish.py` — clean
- [x] `pytest tests/unit/ -k "agent and (publish or install or hub)"` — 38 passed
- [x] `pytest tests/unit/test_agent_pypi_publish.py` — 10 passed (helper drift, wheel `amd-gaia` dep, `gaia-agent-<id>` naming, workflow uses `gh-action-pypi-publish` + `PYPI_API_TOKEN` + `skip-existing`, publish gated on `v*`)
- [x] `python -m build hub/agents/python/summarize` — wheel builds; `twine check` PASSED; metadata declares `Requires-Dist: amd-gaia>=0.20.0`
- [x] `python util/list_agent_packages.py --format matrix` — resolves the 11 migrated agents to their `hub/agents/python/<id>` dirs
- [x] Workflow YAML validates; tag triggers carry no `paths:` filter (so a release isn't skipped when the tagged commit didn't touch an agent)
- [ ] Requires a `PYPI_API_TOKEN` repository/org secret with upload rights to the `gaia-agent-*` projects before the first tagged release

> Note: no live PyPI upload was performed — builds and uploads were dry-run/mocked only.