### PR TITLE
fix(cli): advertise 127.0.0.1 for Agent UI to match bind host

### DIFF
--- a/docs/deployment/ui.mdx
+++ b/docs/deployment/ui.mdx
@@ -157,7 +157,7 @@ these options:
 ```bash
 lemonade-server serve
 python -m gaia.ui.server
-# Open http://localhost:4200
+# Open http://127.0.0.1:4200
 ```
 
 - Install from source or via the project `npm` package and run the
@@ -212,7 +212,7 @@ lemonade-server serve
 # 2. Start Agent UI backend
 python -m gaia.ui.server
 
-# 3. Open http://localhost:4200 in your browser
+# 3. Open http://127.0.0.1:4200 in your browser
 ```
 
 For full documentation, see:

--- a/docs/guides/agent-ui.mdx
+++ b/docs/guides/agent-ui.mdx
@@ -105,7 +105,7 @@ Pick the install path that fits you best:
     gaia-ui
     ```
 
-    The Agent UI opens automatically at [http://localhost:4200](http://localhost:4200).
+    The Agent UI opens automatically at [http://127.0.0.1:4200](http://127.0.0.1:4200).
 
     | Flag | Description |
     |------|-------------|
@@ -130,7 +130,7 @@ Pick the install path that fits you best:
 
     Or equivalently: `gaia chat --ui`
 
-    The Agent UI starts on [http://localhost:4200](http://localhost:4200).
+    The Agent UI starts on [http://127.0.0.1:4200](http://127.0.0.1:4200).
 
     | Flag | Description |
     |------|-------------|

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -939,9 +939,11 @@ def _launch_agent_ui(port=4200, base_url=None, log=None, debug=False, webui_dist
             log.info(f"Using remote Lemonade server: {base_url}")
             print(f"Remote Lemonade server: {base_url}")
 
-        log.info(f"Starting GAIA Agent UI on http://localhost:{port}")
-        print(f"Starting GAIA Agent UI on http://localhost:{port}")
-        print(f"   Open your browser to http://localhost:{port}")
+        # Advertise 127.0.0.1 to match the bind host below — on Windows
+        # "localhost" can resolve to IPv6 ::1 and fail against this IPv4 listener.
+        log.info(f"Starting GAIA Agent UI on http://127.0.0.1:{port}")
+        print(f"Starting GAIA Agent UI on http://127.0.0.1:{port}")
+        print(f"   Open your browser to http://127.0.0.1:{port}")
         print("   Press Ctrl+C to stop")
         print()
         if not base_url:


### PR DESCRIPTION
`gaia chat --ui` binds the Agent UI server to `127.0.0.1`, but the console (and the docs) told users to open `http://localhost:<port>`. On Windows, `localhost` can resolve to IPv6 `::1` first and fail to connect to the IPv4-only listener — forcing users to manually retype the URL as `127.0.0.1`. This aligns every advertised URL with the actual bind address so the UI just opens.

Closes #1471

## Changes

- **CLI** (`src/gaia/cli.py`): the three advertised-URL strings (log line + two prints) now use `127.0.0.1` instead of `localhost`, with a one-line comment naming the advertise-host == bind-host invariant.
- **Docs**: the four "open the Agent UI in your browser" instructions (`docs/guides/agent-ui.mdx`, `docs/deployment/ui.mdx`) now advertise `127.0.0.1:4200`, closing the same `::1` gap a Windows user hits via the docs path. Addresses the review note on this PR. (Backend/API `--backend`/curl references are intentionally left as `localhost` — they're programmatic, not browser-open instructions.)

## Test plan

- [ ] On Windows, run `gaia chat --ui` and confirm the printed URL is `http://127.0.0.1:<port>` and opens directly with no manual retyping.
- [ ] `python util/lint.py --all` passes (no Python logic changed; string-only edit).
