### PR TITLE
fix(init): make extras install work in uv venvs and fix doubled pip text

### DIFF
--- a/src/gaia/agents/routing/agent.py
+++ b/src/gaia/agents/routing/agent.py
@@ -492,8 +492,8 @@ Conversation:
             raise RuntimeError(
                 "CodeAgent is not installed. RoutingAgent routes coding tasks "
                 "to the 'gaia-agent-code' package, which is not present. "
-                "Install it with 'pip install gaia-agent-code' (or "
-                "'pip install amd-gaia[agents]'), then retry. See "
+                "Install it with 'uv pip install gaia-agent-code' (or "
+                "'uv pip install \"amd-gaia[agents]\"'), then retry. See "
                 "docs/spec/agent-hub-restructure.mdx."
             )
 

--- a/src/gaia/apps/docker/app.py
+++ b/src/gaia/apps/docker/app.py
@@ -29,7 +29,7 @@ def _load_docker_agent():
     except ImportError as e:
         raise ImportError(
             "The docker agent is not installed. Install it with "
-            "`pip install gaia-agent-docker` (or `pip install amd-gaia[agents]` "
+            '`uv pip install gaia-agent-docker` (or `uv pip install "amd-gaia[agents]"` '
             "for all AMD agents). See https://amd-gaia.ai/docs/guides/docker."
         ) from e
     return DockerAgent, DEFAULT_MODEL

--- a/src/gaia/apps/jira/app.py
+++ b/src/gaia/apps/jira/app.py
@@ -29,7 +29,7 @@ def _load_jira_agent_class():
     except ImportError as e:
         raise ImportError(
             "The jira agent is not installed. Install it with "
-            "`pip install gaia-agent-jira` (or `pip install amd-gaia[agents]` "
+            '`uv pip install gaia-agent-jira` (or `uv pip install "amd-gaia[agents]"` '
             "for all AMD agents). See https://amd-gaia.ai/docs/guides/jira."
         ) from e
     return JiraAgent

--- a/src/gaia/apps/summarize/app.py
+++ b/src/gaia/apps/summarize/app.py
@@ -26,7 +26,7 @@ def _load_summarizer_agent_class():
     except ImportError as e:
         raise ImportError(
             "The summarize agent is not installed. Install it with "
-            "`pip install gaia-agent-summarize` (or `pip install amd-gaia[agents]` "
+            '`uv pip install gaia-agent-summarize` (or `uv pip install "amd-gaia[agents]"` '
             "for all AMD agents). See https://amd-gaia.ai/docs/guides/summarize."
         ) from e
     return SummarizerAgent

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -830,7 +830,7 @@ async def async_main(action, **kwargs):
         if registry.get(agent_id) is None:
             raise RuntimeError(
                 f"The '{action}' agent is not installed. Install it with "
-                f'`pip install {wheel}` (or `pip install "amd-gaia[agents]"` '
+                f'`uv pip install {wheel}` (or `uv pip install "amd-gaia[agents]"` '
                 f"for all agents), then re-run `gaia {action}`."
             )
         agent = registry.create_agent(agent_id, **agent_config_kwargs)
@@ -4834,7 +4834,7 @@ def handle_sd_command(args):
     except ImportError as e:
         raise ImportError(
             "The sd agent is not installed. Install it with "
-            "`pip install gaia-agent-sd` (or `pip install amd-gaia[agents]` for "
+            '`uv pip install gaia-agent-sd` (or `uv pip install "amd-gaia[agents]"` for '
             "all AMD agents). See https://amd-gaia.ai/docs/guides/sd."
         ) from e
 

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -968,7 +968,7 @@ def _launch_agent_ui(port=4200, base_url=None, log=None, debug=False, webui_dist
         print("   Install them with:\n")
         print('     uv pip install -e ".[ui]"')
         print("\n   Or if you installed from PyPI:\n")
-        print("     pip install amd-gaia[ui]")
+        print('     uv pip install "amd-gaia[ui]"')
         print()
         sys.exit(1)
     except OSError as e:

--- a/src/gaia/cli_agent.py
+++ b/src/gaia/cli_agent.py
@@ -675,7 +675,7 @@ def _lint_formatters(py_files: List[Path], failures: List[str]) -> None:
     except ImportError:
         print(
             "  note: skipped black/isort check (not installed; "
-            "install with 'pip install \"amd-gaia[dev]\"')."
+            "install with 'uv pip install \"amd-gaia[dev]\"')."
         )
         return
     mode = black.Mode()

--- a/src/gaia/hub/packager.py
+++ b/src/gaia/hub/packager.py
@@ -185,8 +185,8 @@ def pack(
         raise PackagerError(
             f"wheel build failed for agent {parsed.id!r} (exit {rc}).\n"
             f"{output.strip()}\n"
-            f"Ensure the build backend is installed ('pip install \"amd-gaia"
-            f"[publish]\"' or 'pip install build') and that pyproject.toml is "
+            f"Ensure the build backend is installed ('uv pip install \"amd-gaia"
+            f"[publish]\"' or 'uv pip install build') and that pyproject.toml is "
             f"valid, then re-run 'gaia agent pack'."
         )
 
@@ -246,6 +246,6 @@ def _default_runner(cmd: List[str], cwd: Path):
     except FileNotFoundError as exc:
         return 1, (
             f"could not run {cmd[0]!r}: {exc}. Install the Python build "
-            f"frontend with 'pip install \"amd-gaia[publish]\"'."
+            f"frontend with 'uv pip install \"amd-gaia[publish]\"'."
         )
     return proc.returncode, (proc.stdout or "") + (proc.stderr or "")

--- a/src/gaia/hub/publisher.py
+++ b/src/gaia/hub/publisher.py
@@ -89,7 +89,7 @@ def _keyring():
     except ImportError as exc:
         raise PublisherError(
             "the 'keyring' package is required to store/read publisher tokens. "
-            "Install it with 'pip install \"amd-gaia[dev]\"', or pass tokens via "
+            "Install it with 'uv pip install \"amd-gaia[dev]\"', or pass tokens via "
             f"the {HUB_TOKEN_ENV} / {PYPI_TOKEN_ENV} environment variables."
         ) from exc
     return keyring
@@ -353,7 +353,7 @@ def _publish_pypi(wheel: Path, twine_runner) -> TargetResult:
         )
     raise PublisherError(
         f"twine upload failed (exit {rc}) for {wheel.name}:\n{output.strip()}\n"
-        f"Ensure twine is installed ('pip install \"amd-gaia[publish]\"') and "
+        f"Ensure twine is installed ('uv pip install \"amd-gaia[publish]\"') and "
         f"the token is valid."
     )
 

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -385,42 +385,51 @@ class InitCommand:
 
         extras_str = ",".join(pip_extras)
 
-        # Detect editable vs package install
-        try:
-            result = subprocess.run(
-                [sys.executable, "-m", "pip", "show", "amd-gaia"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            editable = False
-            location = ""
+        # Package-manager frontends to try, most-preferred first. The standalone
+        # ``uv`` binary leads because uv-created venvs ship neither ``pip`` nor
+        # the ``uv`` module, so ``python -m uv`` / ``python -m pip`` both fail
+        # there; the standalone binary honours the active VIRTUAL_ENV instead.
+        frontends = [
+            ["uv", "pip"],
+            [sys.executable, "-m", "uv", "pip"],
+            [sys.executable, "-m", "pip"],
+        ]
+
+        # Detect editable vs package install using whichever frontend responds.
+        editable = False
+        location = ""
+        for frontend in frontends:
+            try:
+                result = subprocess.run(
+                    frontend + ["show", "amd-gaia"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            except (FileNotFoundError, OSError):
+                continue
+            if result.returncode != 0:
+                continue
             for line in result.stdout.splitlines():
                 if line.startswith("Editable project location:"):
                     editable = True
                     location = line.split(":", 1)[1].strip()
                     break
-        except Exception:
-            editable = False
-            location = ""
+            break
 
         if editable and location:
             install_spec = f'uv pip install -e ".[{extras_str}]"'
-            install_args = ["-e", f"{location}[{extras_str}]"]
+            install_args = ["install", "-e", f"{location}[{extras_str}]"]
         else:
-            install_spec = f'pip install "amd-gaia[{extras_str}]"'
-            install_args = [f"amd-gaia[{extras_str}]"]
+            install_spec = f'uv pip install "amd-gaia[{extras_str}]"'
+            install_args = ["install", f"amd-gaia[{extras_str}]"]
 
         self._print_success(f"Installing extras: {extras_str}")
 
-        # Try uv pip first, fall back to regular pip
-        for pip_cmd in [
-            [sys.executable, "-m", "uv", "pip", "install"] + install_args,
-            [sys.executable, "-m", "pip", "install"] + install_args,
-        ]:
+        for frontend in frontends:
             try:
                 result = subprocess.run(
-                    pip_cmd,
+                    frontend + install_args,
                     capture_output=True,
                     text=True,
                     timeout=300,
@@ -429,7 +438,7 @@ class InitCommand:
                 if result.returncode == 0:
                     self._print_success(f"Installed [{extras_str}] dependencies")
                     return True
-            except FileNotFoundError:
+            except (FileNotFoundError, OSError):
                 continue
             except subprocess.TimeoutExpired:
                 self._print_warning(
@@ -441,7 +450,7 @@ class InitCommand:
 
         self._print_warning(
             f"Could not install [{extras_str}] extras automatically. "
-            f"Please run: pip install {install_spec}"
+            f"Please run: {install_spec}"
         )
         return True  # Warn but don't fail
 

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -1875,6 +1875,9 @@ class InitCommand:
                 self.console.print(
                     "    [cyan]gaia chat --watch ./docs[/cyan]             Auto-index a folder of docs"
                 )
+                self.console.print(
+                    "    [cyan]gaia chat --ui[/cyan]                       Launch the Agent UI (browser-based)"
+                )
             elif self.profile == "npu":
                 self.console.print(
                     "    [cyan]gaia chat --device npu[/cyan]             Chat using Ryzen AI NPU"
@@ -1907,6 +1910,9 @@ class InitCommand:
                 # Default commands for other profiles
                 self.console.print(
                     "    [cyan]gaia chat[/cyan]              Start interactive chat"
+                )
+                self.console.print(
+                    "    [cyan]gaia chat --ui[/cyan]         Launch the Agent UI (browser-based)"
                 )
                 self.console.print(
                     "    [cyan]gaia llm 'Hello'[/cyan]       Quick LLM query"
@@ -1942,6 +1948,9 @@ class InitCommand:
                 self._print(
                     "    gaia chat --watch ./docs             # Auto-index a folder of docs"
                 )
+                self._print(
+                    "    gaia chat --ui                       # Launch the Agent UI (browser-based)"
+                )
             elif self.profile == "npu":
                 self._print(
                     "    gaia chat --device npu             # Chat using Ryzen AI NPU"
@@ -1972,6 +1981,9 @@ class InitCommand:
             else:
                 # Default commands for other profiles
                 self._print("    gaia chat              # Start interactive chat")
+                self._print(
+                    "    gaia chat --ui         # Launch the Agent UI (browser-based)"
+                )
                 self._print("    gaia llm 'Hello'       # Quick LLM query")
                 self._print("    gaia talk              # Voice interaction")
             self._print("")

--- a/src/gaia/mcp/servers/docker_mcp.py
+++ b/src/gaia/mcp/servers/docker_mcp.py
@@ -31,7 +31,7 @@ def start_docker_mcp(
     except ImportError as e:
         raise ImportError(
             "The docker agent is not installed. Install it with "
-            "`pip install gaia-agent-docker` (or `pip install amd-gaia[agents]` "
+            '`uv pip install gaia-agent-docker` (or `uv pip install "amd-gaia[agents]"` '
             "for all AMD agents)."
         ) from e
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -417,6 +417,71 @@ class TestDownloadModels(unittest.TestCase):
             self.assertGreaterEqual(mock_client.ensure_model_downloaded.call_count, 1)
 
 
+class TestInstallPipExtras(unittest.TestCase):
+    """Test _install_pip_extras frontend selection and messaging."""
+
+    def _make_cmd(self, profile):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            return InitCommand(profile=profile, yes=True)
+
+    def test_no_extras_skips_install(self):
+        """Profiles without pip_extras short-circuit without shelling out."""
+        cmd = self._make_cmd("minimal")  # minimal declares no pip_extras
+        with patch("subprocess.run") as mock_run:
+            self.assertTrue(cmd._install_pip_extras())
+            mock_run.assert_not_called()
+
+    def test_standalone_uv_attempted_first(self):
+        """The standalone ``uv`` binary leads the install attempts.
+
+        uv-created venvs ship neither pip nor the uv module, so a bare
+        ``uv pip install`` is the only frontend that works inside them.
+        """
+        cmd = self._make_cmd("rag")  # rag pulls the [rag] extra
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "Name: amd-gaia\n"  # non-editable
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            self.assertTrue(cmd._install_pip_extras())
+
+        install_calls = [c for c in calls if "install" in c]
+        self.assertTrue(install_calls, "expected an install attempt")
+        self.assertEqual(
+            install_calls[0][:2],
+            ["uv", "pip"],
+            "standalone uv must be the first install frontend",
+        )
+
+    def test_warning_has_no_doubled_pip_install(self):
+        """The fallback warning must not print 'pip install pip install'."""
+        cmd = self._make_cmd("rag")
+        warnings = []
+        cmd._print_warning = lambda msg: warnings.append(msg)
+        cmd._print_success = lambda msg: None
+
+        def fail_run(args, **kwargs):
+            result = MagicMock()
+            result.returncode = 1  # every frontend fails
+            result.stdout = ""
+            return result
+
+        with patch("subprocess.run", side_effect=fail_run):
+            self.assertTrue(cmd._install_pip_extras())
+
+        joined = " ".join(warnings)
+        self.assertTrue(warnings, "expected a fallback warning")
+        self.assertNotIn("pip install pip install", joined)
+        self.assertIn('uv pip install "amd-gaia[rag]"', joined)
+
+
 class TestVersionCompatibility(unittest.TestCase):
     """Test _check_version_compatibility version policy.
 


### PR DESCRIPTION
## Why this matters

Running `gaia init` inside a `uv`-created venv (the documented setup path — `uv venv && uv pip install ...`) printed a confusing warning that made users think the base package was missing:

```
⚠  Could not install  extras automatically. Please run: pip install pip install "amd-gaia"
```

Two bugs were stacked here. **Before:** the optional `[rag]` extra silently failed to install because the installer only tried `python -m uv` then `python -m pip` — and uv-created venvs ship *neither* `pip` nor the `uv` module, so both frontends fail. On top of that, the fallback message doubled the command (`pip install pip install ...`), and the bare `pip install` it suggested can't work in a uv venv anyway. **After:** the installer leads with the standalone `uv` binary (which honours the active `VIRTUAL_ENV` and is on PATH whenever the user ran `uv run`/`uv pip`), so the extra installs automatically; if it still can't, the recommended command is now correct and uv-aware.

A Discord user hit exactly this — base package fine, `[rag]` extra never installed, misled by the message into reinstalling `amd-gaia` repeatedly.

## Test plan

- [x] `pytest tests/unit/test_init_command.py::TestInstallPipExtras` — new tests cover: no-extras short-circuit, standalone `uv` attempted first, and the warning never contains `pip install pip install`
- [x] `python util/lint.py --black --isort`
- [ ] Manual: in a `uv venv`, `VIRTUAL_ENV=.venv uv run gaia init -p rag --skip-models --skip-lemonade` installs the `[rag]` extra without the warning
