### PR TITLE
fix(rag): don't let a broken native dep crash every agent import

### DIFF
--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -9,7 +9,6 @@ GAIA RAG SDK - Simple PDF document retrieval and Q&A
 import errno
 import hashlib
 import hmac
-import importlib
 import json
 import os
 import re
@@ -245,7 +244,12 @@ class RAGSDK:
                     pkg == "faiss" and faiss is None
                 ):
                     try:
-                        importlib.import_module(pkg)
+                        # Use the import statement (__import__), not
+                        # importlib.import_module — the latter bypasses
+                        # builtins.__import__, so this path can't be exercised
+                        # by tests that intercept imports, and re-running the
+                        # real import is what re-surfaces the native cause.
+                        __import__(pkg)
                     except ImportError:
                         pass  # genuinely missing → covered by install instructions
                     except Exception as exc:  # pylint: disable=broad-except

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -9,6 +9,7 @@ GAIA RAG SDK - Simple PDF document retrieval and Q&A
 import errno
 import hashlib
 import hmac
+import importlib
 import json
 import os
 import re
@@ -35,21 +36,15 @@ except ImportError:
 # RuntimeError/OSError at import. Treat that the same as "not installed" so a
 # bad install can't crash every module that transitively imports RAG; the loud,
 # actionable error is deferred to RAGSDK._check_dependencies() at point of use.
-# Capture the reason so that error can tell "not installed" from "installed but
-# broken" instead of misdirecting the user to reinstall a package they have.
-_SENTENCE_TRANSFORMERS_IMPORT_ERROR = None
 try:
     from sentence_transformers import SentenceTransformer
-except Exception as _e:  # pylint: disable=broad-except
+except Exception:  # pylint: disable=broad-except
     SentenceTransformer = None
-    _SENTENCE_TRANSFORMERS_IMPORT_ERROR = _e
 
-_FAISS_IMPORT_ERROR = None
 try:
     import faiss
-except Exception as _e:  # pylint: disable=broad-except
+except Exception:  # pylint: disable=broad-except
     faiss = None
-    _FAISS_IMPORT_ERROR = _e
 
 from gaia.chat.sdk import AgentConfig, AgentSDK
 from gaia.logger import get_logger
@@ -238,13 +233,23 @@ class RAGSDK:
             )
             # A package that is installed but failed to import (broken native
             # deps) needs a different fix than a missing one — name the cause.
+            # Re-import on this (already-failing) path to recover the reason,
+            # skipping genuinely-missing packages (ImportError) which the
+            # install instructions above already cover.
             broken = []
-            if SentenceTransformer is None and _SENTENCE_TRANSFORMERS_IMPORT_ERROR:
-                broken.append(
-                    f"  sentence-transformers: {_SENTENCE_TRANSFORMERS_IMPORT_ERROR}"
-                )
-            if faiss is None and _FAISS_IMPORT_ERROR:
-                broken.append(f"  faiss: {_FAISS_IMPORT_ERROR}")
+            for pkg, label in (
+                ("sentence_transformers", "sentence-transformers"),
+                ("faiss", "faiss"),
+            ):
+                if (pkg == "sentence_transformers" and SentenceTransformer is None) or (
+                    pkg == "faiss" and faiss is None
+                ):
+                    try:
+                        importlib.import_module(pkg)
+                    except ImportError:
+                        pass  # genuinely missing → covered by install instructions
+                    except Exception as exc:  # pylint: disable=broad-except
+                        broken.append(f"  {label}: {exc}")
             if broken:
                 error_msg += (
                     "\nThe package(s) below are installed but failed to load — "

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -30,15 +30,26 @@ except ImportError:
     except ImportError:
         PdfReader = None
 
+# Not just ImportError: a broken native dependency (e.g. torchcodec/FFmpeg
+# pulled in by sentence-transformers, or an arch-mismatched faiss build) raises
+# RuntimeError/OSError at import. Treat that the same as "not installed" so a
+# bad install can't crash every module that transitively imports RAG; the loud,
+# actionable error is deferred to RAGSDK._check_dependencies() at point of use.
+# Capture the reason so that error can tell "not installed" from "installed but
+# broken" instead of misdirecting the user to reinstall a package they have.
+_SENTENCE_TRANSFORMERS_IMPORT_ERROR = None
 try:
     from sentence_transformers import SentenceTransformer
-except ImportError:
+except Exception as _e:  # pylint: disable=broad-except
     SentenceTransformer = None
+    _SENTENCE_TRANSFORMERS_IMPORT_ERROR = _e
 
+_FAISS_IMPORT_ERROR = None
 try:
     import faiss
-except ImportError:
+except Exception as _e:  # pylint: disable=broad-except
     faiss = None
+    _FAISS_IMPORT_ERROR = _e
 
 from gaia.chat.sdk import AgentConfig, AgentSDK
 from gaia.logger import get_logger
@@ -225,6 +236,23 @@ class RAGSDK:
                 f"Or install packages directly:\n"
                 f"  uv pip install {' '.join(missing)}\n"
             )
+            # A package that is installed but failed to import (broken native
+            # deps) needs a different fix than a missing one — name the cause.
+            broken = []
+            if SentenceTransformer is None and _SENTENCE_TRANSFORMERS_IMPORT_ERROR:
+                broken.append(
+                    f"  sentence-transformers: {_SENTENCE_TRANSFORMERS_IMPORT_ERROR}"
+                )
+            if faiss is None and _FAISS_IMPORT_ERROR:
+                broken.append(f"  faiss: {_FAISS_IMPORT_ERROR}")
+            if broken:
+                error_msg += (
+                    "\nThe package(s) below are installed but failed to load — "
+                    "reinstalling won't help until the underlying error is fixed "
+                    "(e.g. a missing FFmpeg for torchcodec):\n"
+                    + "\n".join(broken)
+                    + "\n"
+                )
             raise ImportError(error_msg)
 
     def _safe_open(self, file_path: str, mode="rb"):

--- a/tests/unit/rag/test_dependency_guard.py
+++ b/tests/unit/rag/test_dependency_guard.py
@@ -1,0 +1,59 @@
+# Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for RAG dependency-import guards.
+
+A broken native dependency (e.g. torchcodec/FFmpeg under sentence-transformers,
+or an arch-mismatched faiss build) raises ``RuntimeError``/``OSError`` at import
+rather than ``ImportError``. The guard in ``gaia.rag.sdk`` must treat that the
+same as "not installed" so it cannot crash every module that transitively
+imports RAG, while still surfacing a loud, actionable error at point of use.
+"""
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+
+# Importing the module must NOT raise even when an optional native dep is broken
+# in the environment — that is the regression this guard protects against.
+sdk = importlib.import_module("gaia.rag.sdk")
+
+
+def _bare_sdk():
+    """An RAGSDK instance without running __init__ (it only needs the method)."""
+    return sdk.RAGSDK.__new__(sdk.RAGSDK)
+
+
+def test_module_imports_without_optional_deps():
+    """The module is importable regardless of optional-dependency health."""
+    assert hasattr(sdk, "RAGSDK")
+    assert hasattr(sdk, "_SENTENCE_TRANSFORMERS_IMPORT_ERROR")
+    assert hasattr(sdk, "_FAISS_IMPORT_ERROR")
+
+
+def test_broken_install_reports_actionable_cause():
+    """An installed-but-broken dep surfaces the captured cause, not just 'install it'."""
+    cause = RuntimeError("Could not load libtorchcodec (FFmpeg not found)")
+    with (
+        patch.object(sdk, "SentenceTransformer", None),
+        patch.object(sdk, "_SENTENCE_TRANSFORMERS_IMPORT_ERROR", cause),
+    ):
+        with pytest.raises(ImportError) as excinfo:
+            _bare_sdk()._check_dependencies()
+    msg = str(excinfo.value)
+    assert "installed but failed to load" in msg
+    assert "libtorchcodec" in msg  # the captured cause is named
+
+
+def test_genuinely_missing_dep_omits_broken_section():
+    """A simply-missing dep gets install instructions, not the broken-load hint."""
+    with (
+        patch.object(sdk, "SentenceTransformer", None),
+        patch.object(sdk, "_SENTENCE_TRANSFORMERS_IMPORT_ERROR", None),
+    ):
+        with pytest.raises(ImportError) as excinfo:
+            _bare_sdk()._check_dependencies()
+    msg = str(excinfo.value)
+    assert "sentence-transformers" in msg
+    assert "installed but failed to load" not in msg

--- a/tests/unit/rag/test_dependency_guard.py
+++ b/tests/unit/rag/test_dependency_guard.py
@@ -10,8 +10,8 @@ same as "not installed" so it cannot crash every module that transitively
 imports RAG, while still surfacing a loud, actionable error at point of use.
 """
 
+import builtins
 import importlib
-from unittest.mock import patch
 
 import pytest
 
@@ -28,32 +28,45 @@ def _bare_sdk():
 def test_module_imports_without_optional_deps():
     """The module is importable regardless of optional-dependency health."""
     assert hasattr(sdk, "RAGSDK")
-    assert hasattr(sdk, "_SENTENCE_TRANSFORMERS_IMPORT_ERROR")
-    assert hasattr(sdk, "_FAISS_IMPORT_ERROR")
+    assert hasattr(sdk, "SentenceTransformer")
+    assert hasattr(sdk, "faiss")
 
 
-def test_broken_install_reports_actionable_cause():
+def test_broken_install_reports_actionable_cause(monkeypatch):
     """An installed-but-broken dep surfaces the captured cause, not just 'install it'."""
-    cause = RuntimeError("Could not load libtorchcodec (FFmpeg not found)")
-    with (
-        patch.object(sdk, "SentenceTransformer", None),
-        patch.object(sdk, "_SENTENCE_TRANSFORMERS_IMPORT_ERROR", cause),
-    ):
-        with pytest.raises(ImportError) as excinfo:
-            _bare_sdk()._check_dependencies()
+    monkeypatch.setattr(sdk, "SentenceTransformer", None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sentence_transformers":
+            raise RuntimeError("Could not load libtorchcodec (FFmpeg not found)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError) as excinfo:
+        _bare_sdk()._check_dependencies()
     msg = str(excinfo.value)
     assert "installed but failed to load" in msg
     assert "libtorchcodec" in msg  # the captured cause is named
 
 
-def test_genuinely_missing_dep_omits_broken_section():
+def test_genuinely_missing_dep_omits_broken_section(monkeypatch):
     """A simply-missing dep gets install instructions, not the broken-load hint."""
-    with (
-        patch.object(sdk, "SentenceTransformer", None),
-        patch.object(sdk, "_SENTENCE_TRANSFORMERS_IMPORT_ERROR", None),
-    ):
-        with pytest.raises(ImportError) as excinfo:
-            _bare_sdk()._check_dependencies()
+    monkeypatch.setattr(sdk, "SentenceTransformer", None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sentence_transformers":
+            raise ImportError("No module named 'sentence_transformers'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError) as excinfo:
+        _bare_sdk()._check_dependencies()
     msg = str(excinfo.value)
     assert "sentence-transformers" in msg
     assert "installed but failed to load" not in msg


### PR DESCRIPTION
## Why this matters

Before: if the optional RAG stack was installed but a native library underneath it couldn't load — most often torchcodec/FFmpeg pulled in transitively by `sentence-transformers`, or an arch-mismatched `faiss` — `gaia chat` and every other agent died at **import time** with a raw `RuntimeError`, even though RAG was never used. The crash had nothing to do with what the user was running; one broken wheel took the whole CLI down.

After: a broken optional dependency is treated the same as a missing one — the import succeeds, agents load, and if (and only if) RAG is actually used, `RAGSDK` raises a loud, actionable error that names the real cause ("installed but failed to load … e.g. a missing FFmpeg for torchcodec") instead of telling the user to reinstall a package they already have.

Root cause: the guard caught only `ImportError`, but native-load failures raise `RuntimeError`/`OSError`.

## Test plan

- [x] `python -m pytest tests/unit/rag/test_dependency_guard.py -v` — 3 pass
- [x] `import gaia.agents.docqa.agent` no longer raises in an environment with broken torchcodec (previously crashed at module load)
- [x] Instantiating `RAGSDK` with a broken dep raises `ImportError` naming the captured cause; a genuinely missing dep gets install instructions only
- [x] `black` / `isort` clean on changed files