### PR TITLE
ci(behavior-e2e): run steps in PowerShell on the Windows strix-halo runner

### DIFF
--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -1,8 +1,10 @@
 # NOTE: This workflow activates once #1297 (Strix Halo self-hosted runner) lands.
 # Until then it is validated out-of-band on Strix Halo class hardware.
-# The strix-halo runner is Windows, so every run step uses PowerShell — the
-# established convention on the sjlab lab runners (see build_cpp.yml). Bash
-# syntax (&&, \ line-continuation) is NOT available there.
+# The strix-halo runner is Windows. Python/uv setup goes through the
+# ./.github/actions/setup-venv composite action (the lab-runner convention,
+# see build_cpp.yml) which installs uv, creates .venv and puts it on PATH.
+# Inline `run:` steps use PowerShell — bash syntax (&&, \ continuation) is not
+# available there.
 name: Agent Behavior E2E
 
 on:
@@ -22,18 +24,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Python
-        shell: powershell
-        run: |
-          uv venv
-          if ($LASTEXITCODE -ne 0) { throw "uv venv failed" }
-          uv pip install -e ".[dev]"
-          if ($LASTEXITCODE -ne 0) { throw "uv pip install failed" }
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-venv
+        with:
+          install-package: ".[dev]"
 
       - name: Ensure Lemonade
         shell: powershell
         run: |
-          uv run gaia init --skip-lemonade
+          gaia init --skip-lemonade
           if ($LASTEXITCODE -ne 0) { throw "gaia init failed" }
 
       - name: Run behavior E2E harness
@@ -41,7 +40,7 @@ jobs:
         env:
           LEMONADE_BASE_URL: http://localhost:13305/api/v1
         run: |
-          uv run python -m pytest tests/integration/eval/test_behavior_e2e.py `
+          python -m pytest tests/integration/eval/test_behavior_e2e.py `
             -m real_model -v --tb=short `
             --basetemp="${{ runner.temp }}\pytest-behavior"
           if ($LASTEXITCODE -ne 0) { throw "behavior E2E harness failed" }

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -1,5 +1,8 @@
 # NOTE: This workflow activates once #1297 (Strix Halo self-hosted runner) lands.
 # Until then it is validated out-of-band on Strix Halo class hardware.
+# The strix-halo runner is Windows, so every run step uses PowerShell — the
+# established convention on the sjlab lab runners (see build_cpp.yml). Bash
+# syntax (&&, \ line-continuation) is NOT available there.
 name: Agent Behavior E2E
 
 on:
@@ -20,22 +23,32 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
+        shell: powershell
         run: |
-          uv venv && uv pip install -e ".[dev]"
+          uv venv
+          if ($LASTEXITCODE -ne 0) { throw "uv venv failed" }
+          uv pip install -e ".[dev]"
+          if ($LASTEXITCODE -ne 0) { throw "uv pip install failed" }
 
       - name: Ensure Lemonade
-        run: uv run gaia init --skip-lemonade
+        shell: powershell
+        run: |
+          uv run gaia init --skip-lemonade
+          if ($LASTEXITCODE -ne 0) { throw "gaia init failed" }
 
       - name: Run behavior E2E harness
-        run: |
-          uv run python -m pytest tests/integration/eval/test_behavior_e2e.py \
-            -m real_model -v --tb=short
+        shell: powershell
         env:
           LEMONADE_BASE_URL: http://localhost:13305/api/v1
+        run: |
+          uv run python -m pytest tests/integration/eval/test_behavior_e2e.py `
+            -m real_model -v --tb=short `
+            --basetemp="${{ runner.temp }}\pytest-behavior"
+          if ($LASTEXITCODE -ne 0) { throw "behavior E2E harness failed" }
 
       - name: Upload artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: behavior-e2e-artifacts
-          path: /tmp/pytest-*/test_builder_creates_agent_file*/**/artifacts/
+          path: ${{ runner.temp }}/pytest-behavior/**/artifacts/**


### PR DESCRIPTION
## Why this matters

The **Agent Behavior E2E** workflow was authored for a Linux runner, but the `strix-halo` self-hosted runner it targets (`sjlab-stx-halo-18`, label `stx-test`) is **Windows** and defaults `run:` steps to PowerShell 5.1. Every triggered run died immediately at *Setup Python* on `uv venv && uv pip install -e ".[dev]"` — PowerShell 5.1 rejects `&&` as a statement separator. The workflow could never run, so the #1428 false-success guarantee it exists to protect was never actually enforced in CI.

This change makes the job match the proven lab-runner convention (`build_cpp.yml`): Python/uv setup goes through the `./.github/actions/setup-venv` composite action (installs uv, creates `.venv`, puts it on PATH), and the remaining inline steps run in PowerShell.

Threads:
- **setup-venv for Python/uv** — replaces inline `uv venv && uv pip install` (which assumed uv was on the runner's PATH *and* used bash `&&`) with the composite action every other GAIA lab-runner job uses.
- **PowerShell run steps** — the Lemonade-init and pytest steps now use `shell: powershell` with `if ($LASTEXITCODE -ne 0) { throw }`; `setup-venv` puts `.venv\Scripts` on PATH so `gaia`/`pytest` are called directly.
- **Artifact upload fix** — the failure-path glob was `/tmp/pytest-*/...`, which can never match on Windows. Pins pytest's `--basetemp` to `${{ runner.temp }}\pytest-behavior` and uploads from there, so post-mortem `transcripts.json` is actually captured on failure.

## Known limitation (not addressed here)

The *Ensure Lemonade* step runs `gaia init --skip-lemonade`, which does **not start** a Lemonade server. The harness auto-skips when `LEMONADE_BASE_URL` is unreachable, so unless this runner already has Lemonade serving on `:13305`, the job will pass *vacuously* (everything skipped). `build_cpp.yml`'s STX job starts Lemonade explicitly via `install-lemonade` + `start-lemonade.ps1`. Left out of this PR because the right model/ctx and whether the runner pre-runs Lemonade are maintainer decisions — flagging for a follow-up.

## Test plan

- [ ] YAML parses (verified locally).
- [ ] Trigger via `workflow_dispatch` on the strix-halo runner; confirm *Setup Python environment* and *Ensure Lemonade* complete (no `&&` parser error, no "uv not found").
- [ ] Confirm the harness actually **runs** (not skips) — i.e. Lemonade is reachable at `:13305`. If it skips, the Lemonade-start follow-up above is required.
- [ ] Force a failure and confirm the `behavior-e2e-artifacts` upload contains `transcripts.json`.