### PR TITLE
Release v0.20.1

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -440,7 +440,7 @@
             "group": "Release Notes",
             "pages": [
               "releases/index",
-              "releases/v0.21.0",
+              "releases/v0.20.1",
               "releases/v0.20.0",
               "releases/v0.19.0",
               "releases/v0.18.1",
@@ -495,7 +495,7 @@
   "navbar": {
     "links": [
       {
-        "label": "v0.21.0 \u00b7 Lemonade 10.2.0",
+        "label": "v0.20.1 \u00b7 Lemonade 10.2.0",
         "href": "https://github.com/amd/gaia/releases"
       },
       {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -440,6 +440,7 @@
             "group": "Release Notes",
             "pages": [
               "releases/index",
+              "releases/v0.21.0",
               "releases/v0.20.0",
               "releases/v0.19.0",
               "releases/v0.18.1",
@@ -494,7 +495,7 @@
   "navbar": {
     "links": [
       {
-        "label": "v0.20.0 \u00b7 Lemonade 10.2.0",
+        "label": "v0.21.0 \u00b7 Lemonade 10.2.0",
         "href": "https://github.com/amd/gaia/releases"
       },
       {

--- a/docs/plans/agent-ui-agent-capabilities-plan.md
+++ b/docs/plans/agent-ui-agent-capabilities-plan.md
@@ -360,7 +360,7 @@ GAIA already has a robust MCP client infrastructure:
 
 ### 7.2 Most Popular MCP Servers (2026 Ecosystem)
 
-Based on real usage data from [FastMCP](https://fastmcp.me/blog/top-10-most-popular-mcp-servers) (1,864+ servers tracked) and [mcpservers.org](https://mcpservers.org/):
+Based on real usage data from [MCP Directory](https://mcp.directory/blog/top-10-most-popular-mcp-servers) and [mcpservers.org](https://mcpservers.org/):
 
 #### Tier 1 — Essential (High demand, directly useful for Agent UI)
 

--- a/docs/releases/v0.20.1.mdx
+++ b/docs/releases/v0.20.1.mdx
@@ -1,48 +1,30 @@
 ---
-title: "v0.21.0"
-description: "A major email-agent expansion — phishing detection with reversible quarantine, Outlook.com mail and calendar via Microsoft Graph, full-thread reading, and calendar event creation — plus a real-model behavior eval harness and a broad security and bug-fix pass."
+title: "v0.20.1"
+description: "Patch release: bug fixes and security hardening on top of v0.20.0 — a broken optional dependency that crashed agents at import, a clean-install gaia-mcp failure, the Windows app not reopening after auto-upgrade, a low step cap that stalled agents, plus SSRF and XSS hardening."
 ---
 
-# GAIA v0.21.0 Release Notes
+# GAIA v0.20.1 Release Notes
 
-GAIA v0.21.0 is a feature release centered on the email agent. It can now spot phishing and quarantine it safely, work an Outlook.com inbox and calendar (not just Gmail), read whole threads instead of just the latest message, and turn a meeting request into a calendar event — all running locally on your machine. Connecting a personal Microsoft account is first-class via Microsoft Graph. Underneath the features, a new behavior eval harness drives agents through a real model and asserts the tool actually ran — catching a class of "claims success but did nothing" bug that mocked tests never see — alongside a broad security and bug-fix pass.
+GAIA v0.20.1 is a patch release focused on bug fixes and security hardening on top of v0.20.0. It clears several crashes and regressions — a broken optional dependency that could take down every agent at import, `gaia-mcp` failing on a clean install, the Windows app not reopening after an auto-upgrade, and agents stopping mid-task on a step cap set too low — and tightens security with an SSRF DNS-rebind fix and a high-severity XSS dependency patch.
 
 **Why upgrade:**
-- **Phishing detection with safe quarantine** — multi-signal detection (subject, sender domain, body); a flagged message is labelled and archived, never deleted, confirmation-gated, and reversible. Held to a ≥90% precision gate in CI; measured 100% precision on the test corpus, so legitimate mail isn't swept up.
-- **Outlook.com support** — connect a personal Microsoft account (Outlook/Hotmail/Live) for mail and calendar via Microsoft Graph; every existing email tool works against it unchanged, and Gmail stays the default.
-- **Calendar awareness** — the email agent detects meeting requests, checks them against your existing events for conflicts, and creates events — refusing to fabricate one when there's no real date/time.
-- **Full-thread comprehension** — summaries now read the entire thread oldest-first, plus a bounded per-email summary tool, so an ask raised earlier in the thread doesn't get lost.
-- **Real-model behavior testing** — a new eval harness asserts an agent's tools actually take effect against a live model, closing the gap that let the builder silently fail ~40% of the time.
+- **No import-time crash from a broken optional dependency** — if the optional RAG stack was installed but a native library couldn't load, every agent died at import even when RAG was never used. The import is now guarded.
+- **`gaia-mcp` works on a clean install** — a missing base dependency made `gaia-mcp` fail with `ModuleNotFoundError` right after `pip install amd-gaia`. Fixed.
+- **Windows app reopens after auto-upgrade** — an orphaned backend held a handle on `gaia.exe` and broke the upgrade; it's now cleared first.
+- **Agents don't stall mid-task** — the per-step cap was hardcoded low in most places, so agents stopped on routine work; it's raised and centralized on one default.
+- **Security hardening** — SSRF DNS-rebind protection (the IP is now pinned across check and connect) and a patched high-severity XSS dependency in the EMR dashboard.
 
 ---
 
-## What's New
+## In Progress
 
-### Email agent — phishing detection, Outlook, and calendar awareness — `gaia email`
-
-The email agent gained the tools to handle a real inbox safely. It now flags phishing using subject, sender-domain, and body signals together, and can quarantine a flagged message — labelled and archived, never deleted, confirmation-gated, and reversible within the undo window. The detector is held to a ≥90% precision gate in CI and measured 100% precision / 96.7% recall on the test corpus, so legitimate mail isn't swept up (PR [#1434](https://github.com/amd/gaia/pull/1434)).
-
-It also reads context the way a person does: `summarize_thread` reads the entire thread oldest-first instead of just the latest message, so a decision raised three replies ago doesn't get lost (PR [#1352](https://github.com/amd/gaia/pull/1352)), and a per-email summary tool surfaces the key ask in a bounded summary (PR [#1348](https://github.com/amd/gaia/pull/1348)). Calendar awareness is new across the board: the agent detects a meeting request in an email body, checks it against your existing events for conflicts, and creates the event — and it now refuses to fabricate an event with no real date/time, asking you instead (PRs [#1350](https://github.com/amd/gaia/pull/1350), [#1353](https://github.com/amd/gaia/pull/1353), [#1355](https://github.com/amd/gaia/pull/1355)). Four-way triage categorization got sharper too, up 8.6 points on the labelled corpus (PR [#1436](https://github.com/amd/gaia/pull/1436)), and on Ryzen AI hardware the agent can run on a power-efficient on-device NPU model at ~23 tokens/sec (PR [#1433](https://github.com/amd/gaia/pull/1433)).
-
-For automation, the agent is now reachable over a REST API and over MCP (including stdio for clients like VS Code and Claude Desktop), with both surfaces returning byte-identical structured output and the same never-auto-send confirmation gate (PRs [#1351](https://github.com/amd/gaia/pull/1351), [#1357](https://github.com/amd/gaia/pull/1357)). `gaia email --spec` opens a self-contained HTML page documenting the contract offline (PR [#1432](https://github.com/amd/gaia/pull/1432)).
+This release also lands groundwork for several larger features that are **not yet complete and aren't enabled as headline capabilities**: the email agent (phishing detection, Outlook.com mail and calendar, full-thread reading), the Microsoft/Outlook connectors, and a real-model behavior eval harness. That work is in the tree and shows up in the changelog below, but it isn't ready to ship — it will be featured in a future release once it's done.
 
 ---
 
-### Outlook.com support — connect a personal Microsoft account
+## Key Changes
 
-Until now GAIA could only connect Google accounts. A new Microsoft OAuth provider adds a Microsoft tile in Settings → Connectors and grants mail and calendar access via Microsoft Graph (PR [#1347](https://github.com/amd/gaia/pull/1347)). Personal Outlook.com / Hotmail / Live mailboxes and calendars are now first-class: the Outlook backends translate Graph's data into the same shape the Gmail tools already consume, so every existing read/organize/reply tool and every calendar tool works against Outlook with no changes — Gmail stays the default (PRs [#1354](https://github.com/amd/gaia/pull/1354), [#1358](https://github.com/amd/gaia/pull/1358)).
-
-Two connector improvements help headless and embedded use: `gaia connectors configure google --client-id … --client-secret …` sets OAuth credentials from the CLI without launching the Agent UI (PR [#1346](https://github.com/amd/gaia/pull/1346)), and a host application that has already authenticated a user can forward that connection to GAIA over the API so the user isn't asked to consent twice (PR [#1321](https://github.com/amd/gaia/pull/1321)).
-
----
-
-### Behavior eval harness — prove the tool actually ran
-
-Mocked unit tests and UI-render tests both passed while the builder agent silently failed to create an agent about 40% of the time — the "agent says success but the tool never ran" failure class is invisible when the LLM is mocked. The new behavior-E2E harness drives a tool-using agent through the real server with a real model, repeats the run, and asserts the side-effect actually happened — a file on disk, a registry entry — treating a cheerful "done!" with nothing to show for it as a hard failure (PR [#1431](https://github.com/amd/gaia/pull/1431)). The eval framework also now exports per-email categorization and connector-health diagnostics behind a report-mode FP/FN gate, and pipeline latency, peak memory, and NPU utilization behind a report-mode Strix Halo performance gate (PRs [#1359](https://github.com/amd/gaia/pull/1359), [#1361](https://github.com/amd/gaia/pull/1361)).
-
----
-
-## Bug Fixes
+Every shipped change in v0.20.1 is a bug fix or security/hardening fix on top of v0.20.0.
 
 - **Builder silently created nothing ~40% of the time** (PR [#1430](https://github.com/amd/gaia/pull/1430)) — The builder returned "Agent Created!" while writing nothing to disk: the model wrapped its `create_agent` call in a fenced JSON block, and the parser skipped all fenced JSON to avoid grabbing documentation examples, so the tool never ran. Fenced tool-call extraction is now resilient, and four UI sites that swallowed tool errors now surface them.
 - **Builder MCP-only flow ignored the requested persona** (PR [#1533](https://github.com/amd/gaia/pull/1533), closes [#1532](https://github.com/amd/gaia/issues/1532)) — The MCP-only builder flow always scaffolded the built-in placeholder persona regardless of the request; it now authors the persona the user actually asked for.
@@ -161,4 +143,4 @@ Mocked unit tests and UI-render tests both passed while the builder agent silent
 - `7a56ba49` — feat(eval): email-triage throughput benchmark + reusable eval stats/metrics
 - `33db1047` — fix(ui): unload resident model before swapping in the chat load path (#1382) (#1383)
 
-Full Changelog: [v0.20.0...v0.21.0](https://github.com/amd/gaia/compare/v0.20.0...v0.21.0)
+Full Changelog: [v0.20.0...v0.20.1](https://github.com/amd/gaia/compare/v0.20.0...v0.20.1)

--- a/docs/releases/v0.21.0.mdx
+++ b/docs/releases/v0.21.0.mdx
@@ -25,7 +25,7 @@ GAIA's agents used to be a fixed set compiled into one wheel: you got what shipp
 
 The same operations are available headless from the CLI: install/uninstall, `gaia agent configure` to set a model or per-agent options, `gaia agent health` and `gaia agent status` to confirm an agent actually loads, and a checksum-verified installer with pre-update backup so a bad update can be rolled back (PR [#1416](https://github.com/amd/gaia/pull/1416)). Multi-agent setup installs smallest-first and resumes where it left off, so a quick agent is usable while a large one keeps downloading.
 
-Safety is built into the install path: non-verified native (C++) agents are unsandboxed binaries, so installing one is gated behind an explicit trust confirmation, deprecated agents are hidden from the default catalog, and every card carries a verified/community/experimental trust badge (PR [#1414](https://github.com/amd/gaia/pull/1414)). There's also a public web catalog to browse agents before installing at [`/hub`](https://amd-gaia.ai/hub) (PR [#1405](https://github.com/amd/gaia/pull/1405)).
+Safety is built into the install path: non-verified native (C++) agents are unsandboxed binaries, so installing one is gated behind an explicit trust confirmation, deprecated agents are hidden from the default catalog, and every card carries a verified/community/experimental trust badge (PR [#1414](https://github.com/amd/gaia/pull/1414)). A public web catalog to browse agents before installing is also on the way (PR [#1405](https://github.com/amd/gaia/pull/1405)).
 
 ---
 

--- a/docs/releases/v0.21.0.mdx
+++ b/docs/releases/v0.21.0.mdx
@@ -1,0 +1,194 @@
+---
+title: "v0.21.0"
+description: "The Agent Hub — browse, install, and publish GAIA agents from the UI or the terminal, with every agent now shipping as its own versioned package; a major email-agent expansion with phishing detection, Outlook.com support, and calendar awareness; and a real-model behavior eval harness."
+---
+
+# GAIA v0.21.0 Release Notes
+
+GAIA v0.21.0 turns the agent collection into an ecosystem. The new **Agent Hub** lets you browse a catalog of agents, install the ones you want with one click or one command, and publish your own — and every built-in agent now ships as its own independently versioned package instead of being baked into the core wheel. The email agent gets the release's second big push: it can spot phishing and quarantine it safely, work an Outlook.com inbox and calendar (not just Gmail), read whole threads, and turn a message into a calendar event. Underneath, a new behavior eval harness drives agents through a real model and asserts the tool actually ran — catching a class of "claims success but did nothing" bug that mocked tests never see.
+
+**Why upgrade:**
+- **Agent Hub** — browse, install, configure, and roll back agents from the Agent UI's Installed/Available tabs or the `gaia agent` CLI, with a security-tier gate before any unsandboxed native agent runs.
+- **Build and publish your own agent** — `gaia agent init/version/test/pack/publish` scaffolds, validates, and dual-publishes an agent to both the Hub and PyPI (`pip install gaia-agent-<id>`).
+- **Every agent is its own package** — chat, code, email, SD, Docker, Jira, and the rest now version and ship independently of the core release, so you install only what you need.
+- **Email agent grows up** — phishing detection with reversible quarantine (measured 100% precision on the test corpus), Outlook.com mailbox + calendar via Microsoft Graph, full-thread reading, and calendar event creation from an email.
+- **Outlook.com support** — connect a personal Microsoft account (Outlook/Hotmail/Live) for mail and calendar; every existing email tool works against it unchanged.
+- **Real-model behavior testing** — a new eval harness asserts an agent's tools actually take effect against a live model, closing the gap that let the builder silently fail ~40% of the time.
+
+---
+
+## What's New
+
+### Agent Hub — discover, install, and manage agents — `gaia agent`, Agent UI Hub
+
+GAIA's agents used to be a fixed set compiled into one wheel: you got what shipped, with no way to add, remove, or update an agent on its own. The Agent Hub replaces that with a real catalog. In the Agent UI, the Hub now has **Installed** and **Available** tabs — click Install on a card and a live progress bar walks through downloading, verifying, and installing, then the card flips to Installed; compatibility shows green/yellow/red before you commit, and an offline catalog surfaces a "showing cached catalog" banner instead of silently going stale (PRs [#1410](https://github.com/amd/gaia/pull/1410), [#1411](https://github.com/amd/gaia/pull/1411)).
+
+The same operations are available headless from the CLI: install/uninstall, `gaia agent configure` to set a model or per-agent options, `gaia agent health` and `gaia agent status` to confirm an agent actually loads, and a checksum-verified installer with pre-update backup so a bad update can be rolled back (PR [#1416](https://github.com/amd/gaia/pull/1416)). Multi-agent setup installs smallest-first and resumes where it left off, so a quick agent is usable while a large one keeps downloading.
+
+Safety is built into the install path: non-verified native (C++) agents are unsandboxed binaries, so installing one is gated behind an explicit trust confirmation, deprecated agents are hidden from the default catalog, and every card carries a verified/community/experimental trust badge (PR [#1414](https://github.com/amd/gaia/pull/1414)). There's also a public web catalog to browse agents before installing at [`/hub`](https://amd-gaia.ai/hub) (PR [#1405](https://github.com/amd/gaia/pull/1405)).
+
+---
+
+### Build and publish your own agent — `gaia agent init`
+
+Authoring an agent used to mean hand-copying an existing one and hoping it was wired correctly. The new developer workflow makes it a guided path: `gaia agent init <name> --language python|cpp` scaffolds a complete, valid package — manifest, project file, package skeleton, tests, README — that passes `gaia agent test --lint` out of the box; `gaia agent version patch|minor|major` bumps the version everywhere it appears; and `gaia agent test` validates structure, imports, and formatting without an LLM, or confirms the agent answers its starter prompts with `--live` (PR [#1412](https://github.com/amd/gaia/pull/1412)).
+
+When it's ready, `gaia agent pack` builds a wheel and `gaia agent publish` dual-publishes it to both the Hub (the source the UI and website read) and PyPI, so anyone can `pip install gaia-agent-<id>` (PRs [#1415](https://github.com/amd/gaia/pull/1415), [#1454](https://github.com/amd/gaia/pull/1454)). Tokens live in the OS keyring, with env-var overrides for CI. Three annotated reference agents — `hello-world`, `word-count`, and `doc-search` — give a copy-paste starting point at every level of complexity (PR [#1413](https://github.com/amd/gaia/pull/1413)).
+
+Agents aren't limited to Python: a native C++ agent now runs as a plain subprocess over JSON-RPC stdio — the same protocol the desktop app speaks — so native agents work from the web backend too, with a cross-platform build-and-package pipeline behind them (PRs [#1404](https://github.com/amd/gaia/pull/1404), [#1406](https://github.com/amd/gaia/pull/1406)). And any agent can expose itself five ways — interactive TUI, one-shot CLI, stdin/stdout pipe, OpenAI-compatible REST, and MCP — through a single `run_agent_cli()` call (PR [#1403](https://github.com/amd/gaia/pull/1403)).
+
+---
+
+### Every agent is now its own package
+
+To make the Hub possible, every built-in agent moved out of the core wheel into its own `gaia-agent-<id>` package under `hub/agents/`: chat, code, EMR, SD, Docker, Jira, FileIO, Blender, analyst, browser, and connectors-demo (PRs [#1407](https://github.com/amd/gaia/pull/1407), [#1417](https://github.com/amd/gaia/pull/1417), [#1419](https://github.com/amd/gaia/pull/1419), [#1421](https://github.com/amd/gaia/pull/1421), [#1442](https://github.com/amd/gaia/pull/1442), [#1446](https://github.com/amd/gaia/pull/1446)). Each one now versions and ships on its own schedule rather than being chained to the framework's release cycle, and the shared tool mixins they all depend on (RAG, FileIO, Shell, code search) were promoted into the framework so agents no longer import each other (PR [#1401](https://github.com/amd/gaia/pull/1401)).
+
+The Hub also stopped showing duplicate "Lite" cards: where there used to be 13 cards for 7 agents, each agent now appears once with a **Full / Lite (~4B)** model-size selector, and the old `*-lite` IDs still resolve through an alias map (PR [#1418](https://github.com/amd/gaia/pull/1418)).
+
+---
+
+### Email agent — phishing detection, Outlook, and calendar awareness — `gaia email`
+
+The email agent gained the tools to handle a real inbox safely. It now flags phishing using subject, sender-domain, and body signals together, and can quarantine a flagged message — labelled and archived, never deleted, confirmation-gated, and reversible within the undo window. The detector is held to a ≥90% precision gate in CI and measured 100% precision / 96.7% recall on the test corpus, so legitimate mail isn't swept up (PR [#1434](https://github.com/amd/gaia/pull/1434)).
+
+It also reads context the way a person does: `summarize_thread` reads the entire thread oldest-first instead of just the latest message, so a decision raised three replies ago doesn't get lost (PR [#1352](https://github.com/amd/gaia/pull/1352)), and a per-email summary tool surfaces the key ask in a bounded summary (PR [#1348](https://github.com/amd/gaia/pull/1348)). Calendar awareness is new across the board: the agent detects a meeting request in an email body, checks it against your existing events for conflicts, and creates the event — and it now refuses to fabricate an event with no real date/time, asking you instead (PRs [#1350](https://github.com/amd/gaia/pull/1350), [#1353](https://github.com/amd/gaia/pull/1353), [#1355](https://github.com/amd/gaia/pull/1355)). Four-way triage categorization got sharper too, up 8.6 points on the labelled corpus (PR [#1436](https://github.com/amd/gaia/pull/1436)), and on Ryzen AI hardware the agent can run on a power-efficient on-device NPU model at ~23 tokens/sec (PR [#1433](https://github.com/amd/gaia/pull/1433)).
+
+For automation, the agent is now reachable over a REST API and over MCP (including stdio for clients like VS Code and Claude Desktop), with both surfaces returning byte-identical structured output and the same never-auto-send confirmation gate (PRs [#1351](https://github.com/amd/gaia/pull/1351), [#1357](https://github.com/amd/gaia/pull/1357)). `gaia email --spec` opens a self-contained HTML page documenting the contract offline (PR [#1432](https://github.com/amd/gaia/pull/1432)).
+
+---
+
+### Outlook.com support — connect a personal Microsoft account
+
+Until now GAIA could only connect Google accounts. A new Microsoft OAuth provider adds a Microsoft tile in Settings → Connectors and grants mail and calendar access via Microsoft Graph (PR [#1347](https://github.com/amd/gaia/pull/1347)). Personal Outlook.com / Hotmail / Live mailboxes and calendars are now first-class: the Outlook backends translate Graph's data into the same shape the Gmail tools already consume, so every existing read/organize/reply tool and every calendar tool works against Outlook with no changes — Gmail stays the default (PRs [#1354](https://github.com/amd/gaia/pull/1354), [#1358](https://github.com/amd/gaia/pull/1358)).
+
+Two connector improvements help headless and embedded use: `gaia connectors configure google --client-id … --client-secret …` sets OAuth credentials from the CLI without launching the Agent UI (PR [#1346](https://github.com/amd/gaia/pull/1346)), and a host application that has already authenticated a user can forward that connection to GAIA over the API so the user isn't asked to consent twice (PR [#1321](https://github.com/amd/gaia/pull/1321)).
+
+---
+
+### Behavior eval harness — prove the tool actually ran
+
+Mocked unit tests and UI-render tests both passed while the builder agent silently failed to create an agent about 40% of the time — the "agent says success but the tool never ran" failure class is invisible when the LLM is mocked. The new behavior-E2E harness drives a tool-using agent through the real server with a real model, repeats the run, and asserts the side-effect actually happened — a file on disk, a registry entry — treating a cheerful "done!" with nothing to show for it as a hard failure (PR [#1431](https://github.com/amd/gaia/pull/1431)). The eval framework also now exports per-email categorization and connector-health diagnostics behind a report-mode FP/FN gate, and pipeline latency, peak memory, and NPU utilization behind a report-mode Strix Halo performance gate (PRs [#1359](https://github.com/amd/gaia/pull/1359), [#1361](https://github.com/amd/gaia/pull/1361)).
+
+---
+
+## Bug Fixes
+
+- **Builder silently created nothing ~40% of the time** (PR [#1430](https://github.com/amd/gaia/pull/1430)) — The builder returned "Agent Created!" while writing nothing to disk: the model wrapped its `create_agent` call in a fenced JSON block, and the parser skipped all fenced JSON to avoid grabbing documentation examples, so the tool never ran. Fenced tool-call extraction is now resilient, and four UI sites that swallowed tool errors now surface them.
+- **Builder MCP-only flow ignored the requested persona** (PR [#1533](https://github.com/amd/gaia/pull/1533), closes [#1532](https://github.com/amd/gaia/issues/1532)) — The MCP-only builder flow always scaffolded the built-in placeholder persona regardless of the request; it now authors the persona the user actually asked for.
+- **A broken native dependency crashed every agent at import** (PR [#1534](https://github.com/amd/gaia/pull/1534)) — If the optional RAG stack was installed but a native library (e.g. an arch-mismatched faiss, or FFmpeg via sentence-transformers) couldn't load, `gaia chat` and every other agent died at import time even when RAG was never used. The import is now guarded.
+- **SSRF DNS-rebind hardening** (PR [#1299](https://github.com/amd/gaia/pull/1299)) — The pre-flight IP allow-check and the actual TCP connect did separate DNS lookups, so a host could answer the check with a public IP and the connect with an internal one. The resolved IP is now pinned and validated through a single authority.
+- **Agents ran out of steps mid-task** (PR [#1389](https://github.com/amd/gaia/pull/1389)) — The per-step cap was hardcoded low in most places (10, sometimes 5–6) while the CLI used 100, so the browser and other agents would stop on routine work and ask to be re-run with `--max-steps`. The cap is raised and centralized on one global default.
+- **Windows app wouldn't open after auto-upgrade** (PR [#1392](https://github.com/amd/gaia/pull/1392)) — A previous backend left a handle open on `gaia.exe`, so the upgrade's `uv pip install --refresh` failed with `os error 32`. The orphaned backend is now killed before upgrade.
+- **Memory reported the old version after upgrade** (PR [#1390](https://github.com/amd/gaia/pull/1390)) — System-context refresh was a pure 7-day age check with no upgrade trigger, so the memory system kept reporting the pre-upgrade version. It now refreshes on install/upgrade.
+- **`gaia-mcp` crashed on a clean install** (PR [#1380](https://github.com/amd/gaia/pull/1380)) — `python-multipart` was declared only in the `api`/`ui` extras, so a bare `pip install amd-gaia` left `gaia-mcp` failing with `ModuleNotFoundError`. It's now a base dependency.
+- **`gaia init` failed in uv venvs with doubled text** (PR [#1527](https://github.com/amd/gaia/pull/1527)) — Inside a uv-created venv, `gaia init` printed a garbled `pip install pip install "amd-gaia"` warning and silently skipped the `[rag]` extra. Both are fixed.
+- **Agent UI advertised an unreachable URL on Windows** (PR [#1519](https://github.com/amd/gaia/pull/1519), closes [#1471](https://github.com/amd/gaia/issues/1471)) — `gaia chat --ui` binds to `127.0.0.1` but advertised `localhost`, which can resolve to IPv6 `::1` first on Windows and fail to reach the IPv4-only listener. Advertised URLs now match the bind address.
+- **Two LLMs left resident when building an agent** (PR [#1383](https://github.com/amd/gaia/pull/1383)) — Clicking "Build a Custom Agent" loaded the larger model without evicting the pre-loaded chat model, leaving both resident. The resident model is now unloaded before the swap.
+- **High-severity XSS in the EMR dashboard dependency** (PR [#1453](https://github.com/amd/gaia/pull/1453), closes [#1420](https://github.com/amd/gaia/issues/1420)) — `@remix-run/router` was pulled in transitively at a version exposed to a high-severity open-redirect XSS advisory; bumped to the patched release.
+
+---
+
+## Tooling, Testing & CI
+
+- **Behavior-E2E in CI on a self-hosted Strix Halo runner** (PRs [#1535](https://github.com/amd/gaia/pull/1535), [#1431](https://github.com/amd/gaia/pull/1431)) — the real-model behavior harness runs its steps in PowerShell on the Windows Strix Halo runner.
+- **Email CI gate + nightly report-mode eval** (PR [#1362](https://github.com/amd/gaia/pull/1362)) — a unit-test PR gate, a report-mode nightly eval, and the C++ build scaffold for email.
+- **Labelled email-triage corpus + baselines** (PR [#1322](https://github.com/amd/gaia/pull/1322)) — a 220-message synthetic corpus with ground truth replaces a 10-message stub and a baseline that had been measured against the wrong model.
+- **Never-auto-send guard consolidated across surfaces** (PR [#1360](https://github.com/amd/gaia/pull/1360)) and **pre-scan cheap-counts guarantee locked** (PR [#1356](https://github.com/amd/gaia/pull/1356)).
+- **C++ agent cross-compile matrix + static packaging** (PR [#1406](https://github.com/amd/gaia/pull/1406)) — win-x64, linux-x64, and darwin-arm64 build self-contained static binaries, consolidated into one bundle on a version tag.
+- **Cleared pre-existing pylint/mypy debt blocking CI** (PR [#1402](https://github.com/amd/gaia/pull/1402)) and **fixed mcp test library shadowing + a dangling summarizer CI step** (PRs [#1443](https://github.com/amd/gaia/pull/1443), [#1445](https://github.com/amd/gaia/pull/1445)).
+- **Auto-fix opens a PR by default** (PR [#1391](https://github.com/amd/gaia/pull/1391)) instead of posting comment patches.
+- **Installer repo-root resolution locked in launcher scripts** (PR [#1395](https://github.com/amd/gaia/pull/1395)).
+- **Specs updated** — Agent Hub 22-agent enablement (PR [#1457](https://github.com/amd/gaia/pull/1457)), dynamic tool-loader (PR [#1447](https://github.com/amd/gaia/pull/1447)), legacy agent modernization (PR [#1398](https://github.com/amd/gaia/pull/1398)), and the agent skills format (PR [#1399](https://github.com/amd/gaia/pull/1399)).
+
+---
+
+## Full Changelog
+
+**84 commits** since v0.20.0:
+
+- `568bfc57` — feat(hub): publish agent wheels to PyPI (dual R2 + PyPI) (#1179) (#1454)
+- `31c0371f` — test(installer): lock repo-root resolution in bash launcher scripts (#1395)
+- `dcc3d69f` — fix(builder): MCP-only flow with reliable persona authoring (#1532) (#1533)
+- `aab8f41e` — ci(behavior-e2e): run steps in PowerShell on the Windows strix-halo runner (#1535)
+- `cec000eb` — chore(deps-dev): bump electron from 42.3.0 to 42.3.3 in /src/gaia/apps/jira/webui in the jira-app-dependencies group across 1 directory (#1424)
+- `bf0d3e52` — chore(deps-dev): bump electron from 42.3.0 to 42.3.3 in /src/gaia/apps/example/webui in the example-app-dependencies group across 1 directory (#1423)
+- `56fd1eb9` — chore(deps): bump electron from 42.2.0 to 42.3.3 in /hub/agents/python/emr/gaia_agent_emr/dashboard/electron in the emr-dashboard-dependencies group across 1 directory (#1422)
+- `de7c501a` — fix(rag): don't let a broken native dep crash every agent import (#1534)
+- `8303a1a2` — fix(security,agents): harden SSRF DNS-rebind, fail loudly, cover untested modules (#1299)
+- `0721f9fe` — fix(agents): raise step limit and centralize on one global default (#1389)
+- `020960fa` — fix(ui): kill orphaned backend before upgrade to free gaia.exe on Windows (#1392)
+- `5a2e6420` — fix(memory): refresh system version facts on upgrade (#1390)
+- `bbf7062a` — fix(deps): make python-multipart a base dependency for gaia-mcp (#1380)
+- `5e6f0315` — fix(init): make extras install work in uv venvs and fix doubled pip text (#1527)
+- `f7fbd316` — fix(cli): advertise 127.0.0.1 for Agent UI to match bind host (#1519)
+- `f1533ee2` — chore(deps): bump the github-actions group across 1 directory with 4 updates (#1530)
+- `c477e8e8` — chore(deps): bump the agent-ui-dependencies group across 1 directory with 15 updates (#1531)
+- `0c197ef3` — docs(plans): add Agent Hub 22-agent enablement spec (#1457)
+- `cc1e32eb` — fix(deps): bump @remix-run/router to patch XSS in emr dashboard (#1420) (#1453)
+- `a81dd838` — docs(spec): consolidate and correct the dynamic tool-loader spec (#688) (#1447)
+- `91b476e0` — test(eval): behavior-E2E harness — assert tool side-effects against real model (#1431)
+- `1bc4f0ea` — test+ci: fix tests/unit/mcp library shadowing and dangling summarizer CI invocation (#1443)
+- `dba18bb3` — ci: remove stale summarizer step from Windows and Linux workflows (#1445)
+- `468c8714` — feat(email): phishing detection + reversible quarantine, CI-gated ≥90% precision (#1271) (#1434)
+- `53cdb152` — refactor(agents): migrate analyst + browser to hub (#1102) (#1446)
+- `bc0eb0a7` — feat(email): sharpen 4-way categorization (+8.6pp accuracy) (#1266) (#1436)
+- `c8b9aefe` — feat(email): on-device E2B (NPU/FLM) model integration (#1282) (#1433)
+- `e3a67dde` — fix(agents): resilient fenced tool-call extraction + builder fail-loudly (#1430)
+- `30d56543` — refactor(agents): migrate connectors-demo to hub (#1102) (#1442)
+- `3cb3caf5` — feat(email): browser-openable HTML endpoint spec (#1263) (#1432)
+- `d5e606aa` — refactor(agents): migrate code to hub (#1397, #1102) (#1421)
+- `9d31f42a` — refactor(agents): migrate emr to hub (#1397, #1102) (#1419)
+- `dfe2bbbd` — refactor(agents): consolidate regular/lite variants into single agents with model tier (#1162) (#1418)
+- `c07e13c6` — refactor(agents): migrate sd/docker/jira/fileio/blender to hub/ (#1397, #1102) (#1417)
+- `9fc6446f` — feat(hub): agent lifecycle (configure/health/status) + resumable parallel installs (#465, #468) (#1416)
+- `40aefc6e` — feat(hub): gaia agent pack + dual-publish to R2 and PyPI (#1093, #1179) (#1415)
+- `fb285b03` — feat(hub): security tiers, deprecation, and native-agent trust (#1100) (#1414)
+- `2ed01603` — feat(agents): example reference agents for the Agent Hub (#546) (#1413)
+- `63aa0b9c` — feat(cli): gaia agent init/version/test developer workflow (#1098, #1099) (#1412)
+- `9ac90f93` — feat(hub): backend catalog + install/uninstall/rollback API (#1096) (#1411)
+- `542102a4` — feat(webui): Agent Hub Installed/Available tabs + install flow (#1097) (#1410)
+- `8b206e74` — feat(hub): R2 bucket structure + Cloudflare Worker publish API (#1095) (#1409)
+- `5fb7f0d2` — refactor(agents): hub/agents restructure foundation + summarize reference (#1102) (#1407)
+- `7b384a74` — chore(deps-dev): bump electron from 42.2.0 to 42.3.0 in /src/gaia/apps/example/webui in the example-app-dependencies group (#1312)
+- `d037146a` — chore(deps-dev): bump electron from 42.2.0 to 42.3.0 in /src/gaia/apps/jira/webui in the jira-app-dependencies group (#1311)
+- `09938387` — ci(cpp): cross-compile matrix + static binary packaging for C++ agents (#1094) (#1406)
+- `dc39106e` — docs(spec): legacy agent modernization for Agent Hub (#1397) (#1398)
+- `ca7f5c84` — feat(website): Agent Hub browse/discover pages (#1178) (#1405)
+- `dd5c5912` — feat(hub): native C++ agent subprocess launcher (JSON-RPC stdio) (#1092) (#1404)
+- `d12332a9` — feat(agents): framework generic server — 5-interface standard for agents (#1101) (#1403)
+- `b8803cf2` — refactor(agents): promote shared tool mixins to framework (#1396) (#1401)
+- `1a625841` — feat(hub): gaia-agent.yaml manifest parser and validator (#1091) (#1400)
+- `bbc6f0ee` — docs(spec): agent skills format and integration (#285) (#1399)
+- `f2e5c7e4` — fix(lint): clear pre-existing pylint/mypy debt blocking CI (#1402)
+- `6b316f80` — ci(claude): make auto-fix open a PR by default instead of comment patches (#1391)
+- `831d63eb` — fix(ui): render pre-scan card once + plumb mail_provider for Outlook routing (#1387)
+- `39cda801` — fix(email): bound thread transcript + thread-specific summary prompt (#1268 follow-up) (#1378)
+- `c13598c8` — ci(email): unit-test PR gate + report-mode nightly eval + C++ build scaffold (#1362)
+- `dda03ebe` — feat(eval): perf metrics export + report-mode Strix Halo perf gate (#1361)
+- `49b1e44d` — test(email): consolidated cross-surface never-auto-send guard (#1360)
+- `947a11e7` — test(email): lock pre-scan cheap-counts guarantee (#1356)
+- `0c0cf7cf` — feat(email): create calendar events from email context (#1355)
+- `790160a4` — feat(email): Outlook.com personal calendar connector (MS Graph) (#1358)
+- `8607002b` — fix(connectors): provider-aware forwarded-connection scope validation (#1381)
+- `d6ed8052` — feat(mcp): add stdio transport to AgentMCPServer + email REST/MCP parity (#1357)
+- `3475bc43` — feat(email): calendar conflict detection (#1353)
+- `505e9fd9` — feat(email): Outlook.com personal mailbox connector via MS Graph (#1354)
+- `b7cd29e9` — feat(email): full-thread reading & comprehension (#1352)
+- `50a1f54e` — test(email): add summarize_message to EXPECTED_TOOLS allowlist
+- `465f86d0` — chore(email): remove per-issue plan docs from email-agent branch
+- `74c03ea7` — feat(email): per-email summarization tool (#1348)
+- `17303487` — fix(email): reset batch-organize counter across process_query calls (#1345)
+- `de652ba5` — feat(eval): quality & connection metrics export + report-mode FP/FN gate (#1359)
+- `b6f8e660` — feat(email): REST API surface for the agent (single email in, structured out) (#1351)
+- `53b2a490` — feat(email): detect meeting requests in email body (#1350)
+- `00451288` — feat(connectors): Microsoft OAuth provider for MS Graph (consumers tenant) (#1347)
+- `7d82f106` — feat(email): reversible batch archive (20+ emails in one action) (#1349)
+- `d5581478` — feat(connectors): configure OAuth creds via CLI flags (no Agent UI) (#1346)
+- `b596ed65` — feat(eval): labelled email-triage corpus + Gemma-4 categorization baselines (#1322)
+- `2829d265` — feat(connectors): forward a pre-authenticated provider connection via API (no re-auth) (#1321)
+- `a9aa01c0` — feat(email): request/response contract schema (single email + thread) (#1320)
+- `49b3e53e` — feat(email): LLM-assisted triage classification for low-confidence messages
+- `7a56ba49` — feat(eval): email-triage throughput benchmark + reusable eval stats/metrics
+- `33db1047` — fix(ui): unload resident model before swapping in the chat load path (#1382) (#1383)
+
+Full Changelog: [v0.20.0...v0.21.0](https://github.com/amd/gaia/compare/v0.20.0...v0.21.0)

--- a/docs/releases/v0.21.0.mdx
+++ b/docs/releases/v0.21.0.mdx
@@ -1,51 +1,22 @@
 ---
 title: "v0.21.0"
-description: "The Agent Hub — browse, install, and publish GAIA agents from the UI or the terminal, with every agent now shipping as its own versioned package; a major email-agent expansion with phishing detection, Outlook.com support, and calendar awareness; and a real-model behavior eval harness."
+description: "A major email-agent expansion — phishing detection with reversible quarantine, Outlook.com mail and calendar via Microsoft Graph, full-thread reading, and calendar event creation — plus a real-model behavior eval harness and a broad security and bug-fix pass."
 ---
 
 # GAIA v0.21.0 Release Notes
 
-GAIA v0.21.0 turns the agent collection into an ecosystem. The new **Agent Hub** lets you browse a catalog of agents, install the ones you want with one click or one command, and publish your own — and every built-in agent now ships as its own independently versioned package instead of being baked into the core wheel. The email agent gets the release's second big push: it can spot phishing and quarantine it safely, work an Outlook.com inbox and calendar (not just Gmail), read whole threads, and turn a message into a calendar event. Underneath, a new behavior eval harness drives agents through a real model and asserts the tool actually ran — catching a class of "claims success but did nothing" bug that mocked tests never see.
+GAIA v0.21.0 is a feature release centered on the email agent. It can now spot phishing and quarantine it safely, work an Outlook.com inbox and calendar (not just Gmail), read whole threads instead of just the latest message, and turn a meeting request into a calendar event — all running locally on your machine. Connecting a personal Microsoft account is first-class via Microsoft Graph. Underneath the features, a new behavior eval harness drives agents through a real model and asserts the tool actually ran — catching a class of "claims success but did nothing" bug that mocked tests never see — alongside a broad security and bug-fix pass.
 
 **Why upgrade:**
-- **Agent Hub** — browse, install, configure, and roll back agents from the Agent UI's Installed/Available tabs or the `gaia agent` CLI, with a security-tier gate before any unsandboxed native agent runs.
-- **Build and publish your own agent** — `gaia agent init/version/test/pack/publish` scaffolds, validates, and dual-publishes an agent to both the Hub and PyPI (`pip install gaia-agent-<id>`).
-- **Every agent is its own package** — chat, code, email, SD, Docker, Jira, and the rest now version and ship independently of the core release, so you install only what you need.
-- **Email agent grows up** — phishing detection with reversible quarantine (measured 100% precision on the test corpus), Outlook.com mailbox + calendar via Microsoft Graph, full-thread reading, and calendar event creation from an email.
-- **Outlook.com support** — connect a personal Microsoft account (Outlook/Hotmail/Live) for mail and calendar; every existing email tool works against it unchanged.
+- **Phishing detection with safe quarantine** — multi-signal detection (subject, sender domain, body); a flagged message is labelled and archived, never deleted, confirmation-gated, and reversible. Held to a ≥90% precision gate in CI; measured 100% precision on the test corpus, so legitimate mail isn't swept up.
+- **Outlook.com support** — connect a personal Microsoft account (Outlook/Hotmail/Live) for mail and calendar via Microsoft Graph; every existing email tool works against it unchanged, and Gmail stays the default.
+- **Calendar awareness** — the email agent detects meeting requests, checks them against your existing events for conflicts, and creates events — refusing to fabricate one when there's no real date/time.
+- **Full-thread comprehension** — summaries now read the entire thread oldest-first, plus a bounded per-email summary tool, so an ask raised earlier in the thread doesn't get lost.
 - **Real-model behavior testing** — a new eval harness asserts an agent's tools actually take effect against a live model, closing the gap that let the builder silently fail ~40% of the time.
 
 ---
 
 ## What's New
-
-### Agent Hub — discover, install, and manage agents — `gaia agent`, Agent UI Hub
-
-GAIA's agents used to be a fixed set compiled into one wheel: you got what shipped, with no way to add, remove, or update an agent on its own. The Agent Hub replaces that with a real catalog. In the Agent UI, the Hub now has **Installed** and **Available** tabs — click Install on a card and a live progress bar walks through downloading, verifying, and installing, then the card flips to Installed; compatibility shows green/yellow/red before you commit, and an offline catalog surfaces a "showing cached catalog" banner instead of silently going stale (PRs [#1410](https://github.com/amd/gaia/pull/1410), [#1411](https://github.com/amd/gaia/pull/1411)).
-
-The same operations are available headless from the CLI: install/uninstall, `gaia agent configure` to set a model or per-agent options, `gaia agent health` and `gaia agent status` to confirm an agent actually loads, and a checksum-verified installer with pre-update backup so a bad update can be rolled back (PR [#1416](https://github.com/amd/gaia/pull/1416)). Multi-agent setup installs smallest-first and resumes where it left off, so a quick agent is usable while a large one keeps downloading.
-
-Safety is built into the install path: non-verified native (C++) agents are unsandboxed binaries, so installing one is gated behind an explicit trust confirmation, deprecated agents are hidden from the default catalog, and every card carries a verified/community/experimental trust badge (PR [#1414](https://github.com/amd/gaia/pull/1414)). A public web catalog to browse agents before installing is also on the way (PR [#1405](https://github.com/amd/gaia/pull/1405)).
-
----
-
-### Build and publish your own agent — `gaia agent init`
-
-Authoring an agent used to mean hand-copying an existing one and hoping it was wired correctly. The new developer workflow makes it a guided path: `gaia agent init <name> --language python|cpp` scaffolds a complete, valid package — manifest, project file, package skeleton, tests, README — that passes `gaia agent test --lint` out of the box; `gaia agent version patch|minor|major` bumps the version everywhere it appears; and `gaia agent test` validates structure, imports, and formatting without an LLM, or confirms the agent answers its starter prompts with `--live` (PR [#1412](https://github.com/amd/gaia/pull/1412)).
-
-When it's ready, `gaia agent pack` builds a wheel and `gaia agent publish` dual-publishes it to both the Hub (the source the UI and website read) and PyPI, so anyone can `pip install gaia-agent-<id>` (PRs [#1415](https://github.com/amd/gaia/pull/1415), [#1454](https://github.com/amd/gaia/pull/1454)). Tokens live in the OS keyring, with env-var overrides for CI. Three annotated reference agents — `hello-world`, `word-count`, and `doc-search` — give a copy-paste starting point at every level of complexity (PR [#1413](https://github.com/amd/gaia/pull/1413)).
-
-Agents aren't limited to Python: a native C++ agent now runs as a plain subprocess over JSON-RPC stdio — the same protocol the desktop app speaks — so native agents work from the web backend too, with a cross-platform build-and-package pipeline behind them (PRs [#1404](https://github.com/amd/gaia/pull/1404), [#1406](https://github.com/amd/gaia/pull/1406)). And any agent can expose itself five ways — interactive TUI, one-shot CLI, stdin/stdout pipe, OpenAI-compatible REST, and MCP — through a single `run_agent_cli()` call (PR [#1403](https://github.com/amd/gaia/pull/1403)).
-
----
-
-### Every agent is now its own package
-
-To make the Hub possible, every built-in agent moved out of the core wheel into its own `gaia-agent-<id>` package under `hub/agents/`: chat, code, EMR, SD, Docker, Jira, FileIO, Blender, analyst, browser, and connectors-demo (PRs [#1407](https://github.com/amd/gaia/pull/1407), [#1417](https://github.com/amd/gaia/pull/1417), [#1419](https://github.com/amd/gaia/pull/1419), [#1421](https://github.com/amd/gaia/pull/1421), [#1442](https://github.com/amd/gaia/pull/1442), [#1446](https://github.com/amd/gaia/pull/1446)). Each one now versions and ships on its own schedule rather than being chained to the framework's release cycle, and the shared tool mixins they all depend on (RAG, FileIO, Shell, code search) were promoted into the framework so agents no longer import each other (PR [#1401](https://github.com/amd/gaia/pull/1401)).
-
-The Hub also stopped showing duplicate "Lite" cards: where there used to be 13 cards for 7 agents, each agent now appears once with a **Full / Lite (~4B)** model-size selector, and the old `*-lite` IDs still resolve through an alias map (PR [#1418](https://github.com/amd/gaia/pull/1418)).
-
----
 
 ### Email agent — phishing detection, Outlook, and calendar awareness — `gaia email`
 
@@ -94,11 +65,10 @@ Mocked unit tests and UI-render tests both passed while the builder agent silent
 - **Email CI gate + nightly report-mode eval** (PR [#1362](https://github.com/amd/gaia/pull/1362)) — a unit-test PR gate, a report-mode nightly eval, and the C++ build scaffold for email.
 - **Labelled email-triage corpus + baselines** (PR [#1322](https://github.com/amd/gaia/pull/1322)) — a 220-message synthetic corpus with ground truth replaces a 10-message stub and a baseline that had been measured against the wrong model.
 - **Never-auto-send guard consolidated across surfaces** (PR [#1360](https://github.com/amd/gaia/pull/1360)) and **pre-scan cheap-counts guarantee locked** (PR [#1356](https://github.com/amd/gaia/pull/1356)).
-- **C++ agent cross-compile matrix + static packaging** (PR [#1406](https://github.com/amd/gaia/pull/1406)) — win-x64, linux-x64, and darwin-arm64 build self-contained static binaries, consolidated into one bundle on a version tag.
 - **Cleared pre-existing pylint/mypy debt blocking CI** (PR [#1402](https://github.com/amd/gaia/pull/1402)) and **fixed mcp test library shadowing + a dangling summarizer CI step** (PRs [#1443](https://github.com/amd/gaia/pull/1443), [#1445](https://github.com/amd/gaia/pull/1445)).
 - **Auto-fix opens a PR by default** (PR [#1391](https://github.com/amd/gaia/pull/1391)) instead of posting comment patches.
 - **Installer repo-root resolution locked in launcher scripts** (PR [#1395](https://github.com/amd/gaia/pull/1395)).
-- **Specs updated** — Agent Hub 22-agent enablement (PR [#1457](https://github.com/amd/gaia/pull/1457)), dynamic tool-loader (PR [#1447](https://github.com/amd/gaia/pull/1447)), legacy agent modernization (PR [#1398](https://github.com/amd/gaia/pull/1398)), and the agent skills format (PR [#1399](https://github.com/amd/gaia/pull/1399)).
+- **Specs updated** — dynamic tool-loader (PR [#1447](https://github.com/amd/gaia/pull/1447)) and the agent skills format (PR [#1399](https://github.com/amd/gaia/pull/1399)).
 
 ---
 

--- a/src/gaia/apps/webui/package-lock.json
+++ b/src/gaia/apps/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-ui",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.3"

--- a/src/gaia/apps/webui/package-lock.json
+++ b/src/gaia/apps/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.21.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-ui",
-      "version": "0.21.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.3"

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.21.0",
+  "version": "0.20.1",
   "type": "module",
   "productName": "GAIA Agent UI",
   "description": "Privacy-first agentic AI interface with document Q&A - runs 100% locally on AMD Ryzen AI",

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "module",
   "productName": "GAIA Agent UI",
   "description": "Privacy-first agentic AI interface with document Q&A - runs 100% locally on AMD Ryzen AI",

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from importlib.metadata import version as get_package_version_metadata
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 
 # Lemonade version used across CI and installer
 LEMONADE_VERSION = "10.2.0"

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from importlib.metadata import version as get_package_version_metadata
 
-__version__ = "0.21.0"
+__version__ = "0.20.1"
 
 # Lemonade version used across CI and installer
 LEMONADE_VERSION = "10.2.0"


### PR DESCRIPTION
Cuts the **v0.20.1** patch release — bug fixes and security hardening on top of v0.20.0. Headline fixes: a broken optional dependency that crashed every agent at import, a clean-install `gaia-mcp` failure, the Windows app not reopening after auto-upgrade, a step cap set too low that stalled agents mid-task, plus an SSRF DNS-rebind fix and a high-severity XSS dependency patch.

Groundwork for larger features — the email agent (phishing detection, Outlook.com mail/calendar, full-thread reading), the Microsoft/Outlook connectors, and a behavior eval harness — also landed in this range but is **not complete and is not featured**; it will headline a future release once ready.

Full, commit-by-commit notes live in [`docs/releases/v0.20.1.mdx`](docs/releases/v0.20.1.mdx) — that file is the source of truth and is kept in sync with the `v0.20.0..HEAD` range.

Part of milestone 40 (not closing the milestone with this release).

## Release checklist
- [x] `util/validate_release_notes.py docs/releases/v0.20.1.mdx --tag v0.20.1` passes
- [x] `src/gaia/version.py` → `0.20.1`
- [x] `src/gaia/apps/webui/package.json` → `0.20.1`
- [x] `src/gaia/apps/webui/package-lock.json` → `0.20.1`
- [x] Navbar label in `docs/docs.json` → `v0.20.1 · Lemonade 10.2.0`
- [x] All commits in range (`v0.20.0..HEAD`) represented in the notes
- [ ] Review from @kovtcharov-amd addressed
