### PR TITLE
ci(docs): skip fastmcp.me in external link check (incomplete TLS cert chain)

### DIFF
--- a/util/check_doc_links.py
+++ b/util/check_doc_links.py
@@ -59,6 +59,7 @@ SKIP_DOMAINS = {
     "dl.acm.org",  # Blocks automated requests with CAPTCHAs
     "platform.openai.com",  # Rate-limits CI bots
     "www.npmjs.com",  # Returns 403 to automated requests
+    "fastmcp.me",  # Incomplete TLS cert chain -> urllib CERTIFICATE_VERIFY_FAILED
 }
 
 # URL patterns to skip


### PR DESCRIPTION
## Why this matters

The "Verify external URLs" CI job (`check_doc_links.yml`) has failed on **every docs-touching PR since #1419**, blocking a clean check on otherwise-good documentation changes — including the v0.21.0 release PR (#1548).

The cause isn't a dead link. `docs/plans/agent-ui-agent-capabilities-plan.md:363` cites `https://fastmcp.me/blog/top-10-most-popular-mcp-servers`; that page is live, but the server presents an **incomplete TLS certificate chain**, so Python's `urllib` raises `[SSL: CERTIFICATE_VERIFY_FAILED]` on every run (browsers and `curl` succeed because they fetch the missing intermediate certs). It's a CI-only cert quirk, not real breakage.

This adds `fastmcp.me` to the checker's existing `SKIP_DOMAINS` allowlist — the same mechanism already used for `marketplace.visualstudio.com`, `www.npmjs.com`, and `platform.openai.com`, all of which break automated requests — so the check reflects genuine link rot instead of failing red on a domain it can't validate.

## Test plan

- [x] `should_skip("https://fastmcp.me/blog/...")` returns `True`
- [x] `python util/check_doc_links.py --external-only --max-workers 5` → `Broken: 0`, `PASSED` (was: 1 broken on `fastmcp.me`)
- [x] The lone remaining `amd.com/en/developer.html` item is a transient timeout **warning**, not a failure — left as-is
- [x] Change is one line in `SKIP_DOMAINS`; `util/` is outside the black/isort lint scope (`LINT_DIRS = ["src/gaia", "tests"]`), so no formatting impact
