### PR TITLE
feat(email): echo input message_id in triage result

### DIFF
--- a/src/gaia/agents/email/contract.py
+++ b/src/gaia/agents/email/contract.py
@@ -233,7 +233,15 @@ class DraftReply(_Strict):
 
 
 class EmailTriageResult(_Strict):
-    """The structured analysis of a single email or thread."""
+    """The structured analysis of a single email or thread.
+
+    Amendment (#1539): ``message_id`` is optional and echoes the identifying id
+    of the input — ``message.message_id`` for a single email, ``thread_id`` for
+    a thread. Consuming apps use this field to correlate a result back to its
+    input and to deduplicate results across polling loops (cache by message_id).
+    The field is ``Optional`` for backward compatibility with the frozen #1262
+    shape: existing callers that omit it continue to validate without change.
+    """
 
     category: EmailCategory = Field(..., description="One of the four buckets.")
     is_spam: bool = Field(default=False, description="Spam signal (independent).")
@@ -246,6 +254,17 @@ class EmailTriageResult(_Strict):
     )
     draft: Optional[DraftReply] = Field(
         default=None, description="Proposed reply, or null when none is suggested."
+    )
+    message_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Echoes the identifying id of the triaged input: message.message_id "
+            "for a single email, ThreadInput.thread_id for a thread. Use this "
+            "field to correlate a result back to its input and to deduplicate "
+            "results across polling loops (cache by message_id). Null only when "
+            "the result is constructed without an id (e.g. the "
+            "triage_gmail_message path)."
+        ),
     )
 
 

--- a/src/gaia/api/email_routes.py
+++ b/src/gaia/api/email_routes.py
@@ -245,6 +245,9 @@ class EmailTriageService:
         sender = headers.get("from", "")
         label_ids = list(msg.get("labelIds", []))
         principal = EmailAddress(email=principal_email)
+        # No message_id echoed: this Gmail-API path is not a contract request,
+        # so result.message_id stays None (the contract id is set only on the
+        # SingleEmailInput / ThreadInput paths).
         return self._build_result(
             subject=subject,
             sender_raw=sender,
@@ -265,6 +268,7 @@ class EmailTriageService:
             label_ids=[],
             principal=payload.principal,
             reply_to=msg.from_,
+            message_id=msg.message_id,
         )
 
     def _triage_thread(self, payload: ThreadInput) -> EmailTriageResult:
@@ -275,6 +279,8 @@ class EmailTriageService:
         combined_body = "\n\n".join(
             f"{_format_address(m.from_)}: {m.body}" for m in messages
         )
+        # Thread id is the canonical identifier for a thread conversation;
+        # a consumer uses it to correlate and deduplicate triage results.
         result = self._build_result(
             subject=last.subject,
             sender_raw=_format_address(last.from_),
@@ -283,6 +289,7 @@ class EmailTriageService:
             principal=payload.principal,
             reply_to=last.from_,
             summary_prefix=f"Thread of {len(messages)} messages. ",
+            message_id=payload.thread_id,
         )
         return result
 
@@ -300,6 +307,7 @@ class EmailTriageService:
             principal=payload.principal,
             reply_to=msg.from_,
             chat=chat,
+            message_id=msg.message_id,
         )
 
     def _triage_thread_llm(self, payload: ThreadInput, chat: Any) -> EmailTriageResult:
@@ -317,6 +325,7 @@ class EmailTriageService:
             reply_to=last.from_,
             summary_prefix=f"Thread of {len(messages)} messages. ",
             chat=chat,
+            message_id=payload.thread_id,
         )
 
     def _build_result_llm(
@@ -330,6 +339,7 @@ class EmailTriageService:
         reply_to: Optional[EmailAddress],
         summary_prefix: str = "",
         chat: Any,
+        message_id: Optional[str] = None,
     ) -> EmailTriageResult:
         """Build a result using LLM escalation when heuristic confidence is low."""
         from gaia.agents.email.tools.llm_triage import classify_email_llm
@@ -374,6 +384,7 @@ class EmailTriageService:
             summary=summary,
             action_items=action_items,
             draft=draft,
+            message_id=message_id,
         )
 
     def _build_result(
@@ -386,6 +397,7 @@ class EmailTriageService:
         principal: EmailAddress,
         reply_to: Optional[EmailAddress],
         summary_prefix: str = "",
+        message_id: Optional[str] = None,
     ) -> EmailTriageResult:
         heuristic = classify_category_heuristic(
             subject=subject, sender=sender_raw, label_ids=label_ids
@@ -407,6 +419,7 @@ class EmailTriageService:
             summary=summary,
             action_items=action_items,
             draft=draft,
+            message_id=message_id,
         )
 
     def _summarize(self, subject: str, body: str) -> str:

--- a/tests/unit/agents/email/test_contract_schema.py
+++ b/tests/unit/agents/email/test_contract_schema.py
@@ -317,3 +317,52 @@ def test_result_summary_required():
     del payload["result"]["summary"]
     with pytest.raises(ValidationError):
         EmailTriageResult.model_validate(payload["result"])
+
+
+# ---------------------------------------------------------------------------
+# message_id field (#1539) — optional, backward-compatible amendment
+# ---------------------------------------------------------------------------
+
+
+def test_result_message_id_is_optional():
+    """message_id has a default of None — existing payloads validate unchanged."""
+    payload = _single_response()
+    assert "message_id" not in payload["result"]  # existing sample has no field
+    result = EmailTriageResult.model_validate(payload["result"])
+    assert result.message_id is None
+
+
+def test_result_message_id_accepted_when_present():
+    """A result with message_id validates and round-trips."""
+    payload = _single_response()
+    payload["result"]["message_id"] = "msg-abc-001"
+    result = EmailTriageResult.model_validate(payload["result"])
+    assert result.message_id == "msg-abc-001"
+
+
+def test_result_message_id_null_accepted():
+    """Explicit null (None) is accepted."""
+    payload = _single_response()
+    payload["result"]["message_id"] = None
+    result = EmailTriageResult.model_validate(payload["result"])
+    assert result.message_id is None
+
+
+def test_result_message_id_included_in_dump():
+    """message_id is serialized in model_dump output (consumers see it)."""
+    payload = _single_response()
+    payload["result"]["message_id"] = "t-42"
+    result = EmailTriageResult.model_validate(payload["result"])
+    dumped = result.model_dump()
+    assert "message_id" in dumped
+    assert dumped["message_id"] == "t-42"
+
+
+def test_response_with_message_id_round_trips():
+    """Full response envelope with message_id round-trips through dump/validate."""
+    payload = _single_response()
+    payload["result"]["message_id"] = "m-round-trip"
+    response = EmailTriageResponse.model_validate(payload)
+    dumped = response.model_dump()
+    again = EmailTriageResponse.model_validate(dumped)
+    assert again.result.message_id == "m-round-trip"

--- a/tests/unit/agents/email/test_msgid_echo.py
+++ b/tests/unit/agents/email/test_msgid_echo.py
@@ -1,0 +1,294 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for message_id echo in the triage response (issue #1539).
+
+The EmailTriageResult echoes the identifying id of the triaged input so
+consuming apps can correlate results and deduplicate across polling loops.
+
+AC coverage:
+- test_single_triage_echoes_message_id: single email input → result.message_id
+  matches input message.message_id (heuristic engine AND llm engine).
+- test_thread_triage_echoes_id: thread input → result.message_id echoes the
+  thread's identifying id (ThreadInput.thread_id, which the contract requires).
+- test_contract_backward_compatible: EmailTriageResult still validates WITHOUT
+  message_id (optional field — existing callers not broken).
+- Schema tests live in test_contract_schema.py; backward compat assertions here
+  are a superset to keep this file self-contained.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("fastapi")
+
+from gaia.agents.email.contract import (  # noqa: E402
+    EmailAddress,
+    EmailMessage,
+    EmailTriageRequest,
+    EmailTriageResponse,
+    EmailTriageResult,
+    SingleEmailInput,
+    ThreadInput,
+)
+
+# ---------------------------------------------------------------------------
+# Chat double for engine=llm tests (no live Lemonade)
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeChat:
+    """Returns canned JSON for classify and a plain summary for summarize."""
+
+    def __init__(
+        self,
+        category: str = "actionable",
+        summary: str = "Needs your reply.",
+    ) -> None:
+        self._category = category
+        self._summary = summary
+
+    def send_messages(self, messages, system_prompt=None, **kwargs):
+        if system_prompt and "Respond with a single JSON" in system_prompt:
+            cat = self._category
+            return _Resp(
+                f'{{"category": "{cat}", "confidence": 0.82, "reasoning": "stub"}}'
+            )
+        return _Resp(self._summary)
+
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+_PRINCIPAL = EmailAddress(email="alice@example.com")
+_SENDER = EmailAddress(name="Bob Smith", email="bob@company.com")
+
+
+def _single_request(message_id: str) -> EmailTriageRequest:
+    return EmailTriageRequest(
+        payload=SingleEmailInput(
+            principal=_PRINCIPAL,
+            message=EmailMessage(
+                message_id=message_id,
+                from_=_SENDER,
+                to=[_PRINCIPAL],
+                subject="Project update",
+                body="Please review the attached proposal when you get a chance.",
+            ),
+        )
+    )
+
+
+def _thread_request(
+    thread_id: str,
+    msg_ids: list[str],
+) -> EmailTriageRequest:
+    messages = [
+        EmailMessage(
+            message_id=mid,
+            thread_id=thread_id,
+            from_=(_SENDER if i % 2 == 0 else _PRINCIPAL),
+            to=[_PRINCIPAL if i % 2 == 0 else _SENDER],
+            subject="Contract renewal",
+            body=f"Message {i + 1} body.",
+        )
+        for i, mid in enumerate(msg_ids)
+    ]
+    return EmailTriageRequest(
+        payload=ThreadInput(
+            principal=_PRINCIPAL,
+            thread_id=thread_id,
+            messages=messages,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC1: single email echoes message_id
+# ---------------------------------------------------------------------------
+
+
+class TestSingleTriageEchoesMessageId:
+    """result.message_id == input message.message_id for both engines."""
+
+    def test_heuristic_engine_echoes_message_id(self):
+        from gaia.api.email_routes import EmailTriageService
+
+        service = EmailTriageService()
+        response = service.triage_request(_single_request("m-42"))
+
+        assert isinstance(response, EmailTriageResponse)
+        assert response.result.message_id == "m-42"
+
+    def test_llm_engine_echoes_message_id(self):
+        from gaia.api.email_routes import EmailTriageService
+
+        service = EmailTriageService()
+        response = service.triage_request(
+            _single_request("m-99"),
+            engine="llm",
+            chat=_FakeChat(),
+        )
+
+        assert isinstance(response, EmailTriageResponse)
+        assert response.result.message_id == "m-99"
+
+    def test_different_message_ids_echo_correctly(self):
+        """Each request echoes its own id — ids don't bleed across calls."""
+        from gaia.api.email_routes import EmailTriageService
+
+        service = EmailTriageService()
+        for mid in ("abc-1", "xyz-999", ""):
+            resp = service.triage_request(_single_request(mid))
+            assert resp.result.message_id == mid
+
+
+# ---------------------------------------------------------------------------
+# AC2: thread echoes the identifying id
+# ---------------------------------------------------------------------------
+
+
+class TestThreadTriageEchoesId:
+    """Thread result echoes thread_id (the thread's canonical identifier)."""
+
+    def test_thread_echoes_thread_id(self):
+        """ThreadInput.thread_id is the canonical identifier for a thread."""
+        from gaia.api.email_routes import EmailTriageService
+
+        service = EmailTriageService()
+        response = service.triage_request(
+            _thread_request("t-77", ["m-1", "m-2", "m-3"])
+        )
+
+        assert isinstance(response, EmailTriageResponse)
+        assert response.result.message_id == "t-77"
+
+    def test_thread_llm_engine_echoes_thread_id(self):
+        from gaia.api.email_routes import EmailTriageService
+
+        service = EmailTriageService()
+        response = service.triage_request(
+            _thread_request("t-100", ["m-a", "m-b"]),
+            engine="llm",
+            chat=_FakeChat(),
+        )
+
+        assert response.result.message_id == "t-100"
+
+    def test_thread_with_different_id_echoes_correctly(self):
+        from gaia.api.email_routes import EmailTriageService
+
+        service = EmailTriageService()
+        response = service.triage_request(
+            _thread_request("thread-abc-123", ["m-x", "m-y"])
+        )
+        assert response.result.message_id == "thread-abc-123"
+
+
+# ---------------------------------------------------------------------------
+# AC3: backward compatibility — message_id is optional
+# ---------------------------------------------------------------------------
+
+
+class TestContractBackwardCompatible:
+    """EmailTriageResult still validates WITHOUT message_id (optional field)."""
+
+    def test_result_validates_without_message_id(self):
+        """A result dict without message_id validates successfully."""
+        result = EmailTriageResult.model_validate(
+            {
+                "category": "actionable",
+                "is_spam": False,
+                "is_phishing": False,
+                "summary": "Existing result without message_id.",
+                "action_items": [],
+                "draft": None,
+            }
+        )
+        assert result.message_id is None
+
+    def test_result_validates_with_none_message_id(self):
+        result = EmailTriageResult.model_validate(
+            {
+                "category": "informational",
+                "is_spam": False,
+                "is_phishing": False,
+                "summary": "Status update.",
+                "action_items": [],
+                "draft": None,
+                "message_id": None,
+            }
+        )
+        assert result.message_id is None
+
+    def test_result_validates_with_string_message_id(self):
+        result = EmailTriageResult.model_validate(
+            {
+                "category": "urgent",
+                "is_spam": False,
+                "is_phishing": False,
+                "summary": "Needs immediate action.",
+                "action_items": [],
+                "draft": None,
+                "message_id": "msg-abc-123",
+            }
+        )
+        assert result.message_id == "msg-abc-123"
+
+    def test_existing_sample_payloads_still_parse(self):
+        """Sample payloads from test_contract_schema.py still validate."""
+        from gaia.agents.email.contract import SCHEMA_VERSION, EmailTriageResponse
+
+        # The frozen sample response from test_contract_schema — no message_id field.
+        sample = {
+            "schema_version": SCHEMA_VERSION,
+            "request_kind": "single",
+            "result": {
+                "category": "actionable",
+                "is_spam": False,
+                "is_phishing": False,
+                "summary": "Vendor invoice needs review by Friday.",
+                "action_items": [
+                    {"description": "Review the Q2 invoice", "due_hint": "Friday"}
+                ],
+                "draft": {
+                    "to": [{"name": "Bob Sender", "email": "bob@vendor.com"}],
+                    "subject": "Re: Q2 invoice attached",
+                    "body": "Thanks Bob, I'll review and confirm by Friday.",
+                },
+            },
+        }
+        response = EmailTriageResponse.model_validate(sample)
+        assert response.result.message_id is None
+
+    def test_thread_sample_payload_still_parses(self):
+        from gaia.agents.email.contract import SCHEMA_VERSION, EmailTriageResponse
+
+        sample = {
+            "schema_version": SCHEMA_VERSION,
+            "request_kind": "thread",
+            "result": {
+                "category": "actionable",
+                "is_spam": False,
+                "is_phishing": False,
+                "summary": "Bob wants a renewal call; Alice proposed Thursday 2pm.",
+                "action_items": [{"description": "Confirm Thursday 2pm call"}],
+                "draft": None,
+            },
+        }
+        response = EmailTriageResponse.model_validate(sample)
+        assert response.result.message_id is None


### PR DESCRIPTION
Closes #1539

> **Stacked on #1547** (base branch `feat/email-llm-triage-api-1452`). Review after #1547 — the diff here is only the `message_id` echo.

## Why this matters
Before: the triage API accepted `message_id` on input but never echoed it in the response, so a consuming app couldn't correlate a result back to its input or dedupe — it would re-triage the same emails on every polling loop.

After: `EmailTriageResult` echoes the input's identifying id — `message.message_id` for a single email, `thread_id` for a thread — across both engines and both single/thread paths. The consumer caches by this id to dedupe. The field is `Optional`, so the frozen #1262 shape stays backward-compatible (existing callers that omit it still validate). Per the AC, consumer correlation is the documented echoed-id route; no stateful server-side cache is added.

## Test plan
- [x] Unit: result echoes `message_id` for single (heuristic + llm) and thread; validates without the field (backward-compat); sample payloads parse. **374 passed.**
- [x] Lint: black + isort pass.
- [x] Real-world (Linux + Windows): the live API echoes the id — evidence below.

## Real-world evidence (live `gaia api start`, engine=heuristic; branch + field verified before testing)
| OS | HEAD | single (`message_id=rw-single-1`) | thread (`thread_id=rw-thread-7`) |
|----|------|-----------------------------------|----------------------------------|
| Linux — t-nx-strx-halo | 6181908f | result.message_id = `rw-single-1` | result.message_id = `rw-thread-7` |
| Windows — t-win-radeon | 6181908f | result.message_id = `rw-single-1` | result.message_id = `rw-thread-7` |

Both OSes: single echoes the input `message.message_id`, thread echoes `thread_id`. Boxes restored to their original branches after the run.