### PR TITLE
fix(ci): match Vite 8 backtick-quoted version in publish check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -268,14 +268,21 @@ jobs:
         run: |
           PY_VERSION=$(grep -oP '__version__\s*=\s*"\K[^"]+' src/gaia/version.py)
           ESCAPED=$(echo "$PY_VERSION" | sed 's/\./\\./g')
-          APP_VERSION=$(grep -o "\"${ESCAPED}\"" src/gaia/apps/webui/dist/assets/index-*.js | head -1 | tr -d '"' || echo "NOT_FOUND")
-          echo "  version.py: $PY_VERSION"
-          echo "  Built app:  $APP_VERSION"
-          if [ "$APP_VERSION" != "$PY_VERSION" ]; then
-            echo "FAIL: Built app version ($APP_VERSION) != version.py ($PY_VERSION)"
+          # __APP_VERSION__ is injected by Vite's define as a quoted string
+          # literal. The minifier's quote char depends on the Vite/esbuild
+          # version (Vite 8 emits backticks, Vite 5 emitted double quotes),
+          # and the entry chunk is not always named index-*.js, so match any
+          # quote char (" ' `) across every emitted chunk.
+          if grep -rqE "[\"'\`]${ESCAPED}[\"'\`]" src/gaia/apps/webui/dist/assets/*.js; then
+            echo "  version.py: $PY_VERSION"
+            echo "Built app version verified ($PY_VERSION)"
+          else
+            echo "  version.py: $PY_VERSION"
+            echo "FAIL: version $PY_VERSION not found as a quoted literal in any src/gaia/apps/webui/dist/assets/*.js"
+            echo "Version-like strings present in the bundle:"
+            grep -hoE "[0-9]+\.[0-9]+\.[0-9]+" src/gaia/apps/webui/dist/assets/*.js | sort -u | head
             exit 1
           fi
-          echo "Built app version verified"
 
       - name: Run backend tests
         run: |


### PR DESCRIPTION
## Why this matters

The v0.20.1 release is **blocked by a false-negative CI check, not a real build problem.** The `Verify built app version` step in `publish.yml` greps the built Agent UI bundle for the version as a **double-quoted** literal (`"X.Y.Z"`). The v0.20.1 agent-ui dependency bump moved **Vite 5 → 8**, and Vite 8's esbuild minifier emits string literals as **backtick template literals** (`` `0.20.1` ``). The grep no longer matched, so the step failed with an empty `Built app:` value even though `__APP_VERSION__` was injected correctly — the wheel and installers were fine.

Before: every release on Vite ≥ 8 fails the publish at the version-verify gate.
After: the check matches the version regardless of quote char (`"` `'` ``` ```) and across every emitted chunk (the entry isn't always `index-*.js`), and on failure prints the version strings it *did* find.

## Test plan
- [x] Reproduced locally: `npm ci && npm run build` with Vite 8.0.16 embeds `0.20.1` only in backticks; old check finds 0 matches, new check passes.
- [x] Negative test: new check correctly FAILs for a version not present in the bundle (`9.9.9`).
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` — valid YAML.

After merge, the `v0.20.1` tag is moved to include this fix to re-trigger the publish (no GitHub Release was published yet, so moving the tag is safe).