### PR TITLE
fix(ci): drop stale gaia-emr smoke check + make PyPI publish idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -360,6 +360,11 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Make re-runs idempotent: if this version is already on PyPI
+          # (e.g. a later stage failed and the workflow is re-run), skip the
+          # already-uploaded files instead of failing on a duplicate upload.
+          skip-existing: true
 
   publish-npm:
     name: Publish to npm
@@ -448,9 +453,11 @@ jobs:
 
       - name: Verify CLI entry points
         run: |
+          # Only core-wheel console_scripts belong here. gaia-emr / gaia-code
+          # moved to the standalone gaia-agent-emr / gaia-agent-code hub
+          # packages and are no longer installed by ``pip install amd-gaia``.
           gaia --help
           gaia-mcp --help
-          gaia-emr --help
 
       - name: Verify Python import
         env:


### PR DESCRIPTION
## Why this matters

The v0.20.1 publish **shipped the package to PyPI/npm but skipped creating the GitHub Release** — the post-publish smoke test ran `gaia-emr --help` and failed with `command not found` (exit 127). `gaia-emr` moved to the standalone `gaia-agent-emr` hub package during the hub migration and is no longer a core-wheel console_script, so this check fails on **every** release now, and because the GitHub Release job `needs` the smoke test to pass, the release got skipped (had to be created manually).

Before: every release post-hub-migration fails the smoke test → no GitHub Release.
After: the smoke test only verifies core-wheel entry points (`gaia`, `gaia-mcp`), so it passes and the release publishes.

Also makes the PyPI publish **idempotent** (`skip-existing: true`): today a failure in any later stage can't be recovered by re-running the workflow, because the publish step dies on a duplicate upload of an already-published version. With `skip-existing`, a re-run skips the existing files and proceeds to the downstream stages (smoke test, GitHub Release).

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` — valid YAML
- [x] Confirmed `gaia-emr` is absent from core `console_scripts` (setup.py) — it ships with `hub/agents/python/emr` (`gaia_agent_emr.cli:main`)
- [ ] Next release exercises the full publish → smoke → GitHub Release path end-to-end

Note: npm publish has the same non-idempotency (no clean `skip-existing`), left out of scope here.