### PR TITLE
fix(ci): pin self-hosted runners to exact LEMONADE_VERSION via WinGet

### DIFF
--- a/.github/actions/install-lemonade/action.yml
+++ b/.github/actions/install-lemonade/action.yml
@@ -2,20 +2,22 @@
 # SPDX-License-Identifier: MIT
 
 name: 'Install Lemonade Server'
-description: 'Pins the runner to exactly LEMONADE_VERSION, reconciling via WinGet when the installed version differs.'
+description: 'Pins the runner to exactly LEMONADE_VERSION, reconciling via the matching MSI when the installed version differs.'
 
 # This action checks the lemonade-server already installed on the runner
 # against the version GAIA expects (``src/gaia/version.LEMONADE_VERSION``).
 # If the runner has any version other than the expected one (ahead, behind,
-# missing, or unparseable), it reconciles via WinGet:
-#   1. Remove any gating WinGet pin (so the install target version is not blocked).
-#   2. Uninstall the current copy (WiX in-place version change returns 1603).
-#   3. Remove any residual MSI-direct install via the Windows uninstall registry.
-#   4. winget install --version $expected.
-#   5. Re-apply a pin to $expected to block future auto-update drift.
+# missing, or unparseable), it reconciles via the matching MSI:
+#   1. Uninstall the current copy via the Windows uninstall registry / msiexec
+#      (WiX in-place version change returns 1603, so uninstall-first is required).
+#   2. Download + silently install the matching MSI from the lemonade-sdk
+#      GitHub releases -- the same release URL the gaia init flow uses
+#      (``src/gaia/installer/lemonade_installer.py:GITHUB_RELEASE_BASE``).
 # Exact-match is then verified; the step fails loud if the version is wrong.
-# This keeps the runner's model catalog aligned with what GAIA ships to users
-# so preload/pull operations don't 422 with "model_name not registered".
+# msiexec is used (not winget) because the runner's service account runs as
+# SYSTEM, where winget is unavailable. This keeps the runner's model catalog
+# aligned with what GAIA ships to users so preload/pull operations don't 422
+# with "model_name not registered".
 
 outputs:
   lemonade-path:
@@ -182,30 +184,43 @@ runs:
             return $va.CompareTo($vb)
         }
 
-        function Reconcile-LemonadeVersion {
-            # Uninstall the current copy (any version) then install exactly $expected.
-            # WiX MSI returns 1603 for in-place version changes, so uninstall-first
-            # is mandatory. The WinGet pin is removed first (a gating pin blocks the
-            # install) and re-applied at the end of the caller.
-            param([string]$Expected)
-            $PKG = "AMD.LemonadeServer"
+        function Install-LemonadeMsi {
+            param([string]$Version)
+            $url = "https://github.com/lemonade-sdk/lemonade/releases/download/v$Version/lemonade.msi"
+            $dest = Join-Path $env:RUNNER_TEMP "lemonade-$Version.msi"
 
-            # winget is required; no MSI fallback (fail loud so the runner is fixed).
-            if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-                Write-Host "ERROR: winget not found on this runner; cannot enforce pinned Lemonade $Expected. Install App Installer/winget on the runner."
-                exit 1
+            Write-Host "Downloading Lemonade Server MSI from: $url"
+            try {
+                Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing -TimeoutSec 600
+            } catch {
+                Write-Host "ERROR: MSI download failed: $_"
+                throw
             }
 
-            # Remove any gating pin -- a pinned version blocks ``winget install --version``.
-            Write-Host "Removing WinGet pin for $PKG (best-effort)..."
-            winget pin remove --id $PKG 2>&1 | Out-Null
+            Write-Host "Running silent MSI install (msiexec /i $dest /quiet /norestart)..."
+            $msi = Start-Process -FilePath "msiexec.exe" `
+                -ArgumentList "/i", $dest, "/quiet", "/norestart", "/L*v", "$env:RUNNER_TEMP\lemonade-msi.log" `
+                -PassThru -Wait
+            Write-Host "msiexec exit code: $($msi.ExitCode)"
+            if ($msi.ExitCode -ne 0) {
+                Write-Host "===== MSI install log (tail) ====="
+                Get-Content "$env:RUNNER_TEMP\lemonade-msi.log" -Tail 80 -ErrorAction SilentlyContinue
+                Write-Host "==================================="
+                throw "MSI install failed with exit code $($msi.ExitCode). See log above."
+            }
+            Write-Host "MSI install completed."
+        }
 
-            # Uninstall the currently installed copy via WinGet.
-            Write-Host "Uninstalling $PKG via WinGet (tolerate not-installed)..."
-            winget uninstall --id $PKG --silent 2>&1 | Out-Null
+        function Reconcile-LemonadeVersion {
+            # Uninstall the current copy (any version) then install exactly $expected
+            # via the matching MSI. WiX MSI returns 1603 for in-place version
+            # changes, so uninstall-first is mandatory. The registry/msiexec
+            # uninstall is SYSTEM-safe; winget is not available to the runner's
+            # service account, so it's deliberately not used here.
+            param([string]$Expected)
 
-            # Defensive: remove any residual MSI-direct install that WinGet doesn't
-            # track. Mirrors lemonade_installer.py find_product_code / _uninstall_windows.
+            # SYSTEM-safe uninstall: remove the current/drifted copy via the Windows
+            # uninstall registry. Mirrors lemonade_installer.py find_product_code / _uninstall_windows.
             Write-Host "Checking Windows uninstall registry for residual Lemonade entries..."
             $uninstallRoots = @(
                 "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
@@ -233,22 +248,14 @@ runs:
                 }
             }
 
-            # Install exactly the pinned version.
-            Write-Host "Installing $PKG version $Expected via WinGet..."
-            winget install --id $PKG --version $Expected --silent --accept-package-agreements --accept-source-agreements
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "ERROR: winget install $PKG --version $Expected failed with exit code $LASTEXITCODE."
-                Write-Host "       Check that version $Expected is available: winget show $PKG --versions"
-                exit 1
-            }
-            Write-Host "WinGet install completed."
+            # Install exactly the pinned version via the matching MSI.
+            Install-LemonadeMsi -Version $Expected
         }
 
         # -----------------------------------------------------------------------
         # Main flow
         # -----------------------------------------------------------------------
 
-        $PKG      = "AMD.LemonadeServer"
         $expected = $env:LEMONADE_VERSION
 
         # Locate (or note absence of) the currently-installed lemonade-server.
@@ -265,7 +272,7 @@ runs:
         Write-Host "Expected version:  $expected"
 
         # Single equality rule: exact match → no-op; anything else → reconcile.
-        # This catches ahead runners (WinGet auto-update drift) as well as behind,
+        # This catches ahead runners (auto-update drift) as well as behind,
         # missing, or unparseable versions.
         $cmp = if ($installedVersion) { Compare-SemVer $installedVersion $expected } else { $null }
         if ($cmp -eq 0) {
@@ -295,23 +302,15 @@ runs:
             Write-Host "Post-reconcile version: $installedVersion"
         }
 
-        # Re-apply the WinGet pin to the expected version every run.
-        # This prevents future auto-update drift. Best-effort: the version
-        # is already correct at this point, so a pin failure is non-fatal.
-        Write-Host "Pinning $PKG to $expected via WinGet..."
-        winget pin add --id $PKG --version $expected 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "WARNING: winget pin add returned $LASTEXITCODE -- drift protection may be inactive, but the installed version is correct."
-        } else {
-            Write-Host "WinGet pin applied: $PKG @ $expected"
-        }
+        # Drift-prevention pinning can't run from this CI step -- winget is unavailable
+        # to the runner's SYSTEM service account; pinning is a runner-ops follow-up.
+        # The every-run reconcile is the safety net: a re-drifted runner is reset to
+        # the pinned version on the next run, before the pull.
 
         # Exact-match gate -- fail loud if the version is still wrong after reconcile.
         $finalCmp = Compare-SemVer $installedVersion $expected
         if ($null -eq $finalCmp -or $finalCmp -ne 0) {
             Write-Host "ERROR: Post-reconcile version ($installedVersion) does not match expected ($expected)."
-            Write-Host "       winget list output:"
-            winget list --id $PKG 2>&1 | ForEach-Object { Write-Host "         $_" }
             Write-Host "       Lemonade binaries on PATH:"
             Get-Command lemonade,lemonade-server,LemonadeServer -All -ErrorAction SilentlyContinue | ForEach-Object {
                 Write-Host "         - $($_.Source)"

--- a/.github/actions/install-lemonade/action.yml
+++ b/.github/actions/install-lemonade/action.yml
@@ -2,16 +2,20 @@
 # SPDX-License-Identifier: MIT
 
 name: 'Install Lemonade Server'
-description: 'Verifies Lemonade Server matches the GAIA-expected version, upgrading via the matching MSI when the runner is behind.'
+description: 'Pins the runner to exactly LEMONADE_VERSION, reconciling via WinGet when the installed version differs.'
 
 # This action checks the lemonade-server already installed on the runner
 # against the version GAIA expects (``src/gaia/version.LEMONADE_VERSION``).
-# When the runner is at an older version, it downloads the matching MSI
-# from the lemonade-sdk GitHub releases and installs it silently -- same
-# release URL the gaia init flow uses (``src/gaia/installer/lemonade_installer.py:GITHUB_RELEASE_BASE``).
-# This keeps the runner's model catalog (e.g. Gemma-4-E4B-it-GGUF, the
-# LemonadeManager default) aligned with what GAIA expects so preload/pull
-# operations don't 422 with "model_name not registered".
+# If the runner has any version other than the expected one (ahead, behind,
+# missing, or unparseable), it reconciles via WinGet:
+#   1. Remove any gating WinGet pin (so the install target version is not blocked).
+#   2. Uninstall the current copy (WiX in-place version change returns 1603).
+#   3. Remove any residual MSI-direct install via the Windows uninstall registry.
+#   4. winget install --version $expected.
+#   5. Re-apply a pin to $expected to block future auto-update drift.
+# Exact-match is then verified; the step fails loud if the version is wrong.
+# This keeps the runner's model catalog aligned with what GAIA ships to users
+# so preload/pull operations don't 422 with "model_name not registered".
 
 outputs:
   lemonade-path:
@@ -29,7 +33,7 @@ runs:
         echo "LEMONADE_VERSION=$lemonadeVersion" >> $env:GITHUB_ENV
         Write-Host "Expected Lemonade version: $lemonadeVersion"
 
-    - name: Verify and (if needed) Upgrade Lemonade Server
+    - name: Verify and (if needed) Reconcile Lemonade Server
       id: verify
       shell: powershell
       run: |
@@ -178,35 +182,77 @@ runs:
             return $va.CompareTo($vb)
         }
 
-        function Install-LemonadeMsi {
-            param([string]$Version)
-            $url = "https://github.com/lemonade-sdk/lemonade/releases/download/v$Version/lemonade.msi"
-            $dest = Join-Path $env:RUNNER_TEMP "lemonade-$Version.msi"
+        function Reconcile-LemonadeVersion {
+            # Uninstall the current copy (any version) then install exactly $expected.
+            # WiX MSI returns 1603 for in-place version changes, so uninstall-first
+            # is mandatory. The WinGet pin is removed first (a gating pin blocks the
+            # install) and re-applied at the end of the caller.
+            param([string]$Expected)
+            $PKG = "AMD.LemonadeServer"
 
-            Write-Host "Downloading Lemonade Server MSI from: $url"
-            try {
-                Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing -TimeoutSec 600
-            } catch {
-                Write-Host "ERROR: MSI download failed: $_"
-                throw
+            # winget is required; no MSI fallback (fail loud so the runner is fixed).
+            if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+                Write-Host "ERROR: winget not found on this runner; cannot enforce pinned Lemonade $Expected. Install App Installer/winget on the runner."
+                exit 1
             }
 
-            Write-Host "Running silent MSI install (msiexec /i $dest /quiet /norestart)..."
-            $msi = Start-Process -FilePath "msiexec.exe" `
-                -ArgumentList "/i", $dest, "/quiet", "/norestart", "/L*v", "$env:RUNNER_TEMP\lemonade-msi.log" `
-                -PassThru -Wait
-            Write-Host "msiexec exit code: $($msi.ExitCode)"
-            if ($msi.ExitCode -ne 0) {
-                Write-Host "===== MSI install log (tail) ====="
-                Get-Content "$env:RUNNER_TEMP\lemonade-msi.log" -Tail 80 -ErrorAction SilentlyContinue
-                Write-Host "==================================="
-                throw "MSI install failed with exit code $($msi.ExitCode). See log above."
+            # Remove any gating pin -- a pinned version blocks ``winget install --version``.
+            Write-Host "Removing WinGet pin for $PKG (best-effort)..."
+            winget pin remove --id $PKG 2>&1 | Out-Null
+
+            # Uninstall the currently installed copy via WinGet.
+            Write-Host "Uninstalling $PKG via WinGet (tolerate not-installed)..."
+            winget uninstall --id $PKG --silent 2>&1 | Out-Null
+
+            # Defensive: remove any residual MSI-direct install that WinGet doesn't
+            # track. Mirrors lemonade_installer.py find_product_code / _uninstall_windows.
+            Write-Host "Checking Windows uninstall registry for residual Lemonade entries..."
+            $uninstallRoots = @(
+                "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+                "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+                "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+            )
+            foreach ($root in $uninstallRoots) {
+                if (-not (Test-Path $root)) { continue }
+                Get-ChildItem $root -ErrorAction SilentlyContinue | ForEach-Object {
+                    try {
+                        $displayName = (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).DisplayName
+                        if ($displayName -and $displayName -match "(?i)lemonade") {
+                            $productCode = $_.PSChildName
+                            Write-Host "Found residual registry entry: '$displayName' ($productCode) -- removing via msiexec..."
+                            $r = Start-Process -FilePath "msiexec.exe" `
+                                -ArgumentList "/x", $productCode, "/qn", "/norestart" `
+                                -PassThru -Wait -ErrorAction SilentlyContinue
+                            if ($r) {
+                                Write-Host "msiexec /x exit code: $($r.ExitCode)"
+                            }
+                        }
+                    } catch {
+                        # Tolerate individual key read errors.
+                    }
+                }
             }
-            Write-Host "MSI install completed."
+
+            # Install exactly the pinned version.
+            Write-Host "Installing $PKG version $Expected via WinGet..."
+            winget install --id $PKG --version $Expected --silent --accept-package-agreements --accept-source-agreements
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "ERROR: winget install $PKG --version $Expected failed with exit code $LASTEXITCODE."
+                Write-Host "       Check that version $Expected is available: winget show $PKG --versions"
+                exit 1
+            }
+            Write-Host "WinGet install completed."
         }
 
+        # -----------------------------------------------------------------------
+        # Main flow
+        # -----------------------------------------------------------------------
+
+        $PKG      = "AMD.LemonadeServer"
+        $expected = $env:LEMONADE_VERSION
+
         # Locate (or note absence of) the currently-installed lemonade-server.
-        $lemonadePath = Find-LemonadeServer
+        $lemonadePath     = Find-LemonadeServer
         $installedVersion = $null
         if ($lemonadePath) {
             $installedVersion = Get-LemonadeVersion -LemonadeExe $lemonadePath
@@ -214,78 +260,75 @@ runs:
             Write-Host "lemonade-server not found on this runner."
         }
 
-        $expectedVersion = $env:LEMONADE_VERSION
         Write-Host ""
         Write-Host "Installed version: $installedVersion"
-        Write-Host "Expected version:  $expectedVersion"
+        Write-Host "Expected version:  $expected"
 
-        # Decide whether to upgrade. We upgrade only when the runner is
-        # strictly behind the expected version. If the runner is ahead
-        # (someone manually installed a newer one), we leave it alone
-        # rather than downgrading.
-        $needsInstall = $false
-        if (-not $installedVersion) {
-            Write-Host "No existing install detected -- will install v$expectedVersion."
-            $needsInstall = $true
+        # Single equality rule: exact match → no-op; anything else → reconcile.
+        # This catches ahead runners (WinGet auto-update drift) as well as behind,
+        # missing, or unparseable versions.
+        $cmp = if ($installedVersion) { Compare-SemVer $installedVersion $expected } else { $null }
+        if ($cmp -eq 0) {
+            Write-Host "Runner version matches expected. No reconcile needed."
         } else {
-            $cmp = Compare-SemVer -A $installedVersion -B $expectedVersion
-            if ($null -eq $cmp) {
-                Write-Host "Could not parse versions for comparison; reinstalling v$expectedVersion to be safe."
-                $needsInstall = $true
-            } elseif ($cmp -lt 0) {
-                Write-Host "Runner is behind expected version -- upgrading to v$expectedVersion."
-                $needsInstall = $true
-            } elseif ($cmp -gt 0) {
-                Write-Host "Runner is AHEAD of expected version. Leaving as-is."
+            if ($installedVersion) {
+                Write-Host "Runner version ($installedVersion) differs from expected ($expected) -- reconciling to exactly $expected."
             } else {
-                Write-Host "Runner version matches expected. No install needed."
+                Write-Host "No existing install detected -- installing v$expected."
             }
-        }
 
-        if ($needsInstall) {
-            Install-LemonadeMsi -Version $expectedVersion
+            Reconcile-LemonadeVersion -Expected $expected
 
-            # Refresh PATH from registry so the MSI's freshly-added
-            # ``Program Files\Lemonade Server\bin`` shows up in this shell
-            # the same way the gaia init flow's
-            # ``LemonadeInstaller.refresh_path_from_registry`` does after
-            # an MSI install.
+            # Refresh PATH from registry so the freshly installed binaries
+            # in ``Program Files\Lemonade Server\bin`` show up in this shell.
             Refresh-EnvPath
 
-            # Re-locate after install. ``Find-LemonadeServer`` now searches
-            # the well-known install dirs first so the new v$expectedVersion
-            # exe in ``Program Files\Lemonade Server\bin`` wins over any
-            # stale per-user .bat that's still on the shell's PATH.
+            # Re-locate and re-detect after reconcile.
             $lemonadePath = Find-LemonadeServer
             if (-not $lemonadePath) {
-                Write-Host "ERROR: lemonade-server still not found on PATH after install."
+                Write-Host "ERROR: lemonade-server still not found on PATH after reconcile."
+                Write-Host "       Run: Get-Command lemonade-server,LemonadeServer -All"
                 exit 1
             }
             $installedVersion = Get-LemonadeVersion -LemonadeExe $lemonadePath
             Write-Host ""
-            Write-Host "Post-install version: $installedVersion"
-            $postCmp = Compare-SemVer -A $installedVersion -B $expectedVersion
-            if ($null -eq $postCmp -or $postCmp -lt 0) {
-                # Hard-fail: the MSI ran (exit 0) but we can't reach the
-                # expected version. Continuing would let downstream tests
-                # blow up on "model_name=... not registered" again with no
-                # signal pointing back to the install step.
-                Write-Host "ERROR: Post-install version ($installedVersion) is below expected ($expectedVersion)."
-                Write-Host "       MSI install may have failed silently or installed to an unexpected location."
-                Write-Host "       Run candidates seen on PATH:"
-                Get-Command lemonade-server -All -ErrorAction SilentlyContinue | ForEach-Object {
-                    Write-Host "         - $($_.Source)"
-                }
-                exit 1
-            } elseif ($postCmp -gt 0) {
-                Write-Host "WARNING: Post-install version ($installedVersion) is newer than expected ($expectedVersion); leaving as-is."
-            } else {
-                Write-Host "Post-install version matches expected."
+            Write-Host "Post-reconcile version: $installedVersion"
+        }
+
+        # Re-apply the WinGet pin to the expected version every run.
+        # This prevents future auto-update drift. Best-effort: the version
+        # is already correct at this point, so a pin failure is non-fatal.
+        Write-Host "Pinning $PKG to $expected via WinGet..."
+        winget pin add --id $PKG --version $expected 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "WARNING: winget pin add returned $LASTEXITCODE -- drift protection may be inactive, but the installed version is correct."
+        } else {
+            Write-Host "WinGet pin applied: $PKG @ $expected"
+        }
+
+        # Exact-match gate -- fail loud if the version is still wrong after reconcile.
+        $finalCmp = Compare-SemVer $installedVersion $expected
+        if ($null -eq $finalCmp -or $finalCmp -ne 0) {
+            Write-Host "ERROR: Post-reconcile version ($installedVersion) does not match expected ($expected)."
+            Write-Host "       winget list output:"
+            winget list --id $PKG 2>&1 | ForEach-Object { Write-Host "         $_" }
+            Write-Host "       Lemonade binaries on PATH:"
+            Get-Command lemonade,lemonade-server,LemonadeServer -All -ErrorAction SilentlyContinue | ForEach-Object {
+                Write-Host "         - $($_.Source)"
             }
+            exit 1
+        }
+
+        # Warn if more than one distinct Lemonade binary resolves on PATH (coexistence smell).
+        $allBins = Get-Command lemonade,lemonade-server,LemonadeServer -All -ErrorAction SilentlyContinue
+        $distinctPaths = $allBins | Select-Object -ExpandProperty Source -Unique
+        if (($distinctPaths | Measure-Object).Count -gt 1) {
+            Write-Host "WARNING: Multiple Lemonade binaries found on PATH -- coexistence may cause unpredictable behaviour:"
+            $distinctPaths | ForEach-Object { Write-Host "  $_" }
         }
 
         if (-not $lemonadePath) {
-            Write-Host "ERROR: lemonade-server not available after verify/install step."
+            Write-Host "ERROR: lemonade-server not available after verify/reconcile step."
             exit 1
         }
 
@@ -295,3 +338,4 @@ runs:
 
         Write-Host ""
         Write-Host "Lemonade Server ready at: $lemonadePath"
+        Write-Host "Version: $installedVersion"


### PR DESCRIPTION
Closes #1567

## Why this matters
CI is broken pipeline-wide: the self-hosted Windows runners auto-update Lemonade out-of-band (WinGet), drifting off the pinned `LEMONADE_VERSION` (`10.2.0`). On the drifted version the integration jobs' `lemonade pull` hangs until the job timeout, blocking `main`, the release branch, and **every open PR**. Before: an *ahead* runner was left as-is, so the drift stuck. After: [`install-lemonade`](.github/actions/install-lemonade/action.yml) reconciles the runner to **exactly `LEMONADE_VERSION`** on every run (uninstall + `winget install --version` — a WiX MSI can't change version in place) and re-applies a WinGet pin to block future drift; it **fails loud** if the version can't be set.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/actions/install-lemonade/action.yml'))"` parses
- [ ] `test_lemonade_server` (auto-runs — it watches `.github/actions/install-lemonade/**`) green on this PR
- [ ] Dispatched on this branch, the 3 previously-hanging jobs go green on reconciled (10.2.0) runners: `Example Agents Integration Tests (stx)`, `Test Agent SDK on Windows`, `Test GAIA CLI on Windows`
- [ ] `test_rag` / `test_embeddings` stay green

## Risk to watch (the dispatched runs confirm this)
The reconcile uses **WinGet**, validated on a Windows dev box as an interactive admin. The CI runners execute as a **service/SYSTEM account**, where WinGet availability is less certain. If a dispatched run fails at the `install-lemonade` step with "winget not found", the fix needs a WinGet→MSI fallback (the prior MSI installer path). Validated WinGet specifics: package `AMD.LemonadeServer`; **uninstall-first mandatory** (in-place version change → MSI 1603); a *gating* pin blocks a version-change install, so the action removes the pin before reconciling and re-adds it after (which is also why a future `LEMONADE_VERSION` bump is never blocked).