### PR TITLE
fix(ci): publish agent wheels via OIDC trusted publishing (#1568)

### DIFF
--- a/.github/workflows/publish_agents.yml
+++ b/.github/workflows/publish_agents.yml
@@ -20,11 +20,14 @@
 # not change — that is PyPI's native version immutability, not custom overwrite
 # logic (issue #1179).
 #
-# Secret: PYPI_API_TOKEN — a PyPI API token (account- or project-scoped) with
-# upload rights to every gaia-agent-* project. Store it as a *repository* (or
-# org) secret so the matrix publish jobs can read it; the manual gate is the
-# separate "publish" environment on approve-publish. The publisher CLI's local
-# env var is PYPI_TOKEN; the CI secret is intentionally separate.
+# Auth: OIDC trusted publishing — NO stored token (matches publish.yml's
+# publish-pypi job for the core amd-gaia wheel). The publish job requests an
+# id-token and runs in the "pypi" environment; each gaia-agent-* PyPI project
+# authorizes this repo+workflow+environment via a trusted publisher. Because
+# these projects don't exist on PyPI yet, register PyPI *pending* publishers
+# (project gaia-agent-<id>, owner amd, repo gaia, workflow publish_agents.yml,
+# environment pypi) — the first run creates each project. The manual gate stays
+# on the separate "publish" environment on approve-publish.
 
 name: Publish Agent Wheels (PyPI)
 
@@ -143,6 +146,15 @@ jobs:
     needs: [discover, approve-publish]
     if: startsWith(github.ref, 'refs/tags/v') && !cancelled() && needs.approve-publish.result == 'success'
     runs-on: ubuntu-latest
+    # OIDC trusted publishing: the action mints a short-lived id-token PyPI
+    # exchanges for an upload token. Without id-token: write the action falls
+    # back to (missing) password auth and dies with a misleading "trusted
+    # publishing exchange failure" — see issue #1568.
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
@@ -158,4 +170,3 @@ jobs:
           # PyPI's native version immutability: an unchanged agent version is a
           # no-op, not a failure (issue #1179 — "no overwrite logic").
           skip-existing: true
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Why this matters

The v0.20.1 release shipped **zero** agent wheels to PyPI — `pip install gaia-agent-fileio` (and the other 11) 404s — because the Publish Agent Wheels workflow authenticated with `password: secrets.PYPI_API_TOKEN`, a secret that **does not exist** in this repo (audited: no PyPI token at repo, org, or environment scope). When the password resolves to empty, `gh-action-pypi-publish` silently falls back to OIDC trusted publishing and then dies with a misleading `trusted publishing exchange failure` because the job had no `id-token: write`. This change makes agent wheels publish the same way the core `amd-gaia` wheel already does — OIDC trusted publishing, no stored token — so a release tag actually pushes the wheels.

Fixes the publish half of #1568.

> [!IMPORTANT]
> **Maintainer action required before this works.** The 12 `gaia-agent-*` projects don't exist on PyPI yet, so register a [PyPI **pending** trusted publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) for each: project `gaia-agent-<id>`, owner `amd`, repo `gaia`, workflow `publish_agents.yml`, environment `pypi`. Until then this job will fail — by design, it no longer falls back to a phantom token.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish_agents.yml'))"` parses
- [x] Publish job now sets `environment: pypi` + `permissions: id-token: write` and no `password:`, matching `publish.yml`'s `publish-pypi`
- [ ] After PyPI pending publishers are registered, a `v*` tag publishes all 12 wheels (or `skip-existing` no-ops unchanged versions); `pip install gaia-agent-fileio` succeeds
