### PR TITLE
fix(ci): pause agent PyPI publishing until Agent Hub is ready (+ OIDC test fix)

### DIFF
--- a/.github/workflows/publish_agents.yml
+++ b/.github/workflows/publish_agents.yml
@@ -32,13 +32,14 @@
 name: Publish Agent Wheels (PyPI)
 
 on:
-  # Tag pushes trigger the publish path. No `paths:` filter here — a release tag
-  # must always run even when the tagged commit didn't touch an agent (GitHub
-  # applies push `paths` filters to tag pushes too, which would skip publishing).
-  push:
-    tags:
-      - 'v*'
-  # PRs get the build/twine-check only (the publish jobs are gated on a v* tag).
+  # PUBLISHING PAUSED (#1179): agent PyPI publishing is disabled while the Agent
+  # Hub distribution design is being finalized. The release-tag trigger is
+  # intentionally removed so a `v*` tag no longer fires the publish path, and the
+  # approve/publish jobs are additionally hard-gated below. To re-enable, restore
+  # the `push: tags: ['v*']` trigger here and drop the `false &&` guards on the
+  # approve-publish and publish jobs.
+  #
+  # PRs still get the build/twine-check so broken agent wheels are caught in review.
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -134,7 +135,9 @@ jobs:
   approve-publish:
     name: Approve Publishing
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v') && !cancelled() && needs.build.result == 'success'
+    # Publishing paused (#1179) — `false &&` hard-skips this job. Remove it (and
+    # restore the tag trigger above) to re-enable.
+    if: false && startsWith(github.ref, 'refs/tags/v') && !cancelled() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     environment: publish
     steps:
@@ -144,7 +147,9 @@ jobs:
   publish:
     name: Publish ${{ matrix.dist }}
     needs: [discover, approve-publish]
-    if: startsWith(github.ref, 'refs/tags/v') && !cancelled() && needs.approve-publish.result == 'success'
+    # Publishing paused (#1179) — `false &&` hard-skips this job. Remove it (and
+    # restore the tag trigger above) to re-enable.
+    if: false && startsWith(github.ref, 'refs/tags/v') && !cancelled() && needs.approve-publish.result == 'success'
     runs-on: ubuntu-latest
     # OIDC trusted publishing: the action mints a short-lived id-token PyPI
     # exchanges for an upload token. Without id-token: write the action falls

--- a/tests/unit/test_agent_pypi_publish.py
+++ b/tests/unit/test_agent_pypi_publish.py
@@ -83,11 +83,13 @@ def test_pyproject_declares_gaia_agent_entry_point(packages):
 
 
 def test_publish_workflow_exists_and_uses_pypi_action():
-    """The CI workflow publishes via gh-action-pypi-publish with the token secret."""
+    """The CI workflow publishes via gh-action-pypi-publish using OIDC."""
     assert WORKFLOW.exists(), "publish_agents.yml workflow is missing"
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "pypa/gh-action-pypi-publish" in text
-    assert "secrets.PYPI_API_TOKEN" in text
+    # OIDC trusted publishing — no stored token (#1570). The action mints a
+    # short-lived id-token PyPI exchanges for an upload token.
+    assert "id-token: write" in text
     # PyPI-native immutability rather than custom overwrite logic (#1179).
     assert "skip-existing: true" in text
     # Matrix is generated from the helper, not a hand-maintained second list.


### PR DESCRIPTION
## Why this matters

The agent-wheel publish path (#1179) is armed but not ready: a `v*` release tag would fire the publish job — behind a manual gate, against `gaia-agent-*` PyPI projects that don't exist yet — before the Agent Hub distribution design is settled. This pauses publishing until we're ready, while keeping the per-PR wheel build + `twine check` so agent wheels stay well-formed.

It also unblocks CI repo-wide: the OIDC migration (#1570) left `test_agent_pypi_publish` asserting a stored token the workflow no longer uses, turning `main`'s Unit Tests red for every PR touching `src/` or `tests/`. This PR fixes that assertion (OIDC) **and** disables the premature publish path.

**How publishing is disabled** (both clearly commented for one-line re-enable):
- the `push: tags: ['v*']` trigger is removed, so a release tag no longer fires the workflow;
- the `approve-publish` and `publish` jobs are hard-gated with `if: false && …`.

Re-enable = restore the tag trigger + drop the two `false &&` guards.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish_agents.yml'))"` parses
- [x] `pytest tests/unit/test_agent_pypi_publish.py` → 10 passed (OIDC assertions hold against the disabled workflow; no skips)
- [ ] Unit Tests green on this PR
- [ ] Confirm the workflow shows no `publish`/`approve-publish` jobs running on a dispatched run