### PR TITLE
docs(emr): correct VLM execution claim — Qwen3-VL runs on iGPU/Vulkan, not NPU

### DIFF
--- a/docs/playbooks/emr-agent/part-1-getting-started.mdx
+++ b/docs/playbooks/emr-agent/part-1-getting-started.mdx
@@ -43,7 +43,7 @@ graph TD
     E[/"New Intake Form"/] --> C
     C --> F["File Created Event"]
     F --> G["VLM Extraction"]
-    G --> H[("VLM Model<br/>on NPU")]
+    G --> H[("VLM Model<br/>on iGPU (Vulkan)")]
     H --> I["Structured JSON"]
     I --> D
     D --> J[("SQLite DB")]
@@ -61,7 +61,7 @@ graph TD
 **Flow:**
 1. New form dropped in watched folder
 2. FileWatcherMixin triggers callback → `_on_file_created()`
-3. VLM extracts patient data (running on NPU for speed)
+3. VLM extracts patient data (Qwen3-VL GGUF runs on the iGPU via llama.cpp/Vulkan)
 4. JSON parsed and validated
 5. DatabaseMixin stores structured record in SQLite
 6. Agent can now query patients via natural language
@@ -368,7 +368,7 @@ Add VLM to extract patient data from images.
 process_intake_form("patient1.jpg")
   → Read image file as bytes
   → Send to VLM with extraction prompt
-  → VLM processes image (running on NPU for speed)
+  → VLM processes image (Qwen3-VL GGUF runs on the iGPU via llama.cpp/Vulkan)
   → Returns JSON string: {"first_name": "John", ...}
   → Parse JSON to dict
   → Insert into database

--- a/docs/playbooks/emr-agent/part-3-architecture.mdx
+++ b/docs/playbooks/emr-agent/part-3-architecture.mdx
@@ -50,7 +50,7 @@ flowchart TD
 | Component | Technology | Purpose |
 |-----------|------------|---------|
 | **FileWatcher** | watchdog library | Monitors directory for new intake forms |
-| **VLM Extraction** | Qwen3-VL on NPU | Extracts patient data from images/PDFs |
+| **VLM Extraction** | Qwen3-VL on iGPU (Vulkan) | Extracts patient data from images/PDFs |
 | **SQLite DB** | sqlite3 | Local storage for patients, alerts, sessions |
 | **FastAPI Server** | FastAPI + uvicorn | REST API + SSE events for real-time updates |
 | **React Dashboard** | React + Vite | Four views: Dashboard, Patients, Chat, Settings |
@@ -182,7 +182,7 @@ The agent follows a 7-step pipeline from file detection to database storage.
   </Step>
 
   <Step title="VLM Extraction">
-    **Model:** Qwen3-VL-4B-Instruct running on NPU/iGPU
+    **Model:** Qwen3-VL-4B-Instruct (GGUF) running on the iGPU via llama.cpp/Vulkan
 
     ```python
     EXTRACTION_PROMPT = """Extract patient data from this medical intake form.
@@ -481,7 +481,7 @@ classDiagram
 
 ### Performance
 
-- **VLM on NPU** - Ryzen AI accelerates inference
+- **VLM on iGPU** - llama.cpp/Vulkan accelerates inference
 - **Lazy VLM loading** - Model loaded only when first file arrives
 - **Connection pooling** - DatabaseMixin reuses SQLite connections
 


### PR DESCRIPTION
## Why this matters

The EMR playbook told readers the vision model runs on the **NPU**, but it doesn't — the Qwen3-VL GGUF is served via llama.cpp on the **iGPU (Vulkan backend)**. Anyone using the playbook to reason about performance, hardware requirements, or where extraction actually executes was being misled. The agent code confirms the iGPU path: it carries a Vulkan UPSCALE workaround for non-square images (`hub/agents/python/emr/gaia_agent_emr/agent.py:988,1033`).

This corrects the VLM-specific execution claims (architecture diagram node, the two flow descriptions, the component table, and the performance note) to say iGPU/Vulkan. General "Ryzen AI (NPU/iGPU acceleration)" platform statements are left as-is — those are accurate.

Fixes #268.

## Test plan

- [ ] `grep -rn 'on NPU' docs/playbooks/emr-agent/` returns nothing (only accurate platform-level NPU/iGPU mentions remain)
- [ ] Mintlify renders the three EMR playbook pages without MDX errors