### PR TITLE
docs(ci): trim verbose comments on the Lemonade backend-cache cleanup

### DIFF
--- a/.github/actions/install-lemonade/action.yml
+++ b/.github/actions/install-lemonade/action.yml
@@ -286,25 +286,16 @@ runs:
 
             Reconcile-LemonadeVersion -Expected $expected
 
-            # An MSI version change swaps the server exe but leaves the
-            # versioned llama.cpp backend cached under ``%USERPROFILE%\.cache\
-            # lemonade\bin`` (lemonade ``path_utils.cpp`` get_cache_dir /
-            # get_downloaded_bin_dir). A *downgraded* server then can't spawn
-            # the stale newer backend -- the load fails with ``llama-server
-            # failed to start``. Wipe the backend cache so the pinned version
-            # reinstalls a matching one. GGUF weights live in the separate
-            # HuggingFace hub cache (``%USERPROFILE%\.cache\huggingface\hub``)
-            # and are untouched, so only the small backend is re-fetched, never
-            # the models. Runs whenever the action reconciles (a drifted *or*
-            # missing install); a version-matched runner skips this block
-            # entirely and pays nothing.
+            # A reconcile swaps the server exe but leaves the versioned llama.cpp
+            # backend cached; a downgraded server can't spawn the stale one
+            # ("llama-server failed to start"), so wipe it for a matching reinstall.
+            # Models live in the HF hub cache, not here, so only the backend re-downloads.
             $cacheRoots = @(
                 "$env:USERPROFILE\.cache\lemonade",
                 "C:\windows\system32\config\systemprofile\.cache\lemonade"
             )
             if ($env:LEMONADE_CACHE_DIR) { $cacheRoots += $env:LEMONADE_CACHE_DIR }
-            # Case-insensitive dedup (Windows paths) while preserving original
-            # casing for the log line -- Select-Object -Unique alone is case-sensitive.
+            # Case-insensitive dedup (Windows paths); Select-Object -Unique is case-sensitive.
             $seenRoots = @{}
             foreach ($root in ($cacheRoots | Where-Object { $_ })) {
                 $rootKey = $root.ToLowerInvariant()
@@ -313,10 +304,7 @@ runs:
                 $backendDir = Join-Path $root "bin"
                 if (Test-Path $backendDir) {
                     Write-Host "Reconcile: clearing stale llama.cpp backend cache at $backendDir"
-                    # Fail loud: a swallowed wipe (e.g. a DLL locked by a stray
-                    # llama-server) would leave the stale backend in place and
-                    # the next load would fail with the same "llama-server
-                    # failed to start" -- with no signal pointing back here.
+                    # Fail loud: a swallowed wipe leaves the stale backend and the load fails the same opaque way.
                     try {
                         Remove-Item $backendDir -Recurse -Force -ErrorAction Stop
                     } catch {

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -98,15 +98,6 @@ jobs:
                 throw "Server failed to start"
             }
 
-            # Stale-backend cleanup on a version change is handled by the
-            # install-lemonade action's reconcile step (it clears the versioned
-            # llama.cpp backend under %USERPROFILE%\.cache\lemonade\bin so a
-            # downgraded server doesn't fail with "llama-server failed to
-            # start"). The previous model-cache wipe here targeted a v9-era path
-            # (%LOCALAPPDATA%\lemonade-server\models) that doesn't exist in
-            # v10 -- GGUF weights live in the HuggingFace hub cache -- so it was
-            # a silent no-op and has been removed.
-
             # Pull embedding model (actual model used in tests)
             Write-Host "`n=== Pulling Embedding Model ==="
             Write-Host "Pulling nomic-embed-text-v2-moe-GGUF..."


### PR DESCRIPTION
## Why this matters

Follow-up to #1581. That PR landed the backend-cache cleanup with comments that over-explain — most notably a tombstone comment in `test_embeddings.yml` describing a step that was *removed* in the same PR, which reads as confusing dead-history to anyone opening the file now. This trims the comments to tight one-line *why*s per the repo's comment guidance (explain the non-obvious invariant, not the forensics). No behavior change — comment-only.

(My trim was ready before #1581 merged but the PR head was stuck at a stale sha, so the squash merged the pre-trim state. This re-applies just the trim.)

## Test plan

- [ ] `git diff main` is comment-only (6 insertions / 27 deletions across the two files).
- [ ] Both YAML files still parse; the backend-cleanup logic is byte-for-byte unchanged.