### PR TITLE
fix(webui): show file search scope

### DIFF
--- a/src/gaia/apps/webui/src/components/FileBrowser.css
+++ b/src/gaia/apps/webui/src/components/FileBrowser.css
@@ -200,9 +200,29 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 12px;
     font-size: 12px;
     color: var(--text-secondary);
     padding: 4px 0;
+}
+
+.fb-search-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+}
+
+.fb-search-scope {
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fb-search-scope code {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
 }
 
 .fb-back-btn {

--- a/src/gaia/apps/webui/src/components/FileBrowser.tsx
+++ b/src/gaia/apps/webui/src/components/FileBrowser.tsx
@@ -48,6 +48,12 @@ function formatDate(iso: string): string {
     return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: d.getFullYear() !== now.getFullYear() ? 'numeric' : undefined });
 }
 
+function formatSearchScope(locations: string[]): string {
+    if (locations.length === 0) return '';
+    const [first, ...rest] = locations;
+    return rest.length > 0 ? `${first} (+${rest.length} more)` : first;
+}
+
 // Quick link icon mapping
 function getQuickLinkIcon(icon: string) {
     switch (icon) {
@@ -174,6 +180,7 @@ export function FileBrowser() {
     // Search state
     const [searchQuery, setSearchQuery] = useState('');
     const [searchResults, setSearchResults] = useState<any[] | null>(null);
+    const [searchedLocations, setSearchedLocations] = useState<string[]>([]);
     const [isSearching, setIsSearching] = useState(false);
     const [typeFilter, setTypeFilter] = useState('');
 
@@ -197,6 +204,7 @@ export function FileBrowser() {
         setError(null);
         setSearchResults(null);
         setSearchQuery('');
+        setSearchedLocations([]);
         try {
             const data: BrowseResponse = await api.browseFiles(path);
             setCurrentPath(data.current_path);
@@ -228,6 +236,7 @@ export function FileBrowser() {
     const handleSearch = useCallback(async () => {
         if (!searchQuery.trim()) {
             setSearchResults(null);
+            setSearchedLocations([]);
             return;
         }
         setIsSearching(true);
@@ -235,6 +244,7 @@ export function FileBrowser() {
         try {
             const data = await api.searchFiles(searchQuery.trim(), typeFilter || undefined, 30);
             setSearchResults(data.results);
+            setSearchedLocations(data.searched_locations ?? []);
             log.ui.info(`Search "${searchQuery}": ${data.total} results`);
         } catch (err) {
             const msg = err instanceof Error ? err.message : 'Search failed';
@@ -392,6 +402,7 @@ export function FileBrowser() {
         label: seg,
         path: pathSegments.slice(0, i + 1).join('/') + (i === 0 && seg.includes(':') ? '/' : ''),
     }));
+    const searchScope = formatSearchScope(searchedLocations);
 
     // Items to display: search results or browse entries
     const displayItems = searchResults
@@ -448,7 +459,7 @@ export function FileBrowser() {
                             {searchQuery && (
                                 <button
                                     className="fb-search-clear"
-                                    onClick={() => { setSearchQuery(''); setSearchResults(null); }}
+                                    onClick={() => { setSearchQuery(''); setSearchResults(null); setSearchedLocations([]); }}
                                     aria-label="Clear search"
                                 >
                                     <X size={12} />
@@ -503,8 +514,18 @@ export function FileBrowser() {
                     {/* Search results header */}
                     {searchResults && (
                         <div className="fb-search-header">
-                            <span>Found {searchResults.length} result(s) for "{searchQuery}"</span>
-                            <button className="fb-back-btn" onClick={() => { setSearchResults(null); setSearchQuery(''); }}>
+                            <div className="fb-search-summary">
+                                <span>Found {searchResults.length} result(s) for "{searchQuery}"</span>
+                                {searchScope && (
+                                    <span
+                                        className="fb-search-scope"
+                                        title={searchedLocations.join('\n')}
+                                    >
+                                        Searching in: <code>{searchScope}</code>
+                                    </span>
+                                )}
+                            </div>
+                            <button className="fb-back-btn" onClick={() => { setSearchResults(null); setSearchQuery(''); setSearchedLocations([]); }}>
                                 Back to browsing
                             </button>
                         </div>

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -770,6 +770,7 @@ export async function searchFiles(query: string, fileTypes?: string, maxResults?
     results: Array<{ name: string; path: string; size: number; size_display: string; extension: string; modified: string; directory: string }>;
     total: number;
     query: string;
+    searched_locations: string[];
 }> {
     const params = new URLSearchParams({ query });
     if (fileTypes) params.set('file_types', fileTypes);


### PR DESCRIPTION
## Summary
- show the searched filesystem scope in the file browser search results header
- use the `searched_locations` already returned by the file search API
- clear the scope label when search results are cleared or browsing resumes

Closes #581

## Testing
- `npm run build`