### PR TITLE
fix(connectors): persistent event-loop bridge to stop Email Triage UI hang (#1579)

### DIFF
--- a/src/gaia/connectors/_loop.py
+++ b/src/gaia/connectors/_loop.py
@@ -1,0 +1,174 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Persistent asyncio event-loop thread for the sync→async connector bridge.
+
+Why this module exists
+----------------------
+Sync agent tool bodies (``Agent.process_query`` runs in a ThreadPoolExecutor
+worker) need to call async token-refresh code.  The previous approach was
+``asyncio.run(coro)`` — a new event loop per call.  That caused two coupled
+defects:
+
+- **Cross-loop Lock error (platform-independent):** an ``asyncio.Lock``
+  created during one ``asyncio.run`` is bound to that loop.  A subsequent
+  ``asyncio.run`` creates a *different* loop; attempting to use the Lock in
+  it raises ``RuntimeError: <Lock> is bound to a different event loop``
+  (Python ≤ 3.11; fixed in 3.12 but still a latent risk).
+
+- **Windows ProactorEventLoop teardown hang:** repeated loop create/destroy
+  cycles block in the ProactorEventLoop's internal teardown on Windows,
+  causing the email-triage agent to hang indefinitely after ~21 token
+  refreshes (#1579).
+
+The fix: one lazily-initialised daemon thread runs a single asyncio event
+loop for the lifetime of the process.  All connector async work submits to
+that loop via ``asyncio.run_coroutine_threadsafe``.
+
+Contextvar propagation
+----------------------
+``asyncio.run_coroutine_threadsafe`` does NOT inherit the caller's
+contextvars — the coroutine starts with an empty context on the loop thread.
+``run_sync`` explicitly captures ``contextvars.copy_context()`` at submit
+time and runs the coroutine under it, preserving the agent-id contextvar set
+by the agent runtime.
+
+Deadlock guard
+--------------
+Calling ``.result()`` from the loop thread's own thread would block the loop
+permanently.  ``run_sync`` raises ``RuntimeError`` if it detects it is being
+called from the loop thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import logging
+import threading
+import time
+from typing import Any, Coroutine, TypeVar
+
+from gaia.connectors.errors import ConnectorsError
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+# Default timeout for run_sync calls (seconds).  30 s is generous for a
+# token-endpoint round-trip (httpx timeout is 10 s inside _refresh_token)
+# while still surfacing a hang within a reasonable debugging window.
+_DEFAULT_TIMEOUT: float = 30.0
+
+# Module-level singleton state — protected by _init_lock.
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_thread: threading.Thread | None = None
+_init_lock = threading.Lock()
+
+
+def _get_persistent_loop() -> asyncio.AbstractEventLoop:
+    """Return the singleton persistent event loop, starting it if necessary."""
+    global _loop, _loop_thread
+
+    # Fast path (no lock needed once initialised).
+    if _loop is not None and _loop.is_running():
+        return _loop
+
+    with _init_lock:
+        # Double-checked locking: re-test under the lock.
+        if _loop is not None and _loop.is_running():
+            return _loop
+
+        new_loop = asyncio.new_event_loop()
+
+        def _run_loop() -> None:
+            asyncio.set_event_loop(new_loop)
+            new_loop.run_forever()
+
+        t = threading.Thread(target=_run_loop, name="gaia-connectors-loop", daemon=True)
+        t.start()
+
+        # Wait until the loop is actually running before returning it.
+        deadline = 5.0
+        start = time.monotonic()
+        while not new_loop.is_running():
+            if time.monotonic() - start > deadline:
+                raise RuntimeError(
+                    "gaia-connectors-loop thread did not start within "
+                    f"{deadline}s. This is a bug — please report it."
+                )
+            time.sleep(0.001)
+
+        _loop = new_loop
+        _loop_thread = t
+        logger.debug("gaia-connectors persistent loop started (thread=%s)", t.name)
+
+    return _loop
+
+
+async def _ctx_wrap(ctx: contextvars.Context, coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run *coro* under the captured caller context.
+
+    Copies each contextvar from *ctx* into the running task's context so that
+    async code on the loop thread sees the same agent-id (and any other
+    contextvars) as the caller thread that submitted the work.
+    """
+    tokens = []
+    for var, value in ctx.items():
+        tokens.append(var.set(value))
+    try:
+        return await coro
+    finally:
+        for tok in tokens:
+            tok.var.reset(tok)
+
+
+def run_sync(
+    coro: Coroutine[Any, Any, _T],
+    *,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> _T:
+    """Submit *coro* to the persistent loop and block until it completes.
+
+    Parameters
+    ----------
+    coro:
+        An awaitable coroutine created in the caller's thread.
+    timeout:
+        Maximum seconds to wait.  Raises ``ConnectorsError`` (actionable) if
+        the coroutine does not complete within this window.
+
+    Raises
+    ------
+    RuntimeError
+        If called from the persistent loop's own thread (deadlock guard).
+    ConnectorsError
+        If the coroutine does not complete within *timeout* seconds.
+    Any exception raised by *coro* propagates unchanged.
+    """
+    loop = _get_persistent_loop()
+
+    # Deadlock guard: .result() from the loop thread blocks the loop.
+    if threading.current_thread() is _loop_thread:
+        raise RuntimeError(
+            "run_sync() called from the gaia-connectors persistent loop thread. "
+            "This would deadlock — call 'await <coro>' directly from async code "
+            "running on this loop, or restructure to avoid re-entrancy."
+        )
+
+    # Capture the caller's contextvars so the coroutine on the loop thread
+    # sees the same agent-id contextvar as the calling worker thread.
+    ctx = contextvars.copy_context()
+
+    future = asyncio.run_coroutine_threadsafe(_ctx_wrap(ctx, coro), loop)
+
+    try:
+        return future.result(timeout=timeout)
+    except TimeoutError:
+        future.cancel()
+        raise ConnectorsError(
+            f"Connector async operation timed out after {timeout}s. "
+            "Check that the connector provider endpoint is reachable and "
+            "that no background operation is blocking the connectors loop. "
+            "See docs/sdk/infrastructure/connections.mdx."
+        )

--- a/src/gaia/connectors/_loop.py
+++ b/src/gaia/connectors/_loop.py
@@ -43,6 +43,7 @@ called from the loop thread.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import contextvars
 import logging
 import threading
@@ -164,7 +165,11 @@ def run_sync(
 
     try:
         return future.result(timeout=timeout)
-    except TimeoutError as e:
+    except concurrent.futures.TimeoutError as e:
+        # concurrent.futures.TimeoutError is a distinct class on Python 3.10;
+        # only an alias for builtins.TimeoutError on 3.11+. Catch it by its
+        # canonical name so the actionable error fires on every supported
+        # Python (GAIA targets >=3.10).
         future.cancel()
         raise ConnectorsError(
             f"Connector async operation timed out after {timeout}s. "

--- a/src/gaia/connectors/_loop.py
+++ b/src/gaia/connectors/_loop.py
@@ -47,7 +47,6 @@ import concurrent.futures
 import contextvars
 import logging
 import threading
-import time
 from typing import Any, Coroutine, TypeVar
 
 from gaia.connectors.errors import ConnectorsError
@@ -80,25 +79,29 @@ def _get_persistent_loop() -> asyncio.AbstractEventLoop:
         if _loop is not None and _loop.is_running():
             return _loop
 
+        # Re-init path (prior loop exists but stopped): we intentionally do
+        # NOT close/reclaim the old loop here. This is effectively unreachable
+        # today — the daemon loop only stops at process exit — so it is a
+        # latent-only branch, not a live resource leak.
+
         new_loop = asyncio.new_event_loop()
+        ready = threading.Event()
 
         def _run_loop() -> None:
             asyncio.set_event_loop(new_loop)
+            # Fires on the loop's first iteration, i.e. once run_forever is
+            # actually running — a clean handshake with no busy-wait.
+            new_loop.call_soon(ready.set)
             new_loop.run_forever()
 
         t = threading.Thread(target=_run_loop, name="gaia-connectors-loop", daemon=True)
         t.start()
 
-        # Wait until the loop is actually running before returning it.
-        deadline = 5.0
-        start = time.monotonic()
-        while not new_loop.is_running():
-            if time.monotonic() - start > deadline:
-                raise RuntimeError(
-                    "gaia-connectors-loop thread did not start within "
-                    f"{deadline}s. This is a bug — please report it."
-                )
-            time.sleep(0.001)
+        if not ready.wait(timeout=5.0):
+            raise RuntimeError(
+                "gaia-connectors-loop thread did not start within 5s. "
+                "This is a bug — please report it."
+            )
 
         _loop = new_loop
         _loop_thread = t
@@ -170,6 +173,10 @@ def run_sync(
         # only an alias for builtins.TimeoutError on 3.11+. Catch it by its
         # canonical name so the actionable error fires on every supported
         # Python (GAIA targets >=3.10).
+        # Best-effort cancel: run_coroutine_threadsafe's future cannot stop a
+        # coroutine already executing on the loop thread, so a truly-stuck op
+        # keeps running on the shared loop after we raise (bounded in practice
+        # by the inner httpx 10s timeout, well under the 30s default).
         future.cancel()
         raise ConnectorsError(
             f"Connector async operation timed out after {timeout}s. "

--- a/src/gaia/connectors/_loop.py
+++ b/src/gaia/connectors/_loop.py
@@ -164,11 +164,11 @@ def run_sync(
 
     try:
         return future.result(timeout=timeout)
-    except TimeoutError:
+    except TimeoutError as e:
         future.cancel()
         raise ConnectorsError(
             f"Connector async operation timed out after {timeout}s. "
             "Check that the connector provider endpoint is reachable and "
             "that no background operation is blocking the connectors loop. "
             "See docs/sdk/infrastructure/connections.mdx."
-        )
+        ) from e

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -165,15 +165,22 @@ def get_access_token_sync(
     Synchronous wrapper around ``get_access_token``.
 
     Used by sync agent tool bodies (``Agent.process_query`` runs in a
-    ``ThreadPoolExecutor`` worker thread). ``asyncio.run`` inherits the
-    calling thread's contextvars into the new event loop's context, so
-    the agent-id contextvar set by the agent runtime is visible to the
-    async refresh code.
+    ``ThreadPoolExecutor`` worker thread).
 
     Must NOT be called from a thread that already has a running event
-    loop — ``asyncio.run`` would raise ``RuntimeError``. The runtime
-    guard turns this into an actionable error rather than a confusing
-    crash. Use ``await get_access_token(...)`` directly from async code.
+    loop. The runtime guard turns this into an actionable error rather
+    than a confusing crash. Use ``await get_access_token(...)`` directly
+    from async code.
+
+    Submits the coroutine to the persistent connector event loop (see
+    ``_loop.py``) and blocks with a bounded wait. The persistent loop avoids
+    two bugs that ``asyncio.run`` caused (#1579): the cross-loop Lock error
+    (Python ≤ 3.11) and the Windows ProactorEventLoop teardown hang on
+    repeated create/destroy cycles.
+
+    Contextvar propagation: the persistent-loop bridge captures
+    ``copy_context()`` at submit time so the agent-id contextvar set by the
+    agent runtime is visible inside the async refresh code.
     """
     try:
         running = asyncio.get_running_loop()
@@ -186,7 +193,9 @@ def get_access_token_sync(
             "directly from async code instead, or schedule this call on a "
             "worker thread without a running loop."
         )
-    return asyncio.run(
+    from gaia.connectors._loop import run_sync
+
+    return run_sync(
         get_access_token(
             provider=provider,
             scopes=scopes,

--- a/src/gaia/connectors/events.py
+++ b/src/gaia/connectors/events.py
@@ -73,8 +73,9 @@ def emit_change(event_type: str, payload: dict) -> None:
     Lets synchronous callers (``api.py``, the CLI) trigger an event without
     being async themselves. Inside the UI server (a running event loop) the
     coroutine is scheduled on that loop and fanned out to SSE subscribers; in a
-    bare process (the CLI) it is run to completion against the registered
-    emitter — the no-op logging emitter unless an SSE one was registered.
+    bare process (the CLI) it is submitted to the persistent connector event
+    loop (see ``_loop.py``) rather than ``asyncio.run``, avoiding Windows
+    ProactorEventLoop teardown churn (#1579).
     Failures are logged, never silently swallowed.
     """
     try:
@@ -86,7 +87,9 @@ def emit_change(event_type: str, payload: dict) -> None:
         task = loop.create_task(emit(event_type, payload))
         task.add_done_callback(_log_emit_result)
     else:
+        from gaia.connectors._loop import run_sync
+
         try:
-            asyncio.run(emit(event_type, payload))
+            run_sync(emit(event_type, payload))
         except Exception:  # defensive: a notification must not break the write
             logger.exception("emit_change failed for %s", event_type)

--- a/src/gaia/connectors/handler.py
+++ b/src/gaia/connectors/handler.py
@@ -183,6 +183,11 @@ def get_credential_sync(
     Uses the same running-loop guard pattern as ``get_access_token_sync`` in
     ``tokens.py``: raises ``RuntimeError`` if called from inside a running loop
     (callers should use ``await get_credential(...)`` instead).
+
+    Submits to the persistent connector event loop (see ``_loop.py``) rather
+    than ``asyncio.run``, avoiding the Windows ProactorEventLoop teardown hang
+    and cross-loop Lock errors from #1579. Contextvar propagation is preserved
+    via ``copy_context()`` at submit time.
     """
     try:
         loop = asyncio.get_running_loop()
@@ -193,7 +198,9 @@ def get_credential_sync(
             "get_credential_sync() called from inside a running event loop. "
             "Use 'await get_credential(...)' instead."
         )
-    return asyncio.run(
+    from gaia.connectors._loop import run_sync
+
+    return run_sync(
         get_credential(
             connector_id,
             agent_id=agent_id,

--- a/src/gaia/connectors/tokens.py
+++ b/src/gaia/connectors/tokens.py
@@ -230,15 +230,20 @@ def get_or_refresh_sync(
     Synchronous wrapper around ``get_or_refresh`` for sync agent contexts.
 
     Must NOT be called from a thread that already has a running asyncio
-    event loop — ``asyncio.run`` would raise ``RuntimeError``. Use
-    ``await get_or_refresh(...)`` directly from async code instead. This
-    guard makes the failure surface as an actionable error rather than a
-    confusing crash deep inside the runtime.
+    event loop. Use ``await get_or_refresh(...)`` directly from async code
+    instead. This guard makes the failure surface as an actionable error
+    rather than a confusing crash deep inside the runtime.
 
-    Inherits the calling thread's contextvars into the new event loop's
-    context (via ``asyncio.run`` → ``contextvars.copy_context()``). This is
-    the bridge from ``Agent.process_query`` (sync, runs in
-    ``ThreadPoolExecutor``) to the async refresh code path. See
+    Submits the coroutine to the persistent connector event loop (see
+    ``_loop.py``) and blocks with a bounded wait. The persistent loop avoids
+    two bugs that ``asyncio.run`` caused (#1579): the cross-loop Lock error
+    (Python ≤ 3.11) and the Windows ProactorEventLoop teardown hang on
+    repeated create/destroy cycles.
+
+    Contextvar propagation: the persistent-loop bridge captures
+    ``copy_context()`` at submit time, so the agent-id contextvar set by
+    the agent runtime is visible inside the async refresh code — the same
+    guarantee the previous ``asyncio.run`` path provided. See
     ``tests/unit/connectors/test_agent_bridge.py``.
     """
     try:
@@ -252,4 +257,6 @@ def get_or_refresh_sync(
             "from async code instead, or schedule this call on a worker "
             "thread without a running loop."
         )
-    return asyncio.run(get_or_refresh(provider_id, account_email=account_email))
+    from gaia.connectors._loop import run_sync
+
+    return run_sync(get_or_refresh(provider_id, account_email=account_email))

--- a/tests/unit/connectors/test_loop_bridge.py
+++ b/tests/unit/connectors/test_loop_bridge.py
@@ -1,0 +1,314 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for the persistent connector event-loop bridge (``_loop.py``).
+
+Three properties are verified here:
+
+1. **No cross-loop RuntimeError on repeated refresh (AC2)** — calling a sync
+   token wrapper *twice*, with the cache expired between calls, must not raise
+   ``RuntimeError: <Lock> is bound to a different event loop``.  This was the
+   platform-independent half of the #1579 hang.
+
+2. **Bounded wait (AC3)** — if the async op stalls, the sync wrapper raises a
+   ``ConnectorsError`` within ``timeout`` seconds rather than blocking forever.
+
+3. **Contextvar preserved (AC4)** — the agent-id contextvar set in the caller
+   thread is visible inside the async coroutine submitted to the loop thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from gaia.connectors import get_access_token_sync, grant_agent
+from gaia.connectors.context import _agent_context, current_agent_id
+from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.providers import _registry
+from gaia.connectors.store import save_connection
+from gaia.connectors.tokens import _cache
+
+# -------------------------------------------------------------------------
+# Shared fixtures
+# -------------------------------------------------------------------------
+
+
+@pytest.fixture
+def google_provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "test.apps.example")
+    monkeypatch.setattr("gaia.connectors.grants.Path.home", lambda: tmp_path)
+    _registry.clear()
+    from gaia.connectors.providers import get as get_provider
+
+    return get_provider("google")
+
+
+@pytest.fixture
+def seeded(google_provider):
+    save_connection(
+        provider="google",
+        account_email="alice@example.com",
+        refresh_token="seed-rt",
+        scopes=["gmail.readonly"],
+        client_id_hash=google_provider.client_id_hash,
+    )
+    return google_provider
+
+
+def _ok_token():
+    return httpx.Response(
+        200, json={"access_token": "BEARER", "expires_in": 3600, "scope": "x"}
+    )
+
+
+# -------------------------------------------------------------------------
+# AC2: no cross-loop RuntimeError on repeated refresh
+# -------------------------------------------------------------------------
+
+
+class TestNoLockBoundToOtherLoop:
+    """AC2: calling the sync wrapper twice, forcing a refresh both times,
+    must NOT raise ``RuntimeError: <Lock> is bound to a different event loop``.
+
+    The root cause of #1579 (platform-independent half): asyncio.Lock created
+    in one asyncio.run() loop cannot be used from a subsequent asyncio.run()
+    loop (Python ≤ 3.11). On Python 3.12+ the lock binding was fixed, but
+    the Windows-only ProactorEventLoop create/teardown churn (the second half)
+    is still prevented by the persistent-loop architecture.
+
+    This test verifies the solution: the persistent loop thread means all
+    Lock operations happen on the SAME loop, so the issue cannot arise.
+    """
+
+    @respx.mock
+    def test_repeated_refresh_does_not_raise_cross_loop_error(self, seeded):
+        """Force two refreshes from worker threads — each expires the cache
+        between calls.  Must succeed on both, no cross-loop RuntimeError."""
+        respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
+        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+
+        errors: list[Exception] = []
+        tokens: list[str] = []
+
+        def worker():
+            with _agent_context("builtin:chat"):
+                try:
+                    tok = get_access_token_sync(
+                        provider="google", scopes=["gmail.readonly"]
+                    )
+                    tokens.append(tok)
+                except Exception as exc:
+                    errors.append(exc)
+
+        # First call — seeds the cache and creates the Lock.
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(worker).result(timeout=5.0)
+
+        # Expire the cache so the second call forces a refresh.
+        key = ("google", "alice@example.com")
+        if key in _cache:
+            _cache[key].expires_at = 0.0  # force expired
+
+        # Second call — without the fix, the Lock created above is bound
+        # to a different event loop and raises RuntimeError.
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(worker).result(timeout=5.0)
+
+        assert not errors, f"Unexpected errors: {errors}"
+        assert len(tokens) == 2
+        assert tokens[0] == "BEARER"
+        assert tokens[1] == "BEARER"
+
+    def test_persistent_loop_is_singleton(self):
+        """The persistent loop module must return the SAME loop object on
+        repeated calls — a new loop per call would reintroduce the bug."""
+        from gaia.connectors._loop import _get_persistent_loop
+
+        loop1 = _get_persistent_loop()
+        loop2 = _get_persistent_loop()
+        assert loop1 is loop2, "Expected a singleton loop; got two different objects"
+        assert loop1.is_running(), "Persistent loop must be running"
+
+
+# -------------------------------------------------------------------------
+# AC3: bounded wait — slow async op raises actionable error
+# -------------------------------------------------------------------------
+
+
+class TestBoundedWait:
+    """AC3: a stalled async op must surface an actionable ConnectorsError
+    within the configured timeout, not hang forever."""
+
+    def test_run_sync_raises_on_timeout(self):
+        """Patch the persistent loop's run_sync directly to inject a slow
+        coroutine; verify ConnectorsError is raised within ~timeout."""
+        from gaia.connectors._loop import run_sync
+
+        async def slow_op():
+            await asyncio.sleep(60)  # much longer than any test timeout
+            return "never"
+
+        timeout = 0.3  # seconds — fast enough for a test, detectable as timeout
+
+        start = time.monotonic()
+        with pytest.raises(ConnectorsError, match="timed out"):
+            run_sync(slow_op(), timeout=timeout)
+        elapsed = time.monotonic() - start
+
+        # Should raise well within 3× the timeout, not hang.
+        assert elapsed < timeout * 5, f"Took {elapsed:.2f}s — likely hung"
+
+    def test_run_sync_returns_normally_when_fast(self):
+        """A fast coroutine completes normally."""
+        from gaia.connectors._loop import run_sync
+
+        async def fast_op():
+            return "done"
+
+        result = run_sync(fast_op())
+        assert result == "done"
+
+
+# -------------------------------------------------------------------------
+# AC4: contextvar preserved through the loop bridge
+# -------------------------------------------------------------------------
+
+
+class TestContextvarPreserved:
+    """AC4: the agent-id contextvar set in the caller thread must be visible
+    inside the async coroutine running on the persistent loop thread.
+
+    run_coroutine_threadsafe does NOT inherit the caller's contextvars by
+    default; the bridge must explicitly carry them via copy_context().
+    """
+
+    def test_contextvar_visible_inside_bridge(self):
+        """Submit a coroutine via run_sync from a thread with a contextvar
+        set; assert the coroutine sees the contextvar value."""
+        from gaia.connectors._loop import run_sync
+
+        captured: list[Optional[str]] = []
+
+        async def read_ctx():
+            captured.append(current_agent_id())
+
+        _var_token = None
+
+        def worker():
+            with _agent_context("test:agent-42"):
+                run_sync(read_ctx())
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "worker thread timed out"
+
+        assert captured == [
+            "test:agent-42"
+        ], f"Expected ['test:agent-42'], got {captured!r}"
+
+    @respx.mock
+    def test_contextvar_through_token_sync_wrapper(self, seeded):
+        """End-to-end: agent-id contextvar is preserved when calling
+        get_access_token_sync from a ThreadPoolExecutor worker.
+
+        The test verifies the contextvar flows through the persistent-loop
+        bridge by patching get_or_refresh at the api module's import site
+        (where it is bound as a local name) so the spy runs on the loop
+        thread and can read the contextvar there.
+        """
+        respx.post("https://oauth2.googleapis.com/token").mock(return_value=_ok_token())
+        grant_agent("google", "builtin:chat", ["gmail.readonly"])
+
+        observed_in_refresh: list[Optional[str]] = []
+
+        import gaia.connectors.api as _api_mod
+        import gaia.connectors.tokens as _tokens_mod
+
+        original_get_or_refresh = _tokens_mod.get_or_refresh
+
+        async def spy_get_or_refresh(*args, **kwargs):
+            # This runs on the persistent loop thread; the contextvar was
+            # copied from the caller thread by run_sync → _ctx_wrap.
+            observed_in_refresh.append(current_agent_id())
+            return await original_get_or_refresh(*args, **kwargs)
+
+        results: list[str] = []
+        errors: list[Exception] = []
+
+        def worker():
+            # Patch at the api module's import site so get_access_token
+            # (which does `from gaia.connectors.tokens import get_or_refresh`)
+            # actually sees the spy.
+            with patch.object(_api_mod, "get_or_refresh", spy_get_or_refresh):
+                with _agent_context("builtin:chat"):
+                    try:
+                        tok = get_access_token_sync(
+                            provider="google", scopes=["gmail.readonly"]
+                        )
+                        results.append(tok)
+                    except Exception as exc:
+                        errors.append(exc)
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(worker).result(timeout=5.0)
+
+        assert not errors, f"Unexpected errors: {errors}"
+        assert results == ["BEARER"]
+        # The contextvar must have been visible in the async refresh.
+        assert (
+            observed_in_refresh and observed_in_refresh[0] == "builtin:chat"
+        ), f"Expected contextvar 'builtin:chat' in refresh, got {observed_in_refresh!r}"
+
+
+# -------------------------------------------------------------------------
+# AC5: loop-thread deadlock guard
+# -------------------------------------------------------------------------
+
+
+class TestLoopThreadDeadlockGuard:
+    """run_sync must not deadlock when called from the persistent loop's own
+    thread (which would cause .result() to block the loop forever)."""
+
+    def test_run_sync_raises_if_called_from_loop_thread(self):
+        """Submitting run_sync from inside the persistent loop's own thread
+        raises RuntimeError (deadlock guard) rather than hanging."""
+        from gaia.connectors._loop import _get_persistent_loop, run_sync
+
+        errors: list[Exception] = []
+        done = threading.Event()
+
+        def run_from_loop_thread():
+            try:
+
+                async def dummy():
+                    return "x"
+
+                coro = dummy()
+                try:
+                    run_sync(coro)
+                except RuntimeError:
+                    # Expected: close the coroutine to avoid ResourceWarning.
+                    coro.close()
+                    return
+                errors.append(AssertionError("Should have raised RuntimeError"))
+            except Exception as exc:
+                errors.append(exc)
+            finally:
+                done.set()
+
+        # Schedule run_from_loop_thread to execute ON the persistent loop's thread.
+        loop = _get_persistent_loop()
+        loop.call_soon_threadsafe(run_from_loop_thread)
+        done.wait(timeout=5.0)
+
+        assert not errors, f"Unexpected errors: {errors}"

--- a/tests/unit/connectors/test_loop_bridge.py
+++ b/tests/unit/connectors/test_loop_bridge.py
@@ -201,8 +201,6 @@ class TestContextvarPreserved:
         async def read_ctx():
             captured.append(current_agent_id())
 
-        _var_token = None
-
         def worker():
             with _agent_context("test:agent-42"):
                 run_sync(read_ctx())


### PR DESCRIPTION
Closes #1579

## Why this matters

Before: in `gaia chat --ui` on Windows, "Triage my last 20 emails" hangs in the "thinking" phase forever — Lemonade emits one generation, then nothing, and no output ever appears. The Email Triage agent fetches Gmail before its next LLM call, and every Gmail request re-fetches an OAuth token through `get_access_token_sync` → a brand-new `asyncio.run(...)` per call (~21 per triage), from the agent's worker thread, all sharing one module-level `asyncio.Lock`. Spinning up and tearing down a fresh event loop on every call is fragile: on Windows it can block in `ProactorEventLoop` teardown (the reported hang), and on Python ≤3.11 the shared `asyncio.Lock` raises a cross-loop `RuntimeError` on the next refresh.

After: all connector async work runs on a single persistent event loop for the process lifetime. The lock binds to one stable loop, there is no per-call loop teardown churn, and a stalled connector operation now raises an actionable error within a bounded timeout instead of hanging indefinitely.

## Test plan

- [x] `python -m pytest tests/unit/connectors/ -x -q` — 509 passed (incl. 7 new bridge tests: repeated-refresh cross-loop safety, bounded-timeout raise, contextvar propagation, loop-thread deadlock guard)
- [x] `python util/lint.py --all` — clean
- [x] Windows (Python 3.12.10, `WindowsProactorEventLoopPolicy`): 25 rapid `run_sync` httpx cycles on the persistent loop — the per-triage token-fetch pattern — complete with no hang; old `asyncio.run`-per-call path timed alongside for comparison
- [ ] **Confirming gate — interactive Windows session, real Gmail:** "Triage my last 20 emails" in `gaia chat --ui` returns a triage and the UI leaves "thinking" (requires an interactive logon session — the connectors keyring is unreadable over SSH, so this can't be automated)

The synthetic Windows harness verifies the persistent-loop bridge is stable but uses an instant-closing loopback endpoint, so it does not by itself reproduce the production hang (which involves real keep-alive/TLS transports lingering at loop teardown). The fix removes per-call loop teardown entirely; the interactive real-Gmail run is the confirming gate.
