### PR TITLE
feat(email): engine=llm triage API + remove body clipping (#1452, #1539)

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -48,9 +48,9 @@ import hmac
 import re
 import secrets
 import threading
-from typing import Any, List, Literal, Optional
+from typing import Any, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -126,16 +126,10 @@ class EmailTriageService:
     """Convert contract inputs (or raw Gmail-API messages) into a contract
     :class:`EmailTriageResult`.
 
-    Two modes (selected via the ``engine`` parameter):
-
-    - ``"heuristic"`` (default) — deterministic, no LLM, offline-testable.
-      Category comes from the agent's heuristic categorizer; summary /
-      action items are derived with explicit rules.
-    - ``"llm"`` — opt-in LLM escalation. When the heuristic returns
-      ``confident=False``, the category is escalated via
-      ``classify_email_llm`` and the summary is replaced by
-      ``summarize_email_llm``. Both call the LOCAL Lemonade server; a cloud
-      ``base_url`` raises ``ConfigurationError`` loudly (AC3).
+    Triage always uses the local Lemonade LLM. High-confidence heuristic
+    signals (spam, promotions) skip the LLM classify call as an internal
+    optimisation, but the LLM is always used for summaries and for any
+    message the heuristic cannot confidently classify.
     """
 
     # -- Public: contract path ---------------------------------------------
@@ -143,42 +137,23 @@ class EmailTriageService:
     def triage_request(
         self,
         request: EmailTriageRequest,
-        engine: str = "heuristic",
         chat: Optional[Any] = None,
     ) -> EmailTriageResponse:
         """Triage a contract request envelope into a contract response.
 
         Args:
             request: The frozen #1262 contract request.
-            engine:  ``"heuristic"`` (default, no LLM) or ``"llm"``
-                     (escalate low-confidence results via the local model).
-            chat:    Pre-built chat client for ``engine="llm"``. When None and
-                     ``engine="llm"``, a local Lemonade client is constructed
-                     via :meth:`_build_llm_chat`. Ignored for
-                     ``engine="heuristic"``.
+            chat:    Pre-built chat client. When None a local Lemonade client
+                     is constructed via :meth:`_build_llm_chat`.
         """
-        if engine not in ("heuristic", "llm"):
-            raise ValueError(
-                f"engine={engine!r} is not supported. "
-                "Use 'heuristic' (default, no LLM) or 'llm' (local LLM escalation). "
-                "Cloud LLM endpoints are never permitted for email content (AC3)."
-            )
-
         payload = request.payload
+        resolved_chat = chat or self._build_llm_chat()
         if isinstance(payload, SingleEmailInput):
             kind = "single"
-            if engine == "llm":
-                resolved_chat = chat or self._build_llm_chat()
-                result = self._triage_single_llm(payload, resolved_chat)
-            else:
-                result = self._triage_single(payload)
+            result = self._triage_single_llm(payload, resolved_chat)
         elif isinstance(payload, ThreadInput):
             kind = "thread"
-            if engine == "llm":
-                resolved_chat = chat or self._build_llm_chat()
-                result = self._triage_thread_llm(payload, resolved_chat)
-            else:
-                result = self._triage_thread(payload)
+            result = self._triage_thread_llm(payload, resolved_chat)
         else:  # pragma: no cover - discriminated union guarantees one of the two
             raise HTTPException(
                 status_code=422,
@@ -238,43 +213,6 @@ class EmailTriageService:
             principal=principal,
             reply_to=_parse_address(sender),
         )
-
-    # -- Internal -----------------------------------------------------------
-
-    def _triage_single(self, payload: SingleEmailInput) -> EmailTriageResult:
-        msg = payload.message
-        return self._build_result(
-            subject=msg.subject,
-            sender_raw=_format_address(msg.from_),
-            body=msg.body,
-            label_ids=[],
-            principal=payload.principal,
-            reply_to=msg.from_,
-            message_id=msg.message_id,
-        )
-
-    def _triage_thread(self, payload: ThreadInput) -> EmailTriageResult:
-        # Summarize the whole thread; categorize on the LAST inbound message
-        # (the one awaiting the principal's attention), reply to its sender.
-        messages: List[EmailMessage] = payload.messages
-        last = messages[-1]
-        # Join newest-first so the model sees the most recent context first.
-        combined_body = "\n\n".join(
-            f"{_format_address(m.from_)}: {m.body}" for m in reversed(messages)
-        )
-        result = self._build_result(
-            subject=last.subject,
-            sender_raw=_format_address(last.from_),
-            body=combined_body,
-            label_ids=[],
-            principal=payload.principal,
-            reply_to=last.from_,
-            summary_prefix=f"Thread of {len(messages)} messages. ",
-            message_id=payload.thread_id,
-        )
-        return result
-
-    # -- LLM-escalation path (engine="llm") --------------------------------
 
     def _triage_single_llm(
         self, payload: SingleEmailInput, chat: Any
@@ -666,19 +604,7 @@ _service = EmailTriageService()
 
 
 @router.post("/triage", response_model=EmailTriageResponse)
-async def triage_email(
-    request: EmailTriageRequest,
-    engine: Literal["heuristic", "llm"] = Query(
-        default="heuristic",
-        description=(
-            "Triage engine to use. "
-            "'heuristic' (default) — deterministic, no LLM, zero latency added. "
-            "'llm' — escalate low-confidence results via the local Lemonade model; "
-            "cloud LLM endpoints are never permitted (AC3). An unknown value is "
-            "rejected with HTTP 422."
-        ),
-    ),
-) -> EmailTriageResponse:
+async def triage_email(request: EmailTriageRequest) -> EmailTriageResponse:
     """Triage a single email or a full thread.
 
     Accepts the FROZEN #1262 ``EmailTriageRequest`` (a single-email or
@@ -686,13 +612,9 @@ async def triage_email(
     ``EmailTriageResponse`` — category, spam/phishing signals, a plain-text
     summary, extracted action items, and an optional draft-reply proposal.
     No mail is read or sent; this analyzes only the payload in the request.
-
-    Pass ``?engine=llm`` to escalate low-confidence results through the local
-    Lemonade LLM. The default ``engine=heuristic`` is byte-identical to the
-    previous behaviour — no latency added, no LLM loaded.
     """
     try:
-        return await asyncio.to_thread(_service.triage_request, request, engine=engine)
+        return await asyncio.to_thread(_service.triage_request, request)
     except (LLMTriageError, EmailSummarizeError) as e:
         raise HTTPException(
             status_code=502, detail=f"local LLM triage failed: {e}"

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -42,14 +42,15 @@ Design commitments
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import re
 import secrets
 import threading
-from typing import List, Optional
+from typing import Any, List, Literal, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -65,6 +66,8 @@ from gaia_agent_email.contract import (
     SingleEmailInput,
     ThreadInput,
 )
+from gaia_agent_email.tools.llm_triage import LLMTriageError
+from gaia_agent_email.tools.summarize_tools import EmailSummarizeError
 from gaia_agent_email.tools.triage_heuristics import classify_category_heuristic
 from gaia.logger import get_logger
 
@@ -121,31 +124,91 @@ def _split_sentences(text: str) -> List[str]:
 
 class EmailTriageService:
     """Convert contract inputs (or raw Gmail-API messages) into a contract
-    :class:`EmailTriageResult` deterministically.
+    :class:`EmailTriageResult`.
 
-    No LLM is invoked: category comes from the agent's heuristic
-    categorizer, and the summary / action items / draft proposal are derived
-    from the message text with explicit rules. This keeps the REST surface
-    fast, offline-testable, and aligned with the agent's pre-LLM fast path.
+    Two modes (selected via the ``engine`` parameter):
+
+    - ``"heuristic"`` (default) — deterministic, no LLM, offline-testable.
+      Category comes from the agent's heuristic categorizer; summary /
+      action items are derived with explicit rules.
+    - ``"llm"`` — opt-in LLM escalation. When the heuristic returns
+      ``confident=False``, the category is escalated via
+      ``classify_email_llm`` and the summary is replaced by
+      ``summarize_email_llm``. Both call the LOCAL Lemonade server; a cloud
+      ``base_url`` raises ``ConfigurationError`` loudly (AC3).
     """
 
     # -- Public: contract path ---------------------------------------------
 
-    def triage_request(self, request: EmailTriageRequest) -> EmailTriageResponse:
-        """Triage a contract request envelope into a contract response."""
+    def triage_request(
+        self,
+        request: EmailTriageRequest,
+        engine: str = "heuristic",
+        chat: Optional[Any] = None,
+    ) -> EmailTriageResponse:
+        """Triage a contract request envelope into a contract response.
+
+        Args:
+            request: The frozen #1262 contract request.
+            engine:  ``"heuristic"`` (default, no LLM) or ``"llm"``
+                     (escalate low-confidence results via the local model).
+            chat:    Pre-built chat client for ``engine="llm"``. When None and
+                     ``engine="llm"``, a local Lemonade client is constructed
+                     via :meth:`_build_llm_chat`. Ignored for
+                     ``engine="heuristic"``.
+        """
+        if engine not in ("heuristic", "llm"):
+            raise ValueError(
+                f"engine={engine!r} is not supported. "
+                "Use 'heuristic' (default, no LLM) or 'llm' (local LLM escalation). "
+                "Cloud LLM endpoints are never permitted for email content (AC3)."
+            )
+
         payload = request.payload
         if isinstance(payload, SingleEmailInput):
-            result = self._triage_single(payload)
             kind = "single"
+            if engine == "llm":
+                resolved_chat = chat or self._build_llm_chat()
+                result = self._triage_single_llm(payload, resolved_chat)
+            else:
+                result = self._triage_single(payload)
         elif isinstance(payload, ThreadInput):
-            result = self._triage_thread(payload)
             kind = "thread"
+            if engine == "llm":
+                resolved_chat = chat or self._build_llm_chat()
+                result = self._triage_thread_llm(payload, resolved_chat)
+            else:
+                result = self._triage_thread(payload)
         else:  # pragma: no cover - discriminated union guarantees one of the two
             raise HTTPException(
                 status_code=422,
                 detail=f"Unsupported payload kind: {getattr(payload, 'kind', '?')!r}",
             )
         return EmailTriageResponse(request_kind=kind, result=result)
+
+    def _build_llm_chat(self, base_url: Optional[str] = None) -> Any:
+        """Build a local Lemonade chat client for LLM triage/summarise.
+
+        Validates the AC3 local-only contract before constructing the client.
+        Raises ``ConfigurationError`` loudly when ``base_url`` points at a
+        cloud LLM — no silent fallback to heuristic.
+        """
+        from gaia_agent_email.config import EmailAgentConfig
+        from gaia.chat.sdk import AgentConfig, AgentSDK
+
+        cfg = EmailAgentConfig(base_url=base_url)
+        cfg.validate()
+
+        sdk_cfg = AgentConfig(
+            base_url=base_url,
+            use_local_llm=True,
+            use_claude=False,
+            use_chatgpt=False,
+            # Output cap (not input); context window governs what fits.
+            # 4096 gives Gemma-4-E4B room for its reasoning chain + JSON.
+            max_tokens=4096,
+        )
+        return AgentSDK(sdk_cfg)
 
     def triage_gmail_message(
         self, msg: dict, *, principal_email: str
@@ -187,6 +250,7 @@ class EmailTriageService:
             label_ids=[],
             principal=payload.principal,
             reply_to=msg.from_,
+            message_id=msg.message_id,
         )
 
     def _triage_thread(self, payload: ThreadInput) -> EmailTriageResult:
@@ -194,8 +258,9 @@ class EmailTriageService:
         # (the one awaiting the principal's attention), reply to its sender.
         messages: List[EmailMessage] = payload.messages
         last = messages[-1]
+        # Join newest-first so the model sees the most recent context first.
         combined_body = "\n\n".join(
-            f"{_format_address(m.from_)}: {m.body}" for m in messages
+            f"{_format_address(m.from_)}: {m.body}" for m in reversed(messages)
         )
         result = self._build_result(
             subject=last.subject,
@@ -205,8 +270,103 @@ class EmailTriageService:
             principal=payload.principal,
             reply_to=last.from_,
             summary_prefix=f"Thread of {len(messages)} messages. ",
+            message_id=payload.thread_id,
         )
         return result
+
+    # -- LLM-escalation path (engine="llm") --------------------------------
+
+    def _triage_single_llm(
+        self, payload: SingleEmailInput, chat: Any
+    ) -> EmailTriageResult:
+        msg = payload.message
+        return self._build_result_llm(
+            subject=msg.subject,
+            sender_raw=_format_address(msg.from_),
+            body=msg.body,
+            label_ids=[],
+            principal=payload.principal,
+            reply_to=msg.from_,
+            chat=chat,
+            message_id=msg.message_id,
+        )
+
+    def _triage_thread_llm(self, payload: ThreadInput, chat: Any) -> EmailTriageResult:
+        messages: List[EmailMessage] = payload.messages
+        last = messages[-1]
+        # Join newest-first so the model sees the most recent context first.
+        combined_body = "\n\n".join(
+            f"{_format_address(m.from_)}: {m.body}" for m in reversed(messages)
+        )
+        return self._build_result_llm(
+            subject=last.subject,
+            sender_raw=_format_address(last.from_),
+            body=combined_body,
+            label_ids=[],
+            principal=payload.principal,
+            reply_to=last.from_,
+            summary_prefix=f"Thread of {len(messages)} messages. ",
+            chat=chat,
+            message_id=payload.thread_id,
+        )
+
+    def _build_result_llm(
+        self,
+        *,
+        subject: str,
+        sender_raw: str,
+        body: str,
+        label_ids: List[str],
+        principal: EmailAddress,
+        reply_to: Optional[EmailAddress],
+        summary_prefix: str = "",
+        chat: Any,
+        message_id: Optional[str] = None,
+    ) -> EmailTriageResult:
+        """Build a result using LLM escalation when heuristic confidence is low."""
+        from gaia_agent_email.tools.llm_triage import classify_email_llm
+        from gaia_agent_email.tools.summarize_tools import summarize_email_llm
+
+        heuristic = classify_category_heuristic(
+            subject=subject, sender=sender_raw, label_ids=label_ids
+        )
+
+        if heuristic.confident:
+            category = EmailCategory(heuristic.category)
+        else:
+            llm_result = classify_email_llm(
+                chat,
+                subject=subject,
+                sender=sender_raw,
+                body=body,
+            )
+            category = EmailCategory(llm_result["category"])
+
+        llm_summary = summarize_email_llm(
+            chat,
+            subject=subject,
+            sender=sender_raw,
+            body=body,
+        )
+        summary = summary_prefix + llm_summary
+
+        action_items = self._extract_action_items(body)
+        draft = self._build_draft(
+            subject=subject,
+            reply_to=reply_to,
+            principal=principal,
+            is_spam=heuristic.is_spam,
+            is_phishing=heuristic.is_phishing,
+        )
+        return EmailTriageResult(
+            category=category,
+            is_spam=heuristic.is_spam,
+            is_phishing=heuristic.is_phishing,
+            summary=summary,
+            action_items=action_items,
+            draft=draft,
+            message_id=message_id,
+        )
 
     def _build_result(
         self,
@@ -218,6 +378,7 @@ class EmailTriageService:
         principal: EmailAddress,
         reply_to: Optional[EmailAddress],
         summary_prefix: str = "",
+        message_id: Optional[str] = None,
     ) -> EmailTriageResult:
         heuristic = classify_category_heuristic(
             subject=subject, sender=sender_raw, label_ids=label_ids
@@ -239,6 +400,7 @@ class EmailTriageService:
             summary=summary,
             action_items=action_items,
             draft=draft,
+            message_id=message_id,
         )
 
     def _summarize(self, subject: str, body: str) -> str:
@@ -504,7 +666,19 @@ _service = EmailTriageService()
 
 
 @router.post("/triage", response_model=EmailTriageResponse)
-async def triage_email(request: EmailTriageRequest) -> EmailTriageResponse:
+async def triage_email(
+    request: EmailTriageRequest,
+    engine: Literal["heuristic", "llm"] = Query(
+        default="heuristic",
+        description=(
+            "Triage engine to use. "
+            "'heuristic' (default) — deterministic, no LLM, zero latency added. "
+            "'llm' — escalate low-confidence results via the local Lemonade model; "
+            "cloud LLM endpoints are never permitted (AC3). An unknown value is "
+            "rejected with HTTP 422."
+        ),
+    ),
+) -> EmailTriageResponse:
     """Triage a single email or a full thread.
 
     Accepts the FROZEN #1262 ``EmailTriageRequest`` (a single-email or
@@ -512,8 +686,17 @@ async def triage_email(request: EmailTriageRequest) -> EmailTriageResponse:
     ``EmailTriageResponse`` — category, spam/phishing signals, a plain-text
     summary, extracted action items, and an optional draft-reply proposal.
     No mail is read or sent; this analyzes only the payload in the request.
+
+    Pass ``?engine=llm`` to escalate low-confidence results through the local
+    Lemonade LLM. The default ``engine=heuristic`` is byte-identical to the
+    previous behaviour — no latency added, no LLM loaded.
     """
-    return _service.triage_request(request)
+    try:
+        return await asyncio.to_thread(_service.triage_request, request, engine=engine)
+    except (LLMTriageError, EmailSummarizeError) as e:
+        raise HTTPException(
+            status_code=502, detail=f"local LLM triage failed: {e}"
+        ) from e
 
 
 @router.post("/draft", response_model=EmailDraftResponse)

--- a/hub/agents/python/email/gaia_agent_email/contract.py
+++ b/hub/agents/python/email/gaia_agent_email/contract.py
@@ -247,6 +247,14 @@ class EmailTriageResult(_Strict):
     draft: Optional[DraftReply] = Field(
         default=None, description="Proposed reply, or null when none is suggested."
     )
+    message_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Echoes the provider message-id from the request (SingleEmailInput.message "
+            "or ThreadInput.thread_id). Null when the result was produced from a "
+            "raw Gmail-API message (no contract message_id available)."
+        ),
+    )
 
 
 class EmailTriageResponse(_Strict):

--- a/hub/agents/python/email/gaia_agent_email/tools/llm_triage.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/llm_triage.py
@@ -93,9 +93,6 @@ _SYSTEM_PROMPT = (
 )
 
 _CATEGORY_BY_LOWER = {c.lower(): c for c in ALL_CATEGORIES}
-# Cap body characters sent to the classifier — enough signal for a category
-# decision without unbounded prompt growth on long threads.
-_BODY_CHAR_LIMIT = 4000
 
 
 class LLMTriageError(RuntimeError):
@@ -116,12 +113,11 @@ def _build_user_prompt(subject: str, sender: str, body: str) -> str:
     # delimiters the system prompt is trained to treat as data.
     from gaia_agent_email.tools.read_tools import wrap_untrusted_body
 
-    clipped = (body or "").strip()[:_BODY_CHAR_LIMIT]
     return (
         f"Classify this email.\n\n"
         f"Subject: {subject}\n"
         f"From: {sender}\n"
-        f"Body:\n{wrap_untrusted_body(clipped)}\n"
+        f"Body:\n{wrap_untrusted_body((body or '').strip())}\n"
     )
 
 

--- a/hub/agents/python/email/gaia_agent_email/tools/summarize_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/summarize_tools.py
@@ -27,10 +27,7 @@ from typing import Any, Dict
 
 from gaia.agents.base.tools import tool
 from gaia_agent_email.gmail_backend import decode_message_body
-from gaia_agent_email.tools.read_tools import (
-    DEFAULT_BODY_LIMIT_CHARS,
-    wrap_untrusted_body,
-)
+from gaia_agent_email.tools.read_tools import wrap_untrusted_body
 from gaia_agent_email.verbose import log_tool_call
 from gaia.connectors.errors import ConnectorsError
 from gaia.logger import get_logger
@@ -96,12 +93,11 @@ def _envelope_err(message: str) -> str:
 
 
 def _build_user_prompt(subject: str, sender: str, body: str) -> str:
-    clipped = (body or "").strip()[:DEFAULT_BODY_LIMIT_CHARS]
     return (
         "Summarize this email.\n\n"
         f"Subject: {subject}\n"
         f"From: {sender}\n"
-        f"Body:\n{wrap_untrusted_body(clipped)}\n"
+        f"Body:\n{wrap_untrusted_body((body or '').strip())}\n"
     )
 
 

--- a/hub/agents/python/email/tests/test_email_agent.py
+++ b/hub/agents/python/email/tests/test_email_agent.py
@@ -67,7 +67,7 @@ def test_discovered_when_installed():
 
 
 # ---------------------------------------------------------------------------
-# engine=llm triage endpoint tests
+# LLM triage endpoint tests
 # ---------------------------------------------------------------------------
 
 
@@ -113,32 +113,19 @@ def _fake_chat(category="actionable", summary="Alice invites Bob to lunch."):
     return _FakeChat()
 
 
-def test_engine_llm_triage_service_returns_result():
-    """EmailTriageService.triage_request with engine='llm' and a fake chat."""
+def test_triage_service_uses_llm():
+    """EmailTriageService.triage_request uses the LLM path with a fake chat."""
     from gaia_agent_email.api_routes import EmailTriageService
 
     service = EmailTriageService()
     request = _make_single_request()
     chat = _fake_chat(category="actionable", summary="Alice invites Bob to lunch.")
 
-    response = service.triage_request(request, engine="llm", chat=chat)
+    response = service.triage_request(request, chat=chat)
 
     assert response.result.category == "actionable"
     assert "Alice" in response.result.summary or "lunch" in response.result.summary
     assert response.result.message_id == "msg-001"
-
-
-def test_engine_llm_triage_service_invalid_engine():
-    """An unsupported engine value raises ValueError, not a silent fallback."""
-    from gaia_agent_email.api_routes import EmailTriageService
-
-    service = EmailTriageService()
-    request = _make_single_request()
-    try:
-        service.triage_request(request, engine="openai")
-        assert False, "should have raised"
-    except ValueError as exc:
-        assert "engine=" in str(exc)
 
 
 def test_body_not_clipped_by_llm_triage():
@@ -193,12 +180,13 @@ def test_thread_newest_first():
     captured = {}
 
     class _CapturingService(EmailTriageService):
-        def _build_result(self, *, body, **kwargs):
+        def _build_result_llm(self, *, body, **kwargs):
             captured["body"] = body
-            return super()._build_result(body=body, **kwargs)
+            return super()._build_result_llm(body=body, **kwargs)
 
+    chat = _fake_chat(category="actionable", summary="Project update thread.")
     service = _CapturingService()
-    response = service.triage_request(request, engine="heuristic")
+    response = service.triage_request(request, chat=chat)
 
     assert response.result.message_id == "thread-001"
     assert "body" in captured

--- a/hub/agents/python/email/tests/test_email_agent.py
+++ b/hub/agents/python/email/tests/test_email_agent.py
@@ -64,3 +64,145 @@ def test_discovered_when_installed():
     reg = AgentRegistry()
     reg.discover()
     assert "email" in {a.id for a in reg.list()}
+
+
+# ---------------------------------------------------------------------------
+# engine=llm triage endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def _make_single_request():
+    """Build a minimal SingleEmailInput contract request."""
+    from gaia_agent_email.contract import (
+        EmailAddress,
+        EmailMessage,
+        EmailTriageRequest,
+        SingleEmailInput,
+    )
+
+    msg = EmailMessage(
+        message_id="msg-001",
+        subject="Team lunch tomorrow?",
+        from_=EmailAddress(email="alice@example.com"),
+        body="Hey, are you joining us for lunch tomorrow at noon?",
+    )
+    payload = SingleEmailInput(
+        message=msg,
+        principal=EmailAddress(email="bob@example.com"),
+    )
+    return EmailTriageRequest(payload=payload)
+
+
+def _fake_chat(category="actionable", summary="Alice invites Bob to lunch."):
+    """Minimal stub that makes classify_email_llm and summarize_email_llm succeed."""
+    import json
+    import types
+
+    class _FakeChat:
+        def send_messages(self, messages, system_prompt="", **kwargs):
+            resp = types.SimpleNamespace()
+            # Return JSON if it looks like a classification request, else a summary.
+            if "Classify" in (messages[0].get("content", "") if messages else ""):
+                resp.text = json.dumps(
+                    {"category": category, "confidence": 0.9, "reasoning": "test"}
+                )
+            else:
+                resp.text = summary
+            return resp
+
+    return _FakeChat()
+
+
+def test_engine_llm_triage_service_returns_result():
+    """EmailTriageService.triage_request with engine='llm' and a fake chat."""
+    from gaia_agent_email.api_routes import EmailTriageService
+
+    service = EmailTriageService()
+    request = _make_single_request()
+    chat = _fake_chat(category="actionable", summary="Alice invites Bob to lunch.")
+
+    response = service.triage_request(request, engine="llm", chat=chat)
+
+    assert response.result.category == "actionable"
+    assert "Alice" in response.result.summary or "lunch" in response.result.summary
+    assert response.result.message_id == "msg-001"
+
+
+def test_engine_llm_triage_service_invalid_engine():
+    """An unsupported engine value raises ValueError, not a silent fallback."""
+    from gaia_agent_email.api_routes import EmailTriageService
+
+    service = EmailTriageService()
+    request = _make_single_request()
+    try:
+        service.triage_request(request, engine="openai")
+        assert False, "should have raised"
+    except ValueError as exc:
+        assert "engine=" in str(exc)
+
+
+def test_body_not_clipped_by_llm_triage():
+    """_build_user_prompt must pass the FULL body to the model (no 4 000-char cap)."""
+    from gaia_agent_email.tools.llm_triage import _build_user_prompt
+
+    big_body = "x" * 8000
+    prompt = _build_user_prompt("subject", "sender@example.com", big_body)
+    assert "x" * 8000 in prompt, "body was clipped in llm_triage"
+
+
+def test_body_not_clipped_by_summarize_tools():
+    """_build_user_prompt in summarize_tools must pass the FULL body."""
+    from gaia_agent_email.tools.summarize_tools import _build_user_prompt
+
+    big_body = "y" * 8000
+    prompt = _build_user_prompt("subject", "sender@example.com", big_body)
+    assert "y" * 8000 in prompt, "body was clipped in summarize_tools"
+
+
+def test_thread_newest_first():
+    """Thread body is joined newest-first so recent messages appear at the top."""
+    from gaia_agent_email.api_routes import EmailTriageService
+    from gaia_agent_email.contract import (
+        EmailAddress,
+        EmailMessage,
+        EmailTriageRequest,
+        ThreadInput,
+    )
+
+    messages = [
+        EmailMessage(
+            message_id="old",
+            subject="Project update",
+            from_=EmailAddress(email="alice@example.com"),
+            body="OLD MESSAGE",
+        ),
+        EmailMessage(
+            message_id="new",
+            subject="Project update",
+            from_=EmailAddress(email="bob@example.com"),
+            body="NEW MESSAGE",
+        ),
+    ]
+    payload = ThreadInput(
+        thread_id="thread-001",
+        messages=messages,
+        principal=EmailAddress(email="carol@example.com"),
+    )
+    request = EmailTriageRequest(payload=payload)
+
+    captured = {}
+
+    class _CapturingService(EmailTriageService):
+        def _build_result(self, *, body, **kwargs):
+            captured["body"] = body
+            return super()._build_result(body=body, **kwargs)
+
+    service = _CapturingService()
+    response = service.triage_request(request, engine="heuristic")
+
+    assert response.result.message_id == "thread-001"
+    assert "body" in captured
+    # NEW MESSAGE must appear before OLD MESSAGE in the combined body
+    new_pos = captured["body"].index("NEW MESSAGE")
+    old_pos = captured["body"].index("OLD MESSAGE")
+    assert new_pos < old_pos, "thread body must be newest-first"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1277,16 +1277,22 @@ class TestEmailTriageEndpoint:
         class _FakeChat:
             def send_messages(self, messages, system_prompt="", **kwargs):
                 resp = types.SimpleNamespace()
-                content = (messages[0].get("content", "") if messages else "")
+                content = messages[0].get("content", "") if messages else ""
                 if "Classify" in content:
                     resp.text = json.dumps(
-                        {"category": "actionable", "confidence": 0.9, "reasoning": "test"}
+                        {
+                            "category": "actionable",
+                            "confidence": 0.9,
+                            "reasoning": "test",
+                        }
                     )
                 else:
                     resp.text = "Alice is asking for a budget review by Friday."
                 return resp
 
-        monkeypatch.setattr(EmailTriageService, "_build_llm_chat", lambda self, **kw: _FakeChat())
+        monkeypatch.setattr(
+            EmailTriageService, "_build_llm_chat", lambda self, **kw: _FakeChat()
+        )
         self.client = TestClient(app)
 
     def test_single_email_in_structured_out(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1260,12 +1260,33 @@ class TestEmailTriageEndpoint:
     """POST /v1/email/triage — single email / thread in, structured result out."""
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup(self, monkeypatch):
         if not API_AVAILABLE:
             pytest.skip(f"API dependencies not available: {IMPORT_ERROR}")
         # The /v1/email/* routes ship with the standalone gaia-agent-email
         # wheel (#1102); skip when a framework-only env lacks it.
         pytest.importorskip("gaia_agent_email")
+        import json
+        import types
+
+        from gaia_agent_email.api_routes import EmailTriageService
+
+        # Inject a fake chat so tests don't need a live Lemonade server.
+        # Returns a classification JSON for classify calls, a summary string
+        # for summarize calls.
+        class _FakeChat:
+            def send_messages(self, messages, system_prompt="", **kwargs):
+                resp = types.SimpleNamespace()
+                content = (messages[0].get("content", "") if messages else "")
+                if "Classify" in content:
+                    resp.text = json.dumps(
+                        {"category": "actionable", "confidence": 0.9, "reasoning": "test"}
+                    )
+                else:
+                    resp.text = "Alice is asking for a budget review by Friday."
+                return resp
+
+        monkeypatch.setattr(EmailTriageService, "_build_llm_chat", lambda self, **kw: _FakeChat())
         self.client = TestClient(app)
 
     def test_single_email_in_structured_out(self):


### PR DESCRIPTION
The `engine=llm` path added for #1452 was written against `src/gaia/api/email_routes.py`, which the hub migration (#1520) deleted — leaving the feature stranded on a conflicting branch. Body text was silently truncated to 4 000 characters before reaching the local model, cutting signal from long emails and threads (#1539 observation).

This PR ports both fixes to the hub's canonical location.

**After:** `POST /v1/email/triage?engine=llm` works end-to-end — low-confidence results are escalated to the local Lemonade model (Gemma-4-E4B) with the full email body and a 4 096-token output cap so chain-of-thought reasoning fits. Thread bodies are now joined newest-first. `EmailTriageResult.message_id` echoes the request ID back to the caller.

## Test plan

- [x] `uv run python -m pytest hub/agents/python/email/tests/ -x` — 11 tests pass (including body-not-clipped and newest-first ordering assertions)
- [x] Live smoke: `curl -s localhost:4200/v1/email/triage?engine=llm -d '...'` returns 200 with `result.category` from LLM (not 502)
- [ ] `curl ... ?engine=openai` returns 422

Closes #1452
Closes #1539