### PR TITLE
fix(agents): bound and cancel tool execution so hung tools fail loudly

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -111,6 +111,19 @@ gaia browse "research the latest AMD Ryzen AI news"
 
 A few agents intentionally override the default (e.g. the Code agent uses 100 for multi-file generation). An invalid `GAIA_AGENT_MAX_STEPS` value (non-integer or ≤ 0) fails fast with an actionable error rather than silently capping agents.
 
+### Per-tool execution timeout
+
+Each tool call is bounded so a hung tool (e.g. a stuck connector or network request) surfaces an actionable error instead of leaving the agent — and the UI — stuck indefinitely. The default is **180 seconds** per tool.
+
+- **Fleet-wide:** set `GAIA_AGENT_TOOL_TIMEOUT` (seconds) to change the default for every tool at once.
+
+```bash
+# Allow long-running tools more headroom in this shell
+export GAIA_AGENT_TOOL_TIMEOUT=300
+```
+
+Tools that legitimately run longer opt out in code via `@tool(timeout=...)` — for example image generation, which may need to download a model on first use. An invalid `GAIA_AGENT_TOOL_TIMEOUT` value (non-numeric or ≤ 0) fails fast with an actionable error rather than silently removing the guard.
+
 ---
 
 ## Initialization

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -16,9 +16,20 @@ import logging
 import os
 import re
 import subprocess
+import threading
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+)
 
 from gaia.agents.base.console import AgentConsole, SilentConsole
 from gaia.agents.base.errors import format_execution_trace
@@ -70,6 +81,57 @@ def default_max_steps() -> int:
             f"Unset it to use the default ({DEFAULT_MAX_STEPS})."
         )
     return value
+
+
+# Default per-tool execution limit (seconds). Bounds a single ``tool(**args)``
+# call so a hung tool (e.g. a stuck connector/network call) surfaces an
+# actionable error in a sensible window instead of blocking the agent loop —
+# and the producer thread — indefinitely. Well under the UI's 600s consumer cap.
+# Tools that legitimately run longer (e.g. ``generate_image``, which may
+# download a model) opt out via ``@tool(timeout=...)``.
+DEFAULT_TOOL_TIMEOUT = 180.0
+
+
+def tool_execution_timeout() -> float:
+    """Resolve the global default per-tool execution timeout in seconds.
+
+    Reads ``GAIA_AGENT_TOOL_TIMEOUT`` at call time (not import) so the env var
+    can be set after this module is imported and still take effect. Returns
+    ``DEFAULT_TOOL_TIMEOUT`` when the var is unset; raises on a present-but-
+    invalid value so a typo surfaces immediately instead of silently removing
+    the guard.
+    """
+    raw = os.environ.get("GAIA_AGENT_TOOL_TIMEOUT")
+    if raw is None or raw == "":
+        return DEFAULT_TOOL_TIMEOUT
+    try:
+        value = float(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"GAIA_AGENT_TOOL_TIMEOUT must be a positive number of seconds, "
+            f"got {raw!r}. Unset it to use the default ({DEFAULT_TOOL_TIMEOUT})."
+        ) from e
+    if value <= 0:
+        raise ValueError(
+            f"GAIA_AGENT_TOOL_TIMEOUT must be a positive number of seconds, "
+            f"got {value}. Unset it to use the default ({DEFAULT_TOOL_TIMEOUT})."
+        )
+    return value
+
+
+class ToolExecutionTimeout(Exception):
+    """Raised when a tool body exceeds its bounded execution window.
+
+    Caught inside ``Agent._execute_tool`` and converted into a fail-loud,
+    actionable error result; it is not meant to propagate to callers.
+    """
+
+    def __init__(self, tool_name: str, timeout: float):
+        self.tool_name = tool_name
+        self.timeout = timeout
+        super().__init__(
+            f"Tool '{tool_name}' exceeded its {timeout:g}s execution limit"
+        )
 
 
 # Tools that require explicit user confirmation before execution.
@@ -362,6 +424,10 @@ Do NOT wrap conversational replies in JSON.
         self._current_query: Optional[str] = (
             None  # Store current query for error context
         )
+        # Optional cooperative cancel signal. When set (e.g. by the Agent UI's
+        # stream-timeout/disconnect cleanup), the process_query loop bails at the
+        # next step boundary so the producer thread is torn down, not leaked.
+        self._cancel_event: Optional[threading.Event] = None
 
         # Read base_url from environment if not provided
         if base_url is None:
@@ -1688,6 +1754,49 @@ Do NOT wrap conversational replies in JSON.
             return matches[0]
         return None
 
+    def _resolve_tool_timeout(self, tool_name: str) -> float:
+        """Resolve the execution timeout (seconds) for a tool.
+
+        A per-tool ``@tool(timeout=...)`` override wins; otherwise the global
+        ``GAIA_AGENT_TOOL_TIMEOUT`` default applies.
+        """
+        entry = self._tools_registry.get(tool_name) or {}
+        override = entry.get("timeout")
+        if override is not None:
+            return float(override)
+        return tool_execution_timeout()
+
+    def _call_tool_bounded(
+        self, tool: Callable, tool_args: Dict[str, Any], tool_name: str
+    ) -> Any:
+        """Run a tool body under a bounded execution window.
+
+        The tool runs in a daemon worker thread joined with the resolved
+        timeout. On success the worker's return value is returned and any
+        exception it raised is re-raised in the caller (so the existing
+        ``_execute_tool`` error handling applies unchanged). On timeout a
+        ``ToolExecutionTimeout`` is raised — the worker keeps running (Python
+        cannot kill a thread) but it is a daemon, so it cannot block process
+        exit and the agent loop is freed immediately.
+        """
+        timeout = self._resolve_tool_timeout(tool_name)
+        holder: Dict[str, Any] = {}
+
+        def _target():
+            try:
+                holder["result"] = tool(**tool_args)
+            except BaseException as exc:  # noqa: BLE001 — re-raised in caller
+                holder["exc"] = exc
+
+        worker = threading.Thread(target=_target, name=f"tool:{tool_name}", daemon=True)
+        worker.start()
+        worker.join(timeout)
+        if worker.is_alive():
+            raise ToolExecutionTimeout(tool_name, timeout)
+        if "exc" in holder:
+            raise holder["exc"]
+        return holder.get("result")
+
     def _execute_tool(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
         """
         Execute a tool by name with the provided arguments.
@@ -1791,9 +1900,29 @@ Do NOT wrap conversational replies in JSON.
             return {"status": "error", "error": error_msg}
 
         try:
-            result = tool(**tool_args)
+            result = self._call_tool_bounded(tool, tool_args, tool_name)
             logger.debug(f"Tool execution result: {result}")
             return result
+        except ToolExecutionTimeout as e:
+            # Bounded-execution guard fired: the tool body blocked past its
+            # limit. Fail loud with an actionable message — name the tool, the
+            # window, and the override knob — instead of hanging the agent loop.
+            error_msg = (
+                f"Tool '{tool_name}' did not return within {e.timeout:g}s and "
+                f"was abandoned. The call may be hung (e.g. an unreachable "
+                f"service or stuck network request). Check the tool/connector, "
+                f"or raise GAIA_AGENT_TOOL_TIMEOUT if it legitimately needs "
+                f"longer."
+            )
+            logger.error(error_msg)
+            self.error_history.append(error_msg)
+            self.console.print_error(error_msg)
+            return {
+                "status": "error",
+                "error": error_msg,
+                "timeout": True,
+                "tool_name": tool_name,
+            }
         except subprocess.TimeoutExpired as e:
             # Handle subprocess timeout specifically
             error_msg = f"Tool {tool_name} timed out: {str(e)}"
@@ -2469,6 +2598,25 @@ Do NOT wrap conversational replies in JSON.
 
         # Process the query in steps, allowing for multiple tool usages
         while steps_taken < steps_limit and final_answer is None:
+            # Cooperative cancellation: if a consumer (e.g. the Agent UI's
+            # stream-timeout/disconnect cleanup) signalled cancel, stop here so
+            # the producer thread is torn down rather than left running. Checked
+            # at the step boundary; per-tool timeouts keep each step bounded so
+            # this point is always reached in finite time.
+            cancel_event = getattr(self, "_cancel_event", None)
+            if cancel_event is not None and cancel_event.is_set():
+                logger.warning(
+                    "Agent run cancelled at step %d/%d via cancel_event",
+                    steps_taken,
+                    steps_limit,
+                )
+                final_answer = (
+                    "The request was stopped because it exceeded the allowed "
+                    "time before completing. Try a simpler request or break it "
+                    "into smaller steps."
+                )
+                break
+
             # Build the next prompt based on current state (this is for fallback mode only)
             # In chat mode, we'll just add to messages array
             steps_taken += 1

--- a/src/gaia/agents/base/tools.py
+++ b/src/gaia/agents/base/tools.py
@@ -21,6 +21,7 @@ def tool(
     *,
     atomic: bool = False,
     display_label: str | None = None,
+    timeout: float | None = None,
     **kwargs,  # pylint: disable=unused-argument
 ) -> Callable:
     """
@@ -33,6 +34,12 @@ def tool(
     Args:
         func: Function to register as a tool (when used as @tool)
         atomic: If True, marks this tool as atomic (can execute without multi-step planning)
+        display_label: Optional user-facing label for UI progress strips
+        timeout: Per-tool execution limit in seconds. Overrides the global
+            ``GAIA_AGENT_TOOL_TIMEOUT`` default in ``Agent._execute_tool``. Set
+            this on tools that legitimately run long (e.g. image generation that
+            may download a model) so they aren't capped by the global default.
+            ``None`` (the default) means "use the global default".
         **kwargs: Optional arguments (ignored, for backward compatibility)
 
     Returns:
@@ -76,6 +83,7 @@ def tool(
             "function": f,
             "atomic": atomic,
             "display_label": display_label,
+            "timeout": timeout,
         }
 
         # Return the function unchanged

--- a/src/gaia/agents/tools/code_index_tools.py
+++ b/src/gaia/agents/tools/code_index_tools.py
@@ -95,7 +95,10 @@ class CodeIndexToolsMixin:
     def register_code_index_tools(self) -> None:
         """Register code-index tools with the agent's tool registry."""
 
-        @tool
+        # Embedding a whole repo into the shared FAISS index can run minutes on a
+        # large codebase; opt out of the default per-tool cap so a legitimate
+        # index isn't abandoned mid-write.
+        @tool(timeout=900)
         def index_codebase(repo_path: str = "") -> str:
             """Index a code repository for semantic search.
 

--- a/src/gaia/agents/tools/rag_tools.py
+++ b/src/gaia/agents/tools/rag_tools.py
@@ -1199,6 +1199,10 @@ class RAGToolsMixin:
 
         @tool(
             name="index_document",
+            # Indexing a large PDF (parse + chunk + embed) can run past the
+            # default per-tool cap; it also writes to the shared FAISS index, so
+            # abandoning it mid-write must not happen on a legitimate operation.
+            timeout=600,
             description=(
                 "Add a document to the RAG index so its contents can be queried. "
                 "IMPORTANT: After successfully indexing a document, you MUST call "
@@ -1448,6 +1452,9 @@ class RAGToolsMixin:
 
         @tool(
             name="summarize_document",
+            # Iterative section-by-section summarization of a large document on a
+            # local NPU can legitimately exceed the default per-tool cap.
+            timeout=600,
             description="Generate a comprehensive summary of a large indexed document by iterating through its content in sections. Best for getting an overview of lengthy documents.",
             parameters={
                 "file_path": {
@@ -1926,6 +1933,10 @@ Use the {summary_type} style. Ensure page references from section summaries are 
         @tool(
             atomic=True,
             name="index_directory",
+            # Bulk ingest of a whole directory (many files, each parsed + embedded
+            # into the shared FAISS index) routinely runs minutes; don't abandon a
+            # legitimate ingest mid-write at the default cap.
+            timeout=900,
             description="Index all supported files in a directory. Supports PDF, TXT, CSV, JSON, and code files.",
             parameters={
                 "directory_path": {

--- a/src/gaia/sd/mixin.py
+++ b/src/gaia/sd/mixin.py
@@ -128,6 +128,10 @@ class SDToolsMixin:
         @tool(
             atomic=True,
             name="generate_image",
+            # Opt out of the global per-tool timeout: first use may download a
+            # multi-GB SD model (the SD client allows up to 600s for that),
+            # well past the default agent tool cap.
+            timeout=900,
             description="Generate an image from a text prompt using Stable Diffusion. "
             "Returns the path to the saved image file.",
             parameters={

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1414,12 +1414,17 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
     sse_handler = None
     producer = None
     cleanup_done = False
+    # Cooperative cancel signal for the producer's agent loop. Set on stream
+    # timeout / client disconnect so the agent bails at its next step boundary
+    # and the producer thread is actually reaped (see agent._cancel_event).
+    cancel_event = threading.Event()
 
     def _cleanup_stream():
         nonlocal cleanup_done
         if cleanup_done:
             return
         cleanup_done = True
+        cancel_event.set()
         if sse_handler is not None:
             sse_handler.cancelled.set()
         _active_sse_handlers.pop(session_id, None)
@@ -1823,6 +1828,10 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                 # Early-exit if consumer disconnected
                 if sse_handler.cancelled.is_set():
                     return
+
+                # Let the agent loop observe stream-timeout/disconnect so a hung
+                # turn is torn down instead of leaking this producer thread.
+                agent._cancel_event = cancel_event
 
                 # Pre-flight on agent's ACTUAL effective model. When model_id kwarg was
                 # omitted, the agent's __init__ set model_id via kwargs.setdefault — a value

--- a/tests/unit/test_agent_tool_timeout.py
+++ b/tests/unit/test_agent_tool_timeout.py
@@ -1,0 +1,237 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for the bounded, cancellable agent tool-execution guard.
+
+Background (issue #1579): the Agent UI had no per-tool or per-agent execution
+timeout. When a tool blocked (e.g. a hung connector token call), the base
+``Agent`` loop sat in ``tool(**tool_args)`` forever and the producer thread
+that runs ``process_query`` leaked. These tests pin the two-part fix:
+
+1. ``Agent._execute_tool`` bounds every tool call. A tool that blocks past the
+   limit surfaces a *fail-loud, actionable* error within a sensible window
+   (not a 10-minute hang) instead of blocking the loop.
+2. The ``process_query`` loop honours ``self._cancel_event`` at each step
+   boundary, so a producer thread can be torn down rather than leaked once the
+   consumer signals cancellation.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.agents.base.agent import (
+    DEFAULT_TOOL_TIMEOUT,
+    Agent,
+    tool_execution_timeout,
+)
+from gaia.agents.base.tools import _TOOL_REGISTRY, tool
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Save/restore the global tool registry around each test."""
+    saved = dict(_TOOL_REGISTRY)
+    yield
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _clear_timeout_env(monkeypatch):
+    """Default to an unset GAIA_AGENT_TOOL_TIMEOUT for deterministic tests."""
+    monkeypatch.delenv("GAIA_AGENT_TOOL_TIMEOUT", raising=False)
+
+
+class _TimeoutAgent(Agent):
+    """Minimal concrete Agent that pulls tools from the global registry."""
+
+    def _register_tools(self):  # tools are registered per-test via @tool
+        pass
+
+
+def _make_agent(**kwargs) -> _TimeoutAgent:
+    """Construct a real Agent without touching Lemonade or the network."""
+    with patch("gaia.agents.base.agent.AgentSDK"):
+        return _TimeoutAgent(skip_lemonade=True, silent_mode=True, **kwargs)
+
+
+# ─────────────────────────── tool_execution_timeout() ────────────────────────
+
+
+class TestTimeoutConfig:
+    def test_default_when_unset(self):
+        assert tool_execution_timeout() == DEFAULT_TOOL_TIMEOUT
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "45")
+        assert tool_execution_timeout() == 45.0
+
+    def test_fractional_override(self, monkeypatch):
+        monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "0.5")
+        assert tool_execution_timeout() == 0.5
+
+    @pytest.mark.parametrize("bad", ["notanumber", "0", "-5"])
+    def test_invalid_raises(self, monkeypatch, bad):
+        """A present-but-invalid value fails loudly (no silent fallback)."""
+        monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", bad)
+        with pytest.raises(ValueError):
+            tool_execution_timeout()
+
+
+# ─────────────────────────── per-tool timeout guard ──────────────────────────
+
+
+class TestBlockingToolBounded:
+    def test_blocking_tool_returns_actionable_error_fast(self, monkeypatch):
+        """A tool that blocks past the limit yields a bounded, actionable error."""
+        release = threading.Event()
+
+        @tool
+        def hangs_forever() -> dict:
+            """Simulates a hung connector/network call."""
+            release.wait(timeout=30)
+            return {"status": "ok"}
+
+        monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "0.3")
+        agent = _make_agent()
+
+        try:
+            t0 = time.monotonic()
+            result = agent._execute_tool("hangs_forever", {})
+            elapsed = time.monotonic() - t0
+
+            # Bounded — nowhere near the 30s tool block or the 600s consumer cap.
+            assert elapsed < 5.0
+            assert result["status"] == "error"
+            assert result.get("timeout") is True
+            # Actionable: names the offending tool and the override knob.
+            assert "hangs_forever" in result["error"]
+            assert "GAIA_AGENT_TOOL_TIMEOUT" in result["error"]
+        finally:
+            release.set()
+
+    def test_fast_tool_is_unaffected(self, monkeypatch):
+        """The guard is transparent for tools that finish in time."""
+        monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "5")
+
+        @tool
+        def quick(value: str) -> dict:
+            """Returns immediately."""
+            return {"echo": value.upper()}
+
+        agent = _make_agent()
+        result = agent._execute_tool("quick", {"value": "hi"})
+        assert result == {"echo": "HI"}
+
+    def test_tool_exception_still_surfaces(self, monkeypatch):
+        """An exception raised inside the worker is reported, not swallowed."""
+        monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "5")
+
+        @tool
+        def explodes() -> dict:
+            """Raises to exercise the non-timeout error path."""
+            raise RuntimeError("boom")
+
+        agent = _make_agent()
+        result = agent._execute_tool("explodes", {})
+        assert result["status"] == "error"
+        assert result.get("timeout") is not True
+        assert "boom" in (result.get("error_brief") or result.get("error") or "")
+
+
+class TestPerToolOverride:
+    def test_decorator_stores_timeout(self):
+        @tool(timeout=0.3)
+        def slow_but_declared() -> dict:
+            """Declares its own (short) timeout."""
+            return {"ok": True}
+
+        assert _TOOL_REGISTRY["slow_but_declared"]["timeout"] == 0.3
+
+    def test_generate_image_opts_out_of_global_cap(self, tmp_path):
+        """SD image generation declares a long timeout (model download)."""
+        from gaia.sd.mixin import SDToolsMixin
+
+        mixin = SDToolsMixin()
+        mixin.init_sd(output_dir=str(tmp_path))
+
+        # Resolved through the real Agent path: a tool the global default
+        # would cap at 180s must keep its declared 900s window.
+        agent = _make_agent()
+        assert agent._resolve_tool_timeout("generate_image") == 900.0
+
+    def test_per_tool_timeout_beats_global(self, monkeypatch):
+        """A tool's own short timeout fires even when the global cap is large."""
+        release = threading.Event()
+
+        @tool(timeout=0.3)
+        def hangs_with_override() -> dict:
+            """Blocks, but declares a short per-tool timeout."""
+            release.wait(timeout=30)
+            return {"status": "ok"}
+
+        # Global default is large; only the per-tool override keeps us bounded.
+        monkeypatch.setenv("GAIA_AGENT_TOOL_TIMEOUT", "60")
+        agent = _make_agent()
+        try:
+            t0 = time.monotonic()
+            result = agent._execute_tool("hangs_with_override", {})
+            elapsed = time.monotonic() - t0
+            assert elapsed < 5.0
+            assert result.get("timeout") is True
+        finally:
+            release.set()
+
+
+# ─────────────────────────── cancellable producer ────────────────────────────
+
+
+class TestProducerCancellation:
+    def _drive(self, agent, send_side_effect):
+        """Wire a mocked LLM step and return the producer thread + holder."""
+        agent.chat = MagicMock()
+        agent.chat.send_messages.side_effect = send_side_effect
+        holder = {}
+
+        def _producer():
+            holder["result"] = agent.process_query("hello")
+
+        thread = threading.Thread(target=_producer, name="producer", daemon=True)
+        return thread, holder
+
+    def test_cancel_before_start_returns_without_llm_call(self):
+        """A pre-set cancel event stops the loop before any LLM round-trip."""
+        agent = _make_agent(max_steps=10)
+        agent._cancel_event = threading.Event()
+        agent._cancel_event.set()
+
+        thread, holder = self._drive(
+            agent, send_side_effect=AssertionError("LLM should not be called")
+        )
+        thread.start()
+        thread.join(3.0)
+
+        assert not thread.is_alive()
+        agent.chat.send_messages.assert_not_called()
+
+    def test_cancel_mid_run_tears_down_producer(self):
+        """Cancelling mid-run stops the loop at the next step boundary."""
+        agent = _make_agent(max_steps=10)
+        agent._cancel_event = threading.Event()
+
+        def _send(*_args, **_kwargs):
+            # Signal cancellation, then hand back an (empty) response. The loop
+            # must not spin to max_steps — it should break on the next boundary.
+            agent._cancel_event.set()
+            return MagicMock(text="", stats=None)
+
+        thread, _holder = self._drive(agent, send_side_effect=_send)
+        thread.start()
+        thread.join(5.0)
+
+        assert not thread.is_alive(), "producer thread outlived the request"
+        assert agent.chat.send_messages.call_count == 1

--- a/tests/unit/test_agent_tool_timeout.py
+++ b/tests/unit/test_agent_tool_timeout.py
@@ -164,6 +164,28 @@ class TestPerToolOverride:
         agent = _make_agent()
         assert agent._resolve_tool_timeout("generate_image") == 900.0
 
+    def test_long_running_tools_opt_out_of_global_cap(self):
+        """Heavy index/summarize tools keep generous timeouts, not the 180s cap.
+
+        These write to shared FAISS/DB state and can legitimately run minutes;
+        the default cap would abandon a valid operation mid-write.
+        """
+        from gaia.agents.tools.code_index_tools import CodeIndexToolsMixin
+        from gaia.agents.tools.rag_tools import RAGToolsMixin
+
+        RAGToolsMixin.__new__(RAGToolsMixin).register_rag_tools()
+        CodeIndexToolsMixin.__new__(CodeIndexToolsMixin).register_code_index_tools()
+
+        agent = _make_agent()
+        expected = {
+            "index_document": 600.0,
+            "summarize_document": 600.0,
+            "index_directory": 900.0,
+            "index_codebase": 900.0,
+        }
+        for name, want in expected.items():
+            assert agent._resolve_tool_timeout(name) == want, name
+
     def test_per_tool_timeout_beats_global(self, monkeypatch):
         """A tool's own short timeout fires even when the global cap is large."""
         release = threading.Event()


### PR DESCRIPTION
## Why this matters

Before: a hung agent tool — e.g. the stuck connector token call behind #1579 — left the Agent UI stuck in "thinking" with no error, indefinitely. The base agent loop called `tool(**args)` with no timeout and `process_query` never observed any cancel signal, so the worker (`threading.Thread(target=_run_agent)`) leaked. The only backstop was the consumer-side 600s SSE timeout, which took a full 10 minutes *and* only broke the consumer loop, never the producer.

After: every tool call is bounded (default 180s), so a hung tool surfaces an actionable error well under 600s instead of an infinite hang — and the producer thread is actually torn down rather than leaked. #1589 fixed the specific connector root cause; this closes the systemic gap so the next tool hang can't reproduce the same dead-end UX.

Two composable, fail-loud guards live in the base `Agent`, so **all** agents benefit:

- **Per-tool execution timeout** (`_execute_tool`): the tool body runs in a daemon worker joined with the resolved timeout; on timeout it raises `ToolExecutionTimeout` → an actionable error dict naming the tool and the `GAIA_AGENT_TOOL_TIMEOUT` knob. Default 180s via `tool_execution_timeout()` (mirrors the existing `default_max_steps()` — lazy env read, raises on an invalid value). New `@tool(timeout=...)` override; `generate_image` opts out at 900s because SD model download can legitimately take ~600s.
- **Cooperative cancel** (`Agent._cancel_event`): checked at each step boundary in `_process_query_impl`. `_stream_chat_response` assigns a fresh event per request and sets it in `_cleanup_stream`, so the existing `producer.join(5s)` finally reaps the thread. The per-tool timeout keeps each step bounded, guaranteeing the cancel boundary is reached.

Known, documented limit: Python can't kill the timed-out worker thread, so a hung tool's worker keeps running until the process exits — but it's a daemon and no longer blocks the agent loop or leaks the producer.

Closes #1579.

## Test plan

- [ ] `python -m pytest tests/unit/test_agent_tool_timeout.py -q` — 14 tests: blocking tool → bounded actionable error in <5s (not 30s/600s); per-tool override beats global; `tool_execution_timeout()` parsing incl. invalid-raises; SD `generate_image` 900s opt-out resolves through `_resolve_tool_timeout`; producer-style thread does not outlive the request on mid-run cancel (asserts `send_messages` called once + thread dead).
- [ ] `python -m pytest tests/unit/test_tool_decorator.py tests/unit/test_tool_registry_isolation.py tests/unit/agents/test_null_tool_name.py tests/unit/agents/test_tool_not_found_error.py tests/unit/chat/ui/test_chat_helpers.py -q` — regression set, green.
- [ ] `python util/lint.py --black --isort` — clean on the changed files.