### PR TITLE
feat(agent-ui): mailbox-provider selector so Outlook users can triage from the UI (#1596)

### DIFF
--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -110,9 +110,11 @@ function App() {
     }, [loadAgents]);
 
     // Refresh connected-providers at boot so the mail-provider selector
-    // (issue #1596) knows what's connected without opening Settings first.
+    // knows what's connected without opening Settings first.
     useEffect(() => {
-        useConnectionsStore.getState().refresh().catch(() => { /* non-critical */ });
+        useConnectionsStore.getState().refresh().catch((err) => {
+            log.chat.warn('Boot-time connections refresh failed', err);
+        });
     }, []);
 
     // Mobile gateway state
@@ -354,7 +356,7 @@ function App() {
             const activeAgent = agents.find((a) => a.id === activeAgentId);
             const tier = activeAgent?.model_tiers?.find((t) => t.name === activeModelTier);
             const tierModel = tier?.models?.[0];
-            // AC1/AC2 (#1596): resolve mail provider for email sessions.
+            // Resolve the mail provider for email sessions.
             // One connected mail provider → auto-select; multiple → use stored choice.
             const mailProvider = activeAgentId === 'email'
                 ? resolveMailProvider(

--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -18,9 +18,11 @@ import { PermissionPrompt } from './components/PermissionPrompt';
 import { NotificationCenter } from './components/NotificationCenter';
 import { useChatStore } from './stores/chatStore';
 import { useNotificationStore } from './stores/notificationStore';
+import { useConnectionsStore } from './stores/connectorsStore';
 import * as api from './services/api';
 import { log, logBanner } from './utils/logger';
 import { getSessionHash, findSessionByHash } from './utils/format';
+import { resolveMailProvider } from './utils/mailProviderDefault';
 
 /** Wrapper that delays unmount to allow CSS exit animations to play. */
 function AnimatedPresence({ show, children, duration = 250 }: {
@@ -106,6 +108,12 @@ function App() {
         const interval = setInterval(loadAgents, 30_000);
         return () => clearInterval(interval);
     }, [loadAgents]);
+
+    // Refresh connected-providers at boot so the mail-provider selector
+    // (issue #1596) knows what's connected without opening Settings first.
+    useEffect(() => {
+        useConnectionsStore.getState().refresh().catch(() => { /* non-critical */ });
+    }, []);
 
     // Mobile gateway state
     const [showMobileAccess, setShowMobileAccess] = useState(false);
@@ -346,11 +354,20 @@ function App() {
             const activeAgent = agents.find((a) => a.id === activeAgentId);
             const tier = activeAgent?.model_tiers?.find((t) => t.name === activeModelTier);
             const tierModel = tier?.models?.[0];
+            // AC1/AC2 (#1596): resolve mail provider for email sessions.
+            // One connected mail provider → auto-select; multiple → use stored choice.
+            const mailProvider = activeAgentId === 'email'
+                ? resolveMailProvider(
+                    useConnectionsStore.getState().connections.map((c) => c.provider),
+                    useConnectionsStore.getState().pendingMailProvider,
+                )
+                : undefined;
             const session = await api.createSession({
                 title: 'New Task',
                 agent_type: activeAgentId,
                 device: activeDevice,
                 ...(tierModel ? { model: tierModel } : {}),
+                ...(mailProvider ? { mail_provider: mailProvider } : {}),
             });
             log.chat.info(`Session created: id=${session.id}, title="${session.title}"`);
             addSession(session);

--- a/src/gaia/apps/webui/src/components/ChatView.css
+++ b/src/gaia/apps/webui/src/components/ChatView.css
@@ -789,6 +789,25 @@
     font-weight: 600;
 }
 
+/* ── Mail-provider pill (issue #1596) ───────────────────────────── */
+/* Non-interactive badge shown when exactly one mail provider is connected. */
+.mail-provider-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    font-weight: 500;
+    color: var(--text-muted);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-full);
+    white-space: nowrap;
+    line-height: 1;
+    height: 20px;
+}
+
 /* ── Attachments ─────────────────────────────────────────────────── */
 
 .input-content {

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -2,19 +2,24 @@
 // SPDX-License-Identifier: MIT
 
 import { useEffect, useRef, useCallback, useState, useMemo } from 'react';
-import { Bell, Edit3, Paperclip, Download, Send, Upload, MessageSquare, Square, ArrowDown, Lock, FileText, FolderSearch, CheckCircle2, X, Brain, EyeOff, Bot, ChevronDown, Plus } from 'lucide-react';
+import { Bell, Edit3, Paperclip, Download, Send, Upload, MessageSquare, Square, ArrowDown, Lock, FileText, FolderSearch, CheckCircle2, X, Brain, EyeOff, Bot, ChevronDown, Plus, Mail } from 'lucide-react';
 import { MessageBubble } from './MessageBubble';
 import { useChatStore } from '../stores/chatStore';
 import { useNotificationStore, ALWAYS_ALLOW_TOOLS_KEY, selectUnreadCount } from '../stores/notificationStore';
+import { useConnectionsStore } from '../stores/connectorsStore';
 import type { GaiaNotification } from '../types/agent';
 import * as api from '../services/api';
 import { log } from '../utils/logger';
 import { bugReportUrl } from './UnsupportedFeature';
 import type { Message, StreamEvent, AgentStep, Attachment, Session } from '../types';
+import { MAIL_PROVIDERS, type MailProvider } from '../utils/mailProviderDefault';
 
 import './ChatView.css';
 import DashboardProgress from './DashboardProgress';
 
+
+/** Human-readable labels for mail providers (issue #1596). */
+const PROVIDER_LABELS: Record<string, string> = { google: 'Gmail', microsoft: 'Outlook' };
 
 const EMPTY_SUGGESTIONS = [
     'Summarize a document',
@@ -195,6 +200,48 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
     // Resolve human-readable agent names for the message header
     const sessionAgentName = agents.find((a) => a.id === session?.agent_type)?.name;
     const activeAgentName = agents.find((a) => a.id === activeAgentId)?.name;
+
+    // Mail-provider picker (issue #1596) — only rendered for email sessions.
+    const [mailProviderPickerOpen, setMailProviderPickerOpen] = useState(false);
+    const mailProviderPickerRef = useRef<HTMLDivElement>(null);
+    const connectedProviders = useConnectionsStore((s) => s.connections.map((c) => c.provider));
+    const connectedMailProviders = connectedProviders.filter(
+        (p): p is MailProvider => (MAIL_PROVIDERS as readonly string[]).includes(p),
+    );
+    // AC3: the session header shows which mailbox is active.
+    const displayedMailProvider = session?.mail_provider;
+
+    // Close mail-provider picker on outside click
+    useEffect(() => {
+        if (!mailProviderPickerOpen) return;
+        const handler = (e: MouseEvent) => {
+            if (mailProviderPickerRef.current && !mailProviderPickerRef.current.contains(e.target as Node)) {
+                setMailProviderPickerOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [mailProviderPickerOpen]);
+
+    const handleMailProviderChange = useCallback(async (newProvider: MailProvider) => {
+        setMailProviderPickerOpen(false);
+        if (newProvider === displayedMailProvider) return;
+        const previousProvider = displayedMailProvider;
+        // Store the choice for the next session create (App.tsx handleNewTask reads it).
+        useConnectionsStore.getState().setPendingMailProvider(newProvider);
+        if (messages.length === 0) {
+            // Empty session — update in place (mirrors handleAgentChange pattern).
+            updateSessionInList(sessionId, { mail_provider: newProvider } as Partial<Session>);
+            try {
+                await api.updateSession(sessionId, { mail_provider: newProvider });
+            } catch {
+                // Roll back optimistic update on failure.
+                updateSessionInList(sessionId, { mail_provider: previousProvider } as Partial<Session>);
+            }
+        }
+        // If messages exist we don't start a new session — the header pill stays
+        // non-interactive once the session has content (same guard as agent change).
+    }, [displayedMailProvider, messages.length, sessionId, updateSessionInList]);
 
     // Close agent picker on outside click
     useEffect(() => {
@@ -1347,6 +1394,51 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                     )}
                 </div>
                 <div className="task-header-right">
+                    {/* Mail-provider selector — only for email sessions (issue #1596). */}
+                    {session?.agent_type === 'email' && (
+                        connectedMailProviders.length === 1 ? (
+                            /* AC3: single connected provider → non-interactive pill */
+                            <span
+                                className="mail-provider-pill"
+                                title={`Mailbox: ${PROVIDER_LABELS[connectedMailProviders[0]] ?? connectedMailProviders[0]}`}
+                            >
+                                <Mail size={10} />
+                                {PROVIDER_LABELS[connectedMailProviders[0]] ?? connectedMailProviders[0]}
+                            </span>
+                        ) : (
+                            /* AC2: multiple providers → interactive dropdown */
+                            <div className="agent-picker mail-provider-picker" ref={mailProviderPickerRef}>
+                                <button
+                                    className="agent-picker-btn"
+                                    onClick={() => setMailProviderPickerOpen((o) => !o)}
+                                    aria-haspopup="listbox"
+                                    aria-expanded={mailProviderPickerOpen}
+                                    title="Switch mailbox provider"
+                                >
+                                    <Mail size={10} />
+                                    {displayedMailProvider
+                                        ? (PROVIDER_LABELS[displayedMailProvider] ?? displayedMailProvider)
+                                        : 'Mailbox'}
+                                    <ChevronDown size={10} />
+                                </button>
+                                {mailProviderPickerOpen && (
+                                    <div className="agent-picker-dropdown" role="listbox">
+                                        {MAIL_PROVIDERS.map((p) => (
+                                            <button
+                                                key={p}
+                                                className={`agent-picker-option${displayedMailProvider === p ? ' active' : ''}`}
+                                                role="option"
+                                                aria-selected={displayedMailProvider === p}
+                                                onClick={() => handleMailProviderChange(p)}
+                                            >
+                                                {PROVIDER_LABELS[p] ?? p}
+                                            </button>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        )
+                    )}
                     <span
                         className={`model-badge ${!systemStatus?.model_loaded ? 'no-model' : ''}`}
                         title={

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -19,7 +19,7 @@ import './ChatView.css';
 import DashboardProgress from './DashboardProgress';
 
 
-/** Human-readable labels for mail providers (issue #1596). */
+/** Human-readable labels for mail providers. */
 const PROVIDER_LABELS: Record<string, string> = { google: 'Gmail', microsoft: 'Outlook' };
 
 const EMPTY_SUGGESTIONS = [
@@ -222,7 +222,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
     );
     const DisplayedAgentIcon = getAgentIcon(displayedAgent?.icon);
 
-    // Mail-provider picker (issue #1596) — only rendered for email sessions.
+    // Mail-provider picker — only rendered for email sessions.
     const [mailProviderPickerOpen, setMailProviderPickerOpen] = useState(false);
     const mailProviderPickerRef = useRef<HTMLDivElement>(null);
     // Select the stable `connections` reference, then derive — mapping inside the
@@ -1428,7 +1428,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                     )}
                 </div>
                 <div className="task-header-right">
-                    {/* Mail-provider selector — only for email sessions (issue #1596). */}
+                    {/* Mail-provider selector — only for email sessions. */}
                     {session?.agent_type === 'email' && connectedMailProviders.length > 0 && (
                         connectedMailProviders.length === 1 ? (
                             /* AC3: single connected provider → non-interactive pill */

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -237,6 +237,9 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
     );
     // AC3: the session header shows which mailbox is active.
     const displayedMailProvider = session?.mail_provider;
+    // The single-provider pill reflects what THIS session triages (the stored
+    // session value), falling back to the sole connected provider when unset.
+    const activeMailbox = displayedMailProvider ?? connectedMailProviders[0];
 
     // Close mail-provider picker on outside click
     useEffect(() => {
@@ -1431,10 +1434,10 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                             /* AC3: single connected provider → non-interactive pill */
                             <span
                                 className="mail-provider-pill"
-                                title={`Mailbox: ${PROVIDER_LABELS[connectedMailProviders[0]] ?? connectedMailProviders[0]}`}
+                                title={`Mailbox: ${PROVIDER_LABELS[activeMailbox] ?? activeMailbox}`}
                             >
                                 <Mail size={10} />
-                                {PROVIDER_LABELS[connectedMailProviders[0]] ?? connectedMailProviders[0]}
+                                {PROVIDER_LABELS[activeMailbox] ?? activeMailbox}
                             </span>
                         ) : (
                             /* AC2: multiple providers → interactive dropdown */

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -1429,7 +1429,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 </div>
                 <div className="task-header-right">
                     {/* Mail-provider selector — only for email sessions (issue #1596). */}
-                    {session?.agent_type === 'email' && (
+                    {session?.agent_type === 'email' && connectedMailProviders.length > 0 && (
                         connectedMailProviders.length === 1 ? (
                             /* AC3: single connected provider → non-interactive pill */
                             <span
@@ -1458,7 +1458,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                                 </button>
                                 {mailProviderPickerOpen && (
                                     <div className="agent-picker-dropdown" role="listbox">
-                                        {MAIL_PROVIDERS.map((p) => (
+                                        {connectedMailProviders.map((p) => (
                                             <button
                                                 key={p}
                                                 className={`agent-picker-option${displayedMailProvider === p ? ' active' : ''}`}

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -234,7 +234,8 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
             updateSessionInList(sessionId, { mail_provider: newProvider } as Partial<Session>);
             try {
                 await api.updateSession(sessionId, { mail_provider: newProvider });
-            } catch {
+            } catch (err) {
+                log.chat.error('Failed to update mail provider', err);
                 // Roll back optimistic update on failure.
                 updateSessionInList(sessionId, { mail_provider: previousProvider } as Partial<Session>);
             }
@@ -1410,10 +1411,11 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                             <div className="agent-picker mail-provider-picker" ref={mailProviderPickerRef}>
                                 <button
                                     className="agent-picker-btn"
-                                    onClick={() => setMailProviderPickerOpen((o) => !o)}
+                                    onClick={() => !messages.length && setMailProviderPickerOpen((o) => !o)}
                                     aria-haspopup="listbox"
                                     aria-expanded={mailProviderPickerOpen}
-                                    title="Switch mailbox provider"
+                                    disabled={messages.length > 0}
+                                    title={messages.length > 0 ? 'Mailbox is locked once a session has messages — start a new task to change it' : 'Switch mailbox provider'}
                                 >
                                     <Mail size={10} />
                                     {displayedMailProvider

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -425,7 +425,7 @@ export async function getSession(id: string): Promise<Session> {
     return apiFetch('GET', `/sessions/${id}`);
 }
 
-export async function updateSession(id: string, data: { title?: string; system_prompt?: string; private?: boolean; agent_type?: string }): Promise<Session> {
+export async function updateSession(id: string, data: { title?: string; system_prompt?: string; private?: boolean; agent_type?: string; mail_provider?: string }): Promise<Session> {
     return apiFetch('PUT', `/sessions/${id}`, data);
 }
 

--- a/src/gaia/apps/webui/src/stores/__tests__/connectorsStore.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/connectorsStore.test.ts
@@ -1,0 +1,84 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useConnectionsStore } from '../connectorsStore';
+import type { ConnectorInfo } from '../../types';
+
+const conn = (provider: string): ConnectorInfo => ({
+    provider,
+    account_email: `test@${provider}.com`,
+    scopes: [],
+    connected_at: null,
+});
+
+describe('connectorsStore — pendingMailProvider clearing', () => {
+    beforeEach(() => {
+        useConnectionsStore.setState({
+            connections: [],
+            grants: {},
+            loading: false,
+            error: null,
+            pendingMailProvider: undefined,
+        });
+    });
+
+    describe('removeConnection', () => {
+        it('clears pendingMailProvider when the removed provider matches', () => {
+            useConnectionsStore.setState({
+                connections: [conn('google'), conn('microsoft')],
+                pendingMailProvider: 'google',
+            });
+            useConnectionsStore.getState().removeConnection('google');
+            expect(useConnectionsStore.getState().pendingMailProvider).toBeUndefined();
+        });
+
+        it('preserves pendingMailProvider when a different provider is removed', () => {
+            useConnectionsStore.setState({
+                connections: [conn('google'), conn('microsoft')],
+                pendingMailProvider: 'google',
+            });
+            useConnectionsStore.getState().removeConnection('microsoft');
+            expect(useConnectionsStore.getState().pendingMailProvider).toBe('google');
+        });
+
+        it('is a no-op on pendingMailProvider when it is already undefined', () => {
+            useConnectionsStore.setState({
+                connections: [conn('google')],
+                pendingMailProvider: undefined,
+            });
+            useConnectionsStore.getState().removeConnection('google');
+            expect(useConnectionsStore.getState().pendingMailProvider).toBeUndefined();
+        });
+    });
+
+    describe('setConnections', () => {
+        it('clears pendingMailProvider when that provider is no longer in the new connection list', () => {
+            useConnectionsStore.setState({
+                connections: [conn('google'), conn('microsoft')],
+                pendingMailProvider: 'microsoft',
+            });
+            // Simulate a SSE bulk refresh that drops microsoft
+            useConnectionsStore.getState().setConnections([conn('google')]);
+            expect(useConnectionsStore.getState().pendingMailProvider).toBeUndefined();
+        });
+
+        it('preserves pendingMailProvider when the provider is still connected after refresh', () => {
+            useConnectionsStore.setState({
+                connections: [conn('google'), conn('microsoft')],
+                pendingMailProvider: 'google',
+            });
+            useConnectionsStore.getState().setConnections([conn('google')]);
+            expect(useConnectionsStore.getState().pendingMailProvider).toBe('google');
+        });
+
+        it('preserves undefined pendingMailProvider across any refresh', () => {
+            useConnectionsStore.setState({
+                connections: [conn('google')],
+                pendingMailProvider: undefined,
+            });
+            useConnectionsStore.getState().setConnections([]);
+            expect(useConnectionsStore.getState().pendingMailProvider).toBeUndefined();
+        });
+    });
+});

--- a/src/gaia/apps/webui/src/stores/connectorsStore.ts
+++ b/src/gaia/apps/webui/src/stores/connectorsStore.ts
@@ -21,6 +21,12 @@ interface ConnectionsState {
     loading: boolean;
     error: string | null;
 
+    /**
+     * Issue #1596 — user's explicit mail-provider choice for the next email session.
+     * Undefined means "no explicit preference" (auto-select if only one is connected).
+     */
+    pendingMailProvider: string | undefined;
+
     /** Initial load — populates connections + grants in one round-trip. */
     refresh: () => Promise<void>;
 
@@ -33,6 +39,9 @@ interface ConnectionsState {
     removeGrant: (provider: string, agentId: string) => void;
 
     setError: (msg: string | null) => void;
+
+    /** Set the mail provider the user explicitly chose in the selector. */
+    setPendingMailProvider: (provider: string | undefined) => void;
 }
 
 export const useConnectionsStore = create<ConnectionsState>((set, get) => ({
@@ -40,6 +49,7 @@ export const useConnectionsStore = create<ConnectionsState>((set, get) => ({
     grants: {},
     loading: false,
     error: null,
+    pendingMailProvider: undefined,
 
     refresh: async () => {
         set({ loading: true, error: null });
@@ -94,4 +104,6 @@ export const useConnectionsStore = create<ConnectionsState>((set, get) => ({
         }),
 
     setError: (msg) => set({ error: msg }),
+
+    setPendingMailProvider: (provider) => set({ pendingMailProvider: provider }),
 }));

--- a/src/gaia/apps/webui/src/stores/connectorsStore.ts
+++ b/src/gaia/apps/webui/src/stores/connectorsStore.ts
@@ -76,7 +76,15 @@ export const useConnectionsStore = create<ConnectionsState>((set, get) => ({
         }
     },
 
-    setConnections: (conns) => set({ connections: conns }),
+    setConnections: (conns) =>
+        set((s) => {
+            const connectedProviders = new Set(conns.map((c) => c.provider));
+            const pendingStillConnected = s.pendingMailProvider === undefined || connectedProviders.has(s.pendingMailProvider);
+            return {
+                connections: conns,
+                ...(pendingStillConnected ? {} : { pendingMailProvider: undefined }),
+            };
+        }),
     addConnection: (conn) =>
         set((s) => {
             const without = s.connections.filter((c) => c.provider !== conn.provider);
@@ -85,6 +93,8 @@ export const useConnectionsStore = create<ConnectionsState>((set, get) => ({
     removeConnection: (provider) =>
         set((s) => ({
             connections: s.connections.filter((c) => c.provider !== provider),
+            // Clear the pending choice if the provider it referenced was disconnected.
+            ...(s.pendingMailProvider === provider ? { pendingMailProvider: undefined } : {}),
         })),
 
     setGrants: (provider, grants) =>

--- a/src/gaia/apps/webui/src/stores/connectorsStore.ts
+++ b/src/gaia/apps/webui/src/stores/connectorsStore.ts
@@ -22,7 +22,7 @@ interface ConnectionsState {
     error: string | null;
 
     /**
-     * Issue #1596 — user's explicit mail-provider choice for the next email session.
+     * User's explicit mail-provider choice for the next email session.
      * Undefined means "no explicit preference" (auto-select if only one is connected).
      */
     pendingMailProvider: string | undefined;

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -16,6 +16,8 @@ export interface Session {
     agent_type?: string;
     /** Device used for this session (cpu / gpu / npu). */
     device?: string;
+    /** Mail provider for email-triage sessions ("google" | "microsoft"). */
+    mail_provider?: string;
 }
 
 /** Per-device configuration for an agent (CPU / GPU / NPU). */

--- a/src/gaia/apps/webui/src/utils/__tests__/mailProviderDefault.test.ts
+++ b/src/gaia/apps/webui/src/utils/__tests__/mailProviderDefault.test.ts
@@ -1,0 +1,44 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import { resolveMailProvider } from '../mailProviderDefault';
+
+/**
+ * Provider-default logic for issue #1596 — the Agent UI mailbox-provider selector.
+ *
+ * AC1: exactly one of google/microsoft connected → auto-select it.
+ * AC2: both connected (or neither) → fall back to the caller's explicit choice.
+ */
+describe('resolveMailProvider', () => {
+    it('auto-selects google when only google is connected', () => {
+        expect(resolveMailProvider(['google'], undefined)).toBe('google');
+    });
+
+    it('auto-selects microsoft when only microsoft is connected', () => {
+        expect(resolveMailProvider(['microsoft'], undefined)).toBe('microsoft');
+    });
+
+    it('returns explicit choice when both providers are connected', () => {
+        expect(resolveMailProvider(['google', 'microsoft'], 'microsoft')).toBe('microsoft');
+        expect(resolveMailProvider(['google', 'microsoft'], 'google')).toBe('google');
+    });
+
+    it('returns explicit choice when neither provider is connected', () => {
+        expect(resolveMailProvider([], 'google')).toBe('google');
+    });
+
+    it('returns undefined when both connected and no explicit choice provided', () => {
+        // No auto-select when ambiguous — caller must show the interactive selector
+        expect(resolveMailProvider(['google', 'microsoft'], undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when nothing connected and no explicit choice', () => {
+        expect(resolveMailProvider([], undefined)).toBeUndefined();
+    });
+
+    it('ignores non-mail providers (e.g. github) when determining auto-select', () => {
+        // github is connected but is not a mail provider → still auto-selects google
+        expect(resolveMailProvider(['google', 'github'], undefined)).toBe('google');
+    });
+});

--- a/src/gaia/apps/webui/src/utils/mailProviderDefault.ts
+++ b/src/gaia/apps/webui/src/utils/mailProviderDefault.ts
@@ -1,0 +1,26 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/** Mail providers the backend accepts (backend pattern: ^(google|microsoft)$). */
+export const MAIL_PROVIDERS = ['google', 'microsoft'] as const;
+export type MailProvider = (typeof MAIL_PROVIDERS)[number];
+
+/**
+ * Resolve the mail provider to use for a new email-triage session.
+ *
+ * AC1 — exactly one of google/microsoft is connected → auto-select it.
+ * AC2 — both connected (or neither) → return the caller's explicit choice (may be undefined).
+ *
+ * @param connectedProviders  All provider ids currently in the connections store.
+ * @param explicitChoice      Value the user explicitly selected (or undefined if none).
+ */
+export function resolveMailProvider(
+    connectedProviders: string[],
+    explicitChoice: string | undefined,
+): string | undefined {
+    const mailConnected = connectedProviders.filter(
+        (p): p is MailProvider => (MAIL_PROVIDERS as readonly string[]).includes(p),
+    );
+    if (mailConnected.length === 1) return mailConnected[0];
+    return explicitChoice;
+}


### PR DESCRIPTION
A user who connected a personal Microsoft/Outlook account couldn't triage Outlook from the Agent UI: every session was hardwired to Gmail, so an Outlook-only user hit "no grant for google" and "triage my Outlook emails" silently triaged Gmail. The backend already honored a per-session `mail_provider` (verified live) — only the frontend control was missing. This adds a mailbox selector in the Email Triage chat header: it auto-selects the sole connected provider (an Outlook-only user gets Outlook with no CLI/API step), lets the user choose when both are connected, and always shows which mailbox the session triages.

Closes #1596

## Test plan
- [x] `cd src/gaia/apps/webui && npm run build` (tsc strict + vite)
- [x] vitest — 60/60 (`resolveMailProvider` defaulting + stale-`pendingMailProvider` clearing)
- [ ] Real-world (t-nx-strx-halo): Microsoft-only user triages Outlook from the UI; with both connected, switching the selector triages the chosen mailbox; selection visible in the header — **pending live OAuth**

Frontend-only; the provider-aware "Connect Microsoft" CTA edge case is owned by #1592.