### PR TITLE
chore(ci): route build_agent_package version/dist/path through env: for hardening uniformity

### DIFF
--- a/.github/workflows/build_agent_package.yml
+++ b/.github/workflows/build_agent_package.yml
@@ -52,7 +52,12 @@ jobs:
           ENTRY=$(python util/list_agent_packages.py --format matrix --only "$AGENT_ID")
           PATHV=$(echo "$ENTRY" | python -c "import json,sys;e=json.load(sys.stdin)['include'][0];print(e['path'])")
           DIST=$(echo  "$ENTRY" | python -c "import json,sys;e=json.load(sys.stdin)['include'][0];print(e['dist'])")
-          VERSION=$(python -c "import tomllib;print(tomllib.load(open('$PATHV/pyproject.toml','rb'))['project']['version'])")
+          VERSION=$(PATHV="$PATHV" python <<'PY'
+          import os, tomllib
+          with open(os.path.join(os.environ["PATHV"], "pyproject.toml"), "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )
           echo "path=$PATHV"    >> "$GITHUB_OUTPUT"
           echo "dist=$DIST"     >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -66,13 +71,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           AGENT_ID: ${{ inputs.agent_id }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          DIST: ${{ steps.meta.outputs.dist }}
+          PKG_PATH: ${{ steps.meta.outputs.path }}
         run: |
           set -euo pipefail
           # Tag the actually-built commit (the checked-out ref), not GITHUB_SHA —
           # which is the dispatch branch head and diverges when `ref` is set.
           SHA="$(git rev-parse HEAD)"
-          TAG="agent-pkg-${AGENT_ID}-v${{ steps.meta.outputs.version }}"
-          DIST_DIR="${{ steps.meta.outputs.path }}/dist"
+          TAG="agent-pkg-${AGENT_ID}-v${VERSION}"
+          DIST_DIR="${PKG_PATH}/dist"
           # Fail loud if the build produced nothing — never upload an empty release.
           ls "$DIST_DIR"/*.whl "$DIST_DIR"/*.tar.gz
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -80,6 +88,6 @@ jobs:
           else
             gh release create "$TAG" "$DIST_DIR"/* --prerelease --target "$SHA" \
               --title "$TAG" \
-              --notes "Interim GitHub-native share of ${{ steps.meta.outputs.dist }} built from $SHA. Not a PyPI release (#1179)."
+              --notes "Interim GitHub-native share of ${DIST} built from $SHA. Not a PyPI release (#1179)."
           fi
           echo "Release: https://github.com/amd/gaia/releases/tag/$TAG"


### PR DESCRIPTION
### Why this matters

`build_agent_package.yml` already routes the user-supplied `agent_id` through `env:` before any shell, but `version`, `dist`, and `path` were still interpolated as raw `${{ … }}` expressions inside `run:` blocks, and the version read embedded a shell var inside a `python -c` code string. The injection risk **today is nil** — those values are workflow/repo-controlled, not user input — but applying the `env:` convention **uniformly** makes the hardening obvious so a future copy-paste onto a path that *does* carry user input can't silently reintroduce a real injection.

**No behavior change.** Verified live on the real runner: a `workflow_dispatch` of the hardened workflow on this branch produced the identical `agent-pkg-email-v0.1.0` prerelease (wheel + sdist), green end-to-end.

### Test plan

- [x] `actionlint` clean on `build_agent_package.yml` (only a pre-existing `SC2129` style note, unchanged by this PR)
- [x] YAML parses (`yaml.safe_load`)
- [x] **No `${{ … }}` remains in any `run:` block** — every dynamic value (`agent_id`, `version`, `dist`, `path`) now reaches the shell/Python via `env:`; the version read uses a here-doc reading `os.environ["PATHV"]`
- [x] Live `workflow_dispatch` on this branch → green run, identical `agent-pkg-email-v0.1.0` prerelease with `.whl` + `.tar.gz` ([run](https://github.com/amd/gaia/actions/runs/27381745579))
- [x] Anonymous `curl` of both release assets → HTTP 200; clean-venv `pip install` of the wheel + `import gaia_agent_email` works
- [x] No PyPI publish path fired — #1179 stays untouched

Full post-merge verification evidence (all 8 ACs) is captured in #1602.

Closes #1611

Related: #1598, #1601, #1602