### PR TITLE
feat(email): connector-derived mailbox selection — multi-inbox triage + send (#1603, #1594)

### DIFF
--- a/.github/workflows/test_email_agent_unit.yml
+++ b/.github/workflows/test_email_agent_unit.yml
@@ -13,7 +13,7 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'src/gaia/agents/email/**'
+      - 'hub/agents/python/email/**'
       - 'src/gaia/agents/base/**'
       - 'src/gaia/connectors/**'
       - 'src/gaia/eval/**'
@@ -29,7 +29,7 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'src/gaia/agents/email/**'
+      - 'hub/agents/python/email/**'
       - 'src/gaia/agents/base/**'
       - 'src/gaia/connectors/**'
       - 'src/gaia/eval/**'

--- a/hub/agents/python/email/gaia_agent_email/action_store.py
+++ b/hub/agents/python/email/gaia_agent_email/action_store.py
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS email_actions (
     thread_id    TEXT,
     payload_json TEXT NOT NULL,
     batch_id     TEXT,
+    mailbox      TEXT,
     created_at   REAL NOT NULL,
     undone_at    REAL
 );
@@ -75,9 +76,25 @@ BODY_PREVIEW_MAX_CHARS = 100
 
 
 def init_schema(db) -> None:
-    """Create both tables if they don't exist. Idempotent."""
+    """Create both tables if they don't exist, then run migrations. Idempotent."""
     db.execute(EMAIL_ACTIONS_DDL)
     db.execute(EMAIL_DRAFTS_DDL)
+    _migrate_email_actions_mailbox(db)
+
+
+def _migrate_email_actions_mailbox(db) -> None:
+    """Add the ``mailbox`` column to a pre-#1603 ``email_actions`` table.
+
+    A fresh DB already has the column (it is in the DDL); an existing DB created
+    before Phase 2 does not. We ADD it guarded by a ``PRAGMA table_info``
+    existence check and backfill legacy rows to 'google' — every action recorded
+    before multi-inbox could only have hit the single (Gmail) mailbox.
+    """
+    cols = {row["name"] for row in db.query("PRAGMA table_info(email_actions)")}
+    if "mailbox" in cols:
+        return
+    db.execute("ALTER TABLE email_actions ADD COLUMN mailbox TEXT")
+    db.update("email_actions", {"mailbox": "google"}, "mailbox IS NULL", {})
 
 
 # ---------------------------------------------------------------------------
@@ -93,12 +110,16 @@ def record_action(
     thread_id: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
     batch_id: Optional[str] = None,
+    mailbox: Optional[str] = None,
 ) -> str:
     """Insert a row, return the new action_id.
 
     ``payload`` carries the data needed to reverse the action — e.g. for
     ``trash`` the message id is enough; for ``add_label`` we record the
     added label id so undo can ``remove_label`` exactly that one.
+
+    ``mailbox`` records which mailbox the action hit ('google' / 'microsoft')
+    so undo routes to the right account when multiple are connected (#1603).
     """
     action_id = uuid.uuid4().hex
     db.insert(
@@ -110,6 +131,7 @@ def record_action(
             "thread_id": thread_id,
             "payload_json": json.dumps(payload or {}),
             "batch_id": batch_id,
+            "mailbox": mailbox,
             "created_at": time.time(),
             "undone_at": None,
         },
@@ -145,6 +167,7 @@ def fetch_undoable(
         "thread_id": row["thread_id"],
         "payload": payload,
         "batch_id": row["batch_id"],
+        "mailbox": row["mailbox"],
         "created_at": row["created_at"],
     }
 
@@ -179,6 +202,7 @@ def fetch_batch_undoable(
                 "thread_id": row["thread_id"],
                 "payload": payload,
                 "batch_id": row["batch_id"],
+                "mailbox": row["mailbox"],
                 "created_at": row["created_at"],
             }
         )

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -472,6 +472,9 @@ class EmailTriageAgent(
             for item in out["results"]:
                 item["mailbox"] = provider
                 self._remember_message_mailbox(item.get("id"), provider)
+                # Thread ids share the provenance map so get_thread /
+                # summarize_thread route to the right mailbox too.
+                self._remember_message_mailbox(item.get("thread_id"), provider)
                 merged.append(item)
         merged = merged[:max_messages]
         # Re-group the merged, capped list so the bucketed view matches what the
@@ -520,14 +523,17 @@ class EmailTriageAgent(
             for item in out.get("urgent", []):
                 item["mailbox"] = provider
                 self._remember_message_mailbox(item.get("message_id"), provider)
+                self._remember_message_mailbox(item.get("thread_id"), provider)
                 urgent.append(item)
             for item in out.get("actionable", []):
                 item["mailbox"] = provider
                 self._remember_message_mailbox(item.get("message_id"), provider)
+                self._remember_message_mailbox(item.get("thread_id"), provider)
                 actionable.append(item)
             for item in out.get("suggested_archives", []):
                 item["mailbox"] = provider
                 self._remember_message_mailbox(item.get("message_id"), provider)
+                self._remember_message_mailbox(item.get("thread_id"), provider)
                 suggested_archives.append(item)
             informational_count += int(out.get("informational_count", 0))
         return {

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -228,6 +228,9 @@ class EmailTriageAgent(
         # tools route each message to the mailbox it came from (no cross-mailbox
         # 404s when multiple are connected). See ``_backend_for_message``.
         self._message_mailbox: dict[str, str] = {}
+        # draft_id → provider, so send_draft routes back to the mailbox the
+        # draft was created in.
+        self._draft_mailbox: dict[str, str] = {}
         # ``resolve_calendar_backend`` picks Google vs Outlook from
         # ``config.calendar_provider`` (#1276) — the tools treat either as a
         # ``CalendarBackend``. An injected backend (eval/test seam) wins inside
@@ -304,6 +307,244 @@ class EmailTriageAgent(
         self._register_calendar_tools()
         self._register_preference_tools()
         self._register_phishing_tools()
+
+    # -- Phase 2 multi-inbox routing (#1603) -------------------------------
+
+    def _remember_message_mailbox(self, message_id: Optional[str], provider: str) -> None:
+        """Record which mailbox a message_id came from, for action routing."""
+        if message_id:
+            self._message_mailbox[message_id] = provider
+
+    def _backend_for_message(
+        self, message_id: str, explicit_mailbox: Optional[str] = None
+    ):
+        """Return the backend the given message belongs to.
+
+        Resolution order:
+          1. ``explicit_mailbox`` when supplied (the LLM passed the tagged value
+             it saw in triage output).
+          2. The provider remembered from triage / scan / read.
+          3. The sole backend when exactly one is connected.
+          4. Otherwise FAIL LOUD — with multiple mailboxes connected and no
+             provenance, guessing would risk a cross-mailbox 404 / wrong-account
+             mutation.
+        """
+        provider = explicit_mailbox or self._message_mailbox.get(message_id)
+        if provider is None:
+            if len(self._backends) == 1:
+                return next(iter(self._backends.values()))
+            raise ValueError(
+                f"Cannot determine which mailbox message {message_id!r} belongs "
+                f"to; multiple mailboxes are connected ({', '.join(self._backends)}). "
+                "Re-run triage so the message is tagged, or pass mailbox= "
+                "explicitly."
+            )
+        backend = self._backends.get(provider)
+        if backend is None:
+            raise ValueError(
+                f"Message {message_id!r} is tagged mailbox {provider!r}, which is "
+                f"not connected. Connected: {', '.join(self._backends) or 'none'}."
+            )
+        return backend
+
+    def _provider_for_message(
+        self, message_id: str, explicit_mailbox: Optional[str] = None
+    ) -> str:
+        """Return the provider name a message routes to (the key in _backends).
+
+        Same resolution as ``_backend_for_message`` but yields the provider
+        STRING so action rows can record which mailbox they hit (undo routing).
+        """
+        backend = self._backend_for_message(message_id, explicit_mailbox)
+        for provider, candidate in self._backends.items():
+            if candidate is backend:
+                return provider
+        # _backend_for_message only ever returns a value from _backends.
+        raise ValueError(
+            f"resolved backend for message {message_id!r} is not in _backends"
+        )
+
+    def _send_backend(self, explicit_mailbox: Optional[str] = None):
+        """Resolve a backend for a send-from-scratch (``send_now``).
+
+        ``send_now`` has no source message, so it defaults to the primary
+        mailbox unless an explicit ``mailbox`` names another connected one.
+        """
+        if explicit_mailbox is None:
+            return self._gmail
+        backend = self._backends.get(explicit_mailbox)
+        if backend is None:
+            raise ValueError(
+                f"Mailbox {explicit_mailbox!r} is not connected. Connected: "
+                f"{', '.join(self._backends) or 'none'}."
+            )
+        return backend
+
+    def _remember_draft_mailbox(
+        self, draft_id: Optional[str], provider: str
+    ) -> None:
+        """Record which mailbox a draft was created in (for send_draft routing)."""
+        if draft_id:
+            self._draft_mailbox[draft_id] = provider
+
+    def _backend_for_draft(self, draft_id: str, explicit_mailbox: Optional[str] = None):
+        """Resolve the backend a draft lives in, for ``send_draft``.
+
+        Prefers an explicit mailbox, then the provider remembered when the draft
+        was created, then the sole backend. Fails loud when ambiguous.
+        """
+        provider = explicit_mailbox or self._draft_mailbox.get(draft_id)
+        if provider is None:
+            if len(self._backends) == 1:
+                return next(iter(self._backends.values()))
+            raise ValueError(
+                f"Cannot determine which mailbox draft {draft_id!r} belongs to; "
+                f"multiple mailboxes are connected ({', '.join(self._backends)}). "
+                "Re-create the draft or pass mailbox= explicitly."
+            )
+        backend = self._backends.get(provider)
+        if backend is None:
+            raise ValueError(
+                f"Draft {draft_id!r} is tagged mailbox {provider!r}, which is not "
+                f"connected. Connected: {', '.join(self._backends) or 'none'}."
+            )
+        return backend
+
+    def _backend_for_action(self, action: dict):
+        """Resolve the backend for a recorded action row (undo routing).
+
+        Prefers the mailbox stored on the row (#1603 D5); falls back to the
+        message's remembered provider, then to the sole backend. Legacy rows
+        with no mailbox default to 'google' when present, else fail loud if the
+        choice is ambiguous.
+        """
+        provider = action.get("mailbox")
+        message_id = action.get("message_id", "")
+        if provider is None:
+            return self._backend_for_message(message_id)
+        backend = self._backends.get(provider)
+        if backend is None:
+            raise ValueError(
+                f"Action for message {message_id!r} is tagged mailbox "
+                f"{provider!r}, which is not connected. Connected: "
+                f"{', '.join(self._backends) or 'none'}."
+            )
+        return backend
+
+    def _triage_all_backends(self, *, max_messages: int) -> dict:
+        """Triage every connected mailbox, tag each item, merge under budget.
+
+        ``max_messages`` is a TOTAL budget split across mailboxes (NEVER
+        per-mailbox) — "triage 20" with two connected stays ~20 total, not 40 —
+        because local inference is slow (~9-31 s/email) and a doubled budget
+        would blow the user's expected wait. Every returned item gains a
+        ``mailbox`` tag and its id is remembered for downstream action routing.
+        """
+        from gaia_agent_email.tools import read_tools
+        from gaia_agent_email.tools.read_tools import triage_inbox_impl
+        from gaia_agent_email.tools.triage_heuristics import group_by_category
+
+        # Reference the factory via the read_tools module so the existing
+        # ``read_tools.make_llm_classifier`` test seam (the pre-scan canary)
+        # keeps intercepting the expensive triage path.
+        chat = getattr(self, "chat", None)
+        classifier = (
+            read_tools.make_llm_classifier(chat) if chat is not None else None
+        )
+        prefs = getattr(self, "_session_preferences", None)
+        force_llm = bool(getattr(self.config, "force_llm", False))
+        debug_flag = bool(getattr(self.config, "debug", False))
+
+        backends = self._backends
+        per_backend = max(1, max_messages // len(backends))
+        merged: list[dict] = []
+        for provider, backend in backends.items():
+            if len(merged) >= max_messages:
+                break
+            out = triage_inbox_impl(
+                backend,
+                max_messages=per_backend,
+                session_preferences=prefs,
+                force_llm=force_llm,
+                classifier=classifier,
+                debug=debug_flag,
+            )
+            for item in out["results"]:
+                item["mailbox"] = provider
+                self._remember_message_mailbox(item.get("id"), provider)
+                merged.append(item)
+        merged = merged[:max_messages]
+        # Re-group the merged, capped list so the bucketed view matches what the
+        # caller actually sees.
+        return {"results": merged, "grouped": group_by_category(merged)}
+
+    def _pre_scan_all_backends(self, *, max_messages: int) -> dict:
+        """Pre-scan every connected mailbox, tag each item, merge under budget.
+
+        Same TOTAL-budget split as ``_triage_all_backends``. Each section item
+        (urgent / actionable / suggested_archives) gains a ``mailbox`` tag and
+        its message_id is remembered for action routing. Per-section caps and
+        the envelope shape are preserved by merging the per-backend envelopes.
+        """
+        from gaia_agent_email.tools.read_tools import (
+            PRE_SCAN_ACTIONABLE_CAP,
+            PRE_SCAN_ARCHIVE_CAP,
+            PRE_SCAN_URGENT_CAP,
+            pre_scan_inbox_impl,
+        )
+
+        prefs = getattr(self, "_session_preferences", None)
+        force_llm = bool(getattr(self.config, "force_llm", False))
+        debug_flag = bool(getattr(self.config, "debug", False))
+
+        backends = self._backends
+        per_backend = max(1, max_messages // len(backends))
+        urgent: list[dict] = []
+        actionable: list[dict] = []
+        suggested_archives: list[dict] = []
+        informational_count = 0
+        scanned = 0
+        merged_prefs_applied: dict = {}
+        for provider, backend in backends.items():
+            if scanned >= max_messages:
+                break
+            out = pre_scan_inbox_impl(
+                backend,
+                max_messages=per_backend,
+                session_preferences=prefs,
+                force_llm=force_llm,
+                debug=debug_flag,
+            )
+            scanned += per_backend
+            merged_prefs_applied = out.get("preferences_applied", merged_prefs_applied)
+            for item in out.get("urgent", []):
+                item["mailbox"] = provider
+                self._remember_message_mailbox(item.get("message_id"), provider)
+                urgent.append(item)
+            for item in out.get("actionable", []):
+                item["mailbox"] = provider
+                self._remember_message_mailbox(item.get("message_id"), provider)
+                actionable.append(item)
+            for item in out.get("suggested_archives", []):
+                item["mailbox"] = provider
+                self._remember_message_mailbox(item.get("message_id"), provider)
+                suggested_archives.append(item)
+            informational_count += int(out.get("informational_count", 0))
+        return {
+            "kind": "email_pre_scan",
+            "urgent": urgent[: max(0, PRE_SCAN_URGENT_CAP)],
+            "actionable": actionable[: max(0, PRE_SCAN_ACTIONABLE_CAP)],
+            "informational_count": informational_count,
+            "suggested_archives": suggested_archives[: max(0, PRE_SCAN_ARCHIVE_CAP)],
+            "suggested_drafts": [],
+            "preferences_applied": merged_prefs_applied,
+            "totals": {
+                "urgent": len(urgent),
+                "actionable": len(actionable),
+                "informational": informational_count,
+                "suggested_archives": len(suggested_archives),
+            },
+        }
 
     # -- Phase I3 batch-organize counter -----------------------------------
 

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import ClassVar, List, Optional
+from typing import Any, ClassVar, List, Optional
 
 from gaia_agent_email import action_store
 from gaia_agent_email.config import EmailAgentConfig
@@ -215,11 +215,19 @@ class EmailTriageAgent(
         self.config = config
 
         # Backend resolution. Production binds to live; eval injects fakes.
-        # ``resolve_mail_backend`` picks Gmail vs Outlook from
-        # ``config.mail_provider`` (#1275) — the tools treat either as a
-        # ``GmailBackend``. The attribute stays ``self._gmail`` for tool-mixin
-        # compatibility regardless of the underlying provider.
-        self._gmail = config.resolve_mail_backend()
+        # ``resolve_mail_backends`` returns provider→backend for every mailbox
+        # the ``mail_provider`` filter admits (#1603 Phase 2): None scans every
+        # connected mailbox, an explicit value restricts to one. Each backend
+        # satisfies the ``GmailBackend`` Protocol so the tools treat Gmail and
+        # Outlook interchangeably.
+        self._backends: dict[str, Any] = dict(config.resolve_mail_backends())
+        # ``self._gmail`` stays the PRIMARY backend (first in registry order) so
+        # existing single-backend tool closures keep working unchanged.
+        self._gmail = next(iter(self._backends.values()))
+        # message_id → provider, populated by triage / scan / read so action
+        # tools route each message to the mailbox it came from (no cross-mailbox
+        # 404s when multiple are connected). See ``_backend_for_message``.
+        self._message_mailbox: dict[str, str] = {}
         # ``resolve_calendar_backend`` picks Google vs Outlook from
         # ``config.calendar_provider`` (#1276) — the tools treat either as a
         # ``CalendarBackend``. An injected backend (eval/test seam) wins inside

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -452,20 +452,25 @@ class ConfirmationStore:
     endpoint. Consuming a token removes it (single-use). The server-side
     secret makes tokens unforgeable; the fingerprint makes them payload-
     specific.
+
+    Tokens may optionally carry a provider binding (D5): when the draft
+    specified ``provider="microsoft"``, the token stores that binding so the
+    send handler routes to the correct backend even when multiple mailboxes
+    are connected.
     """
 
     def __init__(self, secret: Optional[bytes] = None):
         self._secret = secret or secrets.token_bytes(32)
         self._lock = threading.Lock()
-        # token -> fingerprint it authorizes
-        self._tokens: dict[str, str] = {}
+        # token -> (fingerprint, provider_or_None)
+        self._tokens: dict[str, tuple[str, Optional[str]]] = {}
 
-    def issue(self, fingerprint: str) -> str:
+    def issue(self, fingerprint: str, *, provider: Optional[str] = None) -> str:
         token = hmac.new(
             self._secret, (fingerprint + secrets.token_hex(8)).encode("utf-8"), "sha256"
         ).hexdigest()
         with self._lock:
-            self._tokens[token] = fingerprint
+            self._tokens[token] = (fingerprint, provider)
         return token
 
     def consume(self, token: str, fingerprint: str) -> bool:
@@ -476,17 +481,29 @@ class ConfirmationStore:
         A blank/unknown token, or a token issued for a different payload,
         returns False and is NOT consumed.
         """
+        ok, _ = self.consume_with_provider(token, fingerprint)
+        return ok
+
+    def consume_with_provider(
+        self, token: str, fingerprint: str
+    ) -> tuple[bool, Optional[str]]:
+        """Like ``consume`` but also returns the bound provider (or None).
+
+        Returns ``(True, provider_or_None)`` on success; ``(False, None)`` on
+        rejection. The provider is the value passed to ``issue(provider=...)``.
+        """
         if not token:
-            return False
+            return False, None
         with self._lock:
-            expected = self._tokens.get(token)
-            if expected is None:
-                return False
-            if not hmac.compare_digest(expected, fingerprint):
+            entry = self._tokens.get(token)
+            if entry is None:
+                return False, None
+            expected_fp, bound_provider = entry
+            if not hmac.compare_digest(expected_fp, fingerprint):
                 # Right token, wrong payload — do not consume; reject.
-                return False
+                return False, None
             del self._tokens[token]
-            return True
+            return True, bound_provider
 
 
 # Process-wide store. Tokens live only for the life of the server process —
@@ -562,6 +579,46 @@ def get_send_backend():
 resolve_send_backend = get_send_backend
 
 
+def _resolve_backend_for_provider(provider: Optional[str]):
+    """Resolve a send backend for a specific provider.
+
+    When a draft token carries a provider binding, send uses this helper
+    instead of the count-based ``get_send_backend()``. Validates the provider
+    is in the connected set before building the backend — fail loud if not.
+    ``provider=None`` falls through to the count-based resolver.
+    """
+    if provider is None:
+        return resolve_send_backend()
+    connected = connected_mailbox_providers()
+    if provider not in connected:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Mailbox '{provider}' is not connected. Connect it via "
+                "Settings → Connectors, or omit the provider to use the "
+                f"single connected mailbox. Connected: {connected or '(none)'}."
+            ),
+        )
+    if provider == "google":
+        from gaia_agent_email.gmail_backend import LiveGmailBackend, _get_gmail_token
+
+        return LiveGmailBackend(_get_gmail_token)
+    if provider == "microsoft":
+        from gaia_agent_email.outlook_backend import (
+            LiveOutlookBackend,
+            _get_outlook_token,
+        )
+
+        return LiveOutlookBackend(_get_outlook_token)
+    raise HTTPException(
+        status_code=503,
+        detail=(
+            f"Provider '{provider}' has no send backend. "
+            "Expected 'google' or 'microsoft'."
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Send / draft request & response models (LOCAL — contract.py is frozen and
 # triage-only; the send handshake is not part of the #1262 contract).
@@ -580,6 +637,14 @@ class EmailDraftRequest(_Strict):
     )
     subject: str = Field(..., description="Proposed subject line.")
     body: str = Field(..., description="Proposed reply body.")
+    provider: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional provider binding ('google' or 'microsoft'). When set, "
+            "the confirmation token is bound to this provider so the send "
+            "routes to the correct mailbox even when multiple are connected."
+        ),
+    )
 
 
 class EmailDraftResponse(_Strict):
@@ -610,6 +675,14 @@ class EmailSendRequest(_Strict):
         description=(
             "Confirmation token from POST /v1/email/draft. A send without a "
             "valid token for this exact payload is rejected (403)."
+        ),
+    )
+    provider: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional provider override ('google' or 'microsoft'). Ignored "
+            "when the confirmation token carries a provider binding — the "
+            "token's bound provider always wins."
         ),
     )
 
@@ -658,7 +731,7 @@ async def draft_reply(request: EmailDraftRequest) -> EmailDraftResponse:
     user, and only a user-approved send echoes the token back.
     """
     fingerprint = _payload_fingerprint(request.to, request.subject, request.body)
-    token = confirmation_store.issue(fingerprint)
+    token = confirmation_store.issue(fingerprint, provider=request.provider)
     draft = DraftReply(to=request.to, subject=request.subject, body=request.body)
     return EmailDraftResponse(draft=draft, confirmation_token=token)
 
@@ -675,7 +748,10 @@ async def send_email(request: EmailSendRequest) -> EmailSendResponse:
     auto-confirms.
     """
     fingerprint = _payload_fingerprint(request.to, request.subject, request.body)
-    if not confirmation_store.consume(request.confirmation_token or "", fingerprint):
+    gate_ok, bound_provider = confirmation_store.consume_with_provider(
+        request.confirmation_token or "", fingerprint
+    )
+    if not gate_ok:
         raise HTTPException(
             status_code=403,
             detail=(
@@ -691,7 +767,9 @@ async def send_email(request: EmailSendRequest) -> EmailSendResponse:
     # send takes a single 'to' header string. Run off the event loop so
     # get_access_token_sync (used inside the token resolvers) does not hit
     # the "called from a thread with a running event loop" guard (#1594).
-    backend = resolve_send_backend()
+    # The token's bound provider (D5) overrides the count-based D2 logic;
+    # if no binding, fall back to the single-mailbox resolver.
+    backend = _resolve_backend_for_provider(bound_provider)
     to_header = ", ".join(_format_address(a) for a in request.to)
     result = await asyncio.to_thread(
         backend.send_message, to=to_header, subject=request.subject, body=request.body

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -69,6 +69,7 @@ from gaia_agent_email.contract import (
 from gaia_agent_email.tools.llm_triage import LLMTriageError
 from gaia_agent_email.tools.summarize_tools import EmailSummarizeError
 from gaia_agent_email.tools.triage_heuristics import classify_category_heuristic
+from gaia.connectors.api import connected_mailbox_providers
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -499,33 +500,59 @@ confirmation_store = ConfirmationStore()
 
 
 def get_send_backend():
-    """Resolve the Gmail backend used by the send endpoint.
+    """Resolve the send backend from the connected OAuth mailbox.
 
-    Production builds the live backend and fails loudly if Google
-    credentials are not connected — never silently no-ops a send. Tests
-    override this via ``app.dependency_overrides[get_send_backend]`` to
-    inject ``FakeGmailBackend`` so no live mail is touched.
+    Production derives the backend from whichever mailbox the user connected
+    via Settings → Connectors. Fails loudly when the count is ambiguous —
+    never silently chooses or falls back:
 
-    IMPORTANT: this is invoked from the send handler *after* the
-    confirmation gate, NOT as a FastAPI ``Depends`` — a request that lacks a
-    valid confirmation token must be rejected with a 4xx regardless of
-    backend health, so the gate is always evaluated first. (Resolving the
-    backend as a ``Depends`` would let a backend-unavailable 503 preempt the
-    403, masking the missing-confirmation rejection.)
+      - 0 connected → HTTP 503 (actionable: go connect a mailbox)
+      - 2+ connected → HTTP 400 (actionable: use the draft-token provider
+        binding to specify which mailbox to send from)
+      - exactly 1 → build the matching live backend
+
+    IMPORTANT: invoked AFTER the confirmation gate, not as a FastAPI
+    ``Depends``, so a gate rejection (403) always preempts a backend-health
+    error (503/400).
     """
-    from gaia_agent_email.gmail_backend import LiveGmailBackend, _get_gmail_token
-
-    try:
-        return LiveGmailBackend(_get_gmail_token)
-    except Exception as exc:  # noqa: BLE001 - boundary translation, re-raised
+    providers = connected_mailbox_providers()
+    if not providers:
         raise HTTPException(
             status_code=503,
             detail=(
-                "Email send backend unavailable: Google account is not "
-                "connected. Connect Google via the connectors flow before "
-                f"sending. ({type(exc).__name__}: {exc})"
+                "No mailbox connected — connect Google or Microsoft in "
+                "Settings → Connectors before sending."
             ),
-        ) from exc
+        )
+    if len(providers) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Multiple mailboxes connected ({', '.join(providers)}); "
+                "the send API can't choose. Send from the agent/UI (sends "
+                "from the message's mailbox), or include a draft confirmation "
+                "token that binds the provider."
+            ),
+        )
+    provider = providers[0]
+    if provider == "google":
+        from gaia_agent_email.gmail_backend import LiveGmailBackend, _get_gmail_token
+
+        return LiveGmailBackend(_get_gmail_token)
+    if provider == "microsoft":
+        from gaia_agent_email.outlook_backend import (
+            LiveOutlookBackend,
+            _get_outlook_token,
+        )
+
+        return LiveOutlookBackend(_get_outlook_token)
+    raise HTTPException(
+        status_code=503,
+        detail=(
+            f"Connected mailbox provider '{provider}' has no send backend. "
+            "Expected 'google' or 'microsoft'."
+        ),
+    )
 
 
 # Module-level indirection the send handler calls after the gate. Tests swap

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -688,14 +688,19 @@ async def send_email(request: EmailSendRequest) -> EmailSendResponse:
         )
 
     # Gate passed — resolve the backend now (AFTER the gate) and send. Gmail's
-    # send takes a single 'to' header string.
+    # send takes a single 'to' header string. Run off the event loop so
+    # get_access_token_sync (used inside the token resolvers) does not hit
+    # the "called from a thread with a running event loop" guard (#1594).
     backend = resolve_send_backend()
     to_header = ", ".join(_format_address(a) for a in request.to)
-    result = backend.send_message(
-        to=to_header, subject=request.subject, body=request.body
+    result = await asyncio.to_thread(
+        backend.send_message, to=to_header, subject=request.subject, body=request.body
     )
     sent_id = result.get("id") or ""
-    if not sent_id:
+    # Graph sendMail returns 202 with no body → no id, but result["sent"]=True
+    # signals a successful send. Gmail raises on failure, so no-id + no-sent
+    # is an unknown failure state that we still reject loudly.
+    if not sent_id and not result.get("sent"):
         raise HTTPException(
             status_code=502,
             detail="Email backend did not return a message id for the send.",

--- a/hub/agents/python/email/gaia_agent_email/config.py
+++ b/hub/agents/python/email/gaia_agent_email/config.py
@@ -241,11 +241,25 @@ class EmailAgentConfig:
         ``ConfigurationError`` rather than silently triaging one mailbox.
 
         The per-provider eval seam (``gmail_backend`` / ``outlook_backend``) is
-        honored via ``_build_mail_backend``. Distinct from the singular
+        honored via ``_build_mail_backend``. An injected backend also marks its
+        provider as available, so eval / unit tests that inject a fake do NOT
+        need a live keyring connection. Distinct from the singular
         ``resolve_mail_backend``, which stays connector-agnostic for the
         single-backend eval path.
         """
-        connected = connected_mailbox_providers()
+        # Eval seam: when a fake backend is injected, it FULLY defines the
+        # available set — the live keyring is not consulted at all, so an
+        # injected-fake run stays hermetic regardless of the host's real OAuth
+        # connections. Otherwise the available set is the connected mailboxes.
+        injected = set()
+        if self.gmail_backend is not None:
+            injected.add("google")
+        if self.outlook_backend is not None:
+            injected.add("microsoft")
+        available = injected if injected else set(connected_mailbox_providers())
+        # Canonical registry order (google before microsoft) — deterministic
+        # regardless of keyring vs injection ordering.
+        connected = [p for p in ("google", "microsoft") if p in available]
         selected_filter = (self.mail_provider or "").strip().lower()
         if selected_filter:
             selected = [p for p in connected if p == selected_filter]

--- a/hub/agents/python/email/gaia_agent_email/config.py
+++ b/hub/agents/python/email/gaia_agent_email/config.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from gaia.agents.base.agent import default_max_steps
+from gaia.connectors.api import connected_mailbox_providers
 
 
 class ConfigurationError(ValueError):
@@ -82,10 +83,13 @@ class EmailAgentConfig:
       Defaults to ``~/.gaia/email/state.db``. Eval harness passes a
       ``tmp_path``-derived path so concurrent live + eval runs don't
       race on the same SQLite file.
-    - ``mail_provider``: which mailbox provider the agent operates on —
-      ``"google"`` (Gmail, the default) or ``"microsoft"`` (personal
-      Outlook.com / Hotmail / Live via MS Graph, #1275). Selects the live
-      backend in ``resolve_mail_backend``. Case-insensitive.
+    - ``mail_provider``: a FILTER over the connected mailboxes (#1603 Phase 2).
+      ``None`` (the default) means "every connected mailbox" — a both-connected
+      user triages Gmail and Outlook together. ``"google"`` / ``"microsoft"``
+      restricts to that one provider (and only when it is connected). The
+      plural ``resolve_mail_backends`` reads the connected set; the singular
+      ``resolve_mail_backend`` stays connector-agnostic (``None`` → Gmail) for
+      the eval seam. Case-insensitive.
     - ``calendar_provider``: which calendar provider the agent operates on —
       ``"google"`` (the default) or ``"microsoft"`` (personal Outlook.com
       calendar via MS Graph, #1276). Selects the live backend in
@@ -111,7 +115,7 @@ class EmailAgentConfig:
     output_dir: Optional[str] = None
     undo_window_seconds: int = 30
     db_path: Optional[str] = None
-    mail_provider: str = "google"
+    mail_provider: Optional[str] = None
     calendar_provider: Optional[str] = None
     gmail_backend: Optional[Any] = None
     outlook_backend: Optional[Any] = None
@@ -190,6 +194,77 @@ class EmailAgentConfig:
             "supported. Use 'google' (Gmail) or 'microsoft' (Outlook.com / "
             "Hotmail / Live)."
         )
+
+    def _build_mail_backend(self, provider: str) -> Any:
+        """Build (or return the injected) live backend for one provider.
+
+        Honors the per-provider eval seam: ``gmail_backend`` for ``google`` and
+        ``outlook_backend`` for ``microsoft``. An unknown provider raises
+        ``ConfigurationError`` (fail loudly).
+        """
+        if provider == "google":
+            if self.gmail_backend is not None:
+                return self.gmail_backend
+            from gaia_agent_email.gmail_backend import (
+                LiveGmailBackend,
+                _get_gmail_token,
+            )
+
+            return LiveGmailBackend(_get_gmail_token)
+        if provider == "microsoft":
+            if self.outlook_backend is not None:
+                return self.outlook_backend
+            from gaia_agent_email.outlook_backend import (
+                LiveOutlookBackend,
+                _get_outlook_token,
+            )
+
+            return LiveOutlookBackend(_get_outlook_token)
+        raise ConfigurationError(
+            f"Connected mailbox provider {provider!r} has no backend. "
+            "Expected 'google' or 'microsoft'."
+        )
+
+    def resolve_mail_backends(self) -> List[Tuple[str, Any]]:
+        """Return ``[(provider, backend), ...]`` for every admitted mailbox.
+
+        ``mail_provider`` is a FILTER over the connected set (#1603 Phase 2):
+
+          - ``None`` → every connected mailbox (multi-inbox scan).
+          - ``"google"`` / ``"microsoft"`` → only that provider, and only when
+            it is actually connected.
+
+        Connector-derived: the connected set comes from
+        ``connected_mailbox_providers()`` (the keyring), in registry order
+        (google before microsoft). Fails loudly — an explicit filter naming an
+        unconnected provider, or nothing connected at all, raises
+        ``ConfigurationError`` rather than silently triaging one mailbox.
+
+        The per-provider eval seam (``gmail_backend`` / ``outlook_backend``) is
+        honored via ``_build_mail_backend``. Distinct from the singular
+        ``resolve_mail_backend``, which stays connector-agnostic for the
+        single-backend eval path.
+        """
+        connected = connected_mailbox_providers()
+        selected_filter = (self.mail_provider or "").strip().lower()
+        if selected_filter:
+            selected = [p for p in connected if p == selected_filter]
+            if not selected:
+                connected_desc = ", ".join(connected) if connected else "none"
+                raise ConfigurationError(
+                    f"Session selected mailbox {selected_filter!r} but it is "
+                    f"not connected. Connected: {connected_desc}. Connect it in "
+                    "Settings → Connectors, or clear the selection to use every "
+                    "connected mailbox."
+                )
+        else:
+            selected = list(connected)
+        if not selected:
+            raise ConfigurationError(
+                "No mailbox connected — connect Google or Microsoft in "
+                "Settings → Connectors before triaging."
+            )
+        return [(provider, self._build_mail_backend(provider)) for provider in selected]
 
     def resolve_calendar_backend(self) -> Any:
         """Return the calendar backend for the configured ``calendar_provider``.

--- a/hub/agents/python/email/gaia_agent_email/mcp_server.py
+++ b/hub/agents/python/email/gaia_agent_email/mcp_server.py
@@ -47,6 +47,7 @@ from gaia_agent_email.api_routes import (  # read-only reuse of the REST surface
     _format_address,
     _payload_fingerprint,
 )
+from gaia.connectors.api import connected_mailbox_providers
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -283,7 +284,8 @@ class EmailTriageMCPAgent(MCPAgent):
         to_header = ", ".join(_format_address(a) for a in to)
         result = backend.send_message(to=to_header, subject=subject, body=body)
         sent_id = result.get("id") or ""
-        if not sent_id:
+        # Graph sendMail returns 202 with no body → sent=True, empty id is success.
+        if not sent_id and not result.get("sent"):
             return {
                 "sent": False,
                 "error": "Email backend did not return a message id for the send.",
@@ -297,24 +299,48 @@ class EmailTriageMCPAgent(MCPAgent):
         }
 
     def _resolve_send_backend(self):
-        """Resolve the send backend AFTER the gate.
+        """Resolve the send backend AFTER the gate — connector-derived (#1603).
 
-        The opt-in ``GAIA_EMAIL_MCP_FAKE_SEND`` test seam swaps in an
-        in-process fake. Otherwise build the live Gmail backend and fail
-        loudly if Google is not connected — never silently no-op a send.
+        The opt-in ``GAIA_EMAIL_MCP_FAKE_SEND`` seam short-circuits BEFORE the
+        provider count check so parity tests run without a live mailbox. Then:
+
+          - 0 connected → RuntimeError (actionable: go connect a mailbox)
+          - 2+ connected → RuntimeError (actionable: ambiguous, use the agent UI)
+          - exactly 1    → build the matching live backend
+
+        Never silently no-ops a send.
         """
         if os.environ.get(_FAKE_SEND_ENV):
             return _FakeSendBackend()
-        from gaia_agent_email.gmail_backend import LiveGmailBackend, _get_gmail_token
 
-        try:
-            return LiveGmailBackend(_get_gmail_token)
-        except Exception as exc:  # noqa: BLE001 - boundary translation, re-raised
+        providers = connected_mailbox_providers()
+        if not providers:
             raise RuntimeError(
-                "Email send backend unavailable: Google account is not "
-                "connected. Connect Google via the connectors flow before "
-                f"sending. ({type(exc).__name__}: {exc})"
-            ) from exc
+                "No mailbox connected — connect Google or Microsoft in "
+                "Settings → Connectors before sending via MCP."
+            )
+        if len(providers) > 1:
+            raise RuntimeError(
+                f"Multiple mailboxes connected ({', '.join(providers)}); "
+                "the MCP send can't choose. Send from the agent UI (sends "
+                "from the message's mailbox), or draft with a provider binding."
+            )
+        provider = providers[0]
+        if provider == "google":
+            from gaia_agent_email.gmail_backend import LiveGmailBackend, _get_gmail_token
+
+            return LiveGmailBackend(_get_gmail_token)
+        if provider == "microsoft":
+            from gaia_agent_email.outlook_backend import (
+                LiveOutlookBackend,
+                _get_outlook_token,
+            )
+
+            return LiveOutlookBackend(_get_outlook_token)
+        raise RuntimeError(
+            f"Connected mailbox provider '{provider}' has no send backend. "
+            "Expected 'google' or 'microsoft'."
+        )
 
 
 def start_email_mcp(

--- a/hub/agents/python/email/gaia_agent_email/outlook_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/outlook_backend.py
@@ -519,7 +519,9 @@ class LiveOutlookBackend:
             "/me/sendMail",
             json_body={"message": message, "saveToSentItems": True},
         )
-        return {"id": "", "to": to, "subject": subject}
+        # Graph sendMail returns HTTP 202 with no body — no id is echoed back.
+        # "sent": True signals success to the REST handler without inventing a fake id.
+        return {"id": "", "sent": True, "to": to, "subject": subject}
 
     def create_label(  # pylint: disable=unused-argument
         self, *, name: str, label_list_visibility: str = "labelShow"

--- a/hub/agents/python/email/gaia_agent_email/tools/delete_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/delete_tools.py
@@ -13,7 +13,7 @@ the agent level — it never auto-executes.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from gaia.agents.base.tools import tool
 from gaia_agent_email import action_store
@@ -34,7 +34,7 @@ def _envelope_err(message: str) -> str:
 
 
 def trash_message_impl(
-    gmail, db, *, message_id: str, debug: bool = False
+    gmail, db, *, message_id: str, mailbox: Optional[str] = None, debug: bool = False
 ) -> Dict[str, Any]:
     with log_tool_call("trash_message", {"message_id": message_id}, debug=debug) as st:
         prior = gmail.get_message(message_id)
@@ -46,14 +46,22 @@ def trash_message_impl(
             message_id=message_id,
             thread_id=prior.get("threadId"),
             payload={"prior_labels": prior_labels},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id}
 
 
 def restore_message_impl(
-    gmail, db, *, action_id: str, window_seconds: int, debug: bool = False
+    resolve_backend, db, *, action_id: str, window_seconds: int, debug: bool = False
 ) -> Dict[str, Any]:
+    """Undo a trash within the window, routing to the message's own mailbox.
+
+    ``resolve_backend(action: dict) -> backend`` picks the backend for the
+    fetched action row (#1603 Phase 2) — the row records which mailbox the
+    message belongs to, so undo never untrashes against the wrong account when
+    multiple mailboxes are connected.
+    """
     with log_tool_call("restore_message", {"action_id": action_id}, debug=debug) as st:
         action = action_store.fetch_undoable(
             db, action_id=action_id, window_seconds=window_seconds
@@ -70,7 +78,8 @@ def restore_message_impl(
                 f"restore_message only undoes trash actions; got "
                 f"{action['action_type']!r}"
             )
-        gmail.untrash_message(action["message_id"])
+        backend = resolve_backend(action)
+        backend.untrash_message(action["message_id"])
         action_store.mark_undone(db, action_id=action_id)
         st["result_summary"] = {"restored_message_id": action["message_id"]}
         return {
@@ -81,7 +90,7 @@ def restore_message_impl(
 
 
 def permanent_delete_impl(
-    gmail, db, *, message_id: str, debug: bool = False
+    gmail, db, *, message_id: str, mailbox: Optional[str] = None, debug: bool = False
 ) -> Dict[str, Any]:
     with log_tool_call(
         "permanent_delete", {"message_id": message_id}, debug=debug
@@ -94,6 +103,7 @@ def permanent_delete_impl(
             action_type="permanent_delete",
             message_id=message_id,
             payload={"irreversible": True},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {
@@ -105,18 +115,30 @@ def permanent_delete_impl(
 
 class DeleteToolsMixin:
     def _register_delete_tools(self) -> None:
-        gmail = self._gmail
         db = self
+        agent = self  # for per-message backend routing (#1603 Phase 2)
         debug_flag = bool(getattr(self.config, "debug", False))
         window = int(getattr(self.config, "undo_window_seconds", 30))
 
         @tool
-        def trash_message(message_id: str) -> str:
-            """Move to Trash. Reversible via restore_message inside the undo window."""
+        def trash_message(message_id: str, mailbox: str = "") -> str:
+            """Move to Trash. Reversible via restore_message inside the undo window.
+
+            ``mailbox`` (optional) names the source mailbox ('google' or
+            'microsoft') from triage output, so the action routes correctly when
+            multiple mailboxes are connected. Omit it when only one is connected
+            or the message was already tagged by triage.
+            """
             try:
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                backend = agent._backends[provider]
                 return _envelope_ok(
                     trash_message_impl(
-                        gmail, db, message_id=message_id, debug=debug_flag
+                        backend,
+                        db,
+                        message_id=message_id,
+                        mailbox=provider,
+                        debug=debug_flag,
                     )
                 )
             except ConnectorsError as exc:
@@ -131,7 +153,7 @@ class DeleteToolsMixin:
             try:
                 return _envelope_ok(
                     restore_message_impl(
-                        gmail,
+                        agent._backend_for_action,
                         db,
                         action_id=action_id,
                         window_seconds=window,
@@ -145,12 +167,22 @@ class DeleteToolsMixin:
                 return _envelope_err(f"{type(exc).__name__}: {exc}")
 
         @tool
-        def permanent_delete(message_id: str) -> str:
-            """PERMANENTLY delete a message. Irreversible. Requires user confirmation."""
+        def permanent_delete(message_id: str, mailbox: str = "") -> str:
+            """PERMANENTLY delete a message. Irreversible. Requires user confirmation.
+
+            ``mailbox`` (optional) names the source mailbox for routing when
+            multiple are connected (see ``trash_message``).
+            """
             try:
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                backend = agent._backends[provider]
                 return _envelope_ok(
                     permanent_delete_impl(
-                        gmail, db, message_id=message_id, debug=debug_flag
+                        backend,
+                        db,
+                        message_id=message_id,
+                        mailbox=provider,
+                        debug=debug_flag,
                     )
                 )
             except ConnectorsError as exc:

--- a/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
@@ -47,6 +47,7 @@ def archive_message_impl(
     *,
     message_id: str,
     prior: Optional[Dict[str, Any]] = None,
+    mailbox: Optional[str] = None,
     debug: bool = False,
 ) -> Dict[str, Any]:
     with log_tool_call(
@@ -66,59 +67,84 @@ def archive_message_impl(
             message_id=message_id,
             thread_id=prior.get("threadId"),
             payload={"prior_labels": prior_labels},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id}
 
 
 def mark_read_impl(
-    gmail, db, *, message_id: str, debug: bool = False
+    gmail, db, *, message_id: str, mailbox: Optional[str] = None, debug: bool = False
 ) -> Dict[str, Any]:
     with log_tool_call("mark_read", {"message_id": message_id}, debug=debug) as st:
         gmail.mark_read(message_id)
         action_id = action_store.record_action(
-            db, action_type="mark_read", message_id=message_id, payload={}
+            db,
+            action_type="mark_read",
+            message_id=message_id,
+            payload={},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id}
 
 
 def mark_unread_impl(
-    gmail, db, *, message_id: str, debug: bool = False
+    gmail, db, *, message_id: str, mailbox: Optional[str] = None, debug: bool = False
 ) -> Dict[str, Any]:
     with log_tool_call("mark_unread", {"message_id": message_id}, debug=debug) as st:
         gmail.mark_unread(message_id)
         action_id = action_store.record_action(
-            db, action_type="mark_unread", message_id=message_id, payload={}
+            db,
+            action_type="mark_unread",
+            message_id=message_id,
+            payload={},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id}
 
 
-def add_star_impl(gmail, db, *, message_id: str, debug: bool = False) -> Dict[str, Any]:
+def add_star_impl(
+    gmail, db, *, message_id: str, mailbox: Optional[str] = None, debug: bool = False
+) -> Dict[str, Any]:
     with log_tool_call("add_star", {"message_id": message_id}, debug=debug) as st:
         gmail.add_star(message_id)
         action_id = action_store.record_action(
-            db, action_type="add_star", message_id=message_id, payload={}
+            db,
+            action_type="add_star",
+            message_id=message_id,
+            payload={},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id}
 
 
 def remove_star_impl(
-    gmail, db, *, message_id: str, debug: bool = False
+    gmail, db, *, message_id: str, mailbox: Optional[str] = None, debug: bool = False
 ) -> Dict[str, Any]:
     with log_tool_call("remove_star", {"message_id": message_id}, debug=debug) as st:
         gmail.remove_star(message_id)
         action_id = action_store.record_action(
-            db, action_type="remove_star", message_id=message_id, payload={}
+            db,
+            action_type="remove_star",
+            message_id=message_id,
+            payload={},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id}
 
 
 def label_message_impl(
-    gmail, db, *, message_id: str, label_id: str, debug: bool = False
+    gmail,
+    db,
+    *,
+    message_id: str,
+    label_id: str,
+    mailbox: Optional[str] = None,
+    debug: bool = False,
 ) -> Dict[str, Any]:
     with log_tool_call(
         "label_message",
@@ -131,6 +157,7 @@ def label_message_impl(
             action_type="add_label",
             message_id=message_id,
             payload={"label_id": label_id},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id, "label_id": label_id}
@@ -143,6 +170,7 @@ def move_to_label_impl(
     message_id: str,
     label_id: str,
     prior: Optional[Dict[str, Any]] = None,
+    mailbox: Optional[str] = None,
     debug: bool = False,
 ) -> Dict[str, Any]:
     """Add a label and remove INBOX.
@@ -169,13 +197,14 @@ def move_to_label_impl(
             action_type="move_to_label",
             message_id=message_id,
             payload={"label_id": label_id, "prior_labels": prior_labels},
+            mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
         return {"action_id": action_id, "message_id": message_id, "label_id": label_id}
 
 
 def undo_archive_batch_impl(
-    gmail,
+    resolve_backend,
     db,
     *,
     batch_id: str,
@@ -188,9 +217,11 @@ def undo_archive_batch_impl(
     label the message carried before) for every still-undoable ``archive``
     row sharing ``batch_id``, then marks each row undone.
 
-    Raises ``RuntimeError`` if the batch has no undoable rows — the window
-    expired, every row was already undone, or the batch_id is unknown. We
-    fail loudly rather than silently no-op so the caller surfaces it.
+    ``resolve_backend(row) -> backend`` routes each row to the mailbox it was
+    archived from (#1603 Phase 2), so a cross-mailbox batch undoes against the
+    right accounts. Raises ``RuntimeError`` if the batch has no undoable rows —
+    the window expired, every row was already undone, or the batch_id is
+    unknown. We fail loudly rather than silently no-op so the caller surfaces it.
     """
     with log_tool_call("undo_archive_batch", {"batch_id": batch_id}, debug=debug) as st:
         rows = action_store.fetch_batch_undoable(
@@ -209,13 +240,14 @@ def undo_archive_batch_impl(
                 # than mis-restore an unrelated action recorded under the
                 # same id by a future caller.
                 continue
+            backend = resolve_backend(row)
             mid = row["message_id"]
             prior_labels = set(row["payload"].get("prior_labels") or [])
-            current = set(gmail.get_message(mid).get("labelIds", []))
+            current = set(backend.get_message(mid).get("labelIds", []))
             # Archive only ever removes labels (INBOX); re-add whatever the
             # message carried before that it no longer has.
             for lab in prior_labels - current:
-                gmail.add_label(mid, lab)
+                backend.add_label(mid, lab)
             action_store.mark_undone(db, action_id=row["action_id"])
             restored.append({"message_id": mid, "action_id": row["action_id"]})
         st["result_summary"] = {"restored": len(restored)}
@@ -267,17 +299,25 @@ def _coerce_ids(message_ids):
 
 
 def _run_batch(
-    _gmail,
+    resolve_backend,
     db,
     message_ids: list[str],
     *,
-    gmail_op,
+    op_name: str,
+    op_args: tuple = (),
     action_type: str,
+    action_mailbox=None,
     payload: dict | None = None,
     batch_id: str,
     debug: bool = False,
 ) -> dict:
-    """Execute a Gmail mutation for each message_id, recording each action.
+    """Execute a mailbox mutation for each message_id, recording each action.
+
+    ``resolve_backend(mid) -> backend`` routes each id to its own mailbox
+    (#1603 Phase 2), so a batch can span Gmail and Outlook. ``op_name`` is the
+    backend method to call (e.g. ``"mark_read"``); ``op_args`` are trailing
+    positional args (e.g. the label id). ``action_mailbox(mid) -> str`` records
+    which mailbox the action hit so undo routes correctly.
 
     Returns ``{"succeeded": [...], "failed": [...]}``.
     """
@@ -285,13 +325,15 @@ def _run_batch(
     failed: list[dict] = []
     for mid in message_ids:
         try:
-            gmail_op(mid)
+            backend = resolve_backend(mid)
+            getattr(backend, op_name)(mid, *op_args)
             aid = action_store.record_action(
                 db,
                 action_type=action_type,
                 message_id=mid,
                 payload=dict(payload or {}),
                 batch_id=batch_id,
+                mailbox=action_mailbox(mid) if action_mailbox else None,
             )
             succeeded.append({"message_id": mid, "action_id": aid})
         except Exception as exc:
@@ -302,12 +344,13 @@ def _run_batch(
 
 
 def _run_batch_with_prior(
-    gmail,
+    resolve_backend,
     db,
     message_ids: list[str],
     *,
-    gmail_op,
+    backend_op,
     action_type: str,
+    action_mailbox=None,
     prior_fn,
     payload_fn,
     batch_id: str,
@@ -315,16 +358,19 @@ def _run_batch_with_prior(
 ) -> dict:
     """Same as _run_batch but fetches per-message prior state first.
 
-    ``prior_fn(msg) -> prior`` is called once per message.
-    ``payload_fn(msg, prior) -> dict`` builds the action payload.
+    ``resolve_backend(mid) -> backend`` routes per message. ``backend_op(backend,
+    mid)`` performs the mutation on the resolved backend. ``prior_fn(msg) ->
+    prior`` is called once per message; ``payload_fn(msg, prior) -> dict`` builds
+    the action payload.
     """
     succeeded: list[dict] = []
     failed: list[dict] = []
     for mid in message_ids:
         try:
-            msg = gmail.get_message(mid)
+            backend = resolve_backend(mid)
+            msg = backend.get_message(mid)
             prior = prior_fn(msg)
-            gmail_op(mid)
+            backend_op(backend, mid)
             aid = action_store.record_action(
                 db,
                 action_type=action_type,
@@ -332,6 +378,7 @@ def _run_batch_with_prior(
                 thread_id=msg.get("threadId"),
                 payload=payload_fn(msg, prior),
                 batch_id=batch_id,
+                mailbox=action_mailbox(mid) if action_mailbox else None,
             )
             succeeded.append({"message_id": mid, "action_id": aid})
         except Exception as exc:
@@ -343,11 +390,10 @@ def _run_batch_with_prior(
 
 class OrganizeToolsMixin:
     def _register_organize_tools(self) -> None:
-        gmail = self._gmail
         db = self
         debug_flag = bool(getattr(self.config, "debug", False))
         window = int(getattr(self.config, "undo_window_seconds", 30))
-        agent = self  # for batch-threshold counter access
+        agent = self  # batch-threshold counter + per-message backend routing
 
         def _check_threshold() -> Optional[str]:
             """Return error message if Phase I3 threshold is exceeded, else None.
@@ -360,109 +406,38 @@ class OrganizeToolsMixin:
                 return _BATCH_THRESHOLD_ERROR
             return None
 
+        # Per-message backend routing for batch tools (#1603 Phase 2). A batch's
+        # ids may span mailboxes; each is routed to the mailbox it came from.
+        def _batch_backend(mid: str):
+            return agent._backend_for_message(mid)
+
+        def _batch_provider(mid: str) -> str:
+            return agent._provider_for_message(mid)
+
         @tool
-        def archive_message(message_id: str) -> str:
-            """Archive a message (remove from INBOX). Reversible via restore_message."""
+        def archive_message(message_id: str, mailbox: str = "") -> str:
+            """Archive a message (remove from INBOX). Reversible via restore_message.
+
+            ``mailbox`` (optional) names the source mailbox ('google' /
+            'microsoft') from triage output so the action routes correctly when
+            multiple mailboxes are connected.
+            """
             try:
                 if (err := _check_threshold()) is not None:
                     return _envelope_err(err)
-                # Single Gmail fetch — used for both prior_labels (impl)
-                # and sender (counter). Avoids the redundant round-trip
-                # the previous _peek_sender helper introduced.
-                prior = gmail.get_message(message_id)
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                backend = agent._backends[provider]
+                # Single fetch — used for both prior_labels (impl) and sender
+                # (counter). Avoids a redundant round-trip.
+                prior = backend.get_message(message_id)
                 agent._record_organize_op(message_id, _extract_sender(prior))
                 return _envelope_ok(
                     archive_message_impl(
-                        gmail, db, message_id=message_id, prior=prior, debug=debug_flag
-                    )
-                )
-            except ConnectorsError as exc:
-                return _envelope_err(format_connector_error(exc))
-            except Exception as exc:
-                log.exception("email tool error: %s", type(exc).__name__)
-                return _envelope_err(f"{type(exc).__name__}: {exc}")
-
-        @tool
-        def mark_read(message_id: str) -> str:
-            """Mark a message as read."""
-            try:
-                if (err := _check_threshold()) is not None:
-                    return _envelope_err(err)
-                # mark_read does not need prior_labels; only bump
-                # the counter with what we know — the message_id
-                # alone is enough since distinct-sender counting
-                # treats unknown senders as "" (one bucket).
-                agent._record_organize_op(message_id, "")
-                return _envelope_ok(
-                    mark_read_impl(gmail, db, message_id=message_id, debug=debug_flag)
-                )
-            except ConnectorsError as exc:
-                return _envelope_err(format_connector_error(exc))
-            except Exception as exc:
-                log.exception("email tool error: %s", type(exc).__name__)
-                return _envelope_err(f"{type(exc).__name__}: {exc}")
-
-        @tool
-        def mark_unread(message_id: str) -> str:
-            """Mark a message as unread."""
-            try:
-                if (err := _check_threshold()) is not None:
-                    return _envelope_err(err)
-                agent._record_organize_op(message_id, "")
-                return _envelope_ok(
-                    mark_unread_impl(gmail, db, message_id=message_id, debug=debug_flag)
-                )
-            except ConnectorsError as exc:
-                return _envelope_err(format_connector_error(exc))
-            except Exception as exc:
-                log.exception("email tool error: %s", type(exc).__name__)
-                return _envelope_err(f"{type(exc).__name__}: {exc}")
-
-        @tool
-        def add_star(message_id: str) -> str:
-            """Star a message."""
-            try:
-                if (err := _check_threshold()) is not None:
-                    return _envelope_err(err)
-                agent._record_organize_op(message_id, "")
-                return _envelope_ok(
-                    add_star_impl(gmail, db, message_id=message_id, debug=debug_flag)
-                )
-            except ConnectorsError as exc:
-                return _envelope_err(format_connector_error(exc))
-            except Exception as exc:
-                log.exception("email tool error: %s", type(exc).__name__)
-                return _envelope_err(f"{type(exc).__name__}: {exc}")
-
-        @tool
-        def remove_star(message_id: str) -> str:
-            """Remove the star from a message."""
-            try:
-                if (err := _check_threshold()) is not None:
-                    return _envelope_err(err)
-                agent._record_organize_op(message_id, "")
-                return _envelope_ok(
-                    remove_star_impl(gmail, db, message_id=message_id, debug=debug_flag)
-                )
-            except ConnectorsError as exc:
-                return _envelope_err(format_connector_error(exc))
-            except Exception as exc:
-                log.exception("email tool error: %s", type(exc).__name__)
-                return _envelope_err(f"{type(exc).__name__}: {exc}")
-
-        @tool
-        def label_message(message_id: str, label_id: str) -> str:
-            """Add a label to a message. Pass the label id (e.g. ``Label_1``)."""
-            try:
-                if (err := _check_threshold()) is not None:
-                    return _envelope_err(err)
-                agent._record_organize_op(message_id, "")
-                return _envelope_ok(
-                    label_message_impl(
-                        gmail,
+                        backend,
                         db,
                         message_id=message_id,
-                        label_id=label_id,
+                        prior=prior,
+                        mailbox=provider,
                         debug=debug_flag,
                     )
                 )
@@ -473,21 +448,150 @@ class OrganizeToolsMixin:
                 return _envelope_err(f"{type(exc).__name__}: {exc}")
 
         @tool
-        def move_to_label(message_id: str, label_id: str) -> str:
-            """Move a message out of INBOX into a label."""
+        def mark_read(message_id: str, mailbox: str = "") -> str:
+            """Mark a message as read. ``mailbox`` routes when multiple connected."""
             try:
                 if (err := _check_threshold()) is not None:
                     return _envelope_err(err)
-                # Single Gmail fetch — for prior_labels + sender.
-                prior = gmail.get_message(message_id)
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                # mark_read does not need prior_labels; only bump
+                # the counter with what we know — the message_id
+                # alone is enough since distinct-sender counting
+                # treats unknown senders as "" (one bucket).
+                agent._record_organize_op(message_id, "")
+                return _envelope_ok(
+                    mark_read_impl(
+                        agent._backends[provider],
+                        db,
+                        message_id=message_id,
+                        mailbox=provider,
+                        debug=debug_flag,
+                    )
+                )
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def mark_unread(message_id: str, mailbox: str = "") -> str:
+            """Mark a message as unread. ``mailbox`` routes when multiple connected."""
+            try:
+                if (err := _check_threshold()) is not None:
+                    return _envelope_err(err)
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                agent._record_organize_op(message_id, "")
+                return _envelope_ok(
+                    mark_unread_impl(
+                        agent._backends[provider],
+                        db,
+                        message_id=message_id,
+                        mailbox=provider,
+                        debug=debug_flag,
+                    )
+                )
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def add_star(message_id: str, mailbox: str = "") -> str:
+            """Star a message. ``mailbox`` routes when multiple connected."""
+            try:
+                if (err := _check_threshold()) is not None:
+                    return _envelope_err(err)
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                agent._record_organize_op(message_id, "")
+                return _envelope_ok(
+                    add_star_impl(
+                        agent._backends[provider],
+                        db,
+                        message_id=message_id,
+                        mailbox=provider,
+                        debug=debug_flag,
+                    )
+                )
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def remove_star(message_id: str, mailbox: str = "") -> str:
+            """Remove the star from a message. ``mailbox`` routes when multiple connected."""
+            try:
+                if (err := _check_threshold()) is not None:
+                    return _envelope_err(err)
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                agent._record_organize_op(message_id, "")
+                return _envelope_ok(
+                    remove_star_impl(
+                        agent._backends[provider],
+                        db,
+                        message_id=message_id,
+                        mailbox=provider,
+                        debug=debug_flag,
+                    )
+                )
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def label_message(message_id: str, label_id: str, mailbox: str = "") -> str:
+            """Add a label to a message. Pass the label id (e.g. ``Label_1``).
+
+            ``mailbox`` (optional) routes when multiple mailboxes are connected.
+            """
+            try:
+                if (err := _check_threshold()) is not None:
+                    return _envelope_err(err)
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                agent._record_organize_op(message_id, "")
+                return _envelope_ok(
+                    label_message_impl(
+                        agent._backends[provider],
+                        db,
+                        message_id=message_id,
+                        label_id=label_id,
+                        mailbox=provider,
+                        debug=debug_flag,
+                    )
+                )
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def move_to_label(message_id: str, label_id: str, mailbox: str = "") -> str:
+            """Move a message out of INBOX into a label.
+
+            ``mailbox`` (optional) routes when multiple mailboxes are connected.
+            """
+            try:
+                if (err := _check_threshold()) is not None:
+                    return _envelope_err(err)
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                backend = agent._backends[provider]
+                # Single fetch — for prior_labels + sender.
+                prior = backend.get_message(message_id)
                 agent._record_organize_op(message_id, _extract_sender(prior))
                 return _envelope_ok(
                     move_to_label_impl(
-                        gmail,
+                        backend,
                         db,
                         message_id=message_id,
                         label_id=label_id,
                         prior=prior,
+                        mailbox=provider,
                         debug=debug_flag,
                     )
                 )
@@ -510,11 +614,12 @@ class OrganizeToolsMixin:
             try:
                 batch_id = uuid.uuid4().hex
                 result = _run_batch(
-                    gmail,
+                    _batch_backend,
                     db,
                     message_ids,
-                    gmail_op=gmail.mark_read,
+                    op_name="mark_read",
                     action_type="mark_read",
+                    action_mailbox=_batch_provider,
                     batch_id=batch_id,
                     debug=debug_flag,
                 )
@@ -545,11 +650,12 @@ class OrganizeToolsMixin:
             try:
                 batch_id = uuid.uuid4().hex
                 result = _run_batch(
-                    gmail,
+                    _batch_backend,
                     db,
                     message_ids,
-                    gmail_op=gmail.mark_unread,
+                    op_name="mark_unread",
                     action_type="mark_unread",
+                    action_mailbox=_batch_provider,
                     batch_id=batch_id,
                     debug=debug_flag,
                 )
@@ -580,11 +686,12 @@ class OrganizeToolsMixin:
             try:
                 batch_id = uuid.uuid4().hex
                 result = _run_batch(
-                    gmail,
+                    _batch_backend,
                     db,
                     message_ids,
-                    gmail_op=gmail.add_star,
+                    op_name="add_star",
                     action_type="add_star",
+                    action_mailbox=_batch_provider,
                     batch_id=batch_id,
                     debug=debug_flag,
                 )
@@ -615,11 +722,12 @@ class OrganizeToolsMixin:
             try:
                 batch_id = uuid.uuid4().hex
                 result = _run_batch(
-                    gmail,
+                    _batch_backend,
                     db,
                     message_ids,
-                    gmail_op=gmail.remove_star,
+                    op_name="remove_star",
                     action_type="remove_star",
+                    action_mailbox=_batch_provider,
                     batch_id=batch_id,
                     debug=debug_flag,
                 )
@@ -659,11 +767,12 @@ class OrganizeToolsMixin:
                     return {"prior_labels": prior_labels}
 
                 result = _run_batch_with_prior(
-                    gmail,
+                    _batch_backend,
                     db,
                     message_ids,
-                    gmail_op=gmail.archive_message,
+                    backend_op=lambda backend, mid: backend.archive_message(mid),
                     action_type="archive",
+                    action_mailbox=_batch_provider,
                     prior_fn=_archive_prior_fn,
                     payload_fn=_archive_payload_fn,
                     batch_id=batch_id,
@@ -692,7 +801,7 @@ class OrganizeToolsMixin:
             try:
                 return _envelope_ok(
                     undo_archive_batch_impl(
-                        gmail,
+                        agent._backend_for_action,
                         db,
                         batch_id=batch_id,
                         window_seconds=window,
@@ -717,15 +826,14 @@ class OrganizeToolsMixin:
                 batch_id = uuid.uuid4().hex
                 label_id_local = label_id  # closure capture
 
-                def _label_op(mid: str) -> None:
-                    gmail.add_label(mid, label_id_local)
-
                 result = _run_batch(
-                    gmail,
+                    _batch_backend,
                     db,
                     message_ids,
-                    gmail_op=_label_op,
+                    op_name="add_label",
+                    op_args=(label_id_local,),
                     action_type="add_label",
+                    action_mailbox=_batch_provider,
                     payload={"label_id": label_id_local},
                     batch_id=batch_id,
                     debug=debug_flag,
@@ -758,9 +866,9 @@ class OrganizeToolsMixin:
                 batch_id = uuid.uuid4().hex
                 label_id_local = label_id
 
-                def _move_op(mid: str) -> None:
-                    gmail.add_label(mid, label_id_local)
-                    gmail.archive_message(mid)
+                def _move_op(backend, mid: str) -> None:
+                    backend.add_label(mid, label_id_local)
+                    backend.archive_message(mid)
 
                 def _move_prior_fn(msg: Dict[str, Any]) -> List[str]:
                     return list(msg.get("labelIds", []))
@@ -774,11 +882,12 @@ class OrganizeToolsMixin:
                     }
 
                 result = _run_batch_with_prior(
-                    gmail,
+                    _batch_backend,
                     db,
                     message_ids,
-                    gmail_op=_move_op,
+                    backend_op=_move_op,
                     action_type="move_to_label",
+                    action_mailbox=_batch_provider,
                     prior_fn=_move_prior_fn,
                     payload_fn=_move_payload_fn,
                     batch_id=batch_id,

--- a/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
@@ -714,11 +714,11 @@ class ReadToolsMixin:
     """Mixin that registers the read-side tools.
 
     The mixin is state-free at construction time — it relies on the agent
-    class having set ``self._gmail`` (and optionally ``self.config.debug``)
-    before invoking ``self._register_read_tools()``. The ``agent``
-    closure capture is used so triage / pre-scan tools can read live
-    ``self._session_preferences`` (set on the agent instance) at call
-    time, not snapshot at registration time.
+    class having set ``self._gmail``, ``self._backends``, and the
+    ``_backend_for_message`` routing helper (#1603 Phase 2) before invoking
+    ``self._register_read_tools()``. The ``agent`` closure capture is used so
+    triage / pre-scan tools can read live ``self._session_preferences`` (set
+    on the agent instance) at call time, not snapshot at registration time.
     """
 
     def _register_read_tools(self) -> None:
@@ -751,11 +751,17 @@ class ReadToolsMixin:
                 return _envelope_err(f"{type(exc).__name__}: {exc}")
 
         @tool
-        def get_message(message_id: str) -> str:
-            """Fetch a single message by id, including full body."""
+        def get_message(message_id: str, mailbox: str = "") -> str:
+            """Fetch a single message by id, including full body.
+
+            ``mailbox`` (optional) names the source mailbox ('google' /
+            'microsoft') from triage output so the read routes correctly when
+            multiple mailboxes are connected.
+            """
             try:
+                backend = agent._backend_for_message(message_id, mailbox or None)
                 return _envelope_ok(
-                    get_message_impl(gmail, message_id=message_id, debug=debug_flag)
+                    get_message_impl(backend, message_id=message_id, debug=debug_flag)
                 )
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
@@ -764,11 +770,15 @@ class ReadToolsMixin:
                 return _envelope_err(f"{type(exc).__name__}: {exc}")
 
         @tool
-        def get_thread(thread_id: str) -> str:
-            """Fetch every message in a thread (conversation view)."""
+        def get_thread(thread_id: str, mailbox: str = "") -> str:
+            """Fetch every message in a thread (conversation view).
+
+            ``mailbox`` (optional) routes when multiple mailboxes are connected.
+            """
             try:
+                backend = agent._backend_for_message(thread_id, mailbox or None)
                 return _envelope_ok(
-                    get_thread_impl(gmail, thread_id=thread_id, debug=debug_flag)
+                    get_thread_impl(backend, thread_id=thread_id, debug=debug_flag)
                 )
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
@@ -777,7 +787,7 @@ class ReadToolsMixin:
                 return _envelope_err(f"{type(exc).__name__}: {exc}")
 
         @tool
-        def summarize_thread(thread_id: str) -> str:
+        def summarize_thread(thread_id: str, mailbox: str = "") -> str:
             """Summarize an entire email thread, not just its latest message.
 
             Reads every message in the thread and produces one concise,
@@ -803,9 +813,10 @@ class ReadToolsMixin:
                 )
 
                 chat = getattr(agent, "chat", None)
+                backend = agent._backend_for_message(thread_id, mailbox or None)
                 return _envelope_ok(
                     summarize_thread_impl(
-                        gmail,
+                        backend,
                         chat,
                         thread_id=thread_id,
                         debug=debug_flag,

--- a/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
@@ -870,21 +870,12 @@ class ReadToolsMixin:
             """
             try:
                 max_messages = max(1, min(int(max_messages or 25), 100))
-                # Wire LLM follow-up (#1107) for heuristic-uncertain messages.
-                # Built at call time so agent.chat is initialized.
-                chat = getattr(agent, "chat", None)
-                classifier = make_llm_classifier(chat) if chat is not None else None
+                # Phase 2 (#1603): scan every connected mailbox, tag each item
+                # with its source mailbox, split the budget across mailboxes,
+                # and merge. LLM follow-up (#1107) is wired inside the agent
+                # orchestration so agent.chat is initialized at call time.
                 return _envelope_ok(
-                    triage_inbox_impl(
-                        gmail,
-                        max_messages=max_messages,
-                        session_preferences=getattr(
-                            agent, "_session_preferences", None
-                        ),
-                        force_llm=bool(getattr(agent.config, "force_llm", False)),
-                        classifier=classifier,
-                        debug=debug_flag,
-                    )
+                    agent._triage_all_backends(max_messages=max_messages)
                 )
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
@@ -924,16 +915,10 @@ class ReadToolsMixin:
             """
             try:
                 max_messages = max(1, min(int(max_messages or 25), 100))
+                # Phase 2 (#1603): pre-scan every connected mailbox, tag each
+                # section item with its source mailbox, split the budget, merge.
                 return _envelope_ok(
-                    pre_scan_inbox_impl(
-                        gmail,
-                        max_messages=max_messages,
-                        session_preferences=getattr(
-                            agent, "_session_preferences", None
-                        ),
-                        force_llm=bool(getattr(agent.config, "force_llm", False)),
-                        debug=debug_flag,
-                    )
+                    agent._pre_scan_all_backends(max_messages=max_messages)
                 )
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))

--- a/hub/agents/python/email/gaia_agent_email/tools/reply_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/reply_tools.py
@@ -225,18 +225,71 @@ def forward_message_impl(
 
 class ReplyToolsMixin:
     def _register_reply_tools(self) -> None:
-        gmail = self._gmail
         db = self
+        agent = self  # per-message backend routing (#1603 Phase 2)
         debug_flag = bool(getattr(self.config, "debug", False))
 
         @tool
-        def draft_reply(message_id: str, body: str) -> str:
-            """Create a reply draft for a message (does NOT send)."""
+        def draft_reply(message_id: str, body: str, mailbox: str = "") -> str:
+            """Create a reply draft for a message (does NOT send).
+
+            ``mailbox`` (optional) names the source mailbox so the draft is
+            created in the right account when multiple mailboxes are connected.
+            """
             try:
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                backend = agent._backends[provider]
+                result = draft_reply_impl(
+                    backend, db, message_id=message_id, body=body, debug=debug_flag
+                )
+                # Remember which mailbox holds this draft so send_draft routes
+                # back to the same backend.
+                agent._remember_draft_mailbox(result.get("draft_id"), provider)
+                return _envelope_ok(result)
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def draft_forward(
+            message_id: str, to: str, body: str = "", mailbox: str = ""
+        ) -> str:
+            """Create a forward draft for a message (does NOT send).
+
+            ``mailbox`` (optional) routes when multiple mailboxes are connected.
+            """
+            try:
+                provider = agent._provider_for_message(message_id, mailbox or None)
+                backend = agent._backends[provider]
+                result = draft_forward_impl(
+                    backend,
+                    db,
+                    message_id=message_id,
+                    to=to,
+                    body=body,
+                    debug=debug_flag,
+                )
+                agent._remember_draft_mailbox(result.get("draft_id"), provider)
+                return _envelope_ok(result)
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def send_draft(draft_id: str, mailbox: str = "") -> str:
+            """Send a previously-created draft. Requires user confirmation.
+
+            Routes to the mailbox the draft was created in (remembered from
+            ``draft_reply`` / ``draft_forward``). ``mailbox`` overrides that.
+            """
+            try:
+                backend = agent._backend_for_draft(draft_id, mailbox or None)
                 return _envelope_ok(
-                    draft_reply_impl(
-                        gmail, db, message_id=message_id, body=body, debug=debug_flag
-                    )
+                    send_draft_impl(backend, db, draft_id=draft_id, debug=debug_flag)
                 )
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
@@ -245,45 +298,17 @@ class ReplyToolsMixin:
                 return _envelope_err(f"{type(exc).__name__}: {exc}")
 
         @tool
-        def draft_forward(message_id: str, to: str, body: str = "") -> str:
-            """Create a forward draft for a message (does NOT send)."""
-            try:
-                return _envelope_ok(
-                    draft_forward_impl(
-                        gmail,
-                        db,
-                        message_id=message_id,
-                        to=to,
-                        body=body,
-                        debug=debug_flag,
-                    )
-                )
-            except ConnectorsError as exc:
-                return _envelope_err(format_connector_error(exc))
-            except Exception as exc:
-                log.exception("email tool error: %s", type(exc).__name__)
-                return _envelope_err(f"{type(exc).__name__}: {exc}")
+        def send_now(to: str, subject: str, body: str, mailbox: str = "") -> str:
+            """Send an email immediately, no draft step. Requires user confirmation.
 
-        @tool
-        def send_draft(draft_id: str) -> str:
-            """Send a previously-created draft. Requires user confirmation."""
+            ``mailbox`` (optional) chooses which account sends when multiple are
+            connected; defaults to the primary mailbox.
+            """
             try:
-                return _envelope_ok(
-                    send_draft_impl(gmail, db, draft_id=draft_id, debug=debug_flag)
-                )
-            except ConnectorsError as exc:
-                return _envelope_err(format_connector_error(exc))
-            except Exception as exc:
-                log.exception("email tool error: %s", type(exc).__name__)
-                return _envelope_err(f"{type(exc).__name__}: {exc}")
-
-        @tool
-        def send_now(to: str, subject: str, body: str) -> str:
-            """Send an email immediately, no draft step. Requires user confirmation."""
-            try:
+                backend = agent._send_backend(mailbox or None)
                 return _envelope_ok(
                     send_now_impl(
-                        gmail,
+                        backend,
                         db,
                         to=to,
                         subject=subject,
@@ -298,12 +323,18 @@ class ReplyToolsMixin:
                 return _envelope_err(f"{type(exc).__name__}: {exc}")
 
         @tool
-        def forward_message(message_id: str, to: str, note: str = "") -> str:
-            """Forward an email to a new recipient. Requires user confirmation."""
+        def forward_message(
+            message_id: str, to: str, note: str = "", mailbox: str = ""
+        ) -> str:
+            """Forward an email to a new recipient. Requires user confirmation.
+
+            ``mailbox`` (optional) routes when multiple mailboxes are connected.
+            """
             try:
+                provider = agent._provider_for_message(message_id, mailbox or None)
                 return _envelope_ok(
                     forward_message_impl(
-                        gmail,
+                        agent._backends[provider],
                         db,
                         message_id=message_id,
                         to=to,

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -544,11 +544,41 @@ def tripwire_check() -> None:
             logger.warning("tripwire: provider %s check failed: %s", provider_id, e)
 
 
+def connected_mailbox_providers() -> list[str]:
+    """Return ids of OAuth PKCE connectors that have a stored connection.
+
+    "Connected" means the user completed the OAuth flow and a connection blob
+    exists in the keyring — regardless of any per-agent grant. The grant gate
+    fires later at token-fetch time and raises loudly there if needed.
+
+    Returns ids in registry order (google before microsoft). Only
+    ``oauth_pkce`` connectors are considered; MCP-server connectors have no
+    mailbox surface and are excluded.
+
+    Read-only; never returns secrets.
+    """
+    # Importing the catalog populates REGISTRY with the built-in specs (google,
+    # microsoft, mcp_servers). Idempotent: Python's module cache makes repeat
+    # imports a no-op. Mirrors the pattern in _require_mcp_server_for_activation.
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+    from gaia.connectors.registry import REGISTRY
+    from gaia.connectors.store import peek_connection
+
+    result: list[str] = []
+    for spec in REGISTRY.all():
+        if spec.type != "oauth_pkce":
+            continue
+        if peek_connection(spec.id) is not None:
+            result.append(spec.id)
+    return result
+
+
 __all__ = [
     "activate",
     "activate_agent",
     "cancel_flow",
     "complete_authorization",
+    "connected_mailbox_providers",
     "deactivate",
     "deactivate_agent",
     "get_access_token",

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -928,6 +928,19 @@ def _session_agent_kwargs(
     }
 
 
+def _session_mail_provider(session: dict) -> str | None:
+    """Session mailbox FILTER for the email agent (#1596 / #1603 Phase 2).
+
+    ``None`` (unset, null, or empty string from the frontend) means "every
+    connected mailbox" — the email agent scans all of them and fails loudly
+    when none is connected. An explicit ``"google"`` / ``"microsoft"``
+    restricts to that provider. Never coerce a missing pick to "google":
+    that silently triaged Gmail for sessions that never chose a provider
+    and ignored a connected Outlook.
+    """
+    return session.get("mail_provider") or None
+
+
 def _find_last_tool_step(steps: list) -> dict | None:
     """Find the last tool step in captured_steps, searching backwards."""
     for i in range(len(steps) - 1, -1, -1):
@@ -1282,8 +1295,9 @@ async def _get_chat_response(
                     ),
                     # Forwarded only here (not via _session_agent_kwargs, which
                     # also feeds the strict ChatAgentConfig). Non-email factories
-                    # drop it via dataclasses.fields filtering.
-                    mail_provider=session.get("mail_provider") or "google",
+                    # drop it via dataclasses.fields filtering. None = scan every
+                    # connected mailbox (#1596).
+                    mail_provider=_session_mail_provider(session),
                 )
                 logger.info(
                     "chat: Invoking agent %s for session %s, model=%s",
@@ -1746,8 +1760,9 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
                                 session_id=session_id,
                             ),
                             # See the non-streaming path: email-only kwarg,
-                            # filtered out by non-email factories.
-                            mail_provider=session.get("mail_provider") or "google",
+                            # filtered out by non-email factories. None = scan
+                            # every connected mailbox (#1596).
+                            mail_provider=_session_mail_provider(session),
                         )
                         agent.console = sse_handler
                         logger.info(

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -46,7 +46,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     model TEXT NOT NULL DEFAULT 'Gemma-4-E4B-it-GGUF',
     system_prompt TEXT,
     device TEXT DEFAULT 'gpu',
-    mail_provider TEXT DEFAULT 'google'
+    -- Mailbox FILTER (#1596): NULL = every connected mailbox; the legacy
+    -- ALTER migration below still backfills pre-Phase-2 rows to 'google'.
+    mail_provider TEXT
 );
 
 -- Many-to-many: which docs are attached to which session
@@ -313,7 +315,8 @@ class ChatDatabase:
         title = title or "New Chat"
         agent_type = agent_type or "chat"
         device = device or "gpu"
-        mail_provider = mail_provider or "google"
+        # mail_provider is a FILTER (#1596): no pick stays NULL ("every
+        # connected mailbox") — never silently coerce to google.
 
         with self._transaction():
             self._conn.execute(

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -287,7 +287,8 @@ class SessionResponse(BaseModel):
     private: bool = False
     agent_type: str = "chat"
     device: str = "gpu"
-    mail_provider: str = "google"
+    # Mailbox FILTER (#1596): None = every connected mailbox (no pick).
+    mail_provider: Optional[str] = None
 
 
 class SessionListResponse(BaseModel):

--- a/src/gaia/ui/utils.py
+++ b/src/gaia/ui/utils.py
@@ -141,7 +141,9 @@ def session_to_response(session: dict) -> SessionResponse:
         private=bool(session.get("private", 0)),
         agent_type=session.get("agent_type") or "chat",
         device=session.get("device") or "gpu",
-        mail_provider=session.get("mail_provider") or "google",
+        # Filter semantics (#1596): null = "every connected mailbox" — must
+        # reach the frontend as null so the selector shows no phantom pick.
+        mail_provider=session.get("mail_provider"),
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1558,5 +1558,176 @@ class TestEmailSendConfirmationGate:
         assert resp.status_code == 403
 
 
+class TestEmailSendOffLoop:
+    """send_email runs backend.send_message() off the event loop (#1594).
+
+    The FastAPI route is async; calling backend.send_message() (which uses
+    get_access_token_sync) synchronously from the async handler raises a
+    RuntimeError because get_access_token_sync detects a running event loop.
+    The fix: ``asyncio.to_thread(backend.send_message, ...)``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        if not API_AVAILABLE:
+            pytest.skip(f"API dependencies not available: {IMPORT_ERROR}")
+        pytest.importorskip("gaia_agent_email")
+
+    def test_send_runs_on_worker_thread(self, monkeypatch):
+        """backend.send_message must be called from a thread WITHOUT a running loop.
+
+        We inject a backend whose send_message asserts it is NOT on a thread that
+        has a running asyncio event loop — this is the condition that made #1594
+        raise RuntimeError.
+        """
+        import asyncio
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        from gaia_agent_email import api_routes as email_routes
+
+        call_log = []
+
+        class _LoopAssertingBackend:
+            def send_message(self, *, to, subject, body, **_kw):
+                # If called from the event loop thread, get_running_loop() succeeds;
+                # from a worker thread it raises RuntimeError. This is the exact
+                # guard that get_access_token_sync enforces — we assert the same.
+                try:
+                    asyncio.get_running_loop()
+                    call_log.append("ON_LOOP")  # Wrong: called from loop thread
+                except RuntimeError:
+                    call_log.append("OFF_LOOP")  # Correct: called from worker
+                return {"id": "test-id-off-loop", "to": to, "subject": subject}
+
+        monkeypatch.setattr(email_routes, "resolve_send_backend", _LoopAssertingBackend)
+
+        client = TestClient(app)
+        # Get a valid token first
+        draft_resp = client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "test@example.com"}],
+                "subject": "Test",
+                "body": "Hello",
+            },
+        )
+        assert draft_resp.status_code == 200, draft_resp.text
+        token = draft_resp.json()["confirmation_token"]
+
+        send_resp = client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "test@example.com"}],
+                "subject": "Test",
+                "body": "Hello",
+                "confirmation_token": token,
+            },
+        )
+        assert send_resp.status_code == 200, send_resp.text
+        assert call_log == ["OFF_LOOP"], (
+            f"send_message ran on the event loop (call_log={call_log!r}); "
+            "#1594: wrap in asyncio.to_thread"
+        )
+
+
+class TestEmailSendOutlook502Fix:
+    """Graph sendMail returns 202 (no body, no id) — this is success, not 502.
+
+    Prior to D4 the send handler raised 502 any time sent_id was empty, which
+    broke Outlook sends (Graph sendMail legitimately returns 202 with no id).
+    The fix: treat result['sent']==True as success even with no id.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        if not API_AVAILABLE:
+            pytest.skip(f"API dependencies not available: {IMPORT_ERROR}")
+        pytest.importorskip("gaia_agent_email")
+
+    def test_outlook_202_no_id_returns_200(self, monkeypatch):
+        """A backend returning {"id":"","sent":True} must produce HTTP 200."""
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        from gaia_agent_email import api_routes as email_routes
+
+        class _OutlookLikeBackend:
+            # Graph sendMail: 202 No Content; no id echoed back, but no exception.
+            def send_message(self, *, to, subject, body, **_kw):
+                return {"id": "", "sent": True, "to": to, "subject": subject}
+
+        monkeypatch.setattr(email_routes, "resolve_send_backend", _OutlookLikeBackend)
+        client = TestClient(app)
+        draft = client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+            },
+        )
+        token = draft.json()["confirmation_token"]
+        resp = client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "confirmation_token": token,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["sent"] is True
+        assert body["sent_id"] == ""  # No id from Graph, but not a 502
+
+    def test_silent_no_op_backend_still_502s(self, monkeypatch):
+        """A backend returning {"id":""} WITHOUT 'sent':True is still a 502.
+
+        Gmail raises on real failure, so a backend returning no id AND no
+        sent signal is an unknown failure state — still fail loud.
+        """
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        from gaia_agent_email import api_routes as email_routes
+
+        class _SilentNoOpBackend:
+            def send_message(self, *, to, subject, body, **_kw):
+                return {"id": ""}  # No 'sent' key — unknown failure
+
+        monkeypatch.setattr(email_routes, "resolve_send_backend", _SilentNoOpBackend)
+        client = TestClient(app)
+        draft = client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+            },
+        )
+        token = draft.json()["confirmation_token"]
+        resp = client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "confirmation_token": token,
+            },
+        )
+        assert resp.status_code == 502
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/agents/email/test_backend_selection.py
+++ b/tests/unit/agents/email/test_backend_selection.py
@@ -129,6 +129,106 @@ class TestAgentWiring:
         assert any("graph.microsoft.com/Mail" in s for s in ms.scopes)
 
 
+class TestResolveMailBackends:
+    """Plural resolver (#1603 Phase 2): ``mail_provider`` becomes a FILTER.
+
+    ``resolve_mail_backends()`` returns ``[(provider, backend), ...]`` for every
+    CONNECTED mailbox the filter admits — so a both-connected user triages both,
+    and a single-mailbox user gets exactly that one. It is connector-derived
+    (consults ``connected_mailbox_providers``); the singular ``resolve_mail_backend``
+    stays connector-agnostic for the existing eval seam.
+
+    Fail-loud: a filter naming an unconnected provider, or nothing connected,
+    raises ``ConfigurationError`` — never silently picks one.
+    """
+
+    def test_none_filter_both_connected_returns_two_in_order(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        cfg = EmailAgentConfig(mail_provider=None)
+        pairs = cfg.resolve_mail_backends()
+        providers = [p for p, _ in pairs]
+        assert providers == ["google", "microsoft"]
+        assert isinstance(dict(pairs)["google"], LiveGmailBackend)
+        assert isinstance(dict(pairs)["microsoft"], LiveOutlookBackend)
+
+    def test_none_filter_one_connected_returns_one(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["microsoft"],
+        )
+        cfg = EmailAgentConfig(mail_provider=None)
+        pairs = cfg.resolve_mail_backends()
+        assert [p for p, _ in pairs] == ["microsoft"]
+        assert isinstance(pairs[0][1], LiveOutlookBackend)
+
+    def test_explicit_filter_selects_only_that_provider(self, monkeypatch):
+        # Both connected, but the session explicitly chose google → just google.
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        cfg = EmailAgentConfig(mail_provider="google")
+        pairs = cfg.resolve_mail_backends()
+        assert [p for p, _ in pairs] == ["google"]
+        assert isinstance(pairs[0][1], LiveGmailBackend)
+
+    def test_explicit_filter_unconnected_raises_actionable(self, monkeypatch):
+        # Session selected microsoft but only google is connected → fail loud.
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google"],
+        )
+        cfg = EmailAgentConfig(mail_provider="microsoft")
+        with pytest.raises(ConfigurationError) as exc:
+            cfg.resolve_mail_backends()
+        msg = str(exc.value)
+        assert "microsoft" in msg
+        # Names what IS connected so the user can course-correct.
+        assert "google" in msg
+
+    def test_nothing_connected_raises_actionable(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: [],
+        )
+        cfg = EmailAgentConfig(mail_provider=None)
+        with pytest.raises(ConfigurationError) as exc:
+            cfg.resolve_mail_backends()
+        msg = str(exc.value)
+        assert "connect" in msg.lower()
+
+    def test_injected_backend_honored_per_provider(self, monkeypatch):
+        # The eval seam: an injected backend for the connected provider wins
+        # over building a live one.
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google"],
+        )
+        sentinel = object()
+        cfg = EmailAgentConfig(mail_provider=None, gmail_backend=sentinel)
+        pairs = cfg.resolve_mail_backends()
+        assert pairs == [("google", sentinel)]
+
+    def test_injected_outlook_backend_honored_for_microsoft(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["microsoft"],
+        )
+        sentinel = object()
+        cfg = EmailAgentConfig(mail_provider=None, outlook_backend=sentinel)
+        pairs = cfg.resolve_mail_backends()
+        assert pairs == [("microsoft", sentinel)]
+
+    def test_singular_resolver_unchanged_default_is_gmail(self):
+        # D1 must NOT regress the connector-agnostic singular seam: default
+        # (mail_provider=None) still builds Gmail without any connectivity mock.
+        cfg = EmailAgentConfig()
+        assert isinstance(cfg.resolve_mail_backend(), LiveGmailBackend)
+
+
 class TestResolveCalendarBackend:
     """Calendar-backend selection (#1276), mirroring ``resolve_mail_backend``.
 

--- a/tests/unit/agents/email/test_contract_schema.py
+++ b/tests/unit/agents/email/test_contract_schema.py
@@ -320,3 +320,41 @@ def test_result_summary_required():
     del payload["result"]["summary"]
     with pytest.raises(ValidationError):
         EmailTriageResult.model_validate(payload["result"])
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 (#1603) contract freeze guard — the multi-inbox 'mailbox' tag lives
+# on the INTERNAL agent tool-result dicts, NOT on the frozen REST schema.
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_unchanged_by_multi_inbox():
+    """Multi-inbox (#1603 Phase 2) must NOT bump the frozen contract.
+
+    The REST /triage endpoint analyzes a single caller-supplied payload — it
+    never reads mailboxes, so it needs no source-mailbox field and no version
+    bump. If this fails, someone changed the frozen contract; that requires an
+    explicit version negotiation, not a drive-by edit.
+    """
+    assert SCHEMA_VERSION == "1.0"
+
+
+def test_triage_result_gained_no_new_required_field():
+    """Every EmailTriageResult field beyond the original required set must be
+    optional — a new REQUIRED field would break every existing consumer."""
+    required = {
+        name
+        for name, field in EmailTriageResult.model_fields.items()
+        if field.is_required()
+    }
+    assert required == {"category", "summary"}, (
+        f"EmailTriageResult required fields changed: {sorted(required)}. "
+        "Adding a required field is a breaking contract change — it needs a "
+        "SCHEMA_VERSION bump and a migration plan, not a drive-by edit."
+    )
+
+
+def test_triage_result_has_no_mailbox_field():
+    """The 'mailbox' tag is internal to the agent tools; the frozen REST result
+    must not grow one implicitly."""
+    assert "mailbox" not in EmailTriageResult.model_fields

--- a/tests/unit/agents/email/test_draft_token_provider_binding.py
+++ b/tests/unit/agents/email/test_draft_token_provider_binding.py
@@ -24,9 +24,8 @@ import pytest
 pytest.importorskip("fastapi")
 pytest.importorskip("gaia_agent_email")
 
-from fastapi.testclient import TestClient
-
 import gaia_agent_email.api_routes as email_routes
+from fastapi.testclient import TestClient
 from gaia_agent_email.gmail_backend import LiveGmailBackend
 from gaia_agent_email.outlook_backend import LiveOutlookBackend
 
@@ -126,6 +125,7 @@ class TestDraftTokenProviderBinding:
             "connected_mailbox_providers",
             lambda: ["google", "microsoft"],
         )
+
         # Backend resolver: when provider binding overrides, it calls with a
         # single-element list. We track via calls.
         def _resolve_with_provider(provider=None):
@@ -135,7 +135,9 @@ class TestDraftTokenProviderBinding:
                 return _FG()
             return _build(["google", "microsoft"])  # would 400 without binding
 
-        monkeypatch.setattr(email_routes, "_resolve_backend_for_provider", _resolve_with_provider)
+        monkeypatch.setattr(
+            email_routes, "_resolve_backend_for_provider", _resolve_with_provider
+        )
 
         client = TestClient(app)
         draft_resp = client.post(

--- a/tests/unit/agents/email/test_draft_token_provider_binding.py
+++ b/tests/unit/agents/email/test_draft_token_provider_binding.py
@@ -26,8 +26,6 @@ pytest.importorskip("gaia_agent_email")
 
 import gaia_agent_email.api_routes as email_routes
 from fastapi.testclient import TestClient
-from gaia_agent_email.gmail_backend import LiveGmailBackend
-from gaia_agent_email.outlook_backend import LiveOutlookBackend
 
 # The FastAPI app the email router is mounted on.
 try:

--- a/tests/unit/agents/email/test_draft_token_provider_binding.py
+++ b/tests/unit/agents/email/test_draft_token_provider_binding.py
@@ -1,0 +1,257 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Draft-token provider binding tests (#1603, M5).
+
+A draft request may carry an optional ``provider`` field ("google" or
+"microsoft"). When set, the issued confirmation token is bound to that
+provider. When the send echoes the token, it routes to THAT provider's
+backend — even when both mailboxes are connected.
+
+Scenarios:
+  - draft with provider="microsoft" → token bound to microsoft
+  - send echoing that token → routes to Outlook even with both connected
+  - send with a provider not connected → 400
+  - send with a provider that differs from the token's binding → 403 (gate)
+  - one-mailbox draft without provider → unchanged behavior (D2 count logic)
+  - draft with provider="google" → token bound to google, routes to Gmail
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("gaia_agent_email")
+
+from fastapi.testclient import TestClient
+
+import gaia_agent_email.api_routes as email_routes
+from gaia_agent_email.gmail_backend import LiveGmailBackend
+from gaia_agent_email.outlook_backend import LiveOutlookBackend
+
+# The FastAPI app the email router is mounted on.
+try:
+    from gaia.api.openai_server import app
+except ImportError:
+    app = None
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """TestClient with a fake backend seam for each provider."""
+    if app is None:
+        pytest.skip("gaia.api.openai_server not available")
+    pytest.importorskip("gaia_agent_email")
+    return TestClient(app)
+
+
+@pytest.fixture
+def fake_backends(monkeypatch):
+    """Track which backend was used for the send call."""
+    calls = []
+
+    class _FakeGmail:
+        def send_message(self, *, to, subject, body, **_kw):
+            calls.append("google")
+            return {"id": "gmail-sent-id", "to": to, "subject": subject}
+
+    class _FakeOutlook:
+        def send_message(self, *, to, subject, body, **_kw):
+            calls.append("microsoft")
+            return {"id": "", "sent": True, "to": to, "subject": subject}
+
+    def _build_backend(providers):
+        if not providers:
+            from fastapi import HTTPException
+
+            raise HTTPException(503, "No mailbox connected")
+        if len(providers) > 1:
+            from fastapi import HTTPException
+
+            raise HTTPException(400, f"Multiple mailboxes: {providers}")
+        p = providers[0]
+        if p == "google":
+            return _FakeGmail()
+        if p == "microsoft":
+            return _FakeOutlook()
+        from fastapi import HTTPException
+
+        raise HTTPException(503, f"Unknown provider: {p}")
+
+    return calls, _FakeGmail, _FakeOutlook, _build_backend
+
+
+class TestDraftTokenProviderBinding:
+    """Provider binding on the draft is echoed through the token and used on send."""
+
+    def test_draft_model_accepts_provider_field(self):
+        """EmailDraftRequest must accept an optional provider field."""
+        req = email_routes.EmailDraftRequest(
+            to=[{"email": "x@example.com"}],
+            subject="s",
+            body="b",
+            provider="microsoft",
+        )
+        assert req.provider == "microsoft"
+
+    def test_draft_model_provider_defaults_to_none(self):
+        req = email_routes.EmailDraftRequest(
+            to=[{"email": "x@example.com"}],
+            subject="s",
+            body="b",
+        )
+        assert req.provider is None
+
+    def test_send_model_accepts_provider_field(self):
+        req = email_routes.EmailSendRequest(
+            to=[{"email": "x@example.com"}],
+            subject="s",
+            body="b",
+            provider="google",
+        )
+        assert req.provider == "google"
+
+    def test_microsoft_draft_routes_to_outlook_even_with_both_connected(
+        self, monkeypatch, fake_backends
+    ):
+        """draft(provider=microsoft) → token → send → Outlook backend."""
+        if app is None:
+            pytest.skip("gaia.api.openai_server not available")
+        calls, _FG, _FO, _build = fake_backends
+
+        # Both mailboxes are "connected" from the provider-count perspective.
+        monkeypatch.setattr(
+            email_routes,
+            "connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        # Backend resolver: when provider binding overrides, it calls with a
+        # single-element list. We track via calls.
+        def _resolve_with_provider(provider=None):
+            if provider == "microsoft":
+                return _FO()
+            if provider == "google":
+                return _FG()
+            return _build(["google", "microsoft"])  # would 400 without binding
+
+        monkeypatch.setattr(email_routes, "_resolve_backend_for_provider", _resolve_with_provider)
+
+        client = TestClient(app)
+        draft_resp = client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "provider": "microsoft",
+            },
+        )
+        assert draft_resp.status_code == 200, draft_resp.text
+        token = draft_resp.json()["confirmation_token"]
+
+        send_resp = client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "confirmation_token": token,
+            },
+        )
+        assert send_resp.status_code == 200, send_resp.text
+        assert calls == ["microsoft"], f"Expected Outlook send, got {calls}"
+
+    def test_send_with_provider_not_connected_returns_400(self, monkeypatch):
+        """Sending via microsoft when only google is connected → 400."""
+        if app is None:
+            pytest.skip("gaia.api.openai_server not available")
+        monkeypatch.setattr(
+            email_routes,
+            "connected_mailbox_providers",
+            lambda: ["google"],
+        )
+        client = TestClient(app)
+        draft_resp = client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "provider": "microsoft",  # not connected
+            },
+        )
+        assert draft_resp.status_code == 200, draft_resp.text
+        token = draft_resp.json()["confirmation_token"]
+
+        send_resp = client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "confirmation_token": token,
+            },
+        )
+        # Provider 'microsoft' was bound but not connected — must 4xx
+        assert 400 <= send_resp.status_code < 500, send_resp.text
+
+    def test_single_mailbox_draft_without_provider_unchanged(self, monkeypatch):
+        """One connected mailbox, no provider in draft → D2 count logic (unchanged)."""
+        if app is None:
+            pytest.skip("gaia.api.openai_server not available")
+        calls = []
+
+        class _FakeGmail:
+            def send_message(self, *, to, subject, body, **_kw):
+                calls.append("google")
+                return {"id": "gid-1", "to": to, "subject": subject}
+
+        monkeypatch.setattr(
+            email_routes,
+            "connected_mailbox_providers",
+            lambda: ["google"],
+        )
+        monkeypatch.setattr(email_routes, "resolve_send_backend", _FakeGmail)
+
+        client = TestClient(app)
+        draft_resp = client.post(
+            "/v1/email/draft",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: x",
+                "body": "Got it",
+            },
+        )
+        assert draft_resp.status_code == 200
+        token = draft_resp.json()["confirmation_token"]
+
+        send_resp = client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "alice@example.com"}],
+                "subject": "Re: x",
+                "body": "Got it",
+                "confirmation_token": token,
+            },
+        )
+        assert send_resp.status_code == 200, send_resp.text
+
+    def test_confirmation_store_records_provider(self):
+        """ConfirmationStore.issue_with_provider / consume_with_provider stores binding."""
+        store = email_routes.ConfirmationStore()
+        fp = "test-fingerprint"
+        token = store.issue(fp, provider="microsoft")
+        # Consuming returns the provider alongside the bool.
+        ok, bound_provider = store.consume_with_provider(token, fp)
+        assert ok is True
+        assert bound_provider == "microsoft"
+
+    def test_confirmation_store_none_provider_on_unbound_token(self):
+        """Tokens issued without a provider return (True, None) on consume."""
+        store = email_routes.ConfirmationStore()
+        fp = "fp-no-provider"
+        token = store.issue(fp)
+        ok, bound_provider = store.consume_with_provider(token, fp)
+        assert ok is True
+        assert bound_provider is None

--- a/tests/unit/agents/email/test_mcp_send_backend_parity.py
+++ b/tests/unit/agents/email/test_mcp_send_backend_parity.py
@@ -108,7 +108,9 @@ class TestMcpSendOutlook502Parity:
         fp = _payload_fingerprint(to, "Hello", "World")
         token = agent._confirmation_store.issue(fp)
 
-        monkeypatch.setattr(agent, "_resolve_send_backend", lambda: _FakeOutlookBackend())
+        monkeypatch.setattr(
+            agent, "_resolve_send_backend", lambda: _FakeOutlookBackend()
+        )
 
         result = agent._send(
             {

--- a/tests/unit/agents/email/test_mcp_send_backend_parity.py
+++ b/tests/unit/agents/email/test_mcp_send_backend_parity.py
@@ -18,8 +18,6 @@ so that parity tests can run without a live mailbox connection.
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 pytest.importorskip("gaia_agent_email")

--- a/tests/unit/agents/email/test_mcp_send_backend_parity.py
+++ b/tests/unit/agents/email/test_mcp_send_backend_parity.py
@@ -1,0 +1,150 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+MCP send parity — connector-derived backend (#1603, M6).
+
+``EmailTriageMCPAgent._resolve_send_backend()`` must mirror the REST
+connector-derived logic (D2):
+
+  - GAIA_EMAIL_MCP_FAKE_SEND set → _FakeSendBackend (test seam, short-circuits)
+  - 0 connected providers  → RuntimeError with actionable message
+  - 2+ connected providers → RuntimeError with ambiguous-provider message
+  - 1 connected: google    → LiveGmailBackend
+  - 1 connected: microsoft → LiveOutlookBackend
+
+The fake-send seam must short-circuit BEFORE the count check (as today),
+so that parity tests can run without a live mailbox connection.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.gmail_backend import LiveGmailBackend
+from gaia_agent_email.mcp_server import EmailTriageMCPAgent
+from gaia_agent_email.outlook_backend import LiveOutlookBackend
+
+
+def _agent(monkeypatch, providers):
+    """Return an EmailTriageMCPAgent with mocked connected_mailbox_providers."""
+    monkeypatch.setattr(
+        "gaia_agent_email.mcp_server.connected_mailbox_providers",
+        lambda: providers,
+    )
+    return EmailTriageMCPAgent()
+
+
+class TestMcpSendBackendConnectorDerived:
+    """_resolve_send_backend() must be connector-derived (mirrors REST D2)."""
+
+    def test_fake_send_seam_short_circuits_before_count_check(
+        self, monkeypatch, tmp_path
+    ):
+        """GAIA_EMAIL_MCP_FAKE_SEND=1 must bypass provider count, even with 0 connected."""
+        monkeypatch.setattr(
+            "gaia_agent_email.mcp_server.connected_mailbox_providers",
+            lambda: [],  # 0 providers — would error without the seam
+        )
+        monkeypatch.setenv("GAIA_EMAIL_MCP_FAKE_SEND", "1")
+        agent = EmailTriageMCPAgent()
+        # Must not raise even with 0 connected providers.
+        backend = agent._resolve_send_backend()
+        assert backend is not None
+        # Must be the fake (has a send_message that returns a non-empty test id).
+        result = backend.send_message(to="x@example.com", subject="s", body="b")
+        assert result.get("id"), f"fake backend should return a non-empty id: {result}"
+
+    def test_zero_providers_raises_actionable_runtime_error(self, monkeypatch):
+        monkeypatch.delenv("GAIA_EMAIL_MCP_FAKE_SEND", raising=False)
+        agent = _agent(monkeypatch, [])
+        with pytest.raises(RuntimeError) as exc_info:
+            agent._resolve_send_backend()
+        msg = str(exc_info.value).lower()
+        assert "connect" in msg or "mailbox" in msg or "no" in msg
+
+    def test_two_providers_raises_ambiguous_runtime_error(self, monkeypatch):
+        monkeypatch.delenv("GAIA_EMAIL_MCP_FAKE_SEND", raising=False)
+        agent = _agent(monkeypatch, ["google", "microsoft"])
+        with pytest.raises(RuntimeError) as exc_info:
+            agent._resolve_send_backend()
+        msg = str(exc_info.value)
+        # Must name the connected providers so the error is actionable.
+        assert "google" in msg or "microsoft" in msg
+
+    def test_google_only_returns_live_gmail_backend(self, monkeypatch):
+        monkeypatch.delenv("GAIA_EMAIL_MCP_FAKE_SEND", raising=False)
+        agent = _agent(monkeypatch, ["google"])
+        backend = agent._resolve_send_backend()
+        assert isinstance(backend, LiveGmailBackend)
+
+    def test_microsoft_only_returns_live_outlook_backend(self, monkeypatch):
+        monkeypatch.delenv("GAIA_EMAIL_MCP_FAKE_SEND", raising=False)
+        agent = _agent(monkeypatch, ["microsoft"])
+        backend = agent._resolve_send_backend()
+        assert isinstance(backend, LiveOutlookBackend)
+
+
+class TestMcpSendOutlook502Parity:
+    """MCP send mirrors the REST D4 fix: Outlook 202 (no id) is success."""
+
+    def test_outlook_sent_true_returns_success(self, monkeypatch):
+        """A backend returning sent=True, empty id → MCP returns sent:True."""
+        monkeypatch.delenv("GAIA_EMAIL_MCP_FAKE_SEND", raising=False)
+
+        class _FakeOutlookBackend:
+            def send_message(self, *, to, subject, body, **_kw):
+                return {"id": "", "sent": True, "to": to, "subject": subject}
+
+        agent = EmailTriageMCPAgent()
+        # Seed the confirmation store with a valid token.
+        from gaia_agent_email.api_routes import _payload_fingerprint
+        from gaia_agent_email.contract import EmailAddress
+
+        to = [EmailAddress(email="bob@example.com")]
+        fp = _payload_fingerprint(to, "Hello", "World")
+        token = agent._confirmation_store.issue(fp)
+
+        monkeypatch.setattr(agent, "_resolve_send_backend", lambda: _FakeOutlookBackend())
+
+        result = agent._send(
+            {
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "confirmation_token": token,
+            }
+        )
+        assert result.get("sent") is True
+
+    def test_no_id_no_sent_returns_error(self, monkeypatch):
+        """A backend returning {id:'', no sent} → MCP returns sent:False."""
+        monkeypatch.delenv("GAIA_EMAIL_MCP_FAKE_SEND", raising=False)
+
+        class _SilentNoOp:
+            def send_message(self, *, to, subject, body, **_kw):
+                return {"id": ""}
+
+        agent = EmailTriageMCPAgent()
+        from gaia_agent_email.api_routes import _payload_fingerprint
+        from gaia_agent_email.contract import EmailAddress
+
+        to = [EmailAddress(email="bob@example.com")]
+        fp = _payload_fingerprint(to, "Hello", "World")
+        token = agent._confirmation_store.issue(fp)
+
+        monkeypatch.setattr(agent, "_resolve_send_backend", lambda: _SilentNoOp())
+
+        result = agent._send(
+            {
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hello",
+                "body": "World",
+                "confirmation_token": token,
+            }
+        )
+        assert result.get("sent") is not True
+        assert result.get("error")

--- a/tests/unit/agents/email/test_multi_inbox_triage.py
+++ b/tests/unit/agents/email/test_multi_inbox_triage.py
@@ -304,6 +304,35 @@ class TestPerMessageRouting:
         finally:
             agent.close_db()
 
+    def test_get_message_routes_to_tagged_mailbox(self, tmp_path, monkeypatch):
+        # The standard flow is triage → get_message → act; a body read on an
+        # Outlook-tagged id must hit Outlook, not 404 against the primary Gmail.
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            _registered_tool("triage_inbox")(20)
+            envelope = json.loads(_registered_tool("get_message")("m1"))
+            assert envelope["ok"] is True, envelope
+            # The Outlook spy stamps its sender — proves which backend answered.
+            assert "microsoft@example.com" in envelope["data"]["from"]
+        finally:
+            agent.close_db()
+
+    def test_get_thread_routes_to_tagged_mailbox(self, tmp_path, monkeypatch):
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            _registered_tool("triage_inbox")(20)
+            # Thread ids are remembered alongside message ids at triage time.
+            envelope = json.loads(_registered_tool("get_thread")("t-m1"))
+            assert envelope["ok"] is True, envelope
+            senders = [m["from"] for m in envelope["data"]["messages"]]
+            assert any("microsoft@example.com" in s for s in senders)
+        finally:
+            agent.close_db()
+
     def test_undo_routes_to_the_mailbox_the_action_hit(self, tmp_path, monkeypatch):
         # D5: trash an Outlook-tagged message, then restore — the untrash must
         # dispatch to the Outlook backend (read from the action row's mailbox),

--- a/tests/unit/agents/email/test_multi_inbox_triage.py
+++ b/tests/unit/agents/email/test_multi_inbox_triage.py
@@ -304,6 +304,25 @@ class TestPerMessageRouting:
         finally:
             agent.close_db()
 
+    def test_undo_routes_to_the_mailbox_the_action_hit(self, tmp_path, monkeypatch):
+        # D5: trash an Outlook-tagged message, then restore — the untrash must
+        # dispatch to the Outlook backend (read from the action row's mailbox),
+        # never to Gmail.
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            _registered_tool("triage_inbox")(20)
+            trash_env = json.loads(_registered_tool("trash_message")("m1"))
+            assert trash_env["ok"] is True, trash_env
+            action_id = trash_env["data"]["action_id"]
+            restore_env = json.loads(_registered_tool("restore_message")(action_id))
+            assert restore_env["ok"] is True, restore_env
+            assert ("untrash_message", "m1") in spy_m.calls
+            assert all(c[0] != "untrash_message" for c in spy_g.calls)
+        finally:
+            agent.close_db()
+
 
 class TestSingleBackendRoutingUnchanged:
     def test_single_backend_routes_without_provenance(self, tmp_path, monkeypatch):

--- a/tests/unit/agents/email/test_multi_inbox_triage.py
+++ b/tests/unit/agents/email/test_multi_inbox_triage.py
@@ -1,0 +1,329 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Multi-inbox triage + per-message routing (#1603 Phase 2).
+
+With both mailboxes connected, ``triage_inbox`` / ``pre_scan_inbox`` must scan
+BOTH and merge, tagging every item with its source mailbox, while ``max_messages``
+stays a TOTAL budget split across mailboxes (never per-mailbox). Downstream
+actions (reply / archive / trash) must route to the mailbox the message came
+from — no cross-mailbox 404s.
+
+The backends here are lightweight in-test spies that satisfy the ``GmailBackend``
+Protocol surface the triage / action paths touch. No live OAuth, no network.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")  # noqa: E402
+
+from unittest.mock import MagicMock, patch
+
+from gaia_agent_email.agent import EmailTriageAgent
+from gaia_agent_email.config import EmailAgentConfig
+
+# ---------------------------------------------------------------------------
+# In-test spy backend (Gmail-API-shape, records mutations)
+# ---------------------------------------------------------------------------
+
+
+def _msg(message_id: str, *, subject: str = "Hi", sender: str = "a@example.com"):
+    """Build a minimal Gmail-API-shape message.
+
+    Tagged ``CATEGORY_PROMOTIONS`` so the triage heuristic commits confidently
+    (→ "low priority") WITHOUT an LLM call — these tests exercise multi-inbox
+    routing, not classification, so the classifier path is deliberately avoided.
+    """
+    return {
+        "id": message_id,
+        "threadId": f"t-{message_id}",
+        "labelIds": ["INBOX", "CATEGORY_PROMOTIONS"],
+        "snippet": subject,
+        "internalDate": "1000",
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": subject},
+                {"name": "From", "value": sender},
+            ],
+            "body": {"data": ""},
+        },
+    }
+
+
+class SpyBackend:
+    """Minimal GmailBackend-shaped fake that records mutating calls.
+
+    Holds a fixed list of message ids; ``list_messages`` honors ``max_results``
+    so the budget-split assertions can verify the per-backend cap. Every mutate
+    method appends ``(method, message_id)`` to ``calls`` so routing tests can
+    prove which backend received an action.
+    """
+
+    def __init__(self, name: str, message_ids: list[str]):
+        self.name = name
+        self._messages = {
+            mid: _msg(mid, sender=f"{name}@example.com") for mid in message_ids
+        }
+        self.calls: list[tuple[str, str]] = []
+
+    # -- Read ---------------------------------------------------------------
+
+    def list_messages(
+        self, *, query=None, label_ids=None, max_results=25, page_token=None
+    ):
+        ids = list(self._messages)[:max_results]
+        return {"messages": [{"id": m, "threadId": f"t-{m}"} for m in ids]}
+
+    def get_message(self, message_id: str):
+        if message_id not in self._messages:
+            raise KeyError(f"{self.name}: no message {message_id!r}")
+        return self._messages[message_id]
+
+    def get_thread(self, thread_id: str):
+        return {"id": thread_id, "messages": list(self._messages.values())}
+
+    # -- Mutate (record routing) -------------------------------------------
+
+    def trash_message(self, message_id: str):
+        self.calls.append(("trash_message", message_id))
+        return {"id": message_id}
+
+    def untrash_message(self, message_id: str):
+        self.calls.append(("untrash_message", message_id))
+        return {"id": message_id}
+
+    def archive_message(self, message_id: str):
+        self.calls.append(("archive_message", message_id))
+        return {"id": message_id}
+
+    def add_label(self, message_id: str, label_id: str):
+        self.calls.append(("add_label", message_id))
+        return {"id": message_id}
+
+    def create_draft(self, *, to, subject, body, headers=None):
+        self.calls.append(("create_draft", to))
+        return {"id": f"draft-{self.name}"}
+
+    def send_message(self, *, to, subject, body, headers=None):
+        self.calls.append(("send_message", to))
+        return {"id": f"sent-{self.name}", "sent": True}
+
+
+# ---------------------------------------------------------------------------
+# Agent builder with two injected spy backends
+# ---------------------------------------------------------------------------
+
+
+def _agent_two_backends(tmp_path, monkeypatch, *, google_ids, microsoft_ids):
+    """Construct an agent whose ``_backends`` is {google: spyG, microsoft: spyM}.
+
+    Both mailboxes are reported connected; the heuristic-only path is used
+    (chat is a MagicMock, classifier wiring is bypassed because the heuristic is
+    confident on these synthetic messages — and even if it weren't, the mocked
+    chat never actually classifies).
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    spy_g = SpyBackend("google", google_ids)
+    spy_m = SpyBackend("microsoft", microsoft_ids)
+    cfg = EmailAgentConfig(
+        gmail_backend=spy_g,
+        outlook_backend=spy_m,
+        calendar_backend=object(),
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+        mail_provider=None,  # scan all connected
+    )
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent, spy_g, spy_m
+
+
+def _registered_tool(name):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    return _TOOL_REGISTRY[name]["function"]
+
+
+# ---------------------------------------------------------------------------
+# D3 — merge + tag + budget
+# ---------------------------------------------------------------------------
+
+
+class TestMultiInboxTriageMergeAndTag:
+    def test_agent_binds_both_backends(self, tmp_path, monkeypatch):
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            assert set(agent._backends) == {"google", "microsoft"}
+            assert agent._backends["google"] is spy_g
+            assert agent._backends["microsoft"] is spy_m
+        finally:
+            agent.close_db()
+
+    def test_triage_merges_both_and_tags_mailbox(self, tmp_path, monkeypatch):
+        agent, _, _ = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1", "g2"], microsoft_ids=["m1", "m2"]
+        )
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            assert envelope["ok"] is True, envelope
+            results = envelope["data"]["results"]
+            ids = {r["id"] for r in results}
+            # Both mailboxes contributed.
+            assert {"g1", "g2"} & ids
+            assert {"m1", "m2"} & ids
+            # Every item carries a source mailbox tag.
+            assert all(r.get("mailbox") in {"google", "microsoft"} for r in results)
+            by_id = {r["id"]: r["mailbox"] for r in results}
+            assert by_id["g1"] == "google"
+            assert by_id["m1"] == "microsoft"
+        finally:
+            agent.close_db()
+
+    def test_triage_total_budget_split_across_mailboxes(self, tmp_path, monkeypatch):
+        # 10 messages in each mailbox; ask for 20 total → ~10 per mailbox, but
+        # the MERGED total must not exceed the requested budget.
+        agent, _, _ = _agent_two_backends(
+            tmp_path,
+            monkeypatch,
+            google_ids=[f"g{i}" for i in range(10)],
+            microsoft_ids=[f"m{i}" for i in range(10)],
+        )
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            results = envelope["data"]["results"]
+            # TOTAL budget — never per-mailbox-doubled.
+            assert len(results) <= 20
+            # Per-backend cap is max_messages // n_backends == 10.
+            n_google = sum(1 for r in results if r["mailbox"] == "google")
+            n_microsoft = sum(1 for r in results if r["mailbox"] == "microsoft")
+            assert n_google <= 10
+            assert n_microsoft <= 10
+        finally:
+            agent.close_db()
+
+    def test_triage_budget_is_total_not_per_mailbox(self, tmp_path, monkeypatch):
+        # 8 in each; ask for 8 total → 4 per mailbox, 8 merged (NOT 16).
+        agent, _, _ = _agent_two_backends(
+            tmp_path,
+            monkeypatch,
+            google_ids=[f"g{i}" for i in range(8)],
+            microsoft_ids=[f"m{i}" for i in range(8)],
+        )
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(8))
+            results = envelope["data"]["results"]
+            assert len(results) <= 8
+            assert sum(1 for r in results if r["mailbox"] == "google") <= 4
+            assert sum(1 for r in results if r["mailbox"] == "microsoft") <= 4
+        finally:
+            agent.close_db()
+
+    def test_pre_scan_tags_every_section_item(self, tmp_path, monkeypatch):
+        agent, _, _ = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1", "g2"], microsoft_ids=["m1", "m2"]
+        )
+        try:
+            envelope = json.loads(_registered_tool("pre_scan_inbox")(20))
+            assert envelope["ok"] is True, envelope
+            data = envelope["data"]
+            assert data["kind"] == "email_pre_scan"
+            items = data["urgent"] + data["actionable"] + data["suggested_archives"]
+            # Some item was produced and every one carries a mailbox tag.
+            assert items, "pre-scan produced no section items"
+            assert all(it.get("mailbox") in {"google", "microsoft"} for it in items)
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# D4 — per-message backend routing
+# ---------------------------------------------------------------------------
+
+
+class TestPerMessageRouting:
+    def test_trash_routes_to_tagged_mailbox(self, tmp_path, monkeypatch):
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            # Triage tags g1→google, m1→microsoft in _message_mailbox.
+            _registered_tool("triage_inbox")(20)
+            # Trash the Outlook-tagged message — must hit the Outlook spy only.
+            envelope = json.loads(_registered_tool("trash_message")("m1"))
+            assert envelope["ok"] is True, envelope
+            assert ("trash_message", "m1") in spy_m.calls
+            assert all(c[0] != "trash_message" for c in spy_g.calls)
+            # And a Gmail-tagged message routes to the Gmail spy.
+            json.loads(_registered_tool("trash_message")("g1"))
+            assert ("trash_message", "g1") in spy_g.calls
+        finally:
+            agent.close_db()
+
+    def test_archive_routes_to_tagged_mailbox(self, tmp_path, monkeypatch):
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            _registered_tool("triage_inbox")(20)
+            json.loads(_registered_tool("archive_message")("m1"))
+            assert ("archive_message", "m1") in spy_m.calls
+            assert all(c[0] != "archive_message" for c in spy_g.calls)
+        finally:
+            agent.close_db()
+
+    def test_unknown_message_with_two_backends_fails_loud(self, tmp_path, monkeypatch):
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            # Never triaged → no provenance → ambiguous with two backends.
+            envelope = json.loads(_registered_tool("trash_message")("unknown-id"))
+            assert envelope["ok"] is False
+            # No mutation reached either backend.
+            assert spy_g.calls == []
+            assert spy_m.calls == []
+        finally:
+            agent.close_db()
+
+    def test_explicit_mailbox_arg_overrides_provenance(self, tmp_path, monkeypatch):
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            # No triage; pass mailbox explicitly so routing is unambiguous.
+            envelope = json.loads(_registered_tool("trash_message")("m1", "microsoft"))
+            assert envelope["ok"] is True, envelope
+            assert ("trash_message", "m1") in spy_m.calls
+        finally:
+            agent.close_db()
+
+
+class TestSingleBackendRoutingUnchanged:
+    def test_single_backend_routes_without_provenance(self, tmp_path, monkeypatch):
+        # One mailbox connected → no tagging needed; an untriaged id still
+        # routes to the sole backend (preserves the shipped single-mailbox UX).
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        spy_g = SpyBackend("google", ["g1"])
+        cfg = EmailAgentConfig(
+            gmail_backend=spy_g,
+            calendar_backend=object(),
+            db_path=str(tmp_path / "state.db"),
+            silent_mode=True,
+        )
+        with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+            mock_sdk.return_value = MagicMock()
+            agent = EmailTriageAgent(config=cfg)
+        try:
+            assert set(agent._backends) == {"google"}
+            envelope = json.loads(_registered_tool("trash_message")("g1"))
+            assert envelope["ok"] is True, envelope
+            assert ("trash_message", "g1") in spy_g.calls
+        finally:
+            agent.close_db()

--- a/tests/unit/agents/email/test_no_provider_env_var.py
+++ b/tests/unit/agents/email/test_no_provider_env_var.py
@@ -1,0 +1,68 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Guard test: GAIA_EMAIL_PROVIDER (and any hidden mailbox env var) must be absent
+from the repo (#1603 AC).
+
+The email agent's provider selection is connector-derived (peeks keyring, not
+env). An env-var-based override would create a hidden back-door that bypasses
+the connector gate and silently selects a provider. This test locks in that the
+codebase never introduces such a variable.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Repo root is four levels up from this test file:
+# tests/unit/agents/email/test_no_provider_env_var.py → ../../../../
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Paths to scan — the agent source and the connectors framework.
+_SCAN_PATHS = [
+    _REPO_ROOT / "src" / "gaia",
+    _REPO_ROOT / "hub" / "agents" / "python" / "email",
+]
+
+# Env var names that would constitute a hidden mailbox-provider override.
+# GAIA_EMAIL_MCP_FAKE_SEND is an APPROVED test seam — it is NOT on this list.
+_BANNED_ENV_VARS = [
+    "GAIA_EMAIL_PROVIDER",
+    "GAIA_MAIL_PROVIDER",
+    "EMAIL_PROVIDER",
+    "MAIL_PROVIDER",
+]
+
+_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(v) for v in _BANNED_ENV_VARS) + r")\b"
+)
+
+
+def test_no_hidden_mailbox_provider_env_var():
+    """No banned GAIA_EMAIL_PROVIDER (or similar) env var appears in the codebase.
+
+    The email send path is connector-derived; provider selection via env var
+    would bypass the keyring gate and create a silent fallback. This test is a
+    repo-wide static check — if it fails, the new reference must be removed and
+    replaced with the connector-derived path.
+    """
+    hits = []
+    for scan_root in _SCAN_PATHS:
+        if not scan_root.exists():
+            continue
+        for path in scan_root.rglob("*.py"):
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for match in _PATTERN.finditer(text):
+                # Compute line number for the match.
+                line_no = text[: match.start()].count("\n") + 1
+                hits.append(f"{path.relative_to(_REPO_ROOT)}:{line_no}: {match.group()!r}")
+
+    assert not hits, (
+        "Found banned mailbox-provider env var references in the codebase "
+        "(provider selection must be connector-derived, not env-var-based):\n"
+        + "\n".join(f"  {h}" for h in hits)
+    )

--- a/tests/unit/agents/email/test_no_provider_env_var.py
+++ b/tests/unit/agents/email/test_no_provider_env_var.py
@@ -59,7 +59,9 @@ def test_no_hidden_mailbox_provider_env_var():
             for match in _PATTERN.finditer(text):
                 # Compute line number for the match.
                 line_no = text[: match.start()].count("\n") + 1
-                hits.append(f"{path.relative_to(_REPO_ROOT)}:{line_no}: {match.group()!r}")
+                hits.append(
+                    f"{path.relative_to(_REPO_ROOT)}:{line_no}: {match.group()!r}"
+                )
 
     assert not hits, (
         "Found banned mailbox-provider env var references in the codebase "

--- a/tests/unit/agents/email/test_outlook_backend.py
+++ b/tests/unit/agents/email/test_outlook_backend.py
@@ -650,3 +650,37 @@ class TestTriageAgainstOutlook:
         assert out["grouped"]["total"] == 2
         ids = {r["id"] for r in out["results"]}
         assert ids == {"m1", "m2"}
+
+
+# ---------------------------------------------------------------------------
+# send_message returns sent signal (D4 — Graph sendMail 202 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageSentSignal:
+    """LiveOutlookBackend.send_message must return {"sent": True} (#1603, D4).
+
+    Graph sendMail returns HTTP 202 with no body — no message id is echoed back.
+    The REST handler previously raised 502 on empty sent_id; the fix is to
+    include "sent": True in the return dict so the handler can distinguish
+    "Outlook success (no id)" from "unknown failure (no id, no signal)".
+    """
+
+    def test_send_message_returns_sent_true(self):
+        backend, _, _ = _backend(lambda r: httpx.Response(202))
+        result = backend.send_message(
+            to="bob@example.com", subject="Hello", body="World"
+        )
+        assert result.get("sent") is True
+
+    def test_send_message_id_is_empty_string(self):
+        """Graph does NOT return an id for sendMail — empty string, not None."""
+        backend, _, _ = _backend(lambda r: httpx.Response(202))
+        result = backend.send_message(to="x@example.com", subject="s", body="b")
+        assert result.get("id") == ""
+
+    def test_send_message_still_posts_to_sendmail_endpoint(self):
+        """The change to the return value must not affect the actual HTTP call."""
+        backend, rec, _ = _backend(lambda r: httpx.Response(202))
+        backend.send_message(to="bob@example.com", subject="Hi", body="Hello")
+        assert rec.requests[0].url.path.endswith("/me/sendMail")

--- a/tests/unit/agents/email/test_send_backend_selection.py
+++ b/tests/unit/agents/email/test_send_backend_selection.py
@@ -22,9 +22,8 @@ import pytest
 pytest.importorskip("fastapi")
 pytest.importorskip("gaia_agent_email")
 
-from fastapi import HTTPException
-
 import gaia_agent_email.api_routes as email_routes
+from fastapi import HTTPException
 from gaia_agent_email.gmail_backend import LiveGmailBackend
 from gaia_agent_email.outlook_backend import LiveOutlookBackend
 

--- a/tests/unit/agents/email/test_send_backend_selection.py
+++ b/tests/unit/agents/email/test_send_backend_selection.py
@@ -1,0 +1,103 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for connector-derived ``get_send_backend()`` (#1603, M2).
+
+``get_send_backend()`` must be derived from the connected OAuth mailbox, not
+hardcoded to Gmail:
+
+  - 0 providers → HTTP 503 (no mailbox connected)
+  - 2+ providers → HTTP 400 (ambiguous; can't choose)
+  - 1 provider "google"  → LiveGmailBackend
+  - 1 provider "microsoft" → LiveOutlookBackend
+
+The ``resolve_send_backend`` module-level alias is KEPT as the injectable
+test seam (existing tests monkeypatch it).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("gaia_agent_email")
+
+from fastapi import HTTPException
+
+import gaia_agent_email.api_routes as email_routes
+from gaia_agent_email.gmail_backend import LiveGmailBackend
+from gaia_agent_email.outlook_backend import LiveOutlookBackend
+
+
+class TestGetSendBackendConnectorDerived:
+    """get_send_backend() must be connector-derived, fail-loud."""
+
+    def test_no_providers_raises_503(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.api_routes.connected_mailbox_providers",
+            lambda: [],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            email_routes.get_send_backend()
+        assert exc_info.value.status_code == 503
+        detail = exc_info.value.detail
+        assert "connect" in detail.lower() or "mailbox" in detail.lower()
+
+    def test_two_providers_raises_400(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.api_routes.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            email_routes.get_send_backend()
+        assert exc_info.value.status_code == 400
+        detail = exc_info.value.detail
+        # Must name the providers so the error is actionable.
+        assert "google" in detail.lower() or "microsoft" in detail.lower()
+
+    def test_google_only_returns_live_gmail_backend(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.api_routes.connected_mailbox_providers",
+            lambda: ["google"],
+        )
+        backend = email_routes.get_send_backend()
+        assert isinstance(backend, LiveGmailBackend)
+
+    def test_microsoft_only_returns_live_outlook_backend(self, monkeypatch):
+        monkeypatch.setattr(
+            "gaia_agent_email.api_routes.connected_mailbox_providers",
+            lambda: ["microsoft"],
+        )
+        backend = email_routes.get_send_backend()
+        assert isinstance(backend, LiveOutlookBackend)
+
+    def test_resolve_send_backend_alias_preserved(self):
+        """The module-level alias must remain for existing test monkeypatching."""
+        # resolve_send_backend is the injectable seam; it must stay as a module
+        # attribute pointing to the same default callable.
+        assert hasattr(email_routes, "resolve_send_backend")
+        assert callable(email_routes.resolve_send_backend)
+
+    def test_503_detail_is_actionable(self, monkeypatch):
+        """503 must tell the user what to do."""
+        monkeypatch.setattr(
+            "gaia_agent_email.api_routes.connected_mailbox_providers",
+            lambda: [],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            email_routes.get_send_backend()
+        detail = exc_info.value.detail
+        # Must name the settings path (Settings → Connectors or similar) so
+        # the user knows what to do.
+        assert "connect" in detail.lower()
+
+    def test_400_lists_connected_providers(self, monkeypatch):
+        """400 must list which providers are connected so the error is actionable."""
+        monkeypatch.setattr(
+            "gaia_agent_email.api_routes.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            email_routes.get_send_backend()
+        detail = exc_info.value.detail
+        assert "google" in detail and "microsoft" in detail

--- a/tests/unit/agents/email/test_thread_comprehension.py
+++ b/tests/unit/agents/email/test_thread_comprehension.py
@@ -234,10 +234,16 @@ class TestSummarizeThreadImpl:
 
 
 class _Recorder:
-    """Captures the @tool functions a mixin registers without a real Agent."""
+    """Captures the @tool functions a mixin registers without a real Agent.
+
+    Implements the mixin host contract: ``_gmail``/``_backends`` plus the
+    per-message routing helper (#1603 Phase 2) — single-backend here, so it
+    always returns the one fake.
+    """
 
     def __init__(self, gmail, chat, debug=False):
         self._gmail = gmail
+        self._backends = {"google": gmail}
         self.chat = chat
         self._tools = {}
 
@@ -247,6 +253,9 @@ class _Recorder:
         self.config = _Cfg()
         self.config.debug = debug
         self.config.force_llm = False
+
+    def _backend_for_message(self, message_id, explicit_mailbox=None):
+        return self._gmail
 
 
 def _register_read_via_mixin(gmail, chat):

--- a/tests/unit/agents/test_email_agent.py
+++ b/tests/unit/agents/test_email_agent.py
@@ -106,6 +106,18 @@ class TestConstruction:
     def test_response_mode_is_conversational(self, agent):
         assert agent.response_mode == "conversational"
 
+    def test_injected_single_fake_builds_backends_map(self, agent, fake_gmail):
+        # Phase 2 (#1603 D2): the agent binds a provider→backend map. An
+        # injected single fake (no provider) tags as "google" to preserve the
+        # shipped Gmail fixtures, and ``self._gmail`` stays the primary backend.
+        assert agent._backends == {"google": fake_gmail}
+        assert agent._gmail is fake_gmail
+
+    def test_primary_backend_is_first_in_map(self, agent):
+        # self._gmail must be the first value in self._backends so existing
+        # single-backend tool closures keep working unchanged.
+        assert agent._gmail is next(iter(agent._backends.values()))
+
     def test_system_prompt_pre_scan_canary(self, agent):
         """Canary against silent prompt drift.
 

--- a/tests/unit/agents/test_email_agent_soft_delete.py
+++ b/tests/unit/agents/test_email_agent_soft_delete.py
@@ -135,6 +135,126 @@ class TestRecordAndFetch:
 
 
 # ---------------------------------------------------------------------------
+# mailbox column + migration (#1603 Phase 2)
+# ---------------------------------------------------------------------------
+
+
+class TestMailboxColumn:
+    def test_fresh_db_has_mailbox_column(self, db):
+        cols = {row["name"] for row in db.query("PRAGMA table_info(email_actions)")}
+        assert "mailbox" in cols
+
+    def test_record_action_stores_mailbox(self, db):
+        action_id = action_store.record_action(
+            db, action_type="trash", message_id="m1", mailbox="microsoft"
+        )
+        row = action_store.fetch_undoable(db, action_id=action_id, window_seconds=30)
+        assert row is not None
+        assert row["mailbox"] == "microsoft"
+
+    def test_record_action_without_mailbox_stores_null(self, db):
+        action_id = action_store.record_action(db, action_type="trash", message_id="m1")
+        row = action_store.fetch_undoable(db, action_id=action_id, window_seconds=30)
+        assert row is not None
+        assert row["mailbox"] is None
+
+    def test_fetch_batch_undoable_surfaces_mailbox(self, db):
+        action_store.record_action(
+            db,
+            action_type="archive",
+            message_id="m1",
+            batch_id="b1",
+            mailbox="google",
+        )
+        rows = action_store.fetch_batch_undoable(db, batch_id="b1", window_seconds=30)
+        assert rows and rows[0]["mailbox"] == "google"
+
+
+class TestMailboxMigration:
+    """A pre-#1603 DB (no mailbox column) gets the column added + rows
+    backfilled to 'google' — every pre-multi-inbox action could only have hit
+    the single Gmail mailbox.
+    """
+
+    _LEGACY_ACTIONS_DDL = """
+    CREATE TABLE email_actions (
+        action_id    TEXT PRIMARY KEY,
+        action_type  TEXT NOT NULL,
+        message_id   TEXT NOT NULL,
+        thread_id    TEXT,
+        payload_json TEXT NOT NULL,
+        batch_id     TEXT,
+        created_at   REAL NOT NULL,
+        undone_at    REAL
+    );
+    """
+
+    def _legacy_db(self):
+        legacy = _DB()
+        legacy.execute(self._LEGACY_ACTIONS_DDL)
+        legacy.execute(action_store.EMAIL_DRAFTS_DDL)
+        return legacy
+
+    def test_migration_adds_column_to_legacy_db(self):
+        legacy = self._legacy_db()
+        try:
+            cols = {
+                row["name"] for row in legacy.query("PRAGMA table_info(email_actions)")
+            }
+            assert "mailbox" not in cols  # genuinely legacy
+            action_store.init_schema(legacy)
+            cols = {
+                row["name"] for row in legacy.query("PRAGMA table_info(email_actions)")
+            }
+            assert "mailbox" in cols
+        finally:
+            legacy.close_db()
+
+    def test_migration_backfills_legacy_rows_to_google(self):
+        legacy = self._legacy_db()
+        try:
+            legacy.insert(
+                "email_actions",
+                {
+                    "action_id": "legacy1",
+                    "action_type": "trash",
+                    "message_id": "m1",
+                    "thread_id": None,
+                    "payload_json": "{}",
+                    "batch_id": None,
+                    "created_at": time.time(),
+                    "undone_at": None,
+                },
+            )
+            action_store.init_schema(legacy)
+            row = legacy.query(
+                "SELECT mailbox FROM email_actions WHERE action_id = 'legacy1'",
+                one=True,
+            )
+            assert row["mailbox"] == "google"
+        finally:
+            legacy.close_db()
+
+    def test_migration_is_idempotent(self):
+        legacy = self._legacy_db()
+        try:
+            action_store.init_schema(legacy)
+            # Second init must not raise (duplicate-column guard).
+            action_store.init_schema(legacy)
+        finally:
+            legacy.close_db()
+
+    def test_migration_does_not_overwrite_recorded_mailbox(self, db):
+        # A row recorded with an explicit mailbox keeps it across re-init.
+        action_id = action_store.record_action(
+            db, action_type="trash", message_id="m1", mailbox="microsoft"
+        )
+        action_store.init_schema(db)
+        row = action_store.fetch_undoable(db, action_id=action_id, window_seconds=30)
+        assert row["mailbox"] == "microsoft"
+
+
+# ---------------------------------------------------------------------------
 # email_drafts
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/agents/test_email_agent_tools.py
+++ b/tests/unit/agents/test_email_agent_tools.py
@@ -765,8 +765,10 @@ class TestDeleteTools:
         msg_id = list(fake_gmail._messages.keys())[0]
         out = trash_message_impl(fake_gmail, db, message_id=msg_id)
         action_id = out["action_id"]
+        # restore_message_impl now takes a backend resolver (#1603 Phase 2):
+        # resolve_backend(action) -> backend. Single-mailbox test → always fake.
         result = restore_message_impl(
-            fake_gmail, db, action_id=action_id, window_seconds=30
+            lambda _action: fake_gmail, db, action_id=action_id, window_seconds=30
         )
         assert result["restored"] is True
         post = fake_gmail.get_message(msg_id)
@@ -787,7 +789,12 @@ class TestDeleteTools:
             {"id": action_id},
         )
         with pytest.raises(RuntimeError) as exc:
-            restore_message_impl(fake_gmail, db, action_id=action_id, window_seconds=30)
+            restore_message_impl(
+                lambda _action: fake_gmail,
+                db,
+                action_id=action_id,
+                window_seconds=30,
+            )
         assert "undo window" in str(exc.value)
 
     def test_permanent_delete_removes_from_store(self, fake_gmail, db):

--- a/tests/unit/chat/ui/test_database.py
+++ b/tests/unit/chat/ui/test_database.py
@@ -120,9 +120,11 @@ class TestSessions:
         refreshed = db.get_session(session["id"])
         assert refreshed["updated_at"] >= original_updated
 
-    def test_create_session_default_mail_provider(self, db):
+    def test_create_session_default_mail_provider_is_null(self, db):
+        # #1596: mail_provider is a FILTER — no pick stays NULL ("every
+        # connected mailbox"), never silently coerced to google.
         session = db.create_session()
-        assert session["mail_provider"] == "google"
+        assert session["mail_provider"] is None
 
     def test_create_session_with_mail_provider(self, db):
         session = db.create_session(mail_provider="microsoft")
@@ -131,7 +133,7 @@ class TestSessions:
         assert db.get_session(session["id"])["mail_provider"] == "microsoft"
 
     def test_update_session_mail_provider(self, db):
-        session = db.create_session()  # defaults to google
+        session = db.create_session()  # no pick (NULL = all connected)
         updated = db.update_session(session["id"], mail_provider="microsoft")
         assert updated["mail_provider"] == "microsoft"
 

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -829,9 +829,11 @@ class TestSessionEndpoints:
         resp = client.get("/api/sessions/nonexistent-uuid")
         assert resp.status_code == 404
 
-    def test_create_session_default_mail_provider(self, client):
+    def test_create_session_default_mail_provider_is_null(self, client):
+        # #1596: no pick → null in the API response, so the UI selector shows
+        # "no pick" (scan all) instead of a phantom google selection.
         data = client.post("/api/sessions", json={}).json()
-        assert data["mail_provider"] == "google"
+        assert data["mail_provider"] is None
 
     def test_create_session_microsoft_mail_provider(self, client):
         resp = client.post(

--- a/tests/unit/connectors/test_connected_mailbox_providers.py
+++ b/tests/unit/connectors/test_connected_mailbox_providers.py
@@ -1,0 +1,120 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for ``connected_mailbox_providers()`` (#1603).
+
+The helper returns the ids of OAuth PKCE connectors whose connection blob is
+present in the keyring — regardless of per-agent grants. "Connected" means the
+user completed the OAuth flow; "granted" is a separate (per-agent) gate that
+fires later at token time.
+
+Test cases:
+  - no connection stored → []
+  - only google stored → ["google"]
+  - only microsoft stored → ["microsoft"]
+  - both stored → ["google", "microsoft"] (registry order: google before microsoft)
+  - connected-but-ungranted still counted (only peek_connection matters)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("keyring")
+from gaia.connectors.store import DEFAULT_ACCOUNT, SERVICE_NAME, _connection_username
+
+
+# ---------------------------------------------------------------------------
+# Helpers to write blobs directly into the in-memory keyring so we can
+# simulate "google connected", "microsoft connected", etc. without running the
+# real OAuth flow. The autouse _autouse_in_memory_keyring fixture from
+# tests/unit/connectors/conftest.py guarantees we have a clean in-memory
+# keyring for every test.
+# ---------------------------------------------------------------------------
+
+
+def _write_connection(provider: str, keyring_backend):
+    """Write a minimal connection blob for *provider* into the keyring."""
+    import keyring
+
+    username = _connection_username(provider, DEFAULT_ACCOUNT)
+    blob = json.dumps(
+        {
+            "account_email": f"user@{provider}.example.com",
+            "scopes": ["openid"],
+            "connected_at": "2026-01-01T00:00:00Z",
+            "refresh_token": "tok-dummy",
+            "client_id_hash": "testhash",
+        }
+    )
+    keyring.set_password(SERVICE_NAME, username, blob)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnectedMailboxProviders:
+    def _call(self):
+        # Import inside each test so catalog registration is always fresh.
+        from gaia.connectors.api import connected_mailbox_providers
+
+        return connected_mailbox_providers()
+
+    def test_none_connected_returns_empty(self, _autouse_in_memory_keyring):
+        assert self._call() == []
+
+    def test_google_only_returns_google(self, _autouse_in_memory_keyring):
+        _write_connection("google", _autouse_in_memory_keyring)
+        result = self._call()
+        assert result == ["google"]
+
+    def test_microsoft_only_returns_microsoft(self, _autouse_in_memory_keyring):
+        _write_connection("microsoft", _autouse_in_memory_keyring)
+        result = self._call()
+        assert result == ["microsoft"]
+
+    def test_both_connected_returns_both_in_order(self, _autouse_in_memory_keyring):
+        _write_connection("google", _autouse_in_memory_keyring)
+        _write_connection("microsoft", _autouse_in_memory_keyring)
+        result = self._call()
+        # google is tier=1, id='google'; microsoft is tier=1, id='microsoft';
+        # REGISTRY.all() sorts by (tier, id) → google < microsoft alphabetically.
+        assert result == ["google", "microsoft"]
+
+    def test_connected_but_no_grant_still_listed(self, _autouse_in_memory_keyring):
+        """A connected provider with no per-agent grant is still returned.
+
+        connected_mailbox_providers() gates on the OAuth connection (peek_connection),
+        NOT on per-agent grants. The grant check fires later at token fetch time
+        and fails loudly there if needed — but the enumeration layer must not
+        pre-filter by grants, because doing so would mask valid single-mailbox
+        cases for agents that haven't run the grant step yet.
+        """
+        _write_connection("google", _autouse_in_memory_keyring)
+        # No grants are registered at all — still expect google listed.
+        result = self._call()
+        assert "google" in result
+
+    def test_returns_list_not_set(self, _autouse_in_memory_keyring):
+        _write_connection("google", _autouse_in_memory_keyring)
+        result = self._call()
+        assert isinstance(result, list)
+
+    def test_non_oauth_pkce_connectors_excluded(self, _autouse_in_memory_keyring):
+        """Only oauth_pkce connectors are mailbox candidates.
+
+        MCP-server connectors (type != "oauth_pkce") must never appear in
+        the result even if they happen to have a keyring entry with the same
+        key structure.
+        """
+        from gaia.connectors.api import connected_mailbox_providers
+
+        # The result should contain at most google / microsoft, never an
+        # mcp_server type connector id.
+        _write_connection("google", _autouse_in_memory_keyring)
+        result = connected_mailbox_providers()
+        assert all(p in ("google", "microsoft") for p in result)

--- a/tests/unit/connectors/test_connected_mailbox_providers.py
+++ b/tests/unit/connectors/test_connected_mailbox_providers.py
@@ -25,7 +25,6 @@ import pytest
 pytest.importorskip("keyring")
 from gaia.connectors.store import DEFAULT_ACCOUNT, SERVICE_NAME, _connection_username
 
-
 # ---------------------------------------------------------------------------
 # Helpers to write blobs directly into the in-memory keyring so we can
 # simulate "google connected", "microsoft connected", etc. without running the

--- a/tests/unit/test_session_mail_provider.py
+++ b/tests/unit/test_session_mail_provider.py
@@ -1,0 +1,52 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Session mailbox filter pass-through (#1596 / #1603 Phase 2).
+
+The Agent UI session's ``mail_provider`` is a FILTER: ``None`` (or unset/empty)
+means "every connected mailbox". The chat helpers must pass that through to the
+email agent untouched — the old ``or "google"`` coercion silently triaged Gmail
+for sessions that never picked a provider (or had nothing connected), masking
+the fail-loud no-mailbox error and ignoring a connected Outlook.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+pytest.importorskip("gaia.ui._chat_helpers")
+
+from gaia.ui import _chat_helpers
+from gaia.ui._chat_helpers import _session_mail_provider
+
+
+class TestSessionMailProviderPassThrough:
+    def test_unset_stays_none(self):
+        assert _session_mail_provider({}) is None
+
+    def test_none_stays_none(self):
+        assert _session_mail_provider({"mail_provider": None}) is None
+
+    def test_empty_string_normalizes_to_none(self):
+        # The frontend may send "" for "no pick" — same semantics as None.
+        assert _session_mail_provider({"mail_provider": ""}) is None
+
+    def test_explicit_google_preserved(self):
+        assert _session_mail_provider({"mail_provider": "google"}) == "google"
+
+    def test_explicit_microsoft_preserved(self):
+        assert _session_mail_provider({"mail_provider": "microsoft"}) == "microsoft"
+
+
+class TestNoSilentGoogleCoercion:
+    def test_chat_helpers_source_has_no_or_google_fallback(self):
+        """The 'session.get("mail_provider") or "google"' coercion must be gone.
+
+        Source-level canary: both agent-construction call sites must route
+        through _session_mail_provider so None reaches the agent as
+        "all connected mailboxes" (fail-loud when none is connected).
+        """
+        src = inspect.getsource(_chat_helpers)
+        assert 'session.get("mail_provider") or "google"' not in src


### PR DESCRIPTION
Closes #1603
Closes #1594

## Why this matters

Before: the email agent silently assumed Gmail everywhere. The REST/MCP **send** paths hardcoded it, so an Outlook-only user couldn't send at all; live REST sends 500'd (token fetched on the async endpoint's running loop, #1594); and Outlook sends that did go through 502'd on Graph's empty-id 202. On **triage**, a user with both mailboxes connected could only ever scan one, with no way to tell which mailbox a message came from — and downstream reply/archive/delete/undo dispatched every message id to a single backend, so the wrong mailbox 404'd.

After: mailbox selection is **derived from what's actually connected**. Send resolves to the single connected mailbox (or a draft-token-bound one) and fails loud when none/ambiguous; "triage my inbox" scans **all** connected mailboxes, tags every item with its source, splits `max_messages` as a **total** budget across mailboxes, and routes every per-message action to the correct provider. No hidden env vars, no silent Gmail default (a guard test pins `GAIA_EMAIL_PROVIDER` absent). The per-session `mail_provider` (#1596) now reads as a filter: `null` = all connected.

Supersedes #1595 — its off-the-event-loop send fix is folded in here, so #1594 is resolved in this PR.

## Test plan

- [x] `GAIA_MEMORY_DISABLED=1 python -m pytest tests/unit/agents/email/ tests/unit/agents/test_email_agent*.py tests/unit/email/ tests/unit/connectors/ tests/unit/chat/ tests/test_api.py` — **1,747 passed, 0 failed** (independently re-run)
- [x] `python util/lint.py --all` — clean
- [x] **Real-world** — Ryzen AI Strix Halo, Gemma-4-E4B on iGPU (Vulkan), **real Gmail + personal Outlook both OAuth-connected**:

  | Proof | Result |
  |---|---|
  | `connected_mailbox_providers()` (both connected) | `['google','microsoft']` |
  | Send — Gmail (draft-token bound) | 200, real message id |
  | Send — Outlook (draft-token bound) | **200, empty `sent_id` (Graph 202) — not 502** |
  | Send — both connected, unbound | **400 ambiguous** (actionable) |
  | Multi-inbox triage merge + per-item mailbox tags | 6 items, google + microsoft, each tagged |
  | `max_messages` total budget | 3 google + 3 microsoft (= 6, not 12) |
  | Planted-fact retrieval (Gmail) + tag | found, tagged `google` |
  | Per-message routing + fail-loud on unknown id | gmail→google; unknown→`ValueError` |
  | Action routing — Gmail archive+restore | routed google, no 404 |
  | Action routing — Outlook archive | routed microsoft, Graph 201, no 404 |
  | Filter `mail_provider="microsoft"` | only microsoft scanned |

  One item not captured: the Outlook *planted-fact send→retrieve round-trip* — the self-send returned 200 but didn't appear in the scanned Inbox window (Outlook Focused/Other split or delivery delay), an Outlook delivery artifact, not a behavior of this change. Outlook read + tag + action-routing are all proven on real Outlook content.
