### PR TITLE
fix(packaging): add keyring to [api] extra so gaia api + email wheel starts

### DIFF
--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -10,7 +10,13 @@ authors = [{ name = "AMD" }]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["amd-gaia>=0.20.0"]
+# Depend on the [api] extra (not bare amd-gaia) so a consuming app's
+# `pip install gaia-agent-email` pulls the REST-server deps (fastapi/uvicorn)
+# AND keyring automatically — the email REST router's import chain needs keyring
+# at module load and at request time (connected_mailbox_providers). Closes the
+# "consumer forgot [api]" half of #1617. Raise the floor to >=0.21.0 once that
+# release ships keyring-in-[api] for a hard version guarantee.
+dependencies = ["amd-gaia[api]>=0.20.0"]
 
 [project.entry-points."gaia.agent"]
 email = "gaia_agent_email:build_registration"

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,12 @@ setup(
             "fastapi>=0.115.0",
             "uvicorn>=0.32.0",
             "python-multipart>=0.0.9",
+            # [api] auto-mounts the gaia-agent-email REST router (openai_server.py),
+            # whose import chain reaches gaia.connectors.store -> `import keyring`
+            # at module load AND at request time (connected_mailbox_providers).
+            # Declare it so `amd-gaia[api]` + gaia-agent-email starts & serves triage
+            # with zero manual installs. Same pin as [ui]/[dev]. See #1617.
+            "keyring>=24.0.0,<26.0.0",
         ],
         "ui": [
             "fastapi>=0.115.0",

--- a/tests/unit/test_agent_pypi_publish.py
+++ b/tests/unit/test_agent_pypi_publish.py
@@ -18,6 +18,7 @@ wiring by ``test_cli_agent.py``.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -56,11 +57,18 @@ def test_dist_name_and_directory_convention(packages):
 
 
 def test_every_wheel_declares_amd_gaia_dependency(packages):
-    """Issue #1179 scope 3: each wheel depends on amd-gaia>={min_gaia_version}."""
+    """Issue #1179 scope 3: each wheel depends on amd-gaia>={min_gaia_version}.
+
+    An optional ``[extras]`` segment is allowed (e.g. ``amd-gaia[api]>=`` — the
+    email wheel pulls the [api] extra so consumers auto-get the REST-server deps
+    + keyring; see #1617).
+    """
+    # amd-gaia, an optional [extras] group, then a >= floor.
+    pat = re.compile(r"amd-gaia(\[[^\]]*\])?>=")
     for p in packages:
         pyproject = (p.path / "pyproject.toml").read_text(encoding="utf-8")
-        assert (
-            "amd-gaia>=" in pyproject
+        assert pat.search(
+            pyproject
         ), f"{p.dist_name}: pyproject.toml is missing an 'amd-gaia>=' dependency"
 
 

--- a/tests/unit/test_api_extras.py
+++ b/tests/unit/test_api_extras.py
@@ -1,0 +1,66 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Regression test for issue #1617.
+
+The [api] server (gaia.api.openai_server) auto-mounts the gaia-agent-email
+REST router when that wheel is importable. Its import chain reaches
+``import keyring`` at module load time (openai_server -> email_router ->
+gaia.connectors.api -> gaia.connectors.store) AND at request time via
+``connected_mailbox_providers()``. Because ``keyring`` was only declared in
+the ``[ui]`` and ``[dev]`` extras — not in ``[api]`` — a deployment of
+``pip install 'amd-gaia[api]' gaia-agent-email`` would crash on startup with
+``ModuleNotFoundError: No module named 'keyring'``.
+
+This is a packaging assertion, not a runtime import test, so it works in the
+CI unit-tests venv that does not actually install ``[api]``. Same framing as
+test_ui_extras.py's #845 docstring.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SETUP_PY = Path(__file__).resolve().parents[2] / "setup.py"
+
+
+def _parse_api_extra() -> list[str]:
+    """Extract the list of requirement strings from setup.py[api].
+
+    Walks the file line by line so brackets that appear inside ``# comments``
+    don't confuse a naive non-greedy regex match.
+    """
+    lines = SETUP_PY.read_text().splitlines()
+    in_block = False
+    body: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if not in_block:
+            if re.match(r'"api"\s*:\s*\[', stripped):
+                in_block = True
+            continue
+        if stripped.startswith("]"):
+            break
+        # Skip comment-only lines so brackets in comments don't matter.
+        if stripped.startswith("#"):
+            continue
+        body.append(raw)
+    assert in_block, 'Could not find "api" extra in setup.py extras_require'
+    return re.findall(r'"([^"]+)"', "\n".join(body))
+
+
+def test_api_extra_declares_keyring() -> None:
+    """setup.py[api] must declare keyring — see #1617.
+
+    The import chain openai_server -> email_router -> gaia.connectors.api ->
+    gaia.connectors.store reaches ``import keyring`` at module load AND at
+    request time via ``connected_mailbox_providers()``.
+    """
+    api_reqs = _parse_api_extra()
+    matches = [r for r in api_reqs if r.lower().startswith("keyring")]
+    assert matches, (
+        "setup.py[api] is missing 'keyring' (needed by "
+        "openai_server -> email_router -> gaia.connectors.api -> store -> `import keyring`).\n"
+        f"Current [api] extra: {api_reqs}"
+    )

--- a/tests/unit/test_api_extras.py
+++ b/tests/unit/test_api_extras.py
@@ -23,6 +23,14 @@ import re
 from pathlib import Path
 
 SETUP_PY = Path(__file__).resolve().parents[2] / "setup.py"
+EMAIL_PYPROJECT = (
+    Path(__file__).resolve().parents[2]
+    / "hub"
+    / "agents"
+    / "python"
+    / "email"
+    / "pyproject.toml"
+)
 
 
 def _parse_api_extra() -> list[str]:
@@ -63,4 +71,20 @@ def test_api_extra_declares_keyring() -> None:
         "setup.py[api] is missing 'keyring' (needed by "
         "openai_server -> email_router -> gaia.connectors.api -> store -> `import keyring`).\n"
         f"Current [api] extra: {api_reqs}"
+    )
+
+
+def test_email_wheel_requires_amd_gaia_api_extra() -> None:
+    """gaia-agent-email must depend on ``amd-gaia[api]`` — see #1617.
+
+    A bare ``amd-gaia`` dependency let a consuming app's
+    ``pip install gaia-agent-email`` resolve core WITHOUT the [api] extra, so
+    the REST-server deps (fastapi/uvicorn) and keyring were absent and
+    ``gaia api`` crashed. Requesting the [api] extra pulls them automatically.
+    """
+    deps = re.findall(r'"(amd-gaia[^"]*)"', EMAIL_PYPROJECT.read_text())
+    assert deps, f"no amd-gaia dependency found in {EMAIL_PYPROJECT}"
+    assert any("[api]" in d for d in deps), (
+        "gaia-agent-email must depend on amd-gaia[api] so consumers get the "
+        f"REST-server deps + keyring automatically (got {deps})."
     )


### PR DESCRIPTION
**Why this matters**

The documented Milestone-40 partner recipe — `pip install 'amd-gaia[api]' gaia-agent-email`, then `gaia api` — crashed at server startup with `ModuleNotFoundError: No module named 'keyring'`, before serving a single request. `gaia api` auto-mounts the email wheel's REST router, and that import chain reaches a module-level `import keyring` in `gaia.connectors.store` (also hit at request time via `connected_mailbox_providers()`) — but `keyring` was declared only in the `[ui]`/`[dev]` extras, never `[api]`. So the one install combo the partner path depends on couldn't even boot; 0.20.1 only masks it because its server doesn't mount the email router yet.

After this change `[api]` carries `keyring` (same pin as `[ui]`/`[dev]`), so the documented install starts and serves local LLM triage with zero manual installs. Needs to land before the v0.21.0 tag. A packaging guard (`tests/unit/test_api_extras.py`, mirroring `test_ui_extras.py`) fails if `[api]` ever drops keyring again.

**Test plan**
- [x] Guard test is red on `main` (keyring absent from `[api]`), green with the fix.
- [x] `pytest tests/unit/test_api_extras.py tests/unit/test_packaging.py tests/unit/test_ui_extras.py` → 13 passed; `python util/lint.py --all` → clean.
- [x] Real-world, Linux + Radeon dGPU, local Lemonade (Gemma-4-E4B), fresh venvs via the documented `git+` recipe:
  - **Before (`main`):** `from gaia.api.openai_server import app` → `ModuleNotFoundError: No module named 'keyring'` at `store.py:38` (keyring not installed).
  - **After (this branch):** keyring 25.7.0 pulled by `[api]` → import clean → uvicorn boots → `POST /v1/email/triage` → **200** with LLM triage (category `actionable`, summary echoing the planted `$4,820 / INV-90871 / Thursday 3pm` facts, action item + draft reply).

Out of scope: AC3 (partner guide stating the exact install line) is tracked by #1597, and depends on #1601 publishing the `gaia-agent-email` wheel.

Closes #1617.
Related: #1602, #1590, #1597, #915, #1179.