### PR TITLE
fix(packaging): add keyring to base install_requires so gaia connectors works on bare install (#1621)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,8 @@ setup(
         # multipart uploads via python_multipart at import time. Base — not an
         # extra — so a plain `pip install amd-gaia` ships a working gaia-mcp.
         "python-multipart>=0.0.9",
+        # gaia connectors is a base CLI command; keyring is its OS credential store (OAuth tokens #915). #1621
+        "keyring>=24.0.0,<26.0.0",
     ],
     extras_require={
         "image": [

--- a/tests/unit/test_base_keyring_dep.py
+++ b/tests/unit/test_base_keyring_dep.py
@@ -1,0 +1,73 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Regression test for issue #1621.
+
+``gaia connectors`` (list, status, …) is a BASE CLI command — registered in
+``gaia.cli:main`` unconditionally, without any extras gate.  Its import chain
+reaches ``gaia.connectors.store`` which does ``import keyring`` at module load
+time and at request time (OAuth token storage via ``gaia.connectors.api``
+introduced in #915).
+
+Before this fix, ``keyring`` was only in the ``[ui]``, ``[api]``, and ``[dev]``
+extras.  A bare ``pip install amd-gaia`` therefore caused ``gaia connectors
+list`` to crash with ``ModuleNotFoundError: No module named 'keyring'``.
+
+Fix: promote ``keyring`` to ``install_requires`` so the base wheel ships a
+working ``gaia connectors`` out of the box.  The extras keep their own
+declarations independently (``test_api_extras.py`` guards the [api] entry).
+
+This is a static packaging assertion — it works in the CI unit-test venv that
+does not install the package at all.  Modelled on ``test_api_extras.py`` (#1617).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SETUP_PY = Path(__file__).resolve().parents[2] / "setup.py"
+
+
+def _parse_install_requires() -> list[str]:
+    """Extract requirement strings from setup.py install_requires=[...].
+
+    Walks the file line by line so brackets inside ``# comments`` don't
+    confuse a naive non-greedy regex.  Skips comment-only lines.  Stops
+    at the first ``]`` that closes the block.
+    """
+    lines = SETUP_PY.read_text().splitlines()
+    in_block = False
+    body: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if not in_block:
+            if re.match(r"install_requires\s*=\s*\[", stripped):
+                in_block = True
+            continue
+        if stripped.startswith("]"):
+            break
+        # Skip comment-only lines so brackets in comments don't matter.
+        if stripped.startswith("#"):
+            continue
+        body.append(raw)
+    assert in_block, "Could not find install_requires=[ in setup.py"
+    return re.findall(r'"([^"]+)"', "\n".join(body))
+
+
+def test_base_install_requires_declares_keyring() -> None:
+    """setup.py install_requires must include keyring — see #1621.
+
+    ``gaia connectors`` is a base CLI command (no extras gate).  Its import
+    chain reaches ``gaia.connectors.store -> import keyring`` (OAuth token
+    storage introduced in #915).  Without keyring in base, a plain
+    ``pip install amd-gaia`` ships a broken ``gaia connectors`` command.
+    """
+    base_reqs = _parse_install_requires()
+    matches = [r for r in base_reqs if r.lower().startswith("keyring")]
+    assert matches, (
+        "setup.py install_requires is missing 'keyring' (needed by "
+        "gaia.connectors.store -> `import keyring` for OAuth token storage, #915).\n"
+        "gaia connectors is a base CLI command — keyring must ship with the base wheel.\n"
+        f"Current install_requires: {base_reqs}"
+    )


### PR DESCRIPTION
Closes #1621

## Why this matters
`gaia connectors` is a **base** CLI command, but `keyring` — its OS credential-store backend for OAuth tokens (#915) — shipped only in the `[ui]`/`[api]`/`[dev]` extras. So a bare `pip install amd-gaia` crashed `gaia connectors list`/`status` with a raw `ModuleNotFoundError`. This promotes `keyring` to base `install_requires`, matching the command's tier, so connectors works out of the box on every platform.

**Decision record (#1621, Option 1).** keyring is featherweight (pure-Python + `jaraco.*`; the cryptography/SecretStorage chain is Linux-only and ships as a prebuilt wheel) and base already pulls transformers/accelerate, so the added footprint is negligible — whereas a `[connectors]` extra (Option 2) would leave a base command needing an extra to avoid crashing. The guarded import in #1622 ships as defense-in-depth for stripped/minimal installs; the extras keep their own keyring declaration (so #1617's `[api]` guard stays green).

## Test plan
- [ ] `pytest tests/unit/test_base_keyring_dep.py` — new regression guard: base `install_requires` declares keyring
- [ ] `pytest tests/unit/test_api_extras.py` — no regression; extras keep keyring
- [ ] `util/lint.py --all`
- [ ] Real-world: bare `pip install` pulls keyring + `gaia connectors list`/`status` works on macOS / Windows / Linux; guarded actionable error when keyring absent