### PR TITLE
fix(llm): correct LiteLLM embed() model override + finish #1593 review items

### DIFF
--- a/docs/sdk/sdks/llm.mdx
+++ b/docs/sdk/sdks/llm.mdx
@@ -67,7 +67,7 @@ llm_claude = create_client(use_claude=True)
 llm_openai = create_client(use_openai=True)
 
 # LiteLLM gateway — 100+ providers (Bedrock, Vertex AI, Groq, Azure, ...)
-# Requires: pip install gaia[litellm]
+# Requires: pip install 'gaia[litellm]'
 llm_litellm = create_client("litellm", model="anthropic/claude-sonnet-4-6")
 
 # Use same interface

--- a/docs/sdk/sdks/llm.mdx
+++ b/docs/sdk/sdks/llm.mdx
@@ -66,6 +66,10 @@ llm_claude = create_client(use_claude=True)
 # OpenAI API
 llm_openai = create_client(use_openai=True)
 
+# LiteLLM gateway — 100+ providers (Bedrock, Vertex AI, Groq, Azure, ...)
+# Requires: pip install gaia[litellm]
+llm_litellm = create_client("litellm", model="anthropic/claude-sonnet-4-6")
+
 # Use same interface
 response = llm_claude.generate("Explain Python decorators")
 ```

--- a/src/gaia/llm/factory.py
+++ b/src/gaia/llm/factory.py
@@ -24,7 +24,7 @@ def create_client(
     Create an LLM client, auto-detecting provider from parameters.
 
     Args:
-        provider: Explicit provider name ("lemonade", "openai", or "claude").
+        provider: Explicit provider name ("lemonade", "openai", "claude", or "litellm").
                   If not specified, auto-detected from use_claude/use_openai flags.
         use_claude: If True, use Claude provider (ignored if provider is specified)
         use_openai: If True, use OpenAI provider (ignored if provider is specified)

--- a/src/gaia/llm/providers/litellm.py
+++ b/src/gaia/llm/providers/litellm.py
@@ -17,14 +17,17 @@ class LiteLLMProvider(LLMClient):
         system_prompt: Optional[str] = None,
         **kwargs,
     ):
-        import litellm
+        try:
+            import litellm  # noqa: F401  -- validate the optional dependency at construction
+        except ImportError as e:
+            raise ImportError(
+                "litellm is not installed. Install it with: pip install gaia[litellm]"
+            ) from e
 
         self._model = model
         self._system_prompt = system_prompt
         self._api_key = api_key
         self._extra_kwargs = kwargs
-
-        litellm.drop_params = True
 
     @property
     def provider_name(self) -> str:
@@ -59,6 +62,7 @@ class LiteLLMProvider(LLMClient):
             )
 
         call_kwargs = {**self._extra_kwargs, **kwargs}
+        call_kwargs.setdefault("drop_params", True)
         if self._api_key:
             call_kwargs["api_key"] = self._api_key
 
@@ -66,7 +70,6 @@ class LiteLLMProvider(LLMClient):
             model=model or self._model,
             messages=messages,
             stream=stream,
-            drop_params=True,
             **call_kwargs,
         )
         if stream:
@@ -76,14 +79,15 @@ class LiteLLMProvider(LLMClient):
     def embed(self, texts: list[str], **kwargs) -> list[list[float]]:
         import litellm
 
+        model = kwargs.pop("model", self._model)
         call_kwargs = {**self._extra_kwargs, **kwargs}
+        call_kwargs.setdefault("drop_params", True)
         if self._api_key:
             call_kwargs["api_key"] = self._api_key
 
         response = litellm.embedding(
-            model=kwargs.pop("model", self._model),
+            model=model,
             input=texts,
-            drop_params=True,
             **call_kwargs,
         )
         return [item["embedding"] for item in response.data]

--- a/src/gaia/llm/providers/litellm.py
+++ b/src/gaia/llm/providers/litellm.py
@@ -18,12 +18,13 @@ class LiteLLMProvider(LLMClient):
         **kwargs,
     ):
         try:
-            import litellm  # noqa: F401  -- validate the optional dependency at construction
+            import litellm
         except ImportError as e:
             raise ImportError(
                 "litellm is not installed. Install it with: pip install 'gaia[litellm]'"
             ) from e
 
+        self._litellm = litellm
         self._model = model
         self._system_prompt = system_prompt
         self._api_key = api_key
@@ -54,8 +55,6 @@ class LiteLLMProvider(LLMClient):
         stream: bool = False,
         **kwargs,
     ) -> Union[str, Iterator[str]]:
-        import litellm
-
         if self._system_prompt:
             messages = [{"role": "system", "content": self._system_prompt}] + list(
                 messages
@@ -66,7 +65,7 @@ class LiteLLMProvider(LLMClient):
         if self._api_key:
             call_kwargs["api_key"] = self._api_key
 
-        response = litellm.completion(
+        response = self._litellm.completion(
             model=model or self._model,
             messages=messages,
             stream=stream,
@@ -77,15 +76,13 @@ class LiteLLMProvider(LLMClient):
         return response.choices[0].message.content
 
     def embed(self, texts: list[str], **kwargs) -> list[list[float]]:
-        import litellm
-
         model = kwargs.pop("model", self._model)
         call_kwargs = {**self._extra_kwargs, **kwargs}
         call_kwargs.setdefault("drop_params", True)
         if self._api_key:
             call_kwargs["api_key"] = self._api_key
 
-        response = litellm.embedding(
+        response = self._litellm.embedding(
             model=model,
             input=texts,
             **call_kwargs,

--- a/src/gaia/llm/providers/litellm.py
+++ b/src/gaia/llm/providers/litellm.py
@@ -21,7 +21,7 @@ class LiteLLMProvider(LLMClient):
             import litellm  # noqa: F401  -- validate the optional dependency at construction
         except ImportError as e:
             raise ImportError(
-                "litellm is not installed. Install it with: pip install gaia[litellm]"
+                "litellm is not installed. Install it with: pip install 'gaia[litellm]'"
             ) from e
 
         self._model = model

--- a/tests/unit/test_litellm_provider.py
+++ b/tests/unit/test_litellm_provider.py
@@ -132,6 +132,34 @@ class TestLiteLLMGenerate:
         del sys.modules["litellm"]
 
 
+class TestLiteLLMEmbed:
+    def test_embed_default_model(self):
+        fake = _stub_litellm()
+        fake.embedding.return_value = MagicMock(data=[{"embedding": [0.1, 0.2, 0.3]}])
+        from gaia.llm.providers.litellm import LiteLLMProvider
+
+        provider = LiteLLMProvider(api_key="sk-test", model="text-embedding-3-small")
+        result = provider.embed(["hello"])
+
+        assert result == [[0.1, 0.2, 0.3]]
+        assert fake.embedding.call_args.kwargs["model"] == "text-embedding-3-small"
+        assert fake.embedding.call_args.kwargs["api_key"] == "sk-test"
+        del sys.modules["litellm"]
+
+    def test_embed_uses_override_model(self):
+        fake = _stub_litellm()
+        fake.embedding.return_value = MagicMock(data=[{"embedding": [0.0]}])
+        from gaia.llm.providers.litellm import LiteLLMProvider
+
+        provider = LiteLLMProvider(model="text-embedding-3-small")
+        # Overriding the model must NOT raise TypeError (model previously landed
+        # in both the explicit arg and **call_kwargs).
+        provider.embed(["hello"], model="text-embedding-3-large")
+
+        assert fake.embedding.call_args.kwargs["model"] == "text-embedding-3-large"
+        del sys.modules["litellm"]
+
+
 class TestLiteLLMNotSupported:
     def test_vision_raises_not_supported(self):
         _stub_litellm()


### PR DESCRIPTION
Closes #1625

## Why this matters
After #1593 added the LiteLLM provider, `LiteLLMProvider.embed()` crashed with `TypeError: embedding() got multiple values for keyword argument 'model'` the moment a caller overrode the model — `model` was passed both explicitly and inside the spread `**call_kwargs`, and that path had zero test coverage. Now `embed()` works with and without a model override, and the rest of the #1593 review is closed out: the provider is documented, the `create_client` docstring lists it, and the redundant `drop_params` handling is collapsed to a single per-call default callers can override.

## Test plan
- [x] `pytest tests/unit/test_litellm_provider.py` → 12 passed (incl. 2 new `embed()` tests; the override test reproduced the `TypeError` before the fix)
- [x] `util/lint.py --black --isort --flake8` → all PASS
- [ ] CI green after maintainer approves the workflow run