### PR TITLE
fix(agent-ui): render Email Triage mailbox selector — migrate connectorsStore to /api/connectors

### DIFF
--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -196,7 +196,7 @@ export async function rollbackAgent(agentId: string): Promise<InstallStatus> {
 
 // -- Connections (issue #915) ---------------------------------------------------
 
-import type { AgentMcpServer, ConnectorInfo, ConnectorRow } from '../types';
+import type { AgentMcpServer, ConnectorRow } from '../types';
 
 // New framework endpoints (T-8b) — /api/connectors
 const UI_HEADER = { 'x-gaia-ui': '1' };
@@ -361,53 +361,6 @@ export async function deactivateConnectorAgent(
         `/connectors/${connectorId}/activations/${encodeURIComponent(agentId)}`,
         undefined,
         UI_HEADER,
-    );
-}
-
-export async function listConnections(): Promise<{ connections: ConnectorInfo[] }> {
-    return apiFetch('GET', '/connections');
-}
-
-export async function getConnection(provider: string): Promise<ConnectorInfo> {
-    return apiFetch('GET', `/connections/${provider}`);
-}
-
-export async function authorizeConnection(
-    provider: string,
-    scopes: string[],
-): Promise<{ flow_id: string; authorization_url: string }> {
-    return apiFetch('POST', `/connections/${provider}/authorize`, { scopes });
-}
-
-export async function revokeConnection(provider: string): Promise<void> {
-    await apiFetch<unknown>('DELETE', `/connections/${provider}`);
-}
-
-export async function listAgentGrants(provider: string): Promise<{
-    grants: Record<string, string[]>;
-}> {
-    return apiFetch('GET', `/connections/${provider}/grants`);
-}
-
-export async function grantAgent(
-    provider: string,
-    agentId: string,
-    scopes: string[],
-): Promise<{ provider: string; agent_id: string; scopes: string[] }> {
-    return apiFetch(
-        'PUT',
-        `/connections/${provider}/grants/${encodeURIComponent(agentId)}`,
-        { scopes },
-    );
-}
-
-export async function revokeAgentGrant(
-    provider: string,
-    agentId: string,
-): Promise<void> {
-    await apiFetch<unknown>(
-        'DELETE',
-        `/connections/${provider}/grants/${encodeURIComponent(agentId)}`,
     );
 }
 

--- a/src/gaia/apps/webui/src/stores/__tests__/connectorsStore.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/connectorsStore.test.ts
@@ -1,9 +1,11 @@
 // Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useConnectionsStore } from '../connectorsStore';
-import type { ConnectorInfo } from '../../types';
+import type { ConnectorInfo, ConnectorRow } from '../../types';
+
+vi.mock('../../services/api');
 
 const conn = (provider: string): ConnectorInfo => ({
     provider,
@@ -80,5 +82,136 @@ describe('connectorsStore — pendingMailProvider clearing', () => {
             useConnectionsStore.getState().setConnections([]);
             expect(useConnectionsStore.getState().pendingMailProvider).toBeUndefined();
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal ConnectorRow for test fixtures.
+// ---------------------------------------------------------------------------
+function row(overrides: Partial<ConnectorRow> & { id: string }): ConnectorRow {
+    return {
+        display_name: overrides.id,
+        icon: null,
+        category: 'oauth',
+        tier: 'free',
+        type: 'oauth_pkce',
+        description: '',
+        product_url: null,
+        docs_url: null,
+        configured: false,
+        configurable: true,
+        config_error: null,
+        enabled: true,
+        account_id: null,
+        scopes: [],
+        activations: {},
+        last_tested_at: null,
+        mcp_env_keys: [],
+        default_scopes: [],
+        available_scopes: [],
+        ...overrides,
+    } as ConnectorRow;
+}
+
+describe('connectorsStore — refresh()', () => {
+    // Import after vi.mock hoisting resolves.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    let api: typeof import('../../services/api');
+
+    beforeEach(async () => {
+        api = await import('../../services/api');
+        vi.resetAllMocks();
+        useConnectionsStore.setState({
+            connections: [],
+            grants: {},
+            loading: false,
+            error: null,
+            pendingMailProvider: undefined,
+        });
+    });
+
+    it('populates connections with only configured oauth_pkce rows', async () => {
+        vi.mocked(api.listConnectors).mockResolvedValue({
+            connectors: [
+                row({ id: 'google', type: 'oauth_pkce', configured: true, account_id: 'me@gmail.com', scopes: ['s'] }),
+                row({ id: 'microsoft', type: 'oauth_pkce', configured: true, account_id: 'me@outlook.com', scopes: [] }),
+                row({ id: 'foo', type: 'oauth_pkce', configured: false }),
+                row({ id: 'mcp-git', type: 'mcp_server', configured: true }),
+                { id: 'broken', error: 'unavailable' } as unknown as ConnectorRow,
+            ],
+        });
+        vi.mocked(api.listConnectorGrants).mockResolvedValue({ grants: {} });
+
+        await useConnectionsStore.getState().refresh();
+
+        const { connections } = useConnectionsStore.getState();
+        expect(connections).toHaveLength(2);
+        expect(connections[0]).toEqual<ConnectorInfo>({
+            provider: 'google',
+            account_email: 'me@gmail.com',
+            scopes: ['s'],
+            connected_at: null,
+        });
+        expect(connections[1]).toEqual<ConnectorInfo>({
+            provider: 'microsoft',
+            account_email: 'me@outlook.com',
+            scopes: [],
+            connected_at: null,
+        });
+    });
+
+    it('calls listConnectorGrants once per connected OAuth provider', async () => {
+        vi.mocked(api.listConnectors).mockResolvedValue({
+            connectors: [
+                row({ id: 'google', type: 'oauth_pkce', configured: true, account_id: 'me@gmail.com', scopes: [] }),
+                row({ id: 'microsoft', type: 'oauth_pkce', configured: true, account_id: 'me@outlook.com', scopes: [] }),
+            ],
+        });
+        vi.mocked(api.listConnectorGrants)
+            .mockResolvedValueOnce({ grants: { 'builtin:email': ['read'] } })
+            .mockResolvedValueOnce({ grants: { 'builtin:email': ['read', 'send'] } });
+
+        await useConnectionsStore.getState().refresh();
+
+        expect(api.listConnectorGrants).toHaveBeenCalledTimes(2);
+        expect(api.listConnectorGrants).toHaveBeenCalledWith('google');
+        expect(api.listConnectorGrants).toHaveBeenCalledWith('microsoft');
+
+        const { grants } = useConnectionsStore.getState();
+        expect(grants['google']).toEqual({ 'builtin:email': ['read'] });
+        expect(grants['microsoft']).toEqual({ 'builtin:email': ['read', 'send'] });
+    });
+
+    it('defaults grants to {} for a provider when listConnectorGrants rejects, but still populates the other provider', async () => {
+        vi.mocked(api.listConnectors).mockResolvedValue({
+            connectors: [
+                row({ id: 'google', type: 'oauth_pkce', configured: true, account_id: 'me@gmail.com', scopes: [] }),
+                row({ id: 'microsoft', type: 'oauth_pkce', configured: true, account_id: 'me@outlook.com', scopes: [] }),
+            ],
+        });
+        vi.mocked(api.listConnectorGrants)
+            .mockRejectedValueOnce(new Error('network error'))
+            .mockResolvedValueOnce({ grants: { 'builtin:email': ['send'] } });
+
+        await useConnectionsStore.getState().refresh();
+
+        const { grants, error } = useConnectionsStore.getState();
+        // The failing provider falls back to {} — no top-level error.
+        expect(error).toBeNull();
+        // One provider got empty grants, the other populated normally.
+        const googleGrants = grants['google'];
+        const msGrants = grants['microsoft'];
+        expect(googleGrants === undefined || Object.keys(googleGrants).length === 0).toBe(true);
+        expect(msGrants).toEqual({ 'builtin:email': ['send'] });
+    });
+
+    it('sets error and leaves connections empty when listConnectors rejects', async () => {
+        vi.mocked(api.listConnectors).mockRejectedValue(new Error('backend down'));
+
+        await useConnectionsStore.getState().refresh();
+
+        const { error, connections } = useConnectionsStore.getState();
+        expect(error).not.toBeNull();
+        expect(connections).toEqual([]);
     });
 });

--- a/src/gaia/apps/webui/src/stores/connectorsStore.ts
+++ b/src/gaia/apps/webui/src/stores/connectorsStore.ts
@@ -54,16 +54,25 @@ export const useConnectionsStore = create<ConnectionsState>((set, get) => ({
     refresh: async () => {
         set({ loading: true, error: null });
         try {
-            const { connections } = await api.listConnections();
+            const { connectors } = await api.listConnectors();
+            const connected = connectors.filter(
+                (c) => c.type === 'oauth_pkce' && c.configured === true,
+            );
+            const connections: ConnectorInfo[] = connected.map((c) => ({
+                provider: c.id,
+                account_email: c.account_id ?? '',
+                scopes: c.scopes ?? [],
+                connected_at: null,
+            }));
             // Pull grants for every connected provider.
             const grants: Record<string, Record<string, string[]>> = {};
             await Promise.all(
-                connections.map(async (c) => {
+                connected.map(async (c) => {
                     try {
-                        const r = await api.listAgentGrants(c.provider);
-                        grants[c.provider] = r.grants;
+                        const r = await api.listConnectorGrants(c.id);
+                        grants[c.id] = r.grants;
                     } catch {
-                        grants[c.provider] = {};
+                        grants[c.id] = {};
                     }
                 }),
             );


### PR DESCRIPTION
Closes #1630

## Why this matters

**Before:** with a Google and/or Microsoft mailbox connected, opening the Email Triage agent in the Agent UI showed **no mailbox selector** — a Microsoft-only user couldn't pick Outlook, and "triage my Outlook inbox" silently fell back to Gmail. Root cause: the webui `connectorsStore` still fetched the dropped `/api/connections` endpoints (connections moved to the `/api/connectors` T-8b framework), so `refresh()` threw, the store saw zero connected providers, and the selector's render gate (`connectedMailProviders.length > 0`) never fired.

**After:** the store reads the live `/api/connectors` framework, so connected OAuth providers populate correctly and the selector renders — auto-selecting the sole provider, or offering a Gmail/Outlook picker when both are connected. The 7 dead `/api/connections*` helpers are retired so the same trap can't be re-armed.

## Test plan

- [x] `cd src/gaia/apps/webui && npm run test` — 75 passing (+10), including 4 new `refresh()` scenarios that fail red against the pre-migration code (only-configured-oauth mapping, per-provider grant fetch, per-provider failure → `{}`, list failure → error).
- [x] `cd src/gaia/apps/webui && npm run build` — `tsc` clean, proving no dangling reference to a retired helper.
- [x] **Real-world** (Agent UI on AMD hardware, Google + Microsoft mailboxes both connected & mail-scoped): selector renders on an email session; a fresh session shows the interactive **Gmail / Outlook** picker; selecting Outlook persists `mail_provider=microsoft`; **no** `/api/connections` non-JSON console error.

Follow-up (separate from this UI fix): confirm `mail_provider=null` fans out to **all** connected mailboxes per #1614 rather than defaulting to Gmail.