### PR TITLE
ci(behavior-e2e): install [dev,ui] so gaia.ui.server can boot

### DIFF
--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -48,10 +48,13 @@ jobs:
       - name: Run behavior E2E harness
         shell: powershell
         env:
-          LEMONADE_BASE_URL: http://localhost:13305/api/v1
+          # 127.0.0.1, not localhost: on Windows `localhost` resolves to ::1
+          # first and Python requests can hang on it even when the server is up
+          # on IPv4 — that made the harness skip despite a loaded model.
+          LEMONADE_BASE_URL: http://127.0.0.1:13305/api/v1
         run: |
           python -m pytest tests/integration/eval/test_behavior_e2e.py `
-            -m real_model -v --tb=short `
+            -m real_model -v -rs --tb=short `
             --basetemp="${{ runner.temp }}\pytest-behavior"
           if ($LASTEXITCODE -ne 0) { throw "behavior E2E harness failed" }
 

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
         with:
-          install-package: ".[dev]"
+          # [ui] carries fastapi/uvicorn + the RAG deps gaia.ui.server imports at
+          # boot — the harness spawns that server, so [dev] alone fails at import.
+          install-package: ".[dev,ui]"
 
       - name: Ensure Lemonade
         shell: powershell

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -52,6 +52,14 @@ jobs:
           # first and Python requests can hang on it even when the server is up
           # on IPv4 — that made the harness skip despite a loaded model.
           LEMONADE_BASE_URL: http://127.0.0.1:13305/api/v1
+          # Bypass any runner proxy for the loopback Lemonade server. Python
+          # requests honors HTTP(S)_PROXY even for 127.0.0.1, so a configured
+          # proxy made the harness "unreachable" and skip — while PowerShell's
+          # start-lemonade health check (which ignores proxy for loopback)
+          # passed. NO_PROXY covers the reachability check and the spawned
+          # gaia.ui.server (which inherits this env).
+          NO_PROXY: "localhost,127.0.0.1"
+          no_proxy: "localhost,127.0.0.1"
         run: |
           python -m pytest tests/integration/eval/test_behavior_e2e.py `
             -m real_model -v -rs --tb=short `

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -31,47 +31,38 @@ jobs:
           # boot — the harness spawns that server, so [dev] alone fails at import.
           install-package: ".[dev,ui]"
 
-      - name: Start Lemonade Server
-        shell: powershell
-        run: |
-          # Start Lemonade and load the builder agent's model so the harness
-          # runs for real. The previous `gaia init --skip-lemonade` step blocked
-          # on an interactive "Press Enter" prompt when the server was down,
-          # failing every run before the harness (#1639). Mirrors the proven
-          # start pattern in test_examples.yml.
-          .\installer\scripts\start-lemonade.ps1 `
-            -ModelName "Qwen3.5-35B-A3B-GGUF" `
-            -Port 13305 `
-            -CtxSize 32768 `
-            -InitWaitTime 15
-
-      - name: Run behavior E2E harness
+      - name: Start Lemonade + run behavior E2E harness
         shell: powershell
         env:
-          # 127.0.0.1, not localhost: on Windows `localhost` resolves to ::1
-          # first and Python requests can hang on it even when the server is up
-          # on IPv4 — that made the harness skip despite a loaded model.
           LEMONADE_BASE_URL: http://127.0.0.1:13305/api/v1
-          # Bypass any runner proxy for the loopback Lemonade server. Python
-          # requests honors HTTP(S)_PROXY even for 127.0.0.1, so a configured
-          # proxy made the harness "unreachable" and skip — while PowerShell's
-          # start-lemonade health check (which ignores proxy for loopback)
-          # passed. NO_PROXY covers the reachability check and the spawned
-          # gaia.ui.server (which inherits this env).
+          # Loopback server — bypass any runner proxy so Python requests reaches it.
           NO_PROXY: "localhost,127.0.0.1"
         run: |
-          python -m pytest tests/integration/eval/test_behavior_e2e.py `
-            -m real_model -v -rs --tb=short `
-            --basetemp="${{ runner.temp }}\pytest-behavior"
-          if ($LASTEXITCODE -ne 0) { throw "behavior E2E harness failed" }
+          # Start Lemonade AND run the harness in a SINGLE PowerShell session.
+          # The Lemonade server (a detached Start-Process child) does not survive
+          # a GitHub Actions step boundary, so starting it in a separate step made
+          # the harness skip with "Lemonade server not reachable" even though the
+          # model loaded. start-lemonade.ps1 itself notes it must run in one
+          # session "to avoid process lifecycle issues"; test_examples.yml does
+          # the same. The previous `gaia init --skip-lemonade` step also blocked
+          # on an interactive prompt when the server was down (#1639).
+          try {
+              .\installer\scripts\start-lemonade.ps1 `
+                  -ModelName "Qwen3.5-35B-A3B-GGUF" `
+                  -Port 13305 `
+                  -CtxSize 32768 `
+                  -InitWaitTime 15
 
-      - name: Stop Lemonade Server
-        if: always()
-        shell: powershell
-        run: |
-          if ($env:LEMONADE_PROCESS_ID) {
-            Write-Host "Stopping Lemonade server (pid $env:LEMONADE_PROCESS_ID)..."
-            Stop-Process -Id $env:LEMONADE_PROCESS_ID -Force -ErrorAction SilentlyContinue
+              python -m pytest tests/integration/eval/test_behavior_e2e.py `
+                  -m real_model -v -rs --tb=short `
+                  --basetemp="${{ runner.temp }}\pytest-behavior"
+              if ($LASTEXITCODE -ne 0) { throw "behavior E2E harness failed" }
+          }
+          finally {
+              if ($env:LEMONADE_PROCESS_ID) {
+                  Write-Host "Stopping Lemonade server (pid $env:LEMONADE_PROCESS_ID)..."
+                  Stop-Process -Id $env:LEMONADE_PROCESS_ID -Force -ErrorAction SilentlyContinue
+              }
           }
 
       - name: Upload artifacts on failure

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -59,7 +59,6 @@ jobs:
           # passed. NO_PROXY covers the reachability check and the spawned
           # gaia.ui.server (which inherits this env).
           NO_PROXY: "localhost,127.0.0.1"
-          no_proxy: "localhost,127.0.0.1"
         run: |
           python -m pytest tests/integration/eval/test_behavior_e2e.py `
             -m real_model -v -rs --tb=short `

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -31,11 +31,19 @@ jobs:
           # boot — the harness spawns that server, so [dev] alone fails at import.
           install-package: ".[dev,ui]"
 
-      - name: Ensure Lemonade
+      - name: Start Lemonade Server
         shell: powershell
         run: |
-          gaia init --skip-lemonade
-          if ($LASTEXITCODE -ne 0) { throw "gaia init failed" }
+          # Start Lemonade and load the builder agent's model so the harness
+          # runs for real. The previous `gaia init --skip-lemonade` step blocked
+          # on an interactive "Press Enter" prompt when the server was down,
+          # failing every run before the harness (#1639). Mirrors the proven
+          # start pattern in test_examples.yml.
+          .\installer\scripts\start-lemonade.ps1 `
+            -ModelName "Qwen3.5-35B-A3B-GGUF" `
+            -Port 13305 `
+            -CtxSize 32768 `
+            -InitWaitTime 15
 
       - name: Run behavior E2E harness
         shell: powershell
@@ -46,6 +54,15 @@ jobs:
             -m real_model -v --tb=short `
             --basetemp="${{ runner.temp }}\pytest-behavior"
           if ($LASTEXITCODE -ne 0) { throw "behavior E2E harness failed" }
+
+      - name: Stop Lemonade Server
+        if: always()
+        shell: powershell
+        run: |
+          if ($env:LEMONADE_PROCESS_ID) {
+            Write-Host "Stopping Lemonade server (pid $env:LEMONADE_PROCESS_ID)..."
+            Stop-Process -Id $env:LEMONADE_PROCESS_ID -Force -ErrorAction SilentlyContinue
+          }
 
       - name: Upload artifacts on failure
         if: failure()

--- a/tests/integration/eval/test_behavior_e2e.py
+++ b/tests/integration/eval/test_behavior_e2e.py
@@ -105,9 +105,7 @@ def behavior_server(require_real_model, tmp_path_factory):
     )
 
     base_url = f"http://127.0.0.1:{port}"
-    # Cold first boot loads the RAG embedder + connects to Lemonade; 30s is too
-    # tight on slower self-hosted hardware, so the server is still coming up.
-    deadline = time.time() + 120
+    deadline = time.time() + 30
     while time.time() < deadline:
         try:
             resp = requests.get(f"{base_url}/api/health", timeout=2)

--- a/tests/integration/eval/test_behavior_e2e.py
+++ b/tests/integration/eval/test_behavior_e2e.py
@@ -105,7 +105,9 @@ def behavior_server(require_real_model, tmp_path_factory):
     )
 
     base_url = f"http://127.0.0.1:{port}"
-    deadline = time.time() + 30
+    # Cold first boot loads the RAG embedder + connects to Lemonade; 30s is too
+    # tight on slower self-hosted hardware, so the server is still coming up.
+    deadline = time.time() + 120
     while time.time() < deadline:
         try:
             resp = requests.get(f"{base_url}/api/health", timeout=2)


### PR DESCRIPTION
## Why this matters

The **Agent Behavior E2E** workflow had never passed — 0 of 117 runs green. Documented cause: the harness spawns `gaia.ui.server`, which imports `fastapi` at module load, but the workflow installed only `.[dev]` — and `fastapi` lives in `[ui]`/`[api]`, not `[dev]`. Every run died at fixture setup with `ModuleNotFoundError: No module named 'fastapi'`.

This PR fixes that **and** makes the workflow actually able to run the harness:

- **`.[dev,ui]`** so `gaia.ui.server` can import. *Verified on Strix Halo hardware*: with `.[dev]`, `import gaia.ui.server` dies at `server.py:30` (`ModuleNotFoundError: fastapi`); with `.[dev,ui]` the server boots and `GET /api/health` → 200. CI confirms the "Setup Python environment" step now passes.
- **Start Lemonade properly.** The old "Ensure Lemonade" step ran `gaia init --skip-lemonade`, which blocks on an interactive `Press Enter` prompt when the server isn't running — failing every dispatch before the harness. Replaced with the proven `start-lemonade.ps1` pattern (start server + load the builder model), run **in a single PowerShell session** (the helper documents it must — the detached server doesn't survive a step boundary, which otherwise made the harness skip with "Lemonade server not reachable").

With these, the workflow reaches and **actually executes** `test_builder_creates_agent_file` for the first time (model loads, harness runs) — previously it never got past install.

## Remaining: gated on #1297 (runner provisioning)

A confirmed **green** run is blocked by the runner, not this workflow: with the harness now running, `gaia.ui.server` does not become healthy within 120s on the runner (it can't bring up its full RAG stack — embedder/boot deps). The workflow header already notes this workflow "activates once #1297 (Strix Halo self-hosted runner) lands." That provisioning is the remaining blocker; the workflow itself is now correct.

## Test plan

- [x] On Strix Halo: `.[dev]` → `import gaia.ui.server` raises `ModuleNotFoundError: fastapi`; `.[dev,ui]` → server boots, `/api/health` 200.
- [x] CI workflow_dispatch: "Setup Python" passes (no ModuleNotFoundError), Lemonade starts + the builder model loads, the harness now *runs* (no longer skips).
- [ ] (gated on #1297) Green run with `gaia.ui.server` healthy on the runner + `test_builder_creates_agent_file` passing.

Part of #1639.