### PR TITLE
fix(agent-ui): keep chat runs alive after New Task + show running indicator (#1580)

### DIFF
--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -80,6 +80,7 @@ function App() {
         setSystemStatus,
         setBackendConnected,
         setAgents,
+        setRunningSessions,
     } = useChatStore();
     const showNotificationPanel = useNotificationStore((s) => s.showPanel);
     const setShowNotificationPanel = useNotificationStore((s) => s.setShowPanel);
@@ -269,6 +270,25 @@ function App() {
             if (sessionPollRef.current) clearInterval(sessionPollRef.current);
         };
     }, [setSessions, addSession, removeSession, updateSessionInList, setBackendConnected]);
+
+    // Poll which sessions have a running turn so the sidebar can show a
+    // "still running" spinner on backgrounded runs. Backend-truth
+    // (/api/chat/active), independent of any open SSE stream (#1580).
+    const activeRunsPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    useEffect(() => {
+        const poll = () => {
+            api.getActiveRuns()
+                .then((data) => setRunningSessions(data.session_ids || []))
+                .catch(() => { /* non-critical — sidebar just won't show spinners */ });
+        };
+        poll();
+        // 2.6s (off the :00/:30 marks) — responsive enough to feel live without
+        // hammering the backend.
+        activeRunsPollRef.current = setInterval(poll, 2_600);
+        return () => {
+            if (activeRunsPollRef.current) clearInterval(activeRunsPollRef.current);
+        };
+    }, [setRunningSessions]);
 
     // Support URL-based session navigation (?session=<id> or #<hash>)
     useEffect(() => {

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -280,7 +280,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
     const abortRef = useRef<AbortController | null>(null);
     const stepIdRef = useRef(0);
     const toolOccurredRef = useRef(false);
-    const sendMessageRef = useRef<(text?: string) => void>(() => {});
+    const sendMessageRef = useRef<(text?: string, options?: { attach?: boolean }) => void>(() => {});
 
     // ── Streaming chunk buffer ──────────────────────────────────────
     // Buffer SSE chunks in a ref and flush to the store via rAF.
@@ -471,6 +471,12 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
     // Stop streaming — reads fresh state from store to avoid stale closures
     const handleStop = useCallback(() => {
         log.stream.warn('User stopped generation');
+        // Tell the backend to cancel the run. Since runs now outlive the SSE
+        // connection (#1580), aborting the client alone only detaches us — the
+        // agent would keep generating in the background. The cancel endpoint
+        // sets the handler's cancelled flag so the producer bails at its next
+        // step boundary.
+        api.cancelStream(sessionId).catch(() => { /* best-effort */ });
         if (abortRef.current) {
             abortRef.current.abort();
             abortRef.current = null;
@@ -632,7 +638,13 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
     }, []);
 
     // Send message
-    const sendMessage = useCallback(async (overrideText?: string) => {
+    const sendMessage = useCallback(async (overrideText?: string, options?: { attach?: boolean }) => {
+        // attach=true re-subscribes to a run already in flight server-side
+        // (revisiting a backgrounded session, #1580). It reuses the entire
+        // stream-event handling below but skips composing/sending a new turn:
+        // no optimistic user message, no input/attachment handling, and the
+        // controller comes from api.attachToRun instead of api.sendMessageStream.
+        const attach = options?.attach === true;
         const text = (overrideText || input).trim();
         const hasAttachments = attachments.length > 0 && attachments.some(a => a.uploaded);
 
@@ -641,7 +653,10 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         isNearBottomRef.current = true;
 
         const isInitializing = systemStatus?.init_state === 'initializing';
-        if ((!text && !hasAttachments) || isStreaming || isInitializing) {
+        if (attach) {
+            // Don't double-attach if a stream is already live in this view.
+            if (isStreaming) return;
+        } else if ((!text && !hasAttachments) || isStreaming || isInitializing) {
             if (!text && !hasAttachments) log.chat.debug('Send blocked: empty message');
             if (isStreaming) log.chat.debug('Send blocked: already streaming');
             if (isInitializing) log.chat.debug('Send blocked: system initializing');
@@ -650,43 +665,47 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
 
         // Build message text with attachment references
         let messageText = text;
-        const uploadedAttachments = attachments.filter(a => a.uploaded && a.serverUrl);
-        if (uploadedAttachments.length > 0) {
-            const attachmentLines = uploadedAttachments.map(a => {
-                if (a.isImage) {
-                    return `![${a.name}](${a.serverUrl})`;
-                }
-                return `[${a.name}](${a.serverUrl})`;
-            }).join('\n');
-            messageText = messageText
-                ? `${messageText}\n\n${attachmentLines}`
-                : attachmentLines;
+        if (!attach) {
+            const uploadedAttachments = attachments.filter(a => a.uploaded && a.serverUrl);
+            if (uploadedAttachments.length > 0) {
+                const attachmentLines = uploadedAttachments.map(a => {
+                    if (a.isImage) {
+                        return `![${a.name}](${a.serverUrl})`;
+                    }
+                    return `[${a.name}](${a.serverUrl})`;
+                }).join('\n');
+                messageText = messageText
+                    ? `${messageText}\n\n${attachmentLines}`
+                    : attachmentLines;
+            }
+
+            log.chat.info(`Sending message to session=${sessionId}`, { length: messageText.length, preview: messageText.slice(0, 80) });
+
+            setInput('');
+            if (inputRef.current) {
+                inputRef.current.style.height = 'auto';
+                inputRef.current.focus();
+            }
+
+            // Clear attachments
+            setAttachments(prev => {
+                prev.forEach(a => { if (a.url) URL.revokeObjectURL(a.url); });
+                return [];
+            });
+
+            // Optimistic user message
+            const userMsg: Message = {
+                id: Date.now(),
+                session_id: sessionId,
+                role: 'user',
+                content: messageText,
+                created_at: new Date().toISOString(),
+                rag_sources: null,
+            };
+            addMessage(userMsg);
+        } else {
+            log.chat.info(`Re-attaching to background run for session=${sessionId}`);
         }
-
-        log.chat.info(`Sending message to session=${sessionId}`, { length: messageText.length, preview: messageText.slice(0, 80) });
-
-        setInput('');
-        if (inputRef.current) {
-            inputRef.current.style.height = 'auto';
-            inputRef.current.focus();
-        }
-
-        // Clear attachments
-        setAttachments(prev => {
-            prev.forEach(a => { if (a.url) URL.revokeObjectURL(a.url); });
-            return [];
-        });
-
-        // Optimistic user message
-        const userMsg: Message = {
-            id: Date.now(),
-            session_id: sessionId,
-            role: 'user',
-            content: messageText,
-            created_at: new Date().toISOString(),
-            rag_sources: null,
-        };
-        addMessage(userMsg);
 
         // Start streaming
         setStreaming(true);
@@ -703,7 +722,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         let doneHandled = false;
         streamBufferRef.current = '';
 
-        const controller = api.sendMessageStream(sessionId, messageText, {
+        const streamCallbacks: api.StreamCallbacks = {
             onChunk: (event) => {
                 if (isStale()) return; // stop writing after a session switch (#1580)
                 const content = event.content || '';
@@ -1046,7 +1065,9 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 }, 300);
 
                 // Auto-title on first message
-                if (session && session.title === 'New Task') {
+                // Skip client-side auto-title when re-attaching (no user text in
+                // hand and the run's lifecycle already titles server-side, #1580).
+                if (!attach && session && session.title === 'New Task') {
                     const autoTitle = text.slice(0, 50) + (text.length > 50 ? '...' : '');
                     api.updateSession(sessionId, { title: autoTitle })
                         .then(() => updateSessionInList(sessionId, { title: autoTitle }))
@@ -1113,13 +1134,50 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                     .then((data) => useChatStore.getState().setAgents(data.agents || []))
                     .catch(() => { /* non-critical */ });
             },
-        }, undefined, undefined, activeAgentId);
+        };
+
+        const controller = attach
+            ? api.attachToRun(sessionId, streamCallbacks)
+            : api.sendMessageStream(sessionId, messageText, streamCallbacks, undefined, undefined, activeAgentId);
 
         abortRef.current = controller;
     }, [input, attachments, isStreaming, sessionId, session, addMessage, setMessages, setStreaming, flushStreamBuffer, clearStreamContent, updateSessionInList, addAgentStep, updateLastAgentStep, appendThinkingContent, updateLastToolStep, clearAgentSteps, activeAgentId, addNotification, isStale]);
 
     // Keep ref in sync so event listeners always call the latest sendMessage
     sendMessageRef.current = sendMessage;
+
+    // Re-attach to an in-flight background run on mount (#1580). When the
+    // user revisits a session whose turn is still running server-side, hook
+    // back into its live stream so progress resumes in the view instead of
+    // sitting static until the run finishes. Once per session mount; the
+    // attach path no-ops if a stream is already live here.
+    const reattachedRef = useRef(false);
+    useEffect(() => {
+        reattachedRef.current = false;
+    }, [sessionId]);
+    useEffect(() => {
+        const attemptAttach = () => {
+            if (reattachedRef.current) return;
+            if (useChatStore.getState().isStreaming) return;
+            reattachedRef.current = true;
+            log.chat.info(`Resuming live view of background run for session=${sessionId}`);
+            sendMessageRef.current(undefined, { attach: true });
+        };
+        // Fast path: the global poll already knows this session is running.
+        if (useChatStore.getState().runningSessionIds.includes(sessionId)) {
+            attemptAttach();
+            return;
+        }
+        // Otherwise confirm once with the backend on mount.
+        let cancelled = false;
+        api.getActiveRuns()
+            .then(({ session_ids }) => {
+                if (cancelled) return;
+                if (session_ids.includes(sessionId)) attemptAttach();
+            })
+            .catch(() => { /* non-critical — sidebar spinner still signals running */ });
+        return () => { cancelled = true; };
+    }, [sessionId]);
 
     // Listen for programmatic message dispatches from rich-content
     // components (currently the EmailPreScanCard's Approve / Reply

--- a/src/gaia/apps/webui/src/components/Sidebar.css
+++ b/src/gaia/apps/webui/src/components/Sidebar.css
@@ -335,6 +335,16 @@
     vertical-align: middle;
 }
 
+/* Spinner shown inline before the title while a session's agent is still
+   running in the background (#1580). Uses the global `spin` keyframe. */
+.session-running-spinner {
+    flex-shrink: 0;
+    margin-right: 4px;
+    color: var(--accent, var(--text-muted));
+    vertical-align: middle;
+    animation: spin 1s linear infinite;
+}
+
 /* Session hash link -- short permalink for troubleshooting */
 .session-hash {
     font-size: 9px;

--- a/src/gaia/apps/webui/src/components/Sidebar.tsx
+++ b/src/gaia/apps/webui/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { Plus, Search, Settings, Sun, Moon, Trash2, PanelLeftClose, PanelLeftOpen, Smartphone, Brain, EyeOff, Clock } from 'lucide-react';
+import { Plus, Search, Settings, Sun, Moon, Trash2, PanelLeftClose, PanelLeftOpen, Smartphone, Brain, EyeOff, Clock, Loader2 } from 'lucide-react';
 import { useChatStore } from '../stores/chatStore';
 import * as api from '../services/api';
 import { log } from '../utils/logger';
@@ -34,9 +34,10 @@ interface SidebarProps {
 }
 
 /** Extracted session row to share between grouped and flat rendering. */
-function SessionItem({ session: s, isActive, isPendingDelete, isDeleting, onSelect, onKeyDown, onDelete, formatTime }: {
+function SessionItem({ session: s, isActive, isRunning, isPendingDelete, isDeleting, onSelect, onKeyDown, onDelete, formatTime }: {
     session: Session;
     isActive: boolean;
+    isRunning: boolean;
     isPendingDelete: boolean;
     isDeleting: boolean;
     onSelect: (id: string) => void;
@@ -64,6 +65,13 @@ function SessionItem({ session: s, isActive, isPendingDelete, isDeleting, onSele
         >
             <span className="session-title">
                 {s.private && <EyeOff size={10} className="session-private-icon" aria-label="Private session" />}
+                {isRunning && (
+                    <Loader2
+                        size={11}
+                        className="session-running-spinner"
+                        aria-label="Agent running"
+                    />
+                )}
                 {s.title}
             </span>
             <a
@@ -110,6 +118,7 @@ export function Sidebar({ onNewTask, onHome, tunnelActive, tunnelLoading, onMobi
         sidebarCollapsed, toggleSidebarCollapsed,
         sidebarWidth, setSidebarWidth,
         addPendingDelete, removePendingDelete,
+        runningSessionIds,
     } = useChatStore();
 
     const [search, setSearch] = useState('');
@@ -403,6 +412,7 @@ export function Sidebar({ onNewTask, onHome, tunnelActive, tunnelLoading, onMobi
                                     key={s.id}
                                     session={s}
                                     isActive={s.id === currentSessionId}
+                                    isRunning={runningSessionIds.includes(s.id)}
                                     isPendingDelete={pendingDeleteId === s.id}
                                     isDeleting={deletingId === s.id}
                                     onSelect={handleSelect}
@@ -420,6 +430,7 @@ export function Sidebar({ onNewTask, onHome, tunnelActive, tunnelLoading, onMobi
                             key={s.id}
                             session={s}
                             isActive={s.id === currentSessionId}
+                            isRunning={runningSessionIds.includes(s.id)}
                             isPendingDelete={pendingDeleteId === s.id}
                             isDeleting={deletingId === s.id}
                             onSelect={handleSelect}

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -458,9 +458,6 @@ export function sendMessageStream(
 
     const controller = new AbortController();
     const t = log.stream.time();
-    let chunkCount = 0;
-    let totalChars = 0;
-    let agentEventCount = 0;
 
     log.stream.info(`Starting SSE stream for session=${sessionId}`, { messageLength: message.length });
 
@@ -476,100 +473,154 @@ export function sendMessageStream(
         }),
         signal: controller.signal,
     })
-        .then(async (res) => {
-            log.stream.info(`SSE connection opened -> HTTP ${res.status}`);
-
-            if (!res.ok) {
-                const errText = await res.text().catch(() => '');
-                log.stream.error(`SSE connection failed: HTTP ${res.status}`, errText);
-                callbacks.onError(new Error(`HTTP ${res.status}: ${errText}`));
-                return;
-            }
-
-            const reader = res.body?.getReader();
-            if (!reader) {
-                log.stream.error('No response body reader available');
-                callbacks.onError(new Error('No response body'));
-                return;
-            }
-
-            const decoder = new TextDecoder();
-            let buffer = '';
-            let doneReceived = false;
-
-            try {
-                while (true) {
-                    const { done, value } = await reader.read();
-                    if (done) {
-                        log.stream.debug('SSE reader done (stream ended)');
-                        break;
-                    }
-
-                    buffer += decoder.decode(value, { stream: true });
-                    const lines = buffer.split('\n');
-                    buffer = lines.pop() || '';
-
-                    for (const line of lines) {
-                        if (line.startsWith('data: ')) {
-                            const raw = line.slice(6).trim();
-                            if (!raw) continue;
-                            try {
-                                const event: StreamEvent = JSON.parse(raw);
-
-                                if (event.type === 'chunk') {
-                                    chunkCount++;
-                                    totalChars += (event.content || '').length;
-                                    if (chunkCount <= 3 || chunkCount % 50 === 0) {
-                                        log.stream.debug(`Chunk #${chunkCount} (+${(event.content || '').length} chars)`);
-                                    }
-                                    callbacks.onChunk(event);
-                                } else if (event.type === 'answer') {
-                                    // Agent final answer - treat as content
-                                    callbacks.onChunk(event);
-                                } else if (event.type === 'done') {
-                                    doneReceived = true;
-                                    log.stream.timed(`Stream complete: ${chunkCount} chunks, ${totalChars} chars, ${agentEventCount} agent events`, t);
-                                    callbacks.onDone(event);
-                                } else if (event.type === 'error') {
-                                    log.stream.error(`Stream error event:`, event.content);
-                                    callbacks.onError(new Error(event.content || 'Unknown error'));
-                                } else if (event.type === 'agent_created') {
-                                    log.stream.info(`Agent created: ${event.agent_id}`);
-                                    callbacks.onAgentCreated?.(event);
-                                } else if (AGENT_EVENT_TYPES.has(event.type)) {
-                                    agentEventCount++;
-                                    log.stream.debug(`Agent event: ${event.type}`, event);
-                                    callbacks.onAgentEvent(event);
-                                } else {
-                                    log.stream.warn(`Unknown SSE event type: ${event.type}`, event);
-                                }
-                            } catch (parseErr) {
-                                log.stream.warn(`Malformed SSE data, skipping`, { raw: raw.slice(0, 100) });
-                            }
-                        }
-                    }
-                }
-            } finally {
-                // Release the reader to free the underlying connection
-                reader.releaseLock();
-            }
-
-            // Only signal completion if no explicit done event was received during the stream
-            if (!doneReceived) {
-                log.stream.timed(`SSE connection closed without done event: ${chunkCount} chunks, ${agentEventCount} agent events`, t);
-                callbacks.onDone({ type: 'done' });
-            }
-        })
+        .then((res) => consumeSSEResponse(res, callbacks, t))
         .catch((err) => {
             if (err.name === 'AbortError') {
-                log.stream.warn(`Stream aborted by user after ${chunkCount} chunks`);
+                log.stream.warn('Stream aborted by user');
             } else {
-                log.stream.error(`Stream fetch error`, err);
+                log.stream.error('Stream fetch error', err);
                 callbacks.onError(err);
             }
         });
 
     return controller;
+}
+
+/**
+ * Read and dispatch an SSE response body against a set of StreamCallbacks.
+ * Shared by ``sendMessageStream`` (POST /chat/send) and ``attachToRun``
+ * (GET /chat/attach) so both parse events identically.
+ */
+async function consumeSSEResponse(
+    res: Response,
+    callbacks: StreamCallbacks,
+    t: ReturnType<typeof log.stream.time>,
+): Promise<void> {
+    log.stream.info(`SSE connection opened -> HTTP ${res.status}`);
+
+    if (!res.ok) {
+        const errText = await res.text().catch(() => '');
+        log.stream.error(`SSE connection failed: HTTP ${res.status}`, errText);
+        callbacks.onError(new Error(`HTTP ${res.status}: ${errText}`));
+        return;
+    }
+
+    const reader = res.body?.getReader();
+    if (!reader) {
+        log.stream.error('No response body reader available');
+        callbacks.onError(new Error('No response body'));
+        return;
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let doneReceived = false;
+    let chunkCount = 0;
+    let totalChars = 0;
+    let agentEventCount = 0;
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+                log.stream.debug('SSE reader done (stream ended)');
+                break;
+            }
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+                if (line.startsWith('data: ')) {
+                    const raw = line.slice(6).trim();
+                    if (!raw) continue;
+                    try {
+                        const event: StreamEvent = JSON.parse(raw);
+
+                        if (event.type === 'chunk') {
+                            chunkCount++;
+                            totalChars += (event.content || '').length;
+                            if (chunkCount <= 3 || chunkCount % 50 === 0) {
+                                log.stream.debug(`Chunk #${chunkCount} (+${(event.content || '').length} chars)`);
+                            }
+                            callbacks.onChunk(event);
+                        } else if (event.type === 'answer') {
+                            // Agent final answer - treat as content
+                            callbacks.onChunk(event);
+                        } else if (event.type === 'done') {
+                            doneReceived = true;
+                            log.stream.timed(`Stream complete: ${chunkCount} chunks, ${totalChars} chars, ${agentEventCount} agent events`, t);
+                            callbacks.onDone(event);
+                        } else if (event.type === 'error') {
+                            log.stream.error(`Stream error event:`, event.content);
+                            callbacks.onError(new Error(event.content || 'Unknown error'));
+                        } else if (event.type === 'agent_created') {
+                            log.stream.info(`Agent created: ${event.agent_id}`);
+                            callbacks.onAgentCreated?.(event);
+                        } else if (AGENT_EVENT_TYPES.has(event.type)) {
+                            agentEventCount++;
+                            log.stream.debug(`Agent event: ${event.type}`, event);
+                            callbacks.onAgentEvent(event);
+                        } else {
+                            log.stream.warn(`Unknown SSE event type: ${event.type}`, event);
+                        }
+                    } catch (parseErr) {
+                        log.stream.warn(`Malformed SSE data, skipping`, { raw: raw.slice(0, 100) });
+                    }
+                }
+            }
+        }
+    } finally {
+        // Release the reader to free the underlying connection
+        reader.releaseLock();
+    }
+
+    // Only signal completion if no explicit done event was received during the stream
+    if (!doneReceived) {
+        log.stream.timed(`SSE connection closed without done event: ${chunkCount} chunks, ${agentEventCount} agent events`, t);
+        callbacks.onDone({ type: 'done' });
+    }
+}
+
+/**
+ * Re-attach to an in-flight background run and stream its events (#1580).
+ *
+ * Used when the user revisits a session whose turn is still running. The
+ * backend replays everything emitted so far, then streams live events.
+ * Returns an AbortController so the caller can detach on unmount — that
+ * does NOT cancel the run (it keeps going server-side), it only closes
+ * this client's view of it.
+ */
+export function attachToRun(
+    sessionId: string,
+    callbacks: StreamCallbacks,
+): AbortController {
+    const controller = new AbortController();
+    const t = log.stream.time();
+
+    log.stream.info(`Attaching to background run for session=${sessionId}`);
+
+    fetch(`${API_BASE}/chat/attach?session_id=${encodeURIComponent(sessionId)}`, {
+        method: 'GET',
+        signal: controller.signal,
+    })
+        .then((res) => consumeSSEResponse(res, callbacks, t))
+        .catch((err) => {
+            if (err.name === 'AbortError') {
+                log.stream.warn('Run attach detached by client');
+            } else {
+                log.stream.error('Run attach fetch error', err);
+                callbacks.onError(err);
+            }
+        });
+
+    return controller;
+}
+
+/** List session ids that currently have a running chat turn (#1580). */
+export async function getActiveRuns(): Promise<{ session_ids: string[] }> {
+    return apiFetch('GET', '/chat/active');
 }
 
 // -- Tool Confirmation ---------------------------------------------------------

--- a/src/gaia/apps/webui/src/stores/__tests__/chatStore.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/chatStore.test.ts
@@ -52,3 +52,41 @@ describe('chatStore streaming state', () => {
         expect(after.agentSteps).toEqual([]);
     });
 });
+
+describe('chatStore running-sessions registry (#1580)', () => {
+    beforeEach(() => {
+        useChatStore.setState({ runningSessionIds: [] });
+    });
+
+    it('setRunningSessions stores the polled active set', () => {
+        useChatStore.getState().setRunningSessions(['a', 'b']);
+        expect(useChatStore.getState().runningSessionIds).toEqual(['a', 'b']);
+    });
+
+    it('setRunningSessions keeps a stable reference when the set is unchanged', () => {
+        useChatStore.getState().setRunningSessions(['a', 'b']);
+        const first = useChatStore.getState().runningSessionIds;
+
+        // Same membership (order-insensitive) must not produce a new array, so
+        // the 2.6s poll doesn't re-render the sidebar every tick.
+        useChatStore.getState().setRunningSessions(['b', 'a']);
+        expect(useChatStore.getState().runningSessionIds).toBe(first);
+    });
+
+    it('setRunningSessions replaces the array when membership changes', () => {
+        useChatStore.getState().setRunningSessions(['a']);
+        const first = useChatStore.getState().runningSessionIds;
+
+        useChatStore.getState().setRunningSessions(['a', 'c']);
+        const second = useChatStore.getState().runningSessionIds;
+
+        expect(second).not.toBe(first);
+        expect(second).toEqual(['a', 'c']);
+    });
+
+    it('clears to empty when no runs are active', () => {
+        useChatStore.getState().setRunningSessions(['a']);
+        useChatStore.getState().setRunningSessions([]);
+        expect(useChatStore.getState().runningSessionIds).toEqual([]);
+    });
+});

--- a/src/gaia/apps/webui/src/stores/chatStore.ts
+++ b/src/gaia/apps/webui/src/stores/chatStore.ts
@@ -35,6 +35,12 @@ interface ChatState {
     updateSessionInList: (id: string, updates: Partial<Session>) => void;
     addPendingDelete: (id: string) => void;
     removePendingDelete: (id: string) => void;
+    /** Session IDs with a chat turn still running server-side (#1580).
+     *  Backend-truth (polled from /api/chat/active), so it survives
+     *  navigating away, refresh, and revisit — drives the sidebar's
+     *  "still running" spinner on backgrounded sessions. */
+    runningSessionIds: string[];
+    setRunningSessions: (ids: string[]) => void;
 
     // Messages (for current session)
     messages: Message[];
@@ -143,6 +149,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
     sessions: [],
     currentSessionId: null,
     pendingDeleteIds: [],
+    runningSessionIds: [],
+    setRunningSessions: (ids) =>
+        set((state) => {
+            // Reference-stable update: skip the set() when the running set is
+            // unchanged so the polled refresh doesn't re-render the sidebar.
+            const prev = state.runningSessionIds;
+            if (prev.length === ids.length && prev.every((id) => ids.includes(id))) {
+                return state;
+            }
+            return { runningSessionIds: ids };
+        }),
     setSessions: (sessions) =>
         set((state) => ({
             // Filter out any sessions that are pending backend deletion so poll

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1413,12 +1413,20 @@ async def _get_chat_response(
 # ── Streaming Chat ───────────────────────────────────────────────────────────
 
 
-async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRequest):
-    """Stream chat response as Server-Sent Events.
+async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatRequest):
+    """Produce chat-response SSE events for a single run.
 
     Uses ChatAgent with SSEOutputHandler to emit agent activity events
     (steps, tool calls, thinking) alongside text chunks, giving the
     frontend visibility into what the agent is doing.
+
+    This is the run *producer*: it is driven by ``_run_chat_lifecycle``
+    inside a detached task that owns the run for its full duration,
+    independent of any HTTP/SSE client connection. Yielded ``data: ...``
+    strings are buffered and fanned out to attached subscribers by the
+    lifecycle; DB persistence happens here regardless of whether a client
+    is still listening, so navigating away never loses the run (issue
+    #1580 follow-up).
     """
     import queue
 
@@ -1450,6 +1458,9 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
     try:
         # Create SSE handler for streaming events
         sse_handler = SSEOutputHandler()
+        # Expose the handler on the run so an external Stop can signal the
+        # producer to bail even after every client has detached (#1580).
+        run.handler = sse_handler
         # Register so /api/chat/confirm-tool can find this handler.
         _active_sse_handlers[session_id] = sse_handler
 
@@ -2388,6 +2399,84 @@ async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRe
         yield f"data: {error_data}\n\n"
     finally:
         _cleanup_stream()
+
+
+async def _run_chat_lifecycle(
+    run, db: ChatDatabase, session: dict, request: ChatRequest
+):
+    """Drive a single chat run to completion, independent of any client.
+
+    Runs inside a detached task owned by ``RunManager``. Pumps every SSE
+    event from ``_stream_chat_impl`` into the run's replay buffer / live
+    subscribers via ``run.emit``. Because this task is not the HTTP
+    response, a client disconnect cannot cancel it — the producer finishes
+    and persists server-side (#1580 follow-up).
+    """
+    async for data in _stream_chat_impl(run, db, session, request):
+        run.emit(data)
+    # Notify the AgentLoop that a user turn completed (best-effort; no-op if
+    # the autonomy loop isn't running). Fires on real run completion rather
+    # than on subscriber detach.
+    try:
+        from gaia.ui.agent_loop import agent_loop
+
+        agent_loop.notify_user_message(request.session_id)
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+
+async def _stream_chat_response(db: ChatDatabase, session: dict, request: ChatRequest):
+    """Stream a chat turn as SSE for the ``/api/chat/send`` client.
+
+    Starts the run's detached lifecycle (the chat router guarantees no run
+    is already active for this session — it returns 409 otherwise) and
+    subscribes this HTTP connection to it. Yields the replay buffer (empty
+    for a fresh run) followed by live events until the run completes or the
+    client disconnects. Disconnecting only detaches this subscriber; the
+    run keeps going in the background.
+    """
+    from gaia.ui.run_manager import DONE, run_manager
+
+    session_id = request.session_id
+    run = run_manager.get(session_id)
+    if run is None:
+        run = run_manager.start(
+            session_id,
+            lambda r: _run_chat_lifecycle(r, db, session, request),
+        )
+    q = run.subscribe()
+    try:
+        while True:
+            item = await q.get()
+            if item is DONE:
+                break
+            yield item
+    finally:
+        run.unsubscribe(q)
+
+
+async def _attach_chat_stream(session_id: str):
+    """Re-attach an SSE client to an already-running background run (#1580).
+
+    Used by ``GET /api/chat/attach`` when the user revisits a session whose
+    turn is still in flight. Replays everything emitted so far, then streams
+    live events to completion. The caller is responsible for returning 404
+    when no run is active.
+    """
+    from gaia.ui.run_manager import DONE, run_manager
+
+    run = run_manager.get(session_id)
+    if run is None:
+        return
+    q = run.subscribe()
+    try:
+        while True:
+            item = await q.get()
+            if item is DONE:
+                break
+            yield item
+    finally:
+        run.unsubscribe(q)
 
 
 # ── Document Indexing ────────────────────────────────────────────────────────

--- a/src/gaia/ui/routers/chat.py
+++ b/src/gaia/ui/routers/chat.py
@@ -22,6 +22,7 @@ from starlette.background import BackgroundTask
 from ..database import ChatDatabase
 from ..dependencies import get_db
 from ..models import ChatRequest, ChatResponse
+from ..run_manager import run_manager
 from ..sse_handler import (
     _RAG_RESULT_JSON_SUB_RE,
     _THOUGHT_JSON_SUB_RE,
@@ -89,7 +90,14 @@ async def send_message(
     # Reject overlapping turns for the same session. Force-releasing an
     # asyncio.Lock held by another coroutine is unsafe because the lock
     # has no ownership tracking.
-    if session_lock.locked():
+    #
+    # The lock guards the synchronous request window; ``run_manager`` guards
+    # the *background tail* — a streaming run keeps going (and persisting)
+    # after the client disconnects and the HTTP lock is released (#1580), so
+    # a new turn for the same session must also be rejected while that
+    # background run is still active, or it would corrupt the cached agent's
+    # conversation state.
+    if session_lock.locked() or run_manager.is_running(sid):
         raise HTTPException(
             status_code=409,
             detail="A chat request is already in progress for this session. "
@@ -136,10 +144,12 @@ async def send_message(
 
             async def _stream():
                 db.add_message(request.session_id, "user", request.message)
+                # The run's detached lifecycle owns producer + persistence and
+                # fires the AgentLoop notify on real completion; this subscriber
+                # just relays buffered + live events to the browser. Detaching
+                # (client disconnect) no longer cancels the run (#1580).
                 async for chunk in srv._stream_chat_response(db, session, request):
                     yield chunk
-                # Notify AgentLoop after the streaming response completes
-                _notify_loop(request.session_id)
 
             sem_released = True
             return StreamingResponse(
@@ -253,3 +263,42 @@ async def cancel_stream(request: CancelStreamRequest):
         )
     handler.cancelled.set()
     return {"status": "ok", "cancelled": True}
+
+
+@router.get("/api/chat/active")
+async def list_active_runs():
+    """Return the session ids with a currently-running chat turn.
+
+    The Agent UI polls this to render a "still running" indicator on
+    backgrounded sessions in the sidebar — runs continue server-side after
+    the user navigates away, so this is the source of truth independent of
+    any open SSE connection (#1580 follow-up).
+    """
+    return {"session_ids": run_manager.active_sessions()}
+
+
+@router.get("/api/chat/attach")
+async def attach_stream(session_id: str):
+    """Re-attach to an in-flight background run and stream its events (SSE).
+
+    Used when the user revisits a session whose turn is still running. The
+    response replays every event emitted so far, then streams live events
+    to completion. No session lock is taken — the originating ``/send`` run
+    already owns the turn; this is a read-only subscriber.
+    """
+    if not run_manager.is_running(session_id):
+        raise HTTPException(
+            status_code=404,
+            detail="No active run for this session.",
+        )
+
+    srv = _server_mod()
+    return StreamingResponse(
+        srv._attach_chat_stream(session_id),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/src/gaia/ui/routers/sessions.py
+++ b/src/gaia/ui/routers/sessions.py
@@ -138,6 +138,12 @@ async def delete_session(
     """Delete a session and its messages."""
     if not db.delete_session(session_id):
         raise HTTPException(status_code=404, detail="Session not found")
+    # Cancel any background run for this session before tearing it down —
+    # runs now outlive the SSE connection (#1580), so a run left going would
+    # try to persist its answer to a session that no longer exists.
+    from ..run_manager import run_manager
+
+    run_manager.cancel(session_id)
     # Remove the per-session lock to prevent memory leaks
     http_request.app.state.session_locks.pop(session_id, None)
     # Evict the cached ChatAgent for this session so a fresh one is created

--- a/src/gaia/ui/run_manager.py
+++ b/src/gaia/ui/run_manager.py
@@ -1,0 +1,185 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Per-session background chat-run registry for the GAIA Agent UI.
+
+A chat turn used to live and die with the SSE HTTP connection: when the
+user clicked **New Task** (or switched sessions) mid-stream, the browser
+aborted the SSE, the server cancelled the streaming generator, and the
+in-flight answer was discarded with no record it had ever been running
+(issue #1580 follow-up).
+
+``RunManager`` makes each turn a first-class ``Run`` that owns its own
+lifecycle independent of any HTTP connection:
+
+* The agent producer + response persistence run inside a detached
+  ``asyncio`` task, so a client disconnect no longer cancels or loses the
+  run — it finishes server-side and persists to the DB.
+* Every SSE event the run emits is appended to a replay ``buffer`` and
+  fanned out to any number of live subscriber queues. A browser can
+  *attach* to an in-flight run (on revisit) and receive the full history
+  followed by live events.
+* ``active_sessions()`` is the source of truth the sidebar polls to show
+  which sessions are still running.
+
+Threading note: ``Run.emit`` / ``subscribe`` / ``finish`` only mutate the
+buffer and subscriber list, and are only ever called from coroutines on
+the server event loop (the lifecycle task and the subscriber generators).
+They never ``await`` between reading and writing that state, so no extra
+locking is needed — the single-threaded event loop guarantees atomicity.
+The agent itself runs in a separate producer thread that communicates via
+the handler's thread-safe ``queue.Queue``; that boundary is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Sentinel pushed to a subscriber queue when the run is complete so the
+# subscriber generator knows to stop awaiting and close cleanly.
+DONE = object()
+
+
+class Run:
+    """A single in-flight (or just-finished) chat turn for one session."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        # The run's SSEOutputHandler, set by the lifecycle once constructed.
+        # Held so an external cancel can signal the producer to bail.
+        self.handler = None
+        # Append-only log of every SSE ``data: ...`` string emitted so far.
+        # New subscribers replay this before receiving live events.
+        self.buffer: List[str] = []
+        # Live subscriber queues. emit() fans out to each; finish() closes them.
+        self.subscribers: List[asyncio.Queue] = []
+        self.done = asyncio.Event()
+        self.task: Optional[asyncio.Task] = None
+
+    # ── Producer side (called from the lifecycle task) ────────────────
+    def emit(self, data: str) -> None:
+        """Record an SSE event and fan it out to all live subscribers."""
+        self.buffer.append(data)
+        for q in self.subscribers:
+            q.put_nowait(data)
+
+    def finish(self) -> None:
+        """Mark the run complete and close out every live subscriber."""
+        self.done.set()
+        for q in self.subscribers:
+            q.put_nowait(DONE)
+        self.subscribers.clear()
+
+    # ── Consumer side (called from subscriber generators) ─────────────
+    def subscribe(self) -> asyncio.Queue:
+        """Register a subscriber.
+
+        Returns a queue preloaded with the full replay buffer. If the run
+        has already finished, a ``DONE`` sentinel is appended so the caller
+        drains the history then stops; otherwise the queue stays registered
+        to receive live events.
+        """
+        q: asyncio.Queue = asyncio.Queue()
+        for item in self.buffer:
+            q.put_nowait(item)
+        if self.done.is_set():
+            q.put_nowait(DONE)
+        else:
+            self.subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue) -> None:
+        """Drop a subscriber (e.g. its client disconnected).
+
+        The run keeps going regardless — this only stops fanning events to
+        the departed client.
+        """
+        try:
+            self.subscribers.remove(q)
+        except ValueError:
+            pass
+
+
+class RunManager:
+    """Registry of active chat runs, keyed by session id."""
+
+    def __init__(self):
+        self._runs: Dict[str, Run] = {}
+
+    def is_running(self, session_id: str) -> bool:
+        return session_id in self._runs
+
+    def get(self, session_id: str) -> Optional[Run]:
+        return self._runs.get(session_id)
+
+    def active_sessions(self) -> List[str]:
+        """Session ids with a currently-running turn (sidebar source of truth)."""
+        return list(self._runs.keys())
+
+    def start(
+        self,
+        session_id: str,
+        make_lifecycle: Callable[[Run], Awaitable[None]],
+    ) -> Run:
+        """Create a run and launch its detached lifecycle task.
+
+        ``make_lifecycle`` receives the ``Run`` and returns the coroutine
+        that drives the producer and emits events via ``run.emit``. The
+        coroutine runs to completion regardless of whether any client is
+        still attached.
+
+        Raises:
+            RuntimeError: if a run is already active for this session. The
+                caller (chat router) must guard with ``is_running`` first and
+                return 409 — overlapping turns on one session would corrupt
+                the cached agent's conversation state.
+        """
+        if session_id in self._runs:
+            raise RuntimeError(
+                f"A run is already active for session {session_id[:8]}; "
+                "refusing to start an overlapping turn."
+            )
+        run = Run(session_id)
+        self._runs[session_id] = run
+
+        async def _drive() -> None:
+            try:
+                await make_lifecycle(run)
+            except asyncio.CancelledError:
+                logger.info("Run cancelled for session %s", session_id[:8])
+                raise
+            except Exception:  # pylint: disable=broad-except
+                # The lifecycle owns its own user-facing error emission; this
+                # is the backstop so a bug there can't wedge the registry.
+                logger.exception(
+                    "Unhandled error in run lifecycle for session %s",
+                    session_id[:8],
+                )
+            finally:
+                run.finish()
+                self._runs.pop(session_id, None)
+
+        run.task = asyncio.create_task(_drive())
+        return run
+
+    def cancel(self, session_id: str) -> bool:
+        """Request cancellation of an active run (explicit Stop button).
+
+        Sets the handler's cancelled flag; the producer observes it at its
+        next step boundary and tears down. Returns False if no run is
+        active for the session.
+        """
+        run = self._runs.get(session_id)
+        if run is None:
+            return False
+        if run.handler is not None:
+            run.handler.cancelled.set()
+        return True
+
+
+# Process-wide singleton used by the chat router and chat helpers.
+run_manager = RunManager()

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -38,6 +38,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 # expose these names at module level.  The canonical implementations live
 # in ``_chat_helpers`` (shared by both server.py and the router modules).
 # pylint: disable=unused-import
+from ._chat_helpers import _attach_chat_stream  # noqa: F401
 from ._chat_helpers import _build_history_pairs  # noqa: F401
 from ._chat_helpers import _compute_allowed_paths  # noqa: F401
 from ._chat_helpers import _get_chat_response  # noqa: F401

--- a/tests/unit/chat/ui/test_chat_active_attach.py
+++ b/tests/unit/chat/ui/test_chat_active_attach.py
@@ -1,0 +1,110 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Endpoint tests for the background-run surface (#1580 follow-up).
+
+Covers ``GET /api/chat/active`` (sidebar running-indicator source) and
+``GET /api/chat/attach`` (revisit reconnect), plus the new overlap guard
+that rejects a second turn while a run is still active in the registry.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gaia.ui.run_manager import run_manager
+from gaia.ui.server import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app(db_path=":memory:")
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Each test starts and ends with an empty run registry."""
+    run_manager._runs.clear()
+    yield
+    run_manager._runs.clear()
+
+
+@pytest.fixture
+def session_id(client):
+    return client.post("/api/sessions", json={}).json()["id"]
+
+
+class _FakeRun:
+    """Stand-in registry entry — enough for is_running / active_sessions."""
+
+    def __init__(self, session_id):
+        self.session_id = session_id
+        self.handler = None
+
+
+def test_active_empty_by_default(client):
+    resp = client.get("/api/chat/active")
+    assert resp.status_code == 200
+    assert resp.json() == {"session_ids": []}
+
+
+def test_active_reports_running_sessions(client):
+    run_manager._runs["s1"] = _FakeRun("s1")
+    run_manager._runs["s2"] = _FakeRun("s2")
+
+    resp = client.get("/api/chat/active")
+    assert resp.status_code == 200
+    assert set(resp.json()["session_ids"]) == {"s1", "s2"}
+
+
+def test_attach_404_when_not_running(client):
+    resp = client.get("/api/chat/attach", params={"session_id": "nope"})
+    assert resp.status_code == 404
+
+
+def test_attach_streams_existing_run(client):
+    """Attach replays a run's buffered events then closes on DONE."""
+    run_manager._runs["live"] = _FakeRun("live")
+
+    async def fake_attach(session_id):
+        assert session_id == "live"
+        yield 'data: {"type": "chunk", "content": "hi"}\n\n'
+        yield 'data: {"type": "done", "content": "hi"}\n\n'
+
+    with patch("gaia.ui.server._attach_chat_stream", fake_attach):
+        resp = client.get("/api/chat/attach", params={"session_id": "live"})
+        assert resp.status_code == 200
+        body = resp.text
+    assert '"type": "chunk"' in body
+    assert '"type": "done"' in body
+
+
+def test_send_409_when_run_already_active(client, session_id):
+    """A new turn is rejected while a background run is still registered."""
+    run_manager._runs[session_id] = _FakeRun(session_id)
+
+    resp = client.post(
+        "/api/chat/send",
+        json={"session_id": session_id, "message": "hi", "stream": False},
+    )
+    assert resp.status_code == 409
+    assert "already in progress" in resp.json()["detail"]
+
+
+def test_delete_session_cancels_active_run(client, session_id):
+    """Deleting a session cancels its run so it can't persist to a dead session."""
+    import threading
+
+    fake = _FakeRun(session_id)
+    fake.handler = type("H", (), {"cancelled": threading.Event()})()
+    run_manager._runs[session_id] = fake
+
+    resp = client.delete(f"/api/sessions/{session_id}")
+    assert resp.status_code == 200
+    assert fake.handler.cancelled.is_set()

--- a/tests/unit/chat/ui/test_run_manager.py
+++ b/tests/unit/chat/ui/test_run_manager.py
@@ -1,0 +1,179 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the per-session background chat-run registry (#1580).
+
+These exercise ``RunManager``/``Run`` in isolation — no agent, no LLM, no
+HTTP. The lifecycle coroutine is a stub that emits a few SSE strings, so we
+can assert the registry's contract: runs outlive subscriber disconnects,
+late subscribers get a full replay, completion closes subscribers and
+deregisters the run, and overlapping starts are rejected.
+"""
+
+import asyncio
+
+import pytest
+
+from gaia.ui.run_manager import DONE, Run, RunManager
+
+
+class _FakeHandler:
+    """Minimal stand-in for SSEOutputHandler — only ``cancelled`` is used."""
+
+    def __init__(self):
+        import threading
+
+        self.cancelled = threading.Event()
+
+
+async def _drain(q: asyncio.Queue) -> list:
+    """Drain a subscriber queue up to (and excluding) the DONE sentinel."""
+    out = []
+    while True:
+        item = await q.get()
+        if item is DONE:
+            break
+        out.append(item)
+    return out
+
+
+async def test_run_completes_and_deregisters():
+    mgr = RunManager()
+
+    async def lifecycle(run: Run):
+        run.handler = _FakeHandler()
+        run.emit("data: a\n\n")
+        run.emit("data: b\n\n")
+
+    run = mgr.start("sess-1", lifecycle)
+    assert mgr.is_running("sess-1")
+    assert "sess-1" in mgr.active_sessions()
+
+    q = run.subscribe()
+    events = await _drain(q)
+
+    assert events == ["data: a\n\n", "data: b\n\n"]
+    await run.task  # ensure the lifecycle's finally has run
+    assert not mgr.is_running("sess-1")
+    assert run.done.is_set()
+
+
+async def test_run_survives_subscriber_disconnect():
+    """A run keeps emitting + completing after its only subscriber detaches."""
+    mgr = RunManager()
+    gate = asyncio.Event()
+
+    async def lifecycle(run: Run):
+        run.emit("data: first\n\n")
+        await gate.wait()  # hold until the test detaches the subscriber
+        run.emit("data: after-disconnect\n\n")
+
+    run = mgr.start("sess-2", lifecycle)
+    q = run.subscribe()
+    assert await q.get() == "data: first\n\n"
+
+    # Simulate the browser navigating away: drop the subscriber mid-run.
+    run.unsubscribe(q)
+    assert run.subscribers == []
+
+    # The run must continue and finish regardless.
+    gate.set()
+    await run.task
+    assert run.done.is_set()
+    assert not mgr.is_running("sess-2")
+    # The post-disconnect event still landed in the replay buffer.
+    assert "data: after-disconnect\n\n" in run.buffer
+
+
+async def test_late_subscriber_gets_full_replay():
+    """Attaching after events were emitted replays history then live events."""
+    mgr = RunManager()
+    emitted_two = asyncio.Event()
+    release = asyncio.Event()
+
+    async def lifecycle(run: Run):
+        run.emit("data: 1\n\n")
+        run.emit("data: 2\n\n")
+        emitted_two.set()
+        await release.wait()
+        run.emit("data: 3\n\n")
+
+    run = mgr.start("sess-3", lifecycle)
+    await emitted_two.wait()
+
+    # Attach late — should replay 1 & 2, then receive live 3.
+    q = run.subscribe()
+    release.set()
+    events = await _drain(q)
+
+    assert events == ["data: 1\n\n", "data: 2\n\n", "data: 3\n\n"]
+    await run.task
+
+
+async def test_subscribe_after_done_terminates_immediately():
+    mgr = RunManager()
+
+    async def lifecycle(run: Run):
+        run.emit("data: only\n\n")
+
+    run = mgr.start("sess-4", lifecycle)
+    await run.task  # run fully finished before anyone subscribes
+
+    q = run.subscribe()
+    events = await _drain(q)
+    assert events == ["data: only\n\n"]
+    # No lingering registration for a finished run.
+    assert run.subscribers == []
+
+
+async def test_overlapping_start_raises():
+    mgr = RunManager()
+    release = asyncio.Event()
+
+    async def lifecycle(run: Run):
+        await release.wait()
+
+    mgr.start("sess-5", lifecycle)
+    with pytest.raises(RuntimeError):
+        mgr.start("sess-5", lifecycle)
+
+    release.set()
+
+
+async def test_cancel_sets_handler_flag():
+    mgr = RunManager()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def lifecycle(run: Run):
+        run.handler = _FakeHandler()
+        started.set()
+        await release.wait()
+
+    run = mgr.start("sess-6", lifecycle)
+    await started.wait()
+
+    assert mgr.cancel("sess-6") is True
+    assert run.handler.cancelled.is_set()
+
+    release.set()
+    await run.task
+
+    # Cancelling an unknown / finished session is a safe no-op.
+    assert mgr.cancel("nope") is False
+
+
+async def test_active_sessions_reflects_lifecycle():
+    mgr = RunManager()
+    release = asyncio.Event()
+
+    async def lifecycle(run: Run):
+        await release.wait()
+
+    mgr.start("a", lifecycle)
+    mgr.start("b", lifecycle)
+    assert set(mgr.active_sessions()) == {"a", "b"}
+
+    release.set()
+    await asyncio.gather(*(r.task for r in [mgr.get("a"), mgr.get("b")] if r))
+    assert mgr.active_sessions() == []


### PR DESCRIPTION
## Why this matters

Follow-up to #1584. Before: clicking **New Task** (or switching sessions) while an agent was still generating *killed* the run — the SSE was torn down on unmount, the backend cancelled the turn, and the in-flight answer was discarded with no sign it had ever been running. @sdevinenamd reported the visible half ("losing the status bar… hard to tell if the original agent is still running") while waiting on the email-triage agent. After: the run keeps going in the background, finishes and persists on its own, the sidebar shows a spinner on any session with a live run, and re-opening that session re-attaches to its live stream so progress resumes.

A chat turn is now a first-class background run (`RunManager`) that outlives the SSE connection: the producer + persistence run in a detached task, and the SSE endpoint is a thin subscriber over a replay buffer with multi-subscriber fan-out. `GET /api/chat/active` is the backend-truth source for the sidebar indicator (survives refresh/revisit); `GET /api/chat/attach` reconnects to an in-flight run. Because a disconnect no longer cancels, **Stop** now calls the cancel endpoint explicitly, and deleting a session cancels its run so it can't persist to a dead session.

## Test plan

- [x] `pytest tests/unit/chat/ui/` — 720 passed (1 pre-existing Windows cp1252 flake in an unrelated `agent.py`-reading test, deselected). Includes new `test_run_manager.py` (run survives subscriber disconnect & persists, late-subscriber replay, active list, overlap-409, cancel) and `test_chat_active_attach.py` (active/attach endpoints, send-409-while-running, delete-cancels-run).
- [x] `tsc --noEmit` — clean on all app code; `vite build` — clean.
- [x] **Live Agent UI** (real backend + Lemonade/Gemma-4-E4B): started a long run → clicked **New Task** mid-stream → new session opened clean, old session kept its "Agent running" spinner → revisited it → live stream resumed → run completed in the background, answer persisted, session auto-titled, spinner cleared.
- [ ] `vitest run` (added `chatStore` running-sessions cases) — runs in CI; not executed locally (vitest absent from the local env).