### PR TITLE
Release v0.21.1

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -440,6 +440,7 @@
             "group": "Release Notes",
             "pages": [
               "releases/index",
+              "releases/v0.21.1",
               "releases/v0.21.0",
               "releases/v0.20.1",
               "releases/v0.20.0",
@@ -496,7 +497,7 @@
   "navbar": {
     "links": [
       {
-        "label": "v0.21.0 \u00b7 Lemonade 10.2.0",
+        "label": "v0.21.1 \u00b7 Lemonade 10.2.0",
         "href": "https://github.com/amd/gaia/releases"
       },
       {

--- a/docs/releases/v0.21.1.mdx
+++ b/docs/releases/v0.21.1.mdx
@@ -1,0 +1,37 @@
+---
+title: "v0.21.1"
+description: "Patch release: unblocks NPU setup — `gaia init --profile npu` was failing for every NPU user — and gives the email agent a persistent memory store to build personalization on."
+---
+
+# GAIA v0.21.1 Release Notes
+
+GAIA v0.21.1 is a patch release on top of v0.21.0. The headline fix unblocks NPU setup: `gaia init --profile npu` was failing at the model download with an HTTP 400, so no one on a Ryzen AI NPU could get set up — it now downloads, verifies, and runs inference on the NPU. The release also wires a persistent memory store into the email agent, the foundation the upcoming personalization features build on.
+
+**Why upgrade:**
+- **NPU setup works again** — `gaia init --profile npu` was dead on arrival, failing before any NPU user could finish setup. It now pulls the built-in model correctly and runs on the NPU.
+- **The email agent remembers across sessions** — `gaia email` now boots with a persistent memory store instead of forgetting everything on restart, the groundwork for inbox personalization landing in upcoming releases.
+
+---
+
+## What's New
+
+### Persistent memory for the email agent — `gaia email`
+
+The email agent used to start from scratch every session — anything it learned about your inbox was wiped on restart. It now boots with a persistent memory store and the tools to read and write it, so learned state survives across runs. This is the foundation for the inbox personalization (priority senders, profiling, behavioral learning) coming in upcoming releases — triage behavior itself is unchanged in this release (PR [#1632](https://github.com/amd/gaia/pull/1632)).
+
+---
+
+## Bug Fixes
+
+- **`gaia init --profile npu` failed before any NPU user could finish setup** (PR [#1658](https://github.com/amd/gaia/pull/1658)) — the NPU profile pulled its built-in model with a `recipe` argument, which Lemonade rejects with an HTTP 400 unless you're registering a new user model. The built-in model is now pulled by name only, so the NPU profile downloads, verifies, and runs inference on the NPU. The fix also adds a testing rule so this class of fresh-install bug can't slip past a warm cache and a mocked client again.
+
+---
+
+## Full Changelog
+
+**2 commits** since v0.21.0:
+
+- `801a5c1d` — feat(email): wire MemoryMixin into the email agent (#1114) (#1632)
+- `a3e86b02` — fix(init): pull built-in NPU/FLM model by name, not recipe (#1655) (#1658)
+
+Full Changelog: [v0.21.0...v0.21.1](https://github.com/amd/gaia/compare/v0.21.0...v0.21.1)

--- a/src/gaia/apps/webui/package-lock.json
+++ b/src/gaia/apps/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-ui",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.3"

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "productName": "GAIA Agent UI",
   "description": "Privacy-first agentic AI interface with document Q&A - runs 100% locally on AMD Ryzen AI",

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from importlib.metadata import version as get_package_version_metadata
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 # Lemonade version used across CI and installer
 LEMONADE_VERSION = "10.2.0"


### PR DESCRIPTION
Cuts the **v0.21.1** patch release on top of v0.21.0. The headline is a setup fix: `gaia init --profile npu` was **dead on arrival** for every Ryzen AI NPU user — it failed at the model download with an HTTP 400 because the built-in FLM model was pulled with a `recipe` argument Lemonade only accepts when registering a *new user* model. It now pulls the built-in model by name, so the NPU profile downloads, verifies, and runs inference on the NPU.

This release also wires a **persistent memory store** into the email agent (`gaia email`): it boots with a memory DB and the tools to read/write it instead of forgetting everything on restart. Triage behavior is unchanged here — this is the groundwork the upcoming inbox-personalization features (#1288/#1289/#1290) build on.

The init fix also adds a CLAUDE.md testing rule so this *class* of bug — passing every test against a warm cache and a mocked client while the fresh-pull path 400s — can't recur silently.

Full, commit-by-commit notes live in [`docs/releases/v0.21.1.mdx`](docs/releases/v0.21.1.mdx) — that file is the source of truth and is kept in sync with the `v0.21.0..HEAD` range.

## Release checklist
- [x] `util/validate_release_notes.py docs/releases/v0.21.1.mdx --tag v0.21.1` passes
- [x] `src/gaia/version.py` → `0.21.1`
- [x] `src/gaia/apps/webui/package.json` → `0.21.1`
- [x] `src/gaia/apps/webui/package-lock.json` → `0.21.1`
- [x] Navbar label in `docs/docs.json` → `v0.21.1 · Lemonade 10.2.0`
- [x] All commits in range (`v0.21.0..HEAD`) represented in the notes
- [ ] Review from @kovtcharov-amd addressed
