### PR TITLE
docs(release): add #1644 to v0.21.1 changelog

### DIFF
--- a/docs/releases/v0.21.1.mdx
+++ b/docs/releases/v0.21.1.mdx
@@ -29,8 +29,9 @@ The email agent used to start from scratch every session — anything it learned
 
 ## Full Changelog
 
-**2 commits** since v0.21.0:
+**3 commits** since v0.21.0:
 
+- `cc6f2f39` — docs(plans): email agent packaging milestone (npm + sidecar binaries) (#1644)
 - `801a5c1d` — feat(email): wire MemoryMixin into the email agent (#1114) (#1632)
 - `a3e86b02` — fix(init): pull built-in NPU/FLM model by name, not recipe (#1655) (#1658)
 


### PR DESCRIPTION
Completeness fix on the v0.21.1 release notes before tagging. `cc6f2f39` (docs(plans): email agent packaging milestone, #1644) merged into the `v0.21.0..HEAD` range after the release PR #1669 notes were drafted, so the Full Changelog listed 2 commits instead of 3. Adds the missing line and corrects the count.

Must merge before the `v0.21.1` tag is pushed so the tagged tree carries an accurate changelog.

## Test plan
- [x] `util/validate_release_notes.py docs/releases/v0.21.1.mdx --tag v0.21.1` passes
- [x] `git log v0.21.0..HEAD` range (excluding the Release commit) matches the 3 listed entries