### PR TITLE
chore(context7): claim GAIA library on Context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/amd/gaia",
-  "public_key": "pk_OgoOeTPIF21Q3ZUKQIE3E",
+  "public_key": "pk_XqnEKNKLfMIJQneXnq5wZ",
   "projectTitle": "GAIA",
   "description": "AMD's open-source framework for building AI agents in Python and C++ that run entirely on local hardware, with AMD NPU and GPU acceleration on Ryzen AI processors.",
   "folders": ["docs"],

--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/amd/gaia",
+  "public_key": "pk_OgoOeTPIF21Q3ZUKQIE3E",
   "projectTitle": "GAIA",
   "description": "AMD's open-source framework for building AI agents in Python and C++ that run entirely on local hardware, with AMD NPU and GPU acceleration on Ryzen AI processors.",
   "folders": ["docs"],


### PR DESCRIPTION
## Why this matters

Context7 indexes the GAIA docs so AI coding assistants can pull current, GAIA-specific documentation on demand. To take ownership of the `amd/gaia` library on Context7 (and manage its parsing config), the repo must carry a `context7.json` with the `url` and `public_key` that Context7 verifies against. This PR adds those two fields to the existing config; the rest of the parsing rules are unchanged.

## Test plan

- [ ] Confirm `context7.json` is valid JSON and at repo root
- [ ] In the Context7 "Claim Library" dialog, click **Claim Library** and confirm ownership verifies against the pushed `public_key`