### PR TITLE
spike(email-packaging): no-Python frozen email-agent binary (#1647)

### DIFF
--- a/hub/agents/python/email/packaging/.gitignore
+++ b/hub/agents/python/email/packaging/.gitignore
@@ -1,0 +1,5 @@
+# PyInstaller freeze artifacts — large, reproducible, never committed.
+build/
+dist/
+*.spec
+__pycache__/

--- a/hub/agents/python/email/packaging/FINDINGS.md
+++ b/hub/agents/python/email/packaging/FINDINGS.md
@@ -1,0 +1,210 @@
+# De-risk spike — frozen email-agent binary (milestone #49)
+
+**Verdict: ✅ PASS.** A single self-contained PyInstaller executable boots the GAIA
+email agent's REST server and answers requests with **no Python interpreter**
+present, on Windows x64 (this machine's platform). The riskiest assumption of the
+email-agent-packaging milestone (Phase 2 of `docs/plans/email-agent-packaging.mdx`)
+holds.
+
+The binary serves the full email REST surface — `/v1/email/triage`, `/draft`,
+`/send` (the frozen `#1262` contract) plus `/health` and `/version` — and a
+fixture-derived `POST /v1/email/triage` returns a **contract-valid** response,
+all against a stubbed LLM backend (no live Gmail/Outlook, no live model).
+
+---
+
+## Environment
+
+| | |
+|---|---|
+| Platform | Windows 10/11, x64 (`win32-x64`) |
+| Python (build venv) | 3.12.13 (uv picked 3.12 for the venv; repo also has 3.13 on PATH) |
+| Freezer | PyInstaller 6.20.0 (+ pyinstaller-hooks-contrib 2026.6) |
+| Core install | `uv pip install --system-certs -e ".[api]"` (editable) |
+| Email install | `uv pip install --system-certs -e hub/agents/python/email` (editable) |
+
+> **Corporate-TLS gotcha:** plain `uv pip install` failed with
+> `invalid peer certificate: UnknownIssuer` behind the corporate proxy. Adding
+> **`--system-certs`** fixed it. CI on hosted runners won't hit this; document it
+> for local/on-prem builds.
+
+---
+
+## Build
+
+```bash
+# from an activated venv with .[api] + the email package + pyinstaller installed
+python hub/agents/python/email/packaging/freeze.py            # one-dir (default, recommended)
+python hub/agents/python/email/packaging/freeze.py --onefile  # one-file (single .exe)
+```
+
+| Mode | Output | Size | Cold-start to `/health` |
+|------|--------|------|--------------------------|
+| **one-dir** (recommended) | `dist/email-agent/email-agent.exe` (+ `_internal/`) | **86.2 MB** total | **~3.4 s** |
+| one-file | `dist/email-agent.exe` (single file) | **41.7 MB** | **~5.9 s** |
+
+Build time ≈ 150–170 s each. One-file is ~half the on-disk size (LZMA-compressed)
+but pays a per-launch self-extraction cost to `%TEMP%\_MEIxxxxxx` (the ~2.5 s
+delta above) and leaves a temp dir; one-dir starts faster and is friendlier to
+code-signing (sign the `.exe`, ship the folder).
+
+### Launch
+
+```bash
+# spike default: stubbed LLM so it serves with zero backend deps
+dist/email-agent/email-agent.exe --host 127.0.0.1 --port 8131
+# production shape (real local triage via Lemonade):
+dist/email-agent/email-agent.exe --host 127.0.0.1 --port 8131 --no-stub-llm
+```
+
+Flags: `--host` (default `127.0.0.1`), `--port` (default **8131** — deliberately
+**not 4001**), `--no-stub-llm` (use the real local Lemonade model instead of the
+deterministic stub), `--print-openapi` (dump OpenAPI and exit).
+
+---
+
+## Proof (smoke test)
+
+```bash
+python hub/agents/python/email/packaging/smoke_test.py dist/email-agent/email-agent.exe
+```
+
+The harness launches the **binary only** (a subprocess; the harness itself is
+Python, the *server* is not), polls `/health`, then checks OpenAPI, `/version`,
+and a triage round-trip. Final run (one-dir, isolated, clean shutdown):
+
+```
+[smoke] /health ready after 2.6s -> {'status': 'ok', 'service': 'gaia-agent-email'}
+[smoke] startup time to /health: 3.4s
+[smoke] openapi paths: ['/health', '/v1/email/draft', '/v1/email/send', '/v1/email/triage', '/version']
+[smoke] /version -> {'apiVersion': '1.0', 'agentVersion': '0.1.0'}
+[smoke] fixture-derived message: subject='Prod incident follow-up' from='Sarah Chen <...>'
+[smoke] triage HTTP 200 -> {"schema_version":"1.0","request_kind":"single","result":{"category":"actionable", ...}}
+[smoke] contract-valid triage response: request_kind=single category=actionable
+[smoke] VERDICT: PASS
+```
+
+The triage body is derived from `tests/fixtures/email/synthetic_inbox.mbox`
+(first message). The response is validated against the real contract via
+`gaia_agent_email.contract.parse_response` — not a string match.
+
+### No-Python rigor
+
+Confirmed the binary carries its own interpreter and needs no ambient Python:
+
+- `dist/email-agent/_internal/python312.dll` + `python3.dll` are bundled.
+- Launched with a **scrubbed environment** (`PYTHONHOME=` `PYTHONPATH=`
+  `PATH=C:\Windows\System32`) it still served `/health` and `/version` 200 OK.
+
+---
+
+## What the spike stubs (and why it's honest)
+
+`POST /v1/email/triage` normally calls the local Lemonade LLM
+(`classify_email_llm` + `summarize_email_llm`). To keep the spike free of a live
+model and live mail, `server.py --stub-llm` (default ON) swaps the triage
+service's chat client for a deterministic stub that returns a contract-valid
+classification + summary. This is the exact seam the plan calls for ("use
+dependency overrides / a stub backend so the spike does not need live Gmail or a
+live LLM").
+
+- The **REST surface, routing, request/response validation, and the entire
+  frozen contract** are exercised for real — only the model call is stubbed.
+- `/v1/email/send` (the confirmation-gate path) is **mounted and reachable** but
+  not exercised end-to-end: a real send needs a connected mailbox. Its 403
+  no-token gate is pure-python and would work frozen; the live keyring/OAuth
+  backend resolution is untested at runtime (see gotchas).
+
+---
+
+## Gotchas (what needed handling)
+
+1. **Editable installs are invisible to PyInstaller.** With `-e` installs,
+   `gaia_agent_email` and `gaia` are not discoverable by PyInstaller's static
+   analyzer — the first build failed at runtime with
+   `ModuleNotFoundError: No module named 'gaia_agent_email'`. **Fix:** add the
+   source roots to `--paths` (`hub/agents/python/email` and `src`). CI that does
+   a non-editable wheel install won't need this, but the spike (and any local
+   editable build) does. `freeze.py` handles it automatically.
+
+2. **uvicorn string-imports its impls.** Loops/protocols/lifespan are imported by
+   name at runtime, invisible to static analysis. **Fix:**
+   `--collect-submodules uvicorn`.
+
+3. **keyring resolves OS backends via entry points.** `gaia.connectors.store`
+   does `import keyring` at module load (reached when the email router mounts),
+   and keyring finds its Windows backend through `importlib.metadata` entry
+   points. **Fix:** `--collect-submodules keyring` **and** `--copy-metadata
+   keyring`. The binary boots and mounts the router, proving keyring imports
+   under freeze. The actual Windows credential-store *read* (DPAPI via the
+   `keyring.backends.Windows` backend, which needs `pywin32`) is **not exercised**
+   here — validate it when the `/send` path is wired with a connected mailbox.
+
+4. **Lazy tool imports on the triage path.** The router imports its tool modules
+   (`llm_triage`, `summarize_tools`, …) inside functions. **Fix:**
+   `--collect-submodules gaia_agent_email` pulls the whole package so the triage
+   path is present.
+
+5. **The ML stack bloats the freeze.** The triage path lazily reaches
+   `gaia.chat.sdk` → torch/transformers/faiss (~2 GB). With `--stub-llm` none of
+   it runs, so `freeze.py` **excludes** the ML stack (`torch`, `transformers`,
+   `sentence_transformers`, `faiss`, …), cutting the binary to <90 MB. A
+   non-stub binary that runs real triage talks to **Lemonade Server over HTTP**
+   (no in-process torch), so the excludes likely hold for production too —
+   confirm when building the `--no-stub-llm` production binary.
+
+6. **One-file orphans its child on kill.** PyInstaller's one-file bootloader
+   spawns a child; `Popen.terminate()` on the parent leaves the uvicorn child
+   (and the listening socket) alive. **Fix in the harness:** kill the process
+   **tree** (`taskkill /F /T` on Windows). **Host-app implication:** the sidecar
+   supervisor MUST kill the tree on shutdown, not just the spawned PID.
+
+7. **GAIA logger writes to stdout.** `gaia.logger` attaches a colored stdout
+   handler on import, so `--print-openapi`'s JSON is preceded by a log line. Not
+   a problem for the HTTP path (the smoke test uses `/openapi.json`), but a
+   consumer scripting `--print-openapi` should read the last line / use the
+   endpoint instead.
+
+---
+
+## Recommendation
+
+- **One-dir over one-file** as the default distributed artifact: faster startup,
+  no per-launch temp extraction, and cleaner to code-sign (sign the `.exe`, ship
+  the `_internal/` folder alongside). One-file is the better *download* (half the
+  size) — fine if a host prefers a single file and can absorb the ~2.5 s extra
+  cold start. Both PASS.
+- **PyInstaller over Nuitka:** PyInstaller resolved every dependency for this
+  app with only the four `--collect-submodules` / `--copy-metadata` / `--paths`
+  knobs above — no Nuitka fallback was needed. Keep Nuitka in the back pocket
+  only if a future dep defeats PyInstaller's hooks.
+- **No blocker foreseen for the other 3 platforms** (`darwin-arm64`,
+  `darwin-x64`, `linux-x64`). The app is pure-python + fastapi/uvicorn/pydantic/
+  keyring — all cross-platform, all with PyInstaller hooks. Per-platform watch
+  items, none expected to block:
+  - **keyring backend swaps per OS** (macOS Keychain, Linux SecretService/
+    `dbus`/`SecretStorage`). `--collect-submodules keyring` + `--copy-metadata`
+    should carry them; the live read still wants a per-OS check once `/send` is
+    wired.
+  - **macOS** needs sign + **notarize** (Phase 4) or Gatekeeper blocks the
+    bundled binary inside a host app.
+  - **Linux** glibc floor: build on the **oldest** target glibc (manylinux-style)
+    so the binary runs on older distros.
+  - Each platform must build **natively** (PyInstaller doesn't cross-compile) —
+    the milestone's CI matrix already implies this.
+
+## Reproduce
+
+```bash
+uv venv
+uv pip install --system-certs -e ".[api]"
+uv pip install --system-certs -e hub/agents/python/email
+uv pip install --system-certs pyinstaller
+python hub/agents/python/email/packaging/freeze.py
+python hub/agents/python/email/packaging/smoke_test.py \
+    hub/agents/python/email/packaging/dist/email-agent/email-agent.exe
+```
+
+Build artifacts (`build/`, `dist/`, `*.spec`) are git-ignored — only `freeze.py`,
+`server.py`, `smoke_test.py`, and this file are committed. The 86 MB one-dir
+binary is **not** committed; rebuild with the command above.

--- a/hub/agents/python/email/packaging/freeze.py
+++ b/hub/agents/python/email/packaging/freeze.py
@@ -1,0 +1,170 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Reproducible PyInstaller freeze for the GAIA Email Triage REST sidecar
+(packaging spike, milestone #49 / email-agent-packaging Phase 2).
+
+Freezes ``server.py`` into a self-contained executable that boots the email
+REST surface with NO Python interpreter on the target machine.
+
+Usage (from an activated venv with the deps + pyinstaller installed)::
+
+    python hub/agents/python/email/packaging/freeze.py            # one-dir (default)
+    python hub/agents/python/email/packaging/freeze.py --onefile  # one-file
+
+Output:
+    one-dir:  hub/agents/python/email/packaging/dist/email-agent/email-agent[.exe]
+    one-file: hub/agents/python/email/packaging/dist/email-agent[.exe]
+
+Design notes / gotchas baked in (see FINDINGS.md for the why):
+- ``uvicorn`` loads its loops/protocols/lifespan impls by string import, so its
+  submodules are invisible to static analysis -> ``--collect-submodules uvicorn``.
+- ``keyring`` resolves OS backends through entry points -> collect its submodules
+  AND copy its metadata so the entry-point lookup succeeds in the frozen app.
+- The email router lazily imports its tool modules inside functions
+  (``classify_email_llm`` / ``summarize_email_llm`` etc.); collect the whole
+  ``gaia_agent_email`` package so the triage path is present in the freeze.
+- ``gaia.connectors`` discovers providers dynamically; collect it explicitly.
+- We deliberately do NOT ``--collect-submodules gaia`` (the whole core package
+  pulls every agent + RAG + torch and explodes the binary). Static analysis from
+  the email router pulls only the reachable core modules.
+- The triage path lazily imports ``gaia.chat.sdk`` (AgentSDK) inside
+  ``_build_llm_chat``, which statically reaches the ML stack (torch,
+  transformers, …). With ``--stub-llm`` that code never runs, so we EXCLUDE the
+  ML stack to keep the spike binary lean. A non-stub production binary that runs
+  real local triage talks to Lemonade Server over HTTP (no in-proc torch), but
+  if a future build needs these, drop them from ``EXCLUDES``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ENTRY = HERE / "server.py"
+NAME = "email-agent"
+# Repo root: packaging/ -> email/ -> python/ -> agents/ -> hub/ -> <root>
+REPO_ROOT = HERE.parents[4]
+# Editable installs are invisible to PyInstaller's static analyzer, so point it
+# at the source roots directly: the email package and the core ``src`` tree.
+PATHEX = [REPO_ROOT / "hub" / "agents" / "python" / "email", REPO_ROOT / "src"]
+
+# Heavy ML stack reachable only through the lazily-imported, stubbed-out
+# real-LLM path. Excluded to keep the spike binary lean (torch alone is ~2 GB).
+EXCLUDES = [
+    "torch",
+    "transformers",
+    "sentence_transformers",
+    "faiss",
+    "faiss_cpu",
+    "sympy",
+    "tokenizers",
+    "scipy",
+    "pandas",
+    "matplotlib",
+    "safetensors",
+    "torchvision",
+    "torchaudio",
+]
+
+
+def build(onefile: bool = False, clean: bool = True) -> Path:
+    import PyInstaller.__main__
+
+    work = HERE / "build"
+    dist = HERE / "dist"
+    if clean:
+        for d in (work, dist):
+            if d.exists():
+                shutil.rmtree(d, ignore_errors=True)
+
+    args = [
+        str(ENTRY),
+        "--name",
+        NAME,
+        "--console",
+        "--noconfirm",
+        "--clean",
+        "--distpath",
+        str(dist),
+        "--workpath",
+        str(work),
+        "--specpath",
+        str(HERE),
+        # Editable-install source roots (analyzer can't see editable installs).
+        "--paths",
+        str(PATHEX[0]),
+        "--paths",
+        str(PATHEX[1]),
+        # uvicorn: string-imported loops/protocols/lifespan.
+        "--collect-submodules",
+        "uvicorn",
+        # keyring: OS backend resolution via entry points.
+        "--collect-submodules",
+        "keyring",
+        "--copy-metadata",
+        "keyring",
+        # email agent: lazily-imported tool modules on the triage path.
+        "--collect-submodules",
+        "gaia_agent_email",
+        "--copy-metadata",
+        "gaia-agent-email",
+        # connector provider discovery is dynamic.
+        "--collect-submodules",
+        "gaia.connectors",
+        # core metadata (importlib.metadata version probes).
+        "--copy-metadata",
+        "amd-gaia",
+        # pydantic v2 ships a compiled core; collect data to be safe.
+        "--collect-submodules",
+        "pydantic",
+    ]
+    for mod in EXCLUDES:
+        args += ["--exclude-module", mod]
+    if onefile:
+        args.append("--onefile")
+    else:
+        args.append("--onedir")
+
+    t0 = time.time()
+    PyInstaller.__main__.run(args)
+    elapsed = time.time() - t0
+
+    exe = (
+        dist / (NAME + (".exe" if sys.platform == "win32" else ""))
+        if onefile
+        else dist / NAME / (NAME + (".exe" if sys.platform == "win32" else ""))
+    )
+    print(f"\nBuild finished in {elapsed:.1f}s")
+    print(f"Executable: {exe}")
+    if exe.exists():
+        if onefile:
+            size = exe.stat().st_size
+        else:
+            size = sum(
+                p.stat().st_size for p in (dist / NAME).rglob("*") if p.is_file()
+            )
+        print(
+            f"Size: {size / 1e6:.1f} MB ({'one-file exe' if onefile else 'one-dir total'})"
+        )
+    else:
+        print("WARNING: expected executable not found.")
+    return exe
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Freeze the email REST sidecar.")
+    parser.add_argument(
+        "--onefile", action="store_true", help="Build a single-file executable."
+    )
+    args = parser.parse_args(argv)
+    exe = build(onefile=args.onefile)
+    return 0 if exe.exists() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hub/agents/python/email/packaging/server.py
+++ b/hub/agents/python/email/packaging/server.py
@@ -1,0 +1,177 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Frozen-binary entrypoint for the GAIA Email Triage agent REST sidecar
+(packaging spike for milestone #49, Phase 2 of email-agent-packaging).
+
+This is the module PyInstaller (or Nuitka) freezes. It boots a **minimal**
+FastAPI app that mounts ONLY the email REST router (``/v1/email/*``) plus two
+dependency-free probes the sidecar lifecycle handshake needs:
+
+    GET /health   -> {"status": "ok", "service": "gaia-agent-email"}
+    GET /version  -> {"apiVersion": <contract SCHEMA_VERSION>,
+                      "agentVersion": <package __version__>}
+
+Why a minimal app instead of freezing the whole ``gaia api`` (openai_server)
+app: the full app eagerly imports every registered agent (RAG, code, etc.),
+which balloons the frozen binary and multiplies the freeze-time hidden-import
+surface. The sidecar only needs the email surface, so we mount just that router.
+The router import chain is identical to what ``openai_server`` mounts, so the
+served contract is byte-for-byte the same.
+
+``--stub-llm`` (default ON for the spike) swaps the triage service's local
+Lemonade chat client for a deterministic stub, so the frozen binary can prove
+it serves a contract-valid triage round-trip with NO live LLM and NO Gmail
+connector. In a real deployment the flag is off and triage uses the local
+Lemonade model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+log = logging.getLogger("gaia_agent_email.sidecar")
+
+# Default sidecar port for the spike. NOT 4001 (reserved). 8131 is unused here.
+DEFAULT_PORT = 8131
+DEFAULT_HOST = "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic LLM stub (spike only)
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    """Mimics the AgentSDK response object — carries a ``.text`` attribute."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _StubChat:
+    """Deterministic stand-in for ``AgentSDK`` used by the email triage path.
+
+    ``classify_email_llm`` and ``summarize_email_llm`` both call
+    ``chat.send_messages(messages, system_prompt=..., temperature=...)`` and
+    read ``response.text``. We branch on the system prompt to return a
+    contract-valid classification JSON or a plain-text summary — no model, no
+    network. This is ONLY wired in under ``--stub-llm`` for the spike.
+    """
+
+    def send_messages(self, messages, system_prompt: str = "", **_kwargs):
+        sp = (system_prompt or "").lower()
+        if "classification" in sp:
+            # Must be a value in the frozen taxonomy.
+            return _StubResponse(
+                json.dumps(
+                    {
+                        "category": "actionable",
+                        "confidence": 0.95,
+                        "reasoning": "stubbed deterministic classification",
+                    }
+                )
+            )
+        if "summarization" in sp:
+            # Plain text only — the summarizer rejects empty output.
+            user = messages[-1]["content"] if messages else ""
+            first_line = next(
+                (ln for ln in user.splitlines() if ln.startswith("Subject:")),
+                "Subject: (none)",
+            )
+            return _StubResponse(
+                f"[stub summary] {first_line.removeprefix('Subject:').strip()}"
+            )
+        return _StubResponse("[stub] unrecognized prompt")
+
+
+def _install_llm_stub() -> None:
+    """Patch the triage service so triage uses the deterministic stub chat."""
+    from gaia_agent_email import api_routes
+
+    api_routes._service._build_llm_chat = lambda *a, **k: _StubChat()  # type: ignore[attr-defined]
+    log.info("LLM stub installed — triage will NOT call a live model.")
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
+def build_app(stub_llm: bool = True):
+    """Build the minimal FastAPI app hosting the email REST surface."""
+    from fastapi import FastAPI
+    from gaia_agent_email import __version__ as agent_version
+    from gaia_agent_email.api_routes import router as email_router
+    from gaia_agent_email.contract import SCHEMA_VERSION
+
+    app = FastAPI(
+        title="GAIA Email Agent Sidecar",
+        version=agent_version,
+        description="Frozen-binary email triage REST sidecar (spike).",
+    )
+
+    @app.get("/health", include_in_schema=True)
+    async def health() -> dict:
+        return {"status": "ok", "service": "gaia-agent-email"}
+
+    @app.get("/version", include_in_schema=True)
+    async def version() -> dict:
+        # apiVersion is the host-facing REST contract version (the frozen
+        # request/response schema); agentVersion is the package build.
+        return {"apiVersion": SCHEMA_VERSION, "agentVersion": agent_version}
+
+    app.include_router(email_router)
+
+    if stub_llm:
+        _install_llm_stub()
+
+    return app
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="GAIA Email Triage REST sidecar (frozen binary entrypoint)."
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Bind host.")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Bind port.")
+    parser.add_argument(
+        "--no-stub-llm",
+        action="store_true",
+        help="Use the real local Lemonade LLM for triage instead of the stub.",
+    )
+    parser.add_argument(
+        "--print-openapi",
+        action="store_true",
+        help="Print the OpenAPI JSON to stdout and exit (no server).",
+    )
+    args = parser.parse_args(argv)
+
+    stub = not args.no_stub_llm
+    app = build_app(stub_llm=stub)
+
+    if args.print_openapi:
+        print(json.dumps(app.openapi()))
+        return 0
+
+    import uvicorn
+
+    log.info(
+        "Starting GAIA email sidecar on http://%s:%d (stub_llm=%s)",
+        args.host,
+        args.port,
+        stub,
+    )
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hub/agents/python/email/packaging/smoke_test.py
+++ b/hub/agents/python/email/packaging/smoke_test.py
@@ -1,0 +1,319 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+No-Python smoke test for the frozen GAIA email REST sidecar (milestone #49).
+
+Proves the FROZEN BINARY (not ``python -m ...``) boots and serves the email
+REST surface:
+
+  1. Launch the binary as a subprocess (binary only — no interpreter).
+  2. Poll GET /health until ready (dependency-free readiness probe).
+  3. GET /openapi.json and assert the email paths are present.
+  4. GET /version and assert the contract apiVersion is advertised.
+  5. POST /v1/email/triage with a FIXTURE-DERIVED body and validate the
+     response against the frozen contract (stubbed LLM backend, so no live
+     Gmail/Outlook and no live model is required).
+
+This harness itself runs under Python (it is a test driver), but the SERVER
+under test is the frozen binary with no Python available to it. Uses only the
+stdlib (urllib, mailbox, json) so it has no install requirements of its own.
+
+Exit code 0 = PASS, non-zero = FAIL. Verbose logging throughout for debugging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mailbox
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[4]  # .../<repo root>
+FIXTURE_MBOX = REPO / "tests" / "fixtures" / "email" / "synthetic_inbox.mbox"
+
+HOST = "127.0.0.1"
+PORT = 8131  # NOT 4001 (reserved).
+BASE = f"http://{HOST}:{PORT}"
+
+
+def log(msg: str) -> None:
+    print(f"[smoke] {msg}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixture-derived triage body
+# ---------------------------------------------------------------------------
+
+
+def _first_message_fields() -> tuple[str, str, str]:
+    """Pull (subject, from, body) from the first fixture mbox message."""
+    if not FIXTURE_MBOX.exists():
+        raise FileNotFoundError(f"fixture mbox not found: {FIXTURE_MBOX}")
+    box = mailbox.mbox(str(FIXTURE_MBOX))
+    try:
+        for msg in box:
+            subject = msg.get("Subject", "") or "(no subject)"
+            sender = msg.get("From", "alice@example.com")
+            if msg.is_multipart():
+                body = ""
+                for part in msg.walk():
+                    if part.get_content_type() == "text/plain":
+                        raw = part.get_payload(decode=True) or b""
+                        body = raw.decode("utf-8", errors="replace")
+                        break
+            else:
+                raw = msg.get_payload(decode=True) or b""
+                body = (
+                    raw.decode("utf-8", errors="replace")
+                    if isinstance(raw, bytes)
+                    else str(raw)
+                )
+            return subject, sender, (body or "(empty body)")
+    finally:
+        box.close()
+    raise RuntimeError("fixture mbox had no messages")
+
+
+def _parse_from(raw: str) -> dict:
+    raw = (raw or "").strip()
+    if "<" in raw and ">" in raw:
+        name = raw[: raw.index("<")].strip().strip('"') or None
+        email = raw[raw.index("<") + 1 : raw.index(">")].strip()
+    else:
+        name, email = None, raw
+    if "@" not in email:
+        email = "alice@example.com"
+    out = {"email": email}
+    if name:
+        out["name"] = name
+    return out
+
+
+def build_triage_body() -> dict:
+    try:
+        subject, sender_raw, body = _first_message_fields()
+        log(f"fixture-derived message: subject={subject!r} from={sender_raw!r}")
+    except Exception as exc:  # fall back to a representative inline message
+        log(f"fixture unavailable ({exc}); using inline representative message")
+        subject = "Can you review the Q3 report by Friday?"
+        sender_raw = "Alice Example <alice@example.com>"
+        body = "Hi, please review the attached Q3 report and let me know by Friday."
+    sender = _parse_from(sender_raw)
+    return {
+        "schema_version": "1.0",
+        "payload": {
+            "kind": "single",
+            "principal": {"email": "user@example.com"},
+            "message": {
+                "message_id": "smoke-msg-1",
+                "from": sender,
+                "to": [{"email": "user@example.com"}],
+                "subject": subject,
+                "body": body,
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+def _get(path: str, timeout: float = 5.0):
+    req = urllib.request.Request(BASE + path, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, json.loads(resp.read().decode("utf-8"))
+
+
+def _post(path: str, payload: dict, timeout: float = 30.0):
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        BASE + path,
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, json.loads(resp.read().decode("utf-8"))
+
+
+def _kill_tree(proc: subprocess.Popen) -> None:
+    """Kill the server AND its children.
+
+    PyInstaller's one-file bootloader spawns a child process; terminating the
+    parent orphans the child (and the listening socket). On Windows, taskkill
+    /T /F kills the whole tree. A host app must do the same on shutdown.
+    """
+    if proc.poll() is not None:
+        return
+    if sys.platform == "win32":
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def wait_for_health(proc: subprocess.Popen, deadline_s: float = 60.0) -> bool:
+    start = time.time()
+    while time.time() - start < deadline_s:
+        if proc.poll() is not None:
+            log(f"server process exited early with code {proc.returncode}")
+            return False
+        try:
+            status, body = _get("/health", timeout=2.0)
+            if status == 200 and body.get("status") == "ok":
+                log(f"/health ready after {time.time() - start:.1f}s -> {body}")
+                return True
+        except (urllib.error.URLError, ConnectionError, OSError):
+            pass
+        time.sleep(0.5)
+    log(f"/health not ready within {deadline_s}s")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def check_openapi() -> bool:
+    status, spec = _get("/openapi.json", timeout=10.0)
+    paths = set(spec.get("paths", {}).keys())
+    log(f"openapi paths: {sorted(paths)}")
+    required = {"/v1/email/triage", "/v1/email/draft", "/v1/email/send"}
+    missing = required - paths
+    if missing:
+        log(f"FAIL: missing email paths in openapi: {missing}")
+        return False
+    log("openapi check PASS — all email paths present")
+    return True
+
+
+def check_version() -> bool:
+    status, body = _get("/version", timeout=5.0)
+    log(f"/version -> {body}")
+    if not body.get("apiVersion"):
+        log("FAIL: /version missing apiVersion")
+        return False
+    log("version check PASS")
+    return True
+
+
+def check_triage() -> bool:
+    body = build_triage_body()
+    log(f"POST /v1/email/triage body={json.dumps(body)[:300]}...")
+    try:
+        status, resp = _post("/v1/email/triage", body, timeout=60.0)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        log(f"FAIL: triage returned HTTP {e.code}: {detail[:500]}")
+        return False
+    log(f"triage HTTP {status} -> {json.dumps(resp)[:500]}")
+    # Validate against the frozen contract using the harness's own copy.
+    try:
+        from gaia_agent_email.contract import parse_response
+
+        parsed = parse_response(resp)
+        log(
+            "contract-valid triage response: "
+            f"request_kind={parsed.request_kind} "
+            f"category={parsed.result.category.value} "
+            f"summary={parsed.result.summary[:80]!r}"
+        )
+    except Exception as exc:
+        log(f"FAIL: response did not validate against contract: {exc}")
+        return False
+    if parsed.request_kind != "single":
+        log(f"FAIL: expected request_kind=single, got {parsed.request_kind}")
+        return False
+    log("triage check PASS")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Smoke-test the frozen email sidecar.")
+    parser.add_argument(
+        "binary", help="Path to the frozen email-agent executable to test."
+    )
+    args = parser.parse_args(argv)
+
+    binary = Path(args.binary).resolve()
+    if not binary.exists():
+        log(f"FAIL: binary not found: {binary}")
+        return 2
+
+    # Preflight: refuse to run if the port is already taken — otherwise we'd
+    # health-check a stale server and report a false PASS.
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        if s.connect_ex((HOST, PORT)) == 0:
+            log(f"FAIL: port {PORT} already in use — kill the stale server first.")
+            return 2
+
+    log(f"launching frozen binary: {binary}")
+    cmd = [str(binary), "--host", HOST, "--port", str(PORT)]
+    log(f"command: {' '.join(cmd)}")
+    t0 = time.time()
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    results: dict[str, bool] = {}
+    try:
+        ready = wait_for_health(proc)
+        log(f"startup time to /health: {time.time() - t0:.1f}s")
+        if not ready:
+            # Drain whatever the server printed so failures are debuggable.
+            try:
+                out = proc.stdout.read() if proc.stdout else ""
+                log(f"server output:\n{out}")
+            except Exception:
+                pass
+            return 3
+        results["openapi"] = check_openapi()
+        results["version"] = check_version()
+        results["triage"] = check_triage()
+    finally:
+        log("shutting down server")
+        _kill_tree(proc)
+        # Surface server logs for debugging regardless of pass/fail.
+        try:
+            if proc.stdout:
+                tail = proc.stdout.read()
+                if tail:
+                    log(f"server output tail:\n{tail[-2000:]}")
+        except Exception:
+            pass
+
+    log(f"results: {results}")
+    ok = all(results.values()) and len(results) == 3
+    log("VERDICT: PASS" if ok else "VERDICT: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why this matters

Before #49 fans out the npm client, R2 publish, and per-platform CI, we needed to know one thing: **can the email agent actually run with no Python installed?** It can. This spike freezes `gaia-agent-email` into a self-contained PyInstaller binary that boots the `/v1/email/*` REST surface and answers a contract-valid triage request with zero interpreter present — proven on Windows x64 with the env scrubbed (`PYTHONHOME`/`PYTHONPATH` empty). The riskiest assumption of the milestone now holds, and the reusable freeze tooling + a documented gotcha list land here so #1647 and #1648 start from a working baseline instead of a blank page.

De-risks **#1647** (Phase 2 — freeze into self-contained per-platform binaries). Scope delivered vs. that issue's exit criteria:

| #1647 item | This PR |
|---|---|
| Freeze into a self-contained exe that boots the REST server | ✅ `freeze.py` (PyInstaller, one-dir default / `--onefile`) |
| Clean-env smoke test: spawn → health → version → triage | ✅ `smoke_test.py` (binary-only, no `python -m`) |
| Measure binary size | ✅ 86 MB one-dir / 42 MB one-file |
| Per-platform builds (win / mac×2 / linux) | ⏳ only `win32-x64` — needs native CI runners (the rest of #1647 + #1648) |

**Source-only:** no binary, no `build/`/`dist/`/`*.spec` (git-ignored). Rebuild with the command in `FINDINGS.md`.

Key gotchas captured for the real implementation: editable installs are invisible to PyInstaller (needs `--paths`), `uvicorn`/`keyring` need `--collect-submodules`, the ML stack must be excluded (the stubbed triage path never runs torch), and one-file orphans its child process on kill (the sidecar supervisor must kill the tree).

`server.py` is a **spike entrypoint** (minimal FastAPI app mounting only the email router, with a deterministic LLM stub so triage round-trips without a live model/mailbox). Its `/health` + `/version` overlap #1645's territory — the production server, not this throwaway app, is where those land for real.

## Test plan

- [ ] `uv pip install -e ".[api]"` and `uv pip install -e hub/agents/python/email` (add `--system-certs` behind a corporate proxy), then `pip install pyinstaller`
- [ ] `python hub/agents/python/email/packaging/freeze.py` → produces `dist/email-agent/email-agent.exe`
- [ ] `python hub/agents/python/email/packaging/smoke_test.py dist/email-agent/email-agent.exe` → `VERDICT: PASS` (health + OpenAPI email paths + `/version` + contract-valid triage)
- [ ] Confirm no compiled artifacts are tracked: `git ls-files hub/agents/python/email/packaging/` lists only the 5 source files
