### PR TITLE
Redact API debug request logging

### DIFF
--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -40,11 +40,41 @@ from .schemas import (
 
 # Configure logging
 logger = logging.getLogger(__name__)
+_REDACTED_LOG_VALUE = "[redacted]"
 
 # Set logger level based on debug flag
 if os.environ.get("GAIA_API_DEBUG") == "1":
     logger.setLevel(logging.DEBUG)
     logger.info("Debug logging enabled for API server")
+
+
+def _api_debug_enabled() -> bool:
+    return os.environ.get("GAIA_API_DEBUG") == "1"
+
+
+def _log_header_summary(headers) -> None:
+    """Log header names and value sizes without persisting header values."""
+    logger.debug("Headers:")
+    for name, value in headers.items():
+        logger.debug("  %s: %s (%d chars)", name, _REDACTED_LOG_VALUE, len(value))
+
+
+def _log_message_summary(index: int, message) -> None:
+    content_length = len(message.content or "")
+    logger.debug("Message %d:", index)
+    logger.debug("  Role: %s", message.role)
+    logger.debug("  Content: %s (%d chars)", _REDACTED_LOG_VALUE, content_length)
+    if message.tool_calls is not None:
+        logger.debug("  Tool calls: %d", len(message.tool_calls))
+    if message.tool_call_id is not None:
+        logger.debug("  Tool call ID: %s", _REDACTED_LOG_VALUE)
+
+
+def _log_request_parameter_summary(request: ChatCompletionRequest) -> None:
+    logger.debug("Request parameters:")
+    for field_name in ("temperature", "max_tokens", "top_p"):
+        value = getattr(request, field_name, None)
+        logger.debug("  %s: %s", field_name, "set" if value is not None else "not set")
 
 
 def extract_workspace_root(messages):
@@ -120,15 +150,13 @@ async def log_raw_requests(request: Request, call_next):
     Middleware to log raw HTTP requests when debug mode is enabled.
     For streaming endpoints, only log headers to avoid breaking SSE.
     """
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug("=" * 80)
         logger.debug("📥 RAW HTTP REQUEST")
         logger.debug("=" * 80)
         logger.debug(f"Path: {request.url.path}")
         logger.debug(f"Method: {request.method}")
-        logger.debug("Headers:")
-        for name, value in request.headers.items():
-            logger.debug(f"  {name}: {value}")
+        _log_header_summary(request.headers)
 
         # DON'T read body for streaming endpoints - it breaks ASGI message flow
         # Per FastAPI docs: "Never read the request body in middleware for streaming responses"
@@ -142,16 +170,8 @@ async def log_raw_requests(request: Request, call_next):
             logger.debug(f"Body (raw bytes length): {len(body_bytes)}")
             if body_bytes:
                 try:
-                    body_str = body_bytes.decode("utf-8")
-                    logger.debug("Body (decoded UTF-8):")
-                    logger.debug(body_str)
-                    # Try to pretty-print JSON
-                    try:
-                        body_json = json.loads(body_str)
-                        logger.debug("Body (parsed JSON):")
-                        logger.debug(json.dumps(body_json, indent=2))
-                    except json.JSONDecodeError:
-                        pass
+                    body_bytes.decode("utf-8")
+                    logger.debug("Body (decoded UTF-8): %s", _REDACTED_LOG_VALUE)
                 except UnicodeDecodeError:
                     logger.debug("Body contains non-UTF-8 data")
 
@@ -201,7 +221,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
         ```
     """
     # Debug logging: trace incoming request
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug("=" * 80)
         logger.debug("📥 INCOMING CHAT COMPLETION REQUEST")
         logger.debug("=" * 80)
@@ -211,25 +231,10 @@ async def create_chat_completion(request: ChatCompletionRequest):
         logger.debug("-" * 80)
 
         for i, msg in enumerate(request.messages):
-            logger.debug(f"Message {i}:")
-            logger.debug(f"  Role: {msg.role}")
-            # Preview content (truncate if too long); guard against None content
-            content_text = msg.content or ""
-            content_preview = (
-                content_text[:500] if len(content_text) > 500 else content_text
-            )
-            if len(content_text) > 500:
-                content_preview += (
-                    f"\n  ... (truncated, total length: {len(content_text)} chars)"
-                )
-            logger.debug(f"  Content:\n{content_preview}")
+            _log_message_summary(i, msg)
             logger.debug("-" * 40)
 
-        # Log additional request parameters
-        logger.debug("Request parameters:")
-        logger.debug(f"  temperature: {getattr(request, 'temperature', 'not set')}")
-        logger.debug(f"  max_tokens: {getattr(request, 'max_tokens', 'not set')}")
-        logger.debug(f"  top_p: {getattr(request, 'top_p', 'not set')}")
+        _log_request_parameter_summary(request)
         logger.debug("=" * 80)
 
     # Validate model exists
@@ -240,8 +245,8 @@ async def create_chat_completion(request: ChatCompletionRequest):
 
     # Extract workspace root from messages (for converting relative paths to absolute)
     workspace_root = extract_workspace_root(request.messages)
-    if os.environ.get("GAIA_API_DEBUG") == "1" and workspace_root:
-        logger.debug(f"📁 Extracted workspace root: {workspace_root}")
+    if _api_debug_enabled() and workspace_root:
+        logger.debug("📁 Extracted workspace root: %s", _REDACTED_LOG_VALUE)
 
     # Extract user query from messages (get last user message)
     user_message = next(
@@ -254,11 +259,13 @@ async def create_chat_completion(request: ChatCompletionRequest):
         )
 
     # Debug logging: show what we're passing to the agent
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug("🔄 EXTRACTED FOR AGENT:")
-        logger.debug(f"Passing to agent: {user_message[:500]}...")
-        if len(user_message) > 500:
-            logger.debug(f"(Total length: {len(user_message)} chars)")
+        logger.debug(
+            "Passing to agent: %s (%d chars)",
+            _REDACTED_LOG_VALUE,
+            len(user_message),
+        )
         logger.debug("=" * 80)
 
     # Get agent instance for this model
@@ -270,7 +277,7 @@ async def create_chat_completion(request: ChatCompletionRequest):
     # Handle streaming vs non-streaming
     if request.stream:
         # Debug logging for streaming mode
-        if os.environ.get("GAIA_API_DEBUG") == "1":
+        if _api_debug_enabled():
             logger.debug("🌊 Using STREAMING mode")
 
         return StreamingResponse(
@@ -286,20 +293,21 @@ async def create_chat_completion(request: ChatCompletionRequest):
         )
     else:
         # Debug logging for non-streaming mode
-        if os.environ.get("GAIA_API_DEBUG") == "1":
+        if _api_debug_enabled():
             logger.debug("📦 Using NON-STREAMING mode")
 
         # Process query synchronously with workspace root
         result = agent.process_query(user_message, workspace_root=workspace_root)
 
         # Debug logging: show what agent returned
-        if os.environ.get("GAIA_API_DEBUG") == "1":
+        if _api_debug_enabled():
             logger.debug("=" * 80)
             logger.debug("📤 AGENT RESPONSE (NON-STREAMING)")
             logger.debug("=" * 80)
             logger.debug(f"Result type: {type(result)}")
             logger.debug(
-                f"Result keys: {list(result.keys()) if isinstance(result, dict) else 'N/A'}"
+                "Result key count: %s",
+                len(result.keys()) if isinstance(result, dict) else "N/A",
             )
             logger.debug(
                 f"Status: {result.get('status') if isinstance(result, dict) else 'N/A'}"
@@ -307,12 +315,16 @@ async def create_chat_completion(request: ChatCompletionRequest):
             logger.debug(
                 f"Steps taken: {result.get('steps_taken') if isinstance(result, dict) else 'N/A'}"
             )
-            result_preview = (
-                str(result.get("result", ""))[:200]
+            result_length = (
+                len(str(result.get("result", "")))
                 if isinstance(result, dict)
-                else str(result)[:200]
+                else len(str(result))
             )
-            logger.debug(f"Result preview: {result_preview}...")
+            logger.debug(
+                "Result preview: %s (%d chars)",
+                _REDACTED_LOG_VALUE,
+                result_length,
+            )
             logger.debug("=" * 80)
 
         # Extract content from result
@@ -373,7 +385,7 @@ async def create_sse_stream(
         data: [DONE]
     """
     # Debug logging - FIRST LINE to confirm generator starts
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug("🎬 Generator started! Client is consuming the stream.")
 
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
@@ -393,12 +405,12 @@ async def create_sse_stream(
             }
         ],
     }
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug(f"📤 Sending first chunk: {json.dumps(first_chunk)}")
     yield f"data: {json.dumps(first_chunk)}\n\n"
 
     # Debug logging
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug("🔄 Starting agent query processing in thread pool...")
 
     # Process query in thread pool to avoid blocking event loop
@@ -427,7 +439,7 @@ async def create_sse_stream(
                     # Check if this event should be streamed to client
                     if not output_handler.should_stream_as_content(event_type):
                         # Still log it in debug mode
-                        if os.environ.get("GAIA_API_DEBUG") == "1":
+                        if _api_debug_enabled():
                             logger.debug(f"📝 Skipping event: {event_type}")
                         continue
 
@@ -452,9 +464,12 @@ async def create_sse_stream(
                         ],
                     }
 
-                    if os.environ.get("GAIA_API_DEBUG") == "1":
+                    if _api_debug_enabled():
                         logger.debug(
-                            f"📤 Streaming event: {event_type} -> {content_text[:100]}"
+                            "📤 Streaming event: %s -> %s (%d chars)",
+                            event_type,
+                            _REDACTED_LOG_VALUE,
+                            len(content_text),
                         )
 
                     yield f"data: {json.dumps(content_chunk)}\n\n"
@@ -498,13 +513,14 @@ async def create_sse_stream(
                 yield f"data: {json.dumps(content_chunk)}\n\n"
 
         # Debug logging: show what agent returned
-        if os.environ.get("GAIA_API_DEBUG") == "1":
+        if _api_debug_enabled():
             logger.debug("=" * 80)
             logger.debug("📤 AGENT RESPONSE (STREAMING)")
             logger.debug("=" * 80)
             logger.debug(f"Result type: {type(result)}")
             logger.debug(
-                f"Result keys: {list(result.keys()) if isinstance(result, dict) else 'N/A'}"
+                "Result key count: %s",
+                len(result.keys()) if isinstance(result, dict) else "N/A",
             )
             logger.debug(
                 f"Status: {result.get('status') if isinstance(result, dict) else 'N/A'}"
@@ -512,12 +528,16 @@ async def create_sse_stream(
             logger.debug(
                 f"Steps taken: {result.get('steps_taken') if isinstance(result, dict) else 'N/A'}"
             )
-            result_preview = (
-                str(result.get("result", ""))[:200]
+            result_length = (
+                len(str(result.get("result", "")))
                 if isinstance(result, dict)
-                else str(result)[:200]
+                else len(str(result))
             )
-            logger.debug(f"Result preview: {result_preview}...")
+            logger.debug(
+                "Result preview: %s (%d chars)",
+                _REDACTED_LOG_VALUE,
+                result_length,
+            )
             logger.debug("=" * 80)
 
     except Exception as e:
@@ -533,12 +553,12 @@ async def create_sse_stream(
         "model": model,
         "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
     }
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug("📤 Sending final chunk with finish_reason=stop")
     yield f"data: {json.dumps(final_chunk)}\n\n"
 
     # Done marker
-    if os.environ.get("GAIA_API_DEBUG") == "1":
+    if _api_debug_enabled():
         logger.debug("✅ SSE stream complete. Sending [DONE] marker.")
     yield "data: [DONE]\n\n"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ Test coverage includes:
 """
 
 import json
+import logging
 import time
 
 import pytest
@@ -142,6 +143,69 @@ class TestApiUnitValidation:
         assert response.status_code == 200, response.text
         call_args, _ = fake_agent.process_query.call_args
         assert call_args[0] == "second question"
+
+    def test_debug_logging_redacts_chat_request_content(
+        self, mocker, monkeypatch, caplog
+    ):
+        """Debug logs should keep request shape without persisting secrets."""
+        monkeypatch.setenv("GAIA_API_DEBUG", "1")
+        caplog.set_level(logging.DEBUG, logger="gaia.api.openai_server")
+
+        fake_agent = mocker.MagicMock()
+        fake_agent.process_query.return_value = {
+            "status": "success",
+            "result": "assistant secret response",
+        }
+
+        from gaia.api.openai_server import registry as server_registry
+
+        mocker.patch.object(server_registry, "get_agent", return_value=fake_agent)
+
+        prompt = (
+            "<workspace_info>\n"
+            "I am working in a workspace with the following folders:\n"
+            "- /Users/alice/private-project\n"
+            "</workspace_info>\n"
+            "Please summarize customer-secret-token-123"
+        )
+        response = self.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gaia-code",
+                "messages": [{"role": "user", "content": prompt}],
+                "stream": False,
+                "temperature": 0.2,
+            },
+            headers={"Authorization": "Bearer api-secret-token"},
+        )
+
+        assert response.status_code == 200, response.text
+        logs = caplog.text
+        assert "authorization" in logs
+        assert "Bearer api-secret-token" not in logs
+        assert "customer-secret-token-123" not in logs
+        assert "/Users/alice/private-project" not in logs
+        assert "assistant secret response" not in logs
+        assert "[redacted]" in logs
+
+    def test_debug_logging_redacts_non_chat_body(self, monkeypatch, caplog):
+        """Raw request logging must not persist decoded bodies."""
+        monkeypatch.setenv("GAIA_API_DEBUG", "1")
+        caplog.set_level(logging.DEBUG, logger="gaia.api.openai_server")
+
+        response = self.client.post(
+            "/health",
+            json={"refresh_token": "rt-secret", "prompt": "private prompt"},
+            headers={"X-Api-Key": "key-secret"},
+        )
+
+        assert response.status_code == 405
+        logs = caplog.text
+        assert "x-api-key" in logs
+        assert "key-secret" not in logs
+        assert "rt-secret" not in logs
+        assert "private prompt" not in logs
+        assert "Body (decoded UTF-8): [redacted]" in logs
 
     # -------------------------------------------------------------------------
     # Model Validation Tests


### PR DESCRIPTION
## Summary
- redact header values and request bodies in `GAIA_API_DEBUG` logs
- replace chat prompt, workspace path, response, and streaming content previews with shape/length summaries
- add regressions for chat prompt/header redaction and non-chat body redaction

## Why
`GAIA_API_DEBUG=1` previously wrote header values, decoded request bodies, chat message previews, workspace roots, and response previews to logs. That made debug logs risky to share or persist.

## Validation
- `.venv/bin/python -m pytest tests/test_api.py::TestApiUnitValidation` - 25 passed