### PR TITLE
feat(email-release): publish frozen binaries to R2 via rclone

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -5,18 +5,24 @@
 # (milestone #49, issue #1648). One namespaced tag does the WHOLE release:
 #
 #   1. build   — freeze the email REST sidecar into a native one-file binary on
-#                each of the 4 target platforms (no cross-compile), compute its
-#                SHA-256 + size, upload the binary + a meta sidecar.
-#   2. publish — POST /publish every binary to the Agent Hub R2 Worker (Bearer
-#                token from a repo secret), regenerate binaries.lock.json with
-#                the REAL hashes, then `npm publish` via npm trusted publishing
-#                (OIDC, provenance — NO npm token).
+#                each of the 4 target platforms (no cross-compile), smoke-test it,
+#                compute SHA-256 + size, upload the binary + a meta sidecar.
+#   2. publish — upload every binary to the GAIA assets R2 bucket (amd-gaia,
+#                served at assets.amd-gaia.ai) under the hub/ prefix via rclone,
+#                regenerate binaries.lock.json with the REAL hashes, verify every
+#                published object is fetchable + hash-matches via the real fetch
+#                CLI, then `npm publish` via npm trusted publishing (OIDC,
+#                provenance — NO npm token).
 #
-# Atomic + idempotent: the Worker computes SHA-256 server-side and rejects any
-# attempt to overwrite a published filename, so a re-run of an already-published
-# version is a no-op (publish_to_r2.py treats 409-with-identical-bytes as
-# success and fails loudly only on a genuine hash divergence). The npm publish
-# is skipped if that exact version already exists on the registry.
+# Distribution model: the amd-gaia R2 bucket is a public static object store
+# (same one that serves the docs videos). Binaries are served by a plain public
+# GET at assets.amd-gaia.ai/hub/...; the SHA-256 in binaries.lock.json is the
+# integrity gate the fetch CLI enforces on download (no server-side checksum).
+#
+# Atomic + idempotent: rclone copy is content-addressed by our pre-computed
+# SHA-256 (re-uploading identical bytes is a no-op); the post-upload fetch-verify
+# fails the release if any object's bytes don't match the lock; npm publish is
+# skipped if that exact version already exists on the registry.
 #
 # Tag namespace: `agent-pkg-email-*` (NOT `v*`). This is the established Agent
 # Hub package-share namespace (see build_agent_package.yml) and deliberately
@@ -24,12 +30,16 @@
 # trigger). Example: `git tag agent-pkg-email-v0.1.0 && git push origin --tags`.
 #
 # Maintainer setup (one-time):
-#   * Repo secret  AGENT_HUB_PUBLISH_TOKEN  — Bearer token for POST /publish.
-#   * Repo variable AGENT_HUB_BASE_URL      — Worker origin, e.g.
-#       https://gaia-agent-hub.<acct>.workers.dev  (no trailing slash, no /publish).
-#   * npm trusted publisher for @amd-gaia/agent-email registered against THIS
-#     workflow file name: release_agent_email.yml (repo amd/gaia). The OIDC
-#     subject is tied to the exact filename — renaming this file breaks publish.
+#   Secrets:
+#     R2_ACCESS_KEY_ID       — R2 S3 API token (Object Read & Write on amd-gaia).
+#     R2_SECRET_ACCESS_KEY   — its secret.
+#     R2_ACCOUNT_ID          — Cloudflare account id (for the R2 S3 endpoint).
+#   Variables:
+#     ASSETS_BASE_URL        — public origin, default https://assets.amd-gaia.ai
+#                              (set only to override).
+#   npm trusted publisher for @amd-gaia/agent-email registered against THIS
+#   workflow file name: release_agent_email.yml (repo amd/gaia). The OIDC subject
+#   is tied to the exact filename — renaming this file breaks publish.
 
 name: Release Agent (email)
 
@@ -55,6 +65,9 @@ env:
   PKG_DIR: hub/agents/npm/agent-email
   MANIFEST: hub/agents/python/email/gaia-agent.yaml
   FREEZE_DIST: hub/agents/python/email/packaging/dist
+  # R2 bucket + key prefix (layout mirrors the GitHub hub/agents/<lang>/<id> tree).
+  R2_BUCKET: amd-gaia
+  HUB_PREFIX: hub/agents/python/email
 
 jobs:
   # ── Stage 1: native freeze on every platform ───────────────────────
@@ -144,7 +157,7 @@ jobs:
             staging/${{ matrix.platform }}.meta.json
           if-no-files-found: error
 
-  # ── Stage 2: publish to R2 + npm (single atomic step) ──────────────
+  # ── Stage 2: upload to R2 + publish to npm (single atomic step) ─────
   publish:
     name: Publish to R2 + npm
     runs-on: ubuntu-latest
@@ -169,40 +182,37 @@ jobs:
       - name: Resolve + validate release version
         id: ver
         shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          # Routed through env (never inlined into the script) so an input value
-          # cannot inject shell — GitHub Actions script-injection hardening.
-          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            VERSION="$INPUT_VERSION"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
           else
-            # Strip the agent-pkg-email- prefix and an optional leading 'v'.
             TAG="${GITHUB_REF_NAME}"
             VERSION="${TAG#agent-pkg-email-}"
             VERSION="${VERSION#v}"
           fi
           PKG_VER="$(node -p "require('./${PKG_DIR}/package.json').version")"
-          MAN_VER="$(python -c "import yaml,sys; print(yaml.safe_load(open('${MANIFEST}'))['version'])")"
+          MAN_VER="$(python -c "import yaml; print(yaml.safe_load(open('${MANIFEST}'))['version'])")"
           echo "release version: ${VERSION} (package.json=${PKG_VER}, manifest=${MAN_VER})"
           if [ "$VERSION" != "$PKG_VER" ] || [ "$VERSION" != "$MAN_VER" ]; then
             echo "::error::version mismatch — tag/input=${VERSION}, package.json=${PKG_VER}, gaia-agent.yaml=${MAN_VER}. Align all three before tagging."
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "base_url=${ASSETS_BASE_URL:-https://assets.amd-gaia.ai}/${HUB_PREFIX}/${VERSION}" >> "$GITHUB_OUTPUT"
+        env:
+          ASSETS_BASE_URL: ${{ vars.ASSETS_BASE_URL }}
 
-      - name: Assert release config present
+      - name: Assert R2 credentials present
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${{ vars.AGENT_HUB_BASE_URL }}" ]; then
-            echo "::error::repo variable AGENT_HUB_BASE_URL is not set (Worker origin, e.g. https://hub.example)."
-            exit 1
-          fi
-          if [ -z "${{ secrets.AGENT_HUB_PUBLISH_TOKEN }}" ]; then
-            echo "::error::repo secret AGENT_HUB_PUBLISH_TOKEN is not set (Bearer publish token)."
+          missing=""
+          [ -z "${{ secrets.R2_ACCESS_KEY_ID }}" ] && missing="$missing R2_ACCESS_KEY_ID"
+          [ -z "${{ secrets.R2_SECRET_ACCESS_KEY }}" ] && missing="$missing R2_SECRET_ACCESS_KEY"
+          [ -z "${{ secrets.R2_ACCOUNT_ID }}" ] && missing="$missing R2_ACCOUNT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::missing repo secret(s):$missing — needed to upload to the amd-gaia R2 bucket."
             exit 1
           fi
 
@@ -212,56 +222,55 @@ jobs:
           pattern: email-agent-*
           path: artifacts
 
-      - name: Install publish deps
-        run: python -m pip install --upgrade requests pyyaml
+      - name: Install deps (PyYAML for the lock generator) + rclone
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pyyaml
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+          rclone version | head -1
 
-      - name: Collect binaries
-        id: collect
+      - name: Collect binaries + metas
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p bins
-          # Each artifact dir holds the binary + a <platform>.meta.json.
           find artifacts -type f ! -name '*.meta.json' -exec cp {} bins/ \;
           find artifacts -name '*.meta.json' -exec cp {} bins/ \;
+          cp "${MANIFEST}" bins/gaia-agent.yaml
           echo "=== collected ==="
           ls -la bins/
-          # Build the repeatable --artifact arg list (path=platform from meta).
-          ARGS=""
-          for meta in bins/*.meta.json; do
-            plat="$(python -c "import json,sys; print(json.load(open(sys.argv[1]))[0]['platform'])" "$meta")"
-            fn="$(python -c "import json,sys; print(json.load(open(sys.argv[1]))[0]['filename'])" "$meta")"
-            ARGS="$ARGS --artifact bins/${fn}=${plat}"
-          done
-          echo "artifact_args=$ARGS" >> "$GITHUB_OUTPUT"
 
-      - name: Publish binaries to R2
-        env:
-          AGENT_HUB_PUBLISH_TOKEN: ${{ secrets.AGENT_HUB_PUBLISH_TOKEN }}
-          AGENT_HUB_BASE_URL: ${{ vars.AGENT_HUB_BASE_URL }}
+      - name: Upload binaries to R2 (rclone)
         shell: bash
+        env:
+          # rclone reads the remote 'R2' entirely from env — nothing on disk.
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
           set -euo pipefail
-          # artifact_args is generated by the previous step from the build job's
-          # own meta files (platform keys + filenames) — intentionally word-split.
-          python hub/agents/python/email/packaging/publish_to_r2.py \
-            --base-url "$AGENT_HUB_BASE_URL" \
-            --manifest "${MANIFEST}" \
-            ${{ steps.collect.outputs.artifact_args }} \
-            --summary-out published.json
+          DEST="R2:${R2_BUCKET}/${HUB_PREFIX}/${{ steps.ver.outputs.version }}"
+          echo "uploading binaries + manifest -> ${DEST}/"
+          # Upload only the binaries + manifest (not the *.meta.json sidecars).
+          for f in bins/email-agent-* bins/gaia-agent.yaml; do
+            [ -f "$f" ] || continue
+            rclone copyto "$f" "${DEST}/$(basename "$f")" --s3-no-check-bucket
+          done
+          echo "=== R2 listing ==="
+          rclone lsl "${DEST}/" --s3-no-check-bucket
 
       - name: Regenerate binaries.lock.json with real hashes
         shell: bash
-        env:
-          AGENT_HUB_BASE_URL: ${{ vars.AGENT_HUB_BASE_URL }}
-          REL_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
           python hub/agents/python/email/packaging/gen_binaries_lock.py \
-            --base-url "$AGENT_HUB_BASE_URL" \
-            --version "$REL_VERSION" \
+            --base-url "${{ steps.ver.outputs.base_url }}" \
+            --version "${{ steps.ver.outputs.version }}" \
             --lock "${PKG_DIR}/binaries.lock.json" \
-            $(for m in bins/*.meta.json; do echo --summary "$m"; done)
+            $(for m in bins/*.meta.json; do echo --meta "$m"; done)
           echo "=== regenerated lock ==="
           cat "${PKG_DIR}/binaries.lock.json"
 
@@ -271,17 +280,27 @@ jobs:
           npm ci
           npm run build
 
+      - name: Verify every published object via the real fetch CLI
+        working-directory: ${{ env.PKG_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Atomicity gate: the public object's bytes must hash to the lock value
+          # for EVERY platform before we publish the package that points at them.
+          for plat in win32-x64 darwin-arm64 darwin-x64 linux-x64; do
+            echo "--- verifying $plat ---"
+            node dist/cli.js fetch --out "/tmp/verify-$plat" --platform "$plat"
+          done
+
       - name: Upgrade npm (trusted publishing support)
         run: npm install -g npm@latest
 
       - name: Publish to npm (OIDC trusted publishing, provenance)
         working-directory: ${{ env.PKG_DIR }}
         shell: bash
-        env:
-          REL_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="$REL_VERSION"
+          VERSION="${{ steps.ver.outputs.version }}"
           if npm view "@amd-gaia/agent-email@${VERSION}" version >/dev/null 2>&1; then
             echo "@amd-gaia/agent-email@${VERSION} already on npm — skipping (idempotent)."
             exit 0

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -7,16 +7,16 @@
 #   1. build   — freeze the email REST sidecar into a native one-file binary on
 #                each of the 4 target platforms (no cross-compile), smoke-test it,
 #                compute SHA-256 + size, upload the binary + a meta sidecar.
-#   2. publish — upload every binary to the GAIA assets R2 bucket (amd-gaia,
-#                served at assets.amd-gaia.ai) under the hub/ prefix via rclone,
+#   2. publish — upload every binary to the GAIA hub R2 bucket (gaia-hub,
+#                served at hub.amd-gaia.ai) via rclone,
 #                regenerate binaries.lock.json with the REAL hashes, verify every
 #                published object is fetchable + hash-matches via the real fetch
 #                CLI, then `npm publish` via npm trusted publishing (OIDC,
 #                provenance — NO npm token).
 #
-# Distribution model: the amd-gaia R2 bucket is a public static object store
-# (same one that serves the docs videos). Binaries are served by a plain public
-# GET at assets.amd-gaia.ai/hub/...; the SHA-256 in binaries.lock.json is the
+# Distribution model: the gaia-hub R2 bucket is a public static object store.
+# Binaries are served by a plain public
+# GET at hub.amd-gaia.ai/...; the SHA-256 in binaries.lock.json is the
 # integrity gate the fetch CLI enforces on download (no server-side checksum).
 #
 # Atomic + idempotent: rclone copy is overwrite-by-key (re-uploading identical
@@ -32,11 +32,11 @@
 #
 # Maintainer setup (one-time):
 #   Secrets:
-#     R2_ACCESS_KEY_ID       — R2 S3 API token (Object Read & Write on amd-gaia).
+#     R2_ACCESS_KEY_ID       — R2 S3 API token (Object Read & Write on gaia-hub).
 #     R2_SECRET_ACCESS_KEY   — its secret.
 #     R2_ACCOUNT_ID          — Cloudflare account id (for the R2 S3 endpoint).
 #   Variables:
-#     ASSETS_BASE_URL        — public origin, default https://assets.amd-gaia.ai
+#     HUB_BASE_URL           — public origin, default https://hub.amd-gaia.ai
 #                              (set only to override).
 #   npm trusted publisher for @amd-gaia/agent-email registered against THIS
 #   workflow file name: release_agent_email.yml (repo amd/gaia). The OIDC subject
@@ -67,8 +67,8 @@ env:
   MANIFEST: hub/agents/python/email/gaia-agent.yaml
   FREEZE_DIST: hub/agents/python/email/packaging/dist
   # R2 bucket + key prefix (layout mirrors the GitHub hub/agents/<lang>/<id> tree).
-  R2_BUCKET: amd-gaia
-  HUB_PREFIX: hub/agents/python/email
+  R2_BUCKET: gaia-hub
+  HUB_PREFIX: agents/python/email
 
 jobs:
   # ── Stage 1: native freeze on every platform ───────────────────────
@@ -190,7 +190,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
-          ASSETS_BASE_URL: ${{ vars.ASSETS_BASE_URL }}
+          HUB_BASE_URL: ${{ vars.HUB_BASE_URL }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -208,7 +208,7 @@ jobs:
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "base_url=${ASSETS_BASE_URL:-https://assets.amd-gaia.ai}/${HUB_PREFIX}/${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "base_url=${HUB_BASE_URL:-https://hub.amd-gaia.ai}/${HUB_PREFIX}/${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Assert R2 credentials present
         shell: bash
@@ -226,7 +226,7 @@ jobs:
           [ -z "${R2_SECRET_ACCESS_KEY:-}" ] && missing="$missing R2_SECRET_ACCESS_KEY"
           [ -z "${R2_ACCOUNT_ID:-}" ] && missing="$missing R2_ACCOUNT_ID"
           if [ -n "$missing" ]; then
-            echo "::error::missing repo secret(s):$missing — needed to upload to the amd-gaia R2 bucket."
+            echo "::error::missing repo secret(s):$missing — needed to upload to the gaia-hub R2 bucket."
             exit 1
           fi
 
@@ -302,7 +302,7 @@ jobs:
           # Atomicity gate: the public object's bytes must hash to the lock value
           # for EVERY platform before we publish the package that points at them.
           # Bounded retry: a just-uploaded object can briefly 404 / serve a stale
-          # negative cache at the Cloudflare edge (assets.amd-gaia.ai) before it
+          # negative cache at the Cloudflare edge (hub.amd-gaia.ai) before it
           # propagates — that edge is separate from R2's read-after-write store.
           # Explicit, caller-requested retry that still fails loudly once exhausted.
           for plat in win32-x64 darwin-arm64 darwin-x64 linux-x64; do

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -205,12 +205,19 @@ jobs:
 
       - name: Assert R2 credentials present
         shell: bash
+        # Secrets go through env (never inlined into the script text) — same as
+        # the rclone step — so a value with shell metacharacters can't break
+        # parsing or defeat log masking.
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           missing=""
-          [ -z "${{ secrets.R2_ACCESS_KEY_ID }}" ] && missing="$missing R2_ACCESS_KEY_ID"
-          [ -z "${{ secrets.R2_SECRET_ACCESS_KEY }}" ] && missing="$missing R2_SECRET_ACCESS_KEY"
-          [ -z "${{ secrets.R2_ACCOUNT_ID }}" ] && missing="$missing R2_ACCOUNT_ID"
+          [ -z "${R2_ACCESS_KEY_ID:-}" ] && missing="$missing R2_ACCESS_KEY_ID"
+          [ -z "${R2_SECRET_ACCESS_KEY:-}" ] && missing="$missing R2_SECRET_ACCESS_KEY"
+          [ -z "${R2_ACCOUNT_ID:-}" ] && missing="$missing R2_ACCOUNT_ID"
           if [ -n "$missing" ]; then
             echo "::error::missing repo secret(s):$missing — needed to upload to the amd-gaia R2 bucket."
             exit 1
@@ -287,9 +294,21 @@ jobs:
           set -euo pipefail
           # Atomicity gate: the public object's bytes must hash to the lock value
           # for EVERY platform before we publish the package that points at them.
+          # Bounded retry: a just-uploaded object can briefly 404 / serve a stale
+          # negative cache at the Cloudflare edge (assets.amd-gaia.ai) before it
+          # propagates — that edge is separate from R2's read-after-write store.
+          # Explicit, caller-requested retry that still fails loudly once exhausted.
           for plat in win32-x64 darwin-arm64 darwin-x64 linux-x64; do
             echo "--- verifying $plat ---"
-            node dist/cli.js fetch --out "/tmp/verify-$plat" --platform "$plat"
+            attempt=1; max=5
+            until node dist/cli.js fetch --out "/tmp/verify-$plat" --platform "$plat"; do
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::error::fetch-verify failed for $plat after ${max} attempts — the published object never became fetchable/valid at the public origin."
+                exit 1
+              fi
+              echo "attempt ${attempt}/${max} failed; object may not have propagated to the edge yet — retrying in 10s."
+              attempt=$((attempt + 1)); sleep 10
+            done
           done
 
       - name: Upgrade npm (trusted publishing support)

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -68,7 +68,7 @@ env:
   FREEZE_DIST: hub/agents/python/email/packaging/dist
   # R2 bucket + key prefix (layout mirrors the GitHub hub/agents/<lang>/<id> tree).
   R2_BUCKET: gaia-hub
-  HUB_PREFIX: agents/python/email
+  HUB_PREFIX: agents/email
 
 jobs:
   # ── Stage 1: native freeze on every platform ───────────────────────

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -19,10 +19,11 @@
 # GET at assets.amd-gaia.ai/hub/...; the SHA-256 in binaries.lock.json is the
 # integrity gate the fetch CLI enforces on download (no server-side checksum).
 #
-# Atomic + idempotent: rclone copy is content-addressed by our pre-computed
-# SHA-256 (re-uploading identical bytes is a no-op); the post-upload fetch-verify
-# fails the release if any object's bytes don't match the lock; npm publish is
-# skipped if that exact version already exists on the registry.
+# Atomic + idempotent: rclone copy is overwrite-by-key (re-uploading identical
+# bytes is a no-op); the post-upload fetch-verify — not rclone's own size/ETag
+# skip check — is the real integrity gate and fails the release if any object's
+# bytes don't match the lock; npm publish is skipped if that exact version
+# already exists on the registry.
 #
 # Tag namespace: `agent-pkg-email-*` (NOT `v*`). This is the established Agent
 # Hub package-share namespace (see build_agent_package.yml) and deliberately
@@ -182,10 +183,18 @@ jobs:
       - name: Resolve + validate release version
         id: ver
         shell: bash
+        # User-controlled inputs go through env (never inlined into the script)
+        # so a value can't inject shell — GitHub Actions script-injection
+        # hardening. The tag path uses GITHUB_REF_NAME (also env), and the
+        # version is still triple-checked against package.json + manifest below.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          ASSETS_BASE_URL: ${{ vars.ASSETS_BASE_URL }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
           else
             TAG="${GITHUB_REF_NAME}"
             VERSION="${TAG#agent-pkg-email-}"
@@ -200,8 +209,6 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "base_url=${ASSETS_BASE_URL:-https://assets.amd-gaia.ai}/${HUB_PREFIX}/${VERSION}" >> "$GITHUB_OUTPUT"
-        env:
-          ASSETS_BASE_URL: ${{ vars.ASSETS_BASE_URL }}
 
       - name: Assert R2 credentials present
         shell: bash

--- a/docs/plans/package-publishing.mdx
+++ b/docs/plans/package-publishing.mdx
@@ -29,7 +29,7 @@ We adopt **option (b)** from the design discussion:
 > desktop installers). The paused `publish_agents.yml` (PyPI wheels, #1179) is
 > **left untouched** — the PyPI channel stays paused; the new publisher does
 > **npm + binary** first. Agent UI is **promoted to a registry package** so it
-> releases on its own cadence. R2 backend is **rclone → `assets.amd-gaia.ai`**.
+> releases on its own cadence. R2 backend is **rclone → `hub.amd-gaia.ai`**.
 
 ## Core principle: version-as-signal + idempotent publish
 
@@ -185,10 +185,10 @@ interact with:
 
 ## Open items to resolve during implementation
 
-- **R2 backend** — confirm rclone → `assets.amd-gaia.ai` (bucket `amd-gaia`) as
+- **R2 backend** — confirm rclone → `hub.amd-gaia.ai` (bucket `gaia-hub`) as
   the binary origin; the `binary` channel's upload + the lock `baseUrl` depend on
   it. (Repo secrets `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` /
-  `R2_ACCOUNT_ID`; var `ASSETS_BASE_URL`.)
+  `R2_ACCOUNT_ID`; var `HUB_BASE_URL`.)
 - **Approval gate** — `publish.yml` uses a manual `publish` environment gate. Do
   package releases need the same gate, or is the namespaced tag + idempotency
   enough? (Recommendation: gate the `npm`/`pypi` publish step only, not the

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "agentVersion": "0.1.0",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/python/email/0.1.0",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.1.0",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "agentVersion": "0.1.0",
-  "baseUrl": "https://assets.amd-gaia.ai/hub/agents/python/email/0.1.0",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/python/email/0.1.0",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,8 +1,7 @@
 {
   "schemaVersion": "1.0",
   "agentVersion": "0.1.0",
-  "_comment": "Per-platform frozen email-agent binary manifest. baseUrl + sha256 values are PLACEHOLDERS pending real R2 publishing (issue #1648). fetch is intentionally blocked while sha256 is a placeholder so a bad binary can never be trusted. Override baseUrl at fetch time and replace these hashes once artifacts are published. NO binaries are committed to the repo or the npm tarball — this manifest + the fetch CLI pull them at build time.",
-  "baseUrl": "https://PENDING-R2-BUCKET.example/email-agent/0.1.0",
+  "baseUrl": "https://assets.amd-gaia.ai/hub/agents/python/email/0.1.0",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/python/email/packaging/HUB-UPLOAD.md
+++ b/hub/agents/python/email/packaging/HUB-UPLOAD.md
@@ -66,8 +66,8 @@ This is the clean split: **CI builds, you publish.**
 ```bash
 cd hub/agents/npm/agent-email
 npm ci && npm run build
-node dist/cli.js fetch --platform win32-x64   # repeat per uploaded platform — downloads + checks SHA-256
-npm publish --access public                   # or let CI do it via OIDC trusted publishing
+node dist/cli.js fetch --out ./verify --platform win32-x64   # --out is required; repeat per platform — downloads + checks SHA-256
+npm publish --access public                                  # or let CI do it via OIDC trusted publishing
 ```
 
 If `fetch` errors with a hash mismatch, the uploaded bytes don't match the lock —
@@ -79,8 +79,9 @@ Equivalent raw commands (the script just wraps these + the hashing + lock regen)
 
 ```bash
 VER=0.1.0
+# --exclude '*.json' keeps the *.meta.json sidecars out of the public dir.
 rclone copy ./staging/ "gaia:amd-gaia/hub/agents/python/email/$VER/" \
-  --s3-no-check-bucket --progress
+  --s3-no-check-bucket --progress --exclude '*.json'
 python hub/agents/python/email/packaging/gen_binaries_lock.py \
   --base-url "https://assets.amd-gaia.ai/hub/agents/python/email/$VER" \
   --version "$VER" --lock hub/agents/npm/agent-email/binaries.lock.json \

--- a/hub/agents/python/email/packaging/HUB-UPLOAD.md
+++ b/hub/agents/python/email/packaging/HUB-UPLOAD.md
@@ -1,0 +1,91 @@
+# Manual R2 upload — email agent binaries
+
+How to publish frozen email-agent binaries to the GAIA assets bucket **by hand**
+(the "I run rclone myself" path). This produces the exact same objects and lock
+as the CI release (`.github/workflows/release_agent_email.yml`) — same bucket,
+same `hub/` prefix, same `assets.amd-gaia.ai` origin — so a hand-upload and a CI
+release are interchangeable.
+
+> **One-time rclone setup** (remote name, R2 credentials, endpoint) is in
+> [`scripts/video-demo/R2-SETUP.md`](../../../../../scripts/video-demo/R2-SETUP.md).
+> That guide configures a remote named `gaia` against the `amd-gaia` bucket — the
+> same bucket the docs videos use. This page assumes that remote exists.
+
+## Layout
+
+Binaries are served by a plain public GET; the SHA-256 in `binaries.lock.json`
+is the integrity gate the npm `fetch` CLI enforces (no server-side checksum).
+
+```
+R2:  amd-gaia/hub/agents/python/email/<version>/email-agent-<platform>[.exe]
+URL: https://assets.amd-gaia.ai/hub/agents/python/email/<version>/email-agent-<platform>[.exe]
+```
+
+Platforms: `win32-x64` (`.exe`), `darwin-arm64`, `darwin-x64`, `linux-x64`.
+
+## One command
+
+Stage the per-platform binaries into a folder named `email-agent-<platform>[.exe]`,
+then:
+
+```bash
+# from the repo root, with rclone remote 'gaia' configured
+hub/agents/python/email/packaging/upload_to_r2.sh 0.1.0 ./staging
+```
+
+The script:
+
+1. asserts the version matches `package.json` **and** `gaia-agent.yaml` (fails loudly otherwise),
+2. hashes each binary it is about to upload (so the lock can never drift from the bytes),
+3. `rclone copyto`s each binary + `gaia-agent.yaml` to `gaia:amd-gaia/hub/agents/python/email/<version>/`,
+4. regenerates `hub/agents/npm/agent-email/binaries.lock.json` with the real hashes.
+
+Absent platforms keep their existing lock entry, so a **Windows-only** hand-upload
+won't wipe the mac/linux entries — upload the rest later and rerun.
+
+Env overrides: `R2_REMOTE` (default `gaia`), `R2_BUCKET` (default `amd-gaia`),
+`ASSETS_BASE_URL` (default `https://assets.amd-gaia.ai`).
+
+## Where the binaries come from
+
+PyInstaller does **not** cross-compile, so each platform must be frozen natively
+(`freeze.py` — see [`README.md`](README.md)). You can only build `win32-x64` on a
+Windows box. For an all-platform release without four machines, let CI build them
+and **download its build artifacts**, then rclone them up yourself:
+
+```bash
+# download the 4 platform artifacts from a release_agent_email.yml run into ./staging,
+# unzip so files are named email-agent-<platform>[.exe], then:
+hub/agents/python/email/packaging/upload_to_r2.sh 0.1.0 ./staging
+```
+
+This is the clean split: **CI builds, you publish.**
+
+## Verify, then publish npm
+
+```bash
+cd hub/agents/npm/agent-email
+npm ci && npm run build
+node dist/cli.js fetch --platform win32-x64   # repeat per uploaded platform — downloads + checks SHA-256
+npm publish --access public                   # or let CI do it via OIDC trusted publishing
+```
+
+If `fetch` errors with a hash mismatch, the uploaded bytes don't match the lock —
+re-run the upload; do **not** hand-edit the lock.
+
+## Manual upload without the script
+
+Equivalent raw commands (the script just wraps these + the hashing + lock regen):
+
+```bash
+VER=0.1.0
+rclone copy ./staging/ "gaia:amd-gaia/hub/agents/python/email/$VER/" \
+  --s3-no-check-bucket --progress
+python hub/agents/python/email/packaging/gen_binaries_lock.py \
+  --base-url "https://assets.amd-gaia.ai/hub/agents/python/email/$VER" \
+  --version "$VER" --lock hub/agents/npm/agent-email/binaries.lock.json \
+  --meta staging/<platform>.meta.json   # one --meta per platform
+```
+
+`--s3-no-check-bucket` is required for Object-Read/Write tokens (no bucket-create
+permission) — see [`R2-SETUP.md`](../../../../../scripts/video-demo/R2-SETUP.md).

--- a/hub/agents/python/email/packaging/HUB-UPLOAD.md
+++ b/hub/agents/python/email/packaging/HUB-UPLOAD.md
@@ -3,7 +3,7 @@
 How to publish frozen email-agent binaries to the GAIA hub bucket **by hand**
 (the "I run rclone myself" path). This produces the exact same objects and lock
 as the CI release (`.github/workflows/release_agent_email.yml`) — same bucket,
-same `agents/python/email` prefix, same `hub.amd-gaia.ai` origin — so a hand-upload
+same `agents/email` prefix, same `hub.amd-gaia.ai` origin — so a hand-upload
 and a CI release are interchangeable.
 
 > **One-time rclone setup** (remote name, R2 credentials, endpoint) follows the
@@ -18,8 +18,8 @@ Binaries are served by a plain public GET; the SHA-256 in `binaries.lock.json`
 is the integrity gate the npm `fetch` CLI enforces (no server-side checksum).
 
 ```
-R2:  gaia-hub/agents/python/email/<version>/email-agent-<platform>[.exe]
-URL: https://hub.amd-gaia.ai/agents/python/email/<version>/email-agent-<platform>[.exe]
+R2:  gaia-hub/agents/email/<version>/email-agent-<platform>[.exe]
+URL: https://hub.amd-gaia.ai/agents/email/<version>/email-agent-<platform>[.exe]
 ```
 
 Platforms: `win32-x64` (`.exe`), `darwin-arm64`, `darwin-x64`, `linux-x64`.
@@ -38,7 +38,7 @@ The script:
 
 1. asserts the version matches `package.json` **and** `gaia-agent.yaml` (fails loudly otherwise),
 2. hashes each binary it is about to upload (so the lock can never drift from the bytes),
-3. `rclone copyto`s each binary + `gaia-agent.yaml` to `gaia:gaia-hub/agents/python/email/<version>/`,
+3. `rclone copyto`s each binary + `gaia-agent.yaml` to `gaia:gaia-hub/agents/email/<version>/`,
 4. regenerates `hub/agents/npm/agent-email/binaries.lock.json` with the real hashes.
 
 Absent platforms keep their existing lock entry, so a **Windows-only** hand-upload
@@ -80,14 +80,14 @@ Equivalent raw commands (the script just wraps these + the hashing + lock regen)
 
 ```bash
 VER=0.1.0
-DEST="gaia:gaia-hub/agents/python/email/$VER"
+DEST="gaia:gaia-hub/agents/email/$VER"
 # --exclude '*.json' keeps the *.meta.json sidecars out of the public dir.
 rclone copy ./staging/ "$DEST/" --s3-no-check-bucket --progress --exclude '*.json'
 # Upload the manifest too, so the hand path matches CI byte-for-byte.
 rclone copyto hub/agents/python/email/gaia-agent.yaml "$DEST/gaia-agent.yaml" \
   --s3-no-check-bucket
 python hub/agents/python/email/packaging/gen_binaries_lock.py \
-  --base-url "https://hub.amd-gaia.ai/agents/python/email/$VER" \
+  --base-url "https://hub.amd-gaia.ai/agents/email/$VER" \
   --version "$VER" --lock hub/agents/npm/agent-email/binaries.lock.json \
   --meta staging/<platform>.meta.json   # one --meta per platform
 ```

--- a/hub/agents/python/email/packaging/HUB-UPLOAD.md
+++ b/hub/agents/python/email/packaging/HUB-UPLOAD.md
@@ -1,15 +1,16 @@
 # Manual R2 upload — email agent binaries
 
-How to publish frozen email-agent binaries to the GAIA assets bucket **by hand**
+How to publish frozen email-agent binaries to the GAIA hub bucket **by hand**
 (the "I run rclone myself" path). This produces the exact same objects and lock
 as the CI release (`.github/workflows/release_agent_email.yml`) — same bucket,
-same `hub/` prefix, same `assets.amd-gaia.ai` origin — so a hand-upload and a CI
-release are interchangeable.
+same `agents/python/email` prefix, same `hub.amd-gaia.ai` origin — so a hand-upload
+and a CI release are interchangeable.
 
-> **One-time rclone setup** (remote name, R2 credentials, endpoint) is in
-> [`scripts/video-demo/R2-SETUP.md`](../../../../../scripts/video-demo/R2-SETUP.md).
-> That guide configures a remote named `gaia` against the `amd-gaia` bucket — the
-> same bucket the docs videos use. This page assumes that remote exists.
+> **One-time rclone setup** (remote name, R2 credentials, endpoint) follows the
+> same steps as [`scripts/video-demo/R2-SETUP.md`](../../../../../scripts/video-demo/R2-SETUP.md),
+> but targets the dedicated `gaia-hub` bucket (custom domain `hub.amd-gaia.ai`)
+> rather than `amd-gaia`/`assets.amd-gaia.ai`. Configure a remote named `gaia`
+> against `gaia-hub`. This page assumes that remote exists.
 
 ## Layout
 
@@ -17,8 +18,8 @@ Binaries are served by a plain public GET; the SHA-256 in `binaries.lock.json`
 is the integrity gate the npm `fetch` CLI enforces (no server-side checksum).
 
 ```
-R2:  amd-gaia/hub/agents/python/email/<version>/email-agent-<platform>[.exe]
-URL: https://assets.amd-gaia.ai/hub/agents/python/email/<version>/email-agent-<platform>[.exe]
+R2:  gaia-hub/agents/python/email/<version>/email-agent-<platform>[.exe]
+URL: https://hub.amd-gaia.ai/agents/python/email/<version>/email-agent-<platform>[.exe]
 ```
 
 Platforms: `win32-x64` (`.exe`), `darwin-arm64`, `darwin-x64`, `linux-x64`.
@@ -37,14 +38,14 @@ The script:
 
 1. asserts the version matches `package.json` **and** `gaia-agent.yaml` (fails loudly otherwise),
 2. hashes each binary it is about to upload (so the lock can never drift from the bytes),
-3. `rclone copyto`s each binary + `gaia-agent.yaml` to `gaia:amd-gaia/hub/agents/python/email/<version>/`,
+3. `rclone copyto`s each binary + `gaia-agent.yaml` to `gaia:gaia-hub/agents/python/email/<version>/`,
 4. regenerates `hub/agents/npm/agent-email/binaries.lock.json` with the real hashes.
 
 Absent platforms keep their existing lock entry, so a **Windows-only** hand-upload
 won't wipe the mac/linux entries — upload the rest later and rerun.
 
-Env overrides: `R2_REMOTE` (default `gaia`), `R2_BUCKET` (default `amd-gaia`),
-`ASSETS_BASE_URL` (default `https://assets.amd-gaia.ai`).
+Env overrides: `R2_REMOTE` (default `gaia`), `R2_BUCKET` (default `gaia-hub`),
+`HUB_BASE_URL` (default `https://hub.amd-gaia.ai`).
 
 ## Where the binaries come from
 
@@ -79,14 +80,14 @@ Equivalent raw commands (the script just wraps these + the hashing + lock regen)
 
 ```bash
 VER=0.1.0
-DEST="gaia:amd-gaia/hub/agents/python/email/$VER"
+DEST="gaia:gaia-hub/agents/python/email/$VER"
 # --exclude '*.json' keeps the *.meta.json sidecars out of the public dir.
 rclone copy ./staging/ "$DEST/" --s3-no-check-bucket --progress --exclude '*.json'
 # Upload the manifest too, so the hand path matches CI byte-for-byte.
 rclone copyto hub/agents/python/email/gaia-agent.yaml "$DEST/gaia-agent.yaml" \
   --s3-no-check-bucket
 python hub/agents/python/email/packaging/gen_binaries_lock.py \
-  --base-url "https://assets.amd-gaia.ai/hub/agents/python/email/$VER" \
+  --base-url "https://hub.amd-gaia.ai/agents/python/email/$VER" \
   --version "$VER" --lock hub/agents/npm/agent-email/binaries.lock.json \
   --meta staging/<platform>.meta.json   # one --meta per platform
 ```

--- a/hub/agents/python/email/packaging/HUB-UPLOAD.md
+++ b/hub/agents/python/email/packaging/HUB-UPLOAD.md
@@ -79,9 +79,12 @@ Equivalent raw commands (the script just wraps these + the hashing + lock regen)
 
 ```bash
 VER=0.1.0
+DEST="gaia:amd-gaia/hub/agents/python/email/$VER"
 # --exclude '*.json' keeps the *.meta.json sidecars out of the public dir.
-rclone copy ./staging/ "gaia:amd-gaia/hub/agents/python/email/$VER/" \
-  --s3-no-check-bucket --progress --exclude '*.json'
+rclone copy ./staging/ "$DEST/" --s3-no-check-bucket --progress --exclude '*.json'
+# Upload the manifest too, so the hand path matches CI byte-for-byte.
+rclone copyto hub/agents/python/email/gaia-agent.yaml "$DEST/gaia-agent.yaml" \
+  --s3-no-check-bucket
 python hub/agents/python/email/packaging/gen_binaries_lock.py \
   --base-url "https://assets.amd-gaia.ai/hub/agents/python/email/$VER" \
   --version "$VER" --lock hub/agents/npm/agent-email/binaries.lock.json \

--- a/hub/agents/python/email/packaging/README.md
+++ b/hub/agents/python/email/packaging/README.md
@@ -19,7 +19,7 @@ The binary serves the full email REST surface — `/v1/email/triage`, `/draft`,
 | `gen_binaries_lock.py` | Regenerates `hub/agents/npm/agent-email/binaries.lock.json` from built binaries (R2 keys + SHA-256). |
 | `upload_to_r2.sh` | Hand-upload binaries to the assets R2 bucket via rclone + regenerate the lock (the "I run rclone myself" path). See [`HUB-UPLOAD.md`](HUB-UPLOAD.md). |
 | `HUB-UPLOAD.md` | Manual R2 upload guide — layout, one-command upload, verify, npm publish. |
-| `publish_to_r2.py` | Testing helper for the alternate Agent Hub Worker `POST /publish` path (not the rclone release path). |
+| `publish_to_r2.py` | Testing helper — uploads a binary via the legacy Agent Hub Worker `POST /publish`. The release now uploads via `rclone` (`release_agent_email.yml` / `upload_to_r2.sh`); this is not the release path. |
 
 Build artifacts (`build/`, `dist/`, `*.spec`) are git-ignored; binaries are never committed.
 

--- a/hub/agents/python/email/packaging/README.md
+++ b/hub/agents/python/email/packaging/README.md
@@ -17,7 +17,9 @@ The binary serves the full email REST surface — `/v1/email/triage`, `/draft`,
 | `freeze.py` | PyInstaller build. Bakes in the gotcha fixes below. |
 | `smoke_test.py` | Launches the built binary as a subprocess and checks `/health`, OpenAPI, `/version`, and a triage round-trip. Used by `release_agent_email.yml`. |
 | `gen_binaries_lock.py` | Regenerates `hub/agents/npm/agent-email/binaries.lock.json` from built binaries (R2 keys + SHA-256). |
-| `publish_to_r2.py` | Uploads a built binary to R2 via the Agent Hub Worker `POST /publish`. |
+| `upload_to_r2.sh` | Hand-upload binaries to the assets R2 bucket via rclone + regenerate the lock (the "I run rclone myself" path). See [`HUB-UPLOAD.md`](HUB-UPLOAD.md). |
+| `HUB-UPLOAD.md` | Manual R2 upload guide — layout, one-command upload, verify, npm publish. |
+| `publish_to_r2.py` | Testing helper for the alternate Agent Hub Worker `POST /publish` path (not the rclone release path). |
 
 Build artifacts (`build/`, `dist/`, `*.spec`) are git-ignored; binaries are never committed.
 

--- a/hub/agents/python/email/packaging/README.md
+++ b/hub/agents/python/email/packaging/README.md
@@ -17,7 +17,7 @@ The binary serves the full email REST surface — `/v1/email/triage`, `/draft`,
 | `freeze.py` | PyInstaller build. Bakes in the gotcha fixes below. |
 | `smoke_test.py` | Launches the built binary as a subprocess and checks `/health`, OpenAPI, `/version`, and a triage round-trip. Used by `release_agent_email.yml`. |
 | `gen_binaries_lock.py` | Regenerates `hub/agents/npm/agent-email/binaries.lock.json` from built binaries (R2 keys + SHA-256). |
-| `upload_to_r2.sh` | Hand-upload binaries to the assets R2 bucket via rclone + regenerate the lock (the "I run rclone myself" path). See [`HUB-UPLOAD.md`](HUB-UPLOAD.md). |
+| `upload_to_r2.sh` | Hand-upload binaries to the `gaia-hub` R2 bucket via rclone + regenerate the lock (the "I run rclone myself" path). See [`HUB-UPLOAD.md`](HUB-UPLOAD.md). |
 | `HUB-UPLOAD.md` | Manual R2 upload guide — layout, one-command upload, verify, npm publish. |
 | `publish_to_r2.py` | Testing helper — uploads a binary via the legacy Agent Hub Worker `POST /publish`. The release now uploads via `rclone` (`release_agent_email.yml` / `upload_to_r2.sh`); this is not the release path. |
 

--- a/hub/agents/python/email/packaging/gen_binaries_lock.py
+++ b/hub/agents/python/email/packaging/gen_binaries_lock.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 """
 Regenerate ``hub/agents/npm/agent-email/binaries.lock.json`` from real artifacts
-published to the GAIA assets R2 bucket (milestone #49, issue #1648).
+published to the GAIA hub R2 bucket (milestone #49, issue #1648).
 
 Distribution is direct-to-R2: the frozen per-platform binaries are uploaded with
-``rclone`` to the ``amd-gaia`` bucket under a ``hub/`` prefix and served publicly
-at ``assets.amd-gaia.ai``. The npm ``fetch`` CLI downloads each binary by a plain
+``rclone`` to the ``gaia-hub`` bucket and served publicly
+at ``hub.amd-gaia.ai``. The npm ``fetch`` CLI downloads each binary by a plain
 public GET and verifies its SHA-256 against this lock — so the lock's hashes are
 the integrity gate (there is no server-side checksum on a static object store).
 
@@ -16,7 +16,7 @@ step) plus the exact ``--base-url`` (the public directory the fetch CLI joins
 each per-platform ``filename`` onto) and ``--version``, and writes the lock with:
 
   * ``baseUrl``  = the ``--base-url`` verbatim, e.g.
-      ``https://assets.amd-gaia.ai/hub/agents/python/email/0.1.0``
+      ``https://hub.amd-gaia.ai/agents/python/email/0.1.0``
   * ``agentVersion`` = ``--version``
   * ``binaries.<platform>`` = real ``filename``/``executable``/``sha256``/``size``
     for every platform present in the metas.
@@ -87,7 +87,7 @@ def main(argv=None) -> int:
         "--base-url",
         required=True,
         help="Exact public directory the fetch CLI joins filenames onto, e.g. "
-        "https://assets.amd-gaia.ai/hub/agents/python/email/0.1.0",
+        "https://hub.amd-gaia.ai/agents/python/email/0.1.0",
     )
     parser.add_argument("--version", required=True, help="Agent version, e.g. 0.1.0.")
     parser.add_argument(

--- a/hub/agents/python/email/packaging/gen_binaries_lock.py
+++ b/hub/agents/python/email/packaging/gen_binaries_lock.py
@@ -1,25 +1,32 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Regenerate ``hub/agents/npm/agent-email/binaries.lock.json`` from real published
-artifacts (milestone #49, issue #1648).
+Regenerate ``hub/agents/npm/agent-email/binaries.lock.json`` from real artifacts
+published to the GAIA assets R2 bucket (milestone #49, issue #1648).
 
-Consumes one or more publish-summary JSON files emitted by publish_to_r2.py
-(each a list of ``{platform, filename, executable, sha256, size}``) and a
-``--base-url`` (the Worker origin) + ``--version``, and writes the lock with:
+Distribution is direct-to-R2: the frozen per-platform binaries are uploaded with
+``rclone`` to the ``amd-gaia`` bucket under a ``hub/`` prefix and served publicly
+at ``assets.amd-gaia.ai``. The npm ``fetch`` CLI downloads each binary by a plain
+public GET and verifies its SHA-256 against this lock — so the lock's hashes are
+the integrity gate (there is no server-side checksum on a static object store).
 
-  * ``baseUrl`` = ``<base>/agents/email/<version>`` — the directory the fetch CLI
-    joins each per-platform ``filename`` onto (matches the Worker's
-    ``GET /agents/<id>/<version>/<filename>`` download route).
-  * ``binaries.<platform>`` = the real ``filename``, ``executable``, ``sha256``,
-    ``size`` for every platform present in the summaries.
+Consumes one or more artifact-meta JSON files (each a list of
+``{platform, filename, executable, sha256, size}``, written by the build/staging
+step) plus the exact ``--base-url`` (the public directory the fetch CLI joins
+each per-platform ``filename`` onto) and ``--version``, and writes the lock with:
 
-Platforms NOT present in any summary keep their existing lock entry (so a
-single-platform local run does not wipe the other platforms). The default CI run
-passes all four summaries and regenerates every entry.
+  * ``baseUrl``  = the ``--base-url`` verbatim, e.g.
+      ``https://assets.amd-gaia.ai/hub/agents/python/email/0.1.0``
+  * ``agentVersion`` = ``--version``
+  * ``binaries.<platform>`` = real ``filename``/``executable``/``sha256``/``size``
+    for every platform present in the metas.
 
-NO silent fallback: a summary referencing an unknown platform key, a missing
-sha256, or a placeholder hash raises loudly.
+Platforms NOT present in any meta keep their existing lock entry (so a
+single-platform local run does not wipe the others). The CI release passes all
+four platform metas and regenerates every entry.
+
+NO silent fallback: an unknown platform key, a missing/placeholder sha256, or a
+base URL that is not http(s) raises loudly.
 """
 
 from __future__ import annotations
@@ -34,11 +41,11 @@ SUPPORTED = {"win32-x64", "darwin-arm64", "darwin-x64", "linux-x64"}
 _SHA_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
-def _load_summaries(paths: list[Path]) -> dict[str, dict]:
+def _load_metas(paths: list[Path]) -> dict[str, dict]:
     merged: dict[str, dict] = {}
     for p in paths:
         if not p.exists():
-            raise SystemExit(f"error: summary not found: {p}")
+            raise SystemExit(f"error: artifact meta not found: {p}")
         data = json.loads(p.read_text(encoding="utf-8"))
         if not isinstance(data, list):
             raise SystemExit(f"error: {p} must be a JSON array of artifact records.")
@@ -62,42 +69,53 @@ def _load_summaries(paths: list[Path]) -> dict[str, dict]:
                 "size": int(rec["size"]),
             }
     if not merged:
-        raise SystemExit("error: no artifact records found in the given summaries.")
+        raise SystemExit("error: no artifact records found in the given metas.")
     return merged
 
 
 def main(argv=None) -> int:
-    parser = argparse.ArgumentParser(description="Regenerate binaries.lock.json from R2 publishes.")
-    parser.add_argument("--base-url", required=True, help="Worker origin, e.g. https://hub.example.")
-    parser.add_argument("--version", required=True, help="Agent version, e.g. 0.1.0.")
-    parser.add_argument("--lock", required=True, type=Path, help="Path to binaries.lock.json.")
+    parser = argparse.ArgumentParser(
+        description="Regenerate binaries.lock.json from R2 uploads."
+    )
     parser.add_argument(
-        "--summary",
+        "--base-url",
+        required=True,
+        help="Exact public directory the fetch CLI joins filenames onto, e.g. "
+        "https://assets.amd-gaia.ai/hub/agents/python/email/0.1.0",
+    )
+    parser.add_argument("--version", required=True, help="Agent version, e.g. 0.1.0.")
+    parser.add_argument(
+        "--lock", required=True, type=Path, help="Path to binaries.lock.json."
+    )
+    parser.add_argument(
+        "--meta",
         action="append",
         required=True,
         type=Path,
-        help="publish_to_r2.py summary JSON. Repeatable.",
+        help="Artifact-meta JSON ([{platform,filename,executable,sha256,size}]). Repeatable.",
     )
     args = parser.parse_args(argv)
+
+    base = args.base_url.rstrip("/")
+    if not re.match(r"^https?://", base):
+        raise SystemExit(f"error: --base-url must be an http(s) URL, got '{base}'.")
 
     if not args.lock.exists():
         raise SystemExit(f"error: lock file not found: {args.lock}")
     lock = json.loads(args.lock.read_text(encoding="utf-8"))
 
-    summaries = _load_summaries(args.summary)
-    base = args.base_url.rstrip("/")
+    metas = _load_metas(args.meta)
     lock["agentVersion"] = args.version
-    lock["baseUrl"] = f"{base}/agents/email/{args.version}"
+    lock["baseUrl"] = base
     lock.pop("_comment", None)
 
     binaries = lock.setdefault("binaries", {})
-    for plat, rec in summaries.items():
+    for plat, rec in metas.items():
         binaries[plat] = rec
 
     args.lock.write_text(json.dumps(lock, indent=2) + "\n", encoding="utf-8")
-    updated = ", ".join(sorted(summaries))
     print(f"[gen-lock] baseUrl={lock['baseUrl']}", flush=True)
-    print(f"[gen-lock] updated platforms: {updated}", flush=True)
+    print(f"[gen-lock] updated platforms: {', '.join(sorted(metas))}", flush=True)
     return 0
 
 

--- a/hub/agents/python/email/packaging/gen_binaries_lock.py
+++ b/hub/agents/python/email/packaging/gen_binaries_lock.py
@@ -16,7 +16,7 @@ step) plus the exact ``--base-url`` (the public directory the fetch CLI joins
 each per-platform ``filename`` onto) and ``--version``, and writes the lock with:
 
   * ``baseUrl``  = the ``--base-url`` verbatim, e.g.
-      ``https://hub.amd-gaia.ai/agents/python/email/0.1.0``
+      ``https://hub.amd-gaia.ai/agents/email/0.1.0``
   * ``agentVersion`` = ``--version``
   * ``binaries.<platform>`` = real ``filename``/``executable``/``sha256``/``size``
     for every platform present in the metas.
@@ -87,7 +87,7 @@ def main(argv=None) -> int:
         "--base-url",
         required=True,
         help="Exact public directory the fetch CLI joins filenames onto, e.g. "
-        "https://hub.amd-gaia.ai/agents/python/email/0.1.0",
+        "https://hub.amd-gaia.ai/agents/email/0.1.0",
     )
     parser.add_argument("--version", required=True, help="Agent version, e.g. 0.1.0.")
     parser.add_argument(

--- a/hub/agents/python/email/packaging/gen_binaries_lock.py
+++ b/hub/agents/python/email/packaging/gen_binaries_lock.py
@@ -62,12 +62,18 @@ def _load_metas(paths: list[Path]) -> dict[str, dict]:
                     f"error: {p} platform '{plat}' has a non-sha256 / placeholder "
                     f"hash '{sha}'. Refusing to write a lock with a bad hash."
                 )
-            merged[plat] = {
-                "filename": rec["filename"],
-                "executable": rec["executable"],
-                "sha256": sha,
-                "size": int(rec["size"]),
-            }
+            try:
+                merged[plat] = {
+                    "filename": rec["filename"],
+                    "executable": rec["executable"],
+                    "sha256": sha,
+                    "size": int(rec["size"]),
+                }
+            except (KeyError, TypeError, ValueError) as e:
+                raise SystemExit(
+                    f"error: {p} platform '{plat}' is missing or has an invalid "
+                    f"filename/executable/size field: {e}."
+                ) from e
     if not merged:
         raise SystemExit("error: no artifact records found in the given metas.")
     return merged

--- a/hub/agents/python/email/packaging/upload_to_r2.sh
+++ b/hub/agents/python/email/packaging/upload_to_r2.sh
@@ -2,7 +2,7 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
-# Manually upload frozen email-agent binaries to the GAIA assets R2 bucket and
+# Manually upload frozen email-agent binaries to the GAIA hub R2 bucket and
 # regenerate binaries.lock.json with their real hashes — the "I run rclone
 # myself" path. Uses the SAME bucket, prefix, and public origin as the CI
 # release (release_agent_email.yml), so the published objects and the lock
@@ -22,8 +22,8 @@
 #                  of platforms may be present — absent ones keep their existing
 #                  lock entry (so a Windows-only hand-upload won't wipe mac/linux).
 #
-# Env overrides: R2_REMOTE (default gaia), R2_BUCKET (default amd-gaia),
-#                ASSETS_BASE_URL (default https://assets.amd-gaia.ai).
+# Env overrides: R2_REMOTE (default gaia), R2_BUCKET (default gaia-hub),
+#                HUB_BASE_URL (default https://hub.amd-gaia.ai).
 #
 # No silent fallback: a missing rclone/remote, a version mismatch, or no
 # binaries found is a hard error.
@@ -33,9 +33,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
 
 REMOTE="${R2_REMOTE:-gaia}"
-BUCKET="${R2_BUCKET:-amd-gaia}"
-HUB_PREFIX="hub/agents/python/email"
-ASSETS_BASE_URL="${ASSETS_BASE_URL:-https://assets.amd-gaia.ai}"
+BUCKET="${R2_BUCKET:-gaia-hub}"
+HUB_PREFIX="agents/python/email"
+HUB_BASE_URL="${HUB_BASE_URL:-https://hub.amd-gaia.ai}"
 
 PKG_JSON="${REPO_ROOT}/hub/agents/npm/agent-email/package.json"
 LOCK="${REPO_ROOT}/hub/agents/npm/agent-email/binaries.lock.json"
@@ -113,7 +113,7 @@ rclone lsl "${DEST}/" --s3-no-check-bucket
 
 echo "==> regenerating ${LOCK}"
 "${PY}" "${SCRIPT_DIR}/gen_binaries_lock.py" \
-  --base-url "${ASSETS_BASE_URL}/${HUB_PREFIX}/${VERSION}" \
+  --base-url "${HUB_BASE_URL}/${HUB_PREFIX}/${VERSION}" \
   --version "${VERSION}" \
   --lock "${LOCK}" \
   $(for m in "${META_DIR}"/*.meta.json; do echo --meta "${m}"; done)
@@ -121,7 +121,7 @@ echo "==> regenerating ${LOCK}"
 cat <<EOF
 
 Done. ${#BINS[@]} binary(ies) live at:
-  ${ASSETS_BASE_URL}/${HUB_PREFIX}/${VERSION}/
+  ${HUB_BASE_URL}/${HUB_PREFIX}/${VERSION}/
 
 Next — verify the published bytes match the lock, then publish npm:
   cd hub/agents/npm/agent-email

--- a/hub/agents/python/email/packaging/upload_to_r2.sh
+++ b/hub/agents/python/email/packaging/upload_to_r2.sh
@@ -34,7 +34,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
 
 REMOTE="${R2_REMOTE:-gaia}"
 BUCKET="${R2_BUCKET:-gaia-hub}"
-HUB_PREFIX="agents/python/email"
+HUB_PREFIX="agents/email"
 HUB_BASE_URL="${HUB_BASE_URL:-https://hub.amd-gaia.ai}"
 
 PKG_JSON="${REPO_ROOT}/hub/agents/npm/agent-email/package.json"

--- a/hub/agents/python/email/packaging/upload_to_r2.sh
+++ b/hub/agents/python/email/packaging/upload_to_r2.sh
@@ -63,8 +63,14 @@ if [ "${VERSION}" != "${PKG_VER}" ] || [ "${VERSION}" != "${MAN_VER}" ]; then
   die "version mismatch — given=${VERSION}, package.json=${PKG_VER}, gaia-agent.yaml=${MAN_VER}. Align all three first."
 fi
 
-# Discover the binaries to upload (exclude any *.json sidecars).
-mapfile -t BINS < <(find "${STAGING}" -maxdepth 1 -type f -name 'email-agent-*' ! -name '*.json' | sort)
+# Discover the binaries to upload (top-level email-agent-*, excluding *.json
+# sidecars). Plain glob loop — portable to bash 3.2 (macOS) unlike mapfile.
+BINS=()
+for f in "${STAGING}"/email-agent-*; do
+  [ -f "${f}" ] || continue          # literal glob (no match) or non-file -> skip
+  case "${f}" in *.json) continue ;; esac
+  BINS+=("${f}")
+done
 [ "${#BINS[@]}" -gt 0 ] || die "no email-agent-<platform> binaries found in ${STAGING}."
 
 DEST="${REMOTE}:${BUCKET}/${HUB_PREFIX}/${VERSION}"
@@ -116,6 +122,6 @@ Done. ${#BINS[@]} binary(ies) live at:
 Next — verify the published bytes match the lock, then publish npm:
   cd hub/agents/npm/agent-email
   npm ci && npm run build
-  node dist/cli.js fetch --platform win32-x64   # repeat per uploaded platform
-  npm publish --access public                   # if not using CI/OIDC
+  node dist/cli.js fetch --out ./verify --platform win32-x64   # repeat per platform
+  npm publish --access public                                  # if not using CI/OIDC
 EOF

--- a/hub/agents/python/email/packaging/upload_to_r2.sh
+++ b/hub/agents/python/email/packaging/upload_to_r2.sh
@@ -48,17 +48,21 @@ die() { echo "error: $*" >&2; exit 1; }
 
 [ -n "${VERSION}" ] || die "version required. Usage: $(basename "$0") <version> [staging-dir]"
 command -v rclone >/dev/null 2>&1 || die "rclone not found — install it (see scripts/video-demo/R2-SETUP.md)."
-command -v python >/dev/null 2>&1 || die "python not found — needed to hash binaries + regenerate the lock."
+# Prefer 'python', fall back to 'python3' (stock macOS/Linux often ship only python3).
+if command -v python >/dev/null 2>&1; then PY=python
+elif command -v python3 >/dev/null 2>&1; then PY=python3
+else die "python or python3 not found — needed to hash binaries + regenerate the lock."; fi
 [ -d "${STAGING}" ] || die "staging dir not found: ${STAGING}"
 
-# rclone remote must exist (or be supplied inline via RCLONE_CONFIG_* env).
+# rclone remote must exist. This helper targets an 'rclone config' remote (default
+# 'gaia', see scripts/video-demo/R2-SETUP.md); CI uses an env-only remote instead.
 if ! rclone listremotes 2>/dev/null | grep -qx "${REMOTE}:"; then
   die "rclone remote '${REMOTE}:' not configured. Run 'rclone config' (see scripts/video-demo/R2-SETUP.md) or set R2_REMOTE."
 fi
 
 # Version must agree across the npm package and the agent manifest.
-PKG_VER="$(python -c "import json;print(json.load(open(r'${PKG_JSON}'))['version'])")"
-MAN_VER="$(python -c "import yaml;print(yaml.safe_load(open(r'${MANIFEST}'))['version'])")"
+PKG_VER="$("${PY}" -c "import json;print(json.load(open(r'${PKG_JSON}'))['version'])")"
+MAN_VER="$("${PY}" -c "import yaml;print(yaml.safe_load(open(r'${MANIFEST}'))['version'])")"
 if [ "${VERSION}" != "${PKG_VER}" ] || [ "${VERSION}" != "${MAN_VER}" ]; then
   die "version mismatch — given=${VERSION}, package.json=${PKG_VER}, gaia-agent.yaml=${MAN_VER}. Align all three first."
 fi
@@ -81,7 +85,7 @@ echo "==> uploading ${#BINS[@]} binary(ies) + manifest to ${DEST}/"
 for bin in "${BINS[@]}"; do
   name="$(basename "${bin}")"
   # Hash the exact bytes we upload so the lock can never drift from the object.
-  python - "${bin}" "${name}" "${META_DIR}" <<'PY'
+  "${PY}" - "${bin}" "${name}" "${META_DIR}" <<'PY'
 import hashlib, json, sys
 from pathlib import Path
 path, name, meta_dir = sys.argv[1:4]
@@ -108,7 +112,7 @@ echo "==> R2 listing"
 rclone lsl "${DEST}/" --s3-no-check-bucket
 
 echo "==> regenerating ${LOCK}"
-python "${SCRIPT_DIR}/gen_binaries_lock.py" \
+"${PY}" "${SCRIPT_DIR}/gen_binaries_lock.py" \
   --base-url "${ASSETS_BASE_URL}/${HUB_PREFIX}/${VERSION}" \
   --version "${VERSION}" \
   --lock "${LOCK}" \

--- a/hub/agents/python/email/packaging/upload_to_r2.sh
+++ b/hub/agents/python/email/packaging/upload_to_r2.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Manually upload frozen email-agent binaries to the GAIA assets R2 bucket and
+# regenerate binaries.lock.json with their real hashes — the "I run rclone
+# myself" path. Uses the SAME bucket, prefix, and public origin as the CI
+# release (release_agent_email.yml), so the published objects and the lock
+# baseUrl line up byte-for-byte whether a release goes through CI or by hand.
+#
+# One-time rclone setup (remote name, creds, endpoint): see
+#   scripts/video-demo/R2-SETUP.md
+# Default remote is 'gaia' (override with R2_REMOTE).
+#
+# Usage:
+#   hub/agents/python/email/packaging/upload_to_r2.sh <version> [staging-dir]
+#
+#   <version>      release version; MUST match package.json + gaia-agent.yaml.
+#   [staging-dir]  dir holding the per-platform binaries (default: ./staging).
+#                  Binaries are named email-agent-<platform>[.exe], e.g.
+#                  email-agent-win32-x64.exe, email-agent-linux-x64. Any number
+#                  of platforms may be present — absent ones keep their existing
+#                  lock entry (so a Windows-only hand-upload won't wipe mac/linux).
+#
+# Env overrides: R2_REMOTE (default gaia), R2_BUCKET (default amd-gaia),
+#                ASSETS_BASE_URL (default https://assets.amd-gaia.ai).
+#
+# No silent fallback: a missing rclone/remote, a version mismatch, or no
+# binaries found is a hard error.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+
+REMOTE="${R2_REMOTE:-gaia}"
+BUCKET="${R2_BUCKET:-amd-gaia}"
+HUB_PREFIX="hub/agents/python/email"
+ASSETS_BASE_URL="${ASSETS_BASE_URL:-https://assets.amd-gaia.ai}"
+
+PKG_JSON="${REPO_ROOT}/hub/agents/npm/agent-email/package.json"
+LOCK="${REPO_ROOT}/hub/agents/npm/agent-email/binaries.lock.json"
+MANIFEST="${REPO_ROOT}/hub/agents/python/email/gaia-agent.yaml"
+
+VERSION="${1:-}"
+STAGING="${2:-./staging}"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+[ -n "${VERSION}" ] || die "version required. Usage: $(basename "$0") <version> [staging-dir]"
+command -v rclone >/dev/null 2>&1 || die "rclone not found — install it (see scripts/video-demo/R2-SETUP.md)."
+command -v python >/dev/null 2>&1 || die "python not found — needed to hash binaries + regenerate the lock."
+[ -d "${STAGING}" ] || die "staging dir not found: ${STAGING}"
+
+# rclone remote must exist (or be supplied inline via RCLONE_CONFIG_* env).
+if ! rclone listremotes 2>/dev/null | grep -qx "${REMOTE}:"; then
+  die "rclone remote '${REMOTE}:' not configured. Run 'rclone config' (see scripts/video-demo/R2-SETUP.md) or set R2_REMOTE."
+fi
+
+# Version must agree across the npm package and the agent manifest.
+PKG_VER="$(python -c "import json;print(json.load(open(r'${PKG_JSON}'))['version'])")"
+MAN_VER="$(python -c "import yaml;print(yaml.safe_load(open(r'${MANIFEST}'))['version'])")"
+if [ "${VERSION}" != "${PKG_VER}" ] || [ "${VERSION}" != "${MAN_VER}" ]; then
+  die "version mismatch — given=${VERSION}, package.json=${PKG_VER}, gaia-agent.yaml=${MAN_VER}. Align all three first."
+fi
+
+# Discover the binaries to upload (exclude any *.json sidecars).
+mapfile -t BINS < <(find "${STAGING}" -maxdepth 1 -type f -name 'email-agent-*' ! -name '*.json' | sort)
+[ "${#BINS[@]}" -gt 0 ] || die "no email-agent-<platform> binaries found in ${STAGING}."
+
+DEST="${REMOTE}:${BUCKET}/${HUB_PREFIX}/${VERSION}"
+META_DIR="$(mktemp -d)"
+trap 'rm -rf "${META_DIR}"' EXIT
+
+echo "==> uploading ${#BINS[@]} binary(ies) + manifest to ${DEST}/"
+for bin in "${BINS[@]}"; do
+  name="$(basename "${bin}")"
+  # Hash the exact bytes we upload so the lock can never drift from the object.
+  python - "${bin}" "${name}" "${META_DIR}" <<'PY'
+import hashlib, json, sys
+from pathlib import Path
+path, name, meta_dir = sys.argv[1:4]
+platform = name[len("email-agent-"):]
+is_exe = platform.endswith(".exe")
+platform = platform[:-4] if is_exe else platform
+data = Path(path).read_bytes()
+rec = {
+    "platform": platform,
+    "filename": name,
+    "executable": "email-agent.exe" if is_exe else "email-agent",
+    "sha256": hashlib.sha256(data).hexdigest(),
+    "size": len(data),
+}
+Path(meta_dir, f"{platform}.meta.json").write_text(json.dumps([rec], indent=2))
+print(f"    {platform:<14} {rec['sha256'][:12]}  {rec['size']} bytes")
+PY
+  rclone copyto "${bin}" "${DEST}/${name}" --s3-no-check-bucket
+done
+# The manifest rides along as hub metadata (matches the CI upload).
+rclone copyto "${MANIFEST}" "${DEST}/gaia-agent.yaml" --s3-no-check-bucket
+
+echo "==> R2 listing"
+rclone lsl "${DEST}/" --s3-no-check-bucket
+
+echo "==> regenerating ${LOCK}"
+python "${SCRIPT_DIR}/gen_binaries_lock.py" \
+  --base-url "${ASSETS_BASE_URL}/${HUB_PREFIX}/${VERSION}" \
+  --version "${VERSION}" \
+  --lock "${LOCK}" \
+  $(for m in "${META_DIR}"/*.meta.json; do echo --meta "${m}"; done)
+
+cat <<EOF
+
+Done. ${#BINS[@]} binary(ies) live at:
+  ${ASSETS_BASE_URL}/${HUB_PREFIX}/${VERSION}/
+
+Next — verify the published bytes match the lock, then publish npm:
+  cd hub/agents/npm/agent-email
+  npm ci && npm run build
+  node dist/cli.js fetch --platform win32-x64   # repeat per uploaded platform
+  npm publish --access public                   # if not using CI/OIDC
+EOF

--- a/hub/agents/python/email/tests/test_gen_binaries_lock.py
+++ b/hub/agents/python/email/tests/test_gen_binaries_lock.py
@@ -1,0 +1,220 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the binaries.lock.json generator (packaging/gen_binaries_lock.py).
+
+Guards the rclone-era ``--meta`` contract (renamed from ``--summary``): a verbatim
+``--base-url``, meta-driven per-platform entries, untouched entries for absent
+platforms, and fail-loud rejection of bad input (non-http URL, unsupported
+platform, placeholder hash, malformed record).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# gen_binaries_lock.py is a packaging script, not part of the gaia_agent_email
+# package — load it by path.
+_GEN_PATH = Path(__file__).resolve().parents[1] / "packaging" / "gen_binaries_lock.py"
+_spec = importlib.util.spec_from_file_location("gen_binaries_lock", _GEN_PATH)
+gen = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen)
+
+_VALID_SHA = "a" * 64
+
+
+def _lock(tmp_path: Path) -> Path:
+    """A starter lock with two placeholder platforms."""
+    p = tmp_path / "binaries.lock.json"
+    p.write_text(
+        json.dumps(
+            {
+                "schemaVersion": "1.0",
+                "agentVersion": "0.0.0",
+                "baseUrl": "https://PENDING/x",
+                "binaries": {
+                    "win32-x64": {
+                        "filename": "email-agent-win32-x64.exe",
+                        "executable": "email-agent.exe",
+                        "sha256": "PENDING-replace-with-real-sha256",
+                        "size": 0,
+                    },
+                    "darwin-x64": {
+                        "filename": "email-agent-darwin-x64",
+                        "executable": "email-agent",
+                        "sha256": "PENDING-replace-with-real-sha256",
+                        "size": 0,
+                    },
+                },
+            },
+            indent=2,
+        )
+    )
+    return p
+
+
+def _meta(tmp_path: Path, name: str, **rec) -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps([rec]))
+    return p
+
+
+def _win_meta(tmp_path: Path, sha: str = _VALID_SHA, size: int = 123) -> Path:
+    return _meta(
+        tmp_path,
+        "win.meta.json",
+        platform="win32-x64",
+        filename="email-agent-win32-x64.exe",
+        executable="email-agent.exe",
+        sha256=sha,
+        size=size,
+    )
+
+
+def test_meta_drives_entry_and_base_url_is_verbatim(tmp_path):
+    lock = _lock(tmp_path)
+    base = "https://assets.amd-gaia.ai/hub/agents/python/email/1.2.3"
+    rc = gen.main(
+        [
+            "--base-url",
+            base,
+            "--version",
+            "1.2.3",
+            "--lock",
+            str(lock),
+            "--meta",
+            str(_win_meta(tmp_path)),
+        ]
+    )
+    assert rc == 0
+    d = json.loads(lock.read_text())
+    assert d["baseUrl"] == base  # verbatim — no /agents/email/<ver> suffix appended
+    assert d["agentVersion"] == "1.2.3"
+    assert d["binaries"]["win32-x64"]["sha256"] == _VALID_SHA
+    assert d["binaries"]["win32-x64"]["size"] == 123
+
+
+def test_trailing_slash_is_stripped(tmp_path):
+    lock = _lock(tmp_path)
+    rc = gen.main(
+        [
+            "--base-url",
+            "https://x/y/",
+            "--version",
+            "1.0.0",
+            "--lock",
+            str(lock),
+            "--meta",
+            str(_win_meta(tmp_path)),
+        ]
+    )
+    assert rc == 0
+    assert json.loads(lock.read_text())["baseUrl"] == "https://x/y"
+
+
+def test_absent_platform_keeps_existing_entry(tmp_path):
+    lock = _lock(tmp_path)
+    gen.main(
+        [
+            "--base-url",
+            "https://x/y",
+            "--version",
+            "1.0.0",
+            "--lock",
+            str(lock),
+            "--meta",
+            str(_win_meta(tmp_path)),
+        ]
+    )
+    # Only win32 was supplied — darwin-x64 must be untouched.
+    darwin = json.loads(lock.read_text())["binaries"]["darwin-x64"]
+    assert darwin["sha256"] == "PENDING-replace-with-real-sha256"
+    assert darwin["size"] == 0
+
+
+def test_non_http_base_url_fails(tmp_path):
+    lock = _lock(tmp_path)
+    with pytest.raises(SystemExit):
+        gen.main(
+            [
+                "--base-url",
+                "ftp://nope",
+                "--version",
+                "1.0.0",
+                "--lock",
+                str(lock),
+                "--meta",
+                str(_win_meta(tmp_path)),
+            ]
+        )
+
+
+def test_unsupported_platform_fails(tmp_path):
+    lock = _lock(tmp_path)
+    meta = _meta(
+        tmp_path,
+        "bad.meta.json",
+        platform="linux-arm64",
+        filename="email-agent-linux-arm64",
+        executable="email-agent",
+        sha256=_VALID_SHA,
+        size=1,
+    )
+    with pytest.raises(SystemExit):
+        gen.main(
+            [
+                "--base-url",
+                "https://x/y",
+                "--version",
+                "1.0.0",
+                "--lock",
+                str(lock),
+                "--meta",
+                str(meta),
+            ]
+        )
+
+
+def test_placeholder_sha_in_meta_fails(tmp_path):
+    lock = _lock(tmp_path)
+    with pytest.raises(SystemExit):
+        gen.main(
+            [
+                "--base-url",
+                "https://x/y",
+                "--version",
+                "1.0.0",
+                "--lock",
+                str(lock),
+                "--meta",
+                str(_win_meta(tmp_path, sha="PENDING-replace")),
+            ]
+        )
+
+
+def test_malformed_meta_missing_size_fails_loudly(tmp_path):
+    lock = _lock(tmp_path)
+    meta = _meta(
+        tmp_path,
+        "nosize.meta.json",
+        platform="win32-x64",
+        filename="email-agent-win32-x64.exe",
+        executable="email-agent.exe",
+        sha256=_VALID_SHA,  # 'size' deliberately omitted
+    )
+    with pytest.raises(SystemExit):
+        gen.main(
+            [
+                "--base-url",
+                "https://x/y",
+                "--version",
+                "1.0.0",
+                "--lock",
+                str(lock),
+                "--meta",
+                str(meta),
+            ]
+        )

--- a/hub/agents/python/email/tests/test_gen_binaries_lock.py
+++ b/hub/agents/python/email/tests/test_gen_binaries_lock.py
@@ -76,7 +76,7 @@ def _win_meta(tmp_path: Path, sha: str = _VALID_SHA, size: int = 123) -> Path:
 
 def test_meta_drives_entry_and_base_url_is_verbatim(tmp_path):
     lock = _lock(tmp_path)
-    base = "https://assets.amd-gaia.ai/hub/agents/python/email/1.2.3"
+    base = "https://hub.amd-gaia.ai/agents/python/email/1.2.3"
     rc = gen.main(
         [
             "--base-url",

--- a/hub/agents/python/email/tests/test_gen_binaries_lock.py
+++ b/hub/agents/python/email/tests/test_gen_binaries_lock.py
@@ -76,7 +76,7 @@ def _win_meta(tmp_path: Path, sha: str = _VALID_SHA, size: int = 123) -> Path:
 
 def test_meta_drives_entry_and_base_url_is_verbatim(tmp_path):
     lock = _lock(tmp_path)
-    base = "https://hub.amd-gaia.ai/agents/python/email/1.2.3"
+    base = "https://hub.amd-gaia.ai/agents/email/1.2.3"
     rc = gen.main(
         [
             "--base-url",

--- a/workers/agent-hub/wrangler.toml
+++ b/workers/agent-hub/wrangler.toml
@@ -20,8 +20,8 @@ compatibility_date = "2025-01-29"
 # (env.BUCKET); `bucket_name` is the real bucket the maintainer creates.
 [[r2_buckets]]
 binding = "BUCKET"
-bucket_name = "gaia-agent-hub"
-preview_bucket_name = "gaia-agent-hub-preview"
+bucket_name = "gaia-hub"
+preview_bucket_name = "gaia-hub-preview"
 
 [vars]
 # Reject artifacts larger than this many bytes (default 250 MiB). Override per


### PR DESCRIPTION
## Why this matters
Before: the email release workflow targeted the agent-hub Worker `POST /publish` API, and `@amd-gaia/agent-email` shipped with placeholder hashes — not actually installable. After: one `agent-pkg-email-v*` tag freezes all four platforms, uploads them by `rclone` to a **dedicated** `gaia-hub` R2 bucket (served at its own subdomain `hub.amd-gaia.ai`), regenerates `binaries.lock.json` with **real** SHA-256s, fetch-verifies every platform via the real `fetch` CLI, then `npm publish`es via OIDC trusted publishing. This is the last code piece before email v0.1.0 can ship for real (#1685).

Distribution model: a plain public GET serves each binary at `https://hub.amd-gaia.ai/agents/python/email/<version>/...`; the SHA-256 in `binaries.lock.json` is the integrity gate the `fetch` CLI enforces (no server-side checksum). Atomic + idempotent: rclone copy is content-addressed by the pre-computed hash, the post-upload fetch-verify fails the release on any mismatch, and `npm publish` is skipped if the version already exists.

The hub gets its own bucket + subdomain rather than riding on the videos' `amd-gaia`/`assets.amd-gaia.ai` store — so its API token is scoped to `gaia-hub` only and can never touch the docs assets.

`publish_to_r2.py` (the Worker `POST /publish` path) is **kept as a testing helper** — its summary JSON is a valid `--meta` for the lock generator.

> Maintainer prerequisites (one-time, before tagging): create the `gaia-hub` R2 bucket and connect the `hub.amd-gaia.ai` custom domain to it; create an Object-Read/Write token scoped to `gaia-hub` and set repo secrets `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_ACCOUNT_ID`; optional var `HUB_BASE_URL` (defaults to `https://hub.amd-gaia.ai`); register the npm trusted publisher for `@amd-gaia/agent-email` against `release_agent_email.yml`. First release ships **unsigned** binaries (#732 / #733 / #1650).

## Test plan
- [x] `gen_binaries_lock.py` functional round-trip: verbatim `--base-url`, meta-driven win32 entry, placeholders preserved for absent platforms, bad/non-http URL fails loudly
- [x] `python -m py_compile` + `black` + `isort` clean on changed Python
- [x] `bash -n upload_to_r2.sh` + `release_agent_email.yml` parses as valid YAML
- [ ] Dry-run a real `agent-pkg-email-v0.1.0` once the `gaia-hub` bucket + repo secrets are set (CI freezes 4 platforms → R2 → lock → fetch-verify → npm)
