### PR TITLE
fix(agent-email): install pyyaml before the release version-resolve step

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -166,6 +166,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install publish deps
+        run: python -m pip install --upgrade requests pyyaml
+
       - name: Resolve + validate release version
         id: ver
         shell: bash
@@ -211,9 +214,6 @@ jobs:
         with:
           pattern: email-agent-*
           path: artifacts
-
-      - name: Install publish deps
-        run: python -m pip install --upgrade requests pyyaml
 
       - name: Collect binaries
         id: collect


### PR DESCRIPTION
## Why this matters

The tag-triggered email release (`release_agent_email.yml`) resolves the release version by reading `gaia-agent.yaml` with `python -c "import yaml"` in its **Resolve + validate release version** step — but `pyyaml` wasn't installed until the **Install publish deps** step several steps later. On a fresh `actions/setup-python` runner `pyyaml` isn't present, so the very first `agent-pkg-email-v*` tag would die at version resolution before publishing anything. This moves the install ahead of the step that imports it (`requests` installed a few steps early is harmless), so the first `@amd-gaia/agent-email` release can actually run.

This is the only code gap left before the first release — the rest of the email-packaging stack (npm client, freeze, packaging scripts, the release + npm-test workflows) is already on `main`.

## Test plan

- [ ] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release_agent_email.yml'))"` parses clean (verified locally).
- [ ] In the publish job, **Install publish deps** now precedes **Resolve + validate release version** (which runs `import yaml`).
- [ ] On the first `agent-pkg-email-v0.1.0` tag (after maintainer config: `AGENT_HUB_PUBLISH_TOKEN` secret + `AGENT_HUB_BASE_URL` var + npm trusted publisher), the version-resolve step succeeds instead of `ModuleNotFoundError: No module named 'yaml'`.