### PR TITLE
ci(email-release): approval gate + env-secret + Intel build/verify split

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -92,17 +92,17 @@ jobs:
   build:
     name: Freeze (${{ matrix.key }})
     runs-on: ${{ matrix.os }}
-    # darwin-x64 (Intel) is BEST-EFFORT, built on macos-15-intel. macos-13 was
-    # retired (Dec 2025); macos-15-intel is GitHub's recommended Intel image
-    # (supported through Aug 2027) and is a current GA standard runner, so it
-    # doesn't have macos-13's scarcity. We build on the OLDER supported macOS on
-    # purpose: a binary built there links a lower minimum-OS target and runs on a
-    # broader range of Macs. PyInstaller can't cross-compile, so an Intel binary
-    # needs an Intel host. The leg may fail/time out without failing the job
-    # (continue-on-error + required:false); `publish` gates only on the 3 REQUIRED
-    # platforms. A miss is announced LOUDLY (::warning:: + job summary) and Intel
-    # users still fail loudly at install (fetch.ts rejects a missing / placeholder
-    # lock entry) — explicit degradation, never a silent one.
+    # darwin-x64 (Intel) is BEST-EFFORT, built on macos-26-intel (the latest Intel
+    # image; macos-13 retired Dec 2025, Intel images supported through Aug 2027).
+    # TRADE-OFF: building on the newest macOS can raise the frozen binary's
+    # minimum-OS, so Intel-Mac users on older macOS may not be able to run it. If
+    # broad backward-compat matters more than a current toolchain, switch this to
+    # macos-15-intel (older OS → lower min-OS → runs on more Macs). PyInstaller
+    # can't cross-compile, so an Intel binary needs an Intel host. The leg may
+    # fail/time out without failing the job (continue-on-error + required:false);
+    # `publish` gates only on the 3 REQUIRED platforms. A miss is announced LOUDLY
+    # (::warning:: + job summary) and Intel users still fail loudly at install
+    # (fetch.ts rejects a missing / placeholder lock entry) — never silent.
     continue-on-error: ${{ !matrix.required }}
     timeout-minutes: ${{ matrix.required && 30 || 60 }}
     strategy:
@@ -130,7 +130,7 @@ jobs:
             frozen: email-agent
             required: true
           # darwin-x64 (Intel) BEST-EFFORT — see the job-level comment above.
-          - os: macos-15-intel
+          - os: macos-26-intel
             platform: darwin-x64
             key: darwin-x64
             artifact: email-agent-darwin-x64
@@ -199,11 +199,63 @@ jobs:
             staging/${{ matrix.platform }}.meta.json
           if-no-files-found: error
 
+  # ── Stage 1.5: prove the (macos-26-built) Intel binary runs on OLDER macOS ──
+  # We build darwin-x64 on the newest Intel image (macos-26) but must confirm the
+  # frozen binary still runs on an older macOS — backward-compat is the real risk
+  # (forward-compat is reliable). Best-effort, like the build leg: if darwin-x64
+  # wasn't built, this is a no-op; if it was built but FAILS here, `publish` drops
+  # it (ships 3 platforms) rather than shipping a binary broken on older Macs.
+  # continue-on-error so an Intel-runner hiccup can't block the whole release —
+  # `publish` only ships darwin-x64 when this explicitly reports ok=true.
+  verify-darwin-x64-compat:
+    name: Verify darwin-x64 on older macOS (macos-15-intel)
+    runs-on: macos-15-intel
+    needs: [build]
+    continue-on-error: true
+    timeout-minutes: 20
+    outputs:
+      ok: ${{ steps.smoke.outputs.ok }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Download the darwin-x64 binary (absent if its best-effort build skipped)
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: email-agent-darwin-x64
+          path: dl
+
+      - name: Smoke-test the macos-26-built binary on macOS 15
+        id: smoke
+        shell: bash
+        run: |
+          # NOT `-e`: a failed smoke test is captured into an output, not a job failure.
+          set -uo pipefail
+          BIN="dl/email-agent-darwin-x64"
+          if [ ! -f "$BIN" ]; then
+            echo "::notice::darwin-x64 binary absent — nothing to verify."
+            echo "ok=absent" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          chmod +x "$BIN"
+          if python hub/agents/python/email/packaging/smoke_test.py "$BIN"; then
+            echo "darwin-x64 binary (built on macos-26-intel) runs on macOS 15 ✓"
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::darwin-x64 binary (built on macos-26-intel) FAILED its smoke test on macOS 15 — it will be DROPPED from this release so older Intel Macs aren't shipped a broken binary. Build darwin-x64 on macos-15-intel for broader compatibility."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── Stage 2: publish to the hub + npm (single atomic step) ─────────
   publish:
     name: Publish to Hub + npm
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, verify-darwin-x64-compat]
     # Manual approval gate: the `agent-publish` environment is configured (repo
     # Settings → Environments) with required reviewers, so this job pauses until a
     # maintainer approves — the human backstop for an accidental/tampered release
@@ -302,6 +354,10 @@ jobs:
 
       - name: Collect binaries + assert required platforms present
         shell: bash
+        env:
+          # ok=true (built + verified on macOS 15) | false (built, failed on 15) |
+          # absent (not built) | "" (verify job errored — treat as not shippable).
+          DARWIN_X64_COMPAT: ${{ needs.verify-darwin-x64-compat.outputs.ok }}
         run: |
           set -euo pipefail
           # Only the platform binaries are needed — the manifest is read from its
@@ -323,21 +379,28 @@ jobs:
             exit 1
           fi
 
-          # darwin-x64 (Intel) is BEST-EFFORT. Announce its absence LOUDLY so the
-          # gap is visible in the run, not discovered later from a user bug report.
-          if [ -f "bins/email-agent-darwin-x64" ]; then
+          # darwin-x64 (Intel) is BEST-EFFORT. Ship it ONLY if it built AND passed
+          # the older-macOS (macos-15) compat check; otherwise drop it loudly and
+          # release the other 3 platforms.
+          if [ -f "bins/email-agent-darwin-x64" ] && [ "${DARWIN_X64_COMPAT:-}" = "true" ]; then
             echo "DARWIN_X64_PUBLISHED=true" >> "$GITHUB_ENV"
-            echo "darwin-x64 (Intel) binary present — full 4-platform release."
+            echo "darwin-x64 (Intel) binary present + verified on macOS 15 — full 4-platform release."
           else
             echo "DARWIN_X64_PUBLISHED=false" >> "$GITHUB_ENV"
-            echo "::warning::darwin-x64 (Intel macOS) binary is ABSENT — the Intel build leg (macos-15-intel) produced no artifact. Releasing the other 3 platforms; Intel-mac users will get a loud 'no binary for darwin-x64' error at install until a follow-up Intel build is published under this version."
+            rm -f bins/email-agent-darwin-x64   # never publish an absent/incompatible Intel binary
+            if [ "${DARWIN_X64_COMPAT:-}" = "false" ]; then
+              reason="built on macos-26-intel but FAILED its macOS 15 compat check"
+            else
+              reason="was not produced by its best-effort build (or its compat check could not run)"
+            fi
+            echo "::warning::darwin-x64 (Intel macOS) NOT published — it ${reason}. Releasing the other 3 platforms; Intel-mac users get a loud 'no binary for darwin-x64' error at install until an Intel binary is published for this version."
             {
               echo "### ⚠️ Intel macOS (darwin-x64) NOT published"
               echo ""
-              echo "The Intel build leg (\`macos-15-intel\`) produced no artifact, so this release ships **3 of 4** platforms."
+              echo "The darwin-x64 binary ${reason}, so this release ships **3 of 4** platforms."
               echo "Intel-mac (\`darwin-x64\`) users will hit a loud install error until an Intel binary is published for this version."
               echo ""
-              echo "**Follow-up:** re-run the \`build (darwin-x64)\` leg when Intel runner capacity frees up; the POST /publish endpoint is immutable-per-filename, so adding the Intel binary to the *same* version is safe and idempotent."
+              echo "**Follow-up:** re-run once the Intel binary builds + passes the macOS 15 check; \`POST /publish\` is immutable-per-filename, so adding the Intel binary to the *same* version is safe and idempotent."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -37,9 +37,11 @@
 #   Environment:
 #     agent-publish         — create this GitHub environment (Settings →
 #                              Environments) with REQUIRED REVIEWERS and its
-#                              deployment branch restricted to `main`. The publish
-#                              job is bound to it, so a release pauses for human
-#                              approval before any hub/npm publish.
+#                              deployment branches/tags restricted to `main` AND
+#                              the `agent-pkg-*` tag pattern (the release trigger
+#                              is a tag push, so a main-only rule blocks the gate).
+#                              The publish job is bound to it, so a release pauses
+#                              for human approval before any hub/npm publish.
 #   Secrets:
 #     GAIA_HUB_TOKEN         — Agent Hub Bearer publish token; must match an entry
 #                              in the Worker's PUBLISH_TOKENS secret, scoped to the
@@ -261,7 +263,9 @@ jobs:
     # maintainer approves — the human backstop for an accidental/tampered release
     # tag. GAIA_HUB_TOKEN lives as an ENVIRONMENT secret here, so the publish
     # credential isn't even readable until approval. (Set the env + reviewers +
-    # move the secret in repo settings; restrict the env's deployment branch to main.)
+    # move the secret in repo settings; restrict the env's deployment branches/tags
+    # to `main` + the `agent-pkg-*` tag pattern — the release is a tag push, so a
+    # main-only rule would block this gate.)
     environment: agent-publish
     permissions:
       contents: read
@@ -342,7 +346,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GAIA_HUB_TOKEN:-}" ]; then
-            echo "::error::missing repo secret GAIA_HUB_TOKEN — the Agent Hub Bearer publish token (must match the Worker's PUBLISH_TOKENS). See workers/agent-hub/README.md."
+            echo "::error::missing environment secret GAIA_HUB_TOKEN on the agent-publish environment — the Agent Hub Bearer publish token (must match the Worker's PUBLISH_TOKENS). See workers/agent-hub/README.md."
             exit 1
           fi
 

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -34,10 +34,19 @@
 # trigger). Example: `git tag agent-pkg-email-v0.1.0 && git push origin --tags`.
 #
 # Maintainer setup (one-time):
+#   Environment:
+#     agent-publish         — create this GitHub environment (Settings →
+#                              Environments) with REQUIRED REVIEWERS and its
+#                              deployment branch restricted to `main`. The publish
+#                              job is bound to it, so a release pauses for human
+#                              approval before any hub/npm publish.
 #   Secrets:
 #     GAIA_HUB_TOKEN         — Agent Hub Bearer publish token; must match an entry
 #                              in the Worker's PUBLISH_TOKENS secret, scoped to the
-#                              `AMD` author (workers/agent-hub/README.md).
+#                              `AMD` author (workers/agent-hub/README.md). Define it
+#                              as an ENVIRONMENT secret on `agent-publish` (NOT a
+#                              repo secret) so it's unreadable until the gate is
+#                              approved.
 #   Variables:
 #     GAIA_HUB_BASE_URL      — public Worker origin for downloads + the lock
 #                              baseUrl, default https://hub.amd-gaia.ai.
@@ -83,16 +92,17 @@ jobs:
   build:
     name: Freeze (${{ matrix.key }})
     runs-on: ${{ matrix.os }}
-    # darwin-x64 (Intel) is BEST-EFFORT, built on BOTH supported Intel images
-    # (macos-15-intel + macos-26-intel) for redundancy. macos-13 was retired
-    # (Dec 2025); these are GitHub's recommended Intel replacements (supported
-    # through Aug 2027). PyInstaller can't cross-compile, so an Intel binary
-    # needs an Intel host — we won't fake one. Either Intel leg may fail/time out
-    # without failing the job (continue-on-error + required:false); `publish`
-    # gates only on the 3 REQUIRED platforms and keeps whichever Intel binary
-    # arrived. A total Intel miss is announced LOUDLY (::warning:: + job summary)
-    # and Intel users still fail loudly at install (fetch.ts rejects a missing /
-    # placeholder lock entry) — explicit degradation, never a silent one.
+    # darwin-x64 (Intel) is BEST-EFFORT, built on macos-15-intel. macos-13 was
+    # retired (Dec 2025); macos-15-intel is GitHub's recommended Intel image
+    # (supported through Aug 2027) and is a current GA standard runner, so it
+    # doesn't have macos-13's scarcity. We build on the OLDER supported macOS on
+    # purpose: a binary built there links a lower minimum-OS target and runs on a
+    # broader range of Macs. PyInstaller can't cross-compile, so an Intel binary
+    # needs an Intel host. The leg may fail/time out without failing the job
+    # (continue-on-error + required:false); `publish` gates only on the 3 REQUIRED
+    # platforms. A miss is announced LOUDLY (::warning:: + job summary) and Intel
+    # users still fail loudly at install (fetch.ts rejects a missing / placeholder
+    # lock entry) — explicit degradation, never a silent one.
     continue-on-error: ${{ !matrix.required }}
     timeout-minutes: ${{ matrix.required && 30 || 60 }}
     strategy:
@@ -119,19 +129,10 @@ jobs:
             artifact: email-agent-linux-x64
             frozen: email-agent
             required: true
-          # darwin-x64 (Intel) BEST-EFFORT on BOTH supported Intel images for
-          # redundancy — whichever lands provides the binary; neither blocks the
-          # release. They write the same filename, so a later publish step keeps
-          # one. (macos-13 retired Dec 2025; these are GitHub's Intel images.)
+          # darwin-x64 (Intel) BEST-EFFORT — see the job-level comment above.
           - os: macos-15-intel
             platform: darwin-x64
-            key: darwin-x64-macos15
-            artifact: email-agent-darwin-x64
-            frozen: email-agent
-            required: false
-          - os: macos-26-intel
-            platform: darwin-x64
-            key: darwin-x64-macos26
+            key: darwin-x64
             artifact: email-agent-darwin-x64
             frozen: email-agent
             required: false
@@ -203,6 +204,13 @@ jobs:
     name: Publish to Hub + npm
     runs-on: ubuntu-latest
     needs: [build]
+    # Manual approval gate: the `agent-publish` environment is configured (repo
+    # Settings → Environments) with required reviewers, so this job pauses until a
+    # maintainer approves — the human backstop for an accidental/tampered release
+    # tag. GAIA_HUB_TOKEN lives as an ENVIRONMENT secret here, so the publish
+    # credential isn't even readable until approval. (Set the env + reviewers +
+    # move the secret in repo settings; restrict the env's deployment branch to main.)
+    environment: agent-publish
     permissions:
       contents: read
       id-token: write   # npm trusted publishing (OIDC) — no npm token
@@ -322,11 +330,11 @@ jobs:
             echo "darwin-x64 (Intel) binary present — full 4-platform release."
           else
             echo "DARWIN_X64_PUBLISHED=false" >> "$GITHUB_ENV"
-            echo "::warning::darwin-x64 (Intel macOS) binary is ABSENT — neither Intel build leg (macos-15-intel, macos-26-intel) produced an artifact. Releasing the other 3 platforms; Intel-mac users will get a loud 'no binary for darwin-x64' error at install until a follow-up Intel build is published under this version."
+            echo "::warning::darwin-x64 (Intel macOS) binary is ABSENT — the Intel build leg (macos-15-intel) produced no artifact. Releasing the other 3 platforms; Intel-mac users will get a loud 'no binary for darwin-x64' error at install until a follow-up Intel build is published under this version."
             {
               echo "### ⚠️ Intel macOS (darwin-x64) NOT published"
               echo ""
-              echo "Neither Intel build leg (\`macos-15-intel\`, \`macos-26-intel\`) produced an artifact, so this release ships **3 of 4** platforms."
+              echo "The Intel build leg (\`macos-15-intel\`) produced no artifact, so this release ships **3 of 4** platforms."
               echo "Intel-mac (\`darwin-x64\`) users will hit a loud install error until an Intel binary is published for this version."
               echo ""
               echo "**Follow-up:** re-run the \`build (darwin-x64)\` leg when Intel runner capacity frees up; the POST /publish endpoint is immutable-per-filename, so adding the Intel binary to the *same* version is safe and idempotent."
@@ -447,4 +455,8 @@ jobs:
             echo "@amd-gaia/agent-email@${VERSION} already on npm — skipping (idempotent)."
             exit 0
           fi
-          npm publish --access public --provenance
+          # --ignore-scripts: dist/ was already built by the "Build npm package"
+          # step, so no lifecycle script (prepublishOnly/prepare/prepack) needs to
+          # run here — and we don't want any package/dependency script executing in
+          # this OIDC-privileged job. Matches publish.yml.
+          npm publish --access public --provenance --ignore-scripts

--- a/.github/workflows/test_gaia_cli_linux.yml
+++ b/.github/workflows/test_gaia_cli_linux.yml
@@ -135,9 +135,30 @@ jobs:
             exit 1
           fi
 
-          # Pull the model now that server is running
+          # Pull the model now that server is running. Retry with EXPONENTIAL
+          # backoff: HF can transiently 429-throttle CI runners even with auth.
+          # Decent delays (60s → 120s → 240s) give the rate-limit window time to
+          # clear. Explicit retry that still fails LOUDLY once spent.
           echo "=== Pulling Qwen3-0.6B-GGUF model ==="
-          lemonade-server-dev pull Qwen3-0.6B-GGUF
+          pull_ok=false
+          max_attempts=4   # 1 initial + 3 retries
+          delay=60
+          for attempt in $(seq 1 $max_attempts); do
+            if lemonade-server-dev pull Qwen3-0.6B-GGUF; then
+              pull_ok=true
+              break
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "::warning::model pull attempt ${attempt}/${max_attempts} failed (likely a transient HF 429) — retrying in ${delay}s"
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          if [ "$pull_ok" != "true" ]; then
+            echo "::error::model pull failed after ${max_attempts} attempts (Qwen3-0.6B-GGUF)"
+            cat lemonade.log 2>/dev/null || true
+            exit 1
+          fi
 
           # List available models for debugging
           echo "=== Listing Available Models ==="


### PR DESCRIPTION
## Why this matters
Security-audit follow-up that hardens the email release pipeline so it's safe to use as the template for every future agent release. Before: a tagged release ran straight through to an irreversible hub + npm publish, with no human checkpoint and lifecycle scripts executing in the OIDC-privileged job. After: publishing pauses for a required-reviewer approval, the publish credential isn't even readable until that approval, and the npm publish can't run arbitrary scripts. It also makes the Intel build both current *and* verified-compatible with older Macs.

## What's in it
- **Manual approval gate.** The publish job runs in an `agent-publish` GitHub environment with required reviewers, so a release **pauses for human sign-off before any hub/npm publish** — the backstop for an accidental or tampered release tag (the main-branch guard is ancestry-based; a human check closes that gap). Matches `publish.yml`'s environment-gate pattern.
- **`GAIA_HUB_TOKEN` becomes an environment secret.** Moved off the repo and onto `agent-publish`, so the publish credential is unreadable until a reviewer approves — a rogue workflow edit can't exfiltrate it.
- **`--ignore-scripts` on `npm publish`.** `dist/` is already built by the prior step, so no lifecycle/dependency script runs in the OIDC-privileged job. Matches `publish.yml`.
- **Intel build on `macos-26-intel`, verified on `macos-15-intel`.** Dropped the redundant second Intel leg (both built the same x86_64 binary). Building on the newest macOS can raise the binary's minimum-OS, so a `verify-darwin-x64-compat` job smoke-tests the frozen binary on the older OS; if it fails there, publish **drops darwin-x64 (ships the 3 required platforms)** rather than shipping a binary broken on older Intel Macs. Best-effort + `continue-on-error`, so an Intel-runner issue never blocks the release.

Not changed on purpose: the main-only guard stays **ancestry-based** (not `HEAD == origin/main` tip) — the approval gate introduces an arbitrary human delay during which `main` can advance, which would make a strict tip check fail legitimate releases. The approval gate is the stronger mitigation for that risk.

## Maintainer setup (required before the next release) — done
1. `agent-publish` environment created (Settings → Environments) with **required reviewers** and deployment branches/tags restricted to `main` + `agent-pkg-*`.
2. `GAIA_HUB_TOKEN` moved to an **environment secret** on `agent-publish`; the repo-level secret deleted.

## Test plan
- [x] Workflow parses as valid YAML; jobs = `build` (4 legs: 3 required + best-effort `macos-26-intel`), `verify-darwin-x64-compat` (`macos-15-intel`, `continue-on-error`, output `ok`), `publish` (`needs: [build, verify-darwin-x64-compat]`, `environment: agent-publish`); `--ignore-scripts` present
- [x] `agent-publish` environment + env secret confirmed via API; repo-level `GAIA_HUB_TOKEN` removed
- [ ] Tagged release pauses for approval, then (post-approval) publishes hub + npm; darwin-x64 ships only when the macOS-15 compat check reports `ok=true`
