### PR TITLE
fix(agent-ui): match renamed --danger token in error-border test

### DIFF
--- a/tests/electron/test_electron_chat_app.js
+++ b/tests/electron/test_electron_chat_app.js
@@ -1255,7 +1255,7 @@ describe('Chat App Integration', () => {
     });
 
     it('should have red left border for errors', () => {
-      expect(msgCss).toContain('border-left: 2px solid var(--amd-red)');
+      expect(msgCss).toContain('border-left: 2px solid var(--danger)');
     });
 
     it('should have error background tint', () => {


### PR DESCRIPTION
The Electron framework test suite is silently broken on `main`: any PR touching a `webui/` path fails CI with `expect(msgCss).toContain('border-left: 2px solid var(--amd-red)')`, even when unrelated to the UI (e.g. #1694, an installer fix). This unblocks those PRs.

Root cause: the Agent Hub redesign (#1564) renamed the error message's left-border token from `--amd-red` to `--danger` in `MessageBubble.css` but didn't update the CSS-assertion test that pins the old token. `main`'s own Electron CI is path-filtered and hadn't re-run since the rename landed, so it stayed latent until a webui-touching PR triggered it. Same class of issue as #1701.

## Test plan
- [ ] `cd tests/electron && npm test` — all suites pass (was 1 failed)
- [ ] `npx jest test_electron_chat_app.js` — the previously-failing assertion passes