### PR TITLE
ci(windows): pull Gemma via server API, not the lemonade CLI

### DIFF
--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -119,13 +119,23 @@ jobs:
 
           Write-Host "Lemonade server started successfully"
 
-          # Pull the model now that server is running. v10.x replaced
-          # ``lemonade-server pull`` with ``lemonade pull`` -- the old form
-          # prints "This command is deprecated. Use 'lemonade pull --help'
-          # instead." and exits non-zero, which under PowerShell + the
-          # default error-on-stderr behaviour kills this step.
-          Write-Host "Pulling Gemma-4-E4B-it-GGUF model..."
-          lemonade pull Gemma-4-E4B-it-GGUF
+          # Pull the model via the running server's API. Gemma-4-E4B-it-GGUF
+          # is a built-in of the C++ Lemonade server's catalog (recipe
+          # llamacpp), but the standalone ``lemonade pull`` CLI uses a separate
+          # registry that 400s on this name ("When registering a new model, the
+          # model name must include the `user` namespace"). Routing the pull
+          # through /api/v1/pull on the already-healthy server hits the catalog
+          # that actually has the model.
+          Write-Host "Pulling Gemma-4-E4B-it-GGUF via server API..."
+          $pullBody = @{ model_name = "Gemma-4-E4B-it-GGUF" } | ConvertTo-Json
+          try {
+              Invoke-RestMethod -Uri "http://localhost:13305/api/v1/pull" -Method POST -ContentType "application/json" -Body $pullBody -TimeoutSec 900 | Out-Null
+              Write-Host "Model pulled: Gemma-4-E4B-it-GGUF"
+          } catch {
+              Write-Host "Model pull failed: $($_.Exception.Message)"
+              if ($_.ErrorDetails) { Write-Host "Details: $($_.ErrorDetails.Message)" }
+              throw
+          }
 
 
 

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -128,19 +128,23 @@ jobs:
 
           Write-Host "Lemonade server started successfully"
 
-          # Pull the model now that server is running.
-          # ``install-lemonade`` upgrades the runner to the expected
-          # LEMONADE_VERSION first, so newer-than-runner default models
-          # (e.g. Gemma-4-E4B-it-GGUF, which LemonadeManager preloads via
-          # ensure_ready) are already in the upgraded server's catalog --
-          # the preload step picks them up without any explicit pull here.
-          #
-          # v10.x replaced ``lemonade-server pull`` with ``lemonade pull``
-          # (the old form prints "This command is deprecated. Use
-          # 'lemonade pull --help' instead." and exits non-zero, killing
-          # this step under PowerShell).
-          Write-Host "Pulling Gemma-4-E4B-it-GGUF model..."
-          lemonade pull Gemma-4-E4B-it-GGUF
+          # Pull the model via the running server's API. Gemma-4-E4B-it-GGUF
+          # is a built-in of the C++ Lemonade server's catalog (recipe
+          # llamacpp), but the standalone ``lemonade pull`` CLI uses a separate
+          # registry that 400s on this name ("When registering a new model, the
+          # model name must include the `user` namespace"). Routing the pull
+          # through /api/v1/pull on the already-healthy server hits the catalog
+          # that actually has the model.
+          Write-Host "Pulling Gemma-4-E4B-it-GGUF via server API..."
+          $pullBody = @{ model_name = "Gemma-4-E4B-it-GGUF" } | ConvertTo-Json
+          try {
+              Invoke-RestMethod -Uri "http://localhost:13305/api/v1/pull" -Method POST -ContentType "application/json" -Body $pullBody -TimeoutSec 900 | Out-Null
+              Write-Host "Model pulled: Gemma-4-E4B-it-GGUF"
+          } catch {
+              Write-Host "Model pull failed: $($_.Exception.Message)"
+              if ($_.ErrorDetails) { Write-Host "Details: $($_.ErrorDetails.Message)" }
+              throw
+          }
 
       - name: Run Unit Tests (Direct CMD - Full Error Visibility)
         shell: cmd


### PR DESCRIPTION
Follow-up to #1712, which auto-merged at its first commit and left `main` with a raw `lemonade pull Gemma-4-E4B-it-GGUF` in both Windows integration jobs. On the runners that 400s — `When registering a new model, the model name must include the user namespace` — so the Agent SDK and GAIA CLI Windows jobs fail at the model-pull step before any test runs.

This routes the pull through `POST /api/v1/pull` on the already-running server — the same mechanism the green `test_api.yml` uses — and fails loudly if the request errors.

### Root cause
`Gemma-4-E4B-it-GGUF` is a genuine built-in of the Lemonade **server's** catalog at v10.7.0 (recipe `llamacpp`). The failure is not the model or the version — on a clean 10.7.0 install the CLI pull even works. The runner's failure log showed **two** lemonade installs on `PATH` (`...\systemprofile\...` and `C:\Users\user\...`); `lemonade pull` resolved to one whose catalog doesn't carry Gemma-4, so it fell into the "register a new model" path. Pulling through the running server's API removes the dependency on whichever `lemonade` CLI happens to be first on `PATH`.

### Verified on a 10.7.0 box (version parity with CI)
- `POST /api/v1/pull {model_name: Gemma-4-E4B-it-GGUF}` → `{"status":"success"}`
- Gemma-4-E4B loads on 10.7.0's llama.cpp (AMD Radeon) → `Model loaded: Gemma-4-E4B-it-GGUF`
- `test_agent_sdk.py` (GAIA_TEST_MODEL=Gemma-4-E4B-it-GGUF) → `Ran 8 tests in 28.761s / OK`

## Test plan
- [ ] `Test Agent SDK on Windows (Lemonade Integration)` — model-pull step succeeds via the API and the integration tests run
- [ ] `Test GAIA CLI on Windows (Full Integration)` — model-pull step succeeds and the tests run