### PR TITLE
feat(website): Agent Factory homepage redesign

### DIFF
--- a/website/src/components/CodeBlock.astro
+++ b/website/src/components/CodeBlock.astro
@@ -1,0 +1,81 @@
+---
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Syntax-highlighted (Shiki, at build time) code block with a hover copy button.
+import { Code } from 'astro:components';
+
+interface Props {
+  code: string;
+  lang?: string;
+  class?: string;
+}
+const { code, lang = 'bash', class: className = '' } = Astro.props;
+---
+
+<div class={`code-block group relative ${className}`}>
+  <Code code={code} lang={lang as any} theme="github-dark" />
+  <button type="button" class="code-copy" data-code-copy={code} aria-label="Copy to clipboard">
+    <svg class="ic ic-copy" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+    <svg class="ic ic-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+  </button>
+</div>
+
+<script>
+  document.querySelectorAll<HTMLButtonElement>('.code-copy').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(btn.dataset.codeCopy || '');
+      } catch {
+        return;
+      }
+      btn.classList.add('copied');
+      setTimeout(() => btn.classList.remove('copied'), 1500);
+    });
+  });
+</script>
+
+<style>
+  /* Shiki renders its own <pre>; frame it on tokens. */
+  .code-block :global(pre) {
+    margin: 0;
+    padding: 0.8rem 2.6rem 0.8rem 1rem; /* right pad leaves room for the copy button */
+    border-radius: 0.5rem;
+    border: 1px solid rgb(var(--g-border));
+    overflow-x: auto;
+    font-size: 12.5px;
+    line-height: 1.6;
+  }
+  .code-copy {
+    position: absolute;
+    top: 0.45rem;
+    right: 0.45rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.3rem;
+    border-radius: 0.375rem;
+    border: 1px solid rgb(var(--g-border));
+    background: rgb(var(--g-surface));
+    color: rgb(var(--g-muted));
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease;
+  }
+  .code-block:hover .code-copy,
+  .code-copy:focus-visible {
+    opacity: 1;
+  }
+  .code-copy:hover {
+    color: rgb(var(--g-text));
+  }
+  .ic-check {
+    display: none;
+  }
+  .code-copy.copied .ic-copy {
+    display: none;
+  }
+  .code-copy.copied .ic-check {
+    display: inline;
+    color: rgb(var(--g-gold-text));
+  }
+</style>

--- a/website/src/components/DownloadButton.astro
+++ b/website/src/components/DownloadButton.astro
@@ -1,0 +1,79 @@
+---
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// OS-detecting "Download the app" CTA for the GAIA Agent UI.
+// Progressive enhancement: with no JS it links to the GitHub releases page
+// (always works). JS detects the OS to set the label, then best-effort fetches
+// the latest release to deep-link the right installer + show the version.
+// Falls back gracefully at every step.
+
+interface Props {
+  variant?: 'primary' | 'secondary';
+  size?: 'lg' | 'sm';
+  class?: string;
+}
+
+const { variant = 'primary', size = 'lg', class: className = '' } = Astro.props;
+
+const releasesUrl = 'https://github.com/amd/gaia/releases/latest';
+const variantCls =
+  variant === 'primary'
+    ? 'bg-g-gold text-black hover:brightness-110'
+    : 'border border-g-border text-g-text hover:border-g-gold/50';
+const sizeCls = size === 'lg' ? 'px-6 py-3 text-sm gap-2' : 'px-3.5 py-1.5 text-[13px] gap-1.5';
+---
+
+<a
+  href={releasesUrl}
+  data-download-cta
+  class={`inline-flex items-center rounded-md font-semibold transition-colors ${variantCls} ${sizeCls} ${className}`}
+>
+  <span data-dl-label>Download the app</span>
+  <span data-dl-version class="font-normal opacity-70"></span>
+</a>
+
+<script>
+  (() => {
+    const els = document.querySelectorAll<HTMLAnchorElement>('[data-download-cta]');
+    if (!els.length) return;
+
+    const detectOS = (): 'windows' | 'macos' | 'linux' | null => {
+      const ua = navigator.userAgent;
+      if (/Windows/i.test(ua)) return 'windows';
+      if (/Mac/i.test(ua) && !/iPhone|iPad|iPod/i.test(ua)) return 'macos';
+      if (/Linux/i.test(ua) && !/Android/i.test(ua)) return 'linux';
+      return null;
+    };
+
+    const os = detectOS();
+    const osLabel = { windows: 'Windows', macos: 'macOS', linux: 'Linux' } as const;
+    els.forEach((el) => {
+      const label = el.querySelector('[data-dl-label]');
+      if (os && label) label.textContent = `Download for ${osLabel[os]}`;
+    });
+
+    // Best-effort: latest version + the installer asset matching this OS.
+    fetch('https://api.github.com/repos/amd/gaia/releases/latest')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((rel) => {
+        if (!rel) return;
+        const ver: string = rel.tag_name;
+        const assets: { name: string; browser_download_url: string }[] = rel.assets || [];
+        const pick = (re: RegExp) => assets.find((a) => re.test(a.name))?.browser_download_url;
+        const url =
+          os === 'windows' ? pick(/x64-setup\.exe$/)
+          : os === 'macos' ? pick(/arm64\.dmg$/)
+          : os === 'linux' ? pick(/\.AppImage$/)
+          : undefined;
+        els.forEach((el) => {
+          if (url) el.href = url;
+          const v = el.querySelector('[data-dl-version]');
+          if (v && ver) v.textContent = ver;
+        });
+      })
+      .catch(() => {
+        /* keep the releases-page fallback */
+      });
+  })();
+</script>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -2,6 +2,7 @@
 // Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 import ThemeToggle from './ThemeToggle.astro';
+import DownloadButton from './DownloadButton.astro';
 ---
 
 <header class="fixed top-0 inset-x-0 z-50 bg-g-bg/80 backdrop-blur-md border-b border-g-border">
@@ -14,6 +15,7 @@ import ThemeToggle from './ThemeToggle.astro';
 
     <div class="flex items-center gap-1 sm:gap-2">
       <!-- Desktop links -->
+      <a href="https://amd-gaia.ai/docs/quickstart" target="_blank" rel="noopener noreferrer" class="hidden sm:block px-3 py-2 text-sm text-g-muted hover:text-g-text transition-colors">Build</a>
       <a href="/hub" class="hidden sm:block px-3 py-2 text-sm text-g-muted hover:text-g-text transition-colors">Agent Hub</a>
       <a href="https://amd-gaia.ai/docs" target="_blank" rel="noopener noreferrer" class="hidden sm:block px-3 py-2 text-sm text-g-muted hover:text-g-text transition-colors">Docs</a>
       <a href="https://github.com/amd/gaia" target="_blank" rel="noopener noreferrer" aria-label="GitHub" class="px-3 py-2 text-g-muted hover:text-g-text transition-colors">
@@ -21,6 +23,7 @@ import ThemeToggle from './ThemeToggle.astro';
           <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.341-3.369-1.341-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
         </svg>
       </a>
+      <DownloadButton variant="primary" size="sm" class="hidden sm:inline-flex" />
       <ThemeToggle />
 
       <!-- Mobile menu button -->
@@ -43,6 +46,10 @@ import ThemeToggle from './ThemeToggle.astro';
   <!-- Mobile Menu -->
   <div id="mobile-menu" class="sm:hidden hidden border-t border-g-border bg-g-bg/95 backdrop-blur-md">
     <div class="px-6 py-4 space-y-3">
+      <a href="https://amd-gaia.ai/docs/quickstart" target="_blank" rel="noopener noreferrer"
+         class="block text-g-muted hover:text-g-text transition-colors text-base font-medium py-2">
+        Build
+      </a>
       <a href="/hub"
          class="block text-g-muted hover:text-g-text transition-colors text-base font-medium py-2">
         Agent Hub

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -10,6 +10,7 @@ import AuroraBg from '../components/AuroraBg.astro';
 import AgentIcon from '../components/AgentIcon.astro';
 import FeaturedCard from '../components/FeaturedCard.astro';
 import DownloadButton from '../components/DownloadButton.astro';
+import CodeBlock from '../components/CodeBlock.astro';
 import { getCatalog } from '../data/catalog';
 
 const agents = await getCatalog();
@@ -29,8 +30,8 @@ const pipeline = [
   {
     step: 'Run',
     icon: 'cpu',
-    body: 'It runs 100% locally on AI PCs — AMD Ryzen AI first-class, via Lemonade. Private by default, no API keys required. Cloud models are opt-in.',
-    code: 'gaia my-agent "..."',
+    body: 'It runs locally on AI PCs — AMD Ryzen AI first-class, via Lemonade. Private by default, no API keys required; cloud models are opt-in.',
+    code: 'python my_agent.py',
   },
   {
     step: 'Distribute',
@@ -54,6 +55,12 @@ const devInstalls = [
   { label: 'pip', cmd: 'uv pip install amd-gaia', note: 'The Python SDK + CLI framework.' },
   { label: 'script', cmd: 'curl -fsSL https://amd-gaia.ai/install.sh | sh', note: 'One-line install (Windows: irm …install.ps1 | iex).' },
 ];
+
+const embedSnippet = `// embed the email agent as a local sidecar
+import { fetchBinary, startSidecar } from "@amd-gaia/agent-email";
+
+const { binaryPath } = await fetchBinary({ outDir: "resources" });
+const sidecar = await startSidecar({ binaryPath, port: 8131 });`;
 ---
 
 <Layout title="GAIA — The Agent Factory" description="Build, run, and distribute AI agents that run locally on AI PCs.">
@@ -69,17 +76,17 @@ const devInstalls = [
           GAIA — The Agent&nbsp;Factory.
         </h1>
         <p class="mt-5 text-lg text-g-muted max-w-2xl mx-auto">
-          Build, run, and distribute AI agents that run <strong class="text-g-text font-semibold">100% locally on AI PCs</strong> —
+          Build, run, and distribute AI agents that run <strong class="text-g-text font-semibold">locally on AI PCs</strong> —
           private by default, no API keys required. Write one in minutes; publish to the Agent Hub and anyone can install it in one click.
         </p>
         <div class="mt-9 flex flex-wrap items-center justify-center gap-3">
-          <a href={QUICKSTART} class="rounded-md bg-g-gold px-6 py-3 text-sm font-semibold text-black hover:brightness-110 transition">
+          <DownloadButton variant="primary" size="lg" />
+          <a href={QUICKSTART} class="rounded-md border border-g-border px-6 py-3 text-sm font-semibold text-g-text hover:border-g-gold/50 transition-colors">
             Start building
           </a>
-          <DownloadButton variant="secondary" size="lg" />
         </div>
         <p class="mt-3 text-xs text-g-muted">
-          Free · Windows, macOS, Linux · or <a href="#developers" class="text-g-gold-text hover:underline">install via CLI →</a>
+          Fastest start: download, browse the hub, run an agent — then build your own or embed one in your app. Free · Windows, macOS, Linux · or <a href="#developers" class="text-g-gold-text hover:underline">install via CLI →</a>
         </p>
         <!-- Trust strip -->
         <div class="mt-8 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[12px] text-g-muted">
@@ -106,7 +113,7 @@ const devInstalls = [
             </span>
             <h3 class="mt-4 text-lg font-semibold text-g-text">{p.step}</h3>
             <p class="mt-2 text-[14px] text-g-muted leading-relaxed">{p.body}</p>
-            <code class="mt-4 block rounded-md border border-g-border bg-g-bg px-3 py-2 font-mono text-[12.5px] text-g-gold-text overflow-x-auto">$ {p.code}</code>
+            <CodeBlock code={p.code} lang="bash" class="mt-4" />
           </div>
         ))}
       </div>
@@ -147,12 +154,7 @@ const devInstalls = [
             <span>· Signed &amp; checksummed artifacts</span>
           </div>
         </div>
-        <div class="rounded-xl border border-g-border bg-g-bg p-5 font-mono text-[12.5px] text-g-text overflow-x-auto">
-          <span class="text-g-muted">// embed the email agent as a local sidecar</span><br />
-          <span class="text-g-gold-text">import</span> {'{ fetchBinary, startSidecar }'} <span class="text-g-gold-text">from</span> "@amd-gaia/agent-email";<br /><br />
-          <span class="text-g-gold-text">const</span> {'{ binaryPath }'} = <span class="text-g-gold-text">await</span> fetchBinary({'{ outDir: "resources" }'});<br />
-          <span class="text-g-gold-text">const</span> sidecar = <span class="text-g-gold-text">await</span> startSidecar({'{ binaryPath, port: 8131 }'});
-        </div>
+        <CodeBlock code={embedSnippet} lang="ts" />
       </div>
     </section>
 
@@ -162,8 +164,12 @@ const devInstalls = [
         <div>
           <Eyebrow class="mb-2">Agent Hub</Eyebrow>
           <h2 class="text-2xl font-bold tracking-tight">There's an agent for that.</h2>
+          <p class="mt-2 max-w-lg text-[14px] text-g-muted">
+            Each one is <strong class="font-semibold text-g-text">purpose-built</strong> for a single job and
+            <strong class="font-semibold text-g-text">bulletproof</strong> — tested, versioned, and immutable once published.
+          </p>
         </div>
-        <a href="/hub" class="text-sm text-g-gold-text hover:underline">All agents →</a>
+        <a href="/hub" class="whitespace-nowrap text-sm text-g-gold-text hover:underline">All agents →</a>
       </div>
       {featured.length > 0 && (
         <div class="grid sm:grid-cols-3 gap-5">
@@ -182,7 +188,7 @@ const devInstalls = [
           {devInstalls.map((d) => (
             <div class="rounded-xl border border-g-border bg-g-surface p-5">
               <div class="text-[11px] font-bold uppercase tracking-wide text-g-gold-text">{d.label}</div>
-              <code class="mt-2 block rounded-md border border-g-border bg-g-bg px-3 py-2 font-mono text-[12px] text-g-text overflow-x-auto">{d.cmd}</code>
+              <CodeBlock code={d.cmd} lang="bash" class="mt-2" />
               <p class="mt-2 text-[12.5px] text-g-muted">{d.note}</p>
             </div>
           ))}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -7,76 +7,191 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Eyebrow from '../components/Eyebrow.astro';
 import AuroraBg from '../components/AuroraBg.astro';
-import TerminalBlock from '../components/TerminalBlock.astro';
+import AgentIcon from '../components/AgentIcon.astro';
 import FeaturedCard from '../components/FeaturedCard.astro';
+import DownloadButton from '../components/DownloadButton.astro';
 import { getCatalog } from '../data/catalog';
 
 const agents = await getCatalog();
 const featured = agents.filter((a) => !a.deprecated).slice(0, 3);
 
-const demoLines = [
-  { prompt: true, text: 'gaia agent install summarize' },
-  { muted: true, text: '✓ installed — runs on your NPU' },
-  { prompt: true, text: 'gaia summarize quarterly-report.pdf' },
-  { muted: true, text: 'Reading 48 pages… done. Summary written to summary.md' },
+const DOCS = 'https://amd-gaia.ai/docs';
+const QUICKSTART = `${DOCS}/quickstart`;
+
+// The factory pipeline — the spine of the page.
+const pipeline = [
+  {
+    step: 'Build',
+    icon: 'wrench',
+    body: 'Write an agent in a few dozen lines of Python — a system prompt and a few @tool functions. Reuse built-in toolsets, or scaffold a new package with one command.',
+    code: 'gaia agent init my-agent',
+  },
+  {
+    step: 'Run',
+    icon: 'cpu',
+    body: 'It runs 100% locally on AI PCs — AMD Ryzen AI first-class, via Lemonade. Private by default, no API keys required. Cloud models are opt-in.',
+    code: 'gaia my-agent "..."',
+  },
+  {
+    step: 'Distribute',
+    icon: 'package',
+    body: 'Publish to the Agent Hub — versioned, checksummed, immutable. Users install in one click, or one command. Distribute openly on PyPI and npm too.',
+    code: 'gaia agent publish',
+  },
+];
+
+// "Run agents now" — static marketing cards (decoupled from the live catalog so
+// they never depend on publish state); each links into the hub.
+const outcomes = [
+  { icon: 'message-circle', title: 'Chat with your documents', body: 'Ask questions across your PDFs and files — answered locally.' },
+  { icon: 'mail', title: 'Triage your inbox', body: 'Read, sort, and reply to Gmail/Outlook, all on-device.' },
+  { icon: 'code', title: 'Generate & validate code', body: 'Plan, write, and check code against your project.' },
+  { icon: 'align-left', title: 'Summarize anything', body: 'Turn long documents into concise briefs.' },
+];
+
+const devInstalls = [
+  { label: 'npm', cmd: 'npm install -g @amd-gaia/agent-ui', note: 'The desktop app, driven from the CLI.' },
+  { label: 'pip', cmd: 'uv pip install amd-gaia', note: 'The Python SDK + CLI framework.' },
+  { label: 'script', cmd: 'curl -fsSL https://amd-gaia.ai/install.sh | sh', note: 'One-line install (Windows: irm …install.ps1 | iex).' },
 ];
 ---
 
-<Layout title="GAIA — AI that runs on your machine">
+<Layout title="GAIA — The Agent Factory" description="Build, run, and distribute AI agents that run locally on AI PCs.">
   <Header />
   <main id="main-content">
 
-    <!-- 1. Aurora hero -->
+    <!-- 1. Hero -->
     <section class="relative overflow-hidden border-b border-g-border">
       <AuroraBg />
       <div class="relative max-w-6xl mx-auto px-6 pt-40 pb-24 text-center">
-        <Eyebrow class="mb-5">Local AI · Ryzen AI</Eyebrow>
+        <Eyebrow class="mb-5">Local AI · AI PCs · AMD Ryzen AI</Eyebrow>
         <h1 class="text-4xl sm:text-6xl font-bold tracking-tight leading-[1.08]">
-          AI that runs<br />on your machine.
+          GAIA — The Agent&nbsp;Factory.
         </h1>
-        <p class="mt-5 text-lg text-g-muted max-w-xl mx-auto">
-          Open-source agents that work entirely on your hardware. Private by default. No API keys. No cloud.
+        <p class="mt-5 text-lg text-g-muted max-w-2xl mx-auto">
+          Build, run, and distribute AI agents that run <strong class="text-g-text font-semibold">100% locally on AI PCs</strong> —
+          private by default, no API keys required. Write one in minutes; publish to the Agent Hub and anyone can install it in one click.
         </p>
-        <div class="mt-9 flex items-center justify-center gap-3">
-          <a href="https://amd-gaia.ai/docs" class="rounded-md bg-g-gold px-6 py-3 text-sm font-semibold text-black hover:brightness-110 transition">
-            Get started
+        <div class="mt-9 flex flex-wrap items-center justify-center gap-3">
+          <a href={QUICKSTART} class="rounded-md bg-g-gold px-6 py-3 text-sm font-semibold text-black hover:brightness-110 transition">
+            Start building
           </a>
-          <a href="/hub" class="rounded-md border border-g-border px-6 py-3 text-sm font-semibold text-g-text hover:border-g-gold/50 transition-colors">
-            Browse agents
-          </a>
+          <DownloadButton variant="secondary" size="lg" />
+        </div>
+        <p class="mt-3 text-xs text-g-muted">
+          Free · Windows, macOS, Linux · or <a href="#developers" class="text-g-gold-text hover:underline">install via CLI →</a>
+        </p>
+        <!-- Trust strip -->
+        <div class="mt-8 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[12px] text-g-muted">
+          <span>Local on AI PCs</span><span class="opacity-40">·</span>
+          <span>Private</span><span class="opacity-40">·</span>
+          <span>Open source (MIT)</span><span class="opacity-40">·</span>
+          <span>Free</span>
         </div>
       </div>
     </section>
 
-    <!-- 2. Living terminal -->
-    <section class="max-w-2xl mx-auto px-6 -mt-12 relative z-10">
-      <TerminalBlock lines={demoLines} typing />
+    <!-- 2. The pipeline: Build → Run → Distribute -->
+    <section class="max-w-6xl mx-auto px-6 py-24">
+      <div class="text-center mb-12">
+        <Eyebrow class="mb-3">The factory floor</Eyebrow>
+        <h2 class="text-2xl sm:text-3xl font-bold tracking-tight">Build → Run → Distribute.</h2>
+        <p class="mt-3 text-g-muted max-w-xl mx-auto">From an idea to an installable agent — entirely on local hardware.</p>
+      </div>
+      <div class="grid md:grid-cols-3 gap-5">
+        {pipeline.map((p) => (
+          <div class="rounded-xl border border-g-border bg-g-surface p-6">
+            <span class="flex w-10 h-10 rounded-lg border border-g-border items-center justify-center text-g-gold-text">
+              <AgentIcon name={p.icon} class="w-5 h-5" />
+            </span>
+            <h3 class="mt-4 text-lg font-semibold text-g-text">{p.step}</h3>
+            <p class="mt-2 text-[14px] text-g-muted leading-relaxed">{p.body}</p>
+            <code class="mt-4 block rounded-md border border-g-border bg-g-bg px-3 py-2 font-mono text-[12.5px] text-g-gold-text overflow-x-auto">$ {p.code}</code>
+          </div>
+        ))}
+      </div>
     </section>
 
-    <!-- 3. Three pillars -->
-    <section class="max-w-5xl mx-auto px-6 py-24 grid sm:grid-cols-3 gap-10 text-center">
-      <div>
-        <h2 class="text-base font-semibold">Private by default</h2>
-        <p class="mt-2 text-sm text-g-muted">Your documents and prompts never leave your machine.</p>
-      </div>
-      <div>
-        <h2 class="text-base font-semibold">Accelerated by Ryzen AI</h2>
-        <p class="mt-2 text-sm text-g-muted">NPU and GPU acceleration on AMD hardware, out of the box.</p>
-      </div>
-      <div>
-        <h2 class="text-base font-semibold">Open source</h2>
-        <p class="mt-2 text-sm text-g-muted">MIT-licensed, built in the open with the community.</p>
-      </div>
-    </section>
-
-    <!-- 4. Featured agents -->
-    <section class="max-w-6xl mx-auto px-6 pb-28">
+    <!-- 3. Run agents now (the non-dev door) -->
+    <section class="max-w-6xl mx-auto px-6 pb-24">
       <div class="flex items-baseline justify-between mb-6">
-        <Eyebrow>Agent Hub</Eyebrow>
+        <Eyebrow>Run agents now</Eyebrow>
+        <a href="/hub" class="text-sm text-g-gold-text hover:underline">Browse the hub →</a>
+      </div>
+      <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
+        {outcomes.map((o) => (
+          <a href="/hub" class="group rounded-xl border border-g-border bg-g-surface p-5 hover:border-g-gold/40 transition-colors">
+            <span class="flex w-9 h-9 rounded-lg border border-g-border items-center justify-center text-g-muted group-hover:text-g-gold-text transition-colors">
+              <AgentIcon name={o.icon} class="w-5 h-5" />
+            </span>
+            <h3 class="mt-3 text-[15px] font-semibold text-g-text">{o.title}</h3>
+            <p class="mt-1 text-[13px] text-g-muted leading-relaxed">{o.body}</p>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <!-- 4. Embed in your app (integrators / app companies) -->
+    <section class="border-y border-g-border bg-g-surface/40">
+      <div class="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-2 gap-12 items-center">
+        <div>
+          <Eyebrow class="mb-3">For app builders</Eyebrow>
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight">Ship GAIA agents inside your app.</h2>
+          <p class="mt-3 text-g-muted max-w-md">
+            Embed an agent as a local REST sidecar or over MCP — no Python required for your users.
+            GAIA supplies the agents; you ship the experience.
+          </p>
+          <div class="mt-6 flex flex-wrap gap-x-4 gap-y-2 text-[13px] text-g-muted">
+            <span>· Local REST sidecar</span>
+            <span>· MCP server</span>
+            <span>· Signed &amp; checksummed artifacts</span>
+          </div>
+        </div>
+        <div class="rounded-xl border border-g-border bg-g-bg p-5 font-mono text-[12.5px] text-g-text overflow-x-auto">
+          <span class="text-g-muted">// embed the email agent as a local sidecar</span><br />
+          <span class="text-g-gold-text">import</span> {'{ fetchBinary, startSidecar }'} <span class="text-g-gold-text">from</span> "@amd-gaia/agent-email";<br /><br />
+          <span class="text-g-gold-text">const</span> {'{ binaryPath }'} = <span class="text-g-gold-text">await</span> fetchBinary({'{ outDir: "resources" }'});<br />
+          <span class="text-g-gold-text">const</span> sidecar = <span class="text-g-gold-text">await</span> startSidecar({'{ binaryPath, port: 8131 }'});
+        </div>
+      </div>
+    </section>
+
+    <!-- 5. Agent Hub showcase -->
+    <section class="max-w-6xl mx-auto px-6 py-24">
+      <div class="flex items-baseline justify-between mb-6">
+        <div>
+          <Eyebrow class="mb-2">Agent Hub</Eyebrow>
+          <h2 class="text-2xl font-bold tracking-tight">There's an agent for that.</h2>
+        </div>
         <a href="/hub" class="text-sm text-g-gold-text hover:underline">All agents →</a>
       </div>
-      <div class="grid sm:grid-cols-3 gap-5">
-        {featured.map((agent) => <FeaturedCard agent={agent} eyebrow={agent.category} />)}
+      {featured.length > 0 && (
+        <div class="grid sm:grid-cols-3 gap-5">
+          {featured.map((agent) => <FeaturedCard agent={agent} eyebrow={agent.category} />)}
+        </div>
+      )}
+    </section>
+
+    <!-- 6. For developers -->
+    <section id="developers" class="border-t border-g-border">
+      <div class="max-w-6xl mx-auto px-6 py-20">
+        <Eyebrow class="mb-3">For developers</Eyebrow>
+        <h2 class="text-2xl sm:text-3xl font-bold tracking-tight">Prefer the terminal? Start here.</h2>
+        <p class="mt-3 text-g-muted max-w-xl">Install the framework and CLI, then build and publish your own agent.</p>
+        <div class="mt-8 grid sm:grid-cols-3 gap-4">
+          {devInstalls.map((d) => (
+            <div class="rounded-xl border border-g-border bg-g-surface p-5">
+              <div class="text-[11px] font-bold uppercase tracking-wide text-g-gold-text">{d.label}</div>
+              <code class="mt-2 block rounded-md border border-g-border bg-g-bg px-3 py-2 font-mono text-[12px] text-g-text overflow-x-auto">{d.cmd}</code>
+              <p class="mt-2 text-[12.5px] text-g-muted">{d.note}</p>
+            </div>
+          ))}
+        </div>
+        <div class="mt-6 flex flex-wrap gap-3 text-sm">
+          <a href={QUICKSTART} class="text-g-gold-text hover:underline">Build your first agent →</a>
+          <span class="text-g-muted opacity-40">·</span>
+          <a href="/hub/email" class="text-g-gold-text hover:underline">Publish to the hub →</a>
+        </div>
       </div>
     </section>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -36,6 +36,7 @@ const pipeline = [
   {
     step: 'Distribute',
     icon: 'package',
+    badge: 'Coming soon',
     body: 'Publish to the Agent Hub — versioned, checksummed, immutable. Users install in one click, or one command. Distribute openly on PyPI and npm too.',
     code: 'gaia agent publish',
   },
@@ -111,7 +112,12 @@ const sidecar = await startSidecar({ binaryPath, port: 8131 });`;
             <span class="flex w-10 h-10 rounded-lg border border-g-border items-center justify-center text-g-gold-text">
               <AgentIcon name={p.icon} class="w-5 h-5" />
             </span>
-            <h3 class="mt-4 text-lg font-semibold text-g-text">{p.step}</h3>
+            <div class="mt-4 flex items-center gap-2">
+              <h3 class="text-lg font-semibold text-g-text">{p.step}</h3>
+              {p.badge && (
+                <span class="rounded border border-g-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-g-muted">{p.badge}</span>
+              )}
+            </div>
             <p class="mt-2 text-[14px] text-g-muted leading-relaxed">{p.body}</p>
             <CodeBlock code={p.code} lang="bash" class="mt-4" />
           </div>
@@ -142,16 +148,18 @@ const sidecar = await startSidecar({ binaryPath, port: 8131 });`;
     <section class="border-y border-g-border bg-g-surface/40">
       <div class="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-2 gap-12 items-center">
         <div>
-          <Eyebrow class="mb-3">For app builders</Eyebrow>
-          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight">Ship GAIA agents inside your app.</h2>
+          <Eyebrow class="mb-3">Integrate</Eyebrow>
+          <h2 class="text-2xl sm:text-3xl font-bold tracking-tight">Drop GAIA into your own app.</h2>
           <p class="mt-3 text-g-muted max-w-md">
-            Embed an agent as a local REST sidecar or over MCP — no Python required for your users.
-            GAIA supplies the agents; you ship the experience.
+            Integrate whole <strong class="font-semibold text-g-text">agents</strong> — or individual
+            <strong class="font-semibold text-g-text">components</strong> — into your third-party app. No Python
+            required for your users; GAIA supplies the building blocks, you ship the experience.
           </p>
-          <div class="mt-6 flex flex-wrap gap-x-4 gap-y-2 text-[13px] text-g-muted">
-            <span>· Local REST sidecar</span>
-            <span>· MCP server</span>
-            <span>· Signed &amp; checksummed artifacts</span>
+          <div class="mt-6 grid gap-x-5 gap-y-1.5 text-[13px] text-g-muted sm:grid-cols-2">
+            <span>· Agents as a local REST sidecar</span>
+            <span>· MCP server (tools for any client)</span>
+            <span>· OpenAI-compatible API</span>
+            <span>· SDK: RAG, VLM, tools, memory</span>
           </div>
         </div>
         <CodeBlock code={embedSnippet} lang="ts" />
@@ -162,7 +170,10 @@ const sidecar = await startSidecar({ binaryPath, port: 8131 });`;
     <section class="max-w-6xl mx-auto px-6 py-24">
       <div class="flex items-baseline justify-between mb-6">
         <div>
-          <Eyebrow class="mb-2">Agent Hub</Eyebrow>
+          <div class="mb-2 flex items-center gap-2">
+            <Eyebrow>Agent Hub</Eyebrow>
+            <span class="rounded border border-g-gold/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-g-gold-text">Beta</span>
+          </div>
           <h2 class="text-2xl font-bold tracking-tight">There's an agent for that.</h2>
           <p class="mt-2 max-w-lg text-[14px] text-g-muted">
             Each one is <strong class="font-semibold text-g-text">purpose-built</strong> for a single job and
@@ -196,7 +207,7 @@ const sidecar = await startSidecar({ binaryPath, port: 8131 });`;
         <div class="mt-6 flex flex-wrap gap-3 text-sm">
           <a href={QUICKSTART} class="text-g-gold-text hover:underline">Build your first agent →</a>
           <span class="text-g-muted opacity-40">·</span>
-          <a href="/hub/email" class="text-g-gold-text hover:underline">Publish to the hub →</a>
+          <a href="https://amd-gaia.ai/docs/guides/hub-publishing" class="text-g-gold-text hover:underline">Publish your agent →</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Why this matters

The homepage led with a CLI terminal and a generic "Get started → docs." This reframes it around GAIA's positioning — **"The Agent Factory"** — and gives every visitor a clear first step: **download the Agent UI and run an agent**, then build or integrate.

This is the **content + structure + functional download** pass. A visual design pass (spacing, motion) follows separately.

## What's on the page
- **Hero** — "GAIA — The Agent Factory." Primary CTA is an **OS-detected Agent UI download** (the easiest start); `Start building` is secondary. Tagline frames the flow: *download → run an agent → build your own or embed one in your app.*
- **`DownloadButton`** (new) — works with **no JS** (links to the releases page); with JS it sets the OS label and best-effort deep-links the matching installer + shows the live version from the GitHub Releases API.
- **`CodeBlock`** (new) — every code snippet is **Shiki-highlighted** with a **copy button**.
- **Build → Run → Distribute** pipeline. **Distribute is marked "Coming soon."**
- **Run agents now** — outcome cards, intentionally **static** (decoupled from the live catalog).
- **Integrate** — embedding **agents *and* components** in a third-party app (REST sidecar · MCP · OpenAI-compatible API · SDK: RAG/VLM/tools/memory).
- **Agent Hub** showcase — marked **Beta** (one published agent today).
- **For developers** — npm / pip (uv) / one-line install.
- Header **Download** button + **Build** nav.

## Accuracy / honesty
- Says "**locally** on AI PCs," not "100% local" — cloud models are opt-in.
- Run command is `python my_agent.py` — there is no `gaia <id>` command to run an installed agent; running happens via the app.
- **Distribute = Coming soon**, **Agent Hub = Beta** — labeled as such on the page.

## Test plan
- [x] `npm run build` / `astro check` clean; all sections render (verified via DOM snapshot + full-page screenshot).
- [x] Download button: OS label + live version resolve; no-JS fallback → `releases/latest`.
- [x] 7 code blocks render with Shiki highlighting + working copy buttons.
- [ ] Reviewer: copy/positioning sanity. **Visual design pass to follow** (separate).