### PR TITLE
ci(windows): run Gemma on a persistent Lemonade server (fix Windows integration jobs)

### DIFF
--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -80,27 +80,34 @@ jobs:
           }
           Write-Host "Found gaia at: $($gaiaPath.Source)"
 
-          # Start the server in the background as a process (not PowerShell job)
-          Write-Host "Starting lemonade-server in background..."
-          # Start the server as a background process
-          $serverProcess = Start-Process -FilePath "lemonade-server" -ArgumentList "serve", "--no-tray", "--port", "13305" -PassThru -WindowStyle Hidden
-          Write-Host "Started lemonade-server process with ID: $($serverProcess.Id)"
+          # Start the version-matched 10.7.0 server by absolute path. The runner
+          # has no ``lemonade-server`` shim on PATH (a stale copy used to shadow
+          # it); LEMONADE_SERVER_PATH is set by the install-lemonade action and
+          # points at the LemonadeServer.exe whose catalog includes Gemma-4.
+          # Kill any leftover server first so the new one binds 13305 cleanly.
+          Write-Host "Stopping any leftover lemonade/llama processes..."
+          foreach ($n in @("LemonadeServer","lemonade-server","llama-server","lemonade")) { Get-Process -Name $n -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue }
+          Start-Sleep -Seconds 3
 
-          # Wait for server to start up
+          Write-Host "Starting server: $env:LEMONADE_SERVER_PATH"
+          $serverProcess = Start-Process -FilePath "$env:LEMONADE_SERVER_PATH" -PassThru -WindowStyle Hidden
+          Write-Host "Started server process with ID: $($serverProcess.Id)"
+
           Write-Host "Waiting for server to start up..."
-          $maxWaitTime = 30  # seconds
+          $maxWaitTime = 90  # seconds
           $waitTime = 0
           $serverReady = $false
 
           while ($waitTime -lt $maxWaitTime -and -not $serverReady) {
-              Start-Sleep -Seconds 2
-              $waitTime += 2
+              Start-Sleep -Seconds 3
+              $waitTime += 3
 
               try {
                   $response = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/health" -Method GET -TimeoutSec 5
-                  Write-Host "Server is ready and responding to health checks"
+                  Write-Host "Server is ready and responding to health checks (after ${waitTime}s)"
                   $serverReady = $true
               } catch {
+                  if ($serverProcess.HasExited) { Write-Host "Server process exited (code $($serverProcess.ExitCode))"; break }
                   Write-Host "Server not ready yet (waited $waitTime seconds)..."
               }
           }
@@ -114,7 +121,7 @@ jobs:
               } catch {
                   Write-Host "Error stopping server process: $_"
               }
-              throw "Failed to start lemonade-server for tests"
+              throw "Failed to start lemonade server for tests"
           }
 
           Write-Host "Lemonade server started successfully"

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -80,69 +80,12 @@ jobs:
           }
           Write-Host "Found gaia at: $($gaiaPath.Source)"
 
-          # Start the version-matched 10.7.0 server by absolute path. The runner
-          # has no ``lemonade-server`` shim on PATH (a stale copy used to shadow
-          # it); LEMONADE_SERVER_PATH is set by the install-lemonade action and
-          # points at the LemonadeServer.exe whose catalog includes Gemma-4.
-          # Kill any leftover server first so the new one binds 13305 cleanly.
-          Write-Host "Stopping any leftover lemonade/llama processes..."
-          foreach ($n in @("LemonadeServer","lemonade-server","llama-server","lemonade")) { Get-Process -Name $n -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue }
-          Start-Sleep -Seconds 3
-
-          Write-Host "Starting server: $env:LEMONADE_SERVER_PATH"
-          $serverProcess = Start-Process -FilePath "$env:LEMONADE_SERVER_PATH" -PassThru -WindowStyle Hidden
-          Write-Host "Started server process with ID: $($serverProcess.Id)"
-
-          Write-Host "Waiting for server to start up..."
-          $maxWaitTime = 90  # seconds
-          $waitTime = 0
-          $serverReady = $false
-
-          while ($waitTime -lt $maxWaitTime -and -not $serverReady) {
-              Start-Sleep -Seconds 3
-              $waitTime += 3
-
-              try {
-                  $response = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/health" -Method GET -TimeoutSec 5
-                  Write-Host "Server is ready and responding to health checks (after ${waitTime}s)"
-                  $serverReady = $true
-              } catch {
-                  if ($serverProcess.HasExited) { Write-Host "Server process exited (code $($serverProcess.ExitCode))"; break }
-                  Write-Host "Server not ready yet (waited $waitTime seconds)..."
-              }
-          }
-
-          if (-not $serverReady) {
-              Write-Host "Server failed to start within $maxWaitTime seconds"
-              try {
-                  if (-not $serverProcess.HasExited) {
-                      $serverProcess.Kill()
-                  }
-              } catch {
-                  Write-Host "Error stopping server process: $_"
-              }
-              throw "Failed to start lemonade server for tests"
-          }
-
-          Write-Host "Lemonade server started successfully"
-
-          # Pull the model via the running server's API. Gemma-4-E4B-it-GGUF
-          # is a built-in of the C++ Lemonade server's catalog (recipe
-          # llamacpp), but the standalone ``lemonade pull`` CLI uses a separate
-          # registry that 400s on this name ("When registering a new model, the
-          # model name must include the `user` namespace"). Routing the pull
-          # through /api/v1/pull on the already-healthy server hits the catalog
-          # that actually has the model.
-          Write-Host "Pulling Gemma-4-E4B-it-GGUF via server API..."
-          $pullBody = @{ model_name = "Gemma-4-E4B-it-GGUF" } | ConvertTo-Json
-          try {
-              Invoke-RestMethod -Uri "http://localhost:13305/api/v1/pull" -Method POST -ContentType "application/json" -Body $pullBody -TimeoutSec 900 | Out-Null
-              Write-Host "Model pulled: Gemma-4-E4B-it-GGUF"
-          } catch {
-              Write-Host "Model pull failed: $($_.Exception.Message)"
-              if ($_.ErrorDetails) { Write-Host "Details: $($_.ErrorDetails.Message)" }
-              throw
-          }
+          # Ensure a healthy, Gemma-warmed Lemonade server is up on 13305. The
+          # helper launches the version-matched server as a persistent Scheduled
+          # Task (survives across CI jobs since GitHub Actions kills job-spawned
+          # processes), reuses it if already healthy, and warms Gemma-4.
+          powershell -ExecutionPolicy Bypass -File installer\scripts\ensure-lemonade-running.ps1 -WarmModel "Gemma-4-E4B-it-GGUF"
+          if ($LASTEXITCODE -ne 0) { throw "Lemonade server not ready" }
 
 
 

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -89,62 +89,12 @@ jobs:
           }
           Write-Host "Found gaia at: $($gaiaPath.Source)"
 
-          # Start the server in the background as a process (not PowerShell job)
-          Write-Host "Starting lemonade-server in background..."
-          # Start the server as a background process
-          $serverProcess = Start-Process -FilePath "lemonade-server" -ArgumentList "serve", "--no-tray", "--port", "13305" -PassThru -WindowStyle Hidden
-          Write-Host "Started lemonade-server process with ID: $($serverProcess.Id)"
-
-          # Wait for server to start up
-          Write-Host "Waiting for server to start up..."
-          $maxWaitTime = 30  # seconds
-          $waitTime = 0
-          $serverReady = $false
-
-          while ($waitTime -lt $maxWaitTime -and -not $serverReady) {
-              Start-Sleep -Seconds 2
-              $waitTime += 2
-
-              try {
-                  $response = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/health" -Method GET -TimeoutSec 5
-                  Write-Host "Server is ready and responding to health checks"
-                  $serverReady = $true
-              } catch {
-                  Write-Host "Server not ready yet (waited $waitTime seconds)..."
-              }
-          }
-
-          if (-not $serverReady) {
-              Write-Host "Server failed to start within $maxWaitTime seconds"
-              try {
-                  if (-not $serverProcess.HasExited) {
-                      $serverProcess.Kill()
-                  }
-              } catch {
-                  Write-Host "Error stopping server process: $_"
-              }
-              throw "Failed to start lemonade-server for tests"
-          }
-
-          Write-Host "Lemonade server started successfully"
-
-          # Pull the model via the running server's API. Gemma-4-E4B-it-GGUF
-          # is a built-in of the C++ Lemonade server's catalog (recipe
-          # llamacpp), but the standalone ``lemonade pull`` CLI uses a separate
-          # registry that 400s on this name ("When registering a new model, the
-          # model name must include the `user` namespace"). Routing the pull
-          # through /api/v1/pull on the already-healthy server hits the catalog
-          # that actually has the model.
-          Write-Host "Pulling Gemma-4-E4B-it-GGUF via server API..."
-          $pullBody = @{ model_name = "Gemma-4-E4B-it-GGUF" } | ConvertTo-Json
-          try {
-              Invoke-RestMethod -Uri "http://localhost:13305/api/v1/pull" -Method POST -ContentType "application/json" -Body $pullBody -TimeoutSec 900 | Out-Null
-              Write-Host "Model pulled: Gemma-4-E4B-it-GGUF"
-          } catch {
-              Write-Host "Model pull failed: $($_.Exception.Message)"
-              if ($_.ErrorDetails) { Write-Host "Details: $($_.ErrorDetails.Message)" }
-              throw
-          }
+          # Ensure a healthy, Gemma-warmed Lemonade server is up on 13305. The
+          # helper launches the version-matched server as a persistent Scheduled
+          # Task (survives across CI jobs since GitHub Actions kills job-spawned
+          # processes), reuses it if already healthy, and warms Gemma-4.
+          powershell -ExecutionPolicy Bypass -File installer\scripts\ensure-lemonade-running.ps1 -WarmModel "Gemma-4-E4B-it-GGUF"
+          if ($LASTEXITCODE -ne 0) { throw "Lemonade server not ready" }
 
       - name: Run Unit Tests (Direct CMD - Full Error Visibility)
         shell: cmd

--- a/installer/scripts/ensure-lemonade-running.ps1
+++ b/installer/scripts/ensure-lemonade-running.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Ensure a healthy Lemonade server is running on $Port, persisting across CI jobs.
+
+.DESCRIPTION
+    GitHub Actions terminates any process a job spawns when the job ends, so a
+    server started inline never survives to the next job. This launches the
+    version-matched LemonadeServer.exe as a Windows **Scheduled Task** instead --
+    the Task Scheduler owns it, not the job, so it persists across jobs and
+    reboots. The task also auto-starts at boot.
+
+    Idempotent + self-healing:
+      - If a healthy server is already on $Port, returns immediately.
+      - Otherwise (re)registers + starts the task, retrying until healthy, then
+        warms $WarmModel (pull) so the first test request isn't a cold load.
+
+    Use -ForceRestart to recycle the server even if it's currently healthy.
+
+.PARAMETER Port           Server port (default 13305).
+.PARAMETER ServerExe      Path to LemonadeServer.exe. Defaults to LEMONADE_SERVER_PATH.
+.PARAMETER WarmModel      Model to pull so the backend is warm (default Gemma-4-E4B-it-GGUF).
+.PARAMETER ForceRestart   Restart the task even if the server is already healthy.
+#>
+[CmdletBinding()]
+param(
+    [int]$Port = 13305,
+    [string]$ServerExe = $env:LEMONADE_SERVER_PATH,
+    [string]$WarmModel = "Gemma-4-E4B-it-GGUF",
+    [switch]$ForceRestart
+)
+
+$ErrorActionPreference = "Continue"
+$TaskName = "GaiaLemonadeServer"
+function Test-Health {
+    try { Invoke-RestMethod "http://localhost:$Port/api/v1/health" -TimeoutSec 5 | Out-Null; return $true }
+    catch { return $false }
+}
+
+if (-not $ForceRestart -and (Test-Health)) {
+    Write-Host "Lemonade already healthy on port $Port -- reusing persistent server."
+    exit 0
+}
+
+# Resolve the server binary.
+if (-not $ServerExe -or -not (Test-Path $ServerExe)) {
+    $ServerExe = (Get-ChildItem `
+        "C:\Users\*\AppData\Local\lemonade_server\bin\LemonadeServer.exe", `
+        "C:\windows\system32\config\systemprofile\AppData\Local\lemonade_server\bin\LemonadeServer.exe", `
+        "C:\Program Files*\Lemonade Server\bin\LemonadeServer.exe" `
+        -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+}
+if (-not $ServerExe) { Write-Host "ERROR: LemonadeServer.exe not found on the runner."; exit 1 }
+Write-Host "Server binary: $ServerExe"
+
+# (Re)register a Scheduled Task that runs the server as SYSTEM, auto-starting at
+# boot and restarting on failure. Force overwrites any prior definition.
+try {
+    $action    = New-ScheduledTaskAction -Execute $ServerExe
+    $trigger   = New-ScheduledTaskTrigger -AtStartup
+    $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
+    $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                    -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+    Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
+        -Principal $principal -Settings $settings -Force -ErrorAction Stop | Out-Null
+    Write-Host "Registered scheduled task '$TaskName'."
+} catch {
+    Write-Host "ERROR: could not register scheduled task (need admin?): $($_.Exception.Message)"
+    exit 1
+}
+
+# Start the task, retrying until the server answers health checks. Each retry
+# fully stops the task + any stray process so a wedged start can't block the port.
+$healthy = $false
+for ($attempt = 1; $attempt -le 4 -and -not $healthy; $attempt++) {
+    Write-Host "--- start attempt $attempt ---"
+    Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    Get-Process LemonadeServer -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 4
+    Start-ScheduledTask -TaskName $TaskName
+    for ($i = 0; $i -lt 20; $i++) {
+        Start-Sleep -Seconds 3
+        if (Test-Health) { $healthy = $true; Write-Host "Healthy after attempt $attempt (~$((($i+1)*3))s)."; break }
+    }
+    if (-not $healthy) { Write-Host "attempt $attempt did not become healthy in 60s" }
+}
+if (-not $healthy) { Write-Host "ERROR: Lemonade server not healthy on $Port after retries."; exit 1 }
+
+# Warm the model so the first inference isn't a cold pull+load.
+Write-Host "Warming model: $WarmModel"
+try {
+    $b = @{ model_name = $WarmModel } | ConvertTo-Json
+    Invoke-RestMethod "http://localhost:$Port/api/v1/pull" -Method POST -ContentType "application/json" -Body $b -TimeoutSec 1200 | Out-Null
+    Write-Host "Pulled $WarmModel."
+} catch { Write-Host "WARN: warm pull failed: $($_.Exception.Message)" }
+
+Write-Host "Lemonade ready on port $Port (persistent task '$TaskName')."
+exit 0

--- a/installer/scripts/reset-lemonade.ps1
+++ b/installer/scripts/reset-lemonade.ps1
@@ -1,0 +1,265 @@
+<#
+.SYNOPSIS
+    Wipe every Lemonade Server / llama.cpp install from a Windows box and
+    reinstall exactly the version GAIA pins (src/gaia/version.LEMONADE_VERSION).
+
+.DESCRIPTION
+    Self-hosted CI runners accumulate stale Lemonade installs across user
+    profiles (e.g. a leftover ``C:\Users\<user>\AppData\Local\lemonade_server``
+    whose ``lemonade-server`` shim shadows the freshly-installed one on PATH).
+    A stale server serves an old model catalog and an old llama.cpp that cannot
+    load current models (e.g. Gemma-4 -> "Failed to load ... with llama-server").
+
+    This script brings the box to a known-clean state:
+      1. Stop every Lemonade / llama-server / tray process.
+      2. Uninstall Lemonade via the Windows uninstall registry (msiexec /x).
+      3. pip-uninstall lemonade-sdk from any Python on PATH.
+      4. Delete per-user + systemprofile install dirs (all profiles) and the
+         ``.cache\lemonade`` backend cache (llama.cpp binaries live here).
+      5. Strip stale lemonade entries from the user + machine PATH.
+      6. Download + silently install the matching ``lemonade.msi``.
+      7. Verify: start the server, health-check, list the catalog, and confirm
+         the GAIA default model is present and loadable.
+
+    Run elevated (admin) on the runner. Removing other users' profiles and
+    machine PATH entries requires it.
+
+.PARAMETER Version
+    Lemonade version to install. Defaults to LEMONADE_VERSION from
+    src/gaia/version.py when run from a GAIA checkout, else 10.7.0.
+
+.PARAMETER Port
+    Port to verify the server on. Default 13305.
+
+.PARAMETER VerifyModel
+    Model id to confirm is present + loadable after install.
+    Default Gemma-4-E4B-it-GGUF (GAIA's DEFAULT_MODEL_NAME).
+
+.PARAMETER KeepModelCache
+    Keep the Hugging Face model cache (avoids re-downloading GGUFs). Off by
+    default -- a full clean also clears downloaded models.
+
+.PARAMETER SkipInstall
+    Clean only; do not reinstall (leaves the box with no Lemonade).
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File installer\scripts\reset-lemonade.ps1
+.EXAMPLE
+    .\reset-lemonade.ps1 -Version 10.7.0 -VerifyModel Qwen3-4B-Instruct-2507-GGUF
+#>
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [int]$Port = 13305,
+    [string]$VerifyModel = "Gemma-4-E4B-it-GGUF",
+    [switch]$KeepModelCache,
+    [switch]$SkipInstall
+)
+
+$ErrorActionPreference = "Continue"
+function Log($m) { Write-Host "[reset-lemonade] $m" }
+function Section($m) { Write-Host "`n===== $m =====" }
+
+# ---- Resolve target version -------------------------------------------------
+if (-not $Version) {
+    $verPy = Join-Path $PSScriptRoot "..\..\src\gaia\version.py"
+    if (Test-Path $verPy) {
+        $line = Select-String -Path $verPy -Pattern 'LEMONADE_VERSION\s*=\s*"([0-9.]+)"' | Select-Object -First 1
+        if ($line) { $Version = $line.Matches[0].Groups[1].Value }
+    }
+    if (-not $Version) { $Version = "10.7.0" }
+}
+Log "Target Lemonade version: $Version"
+
+# ---- 1. Stop processes ------------------------------------------------------
+Section "Stopping Lemonade / llama-server processes"
+foreach ($name in @("LemonadeServer", "lemonade-server", "lemonade", "llama-server", "llama-server-dev", "lemonade-server-dev")) {
+    Get-Process -Name $name -ErrorAction SilentlyContinue | ForEach-Object {
+        Log "Killing $($_.Name) (PID $($_.Id))"
+        Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+    }
+}
+# Python processes hosting a lemonade server
+Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -match "python" -and $_.CommandLine -match "lemonade" } |
+    ForEach-Object { Log "Killing python lemonade host (PID $($_.ProcessId))"; Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+Start-Sleep -Seconds 2
+
+# ---- 2. Uninstall via registry (msiexec /x) ---------------------------------
+Section "Uninstalling Lemonade via Windows uninstall registry"
+$uninstallRoots = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
+)
+foreach ($root in $uninstallRoots) {
+    Get-ItemProperty $root -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -match "Lemonade" } |
+        ForEach-Object {
+            $dn = $_.DisplayName
+            if ($_.PSChildName -match '^\{[0-9A-Fa-f-]+\}$') {
+                Log "Uninstalling '$dn' ($($_.PSChildName)) via msiexec /x"
+                $p = Start-Process -FilePath "msiexec.exe" `
+                    -ArgumentList "/x", $_.PSChildName, "/quiet", "/norestart" `
+                    -Wait -PassThru -NoNewWindow
+                Log "  msiexec /x exit code: $($p.ExitCode)"
+            } elseif ($_.UninstallString) {
+                Log "Uninstalling '$dn' via UninstallString"
+                try { cmd /c "`"$($_.UninstallString)`" /quiet /norestart" 2>&1 | Out-Null } catch { Log "  failed: $_" }
+            }
+        }
+}
+
+# ---- 3. pip uninstall lemonade-sdk ------------------------------------------
+Section "Removing pip-installed lemonade-sdk (all Python on PATH)"
+$pythons = @()
+foreach ($exe in @("python", "python3")) {
+    Get-Command $exe -ErrorAction SilentlyContinue | ForEach-Object { $pythons += $_.Source }
+}
+$pythons = $pythons | Sort-Object -Unique
+foreach ($py in $pythons) {
+    Log "pip uninstall lemonade-sdk via $py"
+    & $py -m pip uninstall -y lemonade-sdk 2>&1 | ForEach-Object { Log "  $_" }
+}
+
+# ---- 4. Delete install dirs + backend cache (all profiles) ------------------
+Section "Deleting install directories and backend cache"
+$targets = New-Object System.Collections.Generic.List[string]
+# Every user profile's per-user install (catches the stale nimbys one)
+Get-ChildItem "C:\Users" -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+    $targets.Add((Join-Path $_.FullName "AppData\Local\lemonade_server"))
+    $targets.Add((Join-Path $_.FullName ".cache\lemonade"))
+    if (-not $KeepModelCache) {
+        $targets.Add((Join-Path $_.FullName ".cache\huggingface\hub"))  # downloaded GGUFs + llama.cpp models
+    }
+}
+# Service-account profile (CI runs as a service)
+$targets.Add("C:\windows\system32\config\systemprofile\AppData\Local\lemonade_server")
+$targets.Add("C:\windows\system32\config\systemprofile\.cache\lemonade")
+if (-not $KeepModelCache) {
+    $targets.Add("C:\windows\system32\config\systemprofile\.cache\huggingface\hub")
+}
+# Program Files installs
+$targets.Add("$env:ProgramFiles\Lemonade Server")
+$targets.Add("${env:ProgramFiles(x86)}\Lemonade Server")
+
+foreach ($t in ($targets | Sort-Object -Unique)) {
+    if (Test-Path $t) {
+        Log "Removing $t"
+        Remove-Item -LiteralPath $t -Recurse -Force -ErrorAction SilentlyContinue
+        if (Test-Path $t) { Log "  WARN: could not fully remove (in use / permissions): $t" }
+    }
+}
+if ($KeepModelCache) { Log "KeepModelCache set -- left Hugging Face model cache in place" }
+
+# ---- 5. Strip stale lemonade PATH entries -----------------------------------
+Section "Cleaning lemonade entries from PATH (User + Machine)"
+foreach ($scope in @("User", "Machine")) {
+    try {
+        $p = [Environment]::GetEnvironmentVariable("Path", $scope)
+        if ($p) {
+            $kept = ($p -split ';' | Where-Object { $_ -and ($_ -notmatch "lemonade") })
+            $new = ($kept -join ';')
+            if ($new -ne $p) {
+                [Environment]::SetEnvironmentVariable("Path", $new, $scope)
+                Log "Stripped lemonade entries from $scope PATH"
+            } else {
+                Log "No lemonade entries in $scope PATH"
+            }
+        }
+    } catch { Log "Could not edit $scope PATH (need admin?): $_" }
+}
+
+if ($SkipInstall) { Section "SkipInstall set -- done (no reinstall)"; return }
+
+# ---- 6. Install the pinned MSI ----------------------------------------------
+Section "Installing Lemonade $Version (silent MSI)"
+$url  = "https://github.com/lemonade-sdk/lemonade/releases/download/v$Version/lemonade.msi"
+$dest = Join-Path $env:TEMP "lemonade-$Version.msi"
+Log "Downloading $url"
+try {
+    Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing -TimeoutSec 600
+} catch {
+    Log "ERROR: MSI download failed: $_"; exit 1
+}
+Log "Running: msiexec /i $dest /quiet /norestart"
+$msi = Start-Process -FilePath "msiexec.exe" `
+    -ArgumentList "/i", $dest, "/quiet", "/norestart", "/L*v", "$env:TEMP\lemonade-msi-install.log" `
+    -Wait -PassThru -NoNewWindow
+Log "msiexec exit code: $($msi.ExitCode)"
+if ($msi.ExitCode -ne 0) {
+    Log "MSI install failed. Tail of log:"
+    Get-Content "$env:TEMP\lemonade-msi-install.log" -Tail 60 -ErrorAction SilentlyContinue | ForEach-Object { Log "  $_" }
+    exit 1
+}
+
+# ---- 7. Verify --------------------------------------------------------------
+Section "Verifying install (server start + catalog + load)"
+# Locate the freshly installed server binary.
+$serverExe = $null
+foreach ($cand in @(
+    "$env:LOCALAPPDATA\lemonade_server\bin\LemonadeServer.exe",
+    "$env:ProgramFiles\Lemonade Server\bin\LemonadeServer.exe",
+    "${env:ProgramFiles(x86)}\Lemonade Server\bin\LemonadeServer.exe"
+)) { if (Test-Path $cand) { $serverExe = $cand; break } }
+
+if (-not $serverExe) {
+    $found = Get-ChildItem "C:\Users\*\AppData\Local\lemonade_server\bin\LemonadeServer.exe","C:\Program Files*\Lemonade Server\bin\LemonadeServer.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($found) { $serverExe = $found.FullName }
+}
+Log "Server binary: $serverExe"
+
+$lemServer = (Get-Command lemonade-server -ErrorAction SilentlyContinue).Source
+Log "lemonade-server on PATH: $lemServer"
+
+$proc = $null
+if ($lemServer) {
+    Log "Starting via 'lemonade-server serve --no-tray --port $Port'"
+    $proc = Start-Process -FilePath "lemonade-server" -ArgumentList "serve", "--no-tray", "--port", "$Port" -PassThru -WindowStyle Hidden
+} elseif ($serverExe) {
+    Log "No lemonade-server shim; starting LemonadeServer.exe directly"
+    $proc = Start-Process -FilePath $serverExe -PassThru -WindowStyle Hidden
+} else {
+    Log "ERROR: no server binary found after install"; exit 1
+}
+
+$ready = $false
+for ($i = 0; $i -lt 30; $i++) {
+    Start-Sleep -Seconds 2
+    try {
+        $h = Invoke-RestMethod -Uri "http://localhost:$Port/api/v1/health" -TimeoutSec 5
+        $ready = $true; Log "Health OK (version=[$($h.version)])"; break
+    } catch { }
+}
+if (-not $ready) { Log "ERROR: server did not become healthy on port $Port"; exit 1 }
+
+try {
+    $m = Invoke-RestMethod -Uri "http://localhost:$Port/api/v1/models" -TimeoutSec 20
+    Log "Catalog model count: $($m.data.Count)"
+    $present = ($m.data | Where-Object { $_.id -eq $VerifyModel }).Count -gt 0
+    Log "VerifyModel '$VerifyModel' present in catalog: $present"
+} catch { Log "Could not list models: $_" }
+
+Log "Pulling '$VerifyModel' ..."
+try {
+    $body = @{ model_name = $VerifyModel } | ConvertTo-Json
+    Invoke-RestMethod -Uri "http://localhost:$Port/api/v1/pull" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 1200 | Out-Null
+    Log "PULL OK"
+} catch {
+    Log "PULL FAILED: $($_.Exception.Message)"
+    if ($_.ErrorDetails) { Log "  Details: $($_.ErrorDetails.Message)" }
+}
+
+Log "Loading '$VerifyModel' (proves llama.cpp can run it) ..."
+try {
+    $body = @{ model_name = $VerifyModel } | ConvertTo-Json
+    Invoke-RestMethod -Uri "http://localhost:$Port/api/v1/load" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 300 | Out-Null
+    Log "LOAD OK -- '$VerifyModel' runs on this box"
+} catch {
+    Log "LOAD FAILED: $($_.Exception.Message)"
+    if ($_.ErrorDetails) { Log "  Details: $($_.ErrorDetails.Message)" }
+}
+
+Section "Done"
+Log "If health/pull/load all reported OK, the runner now serves '$VerifyModel'."
+Log "Re-open the shell (or refresh PATH) so the new lemonade-server is picked up."


### PR DESCRIPTION
The Windows Agent SDK and GAIA CLI integration jobs were failing because the runner couldn't actually serve `Gemma-4-E4B-it-GGUF` (GAIA's default model). Two root causes: a stale Lemonade install in another profile shadowed the current one on `PATH` (old catalog, no Gemma), and the 10.7.0 server is flaky to start headless per-job — and GitHub Actions kills any server a job spawns when the job ends. After cleaning the runner to a single 10.7.0 install, both jobs now run reliably on Gemma by talking to a **persistent** Lemonade server.

What this does:
- `ensure-lemonade-running.ps1` launches the version-matched server as a Windows **Scheduled Task** (owned by Task Scheduler, not the job, so it survives across jobs and reboots), reuses it when already healthy, retries a wedged start, and warms Gemma-4. Both Windows workflows now call it instead of starting the server inline.
- `reset-lemonade.ps1` is the one-shot runner-cleanup tool (wipe every Lemonade install incl. stale copies → reinstall the pinned version → warm the backend). Already run on the `stx` runner to bring it to a single clean 10.7.0.

Verified on the runner (two consecutive `workflow_dispatch` runs of `test_agent_sdk.yml`):
- Run 1 — registered the task, started the server (healthy in ~3s), warmed Gemma → `Ran 8 tests in 140s / OK`
- Run 2 — `Lemonade already healthy ... reusing persistent server` → `Ran 8 tests in 109s / OK`

## Test plan
- [ ] `Test Agent SDK on Windows (Lemonade Integration)` is green on Gemma-4-E4B-it-GGUF
- [ ] `Test GAIA CLI on Windows (Full Integration)` is green on Gemma-4-E4B-it-GGUF