### PR TITLE
fix(webui): File Browser row-click selects the file, not just preview

### DIFF
--- a/src/gaia/apps/webui/src/components/FileBrowser.css
+++ b/src/gaia/apps/webui/src/components/FileBrowser.css
@@ -325,6 +325,31 @@
     flex-shrink: 0;
 }
 
+/* Per-row preview button (reveals on hover / selection / focus) */
+.fb-entry-preview-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    min-width: 24px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    opacity: 0;
+    flex-shrink: 0;
+    transition: opacity var(--duration-fast) var(--ease),
+                color var(--duration-fast) var(--ease),
+                background var(--duration-fast) var(--ease);
+}
+.fb-entry:hover .fb-entry-preview-btn,
+.fb-entry.selected .fb-entry-preview-btn { opacity: 1; }
+.fb-entry-preview-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.fb-entry-preview-btn:focus-visible { opacity: 1; outline: 2px solid var(--accent); outline-offset: 1px; }
+
 /* Preview Panel */
 .fb-preview {
     width: 280px;

--- a/src/gaia/apps/webui/src/components/FileBrowser.tsx
+++ b/src/gaia/apps/webui/src/components/FileBrowser.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import {
     X, Search, Folder, FileText, Home, Download, Monitor, ChevronRight,
     File, FolderOpen, ArrowUp, Brain, Upload, HardDrive,
-    Table, Code
+    Table, Code, Eye
 } from 'lucide-react';
 import { useChatStore } from '../stores/chatStore';
 import * as api from '../services/api';
@@ -277,6 +277,15 @@ export function FileBrowser() {
         } finally {
             setPreviewLoading(false);
         }
+    }, []);
+
+    const toggleSelection = useCallback((path: string) => {
+        setSelectedFiles(prev => {
+            const next = new Set(prev);
+            if (next.has(path)) next.delete(path);
+            else next.add(path);
+            return next;
+        });
     }, []);
 
     const handleIndexSelected = useCallback(async () => {
@@ -554,7 +563,7 @@ export function FileBrowser() {
                                 <div
                                     key={entry.path}
                                     className={`fb-entry ${entry.type} ${selectedFiles.has(entry.path) ? 'selected' : ''} ${fileUnsupported ? 'unsupported' : ''}`}
-                                    onClick={() => entry.type === 'folder' ? handleEntryClick(entry) : handleFilePreview(entry.path)}
+                                    onClick={() => entry.type === 'folder' ? handleEntryClick(entry) : toggleSelection(entry.path)}
                                     onDoubleClick={() => entry.type === 'folder' ? handleEntryClick(entry) : undefined}
                                     title={fileUnsupported ? `${unsupportedCat?.label || 'This'} file type cannot be indexed` : entry.path}
                                 >
@@ -562,14 +571,7 @@ export function FileBrowser() {
                                         type="checkbox"
                                         className="fb-entry-checkbox"
                                         checked={selectedFiles.has(entry.path)}
-                                        onChange={() => {
-                                            setSelectedFiles(prev => {
-                                                const next = new Set(prev);
-                                                if (next.has(entry.path)) next.delete(entry.path);
-                                                else next.add(entry.path);
-                                                return next;
-                                            });
-                                        }}
+                                        onChange={() => toggleSelection(entry.path)}
                                         onClick={(e) => e.stopPropagation()}
                                         aria-label={`Select ${entry.name}`}
                                     />
@@ -579,6 +581,17 @@ export function FileBrowser() {
                                         <span className="fb-unsupported-badge">
                                             Not indexable
                                         </span>
+                                    )}
+                                    {entry.type === 'file' && (
+                                        <button
+                                            type="button"
+                                            className="fb-entry-preview-btn"
+                                            onClick={(e) => { e.stopPropagation(); handleFilePreview(entry.path); }}
+                                            aria-label={`Preview ${entry.name}`}
+                                            title="Preview file"
+                                        >
+                                            <Eye size={14} />
+                                        </button>
                                     )}
                                     <span className="fb-entry-size">{entry.type === 'file' ? formatSize(entry.size) : ''}</span>
                                     <span className="fb-entry-date">{formatDate(entry.modified)}</span>

--- a/src/gaia/apps/webui/src/components/__tests__/FileBrowser.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/FileBrowser.test.tsx
@@ -1,0 +1,144 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileBrowser } from '../FileBrowser';
+import { useChatStore } from '../../stores/chatStore';
+import * as api from '../../services/api';
+import type { BrowseResponse } from '../../types';
+
+vi.mock('../../services/api');
+
+const mockedApi = vi.mocked(api);
+
+const BROWSE_RESPONSE: BrowseResponse = {
+    current_path: '/home/user/docs',
+    parent_path: '/home/user',
+    entries: [
+        { name: 'report.pdf', path: '/home/user/docs/report.pdf', type: 'file', size: 1024, extension: '.pdf', modified: '' },
+        { name: 'notes.txt', path: '/home/user/docs/notes.txt', type: 'file', size: 512, extension: '.txt', modified: '' },
+    ],
+    quick_links: [],
+};
+
+const FILE_PREVIEW = {
+    path: '/home/user/docs/report.pdf',
+    name: 'report.pdf',
+    size: 1024,
+    size_display: '1 KB',
+    extension: '.pdf',
+    modified: '',
+    is_text: true,
+    preview_lines: ['line 1', 'line 2'],
+    total_lines: 2,
+    columns: null,
+    row_count: null,
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.browseFiles.mockResolvedValue(BROWSE_RESPONSE);
+    mockedApi.previewFile.mockResolvedValue(FILE_PREVIEW);
+
+    useChatStore.setState({
+        currentSessionId: 'session-1',
+        sessions: [],
+        showFileBrowser: true,
+    });
+});
+
+describe('FileBrowser row selection', () => {
+    it('clicking a file row selects it and enables Index Selected and Ask Agent', async () => {
+        render(<FileBrowser />);
+
+        // Wait for the directory listing to load
+        const fileName = await screen.findByText('report.pdf');
+        const row = fileName.closest('.fb-entry') as HTMLElement;
+        expect(row).toBeTruthy();
+
+        const indexBtn = screen.getByRole('button', { name: /Index Selected/i });
+        const askBtn = screen.getByRole('button', { name: /Ask Agent/i });
+
+        // Both buttons disabled before selection
+        expect(indexBtn).toBeDisabled();
+        expect(askBtn).toBeDisabled();
+
+        // Click the row to select
+        fireEvent.click(row);
+
+        // After clicking the row the file should be selected
+        await waitFor(() => {
+            expect(indexBtn).not.toBeDisabled();
+            expect(askBtn).not.toBeDisabled();
+        });
+
+        // The checkbox inside the row should now be checked
+        const checkbox = within(row).getByRole('checkbox');
+        expect(checkbox).toBeChecked();
+    });
+
+    it('clicking the preview icon previews without selecting the file', async () => {
+        render(<FileBrowser />);
+
+        const fileName = await screen.findByText('report.pdf');
+        const row = fileName.closest('.fb-entry') as HTMLElement;
+        expect(row).toBeTruthy();
+
+        const indexBtn = screen.getByRole('button', { name: /Index Selected/i });
+        const askBtn = screen.getByRole('button', { name: /Ask Agent/i });
+
+        // Click the preview button inside the row
+        const previewBtn = within(row).getByRole('button', { name: /Preview/i });
+        fireEvent.click(previewBtn);
+
+        // previewFile should have been called
+        await waitFor(() => {
+            expect(mockedApi.previewFile).toHaveBeenCalledWith('/home/user/docs/report.pdf');
+        });
+
+        // Checkbox should stay unchecked
+        const checkbox = within(row).getByRole('checkbox');
+        expect(checkbox).not.toBeChecked();
+
+        // Buttons should still be disabled (no selection happened)
+        expect(indexBtn).toBeDisabled();
+        expect(askBtn).toBeDisabled();
+    });
+
+    it('checkbox toggles selection on and off (regression guard)', async () => {
+        render(<FileBrowser />);
+
+        const fileName = await screen.findByText('notes.txt');
+        const row = fileName.closest('.fb-entry') as HTMLElement;
+        expect(row).toBeTruthy();
+
+        const indexBtn = screen.getByRole('button', { name: /Index Selected/i });
+        const askBtn = screen.getByRole('button', { name: /Ask Agent/i });
+
+        const checkbox = within(row).getByRole('checkbox');
+
+        // Initially unchecked, buttons disabled
+        expect(checkbox).not.toBeChecked();
+        expect(indexBtn).toBeDisabled();
+        expect(askBtn).toBeDisabled();
+
+        // Click checkbox to select
+        fireEvent.click(checkbox);
+
+        await waitFor(() => {
+            expect(checkbox).toBeChecked();
+            expect(indexBtn).not.toBeDisabled();
+            expect(askBtn).not.toBeDisabled();
+        });
+
+        // Click checkbox again to deselect
+        fireEvent.click(checkbox);
+
+        await waitFor(() => {
+            expect(checkbox).not.toBeChecked();
+            expect(indexBtn).toBeDisabled();
+            expect(askBtn).toBeDisabled();
+        });
+    });
+});


### PR DESCRIPTION
Closes #1562

## Why this matters

Before: in the Agent UI File Browser, **clicking a file row only opened a preview — it never selected the file.** Selection was possible only through the tiny per-row checkbox, so a user who clicked a file the natural way saw a preview, assumed the file was selected, and found **Index Selected** and **Ask Agent** greyed out with no hint why. The core index→ask workflow was effectively undiscoverable unless you guessed the checkbox or used drag-and-drop.

After: **clicking a file row selects it** — the obvious gesture — so the action buttons enable immediately. Preview moves to an explicit per-row eye icon: still one click, just no longer conflated with selection.

## Real-world verification

Production build served by `gaia.ui.server` and driven in a real browser on an AMD Ryzen AI box.

**Before — nothing selected, both buttons disabled:**

![before](https://raw.githubusercontent.com/amd/gaia/tmi/1562-screenshots/1562-01-before-disabled.png)

**After clicking the file row — file selected (checkbox ticked, "1 item(s) selected"), Index Selected + Ask Agent enabled:**

![after](https://raw.githubusercontent.com/amd/gaia/tmi/1562-screenshots/1562-02-rowclick-selected-enabled.png)

**The new eye icon previews without selecting — the previewed file stays unchecked and the selection count is unchanged:**

![preview](https://raw.githubusercontent.com/amd/gaia/tmi/1562-screenshots/1562-03-preview-no-select.png)

## Test plan

- [x] `cd src/gaia/apps/webui && npm run test -- FileBrowser` — new RTL test, 3 cases: row-click selects → buttons enable; eye icon previews without selecting; checkbox still toggles
- [x] `npm test` — full suite green (65 tests, +3 new)
- [x] `npx tsc --noEmit` — clean
- [x] Real-world (AMD Ryzen AI): clicked a file row in the live Agent UI → **Index Selected** and **Ask Agent** enabled (screenshots above)
