### PR TITLE
fix(email): route multi-mailbox message actions by recorded provenance (#1707)

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
@@ -736,19 +736,38 @@ class ReadToolsMixin:
         def list_inbox(max_results: int = 25) -> str:
             """List the most recent INBOX messages.
 
+            When multiple mailboxes are connected, lists from ALL of them with a
+            shared total budget (never per-mailbox-doubled). Each returned message
+            carries a ``mailbox`` field ('google' / 'microsoft') so downstream
+            tools can route actions without re-asking.
+
             Args:
-                max_results: How many messages to return (default 25, max 100).
+                max_results: How many messages to return in total (default 25, max 100).
 
             Returns:
                 JSON envelope with ``{"messages": [...]}`` per message:
                 id, thread_id, subject, from, to, date, label_ids,
                 snippet, body (wrapped in untrusted-input delimiters),
-                body_truncated, attachments.
+                body_truncated, attachments, mailbox.
             """
             try:
                 max_results = max(1, min(int(max_results or 25), 100))
+                backends = agent._backends
+                per_backend = max(1, max_results // len(backends))
+                merged: List[Dict[str, Any]] = []
+                for provider, backend in backends.items():
+                    if len(merged) >= max_results:
+                        break
+                    result = list_inbox_impl(
+                        backend, max_results=per_backend, debug=debug_flag
+                    )
+                    for msg in result.get("messages", []):
+                        msg["mailbox"] = provider
+                        agent._remember_message_mailbox(msg.get("id"), provider)
+                        agent._remember_message_mailbox(msg.get("thread_id"), provider)
+                        merged.append(msg)
                 return _envelope_ok(
-                    list_inbox_impl(gmail, max_results=max_results, debug=debug_flag)
+                    {"messages": merged[:max_results], "next_page_token": None}
                 )
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
@@ -838,21 +857,32 @@ class ReadToolsMixin:
 
         @tool
         def search_messages(query: str, max_results: int = 25) -> str:
-            """Search the user's mailbox.
+            """Search across ALL connected mailboxes.
+
+            When multiple mailboxes are connected, searches both with a shared
+            total budget. Each returned message carries a ``mailbox`` field so
+            downstream tools route actions without re-asking.
 
             ``query`` uses Gmail search syntax (e.g.
             ``"from:boss@example.com is:unread newer_than:7d"``).
             """
             try:
                 max_results = max(1, min(int(max_results or 25), 100))
-                return _envelope_ok(
-                    search_messages_impl(
-                        gmail,
-                        query=query,
-                        max_results=max_results,
-                        debug=debug_flag,
+                backends = agent._backends
+                per_backend = max(1, max_results // len(backends))
+                merged: List[Dict[str, Any]] = []
+                for provider, backend in backends.items():
+                    if len(merged) >= max_results:
+                        break
+                    result = search_messages_impl(
+                        backend, query=query, max_results=per_backend, debug=debug_flag
                     )
-                )
+                    for msg in result.get("messages", []):
+                        msg["mailbox"] = provider
+                        agent._remember_message_mailbox(msg.get("id"), provider)
+                        agent._remember_message_mailbox(msg.get("thread_id"), provider)
+                        merged.append(msg)
+                return _envelope_ok({"messages": merged[:max_results]})
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
             except Exception as exc:

--- a/hub/agents/python/email/gaia_agent_email/tools/summarize_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/summarize_tools.py
@@ -249,30 +249,37 @@ class SummarizeToolsMixin:
     """
 
     def _register_summarize_tools(self) -> None:
-        gmail = self._gmail
         debug_flag = bool(getattr(self.config, "debug", False))
-        agent = self  # captured for live access to ``chat``
+        agent = self  # captured for live access to ``chat`` and routing helpers
 
         @tool
-        def summarize_message(message_id: str) -> str:
+        def summarize_message(message_id: str, mailbox: str = "") -> str:
             """Summarize a single email, capturing its key ask or decision.
 
             Reads the message body locally and returns a concise summary of at
             most a couple of sentences. Use this when the user asks what an
             email says, what it wants, or to summarize one specific message.
 
+            When multiple mailboxes are connected, ``mailbox`` (optional) lets
+            you name the source provider ('google' / 'microsoft') explicitly;
+            when omitted the agent uses the provenance recorded by
+            list_inbox / search_messages / triage_inbox.
+
             Args:
                 message_id: The id of the message to summarize.
+                mailbox: Optional source mailbox ('google' / 'microsoft').
+                    Auto-resolved from prior list/search/triage when absent.
 
             Returns:
                 JSON envelope ``{"ok": true, "data": {"message_id", "subject",
                 "summary"}}`` — ``summary`` is a short, length-bounded string.
             """
             try:
+                backend = agent._backend_for_message(message_id, mailbox or None)
                 chat = getattr(agent, "chat", None)
                 return _envelope_ok(
                     summarize_message_impl(
-                        gmail,
+                        backend,
                         chat,
                         message_id=message_id,
                         debug=debug_flag,

--- a/tests/unit/agents/email/test_multimailbox_provenance.py
+++ b/tests/unit/agents/email/test_multimailbox_provenance.py
@@ -26,7 +26,6 @@ pytest.importorskip("gaia_agent_email")
 from gaia_agent_email.agent import EmailTriageAgent
 from gaia_agent_email.config import EmailAgentConfig
 
-
 # ---------------------------------------------------------------------------
 # Minimal spy backend (Gmail-API-shape)
 # ---------------------------------------------------------------------------
@@ -63,7 +62,9 @@ class SpyBackend:
         }
         self.calls = []
 
-    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+    def list_messages(
+        self, *, query=None, label_ids=None, max_results=25, page_token=None
+    ):
         ids = list(self._messages)[:max_results]
         return {"messages": [{"id": m, "threadId": f"t-{m}"} for m in ids]}
 
@@ -135,9 +136,10 @@ class TestListInboxProvenance:
             messages = env["data"]["messages"]
             assert messages, "list_inbox returned no messages"
             for msg in messages:
-                assert msg.get("mailbox") in {"google", "microsoft"}, (
-                    f"message {msg.get('id')!r} missing mailbox field: {msg}"
-                )
+                assert msg.get("mailbox") in {
+                    "google",
+                    "microsoft",
+                }, f"message {msg.get('id')!r} missing mailbox field: {msg}"
         finally:
             agent.close_db()
 
@@ -183,9 +185,10 @@ class TestSearchMessagesProvenance:
             messages = env["data"]["messages"]
             assert messages, "search_messages returned no messages"
             for msg in messages:
-                assert msg.get("mailbox") in {"google", "microsoft"}, (
-                    f"message {msg.get('id')!r} missing mailbox field"
-                )
+                assert msg.get("mailbox") in {
+                    "google",
+                    "microsoft",
+                }, f"message {msg.get('id')!r} missing mailbox field"
         finally:
             agent.close_db()
 
@@ -257,9 +260,7 @@ class TestSummarizeMessageRouting:
         finally:
             agent.close_db()
 
-    def test_summarize_message_routes_to_google_after_list(
-        self, tmp_path, monkeypatch
-    ):
+    def test_summarize_message_routes_to_google_after_list(self, tmp_path, monkeypatch):
         """After list_inbox surfaces a Gmail id, summarize_message routes there."""
         agent, spy_g, spy_m = _agent_two_backends(
             tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]

--- a/tests/unit/agents/email/test_multimailbox_provenance.py
+++ b/tests/unit/agents/email/test_multimailbox_provenance.py
@@ -1,0 +1,398 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Multi-mailbox provenance: list/search/summarize tag and route correctly (#1707).
+
+These tests cover the gap left after #1603/#1614/#1696:
+- ``list_inbox`` / ``search_messages`` must tag each result with its source
+  mailbox and remember provenance for downstream actions.
+- ``summarize_message`` must accept an optional ``mailbox`` param and route via
+  ``_backend_for_message`` rather than always using the primary (gmail) backend.
+- After list/search surfaces a message id, downstream calls
+  (summarize_message, summarize_thread, archive_message_batch) succeed without
+  the caller passing ``mailbox=``.
+- An id never surfaced by any tool + two mailboxes → still fails loud.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.agent import EmailTriageAgent
+from gaia_agent_email.config import EmailAgentConfig
+
+
+# ---------------------------------------------------------------------------
+# Minimal spy backend (Gmail-API-shape)
+# ---------------------------------------------------------------------------
+
+
+def _msg(message_id, *, subject="Hi", sender="a@example.com"):
+    """Build a minimal Gmail-API-shape message tagged PROMOTIONAL (heuristic confident)."""
+    return {
+        "id": message_id,
+        "threadId": f"t-{message_id}",
+        "labelIds": ["INBOX", "CATEGORY_PROMOTIONS"],
+        "snippet": subject,
+        "internalDate": "1000",
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": subject},
+                {"name": "From", "value": sender},
+                {"name": "Date", "value": "Thu, 01 Jan 2026 00:00:00 +0000"},
+            ],
+            "mimeType": "text/plain",
+            "body": {"data": ""},
+        },
+    }
+
+
+class SpyBackend:
+    """Minimal GmailBackend-shaped fake that records calls."""
+
+    def __init__(self, name, message_ids):
+        self.name = name
+        self._messages = {
+            mid: _msg(mid, sender=f"{name}-user@example.com", subject=f"msg-{mid}")
+            for mid in message_ids
+        }
+        self.calls = []
+
+    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+        ids = list(self._messages)[:max_results]
+        return {"messages": [{"id": m, "threadId": f"t-{m}"} for m in ids]}
+
+    def get_message(self, message_id):
+        if message_id not in self._messages:
+            raise KeyError(f"{self.name}: no message {message_id!r}")
+        self.calls.append(("get_message", message_id))
+        return self._messages[message_id]
+
+    def get_thread(self, thread_id):
+        self.calls.append(("get_thread", thread_id))
+        return {"id": thread_id, "messages": list(self._messages.values())}
+
+    def archive_message(self, message_id):
+        self.calls.append(("archive_message", message_id))
+        return {"id": message_id}
+
+    def trash_message(self, message_id):
+        self.calls.append(("trash_message", message_id))
+        return {"id": message_id}
+
+    def list_labels(self):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Agent builder with two injected spy backends
+# ---------------------------------------------------------------------------
+
+
+def _agent_two_backends(tmp_path, monkeypatch, *, google_ids, microsoft_ids):
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    spy_g = SpyBackend("google", google_ids)
+    spy_m = SpyBackend("microsoft", microsoft_ids)
+    cfg = EmailAgentConfig(
+        gmail_backend=spy_g,
+        outlook_backend=spy_m,
+        calendar_backend=object(),
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+        mail_provider=None,  # scan all connected
+    )
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent, spy_g, spy_m
+
+
+def _tool(name):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    return _TOOL_REGISTRY[name]["function"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_inbox provenance
+# ---------------------------------------------------------------------------
+
+
+class TestListInboxProvenance:
+    def test_list_inbox_items_carry_mailbox_field(self, tmp_path, monkeypatch):
+        """Each message returned by list_inbox has a mailbox field."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            env = json.loads(_tool("list_inbox")())
+            assert env["ok"] is True, env
+            messages = env["data"]["messages"]
+            assert messages, "list_inbox returned no messages"
+            for msg in messages:
+                assert msg.get("mailbox") in {"google", "microsoft"}, (
+                    f"message {msg.get('id')!r} missing mailbox field: {msg}"
+                )
+        finally:
+            agent.close_db()
+
+    def test_list_inbox_remembers_provenance_in_agent(self, tmp_path, monkeypatch):
+        """After list_inbox, agent._message_mailbox has entries for each id."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            json.loads(_tool("list_inbox")())
+            assert agent._message_mailbox.get("g1") == "google"
+            assert agent._message_mailbox.get("m1") == "microsoft"
+        finally:
+            agent.close_db()
+
+    def test_list_inbox_thread_ids_remembered(self, tmp_path, monkeypatch):
+        """list_inbox also remembers thread_id provenance."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            json.loads(_tool("list_inbox")())
+            assert agent._message_mailbox.get("t-g1") == "google"
+            assert agent._message_mailbox.get("t-m1") == "microsoft"
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Tests: search_messages provenance
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMessagesProvenance:
+    def test_search_items_carry_mailbox_field(self, tmp_path, monkeypatch):
+        """Each message returned by search_messages has a mailbox field."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1", "g2"], microsoft_ids=["m1", "m2"]
+        )
+        try:
+            env = json.loads(_tool("search_messages")("subject:msg"))
+            assert env["ok"] is True, env
+            messages = env["data"]["messages"]
+            assert messages, "search_messages returned no messages"
+            for msg in messages:
+                assert msg.get("mailbox") in {"google", "microsoft"}, (
+                    f"message {msg.get('id')!r} missing mailbox field"
+                )
+        finally:
+            agent.close_db()
+
+    def test_search_remembers_provenance_in_agent(self, tmp_path, monkeypatch):
+        """After search_messages, agent._message_mailbox is populated."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            json.loads(_tool("search_messages")("anything"))
+            assert agent._message_mailbox.get("g1") == "google"
+            assert agent._message_mailbox.get("m1") == "microsoft"
+        finally:
+            agent.close_db()
+
+    def test_search_tags_per_source_mailbox(self, tmp_path, monkeypatch):
+        """google ids tagged google, microsoft ids tagged microsoft."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1", "g2"], microsoft_ids=["m1", "m2"]
+        )
+        try:
+            env = json.loads(_tool("search_messages")("anything"))
+            msgs = env["data"]["messages"]
+            by_id = {m["id"]: m["mailbox"] for m in msgs if "mailbox" in m}
+            if "g1" in by_id:
+                assert by_id["g1"] == "google"
+            if "m1" in by_id:
+                assert by_id["m1"] == "microsoft"
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Tests: summarize_message routes via provenance
+# ---------------------------------------------------------------------------
+
+
+class _FakeChat:
+    def send_messages(self, messages, system_prompt=None, **kwargs):
+        class _R:
+            text = "Short summary of the email."
+
+        return _R()
+
+
+class TestSummarizeMessageRouting:
+    def test_summarize_message_routes_to_microsoft_after_list(
+        self, tmp_path, monkeypatch
+    ):
+        """After list_inbox surfaces an Outlook id, summarize_message routes there."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        agent.chat = _FakeChat()
+        try:
+            json.loads(_tool("list_inbox")())
+            assert agent._message_mailbox.get("m1") == "microsoft"
+
+            spy_m.calls.clear()
+            spy_g.calls.clear()
+            env = json.loads(_tool("summarize_message")("m1"))
+            assert env["ok"] is True, env
+
+            assert any(c == ("get_message", "m1") for c in spy_m.calls), (
+                f"summarize_message did not route to microsoft backend. "
+                f"spy_m.calls={spy_m.calls}, spy_g.calls={spy_g.calls}"
+            )
+            assert not any(c == ("get_message", "m1") for c in spy_g.calls)
+        finally:
+            agent.close_db()
+
+    def test_summarize_message_routes_to_google_after_list(
+        self, tmp_path, monkeypatch
+    ):
+        """After list_inbox surfaces a Gmail id, summarize_message routes there."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        agent.chat = _FakeChat()
+        try:
+            json.loads(_tool("list_inbox")())
+            assert agent._message_mailbox.get("g1") == "google"
+
+            spy_g.calls.clear()
+            spy_m.calls.clear()
+            env = json.loads(_tool("summarize_message")("g1"))
+            assert env["ok"] is True, env
+
+            assert any(c == ("get_message", "g1") for c in spy_g.calls)
+            assert not any(c == ("get_message", "g1") for c in spy_m.calls)
+        finally:
+            agent.close_db()
+
+    def test_summarize_message_explicit_mailbox_routes_correctly(
+        self, tmp_path, monkeypatch
+    ):
+        """summarize_message(id, mailbox='microsoft') routes to microsoft."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        agent.chat = _FakeChat()
+        try:
+            spy_m.calls.clear()
+            spy_g.calls.clear()
+            env = json.loads(_tool("summarize_message")("m1", "microsoft"))
+            assert env["ok"] is True, env
+            assert any(c == ("get_message", "m1") for c in spy_m.calls)
+            assert not any(c == ("get_message", "m1") for c in spy_g.calls)
+        finally:
+            agent.close_db()
+
+    def test_summarize_message_unknown_id_two_backends_fails_loud(
+        self, tmp_path, monkeypatch
+    ):
+        """An id never surfaced + two backends -> error envelope, not a guess."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        agent.chat = _FakeChat()
+        try:
+            env = json.loads(_tool("summarize_message")("never-seen-id"))
+            assert env["ok"] is False, "expected error for unknown id with two backends"
+            assert env["error"]
+            assert not any(c[1] == "never-seen-id" for c in spy_g.calls)
+            assert not any(c[1] == "never-seen-id" for c in spy_m.calls)
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Tests: summarize_thread routes via provenance (regression guard #1268)
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeThreadRouting:
+    def test_summarize_thread_routes_after_search(self, tmp_path, monkeypatch):
+        """After search surfaces a thread id, summarize_thread routes correctly."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        agent.chat = _FakeChat()
+        try:
+            json.loads(_tool("search_messages")("anything"))
+
+            spy_m.calls.clear()
+            spy_g.calls.clear()
+            env = json.loads(_tool("summarize_thread")("t-m1"))
+            assert env["ok"] is True, env
+
+            assert any(c[0] == "get_thread" for c in spy_m.calls), (
+                f"summarize_thread did not route to microsoft. "
+                f"spy_m.calls={spy_m.calls}, spy_g.calls={spy_g.calls}"
+            )
+            assert not any(c[0] == "get_thread" for c in spy_g.calls)
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Tests: archive_message_batch routes via provenance (#1270)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchArchiveRouting:
+    def test_batch_archive_routes_each_id_to_its_mailbox(self, tmp_path, monkeypatch):
+        """archive_message_batch routes each id to the correct backend."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            json.loads(_tool("list_inbox")())
+
+            spy_g.calls.clear()
+            spy_m.calls.clear()
+
+            env = json.loads(_tool("archive_message_batch")(["g1", "m1"]))
+            assert env["ok"] is True, env
+            data = env["data"]
+            assert data["total"] == 2
+            assert data["failed"] == []
+
+            assert any(c == ("archive_message", "g1") for c in spy_g.calls), spy_g.calls
+            assert any(c == ("archive_message", "m1") for c in spy_m.calls), spy_m.calls
+            assert not any(c == ("archive_message", "g1") for c in spy_m.calls)
+            assert not any(c == ("archive_message", "m1") for c in spy_g.calls)
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Negative: unknown id + two backends = loud error (no silent guess)
+# ---------------------------------------------------------------------------
+
+
+class TestNoSilentFallback:
+    def test_unknown_id_two_backends_raises_via_list_inbox_tool(
+        self, tmp_path, monkeypatch
+    ):
+        """An id not in any backend's results does not get routing."""
+        agent, spy_g, spy_m = _agent_two_backends(
+            tmp_path, monkeypatch, google_ids=["g1"], microsoft_ids=["m1"]
+        )
+        try:
+            json.loads(_tool("list_inbox")())
+            env = json.loads(_tool("trash_message")("completely-unknown"))
+            assert env["ok"] is False
+            assert not any(c[1] == "completely-unknown" for c in spy_g.calls)
+            assert not any(c[1] == "completely-unknown" for c in spy_m.calls)
+        finally:
+            agent.close_db()

--- a/tests/unit/agents/email/test_summarize_tools.py
+++ b/tests/unit/agents/email/test_summarize_tools.py
@@ -166,18 +166,29 @@ class TestSummarizeEmailLLM:
 
 
 class _Recorder:
-    """Captures the @tool functions a mixin registers without a real Agent."""
+    """Captures the @tool functions a mixin registers without a real Agent.
+
+    Simulates the minimal interface ``SummarizeToolsMixin`` now requires:
+    ``_gmail``, ``_backends`` (single-backend map), and the routing helper
+    ``_backend_for_message`` (always returns the injected gmail backend since
+    there is only one).
+    """
 
     def __init__(self, gmail, chat, debug=False):
         self._gmail = gmail
         self.chat = chat
         self._tools = {}
+        self._backends = {"google": gmail}
 
         class _Cfg:
             pass
 
         self.config = _Cfg()
         self.config.debug = debug
+
+    def _backend_for_message(self, message_id, explicit_mailbox=None):
+        # Single-backend: always return the injected gmail.
+        return self._gmail
 
 
 def _register_via_mixin(gmail, chat):


### PR DESCRIPTION
Closes #1707

**Before:** with Gmail + Outlook both connected, acting on a message/thread id returned by search/list failed — `Cannot determine which mailbox message '<id>' belongs to … multiple mailboxes are connected` — because the id arrived without its source mailbox. Full-thread summary, batch archive, and summarize-message all broke multi-mailbox. **After:** `list_inbox`/`search_messages` scan every connected mailbox, tag each result with its source provider, and record provenance; `summarize_message` accepts an optional `mailbox` and routes via the recorded origin. Actions route deterministically with no `mailbox=`.

## Proof it resolves #1707
Driving the real branch code with two mailbox backends:
```
search_messages   → id=g1 mailbox='google'  |  id=m1 mailbox='microsoft'
summarize_message('m1')  (no mailbox=)  → routed to the microsoft backend; google untouched
```
Full captured output + the unknown-id fail-loud case are in the evidence comment below.

## Test plan
- [x] `pytest tests/unit/agents/email/ tests/unit/email/` → **453 passed** (per-worktree venv pinned to this branch's code)
- [x] New `test_multimailbox_provenance.py` (13 tests): list/search tagging + provenance; summarize / summarize_thread / archive_message_batch route with no `mailbox=`; unknown id + 2 mailboxes fails loud
- [ ] Optional live `gaia email` two-mailbox pass — deterministic code paths already proven above
