### PR TITLE
fix(email): select calendar backend by connected+scoped provider, not a Google default (#1708)

### DIFF
--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -204,6 +204,27 @@ To reverse: ask the agent to unquarantine the message. It restores the original 
 
 The agent **never** auto-acts on links or instructions inside a phishing message, even if you ask it to.
 
+## Calendar provider selection
+
+When the calendar tools run (`list_calendar_events`, `accept_invite`, `decline_invite`,
+`create_event_from_email`), the agent picks a calendar backend using this deterministic order:
+
+1. **Injected backend** (eval / test seam) — always wins.
+2. **Explicit `calendar_provider`** config — used directly, no scope check.
+3. **Explicit `mail_provider`** config — calendar follows the mailbox (a Microsoft-only user
+   who set `mail_provider="microsoft"` gets Outlook Calendar without a separate setting).
+4. **Connector discovery** — queries which providers are connected AND hold a calendar scope:
+   - Google: `calendar.events` or `calendar.readonly`
+   - Microsoft: `Calendars.ReadWrite`
+
+   If exactly one provider is calendar-scoped, it is used. If both are scoped, Google is
+   preferred (registry order). If none are scoped, the agent raises an actionable error naming
+   the scope to grant — it never silently falls back to Google.
+
+**Common mismatch**: both Gmail and Outlook connected, but only Outlook has `Calendars.ReadWrite`
+(Google calendar scope was skipped during consent). Without an explicit provider setting the
+agent used to pick Google and fail. It now picks Outlook correctly.
+
 ## Troubleshooting
 
 ### "AGENT_NOT_GRANTED — Email agent needs additional Google permissions"

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Any, ClassVar, List, Optional
 
 from gaia_agent_email import action_store
-from gaia_agent_email.config import EmailAgentConfig
+from gaia_agent_email.config import ConfigurationError, EmailAgentConfig
 from gaia_agent_email.outlook_scopes import (
     OUTLOOK_CALENDAR_SCOPES,
     OUTLOOK_MAIL_SCOPES,
@@ -65,12 +65,30 @@ from gaia.agents.base.agent import Agent
 from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.memory import MemoryMixin
 from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.connectors.errors import ConnectorsError
 from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.database.mixin import DatabaseMixin
 from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class _UnavailableCalendarBackend:
+    """Placeholder calendar backend when no provider is connected/scoped — or no
+    keyring is available in this environment.
+
+    The agent must still construct so non-calendar work (triage, summaries) runs;
+    any actual calendar operation raises the deferred, actionable error rather
+    than silently doing the wrong thing. ``detect_meeting_request`` touches no
+    backend, so it keeps working.
+    """
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def __getattr__(self, name: str):
+        raise ConfigurationError(self._message)
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +264,13 @@ class EmailTriageAgent(
         # ``config.calendar_provider`` (#1276) — the tools treat either as a
         # ``CalendarBackend``. An injected backend (eval/test seam) wins inside
         # the resolver.
-        self._calendar = config.resolve_calendar_backend()
+        # Resolve eagerly, but if no calendar provider is connected/scoped — or
+        # no keyring is available here — defer the actionable error to
+        # calendar-tool use so the agent still constructs for non-calendar work.
+        try:
+            self._calendar = config.resolve_calendar_backend()
+        except (ConfigurationError, ConnectorsError) as exc:
+            self._calendar = _UnavailableCalendarBackend(str(exc))
 
         # I3 — batch-organize counters. Reset per process_query() call by
         # ``_reset_organize_counter``. Per-turn isolation is sufficient

--- a/hub/agents/python/email/gaia_agent_email/config.py
+++ b/hub/agents/python/email/gaia_agent_email/config.py
@@ -21,7 +21,7 @@ from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from gaia.agents.base.agent import default_max_steps
-from gaia.connectors.api import connected_mailbox_providers
+from gaia.connectors.api import connected_mailbox_providers, get_connection
 
 
 class ConfigurationError(ValueError):
@@ -300,16 +300,22 @@ class EmailAgentConfig:
 
         Resolution order:
           1. An injected ``calendar_backend`` (eval/test seam) — always wins.
-          2. Explicit ``calendar_provider`` config, if set — used directly.
+          2. Explicit ``calendar_provider`` config, if set — used directly
+             (trusted; no scope check).
           3. Explicit ``mail_provider`` config, if set — calendar follows the
              mailbox (a Microsoft-only user need not set ``calendar_provider``
-             separately).
-          4. Connector discovery via ``connected_mailbox_providers()`` — picks
-             the provider that is actually connected. If exactly one is
-             connected, use it; if both are connected without an explicit
-             ``mail_provider`` hint, prefer google (registry order).
-          5. Nothing connected and no explicit provider → ``ConfigurationError``
-             with an actionable message (never silently defaults to Google).
+             separately; trusted; no scope check).
+          4. Connector discovery: query ``connected_mailbox_providers()`` and
+             pick the provider that is BOTH connected AND calendar-scoped.
+             "Calendar-scoped" means the stored connection includes at least one
+             of the provider's calendar scopes
+             (Google: calendar.events / calendar.readonly;
+             Microsoft: Calendars.ReadWrite).
+             If nothing is connected → actionable ``ConfigurationError``.
+             If connected but no provider is calendar-scoped → actionable
+             ``ConfigurationError`` naming the scopes to grant.
+             If exactly one calendar-scoped provider → use it.
+             If both are calendar-scoped → registry order (google first).
 
         Both live backends satisfy the ``CalendarBackend`` Protocol, so the
         agent's calendar tools operate on Google and Outlook calendars
@@ -322,12 +328,20 @@ class EmailAgentConfig:
         if self.calendar_backend is not None:
             return self.calendar_backend
 
-        # Steps 2–3: explicit config takes precedence over connector discovery.
+        # Steps 2–3: explicit config is trusted and bypasses scope discovery.
         explicit = (self.calendar_provider or self.mail_provider or "").strip().lower()
         if explicit:
             provider = explicit
         else:
-            # Step 4: discover from connected providers (mirrors resolve_mail_backends).
+            # Step 4: scope-aware discovery — pick the connected + calendar-scoped provider.
+            from gaia_agent_email.outlook_scopes import OUTLOOK_CALENDAR_SCOPES
+            from gaia_agent_email.scopes import CALENDAR_SCOPES
+
+            _PROVIDER_CALENDAR_SCOPES = {
+                "google": set(CALENDAR_SCOPES),
+                "microsoft": set(OUTLOOK_CALENDAR_SCOPES),
+            }
+
             connected = connected_mailbox_providers()
             if not connected:
                 raise ConfigurationError(
@@ -335,8 +349,26 @@ class EmailAgentConfig:
                     "calendar.events / calendar.readonly) or Microsoft (grant "
                     "Calendars.ReadWrite) in Settings → Connectors, then retry."
                 )
-            # Prefer the first in registry order (google before microsoft).
-            provider = connected[0]
+
+            scoped = [
+                p
+                for p in connected
+                if p in _PROVIDER_CALENDAR_SCOPES
+                and _PROVIDER_CALENDAR_SCOPES[p].intersection(
+                    (get_connection(p) or {}).get("scopes", [])
+                )
+            ]
+
+            if not scoped:
+                raise ConfigurationError(
+                    "Connected providers have no calendar scope. "
+                    "Grant calendar.events or calendar.readonly for Google, "
+                    "or Calendars.ReadWrite for Microsoft, "
+                    "in Settings → Connectors, then retry."
+                )
+
+            # First in registry order (google before microsoft) wins when both are scoped.
+            provider = scoped[0]
 
         if provider == "google":
             from gaia_agent_email.calendar_backend import (

--- a/hub/agents/python/email/gaia_agent_email/config.py
+++ b/hub/agents/python/email/gaia_agent_email/config.py
@@ -298,27 +298,46 @@ class EmailAgentConfig:
     def resolve_calendar_backend(self) -> Any:
         """Return the calendar backend for the configured ``calendar_provider``.
 
-        Resolution order (mirrors ``resolve_mail_backend``):
+        Resolution order:
           1. An injected ``calendar_backend`` (eval/test seam) — always wins.
-          2. The live backend bound to the provider's grant-checked token
-             resolver.
+          2. Explicit ``calendar_provider`` config, if set — used directly.
+          3. Explicit ``mail_provider`` config, if set — calendar follows the
+             mailbox (a Microsoft-only user need not set ``calendar_provider``
+             separately).
+          4. Connector discovery via ``connected_mailbox_providers()`` — picks
+             the provider that is actually connected. If exactly one is
+             connected, use it; if both are connected without an explicit
+             ``mail_provider`` hint, prefer google (registry order).
+          5. Nothing connected and no explicit provider → ``ConfigurationError``
+             with an actionable message (never silently defaults to Google).
 
-        ``calendar_provider`` defaults to ``mail_provider`` when unset, so a
-        Microsoft-only user is not forced to set it twice. Both live backends
-        satisfy the ``CalendarBackend`` Protocol, so the agent's calendar tools
-        operate on Google and Outlook calendars interchangeably. An unknown
-        provider raises ``ConfigurationError`` (fail loudly — never silently
-        default to one calendar).
+        Both live backends satisfy the ``CalendarBackend`` Protocol, so the
+        agent's calendar tools operate on Google and Outlook calendars
+        interchangeably. An unsupported explicit provider raises
+        ``ConfigurationError`` (fail loudly).
 
         Live backend imports are local to keep the module import graph free of
         the ``connectors`` dependency chain at ``config`` import time.
         """
         if self.calendar_backend is not None:
             return self.calendar_backend
-        # Default to the mail provider when calendar_provider is unset.
-        provider = (
-            (self.calendar_provider or self.mail_provider or "google").strip().lower()
-        )
+
+        # Steps 2–3: explicit config takes precedence over connector discovery.
+        explicit = (self.calendar_provider or self.mail_provider or "").strip().lower()
+        if explicit:
+            provider = explicit
+        else:
+            # Step 4: discover from connected providers (mirrors resolve_mail_backends).
+            connected = connected_mailbox_providers()
+            if not connected:
+                raise ConfigurationError(
+                    "No calendar provider connected. Connect Google (grant "
+                    "calendar.events / calendar.readonly) or Microsoft (grant "
+                    "Calendars.ReadWrite) in Settings → Connectors, then retry."
+                )
+            # Prefer the first in registry order (google before microsoft).
+            provider = connected[0]
+
         if provider == "google":
             from gaia_agent_email.calendar_backend import (
                 LiveCalendarBackend,

--- a/hub/agents/python/email/gaia_agent_email/config.py
+++ b/hub/agents/python/email/gaia_agent_email/config.py
@@ -350,6 +350,11 @@ class EmailAgentConfig:
                     "Calendars.ReadWrite) in Settings → Connectors, then retry."
                 )
 
+            # A provider is calendar-scoped iff its stored connection includes one
+            # of its calendar scopes. NOTE: get_connection() returns None while a
+            # provider's re-auth tripwire is active, so a genuinely scoped provider
+            # can be transiently treated as unscoped here — re-auth is required
+            # anyway, and the actionable error below still names the scope to grant.
             scoped = [
                 p
                 for p in connected

--- a/tests/unit/agents/email/test_backend_selection.py
+++ b/tests/unit/agents/email/test_backend_selection.py
@@ -542,3 +542,58 @@ class TestResolveCalendarBackendConnectorAware:
         assert "calendar" in msg.lower()
         # Must NOT default silently to Google or emit the old misleading message.
         assert "additional google permission" not in msg.lower()
+
+
+class TestAgentConstructsWhenCalendarUnavailable:
+    """#1708 regression: agent construction must NOT eagerly require keyring access.
+
+    Scope-aware discovery calls ``connected_mailbox_providers()`` (which reads the
+    keyring). If that is unavailable (CI / headless / no system credential store)
+    or no calendar provider is connected, the agent must still construct so
+    non-calendar work runs; the actionable error is deferred to calendar-tool use.
+    """
+
+    def _build(self, tmp_path, monkeypatch, providers_fn):
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers", providers_fn
+        )
+        from gaia_agent_email.agent import (
+            EmailTriageAgent,
+            _UnavailableCalendarBackend,
+        )
+
+        cfg = EmailAgentConfig(
+            gmail_backend=object(),
+            db_path=str(tmp_path / "s.db"),
+            silent_mode=True,
+            mail_provider=None,
+            calendar_provider=None,
+        )
+        return EmailTriageAgent(config=cfg), _UnavailableCalendarBackend
+
+    def test_constructs_when_keyring_unavailable(self, tmp_path, monkeypatch):
+        from gaia.connectors.errors import ConnectorsError
+
+        def _no_keyring():
+            raise ConnectorsError(
+                "Keyring get_password failed: No recommended backend was available"
+            )
+
+        agent, unavailable = self._build(tmp_path, monkeypatch, _no_keyring)
+        try:
+            assert isinstance(agent._calendar, unavailable)
+            # Calendar use still fails loudly (no silent fallback).
+            with pytest.raises(ConfigurationError):
+                agent._calendar.list_events(time_min="a", time_max="b")
+        finally:
+            agent.close_db()
+
+    def test_constructs_when_no_provider_connected(self, tmp_path, monkeypatch):
+        agent, unavailable = self._build(tmp_path, monkeypatch, lambda: [])
+        try:
+            assert isinstance(agent._calendar, unavailable)
+            with pytest.raises(ConfigurationError):
+                agent._calendar.create_event(summary="x", start="s", end="e")
+        finally:
+            agent.close_db()

--- a/tests/unit/agents/email/test_backend_selection.py
+++ b/tests/unit/agents/email/test_backend_selection.py
@@ -312,3 +312,84 @@ class TestAgentCalendarWiring:
         )
         agent = EmailTriageAgent(config=cfg)
         assert agent._calendar is cal_sentinel
+
+
+class TestResolveCalendarBackendConnectorAware:
+    """Connector-aware calendar-backend selection (#1708).
+
+    ``resolve_calendar_backend()`` must query the live connector state (via
+    ``connected_mailbox_providers``) when neither ``calendar_provider`` nor
+    ``mail_provider`` is explicitly set, so a microsoft-only user gets Outlook
+    — not Google — without having to set an extra config field.
+
+    Five cases from the AC:
+      1. microsoft-only connected → ``LiveOutlookCalendarBackend``
+      2. google-only connected → ``LiveCalendarBackend`` (regression guard)
+      3. both connected, ``mail_provider="microsoft"`` → Outlook (mail-box match)
+      4. neither connected, no explicit provider → actionable ConfigurationError
+      5. explicit ``calendar_provider="google"`` overrides discovery → Google
+
+    Monkeypatching target is ``gaia_agent_email.config.connected_mailbox_providers``
+    (the import bound at module load in config.py:24) — NOT the source module.
+    """
+
+    def test_microsoft_only_connected_yields_outlook_calendar(self, monkeypatch):
+        """Case 1: only microsoft connection present → Outlook calendar."""
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["microsoft"],
+        )
+        cfg = EmailAgentConfig()
+        backend = cfg.resolve_calendar_backend()
+        assert isinstance(backend, LiveOutlookCalendarBackend)
+
+    def test_google_only_connected_yields_google_calendar(self, monkeypatch):
+        """Case 2: only google connection present → Google calendar (regression guard)."""
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google"],
+        )
+        cfg = EmailAgentConfig()
+        backend = cfg.resolve_calendar_backend()
+        assert isinstance(backend, LiveCalendarBackend)
+
+    def test_both_connected_mail_provider_microsoft_yields_outlook(self, monkeypatch):
+        """Case 3: both connected, mail_provider set to microsoft → Outlook."""
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        cfg = EmailAgentConfig(mail_provider="microsoft")
+        backend = cfg.resolve_calendar_backend()
+        assert isinstance(backend, LiveOutlookCalendarBackend)
+
+    def test_no_provider_connected_raises_actionable_error(self, monkeypatch):
+        """Case 4: nothing connected + no explicit provider → loud ConfigurationError.
+
+        Error must NOT say "additional Google permission" (the old confusing
+        message) and MUST name the connection/scope to add so the user can act.
+        """
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: [],
+        )
+        cfg = EmailAgentConfig()
+        with pytest.raises(ConfigurationError) as exc:
+            cfg.resolve_calendar_backend()
+        msg = str(exc.value).lower()
+        # Must be actionable — mention calendar and how to fix it.
+        assert "calendar" in msg
+        assert "connect" in msg
+        # Must NOT be the old confusing Google-only message.
+        assert "additional google permission" not in msg
+
+    def test_explicit_calendar_provider_overrides_discovery(self, monkeypatch):
+        """Case 5: explicit calendar_provider bypasses connector discovery."""
+        # Even with no connector present, an explicit override must win.
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: [],
+        )
+        cfg = EmailAgentConfig(calendar_provider="google")
+        backend = cfg.resolve_calendar_backend()
+        assert isinstance(backend, LiveCalendarBackend)

--- a/tests/unit/agents/email/test_backend_selection.py
+++ b/tests/unit/agents/email/test_backend_selection.py
@@ -294,7 +294,9 @@ class TestAgentCalendarWiring:
         agent = EmailTriageAgent(config=cfg)
         assert isinstance(agent._calendar, LiveOutlookCalendarBackend)
 
-    def test_agent_explicit_google_calendar_provider_wires_google(self, tmp_path, monkeypatch):
+    def test_agent_explicit_google_calendar_provider_wires_google(
+        self, tmp_path, monkeypatch
+    ):
         # Explicit calendar_provider="google" (step 2) wires LiveCalendarBackend
         # without hitting connector discovery.
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
@@ -449,7 +451,9 @@ class TestResolveCalendarBackendConnectorAware:
         backend = cfg.resolve_calendar_backend()
         assert isinstance(backend, LiveCalendarBackend)
 
-    def test_both_connected_only_microsoft_calendar_scoped_yields_outlook(self, monkeypatch):
+    def test_both_connected_only_microsoft_calendar_scoped_yields_outlook(
+        self, monkeypatch
+    ):
         """Case 6 — the #1708 bug scenario: both connected but only Outlook is calendar-scoped."""
         monkeypatch.setattr(
             "gaia_agent_email.config.connected_mailbox_providers",
@@ -468,7 +472,9 @@ class TestResolveCalendarBackendConnectorAware:
         backend = cfg.resolve_calendar_backend()
         assert isinstance(backend, LiveOutlookCalendarBackend)
 
-    def test_both_connected_only_google_calendar_scoped_yields_google(self, monkeypatch):
+    def test_both_connected_only_google_calendar_scoped_yields_google(
+        self, monkeypatch
+    ):
         """Case 7: both connected but only Google is calendar-scoped → Google."""
         monkeypatch.setattr(
             "gaia_agent_email.config.connected_mailbox_providers",
@@ -487,7 +493,9 @@ class TestResolveCalendarBackendConnectorAware:
         backend = cfg.resolve_calendar_backend()
         assert isinstance(backend, LiveCalendarBackend)
 
-    def test_both_connected_both_calendar_scoped_prefers_registry_order(self, monkeypatch):
+    def test_both_connected_both_calendar_scoped_prefers_registry_order(
+        self, monkeypatch
+    ):
         """Case 8: both connected and both calendar-scoped → registry order (google first)."""
         monkeypatch.setattr(
             "gaia_agent_email.config.connected_mailbox_providers",

--- a/tests/unit/agents/email/test_backend_selection.py
+++ b/tests/unit/agents/email/test_backend_selection.py
@@ -597,3 +597,20 @@ class TestAgentConstructsWhenCalendarUnavailable:
                 agent._calendar.create_event(summary="x", start="s", end="e")
         finally:
             agent.close_db()
+
+    def test_constructs_when_calendar_scope_declined(self, tmp_path, monkeypatch):
+        # Reviewer's exact case: Gmail connected, calendar scope declined. Discovery
+        # finds google connected but mail-only-scoped -> no calendar provider. The
+        # agent must still construct so read/organize/reply work; calendar use then
+        # raises the actionable error (deferred, not at startup).
+        monkeypatch.setattr(
+            "gaia_agent_email.config.get_connection",
+            lambda p: {"scopes": ["https://www.googleapis.com/auth/gmail.modify"]},
+        )
+        agent, unavailable = self._build(tmp_path, monkeypatch, lambda: ["google"])
+        try:
+            assert isinstance(agent._calendar, unavailable)
+            with pytest.raises(ConfigurationError):
+                agent._calendar.list_events(time_min="a", time_max="b")
+        finally:
+            agent.close_db()

--- a/tests/unit/agents/email/test_backend_selection.py
+++ b/tests/unit/agents/email/test_backend_selection.py
@@ -234,10 +234,15 @@ class TestResolveCalendarBackend:
 
     The shipped Google calendar path must stay the default; ``microsoft`` must
     route to the Outlook calendar backend; an injected backend always wins.
+
+    Tests here use an explicit ``calendar_provider`` so they exercise the
+    trusted-explicit path (step 2) and don't depend on connector state.
+    Connector-discovery behaviour lives in ``TestResolveCalendarBackendConnectorAware``.
     """
 
-    def test_default_provider_is_google_calendar(self):
-        cfg = EmailAgentConfig()
+    def test_explicit_google_provider_returns_google_calendar(self):
+        # Step 2 (explicit calendar_provider): google → LiveCalendarBackend.
+        cfg = EmailAgentConfig(calendar_provider="google")
         backend = cfg.resolve_calendar_backend()
         assert isinstance(backend, LiveCalendarBackend)
 
@@ -289,11 +294,14 @@ class TestAgentCalendarWiring:
         agent = EmailTriageAgent(config=cfg)
         assert isinstance(agent._calendar, LiveOutlookCalendarBackend)
 
-    def test_agent_keeps_google_calendar_as_default(self, tmp_path, monkeypatch):
+    def test_agent_explicit_google_calendar_provider_wires_google(self, tmp_path, monkeypatch):
+        # Explicit calendar_provider="google" (step 2) wires LiveCalendarBackend
+        # without hitting connector discovery.
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
         from gaia_agent_email.agent import EmailTriageAgent
 
         cfg = EmailAgentConfig(
+            calendar_provider="google",
             gmail_backend=object(),
             db_path=str(tmp_path / "state.db"),
         )
@@ -314,47 +322,94 @@ class TestAgentCalendarWiring:
         assert agent._calendar is cal_sentinel
 
 
+def _make_get_connection(scopes_map):
+    """Build a ``get_connection`` stub that returns scope dicts from ``scopes_map``.
+
+    ``scopes_map`` is ``{provider: [scope, ...]}``.  A provider absent from the
+    map returns ``None`` (not connected).
+    """
+
+    def _stub(provider):
+        if provider in scopes_map:
+            return {"provider": provider, "scopes": scopes_map[provider]}
+        return None
+
+    return _stub
+
+
 class TestResolveCalendarBackendConnectorAware:
     """Connector-aware calendar-backend selection (#1708).
 
-    ``resolve_calendar_backend()`` must query the live connector state (via
-    ``connected_mailbox_providers``) when neither ``calendar_provider`` nor
-    ``mail_provider`` is explicitly set, so a microsoft-only user gets Outlook
-    — not Google — without having to set an extra config field.
+    ``resolve_calendar_backend()`` must query the live connector state when
+    neither ``calendar_provider`` nor ``mail_provider`` is explicitly set,
+    picking the provider that is BOTH connected AND calendar-scoped rather than
+    blindly defaulting to Google.
 
-    Five cases from the AC:
-      1. microsoft-only connected → ``LiveOutlookCalendarBackend``
-      2. google-only connected → ``LiveCalendarBackend`` (regression guard)
-      3. both connected, ``mail_provider="microsoft"`` → Outlook (mail-box match)
-      4. neither connected, no explicit provider → actionable ConfigurationError
+    Cases:
+      1. microsoft-only connected + calendar-scoped → ``LiveOutlookCalendarBackend``
+      2. google-only connected + calendar-scoped → ``LiveCalendarBackend`` (regression guard)
+      3. both connected, ``mail_provider="microsoft"`` (explicit step-3) → Outlook
+      4. nothing connected → actionable ConfigurationError (no silent Google fallback)
       5. explicit ``calendar_provider="google"`` overrides discovery → Google
+      6. both connected, only microsoft calendar-scoped → Outlook (#1708 bug scenario)
+      7. both connected, only google calendar-scoped → Google (#1708 symmetrical guard)
+      8. both connected and both calendar-scoped → registry order (google first)
+      9. connected but neither calendar-scoped → actionable ConfigurationError
 
-    Monkeypatching target is ``gaia_agent_email.config.connected_mailbox_providers``
-    (the import bound at module load in config.py:24) — NOT the source module.
+    Monkeypatching targets:
+      - ``gaia_agent_email.config.connected_mailbox_providers``
+      - ``gaia_agent_email.config.get_connection``
     """
 
-    def test_microsoft_only_connected_yields_outlook_calendar(self, monkeypatch):
-        """Case 1: only microsoft connection present → Outlook calendar."""
+    # --- scope constants used to build realistic stub connection dicts -------
+
+    _GOOGLE_CALENDAR_SCOPES = [
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.readonly",
+    ]
+    _GOOGLE_MAIL_ONLY_SCOPES = [
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+    ]
+    _MS_CALENDAR_SCOPES = [
+        "https://graph.microsoft.com/Calendars.ReadWrite",
+    ]
+    _MS_MAIL_ONLY_SCOPES = [
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send",
+    ]
+
+    def test_microsoft_only_connected_calendar_scoped_yields_outlook(self, monkeypatch):
+        """Case 1: only microsoft connected + calendar-scoped → Outlook calendar."""
         monkeypatch.setattr(
             "gaia_agent_email.config.connected_mailbox_providers",
             lambda: ["microsoft"],
+        )
+        monkeypatch.setattr(
+            "gaia_agent_email.config.get_connection",
+            _make_get_connection({"microsoft": self._MS_CALENDAR_SCOPES}),
         )
         cfg = EmailAgentConfig()
         backend = cfg.resolve_calendar_backend()
         assert isinstance(backend, LiveOutlookCalendarBackend)
 
-    def test_google_only_connected_yields_google_calendar(self, monkeypatch):
-        """Case 2: only google connection present → Google calendar (regression guard)."""
+    def test_google_only_connected_calendar_scoped_yields_google(self, monkeypatch):
+        """Case 2: only google connected + calendar-scoped → Google calendar (regression guard)."""
         monkeypatch.setattr(
             "gaia_agent_email.config.connected_mailbox_providers",
             lambda: ["google"],
+        )
+        monkeypatch.setattr(
+            "gaia_agent_email.config.get_connection",
+            _make_get_connection({"google": self._GOOGLE_CALENDAR_SCOPES}),
         )
         cfg = EmailAgentConfig()
         backend = cfg.resolve_calendar_backend()
         assert isinstance(backend, LiveCalendarBackend)
 
     def test_both_connected_mail_provider_microsoft_yields_outlook(self, monkeypatch):
-        """Case 3: both connected, mail_provider set to microsoft → Outlook."""
+        """Case 3: both connected, explicit mail_provider="microsoft" → Outlook (step-3 trusted path)."""
+        # mail_provider is explicit → step 3 wins without calling get_connection.
         monkeypatch.setattr(
             "gaia_agent_email.config.connected_mailbox_providers",
             lambda: ["google", "microsoft"],
@@ -393,3 +448,89 @@ class TestResolveCalendarBackendConnectorAware:
         cfg = EmailAgentConfig(calendar_provider="google")
         backend = cfg.resolve_calendar_backend()
         assert isinstance(backend, LiveCalendarBackend)
+
+    def test_both_connected_only_microsoft_calendar_scoped_yields_outlook(self, monkeypatch):
+        """Case 6 — the #1708 bug scenario: both connected but only Outlook is calendar-scoped."""
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        monkeypatch.setattr(
+            "gaia_agent_email.config.get_connection",
+            _make_get_connection(
+                {
+                    "google": self._GOOGLE_MAIL_ONLY_SCOPES,  # no calendar scope
+                    "microsoft": self._MS_CALENDAR_SCOPES,
+                }
+            ),
+        )
+        cfg = EmailAgentConfig()
+        backend = cfg.resolve_calendar_backend()
+        assert isinstance(backend, LiveOutlookCalendarBackend)
+
+    def test_both_connected_only_google_calendar_scoped_yields_google(self, monkeypatch):
+        """Case 7: both connected but only Google is calendar-scoped → Google."""
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        monkeypatch.setattr(
+            "gaia_agent_email.config.get_connection",
+            _make_get_connection(
+                {
+                    "google": self._GOOGLE_CALENDAR_SCOPES,
+                    "microsoft": self._MS_MAIL_ONLY_SCOPES,  # no calendar scope
+                }
+            ),
+        )
+        cfg = EmailAgentConfig()
+        backend = cfg.resolve_calendar_backend()
+        assert isinstance(backend, LiveCalendarBackend)
+
+    def test_both_connected_both_calendar_scoped_prefers_registry_order(self, monkeypatch):
+        """Case 8: both connected and both calendar-scoped → registry order (google first)."""
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        monkeypatch.setattr(
+            "gaia_agent_email.config.get_connection",
+            _make_get_connection(
+                {
+                    "google": self._GOOGLE_CALENDAR_SCOPES,
+                    "microsoft": self._MS_CALENDAR_SCOPES,
+                }
+            ),
+        )
+        cfg = EmailAgentConfig()
+        backend = cfg.resolve_calendar_backend()
+        # google comes first in registry order → LiveCalendarBackend
+        assert isinstance(backend, LiveCalendarBackend)
+
+    def test_connected_but_none_calendar_scoped_raises_actionable(self, monkeypatch):
+        """Case 9: connected providers exist but none has calendar scope → actionable error.
+
+        Distinct from the nothing-connected error.  Must name the scopes to
+        grant, not the confusing "additional Google permission" string.
+        """
+        monkeypatch.setattr(
+            "gaia_agent_email.config.connected_mailbox_providers",
+            lambda: ["google", "microsoft"],
+        )
+        monkeypatch.setattr(
+            "gaia_agent_email.config.get_connection",
+            _make_get_connection(
+                {
+                    "google": self._GOOGLE_MAIL_ONLY_SCOPES,
+                    "microsoft": self._MS_MAIL_ONLY_SCOPES,
+                }
+            ),
+        )
+        cfg = EmailAgentConfig()
+        with pytest.raises(ConfigurationError) as exc:
+            cfg.resolve_calendar_backend()
+        msg = str(exc.value)
+        # Must name the scope(s) the user needs to grant.
+        assert "calendar" in msg.lower()
+        # Must NOT default silently to Google or emit the old misleading message.
+        assert "additional google permission" not in msg.lower()


### PR DESCRIPTION
Closes #1708

**Before:** when only the Outlook calendar was scoped, calendar actions (create-event-from-email, conflict detection) failed — `resolve_calendar_backend` hard-defaulted to Google and called the unscoped Google Calendar, erroring with "additional Google permission" even though the Outlook connection held `Calendars.ReadWrite`. **After:** with no explicit provider, selection discovers connected providers and picks the one actually **calendar-scoped** (intersecting each connection's granted scopes against that provider's calendar scopes); if none is scoped it fails loudly with an actionable error naming the exact scope to grant — never a silent Google default. Order documented in `docs/guides/email.mdx`.

## Proof it resolves #1708
Real branch code; the last line reads **this machine's live connector scopes**:
```
both connected, only Outlook calendar-scoped (THE BUG)  → LiveOutlookCalendarBackend
both connected, NEITHER calendar-scoped                 → actionable ConfigurationError (names the scope to grant)
LIVE (this machine's real connectors)                   → LiveOutlookCalendarBackend
```
This machine has the Outlook calendar scoped but not Google — the exact reported condition, now routing to Outlook instead of failing. Full output in the evidence comment below.

## Test plan
- [x] `pytest tests/unit/agents/email/ tests/unit/email/` → **449 passed**
- [x] Scope-aware cases incl. `…only_microsoft_calendar_scoped_yields_outlook` and `…none_calendar_scoped_raises_actionable`
