### PR TITLE
fix(email): detect slot-proposal meetings; restore INBOX on quarantine-undo (#1709)

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/gmail_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/gmail_backend.py
@@ -521,7 +521,11 @@ class LiveGmailBackend:
         return self._post(f"/messages/{message_id}/trash")
 
     def untrash_message(self, message_id: str) -> Dict[str, Any]:
-        return self._post(f"/messages/{message_id}/untrash")
+        # Gmail untrash clears TRASH but does not re-add INBOX, so a
+        # quarantine/soft-delete undo would land in All Mail. Restore the inbox
+        # view so undo returns the message to its original state.
+        self._post(f"/messages/{message_id}/untrash")
+        return self._modify_labels(message_id, add=[GMAIL_LABEL_INBOX])
 
     def permanent_delete(self, message_id: str) -> None:
         self._delete(f"/messages/{message_id}")

--- a/hub/agents/python/email/gaia_agent_email/gmail_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/gmail_backend.py
@@ -47,11 +47,11 @@ from typing import (
 )
 
 import httpx
-
 from gaia_agent_email.scopes import (
     AGENT_NAMESPACED_ID,
     GMAIL_SCOPES,
 )
+
 from gaia.connectors.api import get_access_token_sync
 from gaia.connectors.errors import ConnectorsError
 from gaia.logger import get_logger

--- a/hub/agents/python/email/gaia_agent_email/tools/calendar_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/calendar_tools.py
@@ -31,8 +31,9 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
-from gaia.agents.base.tools import tool
 from gaia_agent_email.verbose import log_tool_call
+
+from gaia.agents.base.tools import tool
 from gaia.connectors.errors import ConnectorsError
 from gaia.connectors.formatting import format_connector_error
 from gaia.logger import get_logger
@@ -205,6 +206,7 @@ _SLOT_PROPOSAL_PHRASES = (
     "i'm available",
     "i am available",
 )
+
 
 def detect_meeting_request_heuristic(subject: str, body: str) -> MeetingDetection:
     """Detect a meeting request via deterministic keyword + time rules.

--- a/hub/agents/python/email/gaia_agent_email/tools/calendar_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/calendar_tools.py
@@ -127,6 +127,9 @@ _INVITE_PHRASES = (
     "lets set up",
     "does that time work",
     "does that work for you",
+    "i'd like to schedule",
+    "would like to schedule",
+    "i want to schedule",
 )
 
 # Meeting nouns — only a positive signal when paired with a concrete time
@@ -183,9 +186,35 @@ _SOFT_PHRASES = (
     "sometime soon",
 )
 
+# Slot-proposal phrases — finding-a-time language that signals the sender is
+# actively trying to schedule a meeting.  These are only a high-confidence
+# positive when they co-occur with a concrete time/day token (_TIME_RE), which
+# distinguishes "here are some times: Mon 2pm" from generic "here are some
+# options".  Decision (#1709): a slot-proposal IS a meeting request.
+_SLOT_PROPOSAL_PHRASES = (
+    "here are some times",
+    "here are a few times",
+    "here are some options",
+    "propose several times",
+    "propose a few times",
+    "let me know what time works",
+    "let me know which time works",
+    "does that work for",
+    "does this work for",
+    "work for you",
+    "i'm available",
+    "i am available",
+)
 
 def detect_meeting_request_heuristic(subject: str, body: str) -> MeetingDetection:
     """Detect a meeting request via deterministic keyword + time rules.
+
+    A **slot-proposal** email — where the sender offers candidate times to find
+    a mutual slot (e.g. "Tue 10am PT / Wed 2pm PT — does either work?") — is
+    treated as a meeting request (#1709).  It is the start of scheduling, and
+    downstream calendar capabilities (conflict detection, RSVP, event creation)
+    should engage.  Slot-proposal phrases are matched as a high-confidence
+    positive when they co-occur with a concrete time/day token.
 
     Args:
         subject: The email subject line (may be empty).
@@ -223,7 +252,23 @@ def detect_meeting_request_heuristic(subject: str, body: str) -> MeetingDetectio
             ),
         )
 
-    # 3. Soft / vague scheduling language — ambiguous. Do NOT commit to a
+    # 3. Slot-proposal phrase + concrete time — high-confidence positive.
+    #    "Here are some times: Mon 10am / Wed 2pm" is the canonical case.
+    #    Requiring a time token keeps precision — generic "work for you" in a
+    #    non-scheduling context won't match without a day or clock reference.
+    slot_hits = [p for p in _SLOT_PROPOSAL_PHRASES if p in text]
+    if slot_hits and time_match:
+        return MeetingDetection(
+            is_meeting_request=True,
+            confidence="high",
+            signals=tuple(slot_hits) + (time_match.group(0),),
+            reason=(
+                f"slot-proposal phrase {slot_hits[0]!r} with concrete time "
+                f"{time_match.group(0)!r}"
+            ),
+        )
+
+    # 4. Soft / vague scheduling language — ambiguous. Do NOT commit to a
     #    positive; flag low confidence so the caller escalates to the LLM.
     soft_hits = [p for p in _SOFT_PHRASES if p in text]
     if soft_hits:
@@ -234,7 +279,7 @@ def detect_meeting_request_heuristic(subject: str, body: str) -> MeetingDetectio
             reason=f"soft scheduling language without a concrete time: {soft_hits[0]!r}",
         )
 
-    # 4. A bare meeting noun with no time and no invite phrase — still
+    # 5. A bare meeting noun with no time and no invite phrase — still
     #    ambiguous (could be "the meeting ran long" vs "set up the meeting").
     if noun_hits:
         return MeetingDetection(
@@ -244,7 +289,7 @@ def detect_meeting_request_heuristic(subject: str, body: str) -> MeetingDetectio
             reason=f"meeting noun {noun_hits[0]!r} without a concrete time or invite",
         )
 
-    # 5. No signal at all — confident negative.
+    # 6. No signal at all — confident negative.
     return MeetingDetection(
         is_meeting_request=False,
         confidence="high",

--- a/tests/unit/agents/email/test_meeting_detection.py
+++ b/tests/unit/agents/email/test_meeting_detection.py
@@ -51,6 +51,35 @@ TRUE_POSITIVES = [
     ("Coffee", "Let's grab lunch on Friday — does noon work for you?"),
 ]
 
+# Slot-proposal emails: the sender proposes candidate times to find a mutual
+# slot.  Decision (#1709): a slot-proposal IS a meeting request — it is the
+# start of scheduling and downstream calendar capabilities should engage.
+SLOT_PROPOSALS = [
+    (
+        "Alignment session",
+        "I'd like to schedule an alignment session — Tue 10am PT / Wed 2pm PT / Thu 9am PT.",
+    ),
+    (
+        "Finding a time",
+        "Here are some times that work for me: Monday 3pm or Wednesday 11am. "
+        "Does either work for you?",
+    ),
+    (
+        "Re: intro call",
+        "I'd like to propose several times for our intro call: "
+        "Thursday 10am or Friday 2pm.",
+    ),
+    (
+        "Catch up",
+        "Let me know what time works for you — I'm available Monday at 10am or "
+        "Tuesday at 3pm.",
+    ),
+    (
+        "Quick chat",
+        "Does Thursday 9am work for you? If not, I can also do Friday afternoon.",
+    ),
+]
+
 # Non-meeting emails — no scheduling intent at all.
 TRUE_NEGATIVES = [
     ("Your order shipped", "Your package is on its way and will arrive Tuesday."),
@@ -147,6 +176,48 @@ class TestHeuristicTruePositive:
             "Meeting request: budget review at 3pm", "See you there."
         )
         assert result.is_meeting_request is True
+
+
+# ---------------------------------------------------------------------------
+# Heuristic — slot proposals (#1709)
+# A slot-proposal ("find a time") email IS a meeting request: it is the start
+# of scheduling.  The heuristic must return is_meeting_request=True with
+# high confidence so that downstream calendar capabilities engage.
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicSlotProposal:
+    @pytest.mark.parametrize("subject,body", SLOT_PROPOSALS)
+    def test_slot_proposal_is_a_meeting_request(self, subject, body):
+        result = detect_meeting_request_heuristic(subject, body)
+        assert result.is_meeting_request is True, (
+            f"Expected slot-proposal to be detected as meeting request, "
+            f"got is_meeting_request={result.is_meeting_request} "
+            f"(confidence={result.confidence!r}, reason={result.reason!r})"
+        )
+
+    @pytest.mark.parametrize("subject,body", SLOT_PROPOSALS)
+    def test_slot_proposal_has_high_confidence(self, subject, body):
+        result = detect_meeting_request_heuristic(subject, body)
+        assert result.confidence == "high", (
+            f"Expected high confidence for slot-proposal, got {result.confidence!r}"
+        )
+
+    def test_slot_proposal_signals_are_surfaced(self):
+        result = detect_meeting_request_heuristic(
+            "Alignment",
+            "Here are some times: Monday 10am or Wednesday 2pm.",
+        )
+        assert result.signals, "Signals should be non-empty for a slot-proposal match"
+
+    def test_generic_available_without_time_does_not_false_positive(self):
+        # "available" alone (no time signal, no scheduling context) must NOT
+        # trigger — avoids matching "I am available for questions".
+        result = detect_meeting_request_heuristic(
+            "Re: report",
+            "The report is available for download.",
+        )
+        assert result.is_meeting_request is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/email/test_meeting_detection.py
+++ b/tests/unit/agents/email/test_meeting_detection.py
@@ -199,9 +199,9 @@ class TestHeuristicSlotProposal:
     @pytest.mark.parametrize("subject,body", SLOT_PROPOSALS)
     def test_slot_proposal_has_high_confidence(self, subject, body):
         result = detect_meeting_request_heuristic(subject, body)
-        assert result.confidence == "high", (
-            f"Expected high confidence for slot-proposal, got {result.confidence!r}"
-        )
+        assert (
+            result.confidence == "high"
+        ), f"Expected high confidence for slot-proposal, got {result.confidence!r}"
 
     def test_slot_proposal_signals_are_surfaced(self):
         result = detect_meeting_request_heuristic(

--- a/tests/unit/email/test_gmail_client.py
+++ b/tests/unit/email/test_gmail_client.py
@@ -161,6 +161,16 @@ class TestRequestShape:
         backend.untrash_message("m1")
         assert rec.requests[0].url.path.endswith("/messages/m1/untrash")
 
+    def test_untrash_readds_inbox_label(self):
+        # Quarantine/soft-delete undo must restore the inbox view: after the
+        # untrash POST, a modify re-adds INBOX so the message returns to where
+        # it started rather than All Mail (#1709).
+        backend, rec, _ = _backend(lambda r: _ok({"id": "m1", "labelIds": ["INBOX"]}))
+        backend.untrash_message("m1")
+        assert rec.requests[0].url.path.endswith("/messages/m1/untrash")
+        assert rec.requests[1].url.path.endswith("/messages/m1/modify")
+        assert json.loads(rec.requests[1].content) == {"addLabelIds": ["INBOX"]}
+
     def test_permanent_delete_uses_delete_method(self):
         backend, rec, _ = _backend(lambda r: httpx.Response(204))
         backend.permanent_delete("m1")


### PR DESCRIPTION
Closes #1709

Two correctness gaps surfaced by #1691 live validation:
- **Meeting detection** treated "let's find a time" slot-proposal emails (e.g. "Tue 10am / Wed 2pm — does either work?") as *not* a meeting request, so calendar capabilities never engaged. They're now detected (slot-proposal phrasing co-occurring with a concrete time), per a documented decision.
- **Quarantine / soft-delete undo** left the message in All Mail: Gmail `untrash` clears TRASH but doesn't re-add INBOX. `untrash_message` now re-adds INBOX so undo restores the original state.

## Proof it resolves #1709
Real branch code:
```
detect_meeting_request("… Tue 10am / Wed 2pm — does either work?")  → is_meeting_request=True   (was False)
   controls:  confirmed single time → True   |   plain FYI → False
untrash_message('m1')  HTTP → POST …/m1/untrash  then  POST …/m1/modify  body={"addLabelIds":["INBOX"]}
```
Full output in the evidence comment below.

## Test plan
- [x] `pytest tests/unit/agents/email/ tests/unit/email/` → **453 passed**
- [x] New parametrized slot-proposal cases + `test_generic_available_without_time_does_not_false_positive`; `test_untrash_readds_inbox_label`
