### PR TITLE
fix(webui): serve frontend dist resolved per-request, not cached at startup

### DIFF
--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -67,7 +67,7 @@ from .tunnel import TunnelManager
 from .utils import ALLOWED_EXTENSIONS as _ALLOWED_EXTENSIONS  # noqa: F401
 from .utils import compute_file_hash as _compute_file_hash  # noqa: F401
 from .utils import sanitize_document_path as _sanitize_document_path  # noqa: F401
-from .utils import sanitize_static_path as _sanitize_static_path  # noqa: F401
+from .utils import sanitize_static_path as _sanitize_static_path
 from .utils import validate_file_path as _validate_file_path  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -769,7 +769,6 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
 
         if not index_html.is_file():
             # Frontend build not present yet -- serve the actionable fallback.
-            # Log only on first miss to avoid flooding logs during a build.
             return HTMLResponse(content=_FALLBACK_HTML, status_code=200)
 
         # 1. Token bootstrap path: only fires for the index-html case
@@ -787,6 +786,13 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             # Static asset (JS, CSS, image) -- never bootstrap a cookie
             # off this path; only the SPA index does that.
             return FileResponse(str(sanitized))
+
+        # A missing file under /assets/ is a real 404 -- don't mask a broken
+        # hashed chunk with index.html, or the browser parses the HTML as JS
+        # (``Uncaught SyntaxError: Unexpected token '<'``). SPA fallback is for
+        # route paths only.
+        if full_path.startswith("assets/"):
+            return HTMLResponse(content="Not Found", status_code=404)
 
         # SPA fallback: serve index.html. Bootstrap the auth cookie
         # if a valid ?token= is present (returns a 303 redirect that

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -595,131 +595,17 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
     )
 
     # ── Serve Frontend Static Files ──────────────────────────────────────
-    # Look for built frontend assets in the webui dist directory
+    # Look for built frontend assets in the webui dist directory.
+    # The dist path is resolved per-request so a build that completes after
+    # startup is served immediately on the next refresh without restarting
+    # the server (issue #1088).
     _default_dist = Path(__file__).resolve().parent.parent / "apps" / "webui" / "dist"
     _webui_dist = Path(webui_dist) if webui_dist else _default_dist
-    if _webui_dist.is_dir():
-        logger.info("Serving frontend from %s", _webui_dist)
 
-        from fastapi.responses import FileResponse
-
-        # Mount static assets (JS, CSS, etc.)
-        app.mount(
-            "/assets",
-            StaticFiles(directory=str(_webui_dist / "assets")),
-            name="static-assets",
-        )
-
-        # Serve index.html for all non-API routes (SPA fallback)
-        _resolved_dist = _webui_dist.resolve()
-        _index_html = str(_resolved_dist / "index.html")
-        # Prevent browsers and tunnel proxies from caching index.html so
-        # that rebuilt assets (with new content hashes) are always picked up.
-        # Hashed files under /assets/ are cached normally by StaticFiles.
-        # ``Referrer-Policy: no-referrer`` ensures that even if a token
-        # transiently appears in the URL (the QR-code landing path), it is
-        # never leaked to outbound requests via the ``Referer`` header.
-        _NO_CACHE = {
-            "Cache-Control": "no-cache, no-store, must-revalidate",
-            "Pragma": "no-cache",
-            "Expires": "0",
-            "Referrer-Policy": "no-referrer",
-        }
-
-        def _maybe_bootstrap_tunnel_cookie(request: Request):
-            """Validate ``?token=<uuid>`` and return a token-stripping redirect.
-
-            When a mobile browser first opens the QR-code URL
-            ``https://<tunnel>/?token=<uuid>``, we validate the token against
-            the active tunnel and:
-
-            1. Set a ``HttpOnly``, ``SameSite=Strict``, ``Secure`` cookie so
-               the SPA's subsequent same-origin ``fetch('/api/...')`` calls
-               authenticate automatically -- no frontend token-plumbing.
-            2. Redirect (303) to the same path with ``token`` stripped so the
-               token doesn't linger in the address bar, browser history, or
-               outbound ``Referer`` headers.
-
-            ``SameSite=Strict`` is the cookie-side defence against CSRF on
-            state-changing endpoints reached via the cookie path -- modern
-            browsers refuse to attach the cookie on any cross-site request.
-
-            Returns the redirect response if a cookie was bootstrapped, or
-            ``None`` if no token was present / valid (caller serves the
-            requested file normally).
-            """
-            tunnel_mgr = getattr(request.app.state, "tunnel", None)
-            qs_token = request.query_params.get("token")
-            if not (
-                tunnel_mgr is not None
-                and tunnel_mgr.active
-                and qs_token
-                and tunnel_mgr.validate_token(qs_token)
-            ):
-                return None
-
-            # ngrok terminates TLS and forwards plain HTTP, so direct
-            # request.url.scheme is often "http".  Trust X-Forwarded-Proto
-            # when present so the Secure flag is set on real tunnel requests.
-            fwd_proto = request.headers.get("x-forwarded-proto", "").lower()
-            is_https = request.url.scheme == "https" or fwd_proto == "https"
-
-            # Build the redirect target: same path, all query params except
-            # ``token``. Preserves friendly params like ``?session=...``.
-            stripped_qs = urlencode(
-                [(k, v) for k, v in request.query_params.multi_items() if k != "token"]
-            )
-            target = request.url.path + (f"?{stripped_qs}" if stripped_qs else "")
-
-            redirect = RedirectResponse(url=target, status_code=303)
-            redirect.set_cookie(
-                key=_TUNNEL_COOKIE_NAME,
-                value=qs_token,
-                httponly=True,
-                secure=is_https,
-                samesite="strict",
-                path="/",
-            )
-            logger.info(
-                "Tunnel auth: bootstrapped cookie for client %s (secure=%s, target=%s)",
-                request.client.host if request.client else "unknown",
-                is_https,
-                request.url.path,
-            )
-            return redirect
-
-        @app.get("/{full_path:path}")
-        async def serve_spa(request: Request, full_path: str):
-            """Serve the React SPA for all non-API routes."""
-            # 1. Token bootstrap path: only fires for the index-html case
-            #    (token always lands on ``/`` from the QR code). On any
-            #    static asset path we ignore the token entirely so the
-            #    cookie can't be planted via ``GET /favicon.png?token=...``.
-            #
-            # 2. Static asset path: use the shared ``sanitize_static_path``
-            #    utility -- it explicitly returns ``None`` for traversal
-            #    attempts, so CodeQL can trace the validation through to
-            #    the ``FileResponse`` call.
-            sanitized = _sanitize_static_path(_resolved_dist, full_path)
-
-            if sanitized is not None and sanitized.is_file():
-                # Static asset (JS, CSS, image) -- never bootstrap a cookie
-                # off this path; only the SPA index does that.
-                return FileResponse(str(sanitized))
-
-            # SPA fallback: serve index.html. Bootstrap the auth cookie
-            # if a valid ?token= is present (returns a 303 redirect that
-            # strips the token from the URL).
-            redirect = _maybe_bootstrap_tunnel_cookie(request)
-            if redirect is not None:
-                return redirect
-            return FileResponse(_index_html, headers=_NO_CACHE)
-
-    else:
-        # Resolve to an absolute path so users can act on the warning. Prefer
-        # the resolved form, but fall back to the raw value if the directory
-        # truly doesn't exist (resolve() of a missing path is harmless on POSIX
-        # but can surprise on Windows).
+    # Warn at startup when the dist dir is absent so that users can diagnose
+    # a wheel install without frontend assets. The warning is advisory only --
+    # the per-request handler will serve the fallback page until a build appears.
+    if not (_webui_dist / "index.html").is_file():
         try:
             _resolved_for_log = _webui_dist.resolve()
         except OSError:
@@ -735,8 +621,24 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             "in src/gaia/apps/webui/.",
             _resolved_for_log,
         )
+    else:
+        logger.info("Serving frontend from %s", _webui_dist)
 
-        _FALLBACK_HTML = """<!DOCTYPE html>
+    from fastapi.responses import FileResponse
+
+    # Prevent browsers and tunnel proxies from caching index.html so
+    # that rebuilt assets (with new content hashes) are always picked up.
+    # ``Referrer-Policy: no-referrer`` ensures that even if a token
+    # transiently appears in the URL (the QR-code landing path), it is
+    # never leaked to outbound requests via the ``Referer`` header.
+    _NO_CACHE = {
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "Referrer-Policy": "no-referrer",
+    }
+
+    _FALLBACK_HTML = """<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -792,15 +694,107 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
 </html>
 """
 
-        @app.get("/", response_class=HTMLResponse)
-        async def no_frontend():
-            """Serve a helpful HTML landing page when no frontend build is present.
+    def _maybe_bootstrap_tunnel_cookie(request: Request):
+        """Validate ``?token=<uuid>`` and return a token-stripping redirect.
 
-            The backend API is still fully functional; this page just tells
-            human visitors where to find the desktop app and API docs instead
-            of returning raw JSON.
-            """
+        When a mobile browser first opens the QR-code URL
+        ``https://<tunnel>/?token=<uuid>``, we validate the token against
+        the active tunnel and:
+
+        1. Set a ``HttpOnly``, ``SameSite=Strict``, ``Secure`` cookie so
+           the SPA's subsequent same-origin ``fetch('/api/...')`` calls
+           authenticate automatically -- no frontend token-plumbing.
+        2. Redirect (303) to the same path with ``token`` stripped so the
+           token doesn't linger in the address bar, browser history, or
+           outbound ``Referer`` headers.
+
+        ``SameSite=Strict`` is the cookie-side defence against CSRF on
+        state-changing endpoints reached via the cookie path -- modern
+        browsers refuse to attach the cookie on any cross-site request.
+
+        Returns the redirect response if a cookie was bootstrapped, or
+        ``None`` if no token was present / valid (caller serves the
+        requested file normally).
+        """
+        tunnel_mgr = getattr(request.app.state, "tunnel", None)
+        qs_token = request.query_params.get("token")
+        if not (
+            tunnel_mgr is not None
+            and tunnel_mgr.active
+            and qs_token
+            and tunnel_mgr.validate_token(qs_token)
+        ):
+            return None
+
+        # ngrok terminates TLS and forwards plain HTTP, so direct
+        # request.url.scheme is often "http".  Trust X-Forwarded-Proto
+        # when present so the Secure flag is set on real tunnel requests.
+        fwd_proto = request.headers.get("x-forwarded-proto", "").lower()
+        is_https = request.url.scheme == "https" or fwd_proto == "https"
+
+        # Build the redirect target: same path, all query params except
+        # ``token``. Preserves friendly params like ``?session=...``.
+        stripped_qs = urlencode(
+            [(k, v) for k, v in request.query_params.multi_items() if k != "token"]
+        )
+        target = request.url.path + (f"?{stripped_qs}" if stripped_qs else "")
+
+        redirect = RedirectResponse(url=target, status_code=303)
+        redirect.set_cookie(
+            key=_TUNNEL_COOKIE_NAME,
+            value=qs_token,
+            httponly=True,
+            secure=is_https,
+            samesite="strict",
+            path="/",
+        )
+        logger.info(
+            "Tunnel auth: bootstrapped cookie for client %s (secure=%s, target=%s)",
+            request.client.host if request.client else "unknown",
+            is_https,
+            request.url.path,
+        )
+        return redirect
+
+    @app.get("/{full_path:path}")
+    async def serve_spa(request: Request, full_path: str):
+        """Serve the React SPA for all non-API routes.
+
+        Resolves the dist directory on every request so a build that
+        completes after startup is picked up immediately without a
+        process restart (issue #1088).
+        """
+        resolved_dist = _webui_dist.resolve()
+        index_html = resolved_dist / "index.html"
+
+        if not index_html.is_file():
+            # Frontend build not present yet -- serve the actionable fallback.
+            # Log only on first miss to avoid flooding logs during a build.
             return HTMLResponse(content=_FALLBACK_HTML, status_code=200)
+
+        # 1. Token bootstrap path: only fires for the index-html case
+        #    (token always lands on ``/`` from the QR code). On any
+        #    static asset path we ignore the token entirely so the
+        #    cookie can't be planted via ``GET /favicon.png?token=...``.
+        #
+        # 2. Static asset path: use the shared ``sanitize_static_path``
+        #    utility -- it explicitly returns ``None`` for traversal
+        #    attempts, so CodeQL can trace the validation through to
+        #    the ``FileResponse`` call.
+        sanitized = _sanitize_static_path(resolved_dist, full_path)
+
+        if sanitized is not None and sanitized.is_file():
+            # Static asset (JS, CSS, image) -- never bootstrap a cookie
+            # off this path; only the SPA index does that.
+            return FileResponse(str(sanitized))
+
+        # SPA fallback: serve index.html. Bootstrap the auth cookie
+        # if a valid ?token= is present (returns a 303 redirect that
+        # strips the token from the URL).
+        redirect = _maybe_bootstrap_tunnel_cookie(request)
+        if redirect is not None:
+            return redirect
+        return FileResponse(str(index_html), headers=_NO_CACHE)
 
     return app
 

--- a/tests/unit/chat/ui/test_spa_hot_dist.py
+++ b/tests/unit/chat/ui/test_spa_hot_dist.py
@@ -1,0 +1,152 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for per-request SPA static file resolution (issue #1088).
+
+The server must NOT cache the presence or absence of the frontend dist directory
+at startup. If dist/ appears after the server is already running (e.g. because
+npm run build finished in the background), a fresh browser refresh must serve the
+real SPA without requiring a process restart.
+
+Acceptance criteria:
+- App started with an EMPTY dist dir serves the "no frontend build found" fallback.
+- After index.html + assets/app.js are written to that same dir, a fresh GET /
+  returns the REAL SPA content (not the fallback).
+- A fresh GET /assets/app.js returns the real asset file content.
+- The healthy-at-startup case continues to work (dist present before create_app()).
+- Path-traversal requests to /assets/../secret are still rejected.
+"""
+
+import tempfile
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from gaia.ui.server import create_app
+
+
+class TestSpaHotDistResolution:
+    """Server resolves the dist dir on every request, not once at startup."""
+
+    def test_fallback_served_when_dist_empty_at_startup(self):
+        """GET / on a freshly-created empty dist dir returns the fallback page."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist_dir = Path(tmpdir)
+            # dist_dir exists but has no index.html  ->  should hit fallback
+            app = create_app(webui_dist=str(dist_dir), db_path=":memory:")
+            client = TestClient(app, raise_server_exceptions=False)
+
+            resp = client.get("/")
+            assert resp.status_code == 200
+            # Must be the fallback page, not the real SPA
+            assert (
+                "no frontend build" in resp.text.lower()
+                or "desktop app" in resp.text.lower()
+            )
+            assert "REAL_SPA_CONTENT" not in resp.text
+
+    def test_real_spa_served_after_build_appears(self):
+        """After dist/index.html is written post-startup, GET / returns the real SPA."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist_dir = Path(tmpdir)
+            # Start with empty dir (no index.html)
+            app = create_app(webui_dist=str(dist_dir), db_path=":memory:")
+            client = TestClient(app, raise_server_exceptions=False)
+
+            # Confirm fallback is served first
+            resp_before = client.get("/")
+            assert "REAL_SPA_CONTENT" not in resp_before.text
+
+            # Simulate npm run build completing: write index.html + assets/
+            assets_dir = dist_dir / "assets"
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            (dist_dir / "index.html").write_text(
+                "<html><body>REAL_SPA_CONTENT</body></html>", encoding="utf-8"
+            )
+            (assets_dir / "app.js").write_text(
+                "/* REAL_ASSET_CONTENT */", encoding="utf-8"
+            )
+
+            # NO app recreation -- same client, same process
+            resp_after = client.get("/")
+            assert resp_after.status_code == 200
+            assert "REAL_SPA_CONTENT" in resp_after.text, (
+                "Expected real SPA content after dist appeared, got fallback: "
+                + resp_after.text[:300]
+            )
+
+    def test_asset_served_after_build_appears(self):
+        """After dist/assets/app.js appears, GET /assets/app.js returns the file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist_dir = Path(tmpdir)
+            app = create_app(webui_dist=str(dist_dir), db_path=":memory:")
+            client = TestClient(app, raise_server_exceptions=False)
+
+            # Before build: asset should NOT be found (or not return real content)
+            resp_before = client.get("/assets/app.js")
+            assert (
+                resp_before.status_code != 200
+                or "REAL_ASSET_CONTENT" not in resp_before.text
+            )
+
+            # Write the assets
+            assets_dir = dist_dir / "assets"
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            (dist_dir / "index.html").write_text(
+                "<html><body>REAL_SPA_CONTENT</body></html>", encoding="utf-8"
+            )
+            (assets_dir / "app.js").write_text(
+                "/* REAL_ASSET_CONTENT */", encoding="utf-8"
+            )
+
+            resp_after = client.get("/assets/app.js")
+            assert resp_after.status_code == 200
+            assert "REAL_ASSET_CONTENT" in resp_after.text
+
+    def test_healthy_startup_case_unchanged(self):
+        """When dist is present at startup, GET / still serves the real SPA."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist_dir = Path(tmpdir)
+            assets_dir = dist_dir / "assets"
+            assets_dir.mkdir(parents=True)
+            (dist_dir / "index.html").write_text(
+                "<html><body>REAL_SPA_CONTENT</body></html>", encoding="utf-8"
+            )
+            (assets_dir / "app.js").write_text(
+                "/* REAL_ASSET_CONTENT */", encoding="utf-8"
+            )
+
+            app = create_app(webui_dist=str(dist_dir), db_path=":memory:")
+            client = TestClient(app, raise_server_exceptions=False)
+
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert "REAL_SPA_CONTENT" in resp.text
+
+    def test_path_traversal_outside_dist_rejected(self):
+        """Requests that escape the dist directory must not serve files from outside it."""
+        with tempfile.TemporaryDirectory() as outer_dir_str:
+            outer_dir = Path(outer_dir_str)
+            dist_dir = outer_dir / "dist"
+            dist_dir.mkdir()
+            assets_dir = dist_dir / "assets"
+            assets_dir.mkdir()
+            (dist_dir / "index.html").write_text(
+                "<html><body>REAL_SPA_CONTENT</body></html>", encoding="utf-8"
+            )
+            # Write a "secret" file OUTSIDE the dist dir (one level up)
+            (outer_dir / "secret.txt").write_text(
+                "SECRET_OUTSIDE_DIST", encoding="utf-8"
+            )
+
+            app = create_app(webui_dist=str(dist_dir), db_path=":memory:")
+            client = TestClient(app, raise_server_exceptions=False)
+
+            # Traversal attempt escaping the dist root -- must NOT serve the file
+            # HTTP clients normalize ".." so we check sanitize_static_path directly
+            from gaia.ui.utils import sanitize_static_path
+
+            result = sanitize_static_path(dist_dir.resolve(), "../secret.txt")
+            assert (
+                result is None
+            ), "_sanitize_static_path should reject traversal outside dist dir"

--- a/tests/unit/chat/ui/test_spa_hot_dist.py
+++ b/tests/unit/chat/ui/test_spa_hot_dist.py
@@ -123,6 +123,37 @@ class TestSpaHotDistResolution:
             assert resp.status_code == 200
             assert "REAL_SPA_CONTENT" in resp.text
 
+    def test_missing_asset_returns_404_not_index_html(self):
+        """A missing file under /assets/ must 404, not fall through to index.html.
+
+        Otherwise a stale hashed chunk request gets index.html (text/html) back,
+        which the browser tries to execute as JS (``Uncaught SyntaxError``).
+        SPA fallback is correct for route paths only (issue #1741 review).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist_dir = Path(tmpdir)
+            assets_dir = dist_dir / "assets"
+            assets_dir.mkdir(parents=True)
+            (dist_dir / "index.html").write_text(
+                "<html><body>REAL_SPA_CONTENT</body></html>", encoding="utf-8"
+            )
+
+            app = create_app(webui_dist=str(dist_dir), db_path=":memory:")
+            client = TestClient(app, raise_server_exceptions=False)
+
+            # Missing hashed chunk under /assets/ -> real 404, not index.html
+            resp = client.get("/assets/old-chunk-abc123.js")
+            assert resp.status_code == 404, (
+                "Missing /assets/* file must 404, not serve index.html; got "
+                f"{resp.status_code}"
+            )
+            assert "REAL_SPA_CONTENT" not in resp.text
+
+            # A non-asset route path still falls back to the SPA (unchanged).
+            resp_route = client.get("/some/app/route")
+            assert resp_route.status_code == 200
+            assert "REAL_SPA_CONTENT" in resp_route.text
+
     def test_path_traversal_outside_dist_rejected(self):
         """Requests that escape the dist directory must not serve files from outside it."""
         with tempfile.TemporaryDirectory() as outer_dir_str:


### PR DESCRIPTION
Closes #1088

## Why this matters
A first-run `gaia chat --ui` user on the silent npm-autoinstall path would see the "no frontend build found" fallback **forever**: the build finished in the background, but the server had cached the dist-missing decision at startup, so refreshing never picked it up — only a manual restart did. Now the server resolves the frontend dist **per request**, so the moment a build appears the next refresh serves the real UI, with no restart.

## Evidence
Live test on this branch — one server process, `--ui-dist` pointed at an empty dir, dist populated in-place mid-run (no restart):

```
# empty dist at startup
GET /  ->  200, title "GAIA Agent UI — Backend API", isFallback: true
# copy the built dist into the SAME path, no restart, refresh:
GET /  ->  200, title "GAIA", isRealSPA: true, stillFallback: false
```

Before→after screenshots captured during validation: the fallback page becomes the full Agent UI in the same process (same PID, no restart).
_How tested:_ `python -m gaia.ui.server --ui-dist <empty-dir>` on the branch, then `cp` the built dist into that dir and refresh the browser.

## Tests
- [x] New integration tests `tests/unit/chat/ui/test_spa_hot_dist.py` — 5/5 pass (empty→fallback, build-appears→real SPA **without restart**, asset served post-build, healthy startup unchanged, path-traversal rejected)
- [x] `pytest -k "server or static or spa"` — 361 passed, 38 skipped (3 failures are pre-existing `No module named 'mcp'`, present on `main`)
- [x] `python util/lint.py --all` — clean
- [x] Real-world (local Mac): fallback → real SPA, same process, no restart (transcript above)