### PR TITLE
feat(documents): persist last_error + reindex API for failed docs

### DIFF
--- a/src/gaia/apps/webui/src/components/DocumentLibrary.css
+++ b/src/gaia/apps/webui/src/components/DocumentLibrary.css
@@ -181,3 +181,9 @@
     background: var(--accent-danger-dim);
     color: var(--accent-danger, #e74c3c);
 }
+.btn-retry:disabled {
+    opacity: 0.6;
+    cursor: default;
+    background: transparent;
+    color: var(--text-muted);
+}

--- a/src/gaia/apps/webui/src/components/DocumentLibrary.css
+++ b/src/gaia/apps/webui/src/components/DocumentLibrary.css
@@ -155,21 +155,29 @@
 .empty-docs p { font-size: 14px; margin-top: 8px; }
 .empty-docs span { font-size: 12px; margin-top: 4px; }
 
-/* Retry button for failed documents */
+/* Failed-doc status: badge + retry need breathing room between them */
+.doc-indexing-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* Retry button for failed documents — subtle ghost, not a second heavy red pill
+   crowding the Failed badge */
 .btn-retry {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 2px 8px;
+    padding: 2px 6px;
     font-size: 11px;
-    border: 1px solid var(--accent-danger, #e74c3c);
+    border: none;
     border-radius: 4px;
     background: transparent;
-    color: var(--accent-danger, #e74c3c);
+    color: var(--text-muted);
     cursor: pointer;
     transition: background 0.15s, color 0.15s;
 }
 .btn-retry:hover {
-    background: var(--accent-danger, #e74c3c);
-    color: #fff;
+    background: var(--accent-danger-dim);
+    color: var(--accent-danger, #e74c3c);
 }

--- a/src/gaia/apps/webui/src/components/DocumentLibrary.css
+++ b/src/gaia/apps/webui/src/components/DocumentLibrary.css
@@ -154,3 +154,22 @@
 }
 .empty-docs p { font-size: 14px; margin-top: 8px; }
 .empty-docs span { font-size: 12px; margin-top: 4px; }
+
+/* Retry button for failed documents */
+.btn-retry {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    font-size: 11px;
+    border: 1px solid var(--accent-danger, #e74c3c);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--accent-danger, #e74c3c);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+.btn-retry:hover {
+    background: var(--accent-danger, #e74c3c);
+    color: #fff;
+}

--- a/src/gaia/apps/webui/src/components/DocumentLibrary.tsx
+++ b/src/gaia/apps/webui/src/components/DocumentLibrary.tsx
@@ -77,6 +77,8 @@ export function DocumentLibrary() {
     const [folderPath, setFolderPath] = useState('');
     // Upload error state for rich error toasts
     const [uploadError, setUploadError] = useState<{ filename: string; error: string } | null>(null);
+    // Documents with a reindex in flight — guards double-click and shows progress
+    const [reindexingIds, setReindexingIds] = useState<Set<string>>(new Set());
     // Track indexing start times for elapsed display
     const indexingStartTimes = useRef<Map<string, number>>(new Map());
     // Force re-render for elapsed time updates
@@ -328,17 +330,33 @@ export function DocumentLibrary() {
     }, [documents, setDocuments]);
 
     const handleReindex = useCallback(async (id: string) => {
+        if (reindexingIds.has(id)) return; // guard against double-click
         const doc = documents.find((d) => d.id === id);
         log.doc.info(`Reindexing document: ${doc?.filename || id}`);
+        setReindexingIds((s) => new Set(s).add(id));
         try {
             await api.reindexDocument(id);
-            const data = await api.listDocuments();
-            setDocuments(data.documents || []);
             log.doc.info(`Reindex complete for: ${doc?.filename || id}`);
         } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
             log.doc.error(`Reindex failed for: ${doc?.filename || id}`, err);
+            setUploadError({ filename: doc?.filename || id, error: msg });
+        } finally {
+            // Refresh regardless of outcome so the updated status / last_error
+            // shows even when the retry failed again.
+            try {
+                const data = await api.listDocuments();
+                setDocuments(data.documents || []);
+            } catch (e) {
+                log.doc.error('Failed to refresh documents after reindex', e);
+            }
+            setReindexingIds((s) => {
+                const next = new Set(s);
+                next.delete(id);
+                return next;
+            });
         }
-    }, [documents, setDocuments]);
+    }, [documents, setDocuments, reindexingIds]);
 
     const handleAttachDoc = useCallback(async (docId: string) => {
         if (!currentSessionId) return;
@@ -413,9 +431,10 @@ export function DocumentLibrary() {
                             onClick={(e) => { e.stopPropagation(); handleReindex(doc.id); }}
                             title="Retry indexing"
                             aria-label={`Retry indexing ${doc.filename}`}
+                            disabled={reindexingIds.has(doc.id)}
                         >
                             <RefreshCcw size={14} />
-                            Retry
+                            {reindexingIds.has(doc.id) ? 'Retrying…' : 'Retry'}
                         </button>
                     </div>
                 );

--- a/src/gaia/apps/webui/src/components/DocumentLibrary.tsx
+++ b/src/gaia/apps/webui/src/components/DocumentLibrary.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { X, Upload, Trash2, FileText, FolderOpen, Search, StopCircle, CheckCircle, AlertCircle, Loader, Clock, Link2 } from 'lucide-react';
+import { X, Upload, Trash2, FileText, FolderOpen, Search, StopCircle, CheckCircle, AlertCircle, Loader, Clock, Link2, RefreshCcw } from 'lucide-react';
 import { useChatStore } from '../stores/chatStore';
 import * as api from '../services/api';
 import { log } from '../utils/logger';
@@ -327,6 +327,19 @@ export function DocumentLibrary() {
         }
     }, [documents, setDocuments]);
 
+    const handleReindex = useCallback(async (id: string) => {
+        const doc = documents.find((d) => d.id === id);
+        log.doc.info(`Reindexing document: ${doc?.filename || id}`);
+        try {
+            await api.reindexDocument(id);
+            const data = await api.listDocuments();
+            setDocuments(data.documents || []);
+            log.doc.info(`Reindex complete for: ${doc?.filename || id}`);
+        } catch (err) {
+            log.doc.error(`Reindex failed for: ${doc?.filename || id}`, err);
+        }
+    }, [documents, setDocuments]);
+
     const handleAttachDoc = useCallback(async (docId: string) => {
         if (!currentSessionId) return;
         const doc = documents.find((d) => d.id === docId);
@@ -387,9 +400,24 @@ export function DocumentLibrary() {
                 );
             case 'failed':
                 return (
-                    <span className="doc-status-badge doc-status-failed">
-                        <AlertCircle size={12} /> Failed
-                    </span>
+                    <div className="doc-indexing-status">
+                        <span
+                            className="doc-status-badge doc-status-failed"
+                            title={doc.last_error || undefined}
+                            aria-label={doc.last_error ? `Failed: ${doc.last_error}` : 'Indexing failed'}
+                        >
+                            <AlertCircle size={12} /> Failed
+                        </span>
+                        <button
+                            className="btn-retry"
+                            onClick={(e) => { e.stopPropagation(); handleReindex(doc.id); }}
+                            title="Retry indexing"
+                            aria-label={`Retry indexing ${doc.filename}`}
+                        >
+                            <RefreshCcw size={14} />
+                            Retry
+                        </button>
+                    </div>
                 );
             case 'cancelled':
                 return (

--- a/src/gaia/apps/webui/src/components/__tests__/DocumentLibrary.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/DocumentLibrary.test.tsx
@@ -1,0 +1,107 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocumentLibrary } from '../DocumentLibrary';
+import { useChatStore } from '../../stores/chatStore';
+import * as api from '../../services/api';
+import type { Document } from '../../types';
+
+vi.mock('../../services/api');
+
+const mockedApi = vi.mocked(api);
+
+const FAILED_DOC: Document = {
+    id: 'doc-fail-1',
+    filename: 'broken.pdf',
+    filepath: '/tmp/broken.pdf',
+    file_size: 1024,
+    chunk_count: 0,
+    indexed_at: new Date().toISOString(),
+    last_accessed_at: null,
+    sessions_using: 0,
+    indexing_status: 'failed',
+    last_error: 'RAG pipeline timed out',
+};
+
+const COMPLETE_DOC: Document = {
+    id: 'doc-ok-1',
+    filename: 'good.pdf',
+    filepath: '/tmp/good.pdf',
+    file_size: 2048,
+    chunk_count: 5,
+    indexed_at: new Date().toISOString(),
+    last_accessed_at: null,
+    sessions_using: 0,
+    indexing_status: 'complete',
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedApi.listDocuments.mockResolvedValue({
+        documents: [FAILED_DOC],
+        total: 1,
+        total_size_bytes: 1024,
+        total_chunks: 0,
+    });
+    mockedApi.reindexDocument.mockResolvedValue({ ...FAILED_DOC, indexing_status: 'complete', last_error: null, chunk_count: 3 });
+
+    useChatStore.setState({
+        currentSessionId: null,
+        sessions: [],
+        showDocLibrary: true,
+    });
+});
+
+describe('DocumentLibrary failed doc', () => {
+    it('renders a failed document with a Retry button', async () => {
+        render(<DocumentLibrary />);
+
+        // Wait for the document list to load
+        await screen.findByText('broken.pdf');
+
+        const retryBtn = screen.getByRole('button', { name: /Retry indexing broken\.pdf/i });
+        expect(retryBtn).toBeTruthy();
+    });
+
+    it('shows the error message as the badge title attribute', async () => {
+        render(<DocumentLibrary />);
+
+        await screen.findByText('broken.pdf');
+
+        // The Failed badge wraps an AlertCircle + "Failed" text and carries the error as title
+        const badge = screen.getByTitle('RAG pipeline timed out');
+        expect(badge).toBeTruthy();
+    });
+
+    it('clicking Retry calls reindexDocument and refreshes the list', async () => {
+        mockedApi.listDocuments.mockResolvedValueOnce({
+            documents: [FAILED_DOC],
+            total: 1,
+            total_size_bytes: 1024,
+            total_chunks: 0,
+        }).mockResolvedValueOnce({
+            documents: [{ ...FAILED_DOC, indexing_status: 'complete', last_error: null, chunk_count: 3 }],
+            total: 1,
+            total_size_bytes: 1024,
+            total_chunks: 3,
+        });
+
+        render(<DocumentLibrary />);
+
+        await screen.findByText('broken.pdf');
+
+        const retryBtn = screen.getByRole('button', { name: /Retry indexing broken\.pdf/i });
+        fireEvent.click(retryBtn);
+
+        await waitFor(() => {
+            expect(mockedApi.reindexDocument).toHaveBeenCalledWith('doc-fail-1');
+        });
+
+        await waitFor(() => {
+            expect(mockedApi.listDocuments).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -713,6 +713,10 @@ export async function cancelIndexing(id: string): Promise<{ cancelled: boolean; 
     return apiFetch('POST', `/documents/${id}/cancel`);
 }
 
+export async function reindexDocument(id: string): Promise<Document> {
+    return apiFetch('POST', `/documents/${id}/reindex`);
+}
+
 export async function attachDocument(sessionId: string, documentId: string): Promise<void> {
     return apiFetch('POST', `/sessions/${sessionId}/documents`, { document_id: documentId });
 }

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -330,6 +330,7 @@ export interface Document {
     last_accessed_at: string | null;
     sessions_using: number;
     indexing_status?: 'pending' | 'indexing' | 'complete' | 'failed' | 'cancelled' | 'missing';
+    last_error?: string | null;
 }
 
 /** A file attached to a message before sending. */

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -881,9 +881,10 @@ class ChatDatabase:
             doc_id: Document ID.
             status: New status ('pending', 'indexing', 'complete', 'failed', 'cancelled').
             chunk_count: If provided, also update the chunk count.
-            last_error: If provided, persist the error message (set to None to clear).
-                        Pass last_error=None without providing it to leave the existing
-                        value unchanged; pass last_error="" to explicitly clear it.
+            last_error: Controls the stored error message.
+                        Omit (default) to leave the existing value unchanged.
+                        Pass None to clear the column (SQL NULL).
+                        Pass a string to store that error message.
 
         Returns:
             True if the document was found and updated.

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -28,6 +28,10 @@ SESSION_DEFAULT_MODEL = "Gemma-4-E4B-it-GGUF"
 # last_error" from "caller did not pass last_error at all" (leaving it unchanged).
 _UNSET = object()
 
+# Cap stored indexing error messages -- they are surfaced verbatim in a UI
+# tooltip and a raw traceback/exception string can be very large (#1749 review).
+_MAX_LAST_ERROR_LEN = 500
+
 SCHEMA_SQL = """
 -- Global document library
 CREATE TABLE IF NOT EXISTS documents (
@@ -902,6 +906,11 @@ class ChatDatabase:
                 params.append(None)
             elif last_error is not _UNSET:
                 parts.append("last_error = ?")
+                if (
+                    isinstance(last_error, str)
+                    and len(last_error) > _MAX_LAST_ERROR_LEN
+                ):
+                    last_error = last_error[: _MAX_LAST_ERROR_LEN - 1] + "…"
                 params.append(last_error)
             parts.append("last_accessed_at = ?")
             params.append(self._now())

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -24,6 +24,10 @@ DEFAULT_DB_PATH = Path.home() / ".gaia" / "chat" / "gaia_chat.db"
 # any code that reads session["model"] and falls back when the field is NULL.
 SESSION_DEFAULT_MODEL = "Gemma-4-E4B-it-GGUF"
 
+# Sentinel used by update_document_status to distinguish "caller passed None to clear
+# last_error" from "caller did not pass last_error at all" (leaving it unchanged).
+_UNSET = object()
+
 SCHEMA_SQL = """
 -- Global document library
 CREATE TABLE IF NOT EXISTS documents (
@@ -34,7 +38,8 @@ CREATE TABLE IF NOT EXISTS documents (
     file_size INTEGER DEFAULT 0,
     chunk_count INTEGER DEFAULT 0,
     indexed_at TEXT DEFAULT (datetime('now')),
-    last_accessed_at TEXT
+    last_accessed_at TEXT,
+    last_error TEXT
 );
 
 -- Sessions (conversations)
@@ -208,6 +213,19 @@ class ChatDatabase:
                 logger.info("Migrated documents table: added file_mtime column")
         except Exception as e:
             logger.debug("Migration check for file_mtime: %s", e)
+
+        # Add last_error column for persisting indexing failure messages
+        try:
+            doc_cols = [
+                row[1]
+                for row in self._conn.execute("PRAGMA table_info(documents)").fetchall()
+            ]
+            if "last_error" not in doc_cols:
+                self._conn.execute("ALTER TABLE documents ADD COLUMN last_error TEXT")
+                self._conn.commit()
+                logger.info("Migrated documents table: added last_error column")
+        except Exception as e:
+            logger.debug("Migration check for last_error: %s", e)
 
         # Add private column to sessions for per-session incognito mode,
         # and agent_type column for per-session agent selection.
@@ -851,7 +869,11 @@ class ChatDatabase:
     # ── Document Status ────────────────────────────────────────────
 
     def update_document_status(
-        self, doc_id: str, status: str, chunk_count: int | None = None
+        self,
+        doc_id: str,
+        status: str,
+        chunk_count: int | None = None,
+        last_error: str | None = _UNSET,
     ) -> bool:
         """Update a document's indexing status and optionally its chunk count.
 
@@ -859,6 +881,9 @@ class ChatDatabase:
             doc_id: Document ID.
             status: New status ('pending', 'indexing', 'complete', 'failed', 'cancelled').
             chunk_count: If provided, also update the chunk count.
+            last_error: If provided, persist the error message (set to None to clear).
+                        Pass last_error=None without providing it to leave the existing
+                        value unchanged; pass last_error="" to explicitly clear it.
 
         Returns:
             True if the document was found and updated.
@@ -869,6 +894,14 @@ class ChatDatabase:
             if chunk_count is not None:
                 parts.append("chunk_count = ?")
                 params.append(chunk_count)
+            # Successful indexing always clears any prior error message.
+            # For other statuses, only write last_error when explicitly passed.
+            if status == "complete":
+                parts.append("last_error = ?")
+                params.append(None)
+            elif last_error is not _UNSET:
+                parts.append("last_error = ?")
+                params.append(last_error)
             parts.append("last_accessed_at = ?")
             params.append(self._now())
             params.append(doc_id)

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -419,6 +419,7 @@ class DocumentResponse(BaseModel):
     indexing_status: str = (
         "complete"  # pending | indexing | complete | failed | cancelled | missing
     )
+    last_error: Optional[str] = None
 
 
 class DocumentListResponse(BaseModel):

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -198,6 +198,7 @@ async def upload_by_path(
         try:
             if file_size <= LARGE_FILE_THRESHOLD:
                 # Small file: index synchronously
+                index_error = None
                 try:
                     chunk_count = await _index_document(temp_path)
                 except Exception as e:
@@ -208,6 +209,7 @@ async def upload_by_path(
                         exc_info=True,
                     )
                     chunk_count = 0
+                    index_error = str(e)
 
                 if chunk_count == 0:
                     doc = db.add_document(
@@ -218,8 +220,12 @@ async def upload_by_path(
                         chunk_count=0,
                         file_mtime=file_mtime,
                     )
-                    db.update_document_status(doc["id"], "failed")
+                    error_text = index_error or "indexing produced 0 chunks"
+                    db.update_document_status(
+                        doc["id"], "failed", last_error=error_text
+                    )
                     doc["indexing_status"] = "failed"
+                    doc["last_error"] = error_text
                     return doc_to_response(doc)
 
                 doc = db.add_document(
@@ -260,7 +266,12 @@ async def upload_by_path(
                     chunk_count = await _index_document(temp_file)
                     if doc_id in indexing_tasks:
                         if chunk_count == 0:
-                            db.update_document_status(doc_id, "failed", chunk_count=0)
+                            db.update_document_status(
+                                doc_id,
+                                "failed",
+                                chunk_count=0,
+                                last_error="indexing produced 0 chunks",
+                            )
                             logger.warning(
                                 "Background indexing returned 0 chunks for %s",
                                 original_name,
@@ -278,7 +289,7 @@ async def upload_by_path(
                     db.update_document_status(doc_id, "cancelled")
                     logger.info("Background indexing cancelled for %s", original_name)
                 except Exception as e:
-                    db.update_document_status(doc_id, "failed")
+                    db.update_document_status(doc_id, "failed", last_error=str(e))
                     logger.error(
                         "Background indexing failed for %s: %s",
                         original_name,
@@ -559,8 +570,14 @@ async def reindex_document(
     db.update_document_status(doc_id, "indexing", last_error=None)
 
     _index_document = _server_mod()._index_document
+    temp_path = None
     try:
-        chunk_count = await _index_document(Path(filepath))
+        # Index a process-controlled temp copy opened atomically with
+        # O_NOFOLLOW + fstat -- the same TOCTOU/symlink hardening the upload
+        # path uses, rather than re-reading the stored path directly.
+        with safe_open_document(filepath) as (fd, _file_stat, safe_filepath):
+            temp_path = _copy_fd_to_temp(fd, safe_filepath.suffix)
+        chunk_count = await _index_document(temp_path)
     except Exception as exc:
         error_msg = str(exc)
         db.update_document_status(doc_id, "failed", last_error=error_msg)
@@ -569,6 +586,9 @@ async def reindex_document(
             status_code=500,
             detail="Reindex failed; see server logs for details",
         ) from exc
+    finally:
+        if temp_path is not None:
+            _cleanup_temp(temp_path)
 
     db.update_document_status(doc_id, "complete", chunk_count=chunk_count)
     logger.info("Reindex complete for %s: %d chunks", doc_id, chunk_count)

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -553,7 +553,7 @@ async def reindex_document(
     if not filepath or not Path(filepath).exists():
         raise HTTPException(
             status_code=422,
-            detail=f"File not found on disk: {filepath!r}",
+            detail=f"File not found on disk for document {doc_id!r}",
         )
 
     db.update_document_status(doc_id, "indexing", last_error=None)
@@ -567,13 +567,17 @@ async def reindex_document(
         logger.error("Reindex failed for %s: %s", doc_id, exc, exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=f"Reindex failed: {error_msg}",
+            detail="Reindex failed; see server logs for details",
         ) from exc
 
     db.update_document_status(doc_id, "complete", chunk_count=chunk_count)
     logger.info("Reindex complete for %s: %d chunks", doc_id, chunk_count)
 
     updated = db.get_document(doc_id)
+    if updated is None:
+        raise HTTPException(
+            status_code=404, detail="Document was deleted during reindex"
+        )
     return doc_to_response(updated)
 
 

--- a/src/gaia/ui/routers/documents.py
+++ b/src/gaia/ui/routers/documents.py
@@ -533,6 +533,50 @@ async def cancel_indexing(
     return {"cancelled": True, "id": doc_id}
 
 
+@router.post("/api/documents/{doc_id}/reindex", response_model=DocumentResponse)
+async def reindex_document(
+    doc_id: str,
+    db: ChatDatabase = Depends(get_db),
+):
+    """Re-run the RAG indexing pipeline for a document.
+
+    Clears any previous failure, sets status to 'indexing', runs the full
+    indexing pipeline, then marks the document 'complete' on success or
+    'failed' (with last_error set) on failure.  Always raises loudly on
+    error — never returns 200 while leaving the document in a bad state.
+    """
+    doc = db.get_document(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    filepath = doc.get("filepath")
+    if not filepath or not Path(filepath).exists():
+        raise HTTPException(
+            status_code=422,
+            detail=f"File not found on disk: {filepath!r}",
+        )
+
+    db.update_document_status(doc_id, "indexing", last_error=None)
+
+    _index_document = _server_mod()._index_document
+    try:
+        chunk_count = await _index_document(Path(filepath))
+    except Exception as exc:
+        error_msg = str(exc)
+        db.update_document_status(doc_id, "failed", last_error=error_msg)
+        logger.error("Reindex failed for %s: %s", doc_id, exc, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Reindex failed: {error_msg}",
+        ) from exc
+
+    db.update_document_status(doc_id, "complete", chunk_count=chunk_count)
+    logger.info("Reindex complete for %s: %d chunks", doc_id, chunk_count)
+
+    updated = db.get_document(doc_id)
+    return doc_to_response(updated)
+
+
 @router.delete("/api/documents/{doc_id}")
 async def delete_document(doc_id: str, db: ChatDatabase = Depends(get_db)):
     """Remove a document from the library.

--- a/src/gaia/ui/utils.py
+++ b/src/gaia/ui/utils.py
@@ -208,6 +208,7 @@ def doc_to_response(doc: dict) -> DocumentResponse:
         last_accessed_at=doc.get("last_accessed_at"),
         sessions_using=doc.get("sessions_using", 0),
         indexing_status=doc.get("indexing_status", "complete"),
+        last_error=doc.get("last_error"),
     )
 
 

--- a/tests/integration/test_documents_router.py
+++ b/tests/integration/test_documents_router.py
@@ -318,8 +318,6 @@ def failed_doc(client, managed_docs_sandbox):
     doc_id = doc["id"]
 
     # Directly set status to failed with a last_error via the DB
-    from gaia.ui.dependencies import get_db as _get_db
-
     # Access the db from the app state
     app = client.app
     db = app.state.db
@@ -331,9 +329,7 @@ def test_reindex_endpoint_happy_path(client, failed_doc, managed_docs_sandbox):
     """POST /api/documents/{id}/reindex on a failed doc re-runs indexing and clears last_error."""
     doc_id = failed_doc["id"]
 
-    with patch(
-        "gaia.ui.server._index_document", new=AsyncMock(return_value=5)
-    ):
+    with patch("gaia.ui.server._index_document", new=AsyncMock(return_value=5)):
         r = client.post(f"/api/documents/{doc_id}/reindex")
 
     assert r.status_code == 200, r.text

--- a/tests/integration/test_documents_router.py
+++ b/tests/integration/test_documents_router.py
@@ -300,3 +300,103 @@ def test_delete_path_document_preserves_user_file(
 def test_delete_nonexistent_returns_404(client):
     r = client.delete("/api/documents/does-not-exist")
     assert r.status_code == 404
+
+
+# ── Reindex endpoint tests ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def failed_doc(client, managed_docs_sandbox):
+    """Upload a document and force its status to 'failed' with a last_error."""
+    # Upload a real file so the DB row has a valid filepath
+    r = client.post(
+        "/api/documents/upload",
+        files={"file": ("error_doc.txt", b"content for failed doc", "text/plain")},
+    )
+    assert r.status_code == 200, r.text
+    doc = r.json()
+    doc_id = doc["id"]
+
+    # Directly set status to failed with a last_error via the DB
+    from gaia.ui.dependencies import get_db as _get_db
+
+    # Access the db from the app state
+    app = client.app
+    db = app.state.db
+    db.update_document_status(doc_id, "failed", last_error="RAG pipeline failure")
+    return doc
+
+
+def test_reindex_endpoint_happy_path(client, failed_doc, managed_docs_sandbox):
+    """POST /api/documents/{id}/reindex on a failed doc re-runs indexing and clears last_error."""
+    doc_id = failed_doc["id"]
+
+    with patch(
+        "gaia.ui.server._index_document", new=AsyncMock(return_value=5)
+    ):
+        r = client.post(f"/api/documents/{doc_id}/reindex")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("id") == doc_id
+
+    # Fetch doc back and verify status + last_error cleared
+    app = client.app
+    db = app.state.db
+    doc = db.get_document(doc_id)
+    assert doc is not None
+    assert doc["indexing_status"] == "complete"
+    assert doc.get("last_error") is None
+
+
+def test_reindex_unknown_id_returns_404(client):
+    """POST /api/documents/{id}/reindex on an unknown id → 404."""
+    r = client.post("/api/documents/does-not-exist/reindex")
+    assert r.status_code == 404
+    assert "detail" in r.json()
+
+
+def test_reindex_failure_sets_failed_with_last_error(
+    client, failed_doc, managed_docs_sandbox
+):
+    """When the reindex pipeline raises, status stays 'failed' and last_error is set."""
+    doc_id = failed_doc["id"]
+
+    with patch(
+        "gaia.ui.server._index_document",
+        new=AsyncMock(side_effect=RuntimeError("re-index boom")),
+    ):
+        r = client.post(f"/api/documents/{doc_id}/reindex")
+
+    # Must NOT return 200 (fail loudly)
+    assert r.status_code == 500
+
+    # DB must reflect the failure with a last_error message
+    app = client.app
+    db = app.state.db
+    doc = db.get_document(doc_id)
+    assert doc is not None
+    assert doc["indexing_status"] == "failed"
+    assert doc.get("last_error") is not None
+
+
+def test_list_documents_includes_last_error(client, managed_docs_sandbox):
+    """GET /api/documents must include last_error in the serialised response."""
+    # Upload, then fail it
+    r = client.post(
+        "/api/documents/upload",
+        files={"file": ("err.txt", b"content", "text/plain")},
+    )
+    assert r.status_code == 200
+    doc_id = r.json()["id"]
+
+    app = client.app
+    db = app.state.db
+    db.update_document_status(doc_id, "failed", last_error="serialization check")
+
+    r2 = client.get("/api/documents")
+    assert r2.status_code == 200
+    docs = r2.json()["documents"]
+    target = next((d for d in docs if d["id"] == doc_id), None)
+    assert target is not None
+    assert target.get("last_error") == "serialization check"

--- a/tests/unit/chat/ui/test_document_reindex.py
+++ b/tests/unit/chat/ui/test_document_reindex.py
@@ -156,6 +156,16 @@ class TestColdSchemaLastError:
         assert row is not None
         assert row["last_error"] == "RAG exploded"
 
+    def test_update_document_status_truncates_long_last_error(self, db):
+        """A very long last_error is capped so it can't bloat the UI tooltip."""
+        doc_id = _insert_doc(db, "indexing", "trunc")
+        db.update_document_status(doc_id, "failed", last_error="x" * 5000)
+        row = db._conn.execute(
+            "SELECT last_error FROM documents WHERE id = ?", (doc_id,)
+        ).fetchone()
+        assert len(row["last_error"]) <= 500
+        assert row["last_error"].endswith("…")
+
     def test_update_document_status_clears_last_error_on_success(self, db):
         """Transitioning to 'complete' must clear any prior last_error."""
         doc_id = _insert_doc(db, "indexing", "b")

--- a/tests/unit/chat/ui/test_document_reindex.py
+++ b/tests/unit/chat/ui/test_document_reindex.py
@@ -14,7 +14,6 @@ import pytest
 
 from gaia.ui.database import ChatDatabase
 
-
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
 
@@ -39,8 +38,7 @@ def legacy_db():
     conn.execute("PRAGMA foreign_keys = ON")
     conn.execute("PRAGMA journal_mode = WAL")
 
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE IF NOT EXISTS documents (
             id TEXT PRIMARY KEY,
             filename TEXT NOT NULL,
@@ -109,8 +107,7 @@ def legacy_db():
         CREATE INDEX IF NOT EXISTS idx_session_docs ON session_documents(session_id);
         CREATE INDEX IF NOT EXISTS idx_schedule_results_task
             ON schedule_results(task_id, executed_at DESC);
-        """
-    )
+        """)
     conn.commit()
 
     # Construct ChatDatabase without calling __init__ (which would create a new

--- a/tests/unit/chat/ui/test_document_reindex.py
+++ b/tests/unit/chat/ui/test_document_reindex.py
@@ -1,0 +1,229 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for document last_error persistence and reindex DB helpers.
+
+Tests both the cold-schema path (fresh DB) and the migration path (ALTER TABLE
+on an existing DB that lacks last_error).
+"""
+
+import sqlite3
+import threading
+
+import pytest
+
+from gaia.ui.database import ChatDatabase
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db():
+    """Fresh in-memory DB — cold schema must include last_error."""
+    database = ChatDatabase(":memory:")
+    yield database
+    database.close()
+
+
+@pytest.fixture
+def legacy_db():
+    """Simulate an existing DB created before last_error was added.
+
+    Builds the documents table *without* last_error or indexing_status to
+    mimic a pre-1079 on-disk database, then wires up a ChatDatabase so
+    _migrate() runs and must add the column via ALTER TABLE.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS documents (
+            id TEXT PRIMARY KEY,
+            filename TEXT NOT NULL,
+            filepath TEXT NOT NULL,
+            file_hash TEXT UNIQUE NOT NULL,
+            file_size INTEGER DEFAULT 0,
+            chunk_count INTEGER DEFAULT 0,
+            indexed_at TEXT DEFAULT (datetime('now')),
+            last_accessed_at TEXT
+        );
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL DEFAULT 'New Chat',
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            model TEXT NOT NULL DEFAULT 'Gemma-4-E4B-it-GGUF',
+            system_prompt TEXT,
+            device TEXT DEFAULT 'gpu',
+            mail_provider TEXT
+        );
+        CREATE TABLE IF NOT EXISTS session_documents (
+            session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE,
+            document_id TEXT REFERENCES documents(id) ON DELETE CASCADE,
+            attached_at TEXT DEFAULT (datetime('now')),
+            PRIMARY KEY (session_id, document_id)
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT REFERENCES sessions(id) ON DELETE CASCADE,
+            role TEXT CHECK(role IN ('user', 'assistant', 'system')) NOT NULL,
+            content TEXT NOT NULL,
+            created_at TEXT DEFAULT (datetime('now')),
+            rag_sources TEXT,
+            agent_steps TEXT,
+            tokens_prompt INTEGER,
+            tokens_completion INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS scheduled_tasks (
+            id               TEXT PRIMARY KEY,
+            name             TEXT UNIQUE NOT NULL,
+            interval_seconds INTEGER NOT NULL,
+            prompt           TEXT NOT NULL,
+            status           TEXT DEFAULT 'active',
+            created_at       TEXT,
+            last_run_at      TEXT,
+            next_run_at      TEXT,
+            last_result      TEXT,
+            run_count        INTEGER DEFAULT 0,
+            error_count      INTEGER DEFAULT 0,
+            session_id       TEXT,
+            schedule_config  TEXT
+        );
+        CREATE TABLE IF NOT EXISTS schedule_results (
+            id          TEXT PRIMARY KEY,
+            task_id     TEXT NOT NULL REFERENCES scheduled_tasks(id) ON DELETE CASCADE,
+            executed_at TEXT NOT NULL,
+            result      TEXT,
+            error       TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(file_hash);
+        CREATE INDEX IF NOT EXISTS idx_session_docs ON session_documents(session_id);
+        CREATE INDEX IF NOT EXISTS idx_schedule_results_task
+            ON schedule_results(task_id, executed_at DESC);
+        """
+    )
+    conn.commit()
+
+    # Construct ChatDatabase without calling __init__ (which would create a new
+    # connection), then inject the pre-seeded connection and run _migrate().
+    database = ChatDatabase.__new__(ChatDatabase)
+    database._db_path = ":memory:"
+    database._lock = threading.RLock()
+    database._conn = conn
+    database._migrate()
+    yield database
+    database.close()
+
+
+def _insert_doc(db: ChatDatabase, status: str = "complete", suffix: str = "") -> str:
+    """Insert a minimal document row and return its id."""
+    doc = db.add_document(
+        filename=f"test{suffix}.txt",
+        filepath=f"/tmp/test{suffix}.txt",
+        file_hash=f"abc123{status}{suffix}",
+        file_size=100,
+        chunk_count=5,
+    )
+    db.update_document_status(doc["id"], status)
+    return doc["id"]
+
+
+# ── Cold-schema tests ────────────────────────────────────────────────────────
+
+
+class TestColdSchemaLastError:
+    def test_documents_table_has_last_error_column(self, db):
+        """Cold DB must have last_error in the documents table."""
+        cols = [
+            row[1]
+            for row in db._conn.execute("PRAGMA table_info(documents)").fetchall()
+        ]
+        assert "last_error" in cols, f"last_error not found in columns: {cols}"
+
+    def test_update_document_status_persists_last_error(self, db):
+        """update_document_status with last_error kwarg writes the message."""
+        doc_id = _insert_doc(db, "indexing", "a")
+        db.update_document_status(doc_id, "failed", last_error="RAG exploded")
+        row = db._conn.execute(
+            "SELECT last_error FROM documents WHERE id = ?", (doc_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["last_error"] == "RAG exploded"
+
+    def test_update_document_status_clears_last_error_on_success(self, db):
+        """Transitioning to 'complete' must clear any prior last_error."""
+        doc_id = _insert_doc(db, "indexing", "b")
+        db.update_document_status(doc_id, "failed", last_error="some error")
+        db.update_document_status(doc_id, "complete")
+        row = db._conn.execute(
+            "SELECT last_error FROM documents WHERE id = ?", (doc_id,)
+        ).fetchone()
+        assert row["last_error"] is None
+
+    def test_update_document_status_without_last_error_leaves_it_unchanged(self, db):
+        """Calling update_document_status without last_error preserves existing value."""
+        doc_id = _insert_doc(db, "indexing", "c")
+        db.update_document_status(doc_id, "failed", last_error="kept error")
+        # Call again without last_error kwarg
+        db.update_document_status(doc_id, "failed")
+        row = db._conn.execute(
+            "SELECT last_error FROM documents WHERE id = ?", (doc_id,)
+        ).fetchone()
+        assert row["last_error"] == "kept error"
+
+    def test_get_document_exposes_last_error(self, db):
+        """get_document must return last_error in the result dict."""
+        doc_id = _insert_doc(db, "indexing", "d")
+        db.update_document_status(doc_id, "failed", last_error="chunk error")
+        doc = db.get_document(doc_id)
+        assert doc is not None
+        assert doc.get("last_error") == "chunk error"
+
+    def test_list_documents_exposes_last_error(self, db):
+        """list_documents must include last_error for each row."""
+        doc_id = _insert_doc(db, "indexing", "e")
+        db.update_document_status(doc_id, "failed", last_error="list error")
+        docs = db.list_documents()
+        target = next((d for d in docs if d["id"] == doc_id), None)
+        assert target is not None
+        assert target.get("last_error") == "list error"
+
+
+# ── Migration path tests ─────────────────────────────────────────────────────
+
+
+class TestMigrationLastError:
+    def test_legacy_db_gains_last_error_column_after_migrate(self, legacy_db):
+        """An old DB without last_error must gain the column after _migrate()."""
+        cols = [
+            row[1]
+            for row in legacy_db._conn.execute(
+                "PRAGMA table_info(documents)"
+            ).fetchall()
+        ]
+        assert "last_error" in cols, f"last_error not found after migration: {cols}"
+
+    def test_legacy_db_write_and_read_last_error(self, legacy_db):
+        """After migration, last_error must be writable and readable."""
+        doc = legacy_db.add_document(
+            filename="migrated.txt",
+            filepath="/tmp/migrated.txt",
+            file_hash="migrated_hash_abc",
+            file_size=50,
+            chunk_count=0,
+        )
+        legacy_db.update_document_status(
+            doc["id"], "failed", last_error="migration test error"
+        )
+        fetched = legacy_db.get_document(doc["id"])
+        assert fetched is not None
+        assert fetched.get("last_error") == "migration test error"

--- a/tests/unit/chat/ui/test_indexing_errors.py
+++ b/tests/unit/chat/ui/test_indexing_errors.py
@@ -168,6 +168,45 @@ class TestUploadIndexingFailure:
         assert data["chunk_count"] == 0
         assert data["indexing_status"] == "failed"
 
+    def test_small_file_failure_records_last_error(self, home_tmp_dir, client):
+        """#1749: a first-upload index failure persists *why* it failed, not just
+        status='failed' with an empty tooltip."""
+        doc_file = home_tmp_dir / "report.txt"
+        doc_file.write_text("hello world")
+
+        async def mock_index_fail(path):
+            raise RuntimeError("embedder unavailable")
+
+        with patch("gaia.ui.server._index_document", mock_index_fail):
+            resp = client.post(
+                "/api/documents/upload-path",
+                json={"filepath": str(doc_file)},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["indexing_status"] == "failed"
+        assert data["last_error"] and "embedder unavailable" in data["last_error"]
+
+    def test_small_file_zero_chunks_records_last_error(self, home_tmp_dir, client):
+        """A 0-chunk failure (no exception) still records an actionable reason."""
+        doc_file = home_tmp_dir / "empty.txt"
+        doc_file.write_text("x")
+
+        async def mock_index_zero(path):
+            return 0
+
+        with patch("gaia.ui.server._index_document", mock_index_zero):
+            resp = client.post(
+                "/api/documents/upload-path",
+                json={"filepath": str(doc_file)},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["indexing_status"] == "failed"
+        assert data["last_error"] == "indexing produced 0 chunks"
+
     def test_small_file_success_has_chunks(self, home_tmp_dir, client):
         """Successful indexing returns chunk_count > 0."""
         doc_file = home_tmp_dir / "test.txt"


### PR DESCRIPTION
Closes #1079

## Why this matters
Before: when a document failed to index it sat in the library forever as a dead `failed` row — `chunk_count=0`, no error message, and no way to retry short of deleting and re-uploading. Users could not tell why it failed or recover from it. After: each document persists its `last_error` (surfaced by the REST API and, automatically, MCP `list_documents`), and a one-click **Retry** re-runs the full indexing pipeline.

## Evidence — live, on a running backend with Lemonade
**AC1 — `last_error` persisted and surfaced (HTTP):**
```
GET /api/documents
  -> { "filename":"encrypted-contract.pdf", "indexing_status":"failed",
       "chunk_count":0, "last_error":"PDF parse error: file is encrypted ..." }
```
**AC2 — reindex re-runs the pipeline (not a flag flip) (HTTP):**
```
# before: failed, chunk_count 0
POST /api/documents/{id}/reindex
  -> { "indexing_status":"complete", "chunk_count":1, "last_error":null }
# genuine re-chunk + re-embed via Lemonade; last_error cleared on success
```
**AC3 — Document Library shows the error + Retry (UI):** the failed doc renders a red **Failed** badge, the `last_error` as a hover tooltip, and a **Retry** button; the recovered doc shows complete. _Verified by driving the live Agent UI (screenshot captured during validation)._

_How tested:_ `gaia.ui.server` on an isolated `HOME`, a failed doc injected via the real `ChatDatabase`, then the live HTTP + UI flows above.

## Tests
- [x] DB unit `tests/unit/chat/ui/test_document_reindex.py` — cold-schema + migration paths for `last_error`
- [x] Router integration `tests/integration/test_documents_router.py` — reindex endpoint + serialization (4 new)
- [x] Frontend `DocumentLibrary.test.tsx` — failed doc renders error + Retry (3 new); 85/85 vitest pass
- [x] `python util/lint.py --all` — clean
- [x] Real-world (local Mac + Lemonade): failed → Retry → recovered, live (above)

<details><summary>Minor follow-up</summary>The `_UNSET` sentinel default on `update_document_status(last_error=...)` is annotated `str | None`; runtime is correct, but strict mypy may warn. A `_UnsetType` wrapper can tidy this later.</details>