### PR TITLE
fix(email): restore both Outlook and Gmail messages on archive-undo (#1738)

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/gmail_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/gmail_backend.py
@@ -146,7 +146,9 @@ class GmailBackend(Protocol):
         """Restore from TRASH."""
         ...
 
-    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+    def unarchive_message(
+        self, message_id: str, prior_labels: List[str]
+    ) -> Dict[str, Any]:
         """Reverse an archive: restore the message to the inbox.
 
         ``message_id`` is the id valid NOW (post-archive for folder-based
@@ -536,7 +538,9 @@ class LiveGmailBackend:
         self._post(f"/messages/{message_id}/untrash")
         return self._modify_labels(message_id, add=[GMAIL_LABEL_INBOX])
 
-    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+    def unarchive_message(
+        self, message_id: str, prior_labels: List[str]
+    ) -> Dict[str, Any]:
         # Re-add INBOX plus any prior labels. Gmail modify is idempotent when
         # adding a label already present, so this is safe to call more than once.
         to_add = list({GMAIL_LABEL_INBOX, *(prior_labels or [])})

--- a/hub/agents/python/email/gaia_agent_email/gmail_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/gmail_backend.py
@@ -541,10 +541,12 @@ class LiveGmailBackend:
     def unarchive_message(
         self, message_id: str, prior_labels: List[str]
     ) -> Dict[str, Any]:
-        # Re-add INBOX plus any prior labels. Gmail modify is idempotent when
-        # adding a label already present, so this is safe to call more than once.
-        to_add = list({GMAIL_LABEL_INBOX, *(prior_labels or [])})
-        return self._modify_labels(message_id, add=to_add)
+        # Archive removes only the INBOX label, so its exact inverse re-adds
+        # only INBOX (idempotent if already present). ``prior_labels`` is unused
+        # — kept for Protocol parity: the message still carries every other
+        # label, and re-applying immutable system labels like SENT/DRAFT is
+        # rejected by Gmail's modify API ("Invalid label: SENT").
+        return self._modify_labels(message_id, add=[GMAIL_LABEL_INBOX])
 
     def permanent_delete(self, message_id: str) -> None:
         self._delete(f"/messages/{message_id}")

--- a/hub/agents/python/email/gaia_agent_email/gmail_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/gmail_backend.py
@@ -146,6 +146,15 @@ class GmailBackend(Protocol):
         """Restore from TRASH."""
         ...
 
+    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+        """Reverse an archive: restore the message to the inbox.
+
+        ``message_id`` is the id valid NOW (post-archive for folder-based
+        backends like Outlook, where archive changed the id). Returns the
+        message resource; the id may change again for folder backends.
+        """
+        ...
+
     def permanent_delete(self, message_id: str) -> None:
         """Permanently delete (DELETE not recoverable). Use sparingly."""
         ...
@@ -526,6 +535,12 @@ class LiveGmailBackend:
         # view so undo returns the message to its original state.
         self._post(f"/messages/{message_id}/untrash")
         return self._modify_labels(message_id, add=[GMAIL_LABEL_INBOX])
+
+    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+        # Re-add INBOX plus any prior labels. Gmail modify is idempotent when
+        # adding a label already present, so this is safe to call more than once.
+        to_add = list({GMAIL_LABEL_INBOX, *(prior_labels or [])})
+        return self._modify_labels(message_id, add=to_add)
 
     def permanent_delete(self, message_id: str) -> None:
         self._delete(f"/messages/{message_id}")

--- a/hub/agents/python/email/gaia_agent_email/outlook_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/outlook_backend.py
@@ -478,6 +478,11 @@ class LiveOutlookBackend:
     def untrash_message(self, message_id: str) -> Dict[str, Any]:
         return self._move(message_id, _FOLDER_INBOX)
 
+    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+        # Move back to the inbox folder; prior_labels unused (categories survive
+        # a folder move — kept for Protocol parity with LiveGmailBackend).
+        return self._move(message_id, _FOLDER_INBOX)
+
     def permanent_delete(self, message_id: str) -> None:
         self._delete(f"/me/messages/{message_id}")
 

--- a/hub/agents/python/email/gaia_agent_email/outlook_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/outlook_backend.py
@@ -62,9 +62,9 @@ from typing import (
 )
 
 import httpx
-
 from gaia_agent_email.outlook_scopes import OUTLOOK_MAIL_SCOPES
 from gaia_agent_email.scopes import AGENT_NAMESPACED_ID
+
 from gaia.connectors.errors import ConnectorsError
 from gaia.connectors.handler import get_credential_sync
 from gaia.logger import get_logger
@@ -478,7 +478,9 @@ class LiveOutlookBackend:
     def untrash_message(self, message_id: str) -> Dict[str, Any]:
         return self._move(message_id, _FOLDER_INBOX)
 
-    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+    def unarchive_message(
+        self, message_id: str, prior_labels: List[str]
+    ) -> Dict[str, Any]:
         # Move back to the inbox folder; prior_labels unused (categories survive
         # a folder move — kept for Protocol parity with LiveGmailBackend).
         return self._move(message_id, _FOLDER_INBOX)

--- a/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
@@ -60,13 +60,17 @@ def archive_message_impl(
             prior = gmail.get_message(message_id)
         prior_labels = list(prior.get("labelIds", []))
         # Gmail call — if this raises, NO db row is written.
-        gmail.archive_message(message_id)
+        result = gmail.archive_message(message_id)
+        # Capture the post-archive id: for folder-based backends (Outlook)
+        # the move returns a new id; for label-based backends (Gmail) it
+        # equals the pre-archive id.
+        post_archive_id = (result or {}).get("id") or message_id
         action_id = action_store.record_action(
             db,
             action_type="archive",
             message_id=message_id,
             thread_id=prior.get("threadId"),
-            payload={"prior_labels": prior_labels},
+            payload={"prior_labels": prior_labels, "post_archive_id": post_archive_id},
             mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
@@ -213,15 +217,20 @@ def undo_archive_batch_impl(
 ) -> Dict[str, Any]:
     """Reverse a batch archive within the undo window.
 
-    Re-adds the labels that ``archive`` removed (INBOX, plus any other
-    label the message carried before) for every still-undoable ``archive``
-    row sharing ``batch_id``, then marks each row undone.
+    Calls ``backend.unarchive_message`` for each still-undoable ``archive``
+    row, which restores it to the inbox in a provider-correct way: Gmail
+    re-adds the INBOX label (stable id); Outlook moves the message back from
+    the archive folder using the post-archive id recorded at archive time.
 
     ``resolve_backend(row) -> backend`` routes each row to the mailbox it was
     archived from (#1603 Phase 2), so a cross-mailbox batch undoes against the
     right accounts. Raises ``RuntimeError`` if the batch has no undoable rows —
     the window expired, every row was already undone, or the batch_id is
     unknown. We fail loudly rather than silently no-op so the caller surfaces it.
+
+    Per-row failures are collected and reported but do NOT abort the rest of the
+    batch: partial success is preferable to a mid-loop abort that leaves some
+    messages stranded.
     """
     with log_tool_call("undo_archive_batch", {"batch_id": batch_id}, debug=debug) as st:
         rows = action_store.fetch_batch_undoable(
@@ -230,10 +239,11 @@ def undo_archive_batch_impl(
         if not rows:
             raise RuntimeError(
                 f"undo window has expired ({window_seconds} s) or batch_id "
-                f"{batch_id!r} has no undoable archive actions. Use Gmail to "
-                "move the messages back to the inbox manually."
+                f"{batch_id!r} has no undoable archive actions. Use your mail "
+                "client to move the messages back to the inbox manually."
             )
         restored: List[Dict[str, Any]] = []
+        failed: List[Dict[str, Any]] = []
         for row in rows:
             if row["action_type"] != "archive":
                 # batch_id is archive-only today; skip anything else rather
@@ -242,16 +252,38 @@ def undo_archive_batch_impl(
                 continue
             backend = resolve_backend(row)
             mid = row["message_id"]
-            prior_labels = set(row["payload"].get("prior_labels") or [])
-            current = set(backend.get_message(mid).get("labelIds", []))
-            # Archive only ever removes labels (INBOX); re-add whatever the
-            # message carried before that it no longer has.
-            for lab in prior_labels - current:
-                backend.add_label(mid, lab)
+            prior_labels = list(row["payload"].get("prior_labels") or [])
+            # Use the post-archive id so Outlook can find the message after the
+            # folder move changed its id.
+            restore_id = row["payload"].get("post_archive_id") or mid
+            try:
+                backend.unarchive_message(restore_id, prior_labels)
+            except Exception as exc:
+                failed.append(
+                    {
+                        "message_id": mid,
+                        "error": format_connector_error(exc)
+                        if isinstance(exc, ConnectorsError)
+                        else f"{type(exc).__name__}: {exc}",
+                    }
+                )
+                if debug:
+                    log.exception("undo failed for %s", mid)
+                continue
             action_store.mark_undone(db, action_id=row["action_id"])
             restored.append({"message_id": mid, "action_id": row["action_id"]})
-        st["result_summary"] = {"restored": len(restored)}
-        return {"batch_id": batch_id, "restored": len(restored), "messages": restored}
+        if rows and not restored and failed:
+            raise RuntimeError(
+                f"undo_archive_batch: all {len(failed)} row(s) failed to restore. "
+                f"First error: {failed[0]['error']}"
+            )
+        st["result_summary"] = {"restored": len(restored), "failed": len(failed)}
+        return {
+            "batch_id": batch_id,
+            "restored": len(restored),
+            "messages": restored,
+            "failed": failed,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -359,9 +391,9 @@ def _run_batch_with_prior(
     """Same as _run_batch but fetches per-message prior state first.
 
     ``resolve_backend(mid) -> backend`` routes per message. ``backend_op(backend,
-    mid)`` performs the mutation on the resolved backend. ``prior_fn(msg) ->
-    prior`` is called once per message; ``payload_fn(msg, prior) -> dict`` builds
-    the action payload.
+    mid) -> result`` performs the mutation on the resolved backend. ``prior_fn(msg)
+    -> prior`` is called once per message; ``payload_fn(msg, prior, op_result) ->
+    dict`` builds the action payload (op_result is the backend_op return value).
     """
     succeeded: list[dict] = []
     failed: list[dict] = []
@@ -370,13 +402,13 @@ def _run_batch_with_prior(
             backend = resolve_backend(mid)
             msg = backend.get_message(mid)
             prior = prior_fn(msg)
-            backend_op(backend, mid)
+            op_result = backend_op(backend, mid)
             aid = action_store.record_action(
                 db,
                 action_type=action_type,
                 message_id=mid,
                 thread_id=msg.get("threadId"),
-                payload=payload_fn(msg, prior),
+                payload=payload_fn(msg, prior, op_result),
                 batch_id=batch_id,
                 mailbox=action_mailbox(mid) if action_mailbox else None,
             )
@@ -762,9 +794,14 @@ class OrganizeToolsMixin:
                     return list(msg.get("labelIds", []))
 
                 def _archive_payload_fn(
-                    _msg: Dict[str, Any], prior_labels: List[str]
+                    _msg: Dict[str, Any],
+                    prior_labels: List[str],
+                    op_result: Optional[Dict[str, Any]],
                 ) -> Dict[str, Any]:
-                    return {"prior_labels": prior_labels}
+                    # Record the post-archive id so undo can find the message even
+                    # when the backend changed its id (Outlook folder-move semantics).
+                    post_id = (op_result or {}).get("id") or _msg["id"]
+                    return {"prior_labels": prior_labels, "post_archive_id": post_id}
 
                 result = _run_batch_with_prior(
                     _batch_backend,
@@ -874,7 +911,9 @@ class OrganizeToolsMixin:
                     return list(msg.get("labelIds", []))
 
                 def _move_payload_fn(
-                    _msg: Dict[str, Any], prior_labels: List[str]
+                    _msg: Dict[str, Any],
+                    prior_labels: List[str],
+                    _op_result: Optional[Dict[str, Any]] = None,
                 ) -> Dict[str, Any]:
                     return {
                         "label_id": label_id_local,

--- a/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
@@ -275,11 +275,17 @@ def undo_archive_batch_impl(
                 continue
             action_store.mark_undone(db, action_id=row["action_id"])
             restored.append({"message_id": mid, "action_id": row["action_id"]})
-        if rows and not restored and failed:
-            raise RuntimeError(
-                f"undo_archive_batch: all {len(failed)} row(s) failed to restore. "
+        if not restored:
+            # rows is non-empty (guarded above), so restoring nothing is a loud
+            # failure — never return ok with restored=0. Either every row failed,
+            # or the batch held no archive rows to restore.
+            detail = (
+                f"all {len(failed)} row(s) failed to restore. "
                 f"First error: {failed[0]['error']}"
+                if failed
+                else f"no archive rows among the {len(rows)} batch row(s) to restore"
             )
+            raise RuntimeError(f"undo_archive_batch: {detail}")
         st["result_summary"] = {"restored": len(restored), "failed": len(failed)}
         return {
             "batch_id": batch_id,

--- a/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/organize_tools.py
@@ -18,9 +18,10 @@ import json
 import uuid
 from typing import Any, Dict, List, Optional
 
-from gaia.agents.base.tools import tool
 from gaia_agent_email import action_store
 from gaia_agent_email.verbose import log_tool_call
+
+from gaia.agents.base.tools import tool
 from gaia.connectors.errors import ConnectorsError
 from gaia.connectors.formatting import format_connector_error
 from gaia.logger import get_logger
@@ -262,9 +263,11 @@ def undo_archive_batch_impl(
                 failed.append(
                     {
                         "message_id": mid,
-                        "error": format_connector_error(exc)
-                        if isinstance(exc, ConnectorsError)
-                        else f"{type(exc).__name__}: {exc}",
+                        "error": (
+                            format_connector_error(exc)
+                            if isinstance(exc, ConnectorsError)
+                            else f"{type(exc).__name__}: {exc}"
+                        ),
                     }
                 )
                 if debug:

--- a/tests/fixtures/email/fake_gmail.py
+++ b/tests/fixtures/email/fake_gmail.py
@@ -424,6 +424,15 @@ class FakeGmailBackend:
         self._transport.record("untrash_message", message_id=message_id)
         return self._modify(message_id, add=["INBOX"], remove=["TRASH"])
 
+    def unarchive_message(
+        self, message_id: str, prior_labels: List[str]
+    ) -> Dict[str, Any]:
+        self._transport.record(
+            "unarchive_message", message_id=message_id, prior_labels=prior_labels
+        )
+        to_add = list({"INBOX", *(prior_labels or [])})
+        return self._modify(message_id, add=to_add)
+
     def permanent_delete(self, message_id: str) -> None:
         self._transport.record("permanent_delete", message_id=message_id)
         self._messages.pop(message_id, None)

--- a/tests/unit/agents/email/test_archive_undo_outlook.py
+++ b/tests/unit/agents/email/test_archive_undo_outlook.py
@@ -111,13 +111,15 @@ class FakeGmailBackend:
     def unarchive_message(
         self, message_id: str, prior_labels: List[str]
     ) -> Dict[str, Any]:
-        """Restore to inbox: re-add INBOX + any prior labels."""
+        """Restore to inbox: re-add only INBOX (archive removed only INBOX).
+
+        Mirrors LiveGmailBackend: re-applying immutable system labels like
+        SENT would be rejected by Gmail's modify API, so undo must not.
+        """
         self.calls.append(("unarchive_message", message_id, prior_labels))
         msg = self._messages[message_id]
-        to_add = list({"INBOX", *(prior_labels or [])})
-        for lab in to_add:
-            if lab not in msg["labelIds"]:
-                msg["labelIds"].append(lab)
+        if "INBOX" not in msg["labelIds"]:
+            msg["labelIds"].append("INBOX")
         return dict(msg)
 
     def add_label(self, message_id: str, label_id: str) -> Dict[str, Any]:
@@ -529,3 +531,32 @@ class TestGmailOnlyUndoRegression:
             assert "undo window" in undo_env["error"].lower()
         finally:
             agent.close_db()
+
+
+class TestGmailUnarchiveAddsOnlyInbox:
+    """Regression for the live-Gmail bug surfaced in #1738 real-world testing.
+
+    Archive removes only the INBOX label, so unarchive must re-add ONLY INBOX.
+    Re-applying the message's other prior labels is both unnecessary and, for
+    immutable system labels like SENT/DRAFT, rejected by Gmail's modify API
+    ("Invalid label: SENT") — which 400'd the whole undo for any sent/archived
+    message. This guards the real LiveGmailBackend logic (the fakes can't).
+    """
+
+    def test_unarchive_adds_only_inbox_ignoring_prior_labels(self):
+        from gaia_agent_email.gmail_backend import LiveGmailBackend
+
+        backend = LiveGmailBackend(lambda: "fake-token")
+        recorded: Dict[str, Any] = {}
+
+        def fake_modify(message_id, *, add=None, remove=None):
+            recorded["add"] = list(add or [])
+            recorded["remove"] = list(remove or [])
+            return {"id": message_id, "labelIds": ["INBOX"]}
+
+        backend._modify_labels = fake_modify
+        backend.unarchive_message("m1", prior_labels=["INBOX", "SENT", "UNREAD"])
+
+        # Only INBOX is re-added; SENT/UNREAD are never sent to modify.
+        assert recorded["add"] == ["INBOX"], recorded
+        assert not recorded["remove"], recorded

--- a/tests/unit/agents/email/test_archive_undo_outlook.py
+++ b/tests/unit/agents/email/test_archive_undo_outlook.py
@@ -1,0 +1,513 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Issue #1738 — Outlook archive-undo: folder move changes the message id.
+
+Outlook.archive_message moves the message to a folder and returns a NEW id.
+The prior undo_archive_batch_impl used get_message(old_id) + add_label loops
+which 404 for Outlook. This file pins all four #1738 acceptance criteria:
+
+1. Outlook archive -> undo restores the message to the inbox (uses new id).
+2. Mixed Gmail+Outlook batch undo restores both providers.
+3. Partial failure in undo (one row's backend raises) reports the failure
+   without aborting the rest of the batch.
+4. archive_message_batch records post_archive_id in the action payload for
+   Outlook (so undo can locate the message after the move).
+
+These tests MUST fail against the un-patched main code and pass after the fix.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+from gaia_agent_email import action_store  # noqa: E402
+from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+
+from tests.fixtures.email.fake_gmail import FakeCalendarBackend  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fake backends
+# ---------------------------------------------------------------------------
+
+
+def _gmail_msg(msg_id: str, labels: Optional[List[str]] = None) -> Dict[str, Any]:
+    """Minimal Gmail-API-shape message in INBOX."""
+    return {
+        "id": msg_id,
+        "threadId": f"t-{msg_id}",
+        "labelIds": labels if labels is not None else ["INBOX", "UNREAD"],
+        "snippet": f"snippet for {msg_id}",
+        "internalDate": "1700000000000",
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": "sender@gmail.com"},
+                {"name": "Subject", "value": f"Gmail msg {msg_id}"},
+            ],
+            "body": {"size": 0, "data": ""},
+        },
+        "sizeEstimate": 100,
+    }
+
+
+def _outlook_msg(msg_id: str) -> Dict[str, Any]:
+    """Minimal Outlook/Graph-API-shape message."""
+    return {
+        "id": msg_id,
+        "threadId": f"t-{msg_id}",
+        "labelIds": [],
+        "snippet": f"Outlook msg {msg_id}",
+        "internalDate": "1700000000000",
+        "payload": {
+            "mimeType": "text/plain",
+            "headers": [{"name": "From", "value": "user@outlook.com"}],
+            "body": {"size": 0},
+        },
+    }
+
+
+class FakeGmailBackend:
+    """Minimal Gmail-shaped fake with stable ids (archive = remove INBOX label)."""
+
+    def __init__(self, messages: Dict[str, Dict[str, Any]]) -> None:
+        self._messages = {k: dict(v) for k, v in messages.items()}
+        self.calls: List[tuple] = []
+
+    def get_user_email(self) -> str:
+        return "user@gmail.com"
+
+    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+        return {"messages": [{"id": k, "threadId": f"t-{k}"} for k in self._messages]}
+
+    def get_message(self, message_id: str) -> Dict[str, Any]:
+        self.calls.append(("get_message", message_id))
+        if message_id not in self._messages:
+            raise KeyError(f"FakeGmailBackend: no message {message_id!r}")
+        return self._messages[message_id]
+
+    def archive_message(self, message_id: str) -> Dict[str, Any]:
+        self.calls.append(("archive_message", message_id))
+        msg = self._messages[message_id]
+        labels = [lab for lab in msg.get("labelIds", []) if lab != "INBOX"]
+        msg["labelIds"] = labels
+        return dict(msg)  # id is STABLE for Gmail
+
+    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+        """Restore to inbox: re-add INBOX + any prior labels."""
+        self.calls.append(("unarchive_message", message_id, prior_labels))
+        msg = self._messages[message_id]
+        to_add = list({"INBOX", *(prior_labels or [])})
+        for lab in to_add:
+            if lab not in msg["labelIds"]:
+                msg["labelIds"].append(lab)
+        return dict(msg)
+
+    def add_label(self, message_id: str, label_id: str) -> Dict[str, Any]:
+        self.calls.append(("add_label", message_id, label_id))
+        msg = self._messages[message_id]
+        if label_id not in msg["labelIds"]:
+            msg["labelIds"].append(label_id)
+        return dict(msg)
+
+    def list_labels(self) -> List[Dict[str, Any]]:
+        return [{"id": "INBOX", "name": "INBOX", "type": "system"}]
+
+    def trash_message(self, message_id: str) -> Dict[str, Any]:
+        self.calls.append(("trash_message", message_id))
+        return self._messages.get(message_id, {"id": message_id})
+
+    def untrash_message(self, message_id: str) -> Dict[str, Any]:
+        self.calls.append(("untrash_message", message_id))
+        return self._messages.get(message_id, {"id": message_id})
+
+    def get_thread(self, thread_id: str) -> Dict[str, Any]:
+        return {"id": thread_id, "messages": list(self._messages.values())}
+
+
+class FakeOutlookBackend:
+    """Outlook fake where archive MOVES the message and assigns a NEW id.
+
+    This is the critical correctness guard for #1738: the old id becomes invalid
+    after archive, so get_message(old_id) would raise.  The fix must use
+    post_archive_id from the action payload for undo.
+    """
+
+    def __init__(self, messages: Dict[str, Dict[str, Any]]) -> None:
+        self._messages = {k: dict(v) for k, v in messages.items()}
+        self._archive_folder: Dict[str, Dict[str, Any]] = {}
+        self.calls: List[tuple] = []
+
+    def get_user_email(self) -> str:
+        return "user@outlook.com"
+
+    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+        return {"messages": [{"id": k, "threadId": f"t-{k}"} for k in self._messages]}
+
+    def get_message(self, message_id: str) -> Dict[str, Any]:
+        self.calls.append(("get_message", message_id))
+        if message_id in self._messages:
+            return self._messages[message_id]
+        if message_id in self._archive_folder:
+            return self._archive_folder[message_id]
+        raise KeyError(f"FakeOutlookBackend: no message {message_id!r} (moved by archive?)")
+
+    def archive_message(self, message_id: str) -> Dict[str, Any]:
+        """Move to archive and return a new id (Outlook semantics)."""
+        self.calls.append(("archive_message", message_id))
+        if message_id not in self._messages:
+            raise KeyError(f"FakeOutlookBackend: no message {message_id!r}")
+        msg = dict(self._messages.pop(message_id))
+        new_id = message_id + "-archived"
+        msg["id"] = new_id
+        self._archive_folder[new_id] = msg
+        return msg  # Returns resource with the NEW id
+
+    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+        """Move back to inbox; prior_labels unused (categories survive folder move)."""
+        self.calls.append(("unarchive_message", message_id, prior_labels))
+        if message_id in self._archive_folder:
+            msg = dict(self._archive_folder.pop(message_id))
+            original_id = message_id.replace("-archived", "")
+            msg["id"] = original_id
+            self._messages[original_id] = msg
+            return msg
+        if message_id in self._messages:
+            return self._messages[message_id]
+        raise KeyError(f"FakeOutlookBackend: no message {message_id!r} to unarchive")
+
+    def add_label(self, message_id: str, label_id: str) -> Dict[str, Any]:
+        self.calls.append(("add_label", message_id, label_id))
+        for store in (self._messages, self._archive_folder):
+            if message_id in store:
+                return store[message_id]
+        raise KeyError(f"FakeOutlookBackend: no message {message_id!r}")
+
+    def list_labels(self) -> List[Dict[str, Any]]:
+        return []
+
+    def trash_message(self, message_id: str) -> Dict[str, Any]:
+        self.calls.append(("trash_message", message_id))
+        return self._messages.get(message_id, {"id": message_id})
+
+    def untrash_message(self, message_id: str) -> Dict[str, Any]:
+        self.calls.append(("untrash_message", message_id))
+        return self._messages.get(message_id, {"id": message_id})
+
+    def get_thread(self, thread_id: str) -> Dict[str, Any]:
+        return {"id": thread_id, "messages": list(self._messages.values())}
+
+    # -- Test helpers ---------------------------------------------------------
+
+    def inbox_contains(self, original_id: str) -> bool:
+        return original_id in self._messages
+
+    def archive_folder_contains(self, archived_id: str) -> bool:
+        return archived_id in self._archive_folder
+
+
+class BrokenBackend:
+    """Backend whose unarchive_message always raises — for partial failure test."""
+
+    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+        raise RuntimeError(f"BrokenBackend: cannot restore {message_id!r}")
+
+    def get_message(self, message_id: str) -> Dict[str, Any]:
+        raise KeyError(f"BrokenBackend: {message_id!r} not found")
+
+    def add_label(self, message_id: str, label_id: str) -> Dict[str, Any]:
+        raise RuntimeError("BrokenBackend.add_label always fails")
+
+
+# ---------------------------------------------------------------------------
+# Agent factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(gmail, outlook, tmp_path):
+    """Create EmailTriageAgent with gmail + outlook backends injected."""
+    cfg = EmailAgentConfig(
+        gmail_backend=gmail,
+        outlook_backend=outlook,
+        calendar_backend=FakeCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+        mail_provider=None,
+    )
+    with (
+        patch("gaia.llm.lemonade_manager.LemonadeManager.ensure_ready"),
+        patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+    ):
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent
+
+
+def _make_single_gmail_agent(gmail, tmp_path):
+    """Create EmailTriageAgent with only a Gmail backend (no Outlook)."""
+    cfg = EmailAgentConfig(
+        gmail_backend=gmail,
+        calendar_backend=FakeCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+    )
+    with (
+        patch("gaia.llm.lemonade_manager.LemonadeManager.ensure_ready"),
+        patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+    ):
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent
+
+
+def _tool(name):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    return _TOOL_REGISTRY[name]["function"]
+
+
+# ---------------------------------------------------------------------------
+# AC 4: archive_message_batch records post_archive_id in payload
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveRecordsPostArchiveId:
+    """AC 4: action store payload contains post_archive_id after Outlook archive."""
+
+    def test_archive_records_post_archive_id_for_outlook(self, tmp_path):
+        """Archiving an Outlook message records post_archive_id in action payload."""
+        outlook = FakeOutlookBackend({"m-outlook": _outlook_msg("m-outlook")})
+        gmail = FakeGmailBackend({})
+        agent = _make_agent(gmail, outlook, tmp_path)
+        try:
+            agent._remember_message_mailbox("m-outlook", "microsoft")
+
+            env = _json.loads(_tool("archive_message_batch")(["m-outlook"]))
+            assert env["ok"] is True, env
+            assert env["data"]["failed"] == []
+
+            rows = agent.query(
+                "SELECT payload_json FROM email_actions WHERE message_id = 'm-outlook'"
+            )
+            assert rows, "No action row recorded"
+            payload = _json.loads(rows[0]["payload_json"])
+            assert "post_archive_id" in payload, (
+                f"post_archive_id not recorded in payload: {payload}"
+            )
+            # Outlook archive changes the id
+            assert payload["post_archive_id"] == "m-outlook-archived", (
+                f"Expected 'm-outlook-archived' got {payload['post_archive_id']!r}"
+            )
+        finally:
+            agent.close_db()
+
+    def test_archive_records_stable_id_for_gmail(self, tmp_path):
+        """For Gmail, post_archive_id equals the pre-archive id (stable id)."""
+        gmail = FakeGmailBackend({"g1": _gmail_msg("g1")})
+        agent = _make_single_gmail_agent(gmail, tmp_path)
+        try:
+            env = _json.loads(_tool("archive_message_batch")(["g1"]))
+            assert env["ok"] is True, env
+
+            rows = agent.query(
+                "SELECT payload_json FROM email_actions WHERE message_id = 'g1'"
+            )
+            assert rows
+            payload = _json.loads(rows[0]["payload_json"])
+            # post_archive_id must be present and equal to original for Gmail
+            if "post_archive_id" in payload:
+                assert payload["post_archive_id"] == "g1"
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# AC 1: Outlook archive -> undo restores to inbox
+# ---------------------------------------------------------------------------
+
+
+class TestUndoArchiveOutlookRestoresToInbox:
+    """AC 1: undo_archive_batch restores Outlook message to the Inbox within the window."""
+
+    def test_undo_archive_outlook_restores_to_inbox(self, tmp_path):
+        """Canonical #1738 repro: archive changes id; undo must use new id to restore."""
+        outlook = FakeOutlookBackend({"m-outlook": _outlook_msg("m-outlook")})
+        gmail = FakeGmailBackend({})
+        agent = _make_agent(gmail, outlook, tmp_path)
+        try:
+            agent._remember_message_mailbox("m-outlook", "microsoft")
+
+            # Archive: id changes to m-outlook-archived
+            env = _json.loads(_tool("archive_message_batch")(["m-outlook"]))
+            assert env["ok"] is True, env
+            batch_id = env["data"]["batch_id"]
+
+            assert outlook.inbox_contains("m-outlook") is False
+            assert outlook.archive_folder_contains("m-outlook-archived") is True
+
+            # Undo: must find the message by post_archive_id (not original id)
+            undo_env = _json.loads(_tool("undo_archive_batch")(batch_id))
+            assert undo_env["ok"] is True, undo_env
+            data = undo_env["data"]
+            assert data["restored"] == 1
+            assert data.get("failed", []) == [], f"undo had failures: {data.get('failed')}"
+
+            # Message is back in the inbox folder
+            assert outlook.inbox_contains("m-outlook"), (
+                "Outlook message was not moved back to inbox"
+            )
+            assert outlook.archive_folder_contains("m-outlook-archived") is False
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# AC 2: Mixed Gmail + Outlook batch undo restores both providers
+# ---------------------------------------------------------------------------
+
+
+class TestUndoArchiveMixedBatchRestoresBoth:
+    """AC 2: mixed-mailbox batch undo restores both providers (no half-undo)."""
+
+    def test_undo_archive_mixed_batch_restores_both(self, tmp_path):
+        """Gmail + Outlook in one batch; undo; assert both restored, failed == []."""
+        outlook = FakeOutlookBackend({"m-outlook": _outlook_msg("m-outlook")})
+        gmail = FakeGmailBackend({"g-gmail": _gmail_msg("g-gmail")})
+        agent = _make_agent(gmail, outlook, tmp_path)
+        try:
+            agent._remember_message_mailbox("g-gmail", "google")
+            agent._remember_message_mailbox("m-outlook", "microsoft")
+
+            env = _json.loads(_tool("archive_message_batch")(["g-gmail", "m-outlook"]))
+            assert env["ok"] is True, env
+            assert env["data"]["failed"] == []
+            batch_id = env["data"]["batch_id"]
+
+            assert "INBOX" not in gmail._messages["g-gmail"]["labelIds"]
+            assert outlook.inbox_contains("m-outlook") is False
+
+            undo_env = _json.loads(_tool("undo_archive_batch")(batch_id))
+            assert undo_env["ok"] is True, undo_env
+            data = undo_env["data"]
+            assert data["restored"] == 2
+            assert data.get("failed", []) == [], f"undo had failures: {data.get('failed')}"
+
+            assert "INBOX" in gmail._messages["g-gmail"]["labelIds"], (
+                "Gmail message not restored to INBOX"
+            )
+            assert outlook.inbox_contains("m-outlook"), (
+                "Outlook message was not moved back to inbox"
+            )
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# AC 3: Partial failure in undo reports failure without aborting
+# ---------------------------------------------------------------------------
+
+
+class TestUndoArchiveBatchPartialFailure:
+    """AC 3: one row's backend raises on restore; other row still restored."""
+
+    def test_undo_archive_batch_partial_failure_reports_not_aborts(self, tmp_path):
+        """Partial undo failure: remaining rows restored, failure in 'failed' list."""
+        gmail = FakeGmailBackend({"g1": _gmail_msg("g1"), "g2": _gmail_msg("g2")})
+        agent = _make_single_gmail_agent(gmail, tmp_path)
+        try:
+            env = _json.loads(_tool("archive_message_batch")(["g1", "g2"]))
+            assert env["ok"] is True, env
+            batch_id = env["data"]["batch_id"]
+
+            broken = BrokenBackend()
+
+            original_backend_for_action = agent._backend_for_action
+
+            def _patched(action):
+                if action.get("message_id") == "g1":
+                    return broken
+                return original_backend_for_action(action)
+
+            agent._backend_for_action = _patched
+
+            undo_env = _json.loads(_tool("undo_archive_batch")(batch_id))
+            assert undo_env["ok"] is True, undo_env
+            data = undo_env["data"]
+
+            assert data["restored"] == 1, f"Expected 1 restored, got {data['restored']}"
+            failed = data.get("failed", [])
+            assert len(failed) == 1, f"Expected 1 failure, got {failed}"
+            assert failed[0]["message_id"] == "g1"
+
+            # g2 is back in inbox
+            assert "INBOX" in gmail._messages["g2"]["labelIds"], "g2 not restored to INBOX"
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: existing Gmail-only undo still green
+# ---------------------------------------------------------------------------
+
+
+class TestGmailOnlyUndoRegression:
+    """Gmail-only batch archive -> undo must still work after the fix."""
+
+    def test_gmail_only_undo_still_works(self, tmp_path):
+        """Single-provider Gmail undo works after the fix."""
+        gmail = FakeGmailBackend({f"g{i}": _gmail_msg(f"g{i}") for i in range(5)})
+        agent = _make_single_gmail_agent(gmail, tmp_path)
+        try:
+            ids = list(gmail._messages.keys())
+            env = _json.loads(_tool("archive_message_batch")(ids))
+            assert env["ok"] is True, env
+            batch_id = env["data"]["batch_id"]
+
+            for mid in ids:
+                assert "INBOX" not in gmail._messages[mid]["labelIds"]
+
+            undo_env = _json.loads(_tool("undo_archive_batch")(batch_id))
+            assert undo_env["ok"] is True, undo_env
+            assert undo_env["data"]["restored"] == len(ids)
+            assert undo_env["data"].get("failed", []) == []
+
+            for mid in ids:
+                assert "INBOX" in gmail._messages[mid]["labelIds"], f"{mid} not restored"
+        finally:
+            agent.close_db()
+
+    def test_undo_fails_after_window_still_works(self, tmp_path):
+        """Outside the undo window, undo still fails loudly (regression guard)."""
+        gmail = FakeGmailBackend({"g1": _gmail_msg("g1")})
+        agent = _make_single_gmail_agent(gmail, tmp_path)
+        try:
+            env = _json.loads(_tool("archive_message_batch")(["g1"]))
+            batch_id = env["data"]["batch_id"]
+
+            agent.update(
+                "email_actions",
+                {"created_at": time.time() - 3600},
+                "batch_id = :b",
+                {"b": batch_id},
+            )
+
+            undo_env = _json.loads(_tool("undo_archive_batch")(batch_id))
+            assert undo_env["ok"] is False
+            assert "undo window" in undo_env["error"].lower()
+        finally:
+            agent.close_db()

--- a/tests/unit/agents/email/test_archive_undo_outlook.py
+++ b/tests/unit/agents/email/test_archive_undo_outlook.py
@@ -33,12 +33,10 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 pytest.importorskip("gaia_agent_email")
-from gaia_agent_email import action_store  # noqa: E402
 from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
 from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
 
 from tests.fixtures.email.fake_gmail import FakeCalendarBackend  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Fake backends
@@ -92,7 +90,9 @@ class FakeGmailBackend:
     def get_user_email(self) -> str:
         return "user@gmail.com"
 
-    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+    def list_messages(
+        self, *, query=None, label_ids=None, max_results=25, page_token=None
+    ):
         return {"messages": [{"id": k, "threadId": f"t-{k}"} for k in self._messages]}
 
     def get_message(self, message_id: str) -> Dict[str, Any]:
@@ -108,7 +108,9 @@ class FakeGmailBackend:
         msg["labelIds"] = labels
         return dict(msg)  # id is STABLE for Gmail
 
-    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+    def unarchive_message(
+        self, message_id: str, prior_labels: List[str]
+    ) -> Dict[str, Any]:
         """Restore to inbox: re-add INBOX + any prior labels."""
         self.calls.append(("unarchive_message", message_id, prior_labels))
         msg = self._messages[message_id]
@@ -156,7 +158,9 @@ class FakeOutlookBackend:
     def get_user_email(self) -> str:
         return "user@outlook.com"
 
-    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+    def list_messages(
+        self, *, query=None, label_ids=None, max_results=25, page_token=None
+    ):
         return {"messages": [{"id": k, "threadId": f"t-{k}"} for k in self._messages]}
 
     def get_message(self, message_id: str) -> Dict[str, Any]:
@@ -165,7 +169,9 @@ class FakeOutlookBackend:
             return self._messages[message_id]
         if message_id in self._archive_folder:
             return self._archive_folder[message_id]
-        raise KeyError(f"FakeOutlookBackend: no message {message_id!r} (moved by archive?)")
+        raise KeyError(
+            f"FakeOutlookBackend: no message {message_id!r} (moved by archive?)"
+        )
 
     def archive_message(self, message_id: str) -> Dict[str, Any]:
         """Move to archive and return a new id (Outlook semantics)."""
@@ -178,7 +184,9 @@ class FakeOutlookBackend:
         self._archive_folder[new_id] = msg
         return msg  # Returns resource with the NEW id
 
-    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+    def unarchive_message(
+        self, message_id: str, prior_labels: List[str]
+    ) -> Dict[str, Any]:
         """Move back to inbox; prior_labels unused (categories survive folder move)."""
         self.calls.append(("unarchive_message", message_id, prior_labels))
         if message_id in self._archive_folder:
@@ -224,7 +232,9 @@ class FakeOutlookBackend:
 class BrokenBackend:
     """Backend whose unarchive_message always raises — for partial failure test."""
 
-    def unarchive_message(self, message_id: str, prior_labels: List[str]) -> Dict[str, Any]:
+    def unarchive_message(
+        self, message_id: str, prior_labels: List[str]
+    ) -> Dict[str, Any]:
         raise RuntimeError(f"BrokenBackend: cannot restore {message_id!r}")
 
     def get_message(self, message_id: str) -> Dict[str, Any]:
@@ -306,13 +316,13 @@ class TestArchiveRecordsPostArchiveId:
             )
             assert rows, "No action row recorded"
             payload = _json.loads(rows[0]["payload_json"])
-            assert "post_archive_id" in payload, (
-                f"post_archive_id not recorded in payload: {payload}"
-            )
+            assert (
+                "post_archive_id" in payload
+            ), f"post_archive_id not recorded in payload: {payload}"
             # Outlook archive changes the id
-            assert payload["post_archive_id"] == "m-outlook-archived", (
-                f"Expected 'm-outlook-archived' got {payload['post_archive_id']!r}"
-            )
+            assert (
+                payload["post_archive_id"] == "m-outlook-archived"
+            ), f"Expected 'm-outlook-archived' got {payload['post_archive_id']!r}"
         finally:
             agent.close_db()
 
@@ -365,12 +375,14 @@ class TestUndoArchiveOutlookRestoresToInbox:
             assert undo_env["ok"] is True, undo_env
             data = undo_env["data"]
             assert data["restored"] == 1
-            assert data.get("failed", []) == [], f"undo had failures: {data.get('failed')}"
+            assert (
+                data.get("failed", []) == []
+            ), f"undo had failures: {data.get('failed')}"
 
             # Message is back in the inbox folder
-            assert outlook.inbox_contains("m-outlook"), (
-                "Outlook message was not moved back to inbox"
-            )
+            assert outlook.inbox_contains(
+                "m-outlook"
+            ), "Outlook message was not moved back to inbox"
             assert outlook.archive_folder_contains("m-outlook-archived") is False
         finally:
             agent.close_db()
@@ -405,14 +417,16 @@ class TestUndoArchiveMixedBatchRestoresBoth:
             assert undo_env["ok"] is True, undo_env
             data = undo_env["data"]
             assert data["restored"] == 2
-            assert data.get("failed", []) == [], f"undo had failures: {data.get('failed')}"
+            assert (
+                data.get("failed", []) == []
+            ), f"undo had failures: {data.get('failed')}"
 
-            assert "INBOX" in gmail._messages["g-gmail"]["labelIds"], (
-                "Gmail message not restored to INBOX"
-            )
-            assert outlook.inbox_contains("m-outlook"), (
-                "Outlook message was not moved back to inbox"
-            )
+            assert (
+                "INBOX" in gmail._messages["g-gmail"]["labelIds"]
+            ), "Gmail message not restored to INBOX"
+            assert outlook.inbox_contains(
+                "m-outlook"
+            ), "Outlook message was not moved back to inbox"
         finally:
             agent.close_db()
 
@@ -455,7 +469,9 @@ class TestUndoArchiveBatchPartialFailure:
             assert failed[0]["message_id"] == "g1"
 
             # g2 is back in inbox
-            assert "INBOX" in gmail._messages["g2"]["labelIds"], "g2 not restored to INBOX"
+            assert (
+                "INBOX" in gmail._messages["g2"]["labelIds"]
+            ), "g2 not restored to INBOX"
         finally:
             agent.close_db()
 
@@ -487,7 +503,9 @@ class TestGmailOnlyUndoRegression:
             assert undo_env["data"].get("failed", []) == []
 
             for mid in ids:
-                assert "INBOX" in gmail._messages[mid]["labelIds"], f"{mid} not restored"
+                assert (
+                    "INBOX" in gmail._messages[mid]["labelIds"]
+                ), f"{mid} not restored"
         finally:
             agent.close_db()
 


### PR DESCRIPTION
Closes #1738

## Why this matters

Before: undoing a batch archive that spanned **Outlook** left messages stranded. Outlook archive is a folder *move* that changes the Graph message id, so the undo path 404'd on the stale id — a mixed Gmail+Outlook batch came back half-undone (Gmail restored, Outlook stuck in Archive). After: undo restores **both** providers — Gmail re-adds `INBOX` on its stable id, Outlook moves back to the inbox using the post-archive id recorded at archive time. Batch undo is now per-message resilient (one provider failing is reported, not fatal) and fails loudly if nothing could be restored.

Real-world testing also caught a second, subtler break: undo re-added *all* prior labels, so any Gmail message carrying `SENT` 400'd (`Invalid label: SENT`). Fixed — archive removes only `INBOX`, so its inverse re-adds only `INBOX`.

## Test plan

- [x] Unit: `python -m pytest tests/unit/agents/email/test_archive_undo_outlook.py -q` — Outlook archive→undo with id change, mixed batch restores both, partial-failure is reported (no abort), and a direct `LiveGmailBackend` guard that undo sends only `INBOX`. Full email suite: **393 passed**.
- [x] Real-world, live Gmail + Outlook (2026-06-18): archived one message in each mailbox, undid within the window.

<details><summary>Real-world capture</summary>

```
archive_message_batch([gmail_id, outlook_id]) → succeeded 2, failed 0
undo_archive_batch(batch_id)  (t+0.58s)       → restored 2, failed []
verify gmail  : INBOX label restored        = True   (stable id; message carried SENT)
verify outlook: message back in inbox folder = True  (id changed by the folder move)
RESULT: PASS
```

The first live run failed on the Gmail `SENT` case above (undo 400'd, Outlook restored); after the fix the same message restores cleanly. Both mailboxes are net-zero (archive→undo).
</details>
