### PR TITLE
fix(email): one ungranted mailbox no longer aborts the whole multi-mailbox scan (#1739)

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -497,14 +497,14 @@ class EmailTriageAgent(
         a genuine bug must fail loudly. The available set stays connection-derived;
         grant enforcement happens at the token layer.
         """
-        from gaia.connectors.formatting import format_connector_error
-
         from gaia_agent_email.tools import read_tools
         from gaia_agent_email.tools.read_tools import (
             extract_sender_email,
             triage_inbox_impl,
         )
         from gaia_agent_email.tools.triage_heuristics import group_by_category
+
+        from gaia.connectors.formatting import format_connector_error
 
         # Reference the factory via the read_tools module so the existing
         # ``read_tools.make_llm_classifier`` test seam (the pre-scan canary)
@@ -622,14 +622,14 @@ class EmailTriageAgent(
         the error is recorded in ``mailbox_errors`` and the loop continues with
         the remaining backends. Non-``ConnectorsError`` exceptions still propagate.
         """
-        from gaia.connectors.formatting import format_connector_error
-
         from gaia_agent_email.tools.read_tools import (
             PRE_SCAN_ACTIONABLE_CAP,
             PRE_SCAN_ARCHIVE_CAP,
             PRE_SCAN_URGENT_CAP,
             pre_scan_inbox_impl,
         )
+
+        from gaia.connectors.formatting import format_connector_error
 
         prefs = getattr(self, "_session_preferences", None)
         force_llm = bool(getattr(self.config, "force_llm", False))

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -489,7 +489,16 @@ class EmailTriageAgent(
         because local inference is slow (~9-31 s/email) and a doubled budget
         would blow the user's expected wait. Every returned item gains a
         ``mailbox`` tag and its id is remembered for downstream action routing.
+
+        When one backend raises ``ConnectorsError`` (e.g. an agent grant was
+        revoked while the connection remains live), the error is recorded as a
+        per-mailbox notice in ``mailbox_errors`` and the loop continues with the
+        remaining backends. Non-``ConnectorsError`` exceptions still propagate —
+        a genuine bug must fail loudly. The available set stays connection-derived;
+        grant enforcement happens at the token layer.
         """
+        from gaia.connectors.formatting import format_connector_error
+
         from gaia_agent_email.tools import read_tools
         from gaia_agent_email.tools.read_tools import (
             extract_sender_email,
@@ -509,17 +518,29 @@ class EmailTriageAgent(
         backends = self._backends
         per_backend = max(1, max_messages // len(backends))
         merged: list[dict] = []
+        mailbox_errors: list[dict] = []
         for provider, backend in backends.items():
             if len(merged) >= max_messages:
                 break
-            out = triage_inbox_impl(
-                backend,
-                max_messages=per_backend,
-                session_preferences=prefs,
-                force_llm=force_llm,
-                classifier=classifier,
-                debug=debug_flag,
-            )
+            try:
+                out = triage_inbox_impl(
+                    backend,
+                    max_messages=per_backend,
+                    session_preferences=prefs,
+                    force_llm=force_llm,
+                    classifier=classifier,
+                    debug=debug_flag,
+                )
+            except ConnectorsError as exc:
+                mailbox_errors.append(
+                    {"mailbox": provider, "error": format_connector_error(exc)}
+                )
+                logger.warning(
+                    "email triage: skipping %s mailbox — %s",
+                    provider,
+                    format_connector_error(exc),
+                )
+                continue
             for item in out["results"]:
                 item["mailbox"] = provider
                 self._remember_message_mailbox(item.get("id"), provider)
@@ -541,7 +562,10 @@ class EmailTriageAgent(
         self._apply_behavioral_promotions()
         # Re-group the merged, capped list so the bucketed view matches what the
         # caller actually sees.
-        return {"results": merged, "grouped": group_by_category(merged)}
+        result: dict = {"results": merged, "grouped": group_by_category(merged)}
+        if mailbox_errors:
+            result["mailbox_errors"] = mailbox_errors
+        return result
 
     def _apply_behavioral_promotions(self) -> None:
         """Promote qualifying senders to priority based on observed reply behavior.
@@ -593,7 +617,13 @@ class EmailTriageAgent(
         (urgent / actionable / suggested_archives) gains a ``mailbox`` tag and
         its message_id is remembered for action routing. Per-section caps and
         the envelope shape are preserved by merging the per-backend envelopes.
+
+        When one backend raises ``ConnectorsError`` (e.g. a revoked agent grant),
+        the error is recorded in ``mailbox_errors`` and the loop continues with
+        the remaining backends. Non-``ConnectorsError`` exceptions still propagate.
         """
+        from gaia.connectors.formatting import format_connector_error
+
         from gaia_agent_email.tools.read_tools import (
             PRE_SCAN_ACTIONABLE_CAP,
             PRE_SCAN_ARCHIVE_CAP,
@@ -613,16 +643,28 @@ class EmailTriageAgent(
         informational_count = 0
         scanned = 0
         merged_prefs_applied: dict = {}
+        mailbox_errors: list[dict] = []
         for provider, backend in backends.items():
             if scanned >= max_messages:
                 break
-            out = pre_scan_inbox_impl(
-                backend,
-                max_messages=per_backend,
-                session_preferences=prefs,
-                force_llm=force_llm,
-                debug=debug_flag,
-            )
+            try:
+                out = pre_scan_inbox_impl(
+                    backend,
+                    max_messages=per_backend,
+                    session_preferences=prefs,
+                    force_llm=force_llm,
+                    debug=debug_flag,
+                )
+            except ConnectorsError as exc:
+                mailbox_errors.append(
+                    {"mailbox": provider, "error": format_connector_error(exc)}
+                )
+                logger.warning(
+                    "email pre-scan: skipping %s mailbox — %s",
+                    provider,
+                    format_connector_error(exc),
+                )
+                continue
             # Count messages actually returned, not the cap — an under-filled
             # backend would otherwise trip the budget guard and skip a later one.
             backend_totals = out.get("totals", {})
@@ -649,7 +691,7 @@ class EmailTriageAgent(
                 self._remember_message_mailbox(item.get("thread_id"), provider)
                 suggested_archives.append(item)
             informational_count += int(out.get("informational_count", 0))
-        return {
+        result = {
             "kind": "email_pre_scan",
             "urgent": urgent[: max(0, PRE_SCAN_URGENT_CAP)],
             "actionable": actionable[: max(0, PRE_SCAN_ACTIONABLE_CAP)],
@@ -664,6 +706,9 @@ class EmailTriageAgent(
                 "suggested_archives": len(suggested_archives),
             },
         }
+        if mailbox_errors:
+            result["mailbox_errors"] = mailbox_errors
+        return result
 
     # -- Phase I3 batch-organize counter -----------------------------------
 

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -66,6 +66,7 @@ from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.memory import MemoryMixin
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.formatting import format_connector_error
 from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.database.mixin import DatabaseMixin
 from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
@@ -504,8 +505,6 @@ class EmailTriageAgent(
         )
         from gaia_agent_email.tools.triage_heuristics import group_by_category
 
-        from gaia.connectors.formatting import format_connector_error
-
         # Reference the factory via the read_tools module so the existing
         # ``read_tools.make_llm_classifier`` test seam (the pre-scan canary)
         # keeps intercepting the expensive triage path.
@@ -532,14 +531,9 @@ class EmailTriageAgent(
                     debug=debug_flag,
                 )
             except ConnectorsError as exc:
-                mailbox_errors.append(
-                    {"mailbox": provider, "error": format_connector_error(exc)}
-                )
-                logger.warning(
-                    "email triage: skipping %s mailbox — %s",
-                    provider,
-                    format_connector_error(exc),
-                )
+                msg = format_connector_error(exc)
+                mailbox_errors.append({"mailbox": provider, "error": msg})
+                logger.warning("email triage: skipping %s mailbox — %s", provider, msg)
                 continue
             for item in out["results"]:
                 item["mailbox"] = provider
@@ -629,8 +623,6 @@ class EmailTriageAgent(
             pre_scan_inbox_impl,
         )
 
-        from gaia.connectors.formatting import format_connector_error
-
         prefs = getattr(self, "_session_preferences", None)
         force_llm = bool(getattr(self.config, "force_llm", False))
         debug_flag = bool(getattr(self.config, "debug", False))
@@ -656,13 +648,10 @@ class EmailTriageAgent(
                     debug=debug_flag,
                 )
             except ConnectorsError as exc:
-                mailbox_errors.append(
-                    {"mailbox": provider, "error": format_connector_error(exc)}
-                )
+                msg = format_connector_error(exc)
+                mailbox_errors.append({"mailbox": provider, "error": msg})
                 logger.warning(
-                    "email pre-scan: skipping %s mailbox — %s",
-                    provider,
-                    format_connector_error(exc),
+                    "email pre-scan: skipping %s mailbox — %s", provider, msg
                 )
                 continue
             # Count messages actually returned, not the cap — an under-filled

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -556,6 +556,13 @@ class EmailTriageAgent(
         self._apply_behavioral_promotions()
         # Re-group the merged, capped list so the bucketed view matches what the
         # caller actually sees.
+        if mailbox_errors and len(mailbox_errors) == len(self._backends):
+            # Every connected mailbox failed — surface it loudly rather than
+            # returning ok with zero results (which reads as "empty inbox").
+            raise ConnectorsError(
+                "All connected mailboxes failed during triage: "
+                + "; ".join(f"{e['mailbox']}: {e['error']}" for e in mailbox_errors)
+            )
         result: dict = {"results": merged, "grouped": group_by_category(merged)}
         if mailbox_errors:
             result["mailbox_errors"] = mailbox_errors
@@ -695,6 +702,13 @@ class EmailTriageAgent(
                 "suggested_archives": len(suggested_archives),
             },
         }
+        if mailbox_errors and len(mailbox_errors) == len(self._backends):
+            # Every connected mailbox failed — surface it loudly rather than
+            # returning ok with zero results (which reads as "empty inbox").
+            raise ConnectorsError(
+                "All connected mailboxes failed during pre-scan: "
+                + "; ".join(f"{e['mailbox']}: {e['error']}" for e in mailbox_errors)
+            )
         if mailbox_errors:
             result["mailbox_errors"] = mailbox_errors
         return result

--- a/hub/agents/python/email/gaia_agent_email/config.py
+++ b/hub/agents/python/email/gaia_agent_email/config.py
@@ -249,11 +249,17 @@ class EmailAgentConfig:
           - ``"google"`` / ``"microsoft"`` → only that provider, and only when
             it is actually connected.
 
-        Connector-derived: the connected set comes from
-        ``connected_mailbox_providers()`` (the keyring), in registry order
-        (google before microsoft). Fails loudly — an explicit filter naming an
-        unconnected provider, or nothing connected at all, raises
-        ``ConfigurationError`` rather than silently triaging one mailbox.
+        Connector-derived (intentional): the available set is the set of
+        CONNECTED providers, not the set of providers the agent is granted for.
+        Grant enforcement is the connectors layer's job — ``get_access_token_sync``
+        raises ``AuthRequiredError(AGENT_NOT_GRANTED)`` eagerly when the token is
+        fetched. The agent catches ``ConnectorsError`` per mailbox in
+        ``_triage_all_backends`` / ``_pre_scan_all_backends`` and surfaces a clean,
+        actionable per-mailbox notice rather than aborting the whole scan.
+
+        Fails loudly — an explicit filter naming an unconnected provider, or
+        nothing connected at all, raises ``ConfigurationError`` rather than
+        silently triaging one mailbox.
 
         The per-provider eval seam (``gmail_backend`` / ``outlook_backend``) is
         honored via ``_build_mail_backend``. An injected backend also marks its
@@ -321,6 +327,12 @@ class EmailAgentConfig:
         agent's calendar tools operate on Google and Outlook calendars
         interchangeably. An unsupported explicit provider raises
         ``ConfigurationError`` (fail loudly).
+
+        Grant enforcement is the connectors layer's job — a calendar backend
+        whose agent grant has been revoked raises ``AuthRequiredError`` when the
+        first calendar tool call fetches the token. The existing per-tool
+        ``ConnectorsError`` handler in ``CalendarToolsMixin`` surfaces that as a
+        clean actionable envelope without requiring any grant reasoning here.
 
         Live backend imports are local to keep the module import graph free of
         the ``connectors`` dependency chain at ``config`` import time.

--- a/tests/unit/agents/email/test_grant_revoked_clean_error.py
+++ b/tests/unit/agents/email/test_grant_revoked_clean_error.py
@@ -356,3 +356,44 @@ class TestCalendarUngrantedCleanError:
             ), f"calendar error not actionable: {error_msg!r}"
         finally:
             agent.close_db()
+
+
+class TestAllMailboxesUngrantedFailsLoudly:
+    """When EVERY connected mailbox errors, the scan must fail loudly (ok:False)
+    rather than return ok:True with zero results — which would read to the user
+    as "your inbox is empty" instead of "every mailbox needs a grant".
+    """
+
+    def test_triage_all_ungranted_returns_error_envelope(self, tmp_path, monkeypatch):
+        agent = _build_agent(
+            tmp_path,
+            monkeypatch,
+            granted_backend=UngrantedBackend("google"),
+            ungranted_backend=UngrantedBackend("microsoft"),
+        )
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            assert (
+                envelope["ok"] is False
+            ), f"all-failed triage must fail loudly, got: {envelope}"
+            err = envelope.get("error", "")
+            assert "google" in err and "microsoft" in err, err
+        finally:
+            agent.close_db()
+
+    def test_pre_scan_all_ungranted_returns_error_envelope(self, tmp_path, monkeypatch):
+        agent = _build_agent(
+            tmp_path,
+            monkeypatch,
+            granted_backend=UngrantedBackend("google"),
+            ungranted_backend=UngrantedBackend("microsoft"),
+        )
+        try:
+            envelope = json.loads(_registered_tool("pre_scan_inbox")(20))
+            assert (
+                envelope["ok"] is False
+            ), f"all-failed pre-scan must fail loudly, got: {envelope}"
+            err = envelope.get("error", "")
+            assert "google" in err and "microsoft" in err, err
+        finally:
+            agent.close_db()

--- a/tests/unit/agents/email/test_grant_revoked_clean_error.py
+++ b/tests/unit/agents/email/test_grant_revoked_clean_error.py
@@ -1,0 +1,339 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+#1739 — per-mailbox clean error on revoked grant, without aborting the whole scan.
+
+When one of multiple connected mailboxes has its agent grant revoked,
+``_triage_all_backends`` and ``_pre_scan_all_backends`` must:
+  - continue scanning the remaining (granted) mailboxes,
+  - surface a clean, per-mailbox notice in ``mailbox_errors`` instead of
+    propagating the raw ``AuthRequiredError``,
+  - never abort the entire multi-mailbox scan.
+
+The connectors layer already raises ``AuthRequiredError(AGENT_NOT_GRANTED)`` eagerly
+at ``get_access_token_sync`` time; the agent only needs to catch ``ConnectorsError``
+per backend and record the error cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")  # noqa: E402
+
+from unittest.mock import MagicMock, patch
+
+from gaia_agent_email.agent import EmailTriageAgent
+from gaia_agent_email.config import EmailAgentConfig
+
+from gaia.connectors.errors import AuthRequiredError, ConnectorsError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg(message_id: str, *, subject: str = "Hi", sender: str = "a@example.com"):
+    """Build a minimal Gmail-API-shape message that heuristic classifies without LLM."""
+    return {
+        "id": message_id,
+        "threadId": f"t-{message_id}",
+        "labelIds": ["INBOX", "CATEGORY_PROMOTIONS"],
+        "snippet": subject,
+        "internalDate": "1000",
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": subject},
+                {"name": "From", "value": sender},
+            ],
+            "body": {"data": ""},
+        },
+    }
+
+
+class GrantedBackend:
+    """Minimal GmailBackend-shaped spy that always succeeds."""
+
+    def __init__(self, name: str, message_ids: list[str]):
+        self.name = name
+        self._messages = {
+            mid: _msg(mid, sender=f"{name}@example.com") for mid in message_ids
+        }
+        self.calls: list[tuple[str, str]] = []
+
+    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+        ids = list(self._messages)[:max_results]
+        return {"messages": [{"id": m, "threadId": f"t-{m}"} for m in ids]}
+
+    def get_message(self, message_id: str):
+        if message_id not in self._messages:
+            raise KeyError(f"{self.name}: no message {message_id!r}")
+        return self._messages[message_id]
+
+    def get_thread(self, thread_id: str):
+        return {"id": thread_id, "messages": list(self._messages.values())}
+
+
+class UngrantedBackend:
+    """Backend whose scan methods raise AuthRequiredError on first call (eager grant gate)."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+        raise AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider=self.name,
+            agent_id="installed:email",
+            missing_scopes=["gmail.readonly"],
+        )
+
+    def get_message(self, message_id: str):
+        raise AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider=self.name,
+            agent_id="installed:email",
+        )
+
+    def get_thread(self, thread_id: str):
+        raise AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider=self.name,
+            agent_id="installed:email",
+        )
+
+
+def _build_agent(tmp_path, monkeypatch, *, granted_backend, ungranted_backend):
+    """Construct an agent with one granted and one ungranted backend.
+
+    Ungranted is microsoft, granted is google (or vice-versa depending on
+    which SpyBackend instance is passed).
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    cfg = EmailAgentConfig(
+        gmail_backend=granted_backend,
+        outlook_backend=ungranted_backend,
+        calendar_backend=object(),
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+        mail_provider=None,  # scan all connected
+    )
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent
+
+
+def _registered_tool(name):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    return _TOOL_REGISTRY[name]["function"]
+
+
+# ---------------------------------------------------------------------------
+# AC — triage loop continues when one mailbox is ungranted
+# ---------------------------------------------------------------------------
+
+
+class TestTriageContinuesOnUngrantedMailbox:
+    def test_triage_continues_when_one_mailbox_ungranted(self, tmp_path, monkeypatch):
+        """The granted mailbox results ARE returned; the scan does NOT raise; the
+        ungranted provider appears in ``mailbox_errors`` with an actionable message.
+        (Today ``_triage_all_backends`` propagates the AuthRequiredError out of the
+        loop and the whole scan fails — this test MUST fail against current main.)
+        """
+        granted = GrantedBackend("google", ["g1", "g2"])
+        ungranted = UngrantedBackend("microsoft")
+        agent = _build_agent(tmp_path, monkeypatch, granted_backend=granted, ungranted_backend=ungranted)
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            assert envelope["ok"] is True, f"scan raised instead of continuing: {envelope}"
+
+            data = envelope["data"]
+            results = data["results"]
+            # Granted mailbox contributed its messages.
+            ids = {r["id"] for r in results}
+            assert "g1" in ids or "g2" in ids, f"no google messages in results: {results}"
+            # Ungranted provider reported as a per-mailbox error, not an unhandled crash.
+            mailbox_errors = data.get("mailbox_errors", [])
+            assert mailbox_errors, "expected mailbox_errors but got none"
+            providers_in_errors = {e["mailbox"] for e in mailbox_errors}
+            assert "microsoft" in providers_in_errors, f"microsoft not in mailbox_errors: {mailbox_errors}"
+            # Error message is actionable.
+            ms_error = next(e for e in mailbox_errors if e["mailbox"] == "microsoft")
+            error_msg = ms_error["error"]
+            assert error_msg, "mailbox_errors entry has empty error message"
+            # The message should be actionable: mentions grant or Settings.
+            assert any(kw in error_msg for kw in ("grant", "Grant", "Settings", "AGENT_NOT_GRANTED")), (
+                f"error message not actionable: {error_msg!r}"
+            )
+        finally:
+            agent.close_db()
+
+    def test_pre_scan_continues_when_one_mailbox_ungranted(self, tmp_path, monkeypatch):
+        """Same for ``_pre_scan_all_backends``: granted mailbox results come back,
+        ungranted appears in ``mailbox_errors``, scan does NOT raise.
+        (Today this also propagates the exception — this test MUST fail against current main.)
+        """
+        granted = GrantedBackend("google", ["g1", "g2"])
+        ungranted = UngrantedBackend("microsoft")
+        agent = _build_agent(tmp_path, monkeypatch, granted_backend=granted, ungranted_backend=ungranted)
+        try:
+            envelope = json.loads(_registered_tool("pre_scan_inbox")(20))
+            assert envelope["ok"] is True, f"scan raised instead of continuing: {envelope}"
+
+            data = envelope["data"]
+            assert data.get("kind") == "email_pre_scan"
+
+            # At least one google message appeared in some section.
+            all_items = (
+                data.get("urgent", [])
+                + data.get("actionable", [])
+                + data.get("suggested_archives", [])
+            )
+            google_items = [it for it in all_items if it.get("mailbox") == "google"]
+            assert google_items, f"no google items in pre-scan: {all_items}"
+
+            # Ungranted provider reported as a per-mailbox error.
+            mailbox_errors = data.get("mailbox_errors", [])
+            assert mailbox_errors, "expected mailbox_errors but got none"
+            providers_in_errors = {e["mailbox"] for e in mailbox_errors}
+            assert "microsoft" in providers_in_errors, f"microsoft not in mailbox_errors: {mailbox_errors}"
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# AC — available set stays connection-derived (ungranted provider still listed)
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableSetConnectionDerived:
+    def test_available_set_still_lists_connected_ungranted_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """``resolve_mail_backends()`` returns BOTH providers even when microsoft
+        has no grant — connection-derived is intentional; grant enforcement is the
+        connectors layer's job.
+
+        The injected eval seam (UngrantedBackend passed as outlook_backend) means
+        the config resolves both providers at construction time — the UNGRANTED
+        check is deferred until the backend's list_messages is called.
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        granted = GrantedBackend("google", ["g1"])
+        ungranted = UngrantedBackend("microsoft")
+        cfg = EmailAgentConfig(
+            gmail_backend=granted,
+            outlook_backend=ungranted,
+            calendar_backend=object(),
+            db_path=str(tmp_path / "state.db"),
+            silent_mode=True,
+            mail_provider=None,
+        )
+        backends = cfg.resolve_mail_backends()
+        providers = [p for p, _ in backends]
+        # Both providers appear — connection-derived, grant is deferred to token time.
+        assert "google" in providers, providers
+        assert "microsoft" in providers, providers
+
+
+# ---------------------------------------------------------------------------
+# AC — injected fakes with no grants file → scan works unchanged (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestInjectedFakeScanUnaffected:
+    def test_injected_fake_scan_unaffected(self, tmp_path, monkeypatch):
+        """Both backends granted → scan works as before (hermetic regression guard)."""
+        google = GrantedBackend("google", ["g1"])
+        microsoft = GrantedBackend("microsoft", ["m1"])
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        cfg = EmailAgentConfig(
+            gmail_backend=google,
+            outlook_backend=microsoft,
+            calendar_backend=object(),
+            db_path=str(tmp_path / "state.db"),
+            silent_mode=True,
+            mail_provider=None,
+        )
+        with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+            mock_sdk.return_value = MagicMock()
+            agent = EmailTriageAgent(config=cfg)
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            assert envelope["ok"] is True, envelope
+            data = envelope["data"]
+            results = data["results"]
+            ids = {r["id"] for r in results}
+            assert "g1" in ids and "m1" in ids, f"expected both mailboxes: {ids}"
+            # No errors when all are granted.
+            assert not data.get("mailbox_errors"), data.get("mailbox_errors")
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# AC — calendar ungranted returns clean actionable error (not an unhandled crash)
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarUngrantedCleanError:
+    def test_calendar_ungranted_returns_clean_actionable_error(
+        self, tmp_path, monkeypatch
+    ):
+        """A connected-but-ungranted calendar raises AuthRequiredError at call time;
+        the calendar tool closure must return a clean error envelope, not crash.
+
+        This verifies the EXISTING per-tool ConnectorsError catch already covers
+        the calendar single-backend case — no multi-loop abort problem here.
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        granted = GrantedBackend("google", ["g1"])
+
+        class UngrantedCalendarBackend:
+            """Simulates a connected calendar whose agent grant has been revoked."""
+
+            def list_events(self, *, time_min=None, time_max=None):
+                raise AuthRequiredError(
+                    AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+                    provider="google",
+                    agent_id="installed:email",
+                    missing_scopes=["calendar.events"],
+                )
+
+            def __getattr__(self, name):
+                raise AuthRequiredError(
+                    AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+                    provider="google",
+                    agent_id="installed:email",
+                )
+
+        cfg = EmailAgentConfig(
+            gmail_backend=granted,
+            calendar_backend=UngrantedCalendarBackend(),
+            db_path=str(tmp_path / "state.db"),
+            silent_mode=True,
+            mail_provider=None,
+        )
+        with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+            mock_sdk.return_value = MagicMock()
+            agent = EmailTriageAgent(config=cfg)
+        try:
+            # The list_calendar_events tool should return a clean error envelope,
+            # not propagate the raw exception.
+            envelope = json.loads(_registered_tool("list_calendar_events")())
+            assert envelope["ok"] is False, (
+                f"expected error envelope but got ok=True: {envelope}"
+            )
+            error_msg = envelope.get("error", "")
+            assert error_msg, "error envelope has empty error message"
+            # The message should be actionable.
+            assert any(kw in error_msg for kw in ("grant", "Grant", "Settings", "AGENT_NOT_GRANTED")), (
+                f"calendar error not actionable: {error_msg!r}"
+            )
+        finally:
+            agent.close_db()

--- a/tests/unit/agents/email/test_grant_revoked_clean_error.py
+++ b/tests/unit/agents/email/test_grant_revoked_clean_error.py
@@ -28,8 +28,7 @@ from unittest.mock import MagicMock, patch
 from gaia_agent_email.agent import EmailTriageAgent
 from gaia_agent_email.config import EmailAgentConfig
 
-from gaia.connectors.errors import AuthRequiredError, ConnectorsError
-
+from gaia.connectors.errors import AuthRequiredError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -64,7 +63,9 @@ class GrantedBackend:
         }
         self.calls: list[tuple[str, str]] = []
 
-    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+    def list_messages(
+        self, *, query=None, label_ids=None, max_results=25, page_token=None
+    ):
         ids = list(self._messages)[:max_results]
         return {"messages": [{"id": m, "threadId": f"t-{m}"} for m in ids]}
 
@@ -83,7 +84,9 @@ class UngrantedBackend:
     def __init__(self, name: str):
         self.name = name
 
-    def list_messages(self, *, query=None, label_ids=None, max_results=25, page_token=None):
+    def list_messages(
+        self, *, query=None, label_ids=None, max_results=25, page_token=None
+    ):
         raise AuthRequiredError(
             AuthRequiredError.Reason.AGENT_NOT_GRANTED,
             provider=self.name,
@@ -147,29 +150,38 @@ class TestTriageContinuesOnUngrantedMailbox:
         """
         granted = GrantedBackend("google", ["g1", "g2"])
         ungranted = UngrantedBackend("microsoft")
-        agent = _build_agent(tmp_path, monkeypatch, granted_backend=granted, ungranted_backend=ungranted)
+        agent = _build_agent(
+            tmp_path, monkeypatch, granted_backend=granted, ungranted_backend=ungranted
+        )
         try:
             envelope = json.loads(_registered_tool("triage_inbox")(20))
-            assert envelope["ok"] is True, f"scan raised instead of continuing: {envelope}"
+            assert (
+                envelope["ok"] is True
+            ), f"scan raised instead of continuing: {envelope}"
 
             data = envelope["data"]
             results = data["results"]
             # Granted mailbox contributed its messages.
             ids = {r["id"] for r in results}
-            assert "g1" in ids or "g2" in ids, f"no google messages in results: {results}"
+            assert (
+                "g1" in ids or "g2" in ids
+            ), f"no google messages in results: {results}"
             # Ungranted provider reported as a per-mailbox error, not an unhandled crash.
             mailbox_errors = data.get("mailbox_errors", [])
             assert mailbox_errors, "expected mailbox_errors but got none"
             providers_in_errors = {e["mailbox"] for e in mailbox_errors}
-            assert "microsoft" in providers_in_errors, f"microsoft not in mailbox_errors: {mailbox_errors}"
+            assert (
+                "microsoft" in providers_in_errors
+            ), f"microsoft not in mailbox_errors: {mailbox_errors}"
             # Error message is actionable.
             ms_error = next(e for e in mailbox_errors if e["mailbox"] == "microsoft")
             error_msg = ms_error["error"]
             assert error_msg, "mailbox_errors entry has empty error message"
             # The message should be actionable: mentions grant or Settings.
-            assert any(kw in error_msg for kw in ("grant", "Grant", "Settings", "AGENT_NOT_GRANTED")), (
-                f"error message not actionable: {error_msg!r}"
-            )
+            assert any(
+                kw in error_msg
+                for kw in ("grant", "Grant", "Settings", "AGENT_NOT_GRANTED")
+            ), f"error message not actionable: {error_msg!r}"
         finally:
             agent.close_db()
 
@@ -180,10 +192,14 @@ class TestTriageContinuesOnUngrantedMailbox:
         """
         granted = GrantedBackend("google", ["g1", "g2"])
         ungranted = UngrantedBackend("microsoft")
-        agent = _build_agent(tmp_path, monkeypatch, granted_backend=granted, ungranted_backend=ungranted)
+        agent = _build_agent(
+            tmp_path, monkeypatch, granted_backend=granted, ungranted_backend=ungranted
+        )
         try:
             envelope = json.loads(_registered_tool("pre_scan_inbox")(20))
-            assert envelope["ok"] is True, f"scan raised instead of continuing: {envelope}"
+            assert (
+                envelope["ok"] is True
+            ), f"scan raised instead of continuing: {envelope}"
 
             data = envelope["data"]
             assert data.get("kind") == "email_pre_scan"
@@ -201,7 +217,9 @@ class TestTriageContinuesOnUngrantedMailbox:
             mailbox_errors = data.get("mailbox_errors", [])
             assert mailbox_errors, "expected mailbox_errors but got none"
             providers_in_errors = {e["mailbox"] for e in mailbox_errors}
-            assert "microsoft" in providers_in_errors, f"microsoft not in mailbox_errors: {mailbox_errors}"
+            assert (
+                "microsoft" in providers_in_errors
+            ), f"microsoft not in mailbox_errors: {mailbox_errors}"
         finally:
             agent.close_db()
 
@@ -326,14 +344,15 @@ class TestCalendarUngrantedCleanError:
             # The list_calendar_events tool should return a clean error envelope,
             # not propagate the raw exception.
             envelope = json.loads(_registered_tool("list_calendar_events")())
-            assert envelope["ok"] is False, (
-                f"expected error envelope but got ok=True: {envelope}"
-            )
+            assert (
+                envelope["ok"] is False
+            ), f"expected error envelope but got ok=True: {envelope}"
             error_msg = envelope.get("error", "")
             assert error_msg, "error envelope has empty error message"
             # The message should be actionable.
-            assert any(kw in error_msg for kw in ("grant", "Grant", "Settings", "AGENT_NOT_GRANTED")), (
-                f"calendar error not actionable: {error_msg!r}"
-            )
+            assert any(
+                kw in error_msg
+                for kw in ("grant", "Grant", "Settings", "AGENT_NOT_GRANTED")
+            ), f"calendar error not actionable: {error_msg!r}"
         finally:
             agent.close_db()


### PR DESCRIPTION
Closes #1739

## Why this matters

Before: if one connected mailbox lacked a per-agent grant, its eager auth error propagated out of the multi-mailbox scan loop and turned the **entire** triage/pre-scan into one error — discarding the *granted* mailbox's results too. After: the scan catches the typed connectors error per-provider, records a clean per-mailbox notice (`mailbox_errors`), and keeps going, so the granted mailbox still triages.

This also resolves #1707's open question with a documented decision: the available-mailbox/calendar set stays **connection-derived** on purpose — grants are enforced at the connection/token layer and the agent stays grant-unaware (no grant/scope logic added to the agent).

## Test plan

- [x] Unit: `python -m pytest tests/unit/agents/email/test_grant_revoked_clean_error.py -q` — triage + pre-scan continue when one mailbox is ungranted; the connected-but-ungranted provider still appears in the available set; calendar yields a clean error; injected-fake/eval seam unaffected. Full email suite: **390 passed**.
- [x] Real-world (2026-06-18, fully reversible — touches only the local grants ledger):

<details><summary>Real-world capture</summary>

```
revoke microsoft grant for installed:email
  available set            → ['google','microsoft']   (connection-derived, unchanged)
  pre_scan_inbox           → ok:True   (scan did NOT abort)
  mailbox_errors           → [{mailbox: microsoft, error: <grant message>}]
  google                   → not in mailbox_errors (kept working)
re-grant exact scopes
  pre_scan_inbox           → ok:True, mailbox_errors []
  grant restored byte-for-byte → True
RESULT: PASS
```
</details>

**Note:** the per-mailbox error *text* shown for a Microsoft grant gap is currently Google-centric — a separate, pre-existing defect in the connectors formatting layer, filed as #1751 (Milestone 40). It's out of scope here by design (this PR keeps the agent grant-unaware; message wording is owned by the connectors layer).
