### PR TITLE
fix(mcp): post-merge review fixes for #1750 (error envelope + session nav)

### DIFF
--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -20,7 +20,8 @@ import { useChatStore } from './stores/chatStore';
 import { useNotificationStore } from './stores/notificationStore';
 import * as api from './services/api';
 import { log, logBanner } from './utils/logger';
-import { getSessionHash, findSessionByHash } from './utils/format';
+import { getSessionHash } from './utils/format';
+import { resolveUrlNavTarget } from './utils/sessionNav';
 import { getApiBase } from './utils/apiBase';
 
 /** Wrapper that delays unmount to allow CSS exit animations to play. */
@@ -291,33 +292,36 @@ function App() {
         };
     }, [setRunningSessions]);
 
-    // Support URL-based session navigation (?session=<id> or #<hash>)
+    // Support URL-based session navigation (?session=<id> or #<hash>).
+    // Responds ONLY to external navigation — initial load, and the user pasting
+    // a URL or using browser back/forward (hashchange/popstate). The app's own
+    // session switches update the hash via replaceState (below), which does NOT
+    // fire hashchange/popstate, so this effect never fights a programmatic
+    // switch and can't oscillate with the SSE-activation handler.
     useEffect(() => {
-        const params = new URLSearchParams(window.location.search);
-        const sessionParam = params.get('session');
-        const hashParam = window.location.hash.replace(/^#/, '');
-        const target = sessionParam || hashParam;
-        if (!target) return;
-        // Already on this session — no switch needed
-        if (target === currentSessionId) return;
-
-        log.nav.info(`URL session parameter: ${target}`);
-        // Defer so session list has time to load
-        const timer = setTimeout(() => {
-            const { sessions } = useChatStore.getState();
-            // Try exact match first (full UUID), then short hash match
-            let matchId: string | null = sessions.some((s: { id: string }) => s.id === target)
-                ? target
-                : findSessionByHash(sessions, target);
+        const navigateFromUrl = () => {
+            const params = new URLSearchParams(window.location.search);
+            const sessionParam = params.get('session');
+            const hashParam = window.location.hash.replace(/^#/, '');
+            const target = sessionParam || hashParam;
+            const { currentSessionId: cur, sessions } = useChatStore.getState();
+            const matchId = resolveUrlNavTarget(target, cur, sessions);
             if (matchId) {
+                log.nav.info(`URL session navigation: ${target}`);
                 setCurrentSession(matchId);
                 setMessages([]);
-            } else {
-                log.nav.warn(`Session ${target} not found in loaded sessions`);
             }
-        }, 500);
-        return () => clearTimeout(timer);
-    }, [currentSessionId, setCurrentSession, setMessages]);
+        };
+        // Defer the initial pass so the session list has time to load.
+        const timer = setTimeout(navigateFromUrl, 500);
+        window.addEventListener('hashchange', navigateFromUrl);
+        window.addEventListener('popstate', navigateFromUrl);
+        return () => {
+            clearTimeout(timer);
+            window.removeEventListener('hashchange', navigateFromUrl);
+            window.removeEventListener('popstate', navigateFromUrl);
+        };
+    }, [setCurrentSession, setMessages]);
 
     // Subscribe to system session-activation events (MCP bridge P1)
     useEffect(() => {
@@ -335,9 +339,15 @@ function App() {
                 try {
                     const data = JSON.parse(ev.data) as { type: string; session_id?: string };
                     if (data.type === 'set_active_session' && data.session_id) {
-                        log.nav.info(`MCP activate session: ${data.session_id}`);
-                        setCurrentSession(data.session_id);
-                        setMessages([]);
+                        // Only switch (and clear messages) when it's actually a
+                        // different session — re-activating the current one must
+                        // not wipe the visible conversation.
+                        const cur = useChatStore.getState().currentSessionId;
+                        if (data.session_id !== cur) {
+                            log.nav.info(`MCP activate session: ${data.session_id}`);
+                            setCurrentSession(data.session_id);
+                            setMessages([]);
+                        }
                     }
                 } catch { /* malformed event — ignore */ }
             };

--- a/src/gaia/apps/webui/src/__tests__/App.test.tsx
+++ b/src/gaia/apps/webui/src/__tests__/App.test.tsx
@@ -2,35 +2,51 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * App.tsx integration tests — MCP/SSE session activation (issue #1086).
+ * App session-navigation tests (issues #1086 / #1750).
+ *
+ * Exercises resolveUrlNavTarget — the guard + match used by App.tsx's URL-nav
+ * effect — including the short-hash same-session case that caused the #1750
+ * session-activation oscillation (a `#<short>` URL for the current session must
+ * NOT trigger a switch).
  */
 
 import { describe, it, expect } from 'vitest';
+import { resolveUrlNavTarget } from '../utils/sessionNav';
+import { getSessionHash } from '../utils/format';
 
-describe('App session navigation guard', () => {
-    it('hash URL format includes # not ?session=', () => {
-        // Verify the contract: bridge uses /#<id>, not /?session=<id>
-        const sessionId = 'abc123';
-        const hashUrl = `http://localhost:4200/#${sessionId}`;
-        const queryUrl = `http://localhost:4200/?session=${sessionId}`;
-        expect(hashUrl).toContain('#');
-        expect(hashUrl).not.toContain('?session=');
-        expect(queryUrl).not.toContain('#');
+const A = '550e8400-e29b-41d4-a716-446655440000';
+const B = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const sessions = [{ id: A }, { id: B }];
+
+describe('resolveUrlNavTarget (URL session navigation guard)', () => {
+    it('returns null when there is no target', () => {
+        expect(resolveUrlNavTarget('', A, sessions)).toBeNull();
+        expect(resolveUrlNavTarget(null, A, sessions)).toBeNull();
     });
 
-    it('set_active_session event shape matches contract', () => {
-        // Verify the SSE event shape the frontend expects
-        const event = { type: 'set_active_session', session_id: 'test-123' };
-        expect(event.type).toBe('set_active_session');
-        expect(event.session_id).toBeDefined();
-        expect(typeof event.session_id).toBe('string');
+    it('returns null when already on the target session (full id)', () => {
+        expect(resolveUrlNavTarget(A, A, sessions)).toBeNull();
     });
-});
 
-describe('index.html title', () => {
-    it('title is GAIA Agent UI', () => {
-        // This test documents the required title value
-        const expectedTitle = 'GAIA Agent UI';
-        expect(expectedTitle).toBe('GAIA Agent UI');
+    it('returns null when target is the SHORT HASH of the current session (#1750)', () => {
+        // The oscillation bug: the app writes a short hash to the URL, so the
+        // guard must recognise it as "already here" and not switch.
+        expect(resolveUrlNavTarget(getSessionHash(A), A, sessions)).toBeNull();
+    });
+
+    it('switches to a different session by full id', () => {
+        expect(resolveUrlNavTarget(B, A, sessions)).toBe(B);
+    });
+
+    it('switches to a different session by short hash', () => {
+        expect(resolveUrlNavTarget(getSessionHash(B), A, sessions)).toBe(B);
+    });
+
+    it('returns null for an unknown target', () => {
+        expect(resolveUrlNavTarget('notarealsession', A, sessions)).toBeNull();
+    });
+
+    it('navigates when no session is currently active', () => {
+        expect(resolveUrlNavTarget(getSessionHash(B), null, sessions)).toBe(B);
     });
 });

--- a/src/gaia/apps/webui/src/utils/sessionNav.ts
+++ b/src/gaia/apps/webui/src/utils/sessionNav.ts
@@ -1,0 +1,30 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { getSessionHash, findSessionByHash } from './format';
+
+/**
+ * Decide which session (if any) a URL navigation target should switch to.
+ *
+ * Returns the session id to switch to, or null when no switch should happen:
+ * no target, already on that session, or the target matches no loaded session.
+ *
+ * The "already on it" check compares BOTH the full id and the short hash, so a
+ * hash-based URL for the current session (`#<short>`) does not trigger a
+ * redundant switch — the bug behind the #1750 session oscillation.
+ */
+export function resolveUrlNavTarget(
+    target: string | null | undefined,
+    currentSessionId: string | null,
+    sessions: { id: string }[],
+): string | null {
+    if (!target) return null;
+    if (
+        currentSessionId &&
+        (target === currentSessionId || target === getSessionHash(currentSessionId))
+    ) {
+        return null;
+    }
+    if (sessions.some((s) => s.id === target)) return target;
+    return findSessionByHash(sessions, target);
+}

--- a/src/gaia/mcp/servers/agent_ui_mcp.py
+++ b/src/gaia/mcp/servers/agent_ui_mcp.py
@@ -291,7 +291,7 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
             r.raise_for_status()
             return {"deleted": True, "session_id": session_id}
         except Exception as e:
-            return {"error": str(e)}
+            return _normalize_error(e, backend_url)
 
     # ── Messages ───────────────────────────────────────────────────
 
@@ -299,7 +299,7 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
     def get_messages(session_id: str) -> Dict[str, Any]:
         """Get all messages in a session (with agent steps and tool outputs)."""
         data = _api(backend_url, "get", f"/sessions/{session_id}/messages")
-        if "error" in data:
+        if data.get("status") == "error":
             return data
         # Simplify for readability
         messages = []
@@ -369,14 +369,14 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
                     f"/sessions/{session_id}/documents",
                     json={"document_id": doc_id},
                 )
-                if "error" not in attach_result:
+                if attach_result.get("status") != "error":
                     result["linked_to_session"] = session_id
                 else:
                     logger.warning(
                         "Failed to link doc %s to session %s: %s",
                         doc_id,
                         session_id,
-                        attach_result.get("error"),
+                        attach_result.get("detail"),
                     )
         return result
 
@@ -463,7 +463,10 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
         try:
             from PIL import Image, ImageGrab
         except ImportError:
-            return {"error": "Pillow not installed. Run: pip install Pillow"}
+            return {
+                "status": "error",
+                "detail": "Pillow not installed. Run: pip install Pillow",
+            }
 
         try:
             bbox = None
@@ -524,7 +527,7 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
                 "file_size_kb": file_size_kb,
             }
         except Exception as e:
-            return {"error": f"Screenshot failed: {e}"}
+            return {"status": "error", "detail": f"Screenshot failed: {e}"}
 
     # ── Memory ────────────────────────────────────────────────────────
     #
@@ -766,16 +769,26 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
 
         target_url = f"{base}/#{session_id}"
 
-        # Signal the frontend to switch to this session via the activate endpoint.
-        # This emits a set_active_session SSE event that App.tsx consumes.
-        _api(backend_url, "post", f"/sessions/{session_id}/activate")
-
-        # Skip opening a duplicate tab for the same URL.
+        # Skip re-opening (and re-activating) when this exact session is already
+        # the one we last opened — avoids emitting a redundant switch event that
+        # would wipe the visible messages for a session the user is already on.
         if _last_opened_url["url"] == target_url:
             return {
                 "opened": False,
                 "url": target_url,
                 "note": "Already open in browser",
+            }
+
+        # Signal the frontend to switch to this session via the activate endpoint
+        # (emits a set_active_session SSE event App.tsx consumes). Surface an
+        # activate failure rather than swallowing it.
+        activate = _api(backend_url, "post", f"/sessions/{session_id}/activate")
+        if isinstance(activate, dict) and activate.get("status") == "error":
+            return {
+                "opened": False,
+                "url": target_url,
+                "status": "error",
+                "detail": activate.get("detail", "activate failed"),
             }
 
         try:
@@ -786,7 +799,8 @@ def create_agent_ui_mcp(backend_url: str = DEFAULT_BACKEND) -> "FastMCP":
             return {
                 "opened": False,
                 "url": target_url,
-                "note": f"Failed to open browser: {e}",
+                "status": "error",
+                "detail": f"Failed to open browser: {e}",
             }
 
     return mcp

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -184,17 +184,6 @@ class SSEOutputHandler(OutputHandler):
         """Push an event to the queue for SSE delivery."""
         self.event_queue.put(event)
 
-    def emit_set_active_session(self, session_id: str) -> None:
-        """Emit a set_active_session event into the per-session chat stream.
-
-        Note: the primary activation path (MCP bridge → App.tsx) routes
-        through _system_emitter in routers/sessions.py, not this method.
-        This is a convenience shim for agent-loop code that already holds
-        an SSEOutputHandler and wants to push the event without importing
-        the sessions router.
-        """
-        self._emit({"type": "set_active_session", "session_id": session_id})
-
     def _elapsed(self) -> float:
         if self._start_time is None:
             return 0.0

--- a/tests/unit/test_agent_ui_mcp.py
+++ b/tests/unit/test_agent_ui_mcp.py
@@ -138,3 +138,48 @@ class TestSendMessageDocstring:
         ), "send_message docstring should not claim real-time streaming"
         # Should mention open_session_in_browser
         assert "open_session_in_browser" in doc
+
+
+class TestErrorEnvelopeCallers:
+    """#1750: internal callers must read the normalized {"status": "error"} shape,
+    not the old "error" key, or backend errors silently vanish."""
+
+    @staticmethod
+    def _build_server():
+        from gaia.mcp.servers.agent_ui_mcp import create_agent_ui_mcp
+
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"mcp_memory_enabled": False}),
+            )
+            mock_get.return_value.raise_for_status.return_value = None
+            return create_agent_ui_mcp("http://localhost:4200")
+
+    def test_get_messages_surfaces_backend_error(self):
+        """A backend error must propagate, not fall through to an empty session."""
+        pytest.importorskip("mcp")
+        mcp = self._build_server()
+        get_messages = mcp._tool_manager._tools["get_messages"].fn
+        with patch(
+            "gaia.mcp.servers.agent_ui_mcp._api",
+            return_value={"status": "error", "detail": "Session not found"},
+        ):
+            result = get_messages(session_id="bogus")
+        assert result.get("status") == "error"
+        assert "messages" not in result  # no silent empty-session fallback
+
+    def test_index_document_does_not_falsely_report_link(self):
+        """A failed session-link must not be reported as a successful link."""
+        pytest.importorskip("mcp")
+        mcp = self._build_server()
+        index_document = mcp._tool_manager._tools["index_document"].fn
+        with patch(
+            "gaia.mcp.servers.agent_ui_mcp._api",
+            side_effect=[
+                {"id": "doc-1"},  # upload-path succeeds
+                {"status": "error", "detail": "attach failed"},  # link fails
+            ],
+        ):
+            result = index_document(filepath="/tmp/x.txt", session_id="sess-1")
+        assert "linked_to_session" not in result


### PR DESCRIPTION
Closes #1755

## Why this matters
The #1750 review surfaced real issues *after* the PR had merged, so these are currently on `main`. Two are silent-failure bugs: an MCP `get_messages` call now returns an empty session instead of surfacing a backend error, and `index_document` reports a session-link as successful even when it failed — both because callers still keyed on the old `{"error"}` shape after the envelope was normalized to `{"status":"error"}`. The third is a 🔴 session-activation oscillation: the Agent UI URL-nav guard re-ran on every session change and read a stale URL hash, scheduling a ~500ms bounce that could ping-pong sessions — breaking the exact MCP→UI flow #1750 added.

## What changed
- **Error-envelope callers** — `get_messages` / `index_document` read `status == "error"`; `delete_session` and the screenshot tools return the structured envelope too.
- **Session nav** — the URL-nav effect now responds only to *external* navigation (initial load + `hashchange`/`popstate`); the app’s own switches use `replaceState`, which fires neither, so it can no longer fight a programmatic switch. Guard logic extracted into `resolveUrlNavTarget` with real unit tests (incl. the short-hash same-session case that caused the bounce). SSE handler clears messages only on an actual switch; `open_session_in_browser` activates only after the duplicate-tab guard and surfaces activate failures.
- Dropped the unused `emit_set_active_session` shim; replaced the tautological `App.test.tsx` with real assertions.

## Evidence
**Live A→B session switch on a running backend (the verification the reviewers asked for):**
- Manual sidebar A→B → hash settled at `#d536798` (B), stable across 8 polls / 3.2s — `oscillating: false`.
- MCP activate (`POST /api/sessions/{A}/activate`) while on B → switched to A (`#93c2222`), stable across 6 polls — no oscillation. Screenshot shows the UI on Session A after activation.

**Silent-fallback / false-success fixes** proven by unit tests that mock the normalized error envelope:
```
get_messages on a backend error  -> {"status":"error", ...}   (not {"messages":[]})
index_document on a failed link   -> no "linked_to_session" key (not a false success)
```

## Test plan
- [x] `pytest tests/unit/test_agent_ui_mcp.py` — 9 pass (mcp present); 5 pass / 4 skip with `mcp` absent (CI parity)
- [x] `npm test` — 7 real `resolveUrlNavTarget` cases (incl. short-hash same-session) + DocumentLibrary; `npm run build` (tsc) clean
- [x] `python util/lint.py --all` — Black / isort / Pylint / Flake8 all clean
- [x] Real-world (local Mac): live A→B + SSE-activate, no oscillation (above)