### PR TITLE
fix(agent-email/npm): regenerate JS/TS client to email contract 2.0

### DIFF
--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -115,13 +115,13 @@ Typed wrapper over the five endpoints. Methods: `triage`, `draft`, `send`,
 
 TypeScript types in `src/types.ts` are **hand-written** to mirror two Python
 sources of truth:
-- `hub/agents/python/email/gaia_agent_email/contract.py` — the frozen #1262
-  triage request/response contract (`SCHEMA_VERSION = "1.0"`).
+- `hub/agents/python/email/gaia_agent_email/contract.py` — the #1262
+  triage request/response contract, evolved to `SCHEMA_VERSION = "2.0"` (#1766).
 - `hub/agents/python/email/gaia_agent_email/api_routes.py` — the local draft/send
   handshake models (the #1264 send-confirmation gate).
 
 Hand-written (vs. generated from `/openapi.json`) because the contract is small
-and frozen, keeping the published package free of a typegen build step. The
+and version-gated, keeping the published package free of a typegen build step. The
 runtime `checkVersion` guard catches contract drift loudly. The server exposes
 `GET /openapi.json` if you prefer to regenerate.
 

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/npm/agent-email/src/lifecycle.ts
+++ b/hub/agents/npm/agent-email/src/lifecycle.ts
@@ -184,7 +184,7 @@ function majorOf(version: string): number {
 }
 
 export interface VersionCheckOptions {
-  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("1.0"). */
+  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("2.0"). */
   expectedApiVersion?: string;
 }
 

--- a/hub/agents/npm/agent-email/src/types.ts
+++ b/hub/agents/npm/agent-email/src/types.ts
@@ -10,25 +10,32 @@
  *    (non-frozen) draft/send handshake models.
  *
  * Why hand-written and not generated from `/openapi.json`: the contract is
- * small, stable (SCHEMA_VERSION is frozen at "1.0"), and hand-writing keeps the
- * published package free of an openapi-typegen build step and its dependency
- * tree. If the contract grows, regenerate from the live `/openapi.json` (the
- * server exposes it) and replace this file. The `apiVersion` check in
- * `lifecycle.ts` guards against silent drift at runtime.
+ * small, stable, and hand-writing keeps the published package free of an
+ * openapi-typegen build step and its dependency tree. If the contract grows,
+ * regenerate from the live `/openapi.json` (the server exposes it) and replace
+ * this file. The `apiVersion` check in `lifecycle.ts` guards against silent
+ * drift at runtime.
  *
  * Wire note: `EmailMessage.from` is the JSON key on the wire (Python aliases its
  * `from_` field to `from`), so this interface uses `from` directly.
+ *
+ * Schema 2.0 (#1615): five-bucket EmailCategory, suggested_action, TriageUsage,
+ * typed ActionItem (type/url discriminator).
  */
 
 /** Frozen contract version echoed by the server's `/version` endpoint. */
-export const SCHEMA_VERSION = "1.0" as const;
+export const SCHEMA_VERSION = "2.0" as const;
 
-/** The frozen four-bucket triage taxonomy (contract.py: EmailCategory). */
+/**
+ * The five-bucket triage taxonomy (schema 2.0, #1615 — contract.py: EmailCategory).
+ * Values are the exact JSON wire strings the server emits.
+ */
 export type EmailCategory =
-  | "urgent"
-  | "actionable"
-  | "informational"
-  | "low priority";
+  | "URGENT"
+  | "NEEDS_RESPONSE"
+  | "FYI"
+  | "PROMOTIONAL"
+  | "PERSONAL";
 
 /** A single email participant (contract.py: EmailAddress). */
 export interface EmailAddress {
@@ -83,20 +90,42 @@ export interface ThreadInput {
 /** Discriminated union on `kind` (contract.py: EmailInput). */
 export type EmailInput = SingleEmailInput | ThreadInput;
 
+/** Optional caller-supplied context that biases categorization (contract.py: TriageContext). */
+export interface TriageContext {
+  /** Important people whose mail should weigh higher. */
+  people?: string[];
+  /** Active projects the principal cares about. */
+  projects?: string[];
+  /** Preferred summary tone, e.g. "concise". */
+  tone?: string | null;
+  /** The principal's own address, so the model knows who "I" is. */
+  self_email?: string | null;
+}
+
 /** Top-level triage request envelope (contract.py: EmailTriageRequest). */
 export interface EmailTriageRequest {
   /** Contract version. Defaults to SCHEMA_VERSION; mismatch fails loudly. */
   schema_version?: string;
   /** The single-email or full-thread input. */
   payload: EmailInput;
+  /** Optional context that biases categorization and summary. */
+  context?: TriageContext | null;
 }
 
-/** A single extracted action (contract.py: ActionItem). */
+/**
+ * A single extracted action (contract.py: ActionItem — schema 2.0).
+ * `type` discriminates plain-text actions from link actions.
+ * When `type` is "link", `url` is required and non-empty.
+ */
 export interface ActionItem {
   /** Imperative action, e.g. "Reply to Bob". */
   description: string;
   /** Free-text due hint as written ("Friday", "EOD"); not parsed. */
   due_hint?: string | null;
+  /** "text" for a plain action; "link" when the action involves a URL. Default "text". */
+  type?: "text" | "link";
+  /** URL for a "link" action item; absent/null for "text". */
+  url?: string | null;
 }
 
 /** A drafted reply the agent proposes (contract.py: DraftReply). */
@@ -109,9 +138,24 @@ export interface DraftReply {
   body: string;
 }
 
+/**
+ * LLM usage metrics for a triage (contract.py: TriageUsage — schema 2.0).
+ * Null on the heuristic-only path where no LLM call was made.
+ */
+export interface TriageUsage {
+  /** Sum of input tokens across the LLM calls. */
+  prompt_tokens: number;
+  /** Sum of output (completion) tokens across the LLM calls. */
+  completion_tokens: number;
+  /** Sum of input + output tokens across the LLM calls. */
+  total_tokens: number;
+  /** Aggregate decode throughput (total output tokens / total decode time). */
+  tokens_per_second: number;
+}
+
 /** The structured analysis of one email or thread (contract.py: EmailTriageResult). */
 export interface EmailTriageResult {
-  /** One of the four buckets. */
+  /** One of the five taxonomy buckets (schema 2.0). */
   category: EmailCategory;
   /** Spam signal (independent). */
   is_spam: boolean;
@@ -123,8 +167,15 @@ export interface EmailTriageResult {
   action_items: ActionItem[];
   /** Proposed reply, or null when none is suggested. */
   draft?: DraftReply | null;
+  /**
+   * Suggested next action (schema 2.0): "reply" for URGENT/NEEDS_RESPONSE,
+   * "archive" for PROMOTIONAL, "none" for FYI/PERSONAL. Default "none".
+   */
+  suggested_action?: "reply" | "none" | "archive";
   /** Echoes the provider message-id / thread-id from the request. */
   message_id?: string | null;
+  /** LLM usage metrics; null on the heuristic-only path. */
+  usage?: TriageUsage | null;
 }
 
 /** Top-level triage response envelope (contract.py: EmailTriageResponse). */

--- a/hub/agents/npm/agent-email/test/client.test.ts
+++ b/hub/agents/npm/agent-email/test/client.test.ts
@@ -21,16 +21,21 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 const triageResponse: EmailTriageResponse = {
-  schema_version: "1.0",
+  schema_version: "2.0",
   request_kind: "single",
   result: {
-    category: "actionable",
+    category: "NEEDS_RESPONSE",
     is_spam: false,
     is_phishing: false,
     summary: "Prod incident follow-up — please review.",
-    action_items: [{ description: "Review the report", due_hint: "by friday" }],
+    action_items: [
+      { description: "Review the report", due_hint: "by friday", type: "text" },
+      { description: "Open the dashboard", type: "link", url: "https://example.com/dashboard" },
+    ],
+    suggested_action: "reply",
     draft: { to: [{ email: "a@b.com" }], subject: "Re: x", body: "" },
     message_id: "m1",
+    usage: { prompt_tokens: 120, completion_tokens: 40, total_tokens: 160, tokens_per_second: 32.5 },
   },
 };
 
@@ -60,8 +65,11 @@ describe("EmailClient", () => {
     };
     const res = await client.triage(req);
     expect(res.request_kind).toBe("single");
-    expect(res.result.category).toBe("actionable");
+    expect(res.result.category).toBe("NEEDS_RESPONSE");
     expect(res.result.action_items[0]?.due_hint).toBe("by friday");
+    expect(res.result.action_items[0]?.type).toBe("text");
+    expect(res.result.suggested_action).toBe("reply");
+    expect(res.result.usage?.total_tokens).toBe(160);
   });
 
   it("normalizes a trailing slash in baseUrl", async () => {
@@ -76,12 +84,12 @@ describe("EmailClient", () => {
 
   it("parses version", async () => {
     const fetchImpl = vi.fn(async () =>
-      jsonResponse({ apiVersion: "1.0", agentVersion: "0.1.0" }),
+      jsonResponse({ apiVersion: "2.0", agentVersion: "0.2.0" }),
     ) as unknown as typeof fetch;
     const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
     const v = await client.version();
-    expect(v.apiVersion).toBe("1.0");
-    expect(v.agentVersion).toBe("0.1.0");
+    expect(v.apiVersion).toBe("2.0");
+    expect(v.agentVersion).toBe("0.2.0");
   });
 
   it("draft + send round-trip types", async () => {

--- a/hub/agents/npm/agent-email/test/version-check.test.ts
+++ b/hub/agents/npm/agent-email/test/version-check.test.ts
@@ -8,7 +8,7 @@ import { EmailClient } from "../src/client.js";
 import { checkVersion } from "../src/lifecycle.js";
 import { VersionMismatchError } from "../src/errors.js";
 
-function clientReturning(apiVersion: string, agentVersion = "0.1.0"): EmailClient {
+function clientReturning(apiVersion: string, agentVersion = "0.2.0"): EmailClient {
   const fetchImpl = (async () =>
     new Response(JSON.stringify({ apiVersion, agentVersion }), {
       status: 200,
@@ -18,25 +18,25 @@ function clientReturning(apiVersion: string, agentVersion = "0.1.0"): EmailClien
 }
 
 describe("checkVersion", () => {
-  it("accepts a matching apiVersion", async () => {
-    const info = await checkVersion(clientReturning("1.0"));
-    expect(info.apiVersion).toBe("1.0");
+  it("accepts apiVersion 2.0 (schema 2.0 default)", async () => {
+    const info = await checkVersion(clientReturning("2.0"));
+    expect(info.apiVersion).toBe("2.0");
   });
 
-  it("accepts a higher MINOR within the same MAJOR (backward-compatible)", async () => {
-    const info = await checkVersion(clientReturning("1.5"), { expectedApiVersion: "1.0" });
-    expect(info.apiVersion).toBe("1.5");
+  it("accepts a higher MINOR within the same MAJOR 2 (backward-compatible)", async () => {
+    const info = await checkVersion(clientReturning("2.5"), { expectedApiVersion: "2.0" });
+    expect(info.apiVersion).toBe("2.5");
   });
 
-  it("rejects a higher MAJOR (breaking)", async () => {
+  it("rejects a major-1 server (old sidecar — breaking)", async () => {
     await expect(
-      checkVersion(clientReturning("2.0"), { expectedApiVersion: "1.0" }),
+      checkVersion(clientReturning("1.0"), { expectedApiVersion: "2.0" }),
     ).rejects.toBeInstanceOf(VersionMismatchError);
   });
 
-  it("rejects a lower MAJOR", async () => {
+  it("rejects a major-3 server (future incompatible major)", async () => {
     await expect(
-      checkVersion(clientReturning("1.0"), { expectedApiVersion: "2.0" }),
+      checkVersion(clientReturning("3.0"), { expectedApiVersion: "2.0" }),
     ).rejects.toBeInstanceOf(VersionMismatchError);
   });
 });


### PR DESCRIPTION
Closes #1766. Part of the Path-2 email-in-Agent-UI epic #1767.

## Why this matters
Before: the `@amd-gaia/agent-email` npm client pinned its version guard to contract **1.0**, so its lifecycle `checkVersion` refused the shipped **2.0** sidecar with `VersionMismatchError` — no version-checked call could complete, which blocked the Path-2 dogfood (#1653). After: the client's types and version negotiation match the live 2.0 contract, and the full `spawn → health → version-check → triage → shutdown` lifecycle completes against the current sidecar. The fail-loud guard is preserved (it still rejects a future incompatible major).

Contract-major step: npm package `0.1.0 → 0.2.0`. `src/types.ts` regenerated from `openapi.email.json` / `contract.py` 2.0 (five-bucket `EmailCategory`, `suggested_action`, response `usage`, typed `ActionItem` with `type`/`url`, `is_spam`/`is_phishing`).

## Evidence
**Lifecycle demo against a live 2.0 sidecar** — the version-check (the fix) now passes; pre-change this same command threw `VersionMismatchError`:
```
$ PYTHON=<2.0-venv> node scripts/demo.mjs
[agent-email:lifecycle] sidecar healthy after 7 probe(s)
[demo] version OK: apiVersion=2.0 agentVersion=0.1.0      ← was VersionMismatchError before #1766
[demo] POST /v1/email/triage (single email) — routes to the real local LLM ...
[demo] VERDICT: PASS
```
(Triage routes correctly; a live result is bounded by the demo's 15s client timeout vs gemma-4-e4b inference latency — independent of this change. The issue accepts "live or 502 triage per Lemonade availability".)

**Unit:** `npm test` → Test Files 3 passed (3) | Tests 18 passed (18). `npm run build` (tsc) clean.

## Test plan
- [ ] `cd hub/agents/npm/agent-email && npm ci && npm run build && npm test` → green
- [ ] `PYTHON=<venv-with-gaia_agent_email> node scripts/demo.mjs` → `version OK: apiVersion=2.0`, `VERDICT: PASS`