### PR TITLE
test(email): running-server OpenAPI conformance + apiVersion bump policy

### DIFF
--- a/.github/workflows/test_email_agent.yml
+++ b/.github/workflows/test_email_agent.yml
@@ -15,6 +15,7 @@ on:
       - 'src/gaia/agents/base/**'
       - 'src/gaia/agents/tools/**'
       - 'setup.py'
+      - 'tests/test_email_openapi_conformance.py'
       - '.github/workflows/test_email_agent.yml'
   pull_request:
     branches: [ main ]
@@ -24,6 +25,7 @@ on:
       - 'src/gaia/agents/base/**'
       - 'src/gaia/agents/tools/**'
       - 'setup.py'
+      - 'tests/test_email_openapi_conformance.py'
       - '.github/workflows/test_email_agent.yml'
   merge_group:
   workflow_dispatch:
@@ -66,6 +68,7 @@ jobs:
           # importorskips without the wheel and runs here with it installed.
           python -m pytest \
             hub/agents/python/email/tests/ \
+            tests/test_email_openapi_conformance.py \
             tests/unit/agents/email/ \
             tests/unit/email/ \
             tests/unit/agents/test_email_agent.py \

--- a/docs/plans/email-agent-packaging.mdx
+++ b/docs/plans/email-agent-packaging.mdx
@@ -233,10 +233,27 @@ A single **OpenAPI spec** is the source of truth for the REST surface. The Pytho
 
 ## Versioning & Contract Governance
 
-- **`apiVersion`** (SemVer) is the host-facing contract version, advertised on `/version`. Breaking REST changes bump its major.
+`apiVersion` is the host-facing contract version (SemVer), advertised on `GET /version` and defined as a single constant — `SCHEMA_VERSION` in `hub/agents/python/email/gaia_agent_email/contract.py`, aliased as `API_VERSION` in `version.py`. Bumping the contract automatically bumps the API version; they cannot drift.
+
+### `apiVersion` bump policy
+
+| Change type | Example | Version bump |
+|-------------|---------|-------------|
+| Field removed, renamed, or retyped on any request/response model | Remove `is_phishing`, rename `body` → `text` | **MAJOR** |
+| Enum value removed or renamed | Remove `PROMOTIONAL` from `EmailCategory` | **MAJOR** |
+| Endpoint removed or its method changed | Delete `POST /triage` | **MAJOR** |
+| New required field added to a request model | Add required `locale` to `EmailTriageRequest` | **MAJOR** |
+| New optional field added to a request or response | Add optional `thread_summary` to `EmailTriageResult` | **minor** |
+| New endpoint added | Add `GET /v1/email/threads` | **minor** |
+| New enum value added | Add `CALENDAR_INVITE` to `EmailCategory` | **minor** |
+| Bug fix with no wire-format change | Fix a 500 on malformed input | none (patch only) |
+
+**Clients must reject a server whose `apiVersion` major is higher than what they support** — fail loudly with an actionable error, never fall back to best-effort parsing against an incompatible schema.  Clients may accept any minor version equal to or greater than their compiled-against minor.
+
+**How to apply a bump:** update `SCHEMA_VERSION` in `contract.py`, regenerate the spec (`python -m gaia_agent_email.export_openapi`), and run `python -m pytest hub/agents/python/email/tests/test_rest_contract.py tests/test_email_openapi_conformance.py` to confirm no drift.
+
 - **Package version** tracks the agent build; the npm package, the R2 binary version (`agents/email/<version>/…`), and the pinned `binaries.lock.json` manifest always publish in lockstep — the manifest references the matching R2 version, never a floating one.
-- The **OpenAPI spec is the single source of truth** — client, Python server, and C++ server are all validated against it in CI. A change to the contract that isn't reflected in all three fails CI.
-- Client refuses a binary whose `apiVersion` major it doesn't support — **fail loudly**, never best-effort against an incompatible server.
+- The **OpenAPI spec (`openapi.email.json`) is the single source of truth** — client, Python server, and C++ server are all validated against it in CI. A change to the contract that isn't reflected in the committed artifact fails CI (`test_rest_contract.py::test_committed_openapi_artifact_is_up_to_date`), and a running server that doesn't conform to the spec fails the conformance suite (`tests/test_email_openapi_conformance.py`).
 
 ---
 

--- a/tests/test_email_openapi_conformance.py
+++ b/tests/test_email_openapi_conformance.py
@@ -1,0 +1,323 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+OpenAPI conformance tests for the Email Triage agent REST surface (#1645).
+
+These tests drive a RUNNING in-process ASGI server (FastAPI TestClient) against
+the committed ``openapi.email.json`` spec and validate that every documented
+path+method returns a response whose shape matches the spec's declared response
+schema.  No live mailbox, no live LLM — the LLM-backed triage path is covered by
+patching ``EmailTriageService.triage_request`` to return a valid canned result.
+
+This is distinct from the static-analysis tests in
+``hub/agents/python/email/tests/test_rest_contract.py``:
+
+- ``test_rest_contract.py`` checks that the committed artifact matches a freshly
+  generated spec (drift detection) and that ``version.py`` constants agree with
+  ``contract.py`` constants.
+- **This file** checks that the running server actually conforms to the spec it
+  declares — i.e. that each endpoint returns a body whose keys match the
+  documented response schema's required fields.  A route that is documented but
+  broken (bad implementation) fails here, not in the drift test.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+# EmailTriageAgent ships as the standalone gaia-agent-email wheel (#1102);
+# skip the whole module cleanly when a framework-only env lacks it.
+pytest.importorskip("gaia_agent_email")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from gaia_agent_email.contract import (  # noqa: E402
+    EmailCategory,
+    EmailTriageResponse,
+    EmailTriageResult,
+)
+from gaia_agent_email.export_openapi import ARTIFACT_PATH, build_app  # noqa: E402
+from gaia_agent_email.version import AGENT_VERSION, API_VERSION  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _schema_name_from_response(spec: dict, method: str, path: str) -> str:
+    """Extract the component schema name from a route's 200 response $ref."""
+    schema = spec["paths"][path][method]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+    ref = schema["$ref"]
+    return ref.rsplit("/", 1)[-1]
+
+
+def _required_keys(spec: dict, schema_name: str) -> set:
+    """Return the ``required`` field-names for a top-level component schema."""
+    schema = spec["components"]["schemas"][schema_name]
+    return set(schema.get("required", []))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def committed_spec() -> dict:
+    """The committed ``openapi.email.json`` (the cross-implementation contract)."""
+    return json.loads(ARTIFACT_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """In-process ASGI test client — a real running ASGI server, no network."""
+    return TestClient(build_app())
+
+
+def _canned_triage_response() -> EmailTriageResponse:
+    """Return a valid schema-2.0 EmailTriageResponse for LLM mock use."""
+    result = EmailTriageResult(
+        category=EmailCategory.NEEDS_RESPONSE,
+        is_spam=False,
+        is_phishing=False,
+        summary="Alice is asking Bob to join her for lunch tomorrow.",
+        action_items=[],
+        draft=None,
+        message_id="msg-conformance-001",
+    )
+    return EmailTriageResponse(request_kind="single", result=result)
+
+
+def _minimal_triage_payload() -> dict:
+    """Minimal valid EmailTriageRequest body for POST /triage."""
+    return {
+        "schema_version": "2.0",
+        "payload": {
+            "kind": "single",
+            "principal": {"email": "bob@example.com"},
+            "message": {
+                "message_id": "msg-conformance-001",
+                "subject": "Lunch tomorrow?",
+                "from": {"email": "alice@example.com"},
+                "body": "Hey, join us for lunch tomorrow at noon?",
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. /health — conformance (running server, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_health_conforms_to_spec(client, committed_spec):
+    """GET /health returns a body with all required fields from the spec."""
+    resp = client.get("/v1/email/health")
+    assert resp.status_code == 200
+
+    schema_name = _schema_name_from_response(committed_spec, "get", "/v1/email/health")
+    required = _required_keys(committed_spec, schema_name)
+    body = resp.json()
+
+    for key in required:
+        assert key in body, f"required key {key!r} missing from /health response"
+
+    assert body["status"] == "ok"
+    assert body["service"] == "gaia-agent-email"
+
+
+# ---------------------------------------------------------------------------
+# 2. /version — conformance (running server, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_version_conforms_to_spec(client, committed_spec):
+    """GET /version returns apiVersion and agentVersion matching the constants."""
+    resp = client.get("/v1/email/version")
+    assert resp.status_code == 200
+
+    schema_name = _schema_name_from_response(
+        committed_spec, "get", "/v1/email/version"
+    )
+    required = _required_keys(committed_spec, schema_name)
+    body = resp.json()
+
+    for key in required:
+        assert key in body, f"required key {key!r} missing from /version response"
+
+    assert body["apiVersion"] == API_VERSION, (
+        f"apiVersion mismatch: server reports {body['apiVersion']!r}, "
+        f"version.API_VERSION is {API_VERSION!r}"
+    )
+    assert body["agentVersion"] == AGENT_VERSION, (
+        f"agentVersion mismatch: server reports {body['agentVersion']!r}, "
+        f"version.AGENT_VERSION is {AGENT_VERSION!r}"
+    )
+
+
+def test_version_has_no_undocumented_fields(client, committed_spec):
+    """GET /version response must not include fields absent from the spec schema."""
+    resp = client.get("/v1/email/version")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    schema_name = _schema_name_from_response(
+        committed_spec, "get", "/v1/email/version"
+    )
+    documented_keys = set(
+        committed_spec["components"]["schemas"][schema_name].get("properties", {})
+    )
+    for key in body:
+        assert key in documented_keys, (
+            f"response field {key!r} is not documented in the spec schema"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. /triage — conformance (LLM mocked; real HTTP layer running)
+# ---------------------------------------------------------------------------
+
+
+def test_triage_conforms_to_spec(client, committed_spec):
+    """POST /triage with a mocked LLM returns a body conforming to the spec schema."""
+    canned = _canned_triage_response()
+
+    with patch(
+        "gaia_agent_email.api_routes.EmailTriageService.triage_request",
+        return_value=canned,
+    ):
+        resp = client.post("/v1/email/triage", json=_minimal_triage_payload())
+
+    assert resp.status_code == 200
+
+    schema_name = _schema_name_from_response(
+        committed_spec, "post", "/v1/email/triage"
+    )
+    required = _required_keys(committed_spec, schema_name)
+    body = resp.json()
+
+    for key in required:
+        assert key in body, f"required key {key!r} missing from /triage response"
+
+    assert body.get("schema_version") == "2.0"
+    assert body.get("request_kind") == "single"
+    assert "result" in body
+    result = body["result"]
+    assert "category" in result
+    assert "summary" in result
+
+
+def test_triage_invalid_payload_returns_422(client):
+    """POST /triage with a malformed body returns 422 (documented validation error)."""
+    resp = client.post("/v1/email/triage", json={"schema_version": "2.0"})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 4. /draft — conformance (no LLM needed; draft only mints a token)
+# ---------------------------------------------------------------------------
+
+
+def test_draft_conforms_to_spec(client, committed_spec):
+    """POST /draft returns a body conforming to the EmailDraftResponse spec schema."""
+    resp = client.post(
+        "/v1/email/draft",
+        json={
+            "to": [{"email": "carol@example.com"}],
+            "subject": "Following up",
+            "body": "Just checking in — any update?",
+        },
+    )
+    assert resp.status_code == 200
+
+    schema_name = _schema_name_from_response(
+        committed_spec, "post", "/v1/email/draft"
+    )
+    required = _required_keys(committed_spec, schema_name)
+    body = resp.json()
+
+    for key in required:
+        assert key in body, f"required key {key!r} missing from /draft response"
+
+    assert "draft" in body
+    assert "confirmation_token" in body
+    assert isinstance(body["confirmation_token"], str)
+    assert len(body["confirmation_token"]) > 0
+
+
+def test_draft_invalid_payload_returns_422(client):
+    """POST /draft with an empty 'to' list returns 422."""
+    resp = client.post(
+        "/v1/email/draft",
+        json={"to": [], "subject": "Hi", "body": "Hello"},
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 5. /send — conformance (documented error shape for missing token)
+# ---------------------------------------------------------------------------
+
+
+def test_send_without_token_returns_403(client):
+    """POST /send without a confirmation token returns 403 (documented behavior).
+
+    The spec documents 200 (EmailSendResponse) as the success path.  A missing
+    or invalid token is a documented gating failure — the detail must guide the
+    caller to POST /draft.
+    """
+    resp = client.post(
+        "/v1/email/send",
+        json={
+            "to": [{"email": "dave@example.com"}],
+            "subject": "Send me",
+            "body": "Without a token.",
+        },
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert "detail" in body
+    detail_lower = body["detail"].lower()
+    assert "confirmation_token" in detail_lower or "draft" in detail_lower, (
+        "403 detail should guide the caller to POST /draft to obtain a token"
+    )
+
+
+def test_send_invalid_payload_returns_422(client):
+    """POST /send with a missing required field returns 422."""
+    resp = client.post("/v1/email/send", json={"subject": "Hi", "body": "Hello"})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 6. All documented paths are covered
+# ---------------------------------------------------------------------------
+
+
+def test_all_documented_paths_covered(committed_spec):
+    """Every path+method in the committed spec is covered by a conformance test.
+
+    This test fails if a new route is added to the spec but no conformance test
+    is written for it — preventing silent gaps.
+    """
+    documented = {
+        (method, path)
+        for path, ops in committed_spec["paths"].items()
+        for method in ops
+    }
+    expected = {
+        ("post", "/v1/email/triage"),
+        ("post", "/v1/email/draft"),
+        ("post", "/v1/email/send"),
+        ("get", "/v1/email/health"),
+        ("get", "/v1/email/version"),
+    }
+    assert documented == expected, (
+        f"Spec has routes not covered by conformance tests: "
+        f"{documented - expected}. Add a conformance test for each new route."
+    )

--- a/tests/test_email_openapi_conformance.py
+++ b/tests/test_email_openapi_conformance.py
@@ -41,7 +41,6 @@ from gaia_agent_email.contract import (  # noqa: E402
 from gaia_agent_email.export_openapi import ARTIFACT_PATH, build_app  # noqa: E402
 from gaia_agent_email.version import AGENT_VERSION, API_VERSION  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -141,9 +140,7 @@ def test_version_conforms_to_spec(client, committed_spec):
     resp = client.get("/v1/email/version")
     assert resp.status_code == 200
 
-    schema_name = _schema_name_from_response(
-        committed_spec, "get", "/v1/email/version"
-    )
+    schema_name = _schema_name_from_response(committed_spec, "get", "/v1/email/version")
     required = _required_keys(committed_spec, schema_name)
     body = resp.json()
 
@@ -166,16 +163,14 @@ def test_version_has_no_undocumented_fields(client, committed_spec):
     assert resp.status_code == 200
     body = resp.json()
 
-    schema_name = _schema_name_from_response(
-        committed_spec, "get", "/v1/email/version"
-    )
+    schema_name = _schema_name_from_response(committed_spec, "get", "/v1/email/version")
     documented_keys = set(
         committed_spec["components"]["schemas"][schema_name].get("properties", {})
     )
     for key in body:
-        assert key in documented_keys, (
-            f"response field {key!r} is not documented in the spec schema"
-        )
+        assert (
+            key in documented_keys
+        ), f"response field {key!r} is not documented in the spec schema"
 
 
 # ---------------------------------------------------------------------------
@@ -195,9 +190,7 @@ def test_triage_conforms_to_spec(client, committed_spec):
 
     assert resp.status_code == 200
 
-    schema_name = _schema_name_from_response(
-        committed_spec, "post", "/v1/email/triage"
-    )
+    schema_name = _schema_name_from_response(committed_spec, "post", "/v1/email/triage")
     required = _required_keys(committed_spec, schema_name)
     body = resp.json()
 
@@ -235,9 +228,7 @@ def test_draft_conforms_to_spec(client, committed_spec):
     )
     assert resp.status_code == 200
 
-    schema_name = _schema_name_from_response(
-        committed_spec, "post", "/v1/email/draft"
-    )
+    schema_name = _schema_name_from_response(committed_spec, "post", "/v1/email/draft")
     required = _required_keys(committed_spec, schema_name)
     body = resp.json()
 
@@ -283,9 +274,9 @@ def test_send_without_token_returns_403(client):
     body = resp.json()
     assert "detail" in body
     detail_lower = body["detail"].lower()
-    assert "confirmation_token" in detail_lower or "draft" in detail_lower, (
-        "403 detail should guide the caller to POST /draft to obtain a token"
-    )
+    assert (
+        "confirmation_token" in detail_lower or "draft" in detail_lower
+    ), "403 detail should guide the caller to POST /draft to obtain a token"
 
 
 def test_send_invalid_payload_returns_422(client):


### PR DESCRIPTION
Closes #1645. Part of the Path-2 email-in-Agent-UI epic #1767.

## Why this matters
The email OpenAPI spec (`openapi.email.json`, v2.0) and `GET /v1/email/version` already shipped, and a byte-equality unit test already guards the committed spec against the code. The two gaps this closes: there was **no CI step validating a *running* server against the committed spec** (only a static spec-vs-code byte check), and the **`apiVersion` SemVer bump policy was undocumented**. After: every documented endpoint is exercised through a live in-process ASGI server and its response validated against the spec on each CI run, and the bump policy is written down so the npm client's fail-loud major-version guard has a documented contract to track.

## Evidence
**Conformance + contract tests green** (10 new conformance tests over all 5 documented endpoints via a running `TestClient`, LLM mocked; plus the 17 existing contract tests):
```
$ python -m pytest hub/agents/python/email/tests/test_rest_contract.py tests/test_email_openapi_conformance.py -q
...........................                                              [100%]
27 passed, 1 warning in 0.53s
```
Wired into `.github/workflows/test_email_agent.yml` (added to the pytest paths + path-filter triggers). Bump policy documented in `docs/plans/email-agent-packaging.mdx` (MAJOR = breaking wire change, minor = additive; clients reject a higher major).

## Test plan
- [ ] `python -m pytest hub/agents/python/email/tests/test_rest_contract.py tests/test_email_openapi_conformance.py -v` → green
- [ ] CI `test_email_agent.yml` runs the new conformance test