### PR TITLE
feat(ui): serve email from the UI backend — mount gaia-agent-email REST router (Path 2)

### DIFF
--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -19,6 +19,7 @@ Endpoint implementations are split into router modules under
 """
 
 import asyncio
+import importlib.util
 import logging
 import os
 import shutil  # noqa: F401  # pylint: disable=unused-import
@@ -583,6 +584,21 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
     app.include_router(connectors_router_mod.router)
     # Issue #1292 — forwarded pre-authenticated connections (/v1/connections).
     app.include_router(connectors_router_mod.forwarded_router)
+    # Issue #1768 — Email REST surface (/v1/email/*).
+    # Ships with the standalone gaia-agent-email wheel; mount only when present.
+    # find_spec gates on wheel availability without importing it; the import and
+    # include_router are outside any except so a broken installed wheel fails
+    # loudly per the no-silent-fallback rule.
+    if importlib.util.find_spec("gaia_agent_email") is None:
+        logger.info(
+            "Email REST routes unavailable: install the email agent "
+            "(pip install gaia-agent-email) to enable POST /v1/email/*. "
+            "(#1768)"
+        )
+    else:
+        from gaia_agent_email.api_routes import router as email_router
+
+        app.include_router(email_router)
 
     # ── Serve Uploaded Files ─────────────────────────────────────────────
     # Mount the uploads directory so uploaded files can be served by URL.

--- a/tests/test_ui_email_router.py
+++ b/tests/test_ui_email_router.py
@@ -28,7 +28,6 @@ from gaia_agent_email.version import API_VERSION  # noqa: E402
 
 from gaia.ui.server import create_app  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Shared fixture: UI app with in-memory DB (no filesystem side effects)
 # ---------------------------------------------------------------------------
@@ -49,7 +48,7 @@ def ui_client():
 
 
 def test_email_health_mounted(ui_client):
-    """GET /v1/email/health -> 200 with ok=True when the wheel is installed."""
+    """GET /v1/email/health -> 200 with status='ok' when the wheel is installed."""
     resp = ui_client.get("/v1/email/health")
     assert resp.status_code == 200, resp.text
     body = resp.json()
@@ -120,7 +119,7 @@ def test_triage_returns_200_schema_2_shape(ui_client):
 
 
 # ---------------------------------------------------------------------------
-# AC3 — fail-loud guard: absent wheel -> clean skip (404, no exception)
+# AC3 — fail-loud guard: absent wheel -> clean skip (no exception, routes unmounted)
 #        present-but-broken wheel -> error propagates (not swallowed)
 # ---------------------------------------------------------------------------
 
@@ -154,6 +153,6 @@ def test_mount_block_absent_wheel_does_not_mount():
     # i.e. they do not return its JSON contract.
     for path in ("/v1/email/version", "/v1/email/health"):
         resp = client.get(path)
-        assert "application/json" not in resp.headers.get("content-type", ""), (
-            f"{path} unexpectedly served by the email router when the wheel is absent"
-        )
+        assert "application/json" not in resp.headers.get(
+            "content-type", ""
+        ), f"{path} unexpectedly served by the email router when the wheel is absent"

--- a/tests/test_ui_email_router.py
+++ b/tests/test_ui_email_router.py
@@ -1,0 +1,149 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Integration tests for the email REST router mounted in the UI backend (#1768).
+
+Verifies that ``gaia.ui.server.create_app`` conditionally mounts the
+``gaia_agent_email`` router when the wheel is installed, and that the mounted
+surface responds correctly to health, version, and triage requests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+# Skip the whole module if FastAPI's TestClient is unavailable (bare [dev]-only env).
+pytest.importorskip("fastapi")
+# Skip if the email wheel is not installed.
+pytest.importorskip("gaia_agent_email")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from gaia_agent_email.contract import (  # noqa: E402
+    EmailCategory,
+    EmailTriageResponse,
+    EmailTriageResult,
+)
+from gaia_agent_email.version import API_VERSION  # noqa: E402
+
+from gaia.ui.server import create_app  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: UI app with in-memory DB (no filesystem side effects)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ui_client():
+    """TestClient for the UI backend with gaia_agent_email wheel present."""
+    app = create_app(db_path=":memory:")
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# AC1 — router is mounted when the wheel is present
+# ---------------------------------------------------------------------------
+
+
+def test_email_health_mounted(ui_client):
+    """GET /v1/email/health -> 200 with ok=True when the wheel is installed."""
+    resp = ui_client.get("/v1/email/health")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("ok") is True
+
+
+def test_email_version_mounted(ui_client):
+    """GET /v1/email/version -> 200 with apiVersion == '2.0'."""
+    resp = ui_client.get("/v1/email/version")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("apiVersion") == API_VERSION
+
+
+# ---------------------------------------------------------------------------
+# AC2 — triage endpoint returns 200 with the schema-2.0 shape (LLM mocked)
+# ---------------------------------------------------------------------------
+
+
+def _stub_triage_response() -> EmailTriageResponse:
+    """A minimal valid schema-2.0 response that doesn't touch the LLM."""
+    result = EmailTriageResult(
+        category=EmailCategory.FYI,
+        summary="Test summary produced by stub.",
+        action_items=[],
+    )
+    return EmailTriageResponse(request_kind="single", result=result)
+
+
+def test_triage_returns_200_schema_2_shape(ui_client):
+    """POST /v1/email/triage -> 200 whose body matches the schema-2.0 shape.
+
+    The LLM layer is mocked so this runs without a Lemonade server.
+    """
+    stub_resp = _stub_triage_response()
+
+    with patch(
+        "gaia_agent_email.api_routes.EmailTriageService.triage_request",
+        return_value=stub_resp,
+    ):
+        payload = {
+            "schema_version": "2.0",
+            "payload": {
+                "kind": "single",
+                "principal": {"name": "Test User", "email": "user@example.com"},
+                "message": {
+                    "message_id": "msg-001",
+                    "from": {"name": "Sender", "email": "sender@example.com"},
+                    "subject": "Hello",
+                    "body": "Just a quick note.",
+                },
+            },
+        }
+        resp = ui_client.post("/v1/email/triage", json=payload)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Schema-2.0 envelope shape
+    assert "schema_version" in body
+    assert body.get("schema_version") == "2.0"
+    assert body.get("request_kind") == "single"
+
+    result = body.get("result", {})
+    assert "category" in result
+    assert "summary" in result
+    assert result["summary"] == "Test summary produced by stub."
+
+
+# ---------------------------------------------------------------------------
+# AC3 — fail-loud guard: absent wheel -> clean skip (404, no exception)
+#        present-but-broken wheel -> error propagates (not swallowed)
+# ---------------------------------------------------------------------------
+
+
+def test_mount_block_absent_wheel_does_not_mount():
+    """When gaia_agent_email is absent, health/version return 404 (not mounted).
+
+    Simulates the absent-wheel path by patching find_spec to return None,
+    then rebuilding the app. Proves the mount block does a clean skip and does
+    NOT raise an ImportError when the wheel is simply not installed.
+    """
+    import importlib
+
+    import gaia.ui.server as server_mod
+
+    with patch("importlib.util.find_spec", return_value=None):
+        importlib.reload(server_mod)
+        app = server_mod.create_app(db_path=":memory:")
+
+    with TestClient(app) as client:
+        resp_health = client.get("/v1/email/health")
+        resp_version = client.get("/v1/email/version")
+        assert resp_health.status_code == 404
+        assert resp_version.status_code == 404
+
+    # Restore the real module state for subsequent tests.
+    importlib.reload(server_mod)

--- a/tests/test_ui_email_router.py
+++ b/tests/test_ui_email_router.py
@@ -38,8 +38,9 @@ from gaia.ui.server import create_app  # noqa: E402
 def ui_client():
     """TestClient for the UI backend with gaia_agent_email wheel present."""
     app = create_app(db_path=":memory:")
-    with TestClient(app, raise_server_exceptions=True) as client:
-        yield client
+    # The email routes are self-contained; skip the UI server's lifespan startup
+    # (connectors sync / MCP reload), which can hang in a bare test env (#1297).
+    yield TestClient(app, raise_server_exceptions=True)
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +53,7 @@ def test_email_health_mounted(ui_client):
     resp = ui_client.get("/v1/email/health")
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body.get("ok") is True
+    assert body.get("status") == "ok"
 
 
 def test_email_version_mounted(ui_client):
@@ -125,25 +126,34 @@ def test_triage_returns_200_schema_2_shape(ui_client):
 
 
 def test_mount_block_absent_wheel_does_not_mount():
-    """When gaia_agent_email is absent, health/version return 404 (not mounted).
+    """When gaia_agent_email is absent, the email paths are not served by the router.
 
-    Simulates the absent-wheel path by patching find_spec to return None,
-    then rebuilding the app. Proves the mount block does a clean skip and does
+    Simulates the absent-wheel path by making only ``gaia_agent_email`` look
+    absent to ``find_spec``. Proves the mount block does a clean skip and does
     NOT raise an ImportError when the wheel is simply not installed.
     """
-    import importlib
+    import importlib.util as ilu
 
-    import gaia.ui.server as server_mod
+    real_find_spec = ilu.find_spec
 
-    with patch("importlib.util.find_spec", return_value=None):
-        importlib.reload(server_mod)
-        app = server_mod.create_app(db_path=":memory:")
+    def _absent_email(name, *args, **kwargs):
+        # Only the email wheel looks absent; every other optional dependency
+        # resolves normally so create_app builds the rest of the app unchanged.
+        if name == "gaia_agent_email":
+            return None
+        return real_find_spec(name, *args, **kwargs)
 
-    with TestClient(app) as client:
-        resp_health = client.get("/v1/email/health")
-        resp_version = client.get("/v1/email/version")
-        assert resp_health.status_code == 404
-        assert resp_version.status_code == 404
+    # find_spec is evaluated at create_app() runtime, so patching it (no module
+    # reload needed) makes the mount block take its clean-skip branch.
+    with patch("importlib.util.find_spec", side_effect=_absent_email):
+        app = create_app(db_path=":memory:")
 
-    # Restore the real module state for subsequent tests.
-    importlib.reload(server_mod)
+    client = TestClient(app)
+    # The mount is skipped, so these paths fall through to the UI's SPA catch-all
+    # (HTML 200) rather than 404 — assert they are NOT served by the email router,
+    # i.e. they do not return its JSON contract.
+    for path in ("/v1/email/version", "/v1/email/health"):
+        resp = client.get(path)
+        assert "application/json" not in resp.headers.get("content-type", ""), (
+            f"{path} unexpectedly served by the email router when the wheel is absent"
+        )


### PR DESCRIPTION
Closes #1768. Part of the Path-2 email-in-Agent-UI epic #1767.

## Why this matters
Path 2: the Agent UI consumes the packaged email agent's REST API **hosted by the UI's own Python backend**, so it works in both browser mode and Electron with **no separate process spawned by Electron**. Before: `gaia.ui.server` mounted 14 routers but **not** `/v1/email`; the UI's email experience was the legacy in-process chat-loop agent. After: with `gaia-agent-email` installed, the UI backend serves `/v1/email/*` (triage/draft/send/health/version) at its own origin, mirroring the existing `gaia.api.openai_server` mount. An absent wheel is a clean `find_spec` skip; a broken installed wheel fails loudly (no silent fallback).

## Evidence
**Integration test — `tests/test_ui_email_router.py` (4 passed):** router mounted via the real `create_app`; version/health 200, `POST /triage` 200 with the schema-2.0 shape (LLM mocked); absent-wheel path takes the clean skip.
```
$ python -m pytest tests/test_ui_email_router.py -q
....                                                                     [100%]
4 passed
```
**Real UI backend origin (macOS, live Gemma-4-E4B)** — booted `python -m gaia.ui.server`, then against its own origin:
```
GET  /v1/email/version  -> 200 {"apiVersion":"2.0","agentVersion":"0.1.0"}
POST /v1/email/triage   -> 200 {"schema_version":"2.0","request_kind":"single",
  "result":{"category":"NEEDS_RESPONSE","suggested_action":"reply",
            "action_items":[{...,"type":"text"}], "usage":{"total_tokens":932,...}}}
```
Triage is served by the UI backend itself — no separate email process, no OAuth needed (email in body).

## Cross-platform
- **macOS ✅** — real uvicorn UI-backend origin, version + live triage above.
- **Linux + Windows** — being validated on an AMD box as a consolidated pass with #1770 (scope consent); reported there.

## Test plan
- [ ] `python -m pytest tests/test_ui_email_router.py -v` → 4 passed
- [ ] `gaia chat --ui` (browser mode) → `GET /v1/email/version` + `POST /v1/email/triage` from the UI backend origin