### PR TITLE
docs(hub-publishing): use uv pip as the canonical install tool

### DIFF
--- a/docs/guides/hub-publishing.mdx
+++ b/docs/guides/hub-publishing.mdx
@@ -13,7 +13,7 @@ serves a catalog file, `index.json`.
 
 Publishing your agent to the Hub does two things:
 
-1. Anyone can install it with `pip install gaia-agent-<id>` (or from the Agent UI's Hub panel).
+1. Anyone can install it with `uv pip install gaia-agent-<id>` (or from the Agent UI's Hub panel).
 2. It **auto-creates the agent's page** on the Hub website
    (`amd-gaia.ai/hub`). The website is generated entirely
    from the Hub's catalog, so **publishing _is_ the website update** — there's no
@@ -288,7 +288,7 @@ be tampered with, stores it so it can **never be overwritten**, attaches your
 curl -s https://hub.amd-gaia.ai/index.json | grep my-agent
 
 # Install it the way a user would (PyPI path):
-pip install gaia-agent-my-agent
+uv pip install gaia-agent-my-agent
 # …or browse and install it from the Agent UI's Hub panel.
 ```
 


### PR DESCRIPTION
The hub-publishing guide already installs dev deps with \`uv pip install\` but left two end-user install commands as bare \`pip install gaia-agent-<id>\` — inconsistent with uv being GAIA's canonical pip frontend (per \`docs/reference/dev.mdx\` and CLAUDE.md). This aligns them so a reader copy-pasting from the guide uses one tool throughout.

### Test plan
- [ ] `grep -n "pip install" docs/guides/hub-publishing.mdx` shows only `uv pip install` (no bare `pip install`).