### PR TITLE
docs(claude): de-stale agent tables + trim stale-prone enumerations in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,7 +404,7 @@ gaia/
 │   │   ├── code_index/ # CodeIndexToolsMixin — semantic code search (FAISS)
 │   │   └── registry.py # Agent registry + KNOWN_TOOLS map
 │   │   #   Packaged agents (code, analyst, browser, fileio, email, summarize, jira,
-│   │   #   blender, docker, sd, emr, connectors_demo) live in hub/agents/python/<id>/.
+│   │   #   blender, docker, sd, emr, connectors-demo) live in hub/agents/python/<id>/.
 │   ├── api/            # OpenAI-compatible REST API server
 │   ├── apps/           # Standalone applications
 │   │   ├── webui/      # Agent UI frontend (React/Vite/Electron)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,26 +397,14 @@ cd src/gaia/apps/webui && npm run dev      # Terminal 2: frontend (port 5174)
 ```
 gaia/
 ├── src/gaia/           # Main source code
-│   ├── agents/         # Agent implementations
-│   │   ├── base/       # Base Agent class, MCPAgent, ApiAgent
-│   │   ├── tools/      # Cross-agent tool mixins (file search, filesystem, scratchpad, browser, screenshot)
-│   │   ├── chat/       # ChatAgent (chat/doc/file profiles) with RAG and shell tools
-│   │   ├── code/       # CodeAgent with orchestration, validators, file_io tools
+│   ├── agents/         # Agent framework + in-core agents
+│   │   ├── base/       # Base Agent class, MCPAgent, ApiAgent mixins
+│   │   ├── tools/      # Cross-agent tool mixins (rag, file, shell, browser, scratchpad, screenshot…)
+│   │   ├── chat/, docqa/, builder/, routing/   # in-core agents
 │   │   ├── code_index/ # CodeIndexToolsMixin — semantic code search (FAISS)
-│   │   ├── analyst/    # AnalystAgent — structured data analysis (CSV/Excel, scratchpad SQL)
-│   │   ├── browser/    # BrowserAgent — web research (search, fetch, download)
-│   │   ├── docqa/      # DocumentQAAgent — standalone document Q&A with RAG
-│   │   ├── fileio/     # FileIOAgent — file read/write/edit operations
-│   │   ├── email/      # EmailTriageAgent — email triage and summarization
-│   │   ├── builder/    # BuilderAgent — scaffolds new agents from templates
-│   │   ├── summarize/  # SummarizerAgent — document/text summarization
-│   │   ├── blender/    # BlenderAgent for 3D automation
-│   │   ├── jira/       # JiraAgent for issue management
-│   │   ├── docker/     # DockerAgent for containerization
-│   │   ├── routing/    # RoutingAgent for intelligent agent selection
-│   │   ├── sd/         # SDAgent for Stable Diffusion image generation
-│   │   ├── connectors_demo/ # ConnectorsDemoAgent — per-agent connector activation demo
 │   │   └── registry.py # Agent registry + KNOWN_TOOLS map
+│   │   #   Packaged agents (code, analyst, browser, fileio, email, summarize, jira,
+│   │   #   blender, docker, sd, emr, connectors_demo) live in hub/agents/python/<id>/.
 │   ├── api/            # OpenAI-compatible REST API server
 │   ├── apps/           # Standalone applications
 │   │   ├── webui/      # Agent UI frontend (React/Vite/Electron)
@@ -503,26 +491,31 @@ The `gaia-emr` console script now ships with the standalone `gaia-agent-emr` hub
 
 ### Agent Implementations
 
-| Agent | Location | Description | Default Model |
-|-------|----------|-------------|---------------|
-| **ChatAgent** | `agents/chat/agent.py` | Multi-profile conversation (chat/doc/file) with RAG | Gemma-4-E4B |
-| **DocumentQAAgent** | `agents/docqa/agent.py` | Standalone document Q&A with RAG | Qwen3.5-35B-A3B |
-| **AnalystAgent** | `agents/analyst/agent.py` | Structured data analysis (CSV/Excel, scratchpad SQL) | Qwen3.5-35B-A3B |
-| **BrowserAgent** | `agents/browser/agent.py` | Web research — search, fetch pages, download | Qwen3.5-35B-A3B |
-| **FileIOAgent** | `agents/fileio/agent.py` | File read/write/edit operations | Qwen3.5-35B-A3B |
-| **EmailTriageAgent** | `agents/email/agent.py` | Email triage for Gmail — local inference, needs the Google connector | Gemma-4-E4B |
-| **CodeAgent** | `agents/code/agent.py` | Code generation with orchestration | Qwen3.5-35B-A3B |
-| **BuilderAgent** | `agents/builder/agent.py` | Scaffolds new agents from templates | Qwen3.5-35B-A3B |
-| **SummarizerAgent** | `agents/summarize/agent.py` | Document/text summarization | Qwen3-4B-Instruct-2507 |
-| **JiraAgent** | `agents/jira/agent.py` | Jira issue management | Qwen3.5-35B-A3B |
-| **BlenderAgent** | `agents/blender/agent.py` | 3D scene automation | Qwen3.5-35B-A3B |
-| **DockerAgent** | `agents/docker/agent.py` | Container management | Qwen3.5-35B-A3B |
-| **MedicalIntakeAgent** | `hub/agents/python/emr/gaia_agent_emr/agent.py` | Medical form processing (VLM) | Gemma-4-E4B |
-| **RoutingAgent** | `agents/routing/agent.py` | Intelligent agent selection | Qwen3.5-35B-A3B (`AGENT_ROUTING_MODEL`) |
-| **SDAgent** | `agents/sd/agent.py` | Stable Diffusion image generation | SDXL-Turbo |
-| **ConnectorsDemoAgent** | `agents/connectors_demo/agent.py` | Per-agent connector activation demo | Qwen3.5-35B-A3B |
+In-core agents live under `src/gaia/agents/`; the rest have moved to standalone hub
+packages under `hub/agents/python/<id>/`. The authoritative registry is
+[`src/gaia/agents/registry.py`](src/gaia/agents/registry.py); each agent's default model
+is set in its own `agent.py` (see [Default Models](#default-models)).
 
-`gaia browse` and `gaia analyze` invoke BrowserAgent and AnalystAgent respectively (see [`src/gaia/cli.py`](src/gaia/cli.py)). `gaia telegram` is a messaging adapter, not an agent. Internal building-block agents (DocumentQAAgent, FileIOAgent, ConnectorsDemoAgent) live under `src/gaia/agents/` but aren't standalone CLI commands.
+| Agent | Description |
+|-------|-------------|
+| **ChatAgent** | Multi-profile conversation (chat/doc/file) with RAG — in-core (`chat/`) |
+| **DocumentQAAgent** | Standalone document Q&A with RAG — in-core (`docqa/`) |
+| **BuilderAgent** | Scaffolds new agents from templates — in-core (`builder/`) |
+| **RoutingAgent** | Intelligent agent selection (`AGENT_ROUTING_MODEL`) — in-core (`routing/`) |
+| **CodeAgent** | Code generation with orchestration |
+| **AnalystAgent** | Structured data analysis (CSV/Excel, scratchpad SQL) |
+| **BrowserAgent** | Web research — search, fetch pages, download |
+| **FileIOAgent** | File read/write/edit operations |
+| **EmailTriageAgent** | Email triage for Gmail (local inference; needs the Google connector) |
+| **SummarizerAgent** | Document/text summarization |
+| **JiraAgent** | Jira issue management |
+| **BlenderAgent** | 3D scene automation |
+| **DockerAgent** | Container management |
+| **SDAgent** | Stable Diffusion image generation |
+| **MedicalIntakeAgent** | Medical form processing (VLM) — `hub/agents/python/emr/` |
+| **ConnectorsDemoAgent** | Per-agent connector activation demo |
+
+`gaia browse` and `gaia analyze` invoke BrowserAgent and AnalystAgent (see [`src/gaia/cli.py`](src/gaia/cli.py)); `gaia telegram` is a messaging adapter, not an agent. DocumentQAAgent, FileIOAgent, and ConnectorsDemoAgent are internal building-block agents (not standalone CLI commands).
 
 ### Agent Registry & Tool Mixins
 
@@ -545,9 +538,10 @@ New agents are Python classes inheriting from `Agent` (see [`src/gaia/agents/bas
 When adding a new tool mixin, register it in `KNOWN_TOOLS` so other agents can compose it by name.
 
 ### Default Models
-- Default for most agents and `gaia llm`: `Gemma-4-E4B-it-GGUF` (`DEFAULT_MODEL_NAME` in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py))
-- Code-heavy agents (Code, Builder, Jira): `Qwen3.5-35B-A3B-GGUF` (hardcoded per agent)
-- Vision tasks: `Gemma-4-E4B-it-GGUF` is the default VLM (VLM mixin and EMR agent); `Qwen3-VL-4B-Instruct-GGUF` is also supported
+- Default for `gaia llm` and any agent that leaves `model_id` unset (Chat, Analyst, Browser, FileIO, Email): `Gemma-4-E4B-it-GGUF` (`DEFAULT_MODEL_NAME` in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py))
+- Code / structured-reasoning agents that hardcode it (Code, Builder, Jira, Docker, Routing, DocumentQA): `Qwen3.5-35B-A3B-GGUF`
+- Summarizer: `Qwen3-4B-Instruct-2507-GGUF`
+- Vision: `Gemma-4-E4B-it-GGUF` is the default VLM (VLM mixin + EMR agent); `Qwen3-VL-4B-Instruct-GGUF` also supported
 - Image generation (SD): `SDXL-Turbo`
 
 ## CLI Commands
@@ -562,16 +556,14 @@ All commands are registered in [`src/gaia/cli.py`](src/gaia/cli.py). Run `gaia -
 - `gaia prompt "<text>"` - Single prompt to LLM (with system-prompt support)
 - `gaia llm "<text>"` - Simple LLM queries
 - `gaia browse` - Web research (search, fetch pages, download)
+- `gaia knowledge {search|extract|usage}` - Web knowledge via Tavily (search/extract)
 - `gaia analyze` - Structured data analysis with scratchpad tables
-- `gaia email` - Email triage and summarization
+- `gaia email` - Email triage for Gmail (local inference; needs the Google connector)
 - `gaia summarize` - Document summarization
 - `gaia blender` - Blender 3D agent
 - `gaia sd` - Stable Diffusion image generation
 - `gaia jira` - Jira integration
 - `gaia docker` - Docker management
-- `gaia browse` - Web research agent (search, page fetch, download)
-- `gaia analyze` - Structured data analysis agent (scratchpad tables)
-- `gaia email` - Email triage for Gmail (local inference; needs the Google connector)
 
 **Servers & infrastructure:**
 - `gaia api` - OpenAI-compatible API server
@@ -604,74 +596,21 @@ All commands are registered in [`src/gaia/cli.py`](src/gaia/cli.py). Run `gaia -
 
 ## Documentation Index
 
-All documentation uses `.mdx` format (Markdown + JSX for Mintlify).
+All docs are `.mdx` (Mintlify). [`docs/docs.json`](docs/docs.json) is the authoritative
+navigation — consult it rather than a hand-maintained copy here. Where things live:
 
-**User Guides:**
-- [`docs/guides/chat.mdx`](docs/guides/chat.mdx) - Chat with RAG
-- [`docs/guides/agent-ui.mdx`](docs/guides/agent-ui.mdx) - Agent UI (desktop chat)
-- [`docs/guides/browse.mdx`](docs/guides/browse.mdx) - Web research (`gaia browse`)
-- [`docs/guides/analyze.mdx`](docs/guides/analyze.mdx) - Structured data analysis (`gaia analyze`)
-- [`docs/guides/email.mdx`](docs/guides/email.mdx) - Email triage (`gaia email`)
-- [`docs/guides/talk.mdx`](docs/guides/talk.mdx) - Voice interaction
-- [`docs/guides/code.mdx`](docs/guides/code.mdx) - Code generation
-- [`docs/guides/blender.mdx`](docs/guides/blender.mdx) - 3D automation
-- [`docs/guides/jira.mdx`](docs/guides/jira.mdx) - Jira integration
-- [`docs/guides/docker.mdx`](docs/guides/docker.mdx) - Docker management
-- [`docs/guides/routing.mdx`](docs/guides/routing.mdx) - Agent routing
-- [`docs/guides/emr.mdx`](docs/guides/emr.mdx) - Medical intake
-- [`docs/guides/telegram-adapter.mdx`](docs/guides/telegram-adapter.mdx) - Telegram messaging adapter
-- [`docs/guides/memory.mdx`](docs/guides/memory.mdx) - Agent memory
-- [`docs/guides/install.mdx`](docs/guides/install.mdx) - Installation
-- [`docs/guides/custom-agent.mdx`](docs/guides/custom-agent.mdx) - Build a custom agent
-- [`docs/guides/hardware-advisor.mdx`](docs/guides/hardware-advisor.mdx) - Hardware advisor
-- [`docs/guides/npu.mdx`](docs/guides/npu.mdx) - NPU setup
-
-**SDK Reference:**
-- [`docs/sdk/core/agent-system.mdx`](docs/sdk/core/agent-system.mdx) - Agent framework
-- [`docs/sdk/core/tools.mdx`](docs/sdk/core/tools.mdx) - Tool decorator
-- [`docs/sdk/core/console.mdx`](docs/sdk/core/console.mdx) - Console output
-- [`docs/sdk/sdks/chat.mdx`](docs/sdk/sdks/chat.mdx) - Agent SDK (formerly Chat SDK)
-- [`docs/sdk/sdks/agent-ui.mdx`](docs/sdk/sdks/agent-ui.mdx) - Agent UI SDK
-- [`docs/sdk/sdks/rag.mdx`](docs/sdk/sdks/rag.mdx) - RAG SDK
-- [`docs/sdk/sdks/llm.mdx`](docs/sdk/sdks/llm.mdx) - LLM clients
-- [`docs/sdk/sdks/vlm.mdx`](docs/sdk/sdks/vlm.mdx) - Vision LLM clients
-- [`docs/sdk/sdks/audio.mdx`](docs/sdk/sdks/audio.mdx) - Audio (ASR/TTS)
-- [`docs/sdk/infrastructure/mcp.mdx`](docs/sdk/infrastructure/mcp.mdx) - MCP protocol
-- [`docs/sdk/infrastructure/api-server.mdx`](docs/sdk/infrastructure/api-server.mdx) - API server
-
-**Reference:**
-- [`docs/reference/cli.mdx`](docs/reference/cli.mdx) - CLI reference
-- [`docs/reference/dev.mdx`](docs/reference/dev.mdx) - Development guide
-- [`docs/reference/faq.mdx`](docs/reference/faq.mdx) - FAQ
-- [`docs/reference/troubleshooting.mdx`](docs/reference/troubleshooting.mdx) - Troubleshooting
-
-**Deployment:**
-- [`docs/deployment/ui.mdx`](docs/deployment/ui.mdx) - Electron UI
-
-**Specifications:** See `docs/spec/` for 40+ technical specifications.
+- **Guides** (`docs/guides/`) — one per feature: chat, agent-ui, browse, analyze, email, talk, code, blender, jira, docker, routing, emr, memory, install, custom-agent, hardware-advisor, npu.
+- **SDK** (`docs/sdk/`) — `core/` (agent-system, tools, console), `sdks/` (chat, agent-ui, rag, llm, vlm, audio), `infrastructure/` (mcp, api-server).
+- **Reference** (`docs/reference/`) — cli, dev, faq, troubleshooting, eval.
+- **Specs** (`docs/spec/`), **Deployment** (`docs/deployment/`), **Integrations** (`docs/integrations/`).
 
 ## Roadmap & Plans
 
-The roadmap is at [`docs/roadmap.mdx`](docs/roadmap.mdx) ([live site](https://amd-gaia.ai/roadmap)). Plan documents are in `docs/plans/`:
-
-**Agent UI:**
-- [`docs/plans/agent-ui.mdx`](docs/plans/agent-ui.mdx) - GaiaAgent comprehensive plan (Phases A-D)
-- [`docs/plans/setup-wizard.mdx`](docs/plans/setup-wizard.mdx) - First-run onboarding and system scanner
-- [`docs/plans/security-model.mdx`](docs/plans/security-model.mdx) - Guardrails, audit trail, credential vault
-- [`docs/plans/email-calendar-integration.mdx`](docs/plans/email-calendar-integration.mdx) - Email triage, calendar, meeting notes
-- [`docs/plans/messaging-integrations-plan.mdx`](docs/plans/messaging-integrations-plan.mdx) - Signal, Discord, Slack, Telegram adapters
-- [`docs/plans/autonomy-engine.mdx`](docs/plans/autonomy-engine.mdx) - Heartbeat, scheduler, background service
-
-**Ecosystem:**
-- [`docs/plans/agent-hub.mdx`](docs/plans/agent-hub.mdx) - Agent marketplace and community hub
-- [`docs/plans/skill-format.mdx`](docs/plans/skill-format.mdx) - SKILL.md specification
-- [`docs/plans/oem-bundling.mdx`](docs/plans/oem-bundling.mdx) - OEM hardware pre-configuration
-
-**Infrastructure:**
-- [`docs/plans/desktop-installer.mdx`](docs/plans/desktop-installer.mdx) - Desktop installer
-- [`docs/plans/mcp-docs.mdx`](docs/plans/mcp-docs.mdx) - MCP integration
-- [`docs/plans/cua.mdx`](docs/plans/cua.mdx) - Computer Use Agent
-- [`docs/plans/docker-containers.mdx`](docs/plans/docker-containers.mdx) - Docker deployment
+The roadmap is at [`docs/roadmap.mdx`](docs/roadmap.mdx) ([live site](https://amd-gaia.ai/roadmap)).
+Plan documents live in [`docs/plans/`](docs/plans/) (run `ls docs/plans/` for the full
+set — Agent UI, setup-wizard, security-model, email/calendar, messaging, autonomy-engine,
+agent-hub, skill-format, OEM bundling, desktop-installer, MCP, CUA, Docker, and more).
+Browse the directory rather than a partial list here.
 
 **Key architectural decisions (April 2026):**
 - **GaiaAgent** rename planned (#696) — not yet landed; the chat agent class is still `ChatAgent` (`src/gaia/agents/chat/agent.py`)
@@ -711,7 +650,7 @@ The documentation is organized in [`docs/docs.json`](docs/docs.json) with the fo
 2. **Check for duplicates:** Search existing issues/PRs to avoid redundant responses
 
 3. **Reference specific files:** Use precise file references with line numbers when possible
-   - Agent implementations: `src/gaia/agents/` (base/, tools/, chat/, code/, code_index/, analyst/, browser/, docqa/, fileio/, email/, builder/, summarize/, blender/, jira/, docker/, emr/, routing/, sd/, connectors_demo/, registry.py)
+   - Agent implementations: `src/gaia/agents/` (in-core: base/, tools/, chat/, docqa/, builder/, routing/, code_index/, registry.py) and `hub/agents/python/<id>/` (packaged agents: code, analyst, browser, email, jira, docker, sd, emr, …)
    - CLI commands: `src/gaia/cli.py`
    - MCP integration: `src/gaia/mcp/`
    - LLM backend: `src/gaia/llm/` (+ `providers/` for Claude/OpenAI)
@@ -828,7 +767,7 @@ Interesting idea! GAIA doesn't currently have built-in Slack integration, but yo
 
 1. The Agent SDK (docs/sdk/sdks/chat.mdx) for message handling
 2. The MCP protocol (docs/sdk/infrastructure/mcp.mdx) for Slack connectivity
-3. Similar pattern to our Jira agent (src/gaia/agents/jira/agent.py)
+3. Similar pattern to our Jira agent (hub/agents/python/jira/)
 
 For AMD optimization: Consider using the local LLM backend (src/gaia/llm/) to keep conversations private and leverage Ryzen AI NPU acceleration.
 
@@ -913,6 +852,9 @@ When a task fits a Superpowers skill (e.g. `superpowers:brainstorming`, `superpo
 
 ## Learned Skills
 
-**Read these before starting related tasks:**
+**Read the matching skill before starting related work.** `.claude/skills/` is the
+authoritative set (run `ls .claude/skills/`); invoke them with the `Skill` tool. Current:
 
-- `.claude/skills/lemonade-client-patterns.md` - Patterns, gotchas, and conventions for modifying LemonadeClient and threading changes through its callers (providers, VLM, UI routers, agent base). Covers: deferred import patch targets, assertLogs child logger levels, SSE test hang prevention, 401 error safety, openai.AuthenticationError ordering. (tags: lemonade, authentication, env-vars, testing, httpx, openai-sdk, tdd)
+- `lemonade-client-patterns` — modifying LemonadeClient and threading changes through its callers (providers, VLM, UI routers, agent base): deferred-import patch targets, assertLogs child-logger levels, SSE test-hang prevention, 401 error safety, `openai.AuthenticationError` ordering.
+- `gaia-release` — cut a GAIA core release end-to-end (draft notes, release PR, pre-tag verification, push the tag, monitor the publish pipeline).
+- `gaia-testing` — GAIA testing workflows, fixtures, and conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,8 +538,8 @@ New agents are Python classes inheriting from `Agent` (see [`src/gaia/agents/bas
 When adding a new tool mixin, register it in `KNOWN_TOOLS` so other agents can compose it by name.
 
 ### Default Models
-- Default for `gaia llm` and any agent that leaves `model_id` unset (Chat, Analyst, Browser, FileIO, Email): `Gemma-4-E4B-it-GGUF` (`DEFAULT_MODEL_NAME` in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py))
-- Code / structured-reasoning agents that hardcode it (Code, Builder, Jira, Docker, Routing, DocumentQA): `Qwen3.5-35B-A3B-GGUF`
+- `gaia llm` default: `Gemma-4-E4B-it-GGUF` (`DEFAULT_MODEL_NAME` in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py)). ChatAgent and EmailTriageAgent explicitly use it too.
+- Agents that leave `model_id` unset fall back to `Qwen3.5-35B-A3B-GGUF` — the base `Agent.__init__` default (`model_id or "Qwen3.5-35B-A3B-GGUF"`). That covers Analyst, Browser, FileIO, plus Code/Builder/Jira/Docker/Routing/DocumentQA which also hardcode it.
 - Summarizer: `Qwen3-4B-Instruct-2507-GGUF`
 - Vision: `Gemma-4-E4B-it-GGUF` is the default VLM (VLM mixin + EMR agent); `Qwen3-VL-4B-Instruct-GGUF` also supported
 - Image generation (SD): `SDXL-Turbo`


### PR DESCRIPTION
CLAUDE.md is the in-context guide every agent reads, and its agent tables had drifted: 12 agents migrated to `hub/agents/python/<id>/` but the Agent Implementations table and Project Structure tree still pointed at `src/gaia/agents/`, and Analyst/Browser/FileIO advertised the wrong default model (they resolve to Gemma-4-E4B, not Qwen3.5-35B-A3B). An agent trusting those would cite dead paths and wrong models. This corrects the facts and replaces the most rot-prone enumerations with pointers to their authoritative source, so they can't silently drift again.

Verified against the codebase (cli.py, setup.py, registry.py, each agent.py): KNOWN_TOOLS, console_scripts, DEFAULT_MODEL_NAME, the 23 `.claude/agents/`, and all doc/plan paths checked out — only the items below were stale.

Threads (each independently reviewable):
- **Agent tables** — fix the 12 migrated paths + 3 wrong models; drop the rot-prone Location/Model columns into a one-line pointer to `registry.py` + Default Models.
- **CLI list** — remove duplicate `gaia browse`/`gaia analyze`/`gaia email` entries; add the missing `gaia knowledge`.
- **Learned Skills** — listed 1 of 3 skills; now lists all + points to `ls .claude/skills/`.
- **Doc Index / Plans** — replace the hand-maintained mirror of `docs/docs.json` and the 13-of-25 plan list with pointers to the authoritative sources.

918 → 859 lines. Durable guidance (communication, version-control discipline, no-fallback, testing/eval rules, security protocol, issue-response) is untouched.

### Test plan
- [ ] `grep -nE "agents/(code|analyst|browser|fileio|email|jira|docker|sd)/agent\.py" CLAUDE.md` → no hits (no stale core paths).
- [ ] `grep -c "gaia analyze" CLAUDE.md` → 2 (one CLI entry + one prose ref, no dup list items).
- [ ] Spot-check the Agent Implementations table: in-core agents (Chat/DocQA/Builder/Routing) marked in-core; the rest map to `hub/agents/python/`.
- [ ] `ls .claude/skills/` matches the three skills now listed under Learned Skills.