### PR TITLE
docs(skills): refresh lemonade-client + gaia-release against current code

### DIFF
--- a/.claude/skills/gaia-release/SKILL.md
+++ b/.claude/skills/gaia-release/SKILL.md
@@ -304,7 +304,7 @@ Do not poll, do not auto-merge. Do not push the tag from the un-merged branch.
    echo "Watching run $RUN_ID"
    gh run watch "$RUN_ID" --repo amd/gaia
    ```
-   **AppImage smoke jobs (`distro-matrix`, `userns-restricted`) are the most flaky** — `userns-restricted` has a 300s `state: ready` poll (raised from 90s to cover a first-run model download). On real failure, **stop** and fix root cause; on transient flake (timeout-only, no logic error), `gh run rerun $RUN_ID --failed` is acceptable.
+   **AppImage smoke jobs (`appimage-distro-matrix`, `appimage-userns-restricted`) are the most flaky** — `appimage-userns-restricted` has a 300s `state: ready` poll (raised from 90s to cover a first-run model download). On real failure, **stop** and fix root cause; on transient flake (timeout-only, no logic error), `gh run rerun $RUN_ID --failed` is acceptable.
 
 ### Gate 3 — green run on the merged commit
 
@@ -345,7 +345,7 @@ Show the user the run URL, the **release PR number** (`#$RELEASE_PR`), and the *
    gh run list --repo amd/gaia --workflow publish.yml --limit 3
    ```
 
-   The flow is: `validate → build (pypi + npm + electron) → approve (manual gate) → publish (PyPI + npm) → github-release`. Surface the run URL.
+   The flow is: `validate → build (build-pypi + build-npm + build-desktop-installers) → approve-publish (manual gate) → publish (publish-pypi + publish-npm) → post-publish-smoke → github-release → refresh-context7`. Surface the run URL.
 
 ---
 
@@ -364,7 +364,7 @@ Show the user the run URL, the **release PR number** (`#$RELEASE_PR`), and the *
 
 3. **On real failure** (logic error, missing artifact, validator failure that wasn't there before): **stop**. Do not push past a red build. Do not delete and re-tag — that path is messy. Surface the failing step + log to the user.
 
-4. **Manual approval gate** — when the run reaches the `approve` step in the `publish` GitHub environment, surface the URL to the user. Tell them: **"Manual approval required at <url>. Claude cannot click this — please approve in browser when ready."** Then wait.
+4. **Manual approval gate** — when the run reaches the `approve-publish` job (gated on the `publish` GitHub environment), surface the URL to the user. Tell them: **"Manual approval required at <url>. Claude cannot click this — please approve in browser when ready."** Then wait.
 
 5. **After approval**, PyPI + npm + GitHub Release jobs run in parallel. Watch to completion.
 

--- a/.claude/skills/gaia-release/SKILL.md
+++ b/.claude/skills/gaia-release/SKILL.md
@@ -197,7 +197,7 @@ These map to [CLAUDE.md](CLAUDE.md). Re-read them whenever this skill runs.
    ```bash
    python util/validate_release_notes.py docs/releases/v<version>.mdx --tag v<version>
    ```
-   Must exit 0 — this is the gate the publish workflow runs on tag push. Fix any errors before continuing. If it fails for reasons unrelated to your changes (missing dep, broken import), stop and surface that — do not silently bypass. Re-running the validator with `--verbose` (if supported) helps localise the failure.
+   Must exit 0 — this is the gate the publish workflow runs on tag push. Fix any errors before continuing. If it fails for reasons unrelated to your changes (missing dep, broken import), stop and surface that — do not silently bypass. The validator prints the first failing check (missing/renamed section, absent `compare/` link, tag mismatch) — read that line to localise the fix; it has no `--verbose` flag.
 
 ### Gate 1 — show the user the draft
 

--- a/.claude/skills/gaia-release/SKILL.md
+++ b/.claude/skills/gaia-release/SKILL.md
@@ -195,7 +195,7 @@ These map to [CLAUDE.md](CLAUDE.md). Re-read them whenever this skill runs.
 
 7. **Validate.** Run from the repo's activated venv (`source .venv/bin/activate` on Linux/macOS, `.venv\Scripts\activate` on Windows; the bare-`python` Microsoft Store stub will fail). If you're working from a git worktree without its own venv, run from the parent checkout's venv.
    ```bash
-   python util/validate_release_notes.py
+   python util/validate_release_notes.py docs/releases/v<version>.mdx --tag v<version>
    ```
    Must exit 0 — this is the gate the publish workflow runs on tag push. Fix any errors before continuing. If it fails for reasons unrelated to your changes (missing dep, broken import), stop and surface that — do not silently bypass. Re-running the validator with `--verbose` (if supported) helps localise the failure.
 
@@ -293,7 +293,7 @@ Do not poll, do not auto-merge. Do not push the tag from the un-merged branch.
 
 3. **Re-run the release notes validator on the merged tree.**
    ```bash
-   python util/validate_release_notes.py
+   python util/validate_release_notes.py docs/releases/v<version>.mdx --tag v<version>
    ```
 
 4. **Trigger Build Installers via `workflow_dispatch` against the merged SHA.** This builds the same artifacts the tag push will build, on the same code, *before* the tag exists.
@@ -304,7 +304,7 @@ Do not poll, do not auto-merge. Do not push the tag from the un-merged branch.
    echo "Watching run $RUN_ID"
    gh run watch "$RUN_ID" --repo amd/gaia
    ```
-   **AppImage smoke jobs (`distro-matrix`, `userns-restricted`) are the most flaky** — `userns-restricted` has a 90s `state: ready` poll that can race a model download. On real failure, **stop** and fix root cause; on transient flake (timeout-only, no logic error), `gh run rerun $RUN_ID --failed` is acceptable.
+   **AppImage smoke jobs (`distro-matrix`, `userns-restricted`) are the most flaky** — `userns-restricted` has a 300s `state: ready` poll (raised from 90s to cover a first-run model download). On real failure, **stop** and fix root cause; on transient flake (timeout-only, no logic error), `gh run rerun $RUN_ID --failed` is acceptable.
 
 ### Gate 3 — green run on the merged commit
 
@@ -368,7 +368,7 @@ Show the user the run URL, the **release PR number** (`#$RELEASE_PR`), and the *
 
 5. **After approval**, PyPI + npm + GitHub Release jobs run in parallel. Watch to completion.
 
-6. **`refresh-context7` is the terminal job and may legitimately fail — that is not a release failure.** This job runs *after* PyPI, npm, GitHub Release, and the desktop installers are already published. Context7's API rejects refresh requests inside a short cooldown window (observed: ~3–6 days between releases), and the response is HTTP 400. If the job is red, the release is still live. Open the job log, read the `Response body:` block between the `::stop-commands::` markers, and either accept the cooldown reason or file a follow-up about a new rejection cause. Do **not** delete or re-tag — see the recovery guidance in the Notes section below.
+6. **`refresh-context7` is the terminal job and may legitimately fail — that is not a release failure.** This job runs *after* PyPI, npm, GitHub Release, and the desktop installers are already published. Context7's API rejects refresh requests inside a short cooldown window (observed: ~3–6 days between releases) with HTTP 429 (rate-limited); the workflow tolerates 429 and treats any other status as a hard failure. If the job is red, the release is still live. Open the job log, read the `Response body:` block between the `::stop-commands::` markers, and either accept the cooldown reason or file a follow-up about a new rejection cause. Do **not** delete or re-tag — see the recovery guidance in the Notes section below.
 
 7. **Never add `set -x` or `curl -v` to the `refresh-context7` step** to "debug" a failure. GHA only masks the verbatim secret value; `curl -v` prints the `Authorization: Bearer <token>` header, which is a transformed form that GHA's masking does not catch. Read the captured response body instead — it carries the same diagnostic signal without the leak risk.
 

--- a/.claude/skills/lemonade-client-patterns.md
+++ b/.claude/skills/lemonade-client-patterns.md
@@ -37,9 +37,9 @@ Misconfigured reverse proxies can reflect the `Authorization` header back in a 4
 - `src/gaia/llm/providers/lemonade.py` — `LemonadeProvider.__init__` uses `backend_kwargs` dict to forward to `LemonadeClient`; add new params with `if param is not None: backend_kwargs["param"] = param`
 - `src/gaia/llm/vlm_client.py` — `VLMClient.__init__` uses deferred import of `LemonadeClient`
 - `src/gaia/ui/routers/system.py` — already imports `DEFAULT_CONTEXT_SIZE` from `lemonade_client` (established cross-package import precedent)
-- `src/gaia/ui/_chat_helpers.py` — 4 Lemonade-bound httpx call sites: auto-title POST (~305), health GET (~836, ~887), stats GET (~2082)
-- `src/gaia/ui/server.py` — 2 health probe httpx GET sites (~266, ~278)
-- `src/gaia/agents/base/agent.py` — `_is_loaded_ctx_too_small()` (~1784) — DEFERRED import pattern
+- `src/gaia/ui/_chat_helpers.py` — 4 Lemonade-bound httpx call sites: auto-title POST (~337), health GET (~1006, ~1058), stats GET (~2289). (Line numbers drift — grep the call, don't trust the offset.)
+- `src/gaia/ui/server.py` — 2 health probe httpx GET sites (~299, ~311)
+- `src/gaia/agents/base/agent.py` — `_is_loaded_ctx_too_small()` (~2177) — DEFERRED import pattern
 - `tests/test_lemonade_client.py` — uses `responses` library for `requests` interception; `TestLemonadeClientMock` class
 - `docs/.env.example` — This is a Mintlify/docs-proxy config file, NOT GAIA's env var file. GAIA env vars go in `.env.example` at the repo root.
 


### PR DESCRIPTION
A complete pass over the Claude skills in `.claude/skills/` against the current codebase. `gaia-testing` verified fully current (no change). `lemonade-client-patterns` was factually correct but had drifted line numbers. `gaia-release` had two bugs that would actually bite during a release:

- **`validate_release_notes.py` was missing its required file argument** — the command as written exits with `the following arguments are required: file`. Now passes `docs/releases/v<version>.mdx --tag v<version>`, matching what `publish.yml` runs.
- **The Context7 cooldown is HTTP 429, not 400** — the skill told a releaser to expect 400; the workflow actually tolerates 429 (rate-limited) and treats everything else as a hard failure, so the old guidance would misdiagnose a real failure as "expected."
- **The `userns-restricted` smoke poll is 300s now** (raised from 90s precisely to stop the model-download race the skill still warned about).

`lemonade-client-patterns`: refreshed the `_chat_helpers.py` / `server.py` / `agent.py` call-site offsets and added a "grep the call, don't trust the offset" note so they don't silently rot again.

### Test plan
- [ ] `grep -n "validate_release_notes.py" .claude/skills/gaia-release/SKILL.md` — both invocations pass a notes file + `--tag`.
- [ ] `grep -nE "HTTP 400|90s" .claude/skills/gaia-release/SKILL.md` — no hits.
- [ ] Spot-check the refreshed offsets resolve: `_is_loaded_ctx_too_small` near `agent.py:2177`, etc.