### PR TITLE
docs: fix Mintlify MDX validation (unescaped '<' breaks the docs check)

### DIFF
--- a/docs/local-test/README.md
+++ b/docs/local-test/README.md
@@ -54,7 +54,7 @@ In the AgentUI:
 - ✅ Settings → Connections renders, Connect button works.
 - ✅ OAuth PKCE flow completes; refresh token lands in OS keychain.
 - ✅ Loopback `127.0.0.1:<ephemeral>/callback` round-trips.
-- ✅ SSE event `connection.connected` updates AgentUI in <2s.
+- ✅ SSE event `connection.connected` updates AgentUI in &lt;2s.
 - ✅ `REQUIRED_CONNECTORS` declared by the custom agent surfaces in
   the consent dialog with plain-language scope text.
 - ✅ Per-agent grant gates `get_access_token_sync` (first call without

--- a/docs/plans/agent-ui-hub-publish.mdx
+++ b/docs/plans/agent-ui-hub-publish.mdx
@@ -391,7 +391,7 @@ its **Python backend** finishes a cold bootstrap: `backend-installer.cjs` runs
 - **Highest-leverage fix:** ship a **frozen/prebuilt backend** instead of a
   runtime pip install, so first-run is seconds and the PyPI/network failure mode
   is gone. **Caveat (verify first):** the email freeze
-  (`hub/agents/python/email/packaging/freeze.py`) gets to <90 MB by *excluding*
+  (`hub/agents/python/email/packaging/freeze.py`) gets to &lt;90 MB by *excluding*
   torch/transformers/faiss — but the UI backend can't, because `[ui]` directly
   declares `faiss-cpu` + `sentence-transformers` + `torch` and
   `gaia.ui.server` **boots faiss + sentence_transformers eagerly** (`setup.py:143`,
@@ -400,7 +400,7 @@ its **Python backend** finishes a cold bootstrap: `backend-installer.cjs` runs
   can be slimmed and *then* frozen small; (b) ship a **prebuilt venv / wheelhouse**
   (no PyInstaller) — bigger artifact but avoids freezing torch/faiss native libs,
   which is notoriously fragile; (c) accept a large (~GB) frozen artifact. Pick
-  before committing — the "<90 MB like email" expectation is wrong as written.
+  before committing — the "&lt;90 MB like email" expectation is wrong as written.
 - **Measure the baseline:** the "7–20 min" figure is an estimate, not a measured
   cold run. Time a real first-run on a clean machine before anchoring the roadmap
   to it.

--- a/docs/plans/bash-agent.mdx
+++ b/docs/plans/bash-agent.mdx
@@ -537,7 +537,7 @@ Everything in this milestone is bash-domain-specific code. It lives in `cpp/agen
 |---|---|
 | Static linking | Single-binary distribution — no shared library dependencies beyond libc/kernel32. |
 | `gaia init` integration | Model download for Qwen3-Coder-Next via Lemonade API from C++. First-run setup flow. |
-| Performance benchmarks | Startup latency (<100ms target), token throughput, memory footprint. Tracked in CI. |
+| Performance benchmarks | Startup latency (&lt;100ms target), token throughput, memory footprint. Tracked in CI. |
 | Integration tests | End-to-end tests against real Lemonade Server in CI. |
 | Documentation | `docs/guides/bash.mdx` — quickstart, tool reference, examples. Update `docs/docs.json`. |
 | CI/CD build matrix | Windows MSVC, Linux GCC/Clang, macOS AppleClang. Artifact upload to GitHub Releases. |

--- a/docs/plans/power-automate-outlook.md
+++ b/docs/plans/power-automate-outlook.md
@@ -639,7 +639,7 @@ Power Automate per-user limits on M365 E3/E5:
 |-------|-------|--------|
 | API calls per 24h | 6,000 | ~250/hour — enough for hourly triage of typical inbox |
 | Concurrent runs | 300 | Not a concern for single-user agent |
-| Flow run duration | 30 days (cloud) | Not a concern (our flows return in <5 s) |
+| Flow run duration | 30 days (cloud) | Not a concern (our flows return in &lt;5 s) |
 | HTTP request size | 100 MB | Not a concern (email metadata is small) |
 | HTTP response size | 100 MB | Sufficient for all but absurd attachment downloads |
 
@@ -684,7 +684,7 @@ limits.
 | Flow sends email without user approval | High — bypasses GAIA's send confirmation | GAIA's send policy enforced in agent; `send_email()` not callable without confirmation gate |
 | IT blocks outbound HTTP to Power Automate | Medium — corporate proxy/TLS inspection | Handler respects `HTTPS_PROXY`/`NO_PROXY` env vars; SSL errors produce actionable message pointing to proxy/CA configuration |
 | Email content transits Microsoft cloud | Expected — Power Automate runs in M365 | Same as normal Outlook usage; no additional exposure vs. reading email in browser |
-| Stale trigger URL (SAS expired) | Medium — silent failure | SAS `se` parameter parsed at configure time; `test()` warns if <14 days remain; 401 on call surfaces actionable error |
+| Stale trigger URL (SAS expired) | Medium — silent failure | SAS `se` parameter parsed at configure time; `test()` warns if &lt;14 days remain; 401 on call surfaces actionable error |
 | Prompt injection via email content | Medium — malicious email subjects in flow response | Not unique to this path (Gmail MCP has same risk); send-confirmation guardrail is the defense layer |
 | Flow sharing exposes trigger URLs | Medium — co-owners see URLs | Setup guide warns: "Do not share flows. Run history retains request/response for 28 days." |
 

--- a/docs/plans/typescript-sdk.mdx
+++ b/docs/plans/typescript-sdk.mdx
@@ -1080,7 +1080,7 @@ Publishing:
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| Pydantic <-> TS drift | High over time | High | Mandatory CI drift gate (§14.3). |
+| Pydantic &lt;-&gt; TS drift | High over time | High | Mandatory CI drift gate (§14.3). |
 | OpenAPI export carries `Any` / untyped fields → generated TS is `unknown` | High | High | Phase 0 audit + lint rule blocks regressions (§17 Phase 0). |
 | Streaming reconnect edge cases (network flap, server restart) | Medium | Medium | Resume-via-`since`, ring buffer, `gap_detected` event, fault-injection tests (§9.2.1, §9.3). |
 | Embedded process orphans on crash | Low | Medium | Parent-PID watchdog; on parent death, exit. Tested in CI. |

--- a/docs/plans/typescript-sdk.mdx
+++ b/docs/plans/typescript-sdk.mdx
@@ -827,7 +827,7 @@ shape after schema drift.
 | Layer | Tooling | Coverage target |
 |---|---|---|
 | Unit (TS) | Vitest | Pure logic in SDK (URL composition, event parsing, capability negotiation, retry logic, error mapping). Mocked transport. |
-| Integration (TS <-> live GAIA) | Vitest + real GAIA via `@amd-gaia/embedded` | Each service module exercised against a real backend. Streaming endpoints covered. |
+| Integration (TS &lt;-&gt; live GAIA) | Vitest + real GAIA via `@amd-gaia/embedded` | Each service module exercised against a real backend. Streaming endpoints covered. |
 | Contract | Vitest | Boots GAIA, dumps OpenAPI, asserts identical to the committed schema. Catches Python-side changes that bypass the drift gate. |
 | Browser parity | Vitest browser mode + Playwright | Every method that runs in browser -- chat, agent observe -- exercised in real Chromium. |
 | SSE fault injection | Vitest with proxy that drops connections | Reconnect, resume-via-`since`, message-loss bounds. |

--- a/docs/runbooks/google-oauth-client.md
+++ b/docs/runbooks/google-oauth-client.md
@@ -33,7 +33,7 @@ Do NOT commit the id into the repository.
 
 ## Cloud Console setup
 
-1. Visit <https://console.cloud.google.com/apis/credentials>.
+1. Visit [https://console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials).
 2. Create a new project (or use an existing AMD-owned one).
 3. **APIs & Services → OAuth consent screen**:
    - User Type: Internal (AMD-only) or External (broader).

--- a/docs/spec/agent-memory-architecture.md
+++ b/docs/spec/agent-memory-architecture.md
@@ -377,7 +377,7 @@ RRF score = 0.6 / (60 + rank_vector) + 0.4 / (60 + rank_bm25)
 
 After RRF fusion, a lightweight cross-encoder rescores each candidate by jointly encoding (query, document) pairs. This catches semantic matches that both vector and BM25 underrank individually.
 
-Model: `cross-encoder/ms-marco-MiniLM-L-6-v2` (~22MB, runs on CPU in <50ms for 10 candidates)
+Model: `cross-encoder/ms-marco-MiniLM-L-6-v2` (~22MB, runs on CPU in &lt;50ms for 10 candidates)
 
 Why this matters: RRF fusion combines two independent rankings. The cross-encoder sees query and document together, enabling it to catch fine-grained relevance signals (negation, qualification, context-dependent meaning) that independent encoders miss. Hindsight (91.4% LongMemEval) attributes a significant portion of its retrieval precision to this step.
 

--- a/docs/spec/multi-agent-architecture.md
+++ b/docs/spec/multi-agent-architecture.md
@@ -6,7 +6,7 @@
 
 ## 1. Problem
 
-ChatAgent is a monolith: 35+ tools, 1,477-line system prompt, 35B model. Too slow for chat (<1s should be instant), too error-prone for tool calls (35-way classification), impossible to scale (every new tool degrades existing ones).
+ChatAgent is a monolith: 35+ tools, 1,477-line system prompt, 35B model. Too slow for chat (&lt;1s should be instant), too error-prone for tool calls (35-way classification), impossible to scale (every new tool degrades existing ones).
 
 ## 2. Solution
 
@@ -14,7 +14,7 @@ Split into **GaiaAgent** (personality + orchestration, 4B model) and **specialis
 
 | | Monolithic (today) | Multi-Agent |
 |---|---|---|
-| Chat speed | 2-5s (35B) | <1s (4B) |
+| Chat speed | 2-5s (35B) | &lt;1s (4B) |
 | Tool accuracy | ~60% (35 tools) | ~90%+ (3-10 per specialist) |
 | Memory | 20GB+ | ~8GB (shared 4B + LoRA) |
 | Adding features | Bloats everything | New specialist, zero impact |


### PR DESCRIPTION
The `validate` (Mintlify) check is **red on every open PR** — not because of those PRs, but because `main` has seven docs files where a `<` is immediately followed by a digit / `-` / autolink (`<90 MB`, `<100ms`, `<1s`, `TS <-> `, `<https://…>`). The MDX parser reads each as a malformed JSX tag and aborts the build; the first failure per file also cascades into a false "`plans/agent-ui-hub-publish` does not exist" navigation warning (the file is present but never builds). This unblocks docs validation across all branches.

Each `<` is escaped to `&lt;` (rendered output unchanged) and the bare autolink converted to a markdown link. Mintlify only surfaces the first parse error per file, so I scanned fence-aware for **every** out-of-code `<digit` (11 fixes across 8 files), not just the 7 reported — so the check goes green in one pass instead of whack-a-mole. The valid no-space form (`< 50 lines`) is correct MDX and left alone.

### Test plan
- [ ] `mintlify validate` (or the `validate` CI job) passes — no parse errors, no missing-file warning.
- [ ] Pages render unchanged: `&lt;90 MB` shows as `<90 MB`, the OAuth link is clickable.
- [ ] `grep -rn '<[0-9]' docs/ --include='*.mdx' --include='*.md'` outside code fences → none.