### PR TITLE
fix(agent-email): align version-triple to 0.2.0 (unblocks next release)

### DIFF
--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.1.0
+version: 0.2.0
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.1.0"
+AGENT_VERSION = "0.2.0"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.1.0"
+version = "0.2.0"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }


### PR DESCRIPTION
The email agent can't be released as-is: its npm package is `0.2.0` (bumped for the contract `SCHEMA_VERSION` 2.0 change in #1771) but the Python side is still `0.1.0` across `gaia-agent.yaml`, `pyproject.toml`, and `AGENT_VERSION`. The release workflow's `Resolve + validate release version` step requires the tag, `package.json`, and `gaia-agent.yaml` to be identical — so the next `agent-pkg-email-*` release would fail loudly on the mismatch. This aligns all three Python version sources to `0.2.0` so the manifest, wheel, binary `/version` self-report, and npm client are uniform.

Surfaced by the agent-hub-release review: the skill's "three versions must match before tagging" rule exists precisely to catch this, and the repo was in violation.

### Test plan
- [ ] `grep -E '^version' hub/agents/python/email/{gaia-agent.yaml,pyproject.toml}` and `AGENT_VERSION` in `version.py` all show `0.2.0`, matching `hub/agents/npm/agent-email/package.json`.
- [ ] A dry `agent-pkg-email-v0.2.0` tag would pass the workflow's version-triple check (tag `0.2.0` == package.json `0.2.0` == gaia-agent.yaml `0.2.0`).