### PR TITLE
fix(email): refresh backends before multi-mailbox scans

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -361,6 +361,17 @@ class EmailTriageAgent(
 
     # -- Phase 2 multi-inbox routing (#1603) -------------------------------
 
+    def _refresh_mail_backends(self) -> None:
+        """Refresh connected mailbox backends for long-lived agent instances.
+
+        Agent UI sessions cache agent instances, while connector grants can
+        change after construction. Re-resolving here lets multi-mailbox scans
+        see newly connected providers without requiring a session restart.
+        """
+        backends = dict(self.config.resolve_mail_backends())
+        self._backends = backends
+        self._gmail = next(iter(backends.values()))
+
     def _remember_message_mailbox(
         self, message_id: Optional[str], provider: str
     ) -> None:
@@ -514,6 +525,7 @@ class EmailTriageAgent(
         force_llm = bool(getattr(self.config, "force_llm", False))
         debug_flag = bool(getattr(self.config, "debug", False))
 
+        self._refresh_mail_backends()
         backends = self._backends
         per_backend = max(1, max_messages // len(backends))
         merged: list[dict] = []
@@ -634,6 +646,7 @@ class EmailTriageAgent(
         force_llm = bool(getattr(self.config, "force_llm", False))
         debug_flag = bool(getattr(self.config, "debug", False))
 
+        self._refresh_mail_backends()
         backends = self._backends
         per_backend = max(1, max_messages // len(backends))
         urgent: list[dict] = []

--- a/tests/unit/agents/email/test_multi_inbox_triage.py
+++ b/tests/unit/agents/email/test_multi_inbox_triage.py
@@ -241,6 +241,42 @@ class TestMultiInboxTriageMergeAndTag:
         finally:
             agent.close_db()
 
+    def test_pre_scan_refreshes_backends_connected_after_agent_construction(
+        self, tmp_path, monkeypatch
+    ):
+        """A cached Agent UI email agent must see mailboxes connected later."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        spy_g = SpyBackend("google", ["g1"])
+        spy_m = SpyBackend("microsoft", ["m1"])
+        cfg = EmailAgentConfig(
+            outlook_backend=spy_m,
+            calendar_backend=object(),
+            db_path=str(tmp_path / "state.db"),
+            silent_mode=True,
+            mail_provider=None,
+        )
+        with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+            mock_sdk.return_value = MagicMock()
+            agent = EmailTriageAgent(config=cfg)
+
+        try:
+            assert set(agent._backends) == {"microsoft"}
+
+            # Simulate connecting Gmail after the Agent UI cached this agent.
+            agent.config.gmail_backend = spy_g
+
+            envelope = json.loads(_registered_tool("pre_scan_inbox")(20))
+            assert envelope["ok"] is True, envelope
+            data = envelope["data"]
+            items = data["urgent"] + data["actionable"] + data["suggested_archives"]
+            mailboxes = {it["mailbox"] for it in items}
+
+            assert mailboxes == {"google", "microsoft"}
+            assert agent._message_mailbox.get("g1") == "google"
+            assert agent._message_mailbox.get("m1") == "microsoft"
+        finally:
+            agent.close_db()
+
     def test_pre_scan_under_budget_backend_not_skipped_when_earlier_backend_underfills(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Summary
- Refresh resolved email backends at the start of multi-mailbox triage/pre-scan.
- Let cached Agent UI email agents pick up mailboxes connected after construction.
- Add a regression covering Outlook-only construction followed by Gmail connection before pre-scan.

Why
Fixes #1789. Agent UI sessions can keep an EmailTriageAgent instance alive while connector grants/backends change. The previous _backends map was resolved only at construction time, so mail_provider=None scans could silently skip a mailbox connected later until the user restarted the session.

Testing
- .venv/bin/python -m pytest tests/unit/agents/email/test_multi_inbox_triage.py -q
- .venv/bin/python -m black --check hub/agents/python/email/gaia_agent_email/agent.py tests/unit/agents/email/test_multi_inbox_triage.py
- .venv/bin/python -m py_compile hub/agents/python/email/gaia_agent_email/agent.py tests/unit/agents/email/test_multi_inbox_triage.py
- git diff --check