### PR TITLE
fix(agent): correct stale default-model comment (Gemma → Qwen3.5-35B-A3B)

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -509,8 +509,9 @@ Do NOT wrap conversational replies in JSON.
         # Initialize AgentSDK with proper configuration
         # Note: We don't set system_prompt in config, we pass it per request
         # Note: Context size is configured when starting Lemonade server, not here
-        # Use the configured default model (Gemma) when no explicit model_id
-        # is provided. The 0.5B model is too small for complex agent tasks.
+        # Default an agent with no explicit model_id to Qwen3.5-35B-A3B — small
+        # models are too weak for complex agent tasks. (This is the *agent* default;
+        # `gaia llm` defaults to DEFAULT_MODEL_NAME / Gemma-4-E4B via a separate path.)
         chat_config = AgentConfig(
             model=model_id or "Qwen3.5-35B-A3B-GGUF",
             use_claude=use_claude,


### PR DESCRIPTION
The comment above the base `Agent`'s model resolution claimed agents default to *Gemma* — but the code right below it is `model=model_id or "Qwen3.5-35B-A3B-GGUF"`, so an agent with no explicit `model_id` actually gets **Qwen3.5-35B-A3B**. The comment also referenced a "0.5B model" that has nothing to do with this path. This wrong comment has repeatedly misled readers — and an automated PR reviewer — into documenting the agent default as Gemma. Corrected to match the code (and to note that `gaia llm`'s Gemma default is a separate path). Comment-only; no behavior change.

### Test plan
- [ ] `grep -n "model=model_id or" src/gaia/agents/base/agent.py` shows the comment now says Qwen3.5-35B-A3B.
- [ ] No code change — `python -c "import ast; ast.parse(open('src/gaia/agents/base/agent.py').read())"` parses.