### PR TITLE
docs(email): correct the /hub/email JS/TS integration guide

### DIFF
--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -120,6 +120,15 @@ await shutdown(sidecar); // free function — not sidecar.shutdown()
    (`dist/email-agent/email-agent`), not at the parent directory.
 3. **`description`, not `text`** — action items use the field name `description`
    (e.g. `result.action_items[0].description`).
+4. **Running the built binary** — the `freeze.py` binary is dynamically linked
+   against the build host's glibc, so run it on the same machine or a newer OS.
+   A binary built on glibc 2.39 fails to start on an older runtime (e.g.
+   Debian 12 / `node:18` images ship glibc 2.36 → `GLIBC_2.38 not found`); a
+   glibc ≥ 2.38 base (e.g. `node:22-trixie` / Ubuntu 24.04) works. When the
+   consumer app runs in a container, the sidecar reaches a Lemonade on the host
+   via `host.docker.internal` — set
+   `LEMONADE_BASE_URL=http://host.docker.internal:13305` (this also satisfies
+   the local-only allowlist).
 
 ## The `fetch` CLI
 

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -35,20 +35,25 @@ npm install @amd-gaia/agent-email
 
 ## Quick start
 
+There are two ways to use this package, depending on whether you need the full
+agent (live inbox, real send) or a lightweight local binary (triage + draft only).
+
+### Path A — full GAIA (live inbox, all capabilities)
+
+Point `EmailClient` at a GAIA server that mounts `/v1/email/*`. This path
+supports the complete feature set: triage, draft, send, organize, calendar.
+
 ```ts
-import { fetchBinary, startSidecar, shutdown } from "@amd-gaia/agent-email";
+// Browser apps: import from the browser-safe subpath (no Node built-ins).
+// Node apps can use "@amd-gaia/agent-email" directly.
+import { EmailClient } from "@amd-gaia/agent-email/client";
 
-// 1. Build-time: download + verify the binary for this platform.
-const { binaryPath } = await fetchBinary({
-  outDir: "resources",
-  baseUrl: process.env.AGENT_EMAIL_BASE_URL, // real R2 URL pending #1648
-});
+// baseUrl is the GAIA server that exposes /v1/email/*:
+//   gaia api start   → http://localhost:8080  (default)
+//   gaia chat --ui   → http://localhost:4200
+const client = new EmailClient({ baseUrl: "http://localhost:8080" });
 
-// 2. Runtime: spawn -> wait for /health -> version-check.
-const sidecar = await startSidecar({ binaryPath, port: 8131 });
-
-// 3. Use the typed client.
-const res = await sidecar.client.triage({
+const { result } = await client.triage({
   payload: {
     kind: "single",
     principal: { email: "me@example.com" },
@@ -60,11 +65,61 @@ const res = await sidecar.client.triage({
     },
   },
 });
-console.log(res.result.category, res.result.summary);
+console.log(result.category, result.summary);
 
-// 4. Clean shutdown (kills the whole process tree).
-await shutdown(sidecar);
+// Send goes through a draft → confirmation-token → send handshake.
+// A send() without a valid confirmation token is rejected with HTTP 403.
 ```
+
+### Path B — frozen sidecar (no Python; triage + draft only)
+
+The sidecar is a self-contained native binary that runs inference locally via
+Lemonade. **Triage and draft only** — there is no `/v1/connections`, and `send`
+cannot complete (no connected mailbox): a direct `send()` returns **HTTP 403**
+(missing confirmation token), and even a `/draft`-confirmed send returns
+**HTTP 503** (no connected mailbox). Use Path A to send mail.
+
+```ts
+import { startSidecar, shutdown } from "@amd-gaia/agent-email";
+
+// `fetchBinary()` is intentionally blocked until #1648 — binaries.lock.json
+// ships placeholder hashes and fetchBinary() throws a PlatformError.
+// Build the sidecar locally instead:
+//   python hub/agents/python/email/packaging/freeze.py
+// One-dir build (default): binaryPath points at the executable INSIDE the
+// dist directory, not the directory itself.
+const binaryPath =
+  "hub/agents/python/email/packaging/dist/email-agent/email-agent"; // .exe on Windows
+const sidecar = await startSidecar({ binaryPath, port: 8131 });
+
+const { result } = await sidecar.client.triage({
+  payload: {
+    kind: "single",
+    principal: { email: "me@example.com" },
+    message: {
+      message_id: "m1",
+      from: { name: "Sarah Chen", email: "sarah@example.com" },
+      subject: "Prod incident follow-up",
+      body: "Please review the report and reply by Friday.",
+    },
+  },
+  // Full payload schema: see openapi.email.json (served live at GET /openapi.json)
+});
+console.log(result.category, result.summary);
+// result.action_items[0].description  ← field is "description", not "text"
+
+await shutdown(sidecar); // free function — not sidecar.shutdown()
+```
+
+**Consumer gotchas:**
+1. **Absolute `file:` path** — when your app lives outside the package tree, use
+   an absolute path in `package.json` (`file:/abs/path/to/agent-email`); a
+   relative `file:` becomes a broken symlink in npm workspaces.
+2. **One-dir `binaryPath`** — the default PyInstaller build produces a directory
+   (`dist/email-agent/`); `binaryPath` must point at the executable *inside* it
+   (`dist/email-agent/email-agent`), not at the parent directory.
+3. **`description`, not `text`** — action items use the field name `description`
+   (e.g. `result.action_items[0].description`).
 
 ## The `fetch` CLI
 

--- a/hub/agents/python/email/README.md
+++ b/hub/agents/python/email/README.md
@@ -151,6 +151,15 @@ await shutdown(sidecar); // free function — not sidecar.shutdown()
    (`dist/email-agent/email-agent`), not at the parent directory.
 3. **`description`, not `text`** — action items in `EmailTriageResult` use the
    field name `description` (e.g. `result.action_items[0].description`).
+4. **Running the built binary** — the `freeze.py` binary is dynamically linked
+   against the build host's glibc, so run it on the same machine or a newer OS.
+   A binary built on glibc 2.39 fails to start on an older runtime (e.g.
+   Debian 12 / `node:18` images ship glibc 2.36 → `GLIBC_2.38 not found`); a
+   glibc ≥ 2.38 base (e.g. `node:22-trixie` / Ubuntu 24.04) works. When the
+   consumer app runs in a container, the sidecar reaches a Lemonade on the host
+   via `host.docker.internal` — set
+   `LEMONADE_BASE_URL=http://host.docker.internal:13305` (this also satisfies
+   the local-only allowlist).
 
 The `/v1/email/*` routes are a versioned contract shared by the Python agent and
 the frozen binary — `openapi.email.json` is the source of truth.

--- a/hub/agents/python/email/README.md
+++ b/hub/agents/python/email/README.md
@@ -28,6 +28,10 @@ a cloud LLM; local-only inference is enforced at startup.
 Works with **Gmail** (Google connector) and **Outlook.com** (Microsoft
 connector); connect one or both and the agent triages them together.
 
+> **Frozen REST sidecar (JS/TS Path B below):** the standalone binary exposes
+> only **triage and draft** — read/organize/send/calendar are full agent-loop
+> features that require a connected mailbox (Path A).
+
 ## Use it
 
 ### In GAIA (no setup)
@@ -55,25 +59,101 @@ It registers via the `gaia.agent` entry-point group, so the GAIA registry
 discovers it automatically and exposes its REST (`/v1/email/*`) and MCP (stdio)
 surfaces.
 
-JavaScript / TypeScript — embed the agent as a local REST sidecar (no Python
-required) with the companion npm client:
+JavaScript / TypeScript — two paths, depending on whether you want the full
+agent or a lightweight local binary:
 
 ```bash
 npm install @amd-gaia/agent-email
 ```
 
-```ts
-import { fetchBinary, startSidecar } from "@amd-gaia/agent-email";
+**Path A — full GAIA (live inbox, real send, all capabilities)**
 
-const { binaryPath } = await fetchBinary({ outDir: "resources" });
-const sidecar = await startSidecar({ binaryPath, port: 8131 });
-const brief = await sidecar.client.triage({ /* … */ });
+Point `EmailClient` at a running GAIA server that mounts `/v1/email/*` (started
+with `gaia api start` or `gaia chat --ui`). This gives you the complete feature
+set — triage, draft, send, organize, calendar — backed by a connected Gmail or
+Outlook.com mailbox.
+
+```ts
+// Browser apps: import from the browser-safe subpath (no Node built-ins).
+// Node apps: "@amd-gaia/agent-email" works too.
+import { EmailClient } from "@amd-gaia/agent-email/client";
+
+// baseUrl is the GAIA API server that exposes /v1/email/*:
+//   gaia api start   → http://localhost:8080  (default)
+//   gaia chat --ui   → http://localhost:4200
+const client = new EmailClient({ baseUrl: "http://localhost:8080" });
+
+const { result } = await client.triage({
+  payload: {
+    kind: "single",
+    principal: { email: "me@example.com" },
+    message: {
+      message_id: "m1",
+      from: { name: "Sarah Chen", email: "sarah@example.com" },
+      subject: "Prod incident follow-up",
+      body: "Please review the report and reply by Friday.",
+    },
+  },
+});
+console.log(result.category, result.summary);
+
+// Send goes through a draft → confirmation-token → send handshake.
+// A send() without a valid confirmation token is rejected with HTTP 403.
 ```
 
-The package downloads and SHA-256-verifies the right native binary for your
-platform, then spawns and health-checks the sidecar. The `/v1/email/*` routes
-are a versioned contract shared by the Python agent and the frozen binary —
-`openapi.email.json` is the source of truth.
+**Path B — frozen sidecar (no Python required; triage + draft only)**
+
+The sidecar is a self-contained native binary that runs inference locally via
+Lemonade. It exposes only `POST /v1/email/triage` and `POST /v1/email/draft` —
+there is no `/v1/connections`, and `send` cannot complete (no connected mailbox):
+a direct `send()` returns **HTTP 403** (missing confirmation token), and even a
+`/draft`-confirmed send returns **HTTP 503** (no connected mailbox). Use Path A
+for anything that sends mail.
+
+```ts
+import { startSidecar, shutdown } from "@amd-gaia/agent-email";
+
+// `fetchBinary()` is intentionally blocked until #1648 — the binaries.lock.json
+// contains placeholder hashes and fetchBinary() throws a PlatformError.
+// Build the sidecar locally instead:
+//   python hub/agents/python/email/packaging/freeze.py
+// Note: one-dir build (default) — binaryPath points at the executable INSIDE
+// the dist directory, not the directory itself.
+const binaryPath =
+  "hub/agents/python/email/packaging/dist/email-agent/email-agent"; // .exe on Windows
+const sidecar = await startSidecar({ binaryPath, port: 8131 });
+
+const { result } = await sidecar.client.triage({
+  payload: {
+    kind: "single",
+    principal: { email: "me@example.com" },
+    message: {
+      message_id: "m1",
+      from: { name: "Sarah Chen", email: "sarah@example.com" },
+      subject: "Prod incident follow-up",
+      body: "Please review the report and reply by Friday.",
+    },
+  },
+  // Full payload schema: see openapi.email.json (served live at GET /openapi.json)
+});
+console.log(result.category, result.summary);
+// result.action_items[0].description  ← field is "description", not "text"
+
+await shutdown(sidecar); // free function — not sidecar.shutdown()
+```
+
+**Consumer gotchas:**
+1. **Absolute `file:` path** — when your app lives outside the package tree, use
+   an absolute path in `package.json` (`file:/abs/path/to/agent-email`); a
+   relative `file:` becomes a broken symlink in npm workspaces.
+2. **One-dir `binaryPath`** — the default PyInstaller build produces a directory
+   (`dist/email-agent/`); `binaryPath` must point at the executable *inside* it
+   (`dist/email-agent/email-agent`), not at the parent directory.
+3. **`description`, not `text`** — action items in `EmailTriageResult` use the
+   field name `description` (e.g. `result.action_items[0].description`).
+
+The `/v1/email/*` routes are a versioned contract shared by the Python agent and
+the frozen binary — `openapi.email.json` is the source of truth.
 
 ## Requirements
 


### PR DESCRIPTION
Closes #1811

## Why this matters

The `/hub/email` JavaScript/TypeScript guide didn't match how `@amd-gaia/agent-email` actually works: the quick-start led with `fetchBinary`, which **throws today** (binaries unpublished, blocked on #1648), and it presented the frozen sidecar as the full agent when it only does **triage + draft**. A developer copy-pasting it couldn't run it and was misled about send/connections. This splits the guide into two honest, runnable paths and corrects every endpoint, field, and status code to match the merged source.

Both READMEs (the `/hub/email` source and the npm package's own) now document:
- **Path A — full GAIA** (`EmailClient` → a running `gaia api`): live inbox, real send, all capabilities; browser-safe `@amd-gaia/agent-email/client` import called out.
- **Path B — frozen sidecar** (`startSidecar`): **triage + draft only**; `send` → **403** (no confirmation token) / **503** (no connected mailbox); no `/v1/connections`; `fetchBinary` blocked until #1648, with the local `freeze.py` build shown so the snippet runs as written.
- Consumer gotchas: absolute `file:` path, one-dir `binaryPath`, `description` (not `text`), and the locally-built binary's glibc floor + container→host Lemonade access.

Two facts in the issue text were slightly off and are corrected to match source: `triage()` takes the `{ payload: … }` envelope (not a bare payload), and `send` returns **403 before 503**.

## Proof it works

Cold run-through as a brand-new user on an **AMD Ryzen AI MAX+ 395 (Radeon 8060S)** — model **Gemma-4-E4B** on the GPU (Vulkan, `-ngl 99`, ~53 tok/s). Planted facts `APAC-8610` + `violet-otter-92` had to echo back to prove real local inference (not a canned response).

**Path B — frozen sidecar, in a clean `node:22-trixie` Docker container** — sidecar built via `freeze.py`, spawned *inside* the container, Lemonade reached via `host.docker.internal`:

```
# node pathB_container.mjs   (snippet copied verbatim from the corrected README)
[lifecycle] spawning /repo/.../dist/email-agent/email-agent --port 8141
[lifecycle] sidecar healthy · version OK apiVersion=2.0
category: NEEDS_RESPONSE
summary: Please confirm payment of overdue invoice APAC-8610 by Friday and include "violet-otter-92" in your reply.
action_items[0].description: "Hi, please reply to confirm payment of invoice APAC-8610 by Friday."   (field = description ✓)
PLANTED_OK: true   tokens_per_second: 53.68
```

**Path A — `EmailClient` vs a running `gaia api`** (`gaia api start --port 8080`):

```
INFO: 127.0.0.1 - "POST /v1/email/triage HTTP/1.1" 200 OK
category: NEEDS_RESPONSE · APAC-8610 present: true · violet-otter-92 present: true
# const { result } = await client.triage({ payload: {…} })   ← guide destructuring confirmed
```

**Documented caveats, proven exactly:**

```
fetchBinary()  → PlatformError: binaries.lock.json has a PLACEHOLDER sha256 for 'linux-x64' (PENDING-1648…). fetch is intentionally blocked.
sidecar.send() → HttpError status: 403   (missing confirmation token; 503 only after /draft)
```

**Ran on the GPU, not CPU:** Vulkan backend · AMD Radeon 8060S · `-ngl 99` (all 99 layers) · 464.8 MB VRAM · Gemma-4-E4B-it-Q4_K_M.

## Test plan

- [x] Both documented snippets type-check clean: `cd hub/agents/npm/agent-email && npm install && npm run build && tsc --noEmit --strict` → exit 0
- [x] **Path B** in a clean container: `freeze.py` build → `startSidecar` → `triage` returns a real Gemma-4-E4B result with both planted facts
- [x] **Path A**: `EmailClient` → `gaia api start --port 8080` → `POST /v1/email/triage` 200, planted facts present
- [x] Caveats: `fetchBinary` throws `PlatformError`; `send` returns 403
- [x] Every endpoint / field / status-code matches the merged source (AC #6)
