### PR TITLE
fix(agent-email/npm): bind EmailClient fetch to globalThis (browser Illegal invocation)

### DIFF
--- a/hub/agents/npm/agent-email/src/client.ts
+++ b/hub/agents/npm/agent-email/src/client.ts
@@ -55,12 +55,15 @@ export class EmailClient {
     // Normalize: strip trailing slashes so path joins are predictable.
     this.baseUrl = stripTrailingSlashes(opts.baseUrl);
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
-    if (typeof this.fetchImpl !== "function") {
+    const rawFetch = opts.fetchImpl ?? globalThis.fetch;
+    if (typeof rawFetch !== "function") {
       throw new TypeError(
         "global fetch is unavailable — use Node >= 18, or pass fetchImpl in EmailClientOptions",
       );
     }
+    // Bind to globalThis: the browser's `fetch` throws "Illegal invocation" if
+    // invoked as a method on any object other than window/globalThis.
+    this.fetchImpl = rawFetch.bind(globalThis);
   }
 
   /** Triage a single email or a full thread (POST /v1/email/triage). */

--- a/hub/agents/npm/agent-email/test/client.test.ts
+++ b/hub/agents/npm/agent-email/test/client.test.ts
@@ -140,4 +140,22 @@ describe("EmailClient", () => {
     const client = new EmailClient({ baseUrl: "http://127.0.0.1:9", fetchImpl });
     await expect(client.health()).rejects.toBeInstanceOf(HttpError);
   });
+
+  it("invokes fetch bound to globalThis (browser 'Illegal invocation' guard)", async () => {
+    // Regression: a browser's `fetch` throws "Illegal invocation" when called
+    // as a method on any object other than window/globalThis. EmailClient must
+    // bind the impl; a non-arrow fn captures its call-time `this`. Node tests
+    // pass without the bind (which is why the original bug slipped through), so
+    // this asserts the binding directly.
+    let calledThis: unknown = "unset";
+    const fetchImpl = function (this: unknown) {
+      calledThis = this;
+      return Promise.resolve(
+        jsonResponse({ status: "ok", service: "gaia-agent-email" }),
+      );
+    } as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+    await client.health();
+    expect(calledThis).toBe(globalThis);
+  });
 });


### PR DESCRIPTION
## Why this matters

`EmailClient` stored `globalThis.fetch` and called it as `this.fetchImpl(...)` — i.e. as a method on the client object. The browser's `fetch` throws `TypeError: Illegal invocation` unless invoked with `this` === `window`/`globalThis`, so **every** email call from a browser bundle fails. Node and the unit tests don't catch it because they pass a bound mock `fetchImpl`. This binds the impl to `globalThis` so any browser/edge consumer of `@amd-gaia/agent-email` works.

Found during real-world browser testing of an Agent UI → email-sidecar integration; split out of that work so it stands alone.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` → **28/28**, including a new test asserting `EmailClient` invokes `fetch` bound to `globalThis`
