### PR TITLE
Fix extract_json_from_text dropping JSON with a brace in a string value

### DIFF
--- a/src/gaia/utils/parsing.py
+++ b/src/gaia/utils/parsing.py
@@ -58,10 +58,24 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
             logger.debug("No JSON object found in text")
             return None
 
-        # Count braces to find matching close
+        # Count braces to find matching close, ignoring braces inside JSON
+        # string values (and handling escaped characters within them) so a "}"
+        # in a string does not terminate the object prematurely.
         brace_count = 0
+        in_string = False
+        escaped = False
         for i, char in enumerate(text[start:], start):
-            if char == "{":
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "{":
                 brace_count += 1
             elif char == "}":
                 brace_count -= 1

--- a/tests/unit/test_file_watcher.py
+++ b/tests/unit/test_file_watcher.py
@@ -176,7 +176,9 @@ class TestJsonExtraction:
 
     def test_extract_json_with_brace_in_string_value(self):
         """A brace inside a string value must not terminate the object early."""
-        text = 'Here is the data: {"note": "use the } symbol to close", "ok": true} Done!'
+        text = (
+            'Here is the data: {"note": "use the } symbol to close", "ok": true} Done!'
+        )
         result = extract_json_from_text(text)
         assert result == {"note": "use the } symbol to close", "ok": True}
 

--- a/tests/unit/test_file_watcher.py
+++ b/tests/unit/test_file_watcher.py
@@ -174,6 +174,18 @@ class TestJsonExtraction:
         text = "This is just plain text with no JSON"
         assert extract_json_from_text(text) is None
 
+    def test_extract_json_with_brace_in_string_value(self):
+        """A brace inside a string value must not terminate the object early."""
+        text = 'Here is the data: {"note": "use the } symbol to close", "ok": true} Done!'
+        result = extract_json_from_text(text)
+        assert result == {"note": "use the } symbol to close", "ok": True}
+
+    def test_extract_json_with_escaped_quote_and_brace_in_string(self):
+        """Escaped quotes inside a string must not flip string state mid-value."""
+        text = r'{"q": "say \"hi\" }", "n": 2}'
+        result = extract_json_from_text(text)
+        assert result == {"q": 'say "hi" }', "n": 2}
+
 
 class TestFieldChangeDetection:
     """Tests for field change detection."""


### PR DESCRIPTION
## Summary

Fixes #1823.

`extract_json_from_text` (`src/gaia/utils/parsing.py`) — the documented seam for parsing JSON out of LLM/VLM output (consumed by `gaia/vlm/structured_extraction.py`) — silently drops a valid JSON object when any string value in it contains a `}` (or `{`).

The matching-brace scan counts every `{`/`}` character, including those **inside JSON string values**:

```python
brace_count = 0
for i, char in enumerate(text[start:], start):
    if char == "{":
        brace_count += 1
    elif char == "}":
        brace_count -= 1
        if brace_count == 0:
            return json.loads(text[start : i + 1])
```

So an unbalanced brace inside a string (common in real model output — code snippets, templates, prose) drives the counter to zero early, slices an incomplete fragment, `json.loads` raises, and the function returns `None`. This contradicts the docstring ("handles nested JSON objects correctly … unlike simple regex approaches").

```python
extract_json_from_text('Here is the data: {"note": "use the } symbol to close", "ok": true} Done!')
# Expected: {'note': 'use the } symbol to close', 'ok': True}
# Actual:   None
```

## Fix

Make the scan string-aware — track whether we're inside a `"..."` string (with escape handling) and only count braces outside strings:

```python
if in_string:
    if escaped:
        escaped = False
    elif char == "\\":
        escaped = True
    elif char == '"':
        in_string = False
    continue
if char == '"':
    in_string = True
elif char == "{":
    ...
```

## Testing

Added two cases to `TestJsonExtraction` (`tests/unit/test_file_watcher.py`): a brace inside a string value, and an escaped quote followed by a brace.

```
pytest tests/unit/test_file_watcher.py::TestJsonExtraction
7 passed
```
Both new cases fail on `main` (return `None`) and pass with the fix; the existing plain/surrounding/nested/empty/no-JSON cases are unaffected.
