### PR TITLE
feat(ci): let contributors self-assign issues via `.take` comment

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -104,7 +104,7 @@ jobs:
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: issueNumber,
-                body: `@${commenter} I couldn't assign this issue to you automatically. A maintainer will assign it shortly.`,
+                body: `@${commenter} I couldn't assign this to you automatically — GitHub only auto-assigns users it already recognizes as repo contributors. A maintainer can assign you manually; just comment here and we'll sort it out.`,
               });
               return;
             }

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -48,9 +48,18 @@ jobs:
 
             const issueNumber = context.payload.issue.number;
             const commenter = context.payload.comment.user.login;
-            const assignees = context.payload.issue.assignees || [];
 
-            if (context.payload.issue.state === 'closed') {
+            // Read assignees/state LIVE rather than from the event payload —
+            // the payload is a snapshot from comment-creation time, so the
+            // concurrency guard only prevents double-assign if we re-fetch the
+            // current state here after serialization.
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: issueNumber,
+            });
+            const assignees = issue.assignees || [];
+
+            if (issue.state === 'closed') {
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: issueNumber,

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -41,8 +41,11 @@ jobs:
           script: |
             // Require the comment to START with `.take` (a command), not merely
             // mention it in prose. Allow a trailing reason after the command.
-            const body = context.payload.comment.body.trim();
-            if (body !== '.take' && !body.startsWith('.take ') && !body.startsWith('.take\n')) {
+            // Case-insensitive to match the loose `if` gate's contains() (which
+            // is case-insensitive) — otherwise `.Take`/`.TAKE` pass the gate,
+            // burn a runner, then silently no-op here.
+            const cmd = context.payload.comment.body.trim().toLowerCase();
+            if (cmd !== '.take' && !cmd.startsWith('.take ') && !cmd.startsWith('.take\n')) {
               return;
             }
 

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   issues: write
 
+# Serialize per issue so two near-simultaneous `.take` comments don't both read
+# an empty assignees list and double-assign.
+concurrency:
+  group: self-assign-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   self-assign:
     # Gate loosely here to skip PRs and most comments; the exact `.take`
@@ -30,7 +36,7 @@ jobs:
       contains(github.event.comment.body, '.take')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             // Require the comment to START with `.take` (a command), not merely

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -26,6 +26,7 @@ jobs:
     # no trim() function.
     if: >-
       github.event.issue.pull_request == null &&
+      github.event.comment.user.type != 'Bot' &&
       contains(github.event.comment.body, '.take')
     runs-on: ubuntu-latest
     steps:
@@ -71,11 +72,24 @@ jobs:
               return;
             }
 
-            await github.rest.issues.addAssignees({
+            // addAssignees silently ignores a user it can't assign (still 200),
+            // so confirm the commenter actually landed before reacting success.
+            const result = await github.rest.issues.addAssignees({
               ...context.repo,
               issue_number: issueNumber,
               assignees: [commenter],
             });
+            const assigned = (result.data.assignees || []).some(
+              (a) => a.login === commenter
+            );
+            if (!assigned) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issueNumber,
+                body: `@${commenter} I couldn't assign this issue to you automatically. A maintainer will assign it shortly.`,
+              });
+              return;
+            }
             await github.rest.reactions.createForIssueComment({
               ...context.repo,
               comment_id: context.payload.comment.id,

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,83 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Lets ANY contributor self-assign an open issue by commenting `.take` on it.
+# The assignment is performed by GITHUB_TOKEN (the Actions bot), not the
+# commenter — so a read-only external contributor can claim work without being
+# granted any repository role. This replaces the manual comment-then-maintainer-
+# assigns workflow that did not scale.
+#
+# Logic is inline github-script (no third-party action) to keep it auditable and
+# free of supply-chain risk.
+
+name: Self-assign issue
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  self-assign:
+    # Gate loosely here to skip PRs and most comments; the exact `.take`
+    # match (with trimming) happens in the script — Actions expressions have
+    # no trim() function.
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '.take')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // Require the comment to START with `.take` (a command), not merely
+            // mention it in prose. Allow a trailing reason after the command.
+            const body = context.payload.comment.body.trim();
+            if (body !== '.take' && !body.startsWith('.take ') && !body.startsWith('.take\n')) {
+              return;
+            }
+
+            const issueNumber = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+            const assignees = context.payload.issue.assignees || [];
+
+            if (context.payload.issue.state === 'closed') {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issueNumber,
+                body: `@${commenter} this issue is closed, so it can't be assigned. Find an open issue to \`.take\`.`,
+              });
+              return;
+            }
+
+            if (assignees.some((a) => a.login === commenter)) {
+              await github.rest.reactions.createForIssueComment({
+                ...context.repo,
+                comment_id: context.payload.comment.id,
+                content: '+1',
+              });
+              return;
+            }
+
+            if (assignees.length > 0) {
+              const taken = assignees.map((a) => `@${a.login}`).join(', ');
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issueNumber,
+                body: `@${commenter} this issue is already assigned to ${taken}. If they've stalled, comment here and a maintainer can reassign it.`,
+              });
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              ...context.repo,
+              issue_number: issueNumber,
+              assignees: [commenter],
+            });
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1',
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ For security issues, **do not file a public issue** — open a private [security
 
 ## Submitting a pull request
 
-1. **Claim the issue** — comment on it so others know you're working on it.
+1. **Claim the issue** — comment `.take` on it to assign it to yourself (works even without repo access), or comment normally so others know you're working on it.
 2. **Branch off `main`** with a descriptive name (e.g. `fix/lemonade-startup-error`, `feat/jira-bulk-update`).
 3. **Use the [PR template](.github/pull_request_template.md)** — every field matters. Don't delete sections; if a section doesn't apply, say so.
 4. **Link the issue** with `Closes #N` (or `Fixes #N`, `Refs #N` for partial work). GitHub will auto-close the issue on merge.


### PR DESCRIPTION
## Why this matters

External contributors can't be assigned GitHub issues without a repository role, so today a maintainer has to manually assign every task through a comment-then-assign step for each contributor — overhead that grows with community activity and doesn't scale. This adds a workflow that lets **any** contributor comment `.take` on an open issue to assign it to themselves. The assignment runs as `GITHUB_TOKEN` (GitHub permits assigning a user who has commented on the issue), so a fully **read-only external contributor self-serves with no repository role granted** — removing the manual maintainer step without expanding anyone's access.

Behavior:
- `.take` on an open, unassigned issue → assigns the commenter (👍 reaction).
- Already assigned to them → 👍, idempotent no-op.
- Already taken by someone else → polite "already assigned" comment, no steal.
- Closed issue, PR, or `.take` only mentioned in prose → no-op.

Design: inline `actions/github-script` (no third-party action — auditable, no supply-chain risk), scoped to `permissions: issues: write`.

## Test plan

- [x] `self-assign.yml` parses as valid YAML; expression syntax avoids the unsupported `trim()` (trimming done in JS).
- [ ] After merge to `main` (required — `issue_comment` workflows run from the default branch), comment `.take` from a **non-collaborator** account on a test issue → contributor is assigned.
- [ ] Comment `.take` on an already-assigned issue → "already assigned" comment, no reassignment.
- [ ] Comment prose containing ".take" mid-sentence → no action.