### PR TITLE
fix(memory): reconcile procedures by meaning, not exact name (#1818)

### DIFF
--- a/src/gaia/agents/base/procedural_memory.py
+++ b/src/gaia/agents/base/procedural_memory.py
@@ -462,7 +462,11 @@ class ProceduralMemoryMixin:
             # Embed when_to_use (its own corpus).  Embedder failure RE-RAISES.
             vec = self._embed_text(candidate.when_to_use)
             res = reconcile_and_store(
-                candidate, cluster, store, embedding=_embedding_to_blob(vec)
+                candidate,
+                cluster,
+                store,
+                embedding=_embedding_to_blob(vec),
+                similarity_tau=config.similarity_tau,
             )
             if res.action in ("add", "update") and res.skill_id:
                 self._proc_faiss_add(res.skill_id, vec)

--- a/src/gaia/agents/base/skill_synthesis.py
+++ b/src/gaia/agents/base/skill_synthesis.py
@@ -81,6 +81,11 @@ _MAX_NAME_LEN: int = 64
 #: Key in ``memory_settings.json`` carrying threshold overrides.
 _SETTINGS_SECTION: str = "skill_synthesis"
 
+#: Max enabled procedures scanned for the reconcile cosine match. The corpus is
+#: bounded (synthesis is gated + off-by-default), so this is generous; saturating
+#: it is logged loudly rather than silently dropping rows (#1818).
+_RECONCILE_SCAN_LIMIT: int = 500
+
 
 @dataclass(frozen=True)
 class SynthesisConfig:
@@ -572,39 +577,118 @@ def distill_cluster(
     return skill
 
 
+def _nearest_enabled_procedure(
+    store,
+    candidate_blob: Optional[bytes],
+    similarity_tau: float,
+) -> Optional[Dict]:
+    """Find the enabled, non-superseded procedure nearest the candidate by meaning.
+
+    Reconcile matches by ``when_to_use`` embedding cosine rather than exact
+    ``name`` (#1818): the distiller authors a fresh kebab ``name`` each pass, so a
+    recurring goal drifts (``summarize-unread-emails`` ->
+    ``summarize-my-unread-emails``) and an exact-name match would ADD a duplicate
+    instead of superseding.  Matching on the trigger vector keeps one proven
+    recipe per goal across phrasing drift.
+
+    The BLOB is the raw ``memory._embedding_to_blob`` float32 layout, decoded
+    locally with ``np.frombuffer`` (never importing ``memory``) so the
+    ``memory -> procedural_memory -> skill_synthesis`` import direction stays
+    one-way.  Vectors are L2-normalized at storage (``_embed_text``), but the
+    candidate and each row are re-normalized defensively so cosine == dot product.
+
+    Args:
+        store: The ``MemoryStore`` to scan (its ``search_skills`` is the boundary).
+        candidate_blob: The candidate's ``when_to_use`` embedding BLOB.  Falsy or
+            zero-norm means there is no meaning to match on -> treated as new.
+        similarity_tau: Cosine threshold; a row matches iff its score is
+            ``>= similarity_tau`` (the same tau used to cluster goals).
+
+    Returns:
+        The single highest-cosine procedure dict clearing ``similarity_tau``
+        (newest-first on ties, so the most recent row wins deterministically), or
+        None when nothing clears it or the candidate has no usable vector.
+    """
+    if not candidate_blob:
+        return None
+    cand = np.frombuffer(candidate_blob, dtype=np.float32)
+    cand_norm = np.linalg.norm(cand)
+    if cand_norm == 0:
+        return None
+    cand = cand / cand_norm
+
+    rows = store.search_skills(
+        enabled_only=True,
+        include_superseded=False,
+        with_embedding=True,
+        limit=_RECONCILE_SCAN_LIMIT,
+    )
+    if len(rows) >= _RECONCILE_SCAN_LIMIT:
+        logger.warning(
+            "[skill_synthesis] reconcile scan hit the %d-row cap; a drifted "
+            "duplicate beyond it could be missed (#1818)",
+            _RECONCILE_SCAN_LIMIT,
+        )
+
+    best: Optional[Dict] = None
+    best_score = -1.0
+    for row in rows:
+        blob = row.get("embedding")
+        if not blob:
+            continue
+        vec = np.frombuffer(blob, dtype=np.float32)
+        if vec.shape[0] != cand.shape[0]:  # wrong dim — not comparable, skip
+            continue
+        norm = np.linalg.norm(vec)
+        if norm == 0:
+            continue
+        score = float(np.dot(cand, vec / norm))
+        if score > best_score:  # strict-max keeps the newest row on ties
+            best_score = score
+            best = row
+
+    return best if best_score >= similarity_tau else None
+
+
 def reconcile_and_store(
     candidate: Skill,
     cluster: GoalCluster,
     store,
     embedding: Optional[bytes] = None,
+    similarity_tau: float = SIMILARITY_TAU,
 ) -> ReconcileResult:
     """RECONCILE/STORE — persist a distilled candidate as ADD / UPDATE / NOOP.
 
-    Matches an existing enabled, non-superseded procedure by ``name``:
+    Matches an existing enabled, non-superseded procedure by **``when_to_use``
+    embedding cosine ``>= similarity_tau``** (not by ``name``): the distiller
+    authors a fresh kebab ``name`` each pass, so a recurring goal drifts across
+    passes and a name match would ADD a duplicate instead of superseding (#1818).
 
-    * no match -> **ADD** a new row (Mem0 ADD).
-    * the candidate's cluster has a higher ``success_count`` than the existing
+    * no match (nothing clears ``similarity_tau``) -> **ADD** a new row (Mem0 ADD).
+    * the candidate's cluster has a higher ``success_count`` than the matched
       row -> **UPDATE**: store a new row and mark the old one ``superseded_by`` it
       (Zep lineage — the same insert-new-then-supersede shape #606 uses for a
       knowledge UPDATE).  The old row is kept, never deleted.
     * otherwise -> **NOOP**.
 
     No path ever DELETEs.  ``success_count`` is the dominance signal because it is
-    the procedure's empirical track record (the issue's stated supersede rule).
+    the procedure's empirical track record (the issue's stated supersede rule);
+    only the *match key* moved from name to meaning — dominance is unchanged.
 
     Args:
         candidate: The distilled ``Skill`` (intermediate fields).
         cluster: The cluster it was distilled from (track record + provenance).
         store: The ``MemoryStore`` to write to.
-        embedding: The ``when_to_use`` embedding BLOB (its own FAISS corpus).
+        embedding: The ``when_to_use`` embedding BLOB — now both persisted and
+            used as the match vector (previously persist-only).
+        similarity_tau: Cosine threshold for treating a stored procedure as the
+            same goal; defaults to the clustering ``SIMILARITY_TAU``.
 
     Returns:
         A ``ReconcileResult`` describing the action taken.
     """
     provenance = {"source": "synthesized", "from_sessions": cluster.from_sessions}
-    existing = store.search_skills(
-        name=candidate.name, enabled_only=True, include_superseded=False, limit=1
-    )
+    prior = _nearest_enabled_procedure(store, embedding, similarity_tau)
 
     def _insert() -> str:
         return store.put_skill(
@@ -619,30 +703,33 @@ def reconcile_and_store(
             embedding=embedding,
         )
 
-    if not existing:
+    if prior is None:
         new_id = _insert()
         logger.info(
             "[skill_synthesis] ADD procedure %s name=%s", new_id, candidate.name
         )
         return ReconcileResult(action="add", skill_id=new_id)
 
-    prior = existing[0]
     if cluster.success_count > int(prior.get("success_count", 0)):
         new_id = _insert()
         store.supersede_skill(prior["id"], new_id)
         logger.info(
-            "[skill_synthesis] UPDATE procedure name=%s: %s supersedes %s",
-            candidate.name,
+            "[skill_synthesis] UPDATE procedure %s supersedes %s "
+            "(matched by meaning, new name=%s, prior name=%s)",
             new_id,
             prior["id"],
+            candidate.name,
+            prior.get("name"),
         )
         return ReconcileResult(
             action="update", skill_id=new_id, superseded_id=prior["id"]
         )
 
     logger.info(
-        "[skill_synthesis] NOOP procedure name=%s: existing %s already dominates",
-        candidate.name,
+        "[skill_synthesis] NOOP procedure: existing %s already dominates "
+        "(matched by meaning, candidate name=%s, prior name=%s)",
         prior["id"],
+        candidate.name,
+        prior.get("name"),
     )
     return ReconcileResult(action="noop")

--- a/tests/unit/test_memory_mixin.py
+++ b/tests/unit/test_memory_mixin.py
@@ -3328,6 +3328,69 @@ class TestSynthesizeSkills:
         rows = store.search_skills()
         assert len(rows) == 1  # one row, not duplicated, not deleted
 
+    def test_name_drift_across_passes_supersedes(self, mixin_host):
+        """AC #3: the same goal distilled under a drifted name across passes
+        yields ONE surviving row (an UPDATE), not a second ADD.
+
+        The fixture's fixed-vector embedder gives cosine 1.0 between passes, so
+        the two candidates differ only by name — the exact regression the fix
+        targets.  Under the old exact-name match this produced 2 enabled rows.
+        """
+        pytest.importorskip("faiss")
+        store = mixin_host._memory_store
+        goal = "Summarize my unread emails"
+
+        pass1_md = (
+            "---\n"
+            "name: summarize-unread-emails\n"
+            "when_to_use: Summarize the user's unread emails.\n"
+            "tools_required: [list_emails, summarize]\n"
+            "---\n\n"
+            "# Summarize Unread Emails\n\n"
+            "1. List unread with `list_emails`.\n"
+            "2. Summarize them with `summarize`.\n"
+        )
+        pass2_md = (
+            "---\n"
+            "name: summarize-my-unread-emails\n"  # drifted name, same goal
+            "when_to_use: Summarize my unread emails.\n"
+            "tools_required: [list_emails, summarize]\n"
+            "---\n\n"
+            "# Summarize My Unread Emails\n\n"
+            "1. Pull unread mail with `list_emails`.\n"
+            "2. Produce a digest with `summarize`.\n"
+        )
+
+        # Pass 1: 3 qualifying sessions → one ADD.
+        for sid in ["d1", "d2", "d3"]:
+            _seed_qualifying_session(store, sid, goal)
+        mixin_host.chat = _chat_returning(pass1_md)
+        first = mixin_host._synthesize_skills()
+        assert first["stored"] == 1
+        rows_after_1 = store.search_skills()
+        assert len(rows_after_1) == 1
+        assert rows_after_1[0]["name"] == "summarize-unread-emails"
+        pass1_id = rows_after_1[0]["id"]
+
+        # Pass 2: 2 more sessions raise the cluster's aggregate success_count; the
+        # distiller drifts the name. Match-by-meaning must UPDATE, not duplicate.
+        for sid in ["d4", "d5"]:
+            _seed_qualifying_session(store, sid, goal)
+        mixin_host.chat = _chat_returning(pass2_md)
+        second = mixin_host._synthesize_skills()
+        assert second["stored"] == 1  # an UPDATE — not a no-op, not a 2nd ADD
+
+        visible = store.search_skills()  # enabled, non-superseded
+        assert len(visible) == 1
+        assert visible[0]["name"] == "summarize-my-unread-emails"  # pass-2 name
+        assert "digest" in visible[0]["markdown_body"]  # pass-2 body
+        # The pass-1 row is superseded (kept, never deleted).
+        old = store.search_skills(
+            skill_id=pass1_id, include_superseded=True, enabled_only=False
+        )
+        assert len(old) == 1
+        assert old[0]["superseded_by"] == visible[0]["id"]
+
 
 # ===========================================================================
 # Phase 2 — Skill Recall + system-prompt injection (#887)

--- a/tests/unit/test_skill_synthesis.py
+++ b/tests/unit/test_skill_synthesis.py
@@ -12,7 +12,8 @@ All tests run without a live backend — the embedder and the chat LLM are passe
 in as plain callables, and store-backed tests use a temp-file ``MemoryStore``.
 """
 
-from unittest.mock import MagicMock
+import logging
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -20,13 +21,16 @@ import yaml
 
 from gaia.agents.base.memory_store import MemoryStore
 from gaia.agents.base.skill_synthesis import (
+    _RECONCILE_SCAN_LIMIT,
     DISTILL_SYSTEM_PROMPT,
     DISTILL_TEMPERATURE,
+    SIMILARITY_TAU,
     GoalCluster,
     ReconcileResult,
     Skill,
     SynthesisConfig,
     _build_distill_user_prompt,
+    _nearest_enabled_procedure,
     cluster_by_goal,
     distill_cluster,
     load_synthesis_config,
@@ -478,7 +482,7 @@ class TestReconcileAndStore:
     def test_add_when_name_is_new(self, store):
         cluster = _cluster(n=4)  # success_count 12, attempt_count 12
         res = reconcile_and_store(
-            self._candidate(), cluster, store, embedding=b"\x00" * 4
+            self._candidate(), cluster, store, embedding=_unit([1, 0, 0]).tobytes()
         )
         assert res.action == "add"
         assert res.skill_id and res.skill_id.startswith("proc_")
@@ -488,32 +492,37 @@ class TestReconcileAndStore:
         assert rows[0]["provenance"]["from_sessions"] == list(cluster.from_sessions)
 
     def test_noop_when_existing_dominates(self, store):
-        # Existing row with a strong track record.
+        # Existing row with a strong track record AND a matching trigger vector
+        # (the new match key is meaning, so the prior must carry an embedding).
+        vec = _unit([1, 0, 0]).tobytes()
         store.put_skill(
             name="triage-support-ticket",
             when_to_use="t",
             markdown_body="b",
             success_count=99,
             attempt_count=100,
+            embedding=vec,
         )
         weak_cluster = _cluster(n=3)  # success_count 9 << 99
-        res = reconcile_and_store(self._candidate(), weak_cluster, store, embedding=b"")
+        res = reconcile_and_store(self._candidate(), weak_cluster, store, embedding=vec)
         assert res.action == "noop"
         assert res.skill_id is None
         # Still exactly one (enabled, non-superseded) row.
         assert len(store.search_skills(name="triage-support-ticket")) == 1
 
     def test_update_supersedes_lower_success_count(self, store):
+        vec = _unit([1, 0, 0]).tobytes()
         old_id = store.put_skill(
             name="triage-support-ticket",
             when_to_use="old trigger",
             markdown_body="old body",
             success_count=2,
             attempt_count=2,
+            embedding=vec,
         )
         strong_cluster = _cluster(n=5)  # success_count 15 > 2
         res = reconcile_and_store(
-            self._candidate(), strong_cluster, store, embedding=b""
+            self._candidate(), strong_cluster, store, embedding=vec
         )
 
         assert res.action == "update"
@@ -529,6 +538,144 @@ class TestReconcileAndStore:
         )
         assert len(old_row) == 1
         assert old_row[0]["superseded_by"] == res.skill_id
+
+    def test_matches_by_meaning_supersedes_under_name_drift(self, store):
+        """AC #1/#2: a drifted name with the same meaning supersedes — not a 2nd ADD.
+
+        The prior recipe is stored under one name; a later pass distills the same
+        goal under a *different* name with an identical trigger vector (cosine
+        1.0 >= tau, modelling the real fixed-vector embedder) and a stronger track
+        record.  The match is by meaning, so it UPDATEs, and the surviving row
+        must carry the *second* candidate's name AND body — pinning supersede
+        direction so a wrong-way supersede (old row surviving) is caught.
+        """
+        v = _unit([1, 0, 0]).tobytes()
+        old_id = store.put_skill(
+            name="summarize-unread-emails",
+            when_to_use="Summarize the user's unread emails.",
+            markdown_body="# Old\n1. step",
+            success_count=2,
+            attempt_count=2,
+            embedding=v,
+        )
+        drifted = Skill(
+            name="summarize-my-unread-emails",  # drifted name, same goal
+            when_to_use="Summarize my unread emails.",
+            body="# New\n1. better step",
+            tools_required=["list_emails", "summarize"],
+        )
+        strong_cluster = _cluster(n=5)  # success_count 15 > 2
+        res = reconcile_and_store(drifted, strong_cluster, store, embedding=v)
+
+        assert res.action == "update"
+        assert res.superseded_id == old_id
+        visible = store.search_skills()  # enabled, non-superseded
+        assert len(visible) == 1
+        assert visible[0]["id"] == res.skill_id
+        assert visible[0]["name"] == "summarize-my-unread-emails"
+        assert visible[0]["markdown_body"] == "# New\n1. better step"
+
+    def test_distinct_meaning_adds_even_with_same_name(self, store):
+        """The key is meaning, not name: same name + orthogonal vector -> ADD."""
+        store.put_skill(
+            name="triage-support-ticket",
+            when_to_use="Triage a support ticket.",
+            markdown_body="b",
+            success_count=2,
+            attempt_count=2,
+            embedding=_unit([1, 0, 0]).tobytes(),
+        )
+        res = reconcile_and_store(
+            self._candidate(name="triage-support-ticket"),  # identical name
+            _cluster(n=5),
+            store,
+            embedding=_unit([0, 1, 0]).tobytes(),  # cosine 0 < tau -> different goal
+        )
+        assert res.action == "add"
+        assert len(store.search_skills()) == 2
+
+    def test_lower_success_same_meaning_noops(self, store):
+        """Dominance is unchanged under the new key: drifted name + matching
+        vector but a weaker cluster -> NOOP (existing row dominates)."""
+        v = _unit([1, 0, 0]).tobytes()
+        store.put_skill(
+            name="summarize-unread-emails",
+            when_to_use="Summarize unread emails.",
+            markdown_body="b",
+            success_count=50,
+            attempt_count=50,
+            embedding=v,
+        )
+        drifted = Skill(
+            name="summarize-my-unread-emails",
+            when_to_use="Summarize my unread emails.",
+            body="weaker",
+            tools_required=["list_emails"],
+        )
+        res = reconcile_and_store(drifted, _cluster(n=3), store, embedding=v)  # 9 < 50
+        assert res.action == "noop"
+        assert len(store.search_skills()) == 1
+
+    def test_reconcile_queries_store_by_embedding_not_name(self, store):
+        """Contract-shape: the match scan queries enabled / non-superseded WITH
+        embeddings and NEVER by name — a name-keyed or embedding-less query would
+        silently reintroduce #1818."""
+        spy = MagicMock(wraps=store.search_skills)
+        with patch.object(store, "search_skills", spy):
+            reconcile_and_store(
+                self._candidate(),
+                _cluster(n=3),
+                store,
+                embedding=_unit([1, 0, 0]).tobytes(),
+            )
+        assert spy.call_count >= 1
+        first = spy.call_args_list[0].kwargs
+        assert first.get("enabled_only") is True
+        assert first.get("include_superseded") is False
+        assert first.get("with_embedding") is True
+        assert all(call.kwargs.get("name") is None for call in spy.call_args_list)
+
+    def test_dim_mismatch_prior_is_skipped(self, store):
+        """A stored row whose embedding dim differs from the candidate is skipped
+        (not fed to np.dot, which would raise) -> reconcile ADDs rather than
+        crashing.  Defensive: guards the match if the embedder dim ever changes."""
+        store.put_skill(
+            name="summarize-unread-emails",
+            when_to_use="x",
+            markdown_body="b",
+            success_count=2,
+            attempt_count=2,
+            embedding=_unit([1, 0, 0, 0]).tobytes(),  # 4-dim — wrong shape
+        )
+        res = reconcile_and_store(
+            self._candidate(name="summarize-my-unread-emails"),
+            _cluster(n=5),
+            store,
+            embedding=_unit([1, 0, 0]).tobytes(),  # 3-dim candidate
+        )
+        assert res.action == "add"
+        assert len(store.search_skills()) == 2
+
+    def test_scan_cap_saturation_warns_no_silent_cap(self, caplog):
+        """Fail-loud (#1818): a saturated scan window logs a WARNING — the cap is
+        never a silent drop.  Driven through a fake store so the test stays fast."""
+        blob = _unit([1, 0, 0]).tobytes()
+        rows = [
+            {"id": f"proc_{i}", "name": f"p{i}", "embedding": blob, "success_count": 1}
+            for i in range(_RECONCILE_SCAN_LIMIT)
+        ]
+
+        class _FakeStore:
+            def search_skills(self, **kwargs):
+                return rows
+
+        with caplog.at_level(
+            logging.WARNING, logger="gaia.agents.base.skill_synthesis"
+        ):
+            match = _nearest_enabled_procedure(_FakeStore(), blob, SIMILARITY_TAU)
+
+        assert match is not None  # a row still matched (cosine 1.0 >= tau)
+        assert "cap" in caplog.text.lower()
 
     def test_result_dataclass_shape(self):
         r = ReconcileResult(action="add", skill_id="proc_x")


### PR DESCRIPTION
## Summary

Procedural memory now keeps **one** proven recipe per goal even when the distiller renames it between synthesis passes — recipes are matched by meaning, not by an exact name string.

## Why

The procedural-memory tier (#887) promises "learn a task once, keep one proven recipe, replace it when a better version appears." Supersession is the *replace* half. But `reconcile_and_store` decided "same recipe?" by exact-string match on `name` — and the distiller LLM authors a fresh kebab name each pass (`DISTILL_TEMPERATURE = 0.1`, kebab-validated only, never canonicalized). So a recurring goal that drifts from `summarize-unread-emails` one pass to `summarize-my-unread-emails` the next slipped past the name lookup: **before**, a drifted name produced a *second* ADD and the supersede branch silently never fired — duplicates accumulated, `recall_skill(top_k=2)` could surface two near-identical copies into the planner prompt, and a genuinely better recipe coexisted with the stale one instead of replacing it. **After**, reconcile matches the nearest enabled, non-superseded procedure by `when_to_use` embedding cosine `>= SIMILARITY_TAU` (0.82), so a drifted name still resolves to the same recipe and supersession fires as designed. Go-forward only — cleaning up rows already duplicated by prior drift is out of scope (the feature is new and off-by-default).

## Linked issue

Closes #1818

## Changes

- **Match key is meaning, not name.** `reconcile_and_store` now finds the prior recipe via a new pure helper `_nearest_enabled_procedure` (cosine `>= similarity_tau` over `when_to_use` vectors), reusing the embedding the call site already computes and passes as `embedding=` — previously persisted but never used for matching. The supersede-by-`success_count` dominance check, the insert-new-then-`superseded_by` lineage, the ADD/UPDATE/NOOP shape, and "never DELETE" are all unchanged; only the match source moved.
- **Live SQLite cosine pass, not the FAISS index** (per maintainer steer in [issue #1818 comment 4772627749](https://github.com/amd/gaia/issues/1818#issuecomment-4772627749)). The scan goes over `search_skills(..., with_embedding=True)`, which sees rows written earlier in the *same* `max_clusters_per_pass` loop (`put_skill` commits immediately) — the FAISS index isn't refreshed until after reconcile returns, so reusing it could let a same-pass double-ADD through. This also keeps `reconcile_and_store` a pure function (`store`-only) that unit-tests without a live backend.
- **Fail-loud, no silent cap.** The scan is bounded by `_RECONCILE_SCAN_LIMIT = 500`; saturating it logs a `warning` rather than silently dropping rows. Degraded inputs (missing/zero-norm/wrong-dim embeddings) are skipped with intent, not swallowed.
- **No import-cycle regression.** Embedding BLOBs are decoded locally with `np.frombuffer` so `skill_synthesis` imports no `memory` symbol, preserving the `memory → procedural_memory → skill_synthesis` one-way direction.

## Test plan

- [x] `python -m pytest tests/unit/test_skill_synthesis.py tests/unit/test_memory_mixin.py tests/unit/test_memory_store.py -q` — all green (578 passed locally), including the 4 new pure-fn tests, the e2e two-pass drift test, and the 3 updated pure-fn tests.
- [x] `python util/lint.py --all` — black/isort/pylint/flake8 clean (remaining MyPy/Bandit warnings are pre-existing and not in the touched files).
- [x] **Regression check (optional but recommended):** revert the one match line in `reconcile_and_store` to the old `search_skills(name=candidate.name, …)` lookup and re-run the four meaning tests — they must FAIL on the old code and PASS on the fix, proving they exercise the changed branch (not vacuous).

> No `gaia eval agent` run is included — this is persistence-only (no prompt, tool schema, recall path, model, or error-classification change), and a cold eval runs from empty memory so it cannot reach the multi-pass name-drift branch the fix targets. The deterministic unit + e2e tests above exercise that branch directly.

## Deviations from the approved sketch

| Sketch / comment said | Code reality | Resolution |
|---|---|---|
| "search the procedures **FAISS index** (or a `search_skills` cosine pass)" | `_proc_faiss_index` lives on the mixin and is refreshed only *after* `reconcile_and_store` returns; the function is pure and takes only `store`. | Took the offered **`search_skills` cosine pass** — keeps the function pure/unit-testable and catches same-pass ADDs the index wouldn't. No behavior gap vs the sketch. |
| Comment cites the call-site vector at `procedural_memory.py:86` | After the #1794 extraction, the vector is computed at [`procedural_memory.py:463`](src/gaia/agents/base/procedural_memory.py#L463) and passed as `embedding=`. | Line-drift only; the vector exists and is reused as the match input. |
| (none — net-new) | The existing pure-fn tests `test_noop_when_existing_dominates` and `test_update_supersedes_lower_success_count` seeded rows with **no embedding** and relied on name equality. | Updated to seed matching embeddings (the new match key) — they would otherwise ADD instead of supersede. In-scope test churn. |

## Checklist

- [x] I have linked a GitHub issue above (`Closes #1818`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] No user-visible/CLI/API surface changed — internal reconcile logic only, so no docs update is required.

---

## Acceptance-criteria proof — #1818

The match key in `reconcile_and_store` moved from exact `name` to `when_to_use` embedding cosine `>= SIMILARITY_TAU` (0.82) via a new live-SQLite cosine pass `_nearest_enabled_procedure` ([skill_synthesis.py:580](src/gaia/agents/base/skill_synthesis.py#L580)); dominance, lineage, and never-DELETE are unchanged.

Every AC is proven by a **deterministic** test that exercises the changed branch — and each is shown to **fail on the old name-match code and pass on the fix** (regression proof below), which is what makes the green meaningful.

### AC → proof map

| Acceptance criterion | Proving test(s) | Key assertions |
|---|---|---|
| **AC #1** — match by `when_to_use` cosine `>= SIMILARITY_TAU`, not `name`; recurring goal → one enabled row under name drift | `test_matches_by_meaning_supersedes_under_name_drift` ([:542](tests/unit/test_skill_synthesis.py#L542)), `test_distinct_meaning_adds_even_with_same_name` ([:578](tests/unit/test_skill_synthesis.py#L578)) | drifted name + cosine-1.0 vector → **1** enabled row; identical `name` + orthogonal vector (cosine 0 < τ) → **2** rows (ADD). Proves the key is meaning, not name. |
| **AC #2** — supersession fires under drift: higher-`success_count` candidate supersedes (insert-new + `superseded_by`, never DELETE); dominance unchanged | `test_matches_by_meaning_supersedes_under_name_drift` ([:542](tests/unit/test_skill_synthesis.py#L542)), `test_lower_success_same_meaning_noops` ([:597](tests/unit/test_skill_synthesis.py#L597)), `test_update_supersedes_lower_success_count` ([:513](tests/unit/test_skill_synthesis.py#L513)), `test_noop_when_existing_dominates` ([:494](tests/unit/test_skill_synthesis.py#L494)) | `action=="update"`, `superseded_id==old_id`, old row kept with `superseded_by` set (never deleted); weaker cluster under a drifted name → `noop` (dominance logic intact under the new key). |
| **AC #3** — same cluster distilled twice with differing names → exactly one surviving enabled, non-superseded row, second supersedes first | `test_name_drift_across_passes_supersedes` ([test_memory_mixin.py:3331](tests/unit/test_memory_mixin.py#L3331)) — two real `_synthesize_skills` passes | pass 1 ADDs `summarize-unread-emails`; pass 2 (drifted `summarize-my-unread-emails`, higher `success_count`) → `stored==1` (UPDATE); `search_skills()` returns **1** row; pass-1 id `superseded_by` the pass-2 id. |

### Comment [#4772627749](https://github.com/amd/gaia/issues/1818#issuecomment-4772627749) refinements — both addressed

**1. "Live SQLite + cosine pass, not `_proc_faiss_search`"** (avoids a stale-index same-pass double-ADD). `_nearest_enabled_procedure` scans `store.search_skills(enabled_only=True, include_superseded=False, with_embedding=True)` — the live table, never the FAISS index. Pinned by a contract-shape spy:

> `test_reconcile_queries_store_by_embedding_not_name` ([:619](tests/unit/test_skill_synthesis.py#L619)) — asserts every `search_skills` call passes `with_embedding=True, enabled_only=True, include_superseded=False` and **`name` is always `None`**, so a silent revert to name-matching (or to the index) is caught.

**2. "Assert the surviving row carries the *second* candidate's name/body, not just count==1"** (catches a wrong-direction supersede). Both the pure-fn and e2e AC tests assert name **and** body of the survivor:
- pure-fn: `visible[0]["name"] == "summarize-my-unread-emails"` **and** `visible[0]["markdown_body"] == "# New\n1. better step"`.
- e2e: `visible[0]["name"] == "summarize-my-unread-emails"` **and** `"digest" in visible[0]["markdown_body"]`, plus `old[0]["superseded_by"] == visible[0]["id"]`.

### Verbatim results

**All AC tests pass on the fix:**

test_matches_by_meaning_supersedes_under_name_drift PASSED
test_distinct_meaning_adds_even_with_same_name      PASSED
test_lower_success_same_meaning_noops               PASSED
test_reconcile_queries_store_by_embedding_not_name  PASSED
test_update_supersedes_lower_success_count          PASSED
test_noop_when_existing_dominates                   PASSED
test_name_drift_across_passes_supersedes            PASSED   (e2e, 2 synthesis passes)
test_rerun_is_noop_and_never_deletes                PASSED   (never-DELETE)
8 passed in 1.28s



**Regression proof — the tests catch the bug** (temporarily revert the match line to the old `search_skills(name=…)` lookup):

=== AC tests against OLD exact-name code — MUST FAIL ===
FAILED test_matches_by_meaning_supersedes_under_name_drift
FAILED test_distinct_meaning_adds_even_with_same_name
FAILED test_lower_success_same_meaning_noops
FAILED test_name_drift_across_passes_supersedes
4 failed in 1.05s

=== same 4 against the fix — MUST PASS ===
4 passed in 0.78s

Full suite for the touched modules: **578 passed**; `python util/lint.py --all` → **ALL QUALITY CHECKS PASSED**.