### PR TITLE
fix(agent-email): use in-repo raw image for README architecture diagram

### DIFF
--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -1,6 +1,6 @@
 # @amd-gaia/agent-email
 
-[![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email) · contract `SCHEMA_VERSION` **2.0**
+[![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email) · contract `SCHEMA_VERSION` **2.0** · last updated **2026-06-23**
 
 Thin JS/TS client, build-time binary fetcher, and sidecar lifecycle helpers for
 the **GAIA email agent** — a frozen, no-Python REST sidecar that triages email

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -1,5 +1,7 @@
 # @amd-gaia/agent-email
 
+[![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email) · contract `SCHEMA_VERSION` **2.0**
+
 Thin JS/TS client, build-time binary fetcher, and sidecar lifecycle helpers for
 the **GAIA email agent** — a frozen, no-Python REST sidecar that triages email
 100% locally on AMD Ryzen AI.
@@ -15,7 +17,7 @@ and helpers to spawn / health-check / version-check / shut down the sidecar.
 
 ## How it fits together
 
-![@amd-gaia/agent-email architecture — your Node code spawns and drives a frozen email-agent sidecar (127.0.0.1:8131) over HTTP, which runs triage inference on a local Lemonade Server; a browser/Electron renderer drives the same sidecar over HTTP via the ./client entry.](https://hub.amd-gaia.ai/agents/email/0.2.0/architecture.webp)
+![@amd-gaia/agent-email architecture — your Node code spawns and drives a frozen email-agent sidecar (127.0.0.1:8131) over HTTP, which runs triage inference on a local Lemonade Server; a browser/Electron renderer drives the same sidecar over HTTP via the ./client entry.](https://raw.githubusercontent.com/amd/gaia/main/hub/agents/npm/agent-email/assets/architecture.webp)
 
 Three tiers, all on the user's machine — no cloud, and **no separate GAIA
 install**:


### PR DESCRIPTION
The email agent's 0.2.0 README embeds its architecture diagram from `https://hub.amd-gaia.ai/agents/email/0.2.0/architecture.webp` — but **nothing publishes that asset there** (the release pipeline uploads only the manifest, binary, and README; `assets/` isn't in the npm `files`), so the image would **404 on npmjs.com and the hub page** the moment 0.2.0 ships. This points the diagram at the in-repo asset via `raw.githubusercontent.com/.../assets/architecture.webp` (which resolves today), so the README renders correctly with no pipeline change — unblocking a clean 0.2.0 release. Since the version is no longer in the image URL, it adds a clear npm-version badge + the `SCHEMA_VERSION 2.0` contract line at the top.

The proper fix — publishing the asset to the versioned hub path and restoring that URL — is tracked in **#1832**. The `stamp_version.py --check` now skip-warns the (absent) versioned architecture URL, which is non-fatal (exit 0, confirmed).

### Test plan
- [ ] `python hub/agents/python/email/packaging/stamp_version.py --check` → exit 0 (architecture.webp shows `SKIP`, all else `OK`).
- [ ] `grep -c "hub.amd-gaia.ai/agents/email/.*architecture" hub/agents/npm/agent-email/README.md` → 0.
- [ ] README renders: version badge + `SCHEMA_VERSION 2.0` at the top; the architecture image loads from the raw GitHub URL.