### PR TITLE
fix(hub): single npm README + fresh catalog on deploy + version on cards

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -84,7 +84,12 @@ permissions:
 env:
   PKG_DIR: hub/agents/npm/agent-email
   MANIFEST: hub/agents/python/email/gaia-agent.yaml
-  README: hub/agents/python/email/README.md
+  # Single canonical README for the agent: the npm client README (architecture
+  # diagram, install/usage, ./client) is the richer, actively-maintained one, so
+  # it's what gets published to the hub AND npm. The python-side README is being
+  # retired with the agent-structure reorg. (Takes effect on the NEXT release —
+  # the catalog snapshots the README at publish time.)
+  README: hub/agents/npm/agent-email/README.md
   FREEZE_DIST: hub/agents/python/email/packaging/dist
   # Hub key prefix (mirrors the Worker's agents/<id> layout). The Worker owns the
   # bucket binding; CI never talks to R2 directly — it POSTs to /publish.

--- a/website/src/components/AgentRow.astro
+++ b/website/src/components/AgentRow.astro
@@ -30,6 +30,7 @@ const { agent } = Astro.props;
   <span class="min-w-0 flex-1">
     <span class="flex items-baseline gap-2.5">
       <span class="text-[15px] font-semibold text-g-text">{agent.name}</span>
+      <span class="font-mono text-[11px] text-g-muted">v{agent.latest_version}</span>
       {agent.security_tier === 'verified' && (
         <span class="text-[10px] font-bold tracking-wide uppercase text-g-gold-text">{securityTierLabel(agent.security_tier)}</span>
       )}

--- a/website/src/components/FeaturedCard.astro
+++ b/website/src/components/FeaturedCard.astro
@@ -26,6 +26,7 @@ const { agent, eyebrow = 'Featured' } = Astro.props;
         <AgentIcon name={agent.icon} class="w-5 h-5" />
       </span>
       <span class="text-xl font-bold tracking-tight text-g-text">{agent.name}</span>
+      <span class="font-mono text-[12px] text-g-muted">v{agent.latest_version}</span>
     </div>
     <p class="text-[14px] text-g-muted max-w-md mb-6">{agent.description}</p>
     <!-- Static chip, not a copy button — the whole card is a link; nested buttons are invalid HTML. -->

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -58,10 +58,17 @@ interface CatalogFile {
 
 async function fetchLiveCatalog(baseUrl: string): Promise<CatalogFile> {
   const url = `${baseUrl.replace(/\/+$/, '')}/index.json`;
+  // Cache-bust the edge. A release publishes the new index.json moments before the
+  // website redeploy runs, but the Cloudflare edge in front of hub.amd-gaia.ai can
+  // still serve a stale copy (the deploy races the cache invalidation) — which would
+  // build the site from the previous version's catalog. A unique per-build query
+  // param + `no-store` forces a fresh origin fetch, so every build reflects the
+  // just-published catalog. Build-time only, so there's no runtime cost.
+  const fetchUrl = `${url}?t=${Date.now()}`;
   console.log(`[catalog] HUB_CATALOG_URL is set — fetching live catalog from ${url}`);
   let res: Response;
   try {
-    res = await fetch(url);
+    res = await fetch(fetchUrl, { cache: 'no-store' });
   } catch (e) {
     throw new Error(
       `[catalog] Failed to fetch the live catalog from ${url}: ${(e as Error).message}. ` +


### PR DESCRIPTION
Three fixes for what the hub website shows after an agent release — all surfaced while shipping email `0.2.0`.

**Threads (reviewer can evaluate independently):**
- **Single canonical README → the hub shows the right content.** The hub renders whatever the release publishes via `--readme`, which was the *python-side* README (capabilities narrative — no architecture diagram, no install/usage flow). The **npm client README** is the richer, actively-maintained one, so it's now the single source published to **both** npm and the hub. *One README per agent* (the python one retires with the upcoming agent-structure reorg). ⚠️ Takes effect on the **next** release — the catalog snapshots the README at publish time, so the live `0.2.0` page still shows the old README until a re-publish.
- **Cache-bust the catalog fetch → no more stale builds.** A release publishes the new `index.json` moments before the website redeploy, but the Cloudflare edge can still serve the previous version's catalog (the deploy races the cache invalidation). The build-time fetch now uses a per-build query param + `no-store`, so every build pulls fresh from the Worker origin. Build-time only, no runtime cost.
- **Show the agent version on cards.** `v<latest_version>` now appears on the hub listing card and the homepage featured card.

### Test plan
- [ ] `HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build` in `website/` → `astro check` 0 errors, loads the live catalog, builds `/hub` + `/hub/email` (verified locally).
- [ ] Cards show `v0.2.0` next to the email agent name.
- [ ] After the next email release, the `/hub/email` page renders the npm README (architecture diagram + install flow) instead of the python one.
- [ ] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release_agent_email.yml'))"` parses.