### PR TITLE
feat(tool-loader): load recalled skills' tools ahead of semantic (#1451)

### DIFF
--- a/docs/plans/tool-loader.mdx
+++ b/docs/plans/tool-loader.mdx
@@ -9,7 +9,7 @@ title: "Dynamic Tool Loader"
 <Note>
 **Component:** Per-turn tool visibility for agents (issue [#688](https://github.com/amd/gaia/issues/688))
 **Module:** `gaia.agents.base.tool_loader`
-**Status:** **Part 0 (#1448) + Part 1 (#1449) + Part 2 (#1450) landed.** Part 1 ships the selection mechanism behind a default-off toggle on the ChatAgent `doc` profile; Part 2 adds the explicit `load_tools` escape hatch (so native tool-calling models can recover a semantic miss) plus the escape-hatch activation-rate tuning signal. Part 3 (skill signal) is still proposed.
+**Status:** **Part 0 (#1448) + Part 1 (#1449) + Part 2 (#1450) + Part 3 (#1451) landed.** Part 1 ships the selection mechanism behind a default-off toggle on the ChatAgent `doc` profile; Part 2 adds the explicit `load_tools` escape hatch (so native tool-calling models can recover a semantic miss) plus the escape-hatch activation-rate tuning signal; Part 3 adds the skill-driven signal — the `tools_required` of a recalled learned procedure (#887) load ahead of the semantic results.
 **Target agent (v1):** `ChatAgent` (`doc` profile), behind a default-off toggle.
 </Note>
 
@@ -45,8 +45,8 @@ against the 12K number — measure first, then justify on TTFT and slope.
 ## Decided design
 
 A semantic selector over a CORE floor, with a model-driven safety net — plus a
-skill-driven signal added later once #887 lands (see
-[Part 3](#part-3-skill-driven-signal-gated-on-887)). Keyword matching is
+skill-driven signal layered on once #887 landed (see
+[Part 3](#part-3-skill-driven-signal-landed-1451)). Keyword matching is
 **explicitly out** — it is too brittle to maintain and was the source of repeated
 review failures on the prior attempts (#811 / #922 / #957 / #958).
 
@@ -387,12 +387,12 @@ it on every model.
 **Cap unchanged at 14** (→ 3 dynamic slots now that CORE = 11). The eval gates
 recall; bump the default only if recall or the escape-hatch rate regresses.
 
-### Part 3 — Skill-driven signal (gated on #887)
+### Part 3 — Skill-driven signal ✅ landed (#1451)
 
-A third selection signal, added **only after** [#887](https://github.com/amd/gaia/issues/887)
-(skill auto-synthesis) lands. A *skill* is a procedure the agent distilled from
-its own successful multi-step runs; each `SKILL.md` declares the exact
-`tools_required` for that recipe in its YAML frontmatter.
+A third selection signal, unblocked once [#887](https://github.com/amd/gaia/issues/887)
+(skill auto-synthesis) landed (PR #1794, refined by #1818/#1828). A *skill* is a
+procedure the agent distilled from its own successful multi-step runs; each
+stored procedure declares the exact `tools_required` for that recipe.
 
 - When `recall_skill(goal)` matches the user's goal, union in the matched skills'
   `tools_required` **ahead of** semantic results.
@@ -408,9 +408,12 @@ its own successful multi-step runs; each `SKILL.md` declares the exact
 - **Additive, not a reshape.** It slots in as one more input to the same
   selector: `loaded = CORE ∪ SKILL ∪ SEMANTIC ∪ escape-hatch`. Precedence is
   CORE > SKILL > SEMANTIC. Nothing in Parts 0–2 changes.
-- **Soft dependency.** Until #887 ships, this signal returns `[]` cleanly and the
-  loader runs on CORE + semantic exactly as in Parts 1–2 — so Parts 1–2 must not
-  assume it exists.
+- **Graceful absence is feature-detected, not import-guarded.** When no procedure
+  has been synthesized yet — the state every new user is in — the `procedures`
+  corpus is empty, so `recall_skill` returns `[]` at its `index.ntotal == 0`
+  guard and the loader runs on CORE + semantic exactly as in Parts 1–2. The
+  signal checks the *populated corpus at runtime*, never catches a missing
+  module, so the regression test exercises the real fall-through path.
 
 **Success criteria:**
 - When a skill matches the goal, its `tools_required` are loaded **ahead of**
@@ -420,6 +423,53 @@ its own successful multi-step runs; each `SKILL.md` declares the exact
 - **Graceful absence** — with #887 disabled/absent, the signal returns `[]` and
   Parts 0–2 behavior is byte-for-byte unchanged (regression test).
 - **No regression** when no skill matches the goal (falls through to semantic).
+
+#### How Part 3 shipped (implementation reference)
+
+**The loader stays memory-agnostic.** `recall_skill` and `Skill` are *not*
+imported into `tool_loader.py` (that would be an upward dependency). Instead
+`ChatAgent` — the composition layer — flattens the recalled procedures'
+`tools_required` into a `List[str]` and passes it to `select()` via a new
+keyword-only `skill_tools` param. The loader admits **plain tool names**; it
+never learns what a skill is.
+
+**Recall runs once per turn; the loader reuses the cache (zero extra TTFT
+cost).** `recall_skill` already runs once per turn in
+`MemoryMixin._refresh_recalled_skills` (before tool selection, via the
+`process_query` → `super()` ordering). Part 3 refactors that method to cache the
+matched `Skill` objects in `self._recalled_skills` alongside the rendered
+prompt; `_recalled_skill_tools()` reads that cache. So the SKILL signal adds
+**no** second embed/FAISS call — TTFT is the whole point of the loader.
+
+**Precedence is realized by admission order, not set union.** `select()` admits
+CORE first (cap-exempt), then the SKILL tools (cap-**bound**, in recall order,
+deduped, no bundle pull-in — the exact recipe), then the semantic candidates.
+Because `new_candidates` is computed after, it naturally excludes skill-admitted
+tools. A fat recipe is cap-bound like any non-CORE tool, so it can never exceed
+`max_tools`; an idle skill tool LRU-evicts next turn, and recall re-runs each
+turn so the set self-heals.
+
+**Graceful absence is feature-detected.** `_recalled_skill_tools()` returns `[]`
+whenever `self._recalled_skills` is empty — the state of every new user (empty
+`procedures` corpus → `recall_skill` `[]`). With `skill_tools` `None`/empty the
+loaded set **and** the `TOOL_LOADER` log line are byte-identical to a
+CORE+SEMANTIC build (the `skill` key is emitted only when the signal fires).
+
+**The query asymmetry is intentional.** The semantic query is *previous +
+current* user message (Part 1), but the SKILL signal derives from the **clean
+current goal** that `recall_skill` matched — skill recall matches a goal-shaped
+trigger, not a conversation window, so the prior turn would blur the match.
+
+**Where the criteria are proven.** The *mechanism* (ahead-of-semantic,
+escape-hatch avoided, graceful absence, no double recall) is proven
+deterministically in
+[`test_tool_loader_selection.py`](https://github.com/amd/gaia/blob/main/tests/unit/test_tool_loader_selection.py)
+and `test_memory_mixin.py` (pure-numpy embedder, no model/Lemonade/GPU). The
+*metric* (precision lift / no-regression) is the
+`gaia eval agent --category tool_selection` run vs the committed
+`scorecard_tool_selection.json` baseline — a cold eval runs from an empty corpus,
+so it proves Part 3 = Parts 0–2 (the no-regression criterion); the precision lift
+needs a seeded procedure matching a scenario goal.
 
 ## Open questions — resolved in Part 1
 
@@ -459,6 +509,12 @@ tool-calling models has shipped (Part 2, #1450): the loader exposes
 counters; `ChatAgent` registers the `load_tools` meta-tool and injects the
 native-only bundle menu; and `gaia.eval.tool_recall` unions mid-loop `load_tools`
 lines, drops the native exemption, and reports the escape-hatch activation rate.
+The skill-driven tier has shipped (Part 3, #1451): `select()` takes a keyword-only
+`skill_tools` list and admits it after CORE and ahead of the semantic candidates;
+`ChatAgent._select_tools_for_turn` feeds it `MemoryMixin._recalled_skill_tools()`,
+which flattens the `tools_required` of the procedures `recall_skill` matched this
+turn — reusing the per-turn recall cache, so the tier adds no extra embed/FAISS
+cost and stays byte-identical to Parts 1–2 whenever no procedure matches.
 
 ## Dependencies
 
@@ -468,7 +524,9 @@ lines, drops the native exemption, and reports the escape-hatch activation rate.
   **user-controllable** — when the user turns it off, the loader reverts to the
   legacy all-tools path (see
   [When memory is off](#when-memory-is-off-all-tools-load-the-legacy-path)).
-- **#887 (procedural memory / skills)** — *not landed.* Provides `recall_skill`
-  and `SKILL.md` `tools_required` frontmatter. The skill tier is **deferred to
-  [Part 3](#part-3-skill-driven-signal-gated-on-887)**, not in v1 (Parts 0–2);
-  it slots in additively once #887 lands and returns `[]` cleanly until then.
+- **#887 (procedural memory / skills)** — *landed* (PR #1794, refined by
+  #1818/#1828). Provides `recall_skill` and the per-procedure `tools_required`.
+  The skill tier shipped on top of it as
+  [Part 3](#part-3-skill-driven-signal-landed-1451); when the `procedures` corpus
+  is empty (every new user) `recall_skill` returns `[]`, so the loader runs on
+  CORE + semantic exactly as in Parts 0–2.

--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -347,6 +347,7 @@ class MemoryMixin(ProceduralMemoryMixin):
             self._proc_faiss_index = None
             self._proc_faiss_id_map = []
             self._recalled_skill_prompt = ""
+            self._recalled_skills = []
             self._memory_post_init_pending = False
             self._memory_session_id = str(uuid4())
             return
@@ -383,6 +384,10 @@ class MemoryMixin(ProceduralMemoryMixin):
         # the composed system prompt.  Empty string = no recall = the system
         # prompt stays byte-identical to a build without procedural memory.
         self._recalled_skill_prompt = ""
+        # The matched Skill objects from the same per-turn recall (#1451): the
+        # tool loader reads their tools_required via _recalled_skill_tools as the
+        # SKILL signal.  Empty list = no recall = no SKILL signal this turn.
+        self._recalled_skills = []
 
         # Step 2: Validate Lemonade embedding service connectivity.
         #

--- a/src/gaia/agents/base/procedural_memory.py
+++ b/src/gaia/agents/base/procedural_memory.py
@@ -323,7 +323,11 @@ class ProceduralMemoryMixin:
         try:
             skills = self.recall_skill(goal, similarity_tau=config.similarity_tau)
         except Exception as e:
-            logger.debug("[MemoryMixin] recalled-skill prompt build failed: %s", e)
+            logger.debug(
+                "[MemoryMixin] per-turn skill recall failed "
+                "(turn degrades to pre-synthesis): %s",
+                e,
+            )
             return [], config
         return skills, config
 

--- a/src/gaia/agents/base/procedural_memory.py
+++ b/src/gaia/agents/base/procedural_memory.py
@@ -15,12 +15,13 @@ resolves on a ``MemoryMixin`` host via the MRO.
 Spec: docs/plans/skill-synthesis.mdx
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
 from gaia.agents.base.skill_synthesis import (
     Skill,
+    SynthesisConfig,
     cluster_by_goal,
     distill_cluster,
     extract_sequences,
@@ -39,7 +40,7 @@ class ProceduralMemoryMixin:
     MemoryMixin host via MRO. Relies on host state/methods that
     MemoryMixin.init_memory and MemoryMixin define: self._memory_store,
     self._proc_faiss_index, self._proc_faiss_id_map, self._recalled_skill_prompt,
-    self._embed_text, self.chat, self.rebuild_system_prompt.
+    self._recalled_skills, self._embed_text, self.chat, self.rebuild_system_prompt.
     """
 
     # ==================================================================
@@ -288,26 +289,29 @@ class ProceduralMemoryMixin:
                 )
         return skills
 
-    def _build_recalled_skills_prompt(self, goal: str) -> str:
-        """Render the recalled-procedure system-prompt section for ``goal``.
+    def _recall_skills_for_turn(
+        self, goal: str
+    ) -> Tuple[List[Skill], Optional[SynthesisConfig]]:
+        """Recall the procedures matching ``goal`` once, with the resolved config.
 
-        Calls ``recall_skill`` and formats the matches into a bounded prompt
-        block.  Each body is capped at ``max_recall_body_chars`` (default 1500)
-        with an explicit ``… (truncated)`` marker; the full body always stays in
-        the ``procedures`` row.  Returns ``""`` when nothing is recalled so the
-        composed system prompt is byte-identical to a no-procedure build.
+        The single per-turn recall pass shared by both consumers:
+        ``_refresh_recalled_skills`` renders the prompt from the returned skills,
+        and ``_recalled_skill_tools`` reads them for the tool-loader SKILL signal
+        (#1451).  Recalling here once keeps that signal free — no second
+        ``recall_skill`` (embed + FAISS) call, so the loader adds zero TTFT cost.
 
-        Any failure degrades to ``""`` (boundary translation): the per-turn
-        injection is an enhancement, so a recall hiccup must never crash the
-        user's query — mirrors ``get_memory_dynamic_context``.
+        Off-states return ``([], None)`` so neither consumer fires:
+
+        * zero-cost off-state — no procedures (new user) or memory disabled
+          (``GAIA_MEMORY_DISABLED`` -> no store -> index never built) -> the
+          empty-index guard short-circuits before the per-turn
+          ``memory_settings.json`` read (mirrors ``recall_skill``);
+        * a recall hiccup (embedder down mid-turn) -> logged + ``([], config)``,
+          so the turn degrades to the pre-synthesis behavior, never crashes.
         """
-        # Zero-cost off-state: no procedures (new user) or memory disabled
-        # (GAIA_MEMORY_DISABLED -> no store -> index never built) means there is
-        # nothing to recall, so short-circuit before the per-turn settings-file
-        # read. Mirrors recall_skill's own empty-index guard.
         index = getattr(self, "_proc_faiss_index", None)
         if index is None or index.ntotal == 0:
-            return ""
+            return [], None
 
         from gaia.agents.base.memory import (
             _load_memory_settings,  # deferred (cycle break)
@@ -320,7 +324,23 @@ class ProceduralMemoryMixin:
             skills = self.recall_skill(goal, similarity_tau=config.similarity_tau)
         except Exception as e:
             logger.debug("[MemoryMixin] recalled-skill prompt build failed: %s", e)
-            return ""
+            return [], config
+        return skills, config
+
+    def _build_recalled_skills_prompt(
+        self, skills: List[Skill], config: Optional[SynthesisConfig]
+    ) -> str:
+        """Render the recalled-procedure system-prompt section from ``skills``.
+
+        Pure renderer over the already-recalled ``skills`` (and the ``config``
+        resolved alongside them by ``_recall_skills_for_turn``) — the recall and
+        the single settings read happen once upstream and feed both this prompt
+        and the loader's ``_recalled_skill_tools`` signal.  Each body is capped at
+        ``config.max_recall_body_chars`` (default 1500) with an explicit
+        ``… (truncated)`` marker; the full body always stays in the
+        ``procedures`` row.  Returns ``""`` when ``skills`` is empty, so the
+        composed system prompt is byte-identical to a no-procedure build.
+        """
         if not skills:
             return ""
 
@@ -342,6 +362,26 @@ class ProceduralMemoryMixin:
         )
         return header + "\n\n" + "\n\n".join(blocks)
 
+    def _recalled_skill_tools(self) -> List[str]:
+        """Return the recalled skills' ``tools_required``, flattened and deduped.
+
+        The tool loader's SKILL signal (#1451): the exact tools the procedure(s)
+        recalled this turn used, in recall rank then declaration order, each kept
+        once.  Reads the per-turn cache ``_refresh_recalled_skills`` populated
+        from a single ``recall_skill`` pass — no extra embed/FAISS work, so the
+        signal adds no TTFT cost.  ``[]`` on every off-state (no recall this turn,
+        memory disabled, or the cache never initialized), so the loader runs on
+        CORE + semantic exactly as in Parts 1-2.
+        """
+        tools: List[str] = []
+        seen: set[str] = set()
+        for skill in getattr(self, "_recalled_skills", []):
+            for tool in skill.tools_required:
+                if tool not in seen:
+                    seen.add(tool)
+                    tools.append(tool)
+        return tools
+
     def get_recalled_skills_system_prompt(self) -> str:
         """Contribute the recalled-procedure block to the composed system prompt.
 
@@ -353,7 +393,14 @@ class ProceduralMemoryMixin:
         return getattr(self, "_recalled_skill_prompt", "")
 
     def _refresh_recalled_skills(self, goal: str) -> None:
-        """Recompute the recalled-skill injection for ``goal``, recomposing on change.
+        """Recompute the per-turn recalled-skill state for ``goal``.
+
+        Recalls the matching procedures **once** and caches both consumers'
+        inputs: ``self._recalled_skills`` (the matched ``Skill`` objects, read by
+        the tool loader through ``_recalled_skill_tools`` — #1451) and the
+        rendered ``self._recalled_skill_prompt`` (the system-prompt block, read by
+        ``get_recalled_skills_system_prompt`` — #887).  The single recall keeps
+        the loader's SKILL signal free (no second ``recall_skill``).
 
         Mirrors ``Agent._refresh_active_tool_filter``: it swaps the cached
         injection and rebuilds the system prompt **only when the recalled set
@@ -361,7 +408,9 @@ class ProceduralMemoryMixin:
         and the backend's KV-cache prefix — untouched.  Called per turn from the
         ``process_query`` override with the clean user goal.
         """
-        new_prompt = self._build_recalled_skills_prompt(goal)
+        skills, config = self._recall_skills_for_turn(goal)
+        self._recalled_skills = skills
+        new_prompt = self._build_recalled_skills_prompt(skills, config)
         if new_prompt != getattr(self, "_recalled_skill_prompt", ""):
             self._recalled_skill_prompt = new_prompt
             # rebuild_system_prompt() recomposes via _compose_system_prompt(),

--- a/src/gaia/agents/base/tool_loader.py
+++ b/src/gaia/agents/base/tool_loader.py
@@ -9,14 +9,22 @@ prompt renderers (text and native) surface to the model.
 
 Selection model (binding — see the design sketch in #688)
 --------------------------------------------------------
-Per turn the loader computes ``CORE ∪ SEMANTIC(query)`` then pulls in whole
-bundles for any semantically-matched member, and accumulates the result into a
-session-scoped *loaded set* that only grows ("expand-on-new-match"). Because
-the loaded set is monotonic and the output is sorted, non-expansion turns
-serialize byte-identically, so the model backend's KV prefix cache stays warm.
+Per turn the loader computes ``CORE ∪ SKILL ∪ SEMANTIC(query)`` then pulls in
+whole bundles for any semantically-matched member, and accumulates the result
+into a session-scoped *loaded set* that only grows ("expand-on-new-match").
+Because the loaded set is monotonic and the output is sorted, non-expansion
+turns serialize byte-identically, so the model backend's KV prefix cache stays
+warm.
 
 * **CORE** — a small always-on set, admitted unconditionally and exempt from
   the cap and from eviction.
+* **SKILL** — the exact ``tools_required`` of any learned procedure the host
+  recalled for this goal (procedural memory, #887/#1451), passed in as plain
+  tool names via ``select(skill_tools=...)``. Admitted **after CORE, ahead of
+  semantic** (precedence ``CORE > SKILL > SEMANTIC``), cap-bound (NOT
+  cap-exempt) and with no bundle pull-in — a high-precision booster that fires
+  only for goals solved before. Empty/absent on every off-state, leaving the
+  loaded set byte-identical to a CORE+SEMANTIC build.
 * **SEMANTIC** — cosine similarity (dot product over L2-normalized embeddings)
   of the query against ``"{name}: {description}"`` for every registered tool;
   a tool matches at ``score >= threshold`` (inclusive).
@@ -100,6 +108,7 @@ class _Selection:
     scores: Dict[str, float] = field(default_factory=dict)
     matched: List[str] = field(default_factory=list)
     bundle_pulled: List[str] = field(default_factory=list)
+    skill: List[str] = field(default_factory=list)
     admitted: List[str] = field(default_factory=list)
     evicted: List[str] = field(default_factory=list)
     skipped_at_cap: List[str] = field(default_factory=list)
@@ -196,11 +205,31 @@ class ToolLoader:
                 "the name — selection must account for every registered tool."
             )
 
-    def select(self, query: str, registry: Dict[str, dict]) -> Optional[List[str]]:
+    def select(
+        self,
+        query: str,
+        registry: Dict[str, dict],
+        *,
+        skill_tools: Optional[Sequence[str]] = None,
+    ) -> Optional[List[str]]:
         """Return the sorted loaded set for this turn, or ``None`` if disabled.
 
         ``None`` is the fail-safe signal: the session is disabled (embedder
         down) and the caller must render the full registry / legacy prompt.
+
+        Args:
+            query: The selection query (previous + current user message).
+            registry: The live tool registry (source of truth for execution).
+            skill_tools: The SKILL signal — exact tool names from a learned
+                procedure the host recalled for this goal (#1451), in recall
+                order. Plain strings (the loader never imports memory). Admitted
+                after CORE and **ahead of** the semantic candidates (precedence
+                ``CORE > SKILL > SEMANTIC``), cap-bound and with no bundle
+                pull-in. ``None`` / empty is the graceful-absence path: the
+                loaded set and the ``TOOL_LOADER`` log are byte-identical to a
+                CORE+SEMANTIC build (no ``skill`` key emitted). Names absent from
+                *registry* are dropped (mirrors bundle-absent handling), not
+                raised.
         """
         if self._session_disabled:
             return None
@@ -253,13 +282,43 @@ class ToolLoader:
                     candidate_scores.get(member, 0.0), new_score
                 )
 
-        # Step 5: admission. CORE first (unconditional, cap-exempt). Then new
+        # Step 5: admission. CORE first (unconditional, cap-exempt). Then SKILL
+        # (the recalled recipe, cap-bound, ahead of semantic), then new
         # candidates by (descending score, ascending name).
         admitted_this_turn: set[str] = set()
         for name in sorted(self._core):
             if name in registry and name not in self._loaded:
                 self._admit(name, sel)
                 admitted_this_turn.add(name)
+
+        # SKILL tier: admit the recalled recipe's tools in recall order, deduped,
+        # before any semantic candidate — SKILL > SEMANTIC by admission order.
+        # Cap-bound (mirrors the semantic loop): under cap admit, at cap LRU-evict
+        # a non-CORE/non-this-turn tool or skip. No bundle pull-in (exact recipe).
+        # Self-heals each turn: recall re-runs, so an idle recipe tool LRU-evicts.
+        seen_skill: set[str] = set()
+        for name in skill_tools or ():
+            if (
+                name in self._core
+                or name in self._loaded
+                or name not in registry
+                or name in seen_skill
+            ):
+                continue
+            seen_skill.add(name)
+            sel.skill.append(name)
+            if len(self._loaded) < self._max_tools:
+                self._admit(name, sel)
+                admitted_this_turn.add(name)
+                continue
+            victim = self._pick_eviction_victim(admitted_this_turn)
+            if victim is None:
+                sel.skipped_at_cap.append(name)
+                continue
+            del self._loaded[victim]
+            sel.evicted.append(victim)
+            self._admit(name, sel)
+            admitted_this_turn.add(name)
 
         new_candidates = [
             n
@@ -496,24 +555,24 @@ class ToolLoader:
         self, query: str, sel: _Selection, loaded_sorted: List[str]
     ) -> None:
         """Emit one structured ``TOOL_LOADER`` INFO line (Part-2 tuning data)."""
-        logger.info(
-            "TOOL_LOADER %s",
-            json.dumps(
-                {
-                    "turn": self._turn,
-                    "query_sha": _sha256(query)[:12],
-                    "threshold": self._threshold,
-                    "max_tools": self._max_tools,
-                    "scores": {k: round(v, 4) for k, v in sel.scores.items()},
-                    "matched": sorted(sel.matched),
-                    "bundle_pulled": sorted(sel.bundle_pulled),
-                    "admitted": sorted(sel.admitted),
-                    "evicted": sorted(sel.evicted),
-                    "skipped_at_cap": sorted(sel.skipped_at_cap),
-                    "loaded": loaded_sorted,
-                }
-            ),
-        )
+        payload = {
+            "turn": self._turn,
+            "query_sha": _sha256(query)[:12],
+            "threshold": self._threshold,
+            "max_tools": self._max_tools,
+            "scores": {k: round(v, 4) for k, v in sel.scores.items()},
+            "matched": sorted(sel.matched),
+            "bundle_pulled": sorted(sel.bundle_pulled),
+            "admitted": sorted(sel.admitted),
+            "evicted": sorted(sel.evicted),
+            "skipped_at_cap": sorted(sel.skipped_at_cap),
+            "loaded": loaded_sorted,
+        }
+        # SKILL key only when the signal fired this turn — keeps the off-state
+        # (no recall) log bytes byte-identical to Parts 0-2 (#1451).
+        if sel.skill:
+            payload["skill"] = sorted(sel.skill)
+        logger.info("TOOL_LOADER %s", json.dumps(payload))
 
     def _log_session_summary(self) -> None:
         """Emit one ``TOOL_LOADER_SESSION`` INFO line — the τ-tuning signal.

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -517,7 +517,19 @@ class ChatAgent(
         )
 
     def _select_tools_for_turn(self, user_input: str) -> Optional[List[str]]:
-        """Return this turn's sorted tool subset, or ``None`` for the full registry."""
+        """Return this turn's sorted tool subset, or ``None`` for the full registry.
+
+        The SKILL signal (#1451) and the semantic query use deliberately
+        different inputs: ``skill_tools`` derives from the **clean current goal**
+        (``_refresh_recalled_skills`` ran recall on ``user_input`` alone, before
+        this hook), while the semantic ``query`` is previous + current. The
+        asymmetry is intentional — skill recall matches a goal-shaped trigger,
+        not a conversation window, so feeding it the prior turn would blur the
+        match; semantic selection wants the prior turn for context like
+        "summarize it". ``_recalled_skill_tools`` is ``[]`` on every off-state
+        (no recall / memory disabled), so the loader runs on CORE + semantic
+        exactly as in Parts 1-2.
+        """
         if not self._dynamic_tools_active():
             return None
         if not self._dynamic_tools_validated:
@@ -526,7 +538,9 @@ class ChatAgent(
             self.tool_loader.validate_registry(self._tools_registry)
             self._dynamic_tools_validated = True
         query = self._build_tool_selection_query(user_input)
-        return self.tool_loader.select(query, self._tools_registry)
+        return self.tool_loader.select(
+            query, self._tools_registry, skill_tools=self._recalled_skill_tools()
+        )
 
     def _on_tool_invoked(self, tool_name: str) -> None:
         """Record tool-use recency for the loader's LRU (no-op when inactive)."""

--- a/tests/unit/test_chat_dynamic_tools.py
+++ b/tests/unit/test_chat_dynamic_tools.py
@@ -156,6 +156,70 @@ def test_active_state_delegates_to_loader_select():
     loader.select.assert_called_once()
 
 
+# ── SKILL signal wiring (Part 3, #1451) ───────────────────────────────────
+
+
+def _skill(name: str, tools: list[str]):
+    """A minimal recalled Skill carrying ``tools_required``."""
+    from gaia.agents.base.skill_synthesis import Skill
+
+    return Skill(name=name, when_to_use="trigger", body="# body", tools_required=tools)
+
+
+def test_recalled_skill_tools_flattens_and_dedupes_in_order():
+    """tools_required flatten in recall rank then declaration order, deduped."""
+    a = _bare_agent(
+        _recalled_skills=[
+            _skill("s1", ["read_file", "query_documents"]),
+            _skill("s2", ["query_documents", "summarize"]),  # dup dropped
+        ]
+    )
+    assert a._recalled_skill_tools() == ["read_file", "query_documents", "summarize"]
+
+
+def test_recalled_skill_tools_empty_on_graceful_absence():
+    """No recall (attr unset or empty list) → no SKILL signal at the agent layer."""
+    assert _bare_agent()._recalled_skill_tools() == []  # attr never set
+    assert _bare_agent(_recalled_skills=[])._recalled_skill_tools() == []
+
+
+def test_select_passes_skill_tools_kwarg_to_loader():
+    """_select_tools_for_turn hands loader.select the flattened skill_tools kwarg.
+
+    Contract-shape assert at the ChatAgent→loader boundary: the kwarg is present,
+    a list[str], and the flattened+deduped recipe — not merely "select was
+    called".
+    """
+    loader = MagicMock()
+    loader.session_disabled = False
+    loader.select.return_value = ["c1"]
+    a = _bare_agent(
+        tool_loader=loader,
+        _recalled_skills=[_skill("s1", ["read_file", "query_documents"])],
+    )
+    with patch.object(
+        ChatAgent, "_tools_registry", new_callable=lambda: property(lambda self: {})
+    ):
+        a._select_tools_for_turn("read the report")
+    _, kwargs = loader.select.call_args
+    assert kwargs["skill_tools"] == ["read_file", "query_documents"]
+    assert isinstance(kwargs["skill_tools"], list)
+
+
+def test_select_skill_tools_empty_kwarg_on_graceful_absence():
+    """With no recalled skills, select still gets skill_tools=[] (graceful absence)."""
+    loader = MagicMock()
+    loader.session_disabled = False
+    loader.select.return_value = ["c1"]
+    a = _bare_agent(tool_loader=loader)  # no _recalled_skills set
+    with patch.object(
+        ChatAgent, "_tools_registry", new_callable=lambda: property(lambda self: {})
+    ):
+        a._select_tools_for_turn("anything")
+    _, kwargs = loader.select.call_args
+    assert kwargs["skill_tools"] == []
+
+
 # ── selection query builder ───────────────────────────────────────────────
 
 

--- a/tests/unit/test_memory_mixin.py
+++ b/tests/unit/test_memory_mixin.py
@@ -3605,54 +3605,116 @@ class TestRecallSkill:
         ] == ["proc-tau"]
 
 
+def _recalled_skill(name, body, when_to_use="trigger", tools_required=None):
+    """A Skill object as recall_skill would return it (for the pure renderer)."""
+    from gaia.agents.base.skill_synthesis import Skill
+
+    return Skill(
+        name=name,
+        when_to_use=when_to_use,
+        body=body,
+        tools_required=tools_required if tools_required is not None else [],
+    )
+
+
 class TestRecalledSkillPromptBuilder:
-    """MemoryMixin._build_recalled_skills_prompt — bounded injection rendering."""
+    """MemoryMixin._build_recalled_skills_prompt — bounded injection rendering.
 
-    def test_no_recall_returns_empty_string(self, mixin_host):
-        """No match → empty injection so the system prompt stays byte-identical."""
-        pytest.importorskip("faiss")
-        assert mixin_host._build_recalled_skills_prompt("goal") == ""
+    The renderer is pure over the already-recalled skills (#1451): the recall and
+    the single settings read happen once upstream in _recall_skills_for_turn (see
+    TestRecallOnceProcedureCache), feeding both this prompt and the loader's
+    _recalled_skill_tools signal. These tests pin the rendering byte-for-byte.
+    """
 
-    def test_off_state_skips_settings_file_read(self, mixin_host):
-        """Empty procedures index → no per-turn memory_settings.json read.
+    @staticmethod
+    def _config():
+        from gaia.agents.base.skill_synthesis import load_synthesis_config
 
-        The zero-procedure / GAIA_MEMORY_DISABLED case must stay zero-cost: the
-        guard short-circuits before load_synthesis_config(_load_memory_settings()).
-        """
-        pytest.importorskip("faiss")
-        with patch("gaia.agents.base.memory._load_memory_settings") as mock_settings:
-            assert mixin_host._build_recalled_skills_prompt("goal") == ""
-        mock_settings.assert_not_called()
+        return load_synthesis_config()
+
+    def test_no_skills_returns_empty_string(self, mixin_host):
+        """Empty recall → empty injection so the system prompt stays byte-identical."""
+        assert mixin_host._build_recalled_skills_prompt([], None) == ""
 
     def test_short_body_kept_intact(self, mixin_host):
         """A body under the cap is injected verbatim, no truncation marker."""
-        pytest.importorskip("faiss")
         body = "# Short\n1. step\n## Edge cases\n- e"
-        _seed_procedure(mixin_host, name="short-proc", body=body)
 
-        prompt = mixin_host._build_recalled_skills_prompt("goal")
+        prompt = mixin_host._build_recalled_skills_prompt(
+            [_recalled_skill("short-proc", body)], self._config()
+        )
 
         assert "RECALLED PROCEDURES" in prompt
         assert "short-proc" in prompt
         assert body in prompt
         assert "(truncated)" not in prompt
 
-    def test_long_body_truncated_at_cap_full_body_retained(self, mixin_host):
-        """A body over the cap is truncated at injection; the row keeps it whole."""
-        pytest.importorskip("faiss")
+    def test_long_body_truncated_at_cap(self, mixin_host):
+        """A body over the cap is truncated at injection (the row keeps it whole)."""
         from gaia.agents.base.skill_synthesis import MAX_RECALL_BODY_CHARS
 
         long_body = "# Big\n" + ("x" * 5000) + "\n## Edge cases\n- e"
-        _seed_procedure(mixin_host, name="big-proc", body=long_body)
 
-        prompt = mixin_host._build_recalled_skills_prompt("goal")
+        prompt = mixin_host._build_recalled_skills_prompt(
+            [_recalled_skill("big-proc", long_body)], self._config()
+        )
 
         assert "… (truncated)" in prompt
         # The injected body carries at most MAX_RECALL_BODY_CHARS of the content.
         assert prompt.count("x") <= MAX_RECALL_BODY_CHARS
-        # The FULL body is retained in the procedures row, untouched.
-        rows = mixin_host._memory_store.search_skills(name="big-proc")
-        assert rows[0]["markdown_body"] == long_body
+
+
+class TestRecallOnceProcedureCache:
+    """_refresh_recalled_skills recalls once and caches both consumers (#1451).
+
+    The tool-loader SKILL signal reuses the per-turn recall cache rather than
+    issuing a second recall_skill (embed + FAISS) call — that reuse is what keeps
+    Part 3 free on TTFT, so it is guarded here.
+    """
+
+    def test_refresh_caches_recalled_skills_for_the_loader(self, mixin_host):
+        """The matched Skill objects are cached, and their tools flatten+dedupe."""
+        pytest.importorskip("faiss")
+        _seed_procedure(
+            mixin_host,
+            name="triage-proc",
+            body="# B\n1. s\n## Edge cases\n- e",
+            tools_required=["query_documents", "read_file"],
+        )
+
+        mixin_host._refresh_recalled_skills("triage this ticket")
+
+        assert [s.name for s in mixin_host._recalled_skills] == ["triage-proc"]
+        assert mixin_host._recalled_skill_tools() == ["query_documents", "read_file"]
+
+    def test_recall_runs_once_for_both_consumers(self, mixin_host):
+        """recall_skill fires exactly once per turn; both consumers read the cache."""
+        pytest.importorskip("faiss")
+        _seed_procedure(mixin_host, name="proc-x", tools_required=["read_file"])
+
+        with patch.object(
+            mixin_host, "recall_skill", wraps=mixin_host.recall_skill
+        ) as spy:
+            mixin_host._refresh_recalled_skills("a goal")
+        assert spy.call_count == 1
+
+        # Both consumers now read the cached result — no second recall.
+        assert mixin_host._recalled_skill_tools() == ["read_file"]
+        assert mixin_host.get_recalled_skills_system_prompt()  # non-empty
+        assert spy.call_count == 1
+
+    def test_off_state_caches_empty_and_skips_settings_read(self, mixin_host):
+        """Empty index → no settings read, empty caches (the zero-cost off-state)."""
+        pytest.importorskip("faiss")
+        assert mixin_host._proc_faiss_index.ntotal == 0
+
+        with patch("gaia.agents.base.memory._load_memory_settings") as mock_settings:
+            mixin_host._refresh_recalled_skills("any goal")
+
+        mock_settings.assert_not_called()
+        assert mixin_host._recalled_skills == []
+        assert mixin_host._recalled_skill_tools() == []
+        assert mixin_host._recalled_skill_prompt == ""
 
 
 class _ComposingAgent(FakeAgent):

--- a/tests/unit/test_tool_loader_selection.py
+++ b/tests/unit/test_tool_loader_selection.py
@@ -255,6 +255,117 @@ def test_record_tool_use_logs_escape_hatch_for_unloaded():
     assert any("TOOL_LOADER_ESCAPE_HATCH" in r.getMessage() for r in records)
 
 
+# ── SKILL tier (Part 3, #1451) ─────────────────────────────────────────────
+
+
+def test_skill_tool_admitted_ahead_of_semantic_at_cap():
+    """At cap, a SKILL tool wins the last slot over a higher-scored semantic tool.
+
+    One free slot, two candidates: the recalled recipe's ``x`` (no semantic
+    match) and ``hi`` (semantic 0.9). SKILL is admitted before semantic, so ``x``
+    takes the slot and the higher-scored ``hi`` is skipped — the precise
+    realization of "ahead of semantic" (precedence CORE > SKILL > SEMANTIC).
+    """
+    tools = ["x", "hi"]
+    embed = _make_embed_fn(tools, {"q": {"x": 0.0, "hi": 0.9}})
+    loader = ToolLoader(frozenset(), [], embed, threshold=0.55, max_tools=1)
+    with _capture("gaia.agents.base.tool_loader") as records:
+        loaded = loader.select("q", _registry(tools), skill_tools=["x"])
+    assert loaded == ["x"]  # SKILL took the only slot
+    payload = _selection_payload(records)
+    assert payload["skill"] == ["x"]
+    assert "hi" in payload["skipped_at_cap"]  # higher-scored semantic, skipped
+
+
+def test_skill_tool_avoids_escape_hatch_activation():
+    """Pre-loading the recipe's tool keeps the escape-hatch counter at 0.
+
+    ``needed`` has no semantic match, so without the SKILL signal it would be
+    absent and executing it would log the escape hatch. The recalled recipe
+    pre-loads it, so the same execution is a normal recency update.
+    """
+    tools = ["needed"]
+    embed = _make_embed_fn(tools, {"q": {"needed": 0.0}})
+
+    # Control: no skill signal → tool absent → execution escape-hatches.
+    control = ToolLoader(frozenset(), [], embed, threshold=0.55, max_tools=14)
+    assert control.select("q", _registry(tools)) == []
+    control.record_tool_use("needed")
+    assert control._escape_hatch_count == 1
+
+    # SKILL signal pre-loads it → execution is a plain recency update.
+    loader = ToolLoader(frozenset(), [], embed, threshold=0.55, max_tools=14)
+    assert loader.select("q", _registry(tools), skill_tools=["needed"]) == ["needed"]
+    loader.record_tool_use("needed")
+    assert loader._escape_hatch_count == 0
+
+
+def test_skill_signal_absent_is_byte_identical():
+    """``skill_tools`` None / [] / omitted give the same loaded set and log bytes.
+
+    Graceful absence: the SKILL signal off must be byte-for-byte Parts 0-2 — same
+    loaded set, same ``TOOL_LOADER`` payload, and no ``skill`` key.
+    """
+    tools = ["c1", "d1"]
+    scores = {"q": {"c1": 0.0, "d1": 0.7}}
+
+    def _run(**kwargs):
+        embed = _make_embed_fn(tools, scores)
+        loader = ToolLoader(frozenset({"c1"}), [], embed, threshold=0.55, max_tools=14)
+        with _capture("gaia.agents.base.tool_loader") as records:
+            loaded = loader.select("q", _registry(tools), **kwargs)
+        return loaded, _selection_payload(records)
+
+    base_loaded, base_payload = _run()
+    none_loaded, none_payload = _run(skill_tools=None)
+    empty_loaded, empty_payload = _run(skill_tools=[])
+
+    assert base_loaded == none_loaded == empty_loaded == ["c1", "d1"]
+    assert base_payload == none_payload == empty_payload
+    assert "skill" not in base_payload
+
+
+def test_skill_tool_not_in_registry_is_dropped():
+    """A recalled tool absent from the registry is dropped, not raised."""
+    tools = ["d1"]
+    embed = _make_embed_fn(tools, {"q": {"d1": 0.7}})
+    loader = ToolLoader(frozenset(), [], embed, threshold=0.55, max_tools=14)
+    with _capture("gaia.agents.base.tool_loader") as records:
+        loaded = loader.select("q", _registry(tools), skill_tools=["ghost"])
+    assert "ghost" not in loaded
+    assert loaded == ["d1"]  # semantic match still loads
+    assert "skill" not in _selection_payload(records)  # ghost dropped, nothing fired
+
+
+def test_skill_tool_in_core_is_noop():
+    """A recalled tool already in CORE is not double-admitted nor SKILL-logged."""
+    tools = ["c1", "d1"]
+    embed = _make_embed_fn(tools, {"q": {"c1": 0.0, "d1": 0.0}})
+    loader = ToolLoader(frozenset({"c1"}), [], embed, threshold=0.55, max_tools=14)
+    with _capture("gaia.agents.base.tool_loader") as records:
+        loaded = loader.select("q", _registry(tools), skill_tools=["c1"])
+    assert loaded == ["c1"]
+    payload = _selection_payload(records)
+    assert payload["admitted"] == ["c1"]  # admitted once, by CORE
+    assert "skill" not in payload  # CORE already covered it; SKILL did not fire
+
+
+def test_skill_log_key_present_only_when_skill_fires():
+    """The ``skill`` log key appears only on a turn the SKILL signal contributes."""
+    tools = ["x"]
+    embed = _make_embed_fn(tools, {"q": {"x": 0.0}})
+    loader = ToolLoader(frozenset(), [], embed, threshold=0.55, max_tools=14)
+
+    with _capture("gaia.agents.base.tool_loader") as fired:
+        loader.select("q", _registry(tools), skill_tools=["x"])
+    assert _selection_payload(fired)["skill"] == ["x"]
+
+    # A later turn with no recall must not carry the key (x already loaded).
+    with _capture("gaia.agents.base.tool_loader") as quiet:
+        loader.select("q", _registry(tools), skill_tools=[])
+    assert "skill" not in _selection_payload(quiet)
+
+
 # ── load_bundle / menu / counters (Part 2, #1450) ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

Agents that had already learned a procedure for a task still re-discovered the tools for it every time: on the `doc` profile's dynamic loader, a repeat goal was served by the same similarity guess as a first-time goal, so the recipe's tools often weren't loaded up front and the run paid an escape-hatch round-trip to fetch them. This PR adds the **SKILL** selection signal — when a goal matches a stored skill (a procedure the agent distilled from its own successful runs, #887), that skill's exact `tools_required` now load **ahead of** the semantic results. The result: for goals solved before, the right tools are present on turn one (fewer escape-hatch activations, fewer wasted tool steps); for every other goal — and for any user who hasn't synthesized a skill yet — behaviour is byte-for-byte identical to Parts 0–2.

## Why

The dynamic tool loader (#688) trims the per-turn tool prompt to cut first-turn TTFT on local inference. Parts 0–2 selected on `CORE ∪ SEMANTIC ∪ escape-hatch` — purely similarity-based, with no memory of what actually worked last time. SKILL is the high-precision tier the spec always reserved a slot for: it fires only for goals solved before, but when it fires the tools come from a recorded successful run rather than a similarity guess, so it raises precision without touching the cold-start path.

## Linked issue

Closes #1451

## Changes

- **SKILL admission tier in the loader** (`tool_loader.py`): a new keyword-only `select(skill_tools=...)` admits recalled-recipe tools **after CORE, before any semantic candidate**, realising precedence `CORE > SKILL > SEMANTIC` by admission order. Cap-bound (respects `max_tools`, not cap-exempt) with the same LRU eviction as the semantic loop; **no bundle pull-in** (exact recipe = high precision).
- **Zero added TTFT cost**: the per-turn skill recall already runs once before tool selection, so the loader **reuses that cached result** instead of recalling — no second embed/FAISS pass. `procedural_memory.py` was refactored to recall once and serve both consumers (prompt rendering + the new `_recalled_skill_tools()` flatten/dedupe accessor).
- **Loader stays memory-agnostic**: it receives plain `List[str]`; `ChatAgent` does the `Skill.tools_required → List[str]` flatten and passes it in — no upward import of memory/`Skill` into `agents/base/`.
- **Graceful absence is feature-detected**: an empty `procedures` corpus short-circuits to `[]` (runtime `index.ntotal == 0` check), so the off-state is byte-identical and the `skill` log key is emitted only on turns the signal fires.
- **Docs**: `docs/plans/tool-loader.mdx` Part 3 flipped from proposed → landed (already registered in `docs.json`; no nav change).

## Deviations from the approved plan

Flagging every row from the plan's deviations table:

1. **#887 is no longer a future gate — it landed (PR #1794).** "Graceful absence" is therefore met by a **feature-detected empty `procedures` corpus**, not the import/module guard the original sketch implied — exactly the maintainer's amendment in [comment 4625281488](https://github.com/amd/gaia/issues/1451#issuecomment-4625281488). The regression test exercises the real new-user fall-through path.
2. **The loader does *not* call `recall_skill` itself** (Example D pseudocode showed it doing so). That would be an upward dependency, and recall already runs per turn. Instead `ChatAgent` flattens the cached recall result into `skill_tools=`. Net effect: loader stays a leaf, and Part 3 adds **zero** extra embed/FAISS work per turn.
3. **"Union ahead of semantic" is realised by admission order, not set algebra.** The loader admits into a cap-bounded set with LRU eviction, so SKILL is admitted after CORE and before `new_candidates`, cap-bound (not cap-exempt) — the precise realisation of "ahead of semantic" that preserves the `max_tools` invariant.
4. **The precision-lift "baseline home" is split** (the open bot question): the *mechanism* (ahead-of-semantic, escape-hatch avoided, graceful absence) is proven **deterministically** in `test_tool_loader_selection.py`; the *no-regression metric* is the `gaia eval agent --category tool_selection` run vs the committed `scorecard_tool_selection.json`. A cold eval runs on an empty corpus, so it proves no-regression — the lift itself is shown by the committed fixture (`test_recalled_recipe_cuts_tool_steps_vs_baseline`).

## Test plan

- [x] **Skill mechanism + regression unit tests** (no backend needed; pure-numpy embedder):
  ```bash
  python -m pytest tests/unit/test_tool_loader_selection.py \
    tests/unit/test_chat_dynamic_tools.py tests/unit/test_memory_mixin.py -q
  ```
  → green, including the 42 skill-specific tests.
- [x] **No regression introduced** — any failures in the full suite are pre-existing on `main`:
  ```bash
  python -m pytest tests/unit/ -q
  ```
  → on this branch: `5375 passed, 81 skipped, 8 failed`; the 8 reproduce identically at merge-base `f7163242` (routing-model drift, `gaia` console-script on PATH, installer tests vs a running Lemonade, memory-router 503) — none touch the files this PR changes.
- [x] **Lint**: `python util/lint.py --all` → clean.
- [x] **tool_selection eval** (LLM-affecting → eval-gated; **serial**, one `gaia eval agent` at a time):
  ```bash
  # backend on :4200 + Lemonade running; confirm nothing else is evaluating:
  ps aux | grep "gaia eval" | grep -v grep | wc -l       # must print 0
  gaia eval agent --category tool_selection --agent-type doc
  gaia eval agent --compare \
    tests/fixtures/eval_baselines/gemma-4-e4b-d71cd914/scorecard_tool_selection.json \
    eval/results/<run-id>/scorecard.json
  ```
  → pass rate flat, no status regressions (cold corpus ⇒ proves Part 3 == Parts 0–2).

## Part 3 (#1451) — Success-criteria proof

All 4 success criteria met. Each maps to the exact code, a committed test (all green), and — where eval-gated — a live run.

| # | Criterion | Status | Primary proof |
|---|-----------|:------:|---------------|
| 1 | Skill `tools_required` load **ahead of** semantic | ✅ | `tool_loader.py:285-311` SKILL tier + `test_skill_tool_admitted_ahead_of_semantic_at_cap` |
| 2 | **Measurable precision lift** with a matching skill | ✅ | `test_recalled_recipe_cuts_tool_steps_vs_baseline` (5→3 steps) + escape-hatch 1→0 |
| 3 | **Graceful absence** → `[]`, behaviour unchanged | ✅ | `ntotal==0` feature-detect (`procedural_memory.py:312-314`) + byte-identical tests |
| 4 | **No regression** when no skill matches | ✅ | byte-identical tests + live `tool_selection` eval (75%→75%) |

**1 — ahead of semantic.** Admission order in `tool_loader.py:285-311` realises `CORE > SKILL > SEMANTIC`; surface is keyword-only `select(skill_tools=...)`. `test_skill_tool_admitted_ahead_of_semantic_at_cap` (`test_tool_loader_selection.py:261`): one free slot, recipe tool `x` takes it over a higher-scored semantic `hi` (0.9), which lands in `skipped_at_cap`. Wiring asserted by `test_select_passes_skill_tools_kwarg_to_loader` (`test_chat_dynamic_tools.py:186`).

**2 — measurable precision lift.** Two committed, deterministic homes: `test_recalled_recipe_cuts_tool_steps_vs_baseline` (`test_memory_mixin.py:3926`) — a surrogate planner probes **5** tools without the recipe vs executes exactly the **3** `needed` with it (`len(recall)=3 < len(baseline)=5`, `recall == needed`); and `test_skill_tool_avoids_escape_hatch_activation` (`test_tool_loader_selection.py:280`) — escape-hatch counter **1 → 0** when the signal pre-loads the tool.

**3 — graceful absence (feature-detected, the maintainer's amendment).** `procedural_memory.py:312-314` short-circuits on `index is None or index.ntotal == 0` (runtime corpus check, before any settings read — not an import guard). `test_off_state_caches_empty_and_skips_settings_read` (`test_memory_mixin.py:3706`) proves the real fall-through (settings read skipped, caches empty); `test_off_state_prompt_is_byte_identical` and `test_skill_signal_absent_is_byte_identical` (`test_tool_loader_selection.py:303`) prove `None`/`[]`/omitted give the same loaded set, same `TOOL_LOADER` payload, no `skill` key.

**4 — no regression on fall-through.** `test_skill_tool_not_in_registry_is_dropped` (unknown recalled tool dropped, semantic still loads), `test_skill_tool_in_core_is_noop` (CORE covers it once), `test_skill_log_key_present_only_when_skill_fires`. Live eval `gaia eval agent --category tool_selection --agent-type doc` (Gemma-4-E4B) vs committed baseline:

```
METRIC                 BASELINE   CURRENT    DELTA
Pass rate (all)           75%       75%       +0%
Avg score                 8.4       8.8      +0.5
[OK] No status changes between runs.
```

| Scenario | Baseline | This run (`eval-20260623-215021`) |
|----------|----------|-----------|
| known_path_read | FAIL 6.67 | PASS 9.4 |
| multi_step_plan | PASS 7.35 | FAIL 7.6 |
| no_tools_needed | PASS 9.98 | PASS 10.0 |
| smart_discovery | PASS 9.45 | PASS 9.9 |

Pass rate flat, avg +0.5, **no net status changes** (the two flips are at the threshold with near-identical raw scores — normal judge/LLM variance). `--compare` exits non-zero only on a wall-clock time flag, which is environmental (generic FAISS build, no AVX2/AVX-512; local Gemma-4-E4B ~13 tok/s) — a per-turn signal that no-ops on the cold path cannot double inference time. The committed baseline was **not** regenerated (quality is flat — nothing to bless).

> Scope note: the live eval runs on an empty procedure corpus (cold start), so it proves *no-regression*; *precision lift* is carried by the committed fixtures, which seed a known matching skill.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #1451`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have updated documentation (`docs/plans/tool-loader.mdx` Part 3 → landed).
