### PR TITLE
release(agent-email): 0.2.1

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,23 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## 0.2.1
+
+Documentation/packaging release — no client API or wire-contract change
+(`SCHEMA_VERSION` stays `2.0`). Republishes so the live hub catalog picks up the
+current README.
+
+### Changed
+
+- **This README is now the single canonical agent README** (hub + npm). The
+  release workflow publishes it to both, so the hub page and the npm listing no
+  longer drift — the architecture diagram and the GAIA/npm install flow show up on
+  `hub.amd-gaia.ai/hub/email`.
+- **Architecture diagram loads from an in-repo raw image** instead of a
+  version-pinned hub URL that the publish pipeline didn't populate, so it renders on
+  GitHub and npm before the binaries are uploaded.
+- **Agent version is shown on the hub cards** (listing + featured + detail).
+
 ## 0.2.0
 
 ### Changed (breaking)

--- a/hub/agents/npm/agent-email/assets/architecture.html
+++ b/hub/agents/npm/agent-email/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.2.0</span>
+      <span class="ver" id="ver">v0.2.1</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.2.0",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.0",
+  "agentVersion": "0.2.1",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.1",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/package-lock.json
+++ b/hub/agents/npm/agent-email/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-email",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "bin": {
         "agent-email": "dist/cli.js"

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/python/email/README.md
+++ b/hub/agents/python/email/README.md
@@ -91,7 +91,7 @@ connector store, so a mailbox connected anywhere (Agent UI, CLI) is usable here
 too — and vice-versa. These connector routes are excluded from the OpenAPI
 contract: a playground convenience, not part of the frozen email REST contract.
 
-![GAIA Email Agent playground — stack health, live triage/draft, and a readiness check, all running against the local sidecar](https://hub.amd-gaia.ai/agents/email/0.2.0/playground.webp)
+![GAIA Email Agent playground — stack health, live triage/draft, and a readiness check, all running against the local sidecar](https://hub.amd-gaia.ai/agents/email/0.2.1/playground.webp)
 
 It's served same-origin with a `Content-Security-Policy: connect-src 'self'`
 header, so the page can only ever reach your local sidecar — email content never

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.2.0
+version: 0.2.1
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.2.0"
+AGENT_VERSION = "0.2.1"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.2.0"
+version = "0.2.1"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }


### PR DESCRIPTION
## Why this matters

The live hub page at `hub.amd-gaia.ai/hub/email` is still showing the **0.2.0** catalog — which snapshots the *old python README* with no architecture diagram and no npm install flow. #1836 (single canonical npm README + version-on-cards) and #1833 (in-repo raw architecture image) already merged, but the catalog only refreshes its README snapshot **on a new publish**. This patch cuts that publish.

No client API or wire-contract change — `SCHEMA_VERSION` stays **2.0**. This is a docs/packaging republish so the hub catalog picks up the current README (diagram + GAIA/npm install flow + version badge).

The version triple the release gate validates (tag == npm `package.json` == `gaia-agent.yaml`) is all **0.2.1**, synced from `version.py` (the source of truth) via `stamp_version.py`.

## Test plan

- [x] `stamp_version.py --check` → all targets match `AGENT_VERSION` 0.2.1 (npm README architecture image correctly SKIPs — it uses the raw-GitHub URL post-#1833)
- [x] npm pre-flight in `hub/agents/npm/agent-email/`: `npm ci && npm run build && npm test` → 32 passed; `npm pack --dry-run` ships README (16.2kB) + CHANGELOG
- [x] `test_stamp_version.py` → 10 passed
- [ ] After merge: tag `agent-pkg-email-v0.2.1` from main → freeze → approve `agent-publish` gate → publish republishes the catalog; confirm `/hub/email` shows the diagram + npm flow + `v0.2.1`