### PR TITLE
feat(agent-email): auto-reap sidecar on parent exit/crash (no manual wiring)

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,19 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## [Unreleased]
+
+### Added
+
+- **Automatic sidecar cleanup (`autoCleanup`, default on).** `startSidecar` /
+  `spawnSidecar` now reap the frozen sidecar's detached process tree when the host
+  process exits, crashes (`uncaughtException` / `unhandledRejection`), or is
+  interrupted (`SIGINT` / `SIGTERM` / `SIGHUP`) — so a skipped or missed
+  `shutdown()` no longer leaves the binary running and holding its port. Pass
+  `autoCleanup: false` to manage the lifecycle yourself; `shutdown()` stays the
+  graceful, awaited path. A hard `SIGKILL` of the host process is the one case no
+  in-process handler can catch.
+
 ## 0.2.1
 
 Documentation/packaging release — no client API or wire-contract change

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -184,15 +184,24 @@ This is a long-lived local resource, not a per-request one. Wire it like this:
   `DEBUG=agent-email` to see the bind error.
 - **Supervise it yourself.** The package does not restart a crashed sidecar. If you
   need resilience, watch `sidecar.child` for `exit` and re-`startSidecar`.
-- **Shut it down on exit.** Wire `shutdown` into your termination path so the
-  frozen binary's child process is always reaped:
+- **Shut it down on exit — including on a crash.** Wire `shutdown` into your
+  termination path so the frozen binary's detached child is always reaped. Cover
+  a hard crash (`uncaughtException` / `unhandledRejection`), not just the
+  termination signals — an uncaught throw otherwise leaves the sidecar running
+  and holding its port:
 
 ```ts
 const sidecar = await startSidecar({ binaryPath, port: 8131 });
-for (const sig of ["SIGTERM", "SIGINT"]) {
-  process.once(sig, () => shutdown(sidecar).finally(() => process.exit(0)));
-}
+
+const reap = (code = 0) => shutdown(sidecar).finally(() => process.exit(code));
+for (const sig of ["SIGTERM", "SIGINT"]) process.once(sig, () => reap(0));
+process.once("uncaughtException", (err) => { console.error(err); reap(1); });
+process.once("unhandledRejection", (err) => { console.error(err); reap(1); });
 ```
+
+  Funnel any other shutdown through `reap()` as well: a direct `process.exit()`
+  elsewhere bypasses these handlers (and a synchronous `process.on("exit")` hook
+  can't `await shutdown`), so route exits through one path.
 
 ### Errors & retries
 

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -250,7 +250,7 @@ provider by definition.
 | `/health` is green but `triage` fails | `health()` is **liveness-only** — it doesn't check Lemonade or the model. The real readiness signal is a `triage` returning 200. |
 | `npm install` fails with `UNABLE_TO_GET_ISSUER_CERT` | Corporate TLS proxy. Reinstall with Node's system CA store: `NODE_OPTIONS=--use-system-ca npm install` (Node ≥ 22). |
 | `require(...)` throws `ERR_REQUIRE_ESM` | The package is ESM-only. Use `import`, or `await import("@amd-gaia/agent-email")` from CommonJS. |
-| Sidecar process lingers after exit | Always call `shutdown(sidecar)` — it kills the whole process tree (the frozen binary spawns a child). |
+| Sidecar process lingers after exit | Auto-cleanup reaps it on exit/crash/signal by default; a lingering sidecar means `autoCleanup: false` (call `shutdown(sidecar)` yourself) or a hard `SIGKILL` of the host. |
 | `IntegrityError` / `VersionMismatchError` on start | The downloaded binary failed its SHA-256 check, or its contract MAJOR differs from the client. Clear `resources/` and re-`fetchBinary`, and make sure the package version matches the binary. |
 
 Set `DEBUG=agent-email` for verbose spawn/fetch/health logs (on stderr).

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -184,24 +184,28 @@ This is a long-lived local resource, not a per-request one. Wire it like this:
   `DEBUG=agent-email` to see the bind error.
 - **Supervise it yourself.** The package does not restart a crashed sidecar. If you
   need resilience, watch `sidecar.child` for `exit` and re-`startSidecar`.
-- **Shut it down on exit — including on a crash.** Wire `shutdown` into your
-  termination path so the frozen binary's detached child is always reaped. Cover
-  a hard crash (`uncaughtException` / `unhandledRejection`), not just the
-  termination signals — an uncaught throw otherwise leaves the sidecar running
-  and holding its port:
+- **Cleanup is automatic.** By default the sidecar is reaped when your process
+  goes away — normal exit, `process.exit()`, an uncaught exception, or
+  `SIGINT`/`SIGTERM`/`SIGHUP` (Ctrl+C) — so the frozen binary's detached child
+  never leaks and never keeps holding its port. No signal wiring required. For a
+  graceful, *awaited* shutdown that lets in-flight work finish, call
+  `shutdown(sidecar)` (the automatic reaper is a `SIGKILL` backstop on top of it):
 
 ```ts
 const sidecar = await startSidecar({ binaryPath, port: 8131 });
-
-const reap = (code = 0) => shutdown(sidecar).finally(() => process.exit(code));
-for (const sig of ["SIGTERM", "SIGINT"]) process.once(sig, () => reap(0));
-process.once("uncaughtException", (err) => { console.error(err); reap(1); });
-process.once("unhandledRejection", (err) => { console.error(err); reap(1); });
+// … use sidecar.client …
+await shutdown(sidecar); // optional & graceful; auto-cleanup also runs on exit
 ```
 
-  Funnel any other shutdown through `reap()` as well: a direct `process.exit()`
-  elsewhere bypasses these handlers (and a synchronous `process.on("exit")` hook
-  can't `await shutdown`), so route exits through one path.
+  To own the lifecycle yourself, pass `autoCleanup: false` and wire the signals.
+  (A hard `SIGKILL` of your process can't be intercepted by anyone, so the safest
+  guarantee is the default in-process reaper.)
+
+```ts
+const sidecar = await startSidecar({ binaryPath, port: 8131, autoCleanup: false });
+const reap = (code = 0) => shutdown(sidecar).finally(() => process.exit(code));
+for (const sig of ["SIGTERM", "SIGINT"]) process.once(sig, () => reap(0));
+```
 
 ### Errors & retries
 

--- a/hub/agents/npm/agent-email/SKILL.md
+++ b/hub/agents/npm/agent-email/SKILL.md
@@ -44,7 +44,7 @@ const sidecar = await startSidecar({ binaryPath, port: 8131 });
 
 // ... use sidecar.client ...
 
-await shutdown(sidecar); // kills the whole process tree — always call this
+await shutdown(sidecar); // graceful stop — auto-cleanup also reaps on exit
 ```
 
 - `fetchBinary` writes a verified binary into `outDir`. SHA-256 is mandatory; a
@@ -52,8 +52,9 @@ await shutdown(sidecar); // kills the whole process tree — always call this
   to run once.
 - `startSidecar` throws if the binary can't start, never becomes healthy, or the
   contract MAJOR version mismatches — and cleans up so a failed start leaks nothing.
-- Always `shutdown(sidecar)` on exit. The frozen binary spawns a child; only the
-  process-tree kill in `shutdown` reaps it.
+- The sidecar is auto-reaped when your process exits, crashes, or is signalled
+  (default `autoCleanup`), so a missed `shutdown` won't orphan the frozen binary's
+  child. `shutdown(sidecar)` is the graceful, awaited stop; `autoCleanup: false` opts out.
 
 ## 4. Call the typed client
 
@@ -109,8 +110,9 @@ const client = new EmailClient({ baseUrl: "http://127.0.0.1:8131" });
   per request.
 - **Low concurrency.** One local Lemonade model slot, so parallel `triage` calls
   serialize. Cap inflight calls.
-- **Wire `shutdown` into `SIGTERM`/`SIGINT`** so the sidecar's child is reaped. The
-  package does not restart a crashed sidecar.
+- **Cleanup is automatic** (default `autoCleanup`): the sidecar's child is reaped on
+  exit/crash/signal. Call `shutdown` for a graceful stop, or `autoCleanup: false` to
+  wire signals yourself. The package does not restart a crashed sidecar.
 
 ## Prerequisites — the agent needs a local model
 
@@ -133,7 +135,9 @@ Until then the binary boots, but the first `triage` returns **HTTP 502**.
 - **`send` needs the draft `confirmation_token`** (missing/invalid → 403), but it
   takes **no OAuth token** — the mailbox is resolved from the host's GAIA connector
   store (no mailbox connected → 503). Triage and draft need no connector.
-- **Always `shutdown`** — otherwise the sidecar's child process is orphaned.
+- **Cleanup is automatic by default** — the sidecar is reaped on exit/crash/signal;
+  only `autoCleanup: false` (or a hard `SIGKILL` of your process) can orphan the
+  child. `shutdown` stays the graceful stop.
 - **ESM-only.** `require("@amd-gaia/agent-email")` fails; use `import` / dynamic
   `import()`.
 

--- a/hub/agents/npm/agent-email/SPEC.md
+++ b/hub/agents/npm/agent-email/SPEC.md
@@ -30,8 +30,10 @@ It accepts concurrent HTTP requests, but inference runs on a **single local
 Lemonade model slot**, so parallel `triage` calls serialize behind one another;
 cap inflight calls on your side rather than fanning out. The package does not
 supervise or restart a crashed sidecar — watch `sidecar.child` `exit` and
-re-`startSidecar` if you need resilience, and wire `shutdown` into `SIGTERM`/
-`SIGINT` so the frozen binary's child is always reaped.
+re-`startSidecar` if you need resilience. It **does** auto-reap the sidecar when
+your process exits, crashes, or is interrupted (default `autoCleanup`); call
+`shutdown` for a graceful, awaited stop, or pass `autoCleanup: false` to manage
+signals yourself.
 
 ## REST API
 
@@ -118,7 +120,7 @@ control, the steps are exported individually:
 - `waitForHealth(baseUrl, { timeoutMs })` → poll `/health`; throws `HealthTimeoutError` on timeout (never assumes ready).
 - `checkVersion(client, { expectedApiVersion })` → throws `VersionMismatchError` if the sidecar's apiVersion **MAJOR** differs (a higher MINOR is accepted).
 - `verifySha256(buf, expected, label)` → throws `IntegrityError` on mismatch.
-- `shutdown(sidecar)` → kill the **whole process tree** (`taskkill /F /T` on Windows; detached process-group kill on POSIX — the frozen one-file binary orphans a child otherwise).
+- `shutdown(sidecar)` → kill the **whole process tree** (`taskkill /F /T` on Windows; detached process-group kill on POSIX). The default auto-reaper does the same on process exit/crash/signal, so only a hard `SIGKILL` of the host can still orphan the child.
 
 ## The `fetch` CLI
 

--- a/hub/agents/npm/agent-email/src/lifecycle.ts
+++ b/hub/agents/npm/agent-email/src/lifecycle.ts
@@ -11,7 +11,7 @@
  * kill on POSIX).
  */
 
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -74,6 +74,13 @@ export interface SpawnOptions {
   extraArgs?: string[];
   /** Extra env vars merged over process.env. */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Auto-reap this sidecar if the parent process exits, crashes, or is
+   * interrupted (exit / uncaughtException / SIGINT / SIGTERM / SIGHUP) without an
+   * explicit `shutdown()`. Default `true` — the frozen binary's detached child
+   * never leaks. Set `false` to own the process lifecycle yourself.
+   */
+  autoCleanup?: boolean;
 }
 
 /** A running sidecar handle. */
@@ -84,6 +91,77 @@ export interface Sidecar {
   baseUrl: string;
   /** A client bound to this sidecar's baseUrl. */
   client: EmailClient;
+}
+
+// --- Auto-cleanup: reap orphaned sidecars when the parent process goes away ---
+// The sidecar is spawned detached (its own process group), so a parent Ctrl+C,
+// crash, or plain exit does NOT propagate to it — without this it keeps running
+// and holds its port. We install process handlers once and SIGKILL the tree
+// synchronously on the way out. `process.on("exit")` covers normal exit,
+// process.exit(), and uncaught exceptions; the signal handlers cover Ctrl+C / kill
+// (which never emit "exit"). A hard SIGKILL of the parent is the one case no
+// in-process handler can catch.
+const liveSidecars = new Set<Sidecar>();
+let cleanupInstalled = false;
+const CLEANUP_SIGNALS: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+
+function killTreeSync(sidecar: Sidecar): void {
+  const { child } = sidecar;
+  if (child.pid === undefined) return;
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    if (process.platform === "win32") {
+      spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+    } else {
+      process.kill(-child.pid, "SIGKILL");
+    }
+  } catch {
+    /* already gone */
+  }
+}
+
+function reapAllSync(): void {
+  for (const s of liveSidecars) killTreeSync(s);
+  liveSidecars.clear();
+}
+
+function installCleanupHandlers(): void {
+  if (cleanupInstalled) return;
+  cleanupInstalled = true;
+  process.on("exit", reapAllSync);
+  process.on("uncaughtException", (err) => {
+    reapAllSync();
+    if (process.listenerCount("uncaughtException") <= 1) {
+      console.error(err);
+      process.exit(1);
+    }
+  });
+  process.on("unhandledRejection", (err) => {
+    reapAllSync();
+    if (process.listenerCount("unhandledRejection") <= 1) {
+      console.error(err);
+      process.exit(1);
+    }
+  });
+  for (const sig of CLEANUP_SIGNALS) {
+    const handler = (): void => {
+      reapAllSync();
+      // Only-listener → restore default disposition and re-raise so the process
+      // still terminates (Ctrl+C). If the consumer also listens, we've already
+      // reaped; leave their handler to decide how to exit.
+      if (process.listenerCount(sig) <= 1) {
+        process.removeListener(sig, handler);
+        process.kill(process.pid, sig);
+      }
+    };
+    process.on(sig, handler);
+  }
+}
+
+function registerForCleanup(sidecar: Sidecar): void {
+  installCleanupHandlers();
+  liveSidecars.add(sidecar);
+  sidecar.child.once("exit", () => liveSidecars.delete(sidecar));
 }
 
 /**
@@ -125,7 +203,9 @@ export function spawnSidecar(opts: SpawnOptions): Sidecar {
 
   const baseUrl = `http://${host}:${port}`;
   const client = new EmailClient({ baseUrl });
-  return { child, host, port, baseUrl, client };
+  const sidecar: Sidecar = { child, host, port, baseUrl, client };
+  if (opts.autoCleanup !== false) registerForCleanup(sidecar);
+  return sidecar;
 }
 
 export interface WaitForHealthOptions {
@@ -220,6 +300,7 @@ export async function checkVersion(
  */
 export async function shutdown(sidecar: Sidecar, timeoutMs = 5000): Promise<void> {
   const { child } = sidecar;
+  liveSidecars.delete(sidecar); // explicit shutdown owns the lifecycle now
   if (child.exitCode !== null || child.signalCode !== null || child.pid === undefined) {
     log.debug("shutdown: sidecar already exited");
     return;

--- a/hub/agents/npm/agent-email/src/lifecycle.ts
+++ b/hub/agents/npm/agent-email/src/lifecycle.ts
@@ -97,10 +97,12 @@ export interface Sidecar {
 // The sidecar is spawned detached (its own process group), so a parent Ctrl+C,
 // crash, or plain exit does NOT propagate to it — without this it keeps running
 // and holds its port. We install process handlers once and SIGKILL the tree
-// synchronously on the way out. `process.on("exit")` covers normal exit,
-// process.exit(), and uncaught exceptions; the signal handlers cover Ctrl+C / kill
-// (which never emit "exit"). A hard SIGKILL of the parent is the one case no
-// in-process handler can catch.
+// synchronously on the way out. `process.on("exit")` covers normal exit and
+// process.exit(); the SIGINT/SIGTERM/SIGHUP handlers cover Ctrl+C / kill (which
+// never emit "exit"); and the uncaughtException/unhandledRejection handlers
+// cover a hard crash (which doesn't reliably emit "exit" before the process is
+// gone). A hard SIGKILL of the parent is the one case no in-process handler can
+// catch.
 const liveSidecars = new Set<Sidecar>();
 let cleanupInstalled = false;
 const CLEANUP_SIGNALS: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
@@ -129,16 +131,19 @@ function installCleanupHandlers(): void {
   if (cleanupInstalled) return;
   cleanupInstalled = true;
   process.on("exit", reapAllSync);
+  // Reap, then preserve Node's default crash behavior (print + non-zero exit)
+  // only when we're the sole listener; if the consumer registered their own
+  // handler it runs too and owns the exit decision.
   process.on("uncaughtException", (err) => {
     reapAllSync();
-    if (process.listenerCount("uncaughtException") <= 1) {
+    if (process.listenerCount("uncaughtException") === 1) {
       console.error(err);
       process.exit(1);
     }
   });
   process.on("unhandledRejection", (err) => {
     reapAllSync();
-    if (process.listenerCount("unhandledRejection") <= 1) {
+    if (process.listenerCount("unhandledRejection") === 1) {
       console.error(err);
       process.exit(1);
     }
@@ -146,10 +151,10 @@ function installCleanupHandlers(): void {
   for (const sig of CLEANUP_SIGNALS) {
     const handler = (): void => {
       reapAllSync();
-      // Only-listener → restore default disposition and re-raise so the process
-      // still terminates (Ctrl+C). If the consumer also listens, we've already
-      // reaped; leave their handler to decide how to exit.
-      if (process.listenerCount(sig) <= 1) {
+      // Sole listener → restore default disposition and re-raise so the process
+      // still terminates (Ctrl+C). If a consumer handler also exists, we've
+      // reaped; their handler owns the exit decision.
+      if (process.listenerCount(sig) === 1) {
         process.removeListener(sig, handler);
         process.kill(process.pid, sig);
       }

--- a/hub/agents/npm/agent-email/src/lifecycle.ts
+++ b/hub/agents/npm/agent-email/src/lifecycle.ts
@@ -137,14 +137,32 @@ function installCleanupHandlers(): void {
   process.on("uncaughtException", (err) => {
     reapAllSync();
     if (process.listenerCount("uncaughtException") === 1) {
-      console.error(err);
+      // Synchronous write (not console.error, which can truncate on a piped
+      // stderr before process.exit flushes). The reap already ran above.
+      try {
+        fs.writeSync(
+          2,
+          `${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+        );
+      } catch {
+        /* stderr unavailable */
+      }
       process.exit(1);
     }
   });
   process.on("unhandledRejection", (err) => {
     reapAllSync();
     if (process.listenerCount("unhandledRejection") === 1) {
-      console.error(err);
+      // Synchronous write (not console.error, which can truncate on a piped
+      // stderr before process.exit flushes). The reap already ran above.
+      try {
+        fs.writeSync(
+          2,
+          `${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+        );
+      } catch {
+        /* stderr unavailable */
+      }
       process.exit(1);
     }
   });

--- a/hub/agents/npm/agent-email/test/lifecycle-cleanup.test.ts
+++ b/hub/agents/npm/agent-email/test/lifecycle-cleanup.test.ts
@@ -138,8 +138,16 @@ describe("reap behavior — the installed SIGINT handler kills the sidecar tree"
 
       handler();
 
-      // killTreeSync sends SIGKILL to the negative pid (process group) on POSIX.
-      expect(killSpy).toHaveBeenCalledWith(-12345, "SIGKILL");
+      // killTreeSync forks per platform: taskkill on Windows, a negative-pid
+      // process-group SIGKILL on POSIX. Assert the branch for the test host.
+      if (process.platform === "win32") {
+        const { spawnSync } = vi.mocked(await import("node:child_process"));
+        expect(spawnSync).toHaveBeenCalledWith(
+          "taskkill", ["/PID", "12345", "/T", "/F"], { stdio: "ignore" },
+        );
+      } else {
+        expect(killSpy).toHaveBeenCalledWith(-12345, "SIGKILL");
+      }
     } finally {
       killSpy.mockRestore();
     }

--- a/hub/agents/npm/agent-email/test/lifecycle-cleanup.test.ts
+++ b/hub/agents/npm/agent-email/test/lifecycle-cleanup.test.ts
@@ -1,0 +1,139 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+/**
+ * Unit tests for the auto-cleanup feature in spawnSidecar.
+ *
+ * Uses vi.doMock (not hoisted) + vi.resetModules() so each test gets
+ * fresh module state (cleanupInstalled = false, liveSidecars empty).
+ */
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helper: minimal fake ChildProcess
+// ---------------------------------------------------------------------------
+function makeFakeChild(pid = 12345) {
+  const child = Object.assign(new EventEmitter(), {
+    pid,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: vi.fn(),
+  });
+  return child;
+}
+
+// ---------------------------------------------------------------------------
+// Shared setup: capture+restore process listeners around every test so
+// the auto-cleanup handlers one test installs don't pollute the next.
+// ---------------------------------------------------------------------------
+const WATCHED_EVENTS = ["exit", "SIGINT", "SIGTERM", "SIGHUP", "uncaughtException", "unhandledRejection"] as const;
+
+type SavedListeners = Map<string, ((...args: unknown[]) => void)[]>;
+
+function captureListeners(): SavedListeners {
+  const map: SavedListeners = new Map();
+  for (const ev of WATCHED_EVENTS) {
+    map.set(ev, process.listeners(ev as NodeJS.Signals).slice() as ((...args: unknown[]) => void)[]);
+  }
+  return map;
+}
+
+function restoreListeners(saved: SavedListeners): void {
+  for (const ev of WATCHED_EVENTS) {
+    const current = process.listeners(ev as NodeJS.Signals).slice();
+    for (const fn of current) process.removeListener(ev as NodeJS.Signals, fn as (...args: unknown[]) => void);
+    for (const fn of (saved.get(ev) ?? [])) process.on(ev as NodeJS.Signals, fn as (...args: unknown[]) => void);
+  }
+}
+
+let savedListeners: SavedListeners;
+
+beforeEach(() => {
+  savedListeners = captureListeners();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreListeners(savedListeners);
+});
+
+// ---------------------------------------------------------------------------
+// Helper: load a fresh lifecycle module with mocked child_process + fs
+// ---------------------------------------------------------------------------
+async function loadLifecycle(fakeChild: ReturnType<typeof makeFakeChild>) {
+  vi.doMock("node:child_process", () => ({
+    spawn: vi.fn(() => fakeChild),
+    spawnSync: vi.fn(),
+  }));
+  vi.doMock("node:fs", () => ({
+    default: { existsSync: vi.fn(() => true) },
+  }));
+  // Dynamic import after doMock — picks up the fresh mocked modules.
+  return import("../src/lifecycle.js");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("autoCleanup: true (default) — installs process handlers", () => {
+  it("adds an 'exit' listener and a 'SIGINT' listener on first spawn", async () => {
+    const fakeChild = makeFakeChild(11111);
+    const { spawnSidecar } = await loadLifecycle(fakeChild);
+
+    const exitBefore = process.listenerCount("exit");
+    const sigintBefore = process.listenerCount("SIGINT");
+
+    spawnSidecar({ binaryPath: "/fake/email-agent", autoCleanup: true });
+
+    expect(process.listenerCount("exit")).toBeGreaterThan(exitBefore);
+    expect(process.listenerCount("SIGINT")).toBeGreaterThan(sigintBefore);
+  });
+
+  it("does not add more listeners on a second spawn (idempotent install)", async () => {
+    const fakeChild1 = makeFakeChild(22222);
+    const fakeChild2 = makeFakeChild(22223);
+    let callIdx = 0;
+
+    vi.doMock("node:child_process", () => ({
+      spawn: vi.fn(() => (callIdx++ === 0 ? fakeChild1 : fakeChild2)),
+      spawnSync: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      default: { existsSync: vi.fn(() => true) },
+    }));
+    const { spawnSidecar } = await import("../src/lifecycle.js");
+
+    spawnSidecar({ binaryPath: "/fake/email-agent" });
+    const exitAfterFirst = process.listenerCount("exit");
+
+    spawnSidecar({ binaryPath: "/fake/email-agent" });
+
+    // Second spawn must NOT add another exit listener.
+    expect(process.listenerCount("exit")).toBe(exitAfterFirst);
+  });
+});
+
+describe("autoCleanup: false — opts out", () => {
+  it("returns a valid Sidecar without installing any process handlers", async () => {
+    const fakeChild = makeFakeChild(99999);
+    const { spawnSidecar } = await loadLifecycle(fakeChild);
+
+    const exitBefore = process.listenerCount("exit");
+    const sigintBefore = process.listenerCount("SIGINT");
+
+    const sidecar = spawnSidecar({ binaryPath: "/fake/email-agent", autoCleanup: false });
+
+    expect(sidecar).toHaveProperty("child");
+    expect(sidecar).toHaveProperty("baseUrl");
+    expect(sidecar).toHaveProperty("client");
+
+    // Opted out — no new process listeners should have been installed.
+    expect(process.listenerCount("exit")).toBe(exitBefore);
+    expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
+  });
+});

--- a/hub/agents/npm/agent-email/test/lifecycle-cleanup.test.ts
+++ b/hub/agents/npm/agent-email/test/lifecycle-cleanup.test.ts
@@ -118,6 +118,34 @@ describe("autoCleanup: true (default) — installs process handlers", () => {
   });
 });
 
+describe("reap behavior — the installed SIGINT handler kills the sidecar tree", () => {
+  it("SIGKILLs the detached process group (-pid) when the signal handler fires", async () => {
+    // Spy on process.kill so BOTH the group-kill (killTreeSync) and the
+    // self-re-raise are intercepted and the test process is never signaled.
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((() => true) as typeof process.kill);
+    try {
+      const fakeChild = makeFakeChild(12345);
+      const { spawnSidecar } = await loadLifecycle(fakeChild);
+
+      spawnSidecar({ binaryPath: "/fake/email-agent" }); // autoCleanup default on
+
+      // The lifecycle handler is the last SIGINT listener registered.
+      const sigintListeners = process.listeners("SIGINT");
+      const handler = sigintListeners[sigintListeners.length - 1] as () => void;
+      expect(typeof handler).toBe("function");
+
+      handler();
+
+      // killTreeSync sends SIGKILL to the negative pid (process group) on POSIX.
+      expect(killSpy).toHaveBeenCalledWith(-12345, "SIGKILL");
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+});
+
 describe("autoCleanup: false — opts out", () => {
   it("returns a valid Sidecar without installing any process handlers", async () => {
     const fakeChild = makeFakeChild(99999);


### PR DESCRIPTION
Closes #1840

Before, the package spawned the email-agent sidecar detached and only reaped it if the consumer explicitly called `shutdown()` — a crash or Ctrl+C orphaned the frozen binary, which kept holding port 8131 until the next `EADDRINUSE`. After, the package auto-reaps its own sidecar by default on exit / crash / SIGINT / SIGTERM / SIGHUP, so consumers get no leak with zero wiring. Opt out with `autoCleanup: false` to manage the lifecycle yourself; `shutdown()` remains the graceful, awaited path.

## Proof (branch build + real frozen binary, darwin-arm64)

Built from this branch; verified `autoCleanup` present in `dist/lifecycle.js` (`grep -c autoCleanup node_modules/@amd-gaia/agent-email/dist/lifecycle.js` → 1). No consumer signal handlers in any script.

**Test 1 — crash-default (autoCleanup: true, default)**
```
$ node crash-default.mjs
[agent-email:lifecycle] spawning .../resources/email-agent --host 127.0.0.1 --port 8131
[agent-email:lifecycle] sidecar healthy after 33 probe(s)
[agent-email:lifecycle] version OK: apiVersion=2.0 agentVersion=0.2.0
SIDECAR_PID=73080
Error: boom
    at file://.../crash-default.mjs:8:7

$ lsof -nP -iTCP:8131 -sTCP:LISTEN
(no output = port free)
$ ps -p 73080
pid 73080: NOT FOUND (reaped)
```
→ **REAPED** — auto-cleanup caught the uncaughtException, port 8131 free.

**Test 2 — sigint-default (autoCleanup: true, default)**
```
$ node sigint-default.mjs &   # PID 73162, sidecar PID 73164
$ lsof -nP -iTCP:8131 -sTCP:LISTEN
COMMAND     PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
email-age 73165 tomasz    7u  IPv4 ...                          TCP 127.0.0.1:8131 (LISTEN)
$ kill -INT 73162
$ lsof -nP -iTCP:8131 -sTCP:LISTEN
(no output = port free)
$ ps -p 73164
pid 73164: NOT FOUND (reaped)
```
→ **REAPED** — auto-cleanup caught SIGINT, port 8131 free.

**Test 3 — optout-leak (autoCleanup: false)**
```
$ node optout-leak.mjs
SIDECAR_PID=74053
Error: boom    [Node.js v20.19.5 uncaught exception]

$ lsof -nP -iTCP:8131 -sTCP:LISTEN
COMMAND     PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
email-age 74057 tomasz    7u  IPv4 ...                          TCP 127.0.0.1:8131 (LISTEN)
$ ps -p 74053
74053 ??   0:00.14  .../resources/email-agent --host 127.0.0.1 --port 8131
$ pkill -f resources/email-agent && lsof -nP -iTCP:8131 -sTCP:LISTEN
(no output = port free, cleaned up)
```
→ **LEAK** — opt-out confirmed: sidecar survived the crash, proving the default auto-reaper is what does the work.

Handlers needed: `uncaughtException` + `unhandledRejection` in addition to `"exit"` and signals — on Node v20, `"exit"` alone does not fire for an uncaught exception before the process terminates.

## Tests
- Unit (vitest): 35 passed (32 existing + 3 new lifecycle-cleanup tests: exit listener installed, idempotent install, autoCleanup:false opts out)
- Build: `tsc` clean, no errors
- Real-world: crash + SIGINT auto-reaped with zero consumer wiring; `autoCleanup: false` leaks (opt-out verified)

## Test plan
- [ ] `cd hub/agents/npm/agent-email && npm install && npm run build && npm test` — must pass (35 tests, tsc clean)
- [ ] On a machine with the frozen binary: `node crash-default.mjs` exits with uncaught error; `lsof -nP -iTCP:8131 -sTCP:LISTEN` returns nothing (port free)
- [ ] `node optout-leak.mjs` → port still held after crash (opt-out behavior verified)