### PR TITLE
feat(hub): whole-package zip download + file list on the agent page

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -502,6 +502,38 @@ jobs:
           npm ci
           npm run build
 
+      - name: Assemble + publish the whole-package zip (all platforms + client + docs)
+        shell: bash
+        env:
+          AGENT_HUB_PUBLISH_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+          GAIA_HUB_PUBLISH_URL: ${{ vars.GAIA_HUB_PUBLISH_URL }}
+          GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}
+        run: |
+          set -euo pipefail
+          VER="${{ steps.ver.outputs.version }}"
+          STAGE="agent-email-${VER}"
+          rm -rf "${STAGE}" "agent-email-${VER}.zip" package-files.json
+          mkdir -p "${STAGE}/binaries" "${STAGE}/dist"
+          # All platform binaries (whatever was published this run — Intel may be absent).
+          cp bins/email-agent-* "${STAGE}/binaries/"
+          # npm client + docs + the real (post-publish) lock + manifest + license.
+          cp -r "${PKG_DIR}/dist/." "${STAGE}/dist/"
+          cp "${PKG_DIR}/README.md" "${PKG_DIR}/SPEC.md" "${PKG_DIR}/SKILL.md" \
+             "${PKG_DIR}/CHANGELOG.md" "${PKG_DIR}/binaries.lock.json" \
+             "${PKG_DIR}/LICENSE" "${STAGE}/"
+          cp "${MANIFEST}" "${STAGE}/gaia-agent.yaml"
+          # Deterministic zip (sorted, no extra metadata).
+          ( cd "${STAGE}/.." && zip -rX "agent-email-${VER}.zip" "agent-email-${VER}" >/dev/null )
+          # File listing for the hub's package file-list display.
+          python hub/agents/python/email/packaging/gen_package_files.py "${STAGE}" package-files.json
+          echo "=== package contents ===" && (cd "${STAGE}" && find . -type f | sort)
+          # Publish the zip as the version's package artifact + its file listing.
+          python hub/agents/python/email/packaging/publish_to_r2.py \
+            --base-url "${GAIA_HUB_PUBLISH_URL:-${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}}" \
+            --manifest "${MANIFEST}" \
+            --artifact "agent-email-${VER}.zip=package" \
+            --package-files package-files.json
+
       - name: Verify every published object via the real fetch CLI
         working-directory: ${{ env.PKG_DIR }}
         shell: bash

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -563,6 +563,38 @@ jobs:
             done
           done
 
+      - name: Verify the published package zip is fetchable at the edge
+        shell: bash
+        env:
+          GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}
+        run: |
+          set -euo pipefail
+          # The package zip rides the `artifact` path (server- + locally-SHA-verified
+          # on upload by publish_to_r2.py), but it is NOT in binaries.lock.json, so the
+          # fetch CLI above doesn't cover it. Round-trip it through the public origin so
+          # a non-propagated / edge-blocked zip fails the release instead of shipping a
+          # 404 download button. Bytes were already proven on upload; here we gate on a
+          # 200 with a Content-Length matching the local zip. Same bounded edge retry.
+          VER="${{ steps.ver.outputs.version }}"
+          BASE="${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}"
+          ZIP="${GITHUB_WORKSPACE}/agent-email-${VER}.zip"
+          URL="${BASE}/agents/email/${VER}/agent-email-${VER}.zip"
+          local_size="$(stat -c%s "${ZIP}" 2>/dev/null || stat -f%z "${ZIP}")"
+          echo "verifying package zip: ${URL} (expecting ${local_size} bytes)"
+          attempt=1; max=5
+          while true; do
+            remote_size="$(curl -fsSL -o /dev/null -w '%{size_download}' "${URL}" || echo "")"
+            if [ "${remote_size}" = "${local_size}" ]; then
+              echo "package zip verified (${remote_size} bytes)."; break
+            fi
+            if [ "${attempt}" -ge "${max}" ]; then
+              echo "::error::package zip verify failed after ${max} attempts (got '${remote_size}', want ${local_size}) — the zip never became fetchable/correct at ${URL}."
+              exit 1
+            fi
+            echo "attempt ${attempt}/${max}: got '${remote_size}', want ${local_size} — retrying in 10s."
+            attempt=$((attempt + 1)); sleep 10
+          done
+
       - name: Upgrade npm (trusted publishing support)
         run: npm install -g npm@latest
 

--- a/hub/agents/python/email/packaging/gen_package_files.py
+++ b/hub/agents/python/email/packaging/gen_package_files.py
@@ -1,0 +1,55 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Emit ``package-files.json`` — the listing of files inside the whole-package
+zip — for the hub's package file-list display.
+
+The release workflow stages the package (``binaries/`` + ``dist/`` + docs + lock +
+manifest + LICENSE), runs this over the staging dir, and POSTs the result as the
+``package_files`` part on ``/publish`` (see ``publish_to_r2.py``). The Worker pairs
+it with the published ``.zip`` artifact to build the catalog's ``package`` entry.
+
+Usage:
+    gen_package_files.py <staging-dir> <out.json>
+
+Output shape (paths are relative to the staging dir, sorted, forward slashes):
+    {"files": [{"name": "README.md", "size_bytes": 13000}, ...]}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def collect(root: str) -> list[dict]:
+    files: list[dict] = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path, root).replace(os.sep, "/")
+            files.append({"name": rel, "size_bytes": os.path.getsize(path)})
+    files.sort(key=lambda f: f["name"])
+    return files
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if len(argv) != 2:
+        raise SystemExit("usage: gen_package_files.py <staging-dir> <out.json>")
+    root, out = argv
+    if not os.path.isdir(root):
+        raise SystemExit(f"error: staging dir not found: {root}")
+    files = collect(root)
+    if not files:
+        raise SystemExit(
+            f"error: no files under {root} — refusing to emit an empty package list"
+        )
+    with open(out, "w", encoding="utf-8") as fh:
+        json.dump({"files": files}, fh)
+    print(f"[package] {out}: {len(files)} files", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hub/agents/python/email/packaging/publish_to_r2.py
+++ b/hub/agents/python/email/packaging/publish_to_r2.py
@@ -127,6 +127,7 @@ def publish_one(
     token: str,
     readme_bytes: bytes | None = None,
     changelog_bytes: bytes | None = None,
+    package_files_bytes: bytes | None = None,
 ) -> dict:
     if not artifact_path.exists():
         raise SystemExit(f"error: artifact not found: {artifact_path}")
@@ -163,6 +164,14 @@ def publish_one(
         # `changelog`, rendered as a Changelog section on the hub agent page.
         if changelog_bytes is not None:
             files["changelog"] = ("CHANGELOG.md", changelog_bytes, "text/markdown")
+        # The whole-package file listing rides with the zip artifact — it becomes
+        # the catalog entry's `package.files` (the hub's file-list display).
+        if package_files_bytes is not None:
+            files["package_files"] = (
+                "package-files.json",
+                package_files_bytes,
+                "application/json",
+            )
         resp = requests.post(
             publish_url,
             headers={"authorization": f"Bearer {token}"},
@@ -243,6 +252,13 @@ def main(argv=None) -> int:
         "(POSTed as the multipart 'changelog' part the Worker accepts).",
     )
     parser.add_argument(
+        "--package-files",
+        type=Path,
+        help='Path to a package-files.json ({"files":[{name,size_bytes}]}) to '
+        "attach to the zip artifact (POSTed as the 'package_files' part). It "
+        "becomes the catalog's package.files (the hub's file-list display).",
+    )
+    parser.add_argument(
         "--summary-out",
         type=Path,
         help="Write a JSON array of {platform,filename,executable,sha256,size}.",
@@ -279,10 +295,29 @@ def main(argv=None) -> int:
             flush=True,
         )
 
+    package_files_bytes = None
+    if args.package_files is not None:
+        if not args.package_files.exists():
+            raise SystemExit(
+                f"error: --package-files path not found: {args.package_files}."
+            )
+        package_files_bytes = args.package_files.read_bytes()
+        print(
+            f"[publish] attaching package file list: {args.package_files} "
+            f"({len(package_files_bytes)} bytes)",
+            flush=True,
+        )
+
     results = []
     for raw in args.artifact:
         path, key = _parse_artifact_arg(raw)
-        platform_key = key or _infer_platform_key(path.name)
+        # A .zip is the whole-package artifact (not a platform binary); it has no
+        # platform key to infer, so default it to "package".
+        platform_key = key or (
+            "package"
+            if path.name.lower().endswith(".zip")
+            else _infer_platform_key(path.name)
+        )
         results.append(
             publish_one(
                 args.base_url,
@@ -293,6 +328,7 @@ def main(argv=None) -> int:
                 token,
                 readme_bytes=readme_bytes,
                 changelog_bytes=changelog_bytes,
+                package_files_bytes=package_files_bytes,
             )
         )
 

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -60,6 +60,13 @@ export interface Agent {
   // (e.g. "http://127.0.0.1:8131/v1/email/playground"). Only resolves once the
   // package is installed and the sidecar is running — a best-effort dev link.
   playground_url?: string;
+  // Whole-package download: a single zip (all platform binaries + client + docs)
+  // and its file listing. Present only when the latest version published one.
+  package?: {
+    filename: string;
+    size_bytes: number;
+    files: { name: string; size_bytes: number }[];
+  };
 }
 
 interface CatalogFile {
@@ -180,6 +187,18 @@ const SECURITY_TIER_LABELS: Record<SecurityTier, string> = {
 
 export function securityTierLabel(tier: SecurityTier): string {
   return SECURITY_TIER_LABELS[tier] ?? tier;
+}
+
+/**
+ * Absolute URL of an agent's whole-package zip, served from the same hub origin
+ * as the catalog (`${HUB_CATALOG_URL}/agents/<id>/<version>/<filename>`). Returns
+ * null when the agent has no published package zip. Build-time only.
+ */
+export function packageDownloadUrl(agent: Agent): string | null {
+  if (!agent.package) return null;
+  const base = process.env.HUB_CATALOG_URL;
+  if (!base) return null;
+  return `${base.replace(/\/+$/, '')}/agents/${agent.id}/${agent.latest_version}/${agent.package.filename}`;
 }
 
 /** Human-readable download size, e.g. "2.3 MB". */

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -19,6 +19,7 @@ import {
   formatBytes,
   platformLabel,
   npuLabel,
+  packageDownloadUrl,
 } from '../../data/catalog';
 import { renderMarkdown } from '../../data/markdown';
 
@@ -41,6 +42,7 @@ const readmeHtml = renderMarkdown(agent.readme);
 // no changelog; render the section only when there's content.
 const changelogHtml = agent.changelog ? renderMarkdown(agent.changelog) : '';
 const req = agent.requirements;
+const pkgUrl = packageDownloadUrl(agent);
 const terminalLines = [
   { prompt: true, text: installCmd },
   { muted: true, text: `✓ ${agent.name} ${agent.latest_version} installed` },
@@ -167,6 +169,37 @@ const terminalLines = [
             </div>
           </dl>
         </section>
+
+        {agent.package && pkgUrl && (
+          <!-- Whole-package download: one zip with the client, docs, and all platform binaries -->
+          <section class="rounded-xl border border-g-border bg-g-surface p-5">
+            <Eyebrow class="mb-2">Package</Eyebrow>
+            <a
+              href={pkgUrl}
+              download={agent.package.filename}
+              class="flex items-center justify-between gap-3 rounded-md border border-g-gold/40 bg-g-bg/40 px-4 py-2.5 text-[13px] font-medium text-g-gold-text hover:border-g-gold/70 transition-colors"
+            >
+              <span>Download .zip</span>
+              <span class="font-mono text-[12px] text-g-muted">{formatBytes(agent.package.size_bytes)}</span>
+            </a>
+            <p class="mt-2 text-[12px] leading-relaxed text-g-muted">
+              One archive — the client, docs, and every platform binary. Runs on any supported OS.
+            </p>
+            <details class="mt-3">
+              <summary class="cursor-pointer text-[12px] text-g-muted hover:text-g-text">
+                {agent.package.files.length} files
+              </summary>
+              <ul class="mt-2 max-h-64 space-y-1 overflow-y-auto pr-1 text-[11px] font-mono text-g-muted">
+                {agent.package.files.map((f) => (
+                  <li class="flex items-baseline justify-between gap-2">
+                    <span class="truncate" title={f.name}>{f.name}</span>
+                    <span class="flex-none text-g-muted/70">{formatBytes(f.size_bytes)}</span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          </section>
+        )}
 
         <!-- Requirements card -->
         <section class="rounded-xl border border-g-border bg-g-surface p-5">

--- a/workers/agent-hub/README.md
+++ b/workers/agent-hub/README.md
@@ -14,7 +14,7 @@ depend on any `src/gaia` code.
 
 | Route | Auth | Purpose |
 |-------|------|---------|
-| `POST /publish` | Bearer | Publish a new agent version (validate → scope-check → immutability-check → checksum → store → rebuild index). Form parts: `manifest` (gaia-agent.yaml text), `artifact` (wheel/binary file), optional `readme` (README.md markdown) and `changelog` (CHANGELOG.md markdown) — both rendered on the website Hub pages |
+| `POST /publish` | Bearer | Publish a new agent version (validate → scope-check → immutability-check → checksum → store → rebuild index). Form parts: `manifest` (gaia-agent.yaml text), `artifact` (wheel/binary/zip file), optional `readme` + `changelog` (markdown, rendered on the Hub pages), and optional `package_files` (JSON `{files:[{name,size_bytes}]}` listing the contents of a whole-package `.zip` artifact — surfaced as the catalog's `package`) |
 | `GET /index.json` | none | Catalog of every agent (latest version only), including the latest README + CHANGELOG markdown |
 | `GET /agents/<id>/manifest.json` | none | Per-agent aggregate manifest (all versions) |
 | `GET /agents/<id>/<version>/<file>` | none | Download an artifact, the raw `gaia-agent.yaml`, `README.md`, or `CHANGELOG.md` |
@@ -91,10 +91,13 @@ schemas live in [`schemas/`](./schemas):
   `min_disk_gb`, `min_context_size`, `platforms`, `npu` as
   `"required"`/`"optional"`, `gpu_vram_gb`), `readme` (latest version's README
   markdown, `""` if none was published), `changelog` (latest version's CHANGELOG
-  markdown, `""` if none was published), and the optional `npm_package` /
+  markdown, `""` if none was published), the optional `npm_package` /
   `playground_url` (present only when the manifest declares them — they drive the
-  hub page's npm install method and playground launcher). This shape is the
-  build-time contract for the website Hub pages (`website/src/data/catalog.ts`).
+  hub page's npm install method and playground launcher), and the optional
+  `package` (`{ filename, size_bytes, files: [{name, size_bytes}] }` — the
+  whole-package `.zip` download + its file listing, present only when a
+  `package_files` manifest was published). This shape is the build-time contract
+  for the website Hub pages (`website/src/data/catalog.ts`).
 - [`schemas/manifest.schema.json`](./schemas/manifest.schema.json) —
   `GET /agents/<id>/manifest.json`. Full display metadata plus a `versions` map;
   each version carries `published_at`, `publisher`, `deprecated`, an `artifact`

--- a/workers/agent-hub/schemas/index.schema.json
+++ b/workers/agent-hub/schemas/index.schema.json
@@ -145,6 +145,31 @@
         "playground_url": {
           "type": "string",
           "description": "Localhost playground URL served by the agent's sidecar; absent otherwise."
+        },
+        "package": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Whole-package download (all platform binaries + client + docs) as a single zip plus its file listing. Present only when a package_files manifest was published for the latest version.",
+          "required": ["filename", "size_bytes", "files"],
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "Zip artifact filename under the version dir, e.g. \"agent-email-0.2.1.zip\"."
+            },
+            "size_bytes": { "type": "integer", "minimum": 0 },
+            "files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "size_bytes"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "size_bytes": { "type": "integer", "minimum": 0 }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/workers/agent-hub/src/catalog.ts
+++ b/workers/agent-hub/src/catalog.ts
@@ -10,6 +10,7 @@ import {
   listAgentIds,
   readAgentManifest,
   readChangelog,
+  readPackageFiles,
   readReadme,
   writeIndex,
 } from "./storage";
@@ -94,16 +95,27 @@ export function upsertVersion(
 }
 
 /**
- * Build the catalog entry for one agent manifest. `readme` and `changelog` are
- * the latest version's markdown ("" if none was published).
+ * Build the catalog entry for one agent manifest. `readme`/`changelog` are the
+ * latest version's markdown ("" if none was published); `packageFiles` is the
+ * whole-package zip's file listing (null if no package zip was published).
  */
 export function toIndexEntry(
   agent: AgentManifest,
   readme: string,
-  changelog: string
+  changelog: string,
+  packageFiles: { files: { name: string; size_bytes: number }[] } | null
 ): IndexEntry {
   const latest = agent.versions[agent.latest_version];
   const req = agent.requirements;
+  // The whole-package download is the published `.zip` artifact of the latest
+  // version, paired with its file listing. Only surface it when both exist.
+  const zip = (latest?.artifacts ?? [latest?.artifact]).find(
+    (a) => a && a.filename.toLowerCase().endsWith(".zip")
+  );
+  const pkg =
+    packageFiles && zip
+      ? { filename: zip.filename, size_bytes: zip.size_bytes, files: packageFiles.files }
+      : undefined;
   return {
     id: agent.id,
     name: agent.name,
@@ -136,6 +148,7 @@ export function toIndexEntry(
     // undefined serializes to "key absent" — only present when the manifest set it.
     npm_package: agent.npm_package,
     playground_url: agent.playground_url,
+    package: pkg,
   };
 }
 
@@ -154,7 +167,8 @@ export async function rebuildIndex(
     if (!agent) continue;
     const readme = await readReadme(bucket, id, agent.latest_version);
     const changelog = await readChangelog(bucket, id, agent.latest_version);
-    entries.push(toIndexEntry(agent, readme, changelog));
+    const packageFiles = await readPackageFiles(bucket, id, agent.latest_version);
+    entries.push(toIndexEntry(agent, readme, changelog, packageFiles));
   }
   entries.sort((a, b) => a.id.localeCompare(b.id));
 

--- a/workers/agent-hub/src/publish.ts
+++ b/workers/agent-hub/src/publish.ts
@@ -259,11 +259,20 @@ export async function handlePublish(
         httpMetadata: { contentType: "text/markdown; charset=utf-8" },
       });
     }
-    if (packageFilesText != null) {
-      await env.BUCKET.put(packageFilesKey(manifest.id, manifest.version), packageFilesText, {
-        httpMetadata: { contentType: "application/json; charset=utf-8" },
-      });
-    }
+  }
+
+  // The package file listing rides the whole-package zip POST, which in a real
+  // release lands AFTER the per-platform binaries have already created this
+  // version — so it must NOT be gated on `!versionExists` (that path only runs on
+  // the first POST). Write it once, keyed per version; a re-POST of the immutable
+  // zip 409s on the artifact above before reaching here, so this can't be rewritten.
+  if (
+    packageFilesText != null &&
+    !(await env.BUCKET.head(packageFilesKey(manifest.id, manifest.version)))
+  ) {
+    await env.BUCKET.put(packageFilesKey(manifest.id, manifest.version), packageFilesText, {
+      httpMetadata: { contentType: "application/json; charset=utf-8" },
+    });
   }
 
   const versionEntry = makeVersionEntry(manifest, artifact, publisher.publisher, now.toISOString());

--- a/workers/agent-hub/src/publish.ts
+++ b/workers/agent-hub/src/publish.ts
@@ -18,6 +18,7 @@ import { parseManifest } from "./manifest";
 import {
   artifactKey,
   changelogKey,
+  packageFilesKey,
   rawManifestKey,
   readAgentManifest,
   readmeKey,
@@ -76,6 +77,49 @@ async function optionalMarkdownPart(
   return text;
 }
 
+/**
+ * Read + validate the optional `package_files` part: the listing of files inside
+ * the published whole-package zip. Must be JSON of shape
+ * `{ files: [{ name, size_bytes }] }`. Absent → null (no package zip). A
+ * present-but-malformed part fails loudly rather than storing junk.
+ */
+async function optionalPackageFiles(form: FormData): Promise<string | null> {
+  const part = form.get("package_files");
+  if (part == null) return null;
+  const text = typeof part === "string" ? part : await (part as Blob).text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    throw new HttpError(
+      400,
+      "invalid_request",
+      `The 'package_files' part is not valid JSON: ${(e as Error).message}. Expected ` +
+        `{ "files": [{ "name": "...", "size_bytes": 0 }] }, or omit the part.`
+    );
+  }
+  const files = (parsed as { files?: unknown }).files;
+  if (
+    !Array.isArray(files) ||
+    files.length === 0 ||
+    !files.every(
+      (f) =>
+        f &&
+        typeof (f as Record<string, unknown>).name === "string" &&
+        typeof (f as Record<string, unknown>).size_bytes === "number"
+    )
+  ) {
+    throw new HttpError(
+      400,
+      "invalid_request",
+      "The 'package_files' part must be { \"files\": [{ \"name\": string, " +
+        '"size_bytes": number }, ...] } with at least one file.'
+    );
+  }
+  // Re-serialize canonically (compact) so the stored object is byte-stable.
+  return JSON.stringify({ files });
+}
+
 export async function handlePublish(
   request: Request,
   env: Env,
@@ -122,6 +166,10 @@ export async function handlePublish(
   // pages). Both are optional; an empty part is rejected (omit it instead).
   const readmeText = await optionalMarkdownPart(form, "readme", "README.md");
   const changelogText = await optionalMarkdownPart(form, "changelog", "CHANGELOG.md");
+  // Optional whole-package file listing (the zip's contents, for the hub's file
+  // list). The zip itself rides in as a normal `artifact`; this is just the
+  // manifest of what's inside it.
+  const packageFilesText = await optionalPackageFiles(form);
 
   const manifest = parseManifest(manifestText);
   assertAuthorAllowed(publisher, manifest.author);
@@ -209,6 +257,11 @@ export async function handlePublish(
     if (changelogText != null) {
       await env.BUCKET.put(changelogKey(manifest.id, manifest.version), changelogText, {
         httpMetadata: { contentType: "text/markdown; charset=utf-8" },
+      });
+    }
+    if (packageFilesText != null) {
+      await env.BUCKET.put(packageFilesKey(manifest.id, manifest.version), packageFilesText, {
+        httpMetadata: { contentType: "application/json; charset=utf-8" },
       });
     }
   }

--- a/workers/agent-hub/src/storage.ts
+++ b/workers/agent-hub/src/storage.ts
@@ -42,6 +42,10 @@ export function changelogKey(id: string, version: string): string {
   return `${versionDir(id, version)}CHANGELOG.md`;
 }
 
+export function packageFilesKey(id: string, version: string): string {
+  return `${versionDir(id, version)}package-files.json`;
+}
+
 /**
  * Read the README markdown for one published version. Returns "" when no
  * README was published for that version — the catalog's documented default,
@@ -70,6 +74,22 @@ export async function readChangelog(
   const obj = await bucket.get(changelogKey(id, version));
   if (!obj) return "";
   return obj.text();
+}
+
+/**
+ * Read the whole-package file listing (`{ files: [{name, size_bytes}] }`) for one
+ * version, or null when none was published — the `package_files` form part on
+ * POST /publish is optional, so its absence is the documented "no package zip"
+ * default, not an error.
+ */
+export async function readPackageFiles(
+  bucket: R2Bucket,
+  id: string,
+  version: string
+): Promise<{ files: { name: string; size_bytes: number }[] } | null> {
+  const obj = await bucket.get(packageFilesKey(id, version));
+  if (!obj) return null;
+  return (await obj.json()) as { files: { name: string; size_bytes: number }[] };
 }
 
 /** Read and parse the per-agent manifest, or null if the agent doesn't exist. */

--- a/workers/agent-hub/src/types.ts
+++ b/workers/agent-hub/src/types.ts
@@ -195,6 +195,28 @@ export interface IndexEntry {
   npm_package?: string;
   /** Localhost playground URL served by the agent's sidecar; absent otherwise. */
   playground_url?: string;
+  /**
+   * Whole-package download: a single zip (all platform binaries + client + docs)
+   * plus its file listing. Present only when a `package_files` manifest was
+   * published for the latest version.
+   */
+  package?: PackageInfo;
+}
+
+/** One file inside the whole-package zip (for the hub's file-list display). */
+export interface PackageFile {
+  name: string;
+  size_bytes: number;
+}
+
+/** The downloadable whole-package zip + its contents. */
+export interface PackageInfo {
+  /** Zip artifact filename, e.g. "agent-email-0.2.1.zip" (downloaded from the version dir). */
+  filename: string;
+  /** Zip size in bytes; 0 if the artifact isn't found. */
+  size_bytes: number;
+  /** Files contained in the zip (sorted), for the hub's file list. */
+  files: PackageFile[];
 }
 
 /** The top-level catalog served at GET /index.json. */

--- a/workers/agent-hub/test/fake-r2.ts
+++ b/workers/agent-hub/test/fake-r2.ts
@@ -157,11 +157,13 @@ export function publishRequest(opts: {
   contentType?: string;
   readme?: string;
   changelog?: string;
+  packageFiles?: string;
 }): Request {
   const form = new FormData();
   form.set("manifest", opts.manifestYaml);
   if (opts.readme !== undefined) form.set("readme", opts.readme);
   if (opts.changelog !== undefined) form.set("changelog", opts.changelog);
+  if (opts.packageFiles !== undefined) form.set("package_files", opts.packageFiles);
   const bytes = typeof opts.artifact === "string" ? new TextEncoder().encode(opts.artifact) : opts.artifact;
   form.set(
     "artifact",

--- a/workers/agent-hub/test/publish.test.ts
+++ b/workers/agent-hub/test/publish.test.ts
@@ -620,6 +620,62 @@ describe("POST /publish — npm_package & playground_url", () => {
   });
 });
 
+describe("POST /publish — whole-package zip + file list", () => {
+  const filesJson = JSON.stringify({
+    files: [
+      { name: "binaries/email-agent-linux-x64", size_bytes: 35000000 },
+      { name: "dist/index.js", size_bytes: 4096 },
+      { name: "README.md", size_bytes: 13000 },
+    ],
+  });
+
+  it("surfaces package { filename, size_bytes, files } in index.json when a zip + package_files are published", async () => {
+    const env = makeEnv();
+    await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest({ id: "sidecar" }),
+      artifact: "ZIPBYTES",
+      filename: "agent-sidecar-0.1.0.zip",
+      packageFiles: filesJson,
+    });
+    const entry = (
+      (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex
+    ).agents.find((a) => a.id === "sidecar")!;
+    expect(entry.package).toBeDefined();
+    expect(entry.package!.filename).toBe("agent-sidecar-0.1.0.zip");
+    expect(entry.package!.size_bytes).toBe("ZIPBYTES".length);
+    expect(entry.package!.files).toHaveLength(3);
+    expect(entry.package!.files[0].name).toBe("binaries/email-agent-linux-x64");
+  });
+
+  it("omits package when no package_files manifest is published (even if a .zip exists)", async () => {
+    const env = makeEnv();
+    await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest({ id: "plain" }),
+      artifact: "z",
+      filename: "plain-0.1.0.zip",
+    });
+    const entry = (
+      (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex
+    ).agents.find((a) => a.id === "plain")!;
+    expect(entry.package).toBeUndefined();
+  });
+
+  it("rejects a malformed package_files part (400)", async () => {
+    const env = makeEnv();
+    const res = await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest({ id: "bad" }),
+      artifact: "z",
+      filename: "bad-0.1.0.zip",
+      packageFiles: '{"files":[{"name":"x"}]}', // missing size_bytes
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error.code).toBe("invalid_request");
+  });
+});
+
 describe("POST /publish — security tier & deprecation", () => {
   it("records the security_tier in the per-agent manifest and index", async () => {
     const env = makeEnv();

--- a/workers/agent-hub/test/publish.test.ts
+++ b/workers/agent-hub/test/publish.test.ts
@@ -648,6 +648,40 @@ describe("POST /publish — whole-package zip + file list", () => {
     expect(entry.package!.files[0].name).toBe("binaries/email-agent-linux-x64");
   });
 
+  it("stores package_files on a LATER POST after the version already exists (real release order)", async () => {
+    // The real release publishes the per-platform binaries first (creating the
+    // version), THEN the whole-package zip + package_files in a separate POST. So
+    // the listing arrives when versionExists is already true — it must still be
+    // stored, or the catalog never gets `package` and the file list never renders.
+    const env = makeEnv();
+    const yaml = sampleManifest({ id: "email", name: "Email", version: "0.1.0" });
+
+    const first = await publish(env, {
+      token: "tok_amd",
+      manifestYaml: yaml,
+      artifact: "linux-binary",
+      filename: "email-agent-linux-x64",
+    });
+    expect(first.status).toBe(201);
+
+    // Second POST: the whole-package zip + the file listing, version now exists.
+    const second = await publish(env, {
+      token: "tok_amd",
+      manifestYaml: yaml,
+      artifact: "ZIPBYTES",
+      filename: "agent-email-0.1.0.zip",
+      packageFiles: filesJson,
+    });
+    expect(second.status).toBe(201);
+
+    const entry = (
+      (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex
+    ).agents.find((a) => a.id === "email")!;
+    expect(entry.package).toBeDefined();
+    expect(entry.package!.filename).toBe("agent-email-0.1.0.zip");
+    expect(entry.package!.files).toHaveLength(3);
+  });
+
   it("omits package when no package_files manifest is published (even if a .zip exists)", async () => {
     const env = makeEnv();
     await publish(env, {


### PR DESCRIPTION
## Why this matters

The hub agent page showed only metadata — a visitor couldn't actually grab the package, and any "download" would have been a single platform binary, not the whole thing. This adds a one-click **Download .zip** (one archive containing the npm client, all docs, and **every platform binary**) plus a **file list** of exactly what's inside — so anyone can pull the complete agent for any OS straight from `hub.amd-gaia.ai/hub/<id>`.

Design (chosen up front): **one cross-platform zip**, **pre-built at release time** (the publish pipeline assembles + uploads it; the hub just links to a stored object).

## What's in it

- **Release pipeline** (`release_agent_email.yml`): after the binaries publish and the lock is regenerated with real hashes, assemble `agent-email-<version>.zip` — `binaries/` (all platforms) + `dist/` (npm client) + README/SPEC/SKILL/CHANGELOG + `binaries.lock.json` + `gaia-agent.yaml` + LICENSE — emit a `package-files.json` listing (new `gen_package_files.py`), and POST both (zip artifact + `package_files`).
- **Worker**: optional `package_files` part on `/publish` → stored per-version → paired with the `.zip` artifact into the catalog's `package` (`{ filename, size_bytes, files }`). `storage`/`publish`/`catalog`/`types`/schema + Worker README + 3 tests.
- **Website**: a **Download .zip** button (with size) and a collapsible **file list** on the agent page, hidden gracefully when no package was published.

## Test plan

- [ ] Worker: `cd workers/agent-hub && npm test` (63 pass) + `npx tsc --noEmit`
- [ ] Website: `cd website && npx astro check` (0 errors) + `npx vitest run` (19) + build
- [ ] Helper: `python hub/agents/python/email/packaging/gen_package_files.py <dir> out.json` → sorted `{files:[{name,size_bytes}]}`
- [ ] `publish_to_r2.py --help` shows `--package-files`
- [ ] After a 0.2.1 release on the new pipeline: `/hub/email` shows the Download .zip button + file list (the zip appears live only once a release publishes it — pre-built at release time)