### PR TITLE
ci(agent-email): make the whole-package zip best-effort (unblocks 0.2.1 npm publish)

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -503,6 +503,11 @@ jobs:
           npm run build
 
       - name: Assemble + publish the whole-package zip (all platforms + client + docs)
+        # Best-effort: the whole-package zip bundles all platform binaries (~177 MB),
+        # which exceeds Cloudflare's 100 MB request-body limit on /publish (502). Until
+        # the zip is uploaded straight to R2 (bypassing the Worker), don't let it block
+        # the npm publish + website redeploy. The package-download card is a nice-to-have.
+        continue-on-error: true
         shell: bash
         env:
           AGENT_HUB_PUBLISH_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
@@ -564,6 +569,9 @@ jobs:
           done
 
       - name: Verify the published package zip is fetchable at the edge
+        # Best-effort to match the publish step above — if the oversized zip wasn't
+        # uploaded, don't fail the release on a missing edge object.
+        continue-on-error: true
         shell: bash
         env:
           GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}


### PR DESCRIPTION
## Why this matters

The 0.2.1 release ([run 28120665597](https://github.com/amd/gaia/actions/runs/28120665597)) published the binaries and flipped the catalog to 0.2.1, but **failed at the whole-package-zip step**, which aborted the job *before* npm publish and the website redeploy. So npm is still stuck at 0.2.0.

Root cause: the whole-package zip bundles all four platform binaries (~177 MB), which exceeds **Cloudflare's 100 MB request-body limit** on `/publish` → 502. A nice-to-have download card should never block the core release.

This makes the zip publish + its edge-verify `continue-on-error: true` (same best-effort treatment the Intel binary already gets). The proper fix for the zip is uploading it straight to R2, bypassing the Worker — tracked separately.

## After merge
Re-dispatch `release_agent_email.yml` with version `0.2.1`: binaries 409-no-op (immutable), the zip is skipped/tolerated, the lock regenerates with real hashes, and **npm publishes 0.2.1 with OIDC provenance** + the site redeploys.

## Test plan
- [ ] Merge, then `gh workflow run release_agent_email.yml -f version=0.2.1`
- [ ] Confirm the run reaches **Publish to npm** and `npm view @amd-gaia/agent-email version` → 0.2.1
- [ ] Zip step shows as tolerated (yellow), not a hard failure