### PR TITLE
chore(agent-email): cut 0.2.2 (first complete publish of the 0.2.1 feature set)

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,23 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## 0.2.2
+
+Release-reliability fix. The 0.2.1 tag published the per-platform binaries to the
+Agent Hub but its npm publish never completed: the Hub Worker buffered the entire
+upload in memory, so the new ~177 MB whole-package zip exceeded Cloudflare's
+128 MB per-Worker memory limit and the publish step 502'd before npm. 0.2.2 fixes
+that and is the first complete publish of the 0.2.1 feature set. No agent
+wire-contract change — `SCHEMA_VERSION` stays `2.0` and the client + REST/MCP
+surface are unchanged.
+
+### Fixed
+
+- **Whole-package zip + npm publish now complete.** The Agent Hub Worker
+  (`POST /publish`) streams large `application/octet-stream` uploads straight to
+  R2 with server-side SHA-256 verification instead of reading the whole body into
+  memory, so the ~177 MB whole-package zip publishes without OOMing the Worker.
+
 ## 0.2.1
 
 Adds the one-command `playground` launcher and automatic sidecar cleanup, and

--- a/hub/agents/npm/agent-email/assets/architecture.html
+++ b/hub/agents/npm/agent-email/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.2.1</span>
+      <span class="ver" id="ver">v0.2.2</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.2.1",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.1",
+  "agentVersion": "0.2.2",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.2",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.2.1
+version: 0.2.2
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.2.1"
+AGENT_VERSION = "0.2.2"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.2.1"
+version = "0.2.2"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }


### PR DESCRIPTION
Bumps the email agent to **0.2.2** so the release can be re-cut now that the Hub publish 502 is fixed on main ([#1849](https://github.com/amd/gaia/pull/1849), the streaming fix). 0.2.1 published its per-platform binaries to the Hub but its npm publish never completed (the worker OOM'd on the ~177 MB whole-package zip), so 0.2.2 is the first *complete* publish of the same feature set. No agent wire-contract change — `SCHEMA_VERSION` stays 2.0.

Keeps all four version sources in sync (the release workflow's version-resolve step asserts this): `gaia-agent.yaml`, `pyproject.toml`, `version.py`, npm `package.json` → 0.2.2, plus the CHANGELOG entry.

> ⚠️ **Prerequisite before tagging `agent-pkg-email-v0.2.2`:** the live Agent Hub **worker must be redeployed** with the streaming fix. Merging #1849 updated the worker *source* on main but no CI deploys the worker — it's a manual `wrangler deploy` (Cloudflare account that owns `agent-hub`). Tagging before that redeploy would 502 again.

## Test plan
- [x] All four version sources read 0.2.2 (sync gate)
- [x] `cd hub/agents/npm/agent-email && npm run build && npm test` — 46 pass; `npm pack` ships README/CHANGELOG/SKILL/SPEC