### PR TITLE
chore(agent-email): cut 0.2.3 (re-cut of 0.2.2 after Hub worker redeploy)

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,14 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## 0.2.3
+
+Re-cut of 0.2.2 after the Agent Hub worker was redeployed with the large-artifact
+streaming fix. 0.2.2 published its per-platform binaries but its whole-package zip
+and npm publish never completed (the live worker hadn't yet picked up the fix);
+0.2.3 is the first fully-published release of this feature set. No agent
+wire-contract change — `SCHEMA_VERSION` stays `2.0`.
+
 ## 0.2.2
 
 Release-reliability fix. The 0.2.1 tag published the per-platform binaries to the

--- a/hub/agents/npm/agent-email/assets/architecture.html
+++ b/hub/agents/npm/agent-email/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.2.2</span>
+      <span class="ver" id="ver">v0.2.3</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.2.2",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.2",
+  "agentVersion": "0.2.3",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.3",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.2.2
+version: 0.2.3
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.2.2"
+AGENT_VERSION = "0.2.3"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.2.2"
+version = "0.2.3"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }


### PR DESCRIPTION
Re-cuts the email agent at **0.2.3** now that the Agent Hub worker has been redeployed with the streaming fix ([#1849](https://github.com/amd/gaia/pull/1849)). 0.2.2 published its per-platform binaries but its whole-package zip + npm publish never completed because the live worker hadn't yet picked up the fix — so 0.2.3 is the first fully-published release of this feature set. No agent wire-contract change (`SCHEMA_VERSION` stays 2.0).

All seven version targets synced via `stamp_version.py` (the sync gate): `version.py` (source), `gaia-agent.yaml`, `pyproject.toml`, npm `package.json`, `binaries.lock.json` (agentVersion + baseUrl), and the `architecture.html` badge → 0.2.3, plus the CHANGELOG entry.

## Test plan
- [x] `stamp_version.py --check` passes on all targets
- [x] `cd hub/agents/npm/agent-email && npm run build && npm test`
- [ ] Tag `agent-pkg-email-v0.2.3` → release run publishes binaries + zip + npm @0.2.3 (the real test that the worker redeploy resolved the 502)