### PR TITLE
feat(hub): Files (package listing), Spec & Skill doc tabs on the agent page

### DIFF
--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -93,6 +93,10 @@ env:
   # Same canonical-doc story for the changelog: the npm CHANGELOG.md is what the
   # hub renders as the agent's Changelog section (and ships in the npm tarball).
   CHANGELOG: hub/agents/npm/agent-email/CHANGELOG.md
+  # SPEC.md (technical reference) + SKILL.md (AI-integration playbook) are rendered
+  # as their own doc tabs on the hub page (catalog entry's `spec` / `skill`).
+  SPEC: hub/agents/npm/agent-email/SPEC.md
+  SKILL: hub/agents/npm/agent-email/SKILL.md
   FREEZE_DIST: hub/agents/python/email/packaging/dist
   # Hub key prefix (mirrors the Worker's agents/<id> layout). The Worker owns the
   # bucket binding; CI never talks to R2 directly — it POSTs to /publish.
@@ -459,6 +463,8 @@ jobs:
             --manifest "${MANIFEST}" \
             --readme "${README}" \
             --changelog "${CHANGELOG}" \
+            --spec "${SPEC}" \
+            --skill "${SKILL}" \
             "${args[@]}" \
             --summary-out published.json
           echo "=== publish summary ==="

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -1,0 +1,64 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# PR + main CI for the marketing/hub website (website/, Astro). Catches the
+# website breaking BEFORE it ships — previously the only build was Railway's
+# post-merge deploy, so a broken page (type error, failed Astro build, broken
+# hub render) reached main and only failed at deploy time. This runs on every PR
+# that touches website/.
+#
+# The build needs a live catalog (website has NO bundled fixture fallback — see
+# website/src/data/catalog.ts), so HUB_CATALOG_URL points at the live Agent Hub
+# Worker, exactly like the Railway production build.
+
+name: Website CI
+
+on:
+  pull_request:
+    paths:
+      - 'website/**'
+      - '.github/workflows/website-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/website-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: website-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Type-check, test, build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    env:
+      # Same source the Railway production build uses; the live catalog is the
+      # real dependency (no fixture fallback). A hub outage fails the build loudly.
+      HUB_CATALOG_URL: https://hub.amd-gaia.ai
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check (astro check)
+        run: npx astro check
+
+      - name: Unit tests (vitest)
+        run: npm test
+
+      - name: Build (astro build from the live catalog)
+        run: npx astro build

--- a/hub/agents/python/email/packaging/publish_to_r2.py
+++ b/hub/agents/python/email/packaging/publish_to_r2.py
@@ -127,6 +127,8 @@ def publish_one(
     token: str,
     readme_bytes: bytes | None = None,
     changelog_bytes: bytes | None = None,
+    spec_bytes: bytes | None = None,
+    skill_bytes: bytes | None = None,
     package_files_bytes: bytes | None = None,
 ) -> dict:
     if not artifact_path.exists():
@@ -164,6 +166,12 @@ def publish_one(
         # `changelog`, rendered as a Changelog section on the hub agent page.
         if changelog_bytes is not None:
             files["changelog"] = ("CHANGELOG.md", changelog_bytes, "text/markdown")
+        # SPEC.md + SKILL.md ride along the same way — they become the catalog
+        # entry's `spec` / `skill`, rendered as their own doc tabs on the hub page.
+        if spec_bytes is not None:
+            files["spec"] = ("SPEC.md", spec_bytes, "text/markdown")
+        if skill_bytes is not None:
+            files["skill"] = ("SKILL.md", skill_bytes, "text/markdown")
         # The whole-package file listing rides with the zip artifact — it becomes
         # the catalog entry's `package.files` (the hub's file-list display).
         if package_files_bytes is not None:
@@ -252,6 +260,18 @@ def main(argv=None) -> int:
         "(POSTed as the multipart 'changelog' part the Worker accepts).",
     )
     parser.add_argument(
+        "--spec",
+        type=Path,
+        help="Path to SPEC.md to publish as the agent's catalog spec "
+        "(POSTed as the multipart 'spec' part the Worker accepts).",
+    )
+    parser.add_argument(
+        "--skill",
+        type=Path,
+        help="Path to SKILL.md to publish as the agent's catalog skill "
+        "(POSTed as the multipart 'skill' part the Worker accepts).",
+    )
+    parser.add_argument(
         "--package-files",
         type=Path,
         help='Path to a package-files.json ({"files":[{name,size_bytes}]}) to '
@@ -295,6 +315,32 @@ def main(argv=None) -> int:
             flush=True,
         )
 
+    spec_bytes = None
+    if args.spec is not None:
+        if not args.spec.exists():
+            raise SystemExit(
+                f"error: --spec path not found: {args.spec}. Pass the agent's "
+                "SPEC.md, or omit --spec to publish without one."
+            )
+        spec_bytes = args.spec.read_bytes()
+        print(
+            f"[publish] attaching spec: {args.spec} ({len(spec_bytes)} bytes)",
+            flush=True,
+        )
+
+    skill_bytes = None
+    if args.skill is not None:
+        if not args.skill.exists():
+            raise SystemExit(
+                f"error: --skill path not found: {args.skill}. Pass the agent's "
+                "SKILL.md, or omit --skill to publish without one."
+            )
+        skill_bytes = args.skill.read_bytes()
+        print(
+            f"[publish] attaching skill: {args.skill} ({len(skill_bytes)} bytes)",
+            flush=True,
+        )
+
     package_files_bytes = None
     if args.package_files is not None:
         if not args.package_files.exists():
@@ -328,6 +374,8 @@ def main(argv=None) -> int:
                 token,
                 readme_bytes=readme_bytes,
                 changelog_bytes=changelog_bytes,
+                spec_bytes=spec_bytes,
+                skill_bytes=skill_bytes,
                 package_files_bytes=package_files_bytes,
             )
         )

--- a/website/src/components/FileTree.astro
+++ b/website/src/components/FileTree.astro
@@ -1,0 +1,50 @@
+---
+// Recursive file-tree renderer for the hub agent page's Files tab. Folders are
+// native <details> so expand/collapse works without JS (and is keyboard- and
+// screen-reader-accessible); text files render as a preview button.
+import { formatBytes } from '../data/catalog';
+import type { FileTreeNode } from '../data/fileTree';
+import Self from './FileTree.astro';
+
+interface Props {
+  nodes: FileTreeNode[];
+  depth?: number;
+}
+const { nodes, depth = 0 } = Astro.props;
+---
+
+<ul class="space-y-0.5">
+  {nodes.map((n) =>
+    n.isFile ? (
+      <li class="flex items-baseline justify-between gap-3 py-0.5">
+        {n.previewUrl ? (
+          <button
+            type="button"
+            data-file-preview={n.previewUrl}
+            data-file-name={n.name}
+            class="truncate text-left text-g-text/85 transition-colors hover:text-g-gold-text hover:underline"
+            title={`Preview ${n.name}`}
+          >{n.name}</button>
+        ) : (
+          <span class="truncate text-g-text/60" title={n.name}>{n.name}</span>
+        )}
+        <span class="flex-none text-[11px] text-g-muted">{formatBytes(n.size)}</span>
+      </li>
+    ) : (
+      <li>
+        <details>
+          <summary class="file-tree-summary flex cursor-pointer list-none items-center justify-between gap-3 py-0.5">
+            <span class="flex min-w-0 items-center gap-1.5 font-semibold text-g-text">
+              <svg class="file-tree-chevron h-3 w-3 flex-none text-g-muted" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M4.5 2.5L8 6l-3.5 3.5"/></svg>
+              <span class="truncate">{n.name}/</span>
+            </span>
+            <span class="flex-none text-[11px] text-g-muted">{n.count} {n.count === 1 ? 'file' : 'files'} · {formatBytes(n.size)}</span>
+          </summary>
+          <div class="ml-2 border-l border-g-border/40 pl-3">
+            <Self nodes={n.children} depth={depth + 1} />
+          </div>
+        </details>
+      </li>
+    )
+  )}
+</ul>

--- a/website/src/components/InstallMethods.astro
+++ b/website/src/components/InstallMethods.astro
@@ -18,26 +18,30 @@ const methods = installMethods(agent);
 ---
 
 <div data-install-methods>
-  <div
-    role="tablist"
-    aria-label={`How to install ${agent.name}`}
-    class="inline-flex flex-wrap gap-1 rounded-lg border border-g-border bg-g-surface p-1"
-  >
-    {methods.map((m, i) => (
-      <button
-        type="button"
-        role="tab"
-        id={`im-tab-${m.key}`}
-        aria-controls={`im-panel-${m.key}`}
-        aria-selected={i === 0 ? 'true' : 'false'}
-        tabindex={i === 0 ? 0 : -1}
-        data-im-tab={m.key}
-        class="im-tab rounded-md px-3.5 py-1.5 text-[13px] font-medium text-g-muted transition-colors hover:text-g-text aria-selected:bg-g-gold aria-selected:font-semibold aria-selected:text-black"
-      >
-        {m.label}
-      </button>
-    ))}
-  </div>
+  {/* The switcher only makes sense with 2+ methods. A single-method agent (e.g.
+      an npm-only sidecar) just shows its command — no lone, inert tab button. */}
+  {methods.length > 1 && (
+    <div
+      role="tablist"
+      aria-label={`How to install ${agent.name}`}
+      class="inline-flex flex-wrap gap-1 rounded-lg border border-g-border bg-g-surface p-1"
+    >
+      {methods.map((m, i) => (
+        <button
+          type="button"
+          role="tab"
+          id={`im-tab-${m.key}`}
+          aria-controls={`im-panel-${m.key}`}
+          aria-selected={i === 0 ? 'true' : 'false'}
+          tabindex={i === 0 ? 0 : -1}
+          data-im-tab={m.key}
+          class="im-tab rounded-md px-3.5 py-1.5 text-[13px] font-medium text-g-muted transition-colors hover:text-g-text aria-selected:bg-g-gold aria-selected:font-semibold aria-selected:text-black"
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  )}
 
   {methods.map((m, i) => (
     <div
@@ -58,7 +62,7 @@ const methods = installMethods(agent);
         <span class="min-w-0 flex-1 truncate">{m.command}</span>
         <span class="im-copy-label flex-none select-none text-[11px] text-g-muted transition-colors group-hover:text-g-gold-text">copy</span>
       </button>
-      <p class="mt-2 text-[12.5px] text-g-muted">{m.note}</p>
+      {m.note && <p class="mt-2 text-[12.5px] text-g-muted">{m.note}</p>}
     </div>
   ))}
 </div>

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -258,7 +258,7 @@ export function installMethods(agent: Agent): InstallMethod[] {
         key: 'npm',
         label: 'npm',
         command: `npm i ${agent.npm_package}`,
-        note: 'Installs the client and fetches the local sidecar binary on first run. Runs 100% locally on AMD Ryzen AI.',
+        note: '',
       },
     ];
   }

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -52,6 +52,11 @@ export interface Agent {
   // Optional at the type level so the site stays resilient to an older index.json
   // served before the hub Worker that adds this field is redeployed.
   changelog?: string;
+  // SPEC.md (technical reference) + SKILL.md (AI-integration playbook) markdown of
+  // the latest version, rendered as their own doc tabs. "" / absent if none was
+  // published. Optional for the same older-index.json resilience as `changelog`.
+  spec?: string;
+  skill?: string;
   // npm package name (e.g. "@amd-gaia/agent-email") when the agent is
   // distributed as an npm client + frozen sidecar. Present → npm is the install
   // path. Absent → the agent installs via pip/GAIA (language-driven).

--- a/website/src/data/fileTree.test.ts
+++ b/website/src/data/fileTree.test.ts
@@ -1,0 +1,70 @@
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { buildFileTree, isTextFile, type FileTreeNode } from './fileTree';
+
+const CDN = 'https://cdn.jsdelivr.net/npm/@amd-gaia/agent-email@0.2.4/';
+
+function child(node: FileTreeNode, name: string): FileTreeNode {
+  const c = node.children.find((x) => x.name === name);
+  if (!c) throw new Error(`no child '${name}' in [${node.children.map((x) => x.name)}]`);
+  return c;
+}
+
+describe('isTextFile', () => {
+  it('accepts text extensions and known doc names', () => {
+    for (const n of ['README.md', 'cli.js', 'types.d.ts', 'package.json', 'gaia-agent.yaml', 'LICENSE', 'cli.js.map']) {
+      expect(isTextFile(n), n).toBe(true);
+    }
+  });
+  it('rejects binaries (no text extension)', () => {
+    for (const n of ['email-agent-linux-x64', 'email-agent-win32-x64.exe', 'model.gguf', 'logo.png']) {
+      expect(isTextFile(n), n).toBe(false);
+    }
+  });
+});
+
+describe('buildFileTree', () => {
+  const files = [
+    { name: 'binaries/email-agent-linux-x64', size_bytes: 100 },
+    { name: 'binaries/email-agent-win32-x64.exe', size_bytes: 200 },
+    { name: 'dist/cli.js', size_bytes: 10 },
+    { name: 'README.md', size_bytes: 5 },
+  ];
+
+  it('groups into folders with aggregated size + count', () => {
+    const root = buildFileTree(files, CDN);
+    const bin = child(root, 'binaries');
+    expect(bin.isFile).toBe(false);
+    expect(bin.count).toBe(2);
+    expect(bin.size).toBe(300);
+    expect(child(root, 'dist').size).toBe(10);
+  });
+
+  it('sorts folders before files, each alphabetical', () => {
+    const root = buildFileTree(files, CDN);
+    expect(root.children.map((c) => c.name)).toEqual(['binaries', 'dist', 'README.md']);
+  });
+
+  it('gives text files a CDN previewUrl but binaries none', () => {
+    const root = buildFileTree(files, CDN);
+    expect(child(root, 'README.md').previewUrl).toBe(`${CDN}README.md`);
+    expect(child(child(root, 'dist'), 'cli.js').previewUrl).toBe(`${CDN}dist/cli.js`);
+    // binaries are not text → not previewable
+    expect(child(child(root, 'binaries'), 'email-agent-linux-x64').previewUrl).toBeUndefined();
+    expect(child(child(root, 'binaries'), 'email-agent-win32-x64.exe').previewUrl).toBeUndefined();
+  });
+
+  it('disables previews entirely when previewBase is null (non-npm agent)', () => {
+    const root = buildFileTree(files, null);
+    expect(child(root, 'README.md').previewUrl).toBeUndefined();
+    expect(child(child(root, 'dist'), 'cli.js').previewUrl).toBeUndefined();
+  });
+
+  it('handles an empty listing', () => {
+    const root = buildFileTree([], CDN);
+    expect(root.children).toEqual([]);
+    expect(root.count).toBe(0);
+  });
+});

--- a/website/src/data/fileTree.ts
+++ b/website/src/data/fileTree.ts
@@ -1,0 +1,84 @@
+// Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Build a nested, collapsible tree from the flat package file listing
+// (catalog `package.files`), used by the hub agent page's Files tab.
+
+export interface FileTreeNode {
+  /** Path segment (file or folder name at this level). */
+  name: string;
+  isFile: boolean;
+  /** File size in bytes, or the aggregate size of everything under a folder. */
+  size: number;
+  /** File count under a folder (1 for a file). */
+  count: number;
+  children: FileTreeNode[];
+  /** Set on text files that can be previewed — the URL to fetch their content. */
+  previewUrl?: string;
+}
+
+// Extensions / names we treat as previewable text. Binaries (no text extension,
+// e.g. `email-agent-linux-x64`, `.exe`) fail this and stay non-clickable.
+const TEXT_EXTS = new Set([
+  'md', 'markdown', 'txt', 'json', 'js', 'mjs', 'cjs', 'ts', 'tsx', 'jsx',
+  'yaml', 'yml', 'lock', 'map', 'css', 'html', 'htm', 'sh', 'toml', 'xml',
+  'ini', 'cfg', 'env',
+]);
+const TEXT_NAMES = new Set(['license', 'readme', 'changelog', 'authors', 'notice']);
+
+export function isTextFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (TEXT_NAMES.has(lower)) return true;
+  const dot = lower.lastIndexOf('.');
+  return dot !== -1 && TEXT_EXTS.has(lower.slice(dot + 1));
+}
+
+/**
+ * Build a sorted (folders-first, then alphabetical) tree from a flat list of
+ * `{ name, size_bytes }`. `previewBase` (e.g. a jsdelivr npm URL prefix) is
+ * prepended to a text file's full path to make its `previewUrl`; pass null to
+ * disable previews (no CDN for non-npm agents).
+ */
+export function buildFileTree(
+  files: { name: string; size_bytes: number }[],
+  previewBase: string | null
+): FileTreeNode {
+  const root: FileTreeNode = { name: '', isFile: false, size: 0, count: 0, children: [] };
+  for (const f of files) {
+    const parts = f.name.split('/').filter(Boolean);
+    let node = root;
+    parts.forEach((seg, i) => {
+      const isLeaf = i === parts.length - 1;
+      let child = node.children.find((c) => c.name === seg && c.isFile === isLeaf);
+      if (!child) {
+        child = {
+          name: seg,
+          isFile: isLeaf,
+          size: isLeaf ? f.size_bytes : 0,
+          count: 0,
+          children: [],
+        };
+        if (isLeaf && previewBase && isTextFile(seg)) {
+          child.previewUrl = previewBase + f.name;
+        }
+        node.children.push(child);
+      }
+      node = child;
+    });
+  }
+  finalize(root);
+  return root;
+}
+
+function finalize(n: FileTreeNode): void {
+  if (n.isFile) {
+    n.count = 1;
+    return;
+  }
+  for (const c of n.children) finalize(c);
+  n.size = n.children.reduce((s, c) => s + c.size, 0);
+  n.count = n.children.reduce((s, c) => s + c.count, 0);
+  n.children.sort((a, b) =>
+    a.isFile === b.isFile ? a.name.localeCompare(b.name) : a.isFile ? 1 : -1
+  );
+}

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -38,11 +38,44 @@ const npmUrl = agent.npm_package ? `https://www.npmjs.com/package/${agent.npm_pa
 const installCmd = isNpm ? `npm i ${agent.npm_package}` : `gaia agent install ${agent.id}`;
 const deepLink = `gaia://hub/install/${agent.id}`;
 const readmeHtml = renderMarkdown(agent.readme);
-// Optional — older index.json (served before the hub Worker adds the field) has
-// no changelog; render the section only when there's content.
+// Optional docs — older index.json (served before the hub Worker adds a field) may
+// lack these; render a tab only when there's content.
 const changelogHtml = agent.changelog ? renderMarkdown(agent.changelog) : '';
+const specHtml = agent.spec ? renderMarkdown(agent.spec) : '';
+const skillHtml = agent.skill ? renderMarkdown(agent.skill) : '';
 const req = agent.requirements;
 const pkgUrl = packageDownloadUrl(agent);
+
+// Package contents → a directory listing for the Files tab. Group each file by its
+// top-level folder (root files under "/"), sorted folders-first then root.
+const packageFiles = agent.package?.files ?? [];
+const fileGroups = (() => {
+  const map = new Map<string, { base: string; size_bytes: number }[]>();
+  for (const f of packageFiles) {
+    const slash = f.name.indexOf('/');
+    const dir = slash === -1 ? '/' : f.name.slice(0, slash);
+    const base = slash === -1 ? f.name : f.name.slice(slash + 1);
+    if (!map.has(dir)) map.set(dir, []);
+    map.get(dir)!.push({ base, size_bytes: f.size_bytes });
+  }
+  return [...map.entries()]
+    .map(([dir, files]) => ({
+      dir,
+      files: files.sort((a, b) => a.base.localeCompare(b.base)),
+      size: files.reduce((s, f) => s + f.size_bytes, 0),
+    }))
+    .sort((a, b) => (a.dir === '/' ? 1 : b.dir === '/' ? -1 : a.dir.localeCompare(b.dir)));
+})();
+
+// Doc tabs that actually have content (README is always present). The Files tab is
+// the package's directory listing; it only appears once a whole-package zip ships.
+const docTabs = [
+  { key: 'readme', label: 'README' },
+  ...(specHtml ? [{ key: 'spec', label: 'Spec' }] : []),
+  ...(skillHtml ? [{ key: 'skill', label: 'Skill' }] : []),
+  ...(changelogHtml ? [{ key: 'changelog', label: 'Changelog' }] : []),
+  ...(packageFiles.length ? [{ key: 'files', label: 'Files' }] : []),
+];
 const terminalLines = [
   { prompt: true, text: installCmd },
   { muted: true, text: `✓ ${agent.name} ${agent.latest_version} installed` },
@@ -108,13 +141,23 @@ const terminalLines = [
       </div>
     </section>
 
-    <!-- Body: tabbed docs (README / Changelog) + manifest-driven cards -->
+    <!-- Body: tabbed docs (README / Spec / Skill / Changelog / Files) + cards -->
     <div class="mt-12 grid lg:grid-cols-[minmax(0,1fr)_280px] gap-12">
       <div class="min-w-0" data-doc-tabs>
-        {changelogHtml && (
-          <div role="tablist" aria-label={`${agent.name} documentation`} class="flex gap-1 border-b border-g-border mb-7">
-            <button type="button" role="tab" id="doctab-readme" aria-controls="docpanel-readme" data-doc-tab="readme" aria-selected="true" tabindex="0" class="doc-tab">README</button>
-            <button type="button" role="tab" id="doctab-changelog" aria-controls="docpanel-changelog" data-doc-tab="changelog" aria-selected="false" tabindex="-1" class="doc-tab">Changelog</button>
+        {docTabs.length > 1 && (
+          <div role="tablist" aria-label={`${agent.name} documentation`} class="flex gap-1 border-b border-g-border mb-7 overflow-x-auto">
+            {docTabs.map((t, i) => (
+              <button
+                type="button"
+                role="tab"
+                id={`doctab-${t.key}`}
+                aria-controls={`docpanel-${t.key}`}
+                data-doc-tab={t.key}
+                aria-selected={i === 0 ? 'true' : 'false'}
+                tabindex={i === 0 ? 0 : -1}
+                class="doc-tab"
+              >{t.label}</button>
+            ))}
           </div>
         )}
         <article role="tabpanel" id="docpanel-readme" aria-labelledby="doctab-readme" data-doc-panel="readme" class="doc max-w-[70ch]">
@@ -124,10 +167,55 @@ const terminalLines = [
             <TerminalBlock lines={terminalLines} typing />
           </div>
         </article>
+        {specHtml && (
+          <article role="tabpanel" id="docpanel-spec" aria-labelledby="doctab-spec" data-doc-panel="spec" class="doc max-w-[70ch]" hidden>
+            <div set:html={specHtml} />
+          </article>
+        )}
+        {skillHtml && (
+          <article role="tabpanel" id="docpanel-skill" aria-labelledby="doctab-skill" data-doc-panel="skill" class="doc max-w-[70ch]" hidden>
+            <div set:html={skillHtml} />
+          </article>
+        )}
         {changelogHtml && (
           <article role="tabpanel" id="docpanel-changelog" aria-labelledby="doctab-changelog" data-doc-panel="changelog" class="doc max-w-[70ch]" hidden>
             <div set:html={changelogHtml} />
           </article>
+        )}
+        {packageFiles.length > 0 && (
+          <section role="tabpanel" id="docpanel-files" aria-labelledby="doctab-files" data-doc-panel="files" hidden>
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <h2 class="text-xl font-semibold tracking-tight">Package contents</h2>
+              {pkgUrl && agent.package && (
+                <a
+                  href={pkgUrl}
+                  download={agent.package.filename}
+                  class="flex items-center gap-2 rounded-md border border-g-gold/40 bg-g-bg/40 px-3 py-1.5 text-[12px] font-medium text-g-gold-text hover:border-g-gold/70 transition-colors"
+                >Download .zip <span class="font-mono text-g-muted">{formatBytes(agent.package.size_bytes)}</span></a>
+              )}
+            </div>
+            <p class="mt-2 mb-5 text-[13px] text-g-muted">
+              {packageFiles.length} files across {fileGroups.length} {fileGroups.length === 1 ? 'folder' : 'folders'} — the client, docs, and every platform binary, in one archive.
+            </p>
+            <div class="overflow-hidden rounded-xl border border-g-border font-mono text-[12.5px]">
+              {fileGroups.map((g) => (
+                <div>
+                  <div class="flex items-center justify-between gap-3 border-b border-g-border bg-g-surface px-4 py-2">
+                    <span class="font-semibold text-g-text">{g.dir === '/' ? '/' : `${g.dir}/`}</span>
+                    <span class="flex-none text-[11px] text-g-muted">{g.files.length} {g.files.length === 1 ? 'file' : 'files'} · {formatBytes(g.size)}</span>
+                  </div>
+                  <ul>
+                    {g.files.map((f) => (
+                      <li class="flex items-baseline justify-between gap-3 border-b border-g-border/40 px-4 py-1.5 last:border-0">
+                        <span class="truncate text-g-text/85" title={f.base}>{f.base}</span>
+                        <span class="flex-none text-[11px] text-g-muted">{formatBytes(f.size_bytes)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </section>
         )}
       </div>
 
@@ -191,19 +279,11 @@ const terminalLines = [
             <p class="mt-2 text-[12px] leading-relaxed text-g-muted">
               One archive — the client, docs, and every platform binary. Runs on any supported OS.
             </p>
-            <details class="mt-3">
-              <summary class="cursor-pointer text-[12px] text-g-muted hover:text-g-text">
-                {agent.package.files.length} files
-              </summary>
-              <ul class="mt-2 max-h-64 space-y-1 overflow-y-auto pr-1 text-[11px] font-mono text-g-muted">
-                {agent.package.files.map((f) => (
-                  <li class="flex items-baseline justify-between gap-2">
-                    <span class="truncate" title={f.name}>{f.name}</span>
-                    <span class="flex-none text-g-muted/70">{formatBytes(f.size_bytes)}</span>
-                  </li>
-                ))}
-              </ul>
-            </details>
+            <button
+              type="button"
+              data-doc-goto="files"
+              class="mt-3 text-[12px] font-medium text-g-gold-text hover:underline"
+            >View all {agent.package.files.length} files →</button>
           </section>
         )}
 
@@ -392,6 +472,17 @@ const terminalLines = [
         next.focus();
       });
     });
+
+    // Cross-links elsewhere on the page (e.g. the Package card's "View all files")
+    // that jump to a specific doc tab and scroll it into view.
+    document.querySelectorAll<HTMLElement>('[data-doc-goto]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const key = btn.getAttribute('data-doc-goto');
+        select(key);
+        tabRoot.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        tabs.find((t) => t.getAttribute('data-doc-tab') === key)?.focus();
+      });
+    });
   }
 
   // Playground card: copy the launch command, and probe the LOCAL sidecar so the
@@ -497,7 +588,7 @@ const terminalLines = [
   .doc p > img:only-child { @apply w-full cursor-zoom-in transition-colors hover:border-g-gold/50; }
   .doc hr { @apply my-8 border-0 border-t border-g-border; }
 
-  /* Doc tabs (README / Changelog) */
+  /* Doc tabs (README / Spec / Skill / Changelog / Files) */
   .doc-tab {
     @apply -mb-px border-b-2 border-transparent px-4 py-2 text-sm font-medium text-g-muted transition-colors hover:text-g-text;
   }

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -248,12 +248,13 @@ const terminalLines = [
           </dl>
         </section>
 
-        {agent.package && (
-          <!-- Package contents: the client, docs, and every platform binary -->
+        {agent.package && packageFiles.length > 0 && (
+          <!-- Package contents: the client, docs, and every platform binary. Gated on
+               files.length too so the "Browse the contents →" jump always has a Files tab. -->
           <section class="rounded-xl border border-g-border bg-g-surface p-5">
             <Eyebrow class="mb-2">Package</Eyebrow>
             <p class="text-[12px] leading-relaxed text-g-muted">
-              The client, docs, and every platform binary — {agent.package.files.length} files in all.
+              The client, docs, and every platform binary — {packageFiles.length} files in all.
             </p>
             <button
               type="button"

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -9,6 +9,7 @@ import Eyebrow from '../../components/Eyebrow.astro';
 import AgentIcon from '../../components/AgentIcon.astro';
 import InstallMethods from '../../components/InstallMethods.astro';
 import TerminalBlock from '../../components/TerminalBlock.astro';
+import FileTree from '../../components/FileTree.astro';
 import {
   getCatalog,
   getAgent,
@@ -19,8 +20,8 @@ import {
   formatBytes,
   platformLabel,
   npuLabel,
-  packageDownloadUrl,
 } from '../../data/catalog';
+import { buildFileTree } from '../../data/fileTree';
 import { renderMarkdown } from '../../data/markdown';
 
 export async function getStaticPaths() {
@@ -44,28 +45,28 @@ const changelogHtml = agent.changelog ? renderMarkdown(agent.changelog) : '';
 const specHtml = agent.spec ? renderMarkdown(agent.spec) : '';
 const skillHtml = agent.skill ? renderMarkdown(agent.skill) : '';
 const req = agent.requirements;
-const pkgUrl = packageDownloadUrl(agent);
 
-// Package contents → a directory listing for the Files tab. Group each file by its
-// top-level folder (root files under "/"), sorted folders-first then root.
 const packageFiles = agent.package?.files ?? [];
-const fileGroups = (() => {
-  const map = new Map<string, { base: string; size_bytes: number }[]>();
-  for (const f of packageFiles) {
-    const slash = f.name.indexOf('/');
-    const dir = slash === -1 ? '/' : f.name.slice(0, slash);
-    const base = slash === -1 ? f.name : f.name.slice(slash + 1);
-    if (!map.has(dir)) map.set(dir, []);
-    map.get(dir)!.push({ base, size_bytes: f.size_bytes });
-  }
-  return [...map.entries()]
-    .map(([dir, files]) => ({
-      dir,
-      files: files.sort((a, b) => a.base.localeCompare(b.base)),
-      size: files.reduce((s, f) => s + f.size_bytes, 0),
-    }))
-    .sort((a, b) => (a.dir === '/' ? 1 : b.dir === '/' ? -1 : a.dir.localeCompare(b.dir)));
-})();
+const topLevelFolders = new Set(
+  packageFiles.filter((f) => f.name.includes('/')).map((f) => f.name.split('/')[0])
+).size;
+
+// Details "Size" is a RANGE across the per-platform binaries (they differ by
+// OS/arch), computed from the package listing's binaries/ entries. Falls back to
+// the primary artifact size when no package zip listing is available.
+const binarySizes = packageFiles
+  .filter((f) => f.name.startsWith('binaries/'))
+  .map((f) => f.size_bytes);
+const sizeMin = binarySizes.length ? Math.min(...binarySizes) : agent.download_size_bytes;
+const sizeMax = binarySizes.length ? Math.max(...binarySizes) : agent.download_size_bytes;
+
+// File browser: a nested, collapsible tree of the package contents. Text files
+// link to their content on the npm CDN (jsdelivr) for inline preview; the zip's
+// binaries aren't on the CDN and aren't text, so they stay non-clickable.
+const previewBase = agent.npm_package
+  ? `https://cdn.jsdelivr.net/npm/${agent.npm_package}@${agent.latest_version}/`
+  : null;
+const fileTree = buildFileTree(packageFiles, previewBase);
 
 // Doc tabs that actually have content (README is always present). The Files tab is
 // the package's directory listing; it only appears once a whole-package zip ships.
@@ -184,36 +185,18 @@ const terminalLines = [
         )}
         {packageFiles.length > 0 && (
           <section role="tabpanel" id="docpanel-files" aria-labelledby="doctab-files" data-doc-panel="files" hidden>
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <h2 class="text-xl font-semibold tracking-tight">Package contents</h2>
-              {pkgUrl && agent.package && (
-                <a
-                  href={pkgUrl}
-                  download={agent.package.filename}
-                  class="flex items-center gap-2 rounded-md border border-g-gold/40 bg-g-bg/40 px-3 py-1.5 text-[12px] font-medium text-g-gold-text hover:border-g-gold/70 transition-colors"
-                >Download .zip <span class="font-mono text-g-muted">{formatBytes(agent.package.size_bytes)}</span></a>
-              )}
+            <h2 class="text-xl font-semibold tracking-tight">Package contents</h2>
+            <div class="mt-2 mb-4 flex flex-wrap items-center justify-between gap-3">
+              <p class="text-[13px] text-g-muted">
+                {packageFiles.length} files across {topLevelFolders} {topLevelFolders === 1 ? 'folder' : 'folders'}{previewBase ? ' — click a text file to preview it.' : '.'}
+              </p>
+              <div class="flex flex-none gap-1.5 text-[11px]" data-file-tree-controls>
+                <button type="button" data-files-expand class="rounded border border-g-border px-2 py-1 text-g-muted transition-colors hover:border-g-gold/50 hover:text-g-text">Expand all</button>
+                <button type="button" data-files-collapse class="rounded border border-g-border px-2 py-1 text-g-muted transition-colors hover:border-g-gold/50 hover:text-g-text">Collapse all</button>
+              </div>
             </div>
-            <p class="mt-2 mb-5 text-[13px] text-g-muted">
-              {packageFiles.length} files across {fileGroups.length} {fileGroups.length === 1 ? 'folder' : 'folders'} — the client, docs, and every platform binary, in one archive.
-            </p>
-            <div class="overflow-hidden rounded-xl border border-g-border font-mono text-[12.5px]">
-              {fileGroups.map((g) => (
-                <div>
-                  <div class="flex items-center justify-between gap-3 border-b border-g-border bg-g-surface px-4 py-2">
-                    <span class="font-semibold text-g-text">{g.dir === '/' ? '/' : `${g.dir}/`}</span>
-                    <span class="flex-none text-[11px] text-g-muted">{g.files.length} {g.files.length === 1 ? 'file' : 'files'} · {formatBytes(g.size)}</span>
-                  </div>
-                  <ul>
-                    {g.files.map((f) => (
-                      <li class="flex items-baseline justify-between gap-3 border-b border-g-border/40 px-4 py-1.5 last:border-0">
-                        <span class="truncate text-g-text/85" title={f.base}>{f.base}</span>
-                        <span class="flex-none text-[11px] text-g-muted">{formatBytes(f.size_bytes)}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
+            <div class="file-tree rounded-xl border border-g-border p-3 font-mono text-[12.5px]" data-file-tree>
+              <FileTree nodes={fileTree.children} />
             </div>
           </section>
         )}
@@ -238,9 +221,10 @@ const terminalLines = [
             <div class="flex justify-between py-2 border-b border-g-border">
               <dt class="text-g-muted">Version</dt><dd class="font-mono">{agent.latest_version}</dd>
             </div>
-            {agent.download_size_bytes > 0 && (
+            {sizeMax > 0 && (
               <div class="flex justify-between py-2 border-b border-g-border">
-                <dt class="text-g-muted">Size</dt><dd class="font-mono">{formatBytes(agent.download_size_bytes)}</dd>
+                <dt class="text-g-muted">Size</dt>
+                <dd class="font-mono">{sizeMin === sizeMax ? formatBytes(sizeMax) : `${formatBytes(sizeMin)} – ${formatBytes(sizeMax)}`}</dd>
               </div>
             )}
             <div class="flex justify-between py-2 border-b border-g-border">
@@ -259,31 +243,23 @@ const terminalLines = [
               <dt class="text-g-muted">Category</dt><dd>{categoryLabel(agent.category)}</dd>
             </div>
             <div class="flex justify-between py-2 last:border-0 border-b border-g-border">
-              <dt class="text-g-muted">Min GAIA</dt><dd class="font-mono">{agent.min_gaia_version || '—'}</dd>
+              <dt class="text-g-muted">Min GAIA SDK</dt><dd class="font-mono">{agent.min_gaia_version || '—'}</dd>
             </div>
           </dl>
         </section>
 
-        {agent.package && pkgUrl && (
-          <!-- Whole-package download: one zip with the client, docs, and all platform binaries -->
+        {agent.package && (
+          <!-- Package contents: the client, docs, and every platform binary -->
           <section class="rounded-xl border border-g-border bg-g-surface p-5">
             <Eyebrow class="mb-2">Package</Eyebrow>
-            <a
-              href={pkgUrl}
-              download={agent.package.filename}
-              class="flex items-center justify-between gap-3 rounded-md border border-g-gold/40 bg-g-bg/40 px-4 py-2.5 text-[13px] font-medium text-g-gold-text hover:border-g-gold/70 transition-colors"
-            >
-              <span>Download .zip</span>
-              <span class="font-mono text-[12px] text-g-muted">{formatBytes(agent.package.size_bytes)}</span>
-            </a>
-            <p class="mt-2 text-[12px] leading-relaxed text-g-muted">
-              One archive — the client, docs, and every platform binary. Runs on any supported OS.
+            <p class="text-[12px] leading-relaxed text-g-muted">
+              The client, docs, and every platform binary — {agent.package.files.length} files in all.
             </p>
             <button
               type="button"
               data-doc-goto="files"
               class="mt-3 text-[12px] font-medium text-g-gold-text hover:underline"
-            >View all {agent.package.files.length} files →</button>
+            >Browse the contents →</button>
           </section>
         )}
 
@@ -390,6 +366,29 @@ const terminalLines = [
   >
     <img id="doc-lightbox-img" src="" alt="" class="max-h-full max-w-full rounded-lg shadow-2xl" />
   </div>
+
+  <!-- File preview modal: shows the text content of a clicked package file. -->
+  <div
+    id="file-preview"
+    class="fixed inset-0 z-[100] hidden items-center justify-center bg-black/80 p-4 backdrop-blur-sm sm:p-8"
+    aria-hidden="true"
+    role="dialog"
+    aria-modal="true"
+    aria-label="File preview (press Escape to close)"
+  >
+    <div class="flex max-h-full w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-g-border bg-g-bg shadow-2xl">
+      <div class="flex flex-none items-center justify-between gap-3 border-b border-g-border bg-g-surface px-4 py-2.5">
+        <span id="file-preview-name" class="truncate font-mono text-[13px] text-g-text"></span>
+        <div class="flex flex-none items-center gap-3">
+          <a id="file-preview-raw" href="#" target="_blank" rel="noopener" class="text-[11px] text-g-muted hover:text-g-gold-text">Raw ↗</a>
+          <button type="button" id="file-preview-close" aria-label="Close preview" class="text-g-muted hover:text-g-text">✕</button>
+        </div>
+      </div>
+      <div class="min-h-0 flex-1 overflow-auto">
+        <pre class="!my-0 !rounded-none !border-0 bg-[#0c0c0e] p-4 text-[12.5px] leading-relaxed"><code id="file-preview-code" class="!bg-transparent"></code></pre>
+      </div>
+    </div>
+  </div>
 </Layout>
 
 <script>
@@ -398,6 +397,8 @@ const terminalLines = [
   import 'prismjs/components/prism-typescript';
   import 'prismjs/components/prism-bash';
   import 'prismjs/components/prism-json';
+  import 'prismjs/components/prism-yaml';
+  import 'prismjs/components/prism-markdown';
 
   // Syntax-highlight rendered code blocks. The renderer emits
   // <code class="language-*">; Prism reads textContent (already HTML-escaped) and
@@ -541,6 +542,78 @@ const terminalLines = [
       setInterval(probe, 3000);
     }
   }
+
+  // Files tab: expand/collapse-all toggles every folder <details> in the tree.
+  const fileTreeEl = document.querySelector('[data-file-tree]');
+  if (fileTreeEl) {
+    const allDetails = () => Array.from(fileTreeEl.querySelectorAll<HTMLDetailsElement>('details'));
+    document.querySelector('[data-files-expand]')?.addEventListener('click', () =>
+      allDetails().forEach((d) => (d.open = true))
+    );
+    document.querySelector('[data-files-collapse]')?.addEventListener('click', () =>
+      allDetails().forEach((d) => (d.open = false))
+    );
+  }
+
+  // File preview: fetch a clicked text file's content from the CDN and show it in
+  // a modal. Content is set as textContent (never innerHTML) and only highlighted
+  // by Prism, so a file's bytes can't inject markup.
+  const fp = document.getElementById('file-preview');
+  const fpCode = document.getElementById('file-preview-code');
+  const fpName = document.getElementById('file-preview-name');
+  const fpRaw = document.getElementById('file-preview-raw') as HTMLAnchorElement | null;
+  const fpClose = document.getElementById('file-preview-close');
+  if (fp && fpCode && fpName && fpRaw) {
+    let lastFocused: HTMLElement | null = null;
+    const langByExt: Record<string, string> = {
+      js: 'javascript', mjs: 'javascript', cjs: 'javascript', ts: 'typescript',
+      tsx: 'typescript', json: 'json', yaml: 'yaml', yml: 'yaml', sh: 'bash',
+      md: 'markdown', markdown: 'markdown',
+    };
+    const closeFp = () => {
+      fp.classList.add('hidden');
+      fp.classList.remove('flex');
+      fp.setAttribute('aria-hidden', 'true');
+      fpCode.textContent = '';
+      lastFocused?.focus();
+    };
+    const openFp = async (url: string, name: string, trigger: HTMLElement) => {
+      lastFocused = trigger;
+      fpName.textContent = name;
+      fpRaw.href = url;
+      const ext = name.toLowerCase().split('.').pop() || '';
+      const lang = langByExt[ext] || 'none';
+      fpCode.className = `!bg-transparent language-${lang}`;
+      fpCode.textContent = 'Loading…';
+      fp.classList.remove('hidden');
+      fp.classList.add('flex');
+      fp.setAttribute('aria-hidden', 'false');
+      (fpClose as HTMLElement | null)?.focus();
+      try {
+        const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+        if (!res.ok) throw new Error(String(res.status));
+        const text = await res.text();
+        // Guard against accidentally rendering a huge/binary file in the modal.
+        fpCode.textContent = text.length > 500_000 ? text.slice(0, 500_000) + '\n…(truncated)' : text;
+        Prism.highlightElement(fpCode);
+      } catch {
+        fpCode.className = '!bg-transparent';
+        fpCode.textContent =
+          `Preview unavailable for this file.\n\nIt may not be part of the published npm package ` +
+          `(e.g. a platform binary), or this version isn't on the CDN yet. Use "Raw ↗" to try directly.`;
+      }
+    };
+    document.querySelectorAll<HTMLButtonElement>('[data-file-preview]').forEach((btn) => {
+      btn.addEventListener('click', () =>
+        openFp(btn.dataset.filePreview || '', btn.dataset.fileName || 'file', btn)
+      );
+    });
+    fpClose?.addEventListener('click', closeFp);
+    fp.addEventListener('click', (e) => { if (e.target === fp) closeFp(); });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !fp.classList.contains('hidden')) closeFp();
+    });
+  }
 </script>
 
 <style is:global>
@@ -587,6 +660,13 @@ const terminalLines = [
      fullscreen on click (see the lightbox script below). */
   .doc p > img:only-child { @apply w-full cursor-zoom-in transition-colors hover:border-g-gold/50; }
   .doc hr { @apply my-8 border-0 border-t border-g-border; }
+
+  /* File tree (Files tab): native <details> collapse, custom chevron, no marker. */
+  .file-tree summary { list-style: none; }
+  .file-tree summary::-webkit-details-marker { display: none; }
+  .file-tree summary:hover .file-tree-chevron { @apply text-g-text; }
+  .file-tree-chevron { transition: transform 0.15s ease; }
+  .file-tree details[open] > summary .file-tree-chevron { transform: rotate(90deg); }
 
   /* Doc tabs (README / Spec / Skill / Changelog / Files) */
   .doc-tab {

--- a/workers/agent-hub/README.md
+++ b/workers/agent-hub/README.md
@@ -17,7 +17,7 @@ depend on any `src/gaia` code.
 | `POST /publish` | Bearer | Publish a new agent version (validate → scope-check → immutability-check → checksum → store → rebuild index). Form parts: `manifest` (gaia-agent.yaml text), `artifact` (wheel/binary/zip file), optional `readme` + `changelog` + `spec` + `skill` (markdown, rendered as the Hub page's doc tabs), and optional `package_files` (JSON `{files:[{name,size_bytes}]}` listing the contents of a whole-package `.zip` artifact — surfaced as the catalog's `package`) |
 | `GET /index.json` | none | Catalog of every agent (latest version only), including the latest README + CHANGELOG + SPEC + SKILL markdown |
 | `GET /agents/<id>/manifest.json` | none | Per-agent aggregate manifest (all versions) |
-| `GET /agents/<id>/<version>/<file>` | none | Download an artifact, the raw `gaia-agent.yaml`, `README.md`, or `CHANGELOG.md` |
+| `GET /agents/<id>/<version>/<file>` | none | Download an artifact, the raw `gaia-agent.yaml`, `README.md`, `CHANGELOG.md`, `SPEC.md`, or `SKILL.md` |
 | `GET /health` | none | Liveness probe |
 
 ### Publish guarantees
@@ -57,6 +57,8 @@ agents/<id>/manifest.json                       # per-agent aggregate (all versi
 agents/<id>/<version>/gaia-agent.yaml           # exact manifest uploaded for this version
 agents/<id>/<version>/README.md                 # README markdown for this version (if published)
 agents/<id>/<version>/CHANGELOG.md              # CHANGELOG markdown for this version (if published)
+agents/<id>/<version>/SPEC.md                   # SPEC markdown for this version (if published)
+agents/<id>/<version>/SKILL.md                  # SKILL markdown for this version (if published)
 agents/<id>/<version>/<filename>                # the artifact (wheel or binary)
 ```
 
@@ -91,7 +93,8 @@ schemas live in [`schemas/`](./schemas):
   `min_disk_gb`, `min_context_size`, `platforms`, `npu` as
   `"required"`/`"optional"`, `gpu_vram_gb`), `readme` (latest version's README
   markdown, `""` if none was published), `changelog` (latest version's CHANGELOG
-  markdown, `""` if none was published), the optional `npm_package` /
+  markdown, `""` if none was published), `spec` + `skill` (latest version's SPEC.md
+  / SKILL.md markdown, `""` if none was published), the optional `npm_package` /
   `playground_url` (present only when the manifest declares them — they drive the
   hub page's npm install method and playground launcher), and the optional
   `package` (`{ filename, size_bytes, files: [{name, size_bytes}] }` — the

--- a/workers/agent-hub/README.md
+++ b/workers/agent-hub/README.md
@@ -14,8 +14,8 @@ depend on any `src/gaia` code.
 
 | Route | Auth | Purpose |
 |-------|------|---------|
-| `POST /publish` | Bearer | Publish a new agent version (validate → scope-check → immutability-check → checksum → store → rebuild index). Form parts: `manifest` (gaia-agent.yaml text), `artifact` (wheel/binary/zip file), optional `readme` + `changelog` (markdown, rendered on the Hub pages), and optional `package_files` (JSON `{files:[{name,size_bytes}]}` listing the contents of a whole-package `.zip` artifact — surfaced as the catalog's `package`) |
-| `GET /index.json` | none | Catalog of every agent (latest version only), including the latest README + CHANGELOG markdown |
+| `POST /publish` | Bearer | Publish a new agent version (validate → scope-check → immutability-check → checksum → store → rebuild index). Form parts: `manifest` (gaia-agent.yaml text), `artifact` (wheel/binary/zip file), optional `readme` + `changelog` + `spec` + `skill` (markdown, rendered as the Hub page's doc tabs), and optional `package_files` (JSON `{files:[{name,size_bytes}]}` listing the contents of a whole-package `.zip` artifact — surfaced as the catalog's `package`) |
+| `GET /index.json` | none | Catalog of every agent (latest version only), including the latest README + CHANGELOG + SPEC + SKILL markdown |
 | `GET /agents/<id>/manifest.json` | none | Per-agent aggregate manifest (all versions) |
 | `GET /agents/<id>/<version>/<file>` | none | Download an artifact, the raw `gaia-agent.yaml`, `README.md`, or `CHANGELOG.md` |
 | `GET /health` | none | Liveness probe |

--- a/workers/agent-hub/schemas/index.schema.json
+++ b/workers/agent-hub/schemas/index.schema.json
@@ -138,6 +138,14 @@
           "type": "string",
           "description": "CHANGELOG.md markdown of the latest version; empty string if none was published."
         },
+        "spec": {
+          "type": "string",
+          "description": "SPEC.md (technical reference) markdown of the latest version; empty string if none was published."
+        },
+        "skill": {
+          "type": "string",
+          "description": "SKILL.md (AI-integration playbook) markdown of the latest version; empty string if none was published."
+        },
         "npm_package": {
           "type": "string",
           "description": "npm package name when the agent is distributed via npm (e.g. \"@amd-gaia/agent-email\"); absent otherwise."

--- a/workers/agent-hub/src/catalog.ts
+++ b/workers/agent-hub/src/catalog.ts
@@ -12,6 +12,8 @@ import {
   readChangelog,
   readPackageFiles,
   readReadme,
+  readSkill,
+  readSpec,
   writeIndex,
 } from "./storage";
 import type {
@@ -103,7 +105,9 @@ export function toIndexEntry(
   agent: AgentManifest,
   readme: string,
   changelog: string,
-  packageFiles: { files: { name: string; size_bytes: number }[] } | null
+  packageFiles: { files: { name: string; size_bytes: number }[] } | null,
+  spec = "",
+  skill = ""
 ): IndexEntry {
   const latest = agent.versions[agent.latest_version];
   const req = agent.requirements;
@@ -145,6 +149,8 @@ export function toIndexEntry(
     },
     readme,
     changelog,
+    spec,
+    skill,
     // undefined serializes to "key absent" — only present when the manifest set it.
     npm_package: agent.npm_package,
     playground_url: agent.playground_url,
@@ -168,7 +174,9 @@ export async function rebuildIndex(
     const readme = await readReadme(bucket, id, agent.latest_version);
     const changelog = await readChangelog(bucket, id, agent.latest_version);
     const packageFiles = await readPackageFiles(bucket, id, agent.latest_version);
-    entries.push(toIndexEntry(agent, readme, changelog, packageFiles));
+    const spec = await readSpec(bucket, id, agent.latest_version);
+    const skill = await readSkill(bucket, id, agent.latest_version);
+    entries.push(toIndexEntry(agent, readme, changelog, packageFiles, spec, skill));
   }
   entries.sort((a, b) => a.id.localeCompare(b.id));
 

--- a/workers/agent-hub/src/publish.ts
+++ b/workers/agent-hub/src/publish.ts
@@ -22,6 +22,8 @@ import {
   rawManifestKey,
   readAgentManifest,
   readmeKey,
+  skillKey,
+  specKey,
   writeAgentManifest,
 } from "./storage";
 import type { ArtifactInfo, Env } from "./types";
@@ -166,6 +168,11 @@ export async function handlePublish(
   // pages). Both are optional; an empty part is rejected (omit it instead).
   const readmeText = await optionalMarkdownPart(form, "readme", "README.md");
   const changelogText = await optionalMarkdownPart(form, "changelog", "CHANGELOG.md");
+  // Optional SPEC.md (technical reference) + SKILL.md (AI-integration playbook),
+  // rendered as their own doc tabs on the hub page. Same per-version, first-POST
+  // semantics as README/CHANGELOG.
+  const specText = await optionalMarkdownPart(form, "spec", "SPEC.md");
+  const skillText = await optionalMarkdownPart(form, "skill", "SKILL.md");
   // Optional whole-package file listing (the zip's contents, for the hub's file
   // list). The zip itself rides in as a normal `artifact`; this is just the
   // manifest of what's inside it.
@@ -256,6 +263,16 @@ export async function handlePublish(
     }
     if (changelogText != null) {
       await env.BUCKET.put(changelogKey(manifest.id, manifest.version), changelogText, {
+        httpMetadata: { contentType: "text/markdown; charset=utf-8" },
+      });
+    }
+    if (specText != null) {
+      await env.BUCKET.put(specKey(manifest.id, manifest.version), specText, {
+        httpMetadata: { contentType: "text/markdown; charset=utf-8" },
+      });
+    }
+    if (skillText != null) {
+      await env.BUCKET.put(skillKey(manifest.id, manifest.version), skillText, {
         httpMetadata: { contentType: "text/markdown; charset=utf-8" },
       });
     }

--- a/workers/agent-hub/src/storage.ts
+++ b/workers/agent-hub/src/storage.ts
@@ -10,6 +10,8 @@
  *   agents/<id>/<version>/gaia-agent.yaml   raw uploaded manifest, per version
  *   agents/<id>/<version>/README.md         README markdown, per version (optional)
  *   agents/<id>/<version>/CHANGELOG.md      changelog markdown, per version (optional)
+ *   agents/<id>/<version>/SPEC.md           spec/reference markdown, per version (optional)
+ *   agents/<id>/<version>/SKILL.md          AI-integration playbook markdown (optional)
  *   agents/<id>/<version>/<filename>        the artifact (wheel or binary)
  */
 
@@ -42,6 +44,14 @@ export function changelogKey(id: string, version: string): string {
   return `${versionDir(id, version)}CHANGELOG.md`;
 }
 
+export function specKey(id: string, version: string): string {
+  return `${versionDir(id, version)}SPEC.md`;
+}
+
+export function skillKey(id: string, version: string): string {
+  return `${versionDir(id, version)}SKILL.md`;
+}
+
 export function packageFilesKey(id: string, version: string): string {
   return `${versionDir(id, version)}package-files.json`;
 }
@@ -72,6 +82,34 @@ export async function readChangelog(
   version: string
 ): Promise<string> {
   const obj = await bucket.get(changelogKey(id, version));
+  if (!obj) return "";
+  return obj.text();
+}
+
+/**
+ * Read the SPEC.md (technical reference) markdown for one version. Returns "" when
+ * none was published — the `spec` form part on POST /publish is optional.
+ */
+export async function readSpec(
+  bucket: R2Bucket,
+  id: string,
+  version: string
+): Promise<string> {
+  const obj = await bucket.get(specKey(id, version));
+  if (!obj) return "";
+  return obj.text();
+}
+
+/**
+ * Read the SKILL.md (AI-integration playbook) markdown for one version. Returns ""
+ * when none was published — the `skill` form part on POST /publish is optional.
+ */
+export async function readSkill(
+  bucket: R2Bucket,
+  id: string,
+  version: string
+): Promise<string> {
+  const obj = await bucket.get(skillKey(id, version));
   if (!obj) return "";
   return obj.text();
 }

--- a/workers/agent-hub/src/types.ts
+++ b/workers/agent-hub/src/types.ts
@@ -191,6 +191,10 @@ export interface IndexEntry {
   readme: string;
   /** CHANGELOG.md markdown of the latest version; empty string if none was published. */
   changelog: string;
+  /** SPEC.md (technical reference) markdown of the latest version; "" if none was published. */
+  spec: string;
+  /** SKILL.md (AI-integration playbook) markdown of the latest version; "" if none was published. */
+  skill: string;
   /** npm package name when the agent is distributed via npm; absent otherwise. */
   npm_package?: string;
   /** Localhost playground URL served by the agent's sidecar; absent otherwise. */

--- a/workers/agent-hub/test/fake-r2.ts
+++ b/workers/agent-hub/test/fake-r2.ts
@@ -157,12 +157,16 @@ export function publishRequest(opts: {
   contentType?: string;
   readme?: string;
   changelog?: string;
+  spec?: string;
+  skill?: string;
   packageFiles?: string;
 }): Request {
   const form = new FormData();
   form.set("manifest", opts.manifestYaml);
   if (opts.readme !== undefined) form.set("readme", opts.readme);
   if (opts.changelog !== undefined) form.set("changelog", opts.changelog);
+  if (opts.spec !== undefined) form.set("spec", opts.spec);
+  if (opts.skill !== undefined) form.set("skill", opts.skill);
   if (opts.packageFiles !== undefined) form.set("package_files", opts.packageFiles);
   const bytes = typeof opts.artifact === "string" ? new TextEncoder().encode(opts.artifact) : opts.artifact;
   form.set(

--- a/workers/agent-hub/test/publish.test.ts
+++ b/workers/agent-hub/test/publish.test.ts
@@ -586,6 +586,69 @@ describe("POST /publish — CHANGELOG", () => {
   });
 });
 
+describe("POST /publish — SPEC & SKILL doc tabs", () => {
+  it("stores spec + skill, serves them, and includes them in index.json", async () => {
+    const env = makeEnv();
+    const spec = "# Spec\n\nThe wire contract is 2.0.\n";
+    const skill = "# Skill\n\nSpawn the sidecar, then call triage.\n";
+    const res = await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest(),
+      artifact: "wheel",
+      filename: "gaia_agent_chat-0.1.0-py3-none-any.whl",
+      spec,
+      skill,
+    });
+    expect(res.status).toBe(201);
+    expect(env.bucket.keys()).toContain("agents/chat/0.1.0/SPEC.md");
+    expect(env.bucket.keys()).toContain("agents/chat/0.1.0/SKILL.md");
+
+    // Served by the existing GET /agents/... download route, as markdown.
+    const getSpec = await worker.fetch(
+      new Request("https://hub.amd-gaia.ai/agents/chat/0.1.0/SPEC.md"),
+      env as never
+    );
+    expect(getSpec.status).toBe(200);
+    expect(getSpec.headers.get("content-type")).toContain("text/markdown");
+    expect(await getSpec.text()).toBe(spec);
+
+    const index = (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex;
+    const entry = index.agents.find((a) => a.id === "chat")!;
+    expect(entry.spec).toBe(spec);
+    expect(entry.skill).toBe(skill);
+  });
+
+  it('defaults spec + skill to "" in index.json when none are published', async () => {
+    const env = makeEnv();
+    await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest(),
+      artifact: "wheel",
+      filename: "gaia_agent_chat-0.1.0-py3-none-any.whl",
+    });
+    expect(env.bucket.keys()).not.toContain("agents/chat/0.1.0/SPEC.md");
+    const entry = (
+      (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex
+    ).agents.find((a) => a.id === "chat")!;
+    expect(entry.spec).toBe("");
+    expect(entry.skill).toBe("");
+  });
+
+  it("rejects an empty spec part (400) — omit it instead", async () => {
+    const env = makeEnv();
+    const res = await publish(env, {
+      token: "tok_amd",
+      manifestYaml: sampleManifest(),
+      artifact: "wheel",
+      filename: "gaia_agent_chat-0.1.0-py3-none-any.whl",
+      spec: "   ",
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error.code).toBe("invalid_request");
+    expect(env.bucket.keys()).toEqual([]);
+  });
+});
+
 describe("POST /publish — npm_package & playground_url", () => {
   it("carries npm_package and playground_url through to index.json", async () => {
     const env = makeEnv();


### PR DESCRIPTION
## Why this matters

The hub agent page only showed README + Changelog, and the package's file list was buried in a cramped sidebar `<details>`. This turns the agent page into a proper docs browser:

- **Files tab** — the whole-package zip's contents as a **grouped directory listing** (folders with per-folder file counts + sizes), so a user can see exactly what's in the download before grabbing it. The Package card now links to it ("View all N files →") instead of an inline expander.
- **Spec tab** — renders the agent's `SPEC.md` (the full technical reference: endpoints, types, lifecycle).
- **Skill tab** — renders `SKILL.md` (the AI-assistant integration playbook).

Tabs only appear when there's content, so non-email agents (no SPEC/SKILL/zip) still show just README (+ Changelog).

## How it's wired
`SPEC.md` / `SKILL.md` ride the catalog exactly like `README`/`CHANGELOG` already do — the release sends optional `spec`/`skill` form parts, the Worker stores them per version and surfaces them on `index.json` (default `""` when absent), and the website renders a tab when content exists. The Files tab reuses the existing `package.files` data — no new catalog field. Takes effect on the next release (the catalog snapshots docs at publish time); the Worker must be `wrangler deploy`'d for the new parts to be stored.

## Test plan
- [x] Worker: `npm test` 79 passing (+3 for spec/skill threading: store, serve, index, default-"", empty-part-400) + `tsc`
- [x] Website: `astro check` clean + `vitest` 19 passing
- [x] `publish_to_r2.py` black-clean; `py_compile` ok
- [x] Local preview (doctored catalog): all five tabs render (README · Spec · Skill · Changelog · Files); Files shows the grouped listing; "View all files" jumps to the tab
- [ ] After merge + Worker deploy + next release: confirm the live email page shows Spec/Skill/Files populated