### PR TITLE
feat(ui): add Beta dynamic tools toggle to Agent UI settings (#1798)

### DIFF
--- a/docs/guides/chat.mdx
+++ b/docs/guides/chat.mdx
@@ -316,8 +316,10 @@ first-turn prompt and speeds up the first reply.
 
 It activates only on the `doc` profile (the registered `doc` agent, the SDK with
 `ChatAgentConfig(prompt_profile="doc")`, or `gaia eval agent --agent-type doc`).
-Turn it on with the config field or an environment variable — the env var wins,
-which is handy for the eval harness:
+Turn it on with the config field, an environment variable, or the Agent UI
+**Settings → Dynamic Tools (Beta)** toggle. The env var wins over both — when it
+is set, the UI toggle reflects the effective value and disables itself — which is
+handy for the eval harness:
 
 ```python
 from gaia.agents.chat.agent import ChatAgent, ChatAgentConfig

--- a/docs/plans/tool-loader.mdx
+++ b/docs/plans/tool-loader.mdx
@@ -266,6 +266,11 @@ A malformed `*_TAU` / `*_MAX` value raises at construction (no silent default).
 The loader is built **only** for `prompt_profile == "doc"` with the toggle on;
 otherwise `self.tool_loader is None` and the agent stays on the legacy path.
 
+As of #1798 the `dynamic_tools` enable knob is also reachable as a **Beta** toggle
+in the Agent UI **Settings** panel (default off). `GAIA_DYNAMIC_TOOLS` still wins
+when set — the toggle then reflects the effective value and disables — so τ and
+the cap stay env-only tuning.
+
 **CORE (10, always-on, cap- & eviction-exempt)** — defined in
 [`tool_bundles.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/chat/tool_bundles.py):
 `remember`, `recall`, `update_memory`, `forget`, `search_past_conversations`,

--- a/src/gaia/agents/chat/agent.py
+++ b/src/gaia/agents/chat/agent.py
@@ -46,6 +46,21 @@ from gaia.vlm.mixin import VLMToolsMixin
 logger = get_logger(__name__)
 
 
+def dynamic_tools_env_override() -> Optional[bool]:
+    """Parse the ``GAIA_DYNAMIC_TOOLS`` override, or ``None`` when it is unset.
+
+    Returns the parsed boolean (truthy set ``1``/``true``/``yes``/``on``,
+    case-insensitive) when the env var is set, else ``None`` to signal "no
+    override — fall back to the persisted/config value". The UI settings
+    router reuses this so the env-wins precedence and the truthy set never
+    drift between the agent resolver and the toggle that surfaces it.
+    """
+    raw = os.getenv("GAIA_DYNAMIC_TOOLS")
+    if raw is None:
+        return None
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
 @dataclass
 class ChatAgentConfig:
     """Configuration for ChatAgent."""
@@ -460,10 +475,10 @@ class ChatAgent(
 
     def _resolve_dynamic_tools_enabled(self) -> bool:
         """Toggle: ``GAIA_DYNAMIC_TOOLS`` (truthy) wins over the config field."""
-        raw = os.getenv("GAIA_DYNAMIC_TOOLS")
-        if raw is None:
-            return bool(self.config.dynamic_tools)
-        return raw.strip().lower() in ("1", "true", "yes", "on")
+        override = dynamic_tools_env_override()
+        if override is not None:
+            return override
+        return bool(self.config.dynamic_tools)
 
     def _resolve_dynamic_tools_threshold(self) -> float:
         """Threshold: ``GAIA_DYNAMIC_TOOLS_TAU`` wins; malformed value fails loudly."""

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.css
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.css
@@ -390,6 +390,11 @@
     outline-offset: 2px;
 }
 
+.toggle-switch input:disabled + .toggle-track {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .grant-scope-warning {
     display: flex;
     align-items: center;

--- a/src/gaia/apps/webui/src/components/SettingsPage.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsPage.tsx
@@ -34,6 +34,12 @@ export function SettingsPage() {
     const [justSaved, setJustSaved] = useState(false);
     const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    // Dynamic Tools (Beta) toggle — #1798
+    const [dynamicTools, setDynamicTools] = useState(false);
+    const [dynamicToolsLocked, setDynamicToolsLocked] = useState(false);
+    const [savingDynamicTools, setSavingDynamicTools] = useState(false);
+    const [dynamicToolsError, setDynamicToolsError] = useState<string | null>(null);
+
     useEffect(() => {
         log.system.info('Checking system status...');
         const t = log.system.time();
@@ -66,6 +72,8 @@ export function SettingsPage() {
                 const value = s.custom_model ?? '';
                 setCustomModel(value);
                 setSavedCustomModel(value);
+                setDynamicTools(s.dynamic_tools);
+                setDynamicToolsLocked(s.dynamic_tools_locked);
             })
             .catch((err) => {
                 log.system.error('Failed to load settings', err);
@@ -100,6 +108,30 @@ export function SettingsPage() {
             setSavingModel(false);
         }
     }, [customModel]);
+
+    const toggleDynamicTools = useCallback(async () => {
+        if (dynamicToolsLocked || savingDynamicTools) return;
+        const previous = dynamicTools;
+        const next = !previous;
+        setDynamicTools(next); // optimistic
+        setSavingDynamicTools(true);
+        setDynamicToolsError(null);
+        try {
+            log.system.info('Saving dynamic_tools setting', { dynamic_tools: next });
+            const updated = await api.updateSettings({ dynamic_tools: next });
+            // Trust the server's effective value (env override may win).
+            setDynamicTools(updated.dynamic_tools);
+            setDynamicToolsLocked(updated.dynamic_tools_locked);
+        } catch (err) {
+            // No silent fallback: revert the optimistic flip and surface the error.
+            const msg = err instanceof Error ? err.message : String(err);
+            log.system.error('Failed to save dynamic_tools', err);
+            setDynamicTools(previous);
+            setDynamicToolsError(msg);
+        } finally {
+            setSavingDynamicTools(false);
+        }
+    }, [dynamicTools, dynamicToolsLocked, savingDynamicTools]);
 
     const customModelDirty = customModel.trim() !== savedCustomModel.trim();
 
@@ -431,6 +463,43 @@ export function SettingsPage() {
                         Current: <code>{currentCtx != null ? `${currentCtx.toLocaleString()} tokens` : 'unknown'}</code>
                         {status?.model_loaded && <> on <code>{status.model_loaded}</code></>}.
                     </p>
+                </section>
+
+                {/* Dynamic Tools (Beta) — #1798 */}
+                <section className="settings-section">
+                    <h4>Dynamic Tools <span className="beta-badge">BETA</span></h4>
+                    <p className="model-override-desc">
+                        Trim each turn&rsquo;s tool list to a semantically-matched subset to
+                        speed up the first response. Currently affects the Doc Agent only.
+                    </p>
+                    <div className="setting-row">
+                        <span>Enable dynamic tool loading</span>
+                        <span className="toggle-switch">
+                            <input
+                                type="checkbox"
+                                checked={dynamicTools}
+                                onChange={() => void toggleDynamicTools()}
+                                disabled={!settingsLoaded || savingDynamicTools || dynamicToolsLocked}
+                                aria-label={dynamicTools ? 'Disable dynamic tools' : 'Enable dynamic tools'}
+                            />
+                            <span className="toggle-track" />
+                        </span>
+                    </div>
+                    {dynamicToolsLocked && (
+                        <p className="model-status-hint">
+                            Controlled by <code>GAIA_DYNAMIC_TOOLS</code> &mdash; unset that
+                            environment variable to change this here.
+                        </p>
+                    )}
+                    {dynamicToolsError && (
+                        <div className="model-warning" role="alert">
+                            <AlertCircle size={14} />
+                            <div className="model-warning-content">
+                                <strong>Could not save</strong>
+                                <p>{dynamicToolsError}</p>
+                            </div>
+                        </div>
+                    )}
                 </section>
 
                 {/* Memory Warnings */}

--- a/src/gaia/apps/webui/src/components/SettingsPage.tsx
+++ b/src/gaia/apps/webui/src/components/SettingsPage.tsx
@@ -472,7 +472,10 @@ export function SettingsPage() {
                         Trim each turn&rsquo;s tool list to a semantically-matched subset to
                         speed up the first response. Currently affects the Doc Agent only.
                     </p>
-                    <div className="setting-row">
+                    {/* <label> wraps the row so a click on the text or the track
+                        forwards to the visually-hidden checkbox (matches the
+                        working connector/grant toggles). */}
+                    <label className="setting-row">
                         <span>Enable dynamic tool loading</span>
                         <span className="toggle-switch">
                             <input
@@ -484,7 +487,7 @@ export function SettingsPage() {
                             />
                             <span className="toggle-track" />
                         </span>
-                    </div>
+                    </label>
                     {dynamicToolsLocked && (
                         <p className="model-status-hint">
                             Controlled by <code>GAIA_DYNAMIC_TOOLS</code> &mdash; unset that

--- a/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
@@ -72,6 +72,23 @@ describe('SettingsPage — Dynamic Tools toggle (#1798)', () => {
         await waitFor(() => expect(getDynamicToolsToggle()).toBeChecked());
     });
 
+    it('toggles when the visible row/label is clicked, not just the hidden input', async () => {
+        // Regression: the checkbox is visually hidden (width:0/height:0) and the
+        // track is a sibling <span>. Clicking the visible control only works if a
+        // <label> forwards the click to the input. Clicking the input element
+        // directly (as the other tests do) would pass even if that wiring is
+        // missing — so click the visible label text here, the way a user does.
+        render(<SettingsPage />);
+        await waitFor(getDynamicToolsToggle);
+
+        await userEvent.click(screen.getByText('Enable dynamic tool loading'));
+
+        await waitFor(() =>
+            expect(mockedApi.updateSettings).toHaveBeenCalledWith({ dynamic_tools: true }),
+        );
+        await waitFor(() => expect(getDynamicToolsToggle()).toBeChecked());
+    });
+
     it('is disabled and reflects the env value when locked', async () => {
         mockedApi.getSettings.mockResolvedValue(
             makeSettings({ dynamic_tools: true, dynamic_tools_locked: true }),

--- a/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
@@ -101,6 +101,30 @@ describe('SettingsPage — Dynamic Tools toggle (#1798)', () => {
         expect(screen.getByText(/GAIA_DYNAMIC_TOOLS/)).toBeInTheDocument();
     });
 
+    it('guards against a double-click while a save is in flight (single PUT)', async () => {
+        // Hold the first save open so the toggle stays mid-save between clicks.
+        let resolveSave!: (value: Settings) => void;
+        mockedApi.updateSettings.mockImplementationOnce(
+            () => new Promise<Settings>((resolve) => { resolveSave = resolve; }),
+        );
+
+        render(<SettingsPage />);
+        const toggle = await waitFor(getDynamicToolsToggle);
+
+        // First click starts the save; the toggle disables (savingDynamicTools).
+        await userEvent.click(toggle);
+        await waitFor(() => expect(getDynamicToolsToggle()).toBeDisabled());
+
+        // Second click while the save is pending must be a no-op, not a second PUT.
+        await userEvent.click(getDynamicToolsToggle());
+
+        // Let the in-flight save settle.
+        resolveSave(makeSettings({ dynamic_tools: true }));
+
+        await waitFor(() => expect(getDynamicToolsToggle()).toBeChecked());
+        expect(mockedApi.updateSettings).toHaveBeenCalledTimes(1);
+    });
+
     it('reverts and surfaces an error when the save fails (no silent fallback)', async () => {
         mockedApi.updateSettings.mockRejectedValue(new Error('network down'));
         render(<SettingsPage />);

--- a/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
@@ -1,0 +1,99 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsPage } from '../SettingsPage';
+import { useChatStore } from '../../stores/chatStore';
+import type { Settings } from '../../types';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+// Heavy child sections make their own API calls; stub them so this test
+// stays focused on the Dynamic Tools toggle.
+vi.mock('../CustomAgentsSection', () => ({ CustomAgentsSection: () => null }));
+vi.mock('../ConnectorsSection', () => ({ ConnectorsSection: () => null }));
+
+const mockedApi = vi.mocked(api);
+
+function makeSettings(overrides: Partial<Settings> = {}): Settings {
+    return {
+        custom_model: null,
+        model_status: null,
+        context_size: null,
+        dynamic_tools: false,
+        dynamic_tools_locked: false,
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.getSystemStatus.mockResolvedValue(null as never);
+    mockedApi.getMCPRuntimeStatus.mockResolvedValue({ servers: [] } as never);
+    mockedApi.getSettings.mockResolvedValue(makeSettings());
+    mockedApi.updateSettings.mockImplementation(async (patch) =>
+        makeSettings(patch as Partial<Settings>),
+    );
+    useChatStore.setState({ sessions: [], agents: [] });
+});
+
+function getDynamicToolsToggle(): HTMLInputElement {
+    // Both enabled/disabled labels resolve to the same control.
+    return (screen.queryByLabelText('Enable dynamic tools')
+        ?? screen.getByLabelText('Disable dynamic tools')) as HTMLInputElement;
+}
+
+describe('SettingsPage — Dynamic Tools toggle (#1798)', () => {
+    it('renders the loaded value (off by default)', async () => {
+        render(<SettingsPage />);
+        const toggle = await waitFor(getDynamicToolsToggle);
+        expect(toggle).not.toBeChecked();
+        expect(toggle).not.toBeDisabled();
+    });
+
+    it('reflects a persisted-on value from the server', async () => {
+        mockedApi.getSettings.mockResolvedValue(makeSettings({ dynamic_tools: true }));
+        render(<SettingsPage />);
+        await waitFor(() => expect(getDynamicToolsToggle()).toBeChecked());
+    });
+
+    it('persists dynamic_tools: true when toggled on', async () => {
+        render(<SettingsPage />);
+        const toggle = await waitFor(getDynamicToolsToggle);
+
+        await userEvent.click(toggle);
+
+        await waitFor(() =>
+            expect(mockedApi.updateSettings).toHaveBeenCalledWith({ dynamic_tools: true }),
+        );
+        await waitFor(() => expect(getDynamicToolsToggle()).toBeChecked());
+    });
+
+    it('is disabled and reflects the env value when locked', async () => {
+        mockedApi.getSettings.mockResolvedValue(
+            makeSettings({ dynamic_tools: true, dynamic_tools_locked: true }),
+        );
+        render(<SettingsPage />);
+        const toggle = await waitFor(getDynamicToolsToggle);
+
+        expect(toggle).toBeChecked();
+        expect(toggle).toBeDisabled();
+        expect(screen.getByText(/GAIA_DYNAMIC_TOOLS/)).toBeInTheDocument();
+    });
+
+    it('reverts and surfaces an error when the save fails (no silent fallback)', async () => {
+        mockedApi.updateSettings.mockRejectedValue(new Error('network down'));
+        render(<SettingsPage />);
+        const toggle = await waitFor(getDynamicToolsToggle);
+
+        await userEvent.click(toggle);
+
+        await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+        expect(screen.getByText('network down')).toBeInTheDocument();
+        // Optimistic flip reverted back to off.
+        await waitFor(() => expect(getDynamicToolsToggle()).not.toBeChecked());
+    });
+});

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -357,6 +357,10 @@ export interface Settings {
     model_status: ModelStatus | null;
     /** Persisted context window size override (tokens). null = use default 32768. */
     context_size: number | null;
+    /** Beta dynamic tool loader (#1798). Effective value: GAIA_DYNAMIC_TOOLS wins when set, else the persisted setting. */
+    dynamic_tools: boolean;
+    /** True when GAIA_DYNAMIC_TOOLS locks the value — the toggle reflects the effective value and disables. */
+    dynamic_tools_locked: boolean;
 }
 
 /** Status of the GAIA Agent UI MCP server (exposes UI tools to Claude Code etc.). */

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -904,6 +904,7 @@ def _session_agent_kwargs(
     library_paths: list,
     allowed: list,
     session_id: str,
+    dynamic_tools: bool = False,
 ) -> dict:
     """Build the session-scoped ChatAgentConfig fields.
 
@@ -916,6 +917,12 @@ def _session_agent_kwargs(
     identical bundle — this PR's blocker bug was one of them forgetting a
     field.
 
+    ``dynamic_tools`` is the Beta tool-loader toggle (#1798): a valid
+    ``ChatAgentConfig`` field whose effect is only observable on the ``doc``
+    agent (``_maybe_build_tool_loader`` gates on ``prompt_profile == "doc"``).
+    Threading it here is what makes the UI toggle actually apply on the
+    loader-active path.
+
     Unknown kwargs are filtered by each factory (manifest agents via
     ``dataclasses.fields`` / ``AgentManifest``) so this stays safe to pass
     to agents that don't need RAG or a path validator.
@@ -925,6 +932,7 @@ def _session_agent_kwargs(
         "library_documents": library_paths,
         "allowed_paths": allowed,
         "ui_session_id": session_id,
+        "dynamic_tools": dynamic_tools,
     }
 
 
@@ -1149,6 +1157,10 @@ async def _get_chat_response(
             )
             model_id = custom_model
 
+        # Beta dynamic tool loader (#1798). Effective only on the doc agent;
+        # GAIA_DYNAMIC_TOOLS still overrides per ChatAgent's resolver.
+        dynamic_tools = db.get_setting("dynamic_tools", "false") == "true"
+
         session_id = request.session_id
         stored_agent_type = session.get("agent_type") or "chat"
         agent_type = request.agent_type or stored_agent_type
@@ -1226,6 +1238,7 @@ async def _get_chat_response(
                 library_paths=library_paths,
                 allowed=allowed,
                 session_id=session_id,
+                dynamic_tools=dynamic_tools,
             )
             config = ChatAgentConfig(
                 model_id=model_id,
@@ -1292,6 +1305,7 @@ async def _get_chat_response(
                         library_paths=library_paths,
                         allowed=allowed,
                         session_id=session_id,
+                        dynamic_tools=dynamic_tools,
                     ),
                     # Forwarded only here (not via _session_agent_kwargs, which
                     # also feeds the strict ChatAgentConfig). Non-email factories
@@ -1510,6 +1524,10 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
                 model_id,
             )
             model_id = custom_model
+
+        # Beta dynamic tool loader (#1798). Effective only on the doc agent;
+        # GAIA_DYNAMIC_TOOLS still overrides per ChatAgent's resolver.
+        dynamic_tools = db.get_setting("dynamic_tools", "false") == "true"
         # ``session_model`` is the model_id we expect to drive the
         # session with, captured here in the outer scope so the
         # auto-title background task at the bottom of this generator
@@ -1629,6 +1647,7 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
                         library_paths=library_paths,
                         allowed=allowed,
                         session_id=session_id,
+                        dynamic_tools=dynamic_tools,
                     )
                     config = ChatAgentConfig(
                         model_id=model_id,
@@ -1769,6 +1788,7 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
                                 library_paths=library_paths,
                                 allowed=allowed,
                                 session_id=session_id,
+                                dynamic_tools=dynamic_tools,
                             ),
                             # See the non-streaming path: email-only kwarg,
                             # filtered out by non-email factories. None = scan

--- a/src/gaia/ui/agent_loop.py
+++ b/src/gaia/ui/agent_loop.py
@@ -353,6 +353,12 @@ class AgentLoop:
                         db, session.get("document_ids", [])
                     )
                     allowed = _helpers._compute_allowed_paths(rag_paths + lib_paths)
+                    # Beta dynamic tool loader (#1798). Inert here: autonomous
+                    # ticks use the default "full" prompt profile and the loader
+                    # only activates on the "doc" profile — wired for future-
+                    # proofing so this path stays in lock-step with server.py's
+                    # scheduled-prompt build if that ever changes.
+                    dynamic_tools = db.get_setting("dynamic_tools", "false") == "true"
                     config = ChatAgentConfig(
                         model_id=model_id,
                         streaming=False,
@@ -360,6 +366,7 @@ class AgentLoop:
                         debug=False,
                         allowed_paths=allowed,
                         ui_session_id=session_id,
+                        dynamic_tools=dynamic_tools,
                     )
                     agent = ChatAgent(config)
                     _helpers._register_agent_memory_ops(agent)

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -138,6 +138,12 @@ class SettingsResponse(BaseModel):
         None  # Persisted ctx_size override; None = use default
     )
     agent_mode: str = "autonomous"  # "manual" | "goal_driven" | "autonomous"
+    # Beta dynamic tool loader (#1798). Effective value: env override
+    # (GAIA_DYNAMIC_TOOLS) wins when set, else the persisted setting.
+    dynamic_tools: bool = False
+    # True when GAIA_DYNAMIC_TOOLS is set ⇒ the env wins ⇒ the UI toggle
+    # reflects the effective value and disables (no silent no-op).
+    dynamic_tools_locked: bool = False
 
 
 class SettingsUpdateRequest(BaseModel):
@@ -167,6 +173,15 @@ class SettingsUpdateRequest(BaseModel):
             "'goal_driven' (execute approved goals), "
             "'autonomous' (observe, infer, and execute own goals). "
             "Default: 'autonomous'."
+        ),
+    )
+    dynamic_tools: Optional[bool] = Field(
+        None,
+        description=(
+            "Beta: enable the semantic dynamic tool loader (#1798), which trims "
+            "each turn's tool prompt to a matched subset to cut first-turn TTFT. "
+            "Default off. GAIA_DYNAMIC_TOOLS overrides this at runtime when set. "
+            "Omit the field to leave the persisted value unchanged."
         ),
     )
 

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -823,6 +823,27 @@ async def _check_model_status(model_name: str) -> ModelStatus:
     return status
 
 
+def _resolve_dynamic_tools_setting(db: ChatDatabase) -> tuple[bool, bool]:
+    """Return ``(effective, locked)`` for the Beta dynamic tool loader (#1798).
+
+    ``GAIA_DYNAMIC_TOOLS`` wins when set (``locked=True`` ⇒ the frontend
+    reflects the effective value and disables the toggle, never a silent
+    no-op); otherwise the persisted ``dynamic_tools`` setting is authoritative.
+    Delegates the env parse to ``dynamic_tools_env_override`` so the UI and
+    ``ChatAgent._resolve_dynamic_tools_enabled`` share one truthy set.
+    """
+    # Function-local import keeps the agents layer off the router's import
+    # path (no cycle, no module-load cost): ui/ → agents/chat/ stays a lazy,
+    # downward dependency.
+    from gaia.agents.chat.agent import dynamic_tools_env_override
+
+    persisted = db.get_setting("dynamic_tools", "false") == "true"
+    override = dynamic_tools_env_override()
+    if override is not None:
+        return override, True
+    return persisted, False
+
+
 @router.get("/api/settings", response_model=SettingsResponse)
 async def get_settings(db: ChatDatabase = Depends(get_db)):
     """Get current user settings with model status."""
@@ -830,11 +851,15 @@ async def get_settings(db: ChatDatabase = Depends(get_db)):
     context_size_str = db.get_setting("context_size")
     context_size = int(context_size_str) if context_size_str else None
     agent_mode = db.get_setting("agent_mode") or "autonomous"
+    dynamic_tools, dynamic_tools_locked = _resolve_dynamic_tools_setting(db)
     logger.debug(
-        "Settings loaded: custom_model=%s, context_size=%s, agent_mode=%s",
+        "Settings loaded: custom_model=%s, context_size=%s, agent_mode=%s, "
+        "dynamic_tools=%s (locked=%s)",
         custom_model,
         context_size,
         agent_mode,
+        dynamic_tools,
+        dynamic_tools_locked,
     )
     model_status = await _check_model_status(custom_model) if custom_model else None
     return SettingsResponse(
@@ -842,6 +867,8 @@ async def get_settings(db: ChatDatabase = Depends(get_db)):
         model_status=model_status,
         context_size=context_size,
         agent_mode=agent_mode,
+        dynamic_tools=dynamic_tools,
+        dynamic_tools_locked=dynamic_tools_locked,
     )
 
 
@@ -899,16 +926,28 @@ async def update_settings(
         db.set_setting("agent_mode", mode)
         logger.info("Agent mode set: %s", mode)
 
+    if (
+        "dynamic_tools" in request.model_fields_set
+        and request.dynamic_tools is not None
+    ):
+        # Persist the user's intent even while GAIA_DYNAMIC_TOOLS locks the
+        # effective value — so their choice applies once the env var is unset.
+        db.set_setting("dynamic_tools", "true" if request.dynamic_tools else "false")
+        logger.info("Dynamic tools setting persisted: %s", request.dynamic_tools)
+
     custom_model = db.get_setting("custom_model")
     context_size_str = db.get_setting("context_size")
     context_size = int(context_size_str) if context_size_str else None
     agent_mode = db.get_setting("agent_mode") or "autonomous"
+    dynamic_tools, dynamic_tools_locked = _resolve_dynamic_tools_setting(db)
     model_status = await _check_model_status(custom_model) if custom_model else None
     return SettingsResponse(
         custom_model=custom_model or None,
         model_status=model_status,
         context_size=context_size,
         agent_mode=agent_mode,
+        dynamic_tools=dynamic_tools,
+        dynamic_tools_locked=dynamic_tools_locked,
     )
 
 

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -370,7 +370,17 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             def _run() -> str:
                 from gaia.agents.chat.agent import ChatAgent, ChatAgentConfig
 
-                config = ChatAgentConfig(max_steps=5, silent_mode=True, debug=False)
+                # Beta dynamic tool loader (#1798). Inert here: scheduled runs
+                # use the default "full" prompt profile and the loader only
+                # activates on the "doc" profile — wired for future-proofing so
+                # this path doesn't silently diverge if that ever changes.
+                dynamic_tools = db.get_setting("dynamic_tools", "false") == "true"
+                config = ChatAgentConfig(
+                    max_steps=5,
+                    silent_mode=True,
+                    debug=False,
+                    dynamic_tools=dynamic_tools,
+                )
                 agent = ChatAgent(config)
                 result = agent.process_query(prompt)
                 if isinstance(result, dict):

--- a/tests/unit/chat/ui/test_chat_helpers.py
+++ b/tests/unit/chat/ui/test_chat_helpers.py
@@ -407,7 +407,7 @@ class TestSessionAgentKwargsShape:
     hit on casual chat turns — see the commit that added this test.
     """
 
-    def test_returns_exactly_the_four_session_fields(self):
+    def test_returns_exactly_the_session_fields(self):
         from gaia.ui._chat_helpers import _session_agent_kwargs
 
         kwargs = _session_agent_kwargs(
@@ -421,7 +421,30 @@ class TestSessionAgentKwargsShape:
             "library_documents",
             "allowed_paths",
             "ui_session_id",
+            "dynamic_tools",
         }
+
+    def test_dynamic_tools_defaults_off_and_forwards_when_set(self):
+        """The Beta tool-loader toggle (#1798) defaults off and round-trips
+        through the helper — the field that makes the UI toggle apply."""
+        from gaia.ui._chat_helpers import _session_agent_kwargs
+
+        off = _session_agent_kwargs(
+            rag_file_paths=[],
+            library_paths=[],
+            allowed=["/root"],
+            session_id="s",
+        )
+        assert off["dynamic_tools"] is False
+
+        on = _session_agent_kwargs(
+            rag_file_paths=[],
+            library_paths=[],
+            allowed=["/root"],
+            session_id="s",
+            dynamic_tools=True,
+        )
+        assert on["dynamic_tools"] is True
 
     def test_empty_rag_file_paths_propagates_to_rag_documents(self):
         """Invariant checked by ``test_streaming_registered_agent_does_not_double_index``.

--- a/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
+++ b/tests/unit/chat/ui/test_chat_helpers_model_resolution.py
@@ -301,6 +301,84 @@ class TestStaticRegressionGuard:
         )
 
 
+class TestDynamicToolsContractShape:
+    """#1798: prove the Beta tool-loader toggle isn't a no-op — the persisted
+    ``dynamic_tools`` setting must reach the outgoing factory kwargs on BOTH
+    chat paths, so the loader-active doc agent actually sees it.
+
+    "Mocks prove the call is valid, not just invoked": we assert the SHAPE of
+    the create_agent kwargs (does it carry ``dynamic_tools``?), not merely that
+    create_agent was called (CLAUDE.md contract-shape guard)."""
+
+    @staticmethod
+    def _db_with_settings(settings: dict):
+        db = MagicMock()
+        db.get_messages.return_value = []
+        db.list_documents.return_value = []
+        db.update_session.return_value = None
+        db.get_session.return_value = {}
+        db.get_setting.side_effect = lambda key, default=None: settings.get(
+            key, default
+        )
+        return db
+
+    def test_non_streaming_forwards_persisted_true(self):
+        """Persisted dynamic_tools="true" ⇒ create_agent receives
+        dynamic_tools=True (non-streaming registered/doc path)."""
+        registry, captured = _make_registry()
+        db = self._db_with_settings({"dynamic_tools": "true"})
+        session = _make_session(model=_DB_DEFAULT)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured["kwargs"].get("dynamic_tools") is True
+
+    def test_non_streaming_forwards_default_false(self):
+        """Cold state (no dynamic_tools key) ⇒ create_agent receives
+        dynamic_tools=False — byte-identical to the pre-#1798 default-off path."""
+        registry, captured = _make_registry()
+        db = self._db_with_settings({})  # nothing persisted
+        session = _make_session(model=_DB_DEFAULT)
+
+        with (
+            patch("gaia.ui._chat_helpers._agent_registry", registry),
+            patch("gaia.ui._chat_helpers._maybe_load_expected_model"),
+        ):
+            _call_non_streaming(session, db)
+
+        assert captured["kwargs"].get("dynamic_tools") is False
+
+    def test_streaming_registered_agent_forwards_dynamic_tools(self):
+        """Streaming registered-agent path threads dynamic_tools into
+        _session_agent_kwargs. Source-shape (like the double-index guard):
+        the streaming generator needs Lemonade HTTP + SSE + a background
+        thread to drive, so a source assertion gives the same ratcheting
+        regression cover at a fraction of the cost."""
+        import re
+
+        src = (Path(__file__).parents[4] / "src/gaia/ui/_chat_helpers.py").read_text()
+        m = re.search(
+            r"registry\.create_agent\(\s*agent_type,\s*\*\*_build_create_kwargs\("
+            r"[^)]*?streaming=True[^)]*?\),\s*\*\*_session_agent_kwargs\(([^)]+)\)",
+            src,
+            re.DOTALL,
+        )
+        assert m, (
+            "Could not locate the streaming registered-agent factory call in "
+            "_chat_helpers.py. Did the call-site structure change?"
+        )
+        block = m.group(1).replace(" ", "").replace("\n", "")
+        assert "dynamic_tools=dynamic_tools" in block, (
+            "Streaming registered-agent branch must forward "
+            "dynamic_tools=dynamic_tools into _session_agent_kwargs, or the "
+            "#1798 toggle is a no-op on the streaming doc path."
+        )
+
+
 class TestPostConstructionPreflight:
     """Verify pre-flight uses agent.model_id (not pre-call model_id variable)."""
 

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -755,6 +755,64 @@ class TestSystemStatus:
         )
 
 
+class TestDynamicToolsSetting:
+    """/api/settings round-trip + env lock for the Beta dynamic tool loader (#1798)."""
+
+    def test_cold_state_defaults_to_off(self, client, monkeypatch):
+        """Fresh DB (no dynamic_tools key) + no env var ⇒ off, unlocked —
+        byte-identical to the pre-#1798 default-off path."""
+        monkeypatch.delenv("GAIA_DYNAMIC_TOOLS", raising=False)
+        data = client.get("/api/settings").json()
+        assert data["dynamic_tools"] is False
+        assert data["dynamic_tools_locked"] is False
+
+    def test_put_true_round_trips(self, client, monkeypatch):
+        """PUT {dynamic_tools: true} persists and a fresh GET reflects it."""
+        monkeypatch.delenv("GAIA_DYNAMIC_TOOLS", raising=False)
+        put = client.put("/api/settings", json={"dynamic_tools": True}).json()
+        assert put["dynamic_tools"] is True
+        assert put["dynamic_tools_locked"] is False
+        get = client.get("/api/settings").json()
+        assert get["dynamic_tools"] is True
+
+    def test_put_false_round_trips(self, client, monkeypatch):
+        monkeypatch.delenv("GAIA_DYNAMIC_TOOLS", raising=False)
+        client.put("/api/settings", json={"dynamic_tools": True})
+        client.put("/api/settings", json={"dynamic_tools": False})
+        assert client.get("/api/settings").json()["dynamic_tools"] is False
+
+    def test_omitting_field_leaves_persisted_value_unchanged(self, client, monkeypatch):
+        """A PUT that omits dynamic_tools must not clobber the persisted value
+        (model_fields_set guard, mirroring context_size/agent_mode)."""
+        monkeypatch.delenv("GAIA_DYNAMIC_TOOLS", raising=False)
+        client.put("/api/settings", json={"dynamic_tools": True})
+        client.put("/api/settings", json={"custom_model": ""})  # unrelated field
+        assert client.get("/api/settings").json()["dynamic_tools"] is True
+
+    def test_env_var_wins_and_locks_regardless_of_persisted(self, client, monkeypatch):
+        """GAIA_DYNAMIC_TOOLS set ⇒ GET returns the env value + locked=True,
+        even when the persisted setting says otherwise."""
+        client.put("/api/settings", json={"dynamic_tools": False})
+        monkeypatch.setenv("GAIA_DYNAMIC_TOOLS", "1")
+        data = client.get("/api/settings").json()
+        assert data["dynamic_tools"] is True
+        assert data["dynamic_tools_locked"] is True
+
+    def test_put_persists_intent_even_while_locked(self, client, monkeypatch):
+        """While locked, PUT returns the env-won effective value but still
+        persists the user's intent for when the env var is later unset."""
+        monkeypatch.setenv("GAIA_DYNAMIC_TOOLS", "1")
+        put = client.put("/api/settings", json={"dynamic_tools": False}).json()
+        # Effective value is env-won (locked); intent is persisted underneath.
+        assert put["dynamic_tools"] is True
+        assert put["dynamic_tools_locked"] is True
+        monkeypatch.delenv("GAIA_DYNAMIC_TOOLS", raising=False)
+        # Env gone → the persisted False intent now wins, unlocked.
+        unlocked = client.get("/api/settings").json()
+        assert unlocked["dynamic_tools"] is False
+        assert unlocked["dynamic_tools_locked"] is False
+
+
 class TestSessionEndpoints:
     """Tests for /api/sessions/* endpoints."""
 

--- a/tests/unit/test_chat_dynamic_tools.py
+++ b/tests/unit/test_chat_dynamic_tools.py
@@ -95,6 +95,39 @@ def test_env_toggle_overrides_config(monkeypatch):
     assert a._maybe_build_tool_loader() is None
 
 
+def test_env_override_helper_none_when_unset(monkeypatch):
+    """``dynamic_tools_env_override`` returns ``None`` so callers fall back to
+    the persisted/config value — the single source of truth the UI router and
+    the agent resolver both read (#1798)."""
+    from gaia.agents.chat.agent import dynamic_tools_env_override
+
+    monkeypatch.delenv("GAIA_DYNAMIC_TOOLS", raising=False)
+    assert dynamic_tools_env_override() is None
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("", False),
+    ],
+)
+def test_env_override_helper_parses_truthy_set(monkeypatch, raw, expected):
+    """Same truthy set the resolver used to inline — pinned so the UI toggle
+    and the agent never disagree on what counts as "on"."""
+    from gaia.agents.chat.agent import dynamic_tools_env_override
+
+    monkeypatch.setenv("GAIA_DYNAMIC_TOOLS", raw)
+    assert dynamic_tools_env_override() is expected
+
+
 def test_env_threshold_and_max_overrides(monkeypatch):
     a = _bare_agent(config=ChatAgentConfig(prompt_profile="doc", dynamic_tools=True))
     monkeypatch.setenv("GAIA_DYNAMIC_TOOLS_TAU", "0.42")


### PR DESCRIPTION
## Summary

The semantic dynamic tool loader — which cuts first-turn latency on the Doc Agent by trimming each turn's tool prompt to a semantically-matched subset — has shipped **dark** since #1449: the only way to switch it on was exporting `GAIA_DYNAMIC_TOOLS` or editing SDK config, so no Agent UI user could discover or try it. This PR adds a single **Beta** toggle under **Settings → Dynamic Tools** so users can opt in without touching env vars. It stays **off by default** and changes *no* loader behavior — it only controls whether the UI-built agent sets `config.dynamic_tools=true`.

## Why

The feature was complete but undiscoverable from the UI — its only on-ramps were a dev/CI env var and an SDK field. `GAIA_DYNAMIC_TOOLS` must stay the authoritative dev/CI/eval override (eval tooling and CI depend on it), so the toggle layers on top rather than replacing it: when the env var is set it **wins**, and the toggle then reflects the effective value and disables itself with an explanation — never a silent no-op that lies about the running state.

## Linked issue

Closes #1798

## Changes

- **Settings toggle (Beta, off by default).** Boolean toggle reusing the existing `.toggle-switch` pattern with an immediate optimistic save; on failure it reverts and surfaces a visible error (no silent fallback). When `GAIA_DYNAMIC_TOOLS` is set, the toggle shows the effective value, disables, and explains why.
- **Env-wins precedence centralized in one parser.** Extracted `dynamic_tools_env_override()` so the agent resolver and the settings router parse the *same* truthy set — no drift between what the toggle shows and what the agent does. `GET`/`PUT /api/settings` now return `dynamic_tools` + `dynamic_tools_locked`; `PUT` persists the user's intent even while the env var locks the effective value, so their choice applies once it's unset.
- **Threaded through every agent construction path, not just the active one.** `_session_agent_kwargs` carries the field to both the streaming and non-streaming Doc-agent builds (the only path where the loader is observable). The scheduled-prompt build and the autonomous agent-loop tick also read it — inert on their `"full"` profile today, wired and commented so they can't silently diverge if that ever changes.
- **Docs + polish (review follow-ups).** Documented the toggle as a third enable path in the chat guide; added a disabled-state style to the shared toggle so a locked control *looks* locked; added a double-click-during-save guard test.

<details>
<summary>Deviations from the issue sketch (flagged per plan)</summary>

| Issue/sketch assumed | Code reality | Resolution in this PR |
|---|---|---|
| Wire at the two `_chat_helpers.py` `chat` sites | Those build the default `"full"` profile, where the loader is inert; the loader-active path is the **`doc`** agent built via `registry.create_agent` in the `else` branch | Thread `dynamic_tools` through `_session_agent_kwargs`, which reaches the active `doc` path **and** the inert `chat` sites in one place |
| "thread through `_session_agent_kwargs` covers all sites" | `server.py`'s scheduled-prompt path does **not** call that helper | `server.py` gets its own `db.get_setting("dynamic_tools")` read + an inert-on-`"full"` comment |
| Frontend should mirror `custom_model` (text input + Save button) | The new control is **boolean** | Used the `.toggle-switch` pattern (immediate save) — appropriate for a boolean, not a text+Save field |
| Persist "mirroring `agent_mode`" | Settings persist as TEXT; booleans use `"true"`/`"false"` (precedent: `memory_enabled`) | Persist `"true"`/`"false"`; read with the same string compare; missing → off |
| TS `Settings` mirrors `SettingsResponse` | TS `Settings` omits `agent_mode` (backend-only) | Added `dynamic_tools` + `dynamic_tools_locked` to the TS type only |
| Plan listed only `server.py` for the inert future-proofed read | The autonomous **`agent_loop.py`** tick is a separate `ChatAgentConfig` build site with the same concern | Also wired + commented there, so both background paths stay in lock-step |

**No eval run** — deliberate, not skipped. The default-off path is byte-identical to today (`config.dynamic_tools is False` ⇒ loader `None`); this PR adds a UI surface + plumbing that sets an already-eval-covered config field and touches no prompt, tool registration, or selection logic. Loader behavior remains covered by #1449/#1762's committed `scorecard_tool_selection.json`.
</details>

## Test plan

- [x] **Backend unit** — round-trip, env-lock, persist-while-locked, cold-state default-off, per-path contract-shape, and the env-override helper:
  ```bash
  python -m pytest tests/unit/chat/ui/test_server.py \
    tests/unit/chat/ui/test_chat_helpers_model_resolution.py \
    tests/unit/test_chat_dynamic_tools.py -xvs
  ```
- [x] **Frontend unit** — off/on, visible-label click, env-locked-disabled, error-revert, and single-PUT-on-double-click (7 cases):
  ```bash
  cd src/gaia/apps/webui && npx vitest run src/components/__tests__/SettingsPage.test.tsx
  ```
- [x] **Lint** — `python util/lint.py --all` → clean (black/isort/ruff).
- [x] **Cold/empty state** — against a fresh UI DB (no `dynamic_tools` key), `GET /api/settings` returns `dynamic_tools: false, dynamic_tools_locked: false`.
- [x] **(Optional, on-hardware)** `gaia chat --ui` → Settings → toggle **Dynamic Tools** on → start a **Doc Agent** session → confirm one `TOOL_LOADER {…}` INFO line in the server log (off ⇒ none). With `GAIA_DYNAMIC_TOOLS=1` exported, the toggle renders on **and** disabled.

## Checklist

- [x] I have linked a GitHub issue above (`Closes #1798`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have updated documentation if user-visible behavior changed (`docs/guides/chat.mdx` — the toggle as a third enable path).
