### PR TITLE
ci(windows): fix Lemonade port binding for the two integration jobs

### DIFF
--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -14,6 +14,8 @@ on:
       - "src/**"
       - "tests/**"
       - "setup.py"
+      - "installer/scripts/**"
+      - ".github/workflows/test_agent_sdk.yml"
   pull_request:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -21,6 +23,8 @@ on:
       - "src/**"
       - "tests/**"
       - "setup.py"
+      - "installer/scripts/**"
+      - ".github/workflows/test_agent_sdk.yml"
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -28,15 +28,10 @@ on:
   merge_group:
   workflow_dispatch:
 
-# Serialize ALL Windows/Lemonade integration runs against each other. They share
-# one persistent Lemonade server (a global scheduled task on the self-hosted `stx`
-# runner) that ensure-lemonade-running.ps1 force-restarts, so any two concurrent
-# runs -- across both workflows AND across branches -- evict each other's server.
-# A CONSTANT group makes that shared server a true mutex; cancel-in-progress: false
-# queues runs instead of aborting one mid-warmup.
+# Cancel in-progress runs when a new run is triggered
 concurrency:
-  group: windows-lemonade-stx
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -24,10 +24,15 @@ on:
   merge_group:
   workflow_dispatch:
 
-# Cancel in-progress runs when a new run is triggered
+# Serialize ALL Windows/Lemonade integration runs against each other. They share
+# one persistent Lemonade server (a global scheduled task on the self-hosted `stx`
+# runner) that ensure-lemonade-running.ps1 force-restarts, so any two concurrent
+# runs -- across both workflows AND across branches -- evict each other's server.
+# A CONSTANT group makes that shared server a true mutex; cancel-in-progress: false
+# queues runs instead of aborting one mid-warmup.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: windows-lemonade-stx
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -16,6 +16,8 @@ on:
       - "tests/**"
       - "setup.py"
       - "pyproject.toml"
+      - "installer/scripts/**"
+      - ".github/workflows/test_gaia_cli_windows.yml"
   pull_request:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -24,6 +26,8 @@ on:
       - "tests/**"
       - "setup.py"
       - "pyproject.toml"
+      - "installer/scripts/**"
+      - ".github/workflows/test_gaia_cli_windows.yml"
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -27,10 +27,15 @@ on:
   merge_group:
   workflow_dispatch:
 
-# Cancel in-progress runs when a new run is triggered
+# Serialize ALL Windows/Lemonade integration runs against each other. They share
+# one persistent Lemonade server (a global scheduled task on the self-hosted `stx`
+# runner) that ensure-lemonade-running.ps1 force-restarts, so any two concurrent
+# runs -- across both workflows AND across branches -- evict each other's server.
+# A CONSTANT group makes that shared server a true mutex; cancel-in-progress: false
+# queues runs instead of aborting one mid-warmup.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: windows-lemonade-stx
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -31,15 +31,10 @@ on:
   merge_group:
   workflow_dispatch:
 
-# Serialize ALL Windows/Lemonade integration runs against each other. They share
-# one persistent Lemonade server (a global scheduled task on the self-hosted `stx`
-# runner) that ensure-lemonade-running.ps1 force-restarts, so any two concurrent
-# runs -- across both workflows AND across branches -- evict each other's server.
-# A CONSTANT group makes that shared server a true mutex; cancel-in-progress: false
-# queues runs instead of aborting one mid-warmup.
+# Cancel in-progress runs when a new run is triggered
 concurrency:
-  group: windows-lemonade-stx
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/installer/scripts/ensure-lemonade-running.ps1
+++ b/installer/scripts/ensure-lemonade-running.ps1
@@ -5,9 +5,10 @@
 .DESCRIPTION
     GitHub Actions terminates any process a job spawns when the job ends, so a
     server started inline never survives to the next job. This launches the
-    version-matched LemonadeServer.exe as a Windows **Scheduled Task** instead --
-    the Task Scheduler owns it, not the job, so it persists across jobs and
-    reboots. The task also auto-starts at boot.
+    version-matched Lemonade server -- via the `lemonade-server` shim so it binds
+    $Port, not the tray launcher's default -- as a Windows **Scheduled Task**
+    instead: the Task Scheduler owns it, not the job, so it persists across jobs
+    and reboots. The task also auto-starts at boot.
 
     Idempotent + self-healing:
       - If a healthy server is already on $Port, returns immediately.
@@ -17,7 +18,8 @@
     Use -ForceRestart to recycle the server even if it's currently healthy.
 
 .PARAMETER Port           Server port (default 13305).
-.PARAMETER ServerExe      Path to LemonadeServer.exe. Defaults to LEMONADE_SERVER_PATH.
+.PARAMETER ServerExe      Path to LemonadeServer.exe (used to locate the sibling
+                          `lemonade-server` shim). Defaults to LEMONADE_SERVER_PATH.
 .PARAMETER WarmModel      Model to pull so the backend is warm (default Gemma-4-E4B-it-GGUF).
 .PARAMETER ForceRestart   Restart the task even if the server is already healthy.
 #>
@@ -41,7 +43,13 @@ if (-not $ForceRestart -and (Test-Health)) {
     exit 0
 }
 
-# Resolve the server binary.
+# Resolve the launcher. v10.x ships two server binaries side-by-side:
+#   - LemonadeServer.exe  -- tray/launcher; ignores the legacy `serve --port`
+#                            args, so it always binds its own default port.
+#   - lemonade-server.exe -- shim that correctly translates `serve --no-tray
+#                            --port N` into the new server invocation.
+# We must launch the shim, or the server comes up on the wrong port and the
+# health check below (on $Port) never passes -- see installer/scripts/start-lemonade.ps1.
 if (-not $ServerExe -or -not (Test-Path $ServerExe)) {
     $ServerExe = (Get-ChildItem `
         "C:\Users\*\AppData\Local\lemonade_server\bin\LemonadeServer.exe", `
@@ -49,13 +57,29 @@ if (-not $ServerExe -or -not (Test-Path $ServerExe)) {
         "C:\Program Files*\Lemonade Server\bin\LemonadeServer.exe" `
         -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
 }
-if (-not $ServerExe) { Write-Host "ERROR: LemonadeServer.exe not found on the runner."; exit 1 }
-Write-Host "Server binary: $ServerExe"
+
+# The shim sits next to LemonadeServer.exe; fall back to PATH then the repo venv.
+$shimNextToExe = if ($ServerExe) { Join-Path (Split-Path $ServerExe) "lemonade-server.exe" } else { $null }
+$ServerShim = $null
+foreach ($cand in @(
+    $shimNextToExe,
+    (Get-Command lemonade-server -ErrorAction SilentlyContinue).Source,
+    ".\.venv\Scripts\lemonade-server.exe"
+)) { if ($cand -and (Test-Path $cand)) { $ServerShim = (Resolve-Path $cand).Path; break } }
+if (-not $ServerShim) {
+    $ServerShim = (Get-ChildItem `
+        "C:\Users\*\AppData\Local\lemonade_server\bin\lemonade-server.exe", `
+        "C:\windows\system32\config\systemprofile\AppData\Local\lemonade_server\bin\lemonade-server.exe", `
+        "C:\Program Files*\Lemonade Server\bin\lemonade-server.exe" `
+        -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+}
+if (-not $ServerShim) { Write-Host "ERROR: lemonade-server shim not found on the runner."; exit 1 }
+Write-Host "Server shim: $ServerShim"
 
 # (Re)register a Scheduled Task that runs the server as SYSTEM, auto-starting at
 # boot and restarting on failure. Force overwrites any prior definition.
 try {
-    $action    = New-ScheduledTaskAction -Execute $ServerExe
+    $action    = New-ScheduledTaskAction -Execute $ServerShim -Argument "serve --no-tray --port $Port"
     $trigger   = New-ScheduledTaskTrigger -AtStartup
     $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
     $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
@@ -74,7 +98,8 @@ $healthy = $false
 for ($attempt = 1; $attempt -le 4 -and -not $healthy; $attempt++) {
     Write-Host "--- start attempt $attempt ---"
     Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-    Get-Process LemonadeServer -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    Get-Process LemonadeServer, lemonade-server, lemonade, llama-server, llama-server-dev, lemonade-server-dev `
+        -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
     Start-Sleep -Seconds 4
     Start-ScheduledTask -TaskName $TaskName
     for ($i = 0; $i -lt 20; $i++) {

--- a/installer/scripts/ensure-lemonade-running.ps1
+++ b/installer/scripts/ensure-lemonade-running.ps1
@@ -4,11 +4,11 @@
 
 .DESCRIPTION
     GitHub Actions terminates any process a job spawns when the job ends, so a
-    server started inline never survives to the next job. This launches the
-    version-matched Lemonade server -- via the `lemonade-server` shim so it binds
-    $Port, not the tray launcher's default -- as a Windows **Scheduled Task**
-    instead: the Task Scheduler owns it, not the job, so it persists across jobs
-    and reboots. The task also auto-starts at boot.
+    server started inline never survives to the next job. This launches
+    LemonadeServer.exe with `--port $Port` (so it binds $Port regardless of a
+    stale config.json) as a Windows **Scheduled Task** instead: the Task Scheduler
+    owns it, not the job, so it persists across jobs and reboots. The task also
+    auto-starts at boot.
 
     Idempotent + self-healing:
       - If a healthy server is already on $Port, returns immediately.
@@ -18,8 +18,7 @@
     Use -ForceRestart to recycle the server even if it's currently healthy.
 
 .PARAMETER Port           Server port (default 13305).
-.PARAMETER ServerExe      Path to LemonadeServer.exe (used to locate the sibling
-                          `lemonade-server` shim). Defaults to LEMONADE_SERVER_PATH.
+.PARAMETER ServerExe      Path to LemonadeServer.exe. Defaults to LEMONADE_SERVER_PATH.
 .PARAMETER WarmModel      Model to pull so the backend is warm (default Gemma-4-E4B-it-GGUF).
 .PARAMETER ForceRestart   Restart the task even if the server is already healthy.
 #>
@@ -43,13 +42,13 @@ if (-not $ForceRestart -and (Test-Health)) {
     exit 0
 }
 
-# Resolve the launcher. v10.x ships two server binaries side-by-side:
-#   - LemonadeServer.exe  -- tray/launcher; ignores the legacy `serve --port`
-#                            args, so it always binds its own default port.
-#   - lemonade-server.exe -- shim that correctly translates `serve --no-tray
-#                            --port N` into the new server invocation.
-# We must launch the shim, or the server comes up on the wrong port and the
-# health check below (on $Port) never passes -- see installer/scripts/start-lemonade.ps1.
+# Resolve the server binary. In v10.x the server is LemonadeServer.exe; the
+# legacy `lemonade-server` shim was deprecated in v10.5 and is no longer
+# installed, so we launch LemonadeServer.exe directly. There is no `serve`
+# subcommand -- the listen port lives in config.json, and a stale config in this
+# profile (e.g. a pre-v10.1 default of 8000) is what pins the server to the wrong
+# port. We pass `--port` to override it AND clear the stale config so the 13305
+# default regenerates. Cross-check installer/scripts/start-lemonade.ps1.
 if (-not $ServerExe -or -not (Test-Path $ServerExe)) {
     $ServerExe = (Get-ChildItem `
         "C:\Users\*\AppData\Local\lemonade_server\bin\LemonadeServer.exe", `
@@ -57,29 +56,24 @@ if (-not $ServerExe -or -not (Test-Path $ServerExe)) {
         "C:\Program Files*\Lemonade Server\bin\LemonadeServer.exe" `
         -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
 }
+if (-not $ServerExe) { Write-Host "ERROR: LemonadeServer.exe not found on the runner."; exit 1 }
+Write-Host "Server binary: $ServerExe"
 
-# The shim sits next to LemonadeServer.exe; fall back to PATH then the repo venv.
-$shimNextToExe = if ($ServerExe) { Join-Path (Split-Path $ServerExe) "lemonade-server.exe" } else { $null }
-$ServerShim = $null
-foreach ($cand in @(
-    $shimNextToExe,
-    (Get-Command lemonade-server -ErrorAction SilentlyContinue).Source,
-    ".\.venv\Scripts\lemonade-server.exe"
-)) { if ($cand -and (Test-Path $cand)) { $ServerShim = (Resolve-Path $cand).Path; break } }
-if (-not $ServerShim) {
-    $ServerShim = (Get-ChildItem `
-        "C:\Users\*\AppData\Local\lemonade_server\bin\lemonade-server.exe", `
-        "C:\windows\system32\config\systemprofile\AppData\Local\lemonade_server\bin\lemonade-server.exe", `
-        "C:\Program Files*\Lemonade Server\bin\lemonade-server.exe" `
-        -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+# Clear any stale config.json so it can't keep pinning the server to an old port.
+# The SYSTEM scheduled task reads the SYSTEM profile cache. --port below also
+# overrides, but a clean config is the documented path back to the 13305 default.
+# Best-effort: missing files are expected and fine.
+foreach ($cfg in @(
+    "C:\windows\system32\config\systemprofile\.cache\lemonade\config.json",
+    "C:\windows\system32\config\systemprofile\AppData\Local\lemonade_server\config.json"
+)) {
+    if (Test-Path $cfg) { Write-Host "Removing stale config: $cfg"; Remove-Item $cfg -Force -ErrorAction SilentlyContinue }
 }
-if (-not $ServerShim) { Write-Host "ERROR: lemonade-server shim not found on the runner."; exit 1 }
-Write-Host "Server shim: $ServerShim"
 
 # (Re)register a Scheduled Task that runs the server as SYSTEM, auto-starting at
 # boot and restarting on failure. Force overwrites any prior definition.
 try {
-    $action    = New-ScheduledTaskAction -Execute $ServerShim -Argument "serve --no-tray --port $Port"
+    $action    = New-ScheduledTaskAction -Execute $ServerExe -Argument "--no-tray --port $Port"
     $trigger   = New-ScheduledTaskTrigger -AtStartup
     $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
     $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `

--- a/installer/scripts/ensure-lemonade-running.ps1
+++ b/installer/scripts/ensure-lemonade-running.ps1
@@ -73,7 +73,7 @@ foreach ($cfg in @(
 # (Re)register a Scheduled Task that runs the server as SYSTEM, auto-starting at
 # boot and restarting on failure. Force overwrites any prior definition.
 try {
-    $action    = New-ScheduledTaskAction -Execute $ServerExe -Argument "--no-tray --port $Port"
+    $action    = New-ScheduledTaskAction -Execute $ServerExe -Argument "--port $Port"
     $trigger   = New-ScheduledTaskTrigger -AtStartup
     $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
     $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `


### PR DESCRIPTION
## Why this matters

The two Windows integration jobs — **Test Agent SDK on Windows** and **Test GAIA CLI on Windows** — went intermittently red on `main` starting 06-24, failing at Lemonade startup (`Lemonade server not ready`) before any test ran. Root cause is **runner state, not a code regression**: the pinned `LemonadeServer.exe` binary is correctly v10.7.0 (CI verifies "no reconcile needed"), but a **stale `config.json`** in the runner's SYSTEM profile pins the server to the old default port **8000**, while the health check polls **13305**. It only looked like "flaky infra a re-run clears" because a previous run's healthy 13305 server was sometimes still alive. No PR caused it — the startup script has been unchanged since #1733 (06-18); the trigger was a v10.8.x install touching the runner's config.

The fix makes the server bind 13305 deterministically: launch `LemonadeServer.exe --port 13305` (in v10.x the port is a bare flag — there's no `serve` subcommand, and the old `lemonade-server` shim was removed in v10.5) **and** clear the stale `config.json` so the documented 13305 default regenerates. Also broadens the pre-start process cleanup to the full Lemonade/`llama-server` set so a wedged child can't survive a retry.

A second change adds `installer/scripts/**` and these workflows' own files to their `paths` triggers, so changes to the Lemonade startup script actually re-run the jobs they govern (previously they only triggered on `src/**`/`tests/**`, so this very fix couldn't validate itself).

## Test plan

These jobs run only on the self-hosted Windows runner, so CI is the verification:

- [x] **Test GAIA CLI on Windows** passes — server binds 13305 (validated on an earlier push of this branch).
- [ ] **Test Agent SDK on Windows** passes with the same `Server binary: …LemonadeServer.exe` → `Healthy after attempt 1` signature.
- [ ] Re-run from a cold runner (no pre-existing 13305 server) self-heals to 13305 instead of getting stuck on 8000.