### PR TITLE
docs(reset-lemonade): bump stale 10.7.0 fallback to 10.8.1

### DIFF
--- a/installer/scripts/reset-lemonade.ps1
+++ b/installer/scripts/reset-lemonade.ps1
@@ -26,7 +26,7 @@
 
 .PARAMETER Version
     Lemonade version to install. Defaults to LEMONADE_VERSION from
-    src/gaia/version.py when run from a GAIA checkout, else 10.7.0.
+    src/gaia/version.py when run from a GAIA checkout, else 10.8.1.
 
 .PARAMETER Port
     Port to verify the server on. Default 13305.
@@ -45,7 +45,7 @@
 .EXAMPLE
     powershell -ExecutionPolicy Bypass -File installer\scripts\reset-lemonade.ps1
 .EXAMPLE
-    .\reset-lemonade.ps1 -Version 10.7.0 -VerifyModel Qwen3-4B-Instruct-2507-GGUF
+    .\reset-lemonade.ps1 -Version 10.8.1 -VerifyModel Qwen3-4B-Instruct-2507-GGUF
 #>
 [CmdletBinding()]
 param(
@@ -67,7 +67,7 @@ if (-not $Version) {
         $line = Select-String -Path $verPy -Pattern 'LEMONADE_VERSION\s*=\s*"([0-9.]+)"' | Select-Object -First 1
         if ($line) { $Version = $line.Matches[0].Groups[1].Value }
     }
-    if (-not $Version) { $Version = "10.7.0" }
+    if (-not $Version) { $Version = "10.8.1" }
 }
 Log "Target Lemonade version: $Version"
 


### PR DESCRIPTION
## Why this matters

Closes the one loose end the #1869 review flagged: `reset-lemonade.ps1` still hardcoded **10.7.0** in its version fallback, docstring, and example after the 10.8.1 upgrade. CI never caught it because the script reads `LEMONADE_VERSION` from `src/gaia/version.py` first — but when run standalone (outside a GAIA checkout) it would install the wrong, now-stale version, and the default would keep drifting on each bump. Now it tracks 10.8.1.

Scope is exactly the three references the review identified; the `docs/releases/v0.21.2.mdx` mention of 10.7.0 is a historical changelog entry and is intentionally left unchanged.

## Test plan

- [x] `grep 10.7.0 installer/scripts/reset-lemonade.ps1` → no matches; all three bumped to 10.8.1.
- [ ] Docs Validation stays green (no version-consistency regression — this only changes a fallback default, not docs refs).