### PR TITLE
ci: run Lemonade-dependent checks when LEMONADE_VERSION changes

### DIFF
--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -13,6 +13,8 @@ on:
   push:
     branches: [ main ]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'cpp/**'
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'
@@ -20,6 +22,8 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'cpp/**'
       - '.github/workflows/build_cpp.yml'
       - '.github/workflows/benchmark_cpp.yml'

--- a/.github/workflows/test_agent_behavior_e2e.yml
+++ b/.github/workflows/test_agent_behavior_e2e.yml
@@ -11,6 +11,8 @@ on:
   workflow_dispatch:
   push:
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/agents/builder/**'
       - 'src/gaia/agents/base/agent.py'
       - 'src/gaia/eval/behavior_harness.py'

--- a/.github/workflows/test_agent_mcp_server.yml
+++ b/.github/workflows/test_agent_mcp_server.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches: [ main ]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/agents/base/mcp_agent.py'
       - 'src/gaia/mcp/**'
       - 'tests/mcp/**'
@@ -19,6 +21,8 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/agents/base/mcp_agent.py'
       - 'src/gaia/mcp/**'
       - 'tests/mcp/**'

--- a/.github/workflows/test_agent_sdk.yml
+++ b/.github/workflows/test_agent_sdk.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches: ["main"]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - "src/**"
       - "tests/**"
       - "setup.py"
@@ -20,6 +22,8 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - "src/**"
       - "tests/**"
       - "setup.py"

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches: ["main"]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/api/**'
       - 'src/gaia/agents/base/**'
       - 'src/gaia/llm/**'
@@ -21,6 +23,8 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/api/**'
       - 'src/gaia/agents/base/**'
       - 'src/gaia/llm/**'

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches: [ main ]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/rag/**'
       - 'src/gaia/llm/**'
       - 'tests/test_lemonade_embeddings.py'
@@ -17,6 +19,8 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/rag/**'
       - 'src/gaia/llm/**'
       - 'tests/test_lemonade_embeddings.py'

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -72,10 +72,6 @@ jobs:
             $serverJob = Start-Job -ScriptBlock {
                 # Workaround for Issue #612: Disable Vulkan cooperative matrix optimization
                 $env:GGML_VK_DISABLE_COOPMAT = "1"
-                # Debug logging so the (otherwise swallowed) llama-server backend
-                # output is captured in the job stream -- lets us record the exact
-                # crash if the MoE embedding load aborts (see retry block below).
-                $env:LEMONADE_LOG_LEVEL = "debug"
                 & lemonade-server serve --host localhost --port 13305 --no-tray 2>&1
             }
             Write-Host "Started Lemonade server job with ID: $($serverJob.Id)"
@@ -127,39 +123,23 @@ jobs:
                 Write-Host "   [WARN] Pull may have failed: $($_.Exception.Message)"
             }
 
-            # Load embedding model into memory, WITH RETRY. The
-            # nomic-embed-text-v2-moe MoE model intermittently aborts
-            # llama-server startup on the AMD Vulkan backend -- a transient
-            # GPU-driver-state fault (upstream llama.cpp #16301 / lemonade #612,
-            # not a GAIA defect; the load succeeds once the GPU state settles).
-            # On every failed attempt we dump the server job's debug output to
-            # capture the exact (otherwise-swallowed) llama-server crash.
+            # Load embedding model into memory (required in Lemonade v9.x)
             Write-Host "`n=== Loading Embedding Model ==="
-            $loadRequest = @{ model_name = "nomic-embed-text-v2-moe-GGUF" } | ConvertTo-Json
-            $loaded = $false
-            for ($attempt = 1; $attempt -le 3 -and -not $loaded; $attempt++) {
-                try {
-                    Write-Host "Loading model (attempt $attempt/3): nomic-embed-text-v2-moe-GGUF"
-                    $loadResponse = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/load" `
-                        -Method POST -Body $loadRequest -ContentType "application/json" -TimeoutSec 60
-                    Write-Host "[OK] Model loaded successfully: $($loadResponse | ConvertTo-Json -Compress)"
-                    $loaded = $true
-                } catch {
-                    Write-Host "[WARN] Model load attempt $attempt failed: $($_.Exception.Message)"
-                    if ($_.ErrorDetails) {
-                        Write-Host "Error details: $($_.ErrorDetails.Message)"
-                    }
-                    # Capture the swallowed llama-server crash from the debug stream.
-                    Write-Host "----- Lemonade server debug output (attempt $attempt) -----"
-                    if ($env:LEMONADE_JOB_ID) {
-                        $jobOut = Receive-Job -Id $env:LEMONADE_JOB_ID -ErrorAction SilentlyContinue
-                        if ($jobOut) { $jobOut | Select-Object -Last 150 | ForEach-Object { Write-Host $_ } }
-                    }
-                    if ($attempt -lt 3) { Write-Host "Retrying in 12s..."; Start-Sleep -Seconds 12 }
+            try {
+                $loadRequest = @{
+                    model_name = "nomic-embed-text-v2-moe-GGUF"
+                } | ConvertTo-Json
+
+                Write-Host "Loading model: nomic-embed-text-v2-moe-GGUF"
+                $loadResponse = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/load" `
+                    -Method POST -Body $loadRequest -ContentType "application/json" -TimeoutSec 60
+                Write-Host "[OK] Model loaded successfully: $($loadResponse | ConvertTo-Json -Compress)"
+            } catch {
+                Write-Host "[ERROR] Model load failed: $($_.Exception.Message)"
+                if ($_.ErrorDetails) {
+                    Write-Host "Error details: $($_.ErrorDetails.Message)"
                 }
-            }
-            if (-not $loaded) {
-                throw "Failed to load embedding model after 3 attempts"
+                throw "Failed to load embedding model"
             }
 
             # Wait for llamacpp backend to fully initialize (increased from 10s)

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -72,6 +72,10 @@ jobs:
             $serverJob = Start-Job -ScriptBlock {
                 # Workaround for Issue #612: Disable Vulkan cooperative matrix optimization
                 $env:GGML_VK_DISABLE_COOPMAT = "1"
+                # Debug logging so the (otherwise swallowed) llama-server backend
+                # output is captured in the job stream -- lets us record the exact
+                # crash if the MoE embedding load aborts (see retry block below).
+                $env:LEMONADE_LOG_LEVEL = "debug"
                 & lemonade-server serve --host localhost --port 13305 --no-tray 2>&1
             }
             Write-Host "Started Lemonade server job with ID: $($serverJob.Id)"
@@ -123,23 +127,39 @@ jobs:
                 Write-Host "   [WARN] Pull may have failed: $($_.Exception.Message)"
             }
 
-            # Load embedding model into memory (required in Lemonade v9.x)
+            # Load embedding model into memory, WITH RETRY. The
+            # nomic-embed-text-v2-moe MoE model intermittently aborts
+            # llama-server startup on the AMD Vulkan backend -- a transient
+            # GPU-driver-state fault (upstream llama.cpp #16301 / lemonade #612,
+            # not a GAIA defect; the load succeeds once the GPU state settles).
+            # On every failed attempt we dump the server job's debug output to
+            # capture the exact (otherwise-swallowed) llama-server crash.
             Write-Host "`n=== Loading Embedding Model ==="
-            try {
-                $loadRequest = @{
-                    model_name = "nomic-embed-text-v2-moe-GGUF"
-                } | ConvertTo-Json
-
-                Write-Host "Loading model: nomic-embed-text-v2-moe-GGUF"
-                $loadResponse = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/load" `
-                    -Method POST -Body $loadRequest -ContentType "application/json" -TimeoutSec 60
-                Write-Host "[OK] Model loaded successfully: $($loadResponse | ConvertTo-Json -Compress)"
-            } catch {
-                Write-Host "[ERROR] Model load failed: $($_.Exception.Message)"
-                if ($_.ErrorDetails) {
-                    Write-Host "Error details: $($_.ErrorDetails.Message)"
+            $loadRequest = @{ model_name = "nomic-embed-text-v2-moe-GGUF" } | ConvertTo-Json
+            $loaded = $false
+            for ($attempt = 1; $attempt -le 3 -and -not $loaded; $attempt++) {
+                try {
+                    Write-Host "Loading model (attempt $attempt/3): nomic-embed-text-v2-moe-GGUF"
+                    $loadResponse = Invoke-RestMethod -Uri "http://localhost:13305/api/v1/load" `
+                        -Method POST -Body $loadRequest -ContentType "application/json" -TimeoutSec 60
+                    Write-Host "[OK] Model loaded successfully: $($loadResponse | ConvertTo-Json -Compress)"
+                    $loaded = $true
+                } catch {
+                    Write-Host "[WARN] Model load attempt $attempt failed: $($_.Exception.Message)"
+                    if ($_.ErrorDetails) {
+                        Write-Host "Error details: $($_.ErrorDetails.Message)"
+                    }
+                    # Capture the swallowed llama-server crash from the debug stream.
+                    Write-Host "----- Lemonade server debug output (attempt $attempt) -----"
+                    if ($env:LEMONADE_JOB_ID) {
+                        $jobOut = Receive-Job -Id $env:LEMONADE_JOB_ID -ErrorAction SilentlyContinue
+                        if ($jobOut) { $jobOut | Select-Object -Last 150 | ForEach-Object { Write-Host $_ } }
+                    }
+                    if ($attempt -lt 3) { Write-Host "Retrying in 12s..."; Start-Sleep -Seconds 12 }
                 }
-                throw "Failed to load embedding model"
+            }
+            if (-not $loaded) {
+                throw "Failed to load embedding model after 3 attempts"
             }
 
             # Wait for llamacpp backend to fully initialize (increased from 10s)

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -18,6 +18,8 @@ on:
   push:
     branches: [ main ]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'examples/**'
       - 'src/gaia/**'
       - 'tests/integration/test_example_agents.py'
@@ -27,6 +29,8 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'examples/**'
       - 'src/gaia/**'
       - 'tests/integration/test_example_agents.py'

--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -12,6 +12,8 @@ on:
   push:
     branches: ["main"]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - "src/**"
       - "tests/**"
       - "setup.py"
@@ -22,6 +24,8 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - "src/**"
       - "tests/**"
       - "setup.py"

--- a/.github/workflows/test_lemonade_server.yml
+++ b/.github/workflows/test_lemonade_server.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches: [ main ]
     paths:
+      - 'src/gaia/version.py'
       - 'src/gaia/llm/**'
       - 'src/gaia/installer/**'
       - 'setup.py'
@@ -20,6 +21,7 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
       - 'src/gaia/llm/**'
       - 'src/gaia/installer/**'
       - 'setup.py'

--- a/.github/workflows/test_rag.yml
+++ b/.github/workflows/test_rag.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches: [ main ]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/rag/**'
       - 'src/gaia/llm/**'
       - 'src/gaia/vlm/**'
@@ -18,6 +20,8 @@ on:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - 'src/gaia/rag/**'
       - 'src/gaia/llm/**'
       - 'src/gaia/vlm/**'

--- a/.github/workflows/test_sd.yml
+++ b/.github/workflows/test_sd.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches: ["main"]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - "src/gaia/sd/**"  # SD mixin and tools
       - "hub/agents/python/sd/**"  # SD agent (standalone wheel #1102)
       - "src/gaia/llm/lemonade_client.py"
@@ -21,6 +23,8 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/gaia/version.py'
+      - '.github/actions/install-lemonade/**'
       - "src/gaia/sd/**"  # SD mixin and tools
       - "hub/agents/python/sd/**"  # SD agent (standalone wheel #1102)
       - "src/gaia/llm/lemonade_client.py"


### PR DESCRIPTION
## Why this matters

A Lemonade version bump edits only `src/gaia/version.py` (`LEMONADE_VERSION`), which the `install-lemonade` action reads to provision the runners. But every Lemonade-dependent workflow was path-filtered to feature code (`src/gaia/rag/**`, `llm/**`, agents, `cpp/**`, …) and **excluded `version.py`** — so the one change that swaps the Lemonade build on the runners triggered **none** of the tests that exercise it.

That's the gap that let Lemonade **10.7.0 → 10.8.1** land while the embedding model `nomic-embed-text-v2-moe` is broken on the bundled `llama-server`: the embeddings/RAG/API/E2E checks simply never ran on the bump. The break only surfaced days later on unrelated PRs (including a `.docx` RAG PR) whose authors had no idea it wasn't their change.

Root cause of the embedding break is upstream, not ours — a Vulkan-backend regression on AMD GPUs since llama.cpp build **b6524** (llama.cpp [#16301](https://github.com/ggml-org/llama.cpp/issues/16301), open), surfaced in Lemonade [#612](https://github.com/lemonade-sdk/lemonade/issues/612) / [#941](https://github.com/lemonade-sdk/lemonade/issues/941). This PR doesn't fix that; it makes our CI **catch** that class of regression on the bump PR instead of silently shipping it.

This adds `src/gaia/version.py` and `.github/actions/install-lemonade/**` to the `push` + `pull_request` path triggers of every Lemonade-using workflow (embeddings, rag, lemonade-server, api, agent-sdk, agent-mcp-server, behavior-e2e, examples, gaia-cli-windows, sd, build_cpp).

## Test plan

- [x] All 11 workflows parse as valid YAML; every `paths:` block (21 total) now contains `src/gaia/version.py` (verified programmatically)
- [ ] Reviewer sanity check: the next `LEMONADE_VERSION` bump PR should now trigger Test Lemonade Embeddings, Test RAG, API Tests, Agent SDK/MCP/Behavior, Lemonade Server Smoke, SD, and C++ build — confirm in that PR's checks list
- [ ] (Separately) the embedding regression itself needs a Lemonade/llama-server fix or a pin to a pre-b6524 build — tracked upstream, out of scope here