### PR TITLE
fix: pin Lemonade back to 10.2.0 (embedding regression on >= b6524)

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -28,12 +28,12 @@ Included demos:
 
 The agent connects to an OpenAI-compatible LLM server at `http://localhost:8000/api/v1` by default. The reference backend is [Lemonade Server](https://github.com/lemonade-sdk/lemonade), which runs models locally on AMD hardware.
 
-Download and install Lemonade Server v10.8.1, then start it:
+Download and install Lemonade Server v10.2.0, then start it:
 
 **Windows:**
 ```powershell
 # Download and run the MSI installer
-curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v10.8.1/lemonade-server-minimal.msi
+curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v10.2.0/lemonade-server-minimal.msi
 msiexec /i lemonade-server-minimal.msi
 ```
 
@@ -44,7 +44,7 @@ sudo add-apt-repository ppa:lemonade-team/stable
 sudo apt install lemonade-server
 ```
 
-Or browse all platform options on the [Lemonade v10.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.8.1).
+Or browse all platform options on the [Lemonade v10.2.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.2.0).
 
 After installation, start the server:
 ```bash

--- a/docs/cpp/setup.mdx
+++ b/docs/cpp/setup.mdx
@@ -76,17 +76,17 @@ icon: "wrench"
 
     The agent needs an OpenAI-compatible LLM server. [Lemonade Server](https://lemonade-server.ai) is recommended (optimized for AMD hardware).
 
-    Download and run the installer (v10.8.1):
+    Download and run the installer (v10.2.0):
 
     ```powershell
     # Download the MSI installer
-    curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v10.8.1/lemonade-server-minimal.msi
+    curl -L -o lemonade-server-minimal.msi https://github.com/lemonade-sdk/lemonade/releases/download/v10.2.0/lemonade-server-minimal.msi
 
     # Run the installer
     msiexec /i lemonade-server-minimal.msi
     ```
 
-    Or download directly from the [Lemonade v10.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.8.1).
+    Or download directly from the [Lemonade v10.2.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.2.0).
 
     After installation, restart your terminal and start the server:
     ```powershell
@@ -176,7 +176,7 @@ icon: "wrench"
     sudo apt-get install -y lemonade-server
     ```
 
-    Or browse all platform options on the [Lemonade v10.8.1 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.8.1).
+    Or browse all platform options on the [Lemonade v10.2.0 release page](https://github.com/lemonade-sdk/lemonade/releases/tag/v10.2.0).
 
     After installation, start the server:
     ```bash
@@ -219,7 +219,7 @@ icon: "wrench"
 | C++ Compiler | C++17 support (MSVC 2019+ or GCC 9+) | `cl` (Windows) or `g++ --version` (Linux) |
 | CMake | 3.14+ | `cmake --version` |
 | Git | any | `git --version` |
-| [Lemonade Server](https://lemonade-server.ai) | 10.8.1 | `lemonade-server --version` |
+| [Lemonade Server](https://lemonade-server.ai) | 10.2.0 | `lemonade-server --version` |
 | uvx | any (optional) | `uvx --version` |
 
 <Note>

--- a/docs/guides/npu.mdx
+++ b/docs/guides/npu.mdx
@@ -12,7 +12,7 @@ GAIA supports running agents on your AMD Ryzen AI NPU via the [FastFlowLM (FLM)]
 - **Hardware:** AMD Ryzen AI 300/400/Max series processor with XDNA2 NPU
   - Strix Point, Strix Halo, Kraken Point, or Gorgon Point
   - Ryzen AI 7000/8000/200-series (XDNA1) is **not supported**
-- **Software:** [Lemonade Server](https://lemonade-server.ai) v10.8.1+
+- **Software:** [Lemonade Server](https://lemonade-server.ai) v10.2.0+
 - **Driver:** Latest AMD NPU driver (firmware v1.1.0.0+)
 
 <Warning>

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -9,7 +9,7 @@ from importlib.metadata import version as get_package_version_metadata
 __version__ = "0.21.2"
 
 # Lemonade version used across CI and installer
-LEMONADE_VERSION = "10.8.1"
+LEMONADE_VERSION = "10.2.0"
 
 
 def get_package_version() -> str:


### PR DESCRIPTION
## Why this matters

RAG embeddings are broken on the AMD NPU/GPU path. Lemonade **10.7.0/10.8.x** bundle a llama.cpp build **≥ b6524**, which crashes loading the embedding model `nomic-embed-text-v2-moe` on the Vulkan backend (`llama-server failed to start`). `Test Lemonade Embeddings` has been red since the 10.x bumps; **10.2.0** is the last version where it passes.

**Upstream is unfixed and there's no working workaround:**
- llama.cpp [#16301](https://github.com/ggml-org/llama.cpp/issues/16301) — b6524 Vulkan regression, **open**, deprioritized by maintainers as niche.
- lemonade [#612](https://github.com/lemonade-sdk/lemonade/issues/612) / [#941](https://github.com/lemonade-sdk/lemonade/issues/941) — **open**, downstream.
- The maintainer's `GGML_VK_DISABLE_COOPMAT=1` workaround is **already applied** in our embeddings CI job (`test_embeddings.yml`) and **still fails** on our Strix/Windows runners — so a downgrade is the only fix available to us.

`10.2.0` is GAIA's documented `min_lemonade_version` floor (`src/gaia/installer/init_command.py`), so this pins to the floor, not below it. Port 13305 (introduced in 10.1.0) still applies, and no per-version checksums are pinned. `version.py` is the single source of truth; the C++ setup docs are updated in lock-step.

## Test plan

- [x] `version.py` + all hardcoded doc references moved 10.8.1 → 10.2.0 (no `10.8.1` remains outside lockfiles)
- [ ] **`Test Lemonade Embeddings` passes on this branch** — the decisive check; manually dispatched against this branch to confirm 10.2.0 loads `nomic-embed-text-v2-moe`
- [ ] RAG / API / agent Lemonade checks green
- [ ] Follow-up (separate): once upstream llama.cpp/​Lemonade ships a fix, bump forward again — pairs with the CI-trigger gap fix (#1871) so the next bump actually runs these checks

Related: #1871 (makes a `LEMONADE_VERSION` bump trigger the full Lemonade test surface, so this class of regression is caught on the bump PR).