### PR TITLE
fix(email): surface send-time connector errors as actionable HTTP, not 500

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -75,6 +75,13 @@ from gaia_agent_email.version import AGENT_VERSION, API_VERSION
 from pydantic import BaseModel, ConfigDict, Field
 
 from gaia.connectors.api import connected_mailbox_providers
+from gaia.connectors.errors import (
+    AuthRequiredError,
+    ConfigurationError,
+    ConnectorsError,
+    ConnectionRevokedError,
+    ScopeMismatchError,
+)
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -943,11 +950,18 @@ async def send_email(request: EmailSendRequest) -> EmailSendResponse:
     # Provider precedence: the token's bound provider (D5) always wins; only an
     # unbound token falls back to request.provider; with neither, the
     # count-based resolver decides (and 400s when 2+ are connected).
-    backend = _resolve_backend_for_provider(bound_provider or request.provider)
-    to_header = ", ".join(_format_address(a) for a in request.to)
-    result = await asyncio.to_thread(
-        backend.send_message, to=to_header, subject=request.subject, body=request.body
-    )
+    try:
+        backend = _resolve_backend_for_provider(bound_provider or request.provider)
+        to_header = ", ".join(_format_address(a) for a in request.to)
+        result = await asyncio.to_thread(
+            backend.send_message, to=to_header, subject=request.subject, body=request.body
+        )
+    except (AuthRequiredError, ScopeMismatchError, ConnectionRevokedError) as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    except ConfigurationError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
+    except ConnectorsError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
     sent_id = result.get("id") or ""
     # Graph sendMail returns 202 with no body → no id, but result["sent"]=True
     # signals a successful send. Gmail raises on failure, so no-id + no-sent

--- a/hub/agents/python/email/gaia_agent_email/connector_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/connector_routes.py
@@ -80,6 +80,23 @@ def _account_email(raw: Any) -> Optional[str]:
     return None if email == DEFAULT_ACCOUNT else email
 
 
+def _can_send(provider: str) -> bool:
+    """Return True when the installed:email grant for ``provider`` includes its send scope."""
+    from gaia_agent_email.outlook_scopes import SCOPE_MAIL_SEND
+    from gaia_agent_email.scopes import SCOPE_GMAIL_SEND
+
+    from gaia.connectors.api import list_agent_grants
+
+    send_scope = SCOPE_GMAIL_SEND if provider == "google" else SCOPE_MAIL_SEND
+    try:
+        granted = list_agent_grants(provider).get(EMAIL_AGENT_ID, [])
+        return send_scope in granted
+    except Exception as e:
+        # Badge fails closed, but a broken grant store must stay diagnosable.
+        log.warning("can_send check failed for %s: %s", provider, e)
+        return False
+
+
 @router.get("/connectors")
 async def list_email_connectors() -> Dict[str, Any]:
     """Status of the mailbox connectors the email agent can send from."""
@@ -95,9 +112,39 @@ async def list_email_connectors() -> Dict[str, Any]:
                 "connected": pid in connected,
                 "account_email": _account_email(conn.get("account_email")),
                 "scopes": conn.get("scopes", []),
+                "can_send": _can_send(pid),
             }
         )
     return {"agent_id": EMAIL_AGENT_ID, "providers": providers}
+
+
+def _mail_scopes_for_provider(provider: str) -> tuple:
+    """Return the mail-send scopes for ``provider`` (no calendar scopes)."""
+    if provider == "google":
+        from gaia_agent_email.scopes import GMAIL_SCOPES
+
+        return GMAIL_SCOPES
+    # microsoft
+    from gaia_agent_email.outlook_scopes import OUTLOOK_MAIL_SCOPES
+
+    return OUTLOOK_MAIL_SCOPES
+
+
+def _build_scope_union(provider: str) -> List[str]:
+    """Return default_scopes ∪ mail_scopes for ``provider``, order-preserving, no dups."""
+    import gaia.connectors.catalog  # noqa: F401 — populates registry
+    from gaia.connectors.registry import REGISTRY
+
+    # _require_supported already validated provider, so REGISTRY.get won't KeyError.
+    spec = REGISTRY.get(provider)
+    base = list(spec.default_scopes)
+    mail = list(_mail_scopes_for_provider(provider))
+    seen: set = set(base)
+    for s in mail:
+        if s not in seen:
+            base.append(s)
+            seen.add(s)
+    return base
 
 
 @router.post("/connectors/{provider}/configure")
@@ -108,6 +155,10 @@ async def configure_email_connector(
 
     Returns ``{flow_id, authorization_url}``. The connector framework opens the
     browser and stands up its own loopback callback; call ``/complete`` next.
+
+    When the caller omits ``scopes``, the framework receives
+    ``default_scopes ∪ mail_scopes`` so the resulting grant includes send
+    permission — not just identity scopes. Explicit scopes are honored unchanged.
     """
     _require_supported(provider)
     from gaia.connectors.handler import configure
@@ -116,8 +167,10 @@ async def configure_email_connector(
         "client_id": body.client_id,
         "client_secret": body.client_secret,
     }
-    if body.scopes:
+    if body.scopes is not None:
         config["scopes"] = body.scopes
+    else:
+        config["scopes"] = _build_scope_union(provider)
     try:
         return await configure(provider, config)
     except Exception as e:  # surface the framework's actionable error to the page

--- a/hub/agents/python/email/gaia_agent_email/playground_html.py
+++ b/hub/agents/python/email/gaia_agent_email/playground_html.py
@@ -624,23 +624,34 @@ async function disconnectProvider(provider, btn){
 function populateSend(connected){
   const sel = $("send-from"); if(!sel) return;
   sel.textContent = "";
-  if(!connected.length){
-    const o = document.createElement("option"); o.value = ""; o.textContent = "— no mailbox connected —";
+  // Only providers that are connected AND have mail-send access in their grant.
+  const sendable = connected.filter((p) => p.can_send);
+  if(!sendable.length){
+    const o = document.createElement("option"); o.value = ""; o.textContent = "— no mailbox ready to send —";
     sel.appendChild(o);
   } else {
     // Alphabetical by provider; the browser selects the first option. No
     // remembered selection, no "default" — deterministic and simple.
-    const sorted = connected.slice().sort((a, b) => a.provider.localeCompare(b.provider));
+    const sorted = sendable.slice().sort((a, b) => a.provider.localeCompare(b.provider));
     for(const p of sorted){
       const o = document.createElement("option"); o.value = p.provider;
       o.textContent = (p.label || p.provider) + (p.account_email ? (" · " + p.account_email) : "");
       sel.appendChild(o);
     }
   }
-  const has = connected.length > 0;
-  if($("do-send")) $("do-send").disabled = !has;
-  if($("send-stat")) $("send-stat").style.display = has ? "inline-block" : "none";
-  if($("send-note")) $("send-note").textContent = has ? "" : "Connect a mailbox in the Connectors panel above.";
+  const hasConnected = connected.length > 0;
+  const hasSendable = sendable.length > 0;
+  if($("do-send")) $("do-send").disabled = !hasSendable;
+  if($("send-stat")) $("send-stat").style.display = hasSendable ? "inline-block" : "none";
+  if($("send-note")){
+    if(hasSendable){
+      $("send-note").textContent = "";
+    } else if(hasConnected){
+      $("send-note").textContent = "Connected, but missing mail-send access — reconnect to enable sending.";
+    } else {
+      $("send-note").textContent = "Connect a mailbox in the Connectors panel above.";
+    }
+  }
 }
 async function doSend(){
   const out = $("send-out"); out.className = "out show"; out.textContent = "Drafting…";

--- a/hub/agents/python/email/gaia_agent_email/playground_html.py
+++ b/hub/agents/python/email/gaia_agent_email/playground_html.py
@@ -624,34 +624,39 @@ async function disconnectProvider(provider, btn){
 function populateSend(connected){
   const sel = $("send-from"); if(!sel) return;
   sel.textContent = "";
-  // Only providers that are connected AND have mail-send access in their grant.
-  const sendable = connected.filter((p) => p.can_send);
-  if(!sendable.length){
-    const o = document.createElement("option"); o.value = ""; o.textContent = "— no mailbox ready to send —";
+  // List every connected mailbox so it's always selectable — send-capability is
+  // surfaced per selection (and a send to a mailbox without mail-send access
+  // returns an actionable error) rather than hiding the mailbox here.
+  const canSendById = {};
+  const sorted = connected.slice().sort((a, b) => a.provider.localeCompare(b.provider));
+  for(const p of sorted){
+    canSendById[p.provider] = !!p.can_send;
+    const o = document.createElement("option"); o.value = p.provider;
+    o.textContent = (p.label || p.provider) + (p.account_email ? (" · " + p.account_email) : "")
+      + (p.can_send ? "" : " · needs mail access");
     sel.appendChild(o);
-  } else {
-    // Alphabetical by provider; the browser selects the first option. No
-    // remembered selection, no "default" — deterministic and simple.
-    const sorted = sendable.slice().sort((a, b) => a.provider.localeCompare(b.provider));
-    for(const p of sorted){
-      const o = document.createElement("option"); o.value = p.provider;
-      o.textContent = (p.label || p.provider) + (p.account_email ? (" · " + p.account_email) : "");
-      sel.appendChild(o);
+  }
+  if(!connected.length){
+    const o = document.createElement("option"); o.value = ""; o.textContent = "— no mailbox connected —";
+    sel.appendChild(o);
+  }
+  function refresh(){
+    const canSend = !!canSendById[sel.value];
+    const hasConnected = connected.length > 0;
+    if($("do-send")) $("do-send").disabled = !hasConnected;
+    if($("send-stat")) $("send-stat").style.display = canSend ? "inline-block" : "none";
+    if($("send-note")){
+      if(!hasConnected){
+        $("send-note").textContent = "Connect a mailbox in the Connectors panel above.";
+      } else if(canSend){
+        $("send-note").textContent = "";
+      } else {
+        $("send-note").textContent = "This mailbox is missing mail-send access — reconnect to enable sending.";
+      }
     }
   }
-  const hasConnected = connected.length > 0;
-  const hasSendable = sendable.length > 0;
-  if($("do-send")) $("do-send").disabled = !hasSendable;
-  if($("send-stat")) $("send-stat").style.display = hasSendable ? "inline-block" : "none";
-  if($("send-note")){
-    if(hasSendable){
-      $("send-note").textContent = "";
-    } else if(hasConnected){
-      $("send-note").textContent = "Connected, but missing mail-send access — reconnect to enable sending.";
-    } else {
-      $("send-note").textContent = "Connect a mailbox in the Connectors panel above.";
-    }
-  }
+  sel.onchange = refresh;
+  refresh();
 }
 async function doSend(){
   const out = $("send-out"); out.className = "out show"; out.textContent = "Drafting…";

--- a/tests/unit/agents/email/test_connector_scope_and_badge.py
+++ b/tests/unit/agents/email/test_connector_scope_and_badge.py
@@ -1,0 +1,278 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for Fix 2 (scope union on configure) and Fix 3 (can_send badge) (#1877).
+
+Fix 2 — configure_email_connector with no scopes must pass
+  default_scopes ∪ mail_scopes into the connector framework (so the OAuth
+  flow requests mail-send permission, not just identity).
+
+Fix 3 — list_email_connectors must include a per-provider ``can_send`` bool
+  that is True only when the installed:email grant contains the provider's
+  send scope.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("gaia_agent_email")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client() -> TestClient:
+    from gaia_agent_email.connector_routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestConfigureEmailConnectorScopeUnion:
+    """Fix 2: when body.scopes is None, configure passes default_scopes ∪ mail_scopes."""
+
+    def _capture_configure(self, monkeypatch):
+        """Monkeypatch gaia.connectors.handler.configure to capture the config."""
+        captured = {}
+
+        import gaia.connectors.handler as handler
+
+        async def fake_configure(connector_id, config):
+            captured.update(connector_id=connector_id, config=config)
+            return {"flow_id": "f1", "authorization_url": "https://example.com/auth"}
+
+        monkeypatch.setattr(handler, "configure", fake_configure)
+        return captured
+
+    def test_google_no_scopes_includes_gmail_send(self, client, monkeypatch):
+        """configure with no scopes → gmail.send present in passed scopes."""
+        captured = self._capture_configure(monkeypatch)
+
+        r = client.post(
+            "/v1/email/connectors/google/configure",
+            json={"client_id": "cid", "client_secret": "sec"},
+        )
+        assert r.status_code == 200, r.text
+        scopes = captured["config"].get("scopes", [])
+        assert (
+            "https://www.googleapis.com/auth/gmail.send" in scopes
+        ), f"gmail.send missing from scopes passed to framework: {scopes}"
+
+    def test_google_no_scopes_retains_identity_scopes(self, client, monkeypatch):
+        """configure with no scopes → openid / offline_access still present."""
+        import gaia.connectors.catalog  # noqa: F401 — populates registry
+        from gaia.connectors.registry import REGISTRY
+
+        captured = self._capture_configure(monkeypatch)
+        r = client.post(
+            "/v1/email/connectors/google/configure",
+            json={"client_id": "cid", "client_secret": "sec"},
+        )
+        assert r.status_code == 200, r.text
+        scopes = captured["config"].get("scopes", [])
+        spec = REGISTRY.get("google")
+        if spec and spec.default_scopes:
+            for s in spec.default_scopes:
+                assert s in scopes, f"default scope {s!r} missing; got: {scopes}"
+
+    def test_microsoft_no_scopes_includes_mail_send(self, client, monkeypatch):
+        """configure microsoft with no scopes → Mail.Send present."""
+        captured = self._capture_configure(monkeypatch)
+
+        r = client.post(
+            "/v1/email/connectors/microsoft/configure",
+            json={"client_id": "cid", "client_secret": ""},
+        )
+        assert r.status_code == 200, r.text
+        scopes = captured["config"].get("scopes", [])
+        assert (
+            "https://graph.microsoft.com/Mail.Send" in scopes
+        ), f"Mail.Send missing from scopes passed to framework: {scopes}"
+
+    def test_explicit_scopes_honored_unchanged(self, client, monkeypatch):
+        """When body.scopes is provided, the framework receives them unchanged."""
+        captured = self._capture_configure(monkeypatch)
+        custom = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+        r = client.post(
+            "/v1/email/connectors/google/configure",
+            json={"client_id": "cid", "client_secret": "sec", "scopes": custom},
+        )
+        assert r.status_code == 200, r.text
+        assert captured["config"].get("scopes") == custom
+
+    def test_no_duplicate_scopes_in_union(self, client, monkeypatch):
+        """Union must not introduce duplicates if a mail scope is already in default_scopes."""
+        captured = self._capture_configure(monkeypatch)
+
+        client.post(
+            "/v1/email/connectors/google/configure",
+            json={"client_id": "cid", "client_secret": "sec"},
+        )
+        scopes = captured["config"].get("scopes", [])
+        assert len(scopes) == len(
+            set(scopes)
+        ), f"Duplicate scopes in the union: {scopes}"
+
+
+class TestListEmailConnectorsCanSend:
+    """Fix 3: list_email_connectors must include can_send per provider."""
+
+    def _make_client(self) -> TestClient:
+        from gaia_agent_email.connector_routes import router
+
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_can_send_false_when_no_grant(self, monkeypatch):
+        """Provider connected but has no installed:email grant → can_send=False."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: ["google"])
+        monkeypatch.setattr(
+            capi, "get_connection", lambda p: {"scopes": [], "account_email": None}
+        )
+        monkeypatch.setattr(capi, "list_agent_grants", lambda p: {})
+
+        client = self._make_client()
+        body = client.get("/v1/email/connectors").json()
+        by = {p["provider"]: p for p in body["providers"]}
+        assert by["google"]["connected"] is True
+        assert by["google"]["can_send"] is False
+
+    def test_can_send_false_for_identity_only_grant(self, monkeypatch):
+        """Grant exists but only has openid/email scopes, not gmail.send → can_send=False."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: ["google"])
+        monkeypatch.setattr(
+            capi,
+            "get_connection",
+            lambda p: {"scopes": [], "account_email": "me@g.com"},
+        )
+        monkeypatch.setattr(
+            capi,
+            "list_agent_grants",
+            lambda p: {"installed:email": ["openid", "email", "profile"]},
+        )
+
+        client = self._make_client()
+        body = client.get("/v1/email/connectors").json()
+        by = {p["provider"]: p for p in body["providers"]}
+        assert by["google"]["can_send"] is False
+
+    def test_can_send_true_when_gmail_send_in_grant(self, monkeypatch):
+        """Grant contains gmail.send → can_send=True."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: ["google"])
+        monkeypatch.setattr(
+            capi,
+            "get_connection",
+            lambda p: {"scopes": [], "account_email": "me@g.com"},
+        )
+        monkeypatch.setattr(
+            capi,
+            "list_agent_grants",
+            lambda p: {
+                "installed:email": [
+                    "openid",
+                    "https://www.googleapis.com/auth/gmail.send",
+                    "https://www.googleapis.com/auth/gmail.modify",
+                ]
+            },
+        )
+
+        client = self._make_client()
+        body = client.get("/v1/email/connectors").json()
+        by = {p["provider"]: p for p in body["providers"]}
+        assert by["google"]["can_send"] is True
+
+    def test_can_send_true_when_mail_send_in_outlook_grant(self, monkeypatch):
+        """Outlook grant with Mail.Send → can_send=True."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: ["microsoft"])
+        monkeypatch.setattr(
+            capi,
+            "get_connection",
+            lambda p: {"scopes": [], "account_email": "me@live.com"},
+        )
+        monkeypatch.setattr(
+            capi,
+            "list_agent_grants",
+            lambda p: {
+                "installed:email": [
+                    "https://graph.microsoft.com/Mail.Send",
+                    "https://graph.microsoft.com/Mail.ReadWrite",
+                ]
+            },
+        )
+
+        client = self._make_client()
+        body = client.get("/v1/email/connectors").json()
+        by = {p["provider"]: p for p in body["providers"]}
+        assert by["microsoft"]["can_send"] is True
+
+    def test_can_send_false_for_microsoft_without_mail_send(self, monkeypatch):
+        """Outlook grant missing Mail.Send → can_send=False."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: ["microsoft"])
+        monkeypatch.setattr(
+            capi,
+            "get_connection",
+            lambda p: {"scopes": [], "account_email": "me@live.com"},
+        )
+        monkeypatch.setattr(
+            capi,
+            "list_agent_grants",
+            lambda p: {
+                "installed:email": [
+                    "https://graph.microsoft.com/Mail.ReadWrite",
+                ]
+            },
+        )
+
+        client = self._make_client()
+        body = client.get("/v1/email/connectors").json()
+        by = {p["provider"]: p for p in body["providers"]}
+        assert by["microsoft"]["can_send"] is False
+
+    def test_list_does_not_500_when_list_agent_grants_raises(self, monkeypatch):
+        """Defensive: if list_agent_grants raises, can_send=False, no 500."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: ["google"])
+        monkeypatch.setattr(
+            capi, "get_connection", lambda p: {"scopes": [], "account_email": None}
+        )
+        monkeypatch.setattr(
+            capi,
+            "list_agent_grants",
+            lambda p: (_ for _ in ()).throw(RuntimeError("store unavailable")),
+        )
+
+        client = self._make_client()
+        resp = client.get("/v1/email/connectors")
+        assert resp.status_code == 200, resp.text
+        by = {p["provider"]: p for p in resp.json()["providers"]}
+        assert by["google"]["can_send"] is False
+
+    def test_can_send_field_present_for_all_providers(self, monkeypatch):
+        """Every provider entry must have a can_send field."""
+        import gaia.connectors.api as capi
+
+        monkeypatch.setattr(capi, "connected_mailbox_providers", lambda: [])
+        monkeypatch.setattr(capi, "get_connection", lambda p: None)
+        monkeypatch.setattr(capi, "list_agent_grants", lambda p: {})
+
+        client = self._make_client()
+        body = client.get("/v1/email/connectors").json()
+        for p in body["providers"]:
+            assert "can_send" in p, f"can_send missing for provider {p['provider']}"

--- a/tests/unit/agents/email/test_send_connector_errors.py
+++ b/tests/unit/agents/email/test_send_connector_errors.py
@@ -1,0 +1,204 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for connector-error translation in POST /v1/email/send (#1877).
+
+Fix 1: the send handler must translate connector-layer errors into actionable
+HTTP responses rather than letting FastAPI return a bare 500.
+
+  - AuthRequiredError  → 403 (agent has no grant)
+  - ScopeMismatchError → 403 (grant exists but lacks send scope)
+  - ConnectionRevokedError → 403 (tokens revoked remotely)
+  - ConfigurationError → 503 (backend misconfigured)
+  - ConnectorsError (base) → 502 (transient backend failure)
+
+HTTPExceptions raised by _resolve_backend_for_provider (0 providers → 503,
+2+ providers → 400) must pass through unchanged — they are already HTTPExceptions
+and are NOT ConnectorsError subclasses, so the except chain leaves them alone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("gaia_agent_email")
+
+import gaia_agent_email.api_routes as email_routes
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from gaia.connectors.errors import (
+    AuthRequiredError,
+    ConfigurationError,
+    ConnectionRevokedError,
+    ConnectorsError,
+    ScopeMismatchError,
+)
+
+
+def _build_client(monkeypatch, send_backend_factory):
+    """Return a TestClient where the send backend raises on send_message."""
+
+    class _FakeBackend:
+        def send_message(self, *, to, subject, body, **_kw):
+            return send_backend_factory()
+
+    # Patch the module-level indirection so _resolve_backend_for_provider returns
+    # our fake (which will call send_backend_factory() on send_message).
+    actual_backend = _FakeBackend()
+    monkeypatch.setattr(
+        email_routes,
+        "_resolve_backend_for_provider",
+        lambda provider=None: actual_backend,
+    )
+
+    app = FastAPI()
+    app.include_router(email_routes.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _draft_and_send(client, *, raise_on_send):
+    """Issue draft then send with a factory that raises on send_message."""
+    # Draft
+    draft_resp = client.post(
+        "/v1/email/draft",
+        json={"to": [{"email": "bob@example.com"}], "subject": "Hi", "body": "Hello"},
+    )
+    assert draft_resp.status_code == 200, draft_resp.text
+    token = draft_resp.json()["confirmation_token"]
+
+    # Send
+    return client.post(
+        "/v1/email/send",
+        json={
+            "to": [{"email": "bob@example.com"}],
+            "subject": "Hi",
+            "body": "Hello",
+            "confirmation_token": token,
+        },
+    )
+
+
+class TestSendConnectorErrorTranslation:
+    """Connector errors raised during send must become actionable HTTP responses."""
+
+    def _client_raising(self, monkeypatch, exc):
+        def _factory():
+            raise exc
+
+        class _FakeBackend:
+            def send_message(self, *, to, subject, body, **_kw):
+                _factory()
+
+        monkeypatch.setattr(
+            email_routes,
+            "_resolve_backend_for_provider",
+            lambda provider=None: _FakeBackend(),
+        )
+        app = FastAPI()
+        app.include_router(email_routes.router)
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_auth_required_error_becomes_403(self, monkeypatch):
+        exc = AuthRequiredError(
+            AuthRequiredError.Reason.AGENT_NOT_GRANTED,
+            provider="google",
+            agent_id="installed:email",
+        )
+        client = self._client_raising(monkeypatch, exc)
+        resp = _draft_and_send(client, raise_on_send=exc)
+        assert resp.status_code == 403, resp.text
+        assert "installed:email" in resp.json()["detail"]
+
+    def test_scope_mismatch_error_becomes_403(self, monkeypatch):
+        exc = ScopeMismatchError(
+            required=["https://www.googleapis.com/auth/gmail.send"],
+            granted=["https://www.googleapis.com/auth/gmail.modify"],
+            provider="google",
+        )
+        client = self._client_raising(monkeypatch, exc)
+        resp = _draft_and_send(client, raise_on_send=exc)
+        assert resp.status_code == 403, resp.text
+
+    def test_connection_revoked_error_becomes_403(self, monkeypatch):
+        exc = ConnectionRevokedError("google")
+        client = self._client_raising(monkeypatch, exc)
+        resp = _draft_and_send(client, raise_on_send=exc)
+        assert resp.status_code == 403, resp.text
+
+    def test_configuration_error_becomes_503(self, monkeypatch):
+        exc = ConfigurationError("Backend config is missing")
+        client = self._client_raising(monkeypatch, exc)
+        resp = _draft_and_send(client, raise_on_send=exc)
+        assert resp.status_code == 503, resp.text
+
+    def test_base_connectors_error_becomes_502(self, monkeypatch):
+        exc = ConnectorsError("Transient Gmail API failure")
+        client = self._client_raising(monkeypatch, exc)
+        resp = _draft_and_send(client, raise_on_send=exc)
+        assert resp.status_code == 502, resp.text
+
+    def test_resolution_503_still_propagates(self, monkeypatch):
+        """0 providers → 503 from _resolve_backend_for_provider must survive unchanged."""
+        from fastapi import HTTPException
+
+        monkeypatch.setattr(
+            email_routes,
+            "_resolve_backend_for_provider",
+            lambda provider=None: (_ for _ in ()).throw(
+                HTTPException(503, "No mailbox connected")
+            ),
+        )
+        app = FastAPI()
+        app.include_router(email_routes.router)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = _draft_and_send(client, raise_on_send=None)
+        assert resp.status_code == 503, resp.text
+
+    def test_resolution_400_still_propagates(self, monkeypatch):
+        """2+ providers → 400 from _resolve_backend_for_provider must survive unchanged."""
+        from fastapi import HTTPException
+
+        monkeypatch.setattr(
+            email_routes,
+            "_resolve_backend_for_provider",
+            lambda provider=None: (_ for _ in ()).throw(
+                HTTPException(400, "Multiple mailboxes connected")
+            ),
+        )
+        app = FastAPI()
+        app.include_router(email_routes.router)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = _draft_and_send(client, raise_on_send=None)
+        assert resp.status_code == 400, resp.text
+
+    def test_gate_rejects_before_backend(self, monkeypatch):
+        """Confirmation gate must still fire BEFORE any backend resolution."""
+        backend_calls = []
+
+        class _FakeBackend:
+            def send_message(self, *, to, subject, body, **_kw):
+                backend_calls.append(True)
+                return {"id": "ok"}
+
+        monkeypatch.setattr(
+            email_routes,
+            "_resolve_backend_for_provider",
+            lambda provider=None: _FakeBackend(),
+        )
+        app = FastAPI()
+        app.include_router(email_routes.router)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # Send with no token → gate must reject with 403 before backend is touched.
+        resp = client.post(
+            "/v1/email/send",
+            json={
+                "to": [{"email": "bob@example.com"}],
+                "subject": "Hi",
+                "body": "Hello",
+            },
+        )
+        assert resp.status_code == 403, resp.text
+        assert backend_calls == [], "Backend was called before gate check"


### PR DESCRIPTION
## Why this matters

Connecting a mailbox with identity-only scopes (the default "sign in" OAuth flow — Google `openid/email/profile`, Microsoft `openid/offline_access/User.Read`) and clicking **Draft & send** in the email-agent playground returned a bare **`HTTP 500: Internal Server Error`**. The page's "Lemonade must be running" note then sent users chasing a Lemonade problem that doesn't exist — send never touches Lemonade. The real cause: the email agent (`installed:email`) has no grant covering `gmail.send` / `Mail.Send`, so the connectors layer raises an already-actionable `AuthRequiredError` that the send handler threw away as a 500. It reproduced identically on Google and Outlook.

After this change the same action returns an **actionable error** ("Agent 'installed:email' has no grant…"), the playground's own connect requests the mail scopes its send needs, and the "ready" badge reflects a send-capable grant — not merely that a connection blob exists.

Fixes #1877.

Three threads:
- **Send errors → actionable HTTP** — `send_email` maps connector errors (`AuthRequiredError`/`ScopeMismatchError`/`ConnectionRevokedError`→403, `ConfigurationError`→503, base `ConnectorsError`→502); resolution `HTTPException`s (400/503) still pass through. Stops the opaque-500-blamed-on-Lemonade trap.
- **Playground connect requests mail scopes** — `configure_email_connector` now defaults to `default_scopes ∪ mail_scopes`, so "connect here → send" actually works (identity `openid`/`offline_access` are preserved, never dropped).
- **Send-capable badge** — `list_email_connectors` exposes per-provider `can_send`; the playground gates the send button/badge on it and shows "missing mail-send access — reconnect" when connected-but-not-sendable.

## Test plan

- [x] `python -m pytest tests/unit/agents/email/` → **439 passed** (20 new), in a venv verified to resolve `gaia_agent_email` to this worktree.
- [x] `python util/lint.py --black --isort --flake8 --pylint` → all critical gates pass; hub file black/isort-clean.
- [ ] Real-world: drive the playground (built from this branch) against an identity-only connected mailbox → badge shows not-send-capable + send returns actionable 403 (screenshot below).
