### PR TITLE
chore(agent-email): cut 0.2.5

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,16 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## 0.2.5
+
+Sending from a mailbox connected with identity-only scopes now returns an
+actionable 4xx (naming the missing `installed:email` grant) instead of an opaque
+HTTP 500, so the playground no longer points users at Lemonade for what is really
+an OAuth-scope problem. The playground's mailbox connect now requests mail-send
+scopes (so connect → send works), and the send panel keeps every connected
+mailbox selectable while marking ones that lack mail-send access. No agent
+wire-contract change — `SCHEMA_VERSION` stays `2.0`.
+
 ## 0.2.4
 
 First fully-published release of this feature set. The whole-package zip download

--- a/hub/agents/npm/agent-email/assets/architecture.html
+++ b/hub/agents/npm/agent-email/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.2.4</span>
+      <span class="ver" id="ver">v0.2.5</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.2.4",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.4",
+  "agentVersion": "0.2.5",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.5",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.2.4
+version: 0.2.5
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.2.4"
+AGENT_VERSION = "0.2.5"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.2.4"
+version = "0.2.5"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }


### PR DESCRIPTION
Version bump for the `@amd-gaia/agent-email` sidecar to **0.2.5**, picking up the #1878 fix (merged): send-time connector errors surface as an actionable 4xx instead of an opaque 500, playground connect requests mail-send scopes, and the send panel marks non-send-capable mailboxes while keeping them selectable. No wire-contract change — `SCHEMA_VERSION` stays 2.0.

Bumped via `gaia_agent_email/version.py` (single source of truth) + `stamp_version.py`.

## Test plan
- [x] `stamp_version.py --check` — all 6 targets at 0.2.5
- [x] `npm run build` + `npm test` — 46 passed
- [x] `npm pack --dry-run` — ships README + CHANGELOG
- [ ] After merge: tag `agent-pkg-email-v0.2.5` from main → freeze/publish pipeline → approve `agent-publish` gate