### PR TITLE
fix(eval): weight scorecard accuracy, reject non-finite scores, align eval limit

### DIFF
--- a/.claude/skills/adding-eval-scorecard/SKILL.md
+++ b/.claude/skills/adding-eval-scorecard/SKILL.md
@@ -49,11 +49,11 @@ PYTHONPATH="$(pwd)" \
     --model Gemma-4-E4B-it-GGUF \
     --mbox-path tests/fixtures/email/synthetic_inbox.mbox \
     --ground-truth tests/fixtures/email/ground_truth.json \
-    --limit 25 --output-dir <persistent-dir>
+    --limit 220 --output-dir <persistent-dir>
 
 PYTHONPATH="$(pwd)" \
 <venv>/bin/python hub/agents/python/email/packaging/gen_scorecard.py \
-    --benchmark-dir <persistent-dir> --limit 25
+    --benchmark-dir <persistent-dir> --limit 220
 # → writes hub/agents/npm/agent-email/SCORECARD.md in place
 ```
 

--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -32,7 +32,7 @@ on:
       limit:
         description: 'Messages to triage (must match the committed scorecard for comparability)'
         required: false
-        default: '25'
+        default: '220'
       model:
         description: 'Lemonade model id'
         required: false
@@ -58,7 +58,7 @@ permissions:
 env:
   SCORECARD: hub/agents/npm/agent-email/SCORECARD.md
   MANIFEST: hub/agents/python/email/gaia-agent.yaml
-  LIMIT: ${{ github.event.inputs.limit || '25' }}
+  LIMIT: ${{ github.event.inputs.limit || '220' }}
   MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
 
 jobs:

--- a/docs/reference/eval-scorecard.mdx
+++ b/docs/reference/eval-scorecard.mdx
@@ -42,21 +42,21 @@ recipe:
   config:
     harness: gaia eval benchmark
     model: Gemma-4-E4B-it-GGUF
-    limit: 25
+    limit: 220
 results:
-  test_cases_run: 25
+  test_cases_run: 100
   metrics:
     - name: category_accuracy
-      value: 0.40
+      value: 0.46
       weight: 1.0
 aggregate:
   name: weighted_accuracy
   formula: "round(100 * sum(weight_i * value_i) / sum(weight_i), 2)"
   components:
     - metric: category_accuracy
-      value: 0.40
+      value: 0.46
       weight: 1.0
-  value: 40.0
+  value: 46.0
 generated_at: "2026-06-26T16:47:13+00:00"
 inherited_from: null
 ---
@@ -178,13 +178,13 @@ gaia eval benchmark \
   --model Gemma-4-E4B-it-GGUF \
   --mbox-path tests/fixtures/email/synthetic_inbox.mbox \
   --ground-truth tests/fixtures/email/ground_truth.json \
-  --limit 25 \
+  --limit 220 \
   --output-dir /tmp/email-eval
 
 PYTHONPATH="$(pwd)" \
 python hub/agents/python/email/packaging/gen_scorecard.py \
   --benchmark-dir /tmp/email-eval \
-  --limit 25
+  --limit 220
 ```
 
 This writes `hub/agents/npm/agent-email/SCORECARD.md` in place.

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -22,7 +22,7 @@ Usage::
     python hub/agents/python/email/packaging/gen_scorecard.py \\
         --benchmark-dir /tmp/email-eval \\
         [--ground-truth tests/fixtures/email/ground_truth.json] \\
-        [--limit 25]
+        [--limit 220]
 
 The ``--ground-truth`` path defaults to the canonical fixture in the repository.
 """
@@ -166,12 +166,24 @@ def build_payload(benchmark_dir: Path, ground_truth_path: Path, limit=None):
             f"Benchmark dir: {benchmark_dir}"
         )
 
-    # Aggregate metrics from judged scenarios
-    category_accuracy = sum(
-        s["quality"]["category_accuracy"] for s in judged
-    ) / len(judged)
-
+    # Weight each scenario's accuracy by the emails it scored, so the headline
+    # value is the true per-email accuracy over test_cases_run. An unweighted
+    # scenario mean misreports the number (and the gate that compares it) when
+    # judged scenarios have unequal sizes.
     test_cases_run = sum(int(s.get("total_emails", 0)) for s in judged)
+    if test_cases_run <= 0:
+        raise ValueError(
+            f"Judged scenarios in {scorecard_path} report no emails "
+            f"(total_emails sums to {test_cases_run}); cannot compute a "
+            f"per-email accuracy. Check the benchmark output."
+        )
+    category_accuracy = (
+        sum(
+            float(s["quality"]["category_accuracy"]) * int(s.get("total_emails", 0))
+            for s in judged
+        )
+        / test_cases_run
+    )
 
     # Dataset size = labeled entries in ground_truth.json (excluding _meta key)
     if not ground_truth_path.exists():

--- a/src/gaia/eval/release_scorecard.py
+++ b/src/gaia/eval/release_scorecard.py
@@ -30,6 +30,7 @@ Usage pattern::
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -381,6 +382,18 @@ def validate_scorecard(parsed: dict) -> list:
         for sub in ("name", "formula", "value"):
             if sub not in aggregate:
                 errors.append(f"Missing required field: 'aggregate.{sub}'")
+        # The gate compares aggregate.value numerically; a non-finite value
+        # (NaN/inf) silently passes every `<` regression check, so reject it here.
+        if "value" in aggregate:
+            value = aggregate["value"]
+            if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not math.isfinite(value)
+            ):
+                errors.append(
+                    f"Field 'aggregate.value' must be a finite number, got {value!r}"
+                )
 
     return errors
 

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -118,6 +118,23 @@ class TestSchemaValidator:
         errors = validate_scorecard(parsed)
         assert errors, "Expected a non-dict 'agent' section to be flagged"
 
+    @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_aggregate_value_flagged(self, bad_value):
+        # A NaN/inf aggregate.value silently passes the gate's `<` regression
+        # check, so validation must reject it.
+        payload = _make_payload()
+        parsed = parse_scorecard(render_scorecard(payload))
+        parsed["aggregate"]["value"] = bad_value
+        errors = validate_scorecard(parsed)
+        assert any("aggregate.value" in e for e in errors), errors
+
+    def test_non_numeric_aggregate_value_flagged(self):
+        payload = _make_payload()
+        parsed = parse_scorecard(render_scorecard(payload))
+        parsed["aggregate"]["value"] = "46.0"
+        errors = validate_scorecard(parsed)
+        assert any("aggregate.value" in e for e in errors), errors
+
 
 # ---------------------------------------------------------------------------
 # 2. Aggregate computation
@@ -462,6 +479,42 @@ class TestEmailAdapter:
         assert payload.metrics[0]["value"] == pytest.approx(
             expected_mean
         ), f"Expected metric value {expected_mean}, got {payload.metrics[0]['value']}"
+
+    def test_build_payload_weighted_by_total_emails(self, tmp_path):
+        # Unequal scenario sizes: the aggregate must be the per-email accuracy
+        # (weighted by total_emails), not an unweighted scenario mean.
+        mod = self._load_gen_scorecard()
+
+        benchmark_dir = tmp_path / "benchmark"
+        benchmark_dir.mkdir()
+        scorecard = {
+            "run_id": "weighted-fixture",
+            "scenarios": [
+                {
+                    "category": "m",
+                    "status": "PASS",
+                    "total_emails": 90,
+                    "quality": {"category_accuracy": 0.90},
+                },
+                {
+                    "category": "m",
+                    "status": "PASS",
+                    "total_emails": 10,
+                    "quality": {"category_accuracy": 0.00},
+                },
+            ],
+        }
+        (benchmark_dir / "email_benchmark_scorecard.json").write_text(
+            json.dumps(scorecard)
+        )
+        gt_path = tmp_path / "ground_truth.json"
+        gt_path.write_text(json.dumps({"a": {"label": "x"}, "b": {"label": "y"}}))
+
+        payload = mod.build_payload(benchmark_dir, gt_path)
+
+        # Weighted: (0.90*90 + 0.00*10) / 100 = 0.81  (unweighted would be 0.45)
+        assert payload.metrics[0]["value"] == pytest.approx(0.81)
+        assert payload.test_cases_run == 100
 
     def test_build_payload_test_cases_run(self, tmp_path):
         mod = self._load_gen_scorecard()


### PR DESCRIPTION
Stacked on #1873. Three scorecard-correctness fixes the full-corpus run surfaced — without them the headline score can be wrong, a corrupt baseline disables the gate, and the refresh workflow would spuriously fail.

- **Weighted accuracy.** `gen_scorecard` averaged per-scenario accuracy but reported `test_cases_run` as the email count. The 0.2.4 run produced multiple scenarios (100 emails), so `46.0` was a per-*scenario* mean, not the per-*email* accuracy a reader recomputes. Now weighted by `total_emails` (equal-sized scenarios are unchanged, so today's number only moves if the scenarios were uneven — the next refresh run confirms it).
- **Gate can't be silently disabled.** `validate_scorecard` accepted a non-finite `aggregate.value`; a `NaN` baseline makes every `candidate < prior` check `False`, so any regression passes forever. Now rejected at validation.
- **Refresh comparability.** `email_scorecard_refresh.yml` defaulted to `--limit 25` while the committed card is `--limit 220` — a refresh would eval a different subset and fail the same-version check for a reason unrelated to quality. Defaulted to `220`; docs/skill examples aligned to the shipped card.

## Test plan

- [x] `pytest tests/unit/eval/` → 323 passed (incl. new weighted-mean + non-finite-value tests)
- [x] `black --check` + `isort --check` clean on all touched files
- [x] `email_scorecard_refresh.yml` parses; `--limit` default now matches `SCORECARD.md`
- [ ] Re-run `gaia eval benchmark --limit 220` on AMD hardware to regenerate `SCORECARD.md` and confirm the weighted aggregate (the refresh workflow does this on push)

Does **not** change the per-PR-vs-release-time eval topology — that design decision is left to #1873.