### PR TITLE
feat(email): add batch triage endpoint alongside the single-email API (array in / array out)

### DIFF
--- a/docs/spec/email-contract.mdx
+++ b/docs/spec/email-contract.mdx
@@ -134,6 +134,101 @@ the principal is not necessarily a recipient of every message.
 
 ---
 
+## Batch endpoint (`POST /v1/email/triage/batch`)
+
+Added in agent `0.3.0` (#1887) **beside** the single-email endpoint — the single
+`POST /v1/email/triage` and its schema above are unchanged, and `SCHEMA_VERSION`
+stays `"2.0"`. The batch endpoint triages up to **100** emails or threads in one
+request: an `items` array in, a parallel `results` array out, order-preserved.
+
+`BatchTriageRequest` — top-level envelope:
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Contract version. Defaults to `"2.0"`. |
+| `items` | `(SingleEmailInput \| ThreadInput)[]` | 1–100 inputs, discriminated on `kind` — the same item shapes the single endpoint's `payload` accepts. Over 100 → `422`. |
+| `context` | `TriageContext` \| null | Optional; applied to **all** items. |
+
+`BatchTriageResponse` — top-level envelope:
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Echoes the contract version. |
+| `results` | `BatchItemResult[]` | One entry per request item, order-preserved, 1:1 with `items`. |
+
+`BatchItemResult` — exactly one of `result` / `error` is set:
+
+| Field | Type | Notes |
+|---|---|---|
+| `index` | int | 0-based position in the request `items` array. |
+| `result` | `EmailTriageResult` \| null | Set when the item succeeded (same shape as the single response's `result`). |
+| `error` | `BatchItemError` \| null | Set when the item failed; `BatchItemError` carries a `message`. |
+
+**Per-item isolation — read the results, not the status.** A failure on one item
+sets that entry's `error` and the rest still run, so **HTTP 200 with every item
+errored is a valid response**. Consumers MUST inspect each `results[].error`, never
+just the HTTP status. A `502` means the local LLM was unreachable before any item
+was processed — the whole batch fails.
+
+### Example — batch request
+
+```json
+{
+  "schema_version": "2.0",
+  "items": [
+    {
+      "kind": "single",
+      "principal": { "email": "alice@example.com" },
+      "message": {
+        "message_id": "msg-1",
+        "from": { "email": "bob@vendor.com" },
+        "subject": "Q2 invoice",
+        "body": "Please review the attached invoice by Friday."
+      }
+    },
+    {
+      "kind": "single",
+      "principal": { "email": "alice@example.com" },
+      "message": {
+        "message_id": "msg-2",
+        "from": { "email": "promo@shop.example" },
+        "subject": "50% off this weekend",
+        "body": "Limited-time offer — shop now."
+      }
+    }
+  ]
+}
+```
+
+### Example — batch response (one item errored)
+
+```json
+{
+  "schema_version": "2.0",
+  "results": [
+    {
+      "index": 0,
+      "result": {
+        "category": "NEEDS_RESPONSE",
+        "is_spam": false,
+        "is_phishing": false,
+        "summary": "Vendor invoice needs review by Friday.",
+        "action_items": [{ "description": "Review the Q2 invoice", "due_hint": "Friday" }]
+      }
+    },
+    {
+      "index": 1,
+      "error": { "message": "local LLM triage failed for this item" }
+    }
+  ]
+}
+```
+
+The MCP surface mirrors this with a `triage_email_batch` tool (the single
+`triage_email` tool is unchanged).
+
+---
+
 ## Example — single email
 
 ### Request

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,21 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## 0.3.0
+
+Adds a batch triage endpoint — `POST /v1/email/triage/batch` — beside the
+single-email endpoint, so a caller can triage up to 100 emails or threads in one
+request instead of one HTTP round-trip per message. The body carries an `items`
+array; the response carries a parallel `results` array, order-preserved, each
+entry holding exactly one of `result` or `error`. Per-item failures are isolated:
+HTTP 200 with every item errored is a valid response, so consumers MUST inspect
+each `results[].error`, not just the HTTP status. New npm surface:
+`client.triageBatch()`, the `BatchTriageRequest` / `BatchTriageResponse` /
+`BatchItemResult` / `BatchItemError` types, and the `MAX_BATCH_SIZE` constant.
+New MCP tool `triage_email_batch`. This is **purely additive** — the single
+`triage()` / `POST /v1/email/triage` / MCP `triage_email` are unchanged and
+`SCHEMA_VERSION` stays `2.0`; existing consumers need no migration.
+
 ## 0.2.5
 
 Sending from a mailbox connected with identity-only scopes now returns an

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -90,6 +90,36 @@ console.log(res.result.category, res.result.summary);
 await shutdown(sidecar); // kills the whole process tree
 ```
 
+### Triage many at once
+
+`triageBatch` sends up to 100 emails or threads in a single request and returns a
+parallel `results` array (one entry per item, order-preserved). It's additive — the
+single `triage()` above is unchanged. Per-item failures are isolated, so an HTTP 200
+can still carry errored items: inspect each `results[].error`, never just the status.
+
+```ts
+const batch = await sidecar.client.triageBatch({
+  items: [
+    {
+      kind: "single",
+      principal: { email: "me@example.com" },
+      message: { message_id: "m1", from: { email: "sarah@example.com" },
+        subject: "Prod incident", body: "Reply by Friday." },
+    },
+    {
+      kind: "single",
+      principal: { email: "me@example.com" },
+      message: { message_id: "m2", from: { email: "promo@shop.example" },
+        subject: "Sale", body: "Shop now." },
+    },
+  ],
+});
+for (const item of batch.results) {
+  if (item.error) console.warn(`item ${item.index} failed: ${item.error.message}`);
+  else console.log(`item ${item.index}:`, item.result!.category);
+}
+```
+
 ### Browser / Electron renderer
 
 The `.` entry uses Node built-ins, so it can't be bundled for a browser or an
@@ -138,6 +168,7 @@ example above). Every non-2xx response throws `HttpError` (with `status`, `url`,
 | Call | Needs | Does |
 |------|-------|------|
 | `triage(req)` | Local LLM only | Classifies the message you pass, summarizes it, and extracts action items + spam/phishing signals. No mailbox is read. |
+| `triageBatch(req)` | Local LLM only | Same as `triage`, but for an `items` array (1–100). Returns a parallel `results` array; per-item failures isolate (HTTP 200 can carry errored items — inspect `results[].error`). |
 | `draft(req)` | Nothing external | Proposes a reply (`to` is a list of `{ email }` objects, not strings) and returns a single-use confirmation token. |
 | `send(req)` | A connected Gmail/Outlook mailbox + the token | Actually transmits the mail. |
 

--- a/hub/agents/npm/agent-email/SKILL.md
+++ b/hub/agents/npm/agent-email/SKILL.md
@@ -74,11 +74,31 @@ const res = await sidecar.client.triage({
 console.log(res.result.category, res.result.summary);
 ```
 
+To classify many messages at once, use `triageBatch` — an `items` array (1–100) in,
+a parallel `results` array out, order-preserved. It's additive (the single `triage`
+above is unchanged). Per-item failures isolate, so an HTTP 200 can still carry
+errored items — inspect each `results[].error`, never just the status:
+
+```ts
+const batch = await sidecar.client.triageBatch({
+  items: [
+    { kind: "single", principal: { email: "me@example.com" },
+      message: { message_id: "m1", from: { email: "sarah@example.com" },
+        subject: "Prod incident", body: "Reply by Friday." } },
+  ],
+});
+for (const r of batch.results) {
+  if (r.error) console.warn(`item ${r.index} failed: ${r.error.message}`);
+  else console.log(`item ${r.index}:`, r.result!.category);
+}
+```
+
 The interface:
 
 | Call | Needs | Notes |
 |------|-------|-------|
 | `triage(req)` | Local LLM only | Classify / summarize / extract action items + phishing signals on the message you pass. No mailbox read. |
+| `triageBatch(req)` | Local LLM only | Same as `triage` for an `items` array (1–100). Parallel `results` array; per-item failures isolate (200 can carry errored items — inspect `results[].error`). |
 | `draft(req)` | Nothing external | Returns a single-use confirmation token. |
 | `send(req)` | Draft token + a connected mailbox | Gate fires first: no/invalid `draft` token → 403; valid token but no mailbox connected on the host → 503. |
 

--- a/hub/agents/npm/agent-email/SPEC.md
+++ b/hub/agents/npm/agent-email/SPEC.md
@@ -38,8 +38,8 @@ signals yourself.
 ## REST API
 
 `EmailClient` is a typed wrapper over the sidecar's HTTP surface. Methods:
-`triage`, `draft`, `send`, `health`, `version`, `emailHealth`, `emailVersion`,
-`spec`, `openapi`. `health`/`version` hit the **root** routes (the standalone
+`triage`, `triageBatch`, `draft`, `send`, `health`, `version`, `emailHealth`,
+`emailVersion`, `spec`, `openapi`. `health`/`version` hit the **root** routes (the standalone
 sidecar); `emailHealth`/`emailVersion` hit the **`/v1/email`-scoped** mirrors (for
 when the router is mounted on a product app). Every non-2xx response throws
 `HttpError` (carrying `status`, `url`, `bodyText`) — never a silent empty/null
@@ -48,6 +48,7 @@ result.
 | Endpoint | Client method | Auth | What it needs |
 |----------|---------------|------|---------------|
 | `POST /v1/email/triage` | `triage()` | **Standalone** | Local Lemonade LLM only. Categorizes / summarizes / extracts action items + spam/phishing **signals** on the message you send in. *No mailbox is read.* |
+| `POST /v1/email/triage/batch` | `triageBatch()` | **Standalone** | Same as `triage` for an `items` array (1–100). Returns a parallel `results` array, order-preserved; per-item failures isolate (HTTP 200 can carry errored items — inspect `results[].error`). A `502` fails the whole batch (Lemonade unreachable). |
 | `POST /v1/email/draft` | `draft()` | **Standalone** | Nothing external — wraps your `(to, subject, body)` and returns a single-use confirmation token. |
 | `POST /v1/email/send` | `send()` | **Connector** | A valid `draft` confirmation token **and** a connected Google/Microsoft mailbox. The token gate fires first: no/invalid token → `403`; then `503` if no mailbox is connected, `400` if 2+ are. |
 | `GET /health` | `health()` | **Standalone** | Liveness only — does **not** check Lemonade/model. |
@@ -107,6 +108,26 @@ console.log(sent.sent_id);
 
 The full request/response types are exported from the package (`src/types.ts`) for
 exact field-level reference.
+
+### Batch triage shape (additive, #1887)
+
+`triageBatch` takes `{ schema_version?, items, context? }` where `items` is 1–100
+`EmailInput` objects (the same `SingleEmailInput` / `ThreadInput` shapes `triage`
+accepts, discriminated on `kind`), and `context` — when present — applies to **all**
+items. It returns `{ schema_version, results }` with one `BatchItemResult` per item,
+order-preserved (1:1 with `items`):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `index` | `number` | 0-based position in the request `items` array. |
+| `result` | `EmailTriageResult \| null` | Set when the item succeeded (same shape as `triage`'s `result`). |
+| `error` | `BatchItemError \| null` | Set (with a `message`) when the item failed. Exactly one of `result` / `error` is set. |
+
+**HTTP 200 with every item errored is a valid response** — a per-item failure does
+not fail the request, so always inspect each `results[].error`, never just the HTTP
+status. A `502` means Lemonade was unreachable before any item ran (the whole batch
+fails). The single `triage()` endpoint and its types are unchanged; `MAX_BATCH_SIZE`
+is exported for the 100-item cap (over-cap → `422`).
 
 ## Lifecycle helpers
 

--- a/hub/agents/npm/agent-email/assets/architecture.html
+++ b/hub/agents/npm/agent-email/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.2.5</span>
+      <span class="ver" id="ver">v0.3.0</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.2.5",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.2.5",
+  "agentVersion": "0.3.0",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.3.0",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/npm/agent-email/src/client.ts
+++ b/hub/agents/npm/agent-email/src/client.ts
@@ -28,6 +28,8 @@ import { HttpError } from "./errors.js";
 import { createLogger } from "./logger.js";
 import { stripTrailingSlashes } from "./url.js";
 import type {
+  BatchTriageRequest,
+  BatchTriageResponse,
   EmailDraftRequest,
   EmailDraftResponse,
   EmailSendRequest,
@@ -80,6 +82,17 @@ export class EmailClient {
   /** Triage a single email or a full thread (POST /v1/email/triage). */
   async triage(request: EmailTriageRequest): Promise<EmailTriageResponse> {
     return this.post<EmailTriageResponse>("/v1/email/triage", request);
+  }
+
+  /**
+   * Triage a batch of emails/threads in one request (POST /v1/email/triage/batch).
+   * Returns one `results[]` entry per item, order-preserved. A 200 with every
+   * item errored is valid — inspect each `results[].error`, not just the status.
+   */
+  async triageBatch(
+    request: BatchTriageRequest,
+  ): Promise<BatchTriageResponse> {
+    return this.post<BatchTriageResponse>("/v1/email/triage/batch", request);
   }
 
   /** Propose a reply and mint a confirmation token (POST /v1/email/draft). */

--- a/hub/agents/npm/agent-email/src/index.ts
+++ b/hub/agents/npm/agent-email/src/index.ts
@@ -66,5 +66,5 @@ export {
   BinaryNotFoundError,
 } from "./errors.js";
 
-export { SCHEMA_VERSION } from "./types.js";
+export { SCHEMA_VERSION, MAX_BATCH_SIZE } from "./types.js";
 export type * from "./types.js";

--- a/hub/agents/npm/agent-email/src/types.ts
+++ b/hub/agents/npm/agent-email/src/types.ts
@@ -189,6 +189,55 @@ export interface EmailTriageResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Batch triage (#1887) — ADDITIVE beside the single-email triage above.
+// POST /v1/email/triage/batch: an items array in, a results array out. The
+// single triage() / EmailTriageRequest / EmailTriageResponse are unchanged.
+// ---------------------------------------------------------------------------
+
+/** Maximum number of items in one batch request (contract.py: MAX_BATCH_SIZE). */
+export const MAX_BATCH_SIZE = 100 as const;
+
+/** Why one batch item could not be triaged (contract.py: BatchItemError). */
+export interface BatchItemError {
+  /** Actionable failure reason for this item. */
+  message: string;
+}
+
+/**
+ * One item's outcome in a batch triage (contract.py: BatchItemResult).
+ * Exactly one of `result` or `error` is set, correlated by 0-based `index`.
+ */
+export interface BatchItemResult {
+  /** 0-based position in the request `items` array. */
+  index: number;
+  /** Set when the item succeeded. */
+  result?: EmailTriageResult | null;
+  /** Set when the item failed. */
+  error?: BatchItemError | null;
+}
+
+/** Top-level batch triage request envelope (contract.py: BatchTriageRequest). */
+export interface BatchTriageRequest {
+  /** Contract version. Defaults to SCHEMA_VERSION; mismatch fails loudly. */
+  schema_version?: string;
+  /** 1..MAX_BATCH_SIZE single-email or thread inputs to triage. */
+  items: EmailInput[];
+  /** Optional context applied to ALL items. */
+  context?: TriageContext | null;
+}
+
+/** Top-level batch triage response envelope (contract.py: BatchTriageResponse). */
+export interface BatchTriageResponse {
+  /** Echoes the contract version. */
+  schema_version: string;
+  /**
+   * One entry per request item, order-preserved, 1:1 with `items`. HTTP 200
+   * with every item errored is valid — inspect each `results[].error`.
+   */
+  results: BatchItemResult[];
+}
+
+// ---------------------------------------------------------------------------
 // Draft / send handshake (api_routes.py — LOCAL, not part of the frozen triage
 // contract; the send-confirmation gate).
 // ---------------------------------------------------------------------------

--- a/hub/agents/npm/agent-email/test/client.test.ts
+++ b/hub/agents/npm/agent-email/test/client.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it, vi } from "vitest";
 import { EmailClient } from "../src/client.js";
 import { HttpError } from "../src/errors.js";
 import type {
+  BatchTriageRequest,
+  BatchTriageResponse,
   EmailTriageRequest,
   EmailTriageResponse,
   EmailDraftResponse,
@@ -70,6 +72,58 @@ describe("EmailClient", () => {
     expect(res.result.action_items[0]?.type).toBe("text");
     expect(res.result.suggested_action).toBe("reply");
     expect(res.result.usage?.total_tokens).toBe(160);
+  });
+
+  it("sends a typed batch triage request to /triage/batch and parses results", async () => {
+    const batchResponse: BatchTriageResponse = {
+      schema_version: "2.0",
+      results: [
+        { index: 0, result: triageResponse.result },
+        { index: 1, error: { message: "injected failure" } },
+      ],
+    };
+    const fetchImpl = vi.fn(async (url, init) => {
+      // The batch method must POST to the batch path with an `items` array.
+      expect(String(url)).toContain("/v1/email/triage/batch");
+      expect(init?.method).toBe("POST");
+      const parsed = JSON.parse(String(init?.body));
+      expect(Array.isArray(parsed.items)).toBe(true);
+      expect(parsed.items).toHaveLength(2);
+      expect(parsed.items[0].kind).toBe("single");
+      return jsonResponse(batchResponse);
+    }) as unknown as typeof fetch;
+
+    const client = new EmailClient({ baseUrl: "http://127.0.0.1:8131", fetchImpl });
+    const req: BatchTriageRequest = {
+      items: [
+        {
+          kind: "single",
+          principal: { email: "me@example.com" },
+          message: {
+            message_id: "m1",
+            from: { email: "sarah@example.com" },
+            subject: "Prod incident follow-up",
+            body: "Please review by Friday.",
+          },
+        },
+        {
+          kind: "single",
+          principal: { email: "me@example.com" },
+          message: {
+            message_id: "m2",
+            from: { email: "promo@shop.example" },
+            subject: "Sale",
+            body: "Shop now.",
+          },
+        },
+      ],
+    };
+    const res = await client.triageBatch(req);
+    expect(res.results).toHaveLength(2);
+    expect(res.results[0]?.index).toBe(0);
+    expect(res.results[0]?.result?.category).toBe("NEEDS_RESPONSE");
+    expect(res.results[1]?.error?.message).toBe("injected failure");
+    expect(res.results[1]?.result ?? null).toBeNull();
   });
 
   it("normalizes a trailing slash in baseUrl", async () => {

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.2.5
+version: 0.3.0
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -54,6 +54,10 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse
 from gaia_agent_email.contract import (
     ActionItem,
+    BatchItemError,
+    BatchItemResult,
+    BatchTriageRequest,
+    BatchTriageResponse,
     DraftReply,
     EmailAddress,
     EmailCategory,
@@ -219,6 +223,47 @@ class EmailTriageService:
                 detail=f"Unsupported payload kind: {getattr(payload, 'kind', '?')!r}",
             )
         return EmailTriageResponse(request_kind=kind, result=result)
+
+    def triage_batch(
+        self,
+        request: BatchTriageRequest,
+        chat: Optional[Any] = None,
+    ) -> BatchTriageResponse:
+        """Triage a batch of emails/threads into a per-item result array (#1887).
+
+        The pre-loop Lemonade probe runs ONCE — if it raises ``LLMTriageError``
+        (server unreachable), the whole request fails with a 502; that error is
+        intentionally NOT caught here. Per-item failures (``LLMTriageError``,
+        ``EmailSummarizeError``) are caught inside the loop and surfaced as a
+        ``BatchItemResult.error`` for that index while remaining items continue.
+
+        Args:
+            request: The batch request envelope (1..MAX_BATCH_SIZE items).
+            chat:    Pre-built chat client. When None a local Lemonade client
+                     is constructed via :meth:`_build_llm_chat` (probe once).
+        """
+        # Pre-loop probe: fail fast if Lemonade is unreachable before spending
+        # time on any item. Raises LLMTriageError → propagates as 502.
+        resolved_chat = chat or self._build_llm_chat()
+        context = request.context
+        results: List[BatchItemResult] = []
+        for index, item in enumerate(request.items):
+            try:
+                if isinstance(item, SingleEmailInput):
+                    res = self._triage_single_llm(item, resolved_chat, context=context)
+                elif isinstance(item, ThreadInput):
+                    res = self._triage_thread_llm(item, resolved_chat, context=context)
+                else:  # pragma: no cover — discriminated union guarantees one of the two
+                    raise HTTPException(
+                        status_code=422,
+                        detail=f"Unsupported item kind: {getattr(item, 'kind', '?')!r}",
+                    )
+                results.append(BatchItemResult(index=index, result=res))
+            except (LLMTriageError, EmailSummarizeError) as e:
+                results.append(
+                    BatchItemResult(index=index, error=BatchItemError(message=str(e)))
+                )
+        return BatchTriageResponse(results=results)
 
     def _build_llm_chat(self, base_url: Optional[str] = None) -> Any:
         """Build a local Lemonade chat client for LLM triage/summarise.
@@ -896,6 +941,28 @@ async def triage_email(request: EmailTriageRequest) -> EmailTriageResponse:
     try:
         return await asyncio.to_thread(_service.triage_request, request)
     except (LLMTriageError, EmailSummarizeError) as e:
+        raise HTTPException(
+            status_code=502, detail=f"local LLM triage failed: {e}"
+        ) from e
+
+
+@router.post("/triage/batch", response_model=BatchTriageResponse)
+async def triage_email_batch(request: BatchTriageRequest) -> BatchTriageResponse:
+    """Triage an array of emails or threads in a single request (#1887).
+
+    Accepts a ``BatchTriageRequest`` (1..MAX_BATCH_SIZE ``EmailInput`` items)
+    and returns a ``BatchTriageResponse`` — one ``BatchItemResult`` per item,
+    order-preserved. Per-item failures surface as ``BatchItemResult.error``
+    (HTTP 200 with all items errored is valid — inspect each result). A 502
+    means Lemonade was unreachable before any item was processed. No mail is
+    read or sent; this analyzes only the items in the request.
+    """
+    try:
+        return await asyncio.to_thread(_service.triage_batch, request)
+    except LLMTriageError as e:
+        # Only LLMTriageError can escape triage_batch — it is raised by the
+        # pre-loop Lemonade probe when the server is unreachable. Per-item
+        # EmailSummarizeError/LLMTriageError are caught inside triage_batch.
         raise HTTPException(
             status_code=502, detail=f"local LLM triage failed: {e}"
         ) from e

--- a/hub/agents/python/email/gaia_agent_email/contract.py
+++ b/hub/agents/python/email/gaia_agent_email/contract.py
@@ -36,7 +36,7 @@ Design notes
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Literal, Optional, Union, cast
+from typing import Annotated, List, Literal, Optional, Union, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -58,6 +58,10 @@ CATEGORY_PERSONAL = "PERSONAL"
 # response so a consumer can detect a mismatch loudly instead of silently
 # mis-parsing. The first frozen revision is "1.0".
 SCHEMA_VERSION = "2.0"
+
+# Maximum number of items in a single batch request. Protects the single-tenant
+# local model slot from runaway batches. Enforced via Pydantic max_length.
+MAX_BATCH_SIZE = 100
 
 
 class _Strict(BaseModel):
@@ -364,6 +368,95 @@ class EmailTriageResponse(_Strict):
 
 
 # ---------------------------------------------------------------------------
+# Batch triage contract (#1887) — ADDITIVE beside the single-email models above
+# ---------------------------------------------------------------------------
+
+
+class BatchItemError(_Strict):
+    """Why one batch item could not be triaged (surfaced loudly, never swallowed).
+
+    Kept as an object (not a bare string) so a future ``code``/``type`` field is
+    additive rather than another breaking change.
+    """
+
+    message: str = Field(..., description="Actionable failure reason for this item.")
+
+
+class BatchItemResult(_Strict):
+    """One item's outcome in a batch triage, correlated by 0-based index.
+
+    Exactly one of ``result`` or ``error`` is set. ``index`` matches the item's
+    position in the request ``items`` array so out-of-order processing is safe
+    (the current implementation is sequential and order-preserving).
+    """
+
+    index: int = Field(
+        ..., ge=0, description="0-based position in the request ``items`` array."
+    )
+    result: Optional[EmailTriageResult] = Field(
+        default=None, description="Set when the item succeeded."
+    )
+    error: Optional[BatchItemError] = Field(
+        default=None, description="Set when the item failed."
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one(self) -> "BatchItemResult":
+        if (self.result is None) == (self.error is None):
+            raise ValueError("exactly one of result/error must be set")
+        return self
+
+
+class BatchTriageRequest(_Strict):
+    """Top-level batch triage request envelope (#1887).
+
+    Accepts 1..MAX_BATCH_SIZE ``EmailInput`` items (same discriminated union as
+    the single-email endpoint's ``payload``). ``context`` applies to ALL items;
+    per-item context override is out of scope.
+    """
+
+    schema_version: str = Field(
+        default=SCHEMA_VERSION,
+        description="Contract version. Mismatch lets a consumer fail loudly.",
+    )
+    items: List[Annotated[EmailInput, Field(discriminator="kind")]] = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_BATCH_SIZE,
+        description=(
+            "The emails / threads to triage, 1..MAX_BATCH_SIZE items. "
+            "Each is a SingleEmailInput or ThreadInput discriminated by ``kind``."
+        ),
+    )
+    context: Optional[TriageContext] = Field(
+        default=None,
+        description=(
+            "Optional context (people/projects/tone/self-email) applied to ALL "
+            "items. Absent → behavior unchanged for every item."
+        ),
+    )
+
+
+class BatchTriageResponse(_Strict):
+    """Top-level batch triage response envelope (#1887).
+
+    One ``BatchItemResult`` per request item, order-preserved, 1:1 with
+    ``items``. HTTP 200 with all items errored is valid — consumers MUST inspect
+    each ``results[].error``, not just the HTTP status.
+    """
+
+    schema_version: str = Field(
+        default=SCHEMA_VERSION, description="Echoes the contract version."
+    )
+    results: List[BatchItemResult] = Field(
+        ...,
+        description=(
+            "One entry per request item, order-preserved, 1:1 with ``items``."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -389,6 +482,7 @@ def parse_response(data: dict) -> EmailTriageResponse:
 
 __all__ = [
     "SCHEMA_VERSION",
+    "MAX_BATCH_SIZE",
     "EmailCategory",
     "EmailAddress",
     "EmailMessage",
@@ -402,6 +496,11 @@ __all__ = [
     "TriageUsage",
     "EmailTriageResult",
     "EmailTriageResponse",
+    # Batch triage (#1887) — additive beside the single-email models above
+    "BatchItemError",
+    "BatchItemResult",
+    "BatchTriageRequest",
+    "BatchTriageResponse",
     "parse_request",
     "parse_response",
 ]

--- a/hub/agents/python/email/gaia_agent_email/mcp_server.py
+++ b/hub/agents/python/email/gaia_agent_email/mcp_server.py
@@ -37,6 +37,7 @@ from typing import Any, Dict, List, Optional
 from gaia.agents.base.console import SilentConsole
 from gaia.agents.base.mcp_agent import MCPAgent
 from gaia_agent_email.contract import (
+    BatchTriageRequest,
     DraftReply,
     EmailAddress,
     EmailTriageRequest,
@@ -97,6 +98,46 @@ _TRIAGE_SCHEMA = {
         },
     },
     "required": ["payload"],
+}
+
+# triage_email_batch accepts BatchTriageRequest. ``items`` is the list of
+# SingleEmailInput / ThreadInput objects; ``schema_version`` and ``context``
+# are optional. Discriminator on ``kind`` is enforced by pydantic.
+_BATCH_TRIAGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "description": (
+                "1..100 email or thread inputs to triage. Each item must be a "
+                "SingleEmailInput (kind='single', with 'principal' + 'message') "
+                "or a ThreadInput (kind='thread', with 'principal' + 'thread_id' "
+                "+ 'messages'). Order is preserved in the response."
+            ),
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {"type": "object"},
+        },
+        "schema_version": {
+            "type": "string",
+            "description": "Contract version. Defaults to the frozen current revision.",
+        },
+        "context": {
+            "type": "object",
+            "description": (
+                "Optional context applied to ALL items (#1541): "
+                "people (list), projects (list), tone (string), self_email "
+                "(string). Absent → behavior unchanged."
+            ),
+            "properties": {
+                "people": {"type": "array", "items": {"type": "string"}},
+                "projects": {"type": "array", "items": {"type": "string"}},
+                "tone": {"type": "string"},
+                "self_email": {"type": "string"},
+            },
+        },
+    },
+    "required": ["items"],
 }
 
 # draft_reply / send_email mirror EmailDraftRequest / EmailSendRequest. ``to``
@@ -222,6 +263,20 @@ class EmailTriageMCPAgent(MCPAgent):
                 "inputSchema": _TRIAGE_SCHEMA,
             },
             {
+                "name": "triage_email_batch",
+                "description": (
+                    "Triage a batch of emails or threads in a single call "
+                    "(#1887). Accepts 1..100 EmailInput items (each a "
+                    "SingleEmailInput or ThreadInput) and returns a "
+                    "BatchTriageResponse with one BatchItemResult per item, "
+                    "order-preserved. Per-item failures set "
+                    "BatchItemResult.error; remaining items are still "
+                    "processed. HTTP-200 with all items errored is valid — "
+                    "inspect each result. Reads/sends no mail."
+                ),
+                "inputSchema": _BATCH_TRIAGE_SCHEMA,
+            },
+            {
                 "name": "draft_reply",
                 "description": (
                     "Propose a reply and mint a single-use confirmation token "
@@ -246,6 +301,8 @@ class EmailTriageMCPAgent(MCPAgent):
     ) -> Dict[str, Any]:
         if tool_name == "triage_email":
             return self._triage(arguments)
+        if tool_name == "triage_email_batch":
+            return self._triage_batch(arguments)
         if tool_name == "draft_reply":
             return self._draft(arguments)
         if tool_name == "send_email":
@@ -261,6 +318,14 @@ class EmailTriageMCPAgent(MCPAgent):
         response = self._service.triage_request(request)
         # JSON mode so enums serialize to their string values — the exact wire
         # form the REST endpoint returns. This is what guarantees parity.
+        return response.model_dump(mode="json")
+
+    def _triage_batch(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        # Same validation + JSON-mode serialization pattern as _triage — parity
+        # with the REST /triage/batch endpoint is guaranteed by using the same
+        # contract models and the same service method.
+        request = BatchTriageRequest.model_validate(arguments)
+        response = self._service.triage_batch(request)
         return response.model_dump(mode="json")
 
     def _draft(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/hub/agents/python/email/gaia_agent_email/playground_html.py
+++ b/hub/agents/python/email/gaia_agent_email/playground_html.py
@@ -185,6 +185,32 @@ _HTML = r"""<!doctype html>
     </div>
   </details>
 
+  <!-- Batch triage (#1887) -->
+  <details class="card">
+    <summary><span class="sum-title">Batch triage</span>
+      <span class="sum-desc">array in · array out · /v1/email/triage/batch</span><span class="chev">›</span></summary>
+    <div class="card-body">
+      <p class="note">Sends the two emails below as one <code>items</code> array and renders the
+        parallel <code>results</code> array — each entry carries either a <code>result</code> or an
+        <code>error</code>, correlated by <code>index</code>. Additive: the single Triage card above is unchanged.</p>
+      <div class="grid2">
+        <div><label>Item 0 — From</label><input id="tb-from0" value="Sarah Chen &lt;sarah@example.com&gt;" /></div>
+        <div><label>Item 0 — Subject</label><input id="tb-subject0" value="Prod incident follow-up" /></div>
+      </div>
+      <label style="display:block;margin-top:10px">Item 0 — Body</label>
+      <textarea id="tb-body0">Please review the incident report and reply by Friday. Action required.</textarea>
+      <div class="grid2" style="margin-top:10px">
+        <div><label>Item 1 — From</label><input id="tb-from1" value="Deals &lt;promo@shop.example&gt;" /></div>
+        <div><label>Item 1 — Subject</label><input id="tb-subject1" value="50% off this weekend only" /></div>
+      </div>
+      <label style="display:block;margin-top:10px">Item 1 — Body</label>
+      <textarea id="tb-body1">Limited-time offer — shop now and save big before Sunday.</textarea>
+      <div class="actions"><button id="do-triage-batch">Triage batch</button>
+        <span class="note">Needs Lemonade + the model. HTTP 200 with all items errored is valid — inspect each result.</span></div>
+      <div class="out" id="tb-out"></div>
+    </div>
+  </details>
+
   <!-- Draft -->
   <details class="card">
     <summary><span class="sum-title">Draft a reply</span>
@@ -388,6 +414,35 @@ function renderTriage(out, r){
     const ul = document.createElement("ul"); ul.className = "items";
     for(const a of r.action_items){ const li=document.createElement("li"); li.textContent = a.description + (a.due_hint?(" — "+a.due_hint):""); ul.appendChild(li); }
     out.appendChild(ul);
+  }
+}
+function tbItem(idx){
+  const m = parseFrom($("tb-from"+idx).value);
+  return { kind:"single", principal:{ email:"me@example.com" },
+    message:{ message_id:"playground-batch-"+idx, from:m, to:[{ email:"me@example.com" }],
+      subject:$("tb-subject"+idx).value, body:$("tb-body"+idx).value } };
+}
+async function doTriageBatch(){
+  const out = $("tb-out"); out.className = "out show"; out.textContent = "Triaging batch…";
+  try{
+    const res = await postJSON("/v1/email/triage/batch", { items:[ tbItem(0), tbItem(1) ] });
+    out.textContent = "";
+    for(const item of res.results){
+      const block = document.createElement("div"); block.style.marginTop = "10px";
+      const hdr = document.createElement("div"); hdr.style.fontSize="12px"; hdr.style.color="var(--faint)";
+      hdr.textContent = "index " + item.index; block.appendChild(hdr);
+      if(item.error){
+        const er = document.createElement("div"); er.textContent = "✗ " + item.error.message; block.appendChild(er);
+      }else{
+        const inner = document.createElement("div"); renderTriage(inner, item.result); block.appendChild(inner);
+      }
+      out.appendChild(block);
+    }
+  }catch(e){
+    out.textContent = ""; const d = diagnose(e);
+    const p = document.createElement("div");
+    p.textContent = (e.status===502||e.status===0) ? ("✗ " + d.cause + " — " + d.hint + (d.cmd?(" ("+d.cmd+")"):"")) : ("✗ HTTP " + e.status + ": " + (e.body||e.message));
+    out.appendChild(p);
   }
 }
 async function doDraft(){
@@ -674,6 +729,7 @@ $("recheck").onclick = healthCheck;
 $("do-init").onclick = doInit;
 $("do-provision").onclick = doProvision;
 $("do-triage").onclick = doTriage;
+$("do-triage-batch").onclick = doTriageBatch;
 $("do-draft").onclick = doDraft;
 $("do-send").onclick = doSend;
 healthCheck();

--- a/hub/agents/python/email/gaia_agent_email/spec_html.py
+++ b/hub/agents/python/email/gaia_agent_email/spec_html.py
@@ -16,13 +16,27 @@ from __future__ import annotations
 import html as _html_lib
 import webbrowser
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, Type, Union, get_args, get_origin
+from typing import (
+    Annotated,
+    Any,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from pydantic import BaseModel
 
 from gaia_agent_email.contract import (
     SCHEMA_VERSION,
     ActionItem,
+    BatchItemError,
+    BatchItemResult,
+    BatchTriageRequest,
+    BatchTriageResponse,
     DraftReply,
     EmailAddress,
     EmailCategory,
@@ -209,8 +223,14 @@ def _annotation_label(annotation: Any) -> str:
     ``Optional[List[EmailAddress]]`` render as ``list[EmailAddress]``
     rather than the bare outer name. NoneType arms (from Optional) are
     dropped so the label names the value type, not ``| None``.
+    ``Annotated[X, …]`` (e.g. a discriminated-union list element) is unwrapped
+    to ``X`` so the label names the value type, not the ``Annotated`` wrapper.
     """
     origin = get_origin(annotation)
+    # Unwrap Annotated[X, metadata…] → X before any other handling, so a
+    # discriminated-union element renders as the union, not 'Annotated[...'.
+    if origin is Annotated:
+        return _annotation_label(get_args(annotation)[0])
     if origin is None:
         # A concrete class (str, bool, EmailAddress, …) or a bare name.
         return getattr(annotation, "__name__", None) or str(annotation)
@@ -351,6 +371,29 @@ def render_endpoint_spec_html() -> str:
         f"</div>"
     )
 
+    batch_block = (
+        f'<div class="endpoint-block">'
+        f'<span class="method-badge">POST</span>'
+        f'<span class="path">/v1/email/triage/batch</span>'
+        f'<p class="desc">Triage a batch of emails or threads in one request (#1887). '
+        f"Accepts a BatchTriageRequest (an <code>items</code> array of 1–100 "
+        f"single-email / thread inputs) and returns a BatchTriageResponse — one "
+        f"BatchItemResult per item, order-preserved. This is additive: the single "
+        f"<code>/v1/email/triage</code> endpoint above is unchanged.</p>"
+        f"<p class='desc'><strong>Per-item isolation:</strong> a failure on one "
+        f"item sets that entry's <code>error</code> and the rest still run. "
+        f"<strong>HTTP 200 with every item errored is valid</strong> — inspect each "
+        f"<code>results[].error</code>, not just the status. A 502 means the local "
+        f"LLM was unreachable before any item was processed (the whole batch fails).</p>"
+        f"<h3>Request envelope</h3>"
+        f"{_model_table(BatchTriageRequest, 'BatchTriageRequest')}"
+        f"<h3>Response envelope</h3>"
+        f"{_model_table(BatchTriageResponse, 'BatchTriageResponse')}"
+        f"{_model_table(BatchItemResult, 'BatchItemResult (exactly one of result / error)')}"
+        f"{_model_table(BatchItemError, 'BatchItemError')}"
+        f"</div>"
+    )
+
     # /draft and /send are derived from the REST route models (the same
     # pydantic classes the endpoints actually use) via _endpoint_block, so the
     # tables cannot drift from the live request/response shapes. Imported
@@ -412,6 +455,8 @@ def render_endpoint_spec_html() -> str:
 <h2>Endpoints</h2>
 
 {triage_block}
+
+{batch_block}
 
 {draft_block}
 

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.2.5"
+AGENT_VERSION = "0.3.0"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/openapi.email.json
+++ b/hub/agents/python/email/openapi.email.json
@@ -51,6 +51,138 @@
         "title": "ActionItem",
         "type": "object"
       },
+      "BatchItemError": {
+        "additionalProperties": false,
+        "description": "Why one batch item could not be triaged (surfaced loudly, never swallowed).\n\nKept as an object (not a bare string) so a future ``code``/``type`` field is\nadditive rather than another breaking change.",
+        "properties": {
+          "message": {
+            "description": "Actionable failure reason for this item.",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "BatchItemError",
+        "type": "object"
+      },
+      "BatchItemResult": {
+        "additionalProperties": false,
+        "description": "One item's outcome in a batch triage, correlated by 0-based index.\n\nExactly one of ``result`` or ``error`` is set. ``index`` matches the item's\nposition in the request ``items`` array so out-of-order processing is safe\n(the current implementation is sequential and order-preserving).",
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BatchItemError"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set when the item failed."
+          },
+          "index": {
+            "description": "0-based position in the request ``items`` array.",
+            "minimum": 0.0,
+            "title": "Index",
+            "type": "integer"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EmailTriageResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Set when the item succeeded."
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "title": "BatchItemResult",
+        "type": "object"
+      },
+      "BatchTriageRequest": {
+        "additionalProperties": false,
+        "description": "Top-level batch triage request envelope (#1887).\n\nAccepts 1..MAX_BATCH_SIZE ``EmailInput`` items (same discriminated union as\nthe single-email endpoint's ``payload``). ``context`` applies to ALL items;\nper-item context override is out of scope.",
+        "properties": {
+          "context": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TriageContext"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional context (people/projects/tone/self-email) applied to ALL items. Absent → behavior unchanged for every item."
+          },
+          "items": {
+            "description": "The emails / threads to triage, 1..MAX_BATCH_SIZE items. Each is a SingleEmailInput or ThreadInput discriminated by ``kind``.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "single": "#/components/schemas/SingleEmailInput",
+                  "thread": "#/components/schemas/ThreadInput"
+                },
+                "propertyName": "kind"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SingleEmailInput"
+                },
+                {
+                  "$ref": "#/components/schemas/ThreadInput"
+                }
+              ]
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          },
+          "schema_version": {
+            "default": "2.0",
+            "description": "Contract version. Mismatch lets a consumer fail loudly.",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "BatchTriageRequest",
+        "type": "object"
+      },
+      "BatchTriageResponse": {
+        "additionalProperties": false,
+        "description": "Top-level batch triage response envelope (#1887).\n\nOne ``BatchItemResult`` per request item, order-preserved, 1:1 with\n``items``. HTTP 200 with all items errored is valid — consumers MUST inspect\neach ``results[].error``, not just the HTTP status.",
+        "properties": {
+          "results": {
+            "description": "One entry per request item, order-preserved, 1:1 with ``items``.",
+            "items": {
+              "$ref": "#/components/schemas/BatchItemResult"
+            },
+            "title": "Results",
+            "type": "array"
+          },
+          "schema_version": {
+            "default": "2.0",
+            "description": "Echoes the contract version.",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "results"
+        ],
+        "title": "BatchTriageResponse",
+        "type": "object"
+      },
       "DraftReply": {
         "additionalProperties": false,
         "description": "A drafted reply the agent proposes. Never sent without confirmation\n(#1264) — this is a proposal, not an action.",
@@ -917,6 +1049,48 @@
           }
         },
         "summary": "Triage Email",
+        "tags": [
+          "email"
+        ]
+      }
+    },
+    "/v1/email/triage/batch": {
+      "post": {
+        "description": "Triage an array of emails or threads in a single request (#1887).\n\nAccepts a ``BatchTriageRequest`` (1..MAX_BATCH_SIZE ``EmailInput`` items)\nand returns a ``BatchTriageResponse`` — one ``BatchItemResult`` per item,\norder-preserved. Per-item failures surface as ``BatchItemResult.error``\n(HTTP 200 with all items errored is valid — inspect each result). A 502\nmeans Lemonade was unreachable before any item was processed. No mail is\nread or sent; this analyzes only the items in the request.",
+        "operationId": "triage_email_batch_v1_email_triage_batch_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchTriageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchTriageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Triage Email Batch",
         "tags": [
           "email"
         ]

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.2.5"
+version = "0.3.0"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }

--- a/hub/agents/python/email/specification.html
+++ b/hub/agents/python/email/specification.html
@@ -392,7 +392,7 @@
     <table class="tbl">
       <thead><tr><th>Capability</th><th>REST</th><th>MCP</th><th>Agent</th></tr></thead>
       <tbody>
-        <tr><td><b>1</b> · 4-way triage</td><td>✓ <code>/v1/email/triage</code></td><td>✓ <code>triage_email</code></td><td>✓</td></tr>
+        <tr><td><b>1</b> · 4-way triage</td><td>✓ <code>/v1/email/triage</code> <span class="opt">· batch: <code>/v1/email/triage/batch</code></span></td><td>✓ <code>triage_email</code> <span class="opt">· <code>triage_email_batch</code></span></td><td>✓</td></tr>
         <tr><td><b>2</b> · Per-email summary</td><td>✓ <span class="opt">(in triage result)</span></td><td>✓</td><td>✓</td></tr>
         <tr><td><b>3</b> · Draft reply</td><td>✓ <code>/v1/email/draft</code></td><td>✓ <code>draft_reply</code></td><td>✓</td></tr>
         <tr><td><b>4</b> · Phishing detection</td><td>✓ <span class="opt">(flag in triage)</span></td><td>✓</td><td>✓ <span class="opt">(+ quarantine)</span></td></tr>
@@ -1307,6 +1307,30 @@ one-shot: "in 2 days", "tomorrow at 9am"</pre>
         <tr><td><code>schema_version</code></td><td>string</td><td>Echoes the contract version.</td></tr>
         <tr><td><code>request_kind</code></td><td>"single" | "thread"</td><td>Which input shape produced the result.</td></tr>
         <tr><td><code>result</code></td><td>EmailTriageResult</td><td>The structured analysis (below).</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="endpoint" id="ep-triage-batch">
+      <span class="badge">POST</span><span class="path">/v1/email/triage/batch</span>
+      <p class="desc">Triage many emails or threads in one request (<a class="iss" href="https://github.com/amd/gaia/issues/1887" target="_blank" rel="noopener">#1887</a>). Same per-item analysis as <a class="eplink" href="#ep-triage"><code>/triage</code></a>, but the body carries an <code>items</code> array (1–100) and the response carries a parallel <code>results</code> array, order-preserved. Additive — the single <a class="eplink" href="#ep-triage"><code>/triage</code></a> endpoint is unchanged. Reads/sends no mail.</p>
+      <h4>Per-item isolation</h4>
+      <p class="body-t">Each item is triaged independently: a failure on one item sets that entry's <code>error</code> and the remaining items still run. <b>HTTP 200 with every item errored is a valid response</b> — consumers MUST inspect each <code>results[].error</code>, not just the HTTP status. A <code>502</code> means the local LLM was unreachable before any item was processed (the whole batch fails).</p>
+      <h4>Request body — BatchTriageRequest</h4>
+      <table class="tbl"><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead><tbody>
+        <tr><td><code>schema_version</code></td><td>string <span class="opt">optional</span></td><td>Contract version. Defaults to <code>"2.0"</code>.</td></tr>
+        <tr><td><code>items</code></td><td>list[EmailInput] <span class="req">required</span></td><td>1–100 <code>SingleEmailInput</code> / <code>ThreadInput</code> objects, discriminated on <code>kind</code>. Over 100 → <code>422</code>.</td></tr>
+        <tr><td><code>context</code></td><td>TriageContext <span class="opt">optional</span></td><td>Applied to <b>all</b> items.</td></tr>
+      </tbody></table>
+      <h4>Response body — BatchTriageResponse</h4>
+      <table class="tbl"><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead><tbody>
+        <tr><td><code>schema_version</code></td><td>string</td><td>Echoes the contract version.</td></tr>
+        <tr><td><code>results</code></td><td>list[BatchItemResult]</td><td>One entry per item, order-preserved, 1:1 with <code>items</code>.</td></tr>
+      </tbody></table>
+      <h4>BatchItemResult — exactly one of result / error</h4>
+      <table class="tbl"><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead><tbody>
+        <tr><td><code>index</code></td><td>int</td><td>0-based position in the request <code>items</code> array.</td></tr>
+        <tr><td><code>result</code></td><td>EmailTriageResult <span class="opt">optional</span></td><td>Set when the item succeeded.</td></tr>
+        <tr><td><code>error</code></td><td>BatchItemError <span class="opt">optional</span></td><td>Set (with a <code>message</code>) when the item failed.</td></tr>
       </tbody></table>
     </div>
 

--- a/hub/agents/python/email/tests/test_rest_contract.py
+++ b/hub/agents/python/email/tests/test_rest_contract.py
@@ -34,6 +34,8 @@ from gaia_agent_email import __version__ as package_version  # noqa: E402
 from gaia_agent_email import export_openapi  # noqa: E402
 from gaia_agent_email.contract import (  # noqa: E402
     SCHEMA_VERSION,
+    BatchTriageRequest,
+    BatchTriageResponse,
     EmailTriageRequest,
     EmailTriageResponse,
 )
@@ -43,6 +45,7 @@ from gaia_agent_email.version import AGENT_VERSION, API_VERSION  # noqa: E402
 # Maps (method, path) -> the component schema name the handler declares.
 _EXPECTED_RESPONSE_MODELS = {
     ("post", "/v1/email/triage"): "EmailTriageResponse",
+    ("post", "/v1/email/triage/batch"): "BatchTriageResponse",  # #1887 additive
     ("post", "/v1/email/draft"): "EmailDraftResponse",
     ("post", "/v1/email/send"): "EmailSendResponse",
     ("get", "/v1/email/health"): "HealthResponse",
@@ -96,11 +99,22 @@ def test_spec_info_version_is_api_version(spec):
 
 def test_contract_models_present_in_spec(spec):
     schemas = spec["components"]["schemas"]
-    for name in ("EmailTriageRequest", "EmailTriageResponse", "EmailTriageResult"):
+    for name in (
+        "EmailTriageRequest",
+        "EmailTriageResponse",
+        "EmailTriageResult",
+        # Batch models (#1887 additive)
+        "BatchTriageRequest",
+        "BatchTriageResponse",
+        "BatchItemResult",
+    ):
         assert name in schemas, f"{name} missing from exported OpenAPI components"
 
 
-@pytest.mark.parametrize("model", [EmailTriageRequest, EmailTriageResponse])
+@pytest.mark.parametrize(
+    "model",
+    [EmailTriageRequest, EmailTriageResponse, BatchTriageRequest, BatchTriageResponse],
+)
 def test_spec_schema_matches_contract_model(spec, model):
     """Field names + required set in the exported spec must match the pydantic
     contract model — drift between contract.py and the published spec fails."""

--- a/tests/mcp/test_email_mcp_stdio_parity.py
+++ b/tests/mcp/test_email_mcp_stdio_parity.py
@@ -108,6 +108,16 @@ THREAD_REQUEST: Dict[str, Any] = {
 }
 
 
+# Batch envelope (#1887): one single + one thread item, reusing the exact
+# message payloads above so the per-item decisions match the single fixtures.
+BATCH_REQUEST: Dict[str, Any] = {
+    "items": [
+        SINGLE_REQUEST["payload"],
+        THREAD_REQUEST["payload"],
+    ]
+}
+
+
 def _rest_triage(request: Dict[str, Any]) -> Dict[str, Any]:
     """Run the REST-side service and return the JSON-mode response dict.
 
@@ -122,8 +132,20 @@ def _rest_triage(request: Dict[str, Any]) -> Dict[str, Any]:
     return resp.model_dump(mode="json")
 
 
+def _rest_triage_batch(request: Dict[str, Any]) -> Dict[str, Any]:
+    """Run the REST-side batch service and return the JSON-mode response dict.
+
+    Same deterministic path as :func:`_rest_triage` but for the #1887 batch
+    envelope (``{items: […]}`` in, ``{results: […]}`` out).
+    """
+    from gaia_agent_email.contract import BatchTriageRequest
+
+    resp = EmailTriageService().triage_batch(BatchTriageRequest.model_validate(request))
+    return resp.model_dump(mode="json")
+
+
 def _strip_runtime_usage(response: Dict[str, Any]) -> Dict[str, Any]:
-    """Drop the whole ``usage`` block before a byte-for-byte parity compare.
+    """Drop every ``usage`` block before a byte-for-byte parity compare.
 
     ``usage`` (#1540) reuses the runtime AgentResponse.stats measurement read
     from Lemonade's stateful ``/stats`` endpoint. None of its fields is
@@ -134,13 +156,23 @@ def _strip_runtime_usage(response: Dict[str, Any]) -> Dict[str, Any]:
     summary, action items, draft, suggested_action) is the property under
     test — not the reproducibility of a usage measurement, which each test
     asserts is *present* on both surfaces separately.
+
+    Walks BOTH response shapes: the single ``{request_kind, result}`` envelope
+    and the batch ``{results: [{index, result|error}, …]}`` envelope (#1887).
     """
     import copy
 
     out = copy.deepcopy(response)
+    # Single-email envelope: drop result.usage.
     result = out.get("result")
     if isinstance(result, dict):
         result.pop("usage", None)
+    # Batch envelope: drop usage from every per-item result.
+    results = out.get("results")
+    if isinstance(results, list):
+        for item in results:
+            if isinstance(item, dict) and isinstance(item.get("result"), dict):
+                item["result"].pop("usage", None)
     return out
 
 
@@ -226,9 +258,14 @@ class TestEmailMcpStdioParity:
 
     def test_tools_list_exposes_rest_surface(self):
         """The MCP server exposes the same capability set as the REST surface:
-        triage, draft, send."""
+        triage, batch triage, draft, send."""
         names = anyio.run(_list_tool_names)
-        assert {"triage_email", "draft_reply", "send_email"} <= set(names)
+        assert {
+            "triage_email",
+            "triage_email_batch",
+            "draft_reply",
+            "send_email",
+        } <= set(names)
 
     def test_single_email_parity(self):
         """Single-email triage: MCP stdio output == REST service output."""
@@ -257,6 +294,37 @@ class TestEmailMcpStdioParity:
         ), "MCP stdio triage diverged from REST for the thread fixture"
         parsed = parse_response(mcp_out)
         assert parsed.request_kind == "thread"
+
+    def test_batch_parity(self):
+        """Batch triage (#1887): MCP stdio output == REST service output.
+
+        Drives the SAME ``{items: [single, thread]}`` envelope over both
+        surfaces — ``triage_email_batch`` over MCP stdio and ``triage_batch``
+        on the REST service — and asserts the structured ``results[]`` arrays
+        are identical after stripping the non-reproducible per-item ``usage``.
+        """
+        rest = _rest_triage_batch(BATCH_REQUEST)
+        mcp_out = anyio.run(_call_tool, "triage_email_batch", BATCH_REQUEST)
+        assert _strip_runtime_usage(mcp_out) == _strip_runtime_usage(
+            rest
+        ), "MCP stdio batch triage diverged from REST for the batch fixture"
+        # Both surfaces produce a 2-item, order-preserved results array, each
+        # carrying a populated result (the deterministic path never errors).
+        assert len(mcp_out["results"]) == 2
+        for index, item in enumerate(mcp_out["results"]):
+            assert item["index"] == index
+            assert item["result"] is not None
+            assert item["error"] is None
+        # The batch results must match the single-path decisions for the same
+        # inputs — index 0 mirrors the single fixture, index 1 the thread.
+        single_rest = _strip_runtime_usage(_rest_triage(SINGLE_REQUEST))["result"]
+        thread_rest = _strip_runtime_usage(_rest_triage(THREAD_REQUEST))["result"]
+        stripped = _strip_runtime_usage(mcp_out)["results"]
+        assert stripped[0]["result"] == single_rest
+        assert stripped[1]["result"] == thread_rest
+        # usage echoes on both surfaces for every successful item (#1540).
+        assert mcp_out["results"][0]["result"]["usage"] is not None
+        assert rest["results"][0]["result"]["usage"] is not None
 
     def test_suggested_action_present_on_both_surfaces(self):
         """Schema 2.0: suggested_action must be present in both REST and MCP stdio (#1615)."""

--- a/tests/test_email_openapi_conformance.py
+++ b/tests/test_email_openapi_conformance.py
@@ -34,6 +34,7 @@ pytest.importorskip("gaia_agent_email")
 
 from fastapi.testclient import TestClient  # noqa: E402
 from gaia_agent_email.contract import (  # noqa: E402
+    BatchTriageResponse,
     EmailCategory,
     EmailTriageResponse,
     EmailTriageResult,
@@ -286,7 +287,100 @@ def test_send_invalid_payload_returns_422(client):
 
 
 # ---------------------------------------------------------------------------
-# 6. All documented paths are covered
+# 6. /triage/batch — conformance (LLM mocked; real HTTP layer running, #1887)
+# ---------------------------------------------------------------------------
+
+
+def _minimal_batch_payload() -> dict:
+    """Minimal valid BatchTriageRequest body for POST /triage/batch."""
+    return {
+        "schema_version": "2.0",
+        "items": [
+            {
+                "kind": "single",
+                "principal": {"email": "bob@example.com"},
+                "message": {
+                    "message_id": "msg-batch-001",
+                    "subject": "Batch test",
+                    "from": {"email": "alice@example.com"},
+                    "body": "Can you review this before Monday?",
+                },
+            }
+        ],
+    }
+
+
+def _canned_batch_response() -> BatchTriageResponse:
+    """Return a valid BatchTriageResponse for LLM mock use."""
+    from gaia_agent_email.contract import BatchItemResult
+
+    result = EmailTriageResult(
+        category=EmailCategory.NEEDS_RESPONSE,
+        is_spam=False,
+        is_phishing=False,
+        summary="Review request for Monday.",
+        action_items=[],
+        draft=None,
+    )
+    return BatchTriageResponse(results=[BatchItemResult(index=0, result=result)])
+
+
+def test_triage_batch_conforms_to_spec(client, committed_spec):
+    """POST /triage/batch with a mocked LLM returns a body conforming to the spec."""
+    canned = _canned_batch_response()
+
+    with patch(
+        "gaia_agent_email.api_routes.EmailTriageService.triage_batch",
+        return_value=canned,
+    ):
+        resp = client.post("/v1/email/triage/batch", json=_minimal_batch_payload())
+
+    assert resp.status_code == 200
+
+    schema_name = _schema_name_from_response(
+        committed_spec, "post", "/v1/email/triage/batch"
+    )
+    required = _required_keys(committed_spec, schema_name)
+    body = resp.json()
+
+    for key in required:
+        assert key in body, f"required key {key!r} missing from /triage/batch response"
+
+    assert body.get("schema_version") == "2.0"
+    assert "results" in body
+    assert len(body["results"]) == 1
+    assert body["results"][0]["index"] == 0
+    assert "result" in body["results"][0]
+
+
+def test_triage_batch_invalid_payload_returns_422(client):
+    """POST /triage/batch with empty items returns 422."""
+    resp = client.post("/v1/email/triage/batch", json={"items": []})
+    assert resp.status_code == 422
+
+
+def test_triage_batch_payload_shape_returns_422(client):
+    """POST /triage/batch with the single-email 'payload' shape returns 422."""
+    resp = client.post(
+        "/v1/email/triage/batch",
+        json={
+            "payload": {
+                "kind": "single",
+                "principal": {"email": "alice@example.com"},
+                "message": {
+                    "message_id": "msg-x",
+                    "from": {"email": "bob@example.com"},
+                    "subject": "Wrong shape",
+                    "body": "This belongs on /triage, not /triage/batch.",
+                },
+            }
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 7. All documented paths are covered
 # ---------------------------------------------------------------------------
 
 
@@ -303,6 +397,7 @@ def test_all_documented_paths_covered(committed_spec):
     }
     expected = {
         ("post", "/v1/email/triage"),
+        ("post", "/v1/email/triage/batch"),  # #1887 additive
         ("post", "/v1/email/draft"),
         ("post", "/v1/email/send"),
         ("get", "/v1/email/health"),

--- a/tests/unit/agents/email/test_batch_contract.py
+++ b/tests/unit/agents/email/test_batch_contract.py
@@ -83,9 +83,9 @@ def _minimal_triage_result() -> EmailTriageResult:
 
 def test_schema_version_is_still_2_0():
     """The additive batch endpoint must NOT bump SCHEMA_VERSION."""
-    assert SCHEMA_VERSION == "2.0", (
-        f"SCHEMA_VERSION is {SCHEMA_VERSION!r}; additive change must NOT bump it"
-    )
+    assert (
+        SCHEMA_VERSION == "2.0"
+    ), f"SCHEMA_VERSION is {SCHEMA_VERSION!r}; additive change must NOT bump it"
 
 
 # ---------------------------------------------------------------------------
@@ -235,20 +235,20 @@ def test_batch_triage_request_rejects_unknown_field():
 
 def test_email_triage_request_still_has_payload_field():
     """Additive guarantee: the single-email EmailTriageRequest.payload is unchanged."""
-    assert "payload" in EmailTriageRequest.model_fields, (
-        "EmailTriageRequest lost its 'payload' field — the additive contract was broken"
-    )
+    assert (
+        "payload" in EmailTriageRequest.model_fields
+    ), "EmailTriageRequest lost its 'payload' field — the additive contract was broken"
 
 
 def test_email_triage_response_still_has_request_kind():
     """Additive guarantee: EmailTriageResponse.request_kind is unchanged."""
-    assert "request_kind" in EmailTriageResponse.model_fields, (
-        "EmailTriageResponse lost 'request_kind' — the additive contract was broken"
-    )
+    assert (
+        "request_kind" in EmailTriageResponse.model_fields
+    ), "EmailTriageResponse lost 'request_kind' — the additive contract was broken"
 
 
 def test_email_triage_response_still_has_result():
     """Additive guarantee: EmailTriageResponse.result is unchanged."""
-    assert "result" in EmailTriageResponse.model_fields, (
-        "EmailTriageResponse lost 'result' — the additive contract was broken"
-    )
+    assert (
+        "result" in EmailTriageResponse.model_fields
+    ), "EmailTriageResponse lost 'result' — the additive contract was broken"

--- a/tests/unit/agents/email/test_batch_contract.py
+++ b/tests/unit/agents/email/test_batch_contract.py
@@ -1,0 +1,254 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Batch triage contract tests for issue #1887 (ADDITIVE redesign).
+
+These tests define the schema-2.0 batch contract that lives BESIDE the
+single-email contract.  They FAIL until:
+  - BatchItemError, BatchItemResult, BatchTriageRequest, BatchTriageResponse,
+    and MAX_BATCH_SIZE exist in gaia_agent_email.contract
+  - SCHEMA_VERSION stays "2.0" (NOT bumped — this is additive)
+  - The original EmailTriageRequest (payload) / EmailTriageResponse
+    (request_kind/result) are UNCHANGED.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+# EmailTriageAgent ships as the standalone gaia-agent-email wheel (#1102);
+# skip when a framework-only env lacks it.
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.contract import (  # noqa: E402
+    MAX_BATCH_SIZE,
+    SCHEMA_VERSION,
+    BatchItemError,
+    BatchItemResult,
+    BatchTriageRequest,
+    BatchTriageResponse,
+    EmailTriageRequest,
+    EmailTriageResponse,
+    EmailTriageResult,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal builders
+# ---------------------------------------------------------------------------
+
+
+def _single_item() -> dict:
+    """A SingleEmailInput dict for use inside a `items` list."""
+    return {
+        "kind": "single",
+        "principal": {"email": "alice@example.com"},
+        "message": {
+            "message_id": "msg-1",
+            "from": {"name": "Bob", "email": "bob@vendor.com"},
+            "to": [{"email": "alice@example.com"}],
+            "subject": "Q2 invoice",
+            "body": "Please review by Friday.",
+        },
+    }
+
+
+def _thread_item() -> dict:
+    """A ThreadInput dict for use inside a `items` list."""
+    return {
+        "kind": "thread",
+        "principal": {"email": "alice@example.com"},
+        "thread_id": "thread-42",
+        "messages": [
+            {
+                "message_id": "msg-2",
+                "from": {"email": "bob@vendor.com"},
+                "subject": "Renewal call",
+                "body": "Can we hop on a call?",
+            }
+        ],
+    }
+
+
+def _minimal_triage_result() -> EmailTriageResult:
+    return EmailTriageResult.model_validate(
+        {"category": "NEEDS_RESPONSE", "summary": "test summary"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1a — SCHEMA_VERSION must still be "2.0" (NOT bumped)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_still_2_0():
+    """The additive batch endpoint must NOT bump SCHEMA_VERSION."""
+    assert SCHEMA_VERSION == "2.0", (
+        f"SCHEMA_VERSION is {SCHEMA_VERSION!r}; additive change must NOT bump it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1b — MAX_BATCH_SIZE is 100
+# ---------------------------------------------------------------------------
+
+
+def test_max_batch_size_is_100():
+    assert MAX_BATCH_SIZE == 100
+
+
+# ---------------------------------------------------------------------------
+# 1c — BatchTriageRequest with items list validates and round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_batch_triage_request_validates():
+    """BatchTriageRequest accepts an `items` list of EmailInput."""
+    req = BatchTriageRequest.model_validate({"items": [_single_item(), _thread_item()]})
+    assert len(req.items) == 2
+    assert req.items[0].kind == "single"
+    assert req.items[1].kind == "thread"
+    assert req.schema_version == SCHEMA_VERSION
+
+
+def test_batch_triage_request_round_trips():
+    req = BatchTriageRequest.model_validate({"items": [_single_item(), _thread_item()]})
+    dumped = req.model_dump(by_alias=True, mode="json")
+    again = BatchTriageRequest.model_validate(dumped)
+    assert again == req
+
+
+def test_batch_triage_request_with_context():
+    req = BatchTriageRequest.model_validate(
+        {
+            "items": [_single_item()],
+            "context": {
+                "people": ["Boss"],
+                "projects": ["Apollo"],
+                "tone": "concise",
+            },
+        }
+    )
+    assert req.context is not None
+    assert req.context.people == ["Boss"]
+
+
+# ---------------------------------------------------------------------------
+# 1d — BatchTriageResponse with results list validates and round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_batch_triage_response_validates():
+    """BatchTriageResponse accepts a `results` list of BatchItemResult."""
+    result = _minimal_triage_result()
+    item_result = BatchItemResult(index=0, result=result)
+    resp = BatchTriageResponse(results=[item_result])
+    assert len(resp.results) == 1
+    assert resp.results[0].index == 0
+    assert resp.results[0].result is not None
+    assert resp.schema_version == SCHEMA_VERSION
+
+
+def test_batch_triage_response_round_trips():
+    result = _minimal_triage_result()
+    resp = BatchTriageResponse(results=[BatchItemResult(index=0, result=result)])
+    dumped = resp.model_dump(mode="json")
+    again = BatchTriageResponse.model_validate(dumped)
+    assert again == resp
+
+
+# ---------------------------------------------------------------------------
+# 1e — BatchItemResult: exactly-one constraint
+# ---------------------------------------------------------------------------
+
+
+def test_batch_item_result_rejects_both_result_and_error():
+    """A BatchItemResult cannot have both result and error set."""
+    result = _minimal_triage_result()
+    with pytest.raises((ValueError, ValidationError)):
+        BatchItemResult(
+            index=0,
+            result=result,
+            error=BatchItemError(message="something went wrong"),
+        )
+
+
+def test_batch_item_result_rejects_neither_result_nor_error():
+    """A BatchItemResult must have exactly one of result or error."""
+    with pytest.raises((ValueError, ValidationError)):
+        BatchItemResult(index=0)
+
+
+def test_batch_item_result_with_result_only_validates():
+    result = _minimal_triage_result()
+    item = BatchItemResult(index=0, result=result)
+    assert item.result is not None
+    assert item.error is None
+    assert item.index == 0
+
+
+def test_batch_item_result_with_error_only_validates():
+    item = BatchItemResult(index=0, error=BatchItemError(message="LLM unavailable"))
+    assert item.error is not None
+    assert item.result is None
+    assert item.error.message == "LLM unavailable"
+
+
+# ---------------------------------------------------------------------------
+# 1f — BatchTriageRequest rejects empty items
+# ---------------------------------------------------------------------------
+
+
+def test_batch_triage_request_rejects_empty_items():
+    with pytest.raises((ValueError, ValidationError)):
+        BatchTriageRequest.model_validate({"items": []})
+
+
+# ---------------------------------------------------------------------------
+# 1g — BatchTriageRequest rejects over MAX_BATCH_SIZE
+# ---------------------------------------------------------------------------
+
+
+def test_batch_triage_request_rejects_over_max_batch_size():
+    items = [_single_item() for _ in range(MAX_BATCH_SIZE + 1)]
+    with pytest.raises((ValueError, ValidationError)):
+        BatchTriageRequest.model_validate({"items": items})
+
+
+# ---------------------------------------------------------------------------
+# 1h — BatchTriageRequest rejects unknown fields (extra="forbid")
+# ---------------------------------------------------------------------------
+
+
+def test_batch_triage_request_rejects_unknown_field():
+    with pytest.raises((ValueError, ValidationError)):
+        BatchTriageRequest.model_validate(
+            {"items": [_single_item()], "bogus_field": "surprise"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1i — ADDITIVE GUARANTEE: original EmailTriageRequest and EmailTriageResponse
+#      are unchanged (payload, request_kind, result still exist)
+# ---------------------------------------------------------------------------
+
+
+def test_email_triage_request_still_has_payload_field():
+    """Additive guarantee: the single-email EmailTriageRequest.payload is unchanged."""
+    assert "payload" in EmailTriageRequest.model_fields, (
+        "EmailTriageRequest lost its 'payload' field — the additive contract was broken"
+    )
+
+
+def test_email_triage_response_still_has_request_kind():
+    """Additive guarantee: EmailTriageResponse.request_kind is unchanged."""
+    assert "request_kind" in EmailTriageResponse.model_fields, (
+        "EmailTriageResponse lost 'request_kind' — the additive contract was broken"
+    )
+
+
+def test_email_triage_response_still_has_result():
+    """Additive guarantee: EmailTriageResponse.result is unchanged."""
+    assert "result" in EmailTriageResponse.model_fields, (
+        "EmailTriageResponse lost 'result' — the additive contract was broken"
+    )

--- a/tests/unit/agents/email/test_batch_triage_service.py
+++ b/tests/unit/agents/email/test_batch_triage_service.py
@@ -1,0 +1,344 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Batch triage service tests for issue #1887 (ADDITIVE redesign).
+
+These tests verify the NEW triage_batch method and POST /v1/email/triage/batch
+endpoint, added BESIDE the unchanged single-email path.
+
+They FAIL until:
+  - EmailTriageService.triage_batch(request: BatchTriageRequest) is added
+  - POST /v1/email/triage/batch route is added
+  - The single POST /v1/email/triage route still works (regression)
+"""
+
+from __future__ import annotations
+
+import json as _json
+import types as types_mod
+
+import pytest
+
+# EmailTriageAgent ships as the standalone gaia-agent-email wheel (#1102);
+# skip when a framework-only env lacks it.
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.api_routes import (  # noqa: E402
+    EmailTriageService,
+    LLMTriageError,
+)
+from gaia_agent_email.contract import (  # noqa: E402
+    BatchItemResult,
+    BatchTriageRequest,
+)
+
+# ---------------------------------------------------------------------------
+# _CountingFakeChat — counts send_messages calls, injects failure on demand
+# ---------------------------------------------------------------------------
+
+
+class _CountingFakeChat:
+    """Minimal chat stub that counts calls and can inject a failure at a
+    specific call number.
+
+    Each item in the batch makes 2 LLM calls:
+      call 1+2  → item index 0  (classify + summarize)
+      call 3+4  → item index 1
+      call 5+6  → item index 2
+      …
+    Pass fail_on_call=N to raise LLMTriageError on the Nth call.
+    """
+
+    def __init__(self, fail_on_call=None):
+        self._call = 0
+        self._fail_on = fail_on_call
+
+    def send_messages(self, messages, system_prompt="", **kwargs):
+        self._call += 1
+        if self._fail_on is not None and self._call == self._fail_on:
+            raise LLMTriageError("injected failure")
+        resp = types_mod.SimpleNamespace()
+        first = messages[0].get("content", "") if messages else ""
+        resp.text = (
+            _json.dumps(
+                {"category": "NEEDS_RESPONSE", "confidence": 0.9, "reasoning": "t"}
+            )
+            if "Classify" in first
+            else "summary"
+        )
+        return resp
+
+
+# ---------------------------------------------------------------------------
+# Minimal request builders
+# ---------------------------------------------------------------------------
+
+
+def _single_item_dict() -> dict:
+    return {
+        "kind": "single",
+        "principal": {"email": "alice@example.com"},
+        "message": {
+            "message_id": "msg-1",
+            "from": {"name": "Bob", "email": "bob@vendor.com"},
+            "to": [{"email": "alice@example.com"}],
+            "subject": "Q2 invoice",
+            "body": "Please review the attached invoice by Friday.",
+        },
+    }
+
+
+def _thread_item_dict() -> dict:
+    return {
+        "kind": "thread",
+        "principal": {"email": "alice@example.com"},
+        "thread_id": "thread-42",
+        "messages": [
+            {
+                "message_id": "msg-2",
+                "from": {"email": "bob@vendor.com"},
+                "subject": "Renewal",
+                "body": "Can we hop on a call about the renewal?",
+            }
+        ],
+    }
+
+
+def _batch_request(*item_dicts) -> BatchTriageRequest:
+    return BatchTriageRequest.model_validate({"items": list(item_dicts)})
+
+
+# ---------------------------------------------------------------------------
+# Item 3a — 3-item array: all results populated, indices match, no errors
+# ---------------------------------------------------------------------------
+
+
+def test_three_item_array_all_succeed():
+    """A 3-item request returns 3 BatchItemResults, each with a result set."""
+    req = _batch_request(
+        _single_item_dict(), _thread_item_dict(), _single_item_dict()
+    )
+    fake = _CountingFakeChat()
+    service = EmailTriageService()
+    response = service.triage_batch(req, chat=fake)
+
+    results = response.results
+    assert len(results) == 3, f"expected 3 results, got {len(results)}"
+
+    for i, item_result in enumerate(results):
+        assert isinstance(item_result, BatchItemResult)
+        assert item_result.index == i, f"item {i}: wrong index {item_result.index}"
+        assert item_result.result is not None, f"item {i}: result is None"
+        assert item_result.error is None, f"item {i}: unexpected error {item_result.error}"
+
+
+# ---------------------------------------------------------------------------
+# Item 3b — per-item isolation: item 1 fails, items 0 and 2 still succeed
+# ---------------------------------------------------------------------------
+
+
+def test_per_item_isolation_failure_at_item_1():
+    """A failure on item index 1 sets its error; items 0 and 2 still have results."""
+    req = _batch_request(
+        _single_item_dict(), _single_item_dict(), _single_item_dict()
+    )
+    # Each item makes 2 calls: item0→calls1+2, item1→calls3+4, item2→calls5+6.
+    # Failing call 3 triggers an error on item index 1.
+    fake = _CountingFakeChat(fail_on_call=3)
+    service = EmailTriageService()
+    response = service.triage_batch(req, chat=fake)
+
+    results = response.results
+    assert len(results) == 3
+
+    assert results[0].result is not None, "item 0 should have succeeded"
+    assert results[0].error is None, "item 0 should have no error"
+
+    assert results[1].error is not None, "item 1 should have an error"
+    assert results[1].result is None, "item 1 error result should be None"
+
+    assert results[2].result is not None, "item 2 should have succeeded"
+    assert results[2].error is None, "item 2 should have no error"
+
+
+# ---------------------------------------------------------------------------
+# Item 3c — empty items → 422 via TestClient on /triage/batch
+# ---------------------------------------------------------------------------
+
+
+def test_empty_items_returns_422():
+    """POST {"items": []} to /triage/batch is rejected with HTTP 422."""
+    from fastapi.testclient import TestClient
+
+    from gaia_agent_email.export_openapi import build_app
+
+    client = TestClient(build_app())
+    resp = client.post("/v1/email/triage/batch", json={"items": []})
+    assert resp.status_code == 422, (
+        f"expected 422 for empty items list, got {resp.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 3d — old single-endpoint `payload` shape → 422 on /triage/batch
+# ---------------------------------------------------------------------------
+
+
+def test_old_payload_shape_on_batch_returns_422():
+    """A schema-2.0 {payload: …} body POSTed to /triage/batch is rejected with 422."""
+    from fastapi.testclient import TestClient
+
+    from gaia_agent_email.export_openapi import build_app
+
+    client = TestClient(build_app())
+    old_shape = {
+        "payload": {
+            "kind": "single",
+            "principal": {"email": "alice@example.com"},
+            "message": {
+                "message_id": "msg-x",
+                "from": {"email": "bob@vendor.com"},
+                "subject": "old shape",
+                "body": "This uses the single-email payload field.",
+            },
+        }
+    }
+    resp = client.post("/v1/email/triage/batch", json=old_shape)
+    assert resp.status_code == 422, (
+        f"expected 422 for 'payload' shape on batch endpoint, got {resp.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 3e — over MAX_BATCH_SIZE (101 items) → 422 via TestClient
+# ---------------------------------------------------------------------------
+
+
+def test_over_max_batch_size_returns_422():
+    """POST with 101 items to /triage/batch is rejected with HTTP 422."""
+    from fastapi.testclient import TestClient
+
+    from gaia_agent_email.export_openapi import build_app
+
+    client = TestClient(build_app())
+    items = [_single_item_dict() for _ in range(101)]
+    resp = client.post("/v1/email/triage/batch", json={"items": items})
+    assert resp.status_code == 422, (
+        f"expected 422 for 101 items (over MAX_BATCH_SIZE), got {resp.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 3f — Lemonade unreachable → whole-request 502 / LLMTriageError
+# ---------------------------------------------------------------------------
+
+
+def test_lemonade_unreachable_raises_llm_triage_error(monkeypatch):
+    """When Lemonade is unreachable (no chat arg), triage_batch raises LLMTriageError."""
+    import requests as requests_mod
+
+    def _fake_get(url, *args, **kwargs):
+        raise requests_mod.exceptions.ConnectionError("Connection refused")
+
+    monkeypatch.setattr(requests_mod, "get", _fake_get)
+
+    req = _batch_request(_single_item_dict())
+    service = EmailTriageService()
+
+    with pytest.raises(LLMTriageError):
+        service.triage_batch(req)
+
+
+def test_lemonade_unreachable_returns_502_via_test_client(monkeypatch):
+    """The /v1/email/triage/batch endpoint surfaces a Lemonade failure as HTTP 502."""
+    import requests as requests_mod
+    from fastapi.testclient import TestClient
+
+    from gaia_agent_email.export_openapi import build_app
+
+    def _fake_get(url, *args, **kwargs):
+        raise requests_mod.exceptions.ConnectionError("Connection refused")
+
+    monkeypatch.setattr(requests_mod, "get", _fake_get)
+
+    client = TestClient(build_app(), raise_server_exceptions=False)
+    resp = client.post(
+        "/v1/email/triage/batch",
+        json={"items": [_single_item_dict()]},
+    )
+    assert resp.status_code == 502, (
+        f"expected 502 for unreachable Lemonade, got {resp.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# REGRESSION — single-endpoint still returns schema-2.0 {request_kind, result}
+# ---------------------------------------------------------------------------
+
+
+def test_single_triage_endpoint_unchanged_regression(monkeypatch):
+    """REGRESSION: POST to /v1/email/triage still returns {request_kind, result}.
+
+    This proves the additive guarantee: the existing single-email endpoint
+    is untouched by the batch addition.
+    """
+    import types as types_mod2
+    import json as json_mod
+    import requests as requests_mod
+
+    from fastapi.testclient import TestClient
+    from gaia_agent_email.export_openapi import build_app
+
+    # Patch out the Lemonade probe so TestClient doesn't need a running server.
+    # We override triage_request on the service singleton to return a fixed response.
+    from gaia_agent_email import api_routes as ar_mod
+    from gaia_agent_email.contract import (
+        EmailTriageResponse,
+        EmailTriageResult,
+        EmailCategory,
+    )
+
+    _fake_result = EmailTriageResult(
+        category=EmailCategory.NEEDS_RESPONSE,
+        summary="regression test summary",
+        is_spam=False,
+        is_phishing=False,
+    )
+    _fake_response = EmailTriageResponse(
+        request_kind="single",
+        result=_fake_result,
+    )
+
+    original_triage_request = ar_mod.EmailTriageService.triage_request
+
+    def _patched_triage_request(self, request, chat=None):
+        return _fake_response
+
+    monkeypatch.setattr(ar_mod.EmailTriageService, "triage_request", _patched_triage_request)
+
+    client = TestClient(build_app())
+    payload = {
+        "schema_version": "2.0",
+        "payload": {
+            "kind": "single",
+            "principal": {"email": "alice@example.com"},
+            "message": {
+                "message_id": "msg-reg",
+                "from": {"email": "bob@vendor.com"},
+                "subject": "regression",
+                "body": "Check the contract is unchanged.",
+            },
+        },
+    }
+    resp = client.post("/v1/email/triage", json=payload)
+    assert resp.status_code == 200, (
+        f"single /triage endpoint returned {resp.status_code}: {resp.text}"
+    )
+    body = resp.json()
+    # Must have request_kind and result — the schema-2.0 shape
+    assert "request_kind" in body, f"'request_kind' missing from /triage response: {body}"
+    assert "result" in body, f"'result' missing from /triage response: {body}"
+    # Must NOT have a 'results' key (that's the batch shape)
+    assert "results" not in body, (
+        f"single /triage returned batch 'results' key — endpoint was broken: {body}"
+    )

--- a/tests/unit/agents/email/test_batch_triage_service.py
+++ b/tests/unit/agents/email/test_batch_triage_service.py
@@ -115,9 +115,7 @@ def _batch_request(*item_dicts) -> BatchTriageRequest:
 
 def test_three_item_array_all_succeed():
     """A 3-item request returns 3 BatchItemResults, each with a result set."""
-    req = _batch_request(
-        _single_item_dict(), _thread_item_dict(), _single_item_dict()
-    )
+    req = _batch_request(_single_item_dict(), _thread_item_dict(), _single_item_dict())
     fake = _CountingFakeChat()
     service = EmailTriageService()
     response = service.triage_batch(req, chat=fake)
@@ -129,7 +127,9 @@ def test_three_item_array_all_succeed():
         assert isinstance(item_result, BatchItemResult)
         assert item_result.index == i, f"item {i}: wrong index {item_result.index}"
         assert item_result.result is not None, f"item {i}: result is None"
-        assert item_result.error is None, f"item {i}: unexpected error {item_result.error}"
+        assert (
+            item_result.error is None
+        ), f"item {i}: unexpected error {item_result.error}"
 
 
 # ---------------------------------------------------------------------------
@@ -139,9 +139,7 @@ def test_three_item_array_all_succeed():
 
 def test_per_item_isolation_failure_at_item_1():
     """A failure on item index 1 sets its error; items 0 and 2 still have results."""
-    req = _batch_request(
-        _single_item_dict(), _single_item_dict(), _single_item_dict()
-    )
+    req = _batch_request(_single_item_dict(), _single_item_dict(), _single_item_dict())
     # Each item makes 2 calls: item0→calls1+2, item1→calls3+4, item2→calls5+6.
     # Failing call 3 triggers an error on item index 1.
     fake = _CountingFakeChat(fail_on_call=3)
@@ -169,14 +167,13 @@ def test_per_item_isolation_failure_at_item_1():
 def test_empty_items_returns_422():
     """POST {"items": []} to /triage/batch is rejected with HTTP 422."""
     from fastapi.testclient import TestClient
-
     from gaia_agent_email.export_openapi import build_app
 
     client = TestClient(build_app())
     resp = client.post("/v1/email/triage/batch", json={"items": []})
-    assert resp.status_code == 422, (
-        f"expected 422 for empty items list, got {resp.status_code}"
-    )
+    assert (
+        resp.status_code == 422
+    ), f"expected 422 for empty items list, got {resp.status_code}"
 
 
 # ---------------------------------------------------------------------------
@@ -187,7 +184,6 @@ def test_empty_items_returns_422():
 def test_old_payload_shape_on_batch_returns_422():
     """A schema-2.0 {payload: …} body POSTed to /triage/batch is rejected with 422."""
     from fastapi.testclient import TestClient
-
     from gaia_agent_email.export_openapi import build_app
 
     client = TestClient(build_app())
@@ -204,9 +200,9 @@ def test_old_payload_shape_on_batch_returns_422():
         }
     }
     resp = client.post("/v1/email/triage/batch", json=old_shape)
-    assert resp.status_code == 422, (
-        f"expected 422 for 'payload' shape on batch endpoint, got {resp.status_code}"
-    )
+    assert (
+        resp.status_code == 422
+    ), f"expected 422 for 'payload' shape on batch endpoint, got {resp.status_code}"
 
 
 # ---------------------------------------------------------------------------
@@ -217,15 +213,14 @@ def test_old_payload_shape_on_batch_returns_422():
 def test_over_max_batch_size_returns_422():
     """POST with 101 items to /triage/batch is rejected with HTTP 422."""
     from fastapi.testclient import TestClient
-
     from gaia_agent_email.export_openapi import build_app
 
     client = TestClient(build_app())
     items = [_single_item_dict() for _ in range(101)]
     resp = client.post("/v1/email/triage/batch", json={"items": items})
-    assert resp.status_code == 422, (
-        f"expected 422 for 101 items (over MAX_BATCH_SIZE), got {resp.status_code}"
-    )
+    assert (
+        resp.status_code == 422
+    ), f"expected 422 for 101 items (over MAX_BATCH_SIZE), got {resp.status_code}"
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +248,6 @@ def test_lemonade_unreachable_returns_502_via_test_client(monkeypatch):
     """The /v1/email/triage/batch endpoint surfaces a Lemonade failure as HTTP 502."""
     import requests as requests_mod
     from fastapi.testclient import TestClient
-
     from gaia_agent_email.export_openapi import build_app
 
     def _fake_get(url, *args, **kwargs):
@@ -266,9 +260,9 @@ def test_lemonade_unreachable_returns_502_via_test_client(monkeypatch):
         "/v1/email/triage/batch",
         json={"items": [_single_item_dict()]},
     )
-    assert resp.status_code == 502, (
-        f"expected 502 for unreachable Lemonade, got {resp.status_code}"
-    )
+    assert (
+        resp.status_code == 502
+    ), f"expected 502 for unreachable Lemonade, got {resp.status_code}"
 
 
 # ---------------------------------------------------------------------------
@@ -282,21 +276,17 @@ def test_single_triage_endpoint_unchanged_regression(monkeypatch):
     This proves the additive guarantee: the existing single-email endpoint
     is untouched by the batch addition.
     """
-    import types as types_mod2
-    import json as json_mod
-    import requests as requests_mod
-
     from fastapi.testclient import TestClient
-    from gaia_agent_email.export_openapi import build_app
 
-    # Patch out the Lemonade probe so TestClient doesn't need a running server.
-    # We override triage_request on the service singleton to return a fixed response.
+    # Override triage_request on the service to return a fixed response, so the
+    # TestClient exercises the route shape without a running Lemonade server.
     from gaia_agent_email import api_routes as ar_mod
     from gaia_agent_email.contract import (
+        EmailCategory,
         EmailTriageResponse,
         EmailTriageResult,
-        EmailCategory,
     )
+    from gaia_agent_email.export_openapi import build_app
 
     _fake_result = EmailTriageResult(
         category=EmailCategory.NEEDS_RESPONSE,
@@ -314,7 +304,9 @@ def test_single_triage_endpoint_unchanged_regression(monkeypatch):
     def _patched_triage_request(self, request, chat=None):
         return _fake_response
 
-    monkeypatch.setattr(ar_mod.EmailTriageService, "triage_request", _patched_triage_request)
+    monkeypatch.setattr(
+        ar_mod.EmailTriageService, "triage_request", _patched_triage_request
+    )
 
     client = TestClient(build_app())
     payload = {
@@ -331,14 +323,16 @@ def test_single_triage_endpoint_unchanged_regression(monkeypatch):
         },
     }
     resp = client.post("/v1/email/triage", json=payload)
-    assert resp.status_code == 200, (
-        f"single /triage endpoint returned {resp.status_code}: {resp.text}"
-    )
+    assert (
+        resp.status_code == 200
+    ), f"single /triage endpoint returned {resp.status_code}: {resp.text}"
     body = resp.json()
     # Must have request_kind and result — the schema-2.0 shape
-    assert "request_kind" in body, f"'request_kind' missing from /triage response: {body}"
+    assert (
+        "request_kind" in body
+    ), f"'request_kind' missing from /triage response: {body}"
     assert "result" in body, f"'result' missing from /triage response: {body}"
     # Must NOT have a 'results' key (that's the batch shape)
-    assert "results" not in body, (
-        f"single /triage returned batch 'results' key — endpoint was broken: {body}"
-    )
+    assert (
+        "results" not in body
+    ), f"single /triage returned batch 'results' key — endpoint was broken: {body}"

--- a/tests/unit/agents/email/test_playground.py
+++ b/tests/unit/agents/email/test_playground.py
@@ -55,6 +55,7 @@ class TestPlaygroundHtml:
         for path in (
             '"/v1/email/version"',
             '"/v1/email/triage"',
+            '"/v1/email/triage/batch"',
             '"/v1/email/draft"',
             '"/v1/email/init"',
             '"/v1/email/send"',

--- a/tests/unit/agents/email/test_spec_html.py
+++ b/tests/unit/agents/email/test_spec_html.py
@@ -285,10 +285,14 @@ def test_type_label_unwraps_optional():
 def test_no_truncated_list_label_in_html():
     # The whole page must never contain a truncated 'list[Something' without a
     # closing bracket (the _type_label bracket-ordering bug). Every 'list['
-    # generic that opens must close with ']'.
+    # generic that opens must close with ']'. The inner may be a single type
+    # (list[EmailAddress]) or a union (list[SingleEmailInput | ThreadInput]),
+    # so we require a ']' before the next '<' (HTML tag) — never an unclosed run.
     html = _html()
-    for m in re.finditer(r"list\[[A-Za-z_]+(.?)", html):
-        assert m.group(1) == "]", f"Unclosed list[ label near: {m.group(0)!r}"
+    for m in re.finditer(r"list\[([^\]<]*)(.?)", html):
+        assert m.group(2) == "]", (
+            f"Unclosed list[ label near: {m.group(0)!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/email/test_spec_html.py
+++ b/tests/unit/agents/email/test_spec_html.py
@@ -290,9 +290,7 @@ def test_no_truncated_list_label_in_html():
     # so we require a ']' before the next '<' (HTML tag) — never an unclosed run.
     html = _html()
     for m in re.finditer(r"list\[([^\]<]*)(.?)", html):
-        assert m.group(2) == "]", (
-            f"Unclosed list[ label near: {m.group(0)!r}"
-        )
+        assert m.group(2) == "]", f"Unclosed list[ label near: {m.group(0)!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1887

**Before:** the email triage surface handled one email (or thread) per call — `POST /v1/email/triage` takes a single `payload` and returns a single `result`, so triaging an inbox meant one HTTP round-trip per message. **After:** a **new** `POST /v1/email/triage/batch` accepts an array (`items: […]`) and returns one structured result per item (`results: […]`, order-preserved, 1:1), with per-item errors isolated so one bad message doesn't sink the batch. A single email is simply an array of one.

This is **purely additive** — the existing single `/triage` endpoint, its schema (`2.0`), the MCP `triage_email` tool, the npm `triage()` method, and every existing consumer are **untouched**. Callers opt into batch when they want it. No migration; schema stays `2.0`; package bumps `0.2.5 → 0.3.0` (additive minor).

## What's added (beside the unchanged single path)
- New `POST /v1/email/triage/batch` with a sequential, per-item-isolated service loop; a new MCP `triage_email_batch` tool; an npm `triageBatch()` method + batch types.
- Regenerated `openapi.email.json` (now carries both routes), `specification.html`, and a playground batch probe.
- Docs: a "Batch endpoint" section beside the unchanged single contract in `docs/spec/email-contract.mdx` and npm `README`/`SPEC`/`SKILL`, plus `0.3.0` additive `CHANGELOG` entries (no breaking callout).

## Test plan
- [x] **Single endpoint unchanged** — `git diff main` shows **zero deletions** to `triage_request` / the `/triage` route / `triage_email` (MCP) / `triage()` (npm); a regression test confirms `POST /v1/email/triage` still returns `{request_kind, result}` at schema 2.0. All existing single-path tests stay green untouched.
- [x] **Batch** — new `test_batch_contract.py` + `test_batch_triage_service.py` + an **MCP↔REST parity test** (`test_batch_parity`, driving `{items:[…]}` through the real MCP stdio subprocess and the REST path and asserting identical `results[]`): 3-item mixed (single+thread) array → ordered `results` with `results[i].index == i`; per-item isolation (a stateful fake fails item 1, items 0 & 2 still succeed); empty / over-100 / wrong-shape (`{payload}`) → `422`; envelope-level `502` when Lemonade is unreachable. **602 email tests pass.**
- [x] `export_openapi --check`, `stamp_version.py --check`, npm `build` + `test` (47/47), `util/lint.py --all` — all green. `SCHEMA_VERSION` stays `2.0`.
- [x] **Real-world on AMD Strix Halo** (gemma-4-E4B on GPU) — see Evidence; proves the single endpoint is unchanged *and* the batch endpoint works.

## Real-world evidence — AMD Strix Halo (Ryzen AI MAX+ 395, RDNA 3.5 iGPU), `gemma-4-E4B-it-GGUF` on GPU

Branch `@526e42f8` deployed; `gaia-agent-email 0.3.0` installed editable (resolution **verified in-tree**); 25 batch tests pass; `gaia api` up on `:8080`, both routes serving; inference on the GPU-loaded gemma-4-e4b (~53–57 tok/s).

**(A) The single `/triage` endpoint is UNCHANGED** — old `{payload}` body still returns the 2.0 `{request_kind, result}` shape:

```
POST /v1/email/triage   {"schema_version":"2.0","payload":{"kind":"single", … "subject":"Quick question on the Q3 report" …}}
→ HTTP 200
{"schema_version":"2.0","request_kind":"single","result":{"category":"NEEDS_RESPONSE","suggested_action":"reply", … "message_id":"s1"}}
```

**(B) The new `/triage/batch` endpoint — 3-item mixed array (2 single + 1 thread) → 3 ordered results (HTTP 200):**

<details>
<summary>response — categories correct (URGENT / PROMOTIONAL / FYI)</summary>

```json
{"schema_version":"2.0","results":[
  {"index":0,"result":{"category":"URGENT","suggested_action":"reply","message_id":"b1",
     "summary":"Immediate action is required because the production database has been unreachable…"},"error":null},
  {"index":1,"result":{"category":"PROMOTIONAL","suggested_action":"archive","message_id":"b2",
     "summary":"A 50% off sale on all items is running this weekend only; use code SAVE50…"},"error":null},
  {"index":2,"result":{"category":"FYI","suggested_action":"none","message_id":"thread-99",
     "summary":"Thread of 2 messages. The recipient confirmed attendance at the Friday team lunch…"},"error":null}
]}
```
`results.length == 3`, `results[i].index == i`, every `result` populated, `error: null` — order-preserved, correct live classification on the GPU model.
</details>

**Breaking-shape guards on the batch endpoint:** empty `items` → `422` (*"List should have at least 1 item"*); the single-endpoint `{payload}` body POSTed to `/triage/batch` → `422` (missing `items` + forbidden `payload`).

Per-item **error isolation** is unit-proven (`test_per_item_isolation_failure_at_item_1`); a natural input couldn't force a live LLM exception, so it was not fabricated on the live path.

| Endpoint | HTTP | Time |
|---|---|---|
| `/triage` single (A) | 200 | 13.2s |
| `/triage/batch` 3-item (B) | 200 | 47.2s (~53–57 tok/s) |
| batch empty / wrong-shape (C/D) | 422 | <10ms |
