### PR TITLE
Release v0.22.0

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -494,6 +494,7 @@
             "group": "Release Notes",
             "pages": [
               "releases/index",
+              "releases/v0.22.0",
               "releases/v0.21.2",
               "releases/v0.21.1",
               "releases/v0.21.0",
@@ -552,7 +553,7 @@
   "navbar": {
     "links": [
       {
-        "label": "v0.21.2 \u00b7 Lemonade 10.7.0",
+        "label": "v0.22.0 \u00b7 Lemonade 10.8.1",
         "href": "https://github.com/amd/gaia/releases"
       },
       {

--- a/docs/releases/v0.22.0.mdx
+++ b/docs/releases/v0.22.0.mdx
@@ -1,0 +1,212 @@
+---
+title: "v0.22.0"
+description: "The email agent now runs inside the Agent UI as a no-Node sidecar with batch triage, search, archive, and calendar on the REST contract — plus persistent default models, an NPU context-size fix, and an opt-in dynamic tool loader."
+---
+
+# GAIA v0.22.0 Release Notes
+
+GAIA v0.22.0 brings the email triage agent fully into the Agent UI. It now runs as
+an out-of-process sidecar — no Node.js or npm on the runtime path — so the Agent UI
+stays lean while the email agent gets its own REST surface: batch triage, inbox
+search, pre-scan, archive/quarantine, and calendar all land on the same contract.
+Alongside that, `gaia config` gets a persistent default model, the NPU profile's
+context-size bug is fixed, and a Beta dynamic-tools toggle speeds up the Doc Agent's
+first response.
+
+**Why upgrade:**
+- **Email triage runs natively in the Agent UI, with no Node.js dependency** — the
+  email agent now runs as a managed sidecar process the backend spawns, health-checks,
+  and tree-kills on exit, so heavy email deps never load into core.
+- **Triage a whole inbox in one call** — a new batch endpoint takes an array of
+  emails and returns categorized results in the same order, instead of one
+  request per message.
+- **Search, archive, quarantine, and calendar now have a REST contract** — the email
+  schema grows from triage-only to a full inbox surface, with confirmation-gated
+  destructive actions.
+- **Set your default model once** — `gaia config set default_model <id>` persists
+  across every model-bearing command, so you stop passing `--model` everywhere.
+- **NPU profile context fixed** — the NPU profile was silently capping context at
+  4096 tokens regardless of what the model supported; it now defaults to 32768.
+
+---
+
+## What's New
+
+### Email triage in the Agent UI, no Node.js required — `gaia chat --ui`
+
+The Agent UI could previously only run the email agent in-process, which meant
+pulling its dependencies straight into core. Now the backend runs it as a separate
+sidecar process: it fetches the agent binary (SHA-256 verified), spawns it on an
+ephemeral port, health-checks it, proxies every `/v1/email/*` request to it, and
+tree-kills it the moment the parent process exits or crashes — so nothing is ever
+left orphaned. A `dev` mode runs the same contract straight from source with hot
+reload, for anyone iterating on the agent itself. Try it: open the Agent UI and
+trigger an email triage from the chat — the rest happens automatically. (PR
+[#1884](https://github.com/amd/gaia/pull/1884))
+
+---
+
+### Triage a whole inbox in one call — batch triage endpoint
+
+Triaging more than one email used to mean one HTTP round-trip per message. The REST
+contract now has `POST /v1/email/triage/batch`: send an array of emails, get back
+an array of results in the same order, each with its own category, action items,
+and per-item error handling if one message fails. Useful for catching up on a
+backlog without hammering the API one email at a time. (PR
+[#1893](https://github.com/amd/gaia/pull/1893))
+
+---
+
+### Search, pre-scan, archive, quarantine, and calendar — email schema 2.1
+
+The email REST contract grows well past triage. It now exposes inbox search,
+a lightweight pre-scan summary, archive/unarchive, quarantine/unquarantine for
+phishing or spam, and calendar event listing, preview, creation, and RSVP — all on
+the same `/v1/email/*` surface. Destructive actions like archive require an explicit
+confirmation token, and any route that needs a connected mailbox fails loudly with
+an actionable message instead of guessing. (PR
+[#1883](https://github.com/amd/gaia/pull/1883))
+
+---
+
+### Persistent default model — `gaia config`
+
+Passing `--model` on every command gets old fast. `gaia config set default_model
+<id>` now persists a default to `~/.gaia/config.json`, applied automatically to
+every model-bearing command until overridden by an explicit `--model` flag. Check
+the current value any time with `gaia config show`. (PR
+[#1863](https://github.com/amd/gaia/pull/1863))
+
+---
+
+### Opt-in faster first response — Dynamic Tools (Beta)
+
+The Doc Agent's first response can now skip past a stale or oversized tool list. A
+new Beta toggle in Agent UI settings trims each turn's tool list to a
+semantically-matched subset before the first model call. It's off by default, and
+an environment override (`GAIA_DYNAMIC_TOOLS`) can lock it on or off for a given
+install. (PR [#1857](https://github.com/amd/gaia/pull/1857))
+
+---
+
+## Bug Fixes
+
+- **NPU profile silently capped context at 4096 tokens** (PR
+  [#1747](https://github.com/amd/gaia/pull/1747)) — the NPU profile's FastFlowLM
+  model defaulted to a 4096-token context window no matter what the model actually
+  supported; it now defaults to 32768, matching the rest of the model lineup.
+- **Email triage send errors returned an opaque 500** (PR
+  [#1878](https://github.com/amd/gaia/pull/1878)) — a failure at send time now
+  surfaces as an actionable HTTP error instead of a generic server fault.
+- **Stale email-triage taxonomy in the eval corpus** (PR
+  [#1875](https://github.com/amd/gaia/pull/1875)) — the eval corpus is relabeled to
+  the schema-2.0 5-bucket taxonomy so eval scores reflect the categories triage
+  actually returns.
+- **Lemonade Server pinned to 10.8.1** (PRs
+  [#1869](https://github.com/amd/gaia/pull/1869),
+  [#1868](https://github.com/amd/gaia/pull/1868),
+  [#1867](https://github.com/amd/gaia/pull/1867)) — Windows CI's Lemonade startup is
+  fixed for the post-10.5 binary (the `serve` shim was removed), and the pinned
+  server version is bumped to pick up upstream fixes.
+
+---
+
+## Real-world testing evidence
+
+Every feature above was exercised on real AMD hardware before this release —
+not just unit tests. Summary below; full command output is in the release PR
+description.
+
+| Feature | Hardware | Result |
+|---|---|---|
+| Persistent default model | Strix Halo (NPU) | Set → persisted → overwritten, clean |
+| Email single + batch triage | Radeon GPU + Strix Halo | Both machines, real Lemonade inference |
+| Email schema 2.1 (18 routes) | Radeon GPU | All routes present; confirmation-gated archive (403 without token); fail-loud 503 on missing mailbox |
+| NPU 32k context | Strix Halo (cold NPU load) | `gaia init --profile npu` confirmed `ctx_size: 32768` on `gemma4-it-e2b-FLM`, live inference verified |
+| Email sidecar lifecycle | Radeon GPU | Lazy spawn, health-check, proxied triage, and clean tree-kill on shutdown all confirmed in dev mode |
+| Dynamic Tools toggle | Radeon GPU (Ubuntu, browser) | Toggled on/off in the live Agent UI, state persisted via the settings API |
+
+---
+
+## Full Changelog
+
+**76 commits** since v0.21.2:
+
+- `50c17de6` — feat(ui): Node-free email-agent sidecar with user/dev modes (#1884)
+- `1e45ff3c` — test(eval): vendor-derived email-triage corpus (PERSONAL coverage + balanced 5-bucket) (#1902)
+- `49805125` — feat(eval): acceptance metric + trustworthy scorecard/gate for email triage (#1901)
+- `dbe2764c` — feat(cli): persistent default_model via gaia config (#98) (#1863)
+- `f26ded9a` — docs(guides): reorganize User Guides nav, fill stubs, trim bloated guides (#1865)
+- `7f52903b` — feat(email): expose search, pre-scan, archive/quarantine & calendar on the REST contract (schema 2.1) (#1883)
+- `98e9a0a1` — feat(email): add batch triage endpoint alongside the single-email API (array in / array out) (#1893)
+- `7a82ed92` — docs(plans): email agent in the Agent UI — frozen sidecar + user/dev modes (#1882)
+- `dbe0fc46` — feat(eval): per-agent per-version eval scorecard + release gate (#1873)
+- `fa4280eb` — ci(stx): manual driver-update workflow for the self-hosted AMD runner (#1881)
+- `390361e9` — refactor(agents): migrate chat to hub (#1102) (#1456)
+- `21fff02e` — refactor(agents): migrate docqa + routing to hub (#1102) (#1455)
+- `1d6b71e8` — chore(agent-email): cut 0.2.5 (#1879)
+- `f7d8e418` — fix(email): surface send-time connector errors as actionable HTTP, not 500 (#1878)
+- `e3794410` — fix(eval): relabel email triage corpus to schema-2.0 5-bucket taxonomy (#1875)
+- `a0e3e723` — fix(npu): default 32k context on NPU profile, resolving the 4096↔32768 mismatch (#1747)
+- `0a4e2e18` — docs: add Prerequisites block to memory guide (#1665)
+- `8589f897` — feat(skill): GAIA technical + executive presentation skills (print-ready HTML→PDF) (#1860)
+- `d24c6613` — docs(reset-lemonade): bump stale 10.7.0 fallback to 10.8.1 (#1870)
+- `bd4b2606` — feat(lemonade): upgrade pinned Lemonade Server to 10.8.1 (#1869)
+- `c1bb70ff` — ci(windows): fix Lemonade port binding for the two integration jobs (#1867)
+- `9d82e9e9` — ci(lemonade): start server via LemonadeServer.exe --port (shim removed in v10.5) (#1868)
+- `25e5d528` — feat(skills): add integrate-hub-agent skill for embedding hub agents (#1864)
+- `0436f16a` — test(tool-loader): pin #800 doc-profile data-vs-recall disambiguation (#1844)
+- `88b93286` — feat(ui): add Beta dynamic tools toggle to Agent UI settings (#1798) (#1857)
+- `380cbb5b` — feat(hub): Files (package listing), Spec & Skill doc tabs on the agent page (#1856)
+- `5803b6d4` — fix(hub): revert worker streaming + disable whole-package zip; cut email 0.2.4 (#1855)
+- `4ae68e5e` — chore(agent-email): cut 0.2.3 (re-cut of 0.2.2 after Hub worker redeploy) (#1854)
+- `d71ad3f8` — docs(copilot): add repository instructions bridge (#1853)
+- `ccceea65` — chore(agent-email): cut 0.2.2 (first complete publish of the 0.2.1 feature set) (#1851)
+- `a268d1bc` — fix(hub): stream large artifacts to R2 so the whole-package zip publish stops OOMing (502) (#1849)
+- `22cbcd17` — feat(agent-email): one-command playground launcher + live hub launch card (#1846)
+- `f2d4eb1c` — feat(hub): whole-package zip download + file list on the agent page (#1843)
+- `758fdb31` — ci(claude): correctness-first PR-review rubric (REVIEW.md) base-fetched into the bot (#1845)
+- `e95cb2c9` — feat(agent-email): auto-reap sidecar on parent exit/crash (no manual wiring) (#1841)
+- `f73995eb` — docs(claude): functional changes must sync all bundled docs (README/SPEC/SKILL/CHANGELOG) (#1842)
+- `7be5571f` — docs(integrations): add Guarding the model endpoint (offline I/O guard for Lemonade) (#1809)
+- `f8342e8f` — feat(hub): production agent docs, changelog channel & richer hub rendering (#1839)
+- `34a43108` — docs(quickstart): pin first-agent example to the installed Gemma model (#1835)
+- `cea4c471` — release(agent-email): 0.2.1 (#1838)
+- `9cbb7576` — fix(hub): single npm README + fresh catalog on deploy + version on cards (#1836)
+- `65ff0eec` — feat(tool-loader): load recalled skills' tools ahead of semantic (#1451) (#1837)
+- `853e4930` — fix(agent-email): use in-repo raw image for README architecture diagram (#1833)
+- `bfb7d155` — refactor(agent-email): address review nits from #1829 (connector routes) (#1830)
+- `e7cd4a5a` — fix(email): refresh backends before multi-mailbox scans (#1808)
+- `1d720fcd` — feat(agent-email): playground mailbox connectors + live send (#1829)
+- `ef1c53d2` — test(guard): fail CI on stale migrated-agent paths in AI-instruction files (#1793)
+- `f7163242` — feat(ci): let contributors self-assign issues via `.take` comment (#1827)
+- `7906c66a` — Fix extract_json_from_text dropping JSON with a brace in a string value (#1824)
+- `a8f414ea` — feat(agent-email): single-source version stamping + publish-time --check (bump 0.2.0) (#1822)
+- `4fd499e9` — docs(agent-email): document ./client browser entry, ESM-only, and contract 2.0 (#1776)
+- `a8f0670a` — fix(memory): reconcile procedures by meaning, not exact name (#1818) (#1828)
+- `373b40a3` — docs(quickstart): clarify where to save the agent file per install path (#1826)
+- `54494fc6` — feat(memory): skill auto-synthesis — procedural memory layer (#887) (#1794)
+- `616803cb` — ci(claude): two-part bot output — human summary + collapsed technical details (#1787)
+- `29f36862` — docs(skill): add agent-hub-release skill for publishing sidecar agents (#1777)
+- `4574523f` — fix(agent): correct stale default-model comment (Gemma → Qwen3.5-35B-A3B) (#1810)
+- `45e233d8` — feat(hub): sidecar-served email-agent playground (localhost-only) (#1796) (#1814)
+- `1cb62656` — chore(email): disable in-process email agent discovery (entry point) (#1816)
+- `38c4ec29` — fix(agent-email/npm): bind EmailClient fetch to globalThis (browser Illegal invocation) (#1817)
+- `b9a2bd01` — docs(hub-publishing): use uv pip as the canonical install tool (#1782)
+- `2aace9f2` — docs(skills): refresh lemonade-client + gaia-release against current code (#1786)
+- `7e8632ee` — fix(agent-email): align version-triple to 0.2.0 (unblocks next release) (#1792)
+- `cd0b5529` — docs(agents): de-stale the 23 .claude/agents definitions against current code (#1790)
+- `26dfa67b` — docs(claude): de-stale agent tables + trim stale-prone enumerations in CLAUDE.md (#1784)
+- `3b489096` — docs: fix Mintlify MDX validation (unescaped '<' breaks the docs check) (#1791)
+- `ffdff615` — feat(agents): tool loader Part 2 — explicit escape hatch + tuning (#1450) (#1762)
+- `620b2ba1` — fix(electron): keep app alive on recoverable GPU-process crash (#1799)
+- `35cea1b9` — fix(memory): coerce string-typed days/limit in search_past_conversations (#1764)
+- `fbe00da4` — fix(connectors): make email AGENT_NOT_GRANTED message provider-aware (#1757)
+- `0d5bf4c0` — docs(plans): scope agent-ui Agent Hub publishing + in-app marketplace (#1714)
+- `e9dd58fb` — feat(ui): preserve email connector grant + scope consent under Path 2 (incl. Outlook CTA) (#1775)
+- `3ea793db` — feat(ui): serve email from the UI backend — mount gaia-agent-email REST router (Path 2) (#1774)
+- `42d92c32` — feat(agent-email/npm): browser-safe client-only entry (no Node builtins) (#1773)
+- `004522fa` — test(email): running-server OpenAPI conformance + apiVersion bump policy (#1772)
+- `abcd7809` — fix(agent-email/npm): regenerate JS/TS client to email contract 2.0 (#1771)
+
+Full Changelog: [v0.21.2...v0.22.0](https://github.com/amd/gaia/compare/v0.21.2...v0.22.0)

--- a/docs/releases/v0.22.0.mdx
+++ b/docs/releases/v0.22.0.mdx
@@ -197,7 +197,7 @@ description.
 - `7e8632ee` — fix(agent-email): align version-triple to 0.2.0 (unblocks next release) (#1792)
 - `cd0b5529` — docs(agents): de-stale the 23 .claude/agents definitions against current code (#1790)
 - `26dfa67b` — docs(claude): de-stale agent tables + trim stale-prone enumerations in CLAUDE.md (#1784)
-- `3b489096` — docs: fix Mintlify MDX validation (unescaped '<' breaks the docs check) (#1791)
+- `3b489096` — docs: fix Mintlify MDX validation (unescaped &#39;&lt;&#39; breaks the docs check) (#1791)
 - `ffdff615` — feat(agents): tool loader Part 2 — explicit escape hatch + tuning (#1450) (#1762)
 - `620b2ba1` — fix(electron): keep app alive on recoverable GPU-process crash (#1799)
 - `35cea1b9` — fix(memory): coerce string-typed days/limit in search_past_conversations (#1764)

--- a/docs/releases/v0.22.0.mdx
+++ b/docs/releases/v0.22.0.mdx
@@ -1,14 +1,16 @@
 ---
 title: "v0.22.0"
-description: "The email agent now runs inside the Agent UI as a no-Node sidecar with batch triage, search, archive, and calendar on the REST contract — plus persistent default models, an NPU context-size fix, and an opt-in dynamic tool loader."
+description: "The email agent now runs inside the Agent UI as a no-Node sidecar — triage and batch triage verified end-to-end, with search, archive, and calendar added to the REST contract (connector-gated) — plus persistent default models, an NPU context-size fix, and an opt-in dynamic tool loader."
 ---
 
 # GAIA v0.22.0 Release Notes
 
 GAIA v0.22.0 brings the email triage agent fully into the Agent UI. It now runs as
 an out-of-process sidecar — no Node.js or npm on the runtime path — so the Agent UI
-stays lean while the email agent gets its own REST surface: batch triage, inbox
-search, pre-scan, archive/quarantine, and calendar all land on the same contract.
+stays lean while the email agent gets its own REST surface. Triage and batch triage
+are verified end-to-end on AMD hardware; inbox search, pre-scan, archive/quarantine,
+and calendar are added to the same contract and fail loudly until a Gmail or
+Microsoft mailbox is connected.
 Alongside that, `gaia config` gets a persistent default model, the NPU profile's
 context-size bug is fixed, and a Beta dynamic-tools toggle speeds up the Doc Agent's
 first response.
@@ -20,9 +22,10 @@ first response.
 - **Triage a whole inbox in one call** — a new batch endpoint takes an array of
   emails and returns categorized results in the same order, instead of one
   request per message.
-- **Search, archive, quarantine, and calendar now have a REST contract** — the email
-  schema grows from triage-only to a full inbox surface, with confirmation-gated
-  destructive actions.
+- **Search, archive, quarantine, and calendar added to the REST contract** — the
+  email schema grows from triage-only to a full inbox surface, with
+  confirmation-gated destructive actions. These routes require a connected
+  mailbox; without one they fail loudly with an actionable 503.
 - **Set your default model once** — `gaia config set default_model <id>` persists
   across every model-bearing command, so you stop passing `--model` everywhere.
 - **NPU profile context fixed** — the NPU profile was silently capping context at
@@ -41,7 +44,9 @@ ephemeral port, health-checks it, proxies every `/v1/email/*` request to it, and
 tree-kills it the moment the parent process exits or crashes — so nothing is ever
 left orphaned. A `dev` mode runs the same contract straight from source with hot
 reload, for anyone iterating on the agent itself. Try it: open the Agent UI and
-trigger an email triage from the chat — the rest happens automatically. (PR
+trigger an email triage from the chat — the backend spawns and proxies to the
+sidecar automatically. (Search, archive, and calendar require a connected Gmail
+or Microsoft mailbox.) (PR
 [#1884](https://github.com/amd/gaia/pull/1884))
 
 ---
@@ -64,7 +69,10 @@ a lightweight pre-scan summary, archive/unarchive, quarantine/unquarantine for
 phishing or spam, and calendar event listing, preview, creation, and RSVP — all on
 the same `/v1/email/*` surface. Destructive actions like archive require an explicit
 confirmation token, and any route that needs a connected mailbox fails loudly with
-an actionable message instead of guessing. (PR
+an actionable 503 instead of guessing. For this release, search, archive,
+quarantine, and calendar were verified at the contract level (route shape,
+confirmation-gating, fail-loud); their behavior against live mail is exercised
+once a connector is configured. (PR
 [#1883](https://github.com/amd/gaia/pull/1883))
 
 ---
@@ -120,8 +128,8 @@ description.
 | Feature | Hardware | Result |
 |---|---|---|
 | Persistent default model | Strix Halo (NPU) | Set → persisted → overwritten, clean |
-| Email single + batch triage | Radeon GPU + Strix Halo | Both machines, real Lemonade inference |
-| Email schema 2.1 (18 routes) | Radeon GPU | All routes present; confirmation-gated archive (403 without token); fail-loud 503 on missing mailbox |
+| Email triage (single + batch), agent loop | Strix Halo + Radeon GPU | `gaia eval benchmark` — real LLM tool-calling loop over a synthetic mailbox (FakeGmailBackend), real Lemonade inference |
+| Email schema 2.1 — search / archive / quarantine / calendar | Radeon GPU | Contract-level only: all routes present; archive 403 without token; fail-loud 503 on no connected mailbox. Live-mail behavior connector-gated, not exercised this release |
 | NPU 32k context | Strix Halo (cold NPU load) | `gaia init --profile npu` confirmed `ctx_size: 32768` on `gemma4-it-e2b-FLM`, live inference verified |
 | Email sidecar lifecycle | Radeon GPU | Lazy spawn, health-check, proxied triage, and clean tree-kill on shutdown all confirmed in dev mode |
 | Dynamic Tools toggle | Radeon GPU (Ubuntu, browser) | Toggled on/off in the live Agent UI, state persisted via the settings API |

--- a/src/gaia/apps/webui/package-lock.json
+++ b/src/gaia/apps/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-ui",
-      "version": "0.21.2",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.3"

--- a/src/gaia/apps/webui/package.json
+++ b/src/gaia/apps/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-ui",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "type": "module",
   "productName": "GAIA Agent UI",
   "description": "Privacy-first agentic AI interface with document Q&A - runs 100% locally on AMD Ryzen AI",

--- a/src/gaia/version.py
+++ b/src/gaia/version.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from importlib.metadata import version as get_package_version_metadata
 
-__version__ = "0.21.2"
+__version__ = "0.22.0"
 
 # Lemonade version used across CI and installer
 LEMONADE_VERSION = "10.8.1"


### PR DESCRIPTION
# GAIA v0.22.0 Release Notes

Cuts the **v0.22.0** minor release. The headline: the email triage agent now runs inside the Agent UI as an out-of-process **sidecar** — no Node.js or npm on the runtime path. Triage and batch triage are verified end-to-end through the real agent tool-calling loop; the REST contract also grows to cover search, pre-scan, archive/quarantine, and calendar, verified at the contract level (route shape, confirmation-gating, fail-loud) — their behavior against live mail requires a connected Gmail or Microsoft account, which wasn't available in this test pass.

Alongside that: `gaia config` gets a persistent default model, the NPU profile's context-size bug (silently capped at 4096 tokens) is fixed to 32768, and a Beta dynamic-tools toggle speeds up the Doc Agent's first response.

Full, commit-by-commit notes live in [`docs/releases/v0.22.0.mdx`](docs/releases/v0.22.0.mdx) — that file is the source of truth and is kept in sync with the `v0.21.2..HEAD` range.

## Real-world testing evidence

Every feature in this release was exercised on real AMD hardware (Strix Halo NPU + Radeon GPU) before merging — not just unit tests. Full command transcripts below.

<details>
<summary>🧪 gaia config — persistent default_model (#1863) — Strix Halo</summary>

```
$ gaia config show
Config file: /home/tomas/.gaia/config.json
  profile = npu
  default_device = npu
  default_model = (unset)

$ gaia config set default_model Qwen3.5-35B-A3B-GGUF
✅ Set default_model = Qwen3.5-35B-A3B-GGUF
   Saved to /home/tomas/.gaia/config.json

$ gaia config show
  default_model = Qwen3.5-35B-A3B-GGUF   # persisted ✓

$ gaia config set default_model Gemma-4-E4B-it-GGUF
✅ Set default_model = Gemma-4-E4B-it-GGUF   # overwrite ✓
```
</details>

<details>
<summary>🧪 Email triage — REST contract, single + batch (#1884, #1893) — Radeon GPU + Strix Halo NPU</summary>

Single triage (Radeon, real Lemonade inference):
```
POST /v1/email/triage
{"schema_version":"2.1","result":{"category":"URGENT","action_items":[
  {"description":"Please review the attached budget proposal by EOD today."}],
  "usage":{"total_tokens":895,"tokens_per_second":128.0}}}
```

Batch triage (Strix Halo, two emails, order-preserved):
```
POST /v1/email/triage/batch  {"items":[...]}
  item[0] → category: URGENT       (board-meeting blocker)
  item[1] → category: PROMOTIONAL  (suggested_action: archive)
```
</details>

<details>
<summary>🧪 Email triage — real agent tool-calling loop (Strix Halo, <code>gaia eval benchmark</code>)</summary>

The two tests above hit the REST contract directly via HTTP, bypassing the agent's
own tool-calling loop. This test instead drives the actual chat path: a synthetic
mailbox (`FakeGmailBackend`, no OAuth) is wired into `EmailTriageAgent`, and the
agent is prompted exactly as a user would prompt it — the LLM plans, calls
`triage_inbox` as a tool, and the per-message dispatch/classification all happens
through the real agent loop.

```
$ gaia eval benchmark --model Gemma-4-E4B-it-GGUF --limit 20

🤖 Processing: 'Call triage_inbox for up to 20 messages in my inbox, then give
me a short summary.'
Model: Gemma-4-E4B-it-GGUF
🔧 Executing operation
Tool: triage_inbox  { "max_messages": "20" }

triage_dispatch message=5c7634bea4 decision=needs_llm
triage_decision message=5c7634bea4 category=URGENT
triage_dispatch message=43a746b218 decision=needs_llm
triage_decision message=43a746b218 category=URGENT
triage_dispatch message=3ae438da6e decision=needs_llm
triage_decision message=3ae438da6e category=URGENT
tool_result name=triage_inbox ok=True latency=38719ms

Final Answer: "Here's a summary of your inbox triage — you have 9 total
messages. 🚨 URGENT (3) ... ⚠️ PHISHING ALERT (1) ... ℹ️ FYI (5) ...
🛍️ PROMOTIONAL (1)"

============================================================
  Email-Triage Throughput Benchmark — Gemma-4-E4B-it-GGUF
============================================================
  Throughput:   49.1 tok/s
  TTFT:         2.978 s
  Committed bar (≥10.0 tok/s): PASS
============================================================
EXIT_CODE=0
```
This is the strongest evidence in this release: the LLM itself called the tool,
classified messages it had never seen, and synthesized a final summary — not a
canned response.
</details>

<details>
<summary>🧪 Email schema 2.1 — search/archive/calendar, contract-level only (#1883) — Radeon GPU</summary>

```
GET  /v1/email/health, /version            → 200
POST /v1/email/triage, /triage/batch        → 200
POST /v1/email/search, /prescan             → 503 "No mailbox connected — connect
                                               Google or Microsoft in Settings →
                                               Connectors"  (no silent fallback)
POST /v1/email/archive                      → 403 without confirmation token
GET  /v1/email/calendar/events               → 503 (same fail-loud pattern)
```
All 18 `/v1/email/*` routes confirmed present via the live OpenAPI schema, and the
confirmation/fail-loud guards work correctly. **Caveat:** no OAuth connector
(Google/Microsoft) was configured in this test pass, so search, archive,
quarantine, and calendar were only proven to reach their correct *error* path —
their behavior against real mail data was not exercised. No synthetic-mailbox seam
exists for these routes (only triage has the `FakeGmailBackend` injection point),
so closing this gap requires either a live connector or new test infrastructure —
out of scope for this release's verification pass.
</details>

<details>
<summary>🧪 NPU 32k context — cold FLM load (#1747) — Strix Halo NPU</summary>

```
$ gaia init --profile npu
Ensuring 32768 token context for npu profile...
✓ Context size verified: 32768 tokens

$ curl localhost:13305/v1/models | jq '.data[] | select(.id=="gemma4-it-e2b-FLM")'
{"id":"gemma4-it-e2b-FLM","recipe_options":{"ctx_size":32768},...}

$ curl -X POST localhost:13305/v1/chat/completions -d '{"model":"Gemma-4-E2B-it-GGUF",...}'
→ "NPU_32K_OK"
```
Confirms the real gate from #1745: cold NPU FLM load now requests 32768, not 4096.
</details>

<details>
<summary>🧪 Email sidecar lifecycle in Agent UI (#1884) — Radeon GPU, dev mode</summary>

```
server.py   | Email REST surface served by out-of-process sidecar
            | (GAIA_EMAIL_AGENT_MODE=dev); in-process mount skipped.
manager.py  | email sidecar: spawning (dev mode, attempt 1/3)
            |   uvicorn server:app --reload --app-dir .../packaging --port 33741
manager.py  | email sidecar healthy at http://127.0.0.1:33741
manager.py  | email sidecar contract: apiVersion=2.1 agentVersion=0.3.0

# Triage through the Agent UI proxy (port 4200, not the sidecar port directly):
POST /v1/email/triage → {"category":"URGENT","suggested_action":"reply",
                          "usage":{"tokens_per_second":127.76}}

# Server stop → sidecar reaped:
manager.py  | email sidecar: tree-killing pid=11044
manager.py  | email sidecar: shut down
→ kill -0 11044 → SIDECAR_REAPED (CORRECT)
```
</details>

<details>
<summary>🧪 Dynamic Tools Beta toggle (#1857) — Radeon GPU, Ubuntu, live browser (Playwright)</summary>

```
PAGE_TITLE: GAIA Agent UI
SETTINGS panel → "DYNAMIC TOOLS BETA" section found
  checkbox label: "Enable dynamic tool loading"
  INITIAL_STATE: False
  AFTER_TOGGLE:  True
  RESTORED:      False

PUT /api/settings {"dynamic_tools": true}  → {"dynamic_tools":true,...}
GET /api/settings                          → confirms true
PUT /api/settings {"dynamic_tools": false} → confirms restored
```
Screenshot taken of the live Settings panel confirming the rendered toggle (GAIA v0.21.2 BETA build, Lemonade v10.8.1 running, Gemma-4-E4B-it-GGUF loaded).
</details>

## Release checklist
- [x] `util/validate_release_notes.py docs/releases/v0.22.0.mdx` passes
- [x] `src/gaia/version.py` → `0.22.0`
- [x] `src/gaia/apps/webui/package.json` → `0.22.0`
- [x] `src/gaia/apps/webui/package-lock.json` → `0.22.0`
- [x] Navbar label in `docs/docs.json` → `v0.22.0 · Lemonade 10.8.1`
- [x] All commits in range (`v0.21.2..HEAD`) represented in the notes
- [x] Real-world hardware testing evidence attached (Strix Halo NPU + Radeon GPU)
- [x] Email claims scoped to what was actually tested — triage verified via the
      real agent loop; search/archive/calendar verified at the contract level only
      (connector-gated, not exercised against live mail)
- [ ] Review from @kovtcharov-amd addressed

