### PR TITLE
Release agent-pkg-email-v0.3.0 (npm)

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -63,6 +63,13 @@ Contract bumped to `SCHEMA_VERSION` **2.1** — additive, no triage shape change
   Agent UI's pre-scan card renders. Read-only; reuses the agent's own
   `pre_scan_inbox` classification path. Contract `SCHEMA_VERSION` → `2.1`.
 
+**Verified before release:** the `darwin-arm64` binary was frozen with
+`packaging/freeze.py`, passed the no-Python `smoke_test.py` (OpenAPI surface +
+`/version` + `/v1/email/triage` all PASS), and was driven end-to-end through the
+published `EmailClient`/`checkVersion` — single `triage()` and `triageBatch()`
+both returned real, correctly-categorized Lemonade inference results. Full
+transcript in the release PR.
+
 ## 0.2.5
 
 Sending from a mailbox connected with identity-only scopes now returns an


### PR DESCRIPTION
# Release agent-pkg-email-v0.3.0 (npm)

Cuts the **`@amd-gaia/agent-email` v0.3.0** npm release — the first end-to-end run of the automated binary-freeze + npm publish pipeline (`#1648`, now closed). No code change: `gaia-agent.yaml`, `package.json`, and the `CHANGELOG.md` entry for `0.3.0` are already on `main`; this PR adds the real-world verification record below before tagging.

Full changelog: [`hub/agents/npm/agent-email/CHANGELOG.md`](hub/agents/npm/agent-email/CHANGELOG.md#030).

## Real-world testing evidence (npm package only)

Tested locally on macOS (`darwin-arm64`) — one of the 4 platforms the release CI builds.

<details>
<summary>🧪 Pre-flight — build, tests, pack</summary>

```
$ npm ci && npm run build && npm test
✓ test/cli.test.ts (10 tests)
✓ test/version-check.test.ts (4 tests)
✓ test/lifecycle-cleanup.test.ts (4 tests)
✓ test/client.test.ts (24 tests)
✓ test/fetch.test.ts (8 tests)
✓ test/browser-entry.test.ts (9 tests)
Test Files  6 passed (6)
     Tests  59 passed (59)

$ npm pack --dry-run
package: @amd-gaia/agent-email@0.3.0
README.md, CHANGELOG.md, SPEC.md, SKILL.md, SCORECARD.md, LICENSE all ship
package size: 66.4 kB / unpacked: 234.0 kB / 52 files
```
</details>

<details>
<summary>🧪 Frozen binary — built and smoke-tested with NO Python on the target</summary>

```
$ python packaging/freeze.py
Build finished in 25.8s
Executable: .../packaging/dist/email-agent/email-agent
Size: 80.3 MB (one-dir total)

$ python packaging/smoke_test.py packaging/dist/email-agent/email-agent
[smoke] /health ready after 3.0s -> {'status': 'ok', 'service': 'gaia-agent-email'}
[smoke] openapi paths: [... all 18 /v1/email/* routes present ...]
[smoke] openapi check PASS
[smoke] /version -> {'apiVersion': '2.1', 'agentVersion': '0.3.0'}
[smoke] version check PASS
[smoke] triage check PASS (route accepted + routed the request)
[smoke] VERDICT: PASS
```
</details>

<details>
<summary>🧪 Real-world — the published TS client driving the frozen binary, live Lemonade inference</summary>

Ran the binary standalone, then exercised it through the **actual built `EmailClient`** (the same code that ships to npm) — not curl, not a mock.

```js
import { EmailClient, checkVersion } from "@amd-gaia/agent-email";
const client = new EmailClient({ baseUrl: "http://127.0.0.1:8132" });
```

`checkVersion(client)`:
```json
{ "apiVersion": "2.1", "agentVersion": "0.3.0" }
```

`client.triage(...)` — single email, real Lemonade inference:
```json
{
  "result": {
    "category": "NEEDS_RESPONSE",
    "summary": "Review and approve the attached Q3 budget proposal by Friday...",
    "action_items": [{"description": "...review and approve the attached Q3 budget proposal..."}],
    "suggested_action": "reply",
    "usage": {"total_tokens": 917, "tokens_per_second": 71.5}
  }
}
```

`client.triageBatch(...)` — 2 emails, order-preserved, both real inference:
```json
{
  "results": [
    {"index": 0, "result": {"category": "URGENT", "suggested_action": "reply", ...}},
    {"index": 1, "result": {"category": "PROMOTIONAL", "suggested_action": "archive", ...}}
  ]
}
```
Both classifications are correct (the production-outage email → URGENT/reply, the sale email → PROMOTIONAL/archive) — proves the published client, the wire contract, and the frozen binary all agree end-to-end.
</details>

## Release checklist
- [x] `gaia-agent.yaml` / `package.json` / tag all agree on `0.3.0`
- [x] `npm ci && npm run build && npm test` — 59/59 pass
- [x] `npm pack --dry-run` — README/CHANGELOG/SPEC/SKILL ship
- [x] Frozen `darwin-arm64` binary smoke-tested (no Python on target)
- [x] Published `EmailClient` driven against the frozen binary — real Lemonade inference, both `triage()` and `triageBatch()`
- [x] `#1648` (automated publish pipeline) closed — this is its first real run
- [x] `agent-publish` environment + `GAIA_HUB_TOKEN` + hub vars confirmed present
- [ ] Review addressed
