### PR TITLE
feat(email): scheduled daily inbox briefing (#1608)

### DIFF
--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -143,6 +143,42 @@ Preferences are stored in process memory only — restarting the agent (or quitt
 
 Senders you reply to quickly are automatically promoted to priority on the next triage run — no explicit command needed. The agent measures how long it took you to reply to each sender (using the original message's receipt timestamp as the anchor) and promotes senders whose median reply latency falls below the threshold. Promotion is applied on-demand during triage, not on a background thread, and persists across agent restarts. Works across both connected mailboxes (Gmail and Outlook).
 
+## Scheduled daily briefing (off by default)
+
+The same pre-scan can run on a schedule instead of only on demand — a morning
+briefing that's ready before you ask. **It ships off by default**: nothing scans
+your inbox until you explicitly enable the schedule.
+
+The email sidecar stores the schedule and serves the trigger; it does **not** run
+a timer. A host scheduler — GAIA's autonomy engine once it lands, or any
+cron-like runner today — fires the trigger at your configured time:
+
+```bash
+# Enable once (the sidecar listens on 127.0.0.1:8131 by default):
+curl -s -X PUT http://127.0.0.1:8131/v1/email/briefing/schedule \
+  -H "Content-Type: application/json" \
+  -d '{ "enabled": true, "time": "08:00", "max_messages": 25 }'
+
+# What the scheduler fires daily:
+curl -s -X POST http://127.0.0.1:8131/v1/email/briefing/run
+```
+
+The run returns a `kind: "email_briefing"` envelope whose `pre_scan` field is the
+same `email_pre_scan` card the Agent UI renders, and also persists the envelope to
+`~/.gaia/email/briefing_latest.json` so a consumer can pick up the latest briefing
+without having been the live caller (the interim delivery surface until push
+delivery arrives with the autonomy engine).
+
+Two guarantees, both fail-loud:
+
+- **Disabled means disabled.** The trigger re-checks `enabled` itself — a disabled
+  schedule answers `409` before any mailbox access, so a stale or misfiring
+  scheduler can never scan a mailbox whose briefing you turned off.
+- **A corrupt schedule file is an error, not a guess.** If
+  `~/.gaia/email/briefing.json` exists but can't be parsed, the endpoints return
+  `500` naming the file and the fix — the agent never silently falls back to
+  "disabled" (or worse, "enabled").
+
 ## Action surface
 
 ### Read
@@ -286,9 +322,10 @@ isolated, and dogfoods the exact binary shipped to integrators.
 `GAIA_EMAIL_AGENT_MODE` only selects which *process* answers (`user` default /
 `dev`); there is no in-process fallback. Two surfaces run through it:
 
-- **The `/v1/email/*` REST surface** — the full schema-2.1 contract (triage,
-  batch triage, search, inbox pre-scan, draft/send + confirm, archive/unarchive,
-  quarantine/unquarantine, calendar view/preview/create/respond, health,
+- **The `/v1/email/*` REST surface** — the full schema-2.2 contract (triage,
+  batch triage, search, inbox pre-scan, the scheduled daily briefing, draft/send
+  + confirm, archive/unarchive, quarantine/unquarantine, calendar
+  view/preview/create/respond, health,
   version). This is exactly what third-party integrators consume, so the UI
   exercises the real product. The sidecar's connector OAuth **write** routes are
   never exposed (all grant writes stay on the backend's single-writer path).
@@ -301,7 +338,7 @@ The sidecar is spawned lazily on first email use and tree-killed on shutdown; th
 REST surface and the chat agent share one sidecar process.
 
 **Chat tool surface (in-app email agent):** the sidecar-backed chat agent exposes
-the tools the schema-2.1 REST contract serves today — inbox pre-scan, search,
+the tools the REST contract serves today — inbox pre-scan, search,
 calendar view, and archive + undo. Tools that have no REST route yet (labels,
 stars, mark-read, move, trash/delete, summarize, profile, preferences, forward,
 send) are not exposed in the chat agent until their routes land; the underlying

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,25 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## Unreleased
+
+Contract bumped to `SCHEMA_VERSION` **2.2** — additive, no existing shape change,
+so `checkVersion` (MAJOR-only) keeps accepting 2.x clients.
+
+- **Scheduled daily inbox briefing** (#1608): the sidecar can now turn the
+  pre-scan into a scheduled morning briefing instead of only answering on
+  demand. New REST surface: `GET`/`PUT /v1/email/briefing/schedule` (persisted
+  schedule — **off by default**; enabling it is an explicit `PUT`) and
+  `POST /v1/email/briefing/run` (the trigger a host scheduler fires daily; the
+  sidecar stores the preference but runs no timer — that belongs to the host /
+  GAIA's autonomy engine #555). A disabled schedule makes the trigger a `409`
+  before any mailbox access, so a misfiring scheduler can never scan a mailbox
+  whose briefing is off. The run returns a `kind: "email_briefing"` envelope
+  whose `pre_scan` is byte-compatible with `prescan()`'s card, and atomically
+  persists it to `~/.gaia/email/briefing_latest.json` as the interim pull-based
+  delivery surface until push delivery lands with the autonomy engine.
+  REST-only for now — no typed client methods yet; drive it with `fetch`.
+
 ## 0.3.0
 
 Contract bumped to `SCHEMA_VERSION` **2.1** — additive, no triage shape change, so

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -1,6 +1,6 @@
 # @amd-gaia/agent-email
 
-[![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email) · contract `SCHEMA_VERSION` **2.1** · last updated **2026-06-26**
+[![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email) · contract `SCHEMA_VERSION` **2.2** · last updated **2026-07-01**
 
 **Eval scorecard (v0.3.0): aggregate 84.67 / 100** — within-one-bucket **acceptance** accuracy (3-run mean, 95% CI [83.4, 86.0]) over 100 of 220 labeled emails ([`./SCORECARD.md`](./SCORECARD.md)). Triage priority is ordinal, so the bar (#1437) credits exact-or-adjacent buckets — what users feel — not exact 4-way match (reported as a secondary, 0.46). The linked scorecard carries the full recipe, metrics + reported secondaries, run-to-run variance/CI, a per-category breakdown, the run environment, a worked recomputation, and reproduction steps.
 
@@ -214,9 +214,13 @@ When you need finer control, the steps are exported individually:
 | `checkVersion(client)` | Throw if the sidecar's contract MAJOR differs from the client's. |
 | `shutdown(sidecar)` | Kill the whole process tree. |
 
-As of `SCHEMA_VERSION` 2.1 this package exposes inbox **search** (read-only),
-the **archive** / phishing-**quarantine** mailbox actions (+ their undo), and
-calendar **view / create / respond**. The remaining mailbox **actions** (label,
+As of `SCHEMA_VERSION` 2.2 this package exposes inbox **search** (read-only),
+the **archive** / phishing-**quarantine** mailbox actions (+ their undo),
+calendar **view / create / respond**, and a **scheduled daily briefing** (#1608):
+an off-by-default schedule plus a `POST /v1/email/briefing/run` trigger that
+turns the pre-scan into a morning briefing — REST-only for now (no typed client
+methods yet; drive it with `fetch`), with the timer owned by your app or GAIA's
+autonomy engine, not the sidecar. The remaining mailbox **actions** (label,
 move, mark read/unread) are part of the full agent but not yet exposed through
 this package — see
 [`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md) for the complete surface.

--- a/hub/agents/npm/agent-email/SKILL.md
+++ b/hub/agents/npm/agent-email/SKILL.md
@@ -124,6 +124,28 @@ reversible inside a 30s window via the ungated `unarchive` / `unquarantine`. Eve
 non-2xx response throws `HttpError` (`status`, `url`, `bodyText`) — handle it; there is
 no silent null.
 
+**Scheduled daily briefing (schema 2.2, REST-only).** The sidecar can turn the
+pre-scan into a scheduled morning briefing (#1608), but it does **not** run a
+timer — your app (or GAIA's autonomy engine, once it lands) owns the schedule and
+fires the trigger. No typed client methods yet; use `fetch` against the sidecar:
+
+```ts
+// Enable once (ships OFF by default):
+await fetch(`${base}/v1/email/briefing/schedule`, {
+  method: "PUT",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ enabled: true, time: "08:00", max_messages: 25 }),
+});
+// What your scheduler fires daily — returns { result: { kind: "email_briefing",
+// pre_scan: { kind: "email_pre_scan", … } } }; renders with the same card as prescan().
+const briefing = await fetch(`${base}/v1/email/briefing/run`, { method: "POST" });
+```
+
+A disabled schedule makes the trigger a `409` **before any mailbox access** — a
+misfiring scheduler can never scan a mailbox whose briefing is off. Each run also
+persists the envelope to `~/.gaia/email/briefing_latest.json` for pull-based
+consumers.
+
 ## 5. From a renderer (Electron / browser)
 
 The sidecar serves **same-origin only — no CORS**. A renderer on a different origin

--- a/hub/agents/npm/agent-email/SPEC.md
+++ b/hub/agents/npm/agent-email/SPEC.md
@@ -2,7 +2,7 @@
 
 Detailed reference for `@amd-gaia/agent-email`. For a quick start, see
 [`README.md`](./README.md); for an AI-assisted integration walkthrough, see
-[`SKILL.md`](./SKILL.md). The contract version is `SCHEMA_VERSION` **2.1**.
+[`SKILL.md`](./SKILL.md). The contract version is `SCHEMA_VERSION` **2.2**.
 
 ## Architecture
 
@@ -53,6 +53,9 @@ result.
 | `POST /v1/email/triage/batch` | `triageBatch()` | **Standalone** | Same as `triage` for an `items` array (1–100). Returns a parallel `results` array, order-preserved; per-item failures isolate (HTTP 200 can carry errored items — inspect `results[].error`). A `502` fails the whole batch (Lemonade unreachable). |
 | `POST /v1/email/search` | `search()` | **Connector** | Read-only inbox search. A connected Google/Microsoft mailbox (`503` if none, `400` if 2+); **no** confirmation token. Lists messages matching `query`/`labels` and returns metadata only (no body). |
 | `POST /v1/email/prescan` | `prescan()` | **Connector** | Reads recent inbox messages from the connected Google/Microsoft mailbox and returns the read-only triage-card envelope (`kind: "email_pre_scan"`). `503` if no mailbox is connected, `400` if 2+ are. Heuristic-only — no Lemonade call. |
+| `GET /v1/email/briefing/schedule` | — (REST only, schema 2.2) | **Standalone** | Reads the persisted daily-briefing schedule (#1608). Ships **off by default**; an absent config reports as disabled, a corrupt config file is a `500` naming the file and the fix. |
+| `PUT /v1/email/briefing/schedule` | — (REST only, schema 2.2) | **Standalone** | Replaces the schedule (full-document, contract-validated — bad `time`/`max_messages` → `422` before anything persists). The only way to turn the briefing on. |
+| `POST /v1/email/briefing/run` | — (REST only, schema 2.2) | **Connector** | The scheduled briefing trigger. No body — the persisted schedule is the config. Disabled → `409` **before any mailbox access**; enabled → runs the pre-scan path, returns the `kind: "email_briefing"` envelope, and persists it to `~/.gaia/email/briefing_latest.json`. |
 | `POST /v1/email/draft` | `draft()` | **Standalone** | Nothing external — wraps your `(to, subject, body)` and returns a single-use confirmation token. |
 | `POST /v1/email/send` | `send()` | **Connector** | A valid `draft` confirmation token **and** a connected Google/Microsoft mailbox. The token gate fires first: no/invalid token → `403`; then `503` if no mailbox is connected, `400` if 2+ are. |
 | `POST /v1/email/confirm` | `confirmAction()` | **Standalone** | Nothing external — mints a single-use token for `"archive"`/`"quarantine"`, bound to that exact `(action, message_id)`. |
@@ -108,6 +111,37 @@ const q = await client.quarantine({
 });
 await client.unquarantine({ action_id: q.action_id });
 ```
+
+### Scheduled daily briefing (schema 2.2, #1608)
+
+The daily briefing turns the pre-scan into a scheduled morning summary. The
+sidecar stores the preference and serves the trigger — it does **not** run a
+timer. A host scheduler (GAIA's autonomy engine once it lands — #555 — or any
+cron-like runner in your app) fires `POST /v1/email/briefing/run` at the
+configured `time`:
+
+```bash
+# Enable once (ships off by default):
+curl -s -X PUT http://127.0.0.1:8131/v1/email/briefing/schedule \
+  -H "Content-Type: application/json" \
+  -d '{ "enabled": true, "time": "08:00", "max_messages": 25 }'
+
+# What the scheduler fires daily:
+curl -s -X POST http://127.0.0.1:8131/v1/email/briefing/run
+# → { "schema_version": "2.2",
+#     "result": { "kind": "email_briefing", "generated_at": "…",
+#                 "schedule": { … }, "pre_scan": { "kind": "email_pre_scan", … } } }
+```
+
+The trigger re-checks `enabled` itself: a disabled schedule is a `409` **before
+any mailbox access**, so a stale or misfiring scheduler can never scan a mailbox
+whose briefing the user turned off. `result.pre_scan` is byte-compatible with
+`prescan()`'s envelope, so a consumer that renders the pre-scan card renders the
+briefing. Each run also atomically persists the envelope to
+`~/.gaia/email/briefing_latest.json` — the interim pull-based delivery surface
+until push delivery lands with the autonomy engine. These endpoints are
+REST-only for now (no typed client methods yet); drive them with `fetch` or any
+HTTP client.
 
 ### Calendar (view / create / respond, schema 2.1)
 
@@ -276,12 +310,13 @@ connection through this package's API**, so connector-backed calls only work on 
 machine where the mailbox is already connected in GAIA. Triage and draft, which
 need no connector, work anywhere.
 
-As of `SCHEMA_VERSION` 2.1 this package's REST API exposes the read-only inbox
+As of `SCHEMA_VERSION` 2.2 this package's REST API exposes the read-only inbox
 **search** and **pre-scan** (`search` / `prescan`), the **archive** and
 phishing-**quarantine** mailbox actions plus their undo (`confirmAction` / `archive` /
-`unarchive` / `quarantine` / `unquarantine`), and calendar **view / create / respond**
+`unarchive` / `quarantine` / `unquarantine`), calendar **view / create / respond**
 (`listCalendarEvents` / `previewCalendarEvent` / `createCalendarEvent` /
-`respondToCalendarEvent`). The full GAIA email agent does more on the live mailbox
+`respondToCalendarEvent`), and the **scheduled daily briefing** (REST-only,
+`/v1/email/briefing/*`, #1608). The full GAIA email agent does more on the live mailbox
 (label, move, mark spam) and calendar (detect / conflicts); those remaining actions are
 connector-gated by definition and are **not exposed through this package's REST API
 yet**.
@@ -328,9 +363,10 @@ editors autocomplete but your code never imports them.
 
 TypeScript types in `src/types.ts` mirror two Python sources of truth:
 
-- `contract.py` — the triage request/response contract plus the schema-2.1 additions:
-  inbox search, mailbox actions (archive / quarantine + reversal), calendar, and
-  pre-scan (`SCHEMA_VERSION = "2.1"`).
+- `contract.py` — the triage request/response contract plus the schema-2.1 additions
+  (inbox search, mailbox actions — archive / quarantine + reversal — calendar, and
+  pre-scan) and the schema-2.2 daily-briefing models (`SCHEMA_VERSION = "2.2"`).
+  The briefing endpoints are REST-only for now — no TS types/methods yet.
 - `api_routes.py` — the local draft/send confirmation handshake models.
 
 They are hand-written (vs. generated from `/openapi.json`) because the contract is

--- a/hub/agents/npm/agent-email/src/lifecycle.ts
+++ b/hub/agents/npm/agent-email/src/lifecycle.ts
@@ -287,7 +287,7 @@ function majorOf(version: string): number {
 }
 
 export interface VersionCheckOptions {
-  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("2.1"). */
+  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("2.2"). */
   expectedApiVersion?: string;
 }
 

--- a/hub/agents/npm/agent-email/src/types.ts
+++ b/hub/agents/npm/agent-email/src/types.ts
@@ -27,10 +27,13 @@
  *     confirm-token handshake (#1779)
  *   - calendar view/create/respond (#1780)
  *   - inbox pre-scan (POST /v1/email/prescan, #1778)
+ * Schema 2.2 (additive) adds the scheduled daily-briefing surface (#1608):
+ *   GET/PUT /v1/email/briefing/schedule and POST /v1/email/briefing/run —
+ *   REST-only for now; no typed client methods/types yet.
  */
 
 /** Frozen contract version echoed by the server's `/version` endpoint. */
-export const SCHEMA_VERSION = "2.1" as const;
+export const SCHEMA_VERSION = "2.2" as const;
 
 /**
  * The five-bucket triage taxonomy (schema 2.0 — contract.py: EmailCategory).

--- a/hub/agents/npm/agent-email/test/browser-entry.test.ts
+++ b/hub/agents/npm/agent-email/test/browser-entry.test.ts
@@ -58,7 +58,7 @@ describe("browser entry (./client)", () => {
 
   it("client-entry exports SCHEMA_VERSION and request/response types (runtime const)", async () => {
     const mod = await import("../src/client-entry.js");
-    expect(mod.SCHEMA_VERSION).toBe("2.1");
+    expect(mod.SCHEMA_VERSION).toBe("2.2");
   });
 
   it("client-entry does NOT export spawnSidecar (Node-only)", async () => {

--- a/hub/agents/npm/agent-email/test/version-check.test.ts
+++ b/hub/agents/npm/agent-email/test/version-check.test.ts
@@ -18,9 +18,9 @@ function clientReturning(apiVersion: string, agentVersion = "0.2.0"): EmailClien
 }
 
 describe("checkVersion", () => {
-  it("accepts apiVersion 2.0 against the current 2.1 default (same MAJOR 2)", async () => {
+  it("accepts apiVersion 2.0 against the current 2.2 default (same MAJOR 2)", async () => {
     // checkVersion enforces MAJOR only, so a 2.0 sidecar stays compatible with
-    // this client's default-expected SCHEMA_VERSION (now 2.1).
+    // this client's default-expected SCHEMA_VERSION (now 2.2).
     const info = await checkVersion(clientReturning("2.0"));
     expect(info.apiVersion).toBe("2.0");
   });

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -53,12 +53,20 @@ from typing import Any, Dict, List, Literal, NoReturn, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
+from gaia_agent_email.briefing import (
+    BriefingConfigError,
+    load_schedule,
+    run_scheduled_briefing,
+    save_schedule,
+)
 from gaia_agent_email.contract import (
     ActionItem,
     BatchItemError,
     BatchItemResult,
     BatchTriageRequest,
     BatchTriageResponse,
+    BriefingSchedule,
+    BriefingScheduleResponse,
     CalendarCreateEventRequest,
     CalendarEvent,
     CalendarEventDateTime,
@@ -73,6 +81,8 @@ from gaia_agent_email.contract import (
     EmailAddress,
     EmailArchiveRequest,
     EmailArchiveResponse,
+    EmailBriefingResponse,
+    EmailBriefingResult,
     EmailCategory,
     EmailMessage,
     EmailPreScanRequest,
@@ -1532,6 +1542,96 @@ async def prescan_inbox(
     except ConnectorsError as e:
         raise HTTPException(status_code=502, detail=str(e)) from e
     return EmailPreScanResponse(result=EmailPreScanResult.model_validate(out))
+
+
+@router.get("/briefing/schedule", response_model=BriefingScheduleResponse)
+async def get_briefing_schedule() -> BriefingScheduleResponse:
+    """Read the persisted daily-briefing schedule (#1608).
+
+    An absent config file is the documented default — disabled. A present
+    but corrupt file is a 500 with the fix (never silently reported as
+    "disabled", which would hide a schedule the user thinks is on).
+    """
+    try:
+        schedule = load_schedule()
+    except BriefingConfigError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+    return BriefingScheduleResponse(schedule=schedule)
+
+
+@router.put("/briefing/schedule", response_model=BriefingScheduleResponse)
+async def put_briefing_schedule(schedule: BriefingSchedule) -> BriefingScheduleResponse:
+    """Replace the persisted daily-briefing schedule (#1608).
+
+    Full-document replace: the body is the complete schedule, validated by
+    the contract model (bad ``time``/``max_messages`` → 422 before anything
+    persists). This is how a host turns the briefing on — it ships OFF.
+    """
+    try:
+        path = save_schedule(schedule)
+    except OSError as e:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Could not persist the briefing schedule: {e}. Check that "
+                "~/.gaia/email/ is writable, then retry."
+            ),
+        ) from e
+    logger.info("briefing schedule replaced at %s (enabled=%s)", path, schedule.enabled)
+    return BriefingScheduleResponse(schedule=schedule)
+
+
+@router.post("/briefing/run", response_model=EmailBriefingResponse)
+async def run_briefing() -> EmailBriefingResponse:
+    """The scheduled daily-briefing trigger (#1608).
+
+    A host scheduler (autonomy engine #555, cron, the GAIA UI scheduler)
+    calls this on its tick; no request body — the persisted schedule is the
+    configuration. The disabled check runs FIRST (409, actionable) so a
+    disabled schedule is a clean no-op that never resolves a mailbox
+    backend, let alone reads mail. When enabled, the run reuses the
+    pre-scan classification path via ``run_scheduled_briefing`` and both
+    returns the briefing envelope and persists it as the latest briefing
+    (the interim pull-based delivery surface until push delivery lands
+    with the autonomy engine).
+    """
+    try:
+        schedule = load_schedule()
+    except BriefingConfigError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+    if not schedule.enabled:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "The daily briefing schedule is disabled (it ships off by "
+                "default). Enable it first via PUT /v1/email/briefing/schedule "
+                'with {"enabled": true, "time": "HH:MM"}.'
+            ),
+        )
+    backend = get_prescan_backend()
+    try:
+        out = await asyncio.to_thread(
+            run_scheduled_briefing, backend, schedule=schedule
+        )
+    except (
+        AuthRequiredError,
+        ScopeMismatchError,
+        ConnectionRevokedError,
+    ) as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    except ConfigurationError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
+    except ConnectorsError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
+    except OSError as e:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Briefing ran but could not persist its envelope: {e}. Check "
+                "that ~/.gaia/email/ is writable, then retry."
+            ),
+        ) from e
+    return EmailBriefingResponse(result=EmailBriefingResult.model_validate(out))
 
 
 @router.post("/draft", response_model=EmailDraftResponse)

--- a/hub/agents/python/email/gaia_agent_email/briefing.py
+++ b/hub/agents/python/email/gaia_agent_email/briefing.py
@@ -1,0 +1,157 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Scheduled daily inbox briefing (#1608).
+
+The briefing CONTENT is the existing pre-scan envelope — this module adds
+the SCHEDULED-JOB seam around ``pre_scan_inbox_impl``, not a new scan:
+
+- :func:`load_schedule` / :func:`save_schedule` persist the user's
+  :class:`~gaia_agent_email.contract.BriefingSchedule` (OFF by default) at
+  ``~/.gaia/email/briefing.json``.
+- :func:`run_scheduled_briefing` is the trigger a host scheduler invokes.
+  It re-checks ``enabled`` itself, so a disabled schedule never touches the
+  mailbox regardless of who fires the trigger.
+
+The sidecar does NOT run a timer. Scheduling is owned by the host — the
+autonomy engine (#555) once it lands, or any cron-like runner hitting
+``POST /v1/email/briefing/run`` in the meantime. Push delivery is likewise
+the host's job; until it exists, each run atomically persists its envelope
+to ``~/.gaia/email/briefing_latest.json`` so a consumer can pull the most
+recent briefing without having been the live caller.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from pydantic import ValidationError
+
+from gaia_agent_email.contract import BriefingSchedule
+
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+
+class BriefingConfigError(ValueError):
+    """Raised when the persisted briefing schedule is unreadable or invalid."""
+
+
+def briefing_schedule_path() -> Path:
+    """Where the briefing schedule persists.
+
+    ``Path.home()`` resolves at call time so test HOME/tmp isolation is
+    honored (same rationale as ``EmailAgentConfig.resolved_db_path``).
+    """
+    return Path.home() / ".gaia" / "email" / "briefing.json"
+
+
+def latest_briefing_path() -> Path:
+    """Where the most recent briefing envelope persists."""
+    return Path.home() / ".gaia" / "email" / "briefing_latest.json"
+
+
+def load_schedule(path: Optional[Path] = None) -> BriefingSchedule:
+    """Load the persisted schedule; an absent file is the documented default
+    (disabled — #1608 requires off-by-default).
+
+    A file that exists but cannot be parsed or validated raises
+    :class:`BriefingConfigError` — never a silent fall-back to defaults,
+    which would quietly disable a briefing the user enabled (or worse,
+    re-enable one they disabled by hand-editing the file badly).
+    """
+    p = Path(path) if path is not None else briefing_schedule_path()
+    if not p.exists():
+        return BriefingSchedule()
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise BriefingConfigError(
+            f"Briefing schedule at {p} is unreadable: {e}. Fix or delete the "
+            "file, or overwrite it via PUT /v1/email/briefing/schedule."
+        ) from e
+    try:
+        return BriefingSchedule.model_validate(raw)
+    except ValidationError as e:
+        raise BriefingConfigError(
+            f"Briefing schedule at {p} is invalid: {e}. Expected "
+            '{"enabled": bool, "time": "HH:MM", "max_messages": 1-100}. '
+            "Overwrite it via PUT /v1/email/briefing/schedule."
+        ) from e
+
+
+def save_schedule(
+    schedule: BriefingSchedule, path: Optional[Path] = None
+) -> Path:
+    """Persist ``schedule`` atomically (write-then-rename) and return the path."""
+    p = Path(path) if path is not None else briefing_schedule_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_name(p.name + ".tmp")
+    tmp.write_text(schedule.model_dump_json(indent=2), encoding="utf-8")
+    tmp.replace(p)
+    return p
+
+
+def run_scheduled_briefing(
+    backend: Any,
+    *,
+    schedule: Optional[BriefingSchedule] = None,
+    schedule_path: Optional[Path] = None,
+    latest_path: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> Optional[Dict[str, Any]]:
+    """The scheduled-job trigger: pre-scan the inbox into a briefing envelope.
+
+    This is the seam a host scheduler (autonomy engine #555, cron, the REST
+    trigger) invokes on its tick — no user prompt involved. When the schedule
+    is disabled (the default) it returns ``None`` WITHOUT touching the
+    mailbox: that is the documented contract of an off switch, logged so the
+    skip is observable, not a silent degradation.
+
+    When enabled, the briefing reuses ``pre_scan_inbox_impl`` — the exact
+    classification path behind the agent-loop tool and ``POST
+    /v1/email/prescan`` — wraps it with run metadata (``kind:
+    "email_briefing"``), atomically persists it to :func:`latest_briefing_path`
+    as the interim pull-based delivery surface, and returns it. Scan and
+    write failures propagate to the caller.
+    """
+    sched = schedule if schedule is not None else load_schedule(schedule_path)
+    if not sched.enabled:
+        log.info(
+            "daily briefing schedule is disabled — skipping (enable via "
+            "PUT /v1/email/briefing/schedule)"
+        )
+        return None
+
+    from gaia_agent_email.tools.read_tools import pre_scan_inbox_impl
+
+    pre_scan = pre_scan_inbox_impl(backend, max_messages=sched.max_messages)
+    stamp = now if now is not None else datetime.now(timezone.utc)
+    envelope: Dict[str, Any] = {
+        "kind": "email_briefing",
+        "generated_at": stamp.isoformat(),
+        "schedule": sched.model_dump(),
+        "pre_scan": pre_scan,
+    }
+
+    lp = Path(latest_path) if latest_path is not None else latest_briefing_path()
+    lp.parent.mkdir(parents=True, exist_ok=True)
+    tmp = lp.with_name(lp.name + ".tmp")
+    tmp.write_text(json.dumps(envelope, indent=2), encoding="utf-8")
+    tmp.replace(lp)
+    log.info("daily briefing generated and persisted to %s", lp)
+    return envelope
+
+
+__all__ = [
+    "BriefingConfigError",
+    "briefing_schedule_path",
+    "latest_briefing_path",
+    "load_schedule",
+    "save_schedule",
+    "run_scheduled_briefing",
+]

--- a/hub/agents/python/email/gaia_agent_email/contract.py
+++ b/hub/agents/python/email/gaia_agent_email/contract.py
@@ -63,7 +63,10 @@ CATEGORY_PERSONAL = "PERSONAL"
 #   - archive + phishing-quarantine mailbox actions and their reversal (#1779)
 #   - calendar view/create/respond (#1780)
 #   - inbox pre-scan (#1778)
-SCHEMA_VERSION = "2.1"
+# 2.2 is additive over 2.1: the scheduled daily-briefing surface (#1608) —
+# GET/PUT /v1/email/briefing/schedule and the POST /v1/email/briefing/run
+# trigger. No existing shape changes, so 2.x consumers keep working.
+SCHEMA_VERSION = "2.2"
 
 # Maximum number of items in a single batch request. Protects the single-tenant
 # local model slot from runaway batches. Enforced via Pydantic max_length.
@@ -1178,6 +1181,90 @@ class EmailPreScanResponse(_Strict):
 
 
 # ---------------------------------------------------------------------------
+# Scheduled daily briefing (schema 2.2, #1608)
+# ---------------------------------------------------------------------------
+
+
+class BriefingSchedule(_Strict):
+    """The persisted daily-briefing schedule. OFF by default.
+
+    The sidecar does not run a timer — ``time`` is the preference a HOST
+    scheduler (autonomy engine #555, OS cron, the GAIA UI scheduler) reads to
+    decide when to fire ``POST /v1/email/briefing/run``. The trigger itself
+    re-checks ``enabled``, so a stale or misconfigured scheduler can never
+    scan a mailbox whose briefing the user turned off.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Master switch. False (the default) means the scheduled trigger "
+            "produces no briefing and never touches the mailbox."
+        ),
+    )
+    time: str = Field(
+        default="08:00",
+        pattern=r"^([01]\d|2[0-3]):[0-5]\d$",
+        description=(
+            "Local wall-clock HH:MM the host scheduler should fire the "
+            "briefing trigger at, once per day."
+        ),
+    )
+    max_messages: int = Field(
+        default=25,
+        ge=1,
+        le=100,
+        description=(
+            "How many recent inbox messages the briefing pre-scan reads. "
+            "Bounded like EmailPreScanRequest.max_messages."
+        ),
+    )
+
+
+class BriefingScheduleResponse(_Strict):
+    """Response envelope for the briefing-schedule read/replace endpoints."""
+
+    schema_version: str = Field(
+        default=SCHEMA_VERSION, description="Echoes the contract version."
+    )
+    schedule: BriefingSchedule = Field(
+        ..., description="The currently persisted schedule."
+    )
+
+
+class EmailBriefingResult(_Strict):
+    """One scheduled briefing: the pre-scan envelope plus run metadata.
+
+    ``pre_scan`` is byte-compatible with what ``POST /v1/email/prescan``
+    returns (``kind == "email_pre_scan"``) — same classification path, so a
+    consumer that already renders the pre-scan card renders the briefing.
+    """
+
+    kind: Literal["email_briefing"] = Field(
+        default="email_briefing",
+        description="Envelope discriminator for the briefing card.",
+    )
+    generated_at: str = Field(
+        ..., description="UTC ISO-8601 timestamp of when the briefing ran."
+    )
+    schedule: BriefingSchedule = Field(
+        ..., description="The schedule that produced this briefing."
+    )
+    pre_scan: EmailPreScanResult = Field(
+        ..., description="The inbox pre-scan envelope (kind: email_pre_scan)."
+    )
+
+
+class EmailBriefingResponse(_Strict):
+    """Top-level briefing-trigger response envelope (#1608)."""
+
+    schema_version: str = Field(
+        default=SCHEMA_VERSION, description="Echoes the contract version."
+    )
+    result: EmailBriefingResult = Field(..., description="The briefing envelope.")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -1228,6 +1315,11 @@ __all__ = [
     "EmailPreScanRequest",
     "EmailPreScanResult",
     "EmailPreScanResponse",
+    # Scheduled daily briefing (schema 2.2, #1608)
+    "BriefingSchedule",
+    "BriefingScheduleResponse",
+    "EmailBriefingResult",
+    "EmailBriefingResponse",
     "EmailSearchRequest",
     "EmailSearchResultItem",
     "EmailSearchResponse",

--- a/hub/agents/python/email/gaia_agent_email/spec_html.py
+++ b/hub/agents/python/email/gaia_agent_email/spec_html.py
@@ -35,6 +35,8 @@ from gaia_agent_email.contract import (
     BatchItemResult,
     BatchTriageRequest,
     BatchTriageResponse,
+    BriefingSchedule,
+    BriefingScheduleResponse,
     CalendarCreateEventRequest,
     CalendarEvent,
     CalendarEventDateTime,
@@ -49,6 +51,8 @@ from gaia_agent_email.contract import (
     EmailAddress,
     EmailArchiveRequest,
     EmailArchiveResponse,
+    EmailBriefingResponse,
+    EmailBriefingResult,
     EmailCategory,
     EmailMessage,
     EmailPreScanRequest,
@@ -616,6 +620,56 @@ def render_endpoint_spec_html() -> str:
         response_sections=[("CalendarRespondResponse", CalendarRespondResponse)],
     )
 
+    briefing_get_block = _endpoint_block(
+        path="/v1/email/briefing/schedule",
+        method="GET",
+        description=(
+            "Read the persisted daily-briefing schedule (#1608). Ships OFF by "
+            "default — an absent config is reported as disabled. A corrupt "
+            "config file is a 500 naming the file and the fix, never silently "
+            "reported as disabled."
+        ),
+        request_sections=[],
+        response_sections=[
+            ("BriefingScheduleResponse", BriefingScheduleResponse),
+            ("BriefingSchedule", BriefingSchedule),
+        ],
+    )
+
+    briefing_put_block = _endpoint_block(
+        path="/v1/email/briefing/schedule",
+        method="PUT",
+        description=(
+            "Replace the persisted daily-briefing schedule (#1608) — the only "
+            "way to turn the briefing on. Full-document replace, validated by "
+            "the contract model (bad time/max_messages is a 422 before "
+            "anything persists). The sidecar stores the preference; the HOST "
+            "scheduler (autonomy engine #555, cron, the GAIA UI scheduler) "
+            "owns the timer and fires the /run trigger at the configured time."
+        ),
+        request_sections=[("BriefingSchedule", BriefingSchedule)],
+        response_sections=[("BriefingScheduleResponse", BriefingScheduleResponse)],
+    )
+
+    briefing_run_block = _endpoint_block(
+        path="/v1/email/briefing/run",
+        description=(
+            "The scheduled daily-briefing trigger (#1608). No request body — "
+            "the persisted schedule is the configuration. Disabled schedule → "
+            "409 before any mailbox access (a disabled briefing never reads "
+            "mail). Enabled → runs the same pre-scan classification path as "
+            "/v1/email/prescan, returns the briefing envelope, and persists it "
+            "to ~/.gaia/email/briefing_latest.json as the interim pull-based "
+            "delivery surface until push delivery lands with the autonomy "
+            "engine."
+        ),
+        request_sections=[],
+        response_sections=[
+            ("EmailBriefingResponse", EmailBriefingResponse),
+            ("EmailBriefingResult", EmailBriefingResult),
+        ],
+    )
+
     body = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -644,6 +698,20 @@ def render_endpoint_spec_html() -> str:
 {batch_block}
 
 {prescan_block}
+
+<h2>Scheduled daily briefing (schema 2.2)</h2>
+<p class="subtitle">
+  A host scheduler turns the pre-scan into a scheduled morning briefing (#1608).
+  The schedule ships OFF by default; the sidecar stores the preference and
+  serves the trigger — the timer and push delivery belong to the host
+  (autonomy engine #555).
+</p>
+
+{briefing_get_block}
+
+{briefing_put_block}
+
+{briefing_run_block}
 
 {search_block}
 

--- a/hub/agents/python/email/openapi.email.json
+++ b/hub/agents/python/email/openapi.email.json
@@ -146,7 +146,7 @@
             "type": "array"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -171,7 +171,7 @@
             "type": "array"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -181,6 +181,56 @@
           "results"
         ],
         "title": "BatchTriageResponse",
+        "type": "object"
+      },
+      "BriefingSchedule": {
+        "additionalProperties": false,
+        "description": "The persisted daily-briefing schedule. OFF by default.\n\nThe sidecar does not run a timer — ``time`` is the preference a HOST\nscheduler (autonomy engine #555, OS cron, the GAIA UI scheduler) reads to\ndecide when to fire ``POST /v1/email/briefing/run``. The trigger itself\nre-checks ``enabled``, so a stale or misconfigured scheduler can never\nscan a mailbox whose briefing the user turned off.",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "description": "Master switch. False (the default) means the scheduled trigger produces no briefing and never touches the mailbox.",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "max_messages": {
+            "default": 25,
+            "description": "How many recent inbox messages the briefing pre-scan reads. Bounded like EmailPreScanRequest.max_messages.",
+            "maximum": 100.0,
+            "minimum": 1.0,
+            "title": "Max Messages",
+            "type": "integer"
+          },
+          "time": {
+            "default": "08:00",
+            "description": "Local wall-clock HH:MM the host scheduler should fire the briefing trigger at, once per day.",
+            "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+            "title": "Time",
+            "type": "string"
+          }
+        },
+        "title": "BriefingSchedule",
+        "type": "object"
+      },
+      "BriefingScheduleResponse": {
+        "additionalProperties": false,
+        "description": "Response envelope for the briefing-schedule read/replace endpoints.",
+        "properties": {
+          "schedule": {
+            "$ref": "#/components/schemas/BriefingSchedule",
+            "description": "The currently persisted schedule."
+          },
+          "schema_version": {
+            "default": "2.2",
+            "description": "Echoes the contract version.",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "schedule"
+        ],
+        "title": "BriefingScheduleResponse",
         "type": "object"
       },
       "CalendarCreateEventRequest": {
@@ -248,7 +298,7 @@
             "title": "Provider"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -435,7 +485,7 @@
             "title": "Location"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -475,7 +525,7 @@
             "type": "string"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -506,7 +556,7 @@
             "type": "array"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -542,7 +592,7 @@
             "title": "Provider"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -582,7 +632,7 @@
             "type": "boolean"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -699,7 +749,7 @@
             "type": "string"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -812,7 +862,7 @@
             "type": "string"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -831,6 +881,60 @@
           "undo_window_seconds"
         ],
         "title": "EmailArchiveResponse",
+        "type": "object"
+      },
+      "EmailBriefingResponse": {
+        "additionalProperties": false,
+        "description": "Top-level briefing-trigger response envelope (#1608).",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/EmailBriefingResult",
+            "description": "The briefing envelope."
+          },
+          "schema_version": {
+            "default": "2.2",
+            "description": "Echoes the contract version.",
+            "title": "Schema Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "title": "EmailBriefingResponse",
+        "type": "object"
+      },
+      "EmailBriefingResult": {
+        "additionalProperties": false,
+        "description": "One scheduled briefing: the pre-scan envelope plus run metadata.\n\n``pre_scan`` is byte-compatible with what ``POST /v1/email/prescan``\nreturns (``kind == \"email_pre_scan\"``) — same classification path, so a\nconsumer that already renders the pre-scan card renders the briefing.",
+        "properties": {
+          "generated_at": {
+            "description": "UTC ISO-8601 timestamp of when the briefing ran.",
+            "title": "Generated At",
+            "type": "string"
+          },
+          "kind": {
+            "const": "email_briefing",
+            "default": "email_briefing",
+            "description": "Envelope discriminator for the briefing card.",
+            "title": "Kind",
+            "type": "string"
+          },
+          "pre_scan": {
+            "$ref": "#/components/schemas/EmailPreScanResult",
+            "description": "The inbox pre-scan envelope (kind: email_pre_scan)."
+          },
+          "schedule": {
+            "$ref": "#/components/schemas/BriefingSchedule",
+            "description": "The schedule that produced this briefing."
+          }
+        },
+        "required": [
+          "generated_at",
+          "schedule",
+          "pre_scan"
+        ],
+        "title": "EmailBriefingResult",
         "type": "object"
       },
       "EmailCategory": {
@@ -1004,7 +1108,7 @@
             "type": "integer"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -1022,7 +1126,7 @@
             "description": "The pre-scan envelope."
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1187,7 +1291,7 @@
             "type": "boolean"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1259,7 +1363,7 @@
             "title": "Query"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -1310,7 +1414,7 @@
             "title": "Query"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1515,7 +1619,7 @@
             "title": "Payload"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Contract version. Mismatch lets a consumer fail loudly.",
             "title": "Schema Version",
             "type": "string"
@@ -1545,7 +1649,7 @@
             "description": "The structured analysis."
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1703,7 +1807,7 @@
             "type": "integer"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -1771,7 +1875,7 @@
             "type": "boolean"
           },
           "schema_version": {
-            "default": "2.1",
+            "default": "2.2",
             "description": "Echoes the contract version.",
             "title": "Schema Version",
             "type": "string"
@@ -2201,7 +2305,7 @@
   "info": {
     "description": "REST surface for the GAIA Email Triage agent (/v1/email/*). Cross-implementation contract for the npm client and native builds.",
     "title": "GAIA Email Agent API",
-    "version": "2.1"
+    "version": "2.2"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -2242,6 +2346,90 @@
           }
         },
         "summary": "Archive Email",
+        "tags": [
+          "email"
+        ]
+      }
+    },
+    "/v1/email/briefing/run": {
+      "post": {
+        "description": "The scheduled daily-briefing trigger (#1608).\n\nA host scheduler (autonomy engine #555, cron, the GAIA UI scheduler)\ncalls this on its tick; no request body — the persisted schedule is the\nconfiguration. The disabled check runs FIRST (409, actionable) so a\ndisabled schedule is a clean no-op that never resolves a mailbox\nbackend, let alone reads mail. When enabled, the run reuses the\npre-scan classification path via ``run_scheduled_briefing`` and both\nreturns the briefing envelope and persists it as the latest briefing\n(the interim pull-based delivery surface until push delivery lands\nwith the autonomy engine).",
+        "operationId": "run_briefing_v1_email_briefing_run_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailBriefingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Run Briefing",
+        "tags": [
+          "email"
+        ]
+      }
+    },
+    "/v1/email/briefing/schedule": {
+      "get": {
+        "description": "Read the persisted daily-briefing schedule (#1608).\n\nAn absent config file is the documented default — disabled. A present\nbut corrupt file is a 500 with the fix (never silently reported as\n\"disabled\", which would hide a schedule the user thinks is on).",
+        "operationId": "get_briefing_schedule_v1_email_briefing_schedule_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BriefingScheduleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Briefing Schedule",
+        "tags": [
+          "email"
+        ]
+      },
+      "put": {
+        "description": "Replace the persisted daily-briefing schedule (#1608).\n\nFull-document replace: the body is the complete schedule, validated by\nthe contract model (bad ``time``/``max_messages`` → 422 before anything\npersists). This is how a host turns the briefing on — it ships OFF.",
+        "operationId": "put_briefing_schedule_v1_email_briefing_schedule_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BriefingSchedule"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BriefingScheduleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Briefing Schedule",
         "tags": [
           "email"
         ]

--- a/hub/agents/python/email/specification.html
+++ b/hub/agents/python/email/specification.html
@@ -3,7 +3,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <script>(function(){try{var t=localStorage.getItem('amd-site-theme');if(!t)t=(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)?'dark':'light';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','dark');}})();</script>
-<title>Email Agent — Capability &amp; API Specification · v2.1</title>
+<title>Email Agent — Capability &amp; API Specification · v2.2</title>
 <link rel="icon" href="data:image/svg+xml,&lt;svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'&gt;&lt;rect width='32' height='32' rx='5' fill='%23111114'/&gt;&lt;g fill='none' stroke='%23c9a24a' stroke-width='2.4' stroke-linecap='round'&gt;&lt;path d='M8 9 L15 16 L8 23'/&gt;&lt;path d='M16 9 L23 16 L16 23'/&gt;&lt;/g&gt;&lt;/svg&gt;">
 <style>
   /* Self-hosted latin webfonts, base64-embedded so this spec is a single
@@ -289,16 +289,16 @@
     <h1 style="margin-top:24px">The Email Agent,<br><span class="c1">Defined End to End</span></h1>
     <p class="lead">GAIA's Email Agent reads, triages, drafts, sends, organizes, and schedules your mail — running <em>locally on Ryzen&nbsp;AI</em>, so nothing leaves the device. This spec walks through how to integrate it (REST, MCP, or the full agent), its seventeen capabilities and the guardrails that gate them, the workflows that chain them, the personalization and always-on tracks, the evaluation dataset, and the contract reference — with examples throughout.</p>
     <div class="chips">
-      <div class="chip"><div class="k">Implemented</div><div class="v">schema 2.1</div></div>
-      <div class="chip"><div class="k">New in 2.1</div><div class="v g">REST calendar</div></div>
+      <div class="chip"><div class="k">Implemented</div><div class="v">schema 2.2</div></div>
+      <div class="chip"><div class="k">New in 2.2</div><div class="v g">daily briefing</div></div>
       <div class="chip"><div class="k">Capabilities</div><div class="v g">17</div></div>
       <div class="chip"><div class="k">Personalization</div><div class="v">5</div></div>
       <div class="chip"><div class="k">Workflows</div><div class="v">10</div></div>
       <div class="chip"><div class="k">Inference</div><div class="v">100% on-device</div></div>
       <div class="chip"><div class="k">Milestone</div><div class="v g"><a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">v0.21.0</a></div></div>
     </div>
-    <div style="margin-top:30px;font-family:'JetBrains Mono',monospace;font-size:13px;letter-spacing:.04em;color:var(--faint)">Spec <b style="color:var(--c1)">v2.1</b> &nbsp;·&nbsp; updated <b style="color:var(--ink)">2026-06-26</b> &nbsp;·&nbsp; contract <b style="color:var(--ink)">schema 2.1</b> implemented &nbsp;·&nbsp; status as of <b style="color:var(--ink)"><a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">Milestone 40</a> (<a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">v0.21.0</a>)</b></div>
-    <div style="margin-top:10px;font-family:'JetBrains Mono',monospace;font-size:12px;letter-spacing:.03em;color:var(--faint);max-width:900px;line-height:1.6">The contract reference documents the <b style="color:var(--ink)">implemented schema 2.1</b>: a 5-bucket triage taxonomy plus a <code>suggested_action</code> verb (schema 2.0), and the schema-2.1 REST surfaces — inbox search (<a class="iss" href="https://github.com/amd/gaia/issues/1781" target="_blank" rel="noopener">#1781</a>), inbox pre-scan (<a class="iss" href="https://github.com/amd/gaia/issues/1778" target="_blank" rel="noopener">#1778</a>), archive / quarantine mailbox actions (<a class="iss" href="https://github.com/amd/gaia/issues/1779" target="_blank" rel="noopener">#1779</a>), and calendar view / create / respond (<a class="iss" href="https://github.com/amd/gaia/issues/1780" target="_blank" rel="noopener">#1780</a>).</div>
+    <div style="margin-top:30px;font-family:'JetBrains Mono',monospace;font-size:13px;letter-spacing:.04em;color:var(--faint)">Spec <b style="color:var(--c1)">v2.2</b> &nbsp;·&nbsp; updated <b style="color:var(--ink)">2026-07-01</b> &nbsp;·&nbsp; contract <b style="color:var(--ink)">schema 2.2</b> implemented &nbsp;·&nbsp; status as of <b style="color:var(--ink)"><a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">Milestone 40</a> (<a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">v0.21.0</a>)</b></div>
+    <div style="margin-top:10px;font-family:'JetBrains Mono',monospace;font-size:12px;letter-spacing:.03em;color:var(--faint);max-width:900px;line-height:1.6">The contract reference documents the <b style="color:var(--ink)">implemented schema 2.2</b>: a 5-bucket triage taxonomy plus a <code>suggested_action</code> verb (schema 2.0), the schema-2.1 REST surfaces — inbox search (<a class="iss" href="https://github.com/amd/gaia/issues/1781" target="_blank" rel="noopener">#1781</a>), inbox pre-scan (<a class="iss" href="https://github.com/amd/gaia/issues/1778" target="_blank" rel="noopener">#1778</a>), archive / quarantine mailbox actions (<a class="iss" href="https://github.com/amd/gaia/issues/1779" target="_blank" rel="noopener">#1779</a>), and calendar view / create / respond (<a class="iss" href="https://github.com/amd/gaia/issues/1780" target="_blank" rel="noopener">#1780</a>) — and the schema-2.2 scheduled daily briefing (<a class="iss" href="https://github.com/amd/gaia/issues/1608" target="_blank" rel="noopener">#1608</a>): an off-by-default schedule plus a trigger that turns the pre-scan into a morning briefing.</div>
   </div>
 </section>
 
@@ -388,7 +388,7 @@
     </div>
 
     <h3 style="margin-top:40px">Capability → surface</h3>
-    <p class="body-t">REST and MCP expose the <b>analysis + reply + send</b> core (capabilities 1–4, 6, 7). As of <b>schema 2.1</b> the <b>REST</b> surface additionally exposes the reversible mailbox mutations <b>archive</b> and <b>phishing-quarantine</b> (capabilities 8, 9) — each gated on a single-use confirmation token like <code>/send</code>, each reversible within a 30-second undo window — plus <b>calendar view / create / respond</b> (<a class="iss" href="https://github.com/amd/gaia/issues/1780" target="_blank" rel="noopener">#1780</a>; calendar <i>detect</i> and <i>conflicts</i> remain agent-only). MCP does not surface these. The remaining mailbox/calendar capabilities run through the <b>full agent</b>, which acts via a forwarded connection.</p>
+    <p class="body-t">REST and MCP expose the <b>analysis + reply + send</b> core (capabilities 1–4, 6, 7). As of <b>schema 2.1</b> the <b>REST</b> surface additionally exposes the reversible mailbox mutations <b>archive</b> and <b>phishing-quarantine</b> (capabilities 8, 9) — each gated on a single-use confirmation token like <code>/send</code>, each reversible within a 30-second undo window — plus <b>calendar view / create / respond</b> (<a class="iss" href="https://github.com/amd/gaia/issues/1780" target="_blank" rel="noopener">#1780</a>; calendar <i>detect</i> and <i>conflicts</i> remain agent-only). As of <b>schema 2.2</b> REST also carries the <b>scheduled daily briefing</b> (<a class="iss" href="https://github.com/amd/gaia/issues/1608" target="_blank" rel="noopener">#1608</a>) — an off-by-default schedule plus a trigger that turns the pre-scan into a morning briefing. MCP does not surface these. The remaining mailbox/calendar capabilities run through the <b>full agent</b>, which acts via a forwarded connection.</p>
     <table class="tbl">
       <thead><tr><th>Capability</th><th>REST</th><th>MCP</th><th>Agent</th></tr></thead>
       <tbody>
@@ -403,6 +403,7 @@
         <tr><td><b>9</b> · Quarantine (+ undo)</td><td>✓ <code>/v1/email/quarantine</code> · <code>/unquarantine</code> <span class="opt">(Gmail)</span></td><td>—</td><td>✓ <code>quarantine_phishing_message</code></td></tr>
         <tr><td>Inbox search <span class="opt">(read-only, <a class="iss" href="https://github.com/amd/gaia/issues/1781" target="_blank" rel="noopener">#1781</a>)</span></td><td>✓ <code>/v1/email/search</code></td><td>—</td><td>✓ <code>search_messages</code></td></tr>
         <tr><td>Calendar · view / create / respond <span class="opt">(of capability <b>12</b>)</span></td><td>✓ <code>/v1/email/calendar/*</code> <span class="opt">(2.1)</span></td><td>—</td><td>✓</td></tr>
+        <tr><td>Daily briefing · scheduled pre-scan <span class="opt">(off by default, <a class="iss" href="https://github.com/amd/gaia/issues/1608" target="_blank" rel="noopener">#1608</a>)</span></td><td>✓ <code>/v1/email/briefing/*</code> <span class="opt">(2.2)</span></td><td>—</td><td>—</td></tr>
         <tr><td>calendar <b>detect / conflicts</b> (10–11) &nbsp;·&nbsp; <b>13–17</b> planned &nbsp;·&nbsp; <b>P1–P5</b> personalization</td><td>—</td><td>—</td><td>✓ <b>agent only</b></td></tr>
       </tbody>
     </table>
@@ -457,12 +458,22 @@
     <pre class="code">curl -s http://localhost:8080/v1/email/prescan \
   -H "Content-Type: application/json" \
   -d '{ "max_messages": 25 }'
-# → { "schema_version": "2.1",
+# → { "schema_version": "2.2",
 #     "result": { "kind": "email_pre_scan",
 #                 "urgent": [ … ], "actionable": [ … ],
 #                 "informational_count": 7,
 #                 "suggested_archives": [ … ], "suggested_drafts": [],
 #                 "totals": { "urgent": 2, "actionable": 3, "informational": 7, "suggested_archives": 4 } } }</pre>
+    <p class="body-t"><b>Scheduled daily briefing</b> (schema 2.2, <a class="iss" href="https://github.com/amd/gaia/issues/1608" target="_blank" rel="noopener">#1608</a>) — turn the pre-scan into a morning briefing. Ships <b>off by default</b>; enable the schedule once, then a host scheduler fires the trigger daily (a disabled schedule makes the trigger a <code>409</code> no-op — it never reads mail):</p>
+    <pre class="code">curl -s -X PUT http://localhost:8080/v1/email/briefing/schedule \
+  -H "Content-Type: application/json" \
+  -d '{ "enabled": true, "time": "08:00", "max_messages": 25 }'
+curl -s -X POST http://localhost:8080/v1/email/briefing/run
+# → { "schema_version": "2.2",
+#     "result": { "kind": "email_briefing",
+#                 "generated_at": "2026-07-01T08:00:03+00:00",
+#                 "schedule": { "enabled": true, "time": "08:00", "max_messages": 25 },
+#                 "pre_scan": { "kind": "email_pre_scan", … } } }</pre>
   </div>
 </section>
 
@@ -1332,7 +1343,7 @@ one-shot: "in 2 days", "tomorrow at 9am"</pre>
       <p class="body-t">Each item is triaged independently: a failure on one item sets that entry's <code>error</code> and the remaining items still run. <b>HTTP 200 with every item errored is a valid response</b> — consumers MUST inspect each <code>results[].error</code>, not just the HTTP status. A <code>502</code> means the local LLM was unreachable before any item was processed (the whole batch fails).</p>
       <h4>Request body — BatchTriageRequest</h4>
       <table class="tbl"><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead><tbody>
-        <tr><td><code>schema_version</code></td><td>string <span class="opt">optional</span></td><td>Contract version. Defaults to <code>"2.1"</code>.</td></tr>
+        <tr><td><code>schema_version</code></td><td>string <span class="opt">optional</span></td><td>Contract version. Defaults to <code>"2.2"</code>.</td></tr>
         <tr><td><code>items</code></td><td>list[EmailInput] <span class="req">required</span></td><td>1–100 <code>SingleEmailInput</code> / <code>ThreadInput</code> objects, discriminated on <code>kind</code>. Over 100 → <code>422</code>.</td></tr>
         <tr><td><code>context</code></td><td>TriageContext <span class="opt">optional</span></td><td>Applied to <b>all</b> items.</td></tr>
       </tbody></table>
@@ -1391,7 +1402,7 @@ one-shot: "in 2 days", "tomorrow at 9am"</pre>
       <p class="desc">Search the connected mailbox (<b>read-only</b>) by Gmail-style query / labels (<a class="iss" href="https://github.com/amd/gaia/issues/1781" target="_blank" rel="noopener">#1781</a>). Returns inbox-list metadata for each match — id, thread, subject, from, snippet, labels — <b>not</b> the message body. No mail is sent or modified; no <code>confirmation_token</code> is involved. Restores the agent's in-loop inbox search on the REST contract so the Agent UI drives it through the package.</p>
       <h4>Request body — EmailSearchRequest</h4>
       <table class="tbl"><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead><tbody>
-        <tr><td><code>schema_version</code></td><td>string <span class="opt">optional</span></td><td>Contract version. Defaults to <code>"2.1"</code>; a mismatch lets a consumer fail loudly.</td></tr>
+        <tr><td><code>schema_version</code></td><td>string <span class="opt">optional</span></td><td>Contract version. Defaults to <code>"2.2"</code>; a mismatch lets a consumer fail loudly.</td></tr>
         <tr><td><code>query</code></td><td>string <span class="opt">optional</span></td><td>Gmail-style query (e.g. <code>from:alice is:unread</code>). A query searches <b>all mail</b>; omit it to list by label (the <code>INBOX</code> when labels are also omitted).</td></tr>
         <tr><td><code>labels</code></td><td>list[string] <span class="opt">optional</span></td><td>Label ids to filter by (e.g. <code>["INBOX","UNREAD"]</code>). Omit to apply no label filter; when <code>query</code> is also omitted, the search defaults to <code>INBOX</code>.</td></tr>
         <tr><td><code>max_results</code></td><td>int <span class="opt">optional</span></td><td>Max messages to return, <code>1–100</code> (default <code>25</code>). Each match is hydrated with a per-message fetch, so the count is capped.</td></tr>
@@ -1407,6 +1418,32 @@ one-shot: "in 2 days", "tomorrow at 9am"</pre>
       </tbody></table>
       <h4>Mailbox resolution</h4>
       <p class="body-t">The mailbox is the one connected in GAIA (<i>Settings → Connectors</i>). Fails loud on an ambiguous count — never silently picks: <b>0</b> connected → <code>503</code>, <b>2+</b> connected → <code>400</code>, exactly one → that mailbox.</p>
+    </div>
+
+    <div class="endpoint" id="ep-briefing-schedule">
+      <span class="badge">GET</span><span class="path">/v1/email/briefing/schedule</span>
+      <p class="desc">Read the persisted daily-briefing schedule (schema 2.2, <a class="iss" href="https://github.com/amd/gaia/issues/1608" target="_blank" rel="noopener">#1608</a>). Ships <b>off by default</b>: an absent config is reported as disabled; a corrupt config file is a <code>500</code> naming the file and the fix — never silently reported as disabled. <code>PUT</code> to the same path replaces the schedule (full-document, contract-validated — a bad <code>time</code> or <code>max_messages</code> is a <code>422</code> before anything persists) and is the only way to turn the briefing on. The sidecar stores the preference; the <b>host</b> scheduler (autonomy engine <a class="iss" href="https://github.com/amd/gaia/issues/555" target="_blank" rel="noopener">#555</a>, cron, the GAIA UI scheduler) owns the timer.</p>
+      <h4>Schedule document — BriefingSchedule (PUT request body = GET response's <code>schedule</code>)</h4>
+      <table class="tbl"><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead><tbody>
+        <tr><td><code>enabled</code></td><td>bool <span class="opt">optional</span></td><td>Master switch, default <code>false</code>. While false the scheduled trigger produces no briefing and never touches the mailbox.</td></tr>
+        <tr><td><code>time</code></td><td>string <span class="opt">optional</span></td><td>Local wall-clock <code>HH:MM</code> (default <code>"08:00"</code>) the host scheduler should fire the trigger at, once per day.</td></tr>
+        <tr><td><code>max_messages</code></td><td>int <span class="opt">optional</span></td><td>How many recent inbox messages the briefing pre-scan reads, <code>1–100</code> (default <code>25</code>).</td></tr>
+      </tbody></table>
+    </div>
+
+    <div class="endpoint" id="ep-briefing-run">
+      <span class="badge">POST</span><span class="path">/v1/email/briefing/run</span>
+      <p class="desc">The scheduled daily-briefing trigger (schema 2.2, <a class="iss" href="https://github.com/amd/gaia/issues/1608" target="_blank" rel="noopener">#1608</a>). No request body — the persisted schedule is the configuration. The disabled check runs <b>first</b>: a disabled schedule is a <code>409</code> before any mailbox access, so a stale or misfiring scheduler can never scan a mailbox whose briefing is off. Enabled → runs the same pre-scan classification path as <code>/v1/email/prescan</code>, returns the briefing envelope, and atomically persists it to <code>~/.gaia/email/briefing_latest.json</code> — the interim pull-based delivery surface until push delivery lands with the autonomy engine (<a class="iss" href="https://github.com/amd/gaia/issues/555" target="_blank" rel="noopener">#555</a>).</p>
+      <h4>Response body — EmailBriefingResponse</h4>
+      <table class="tbl"><thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead><tbody>
+        <tr><td><code>schema_version</code></td><td>string</td><td>Echoes the contract version.</td></tr>
+        <tr><td><code>result.kind</code></td><td>const <code>"email_briefing"</code></td><td>Envelope discriminator for the briefing card.</td></tr>
+        <tr><td><code>result.generated_at</code></td><td>string</td><td>UTC ISO-8601 timestamp of when the briefing ran.</td></tr>
+        <tr><td><code>result.schedule</code></td><td>BriefingSchedule</td><td>The schedule that produced this briefing.</td></tr>
+        <tr><td><code>result.pre_scan</code></td><td>EmailPreScanResult</td><td>The inbox pre-scan envelope (<code>kind: "email_pre_scan"</code>) — byte-compatible with <code>/v1/email/prescan</code>, so a consumer that renders the pre-scan card renders the briefing.</td></tr>
+      </tbody></table>
+      <h4>Mailbox resolution</h4>
+      <p class="body-t">Same fail-loud resolution as the pre-scan: <b>0</b> mailboxes connected → <code>503</code>, <b>2+</b> → <code>400</code>, exactly one → that mailbox.</p>
     </div>
 
     <div class="endpoint" id="ep-confirm">
@@ -1665,12 +1702,12 @@ one-shot: "in 2 days", "tomorrow at 9am"</pre>
 <footer class="footer">
   <div class="wrap">
     <p>
-      GAIA Email Agent — Capability &amp; API Specification &nbsp;·&nbsp; <b>v2.1</b> &nbsp;·&nbsp; updated <b>2026-06-26</b> &nbsp;·&nbsp; documents contract <b>schema 2.1</b> (5-bucket triage + REST search / pre-scan / archive · quarantine / calendar) &nbsp;·&nbsp; status as of <a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">Milestone 40</a> (<a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">v0.21.0</a>)<br>
+      GAIA Email Agent — Capability &amp; API Specification &nbsp;·&nbsp; <b>v2.2</b> &nbsp;·&nbsp; updated <b>2026-07-01</b> &nbsp;·&nbsp; documents contract <b>schema 2.2</b> (5-bucket triage + REST search / pre-scan / archive · quarantine / calendar / scheduled daily briefing) &nbsp;·&nbsp; status as of <a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">Milestone 40</a> (<a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">v0.21.0</a>)<br>
       Source of truth:
       <a href="https://github.com/amd/gaia/blob/main/hub/agents/python/email/gaia_agent_email/contract.py" target="_blank" rel="noopener">contract.py</a> ·
       <a href="https://github.com/amd/gaia/blob/main/hub/agents/python/email/gaia_agent_email/api_routes.py" target="_blank" rel="noopener">api_routes.py</a> ·
       <a href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">Milestone 40</a><br>
-      The contract reference reflects the current schema 2.1 models; the capability, guardrail,
+      The contract reference reflects the current schema 2.2 models; the capability, guardrail,
       and workflow sections describe intended behaviour.
     </p>
   </div>

--- a/hub/agents/python/email/tests/test_email_briefing.py
+++ b/hub/agents/python/email/tests/test_email_briefing.py
@@ -1,0 +1,268 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Scheduled daily inbox briefing tests (#1608).
+
+Covers the issue's two test acceptance criteria at the Python seam —
+(1) the scheduled job invokes ``pre_scan_inbox`` and produces the
+``email_pre_scan`` envelope, (2) a disabled schedule produces no briefing
+— plus the schedule persistence contract (off by default, fail-loud on a
+corrupt file) and the REST trigger surface. No live mailbox, no LLM.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+# EmailTriageAgent ships as the standalone gaia-agent-email wheel (#1102);
+# skip cleanly when a framework-only env lacks it.
+pytest.importorskip("gaia_agent_email")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from gaia_agent_email import briefing, export_openapi  # noqa: E402
+from gaia_agent_email.briefing import (  # noqa: E402
+    BriefingConfigError,
+    load_schedule,
+    run_scheduled_briefing,
+    save_schedule,
+)
+from gaia_agent_email.contract import BriefingSchedule  # noqa: E402
+
+
+def _gmail_message(
+    msg_id: str,
+    *,
+    subject: str,
+    sender: str,
+    label_ids: list[str],
+    snippet: str = "",
+) -> dict:
+    """Build a minimal Gmail-API-v1-shaped message the pre-scan path reads."""
+    return {
+        "id": msg_id,
+        "threadId": f"t-{msg_id}",
+        "labelIds": label_ids,
+        "snippet": snippet,
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": subject},
+                {"name": "From", "value": sender},
+            ],
+            "mimeType": "text/plain",
+            "body": {"data": ""},
+        },
+    }
+
+
+class _FakeBackend:
+    """In-memory backend exposing just the read calls pre_scan_inbox_impl uses."""
+
+    def __init__(self, messages: list[dict]):
+        self._messages = {m["id"]: m for m in messages}
+        self.list_calls = 0
+
+    def list_messages(self, *, label_ids=None, max_results=25, **_):  # noqa: ANN001
+        self.list_calls += 1
+        ids = list(self._messages)[:max_results]
+        return {
+            "messages": [
+                {"id": i, "threadId": self._messages[i]["threadId"]} for i in ids
+            ],
+            "nextPageToken": None,
+        }
+
+    def get_message(self, message_id: str) -> dict:
+        return self._messages[message_id]
+
+
+class _ExplodingBackend:
+    """A backend that fails the test if the briefing touches the mailbox."""
+
+    def __getattr__(self, name: str):
+        raise AssertionError(
+            f"disabled schedule must not touch the mailbox (called {name!r})"
+        )
+
+
+def _fake_backend() -> _FakeBackend:
+    return _FakeBackend(
+        [
+            _gmail_message(
+                "m1",
+                subject="50% off this weekend!",
+                sender="deals@shop.example",
+                label_ids=["INBOX", "CATEGORY_PROMOTIONS"],
+            ),
+            _gmail_message(
+                "m2",
+                subject="Project sync notes",
+                sender="alice@corp.example",
+                label_ids=["INBOX"],
+                snippet="Sharing the notes from today's sync.",
+            ),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schedule persistence — off by default, fail-loud on corruption.
+# ---------------------------------------------------------------------------
+
+
+def test_absent_schedule_defaults_to_disabled(tmp_path):
+    sched = load_schedule(tmp_path / "briefing.json")
+    assert sched.enabled is False
+    assert sched.time == "08:00"
+    assert sched.max_messages == 25
+
+
+def test_save_load_round_trip(tmp_path):
+    path = tmp_path / "briefing.json"
+    saved = BriefingSchedule(enabled=True, time="07:30", max_messages=50)
+    save_schedule(saved, path)
+    assert load_schedule(path) == saved
+    # Atomic write leaves no temp file behind.
+    assert list(tmp_path.iterdir()) == [path]
+
+
+def test_corrupt_schedule_fails_loudly(tmp_path):
+    path = tmp_path / "briefing.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(BriefingConfigError, match=re.escape(str(path))):
+        load_schedule(path)
+
+
+def test_invalid_schedule_fields_fail_loudly(tmp_path):
+    path = tmp_path / "briefing.json"
+    path.write_text(json.dumps({"enabled": True, "time": "25:99"}), encoding="utf-8")
+    with pytest.raises(BriefingConfigError, match="briefing/schedule"):
+        load_schedule(path)
+
+
+# ---------------------------------------------------------------------------
+# The scheduled job — the issue's two test acceptance criteria.
+# ---------------------------------------------------------------------------
+
+
+def test_scheduled_job_produces_pre_scan_envelope(tmp_path):
+    """AC: the scheduled job invokes pre_scan_inbox → email_pre_scan envelope."""
+    backend = _fake_backend()
+    latest = tmp_path / "briefing_latest.json"
+    now = datetime(2026, 7, 1, 8, 0, tzinfo=timezone.utc)
+
+    out = run_scheduled_briefing(
+        backend,
+        schedule=BriefingSchedule(enabled=True),
+        latest_path=latest,
+        now=now,
+    )
+
+    assert out is not None
+    assert out["kind"] == "email_briefing"
+    assert out["generated_at"] == now.isoformat()
+    assert out["schedule"]["enabled"] is True
+    # The payload IS the pre-scan envelope — produced by pre_scan_inbox_impl,
+    # which the fake backend proves was invoked (it listed + read messages).
+    assert out["pre_scan"]["kind"] == "email_pre_scan"
+    assert backend.list_calls == 1
+    archived = {m["message_id"] for m in out["pre_scan"]["suggested_archives"]}
+    assert "m1" in archived  # the promotional message
+
+    # Delivery stub: the envelope persists as the latest briefing.
+    assert json.loads(latest.read_text(encoding="utf-8")) == out
+
+
+def test_disabled_schedule_produces_no_briefing(tmp_path):
+    """AC: a disabled schedule produces no briefing and never reads mail."""
+    latest = tmp_path / "briefing_latest.json"
+
+    out = run_scheduled_briefing(
+        _ExplodingBackend(),
+        schedule=BriefingSchedule(enabled=False),
+        latest_path=latest,
+    )
+
+    assert out is None
+    assert not latest.exists()
+
+
+def test_trigger_reads_persisted_schedule(tmp_path):
+    """Without an explicit schedule, the trigger loads the persisted one —
+    the path a dumb scheduler exercises."""
+    sched_path = tmp_path / "briefing.json"
+    save_schedule(BriefingSchedule(enabled=True, max_messages=10), sched_path)
+
+    out = run_scheduled_briefing(
+        _fake_backend(),
+        schedule_path=sched_path,
+        latest_path=tmp_path / "latest.json",
+    )
+    assert out is not None
+    assert out["schedule"]["max_messages"] == 10
+
+
+# ---------------------------------------------------------------------------
+# REST trigger surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def briefing_client(tmp_path, monkeypatch) -> TestClient:
+    """A client whose briefing paths live under tmp_path and whose pre-scan
+    backend is the in-memory fake."""
+    from gaia_agent_email import api_routes
+
+    monkeypatch.setattr(
+        briefing, "briefing_schedule_path", lambda: tmp_path / "briefing.json"
+    )
+    monkeypatch.setattr(
+        briefing, "latest_briefing_path", lambda: tmp_path / "briefing_latest.json"
+    )
+    monkeypatch.setattr(api_routes, "get_prescan_backend", _fake_backend)
+    return TestClient(export_openapi.build_app())
+
+
+def test_rest_schedule_defaults_off(briefing_client):
+    resp = briefing_client.get("/v1/email/briefing/schedule")
+    assert resp.status_code == 200
+    assert resp.json()["schedule"]["enabled"] is False
+
+
+def test_rest_schedule_put_get_round_trip(briefing_client):
+    body = {"enabled": True, "time": "07:15", "max_messages": 40}
+    resp = briefing_client.put("/v1/email/briefing/schedule", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["schedule"] == body
+
+    resp = briefing_client.get("/v1/email/briefing/schedule")
+    assert resp.json()["schedule"] == body
+
+
+def test_rest_schedule_rejects_bad_time_loudly(briefing_client):
+    resp = briefing_client.put(
+        "/v1/email/briefing/schedule", json={"enabled": True, "time": "9am"}
+    )
+    assert resp.status_code == 422
+
+
+def test_rest_run_disabled_is_409(briefing_client, tmp_path):
+    resp = briefing_client.post("/v1/email/briefing/run")
+    assert resp.status_code == 409
+    assert "disabled" in resp.json()["detail"]
+    assert not (tmp_path / "briefing_latest.json").exists()
+
+
+def test_rest_run_enabled_returns_briefing(briefing_client, tmp_path):
+    briefing_client.put(
+        "/v1/email/briefing/schedule", json={"enabled": True, "time": "08:00"}
+    )
+    resp = briefing_client.post("/v1/email/briefing/run")
+    assert resp.status_code == 200
+    result = resp.json()["result"]
+    assert result["kind"] == "email_briefing"
+    assert result["pre_scan"]["kind"] == "email_pre_scan"
+    assert (tmp_path / "briefing_latest.json").exists()

--- a/hub/agents/python/email/tests/test_rest_contract.py
+++ b/hub/agents/python/email/tests/test_rest_contract.py
@@ -48,6 +48,10 @@ _EXPECTED_RESPONSE_MODELS = {
     ("post", "/v1/email/triage/batch"): "BatchTriageResponse",  # #1887 additive
     ("post", "/v1/email/search"): "EmailSearchResponse",
     ("post", "/v1/email/prescan"): "EmailPreScanResponse",
+    # Scheduled daily briefing (schema 2.2, #1608).
+    ("get", "/v1/email/briefing/schedule"): "BriefingScheduleResponse",
+    ("put", "/v1/email/briefing/schedule"): "BriefingScheduleResponse",
+    ("post", "/v1/email/briefing/run"): "EmailBriefingResponse",
     ("post", "/v1/email/draft"): "EmailDraftResponse",
     ("post", "/v1/email/send"): "EmailSendResponse",
     # Mailbox actions (schema 2.1, #1779).

--- a/tests/unit/agents/email/test_contract_schema.py
+++ b/tests/unit/agents/email/test_contract_schema.py
@@ -331,15 +331,16 @@ def test_result_summary_required():
 
 
 def test_schema_version_unchanged_by_multi_inbox():
-    """Schema 2.1 is the current frozen contract version.
+    """Schema 2.2 is the current frozen contract version.
 
     2.1 is additive over the 2.0 5-bucket taxonomy (no triage shape change): it
     added inbox search (#1781), mailbox actions (#1779), the calendar surface
-    (#1780), and inbox pre-scan (#1778). If this fails, someone changed the
+    (#1780), and inbox pre-scan (#1778). 2.2 is additive over 2.1: it added the
+    scheduled daily-briefing surface (#1608). If this fails, someone changed the
     version unexpectedly; that requires an explicit version negotiation, not a
     drive-by edit.
     """
-    assert SCHEMA_VERSION == "2.1"
+    assert SCHEMA_VERSION == "2.2"
 
 
 def test_triage_result_gained_no_new_required_field():


### PR DESCRIPTION
Closes #1608.

The inbox pre-scan only answered when a user asked for it — there was no way to get the morning briefing #1608 describes without typing a prompt. Now the email sidecar carries an **off-by-default** briefing schedule and a scheduled trigger: a host scheduler fires `POST /v1/email/briefing/run` daily and gets back a `kind: "email_briefing"` envelope wrapping the exact `email_pre_scan` card the Agent UI already renders (reusing `pre_scan_inbox_impl` — no re-implemented scan), also persisted to `~/.gaia/email/briefing_latest.json` so a consumer can pull the latest briefing without having been the live caller.

**Scope note (per the issue's autonomy-engine dependency):** the sidecar deliberately runs **no timer** and push delivery has no home until #555 lands — the seam to the autonomy engine is the single documented trigger plus `GET/PUT /v1/email/briefing/schedule`. The trigger re-checks `enabled` itself and answers 409 **before any mailbox access**, so a stale or misfiring scheduler can never scan a mailbox whose briefing is off; a corrupt schedule file is a 500 naming the file and the fix, never a silent fall-back to disabled. Contract `SCHEMA_VERSION` bumps 2.1 → 2.2 (additive, same MAJOR — existing 2.x npm clients keep working; the new endpoints are REST-only for now, typed client methods land with the autonomy-engine integration). No LLM-affecting path changes (no prompts/tools/parsing touched), so no eval run is required.

## Test plan

- [x] `python -m pytest hub/agents/python/email/tests/ tests/unit/agents/email/` — 630 passed (includes the two issue ACs in `test_email_briefing.py`: scheduled job → `email_pre_scan` envelope; disabled schedule → no briefing and the mailbox backend is never touched)
- [x] `npx vitest run` in `hub/agents/npm/agent-email` — 59 passed (TS `SCHEMA_VERSION` 2.2)
- [x] `python util/lint.py --all` — clean
- [x] Real-sidecar smoke (`packaging/server.py` on an ephemeral port): `/version` reports 2.2; schedule defaults disabled; `run` → 409 while disabled; `PUT` round-trips and persists; bad `time` → 422
- [ ] Reviewer: `git grep -n briefing hub/agents/npm/agent-email` — README/SPEC/SKILL/CHANGELOG, `specification.html`, `openapi.email.json` (regenerated), and `docs/guides/email.mdx` all describe the same off-by-default / host-owns-the-timer semantics