### PR TITLE
feat(email): voice/style-matched drafting from Sent history

### DIFF
--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -13,6 +13,7 @@ The Email Triage Agent connects to your Gmail account through GAIA's connectors 
 - **Organize** — archive, label, mark read/unread, star/unstar. Reversible via the per-action undo log.
 - **Soft-delete with undo** — `trash_message` records the action; `restore_message` reverses it within a 30-second window.
 - **Draft + confirmed send** — generate replies (`draft_reply`) and forwards (`draft_forward`); `send_draft` and `send_now` require explicit user confirmation in the UI.
+- **Draft in your own voice** — build a local style profile from your Sent mail (`build_style_profile`) so drafts open, close, and read the way you actually write. The profile never leaves your device.
 - **Calendar** — list events, accept/decline invites, create events from email content (all calendar mutations gated by user confirmation).
 
 ## Setup
@@ -142,6 +143,12 @@ Preferences are stored in process memory only — restarting the agent (or quitt
 
 Senders you reply to quickly are automatically promoted to priority on the next triage run — no explicit command needed. The agent measures how long it took you to reply to each sender (using the original message's receipt timestamp as the anchor) and promotes senders whose median reply latency falls below the threshold. Promotion is applied on-demand during triage, not on a background thread, and persists across agent restarts. Works across both connected mailboxes (Gmail and Outlook).
 
+### Voice-matched drafting (learned from your Sent mail)
+
+Ask the agent to *"learn my writing style"* (or call `build_style_profile` directly) and it samples your recent Sent messages — 25 by default — and derives a **voice profile**: your typical greeting (e.g. `Hi {name},`), sign-off (e.g. `Thanks, Alex`), typical message length, formality, and emoji use. From then on, `draft_reply` bodies are composed in that voice instead of a generic scaffold. Drafts are still always returned for your approval — nothing is ever auto-sent.
+
+The profile is built with deterministic on-device analysis (your Sent bodies are never sent anywhere, not even to the local LLM), stores **derived features only** — never message text — and lives in local storage (`~/.gaia/email/memory.db`). One profile is kept per connected mailbox, so a work voice and a personal voice stay separate. Inspect it with *"what's my writing style?"* (`get_style_profile`) or delete it anytime with *"forget my writing style"* (`clear_style_profile`). Rebuild whenever your style changes — rebuilding replaces the old profile.
+
 ## Action surface
 
 ### Read
@@ -155,6 +162,10 @@ Senders you reply to quickly are automatically promoted to priority on the next 
 ### Inbox profiling
 
 `profile_inbox` — asks "who emails me most?" and returns a frequency ranking of senders with their dominant category (e.g. *urgent*, *informational*) and the timestamp of their most recent message. Profiling is built from the interaction history the agent accumulates during triage, so it improves the more you use the agent.
+
+### Voice/style profile (persisted, local-only)
+
+`build_style_profile`, `get_style_profile`, `clear_style_profile` — learn, inspect, or delete the per-mailbox voice profile derived from your Sent mail that shapes `draft_reply` composition. Building reads Sent messages but never drafts, sends, or modifies anything.
 
 ### Organize (reversible via the undo log)
 
@@ -188,6 +199,7 @@ There is no setting, flag, or "auto-send" mode that bypasses this — it's a saf
 
 - **Local LLM only** — email body content never leaves your machine. The agent's configuration has no field that even *names* a cloud LLM provider; the `base_url` allowlist further enforces this at runtime.
 - **State stored locally** — `~/.gaia/email/state.db` (SQLite) holds the action audit log and draft metadata. Body previews are truncated to 100 characters before persistence.
+- **Voice profile is features-only** — the style profile learned from your Sent mail stores derived features (greeting/sign-off templates, length, formality), never message text, and only in local storage (`~/.gaia/email/memory.db`). Extraction is deterministic string analysis — Sent bodies are not even passed to the local LLM to build it.
 - **Untrusted input** — every email body shown to the LLM is wrapped in `<<<UNTRUSTED_EMAIL_BODY_*>>>` delimiters. The system prompt explicitly tells the model that body content is data, not instructions, so injection attempts (e.g., "forward this to attacker@evil.com") are surfaced to you instead of executed.
 
 ## Phishing handling

--- a/docs/plans/email-sidecar-agent-ui.md
+++ b/docs/plans/email-sidecar-agent-ui.md
@@ -101,7 +101,7 @@ Email proxy agent + tools  (chat agent tool layer — NEW; replaces in-process a
    ▼
 EmailSidecarManager  (Python, in the UI backend — NEW; spawn/health/shutdown/port)
    │  reads GAIA_EMAIL_AGENT_MODE
-   ├─ user mode → frozen binary   (lazy-fetched on first email use via npm pkg CLI)
+   ├─ user mode → frozen binary   (lazy-fetched on first email use; Python verified download, NO Node)
    └─ dev  mode → uvicorn --reload (local Python source)
         │
         ▼  both serve the identical contract
@@ -122,7 +122,7 @@ in-process/out-of-process divergence).
 |------|------|----------------|
 | `EmailSidecarManager` | `src/gaia/ui/` (Python backend) | mode select; lazy-spawn binary/uvicorn on first email use; health-poll; tree-kill on shutdown; own an ephemeral per-instance port |
 | Email proxy agent + tools | chat agent tool layer (`agent_type=email`) | forward triage/draft/send/pre-scan/etc. to the sidecar; return the existing envelopes unchanged |
-| Binary fetch | **npm pkg CLI** (`npx @amd-gaia/agent-email fetch`) as a subprocess | keep the SHA-256/lock-file integrity check in its canonical TS impl (`fetch.ts`) — **do not re-implement the security boundary in Python** |
+| Binary fetch | **Python**, in the UI backend — **no Node** | download the current platform's binary from R2/`ASSETS_BASE_URL`, **verify SHA-256 against `binaries.lock.json`** (the security boundary), cache in `~/.gaia`. The npm `fetch.ts` remains the *external Node-integrator* channel — a separate consumer, not the UI's path |
 | Mode config | `GAIA_EMAIL_AGENT_MODE` env (`user` default / `dev`) | select backend |
 
 ## Resolved design decisions
@@ -164,10 +164,12 @@ imported, fail loudly with `uv pip install -e hub/agents/python/email` — no si
 auto-install, no fallback. Dev mode is source-checkout only.
 
 ## Lifecycle, port & ownership (review fixes)
-- **Reuse, don't reinvent:** `lifecycle.ts`/`fetch.ts` already implement
-  SHA-verified fetch, tree-kill, health-poll, version-check, auto-reap. User-mode
-  fetch goes through the npm CLI; Python owns only spawn + health + tree-kill (not a
-  security boundary).
+- **No Node.js in the Agent UI.** The sidecar is a self-contained HTTP binary; the
+  Python backend fetches (verified download), spawns, health-checks, proxies to, and
+  tree-kills it directly — no Node runtime, no npm package in the UI's path. This is
+  the precise answer to #1767's objection (below). The npm `lifecycle.ts`/`fetch.ts`
+  stay as the *external Node-integrator* channel; they are reference implementations
+  for the Python port of the SHA-verify + tree-kill logic, which has unit tests.
 - **Port:** a fixed `8131` breaks two concurrent `gaia chat --ui` instances. The
   manager binds an **ephemeral port per backend instance** and passes it to the
   proxy agent. **Never 4001.**
@@ -218,15 +220,21 @@ auto-install, no fallback. Dev mode is source-checkout only.
 5. Tests (incl. the dogfood/product check) + a short dev-mode doc.
 
 ## Relationship to epic #1767 (must reconcile before build)
-#1767 **chose the in-process router mount** and **explicitly rejected the
-frozen-binary sidecar for the UI**; its capstone PR #1785 was **closed unmerged on
-2026-06-26**, so the in-process path is abandoned in code but the *decision* stands
-on paper. This plan **pivots to the sidecar**, justified by product validation +
-lightweight core + isolation (above). Its variant also answers #1767's stated
-objection — #1767 rejected the sidecar as "needs a Node host / breaks browser mode,"
-but here the **Python backend** spawns it, so it works in browser mode with no Node
-host. **Action: get maintainer + @itomek sign-off to supersede #1767's in-process
-decision before implementation.**
+#1767 (epic) and its capstone PR #1785 were **closed unmerged on 2026-06-26**.
+@itomek's closing rationale was explicit: *"Given the nature of Agent UI having a
+Python backend, mixing in an npm package that requires Node.js would make it too
+dirty. This will get replaced by a future issue."*
+
+This plan **is that future issue's design**, and it removes the exact thing itomek
+objected to: **there is no npm package and no Node.js in the Agent UI's path.** The
+sidecar is a language-agnostic, self-contained HTTP binary; the Python backend
+fetches it (verified download), spawns it as a subprocess, and proxies to it over
+HTTP. The npm package stays purely as the *external Node-integrator* distribution —
+never imported or executed by the UI. The sidecar is justified over an in-process
+mount by product validation (the UI runs the exact Hub-published artifact),
+lightweight core (no email deps; lazy per-agent download), and crash isolation.
+**Action: get @itomek + maintainer sign-off on this Node-free sidecar direction
+before implementation.**
 
 ## Remaining decision for sign-off
 - Confirm removal of the #1768 in-process `/v1/email` external mount once the UI is

--- a/docs/plans/email-sidecar-agent-ui.md
+++ b/docs/plans/email-sidecar-agent-ui.md
@@ -1,60 +1,91 @@
-# Design: Email Agent in the Agent UI — dual user/dev modes
+# Design: Email Agent in the Agent UI — frozen sidecar + dual user/dev modes
 
 **Date:** 2026-06-26
-**Status:** Draft (v2 — topology corrected after code review) — pending user review
-**Related:** epic #1767 (Email in the Agent UI), #1768 (`/v1/email/*` REST surface),
-npm pkg `@amd-gaia/agent-email` (`hub/agents/npm/agent-email`), Python agent
+**Status:** Draft (v3.1 — sidecar direction, bulletproofed) — pending user review
+**Decision (2026-06-26):** The Agent UI's email backend is the **out-of-process
+frozen sidecar** (the published Hub product), lazily downloaded on demand. Dev mode
+runs the same contract from local Python source for fast iteration. This **reopens
+the in-process decision in epic #1767** — see "Relationship to #1767" — and needs
+maintainer + @itomek sign-off before build.
+**Related:** #1767 (epic), #1768 (`/v1/email/*` REST surface), #1778/#1779/#1780/#1781
+(REST capability build-out), npm pkg `@amd-gaia/agent-email`, Python agent
 `hub/agents/python/email`
 
 ## Problem
 
-We want the GAIA Agent UI to triage the user's **personal Gmail**, with two things
-true at once:
+Triage the user's **personal Gmail** through the Agent UI, with:
+1. **Users** — stable, no-Python: the agent runs as the frozen sidecar; the core
+   backend ships without heavy email deps, and the install stays **lightweight** —
+   only the email sidecar is downloaded, on demand.
+2. **Developers** — improve the agent and see changes **live**, no
+   freeze → `npm publish` → version-bump → re-integrate patch loop.
 
-1. **Users** get a stable, no-Python experience — the agent ships as the frozen
-   `@amd-gaia/agent-email` sidecar binary, with no heavy email deps in the core
-   backend.
-2. **Developers** can improve the agent and see changes **live**, without the
-   freeze → `npm publish` → version-bump → re-integrate patch loop that makes
-   iteration painful today.
+## Why a sidecar (not the simpler in-process editable install)
 
-## How the UI actually wires email today (verified)
+A code review fairly asked: an editable install (`uv pip install -e`) already gives
+in-process hot-iteration — why add a sidecar? Three reasons the sidecar earns its
+place, beyond iteration speed:
 
-This is the ground truth the design must respect — an earlier draft got it wrong.
+1. **It validates the shipped product.** User mode runs the *exact* frozen binary
+   published to the Agent Hub (pinned via `binaries.lock.json`). The Agent UI
+   becomes a first-class consumer of the real artifact — so product regressions
+   surface in our own app, not just in a downstream integrator's. Editable-install
+   never exercises the thing customers actually run.
+2. **It keeps the core backend lightweight.** The email agent's heavy deps stay out
+   of the core wheel/installer; the sidecar is fetched **only when email is used**,
+   and **only the one platform binary** is downloaded — nothing else.
+3. **Crash isolation.** A fault in email tooling can't take down the chat backend.
 
-- The frontend has **no email REST client**. It surfaces email triage through the
+Dev mode (uvicorn-from-source) and user mode (frozen binary) therefore serve two
+distinct purposes — **fast iteration** and **product validation** — over one shared
+REST contract.
+
+## Ground truth: how the UI wires email today (verified)
+
+- The frontend has **no email REST client**. Email triage is surfaced via the
   **chat pipeline**: the chat agent calls a tool (`pre_scan_inbox`), the result is
-  emitted as a structured payload on the chat SSE stream
-  (`src/gaia/ui/sse_handler.py:472`), and the renderer draws it as
-  `EmailPreScanCard` inside `MessageBubble` (`MessageBubble.tsx:727`).
-- The email agent runs **in-process** in the Python UI backend: `_chat_helpers.py`
-  constructs it via the session agent factory (`:1300`, `:1776`, passing
-  `mail_provider`) and runs it through the chat loop.
-- `src/gaia/ui/server.py:599-601` *also* mounts `gaia_agent_email`'s `/v1/email/*`
-  router in-process — but that is a **separate external/programmatic surface**
-  (#1768), not what the UI's own rendering uses.
-- The agent reads the user's mailbox itself via the connectors framework, using the
-  Google grant at `~/.gaia/connectors/grants.json` (`src/gaia/connectors/grants.py:53`).
+  emitted on the chat SSE stream (`sse_handler.py:472`), and the renderer draws
+  `EmailPreScanCard` in `MessageBubble` (`MessageBubble.tsx:727`).
+- The agent runs **in-process** in the Python backend via the session agent factory
+  (`_chat_helpers.py:1300,1776`, passing `mail_provider`); `agent_type=email`
+  selects it.
+- `server.py:599-601` mounts `gaia_agent_email`'s `/v1/email/*` router in-process —
+  a separate external/programmatic surface (#1768), not what the UI renders from.
+- The agent reads the mailbox itself via connectors, using the Google grant at
+  `~/.gaia/connectors/grants.json` (`grants.py:53`); OAuth secrets resolve via the
+  OS keyring, not the JSON ledger.
 
-**Consequences for the design:**
-- The seam for user/dev mode is the **chat agent's email-tool layer in the Python
-  backend** — not the renderer, and not Electron main.
-- The lifecycle host is the **Python UI backend**, which already owns the chat loop
-  and the grant. **No Node.js backend is required** — the frozen sidecar is a
-  self-contained HTTP executable the Python backend can spawn and call directly.
-  (The npm package remains the integration path for *external* Node/Electron apps;
-  it is just not GAIA's own consumption path.)
+## ⚠️ Precondition: the REST contract is not yet sufficient for the UI
 
-## Key insight — one REST seam, two interchangeable backends
+The sidecar's contract **today** (verified) is:
+
+| UI capability | REST route today | Status |
+|---|---|---|
+| triage a pasted email/thread | `POST /v1/email/triage` | ✅ exists |
+| draft / send | `POST /v1/email/draft` · `/send` | ✅ exists |
+| health / version / spec / playground | `GET /health` `/version` `/spec` `/playground` | ✅ exists |
+| connector configure/complete/list/remove | `/v1/email/connectors/*` | ✅ exists |
+| **inbox pre-scan** (`email_pre_scan` card) | — | ❌ in flight (pre-scan REST) |
+| **inbox search** | — | ❌ #1781 |
+| **archive / quarantine** | — | ❌ #1779 |
+| **calendar** | — | ❌ #1780 |
+
+Critically, `/triage` takes the email **in the request body** — it does not scan the
+mailbox. The UI's headline feature, the `email_pre_scan` card, is produced **only**
+by the agent-loop tool that scans the inbox (`agent.py:663-717`, `read_tools.py:572`).
+So the **sidecar cannot serve the UI's inbox features until those become REST
+routes** — work that is in flight (#1779/#1780/#1781 + inbox pre-scan REST). **This
+design is sequenced behind them.** Each new route is a contract change governed by
+the npm version guard (`lifecycle.ts:checkVersion`).
+
+## Key seam — one REST contract, two interchangeable backends
 
 The frozen binary is PyInstaller wrapping `packaging/server.py`'s `build_app()`, so
-the binary and the raw Python source serve a **byte-identical** contract at
-`http://127.0.0.1:8131/v1/email/*`. Anything answering that URL is interchangeable.
-
-Because the agent owns its own mailbox connection and reads the shared
-`~/.gaia/connectors/grants.json`, **personal Gmail works identically in both
-modes**. The user authenticates Google once; the mode only swaps *which process*
-answers the REST calls.
+once the routes above exist, the **binary and the raw Python source serve an
+identical contract** at `http://127.0.0.1:<sidecar-port>/v1/email/*`. The agent owns
+its mailbox connection and reads the shared `~/.gaia/connectors/grants.json`, so
+**personal Gmail works identically in both modes** — the mode only swaps which
+*process* answers the calls.
 
 ## Architecture
 
@@ -62,129 +93,142 @@ answers the REST calls.
 Agent UI renderer  (UNCHANGED — renders email_pre_scan cards from chat SSE)
    │  chat SSE
    ▼
-Python UI backend  (port 4200 — owns chat loop, SSE, grant)
-   │  chat agent calls email tools
+Python UI backend  (port 4200 — owns chat loop, SSE, connector OAuth, grant writes)
+   │  agent_type=email → Email proxy agent
    ▼
-Email proxy tools  (thin HTTP shims, in the chat agent's tool layer — NEW)
-   │  POST http://127.0.0.1:8131/v1/email/*
+Email proxy agent + tools  (chat agent tool layer — NEW; replaces in-process agent)
+   │  POST http://127.0.0.1:<sidecar-port>/v1/email/*
    ▼
-EmailSidecarManager  (Python, in the UI backend — NEW)
+EmailSidecarManager  (Python, in the UI backend — NEW; spawn/health/shutdown/port)
    │  reads GAIA_EMAIL_AGENT_MODE
-   ├─ user mode → spawn frozen binary    (lazy-fetched to ~/.gaia cache)
-   └─ dev  mode → spawn uvicorn --reload  (local Python source)
+   ├─ user mode → frozen binary   (lazy-fetched on first email use via npm pkg CLI)
+   └─ dev  mode → uvicorn --reload (local Python source)
         │
         ▼  both serve the identical contract
-   sidecar :8131  ──reads──> ~/.gaia/connectors/grants.json ──> user's Gmail
+   sidecar  ──reads (no writes)──> ~/.gaia/connectors/grants.json ──> user's Gmail
 ```
 
-The renderer and the SSE card pipeline are untouched: the proxy tools return the
-same `pre_scan_inbox` envelope the in-process agent returns today, so
-`sse_handler.py` and `EmailPreScanCard` keep working unchanged.
+The renderer and SSE card pipeline are untouched: the proxy agent's tools return the
+same envelopes (e.g. `pre_scan_inbox`), so `sse_handler.py` and `EmailPreScanCard`
+keep working once the pre-scan REST route exists.
 
-**Both modes go through the same HTTP path** — only the *served process* differs.
-This is deliberate: it avoids the "works in dev, breaks for users" masking failure
-where an in-process dev path and an out-of-process prod path diverge. Process
-isolation (the thing #1767 cares about) is then identical in both modes.
+**Both modes use the same HTTP path** — only the served process differs. Production
+is now out-of-process too, so dev and prod share the same isolation topology (no
+in-process/out-of-process divergence).
 
 ### Components
 
-| Unit | Home | Responsibility | Depends on |
-|------|------|----------------|------------|
-| `EmailSidecarManager` | `src/gaia/ui/` (Python backend) | Pick mode, spawn the right process, wait for `/health`, expose base URL, tree-kill on shutdown | `subprocess`, the frozen binary / uvicorn |
-| Email proxy tools | chat agent tool layer | Forward `pre_scan_inbox`/triage/draft to the sidecar; return the existing envelope | `EmailSidecarManager` base URL |
-| Mode config | `GAIA_EMAIL_AGENT_MODE` env (`user` default / `dev`) | Select backend | — |
+| Unit | Home | Responsibility |
+|------|------|----------------|
+| `EmailSidecarManager` | `src/gaia/ui/` (Python backend) | mode select; lazy-spawn binary/uvicorn on first email use; health-poll; tree-kill on shutdown; own an ephemeral per-instance port |
+| Email proxy agent + tools | chat agent tool layer (`agent_type=email`) | forward triage/draft/send/pre-scan/etc. to the sidecar; return the existing envelopes unchanged |
+| Binary fetch | **npm pkg CLI** (`npx @amd-gaia/agent-email fetch`) as a subprocess | keep the SHA-256/lock-file integrity check in its canonical TS impl (`fetch.ts`) — **do not re-implement the security boundary in Python** |
+| Mode config | `GAIA_EMAIL_AGENT_MODE` env (`user` default / `dev`) | select backend |
 
-### User mode (default)
-Lazy-fetch the frozen binary into a **`~/.gaia/agents/email/` cache** on first run
-(R2 + lock-file verified) → spawn → poll `GET /health` → tree-kill on backend exit
-(`taskkill /F /T` on Windows; detached process-group kill on POSIX). Cache means
-offline after first fetch and no installer/build-pipeline change. A failed fetch
-fails loudly (no fallback to dev mode). The core backend ships **without** the
-email agent's Python deps.
+## Resolved design decisions
 
-### Dev mode
-Spawn uvicorn's **CLI with an import string** so hot-reload works:
+1. **Proxy *agent*, not loose tools.** Reuse the existing `agent_type=email` session
+   machinery: replace the in-process `EmailTriageAgent` constructed in
+   `_chat_helpers.py` with a thin **proxy agent** whose tools call the sidecar and
+   return the same envelopes. This preserves session construction, `mail_provider`
+   plumbing, and the SSE card path with the smallest diff.
+2. **Lightweight, lazy, scoped download.** The sidecar is fetched **on first email
+   use** (not at app startup), **only the current platform's binary**, into a
+   `~/.gaia/agents/email/` cache (cache-hit skips re-download; offline thereafter).
+   The core install bundles **no** email sidecar. This establishes a reusable
+   *lazy-per-agent-sidecar* pattern, but scope here is **email only** (YAGNI).
+3. **User mode pins the published artifact.** Fetch verifies against the shipped
+   `binaries.lock.json`, so the UI exercises the exact Hub-published binary
+   (dogfooding). A failed/integrity-mismatched fetch fails loudly — never falls back
+   to dev mode or to in-process.
+4. **The sidecar is the single `/v1/email` surface; remove the in-process mount.**
+   The in-process `server.py:599-601` mount (#1768) becomes redundant once the UI is
+   sidecar-only and contradicts the lightweight-core goal (it imports the email
+   wheel into core). Remove it from core; the sidecar itself serves the external
+   `/v1/email` surface. Coordinate the removal with the #1768 owner.
 
+### Dev mode enabler (one small, owned change)
+Hot-reload needs uvicorn's import-string form, which needs a **module-level app**
+that does not exist today (it lives inside `build_app()`/`main()`):
+
+```python
+# hub/agents/python/email/packaging/server.py — add at module scope:
+app = build_app()        # build_app also mounts /v1/email/connectors/* — fine for dev
 ```
-python -m uvicorn packaging.server:app --reload --host 127.0.0.1 --port 8131
-# cwd = hub/agents/python/email   (app = build_app() exists at module scope)
+```bash
+python -m uvicorn packaging.server:app --reload --host 127.0.0.1 --port <port>
 ```
+Edit any `.py` / prompt / tool → uvicorn reloads in ~1s → next chat action hits new
+code. Dev mode assumes the source env is set up; if uvicorn/the package can't be
+imported, fail loudly with `uv pip install -e hub/agents/python/email` — no silent
+auto-install, no fallback. Dev mode is source-checkout only.
 
-> `packaging/server.py`'s `__main__` calls `uvicorn.run(app, …)` with the *app
-> object*, which cannot hot-reload — dev mode must use the import-string CLI form
-> above (no change to `server.py` required).
+## Lifecycle, port & ownership (review fixes)
+- **Reuse, don't reinvent:** `lifecycle.ts`/`fetch.ts` already implement
+  SHA-verified fetch, tree-kill, health-poll, version-check, auto-reap. User-mode
+  fetch goes through the npm CLI; Python owns only spawn + health + tree-kill (not a
+  security boundary).
+- **Port:** a fixed `8131` breaks two concurrent `gaia chat --ui` instances. The
+  manager binds an **ephemeral port per backend instance** and passes it to the
+  proxy agent. **Never 4001.**
+- **One backend for the UI:** the UI talks only to the sidecar (decision 4).
 
-Edit any `.py` / prompt / tool → uvicorn reloads in ~1s → the next chat action hits
-new code. **No freeze, no publish, no version bump, no UI rebuild.** Dev mode
-assumes the source env is set up; if uvicorn or the package can't be imported, fail
-loudly with `uv pip install -e hub/agents/python/email` — no silent auto-install,
-no fallback to user mode. Dev mode only applies to a source checkout (the packaged
-app has no Python source).
+## Auth & grants (review fixes)
+- **Single writer:** all connector OAuth flows stay on the **Python backend**; the
+  sidecar **reads** the grant + resolves keyring secrets but does **not** run OAuth
+  writes (its `/connectors/{provider}/complete` write route is **not** exposed to
+  the UI). This avoids cross-process writes to `grants.json`, whose concurrency
+  guard is per-process only (`grants.py:56-61`).
+- **Bundling verified:** `freeze.py:119` collects `gaia.connectors`, so the binary
+  can read the grant. Cold-start test must assert a **real keyring token resolve**
+  from the frozen binary, not merely that `gaia.connectors` imports.
 
-## Data flow (both modes, identical)
-1. User asks the chat agent to triage (e.g. "what's in my inbox").
-2. Chat agent calls the `pre_scan_inbox` proxy tool.
-3. Tool POSTs to `http://127.0.0.1:8131/v1/email/*`.
-4. Sidecar (binary or uvicorn) reads the `~/.gaia` grant, calls Gmail, returns the
-   envelope.
-5. Tool returns the envelope unchanged → `sse_handler` injects it → renderer draws
-   the `EmailPreScanCard`.
-
-## Error handling (fail loudly — no silent fallbacks)
-- Binary missing/un-fetchable in user mode → surface `BinaryNotFoundError` with its
-  actionable fetch hint; never silently fall back to dev mode.
-- `/health` not ready within timeout → loud error with the sidecar's last stderr.
-- Lemonade unreachable → sidecar already returns HTTP 502; surface verbatim.
-- Dev mode requested but source/uvicorn missing → loud startup error naming the
-  expected path + the `uv pip install -e` remedy.
-- Port 8131 in use → fail with the conflicting-process hint. **Never touch 4001.**
+## Error handling (fail loudly)
+- Binary missing/integrity-fail in user mode → loud error with the fetch remedy;
+  never fall back to dev/in-process.
+- `/health` timeout → loud error with the sidecar's last stderr.
+- Lemonade unreachable → sidecar returns HTTP 502; surface verbatim.
+- Dev mode without source/uvicorn → loud error naming the path + `uv pip install -e`.
+- Sidecar port in use → fail with the conflicting-process hint.
 
 ## Testing
-- **Unit:** `EmailSidecarManager` mode selection + spawn-arg *shape* (assert dev mode
-  uses the `--reload` import-string form; user mode uses the cached binary path),
-  health-poll, tree-kill on shutdown.
-- **Integration:** with a running sidecar (both modes), `GET /health` then a real
-  `pre_scan_inbox` round-trip through the proxy tool — proves the *call is valid*,
-  not just invoked.
-- **Cold-start:** confirm the frozen binary bundles `gaia.connectors` so user mode
-  reads the grant — verify from an empty-state machine, not a warm box.
-- **Card pipeline:** assert the proxy tool's envelope still triggers the
-  `email_pre_scan` SSE injection and `EmailPreScanCard` render.
-- **Prompt/LLM changes** still require `gaia eval agent` (email category) vs.
-  baseline before "done" — iteration speed ≠ skipping verification.
+- **Unit:** mode selection + spawn-arg *shape* (dev → `--reload` import-string;
+  user → cached binary path); health-poll; tree-kill on shutdown; ephemeral-port
+  wiring to the proxy agent; lazy-fetch only on first email use.
+- **Integration:** with a running sidecar (both modes) `GET /health` then a real
+  inbox pre-scan round-trip through the proxy agent — proves the *call is valid*.
+- **Dogfood/product check:** user mode launches the binary resolved from
+  `binaries.lock.json` and a smoke triage succeeds — proves the *shipped* artifact
+  works end-to-end in the UI.
+- **Cold-start:** frozen binary resolves a real keyring token from an empty-state
+  machine (not a warm box).
+- **Card pipeline:** the proxy agent's envelope still triggers `email_pre_scan` SSE
+  injection + `EmailPreScanCard` render.
+- **Prompt/LLM changes:** `gaia eval agent` (email category) vs. baseline before
+  "done."
 
-## Resolved decisions
-1. **Host:** the Python UI backend, not a new Node backend and not Electron main —
-   that's where the chat loop, the grant, and the existing in-process integration
-   already live. (Electron main *could* optionally own just the sidecar *process*
-   supervision since it already manages subprocesses, but splitting spawn from
-   routing adds coordination/race complexity for no clear gain; keep both in the
-   backend.)
-2. **Faithful modes:** both modes use the same HTTP-proxy path; only the served
-   process differs (binary vs uvicorn-source). No in-process dev shortcut, to avoid
-   dev/prod divergence.
-3. **Frozen binary on disk:** lazy-fetched to a `~/.gaia/agents/email/` cache; loud
-   failure on fetch error.
-4. **Dev env:** assume ready; fail loud with `uv pip install -e …` otherwise.
+## Sequencing
+1. **Blocked on** the REST capability build-out (inbox pre-scan + #1779/#1780/#1781)
+   — the sidecar can't serve the UI's inbox features until those routes exist.
+2. Land the dev-mode enabler (`app = build_app()` at module scope).
+3. Build `EmailSidecarManager` + the email proxy agent; wire user/dev modes + lazy
+   on-demand fetch.
+4. Switch `agent_type=email` sessions from the in-process agent to the proxy agent
+   (`_chat_helpers.py`); remove the in-process #1768 mount (with #1768 owner).
+5. Tests (incl. the dogfood/product check) + a short dev-mode doc.
 
-## Scope / YAGNI
-- **In:** `EmailSidecarManager`, mode flag, both spawn paths, the proxy tool shims,
-  health + shutdown, tests, a short dev-mode doc.
-- **Out (follow-ups):** Settings-UI toggle (env flag is enough now); generalizing
-  the manager to other hub agents; Outlook/multi-mailbox specifics (the agent owns
-  those).
+## Relationship to epic #1767 (must reconcile before build)
+#1767 **chose the in-process router mount** and **explicitly rejected the
+frozen-binary sidecar for the UI**; its capstone PR #1785 was **closed unmerged on
+2026-06-26**, so the in-process path is abandoned in code but the *decision* stands
+on paper. This plan **pivots to the sidecar**, justified by product validation +
+lightweight core + isolation (above). Its variant also answers #1767's stated
+objection — #1767 rejected the sidecar as "needs a Node host / breaks browser mode,"
+but here the **Python backend** spawns it, so it works in browser mode with no Node
+host. **Action: get maintainer + @itomek sign-off to supersede #1767's in-process
+decision before implementation.**
 
-## Relationship to epic #1767
-#1767 rips out the *in-process* email agent. Concretely this design **replaces** the
-in-process agent factory path in `_chat_helpers.py` (and the in-process
-`/v1/email/*` mount in `server.py:599-601`) with: (a) the sidecar-spawning
-`EmailSidecarManager`, and (b) email proxy tools the chat agent calls. The two
-efforts should land together so the UI ends with exactly one email backend — the
-out-of-process sidecar. Sequencing/ownership to be coordinated with @itomek (PR
-#1785).
-
-## Open question for reviewer
-- Should the chat agent's email capability be a single "proxy agent" that maps all
-  its tools to sidecar calls, or a small set of proxy tools composed onto the
-  existing chat agent? (Affects how `agent_type=email` sessions are constructed in
-  `_chat_helpers.py`.)
+## Remaining decision for sign-off
+- Confirm removal of the #1768 in-process `/v1/email` external mount once the UI is
+  sidecar-only (decision 4), vs. keeping it as a distinct external surface. This is
+  the only open architectural choice; everything else is resolved above.

--- a/docs/plans/email-sidecar-agent-ui.md
+++ b/docs/plans/email-sidecar-agent-ui.md
@@ -1,0 +1,138 @@
+# Design: Email Agent in the Agent UI — dual user/dev sidecar modes
+
+**Date:** 2026-06-26
+**Status:** Draft — pending user review
+**Related:** epic #1767 (Email in the Agent UI), npm pkg `@amd-gaia/agent-email` (`hub/agents/npm/agent-email`), Python agent `hub/agents/python/email`
+
+## Problem
+
+We want the GAIA Agent UI to triage the user's **personal Gmail** through the email
+agent. Two things must be true at once:
+
+1. **Users** get a stable, no-Python experience — the agent ships as the frozen
+   `@amd-gaia/agent-email` npm sidecar binary.
+2. **Developers** can improve the agent and see changes **live**, without the
+   freeze → `npm publish` → version-bump → re-integrate patch loop that makes
+   iteration painful today.
+
+## Key insight — one REST seam, two interchangeable backends
+
+`EmailClient` (and therefore the whole UI) only ever speaks HTTP to a fixed
+address: `http://127.0.0.1:8131/v1/email/*`. The frozen npm binary is just
+PyInstaller wrapping `hub/agents/python/email/packaging/server.py`, so **the
+binary and the raw Python source serve a byte-identical contract**. Anything that
+answers that URL is interchangeable.
+
+The agent owns its own Gmail connection — it reads the inbox itself via the
+connectors framework (`get_credential_sync`, `list_inbox`, `triage_inbox`,
+`pre_scan_inbox`) using the Google OAuth grant stored locally in `~/.gaia`. The UI
+never passes raw email payloads. Consequence: **personal Gmail works identically
+in both modes**, because both run the same agent code against the same local grant.
+The user authenticates Google once; the mode only swaps which *process* answers the
+REST calls.
+
+## Architecture
+
+```
+Agent UI renderer
+   │  (UNCHANGED — calls one fixed base URL: http://127.0.0.1:8131)
+   ▼
+EmailSidecarManager   (Electron main process, Node — NEW)
+   │  reads GAIA_EMAIL_AGENT_MODE
+   ├─ user mode → spawn frozen binary   (npm pkg: resolveBinaryPath → spawn → health-wait → tree-kill)
+   └─ dev  mode → spawn uvicorn --reload (local Python source)
+        │
+        ▼  both serve the identical REST contract
+   http://127.0.0.1:8131/v1/email/*  ──reads──> ~/.gaia Google grant ──> user's Gmail
+```
+
+### Components
+
+| Unit | Home | Responsibility | Depends on |
+|------|------|----------------|------------|
+| `EmailSidecarManager` | `src/gaia/apps/webui/services/email-sidecar-manager.cjs` (Electron main) | Pick mode, spawn the right process, wait for `/health`, expose status + base URL to the renderer, tree-kill on shutdown | npm pkg lifecycle helpers (`lifecycle.ts`), child_process |
+| Renderer email client | existing UI services | Call `/v1/email/*` at the manager-provided base URL | base URL only — **no mode awareness** |
+| Mode config | `GAIA_EMAIL_AGENT_MODE` env (`user` default / `dev`); optional `emailAgentMode` key in `~/.gaia/tray-config.json` | Select backend | — |
+
+The manager mirrors the existing `AgentProcessManager` patterns (spawn, health
+check, graceful-then-force shutdown, crash logging) but over **HTTP**, not stdio
+JSON-RPC.
+
+### User mode (default)
+Reuse the npm package's Node lifecycle helpers verbatim:
+`fetchBinary({ outDir })` (guarded by `binaryExists`) lazily downloads the frozen
+binary into a **`~/.gaia/agents/email/` cache** on first run (R2 + lock-file
+verified) → `resolveBinaryPath({ resourcesDir })` → `spawn` → poll `GET /health`
+→ on app exit tree-kill (`taskkill /F /T` on Windows; detached process-group kill
+on POSIX). Cache means offline after the first fetch and no installer/build-pipeline
+change. A failed fetch fails loudly (no fallback to dev mode).
+
+### Dev mode
+Spawn uvicorn's **CLI with an import string** so hot-reload works:
+
+```
+python -m uvicorn packaging.server:app --reload --host 127.0.0.1 --port 8131
+# cwd = hub/agents/python/email   (app = build_app() exists at module scope)
+```
+
+> Note: `packaging/server.py`'s `__main__` calls `uvicorn.run(app, …)` with the
+> *app object*, which cannot hot-reload. Dev mode must use the import-string CLI
+> form above (no change to `server.py` required).
+
+Edit any `.py` / prompt / tool → uvicorn reloads in ~1s → the next UI action hits
+new code. **No freeze, no publish, no version bump, no UI rebuild.**
+
+Dev mode assumes the source environment is set up (the email package is
+importable). If `uvicorn` or the package can't be imported, fail loudly with the
+exact remedy (`uv pip install -e hub/agents/python/email`) — **no silent
+auto-install, no fallback to user mode.**
+
+## Data flow (both modes, identical)
+1. Renderer issues an email action (e.g. "triage my inbox").
+2. Request goes to `http://127.0.0.1:8131/v1/email/*` (base URL from the manager).
+3. Sidecar (binary or uvicorn) reads the `~/.gaia` Google grant and calls Gmail.
+4. Sidecar returns the triage/draft result; renderer renders the existing cards.
+
+## Error handling (fail loudly — no silent fallbacks)
+- Binary missing in user mode → surface the npm package's `BinaryNotFoundError`
+  with its actionable fetch hint; do **not** silently fall back to dev mode.
+- `/health` not ready within timeout → `HealthTimeoutError`; show a UI error with
+  the sidecar's last stderr lines.
+- Lemonade unreachable → sidecar already returns HTTP 502; surface it verbatim.
+- Dev mode requested but Python/source missing → loud startup error naming the
+  expected path and how to set up the source checkout. No fallback to user mode.
+- Port 8131 in use → fail with the conflicting-process hint (never silently pick
+  another port the renderer can't find). **Never touch 4001.**
+
+## Testing
+- **Unit (Node):** `EmailSidecarManager` mode selection, spawn-arg shape
+  (assert dev mode uses the `--reload` import-string form; user mode uses
+  `resolveBinaryPath`), health-poll, tree-kill on shutdown.
+- **Integration:** with a running sidecar (both modes), `GET /health` then a real
+  `/v1/email/triage` round-trip — proves the *call is valid*, not just invoked.
+- **Cold-start check:** confirm the frozen binary bundles `gaia.connectors` so user
+  mode can read the grant (verify from an empty-state machine, not a warm box).
+- **Prompt/LLM changes** still require `gaia eval agent` against the email category
+  vs. baseline before "done" — iteration speed ≠ skipping verification.
+
+## Scope / YAGNI
+- **In:** `EmailSidecarManager`, mode flag, both spawn paths, health + shutdown,
+  tests, a short dev-mode doc.
+- **Out (follow-ups):** Settings-UI toggle (env/config flag is enough now);
+  generalizing the manager to other hub agents; multi-mailbox/Outlook specifics
+  (handled by the agent, not this integration).
+
+## Relationship to epic #1767
+#1767 / PR #1785 rips out the *in-process* email agent. This design is the
+*consumption* side — how the UI talks to the **out-of-process sidecar** that
+replaces it. They are complementary; this should land on top of (or coordinate
+with) the rip-out so the UI has exactly one email backend: the sidecar.
+
+## Resolved decisions
+1. **Frozen binary on disk:** lazy-fetched into a `~/.gaia/agents/email/` cache on
+   first run (via the npm package's `fetchBinary`/`binaryExists`). No
+   installer/build-pipeline change; offline after first fetch; loud failure if the
+   fetch fails.
+2. **Dev-mode environment:** assume the source env is ready; if the package isn't
+   importable, fail loudly with `uv pip install -e hub/agents/python/email`. No
+   silent auto-install, no fallback to user mode.

--- a/docs/plans/email-sidecar-agent-ui.md
+++ b/docs/plans/email-sidecar-agent-ui.md
@@ -1,71 +1,106 @@
-# Design: Email Agent in the Agent UI — dual user/dev sidecar modes
+# Design: Email Agent in the Agent UI — dual user/dev modes
 
 **Date:** 2026-06-26
-**Status:** Draft — pending user review
-**Related:** epic #1767 (Email in the Agent UI), npm pkg `@amd-gaia/agent-email` (`hub/agents/npm/agent-email`), Python agent `hub/agents/python/email`
+**Status:** Draft (v2 — topology corrected after code review) — pending user review
+**Related:** epic #1767 (Email in the Agent UI), #1768 (`/v1/email/*` REST surface),
+npm pkg `@amd-gaia/agent-email` (`hub/agents/npm/agent-email`), Python agent
+`hub/agents/python/email`
 
 ## Problem
 
-We want the GAIA Agent UI to triage the user's **personal Gmail** through the email
-agent. Two things must be true at once:
+We want the GAIA Agent UI to triage the user's **personal Gmail**, with two things
+true at once:
 
 1. **Users** get a stable, no-Python experience — the agent ships as the frozen
-   `@amd-gaia/agent-email` npm sidecar binary.
+   `@amd-gaia/agent-email` sidecar binary, with no heavy email deps in the core
+   backend.
 2. **Developers** can improve the agent and see changes **live**, without the
    freeze → `npm publish` → version-bump → re-integrate patch loop that makes
    iteration painful today.
 
+## How the UI actually wires email today (verified)
+
+This is the ground truth the design must respect — an earlier draft got it wrong.
+
+- The frontend has **no email REST client**. It surfaces email triage through the
+  **chat pipeline**: the chat agent calls a tool (`pre_scan_inbox`), the result is
+  emitted as a structured payload on the chat SSE stream
+  (`src/gaia/ui/sse_handler.py:472`), and the renderer draws it as
+  `EmailPreScanCard` inside `MessageBubble` (`MessageBubble.tsx:727`).
+- The email agent runs **in-process** in the Python UI backend: `_chat_helpers.py`
+  constructs it via the session agent factory (`:1300`, `:1776`, passing
+  `mail_provider`) and runs it through the chat loop.
+- `src/gaia/ui/server.py:599-601` *also* mounts `gaia_agent_email`'s `/v1/email/*`
+  router in-process — but that is a **separate external/programmatic surface**
+  (#1768), not what the UI's own rendering uses.
+- The agent reads the user's mailbox itself via the connectors framework, using the
+  Google grant at `~/.gaia/connectors/grants.json` (`src/gaia/connectors/grants.py:53`).
+
+**Consequences for the design:**
+- The seam for user/dev mode is the **chat agent's email-tool layer in the Python
+  backend** — not the renderer, and not Electron main.
+- The lifecycle host is the **Python UI backend**, which already owns the chat loop
+  and the grant. **No Node.js backend is required** — the frozen sidecar is a
+  self-contained HTTP executable the Python backend can spawn and call directly.
+  (The npm package remains the integration path for *external* Node/Electron apps;
+  it is just not GAIA's own consumption path.)
+
 ## Key insight — one REST seam, two interchangeable backends
 
-`EmailClient` (and therefore the whole UI) only ever speaks HTTP to a fixed
-address: `http://127.0.0.1:8131/v1/email/*`. The frozen npm binary is just
-PyInstaller wrapping `hub/agents/python/email/packaging/server.py`, so **the
-binary and the raw Python source serve a byte-identical contract**. Anything that
-answers that URL is interchangeable.
+The frozen binary is PyInstaller wrapping `packaging/server.py`'s `build_app()`, so
+the binary and the raw Python source serve a **byte-identical** contract at
+`http://127.0.0.1:8131/v1/email/*`. Anything answering that URL is interchangeable.
 
-The agent owns its own Gmail connection — it reads the inbox itself via the
-connectors framework (`get_credential_sync`, `list_inbox`, `triage_inbox`,
-`pre_scan_inbox`) using the Google OAuth grant stored locally in `~/.gaia`. The UI
-never passes raw email payloads. Consequence: **personal Gmail works identically
-in both modes**, because both run the same agent code against the same local grant.
-The user authenticates Google once; the mode only swaps which *process* answers the
-REST calls.
+Because the agent owns its own mailbox connection and reads the shared
+`~/.gaia/connectors/grants.json`, **personal Gmail works identically in both
+modes**. The user authenticates Google once; the mode only swaps *which process*
+answers the REST calls.
 
 ## Architecture
 
 ```
-Agent UI renderer
-   │  (UNCHANGED — calls one fixed base URL: http://127.0.0.1:8131)
+Agent UI renderer  (UNCHANGED — renders email_pre_scan cards from chat SSE)
+   │  chat SSE
    ▼
-EmailSidecarManager   (Electron main process, Node — NEW)
+Python UI backend  (port 4200 — owns chat loop, SSE, grant)
+   │  chat agent calls email tools
+   ▼
+Email proxy tools  (thin HTTP shims, in the chat agent's tool layer — NEW)
+   │  POST http://127.0.0.1:8131/v1/email/*
+   ▼
+EmailSidecarManager  (Python, in the UI backend — NEW)
    │  reads GAIA_EMAIL_AGENT_MODE
-   ├─ user mode → spawn frozen binary   (npm pkg: resolveBinaryPath → spawn → health-wait → tree-kill)
-   └─ dev  mode → spawn uvicorn --reload (local Python source)
+   ├─ user mode → spawn frozen binary    (lazy-fetched to ~/.gaia cache)
+   └─ dev  mode → spawn uvicorn --reload  (local Python source)
         │
-        ▼  both serve the identical REST contract
-   http://127.0.0.1:8131/v1/email/*  ──reads──> ~/.gaia Google grant ──> user's Gmail
+        ▼  both serve the identical contract
+   sidecar :8131  ──reads──> ~/.gaia/connectors/grants.json ──> user's Gmail
 ```
+
+The renderer and the SSE card pipeline are untouched: the proxy tools return the
+same `pre_scan_inbox` envelope the in-process agent returns today, so
+`sse_handler.py` and `EmailPreScanCard` keep working unchanged.
+
+**Both modes go through the same HTTP path** — only the *served process* differs.
+This is deliberate: it avoids the "works in dev, breaks for users" masking failure
+where an in-process dev path and an out-of-process prod path diverge. Process
+isolation (the thing #1767 cares about) is then identical in both modes.
 
 ### Components
 
 | Unit | Home | Responsibility | Depends on |
 |------|------|----------------|------------|
-| `EmailSidecarManager` | `src/gaia/apps/webui/services/email-sidecar-manager.cjs` (Electron main) | Pick mode, spawn the right process, wait for `/health`, expose status + base URL to the renderer, tree-kill on shutdown | npm pkg lifecycle helpers (`lifecycle.ts`), child_process |
-| Renderer email client | existing UI services | Call `/v1/email/*` at the manager-provided base URL | base URL only — **no mode awareness** |
-| Mode config | `GAIA_EMAIL_AGENT_MODE` env (`user` default / `dev`); optional `emailAgentMode` key in `~/.gaia/tray-config.json` | Select backend | — |
-
-The manager mirrors the existing `AgentProcessManager` patterns (spawn, health
-check, graceful-then-force shutdown, crash logging) but over **HTTP**, not stdio
-JSON-RPC.
+| `EmailSidecarManager` | `src/gaia/ui/` (Python backend) | Pick mode, spawn the right process, wait for `/health`, expose base URL, tree-kill on shutdown | `subprocess`, the frozen binary / uvicorn |
+| Email proxy tools | chat agent tool layer | Forward `pre_scan_inbox`/triage/draft to the sidecar; return the existing envelope | `EmailSidecarManager` base URL |
+| Mode config | `GAIA_EMAIL_AGENT_MODE` env (`user` default / `dev`) | Select backend | — |
 
 ### User mode (default)
-Reuse the npm package's Node lifecycle helpers verbatim:
-`fetchBinary({ outDir })` (guarded by `binaryExists`) lazily downloads the frozen
-binary into a **`~/.gaia/agents/email/` cache** on first run (R2 + lock-file
-verified) → `resolveBinaryPath({ resourcesDir })` → `spawn` → poll `GET /health`
-→ on app exit tree-kill (`taskkill /F /T` on Windows; detached process-group kill
-on POSIX). Cache means offline after the first fetch and no installer/build-pipeline
-change. A failed fetch fails loudly (no fallback to dev mode).
+Lazy-fetch the frozen binary into a **`~/.gaia/agents/email/` cache** on first run
+(R2 + lock-file verified) → spawn → poll `GET /health` → tree-kill on backend exit
+(`taskkill /F /T` on Windows; detached process-group kill on POSIX). Cache means
+offline after first fetch and no installer/build-pipeline change. A failed fetch
+fails loudly (no fallback to dev mode). The core backend ships **without** the
+email agent's Python deps.
 
 ### Dev mode
 Spawn uvicorn's **CLI with an import string** so hot-reload works:
@@ -75,64 +110,81 @@ python -m uvicorn packaging.server:app --reload --host 127.0.0.1 --port 8131
 # cwd = hub/agents/python/email   (app = build_app() exists at module scope)
 ```
 
-> Note: `packaging/server.py`'s `__main__` calls `uvicorn.run(app, …)` with the
-> *app object*, which cannot hot-reload. Dev mode must use the import-string CLI
-> form above (no change to `server.py` required).
+> `packaging/server.py`'s `__main__` calls `uvicorn.run(app, …)` with the *app
+> object*, which cannot hot-reload — dev mode must use the import-string CLI form
+> above (no change to `server.py` required).
 
-Edit any `.py` / prompt / tool → uvicorn reloads in ~1s → the next UI action hits
-new code. **No freeze, no publish, no version bump, no UI rebuild.**
-
-Dev mode assumes the source environment is set up (the email package is
-importable). If `uvicorn` or the package can't be imported, fail loudly with the
-exact remedy (`uv pip install -e hub/agents/python/email`) — **no silent
-auto-install, no fallback to user mode.**
+Edit any `.py` / prompt / tool → uvicorn reloads in ~1s → the next chat action hits
+new code. **No freeze, no publish, no version bump, no UI rebuild.** Dev mode
+assumes the source env is set up; if uvicorn or the package can't be imported, fail
+loudly with `uv pip install -e hub/agents/python/email` — no silent auto-install,
+no fallback to user mode. Dev mode only applies to a source checkout (the packaged
+app has no Python source).
 
 ## Data flow (both modes, identical)
-1. Renderer issues an email action (e.g. "triage my inbox").
-2. Request goes to `http://127.0.0.1:8131/v1/email/*` (base URL from the manager).
-3. Sidecar (binary or uvicorn) reads the `~/.gaia` Google grant and calls Gmail.
-4. Sidecar returns the triage/draft result; renderer renders the existing cards.
+1. User asks the chat agent to triage (e.g. "what's in my inbox").
+2. Chat agent calls the `pre_scan_inbox` proxy tool.
+3. Tool POSTs to `http://127.0.0.1:8131/v1/email/*`.
+4. Sidecar (binary or uvicorn) reads the `~/.gaia` grant, calls Gmail, returns the
+   envelope.
+5. Tool returns the envelope unchanged → `sse_handler` injects it → renderer draws
+   the `EmailPreScanCard`.
 
 ## Error handling (fail loudly — no silent fallbacks)
-- Binary missing in user mode → surface the npm package's `BinaryNotFoundError`
-  with its actionable fetch hint; do **not** silently fall back to dev mode.
-- `/health` not ready within timeout → `HealthTimeoutError`; show a UI error with
-  the sidecar's last stderr lines.
-- Lemonade unreachable → sidecar already returns HTTP 502; surface it verbatim.
-- Dev mode requested but Python/source missing → loud startup error naming the
-  expected path and how to set up the source checkout. No fallback to user mode.
-- Port 8131 in use → fail with the conflicting-process hint (never silently pick
-  another port the renderer can't find). **Never touch 4001.**
+- Binary missing/un-fetchable in user mode → surface `BinaryNotFoundError` with its
+  actionable fetch hint; never silently fall back to dev mode.
+- `/health` not ready within timeout → loud error with the sidecar's last stderr.
+- Lemonade unreachable → sidecar already returns HTTP 502; surface verbatim.
+- Dev mode requested but source/uvicorn missing → loud startup error naming the
+  expected path + the `uv pip install -e` remedy.
+- Port 8131 in use → fail with the conflicting-process hint. **Never touch 4001.**
 
 ## Testing
-- **Unit (Node):** `EmailSidecarManager` mode selection, spawn-arg shape
-  (assert dev mode uses the `--reload` import-string form; user mode uses
-  `resolveBinaryPath`), health-poll, tree-kill on shutdown.
+- **Unit:** `EmailSidecarManager` mode selection + spawn-arg *shape* (assert dev mode
+  uses the `--reload` import-string form; user mode uses the cached binary path),
+  health-poll, tree-kill on shutdown.
 - **Integration:** with a running sidecar (both modes), `GET /health` then a real
-  `/v1/email/triage` round-trip — proves the *call is valid*, not just invoked.
-- **Cold-start check:** confirm the frozen binary bundles `gaia.connectors` so user
-  mode can read the grant (verify from an empty-state machine, not a warm box).
-- **Prompt/LLM changes** still require `gaia eval agent` against the email category
-  vs. baseline before "done" — iteration speed ≠ skipping verification.
-
-## Scope / YAGNI
-- **In:** `EmailSidecarManager`, mode flag, both spawn paths, health + shutdown,
-  tests, a short dev-mode doc.
-- **Out (follow-ups):** Settings-UI toggle (env/config flag is enough now);
-  generalizing the manager to other hub agents; multi-mailbox/Outlook specifics
-  (handled by the agent, not this integration).
-
-## Relationship to epic #1767
-#1767 / PR #1785 rips out the *in-process* email agent. This design is the
-*consumption* side — how the UI talks to the **out-of-process sidecar** that
-replaces it. They are complementary; this should land on top of (or coordinate
-with) the rip-out so the UI has exactly one email backend: the sidecar.
+  `pre_scan_inbox` round-trip through the proxy tool — proves the *call is valid*,
+  not just invoked.
+- **Cold-start:** confirm the frozen binary bundles `gaia.connectors` so user mode
+  reads the grant — verify from an empty-state machine, not a warm box.
+- **Card pipeline:** assert the proxy tool's envelope still triggers the
+  `email_pre_scan` SSE injection and `EmailPreScanCard` render.
+- **Prompt/LLM changes** still require `gaia eval agent` (email category) vs.
+  baseline before "done" — iteration speed ≠ skipping verification.
 
 ## Resolved decisions
-1. **Frozen binary on disk:** lazy-fetched into a `~/.gaia/agents/email/` cache on
-   first run (via the npm package's `fetchBinary`/`binaryExists`). No
-   installer/build-pipeline change; offline after first fetch; loud failure if the
-   fetch fails.
-2. **Dev-mode environment:** assume the source env is ready; if the package isn't
-   importable, fail loudly with `uv pip install -e hub/agents/python/email`. No
-   silent auto-install, no fallback to user mode.
+1. **Host:** the Python UI backend, not a new Node backend and not Electron main —
+   that's where the chat loop, the grant, and the existing in-process integration
+   already live. (Electron main *could* optionally own just the sidecar *process*
+   supervision since it already manages subprocesses, but splitting spawn from
+   routing adds coordination/race complexity for no clear gain; keep both in the
+   backend.)
+2. **Faithful modes:** both modes use the same HTTP-proxy path; only the served
+   process differs (binary vs uvicorn-source). No in-process dev shortcut, to avoid
+   dev/prod divergence.
+3. **Frozen binary on disk:** lazy-fetched to a `~/.gaia/agents/email/` cache; loud
+   failure on fetch error.
+4. **Dev env:** assume ready; fail loud with `uv pip install -e …` otherwise.
+
+## Scope / YAGNI
+- **In:** `EmailSidecarManager`, mode flag, both spawn paths, the proxy tool shims,
+  health + shutdown, tests, a short dev-mode doc.
+- **Out (follow-ups):** Settings-UI toggle (env flag is enough now); generalizing
+  the manager to other hub agents; Outlook/multi-mailbox specifics (the agent owns
+  those).
+
+## Relationship to epic #1767
+#1767 rips out the *in-process* email agent. Concretely this design **replaces** the
+in-process agent factory path in `_chat_helpers.py` (and the in-process
+`/v1/email/*` mount in `server.py:599-601`) with: (a) the sidecar-spawning
+`EmailSidecarManager`, and (b) email proxy tools the chat agent calls. The two
+efforts should land together so the UI ends with exactly one email backend — the
+out-of-process sidecar. Sequencing/ownership to be coordinated with @itomek (PR
+#1785).
+
+## Open question for reviewer
+- Should the chat agent's email capability be a single "proxy agent" that maps all
+  its tools to sidecar calls, or a small set of proxy tools composed onto the
+  existing chat agent? (Affects how `agent_type=email` sessions are constructed in
+  `_chat_helpers.py`.)

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,22 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## Unreleased
+
+### Added
+
+- **Voice/style-matched drafting from Sent history (#1607) — agent capability,
+  GAIA chat surface.** The bundled agent can learn a persisted, per-mailbox voice
+  profile from the user's Sent mail (`build_style_profile` / `get_style_profile`
+  / `clear_style_profile`) and compose `draft_reply` bodies in that voice —
+  greeting, sign-off, typical length, formality — instead of a generic scaffold.
+  The profile stores derived features only (never message text), is built with
+  deterministic on-device analysis, and never leaves the machine. Drafts stay
+  approval-gated; nothing auto-sends. **No wire-contract change** —
+  `SCHEMA_VERSION` stays `2.0` and the REST/MCP surface is unchanged
+  (`POST /v1/email/draft` still wraps a caller-supplied body); exposing the
+  profile over REST is a follow-up.
+
 ## 0.2.2
 
 Release-reliability fix. The 0.2.1 tag published the per-platform binaries to the

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -59,6 +59,7 @@ from gaia_agent_email.tools.preference_tools import (
 from gaia_agent_email.tools.profile_tools import ProfileToolsMixin
 from gaia_agent_email.tools.read_tools import ReadToolsMixin
 from gaia_agent_email.tools.reply_tools import ReplyToolsMixin
+from gaia_agent_email.tools.style_tools import StyleToolsMixin
 from gaia_agent_email.tools.summarize_tools import SummarizeToolsMixin
 
 from gaia.agents.base.agent import Agent
@@ -139,6 +140,10 @@ ACTIONS:
   set_category_default, clear_session_preferences) — mutate persistent
   classification preferences that survive across restarts. Confirm the
   change in plain English.
+- Style tools (build_style_profile, get_style_profile,
+  clear_style_profile) — learn, inspect, or delete a local voice profile
+  derived from the user's Sent mail. When a VOICE & STYLE PROFILE section
+  is present, match it when composing draft bodies.
 
 PRE-SCAN BEHAVIOR:
 When the user asks for a pre-scan, morning brief, triage view, or "what's
@@ -175,6 +180,7 @@ class EmailTriageAgent(
     PreferenceToolsMixin,
     PhishingToolsMixin,
     ProfileToolsMixin,
+    StyleToolsMixin,
 ):
     """Email Triage Agent — Gmail + Calendar through the connectors
     framework, all body inference local on Lemonade.
@@ -285,6 +291,11 @@ class EmailTriageAgent(
         # for the schema and the tools that mutate this state.
         self._session_preferences = init_session_preferences()
 
+        # Voice/style profiles per mailbox provider (#1607), learned from
+        # Sent mail and fed into the draft-composition prompt. Seeded from
+        # persisted records after init_memory() below.
+        self._style_profiles: dict[str, dict] = {}
+
         # SQLite for the action log. Default ``~/.gaia/email/state.db``.
         # Eval / unit tests inject ``db_path=tmp_path/state.db``.
         db_path = config.resolved_db_path()
@@ -304,6 +315,7 @@ class EmailTriageAgent(
         # init_memory() (so _memory_store is set) and after
         # _session_preferences is set (done above).
         self._load_persisted_preferences()
+        self._load_persisted_style_profiles()
 
         # LLM connection. Default to Lemonade — the config's base_url
         # allowlist guarantees the host is local.
@@ -357,6 +369,7 @@ class EmailTriageAgent(
         self._register_preference_tools()
         self._register_phishing_tools()
         self._register_profile_tools()
+        self._register_style_tools()
         self.register_memory_tools()
 
     # -- Phase 2 multi-inbox routing (#1603) -------------------------------

--- a/hub/agents/python/email/gaia_agent_email/outlook_backend.py
+++ b/hub/agents/python/email/gaia_agent_email/outlook_backend.py
@@ -83,6 +83,7 @@ _FOLDER_DELETED = "deleteditems"
 _LABEL_INBOX = "INBOX"
 _LABEL_UNREAD = "UNREAD"
 _LABEL_STARRED = "STARRED"
+_LABEL_SENT = "SENT"
 
 # ``$select`` for ``get_message`` — pull exactly the fields the Gmail-shape
 # translation needs (Graph returns a large default projection otherwise).
@@ -368,6 +369,11 @@ class LiveOutlookBackend:
                 params["$filter"] = "isRead eq false"
                 params["$orderby"] = "receivedDateTime desc"
                 path = "/me/mailFolders/inbox/messages"
+            elif _LABEL_SENT in labels:
+                # Sent history for the style profile (#1607) — the Gmail
+                # SENT system label maps to Graph's sentitems folder.
+                params["$orderby"] = "sentDateTime desc"
+                path = "/me/mailFolders/sentitems/messages"
             else:
                 # Default (INBOX or unspecified) -> inbox folder, newest first.
                 params["$orderby"] = "receivedDateTime desc"

--- a/hub/agents/python/email/gaia_agent_email/tools/style_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/style_tools.py
@@ -1,0 +1,519 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Voice/style-profile tools mixin for ``EmailTriageAgent`` (#1607).
+
+Builds a local voice/style profile from a sample of the user's **Sent**
+messages so ``draft_reply`` bodies read like the user wrote them —
+greeting, sign-off, typical length, and formality — instead of a generic
+scaffold. Extends #1269 (per-request tone matching) with a *persisted*
+profile.
+
+Privacy invariant (AC3): the profile is DERIVED FEATURES ONLY — no raw
+Sent bodies are ever stored. Extraction is deterministic string analysis
+on-device (no LLM call), the profile lives in the agent's local
+MemoryStore (``~/.gaia/email/memory.db``), and the prompt fragment it
+feeds is only ever sent to the local Lemonade backend (the agent's
+``base_url`` allowlist forbids cloud LLMs). No Sent content leaves the
+device.
+
+Profiles are stored per mailbox provider (a work Outlook voice and a
+personal Gmail voice can differ) under one rolling record each — entity
+``email:style_profile:<provider>`` — using the same upsert pattern as
+``preference_tools.py``. When memory is disabled the tools still work
+in-process; the profile just does not survive a restart.
+
+The profile reaches the LLM through ``get_voice_style_system_prompt()``,
+auto-discovered by the base agent's ``_get_mixin_prompts()``. The draft
+itself is still only ever created via ``draft_reply`` (a Gmail/Outlook
+*draft*, never a send) and sending stays confirmation-gated (#1264).
+
+Tools registered:
+
+- ``build_style_profile(sample_size, mailbox)`` — sample Sent mail, build
+  and persist the profile, refresh the system prompt.
+- ``get_style_profile(mailbox)`` — inspect the stored profile(s).
+- ``clear_style_profile(mailbox)`` — remove profile(s), in-process and
+  persisted.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from gaia_agent_email.gmail_backend import decode_message_body
+
+from gaia.agents.base.tools import tool
+from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.formatting import format_connector_error
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+# Stable entity prefix for per-mailbox style-profile records.
+# Entity = f"{_STYLE_ENTITY_PREFIX}{provider}" (e.g. "email:style_profile:google")
+_STYLE_ENTITY_PREFIX = "email:style_profile:"
+_STYLE_DOMAIN = "email_agent_style"
+_STYLE_CATEGORY = "style_profile"
+
+# How many Sent messages to sample by default, and the floor below which a
+# profile would be noise rather than signal. Both module-level so tests and
+# callers can import them.
+DEFAULT_SENT_SAMPLE_SIZE = 25
+MIN_STYLE_SAMPLE = 3
+MAX_SENT_SAMPLE_SIZE = 100
+
+# Sanity ceiling mirroring profile_tools: never silently truncate coverage.
+_MAX_STYLE_RECORDS = 100
+
+# ---------------------------------------------------------------------------
+# Deterministic feature extraction (pure functions — no LLM, no I/O)
+# ---------------------------------------------------------------------------
+
+_GREETING_RE = re.compile(
+    r"^(good (?:morning|afternoon|evening)|hi there|hey there|hi|hello|hey|"
+    r"dear|greetings)\b(?P<rest>[^\n]*)$",
+    re.IGNORECASE,
+)
+
+_SIGNOFF_RE = re.compile(
+    r"^(best regards|kind regards|warm regards|warm wishes|many thanks|"
+    r"thanks so much|thank you|thanks|thx|best|cheers|regards|sincerely|"
+    r"talk soon|take care|br)\s*[,.!]?$",
+    re.IGNORECASE,
+)
+
+# Reply/forward separators — everything from the first match down is quoted
+# history, not the user's own words.
+_QUOTE_BLOCK_RES = (
+    re.compile(r"^On .{4,200} wrote:\s*$"),
+    re.compile(r"^-{2,}\s*Original Message\s*-{2,}$", re.IGNORECASE),
+    re.compile(r"^-{2,}\s*Forwarded message\s*-{2,}$", re.IGNORECASE),
+)
+
+_CASUAL_MARKERS = (
+    "hey",
+    "yeah",
+    "yep",
+    "gonna",
+    "wanna",
+    "btw",
+    "fyi",
+    "thx",
+    "lol",
+    "cheers",
+    "no worries",
+    "sounds good",
+)
+_FORMAL_MARKERS = (
+    "dear",
+    "sincerely",
+    "regards",
+    "please find",
+    "kindly",
+    "hereby",
+    "pursuant",
+    "attached please",
+    "to whom it may concern",
+)
+
+_EMOJI_RE = re.compile(
+    "[\U0001f300-\U0001faff\U00002600-\U000027bf\U0001f000-\U0001f02f]"
+)
+
+
+def strip_quoted_text(body: str) -> str:
+    """Return only the user-authored part of a Sent body.
+
+    Cuts everything below the first reply/forward separator and drops
+    ``>``-quoted lines, so quoted history never pollutes the style sample.
+    """
+    kept: List[str] = []
+    for line in (body or "").splitlines():
+        stripped = line.strip()
+        if any(rx.match(stripped) for rx in _QUOTE_BLOCK_RES):
+            break
+        if stripped.startswith(">"):
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def extract_greeting(body: str) -> Optional[str]:
+    """Normalize the first line into a greeting template, or None.
+
+    ``"Hi Bob,"`` → ``"Hi {name},"`` and ``"Hey,"`` → ``"Hey,"`` — the
+    recipient's name is replaced with a ``{name}`` placeholder so the
+    template generalizes (and so no correspondent name is stored).
+    """
+    for line in (body or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = _GREETING_RE.match(line)
+        if not m:
+            return None
+        salutation = m.group(1)
+        rest = m.group("rest")
+        trailing = line[-1] if line[-1] in ",!:—-" else ""
+        has_name = bool(rest.strip().rstrip(",!:—-").strip())
+        if has_name:
+            return f"{salutation} {{name}}{trailing}"
+        return f"{salutation}{trailing}"
+    return None
+
+
+def extract_signoff(body: str) -> Optional[str]:
+    """Return the closing template from the last lines of a body, or None.
+
+    A sign-off is a known closing phrase (``Thanks,`` / ``Best regards.``
+    / …) optionally followed by a short name line. The name line is kept —
+    it is the user's OWN sign-off name, part of their voice, not
+    correspondent content.
+    """
+    lines = [ln.strip() for ln in (body or "").splitlines() if ln.strip()]
+    # Scan the last few lines; the sign-off phrase is never buried deep.
+    for idx in range(len(lines) - 1, max(len(lines) - 4, -1), -1):
+        if _SIGNOFF_RE.match(lines[idx]):
+            name_lines = lines[idx + 1 :]
+            # A trailing short line (≤4 words) right after the phrase is the
+            # signature name; anything longer is body text, not a signature.
+            if len(name_lines) == 1 and len(name_lines[0].split()) <= 4:
+                return f"{lines[idx]}\n{name_lines[0]}"
+            if not name_lines:
+                return lines[idx]
+    return None
+
+
+def classify_formality(body: str) -> str:
+    """Heuristic formality label for one body: formal / neutral / casual."""
+    low = (body or "").lower()
+    casual = sum(low.count(marker) for marker in _CASUAL_MARKERS)
+    casual += low.count("!")
+    casual += len(_EMOJI_RE.findall(low))
+    formal = sum(low.count(marker) for marker in _FORMAL_MARKERS)
+    if casual > formal:
+        return "casual"
+    if formal > casual:
+        return "formal"
+    return "neutral"
+
+
+def _top_variant(counts: Dict[str, int]) -> Optional[str]:
+    """Most frequent variant; ties broken lexicographically for determinism."""
+    if not counts:
+        return None
+    return max(counts, key=lambda k: (counts[k], k))
+
+
+def build_profile_from_bodies(bodies: List[str], *, mailbox: str) -> Dict[str, Any]:
+    """Build the style profile dict from user-authored Sent bodies.
+
+    Deterministic — same bodies always yield the same profile. The result
+    contains ONLY aggregate features (templates, counts, labels), never the
+    bodies themselves; ``test_email_style_profile.py`` enforces that no raw
+    Sent content survives into the stored profile.
+    """
+    greeting_counts: Dict[str, int] = {}
+    signoff_counts: Dict[str, int] = {}
+    word_counts: List[int] = []
+    formality_votes: Dict[str, int] = {"casual": 0, "neutral": 0, "formal": 0}
+    emoji_seen = False
+
+    for body in bodies:
+        greeting = extract_greeting(body)
+        if greeting:
+            greeting_counts[greeting] = greeting_counts.get(greeting, 0) + 1
+        signoff = extract_signoff(body)
+        if signoff:
+            signoff_counts[signoff] = signoff_counts.get(signoff, 0) + 1
+        word_counts.append(len(body.split()))
+        formality_votes[classify_formality(body)] += 1
+        emoji_seen = emoji_seen or bool(_EMOJI_RE.search(body))
+
+    formality = _top_variant(formality_votes) or "neutral"
+    return {
+        "mailbox": mailbox,
+        "sample_size": len(bodies),
+        "greeting": _top_variant(greeting_counts),
+        "signoff": _top_variant(signoff_counts),
+        "median_word_count": int(statistics.median(word_counts)) if word_counts else 0,
+        "formality": formality,
+        "uses_emoji": emoji_seen,
+        "built_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+def format_style_guidance(profiles: Dict[str, Dict[str, Any]]) -> str:
+    """Render stored profiles into the draft-composition prompt fragment.
+
+    Returns "" when no profile exists, so the composed system prompt is
+    byte-identical to the pre-#1607 prompt until the user builds one.
+    """
+    if not profiles:
+        return ""
+    parts: List[str] = [
+        "VOICE & STYLE PROFILE (learned locally from the user's Sent mail; "
+        "stored on-device only):",
+        "When composing the body for draft_reply or draft_forward, write in "
+        "the user's own voice:",
+    ]
+    multiple = len(profiles) > 1
+    for provider in sorted(profiles):
+        profile = profiles[provider]
+        if multiple:
+            parts.append(f"[mailbox: {provider}]")
+        if profile.get("greeting"):
+            parts.append(
+                f'- Open with: "{profile["greeting"]}" '
+                "(replace {name} with the recipient's first name)"
+            )
+        if profile.get("signoff"):
+            # Verbatim on its own lines — small local models follow a literal
+            # sign-off block far more reliably than an inlined description.
+            parts.append(
+                "- End every draft with this exact sign-off on its own "
+                f"lines:\n{profile['signoff']}"
+            )
+        if profile.get("median_word_count"):
+            parts.append(
+                f"- Typical length: about {profile['median_word_count']} words "
+                "— keep drafts near this unless the user asks otherwise."
+            )
+        parts.append(f"- Formality: {profile.get('formality', 'neutral')}.")
+        if not profile.get("uses_emoji"):
+            parts.append("- The user does not use emoji; avoid them.")
+    parts.append(
+        "Drafts are ALWAYS returned for the user's approval — never send "
+        "without explicit confirmation."
+    )
+    return "\n".join(parts)
+
+
+def collect_sent_bodies(
+    backend: Any, *, sample_size: int
+) -> List[str]:
+    """Fetch up to *sample_size* Sent messages and return user-authored bodies.
+
+    Uses the ``SENT`` system label (Gmail native; mapped to the
+    ``sentitems`` folder by the Outlook backend). Quoted history is
+    stripped; empty results are dropped.
+    """
+    listing = backend.list_messages(label_ids=["SENT"], max_results=sample_size)
+    bodies: List[str] = []
+    for ref in listing.get("messages", []):
+        msg = backend.get_message(ref["id"])
+        body, _attachments = decode_message_body(msg.get("payload") or {})
+        authored = strip_quoted_text(body)
+        if authored:
+            bodies.append(authored)
+    return bodies
+
+
+# ---------------------------------------------------------------------------
+# Envelopes
+# ---------------------------------------------------------------------------
+
+
+def _envelope_ok(data: Any) -> str:
+    return json.dumps({"ok": True, "data": data}, default=str)
+
+
+def _envelope_err(message: str) -> str:
+    return json.dumps({"ok": False, "error": message})
+
+
+# ---------------------------------------------------------------------------
+# Mixin
+# ---------------------------------------------------------------------------
+
+
+class StyleToolsMixin:
+    """Mixin that registers voice/style-profile tools (#1607).
+
+    State-free at construction time except for ``self._style_profiles``
+    (a ``dict[provider, profile]`` set by the agent's ``__init__``).
+    Persistence mirrors ``preference_tools.py``: one MemoryStore record
+    per mailbox, upserted in place; skipped when memory is disabled or
+    the session is incognito.
+    """
+
+    def get_voice_style_system_prompt(self) -> str:
+        """Prompt fragment auto-discovered by ``_get_mixin_prompts()``.
+
+        Empty (fragment omitted) until a profile has been built.
+        """
+        return format_style_guidance(getattr(self, "_style_profiles", {}) or {})
+
+    def _load_persisted_style_profiles(self) -> None:
+        """Seed ``_style_profiles`` from persisted records on construction."""
+        store = getattr(self, "_memory_store", None)
+        if store is None:
+            return
+        rows = store.get_by_category(
+            _STYLE_CATEGORY, domain=_STYLE_DOMAIN, limit=_MAX_STYLE_RECORDS
+        )
+        profiles = getattr(self, "_style_profiles", None)
+        if profiles is None:
+            return
+        for row in rows:
+            try:
+                payload = json.loads(row["content"])
+                provider = payload["mailbox"]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                log.warning(
+                    "style_tools: skipping malformed style-profile record %s",
+                    row.get("id"),
+                )
+                continue
+            profiles[provider] = payload
+
+    def _persist_style_profile(self, provider: str, profile: Dict[str, Any]) -> bool:
+        """Upsert the profile record for *provider*. Returns True when persisted.
+
+        Skipped (returns False) when memory is disabled or the session is
+        incognito — the profile then lives in-process only, matching the
+        preference-tools semantics.
+        """
+        store = getattr(self, "_memory_store", None)
+        if store is None or getattr(self, "_incognito", False):
+            return False
+        entity = f"{_STYLE_ENTITY_PREFIX}{provider}"
+        content = json.dumps(profile)
+        existing = store.get_by_entity(entity)
+        if existing:
+            store.update(existing[0]["id"], content=content)
+        else:
+            store.store(
+                category=_STYLE_CATEGORY,
+                content=content,
+                domain=_STYLE_DOMAIN,
+                entity=entity,
+                context=getattr(self, "_memory_context", "email"),
+                confidence=1.0,
+                source="style_tools",
+            )
+        return True
+
+    def _delete_persisted_style_profile(self, provider: str) -> None:
+        store = getattr(self, "_memory_store", None)
+        if store is None or getattr(self, "_incognito", False):
+            return
+        for row in store.get_by_entity(f"{_STYLE_ENTITY_PREFIX}{provider}"):
+            store.delete(row["id"])
+
+    def _register_style_tools(self) -> None:
+        agent = self  # closure for live access to backends / memory / prompt
+
+        @tool
+        def build_style_profile(
+            sample_size: int = DEFAULT_SENT_SAMPLE_SIZE, mailbox: str = ""
+        ) -> str:
+            """Learn the user's writing voice from their Sent mail (local-only).
+
+            Samples recent Sent messages, derives greeting / sign-off /
+            typical length / formality with deterministic on-device
+            analysis (no message content is sent anywhere, not even to the
+            local LLM), and persists the profile so future draft_reply
+            bodies match the user's own voice. Rebuilding replaces the
+            previous profile for that mailbox.
+
+            Args:
+                sample_size: How many recent Sent messages to sample
+                    (default 25, max 100). At least 3 usable messages are
+                    required.
+                mailbox: Which connected mailbox to learn from (e.g.
+                    ``google``); defaults to the primary mailbox.
+            """
+            try:
+                size = int(sample_size)
+                if size < MIN_STYLE_SAMPLE:
+                    return _envelope_err(
+                        f"build_style_profile: sample_size must be at least "
+                        f"{MIN_STYLE_SAMPLE} (got {sample_size})."
+                    )
+                size = min(size, MAX_SENT_SAMPLE_SIZE)
+                # Long-lived Agent UI instances: see newly connected mailboxes
+                # without a session restart (same refresh as triage).
+                agent._refresh_mail_backends()
+                provider = mailbox or next(iter(agent._backends))
+                backend = agent._backends.get(provider)
+                if backend is None:
+                    return _envelope_err(
+                        f"build_style_profile: mailbox {provider!r} is not "
+                        f"connected. Connected: "
+                        f"{', '.join(agent._backends) or 'none'}."
+                    )
+                bodies = collect_sent_bodies(backend, sample_size=size)
+                if len(bodies) < MIN_STYLE_SAMPLE:
+                    return _envelope_err(
+                        f"build_style_profile: only {len(bodies)} usable Sent "
+                        f"message(s) found in mailbox {provider!r}; need at "
+                        f"least {MIN_STYLE_SAMPLE}. Send a few emails first, "
+                        "then rebuild the profile."
+                    )
+                profile = build_profile_from_bodies(bodies, mailbox=provider)
+                agent._style_profiles[provider] = profile
+                persisted = agent._persist_style_profile(provider, profile)
+                # The profile feeds the draft-composition prompt; recompose so
+                # it takes effect this session, not after a restart.
+                agent.rebuild_system_prompt()
+                return _envelope_ok({"profile": profile, "persisted": persisted})
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("build_style_profile failed: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def get_style_profile(mailbox: str = "") -> str:
+            """Show the stored voice/style profile(s) learned from Sent mail.
+
+            Args:
+                mailbox: Restrict to one connected mailbox; default returns
+                    every stored profile.
+            """
+            try:
+                profiles = agent._style_profiles
+                if mailbox:
+                    profile = profiles.get(mailbox)
+                    data = {"profiles": [profile] if profile else []}
+                else:
+                    data = {"profiles": [profiles[p] for p in sorted(profiles)]}
+                if not data["profiles"]:
+                    data["hint"] = (
+                        "No style profile yet — run build_style_profile to "
+                        "learn the user's voice from their Sent mail."
+                    )
+                return _envelope_ok(data)
+            except Exception as exc:
+                log.exception("get_style_profile failed: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def clear_style_profile(mailbox: str = "") -> str:
+            """Delete the stored voice/style profile(s), in-process and persisted.
+
+            Drafts fall back to the default (profile-free) composition
+            prompt immediately.
+
+            Args:
+                mailbox: Clear only this mailbox's profile; default clears
+                    all of them.
+            """
+            try:
+                providers = [mailbox] if mailbox else list(agent._style_profiles)
+                cleared: List[str] = []
+                for provider in providers:
+                    if provider in agent._style_profiles:
+                        del agent._style_profiles[provider]
+                        cleared.append(provider)
+                    agent._delete_persisted_style_profile(provider)
+                agent.rebuild_system_prompt()
+                return _envelope_ok({"cleared": cleared})
+            except Exception as exc:
+                log.exception("clear_style_profile failed: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")

--- a/hub/agents/python/email/specification.html
+++ b/hub/agents/python/email/specification.html
@@ -814,7 +814,7 @@ quarantine_phishing_message → { "ok": true, "data": {
   <div class="wrap">
     <div class="eyebrow"><span class="bar"></span>Part 1b · Personalization &amp; memory</div>
     <h2 style="margin-top:16px">Learns how you work <span class="pill t0" style="vertical-align:middle"><a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">Milestone 40</a></span></h2>
-    <p class="body-t">These features make the agent <b>adapt to the individual user</b>, entirely on-device. Today, classification preferences are <b>session-scoped</b> (<code>set_priority_sender</code>, <code>set_low_priority_sender</code>, <code>set_category_default</code>) and wiped on restart by design; the work below makes them <b>durable and learned</b> rather than hand-set. P1–P4 are <b>in flight</b>; P5 is <b>planned</b>.</p>
+    <p class="body-t">These features make the agent <b>adapt to the individual user</b>, entirely on-device. Today, classification preferences are <b>session-scoped</b> (<code>set_priority_sender</code>, <code>set_low_priority_sender</code>, <code>set_category_default</code>) and wiped on restart by design; the work below makes them <b>durable and learned</b> rather than hand-set. P1–P5 are <b>in flight</b>.</p>
 
     <div class="cap">
       <div class="cap-head"><span class="num">P1</span><h3>Behavioral sender prioritization</h3><span class="pill wip">In flight</span><span class="pill t0">Tier 0</span></div>
@@ -853,10 +853,10 @@ quarantine_phishing_message → { "ok": true, "data": {
     </div>
 
     <div class="cap">
-      <div class="cap-head"><span class="num">P5</span><h3>Voice / style-matched drafting</h3><span class="pill planned">Planned</span><span class="pill t0">Tier 0 · draft</span></div>
+      <div class="cap-head"><span class="num">P5</span><h3>Voice / style-matched drafting</h3><span class="pill wip">In flight</span><span class="pill t0">Tier 0 · draft</span></div>
       <div class="field"><div class="fl">Use-case</div><div class="fv">Draft replies in the user's own voice — greeting, sign-off, sentence length, formality — learned from a sample of their Sent mail, instead of a generic scaffold. The style profile is built and stored locally, exactly the kind of private history that shouldn't go to a cloud service, which makes it a natural fit for GAIA's on-device model. It extends the already-shipped per-request tone/context matching with a persisted, personalized voice profile.</div></div>
       <div class="field"><div class="fl">Why it matters</div><div class="fv">A blank-bodied or generic draft reads as "autocomplete"; a voice-matched draft is what makes users call an assistant genuinely theirs — a headline feature of comparable tools.</div></div>
-      <div class="field"><div class="fl">Backed by</div><div class="fv">A local style profile over Sent mail feeding <code>draft_reply</code>; extends the closed <a class="iss" href="https://github.com/amd/gaia/issues/1269" target="_blank" rel="noopener">#1269</a> (tone matching). Related: <a class="iss" href="https://github.com/amd/gaia/issues/704" target="_blank" rel="noopener">#704</a>.</div></div>
+      <div class="field"><div class="fl">Backed by</div><div class="fv">A persisted per-mailbox style profile over Sent mail (<code>build_style_profile</code> / <code>get_style_profile</code> / <code>clear_style_profile</code>) feeding the <code>draft_reply</code> composition prompt — derived features only, no message text stored; extends the closed <a class="iss" href="https://github.com/amd/gaia/issues/1269" target="_blank" rel="noopener">#1269</a> (tone matching). Related: <a class="iss" href="https://github.com/amd/gaia/issues/704" target="_blank" rel="noopener">#704</a>. Remaining for validation: the judge-scored style-match eval.</div></div>
       <div class="field"><div class="fl">Guardrails</div><div class="fv">Tier 0 — drafting; the send still stays Tier 2. Profile is local-only.</div></div>
       <div class="field"><div class="fl">Milestone</div><div class="fv"><a class="iss" href="https://github.com/amd/gaia/issues/1607" target="_blank" rel="noopener">#1607</a> · <a class="iss" href="https://github.com/amd/gaia/milestone/40" target="_blank" rel="noopener">Milestone 40</a> (P3 stretch)</div></div>
     </div>

--- a/hub/agents/python/email/tests/test_email_style_profile.py
+++ b/hub/agents/python/email/tests/test_email_style_profile.py
@@ -1,0 +1,474 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Voice/style-profile tests for EmailTriageAgent (#1607).
+
+Acceptance criteria covered:
+- AC1: a local style profile is built from a sample of the user's Sent
+  messages (greeting / sign-off / length / formality features).
+- AC2 (deterministic form): the profile features shape the draft — the
+  draft-composition system prompt carries the learned greeting/sign-off,
+  and drafts stay approval-gated. The judge-scored style-match eval
+  against the #1230 corpus is a follow-up (no Sent-history corpus with a
+  known voice exists in-repo yet).
+- AC3: the profile is local-only AND content-free — no raw Sent body text
+  survives into the persisted record.
+- Test-AC: draft generation (build_style_profile and draft_reply) triggers
+  NO send side-effect.
+
+Embedder is mocked (same pattern as test_email_preferences_persist.py) so
+tests run hermetically without Lemonade.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path / import bootstrap
+# ---------------------------------------------------------------------------
+
+# parents[0] = tests/,  [1] = email/,  [2] = python/,  [3] = agents/,
+# [4] = hub/,  [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+from gaia_agent_email.tools.style_tools import (  # noqa: E402
+    build_profile_from_bodies,
+    classify_formality,
+    extract_greeting,
+    extract_signoff,
+    strip_quoted_text,
+)
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+EMBEDDING_DIM = 768
+
+_STYLE_ENTITY = "email:style_profile:google"
+
+# A distinctive sentence that must NEVER survive into the persisted profile
+# (AC3 — the profile stores derived features only, no raw Sent content).
+_PRIVATE_MARKER = "the Zephyr acquisition closes at 4M on Thursday"
+
+
+class _MinimalCalendarBackend:
+    pass
+
+
+def _fake_embed(text: str) -> np.ndarray:
+    """Deterministic unit vector — keeps FAISS happy."""
+    vec = np.ones(EMBEDDING_DIM, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    return vec
+
+
+def _b64url(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _sent_msg(msg_id: str, *, body: str, to: str = "Sam <sam@example.com>") -> dict:
+    """One Gmail-API-shape message carrying the SENT system label."""
+    return {
+        "id": msg_id,
+        "threadId": f"t-{msg_id}",
+        "labelIds": ["SENT"],
+        "snippet": body[:80],
+        "internalDate": "1750000000000",
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": "User <user@example.com>"},
+                {"name": "To", "value": to},
+                {"name": "Subject", "value": f"Update {msg_id}"},
+                {"name": "Date", "value": "Mon, 15 Jun 2026 10:00:00 -0700"},
+            ],
+            "body": {"size": len(body), "data": _b64url(body)},
+        },
+        "sizeEstimate": len(body),
+    }
+
+
+def _inbox_msg(msg_id: str, *, sender: str = "Sam <sam@example.com>") -> dict:
+    body = "Could you send over the latest numbers when you get a chance?"
+    return {
+        "id": msg_id,
+        "threadId": f"t-{msg_id}",
+        "labelIds": ["INBOX", "UNREAD"],
+        "snippet": body[:80],
+        "internalDate": "1750000100000",
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "To", "value": "User <user@example.com>"},
+                {"name": "Subject", "value": "Numbers?"},
+                {"name": "Date", "value": "Mon, 15 Jun 2026 10:05:00 -0700"},
+                {"name": "Message-ID", "value": f"<{msg_id}@example.com>"},
+            ],
+            "body": {"size": len(body), "data": _b64url(body)},
+        },
+        "sizeEstimate": len(body),
+    }
+
+
+_SENT_BODIES = [
+    f"Hi Sam,\n\nSounds good — I'll get the numbers over to you "
+    f"tomorrow. Btw {_PRIVATE_MARKER}.\n\nThanks,\nKalin",
+    "Hi Priya,\n\nYeah, works for me. Let's lock in Tuesday.\n\nThanks,\nKalin",
+    "Hi Dana,\n\nQuick heads up — the report is done and shared.\n\nThanks,\nKalin",
+    "Hey,\n\nNo worries, take your time on the review.\n\nCheers,\nKalin",
+    "Hi Lee,\n\nGreat catch, fixed and pushed.\n\nThanks,\nKalin",
+]
+
+
+def _seed_sent(gmail: FakeGmailBackend) -> None:
+    for i, body in enumerate(_SENT_BODIES):
+        gmail.add_message(_sent_msg(f"s{i}", body=body))
+
+
+def _build_agent(
+    tmp_path: Path,
+    gmail: FakeGmailBackend,
+    *,
+    memory_disabled: bool = False,
+) -> EmailTriageAgent:
+    """Build EmailTriageAgent with an injected FakeGmailBackend and tmp dbs."""
+    cfg = EmailAgentConfig(
+        gmail_backend=gmail,
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+    )
+
+    def _do_build() -> EmailTriageAgent:
+        with (
+            patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+            patch(
+                "gaia.agents.base.memory.MemoryMixin._get_embedder",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "gaia.agents.base.memory.MemoryMixin._embed_text",
+                side_effect=_fake_embed,
+            ),
+            patch(
+                "gaia.agents.base.memory.MemoryMixin._backfill_embeddings",
+                return_value=0,
+            ),
+            patch("gaia.agents.base.memory.MemoryMixin._rebuild_faiss_index"),
+            patch("gaia.agents.base.memory.MemoryMixin.init_system_context"),
+        ):
+            mock_sdk.return_value = MagicMock()
+            return EmailTriageAgent(config=cfg)
+
+    if memory_disabled:
+        prior = os.environ.get("GAIA_MEMORY_DISABLED")
+        os.environ["GAIA_MEMORY_DISABLED"] = "1"
+        try:
+            return _do_build()
+        finally:
+            if prior is None:
+                del os.environ["GAIA_MEMORY_DISABLED"]
+            else:
+                os.environ["GAIA_MEMORY_DISABLED"] = prior
+    return _do_build()
+
+
+def _invoke(tool_name: str, *args, **kwargs) -> dict:
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    entry = _TOOL_REGISTRY.get(tool_name)
+    assert entry is not None, f"{tool_name} not registered"
+    return json.loads(entry["function"](*args, **kwargs))
+
+
+_SEND_METHODS = {"send_draft", "send_message"}
+
+
+def _sent_calls(gmail: FakeGmailBackend) -> list:
+    return [c for c in gmail.transport.calls if c[0] in _SEND_METHODS]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic feature extraction (pure functions)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureExtraction:
+    def test_greeting_with_name_becomes_template(self):
+        assert extract_greeting("Hi Bob,\n\nbody") == "Hi {name},"
+        assert extract_greeting("Hello Maria!\ntext") == "Hello {name}!"
+
+    def test_greeting_without_name_kept_verbatim(self):
+        assert extract_greeting("Hey,\n\nbody") == "Hey,"
+
+    def test_non_greeting_first_line_yields_none(self):
+        assert extract_greeting("The report is attached.\n\nThanks,") is None
+
+    def test_signoff_with_name(self):
+        body = "Hi,\n\nAll set.\n\nThanks,\nKalin"
+        assert extract_signoff(body) == "Thanks,\nKalin"
+
+    def test_signoff_phrase_only(self):
+        assert extract_signoff("Hi,\n\nAll set.\n\nCheers") == "Cheers"
+
+    def test_no_signoff_yields_none(self):
+        assert extract_signoff("Hi,\n\nSee the attached report today.") is None
+
+    def test_strip_quoted_text_removes_reply_history(self):
+        body = (
+            "Sounds good.\n\nThanks,\nKalin\n\n"
+            "On Mon, Jun 15, 2026 Sam <sam@example.com> wrote:\n"
+            "> secret quoted content\n> more quoted"
+        )
+        stripped = strip_quoted_text(body)
+        assert "quoted" not in stripped
+        assert stripped.startswith("Sounds good.")
+
+    def test_classify_formality(self):
+        assert classify_formality("Hey, yeah sounds good! btw thx") == "casual"
+        assert (
+            classify_formality("Dear Dr. Smith, please find attached. Sincerely,")
+            == "formal"
+        )
+
+    def test_build_profile_is_deterministic_and_aggregates(self):
+        profile_a = build_profile_from_bodies(list(_SENT_BODIES), mailbox="google")
+        profile_b = build_profile_from_bodies(list(_SENT_BODIES), mailbox="google")
+        profile_b["built_at"] = profile_a["built_at"]
+        assert profile_a == profile_b
+        assert profile_a["greeting"] == "Hi {name},"
+        assert profile_a["signoff"] == "Thanks,\nKalin"
+        assert profile_a["sample_size"] == len(_SENT_BODIES)
+        assert profile_a["formality"] == "casual"
+        assert profile_a["median_word_count"] > 0
+
+
+# ---------------------------------------------------------------------------
+# build_style_profile tool (AC1 + AC3 + no-send)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStyleProfile:
+    def test_builds_profile_from_sent_sample(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            result = _invoke("build_style_profile")
+            assert result["ok"] is True, f"build_style_profile failed: {result}"
+            profile = result["data"]["profile"]
+            assert profile["greeting"] == "Hi {name},"
+            assert profile["signoff"] == "Thanks,\nKalin"
+            assert profile["sample_size"] == len(_SENT_BODIES)
+            assert result["data"]["persisted"] is True
+        finally:
+            agent.close_db()
+
+    def test_build_triggers_no_send_side_effect(self, tmp_path):
+        """Test-AC: profile building never sends or even drafts anything."""
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            result = _invoke("build_style_profile")
+            assert result["ok"] is True
+            assert _sent_calls(gmail) == []
+            assert not any(c[0] == "create_draft" for c in gmail.transport.calls)
+        finally:
+            agent.close_db()
+
+    def test_profile_stores_no_raw_sent_content(self, tmp_path):
+        """AC3: only derived features are persisted — never body text."""
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            assert _invoke("build_style_profile")["ok"] is True
+        finally:
+            agent.close_db()
+
+        from gaia.agents.base.memory_store import MemoryStore
+
+        store = MemoryStore(tmp_path / "memory.db")
+        rows = store.get_by_entity(_STYLE_ENTITY)
+        assert len(rows) == 1, f"expected 1 profile record, got {len(rows)}"
+        assert _PRIVATE_MARKER not in rows[0]["content"]
+        # Recipient names must not leak either — the greeting is a template.
+        assert "Sam" not in rows[0]["content"]
+
+    def test_rebuild_keeps_single_record(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            for _ in range(3):
+                assert _invoke("build_style_profile")["ok"] is True
+        finally:
+            agent.close_db()
+
+        from gaia.agents.base.memory_store import MemoryStore
+
+        store = MemoryStore(tmp_path / "memory.db")
+        assert len(store.get_by_entity(_STYLE_ENTITY)) == 1
+
+    def test_insufficient_sent_history_fails_actionably(self, tmp_path):
+        gmail = FakeGmailBackend()
+        gmail.add_message(_sent_msg("only", body="Hi,\n\nok.\n\nThanks,\nKalin"))
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            result = _invoke("build_style_profile")
+            assert result["ok"] is False
+            assert "Sent" in result["error"]
+            assert "at least" in result["error"]
+        finally:
+            agent.close_db()
+
+    def test_memory_disabled_builds_in_process_only(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail, memory_disabled=True)
+        try:
+            result = _invoke("build_style_profile")
+            assert result["ok"] is True
+            assert result["data"]["persisted"] is False
+            assert "google" in agent._style_profiles
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# AC2 (deterministic): the profile shapes the draft-composition prompt,
+# and draft_reply stays a draft — no send side-effect.
+# ---------------------------------------------------------------------------
+
+
+class TestProfileShapesDraftComposition:
+    def test_prompt_has_no_style_section_before_build(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            assert "VOICE & STYLE PROFILE (learned locally" not in agent.system_prompt
+        finally:
+            agent.close_db()
+
+    def test_prompt_carries_profile_features_after_build(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            # Populate the lazy prompt cache first — the tool must refresh it
+            # mid-session, not rely on first access happening after the build.
+            assert "VOICE & STYLE PROFILE (learned locally" not in agent.system_prompt
+            assert _invoke("build_style_profile")["ok"] is True
+            prompt = agent.system_prompt
+            assert "VOICE & STYLE PROFILE (learned locally" in prompt
+            assert "Hi {name}," in prompt
+            assert "Thanks,\nKalin" in prompt
+            assert "casual" in prompt
+        finally:
+            agent.close_db()
+
+    def test_draft_reply_creates_draft_but_never_sends(self, tmp_path):
+        """Test-AC: draft generation triggers NO send side-effect."""
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        gmail.add_message(_inbox_msg("in1"))
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            assert _invoke("build_style_profile")["ok"] is True
+            result = _invoke(
+                "draft_reply",
+                "in1",
+                "Hi Sam,\n\nNumbers attached.\n\nThanks,\nKalin",
+            )
+            assert result["ok"] is True, f"draft_reply failed: {result}"
+            assert result["data"]["draft_id"]
+            drafted = [c for c in gmail.transport.calls if c[0] == "create_draft"]
+            assert len(drafted) == 1
+            assert _sent_calls(gmail) == [], (
+                "draft_reply must never send — found send calls: "
+                f"{_sent_calls(gmail)}"
+            )
+        finally:
+            agent.close_db()
+
+    def test_clear_style_profile_removes_prompt_section(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent = _build_agent(tmp_path, gmail)
+        try:
+            assert _invoke("build_style_profile")["ok"] is True
+            assert "VOICE & STYLE PROFILE (learned locally" in agent.system_prompt
+            result = _invoke("clear_style_profile")
+            assert result["ok"] is True
+            assert result["data"]["cleared"] == ["google"]
+            assert "VOICE & STYLE PROFILE (learned locally" not in agent.system_prompt
+        finally:
+            agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Persistence across restart (local-only storage)
+# ---------------------------------------------------------------------------
+
+
+class TestProfilePersistsAcrossRestart:
+    def test_profile_survives_restart(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent_a = _build_agent(tmp_path, gmail)
+        try:
+            assert _invoke("build_style_profile")["ok"] is True
+        finally:
+            agent_a.close_db()
+
+        agent_b = _build_agent(tmp_path, FakeGmailBackend())
+        try:
+            assert "google" in agent_b._style_profiles
+            profile = agent_b._style_profiles["google"]
+            assert profile["greeting"] == "Hi {name},"
+            assert profile["signoff"] == "Thanks,\nKalin"
+            assert "VOICE & STYLE PROFILE (learned locally" in agent_b.system_prompt
+        finally:
+            agent_b.close_db()
+
+    def test_clear_persists_across_restart(self, tmp_path):
+        gmail = FakeGmailBackend()
+        _seed_sent(gmail)
+        agent_a = _build_agent(tmp_path, gmail)
+        try:
+            assert _invoke("build_style_profile")["ok"] is True
+            assert _invoke("clear_style_profile")["ok"] is True
+        finally:
+            agent_a.close_db()
+
+        agent_b = _build_agent(tmp_path, FakeGmailBackend())
+        try:
+            assert agent_b._style_profiles == {}
+            assert "VOICE & STYLE PROFILE (learned locally" not in agent_b.system_prompt
+        finally:
+            agent_b.close_db()

--- a/tests/unit/agents/test_email_agent.py
+++ b/tests/unit/agents/test_email_agent.py
@@ -199,6 +199,10 @@ class TestToolRegistry:
         "clear_session_preferences",
         # Inbox profiling from memory (#1289)
         "profile_inbox",
+        # Voice/style profile from Sent history (#1607)
+        "build_style_profile",
+        "get_style_profile",
+        "clear_style_profile",
     }
 
     def test_every_expected_tool_is_registered(self, agent):


### PR DESCRIPTION
Closes #1607.

Before, `draft_reply` bodies read like generic autocomplete no matter how the user actually writes. Now the agent can learn a persisted, per-mailbox **voice profile** from a sample of the user's Sent mail — greeting, sign-off, typical length, formality — and compose drafts in that voice, extending the per-request tone matching from #1269 into a durable profile. Privacy holds by construction: extraction is deterministic on-device analysis (Sent bodies are never sent anywhere, not even to the local LLM), the profile stores derived features only — no message text, no correspondent names — and it lives in local storage. Nothing auto-sends: building a profile creates no draft and no send, and sends stay confirmation-gated (#1264).

New tools: `build_style_profile` / `get_style_profile` / `clear_style_profile`. The profile feeds the draft-composition prompt via an auto-discovered mixin fragment, so the composed system prompt is byte-identical to today's until a profile exists. Outlook's `SENT` label now maps to Graph's `sentitems` folder (previously it would have silently listed the inbox). REST/MCP wire contract unchanged (`SCHEMA_VERSION` 2.0); npm README/SPEC/SKILL therefore carry no stale claims to update — CHANGELOG notes the capability and its surface scope.

## Test plan

- [x] Unit: `hub/agents/python/email/tests/test_email_style_profile.py` (21 tests) — deterministic feature extraction; profile built from a seeded SENT sample; **no send side-effect** from `build_style_profile` or `draft_reply` (asserted against the fake backend's transport log); no raw Sent content or correspondent names in the persisted record; profile survives restart; clear works; memory-disabled degrades to in-process.
- [x] Deterministic AC2 stand-in: the learned greeting/sign-off/length verifiably shape the draft-composition prompt (asserted string-level), since the LLM composes the body before `draft_reply` runs.
- [x] Full email sweep: 762 passed across `hub/agents/python/email/tests/`, `tests/unit/email/`, `tests/unit/agents/email/`, `tests/unit/agents/test_email_agent*.py`. (3 failures on my machine are pre-existing/environmental: two reproduce on a clean `main` checkout because the tests read the developer's real `~/.gaia/email/memory.db`, and one is venv version skew vs a different worktree.)
- [x] Live end-to-end smoke against local Lemonade (Gemma-4-E4B, the agent's default model): "learn my writing style" → "draft a reply to Sam" produced `Hi Sam, … Thanks,\nKalin` matching the learned voice, one `create_draft`, **zero** send calls.
- [x] `python util/lint.py --all` clean.
- [ ] **Pre-merge follow-up (judge-scored AC):** wire a `style_match` scenario into the eval harness per the issue — there is no `gaia eval agent` email category or Sent-history corpus with a known voice in-repo today (the #1230 corpus is inbox/triage-side), so the judge-scored "voice-matched beats blank scaffold" comparison can't run yet. The committed `gaia eval agent` baselines (rag_quality etc.) exercise ChatAgent/DocQA, which this PR does not touch; the email triage classifier prompt (`llm_triage.py`) is also untouched.