### PR TITLE
feat(email): voice/style-matched drafting from Sent history (#1607)

### DIFF
--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -14,6 +14,7 @@ The Email Triage Agent connects to your Gmail account through GAIA's connectors 
 - **Organize** — archive, label, mark read/unread, star/unstar. Reversible via the per-action undo log.
 - **Soft-delete with undo** — `trash_message` records the action; `restore_message` reverses it within a 30-second window.
 - **Draft + confirmed send** — generate replies (`draft_reply`) and forwards (`draft_forward`); `send_draft` and `send_now` require explicit user confirmation in the UI.
+- **Voice-matched drafting** — learn your writing style from your Sent mail (`build_voice_profile`) so drafts sound like you; the style profile is derived and stored locally, nothing leaves the device.
 - **Calendar** — list events, accept/decline invites, create events from email content (all calendar mutations gated by user confirmation).
 
 ## Setup
@@ -156,6 +157,10 @@ Senders you reply to quickly are automatically promoted to priority on the next 
 ### Inbox profiling
 
 `profile_inbox` — asks "who emails me most?" and returns a frequency ranking of senders with their dominant category (e.g. *urgent*, *informational*) and the timestamp of their most recent message. Profiling is built from the interaction history the agent accumulates during triage, so it improves the more you use the agent.
+
+### Voice-matched drafting
+
+`build_voice_profile` — ask the agent to "learn my writing style" and it samples your recent Sent mail, derives a style profile (usual greeting, sign-off, typical length, formality), and stores it on-device. From then on, drafted replies come out in your voice instead of neutral boilerplate — still returned for your approval, never auto-sent. The profile keeps derived features only (never your Sent message content) and lives in the agent's local SQLite database; nothing leaves the device. `clear_voice_profile` forgets it.
 
 ### Organize (reversible via the undo log)
 

--- a/hub/agents/python/email/gaia_agent_email/action_store.py
+++ b/hub/agents/python/email/gaia_agent_email/action_store.py
@@ -68,6 +68,17 @@ CREATE TABLE IF NOT EXISTS email_drafts (
 );
 """
 
+# Voice/style profile derived from Sent mail (#1607). One row per mailbox.
+# ``profile_json`` holds DERIVED features only (greetings, sign-offs, length,
+# formality signals) — never raw Sent content. See ``voice_profile.py``.
+EMAIL_VOICE_PROFILE_DDL = """
+CREATE TABLE IF NOT EXISTS email_voice_profile (
+    mailbox      TEXT PRIMARY KEY,
+    profile_json TEXT NOT NULL,
+    built_at     REAL NOT NULL
+);
+"""
+
 
 # 100 chars max — see plan A4 + adversarial S15. Email bodies routinely
 # carry MFA codes, password reset URLs, banking transaction summaries; a
@@ -76,9 +87,10 @@ BODY_PREVIEW_MAX_CHARS = 100
 
 
 def init_schema(db) -> None:
-    """Create both tables if they don't exist, then run migrations. Idempotent."""
+    """Create the tables if they don't exist, then run migrations. Idempotent."""
     db.execute(EMAIL_ACTIONS_DDL)
     db.execute(EMAIL_DRAFTS_DDL)
+    db.execute(EMAIL_VOICE_PROFILE_DDL)
     _migrate_email_actions_mailbox(db)
 
 
@@ -276,16 +288,74 @@ def fetch_draft(db, *, draft_id: str) -> Optional[Dict[str, Any]]:
     return result
 
 
+# ---------------------------------------------------------------------------
+# email_voice_profile API (#1607)
+# ---------------------------------------------------------------------------
+
+
+def save_voice_profile(db, *, mailbox: str, profile: Dict[str, Any]) -> None:
+    """Upsert the voice profile for *mailbox* (one row per mailbox).
+
+    Update-then-insert (not delete-then-insert) so a failure between the
+    two statements can never lose the existing profile.
+    """
+    row = {
+        "profile_json": json.dumps(profile),
+        "built_at": time.time(),
+    }
+    updated = db.update("email_voice_profile", row, "mailbox = :m", {"m": mailbox})
+    if not updated:
+        db.insert("email_voice_profile", dict(row, mailbox=mailbox))
+
+
+def fetch_voice_profile(
+    db, *, mailbox: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Return the stored profile dict, or ``None`` when none has been built.
+
+    With ``mailbox=None`` returns the most recently built profile across
+    mailboxes — the common single-mailbox case and the system-prompt path.
+    """
+    if mailbox:
+        row = db.query(
+            "SELECT profile_json FROM email_voice_profile WHERE mailbox = :m",
+            {"m": mailbox},
+            one=True,
+        )
+    else:
+        row = db.query(
+            "SELECT profile_json FROM email_voice_profile "
+            "ORDER BY built_at DESC LIMIT 1",
+            {},
+            one=True,
+        )
+    if row is None:
+        return None
+    return json.loads(row["profile_json"])
+
+
+def delete_voice_profile(db, *, mailbox: Optional[str] = None) -> None:
+    """Delete the profile for *mailbox*, or all profiles when ``None``."""
+    if mailbox:
+        db.delete("email_voice_profile", "mailbox = :m", {"m": mailbox})
+    else:
+        db.delete("email_voice_profile", "1 = 1", {})
+
+
 __all__ = [
     "BODY_PREVIEW_MAX_CHARS",
     "EMAIL_ACTIONS_DDL",
     "EMAIL_DRAFTS_DDL",
+    "EMAIL_VOICE_PROFILE_DDL",
+    "delete_voice_profile",
     "fetch_batch_undoable",
     "fetch_draft",
     "fetch_undoable",
+    "fetch_voice_profile",
     "init_schema",
     "mark_draft_sent",
     "mark_undone",
     "record_action",
     "record_draft",
+    "save_voice_profile",
 ]

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -60,6 +60,8 @@ from gaia_agent_email.tools.profile_tools import ProfileToolsMixin
 from gaia_agent_email.tools.read_tools import ReadToolsMixin
 from gaia_agent_email.tools.reply_tools import ReplyToolsMixin
 from gaia_agent_email.tools.summarize_tools import SummarizeToolsMixin
+from gaia_agent_email.tools.voice_tools import VoiceToolsMixin
+from gaia_agent_email.voice_profile import render_style_guidance
 
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.console import AgentConsole
@@ -139,6 +141,9 @@ ACTIONS:
   set_category_default, clear_session_preferences) — mutate persistent
   classification preferences that survive across restarts. Confirm the
   change in plain English.
+- Style tools (build_voice_profile, clear_voice_profile) — learn or
+  forget the user's writing style from their Sent mail. Local-only:
+  reads mail, sends nothing; the profile is stored on-device.
 
 PRE-SCAN BEHAVIOR:
 When the user asks for a pre-scan, morning brief, triage view, or "what's
@@ -175,6 +180,7 @@ class EmailTriageAgent(
     PreferenceToolsMixin,
     PhishingToolsMixin,
     ProfileToolsMixin,
+    VoiceToolsMixin,
 ):
     """Email Triage Agent — Gmail + Calendar through the connectors
     framework, all body inference local on Lemonade.
@@ -332,7 +338,13 @@ class EmailTriageAgent(
         return AgentConsole()
 
     def _get_system_prompt(self) -> str:
-        return _SYSTEM_PROMPT
+        # Voice/style-matched drafting (#1607): once a profile has been
+        # built from Sent mail, every turn's prompt carries the style
+        # guidance so draft bodies come out in the user's own voice.
+        profile = action_store.fetch_voice_profile(self)
+        if profile is None:
+            return _SYSTEM_PROMPT
+        return _SYSTEM_PROMPT + "\n" + render_style_guidance(profile)
 
     def process_query(self, *args, **kwargs):
         # Zero the batch-organize counter per turn so a long-lived instance
@@ -357,6 +369,7 @@ class EmailTriageAgent(
         self._register_preference_tools()
         self._register_phishing_tools()
         self._register_profile_tools()
+        self._register_voice_tools()
         self.register_memory_tools()
 
     # -- Phase 2 multi-inbox routing (#1603) -------------------------------

--- a/hub/agents/python/email/gaia_agent_email/tools/voice_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/voice_tools.py
@@ -1,0 +1,146 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Voice/style profile tools mixin for ``EmailTriageAgent`` (#1607).
+
+``build_voice_profile`` samples the user's Sent mail through the mail
+backend, derives a style profile (``voice_profile.analyze_sent_bodies``),
+and persists it locally via ``action_store``. The agent's system prompt
+picks the stored profile up on the next turn, so draft bodies composed for
+``draft_reply``/``draft_forward`` match the user's own voice.
+
+Both tools are local-only: reading Sent mail mutates nothing remote, and
+the profile lives in the agent's SQLite ``state.db`` — no Sent content
+leaves the device (derived features only are stored).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from gaia_agent_email import action_store
+from gaia_agent_email.gmail_backend import decode_message_body
+from gaia_agent_email.verbose import log_tool_call
+from gaia_agent_email.voice_profile import analyze_sent_bodies
+
+from gaia.agents.base.tools import tool
+from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.formatting import format_connector_error
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+# Default Sent-mail sample. Big enough to smooth over one-off outliers,
+# small enough to stay fast on first run (one get_message per sample).
+DEFAULT_SAMPLE_SIZE = 50
+
+
+def _envelope_ok(data: Any) -> str:
+    return json.dumps({"ok": True, "data": data}, default=str)
+
+
+def _envelope_err(message: str) -> str:
+    return json.dumps({"ok": False, "error": message})
+
+
+def build_voice_profile_impl(
+    gmail,
+    db,
+    *,
+    mailbox: str,
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+    debug: bool = False,
+) -> dict:
+    with log_tool_call(
+        "build_voice_profile",
+        {"mailbox": mailbox, "sample_size": sample_size},
+        debug=debug,
+    ) as st:
+        listing = gmail.list_messages(label_ids=["SENT"], max_results=sample_size)
+        refs = listing.get("messages", [])
+        if not refs:
+            raise ValueError(
+                f"no Sent messages found in mailbox '{mailbox}' — a voice "
+                "profile needs Sent history to learn from. Send a few emails "
+                "first, or connect a mailbox that has Sent mail."
+            )
+        bodies = []
+        for ref in refs:
+            msg = gmail.get_message(ref["id"])
+            body, _attachments = decode_message_body(msg.get("payload") or {})
+            if body.strip():
+                bodies.append(body)
+        profile = analyze_sent_bodies(bodies)
+        action_store.save_voice_profile(db, mailbox=mailbox, profile=profile)
+        st["result_summary"] = {"sample_count": profile["sample_count"]}
+        return dict(profile, mailbox=mailbox)
+
+
+class VoiceToolsMixin:
+    """Registers ``build_voice_profile`` and ``clear_voice_profile``."""
+
+    def _register_voice_tools(self) -> None:
+        db = self
+        agent = self
+        debug_flag = bool(getattr(self.config, "debug", False))
+
+        @tool
+        def build_voice_profile(
+            sample_size: int = DEFAULT_SAMPLE_SIZE, mailbox: str = ""
+        ) -> str:
+            """Learn the user's writing voice from their Sent mail.
+
+            Samples recent Sent messages, derives a local style profile
+            (greeting, sign-off, typical length, formality), and stores it
+            on-device. Future draft bodies should match this profile. Reads
+            mail only — sends nothing, mutates nothing remote.
+
+            ``sample_size`` (optional, default 50) caps how many recent Sent
+            messages are analyzed. ``mailbox`` (optional) selects which
+            connected mailbox to learn from; defaults to the primary one.
+            """
+            try:
+                if sample_size <= 0:
+                    return _envelope_err(
+                        f"sample_size must be positive, got {sample_size}"
+                    )
+                if not agent._backends:
+                    return _envelope_err(
+                        "no mailbox is connected — connect Gmail or Outlook "
+                        "via `gaia connectors` first, then retry"
+                    )
+                provider = mailbox or next(iter(agent._backends))
+                backend = agent._backends.get(provider)
+                if backend is None:
+                    return _envelope_err(
+                        f"mailbox '{provider}' is not connected — connected "
+                        f"mailboxes: {sorted(agent._backends)}"
+                    )
+                profile = build_voice_profile_impl(
+                    backend,
+                    db,
+                    mailbox=provider,
+                    sample_size=sample_size,
+                    debug=debug_flag,
+                )
+                return _envelope_ok(profile)
+            except ConnectorsError as exc:
+                return _envelope_err(format_connector_error(exc))
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")
+
+        @tool
+        def clear_voice_profile(mailbox: str = "") -> str:
+            """Forget the learned voice profile.
+
+            Removes the stored style profile so drafts go back to neutral
+            phrasing. ``mailbox`` (optional) clears one mailbox's profile;
+            default clears all.
+            """
+            try:
+                action_store.delete_voice_profile(db, mailbox=mailbox or None)
+                return _envelope_ok({"cleared": mailbox or "all"})
+            except Exception as exc:
+                log.exception("email tool error: %s", type(exc).__name__)
+                return _envelope_err(f"{type(exc).__name__}: {exc}")

--- a/hub/agents/python/email/gaia_agent_email/voice_profile.py
+++ b/hub/agents/python/email/gaia_agent_email/voice_profile.py
@@ -1,0 +1,169 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Local voice/style profile derived from the user's Sent mail (#1607).
+
+Pure functions only — no I/O, no LLM. ``build_voice_profile`` (see
+``tools/voice_tools.py``) fetches Sent bodies through the mail backend,
+runs :func:`analyze_sent_bodies`, and persists the resulting profile via
+``action_store``. The profile holds DERIVED features (greeting/sign-off
+phrases, length, formality signals) — never raw Sent content — so the
+SQLite row can't leak private mail even if exfiltrated.
+"""
+
+from __future__ import annotations
+
+import re
+import statistics
+from collections import Counter
+from typing import Any, Dict, List
+
+# Lines like "On Mon, Jun 2, 2026 at 9:00 AM Maria <m@x.com> wrote:" start
+# the quoted original in Gmail-style replies; everything after is not the
+# user's own writing.
+_ATTRIBUTION_RE = re.compile(r"^On\b.*wrote:\s*$", re.IGNORECASE)
+_ORIGINAL_MESSAGE_RE = re.compile(
+    r"^-{2,}\s*(Original|Forwarded) Message\s*-{2,}", re.IGNORECASE
+)
+
+_GREETING_RE = re.compile(
+    r"^(hey|hi|hello|dear|greetings|good (?:morning|afternoon|evening))\b",
+    re.IGNORECASE,
+)
+
+_SIGNOFF_RE = re.compile(
+    r"^(cheers|thanks|thank you|many thanks|best|best regards|regards|"
+    r"kind regards|warm regards|sincerely|talk soon|take care)[\s,.!]*$",
+    re.IGNORECASE,
+)
+
+# ['’] — mail clients (Gmail web composer included) emit typographic
+# apostrophes; matching only ASCII would misread casual writers as formal.
+_CONTRACTION_RE = re.compile(r"\b\w+['’](?:ll|re|ve|d|s|t|m)\b", re.IGNORECASE)
+
+# How many top greeting / sign-off variants the profile keeps.
+_TOP_N = 3
+
+
+def strip_quoted_text(body: str) -> str:
+    """Return only the user's own writing from a reply/forward body.
+
+    Cuts at the first attribution line ("On ... wrote:", "--- Original
+    Message ---") and drops ``>``-quoted lines.
+    """
+    kept: List[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if _ATTRIBUTION_RE.match(stripped) or _ORIGINAL_MESSAGE_RE.match(stripped):
+            break
+        if stripped.startswith(">"):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def _first_nonempty_line(text: str) -> str:
+    for line in text.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+# 8 lines: sign-offs sit above the name + a signature block (title, phone,
+# address, URL) that routinely runs 4-6 lines.
+_SIGNOFF_SCAN_LINES = 8
+
+
+def _trailing_lines(text: str, count: int = _SIGNOFF_SCAN_LINES) -> List[str]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    return lines[-count:]
+
+
+def analyze_sent_bodies(bodies: List[str]) -> Dict[str, Any]:
+    """Derive a style profile from Sent message bodies.
+
+    Raises ``ValueError`` when no body contains usable (non-quoted,
+    non-empty) text — the caller surfaces that as an actionable error
+    instead of persisting an empty profile.
+    """
+    usable = [
+        cleaned
+        for cleaned in (strip_quoted_text(b or "").strip() for b in bodies)
+        if cleaned
+    ]
+    if not usable:
+        raise ValueError(
+            "no usable Sent message bodies to analyze — the sampled Sent "
+            "messages were empty or entirely quoted text"
+        )
+
+    greeting_counts: Counter = Counter()
+    signoff_counts: Counter = Counter()
+    word_counts: List[int] = []
+    messages_with_contractions = 0
+    exclamations = 0
+
+    for text in usable:
+        first = _first_nonempty_line(text)
+        greeting_match = _GREETING_RE.match(first)
+        if greeting_match:
+            greeting_counts[greeting_match.group(1).capitalize()] += 1
+        # Bottom-up so the sign-off is found even under a long signature
+        # block; only one sign-off is credited per message.
+        for line in reversed(_trailing_lines(text)):
+            signoff_match = _SIGNOFF_RE.match(line)
+            if signoff_match:
+                signoff_counts[signoff_match.group(1).capitalize()] += 1
+                break
+        word_counts.append(len(text.split()))
+        if _CONTRACTION_RE.search(text):
+            messages_with_contractions += 1
+        exclamations += text.count("!")
+
+    sample_count = len(usable)
+    return {
+        "greetings": [g for g, _ in greeting_counts.most_common(_TOP_N)],
+        "signoffs": [s for s, _ in signoff_counts.most_common(_TOP_N)],
+        "median_words": int(statistics.median(word_counts)),
+        "uses_contractions": messages_with_contractions / sample_count >= 0.3,
+        "exclamation_rate": round(exclamations / sample_count, 2),
+        "sample_count": sample_count,
+    }
+
+
+def render_style_guidance(profile: Dict[str, Any]) -> str:
+    """Render the profile as a system-prompt block for draft composition."""
+    greetings = profile.get("greetings") or []
+    signoffs = profile.get("signoffs") or []
+    median_words = profile.get("median_words", 0)
+    tone_bits: List[str] = []
+    if profile.get("uses_contractions"):
+        tone_bits.append("use contractions naturally (I'll, let's, can't)")
+    else:
+        tone_bits.append("avoid contractions; keep phrasing formal")
+    if profile.get("exclamation_rate", 0) >= 0.3:
+        tone_bits.append("an occasional exclamation mark fits their voice")
+    else:
+        tone_bits.append("avoid exclamation marks")
+
+    greeting_line = (
+        f'- Open with their usual greeting style: {", ".join(repr(g) for g in greetings)}\n'
+        if greetings
+        else ""
+    )
+    signoff_line = (
+        f'- Sign off the way they do: {", ".join(repr(s) for s in signoffs)}\n'
+        if signoffs
+        else ""
+    )
+    return (
+        "VOICE & STYLE (derived locally from the user's Sent mail, "
+        f"sample of {profile.get('sample_count', 0)}):\n"
+        "When composing any draft body (draft_reply, draft_forward), write "
+        "in the user's own voice:\n"
+        f"{greeting_line}"
+        f"{signoff_line}"
+        f"- Aim for roughly {median_words} words — match their typical length.\n"
+        f"- Tone: {'; '.join(tone_bits)}.\n"
+        "Drafts are still returned for user approval — never send without "
+        "confirmation."
+    )

--- a/hub/agents/python/email/tests/test_email_voice_profile.py
+++ b/hub/agents/python/email/tests/test_email_voice_profile.py
@@ -1,0 +1,393 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Voice/style-matched drafting tests (#1607).
+
+Acceptance criteria covered:
+- AC: a local style profile is built from a sample of the user's Sent
+  messages (greeting/sign-off/length/formality).
+- AC: the draft-composition prompt reflects that profile — the agent's
+  system prompt carries the style guidance once a profile exists.
+- AC: the profile is local-only — derived features go to SQLite; raw Sent
+  body content is never persisted.
+- Test-AC: building the profile and drafting a reply trigger NO send
+  side-effect (extends the #1264 never-auto-send invariant).
+
+Embedder is mocked (same pattern as test_email_behavioral_learning.py) so
+tests run hermetically without Lemonade.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path / import bootstrap
+# ---------------------------------------------------------------------------
+
+# parents[0] = tests/,  [1] = email/,  [2] = python/,  [3] = agents/,
+# [4] = hub/,  [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email import action_store  # noqa: E402
+from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+from gaia_agent_email.voice_profile import (  # noqa: E402
+    analyze_sent_bodies,
+    render_style_guidance,
+    strip_quoted_text,
+)
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture data — a distinctive user voice
+# ---------------------------------------------------------------------------
+
+# Sentinel sentence that must NEVER show up in the persisted profile: the
+# local-only guarantee is that we store derived features, not Sent content.
+_PRIVATE_SENTINEL = "the acquisition closes on March 14 at 9am sharp"
+
+_SENT_BODIES = [
+    f"Hey Maria,\n\nQuick heads up — {_PRIVATE_SENTINEL}. Don't worry about "
+    "the deck, I'll handle it!\n\nCheers,\nKalin",
+    "Hey Tom,\n\nSounds good, let's do Thursday. I'll send the invite!\n\n"
+    "Cheers,\nKalin",
+    "Hey Priya,\n\nThanks for the summary — that's exactly what I needed. "
+    "I'll loop in finance tomorrow.\n\nCheers,\nKalin",
+    "Hey team,\n\nGreat work this sprint! Let's keep the momentum going.\n\n"
+    "Cheers,\nKalin",
+    "Hey Alex,\n\nCan't make it at 3, does 4 work? Happy to move things "
+    "around if not.\n\nCheers,\nKalin",
+]
+
+EMBEDDING_DIM = 768
+
+
+def _fake_embed(text: str) -> np.ndarray:
+    vec = np.ones(EMBEDDING_DIM, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    return vec
+
+
+def _b64url(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _gmail_message(
+    msg_id: str,
+    *,
+    body: str,
+    label_ids: list,
+    sender: str = "user@example.com",
+    to: str = "someone@example.com",
+    subject: str = "Re: plans",
+    internal_date: str = "1717502400000",
+) -> dict:
+    """Minimal Gmail-API-shape message accepted by FakeGmailBackend."""
+    return {
+        "id": msg_id,
+        "threadId": f"t-{msg_id}",
+        "labelIds": list(label_ids),
+        "internalDate": internal_date,
+        "snippet": body[:80],
+        "payload": {
+            "mimeType": "text/plain",
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "To", "value": to},
+                {"name": "Subject", "value": subject},
+                {"name": "Message-ID", "value": f"<{msg_id}@example.com>"},
+            ],
+            "body": {"data": _b64url(body)},
+        },
+    }
+
+
+def _seed_sent_history(backend: FakeGmailBackend) -> None:
+    for i, body in enumerate(_SENT_BODIES):
+        backend.add_message(
+            _gmail_message(
+                f"sent-{i}",
+                body=body,
+                label_ids=["SENT"],
+                sender="user@example.com",
+                to=f"peer{i}@example.com",
+                internal_date=str(1717502400000 + i),
+            )
+        )
+
+
+def _build_agent(tmp_path: Path, backend: FakeGmailBackend) -> EmailTriageAgent:
+    """EmailTriageAgent with an injected fake Gmail backend and tmp DBs."""
+    cfg = EmailAgentConfig(
+        gmail_backend=backend,
+        calendar_backend=MagicMock(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+    )
+    with (
+        patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._get_embedder",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._embed_text",
+            side_effect=_fake_embed,
+        ),
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._backfill_embeddings",
+            return_value=0,
+        ),
+        patch("gaia.agents.base.memory.MemoryMixin._rebuild_faiss_index"),
+        patch("gaia.agents.base.memory.MemoryMixin.init_system_context"),
+    ):
+        mock_sdk.return_value = MagicMock()
+        return EmailTriageAgent(config=cfg)
+
+
+def _invoke_tool(name: str, **kwargs) -> dict:
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    entry = _TOOL_REGISTRY.get(name)
+    assert entry is not None, f"{name} tool not registered"
+    return json.loads(entry["function"](**kwargs))
+
+
+# ===========================================================================
+# Pure analysis — gaia_agent_email.voice_profile
+# ===========================================================================
+
+
+class TestStripQuotedText:
+    def test_removes_quoted_lines_and_attribution(self):
+        body = (
+            "Sounds good, see you then.\n\n"
+            "Cheers,\nKalin\n\n"
+            "On Mon, Jun 2, 2026 at 9:00 AM Maria <m@x.com> wrote:\n"
+            "> Are we still on for Thursday?\n"
+            "> Let me know.\n"
+        )
+        cleaned = strip_quoted_text(body)
+        assert "Are we still on" not in cleaned
+        assert "wrote:" not in cleaned
+        assert "Sounds good" in cleaned
+
+    def test_plain_body_unchanged(self):
+        body = "Just the reply text.\n\nCheers,\nKalin"
+        assert strip_quoted_text(body).strip() == body.strip()
+
+
+class TestAnalyzeSentBodies:
+    def test_extracts_dominant_greeting_and_signoff(self):
+        profile = analyze_sent_bodies(_SENT_BODIES)
+        assert any("hey" in g.lower() for g in profile["greetings"])
+        assert any("cheers" in s.lower() for s in profile["signoffs"])
+        assert profile["sample_count"] == len(_SENT_BODIES)
+
+    def test_reports_length_and_informality_signals(self):
+        profile = analyze_sent_bodies(_SENT_BODIES)
+        assert profile["median_words"] > 0
+        # The fixture voice uses contractions ("I'll", "let's", "can't")
+        # and exclamation marks.
+        assert profile["uses_contractions"] is True
+        assert profile["exclamation_rate"] > 0
+
+    def test_no_usable_bodies_raises(self):
+        with pytest.raises(ValueError):
+            analyze_sent_bodies([])
+        with pytest.raises(ValueError):
+            analyze_sent_bodies(["", "   \n  "])
+
+    def test_curly_apostrophe_contractions_detected(self):
+        # Gmail's web composer emits typographic apostrophes.
+        bodies = [
+            "Hey Sam,\n\nI’ll get back to you tomorrow, can’t today."
+            "\n\nCheers,\nKalin"
+        ] * 3
+        profile = analyze_sent_bodies(bodies)
+        assert profile["uses_contractions"] is True
+
+    def test_signoff_found_above_long_signature(self):
+        bodies = [
+            "Hey Sam,\n\nWorks for me.\n\nCheers,\nKalin Ovtcharov\n"
+            "CEO, Acme Corp\n+1 555 0100\n123 Main St, Springfield\n"
+            "www.acme.example"
+        ] * 3
+        profile = analyze_sent_bodies(bodies)
+        assert any("cheers" in s.lower() for s in profile["signoffs"])
+
+
+class TestRenderStyleGuidance:
+    def test_mentions_greeting_signoff_and_length(self):
+        profile = analyze_sent_bodies(_SENT_BODIES)
+        block = render_style_guidance(profile)
+        assert "VOICE" in block
+        assert "Hey" in block or "hey" in block
+        assert "Cheers" in block or "cheers" in block
+        assert str(profile["median_words"]) in block
+
+
+# ===========================================================================
+# Persistence — action_store voice-profile table
+# ===========================================================================
+
+
+class TestVoiceProfileStore:
+    def test_round_trip_upsert_and_delete(self, tmp_path):
+        backend = FakeGmailBackend()
+        agent = _build_agent(tmp_path, backend)
+
+        assert action_store.fetch_voice_profile(agent) is None
+
+        profile = analyze_sent_bodies(_SENT_BODIES)
+        action_store.save_voice_profile(agent, mailbox="google", profile=profile)
+        fetched = action_store.fetch_voice_profile(agent)
+        assert fetched is not None
+        assert fetched["greetings"] == profile["greetings"]
+
+        # Upsert — a rebuild replaces, never duplicates.
+        profile2 = dict(profile, median_words=999)
+        action_store.save_voice_profile(agent, mailbox="google", profile=profile2)
+        assert action_store.fetch_voice_profile(agent)["median_words"] == 999
+
+        action_store.delete_voice_profile(agent, mailbox="google")
+        assert action_store.fetch_voice_profile(agent) is None
+
+
+# ===========================================================================
+# Tool — build_voice_profile / clear_voice_profile
+# ===========================================================================
+
+
+class TestBuildVoiceProfileTool:
+    def test_reads_sent_label_only(self, tmp_path):
+        backend = FakeGmailBackend()
+        _seed_sent_history(backend)
+        # An INBOX message that must NOT contribute to the profile.
+        backend.add_message(
+            _gmail_message(
+                "inbox-1",
+                body="Dear Sir or Madam, kindly find attached the invoice.",
+                label_ids=["INBOX"],
+                sender="vendor@example.com",
+                to="user@example.com",
+            )
+        )
+        _build_agent(tmp_path, backend)
+
+        result = _invoke_tool("build_voice_profile")
+        assert result["ok"], result
+        assert result["data"]["sample_count"] == len(_SENT_BODIES)
+
+        list_calls = [
+            kwargs
+            for method, kwargs in backend.transport.calls
+            if method == "list_messages"
+        ]
+        assert list_calls, "build_voice_profile never listed messages"
+        assert all(kwargs["label_ids"] == ["SENT"] for kwargs in list_calls)
+
+    def test_prompt_gains_voice_block_after_build(self, tmp_path):
+        backend = FakeGmailBackend()
+        _seed_sent_history(backend)
+        agent = _build_agent(tmp_path, backend)
+
+        assert "VOICE" not in agent._get_system_prompt()
+        result = _invoke_tool("build_voice_profile")
+        assert result["ok"], result
+        prompt = agent._get_system_prompt()
+        assert "VOICE" in prompt
+        assert "hey" in prompt.lower()
+        assert "cheers" in prompt.lower()
+
+    def test_profile_persists_across_restart(self, tmp_path):
+        backend = FakeGmailBackend()
+        _seed_sent_history(backend)
+        _build_agent(tmp_path, backend)
+        result = _invoke_tool("build_voice_profile")
+        assert result["ok"], result
+
+        # New agent instance, same state.db — profile must survive.
+        agent2 = _build_agent(tmp_path, FakeGmailBackend())
+        assert "VOICE" in agent2._get_system_prompt()
+
+    def test_stored_profile_has_no_raw_sent_content(self, tmp_path):
+        backend = FakeGmailBackend()
+        _seed_sent_history(backend)
+        agent = _build_agent(tmp_path, backend)
+        result = _invoke_tool("build_voice_profile")
+        assert result["ok"], result
+
+        row = agent.query("SELECT profile_json FROM email_voice_profile", {}, one=True)
+        assert row is not None
+        assert _PRIVATE_SENTINEL not in row["profile_json"]
+
+    def test_no_sent_history_errors_actionably(self, tmp_path):
+        _build_agent(tmp_path, FakeGmailBackend())
+        result = _invoke_tool("build_voice_profile")
+        assert result["ok"] is False
+        assert "sent" in result["error"].lower()
+
+    def test_clear_voice_profile_removes_block(self, tmp_path):
+        backend = FakeGmailBackend()
+        _seed_sent_history(backend)
+        agent = _build_agent(tmp_path, backend)
+        result = _invoke_tool("build_voice_profile")
+        assert result["ok"], result
+        assert "VOICE" in agent._get_system_prompt()
+
+        result = _invoke_tool("clear_voice_profile")
+        assert result["ok"], result
+        assert "VOICE" not in agent._get_system_prompt()
+
+
+# ===========================================================================
+# Never-auto-send — profile build + draft produce zero send side-effects
+# ===========================================================================
+
+
+class TestNoSendSideEffect:
+    def test_build_and_draft_cause_no_send_calls(self, tmp_path):
+        backend = FakeGmailBackend()
+        _seed_sent_history(backend)
+        backend.add_message(
+            _gmail_message(
+                "inbox-reply-me",
+                body="Are we still on for Thursday?",
+                label_ids=["INBOX"],
+                sender="maria@example.com",
+                to="user@example.com",
+            )
+        )
+        _build_agent(tmp_path, backend)
+
+        result = _invoke_tool("build_voice_profile")
+        assert result["ok"], result
+        result = _invoke_tool(
+            "draft_reply",
+            message_id="inbox-reply-me",
+            body="Hey Maria,\n\nYes — see you Thursday!\n\nCheers,\nKalin",
+        )
+        assert result["ok"], result
+
+        methods = {method for method, _ in backend.transport.calls}
+        assert "create_draft" in methods
+        forbidden = {"send_draft", "send_message"}
+        assert not (
+            methods & forbidden
+        ), f"send side-effect detected: {methods & forbidden}"

--- a/tests/unit/agents/test_email_agent.py
+++ b/tests/unit/agents/test_email_agent.py
@@ -199,6 +199,9 @@ class TestToolRegistry:
         "clear_session_preferences",
         # Inbox profiling from memory (#1289)
         "profile_inbox",
+        # Voice/style profile from Sent mail (#1607)
+        "build_voice_profile",
+        "clear_voice_profile",
     }
 
     def test_every_expected_tool_is_registered(self, agent):


### PR DESCRIPTION
Closes #1607.

Draft replies came out as neutral boilerplate no matter how the user actually writes. Now the agent can learn the user's voice from their own Sent mail — usual greeting, sign-off, typical length, formality — and every drafted reply comes out sounding like them, while staying approval-gated (#1264): building the profile and drafting trigger zero send side-effects, with a regression test. Local-first by construction: only derived features are persisted to the agent's SQLite `state.db` (never raw Sent content), and greeting/sign-off extraction matches a closed vocabulary, so hostile text in a Sent body cannot reach the system prompt.

Per the issue notes, the profile plugs into the draft-composition prompt (the LLM composes `draft_reply` bodies in the agent loop), not into `draft_reply` itself — the sidecar REST contract is unchanged.

## Test plan

- [x] `PYTHONPATH=$PWD/hub/agents/python/email python -m pytest hub/agents/python/email/tests/test_email_voice_profile.py -q` — 16 new tests: analyzer (greeting/sign-off/length/formality, quoted-text stripping, curly apostrophes, long signature blocks), persistence round-trip + restart survival, SENT-label-only sampling, prompt injection before/after build, no-raw-content-persisted sentinel, and the no-send-side-effect acceptance test.
- [x] Full email sweep (hub package tests + `tests/unit/agents/test_email_agent*.py` + `tests/integration/test_never_auto_send.py` + `tests/unit/agents/email/`) — 748 passed; the 2 failures are pre-existing environment skew, fail identically on a clean tree.
- [x] `black`/`isort` clean on all touched files; `util/lint.py --all` passes.

## Deliberately deferred

- **Judge-scored `style_match` eval AC**: needs the email eval harness extended (draft-quality judging against the #1230 corpus) plus a Strix Halo hardware run — shipping an unrunnable scenario file would be half-finished work. Proposing a follow-up issue for it.
- **Multi-mailbox voice routing**: with several mailboxes connected, the prompt uses the most-recently-built profile rather than routing per-message; ties into the #1603 multi-inbox work.