### PR TITLE
fix(tests): match chat-app title assertion to renamed Agent UI title

### DIFF
--- a/tests/electron/test_electron_chat_app.js
+++ b/tests/electron/test_electron_chat_app.js
@@ -166,7 +166,7 @@ describe('Chat App Integration', () => {
     });
 
     it('should have GAIA title', () => {
-      expect(htmlContent).toContain('<title>GAIA</title>');
+      expect(htmlContent).toContain('<title>GAIA Agent UI</title>');
     });
 
     it('should have React root div', () => {


### PR DESCRIPTION
"Test Electron Framework" has been red on main and every PR since 2026-06-22: #1750 renamed the Agent UI window title to "GAIA Agent UI", but `test_electron_chat_app.js` still expects `<title>GAIA</title>`. This aligns the assertion with the actual title — the same suite already asserts `displayName: 'GAIA Agent UI'`, so the rename was clearly intentional. Unblocks the check on Dependabot PRs #1803, #1805, #1861 among others.

## Test plan
- [x] `npx jest test_electron_chat_app.js` locally: 196/196 pass with the fix (previously 195/196)
- [ ] "Test Electron Framework" green on this PR