### PR TITLE
fix(emr): dashboard context size read from Lemonade ≥10.x health payload

### DIFF
--- a/hub/agents/python/emr/gaia_agent_emr/dashboard/server.py
+++ b/hub/agents/python/emr/gaia_agent_emr/dashboard/server.py
@@ -315,6 +315,44 @@ class DashboardEventHandler:
         _broadcast_sync(event)
 
 
+def _is_positive_int(value: Any) -> bool:
+    # bool is an int subclass — a truthy `ctx_size: true` must not count.
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _derive_context_size(health: Dict[str, Any], preferred_model: str) -> int:
+    """Context size from a Lemonade health payload.
+
+    Lemonade >=10.x reports ctx per loaded model under
+    ``all_models_loaded[].recipe_options.ctx_size``; older servers reported a
+    top-level ``context_size``. Prefers ``preferred_model``'s ctx, falling back
+    to the largest loaded ctx (which may be a non-VLM model's while the VLM is
+    still loading), then 0 (rendered as "unknown" in the UI). Malformed
+    payload shapes degrade to 0 rather than raising.
+    """
+    top_level = health.get("context_size")
+    if _is_positive_int(top_level):
+        return top_level
+
+    sizes: Dict[str, int] = {}
+    models = health.get("all_models_loaded")
+    for model in models if isinstance(models, list) else []:
+        if not isinstance(model, dict):
+            continue
+        recipe_options = model.get("recipe_options")
+        ctx = recipe_options.get("ctx_size") if isinstance(recipe_options, dict) else None
+        if _is_positive_int(ctx):
+            name = model.get("model_name")
+            if isinstance(name, str) and name:
+                sizes[name] = ctx
+            else:
+                sizes[f"_unnamed_{len(sizes)}"] = ctx
+
+    if preferred_model in sizes:
+        return sizes[preferred_model]
+    return max(sizes.values(), default=0)
+
+
 def create_app(
     watch_dir: str = "./intake_forms",
     db_path: str = "./data/patients.db",
@@ -1275,7 +1313,7 @@ def create_app(
             try:
                 health = client.health_check()
                 server_running = health.get("status") == "ok"
-                context_size = health.get("context_size", 0)
+                context_size = _derive_context_size(health, vlm_model)
             except Exception:
                 return {
                     "initialized": False,

--- a/hub/agents/python/emr/tests/test_init_status_context_size.py
+++ b/hub/agents/python/emr/tests/test_init_status_context_size.py
@@ -1,0 +1,100 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for deriving context size from the Lemonade health payload."""
+
+import unittest
+
+# Representative /api/v1/health payload from Lemonade 10.7.0 (no top-level
+# context_size; ctx lives per-model under recipe_options).
+LEMONADE_10_7_HEALTH = {
+    "status": "ok",
+    "version": "10.7.0",
+    "model_loaded": "nomic-embed-text-v2-moe-GGUF",
+    "websocket_port": 9000,
+    "max_models": {"embedding": 2, "llm": 2},
+    "all_models_loaded": [
+        {
+            "backend_url": "http://127.0.0.1:8002/v1",
+            "checkpoint": "nomic-ai/nomic-embed-text-v2-moe-GGUF:Q8_0",
+            "device": "gpu",
+            "model_name": "nomic-embed-text-v2-moe-GGUF",
+            "recipe": "llamacpp",
+            "recipe_options": {"ctx_size": 32768},
+            "type": "embedding",
+        },
+        {
+            "backend_url": "http://127.0.0.1:8003/v1",
+            "checkpoint": "unsloth/Qwen3-VL-4B-Instruct-GGUF:Q4_K_M",
+            "device": "gpu",
+            "model_name": "Qwen3-VL-4B-Instruct-GGUF",
+            "recipe": "llamacpp",
+            "recipe_options": {"ctx_size": 16384},
+            "type": "llm",
+        },
+    ],
+}
+
+
+class TestDeriveContextSize(unittest.TestCase):
+    """_derive_context_size must read per-model ctx from 10.x health payloads."""
+
+    def _derive(self, health, model="Qwen3-VL-4B-Instruct-GGUF"):
+        from gaia_agent_emr.dashboard.server import _derive_context_size
+
+        return _derive_context_size(health, model)
+
+    def test_prefers_the_requested_models_ctx(self):
+        """The VLM's own ctx wins over other loaded models'."""
+        self.assertEqual(self._derive(LEMONADE_10_7_HEALTH), 16384)
+
+    def test_falls_back_to_max_loaded_ctx_when_model_absent(self):
+        """If the VLM isn't loaded, report the largest loaded ctx."""
+        self.assertEqual(self._derive(LEMONADE_10_7_HEALTH, model="not-loaded"), 32768)
+
+    def test_returns_zero_when_nothing_loaded(self):
+        health = {"status": "ok", "version": "10.7.0", "all_models_loaded": []}
+        self.assertEqual(self._derive(health), 0)
+
+    def test_legacy_top_level_context_size_still_honored(self):
+        """Pre-10.x payloads with a top-level context_size keep working."""
+        health = {"status": "ok", "context_size": 32768}
+        self.assertEqual(self._derive(health), 32768)
+
+    def test_missing_recipe_options_is_not_an_error(self):
+        health = {
+            "status": "ok",
+            "all_models_loaded": [{"model_name": "m", "recipe_options": None}],
+        }
+        self.assertEqual(self._derive(health, model="m"), 0)
+
+    def test_bool_values_are_rejected(self):
+        """bool is an int subclass; a truthy ctx must not count as a size."""
+        health = {
+            "status": "ok",
+            "context_size": True,
+            "all_models_loaded": [
+                {"model_name": "m", "recipe_options": {"ctx_size": True}}
+            ],
+        }
+        self.assertEqual(self._derive(health, model="m"), 0)
+
+    def test_malformed_shapes_degrade_to_zero(self):
+        """Non-dict entries and non-dict recipe_options must not raise."""
+        health = {
+            "status": "ok",
+            "all_models_loaded": [
+                "not-a-dict",
+                {"model_name": "m", "recipe_options": "oops"},
+                {"recipe_options": {"ctx_size": 8192}},  # unnamed model still counts
+            ],
+        }
+        self.assertEqual(self._derive(health, model="m"), 8192)
+
+    def test_non_list_all_models_loaded_degrades_to_zero(self):
+        health = {"status": "ok", "all_models_loaded": "oops"}
+        self.assertEqual(self._derive(health), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1935.

The EMR dashboard's Settings panel always reported Lemonade's context size as unknown — even with every model loaded at 32,768 — because the backend read a top-level `context_size` key that Lemonade ≥10.x no longer returns (ctx now lives per-model under `all_models_loaded[].recipe_options.ctx_size`). The endpoint now derives the value from the per-model entries (preferring the VLM's, falling back to the largest loaded ctx), so the panel shows the real number and the 32,768 recommendation check actually works; older servers with a top-level `context_size` keep working.

## Evidence

Tested against a live Lemonade 10.7.0 on :13305 with two models loaded at ctx 32,768 — same machine, same server, before vs. after this change:

```
# before (main): the key doesn't exist, so the value is always 0
{'server_running': True, 'context_size': 0, 'context_size_ok': False, 'required_context_size': 32768, 'message': '2/3 models ready'}

# after (this PR)
{'server_running': True, 'context_size': 32768, 'context_size_ok': True, 'required_context_size': 32768, 'message': '2/3 models ready'}
```

## Test plan

- [ ] `cd hub/agents/python/emr && PYTHONPATH=. python -m pytest tests/ -q` → 63 passed (8 new tests exercise the derivation with a representative Lemonade 10.7.0 health payload: preferred-model ctx, max-loaded fallback, nothing loaded, legacy top-level key, missing/malformed `recipe_options`, bool rejection, non-list payloads)
- [ ] With Lemonade running and models loaded: `gaia-emr dashboard`, open Settings → Context Size shows the real value instead of "Unknown"
