### PR TITLE
test(webui): deflake SettingsPage dynamic-tools toggle tests

### DIFF
--- a/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/SettingsPage.test.tsx
@@ -49,9 +49,10 @@ function getDynamicToolsToggle(): HTMLInputElement {
 describe('SettingsPage — Dynamic Tools toggle (#1798)', () => {
     it('renders the loaded value (off by default)', async () => {
         render(<SettingsPage />);
-        const toggle = await waitFor(getDynamicToolsToggle);
-        expect(toggle).not.toBeChecked();
-        expect(toggle).not.toBeDisabled();
+        // Disabled-while-loading: wait for the enabled (loaded) state, not
+        // just the element, or slow runners race the settings fetch.
+        await waitFor(() => expect(getDynamicToolsToggle()).not.toBeDisabled());
+        expect(getDynamicToolsToggle()).not.toBeChecked();
     });
 
     it('reflects a persisted-on value from the server', async () => {
@@ -94,10 +95,11 @@ describe('SettingsPage — Dynamic Tools toggle (#1798)', () => {
             makeSettings({ dynamic_tools: true, dynamic_tools_locked: true }),
         );
         render(<SettingsPage />);
-        const toggle = await waitFor(getDynamicToolsToggle);
+        // The toggle exists (disabled, unchecked) while settings load — wait
+        // for the loaded state, not just the element, or slow runners race.
+        await waitFor(() => expect(getDynamicToolsToggle()).toBeChecked());
 
-        expect(toggle).toBeChecked();
-        expect(toggle).toBeDisabled();
+        expect(getDynamicToolsToggle()).toBeDisabled();
         expect(screen.getByText(/GAIA_DYNAMIC_TOOLS/)).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Fixes #1937.

Two SettingsPage tests raced the settings fetch: they grabbed the dynamic-tools toggle as soon as it rendered (disabled + unchecked while loading) and immediately asserted its final state, which fails on slow CI runners — seen on PR #1930's "Test Agent UI Components (Vitest)" run against code that doesn't touch the UI. Both now wait for the loaded state inside `waitFor`, the pattern the file's other five tests already use. Test-only change; no component code touched.

## Test plan

- [ ] `cd src/gaia/apps/webui && npx vitest run src/components/__tests__/SettingsPage.test.tsx` → 7 passed (verified 3× in a row locally)
- [ ] `npx vitest run` (full webui suite) → 13 files / 109 tests passed