### PR TITLE
ci(api-tests): install gaia-agent-email so email routes mount

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -69,6 +69,10 @@ jobs:
           # tests exercise the real agent instead of the missing-wheel error.
           uv pip install -e hub/agents/python/routing --python .venv\Scripts\python.exe
           uv pip install -e hub/agents/python/code --python .venv\Scripts\python.exe
+          # The email REST router only mounts when gaia-agent-email is
+          # importable; without it every /v1/email test in tests/test_api.py
+          # 404s (red on main since the email agent moved to a hub wheel).
+          uv pip install -e hub/agents/python/email --python .venv\Scripts\python.exe
 
       - name: Install Lemonade Server
         uses: ./.github/actions/install-lemonade


### PR DESCRIPTION
The "API Tests" check has been red on every branch including main since the email agent moved to a standalone hub wheel: the workflow installs the routing and code hub packages into its venv but not `gaia-agent-email`, so the email REST router never mounts and every `/v1/email` test in `tests/test_api.py` fails with `404 {"detail":"Not Found"}`. One install line fixes it.

**Test plan**
- [ ] "API Tests" check on this PR goes green (the email tests were the only failures — same signature as main run 28462826567)
- [ ] After merge, re-run API Tests on open PRs #1917/#1919 — they should go fully green

<details>
<summary>Evidence</summary>

- Main's latest run of this workflow (28462826567 @ 50c17de6) fails with the identical email-route 404 list as every PR branch — e.g. `TestEmailTriageEndpoint::test_single_email_in_structured_out`: `assert 404 == 200`.
- Last green main run of this workflow was #1455 (2026-06-26) — the last commit to touch `test_api.yml`; the failures start with the hub-migration commits that followed.
- The workflow already installs the other two hub wheels for exactly this reason (routing/code, #1102) — email was missed.
</details>