### PR TITLE
ci(lemonade-bump): allow bot actors past claude-code-action gate

### DIFF
--- a/.github/workflows/lemonade-version-bump.yml
+++ b/.github/workflows/lemonade-version-bump.yml
@@ -141,6 +141,11 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Scheduled runs execute as a bot actor (e.g. github-merge-queue), which the
+          # action's actor gate rejects unless allow-listed. This workflow only triggers
+          # via schedule / workflow_dispatch — both trusted, no untrusted-fork path — so
+          # allowing bot actors here adds no new exposure.
+          allowed_bots: "*"
           prompt: |
             REPO: ${{ github.repository }}
             CURRENT LEMONADE VERSION: ${{ steps.detect.outputs.current_version }}


### PR DESCRIPTION
The weekly Lemonade version-bump workflow has been failing at the "Open Lemonade bump PR" step with `Workflow initiated by non-human actor: github-merge-queue (actor not found on GitHub)`. Scheduled runs execute under a bot actor, and `claude-code-action`'s actor gate aborts before Claude runs — so the pinned Lemonade version silently goes stale even when a newer release exists. This adds `allowed_bots: "*"` to the bump step so scheduled runs get past the gate.

Safe because this workflow only triggers via `schedule` and `workflow_dispatch` (both trusted, maintainer-only) — there's no untrusted fork/PR path, so allowing bot actors adds no new exposure.

## Test plan
- [ ] Trigger via *Run workflow* (`workflow_dispatch`, `force_version` set to a newer Lemonade release) and confirm the bump step runs Claude instead of aborting at the actor gate
- [ ] Confirm the next scheduled Thursday run no longer fails with the "non-human actor" error
