### PR TITLE
ci: reap stray Lemonade processes before starting the server

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Install Lemonade Server
         uses: ./.github/actions/install-lemonade
 
+      - name: Free Lemonade port (reap stray processes from prior jobs)
+        shell: powershell
+        run: .\installer\scripts\cleanup-lemonade.ps1 -Port 13305
+
       - name: Start Lemonade Server and Run Tests
         shell: powershell
         run: |

--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -52,6 +52,10 @@ jobs:
     - name: Install Lemonade Server
       uses: ./.github/actions/install-lemonade
 
+    - name: Free Lemonade port (reap stray processes from prior jobs)
+      shell: powershell
+      run: .\installer\scripts\cleanup-lemonade.ps1 -Port 13305
+
     - name: Start Lemonade Server and Run Tests
       shell: powershell
       run: |

--- a/.github/workflows/test_rag.yml
+++ b/.github/workflows/test_rag.yml
@@ -94,6 +94,10 @@ jobs:
     - name: Install Lemonade Server
       uses: ./.github/actions/install-lemonade
 
+    - name: Free Lemonade port (reap stray processes from prior jobs)
+      shell: powershell
+      run: .\installer\scripts\cleanup-lemonade.ps1 -Port 13305
+
     - name: Start Lemonade Server and Run Tests
       shell: powershell
       run: |

--- a/installer/scripts/cleanup-lemonade.ps1
+++ b/installer/scripts/cleanup-lemonade.ps1
@@ -1,0 +1,90 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+<#
+.SYNOPSIS
+    Free a Lemonade port and reap stray Lemonade/llama-server processes before a
+    fresh server starts.
+
+.DESCRIPTION
+    Self-hosted (stx / strix-halo) runners reuse the same machine across jobs, so
+    a crashed or leaked Lemonade Server from a prior job keeps listening on the
+    port. The next job's ``lemonade-server serve`` / ``LemonadeServer.exe`` then
+    dies with ``[Errno 10048] only one usage of each socket address`` (a bind
+    collision on the port, IPv4 or IPv6), and any leaked ``llama-server`` backend
+    child keeps a model resident so the next ``/load`` returns
+    ``llama-server failed to start``.
+
+    This script makes the start deterministic: it kills whatever owns the port
+    (both IPv4 and IPv6 listeners), reaps orphaned Lemonade/llama-server
+    processes by name, then blocks until the port is actually free so the caller
+    can bind it. It is idempotent and safe to run when nothing is listening.
+
+.PARAMETER Port
+    TCP port the next Lemonade Server will bind (default: 13305).
+
+.PARAMETER WaitSeconds
+    Max seconds to wait for the port to become free after killing owners
+    (default: 15).
+
+.EXAMPLE
+    .\installer\scripts\cleanup-lemonade.ps1 -Port 13305
+#>
+
+param(
+    [Parameter(Mandatory = $false)]
+    [int]$Port = 13305,
+
+    [Parameter(Mandatory = $false)]
+    [int]$WaitSeconds = 15
+)
+
+# Best-effort cleanup: never abort the caller because a process was already gone.
+$ErrorActionPreference = "Continue"
+
+Write-Host "=== Cleaning up stray Lemonade processes (port $Port) ==="
+
+function Stop-PortOwners {
+    param([int]$TargetPort)
+    # -State Listen covers both the IPv4 (0.0.0.0/127.0.0.1) and IPv6 (::1)
+    # listeners; the bind collision we hit was on ('::1', 13305).
+    $conns = Get-NetTCPConnection -LocalPort $TargetPort -State Listen -ErrorAction SilentlyContinue
+    if (-not $conns) { return $false }
+    $killed = $false
+    foreach ($processId in ($conns.OwningProcess | Select-Object -Unique)) {
+        if ($processId -and $processId -ne 0) {
+            Write-Host "[cleanup] Port $TargetPort held by PID $processId - killing"
+            Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+            $killed = $true
+        }
+    }
+    return $killed
+}
+
+# 1. Kill whatever currently owns the port.
+[void](Stop-PortOwners -TargetPort $Port)
+
+# 2. Reap Lemonade servers and llama-server backend children by name. These are
+#    never a runner process, so name-based reaping only removes leaked GAIA
+#    servers -- it catches orphans that already released the port but still hold
+#    a model / VRAM and would fail the next /load.
+$names = @("LemonadeServer", "lemonade-server", "llama-server")
+foreach ($name in $names) {
+    Get-Process -Name $name -ErrorAction SilentlyContinue | ForEach-Object {
+        Write-Host "[cleanup] Stopping stray $($_.ProcessName) (PID $($_.Id))"
+        Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# 3. Block until the port is actually free so the caller's bind succeeds.
+$deadline = (Get-Date).AddSeconds($WaitSeconds)
+while ((Get-Date) -lt $deadline) {
+    # Re-kill any owner that reappears (a dying parent can respawn a child).
+    if (-not (Stop-PortOwners -TargetPort $Port)) {
+        Write-Host "[OK] Port $Port is free"
+        return
+    }
+    Start-Sleep -Milliseconds 500
+}
+
+Write-Host "[WARN] Port $Port still shows a listener after ${WaitSeconds}s; continuing anyway"

--- a/installer/scripts/start-lemonade.ps1
+++ b/installer/scripts/start-lemonade.ps1
@@ -62,20 +62,10 @@ try {
     Write-Host "=========================================="
     Write-Host ""
 
-    # Check port availability
-    Write-Host "=== Checking Port $Port ==="
-    $portInUse = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
-    if ($portInUse) {
-        # Get unique PIDs (may have multiple connections on same port)
-        $processIds = $portInUse.OwningProcess | Select-Object -Unique
-        foreach ($processId in $processIds) {
-            Write-Host "[WARN] Port $Port in use by PID: $processId - killing orphaned process"
-            Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
-        }
-        Start-Sleep -Seconds 2
-    } else {
-        Write-Host "[OK] Port $Port is available"
-    }
+    # Free the port and reap stray Lemonade/llama-server processes from prior
+    # jobs on this shared runner (otherwise the server dies with a winerror
+    # 10048 bind collision). Shared with the inline-start CI workflows.
+    & "$PSScriptRoot\cleanup-lemonade.ps1" -Port $Port
     Write-Host ""
 
     # Check installation. v10.x ships:


### PR DESCRIPTION
## Why this matters

Five of the current open PRs show the same red checks — **Test Lemonade Embeddings API** and **RAG Integration Tests** — and none of them are code failures. On the self-hosted `stx`/`strix-halo` runners the machine is reused across jobs, so a crashed or leaked Lemonade Server from a prior job keeps listening on port 13305. The next job's Lemonade start then dies with `[Errno 10048] only one usage of each socket address` (a bind collision on `::1:13305`), and any leaked `llama-server` backend child keeps a model resident so the next `/load` returns `llama-server failed to start`. The result is spurious failures that force repeated manual re-runs.

After this change the port is freed and stray Lemonade/`llama-server` processes are reaped **before** each server start, so the bind is deterministic. `start-lemonade.ps1` already had a weaker version of this (port-owner kill only); the inline-start workflows (embeddings, rag, api) had **no** cleanup at all — which is exactly where the collisions came from.

The cleanup lives in one script (`installer/scripts/cleanup-lemonade.ps1`) reused by both `start-lemonade.ps1` and the inline workflows, so there's a single source of truth. It frees IPv4 **and** IPv6 listeners (the collision was on `::1`), reaps orphans by name, and blocks until the port is actually free.

## Test plan

- [x] `cleanup-lemonade.ps1` parses cleanly (PowerShell AST parser) and runs idempotently — verified locally it kills a live server holding 13305, then is a clean no-op when the port is free.
- [x] `start-lemonade.ps1` parses cleanly after the refactor; the `&` call keeps its `$ErrorActionPreference='Stop'` intact (child scope).
- [x] All three edited workflow YAMLs validate.
- [ ] Re-run **Test Lemonade Embeddings API** + **RAG Integration Tests** on a PR that carries this change and confirm they go green on the first attempt (needs a runner that previously had the leak).