### PR TITLE
docs(email): correct v0.3.0 scorecard figures + fix broken SCORECARD link

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -64,9 +64,9 @@ Contract bumped to `SCHEMA_VERSION` **2.1** — additive, no triage shape change
 - **Eval scorecard now measures acceptance, and the release gate enforces it** (#1437,
   #1894): the `SCORECARD.md` aggregate is now **within-one-bucket acceptance accuracy**
   (triage priority is ordinal, so exact-or-adjacent buckets are credited — what users
-  feel) instead of exact 4-way match. Measured **0.8467** (3-run mean on Strix Halo /
-  Gemma-4-E4B, 95% CI [0.834, 0.860]) vs the **0.80** bar (#1437); exact 4-way stays a
-  reported secondary (0.46). The card now carries run-to-run variance/CI, and the
+  feel) instead of exact 4-way match. Measured **0.834** (3-run mean on Strix Halo /
+  Gemma-4-E4B, 95% CI [0.821, 0.847]) vs the **0.80** bar (#1437); exact 4-way stays a
+  reported secondary (0.77). The card now carries run-to-run variance/CI, and the
   release gate enforces the 0.80 bar plus an anti-gaming URGENT-recall floor and a
   variance-aware regression check. No runtime/contract change — eval + packaging only.
 - **Batch triage endpoint** (#1887): new `POST /v1/email/triage/batch` /

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email) · contract `SCHEMA_VERSION` **2.2** · last updated **2026-07-01**
 
-**Eval scorecard (v0.3.0): aggregate 84.67 / 100** — within-one-bucket **acceptance** accuracy (3-run mean, 95% CI [83.4, 86.0]) over 100 of 220 labeled emails ([`./SCORECARD.md`](./SCORECARD.md)). Triage priority is ordinal, so the bar (#1437) credits exact-or-adjacent buckets — what users feel — not exact 4-way match (reported as a secondary, 0.46). The linked scorecard carries the full recipe, metrics + reported secondaries, run-to-run variance/CI, a per-category breakdown, the run environment, a worked recomputation, and reproduction steps.
+**Eval scorecard (v0.3.0): aggregate 83.4 / 100** — within-one-bucket **acceptance** accuracy (3-run mean, 95% CI [82.1, 84.7]) over the full 249-email labeled corpus ([`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md)). Triage priority is ordinal, so the bar (#1437) credits exact-or-adjacent buckets — what users feel — not exact 4-way match (reported as a secondary, 0.77). The linked scorecard carries the full recipe, metrics + reported secondaries, run-to-run variance/CI, a per-category breakdown, the run environment, a worked recomputation, and reproduction steps.
 
 Embed the **GAIA email agent** in your JS/TS app. It triages, organizes, replies
 to, and schedules from Gmail and Outlook — with every email body analyzed


### PR DESCRIPTION
The email agent page on the hub (amd-gaia.ai/hub/email) and the npm/GitHub README headlined the eval as **84.67 / 100**, but the authoritative generated `SCORECARD.md` says **83.4 / 100**. The prose drifted when the vendor-derived 249-email corpus landed (#1902) regenerated the scorecard but nothing forced the README to follow. To make it worse, the link to that scorecard was relative (`./SCORECARD.md`), so on the website it resolved to `amd-gaia.ai/hub/SCORECARD.md` and **404'd** — the card backing the headline number was unreachable, so no one could catch the mismatch. This aligns the README + CHANGELOG to the scorecard and makes the link resolve.

Corrections (all matched to `SCORECARD.md`):
- aggregate `84.67 / 100` → `83.4 / 100`; 95% CI `[83.4, 86.0]` → `[82.1, 84.7]`
- "100 of 220 labeled emails" → "the full 249-email labeled corpus"
- exact 4-way secondary `0.46` → `0.77` (`category_accuracy` 0.7684)
- `./SCORECARD.md` → absolute `github.com/.../SCORECARD.md`

Docs only — no runtime or contract change. Note: the live hub page renders the *published* 0.3.0 README, so it will keep showing the old number until the next email release republishes.

Follow-up worth doing: add a check asserting the README headline matches `SCORECARD.md`'s aggregate, so this can't silently drift again.

## Test plan
- [x] `SCORECARD.md` aggregate (`within_one_bucket_accuracy` mean 0.834 → 83.4) matches the new README figure
- [x] CI bounds match (`ci95_low` 0.8209 → 82.1, `ci95_high` 0.8471 → 84.7)
- [x] `category_accuracy` 0.7684 → 0.77 secondary matches
- [x] `https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md` → 200
- [x] no remaining `84.67` / `0.8467` / `0.46` / "100 of 220" references in the email agent docs