### PR TITLE
feat(eval): judge-scored voice/style drafting quality eval for the email agent

### DIFF
--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -14,8 +14,9 @@
 # only through the harness loaders (no thresholds are hardcoded in this YAML):
 #   - tests/fixtures/email/quality_gate_thresholds.json  (FP<5% / FN<2%)
 #   - tests/fixtures/email/perf_gate_thresholds.json      (TTFT / tps / latency / mem)
-# CI keys off each gate's `should_fail` (= enforce and not passed). Both manifests
-# ship `enforce: false`, so `should_fail` is always false today: the gate
+#   - tests/fixtures/email/drafting_gate_thresholds.json  (draft-approval >=70%, #1269)
+# CI keys off each gate's `should_fail` (= enforce and not passed). All three
+# manifests ship `enforce: false`, so `should_fail` is always false today: the gate
 # machinery runs, logs, and uploads, but the build stays green. This is the
 # honest posture — categorization accuracy is still ~0.40, so the FP/FN bars are
 # not yet meaningful and the Strix Halo perf bars are not yet confirmed on
@@ -23,13 +24,15 @@
 # what makes the build start failing on a breach, once #1266 (categorization),
 # #1271 (phishing) and the perf bars land. No edit to this file is needed then.
 #
-# NOTE on accuracy gates: categorization >=85% (#1266), phishing precision >=90%
-# (#1271) and draft-approval >=70% (#1269) do not yet have committed threshold
-# manifests (they are owned by those issues). This workflow REPORTS the
-# categorization accuracy and phishing precision the benchmark already emits, but
-# does not gate on them — there is no committed bar to read, and inventing one in
-# YAML would violate the single-source rule above. They become gating once their
-# manifests land and this gate-reader is pointed at them.
+# NOTE on accuracy gates: categorization >=85% (#1266) and phishing precision
+# >=90% (#1271) do not yet have committed threshold manifests (they are owned by
+# those issues). This workflow REPORTS the categorization accuracy and phishing
+# precision the benchmark already emits, but does not gate on them — there is no
+# committed bar to read, and inventing one in YAML would violate the single-source
+# rule above. They become gating once their manifests land and this gate-reader is
+# pointed at them. Draft-approval >=70% (#1269) DOES now have a committed manifest
+# (tests/fixtures/email/drafting_gate_thresholds.json, enforce:false) — it is
+# scored by the voice-drafting eval step below (#1607 / #1948), report mode.
 #
 # Self-hosted: this needs a running Lemonade Server with the email-triage model
 # loaded on AMD hardware (Ryzen AI / Strix Halo). That hardware is the gating
@@ -200,8 +203,9 @@ jobs:
           quality = summary.get("quality", {})
           perf = summary.get("scorecard", {}).get("performance", {})
 
-          # Reported-only accuracy numbers (gates pending #1266 / #1271 / #1269 —
-          # no committed accuracy-threshold manifest yet, so we log, not gate).
+          # Reported-only accuracy numbers (gates pending #1266 / #1271 — no
+          # committed accuracy-threshold manifest yet, so we log, not gate).
+          # Draft-approval (#1269) is scored by the drafting eval step below.
           cat_acc = quality.get("category_accuracy")
           phishing = quality.get("phishing", {})
           phishing_precision = (
@@ -211,7 +215,7 @@ jobs:
           print("\n================ EMAIL EVAL GATE REPORT (report mode) ================")
           print(f"  Categorization accuracy : {cat_acc}   (target >=0.85 #1266, REPORTED)")
           print(f"  Phishing precision      : {phishing_precision}   (target >=0.90 #1271, REPORTED)")
-          print(f"  Draft-approval rate     : not emitted by the benchmark yet (#1269, REPORTED)")
+          print(f"  Draft-approval rate     : scored by the voice-drafting eval step below (#1269, REPORTED)")
           print("  ----------------------------------------------------------------")
           print(f"  Quality gate (FP/FN)    : passed={quality_gate.get('passed')} "
                 f"breaches={len(quality_gate.get('breaches', []))} "
@@ -256,6 +260,144 @@ jobs:
               sys.exit(1)
           print("[GATE] report mode (or no breach) — gates do not block the build.")
           PY
+
+      # =================================================================
+      # BEGIN voice-drafting quality eval (#1607 feature / #1269 metric /
+      # #1948 tracking) — ADDITIVE, self-contained block. Report mode.
+      #
+      # Judge-scored draft quality: the agent composes replies over the
+      # committed drafting seed corpus with the #1607 voice profile active
+      # (Lemonade, FakeGmailBackend — drafting only, nothing is ever sent),
+      # and a Claude judge scores each draft against the case rubric. The
+      # aggregate draft_approval_rate is compared to the committed manifest
+      #   tests/fixtures/email/drafting_gate_thresholds.json  (enforce:false)
+      # via gaia.eval.draft_quality — same single-source rule as the gates
+      # above: no thresholds inlined in this YAML; flip `enforce` in the
+      # manifest (data, not code) to make this gate block.
+      #
+      # Runs AFTER the triage benchmark in the same job, so Lemonade access
+      # stays strictly serial (CLAUDE.md: evals serial). Keep this block
+      # self-contained so concurrent edits to this workflow merge cleanly.
+      # =================================================================
+      - name: Voice-drafting quality eval (judge-scored, report mode)
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+          EMAIL_EVAL_MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+          # Judge credential for gaia.eval.claude.ClaudeClient. When the
+          # secret is unavailable the step logs a LOUD skip (never a pass).
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -e
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          from gaia.eval.draft_quality import (
+              default_drafting_thresholds_path,
+              generate_drafts,
+              judge_drafts,
+              load_default_drafting_thresholds,
+              load_drafting_corpus,
+              make_claude_judge,
+              summarize_drafting,
+          )
+
+          model = os.environ["EMAIL_EVAL_MODEL"]
+          corpus_path = "tests/fixtures/email/drafting_ground_truth.json"
+          out = Path("eval-out")
+          out.mkdir(parents=True, exist_ok=True)
+
+          thresholds = load_default_drafting_thresholds()
+          print(f"[DRAFT-EVAL] manifest: {default_drafting_thresholds_path()}")
+          print(
+              f"[DRAFT-EVAL] enforce={thresholds.enforce} "
+              f"approval_min={thresholds.approval_min} (#1269 target, REPORTED)"
+          )
+
+          if not os.environ.get("ANTHROPIC_API_KEY"):
+              # Loud, explicit skip — the judge credential is absent, so no
+              # draft can be scored. Never invents a pass; the report says so.
+              report = {
+                  "skipped": True,
+                  "reason": (
+                      "ANTHROPIC_API_KEY not available on this runner — the "
+                      "Claude judge cannot score drafts"
+                  ),
+                  "enforce": thresholds.enforce,
+                  "should_fail": False,
+              }
+              (out / "drafting_gate_report.json").write_text(
+                  json.dumps(report, indent=2), encoding="utf-8"
+              )
+              print(
+                  "[DRAFT-EVAL] SKIPPED: no judge credential — wrote "
+                  "eval-out/drafting_gate_report.json"
+              )
+              sys.exit(0)
+
+          # Generation: drives the #1607 voice-profile drafting path per case
+          # (Lemonade — this job holds the serial lemonade-eval slot).
+          generations = generate_drafts(model, corpus_path=corpus_path)
+          produced = sum(1 for g in generations if g["draft"])
+          print(f"[DRAFT-EVAL] generated {produced}/{len(generations)} drafts")
+
+          results = judge_drafts(
+              load_drafting_corpus(corpus_path),
+              generations,
+              make_claude_judge(),
+              model_id=model,
+          )
+          summary = summarize_drafting(
+              results,
+              run_id=f"email-draft-eval-{model.replace('/', '-').lower()}",
+              thresholds=thresholds,
+          )
+
+          gate = summary.get("drafting_gate", {})
+          agg = summary.get("drafting", {})
+          print("\n============ EMAIL DRAFTING EVAL REPORT (report mode) ============")
+          print(
+              f"  Draft-approval rate : {agg.get('draft_approval_rate')}   "
+              f"(target >={thresholds.approval_min} #1269, REPORTED)"
+          )
+          print(f"  Voice-match mean    : {agg.get('voice_match_mean')}")
+          print(f"  Grounded rate       : {agg.get('grounded_rate')}")
+          print(
+              f"  Cases judged/errored: {agg.get('cases_judged')}/"
+              f"{agg.get('cases_errored')}"
+          )
+          print(
+              f"  Drafting gate       : passed={gate.get('passed')} "
+              f"enforce={gate.get('enforce')} "
+              f"should_fail={gate.get('should_fail')} "
+              f"skipped={gate.get('skipped', False)}"
+          )
+          print("==================================================================\n")
+
+          (out / "drafting_gate_report.json").write_text(
+              json.dumps(
+                  {"model": model, "corpus": corpus_path, "summary": summary},
+                  indent=2,
+                  ensure_ascii=False,
+              ),
+              encoding="utf-8",
+          )
+          print("[OUT] wrote eval-out/drafting_gate_report.json")
+
+          # Same hook contract as the gates above: report mode never fails.
+          if gate.get("should_fail"):
+              print("[DRAFT-EVAL] enforced gate breach — failing the build.")
+              sys.exit(1)
+          print(
+              "[DRAFT-EVAL] report mode (or no breach) — gate does not block "
+              "the build."
+          )
+          PY
+      # =================================================================
+      # END voice-drafting quality eval
+      # =================================================================
 
       - name: Upload eval scorecard + gate report
         if: always()

--- a/src/gaia/eval/draft_quality.py
+++ b/src/gaia/eval/draft_quality.py
@@ -1,0 +1,736 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Judge-scored draft-quality eval for the email agent's voice/style drafting
+(#1607 feature, #1269 metric, #1948 tracking).
+
+Sibling of :mod:`gaia.eval.benchmark` (the triage benchmark): the same
+committed-fixture / report-mode conventions, applied to the drafting path.
+Three separable stages so each is testable on its own:
+
+1. **Generation** (:func:`generate_drafts` — needs Lemonade + the email
+   agent): per corpus case, build an ``EmailTriageAgent`` over a
+   ``FakeGmailBackend`` seeded with the case's incoming email, derive the
+   #1607 voice profile from the case's ``sent_history`` (the REAL feature
+   path — ``analyze_sent_bodies`` + ``action_store.save_voice_profile``,
+   picked up by ``_get_system_prompt``), then ask the agent to draft the
+   reply and harvest the composed draft from the fake backend. Drafting
+   only — nothing is ever sent.
+2. **Judging** (:func:`judge_drafts` — needs a judge callable): score each
+   generated draft against the case rubric with an LLM judge
+   (:func:`make_claude_judge` wraps :class:`gaia.eval.claude.ClaudeClient`;
+   tests inject a stub). The verdict is strict JSON, parsed fail-loud.
+3. **Aggregation** (:func:`summarize_drafting`): roll per-case results into
+   a ``build_scorecard``-compatible summary with the aggregate
+   ``draft_approval_rate``, and score the committed drafting gate manifest
+   (``tests/fixtures/email/drafting_gate_thresholds.json``) the same way the
+   FP/FN and perf gates work — report mode unless the manifest flips
+   ``enforce``.
+
+Fail-loud contract: a malformed corpus, a judge reply that is not the
+documented JSON verdict, or a missing thresholds manifest raise actionable
+errors — nothing silently scores as a pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+# ---------------------------------------------------------------------------
+# Corpus loading (offline)
+# ---------------------------------------------------------------------------
+
+# Keys that are corpus metadata, not cases (same convention as ground_truth).
+_METADATA_PREFIX = "_"
+
+_REQUIRED_INCOMING_FIELDS = ("from", "subject", "body")
+_MIN_SENT_HISTORY = 3
+
+
+def _validate_case(case_id: str, case: Any) -> None:
+    if not isinstance(case, dict):
+        raise ValueError(
+            f"drafting corpus case '{case_id}' must be a JSON object, got "
+            f"{type(case).__name__}."
+        )
+    persona = case.get("persona")
+    if not isinstance(persona, str) or not persona.strip():
+        raise ValueError(f"case '{case_id}': 'persona' must be a non-empty string.")
+    incoming = case.get("incoming")
+    if not isinstance(incoming, dict):
+        raise ValueError(f"case '{case_id}': 'incoming' must be an object.")
+    for field in _REQUIRED_INCOMING_FIELDS:
+        if not isinstance(incoming.get(field), str) or not incoming[field].strip():
+            raise ValueError(
+                f"case '{case_id}': incoming.{field} must be a non-empty string."
+            )
+    history = case.get("sent_history")
+    if (
+        not isinstance(history, list)
+        or len(history) < _MIN_SENT_HISTORY
+        or not all(isinstance(b, str) and b.strip() for b in history)
+    ):
+        raise ValueError(
+            f"case '{case_id}': 'sent_history' must be a list of >= "
+            f"{_MIN_SENT_HISTORY} non-empty strings (the voice signal the "
+            "#1607 profile is derived from)."
+        )
+    intent = case.get("reply_intent")
+    if not isinstance(intent, str) or not intent.strip():
+        raise ValueError(
+            f"case '{case_id}': 'reply_intent' must be a non-empty string."
+        )
+    rubric = case.get("rubric")
+    if not isinstance(rubric, dict):
+        raise ValueError(f"case '{case_id}': 'rubric' must be an object.")
+    must = rubric.get("must")
+    must_not = rubric.get("must_not")
+    if not isinstance(must, list) or not must:
+        raise ValueError(
+            f"case '{case_id}': rubric.must must be a non-empty list of strings."
+        )
+    if not isinstance(must_not, list):
+        raise ValueError(f"case '{case_id}': rubric.must_not must be a list.")
+    for label, items in (("must", must), ("must_not", must_not)):
+        if not all(isinstance(i, str) and i.strip() for i in items):
+            raise ValueError(
+                f"case '{case_id}': rubric.{label} entries must be non-empty "
+                "strings."
+            )
+
+
+def _reject_duplicate_keys(pairs: list) -> dict:
+    out: dict = {}
+    for key, value in pairs:
+        if key in out:
+            raise ValueError(f"duplicate case id {key!r} in the drafting corpus")
+        out[key] = value
+    return out
+
+
+def load_drafting_corpus(path: str | Path) -> dict[str, dict]:
+    """Load + validate the drafting corpus (loud on missing/malformed).
+
+    Returns the full mapping including the ``_meta`` block; use
+    :func:`corpus_cases` to get only the scored cases. Duplicate case ids,
+    missing required fields, or wrong types raise ``ValueError``.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f, object_pairs_hook=_reject_duplicate_keys)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"drafting corpus at {path} is not valid JSON: {exc}"
+            ) from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"drafting corpus at {path} must be a JSON object keyed by case id, "
+            f"got {type(data).__name__}."
+        )
+    cases = {k: v for k, v in data.items() if not k.startswith(_METADATA_PREFIX)}
+    if not cases:
+        raise ValueError(f"drafting corpus at {path} contains no cases.")
+    for case_id, case in cases.items():
+        _validate_case(case_id, case)
+    return data
+
+
+def corpus_cases(corpus: Mapping[str, Any]) -> dict[str, dict]:
+    """Only the scored cases (drop ``_``-prefixed metadata blocks)."""
+    return {k: v for k, v in corpus.items() if not k.startswith(_METADATA_PREFIX)}
+
+
+# ---------------------------------------------------------------------------
+# Judge prompt + verdict parsing (offline)
+# ---------------------------------------------------------------------------
+
+# How many sent-history bodies the judge sees as voice exemplars.
+_JUDGE_EXEMPLARS = 3
+
+_VERDICT_BOOL_FIELDS = (
+    "recipient_and_intent",
+    "grounded",
+    "no_fabricated_commitments",
+    "approved",
+)
+_VERDICT_SCORE_FIELDS = ("voice_match", "overall_quality")
+
+
+def build_judge_prompt(case: Mapping[str, Any], draft: Mapping[str, Any]) -> str:
+    """Render the judge prompt for one (case, generated draft) pair.
+
+    ``draft`` carries ``to`` / ``subject`` / ``body`` as harvested from the
+    backend. The judge sees the incoming email, the user's reply intent, the
+    voice exemplars from Sent history, and the case rubric, and must answer
+    with STRICT JSON (see :func:`parse_judge_verdict`).
+    """
+    incoming = case["incoming"]
+    exemplars = "\n\n---\n\n".join(case["sent_history"][:_JUDGE_EXEMPLARS])
+    must = "\n".join(f"- {item}" for item in case["rubric"]["must"])
+    must_not = "\n".join(f"- {item}" for item in case["rubric"]["must_not"])
+    return f"""You are grading an email reply drafted by an AI assistant on the user's behalf. The assistant was supposed to write in the user's own voice (learned from their Sent mail) and follow their stated intent.
+
+## Incoming email being replied to
+From: {incoming['from']}
+Subject: {incoming['subject']}
+
+{incoming['body']}
+
+## What the user asked the assistant to say
+{case['reply_intent']}
+
+## The user's own writing (Sent-mail exemplars — this is the voice to match)
+{exemplars}
+
+## Rubric — an approvable draft MUST:
+{must}
+
+## An approvable draft MUST NOT:
+{must_not}
+
+## The assistant's draft
+To: {draft.get('to', '')}
+Subject: {draft.get('subject', '')}
+
+{draft.get('body', '')}
+
+## Your task
+Score the draft. "Approved" means a reasonable user would send this draft after at most trivial edits: it goes to the right recipient, does what the intent asked, is factually grounded in the thread (no invented facts, numbers, dates, or commitments), and sounds like the user's own writing.
+
+Answer with STRICT JSON only — no prose, no markdown fences, exactly this shape:
+{{
+  "recipient_and_intent": true/false,
+  "grounded": true/false,
+  "no_fabricated_commitments": true/false,
+  "voice_match": 0.0-1.0,
+  "overall_quality": 0.0-1.0,
+  "approved": true/false,
+  "rationale": "one or two sentences"
+}}"""
+
+
+def parse_judge_verdict(text: str) -> dict[str, Any]:
+    """Parse + validate a judge reply into a verdict dict (loud on garbage).
+
+    Tolerates surrounding prose/fences by extracting the outermost JSON
+    object, but the object itself must carry every documented field with the
+    right type and range — a judge reply that can't be scored is an error,
+    never a silent pass or fail.
+    """
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("judge reply is empty — cannot score the draft")
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        raise ValueError(
+            f"judge reply contains no JSON object; snippet: {text[:200]!r}"
+        )
+    try:
+        verdict = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"judge reply is not valid JSON: {exc}; snippet: {text[:200]!r}"
+        ) from exc
+    if not isinstance(verdict, dict):
+        raise ValueError(
+            f"judge verdict decoded to {type(verdict).__name__}, expected object"
+        )
+    for field in _VERDICT_BOOL_FIELDS:
+        if not isinstance(verdict.get(field), bool):
+            raise ValueError(
+                f"judge verdict field '{field}' must be a boolean, got "
+                f"{verdict.get(field)!r}"
+            )
+    for field in _VERDICT_SCORE_FIELDS:
+        value = verdict.get(field)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"judge verdict field '{field}' must be a number in [0, 1], got "
+                f"{value!r}"
+            )
+        if not 0.0 <= float(value) <= 1.0:
+            raise ValueError(
+                f"judge verdict field '{field}' out of range [0, 1]: {value!r}"
+            )
+    if not isinstance(verdict.get("rationale"), str):
+        raise ValueError("judge verdict field 'rationale' must be a string")
+    return verdict
+
+
+def make_claude_judge(model: str | None = None) -> Callable[[str], str]:
+    """A judge callable backed by :class:`gaia.eval.claude.ClaudeClient`.
+
+    Lazy import so the module stays importable (and unit-testable) without
+    the ``[eval]`` extras; ``ClaudeClient`` itself fails loud when the judge
+    credential is absent.
+    """
+    from gaia.eval.claude import ClaudeClient
+
+    client = ClaudeClient(model=model)
+
+    def judge(prompt: str) -> str:
+        content = client.get_completion(prompt)
+        # Anthropic returns a list of content blocks; the verdict is text.
+        parts = [
+            getattr(block, "text", "") for block in content if hasattr(block, "text")
+        ]
+        return "".join(parts)
+
+    return judge
+
+
+# ---------------------------------------------------------------------------
+# Result assembly + aggregation (offline — mocked-judge testable)
+# ---------------------------------------------------------------------------
+
+
+def build_draft_result(
+    case_id: str,
+    *,
+    model_id: str,
+    draft: Mapping[str, Any] | None,
+    verdict: Mapping[str, Any] | None,
+    error: str = "",
+    duration_ms: int = 0,
+) -> dict[str, Any]:
+    """One ``build_scorecard``-compatible result row for a corpus case.
+
+    ``PASS`` = the judge approved the draft; ``FAIL`` = generated (or judged)
+    but not approved; ``ERRORED`` = no draft was produced or the judge could
+    not score it (``error`` says why). ``overall_score`` maps the judge's
+    ``overall_quality`` onto the scorecard's 0–10 scale.
+    """
+    out: dict[str, Any] = {
+        "id": case_id,
+        "category": model_id,
+        "total_duration_ms": duration_ms,
+    }
+    if draft is not None:
+        out["draft"] = dict(draft)
+    if verdict is not None:
+        out["draft_judgement"] = dict(verdict)
+        out["overall_score"] = round(float(verdict["overall_quality"]) * 10.0, 2)
+        out["status"] = "PASS" if verdict["approved"] else "FAIL"
+    else:
+        out["status"] = "ERRORED"
+        out["error"] = error or "no draft produced and no judge verdict"
+    return out
+
+
+def summarize_drafting(
+    results: list[dict],
+    *,
+    run_id: str,
+    thresholds: "DraftingThresholds | None" = None,
+) -> dict[str, Any]:
+    """Aggregate per-case results into a scorecard + drafting-gate summary.
+
+    Reuses :func:`gaia.eval.scorecard.build_scorecard` unchanged. The
+    ``drafting`` block carries the #1269 aggregate (``draft_approval_rate``)
+    plus reported secondaries; when ``thresholds`` is given the drafting gate
+    runs against it — report mode unless the manifest sets ``enforce``. When
+    no case was judged the gate is a loud explicit skip, never an invented
+    pass.
+    """
+    from gaia.eval.scorecard import build_scorecard
+
+    scorecard = build_scorecard(run_id, results, {"benchmark": "email_draft_quality"})
+    summary: dict[str, Any] = {"scorecard": scorecard}
+
+    judged = [r for r in results if isinstance(r.get("draft_judgement"), dict)]
+    aggregate: dict[str, Any] | None = None
+    if judged:
+        verdicts = [r["draft_judgement"] for r in judged]
+        n = len(verdicts)
+        aggregate = {
+            "cases_total": len(results),
+            "cases_judged": n,
+            "cases_errored": sum(1 for r in results if r.get("status") == "ERRORED"),
+            "draft_approval_rate": round(
+                sum(1 for v in verdicts if v["approved"]) / n, 4
+            ),
+            "voice_match_mean": round(
+                sum(float(v["voice_match"]) for v in verdicts) / n, 4
+            ),
+            "overall_quality_mean": round(
+                sum(float(v["overall_quality"]) for v in verdicts) / n, 4
+            ),
+            "grounded_rate": round(sum(1 for v in verdicts if v["grounded"]) / n, 4),
+            "no_fabricated_commitments_rate": round(
+                sum(1 for v in verdicts if v["no_fabricated_commitments"]) / n, 4
+            ),
+            "per_case": [
+                {
+                    "id": r.get("id"),
+                    "status": r.get("status"),
+                    "approved": r["draft_judgement"]["approved"],
+                    "voice_match": r["draft_judgement"]["voice_match"],
+                    "overall_quality": r["draft_judgement"]["overall_quality"],
+                    "rationale": r["draft_judgement"]["rationale"],
+                }
+                for r in judged
+            ],
+        }
+        summary["drafting"] = aggregate
+
+    if thresholds is not None:
+        if aggregate is None:
+            summary["drafting_gate"] = {
+                "skipped": True,
+                "reason": (
+                    "no case carried a judge verdict; the draft-approval gate "
+                    "cannot be evaluated"
+                ),
+                "enforce": thresholds.enforce,
+                "should_fail": False,
+            }
+        else:
+            summary["drafting_gate"] = evaluate_drafting_gate(aggregate, thresholds)
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Committed-threshold gate (#1269 — report mode; flip enforce in the manifest)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DraftingThresholds:
+    """Draft-approval bar for the drafting gate (#1269 target).
+
+    ``enforce`` is the single safety switch, same contract as the FP/FN and
+    perf gates: ``False`` (the committed value) means the gate computes and
+    reports but never fails the harness. Flip it in the manifest — data, not
+    code — once a real baseline confirms the bar.
+    """
+
+    approval_min: float
+    enforce: bool = False
+
+
+def load_drafting_thresholds(path: str | Path) -> DraftingThresholds:
+    """Load the drafting-gate thresholds manifest (loud on missing/malformed)."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"drafting-gate thresholds manifest at {path} must be a JSON object, "
+            f"got {type(data).__name__}."
+        )
+    if "approval_min" not in data:
+        raise ValueError(
+            f"drafting-gate thresholds manifest at {path} is missing required "
+            "key 'approval_min'. Optional: 'enforce' (default false)."
+        )
+    bar = data["approval_min"]
+    if isinstance(bar, bool) or not isinstance(bar, (int, float)):
+        raise ValueError(
+            f"drafting-gate threshold 'approval_min' in {path} must be numeric, "
+            f"got {bar!r}."
+        )
+    return DraftingThresholds(
+        approval_min=float(bar), enforce=bool(data.get("enforce", False))
+    )
+
+
+# Canonical location of the committed drafting-gate thresholds manifest. The
+# single entry point CI consumes — flip 'enforce' in this file (data, not
+# code) to make CI gate on the #1269 draft-approval bar.
+_DRAFTING_THRESHOLDS_MANIFEST = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "email"
+    / "drafting_gate_thresholds.json"
+)
+
+
+def default_drafting_thresholds_path() -> Path:
+    """Path to the committed drafting-gate thresholds manifest (#1269/#1948)."""
+    return _DRAFTING_THRESHOLDS_MANIFEST
+
+
+def load_default_drafting_thresholds() -> DraftingThresholds:
+    """Load the committed drafting-gate thresholds (loud if absent/malformed)."""
+    return load_drafting_thresholds(default_drafting_thresholds_path())
+
+
+def evaluate_drafting_gate(
+    aggregate: Mapping[str, Any], thresholds: DraftingThresholds
+) -> dict[str, Any]:
+    """Compare the aggregate ``draft_approval_rate`` to the committed bar.
+
+    Same result shape + ``should_fail`` contract as
+    :func:`gaia.eval.quality_metrics.evaluate_gate`: in report mode
+    (``enforce=False``) ``should_fail`` is always ``False`` even on a breach.
+    Fail-loud on a missing rate — a gate that can't find its input must not
+    silently pass.
+    """
+    if "draft_approval_rate" not in aggregate:
+        raise ValueError(
+            "drafting gate needs 'draft_approval_rate' in the aggregate block "
+            f"(have: {sorted(aggregate.keys())})."
+        )
+    rate = float(aggregate["draft_approval_rate"])
+    breaches: list[dict[str, Any]] = []
+    if rate < thresholds.approval_min:
+        breaches.append(
+            {
+                "metric": "draft_approval_rate",
+                "value": rate,
+                "min": thresholds.approval_min,
+            }
+        )
+    passed = not breaches
+    return {
+        "metric": "draft_approval_rate",
+        "value": rate,
+        "min": thresholds.approval_min,
+        "passed": passed,
+        "breaches": breaches,
+        "enforce": thresholds.enforce,
+        "should_fail": thresholds.enforce and not passed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Judging stage (offline with an injected judge)
+# ---------------------------------------------------------------------------
+
+
+def judge_drafts(
+    corpus: Mapping[str, Any],
+    generations: list[dict],
+    judge_fn: Callable[[str], str],
+    *,
+    model_id: str,
+) -> list[dict[str, Any]]:
+    """Score generated drafts against their case rubrics.
+
+    ``generations`` is :func:`generate_drafts` output (or an equivalent stub):
+    ``[{case_id, draft|None, error, duration_ms}]``. A generation that carried
+    no draft stays ``ERRORED`` with its generation error; a judge reply that
+    cannot be parsed becomes ``ERRORED`` with the parse error — visible in the
+    scorecard, never a silent pass or fail.
+    """
+    cases = corpus_cases(corpus)
+    results: list[dict[str, Any]] = []
+    for gen in generations:
+        case_id = gen["case_id"]
+        if case_id not in cases:
+            raise ValueError(
+                f"generation references unknown case id {case_id!r} — corpus "
+                "and generations are out of sync"
+            )
+        draft = gen.get("draft")
+        duration_ms = int(gen.get("duration_ms", 0))
+        if not draft:
+            results.append(
+                build_draft_result(
+                    case_id,
+                    model_id=model_id,
+                    draft=None,
+                    verdict=None,
+                    error=gen.get("error") or "agent produced no draft",
+                    duration_ms=duration_ms,
+                )
+            )
+            continue
+        prompt = build_judge_prompt(cases[case_id], draft)
+        try:
+            verdict = parse_judge_verdict(judge_fn(prompt))
+        except ValueError as exc:
+            results.append(
+                build_draft_result(
+                    case_id,
+                    model_id=model_id,
+                    draft=draft,
+                    verdict=None,
+                    error=f"judge verdict unusable: {exc}",
+                    duration_ms=duration_ms,
+                )
+            )
+            continue
+        results.append(
+            build_draft_result(
+                case_id,
+                model_id=model_id,
+                draft=draft,
+                verdict=verdict,
+                duration_ms=duration_ms,
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Generation stage (live — needs Lemonade + the email agent)
+# ---------------------------------------------------------------------------
+
+
+def _incoming_payload(case_id: str, incoming: Mapping[str, str]) -> dict[str, Any]:
+    """A Gmail-API-shape message dict for ``FakeGmailBackend.add_message``.
+
+    Mirrors the single-part text/plain shape
+    ``tests.fixtures.email.fake_gmail.mbox_message_to_gmail_payload`` emits, so
+    the agent's read tools and ``decode_message_body`` handle it identically.
+    """
+    body = incoming["body"]
+    data = base64.urlsafe_b64encode(body.encode("utf-8")).decode("ascii").rstrip("=")
+    return {
+        "id": case_id,
+        "threadId": case_id,
+        "labelIds": ["INBOX", "UNREAD"],
+        "snippet": " ".join(body.split())[:200],
+        "internalDate": "1751500000000",
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": incoming["from"]},
+                {"name": "To", "value": "user@example.com"},
+                {"name": "Subject", "value": incoming["subject"]},
+                {"name": "Message-ID", "value": f"<{case_id}@drafting.eval>"},
+            ],
+            "body": {"size": len(body.encode("utf-8")), "data": data},
+        },
+        "sizeEstimate": len(body.encode("utf-8")),
+    }
+
+
+def _newest_draft(backend: Any) -> dict[str, Any] | None:
+    """The most recently created draft on a ``FakeGmailBackend`` (or None)."""
+    drafts = backend.list_drafts()
+    if not drafts:
+        return None
+    # Draft ids are "draft_<seq>" with a monotonically increasing seq.
+    newest = max(drafts, key=lambda d: int(str(d["id"]).rsplit("_", 1)[-1]))
+    return {
+        "to": newest.get("to", ""),
+        "subject": newest.get("subject", ""),
+        "body": newest.get("body", ""),
+    }
+
+
+def generate_drafts(
+    model_id: str,
+    *,
+    corpus_path: str | Path,
+    base_url: str | None = None,
+    db_dir: str | Path | None = None,
+    limit: int | None = None,
+    agent_factory: Callable[[Any, str], Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Drive the #1607 drafting path per corpus case and harvest the drafts.
+
+    Per case: seed a fresh ``FakeGmailBackend`` with the incoming email,
+    build the agent with a case-scoped SQLite ``db_path``, derive + persist
+    the voice profile from the case's ``sent_history`` (the real feature
+    path — the profile reaches the LLM via ``_get_system_prompt``), then ask
+    the agent to compose the reply with ``draft_reply``. Drafting only: the
+    fake backend records the draft; nothing is sent.
+
+    ``agent_factory(backend, db_path)`` overrides agent construction (tests
+    inject a stub; keeps the unit path Lemonade-free). Returns
+    ``[{case_id, draft|None, error, duration_ms}]`` for :func:`judge_drafts`.
+    """
+    corpus = load_drafting_corpus(corpus_path)
+    cases = corpus_cases(corpus)
+    case_items = list(cases.items())
+    if limit is not None:
+        case_items = case_items[:limit]
+
+    if agent_factory is None:
+        # Lazy imports: keep `import gaia.eval.draft_quality` free of the
+        # agent stack. EmailTriageAgent ships as the standalone
+        # gaia-agent-email wheel (#1102); the fake backend needs a repo
+        # checkout.
+        try:
+            from gaia_agent_email.agent import EmailTriageAgent
+            from gaia_agent_email.config import EmailAgentConfig
+        except ImportError as exc:
+            raise RuntimeError(
+                "The drafting eval needs the email agent. Install it with "
+                "`pip install gaia-agent-email` (or `pip install "
+                '"amd-gaia[agents]"`). '
+                f"Original import error: {exc}"
+            ) from exc
+
+        def agent_factory(backend: Any, db_path: str) -> Any:
+            config = EmailAgentConfig(
+                model_id=model_id,
+                base_url=base_url,
+                gmail_backend=backend,
+                db_path=db_path,
+                show_stats=True,
+                silent_mode=True,
+            )
+            return EmailTriageAgent(config=config)
+
+    try:
+        from gaia_agent_email import action_store
+        from gaia_agent_email.voice_profile import analyze_sent_bodies
+    except ImportError as exc:
+        raise RuntimeError(
+            "The drafting eval needs gaia_agent_email.voice_profile (#1607). "
+            f"Original import error: {exc}"
+        ) from exc
+    try:
+        from tests.fixtures.email.fake_gmail import FakeGmailBackend
+    except ImportError as exc:
+        raise RuntimeError(
+            "The drafting eval must run from a GAIA repo checkout — it drives "
+            "the FakeGmailBackend in tests/fixtures/email and is not available "
+            f"in a packaged install. Original import error: {exc}"
+        ) from exc
+
+    if db_dir is None:
+        db_dir = tempfile.mkdtemp(prefix="gaia-drafting-eval-")
+    db_dir = Path(db_dir)
+    db_dir.mkdir(parents=True, exist_ok=True)
+
+    generations: list[dict[str, Any]] = []
+    for case_id, case in case_items:
+        backend = FakeGmailBackend()
+        backend.add_message(_incoming_payload(case_id, case["incoming"]))
+        agent = agent_factory(backend, str(db_dir / f"{case_id}.db"))
+
+        # The REAL #1607 path: derive the profile from the case's Sent
+        # history and persist it; the agent's system prompt picks it up.
+        profile = analyze_sent_bodies(case["sent_history"])
+        action_store.save_voice_profile(agent, mailbox="google", profile=profile)
+
+        prompt = (
+            f"Draft a reply to the email from {case['incoming']['from']} with "
+            f"subject '{case['incoming']['subject']}' (message id '{case_id}'). "
+            f"The reply should: {case['reply_intent']} "
+            "Compose the full reply body yourself in the user's voice and call "
+            "draft_reply with it. Create the draft only — do not send anything."
+        )
+        start = time.monotonic()
+        error = ""
+        try:
+            agent.process_query(prompt)
+        except Exception as exc:  # surfaced per-case, never swallowed silently
+            error = f"{type(exc).__name__}: {exc}"
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        draft = _newest_draft(backend)
+        if draft is None and not error:
+            error = "agent finished without creating a draft (draft_reply not called)"
+        generations.append(
+            {
+                "case_id": case_id,
+                "draft": draft,
+                "error": error,
+                "duration_ms": duration_ms,
+            }
+        )
+    return generations

--- a/tests/fixtures/email/drafting_gate_thresholds.json
+++ b/tests/fixtures/email/drafting_gate_thresholds.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Draft-approval bar for the voice/style drafting eval (#1607 feature, #1269 metric, #1948 tracking). 'approval_min' is the REPORTED target from #1269 (draft-approval >= 70%), NOT an enforced gate: 'enforce' is the SINGLE switch CI keys off and it ships FALSE (report mode) on purpose — no real judged baseline exists yet, so the bar is not yet confirmed meaningful on hardware. Flip 'enforce' to true HERE (data, not code) once the nightly report establishes a stable baseline. Loaded by gaia.eval.draft_quality.load_drafting_thresholds.",
+  "approval_min": 0.70,
+  "enforce": false
+}

--- a/tests/fixtures/email/drafting_ground_truth.json
+++ b/tests/fixtures/email/drafting_ground_truth.json
@@ -1,0 +1,489 @@
+{
+  "_meta": {
+    "fixture": "drafting_ground_truth.json",
+    "fixture_kind": "hand-authored-seed",
+    "schema_version": 1,
+    "description": "Labeled seed corpus for the voice/style drafting quality eval (#1607 feature, #1269 metric, #1948 tracking). Each case is one draft-composition scenario: an incoming email, the user's Sent history (the style signal the #1607 voice profile is derived from), the reply intent the user asked for, and a rubric of what an approvable draft must and must not do. Scored by gaia.eval.draft_quality: the agent composes the draft locally (Lemonade), an LLM judge scores it against the rubric, and the aggregate draft_approval_rate is compared to drafting_gate_thresholds.json in report mode.",
+    "case_schema": {
+      "persona": "str — short label for the writing voice the sent_history encodes",
+      "incoming": "{from: str, subject: str, body: str} — the email being replied to",
+      "sent_history": "list[str] (>=3) — the user's own Sent bodies; fed to gaia_agent_email.voice_profile.analyze_sent_bodies to build the voice profile, and shown to the judge as voice exemplars",
+      "reply_intent": "str — what the user asked the agent to say",
+      "rubric": "{must: list[str], must_not: list[str]} — approval criteria the judge scores against"
+    }
+  },
+  "draft-001": {
+    "persona": "sam-casual-pm",
+    "incoming": {
+      "from": "Dana Kim <dana@acme.io>",
+      "subject": "Design review + onboarding flow",
+      "body": "Hey Sam,\n\nTwo things: can we move Thursday's design review from 1pm to 3pm? Rachel has a conflict. Also, did you get a chance to look at the new onboarding flow I shared on Monday?\n\nDana"
+    },
+    "sent_history": [
+      "Hey Alice,\n\nThanks for sending this over! I'll take a look tonight and get back to you tomorrow. Quick heads up — we're shipping the beta on Friday, so things are a bit hectic.\n\nCheers,\nSam",
+      "Hey Marcus,\n\nGood catch on the pricing page — that's definitely a typo. I've pinged design and it'll be fixed by EOD. Let me know if anything else looks off!\n\nCheers,\nSam",
+      "Hey Dana,\n\nLet's do Tuesday at 10 — works better for the team. I'll send an invite in a sec. Can't wait to see the new mockups!\n\nCheers,\nSam",
+      "Hey Priya,\n\nWe can't make the offsite this quarter, sadly — budget's tight. Totally up for a virtual session though, maybe early next month?\n\nCheers,\nSam"
+    ],
+    "reply_intent": "Agree to moving the design review to 3pm Thursday, and say I'll send onboarding-flow feedback tomorrow.",
+    "rubric": {
+      "must": [
+        "Agree to the 3pm Thursday time for the design review",
+        "Say feedback on the onboarding flow is coming tomorrow",
+        "Sound casual and brief, like the sent history (contractions, informal greeting/sign-off)"
+      ],
+      "must_not": [
+        "Invent other meetings, attendees, or scheduling constraints not in the thread",
+        "Promise feedback earlier than or on anything beyond the onboarding flow"
+      ]
+    }
+  },
+  "draft-002": {
+    "persona": "margaret-formal-counsel",
+    "incoming": {
+      "from": "Robert Alvarez <ralvarez@dunmorelaw.com>",
+      "subject": "RE: Licensing agreement — clause 7.2",
+      "body": "Dear Ms. Chen,\n\nFollowing up on the licensing agreement: when can we expect your marked revision? My client would also like confirmation that you accept the revised indemnity language in clause 7.2 as circulated.\n\nRegards,\nRobert Alvarez"
+    },
+    "sent_history": [
+      "Dear Mr. Alvarez,\n\nThank you for your message regarding the licensing agreement. I have reviewed the proposed amendments and will provide a marked revision by Thursday, 12 June. Please note that clause 7.2 requires further discussion with our compliance team before we can agree to the revised indemnity language.\n\nPlease do not hesitate to contact me should you require anything further.\n\nKind regards,\nMargaret Chen",
+      "Dear Ms. Osei,\n\nThank you for the updated schedule. I confirm receipt of the exhibits and will circulate them to the working group this afternoon. We remain on track for the 30 June filing date.\n\nKind regards,\nMargaret Chen",
+      "Dear Dr. Feld,\n\nI appreciate your patience on this matter. The board has approved the engagement letter, and a signed copy will follow by courier. Our first review call is scheduled for Monday at 2:00 PM.\n\nKind regards,\nMargaret Chen",
+      "Dear Mr. Whitfield,\n\nI regret that I am unable to attend Thursday's session in person. I would welcome the opportunity to join by video conference, and I have asked my assistant to coordinate a suitable time.\n\nKind regards,\nMargaret Chen"
+    ],
+    "reply_intent": "Tell him the marked revision will arrive Thursday, and that we cannot yet agree to the clause 7.2 indemnity language — compliance review is still pending.",
+    "rubric": {
+      "must": [
+        "State the marked revision will be provided by Thursday",
+        "Decline (for now) to accept the clause 7.2 indemnity language, citing pending compliance review",
+        "Use a formal register consistent with the sent history (formal salutation and sign-off, no contractions)"
+      ],
+      "must_not": [
+        "Accept or agree to the indemnity language",
+        "Commit to a date for the compliance decision that was not given"
+      ]
+    }
+  },
+  "draft-003": {
+    "persona": "priya-warm-academic",
+    "incoming": {
+      "from": "Elena Vasquez <evasquez@jmlr-editors.org>",
+      "subject": "Review request: manuscript #2214",
+      "body": "Dear Dr. Rao,\n\nWe would be grateful if you could review manuscript #2214, 'Sparse Attention for Long-Context Retrieval'. The review would be due by June 20. Please let us know if you can take this on.\n\nBest wishes,\nElena Vasquez"
+    },
+    "sent_history": [
+      "Hi Tom,\n\nThanks for the draft — I've added comments in the margins. I think the second section could use a stronger example, but overall it's in great shape. Happy to talk it through on Thursday if that helps.\n\nBest,\nPriya",
+      "Hi Lena,\n\nI'd be glad to serve on the committee. My only constraint is that I'm traveling the first week of October, so I'll miss the kickoff — happy to catch up async.\n\nBest,\nPriya",
+      "Hi Sofia,\n\nThe dataset looks solid. I'd suggest we rerun the ablation with the larger split before we submit — reviewers will ask. I can have results by Monday.\n\nBest,\nPriya",
+      "Hi James,\n\nThanks for the invitation. I can't commit to the full workshop, but I'd be happy to give the opening talk and stay for the morning discussion.\n\nBest,\nPriya"
+    ],
+    "reply_intent": "Accept the review, but ask for a one-week extension to June 27 because of grant deadlines.",
+    "rubric": {
+      "must": [
+        "Accept the review of manuscript #2214",
+        "Ask for an extension to June 27 (one week past the June 20 due date)",
+        "Sound warm and collegial like the sent history"
+      ],
+      "must_not": [
+        "Decline the review",
+        "Invent details about the manuscript's content or quality"
+      ]
+    }
+  },
+  "draft-004": {
+    "persona": "viktor-terse-engineer",
+    "incoming": {
+      "from": "Maya Okafor <maya.okafor@nexusops.dev>",
+      "subject": "Cache bug — root cause + timeline?",
+      "body": "Viktor,\n\nLeadership is asking about the stale-data reports from yesterday. Do we have a root cause, and when does the fix ship? Also, do we need to backport?\n\nMaya"
+    },
+    "sent_history": [
+      "Deploy went out at 14:05. Rollback plan is in the runbook if error rates spike. I'll watch the dashboards for the next hour.\n\nThanks,\nViktor",
+      "Repro'd the bug. It's the cache invalidation path — fix is a two-liner, PR up shortly. We should backport to 2.4 as well.\n\nThanks,\nViktor",
+      "Can't join the 9am — conflict with the vendor call. Notes are fine, I'll read them after. Ping me if anything needs a decision.\n\nThanks,\nViktor",
+      "Benchmarks attached. p99 dropped 18% after the pool change. I'd hold the second patch until we have a week of data.\n\nThanks,\nViktor"
+    ],
+    "reply_intent": "Root cause is the cache invalidation path; the fix is in a PR now. A 2.4 backport makes sense but don't commit to a backport date yet.",
+    "rubric": {
+      "must": [
+        "Name the cache invalidation path as the root cause",
+        "Say the fix is in a PR / shipping shortly",
+        "Recommend backporting to 2.4 without committing to a date",
+        "Be terse and direct like the sent history"
+      ],
+      "must_not": [
+        "Commit to a specific backport date or release date not provided",
+        "Blame a component other than cache invalidation"
+      ]
+    }
+  },
+  "draft-005": {
+    "persona": "sam-casual-pm",
+    "incoming": {
+      "from": "Trevor Bell <trevor@launchmetrics.co>",
+      "subject": "Quick demo of LaunchMetrics for your team?",
+      "body": "Hi Sam,\n\nI lead sales at LaunchMetrics — we help product teams cut activation-funnel drop-off by up to 30%. Do you have 20 minutes this week or next for a quick demo?\n\nTrevor"
+    },
+    "sent_history": [
+      "Hey Alice,\n\nThanks for sending this over! I'll take a look tonight and get back to you tomorrow. Quick heads up — we're shipping the beta on Friday, so things are a bit hectic.\n\nCheers,\nSam",
+      "Hey Marcus,\n\nGood catch on the pricing page — that's definitely a typo. I've pinged design and it'll be fixed by EOD. Let me know if anything else looks off!\n\nCheers,\nSam",
+      "Hey Dana,\n\nLet's do Tuesday at 10 — works better for the team. I'll send an invite in a sec. Can't wait to see the new mockups!\n\nCheers,\nSam",
+      "Hey Priya,\n\nWe can't make the offsite this quarter, sadly — budget's tight. Totally up for a virtual session though, maybe early next month?\n\nCheers,\nSam"
+    ],
+    "reply_intent": "Decline politely — no budget this quarter — but say I'm open to revisiting next quarter.",
+    "rubric": {
+      "must": [
+        "Decline the demo for now, citing no budget this quarter",
+        "Leave the door open for next quarter",
+        "Stay friendly and brief like the sent history"
+      ],
+      "must_not": [
+        "Agree to a demo, call, or meeting now",
+        "Share internal metrics or commit to a purchase"
+      ]
+    }
+  },
+  "draft-006": {
+    "persona": "margaret-formal-counsel",
+    "incoming": {
+      "from": "Dr. Samuel Feld <sfeld@feldadvisory.com>",
+      "subject": "Engagement letter + first call",
+      "body": "Dear Ms. Chen,\n\nHas the board reached a decision on the engagement letter? If so, I would like to schedule our first review call — would Monday at 2:00 PM suit you?\n\nWith thanks,\nSamuel Feld"
+    },
+    "sent_history": [
+      "Dear Mr. Alvarez,\n\nThank you for your message regarding the licensing agreement. I have reviewed the proposed amendments and will provide a marked revision by Thursday, 12 June. Please note that clause 7.2 requires further discussion with our compliance team before we can agree to the revised indemnity language.\n\nPlease do not hesitate to contact me should you require anything further.\n\nKind regards,\nMargaret Chen",
+      "Dear Ms. Osei,\n\nThank you for the updated schedule. I confirm receipt of the exhibits and will circulate them to the working group this afternoon. We remain on track for the 30 June filing date.\n\nKind regards,\nMargaret Chen",
+      "Dear Dr. Feld,\n\nI appreciate your patience on this matter. The board has approved the engagement letter, and a signed copy will follow by courier. Our first review call is scheduled for Monday at 2:00 PM.\n\nKind regards,\nMargaret Chen",
+      "Dear Mr. Whitfield,\n\nI regret that I am unable to attend Thursday's session in person. I would welcome the opportunity to join by video conference, and I have asked my assistant to coordinate a suitable time.\n\nKind regards,\nMargaret Chen"
+    ],
+    "reply_intent": "Confirm the board approved the engagement letter (signed copy follows by courier) and accept the Monday 2:00 PM call.",
+    "rubric": {
+      "must": [
+        "Confirm the board approved the engagement letter",
+        "Mention the signed copy follows by courier",
+        "Accept Monday at 2:00 PM for the first call",
+        "Use the formal register of the sent history"
+      ],
+      "must_not": [
+        "Propose a different time",
+        "Add engagement terms or fees not in the thread"
+      ]
+    }
+  },
+  "draft-007": {
+    "persona": "priya-warm-academic",
+    "incoming": {
+      "from": "Daniel Wu <dwu@student.northgate.edu>",
+      "subject": "Reference letter for PhD applications",
+      "body": "Dear Dr. Rao,\n\nI'm applying to PhD programs this cycle and the first deadline is June 15. Would you be willing to write me a reference letter? I took your ML systems course last spring and worked in your lab over the summer.\n\nThank you,\nDaniel Wu"
+    },
+    "sent_history": [
+      "Hi Tom,\n\nThanks for the draft — I've added comments in the margins. I think the second section could use a stronger example, but overall it's in great shape. Happy to talk it through on Thursday if that helps.\n\nBest,\nPriya",
+      "Hi Lena,\n\nI'd be glad to serve on the committee. My only constraint is that I'm traveling the first week of October, so I'll miss the kickoff — happy to catch up async.\n\nBest,\nPriya",
+      "Hi Sofia,\n\nThe dataset looks solid. I'd suggest we rerun the ablation with the larger split before we submit — reviewers will ask. I can have results by Monday.\n\nBest,\nPriya",
+      "Hi James,\n\nThanks for the invitation. I can't commit to the full workshop, but I'd be happy to give the opening talk and stay for the morning discussion.\n\nBest,\nPriya"
+    ],
+    "reply_intent": "Agree to write the letter. Ask him to send his CV and a short list of points to highlight by June 10.",
+    "rubric": {
+      "must": [
+        "Agree to write the reference letter",
+        "Ask for his CV and highlight points by June 10",
+        "Sound warm and encouraging like the sent history"
+      ],
+      "must_not": [
+        "Decline or express doubt about his qualifications",
+        "Invent details about his coursework or lab performance beyond what the thread states"
+      ]
+    }
+  },
+  "draft-008": {
+    "persona": "viktor-terse-engineer",
+    "incoming": {
+      "from": "Priyanka Shah <pshah@nexusops.dev>",
+      "subject": "Ship patch 2 this week?",
+      "body": "Viktor,\n\nProduct wants the second connection-pool patch in this week's release. Your call — are the numbers good enough?\n\nPriyanka"
+    },
+    "sent_history": [
+      "Deploy went out at 14:05. Rollback plan is in the runbook if error rates spike. I'll watch the dashboards for the next hour.\n\nThanks,\nViktor",
+      "Repro'd the bug. It's the cache invalidation path — fix is a two-liner, PR up shortly. We should backport to 2.4 as well.\n\nThanks,\nViktor",
+      "Can't join the 9am — conflict with the vendor call. Notes are fine, I'll read them after. Ping me if anything needs a decision.\n\nThanks,\nViktor",
+      "Benchmarks attached. p99 dropped 18% after the pool change. I'd hold the second patch until we have a week of data.\n\nThanks,\nViktor"
+    ],
+    "reply_intent": "Recommend holding the second patch until we have a full week of benchmark data; the first pool change already dropped p99 by 18%.",
+    "rubric": {
+      "must": [
+        "Recommend holding the second patch this week",
+        "Cite wanting a full week of data",
+        "Reference the 18% p99 improvement from the first change",
+        "Be terse like the sent history"
+      ],
+      "must_not": [
+        "Agree to ship the second patch this week",
+        "Invent different benchmark numbers"
+      ]
+    }
+  },
+  "draft-009": {
+    "persona": "sam-casual-pm",
+    "incoming": {
+      "from": "Accounts <billing@brighthost.com>",
+      "subject": "Invoice #4417 — due June 15",
+      "body": "Hello,\n\nPlease find attached invoice #4417 for $12,400, due June 15, covering your Q2 hosting plan.\n\nBrightHost Billing"
+    },
+    "sent_history": [
+      "Hey Alice,\n\nThanks for sending this over! I'll take a look tonight and get back to you tomorrow. Quick heads up — we're shipping the beta on Friday, so things are a bit hectic.\n\nCheers,\nSam",
+      "Hey Marcus,\n\nGood catch on the pricing page — that's definitely a typo. I've pinged design and it'll be fixed by EOD. Let me know if anything else looks off!\n\nCheers,\nSam",
+      "Hey Dana,\n\nLet's do Tuesday at 10 — works better for the team. I'll send an invite in a sec. Can't wait to see the new mockups!\n\nCheers,\nSam",
+      "Hey Priya,\n\nWe can't make the offsite this quarter, sadly — budget's tight. Totally up for a virtual session though, maybe early next month?\n\nCheers,\nSam"
+    ],
+    "reply_intent": "Flag that our purchase order was for $11,900, not $12,400 — ask them to send a corrected invoice before we pay.",
+    "rubric": {
+      "must": [
+        "Point out the discrepancy: invoice #4417 says $12,400 but the PO was $11,900",
+        "Ask for a corrected invoice before payment",
+        "Keep the numbers exactly as stated ($12,400 invoiced, $11,900 on the PO)"
+      ],
+      "must_not": [
+        "Agree to pay the invoiced amount",
+        "Misquote either amount or the invoice number"
+      ]
+    }
+  },
+  "draft-010": {
+    "persona": "margaret-formal-counsel",
+    "incoming": {
+      "from": "Charles Whitfield <cwhitfield@sentinelforum.org>",
+      "subject": "Panel invitation — Thursday session",
+      "body": "Dear Ms. Chen,\n\nWe would be honoured to have you join Thursday's regulatory panel in person at our London forum. May I confirm your attendance?\n\nYours sincerely,\nCharles Whitfield"
+    },
+    "sent_history": [
+      "Dear Mr. Alvarez,\n\nThank you for your message regarding the licensing agreement. I have reviewed the proposed amendments and will provide a marked revision by Thursday, 12 June. Please note that clause 7.2 requires further discussion with our compliance team before we can agree to the revised indemnity language.\n\nPlease do not hesitate to contact me should you require anything further.\n\nKind regards,\nMargaret Chen",
+      "Dear Ms. Osei,\n\nThank you for the updated schedule. I confirm receipt of the exhibits and will circulate them to the working group this afternoon. We remain on track for the 30 June filing date.\n\nKind regards,\nMargaret Chen",
+      "Dear Dr. Feld,\n\nI appreciate your patience on this matter. The board has approved the engagement letter, and a signed copy will follow by courier. Our first review call is scheduled for Monday at 2:00 PM.\n\nKind regards,\nMargaret Chen",
+      "Dear Mr. Whitfield,\n\nI regret that I am unable to attend Thursday's session in person. I would welcome the opportunity to join by video conference, and I have asked my assistant to coordinate a suitable time.\n\nKind regards,\nMargaret Chen"
+    ],
+    "reply_intent": "Decline in-person attendance with regret, but offer to join by video conference and say my assistant will coordinate.",
+    "rubric": {
+      "must": [
+        "Decline in-person attendance politely",
+        "Offer to join by video conference",
+        "Mention the assistant will coordinate timing",
+        "Use the formal register of the sent history"
+      ],
+      "must_not": [
+        "Confirm in-person attendance",
+        "Invent travel plans or reasons not given"
+      ]
+    }
+  },
+  "draft-011": {
+    "persona": "priya-warm-academic",
+    "incoming": {
+      "from": "Sofia Marchetti <sofia.marchetti@uni-crest.edu>",
+      "subject": "Should we push the submission?",
+      "body": "Hi Priya,\n\nI'm nervous about the ablation results — should we push the submission to the next cycle, or can we still make this deadline?\n\nSofia"
+    },
+    "sent_history": [
+      "Hi Tom,\n\nThanks for the draft — I've added comments in the margins. I think the second section could use a stronger example, but overall it's in great shape. Happy to talk it through on Thursday if that helps.\n\nBest,\nPriya",
+      "Hi Lena,\n\nI'd be glad to serve on the committee. My only constraint is that I'm traveling the first week of October, so I'll miss the kickoff — happy to catch up async.\n\nBest,\nPriya",
+      "Hi Sofia,\n\nThe dataset looks solid. I'd suggest we rerun the ablation with the larger split before we submit — reviewers will ask. I can have results by Monday.\n\nBest,\nPriya",
+      "Hi James,\n\nThanks for the invitation. I can't commit to the full workshop, but I'd be happy to give the opening talk and stay for the morning discussion.\n\nBest,\nPriya"
+    ],
+    "reply_intent": "Reassure her: keep the current deadline. I'll rerun the ablation on the larger split and have results by Monday.",
+    "rubric": {
+      "must": [
+        "Recommend keeping the current submission deadline",
+        "Say the ablation rerun on the larger split will be done with results by Monday",
+        "Sound reassuring and warm like the sent history"
+      ],
+      "must_not": [
+        "Agree to push to the next cycle",
+        "Promise results earlier than Monday"
+      ]
+    }
+  },
+  "draft-012": {
+    "persona": "viktor-terse-engineer",
+    "incoming": {
+      "from": "Tom Reyes <treyes@nexusops.dev>",
+      "subject": "9am architecture sync tomorrow",
+      "body": "Viktor — adding you to the 9am architecture sync tomorrow. Can you make it? We're deciding on the queue migration.\n\nTom"
+    },
+    "sent_history": [
+      "Deploy went out at 14:05. Rollback plan is in the runbook if error rates spike. I'll watch the dashboards for the next hour.\n\nThanks,\nViktor",
+      "Repro'd the bug. It's the cache invalidation path — fix is a two-liner, PR up shortly. We should backport to 2.4 as well.\n\nThanks,\nViktor",
+      "Can't join the 9am — conflict with the vendor call. Notes are fine, I'll read them after. Ping me if anything needs a decision.\n\nThanks,\nViktor",
+      "Benchmarks attached. p99 dropped 18% after the pool change. I'd hold the second patch until we have a week of data.\n\nThanks,\nViktor"
+    ],
+    "reply_intent": "Can't make the 9am — vendor call conflict. Ask for the notes and say to ping me if the queue-migration decision needs my input.",
+    "rubric": {
+      "must": [
+        "Decline the 9am citing the vendor-call conflict",
+        "Ask for notes afterwards",
+        "Offer to weigh in on the queue-migration decision if pinged",
+        "Be terse like the sent history"
+      ],
+      "must_not": [
+        "Accept the meeting",
+        "State a position on the queue migration itself"
+      ]
+    }
+  },
+  "draft-013": {
+    "persona": "sam-casual-pm",
+    "incoming": {
+      "from": "Jordan Lee <jordan.lee@ferngate.app>",
+      "subject": "Export button broken on Safari",
+      "body": "Hi Sam,\n\nHeads up — the CSV export button does nothing on Safari 18. Works fine in Chrome. A few of our analysts are blocked. Any chance of a quick fix, or should we expect a refund for this month?\n\nJordan"
+    },
+    "sent_history": [
+      "Hey Alice,\n\nThanks for sending this over! I'll take a look tonight and get back to you tomorrow. Quick heads up — we're shipping the beta on Friday, so things are a bit hectic.\n\nCheers,\nSam",
+      "Hey Marcus,\n\nGood catch on the pricing page — that's definitely a typo. I've pinged design and it'll be fixed by EOD. Let me know if anything else looks off!\n\nCheers,\nSam",
+      "Hey Dana,\n\nLet's do Tuesday at 10 — works better for the team. I'll send an invite in a sec. Can't wait to see the new mockups!\n\nCheers,\nSam",
+      "Hey Priya,\n\nWe can't make the offsite this quarter, sadly — budget's tight. Totally up for a virtual session though, maybe early next month?\n\nCheers,\nSam"
+    ],
+    "reply_intent": "Acknowledge the Safari export bug, say engineering is on it and a fix should land this week. Don't promise a refund — say I'll follow up once the fix ships.",
+    "rubric": {
+      "must": [
+        "Acknowledge the Safari CSV-export bug",
+        "Say a fix is expected this week",
+        "Defer the refund question rather than granting or refusing it",
+        "Stay friendly and apologetic-but-brief like the sent history"
+      ],
+      "must_not": [
+        "Promise or refuse a refund",
+        "Commit to a specific day or hour for the fix"
+      ]
+    }
+  },
+  "draft-014": {
+    "persona": "margaret-formal-counsel",
+    "incoming": {
+      "from": "Abena Osei <aosei@garrickpartners.com>",
+      "subject": "Exhibits C through F attached",
+      "body": "Dear Ms. Chen,\n\nPlease find attached exhibits C through F, updated per Friday's discussion. Kindly confirm receipt, and that the 30 June filing date still stands.\n\nBest regards,\nAbena Osei"
+    },
+    "sent_history": [
+      "Dear Mr. Alvarez,\n\nThank you for your message regarding the licensing agreement. I have reviewed the proposed amendments and will provide a marked revision by Thursday, 12 June. Please note that clause 7.2 requires further discussion with our compliance team before we can agree to the revised indemnity language.\n\nPlease do not hesitate to contact me should you require anything further.\n\nKind regards,\nMargaret Chen",
+      "Dear Ms. Osei,\n\nThank you for the updated schedule. I confirm receipt of the exhibits and will circulate them to the working group this afternoon. We remain on track for the 30 June filing date.\n\nKind regards,\nMargaret Chen",
+      "Dear Dr. Feld,\n\nI appreciate your patience on this matter. The board has approved the engagement letter, and a signed copy will follow by courier. Our first review call is scheduled for Monday at 2:00 PM.\n\nKind regards,\nMargaret Chen",
+      "Dear Mr. Whitfield,\n\nI regret that I am unable to attend Thursday's session in person. I would welcome the opportunity to join by video conference, and I have asked my assistant to coordinate a suitable time.\n\nKind regards,\nMargaret Chen"
+    ],
+    "reply_intent": "Confirm receipt of exhibits C through F and confirm we remain on track for the 30 June filing.",
+    "rubric": {
+      "must": [
+        "Confirm receipt of exhibits C through F",
+        "Confirm the 30 June filing date stands",
+        "Use the formal register of the sent history"
+      ],
+      "must_not": [
+        "Raise new issues with the exhibits that the user did not mention",
+        "Alter the filing date"
+      ]
+    }
+  },
+  "draft-015": {
+    "persona": "priya-warm-academic",
+    "incoming": {
+      "from": "James Okonkwo <j.okonkwo@mlsummit.org>",
+      "subject": "Full-day workshop chair role",
+      "body": "Dear Dr. Rao,\n\nWould you chair our full-day efficient-inference workshop in November? It involves the opening talk, moderating all four sessions, and the closing panel.\n\nWarm regards,\nJames Okonkwo"
+    },
+    "sent_history": [
+      "Hi Tom,\n\nThanks for the draft — I've added comments in the margins. I think the second section could use a stronger example, but overall it's in great shape. Happy to talk it through on Thursday if that helps.\n\nBest,\nPriya",
+      "Hi Lena,\n\nI'd be glad to serve on the committee. My only constraint is that I'm traveling the first week of October, so I'll miss the kickoff — happy to catch up async.\n\nBest,\nPriya",
+      "Hi Sofia,\n\nThe dataset looks solid. I'd suggest we rerun the ablation with the larger split before we submit — reviewers will ask. I can have results by Monday.\n\nBest,\nPriya",
+      "Hi James,\n\nThanks for the invitation. I can't commit to the full workshop, but I'd be happy to give the opening talk and stay for the morning discussion.\n\nBest,\nPriya"
+    ],
+    "reply_intent": "Decline the full-day chair role, but offer to give the opening talk and stay for the morning sessions.",
+    "rubric": {
+      "must": [
+        "Decline the full-day chair commitment",
+        "Offer the opening talk plus morning attendance instead",
+        "Sound appreciative and warm like the sent history"
+      ],
+      "must_not": [
+        "Accept the full chair role",
+        "Commit to moderating sessions or the closing panel"
+      ]
+    }
+  },
+  "draft-016": {
+    "persona": "viktor-terse-engineer",
+    "incoming": {
+      "from": "Maya Okafor <maya.okafor@nexusops.dev>",
+      "subject": "Postmortem: yesterday's outage?",
+      "body": "Viktor,\n\nFor the postmortem doc: how long was yesterday's outage after the 14:05 deploy, and what was the error-rate peak?\n\nMaya"
+    },
+    "sent_history": [
+      "Deploy went out at 14:05. Rollback plan is in the runbook if error rates spike. I'll watch the dashboards for the next hour.\n\nThanks,\nViktor",
+      "Repro'd the bug. It's the cache invalidation path — fix is a two-liner, PR up shortly. We should backport to 2.4 as well.\n\nThanks,\nViktor",
+      "Can't join the 9am — conflict with the vendor call. Notes are fine, I'll read them after. Ping me if anything needs a decision.\n\nThanks,\nViktor",
+      "Benchmarks attached. p99 dropped 18% after the pool change. I'd hold the second patch until we have a week of data.\n\nThanks,\nViktor"
+    ],
+    "reply_intent": "Correct the record: there was no outage. The 14:05 deploy went out clean, error rates never spiked, and I watched the dashboards for an hour after.",
+    "rubric": {
+      "must": [
+        "State clearly that there was no outage after the 14:05 deploy",
+        "Say error rates never spiked and the dashboards were monitored",
+        "Be terse and factual like the sent history"
+      ],
+      "must_not": [
+        "Apologize for or describe an outage that did not happen",
+        "Invent an outage duration or error-rate figure"
+      ]
+    }
+  },
+  "draft-017": {
+    "persona": "sam-casual-pm",
+    "incoming": {
+      "from": "Nina Petrova <nina@haloventures.vc>",
+      "subject": "Intro: Sam <> Omar (Cloudpath)",
+      "body": "Hi both,\n\nSam — meet Omar, CTO at Cloudpath. I think there's a real integration story between your products. Omar — Sam runs product at Ferngate. I'll let you two take it from here!\n\nNina"
+    },
+    "sent_history": [
+      "Hey Alice,\n\nThanks for sending this over! I'll take a look tonight and get back to you tomorrow. Quick heads up — we're shipping the beta on Friday, so things are a bit hectic.\n\nCheers,\nSam",
+      "Hey Marcus,\n\nGood catch on the pricing page — that's definitely a typo. I've pinged design and it'll be fixed by EOD. Let me know if anything else looks off!\n\nCheers,\nSam",
+      "Hey Dana,\n\nLet's do Tuesday at 10 — works better for the team. I'll send an invite in a sec. Can't wait to see the new mockups!\n\nCheers,\nSam",
+      "Hey Priya,\n\nWe can't make the offsite this quarter, sadly — budget's tight. Totally up for a virtual session though, maybe early next month?\n\nCheers,\nSam"
+    ],
+    "reply_intent": "Thank Nina for the intro (moving her to BCC), welcome Omar, and propose a 30-minute call next week to explore the integration idea.",
+    "rubric": {
+      "must": [
+        "Thank Nina for the introduction",
+        "Greet Omar and propose a 30-minute call next week",
+        "Stay casual and enthusiastic like the sent history"
+      ],
+      "must_not": [
+        "Commit to a partnership, pricing, or an integration plan",
+        "Invent product details about Cloudpath"
+      ]
+    }
+  },
+  "draft-018": {
+    "persona": "margaret-formal-counsel",
+    "incoming": {
+      "from": "Robert Alvarez <ralvarez@dunmorelaw.com>",
+      "subject": "Settlement proposal — $240,000",
+      "body": "Dear Ms. Chen,\n\nMy client is prepared to settle the matter for $240,000, inclusive of costs, provided we reach agreement by the end of the month. Please advise your client's position.\n\nRegards,\nRobert Alvarez"
+    },
+    "sent_history": [
+      "Dear Mr. Alvarez,\n\nThank you for your message regarding the licensing agreement. I have reviewed the proposed amendments and will provide a marked revision by Thursday, 12 June. Please note that clause 7.2 requires further discussion with our compliance team before we can agree to the revised indemnity language.\n\nPlease do not hesitate to contact me should you require anything further.\n\nKind regards,\nMargaret Chen",
+      "Dear Ms. Osei,\n\nThank you for the updated schedule. I confirm receipt of the exhibits and will circulate them to the working group this afternoon. We remain on track for the 30 June filing date.\n\nKind regards,\nMargaret Chen",
+      "Dear Dr. Feld,\n\nI appreciate your patience on this matter. The board has approved the engagement letter, and a signed copy will follow by courier. Our first review call is scheduled for Monday at 2:00 PM.\n\nKind regards,\nMargaret Chen",
+      "Dear Mr. Whitfield,\n\nI regret that I am unable to attend Thursday's session in person. I would welcome the opportunity to join by video conference, and I have asked my assistant to coordinate a suitable time.\n\nKind regards,\nMargaret Chen"
+    ],
+    "reply_intent": "Acknowledge receipt of the settlement proposal and say we will respond after consulting our client. Take no position on the number.",
+    "rubric": {
+      "must": [
+        "Acknowledge receipt of the $240,000 settlement proposal",
+        "Say a response will follow after client consultation",
+        "Use the formal register of the sent history"
+      ],
+      "must_not": [
+        "Accept, reject, or counter the proposal",
+        "State any view on the amount or the end-of-month condition"
+      ]
+    }
+  }
+}

--- a/tests/unit/email/test_drafting_corpus_integrity.py
+++ b/tests/unit/email/test_drafting_corpus_integrity.py
@@ -1,0 +1,296 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the voice/style drafting eval (#1607 / #1269 / #1948).
+
+Mirrors ``test_corpus_integrity.py`` for the drafting seed corpus, plus
+offline coverage of the judge scorer in ``gaia.eval.draft_quality``:
+
+- The committed corpus loads, is the declared size, and every case is
+  schema-well-formed (the loader is the validator — fail-loud).
+- Duplicate case ids and missing required fields are rejected loudly.
+- Every case's ``sent_history`` feeds the REAL #1607 analyzer
+  (``analyze_sent_bodies``) and yields a profile — the corpus can actually
+  drive the feature path.
+- The judge prompt carries the rubric, intent, and draft.
+- Verdict parsing accepts the documented JSON and rejects garbage,
+  missing fields, and out-of-range scores.
+- The scorer runs end-to-end on a mocked judge (no backend, no network)
+  and produces an approval rate in range plus a build_scorecard-compatible
+  summary.
+- The committed thresholds manifest ships the #1269 bar in report mode
+  (``enforce: false``) and the gate honors the ``should_fail`` contract.
+
+Everything here runs offline: no Lemonade, no Anthropic, no live mailbox.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaia.eval import draft_quality as dq
+from gaia.eval.scorecard import build_scorecard
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+CORPUS_PATH = _REPO_ROOT / "tests" / "fixtures" / "email" / "drafting_ground_truth.json"
+THRESHOLDS_PATH = (
+    _REPO_ROOT / "tests" / "fixtures" / "email" / "drafting_gate_thresholds.json"
+)
+
+
+@pytest.fixture(scope="module")
+def corpus() -> dict:
+    return dq.load_drafting_corpus(CORPUS_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Corpus integrity
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_loads_and_has_seed_size(corpus):
+    """Seed corpus is committed, loadable, and in the declared 15–25 range."""
+    cases = dq.corpus_cases(corpus)
+    assert 15 <= len(cases) <= 25, f"seed corpus size out of range: {len(cases)}"
+
+
+def test_meta_block_present_and_well_formed(corpus):
+    meta = corpus["_meta"]
+    assert meta["fixture"] == "drafting_ground_truth.json"
+    assert meta["fixture_kind"] == "hand-authored-seed"
+    assert isinstance(meta["schema_version"], int)
+
+
+def test_every_case_is_schema_well_formed(corpus):
+    """The loader already validates; assert the shape it guarantees."""
+    for case_id, case in dq.corpus_cases(corpus).items():
+        assert not case_id.startswith("_")
+        assert case["persona"].strip()
+        for field in ("from", "subject", "body"):
+            assert case["incoming"][field].strip(), f"{case_id}: incoming.{field}"
+        assert len(case["sent_history"]) >= 3, case_id
+        assert case["reply_intent"].strip(), case_id
+        assert case["rubric"]["must"], case_id
+        assert isinstance(case["rubric"]["must_not"], list), case_id
+
+
+def test_duplicate_case_ids_rejected(tmp_path):
+    dup = tmp_path / "dup.json"
+    dup.write_text(
+        '{"draft-001": {}, "draft-001": {}}',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate case id"):
+        dq.load_drafting_corpus(dup)
+
+
+def test_missing_required_field_rejected(tmp_path, corpus):
+    cases = dq.corpus_cases(corpus)
+    case_id, case = next(iter(cases.items()))
+    broken = {case_id: {k: v for k, v in case.items() if k != "reply_intent"}}
+    path = tmp_path / "broken.json"
+    path.write_text(json.dumps(broken), encoding="utf-8")
+    with pytest.raises(ValueError, match="reply_intent"):
+        dq.load_drafting_corpus(path)
+
+
+def test_sent_history_drives_the_real_voice_analyzer(corpus):
+    """Every case's style signal must survive the REAL #1607 analyzer —
+    otherwise the live generation stage could not build a profile from it.
+    """
+    pytest.importorskip("gaia_agent_email")
+    from gaia_agent_email.voice_profile import analyze_sent_bodies
+
+    for case_id, case in dq.corpus_cases(corpus).items():
+        profile = analyze_sent_bodies(case["sent_history"])
+        assert profile["sample_count"] == len(case["sent_history"]), case_id
+        assert profile["median_words"] > 0, case_id
+
+
+# ---------------------------------------------------------------------------
+# Judge prompt + verdict parsing
+# ---------------------------------------------------------------------------
+
+_DRAFT = {
+    "to": "Dana Kim <dana@acme.io>",
+    "subject": "Re: Design review + onboarding flow",
+    "body": "Hey Dana,\n\n3pm Thursday works! I'll send onboarding notes tomorrow.\n\nCheers,\nSam",
+}
+
+
+def _verdict_json(**overrides):
+    verdict = {
+        "recipient_and_intent": True,
+        "grounded": True,
+        "no_fabricated_commitments": True,
+        "voice_match": 0.9,
+        "overall_quality": 0.85,
+        "approved": True,
+        "rationale": "Matches intent and voice.",
+    }
+    verdict.update(overrides)
+    return json.dumps(verdict)
+
+
+def test_judge_prompt_carries_rubric_intent_and_draft(corpus):
+    case = dq.corpus_cases(corpus)["draft-001"]
+    prompt = dq.build_judge_prompt(case, _DRAFT)
+    assert case["reply_intent"] in prompt
+    for item in case["rubric"]["must"] + case["rubric"]["must_not"]:
+        assert item in prompt
+    assert _DRAFT["body"] in prompt
+    # Voice exemplars from Sent history are what the judge matches against.
+    assert case["sent_history"][0] in prompt
+
+
+def test_parse_verdict_happy_path_tolerates_fences():
+    text = "```json\n" + _verdict_json() + "\n```"
+    verdict = dq.parse_judge_verdict(text)
+    assert verdict["approved"] is True
+    assert verdict["voice_match"] == 0.9
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "no json here",
+        '{"approved": true}',  # missing fields
+        _verdict_json(voice_match=1.7),  # out of range
+        _verdict_json(approved="yes"),  # wrong type
+        _verdict_json(overall_quality=True),  # bool is not a score
+    ],
+)
+def test_parse_verdict_rejects_garbage(bad):
+    with pytest.raises(ValueError):
+        dq.parse_judge_verdict(bad)
+
+
+# ---------------------------------------------------------------------------
+# Scorer on a mocked judge (offline end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def _generations(corpus, *, drop_draft_for=()):
+    gens = []
+    for case_id in dq.corpus_cases(corpus):
+        draft = None if case_id in drop_draft_for else dict(_DRAFT)
+        gens.append(
+            {
+                "case_id": case_id,
+                "draft": draft,
+                "error": "stub: no draft" if draft is None else "",
+                "duration_ms": 10,
+            }
+        )
+    return gens
+
+
+def test_scorer_end_to_end_with_mocked_judge(corpus):
+    """Mocked judge → approval rate in range, scorecard-compatible rows."""
+    calls = {"n": 0}
+
+    def mock_judge(prompt: str) -> str:
+        calls["n"] += 1
+        # Alternate approve/reject so the rate is strictly inside (0, 1).
+        return _verdict_json(approved=calls["n"] % 2 == 1)
+
+    results = dq.judge_drafts(
+        corpus, _generations(corpus), mock_judge, model_id="stub-model"
+    )
+    cases = dq.corpus_cases(corpus)
+    assert len(results) == len(cases)
+    assert calls["n"] == len(cases)
+    for r in results:
+        assert r["status"] in {"PASS", "FAIL"}
+        assert r["category"] == "stub-model"
+        assert 0.0 <= r["overall_score"] <= 10.0
+
+    summary = dq.summarize_drafting(
+        results,
+        run_id="unit",
+        thresholds=dq.DraftingThresholds(approval_min=0.70, enforce=False),
+    )
+    agg = summary["drafting"]
+    assert 0.0 < agg["draft_approval_rate"] < 1.0
+    assert agg["cases_judged"] == len(cases)
+    assert len(agg["per_case"]) == len(cases)
+    # The rows also aggregate through the shared scorecard builder unchanged.
+    scorecard = build_scorecard("unit", results, {})
+    assert scorecard["summary"]["total_scenarios"] == len(cases)
+    assert scorecard["summary"]["passed"] + scorecard["summary"]["failed"] == len(cases)
+
+
+def test_missing_draft_and_unparseable_judge_become_errored(corpus):
+    cases = list(dq.corpus_cases(corpus))
+    first, second = cases[0], cases[1]
+
+    def judge(prompt: str) -> str:
+        return "not json at all"
+
+    results = dq.judge_drafts(
+        corpus,
+        _generations(corpus, drop_draft_for={first}),
+        judge,
+        model_id="stub-model",
+    )
+    by_id = {r["id"]: r for r in results}
+    assert by_id[first]["status"] == "ERRORED"
+    assert "no draft" in by_id[first]["error"]
+    assert by_id[second]["status"] == "ERRORED"
+    assert "judge verdict unusable" in by_id[second]["error"]
+
+    # No verdicts at all → gate is a loud explicit skip, never a pass.
+    summary = dq.summarize_drafting(
+        results,
+        run_id="unit",
+        thresholds=dq.DraftingThresholds(approval_min=0.70, enforce=False),
+    )
+    assert "drafting" not in summary
+    assert summary["drafting_gate"]["skipped"] is True
+    assert summary["drafting_gate"]["should_fail"] is False
+
+
+# ---------------------------------------------------------------------------
+# Committed thresholds manifest + gate contract
+# ---------------------------------------------------------------------------
+
+
+def test_committed_thresholds_manifest_is_report_mode():
+    thresholds = dq.load_drafting_thresholds(THRESHOLDS_PATH)
+    assert thresholds.approval_min == 0.70  # the #1269 reported target
+    assert thresholds.enforce is False  # report mode — see the manifest comment
+    # The module default points at the same committed manifest.
+    assert dq.default_drafting_thresholds_path() == THRESHOLDS_PATH
+
+
+def test_malformed_thresholds_manifest_rejected(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text('{"enforce": false}', encoding="utf-8")
+    with pytest.raises(ValueError, match="approval_min"):
+        dq.load_drafting_thresholds(path)
+
+
+def test_gate_report_mode_never_fails_the_build():
+    gate = dq.evaluate_drafting_gate(
+        {"draft_approval_rate": 0.25},
+        dq.DraftingThresholds(approval_min=0.70, enforce=False),
+    )
+    assert gate["passed"] is False
+    assert gate["breaches"]
+    assert gate["should_fail"] is False
+
+
+def test_gate_enforced_breach_fails():
+    gate = dq.evaluate_drafting_gate(
+        {"draft_approval_rate": 0.25},
+        dq.DraftingThresholds(approval_min=0.70, enforce=True),
+    )
+    assert gate["should_fail"] is True
+
+
+def test_gate_missing_rate_is_loud():
+    with pytest.raises(ValueError, match="draft_approval_rate"):
+        dq.evaluate_drafting_gate({}, dq.DraftingThresholds(approval_min=0.70))


### PR DESCRIPTION
Closes #1948.

The #1607 voice/style drafting capability (merged in #1925) ships with unit tests only — a prompt change that makes drafts go off-voice, invent commitments, or miss the user's intent passes CI and reaches users undetected. This adds the judge-scored draft-quality eval that feature PR explicitly deferred: an LLM judge now scores agent-composed drafts against a labeled rubric corpus, and the aggregate **draft-approval rate (#1269, target ≥0.70)** lands in the nightly email-eval report. Report mode, matching the existing FP/FN and perf gates: the committed manifest ships `enforce:false`, so a regression is logged and uploaded, never a build failure — flipping `enforce` in the manifest (data, not code) is what makes it gate later.

## What's in it

- **Seed corpus** — `tests/fixtures/email/drafting_ground_truth.json`, 18 hand-authored cases across four writing personas (casual PM, formal counsel, warm academic, terse engineer), with grounding traps (exact invoice amounts, a "no outage happened" correction) and commitment traps (decline-without-agreeing, no-date promises). Case schema (also documented in the fixture's `_meta`): `persona`, `incoming {from, subject, body}`, `sent_history` (≥3 Sent bodies — the #1607 style signal), `reply_intent`, `rubric {must, must_not}`.
- **Scorer** — `gaia.eval.draft_quality`, a sibling of the triage benchmark. Generation drives the real feature path (`analyze_sent_bodies` → `save_voice_profile` → system-prompt pickup → the agent composes `draft_reply` over `FakeGmailBackend`; drafting only, nothing is ever sent). Judging reuses `gaia.eval.claude.ClaudeClient` with strict-JSON verdicts parsed fail-loud. Aggregation is `build_scorecard`-compatible and evaluates the committed gate manifest (`drafting_gate_thresholds.json`, `enforce:false`).
- **CI wiring** — one additive, self-contained report-mode step in `test_email_agent_eval.yml`, after the triage benchmark in the same job so Lemonade access stays strictly serial. Loud explicit skip (never a silent pass) when the judge credential is unavailable.

No baseline is committed: the local Lemonade Server was not reachable, so the first real judged report will be produced by this workflow's nightly run in report mode — no fabricated numbers.

## Test plan

- [x] `python -m pytest tests/unit/email/` — 137 passed (includes the 21 new corpus-integrity + scorer tests, offline, no backend)
- [x] `python -m pytest hub/agents/python/email/tests/` — 230 passed
- [x] `python -m pytest tests/unit/eval tests/test_eval.py` — 518 passed
- [x] `python util/lint.py --all` — clean
- [x] Offline wiring smoke test against the real agent: corpus payload round-trips `decode_message_body`, the derived profile reaches `_get_system_prompt` ("VOICE & STYLE" block), and `draft_reply` → draft harvest works end-to-end on `FakeGmailBackend`
- [x] Workflow YAML parses; the embedded gate-reader python compiles
- [ ] First real judged report: next nightly `Email Agent Eval` run (or `workflow_dispatch`) on the self-hosted Lemonade runner

Refs #1269, #1607, #1925.