### PR TITLE
ci: run Agent UI Vitest suite on src/gaia/apps/webui changes (#1934)

### DIFF
--- a/.github/workflows/test_electron.yml
+++ b/.github/workflows/test_electron.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'src/gaia/electron/**'
       - 'src/gaia/apps/*/webui/**'
+      - 'src/gaia/apps/webui/**'
       - 'hub/agents/python/emr/gaia_agent_emr/dashboard/electron/**'
       - 'tests/electron/**'
       - '.github/workflows/test_electron.yml'
@@ -19,6 +20,7 @@ on:
     paths:
       - 'src/gaia/electron/**'
       - 'src/gaia/apps/*/webui/**'
+      - 'src/gaia/apps/webui/**'
       - 'hub/agents/python/emr/gaia_agent_emr/dashboard/electron/**'
       - 'tests/electron/**'
       - '.github/workflows/test_electron.yml'


### PR DESCRIPTION
The Electron workflow's path filter only matched `src/gaia/apps/*/webui/**`. Because the `*` glob does not cross `/`, changes to the Agent UI at `src/gaia/apps/webui/**` never triggered the workflow — so its Vitest suite silently skipped on the very changes it exists to guard. This adds `src/gaia/apps/webui/**` alongside the existing glob (kept intact) in both the `push.paths` and `pull_request.paths` blocks, so Agent UI edits now run the suite.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/test_electron.yml', encoding='utf-8'))"` parses cleanly
- [ ] A PR touching `src/gaia/apps/webui/**` triggers the `Test Electron Framework and Apps` workflow

Closes #1934