### PR TITLE
feat(eval): extraction-quality eval for email action-item extraction (#1949)

### DIFF
--- a/src/gaia/eval/action_item_quality.py
+++ b/src/gaia/eval/action_item_quality.py
@@ -1,0 +1,924 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Extraction-quality eval for the email agent's action-item extraction
+(#1605 feature, #1949 tracking).
+
+Sibling of :mod:`gaia.eval.benchmark` (triage) and :mod:`gaia.eval.draft_quality`
+(drafting): the same committed-fixture / report-mode conventions, applied to the
+action-item path. The deterministic unit tests for #1605 prove the extractor
+*runs*; they say nothing about whether it pulls the *right* tasks. This module
+measures that — precision / recall / F1 of the extracted action set against a
+hand-labeled corpus, with the hard-negative false-positive case (an email with
+no real task) treated as first-class.
+
+Three separable stages, each testable on its own:
+
+1. **Generation** (:func:`generate_extractions` — needs Lemonade + the email
+   agent): per corpus case, drive the REAL triage path
+   (``triage_inbox`` over a ``FakeGmailBackend`` seeded with the case's email)
+   and harvest the ``action_items`` the agent produced.
+2. **Matching + scoring** (:func:`score_case`, :func:`match_action_items` —
+   fully offline): match each extracted action item against the expected set
+   with **fuzzy-primary** matching (normalized char-ratio + token overlap); an
+   optional injected LLM judge (:func:`make_claude_judge`) only resolves
+   borderline pairs in the gray band. No judge → pure-fuzzy, deterministic.
+3. **Aggregation** (:func:`summarize_extraction`): micro-average tp/fp/fn into
+   corpus-wide precision / recall / F1, roll per-case rows into a
+   ``build_scorecard``-compatible summary, and score the committed gate manifest
+   (``action_items_gate_thresholds.json``, ``enforce:false``).
+
+Fail-loud contract: a malformed corpus, a judge reply that is not the documented
+yes/no verdict, or a missing thresholds manifest raise actionable errors —
+nothing silently scores as a pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import tempfile
+import time
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from gaia.eval.quality_metrics import Confusion
+
+# ---------------------------------------------------------------------------
+# Corpus loading (offline)
+# ---------------------------------------------------------------------------
+
+# Keys that are corpus metadata, not cases (same convention as ground_truth).
+_METADATA_PREFIX = "_"
+
+_REQUIRED_EMAIL_FIELDS = ("from", "subject", "body")
+_VALID_ITEM_TYPES = {"text", "link"}
+
+
+def _validate_expected_item(case_id: str, idx: int, item: Any) -> None:
+    if not isinstance(item, dict):
+        raise ValueError(
+            f"case '{case_id}': expected_action_items[{idx}] must be an object, "
+            f"got {type(item).__name__}."
+        )
+    desc = item.get("description")
+    if not isinstance(desc, str) or not desc.strip():
+        raise ValueError(
+            f"case '{case_id}': expected_action_items[{idx}].description must be "
+            "a non-empty string."
+        )
+    item_type = item.get("type", "text")
+    if item_type not in _VALID_ITEM_TYPES:
+        raise ValueError(
+            f"case '{case_id}': expected_action_items[{idx}].type must be one of "
+            f"{sorted(_VALID_ITEM_TYPES)}, got {item_type!r}."
+        )
+    url = item.get("url")
+    # Mirror the real ActionItem invariant: url required iff type == 'link'.
+    if item_type == "link":
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError(
+                f"case '{case_id}': expected_action_items[{idx}] has type 'link' "
+                "but no non-empty 'url'."
+            )
+    elif url is not None:
+        raise ValueError(
+            f"case '{case_id}': expected_action_items[{idx}] has type 'text' but "
+            "carries a 'url' (url must be null for text actions)."
+        )
+    due = item.get("due_hint")
+    if due is not None and not isinstance(due, str):
+        raise ValueError(
+            f"case '{case_id}': expected_action_items[{idx}].due_hint must be a "
+            "string or absent."
+        )
+
+
+def _validate_case(case_id: str, case: Any) -> None:
+    if not isinstance(case, dict):
+        raise ValueError(
+            f"action-item corpus case '{case_id}' must be a JSON object, got "
+            f"{type(case).__name__}."
+        )
+    scenario = case.get("scenario")
+    if not isinstance(scenario, str) or not scenario.strip():
+        raise ValueError(f"case '{case_id}': 'scenario' must be a non-empty string.")
+    email = case.get("email")
+    if not isinstance(email, dict):
+        raise ValueError(f"case '{case_id}': 'email' must be an object.")
+    for f in _REQUIRED_EMAIL_FIELDS:
+        if not isinstance(email.get(f), str) or not email[f].strip():
+            raise ValueError(f"case '{case_id}': email.{f} must be a non-empty string.")
+    expected = case.get("expected_action_items")
+    if not isinstance(expected, list):
+        raise ValueError(
+            f"case '{case_id}': 'expected_action_items' must be a list (empty for "
+            "a hard negative)."
+        )
+    for idx, item in enumerate(expected):
+        _validate_expected_item(case_id, idx, item)
+    # 'is_hard_negative' is optional metadata, but if present it must agree with
+    # the labeled set — a mislabeled hard negative silently corrupts the FP math.
+    hard = case.get("is_hard_negative")
+    if hard is not None:
+        if not isinstance(hard, bool):
+            raise ValueError(f"case '{case_id}': 'is_hard_negative' must be a boolean.")
+        if hard != (len(expected) == 0):
+            raise ValueError(
+                f"case '{case_id}': 'is_hard_negative' is {hard} but "
+                f"expected_action_items has {len(expected)} item(s) — the flag "
+                "and the labeled set disagree."
+            )
+
+
+def _reject_duplicate_keys(pairs: list) -> dict:
+    out: dict = {}
+    for key, value in pairs:
+        if key in out:
+            raise ValueError(f"duplicate case id {key!r} in the action-item corpus")
+        out[key] = value
+    return out
+
+
+def load_action_item_corpus(path: str | Path) -> dict[str, dict]:
+    """Load + validate the action-item corpus (loud on missing/malformed).
+
+    Returns the full mapping including the ``_meta`` block; use
+    :func:`corpus_cases` to get only the scored cases. Duplicate case ids,
+    missing required fields, or a hard-negative flag that disagrees with the
+    labeled set raise ``ValueError``.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        try:
+            data = json.load(fh, object_pairs_hook=_reject_duplicate_keys)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"action-item corpus at {path} is not valid JSON: {exc}"
+            ) from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"action-item corpus at {path} must be a JSON object keyed by case id, "
+            f"got {type(data).__name__}."
+        )
+    cases = {k: v for k, v in data.items() if not k.startswith(_METADATA_PREFIX)}
+    if not cases:
+        raise ValueError(f"action-item corpus at {path} contains no cases.")
+    for case_id, case in cases.items():
+        _validate_case(case_id, case)
+    return data
+
+
+def corpus_cases(corpus: Mapping[str, Any]) -> dict[str, dict]:
+    """Only the scored cases (drop ``_``-prefixed metadata blocks)."""
+    return {k: v for k, v in corpus.items() if not k.startswith(_METADATA_PREFIX)}
+
+
+def is_hard_negative(case: Mapping[str, Any]) -> bool:
+    """True when the case has no expected action items (extract-nothing case)."""
+    return not case.get("expected_action_items")
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy matching (offline, deterministic)
+# ---------------------------------------------------------------------------
+
+# Similarity at/above this counts as a fuzzy match without any judge.
+DEFAULT_MATCH_THRESHOLD = 0.5
+# Below this, two descriptions are treated as clearly unrelated — no judge is
+# consulted (an LLM call there would only add cost and noise).
+DEFAULT_JUDGE_FLOOR = 0.3
+
+# Short function words dropped before token-overlap so "reply to Dana" and
+# "send Dana a reply" score on content words, not glue.
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "to",
+        "of",
+        "for",
+        "and",
+        "or",
+        "in",
+        "on",
+        "at",
+        "by",
+        "with",
+        "is",
+        "are",
+        "be",
+        "your",
+        "you",
+        "please",
+        "so",
+        "that",
+        "this",
+        "it",
+        "as",
+        "if",
+        "we",
+        "i",
+        "me",
+        "my",
+        "our",
+    }
+)
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip punctuation to spaces, collapse whitespace."""
+    return " ".join(_WORD_RE.findall((text or "").lower()))
+
+
+def _content_tokens(text: str) -> set[str]:
+    return {t for t in _normalize(text).split() if t not in _STOPWORDS}
+
+
+def _token_overlap(a: str, b: str) -> float:
+    """Jaccard overlap of content-word sets (order-insensitive)."""
+    ta, tb = _content_tokens(a), _content_tokens(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+def description_similarity(a: str, b: str) -> float:
+    """Fuzzy similarity of two action-item descriptions in ``[0, 1]``.
+
+    The max of a normalized character-sequence ratio (:class:`SequenceMatcher`,
+    good at typos/rewordings) and content-token Jaccard overlap (good at
+    reordering and partial phrasing). Deterministic — no network, no model.
+    """
+    na, nb = _normalize(a), _normalize(b)
+    if not na or not nb:
+        return 0.0
+    ratio = SequenceMatcher(None, na, nb).ratio()
+    return round(max(ratio, _token_overlap(a, b)), 4)
+
+
+def _item_description(item: Any) -> str:
+    """Pull the description string out of a predicted/expected item.
+
+    Accepts the real ActionItem dict shape ``{description, ...}`` or a bare
+    string (a lenient generation path may hand back plain strings).
+    """
+    if isinstance(item, str):
+        return item
+    if isinstance(item, Mapping):
+        return str(item.get("description", ""))
+    raise ValueError(
+        f"action item must be a string or an object with 'description', got "
+        f"{type(item).__name__}"
+    )
+
+
+@dataclass
+class MatchResult:
+    """Outcome of matching one email's predicted vs expected action items."""
+
+    matched: list[dict[str, Any]] = field(default_factory=list)
+    false_positives: list[int] = field(default_factory=list)  # predicted indices
+    false_negatives: list[int] = field(default_factory=list)  # expected indices
+    judged_pairs: int = 0  # borderline pairs resolved by the injected judge
+
+    @property
+    def tp(self) -> int:
+        return len(self.matched)
+
+    @property
+    def fp(self) -> int:
+        return len(self.false_positives)
+
+    @property
+    def fn(self) -> int:
+        return len(self.false_negatives)
+
+
+def match_action_items(
+    predicted: Sequence[Any],
+    expected: Sequence[Any],
+    *,
+    threshold: float = DEFAULT_MATCH_THRESHOLD,
+    judge_floor: float = DEFAULT_JUDGE_FLOOR,
+    judge_fn: Callable[[str, str], bool] | None = None,
+) -> MatchResult:
+    """Greedy 1:1 match of predicted action items against expected ones.
+
+    Fuzzy-primary: every predicted×expected pair is scored with
+    :func:`description_similarity`; pairs are consumed highest-first, each side
+    used at most once, and a pair at/above ``threshold`` is a match (true
+    positive). Left-over predicted items are false positives; left-over expected
+    items are false negatives.
+
+    Minimal-judge: when a top pair falls in the gray band ``[judge_floor,
+    threshold)`` and ``judge_fn`` is supplied, the judge is asked whether the two
+    describe the same action (``judge_fn(predicted_desc, expected_desc) -> bool``);
+    only an affirmative promotes it to a match. With no ``judge_fn`` the band is
+    treated as no-match — pure-fuzzy and deterministic. Pairs below
+    ``judge_floor`` never reach the judge.
+    """
+    pred_desc = [_item_description(p) for p in predicted]
+    exp_desc = [_item_description(e) for e in expected]
+
+    # Score every candidate pair once, then consume greedily by similarity.
+    scored: list[tuple[float, int, int]] = []
+    for pi, pd in enumerate(pred_desc):
+        for ei, ed in enumerate(exp_desc):
+            scored.append((description_similarity(pd, ed), pi, ei))
+    # Sort by similarity desc; ties broken by indices for determinism.
+    scored.sort(key=lambda t: (-t[0], t[1], t[2]))
+
+    used_pred: set[int] = set()
+    used_exp: set[int] = set()
+    result = MatchResult()
+
+    for sim, pi, ei in scored:
+        if pi in used_pred or ei in used_exp:
+            continue
+        is_match = False
+        if sim >= threshold:
+            is_match = True
+        elif sim >= judge_floor and judge_fn is not None:
+            result.judged_pairs += 1
+            is_match = bool(judge_fn(pred_desc[pi], exp_desc[ei]))
+        if is_match:
+            used_pred.add(pi)
+            used_exp.add(ei)
+            result.matched.append(
+                {
+                    "predicted_index": pi,
+                    "expected_index": ei,
+                    "predicted": pred_desc[pi],
+                    "expected": exp_desc[ei],
+                    "similarity": round(sim, 4),
+                }
+            )
+
+    result.false_positives = [i for i in range(len(pred_desc)) if i not in used_pred]
+    result.false_negatives = [i for i in range(len(exp_desc)) if i not in used_exp]
+    return result
+
+
+def prf(tp: int, fp: int, fn: int) -> dict[str, float]:
+    """Precision / recall / F1 for a set of item counts.
+
+    Hard-negative convention: when there is nothing to find AND nothing was
+    predicted (``tp == fp == fn == 0``) the case is a *perfect* extract-nothing
+    result — precision/recall/F1 all ``1.0``. This is what makes a correctly
+    silent extraction on a no-action email count as a win rather than an
+    undefined ``0/0``. Any spurious extraction there (``fp > 0``) drops
+    precision as normal.
+    """
+    if tp == 0 and fp == 0 and fn == 0:
+        return {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-case scoring → build_scorecard-compatible rows (offline)
+# ---------------------------------------------------------------------------
+
+
+def score_case(
+    case_id: str,
+    case: Mapping[str, Any],
+    predicted: Sequence[Any] | None,
+    *,
+    model_id: str,
+    error: str = "",
+    duration_ms: int = 0,
+    threshold: float = DEFAULT_MATCH_THRESHOLD,
+    judge_floor: float = DEFAULT_JUDGE_FLOOR,
+    judge_fn: Callable[[str, str], bool] | None = None,
+) -> dict[str, Any]:
+    """Score one case into a ``build_scorecard``-compatible result row.
+
+    ``predicted`` is the extracted action-item list (dicts or strings); ``None``
+    means the agent produced nothing usable (``error`` says why) and the row is
+    ``ERRORED`` — never silently scored. Otherwise the row is ``PASS`` when the
+    extraction is perfect for the email (F1 == 1.0: every expected item matched,
+    no spurious ones — including "extracted nothing" on a hard negative) and
+    ``FAIL`` otherwise. ``overall_score`` maps case F1 onto the 0–10 scorecard
+    scale, and ``action_item_match`` carries the tp/fp/fn the aggregator sums.
+    """
+    out: dict[str, Any] = {
+        "id": case_id,
+        "category": model_id,
+        "scenario": case.get("scenario", ""),
+        "hard_negative": is_hard_negative(case),
+        "total_duration_ms": duration_ms,
+    }
+    if predicted is None:
+        out["status"] = "ERRORED"
+        out["error"] = error or "agent produced no action-item extraction"
+        return out
+
+    expected = case.get("expected_action_items", [])
+    match = match_action_items(
+        predicted,
+        expected,
+        threshold=threshold,
+        judge_floor=judge_floor,
+        judge_fn=judge_fn,
+    )
+    scores = prf(match.tp, match.fp, match.fn)
+    out["predicted_action_items"] = [_item_description(p) for p in predicted]
+    out["action_item_match"] = {
+        "tp": match.tp,
+        "fp": match.fp,
+        "fn": match.fn,
+        "precision": scores["precision"],
+        "recall": scores["recall"],
+        "f1": scores["f1"],
+        "matched": match.matched,
+        "false_positive_predictions": [
+            _item_description(predicted[i]) for i in match.false_positives
+        ],
+        "false_negative_expected": [
+            _item_description(expected[i]) for i in match.false_negatives
+        ],
+        "judged_pairs": match.judged_pairs,
+    }
+    out["overall_score"] = round(scores["f1"] * 10.0, 2)
+    out["status"] = "PASS" if scores["f1"] == 1.0 else "FAIL"
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Aggregation (offline)
+# ---------------------------------------------------------------------------
+
+
+def summarize_extraction(
+    results: list[dict],
+    *,
+    run_id: str,
+    thresholds: "ExtractionThresholds | None" = None,
+) -> dict[str, Any]:
+    """Aggregate per-case rows into a scorecard + extraction-gate summary.
+
+    Micro-averages tp/fp/fn across every scored case into corpus-wide
+    precision / recall / F1 (reusing :class:`gaia.eval.quality_metrics.Confusion`
+    for the arithmetic), reports the hard-negative extract-nothing rate
+    separately (micro-F1 alone does not reward a correctly silent extraction),
+    and reuses :func:`gaia.eval.scorecard.build_scorecard` unchanged. When
+    ``thresholds`` is given the extraction gate runs — report mode unless the
+    manifest sets ``enforce``. When no case was scored the gate is a loud
+    explicit skip, never an invented pass.
+    """
+    from gaia.eval.scorecard import build_scorecard
+
+    scorecard = build_scorecard(
+        run_id, results, {"benchmark": "email_action_item_extraction"}
+    )
+    summary: dict[str, Any] = {"scorecard": scorecard}
+
+    scored = [r for r in results if isinstance(r.get("action_item_match"), dict)]
+    aggregate: dict[str, Any] | None = None
+    if scored:
+        conf = Confusion()
+        hard_total = 0
+        hard_correct = 0
+        for r in scored:
+            m = r["action_item_match"]
+            conf.tp += int(m["tp"])
+            conf.fp += int(m["fp"])
+            conf.fn += int(m["fn"])
+            if r.get("hard_negative"):
+                hard_total += 1
+                if int(m["fp"]) == 0:
+                    hard_correct += 1
+        aggregate = {
+            "cases_total": len(results),
+            "cases_scored": len(scored),
+            "cases_errored": sum(1 for r in results if r.get("status") == "ERRORED"),
+            "total_expected": conf.tp + conf.fn,
+            "total_predicted": conf.tp + conf.fp,
+            "tp": conf.tp,
+            "fp": conf.fp,
+            "fn": conf.fn,
+            "precision": conf.precision,
+            "recall": conf.recall,
+            "f1": conf.f1,
+            "hard_negatives_total": hard_total,
+            "hard_negatives_correct": hard_correct,
+            "hard_negative_correct_rate": (
+                round(hard_correct / hard_total, 4) if hard_total else 0.0
+            ),
+            "per_case": [
+                {
+                    "id": r.get("id"),
+                    "status": r.get("status"),
+                    "hard_negative": r.get("hard_negative", False),
+                    "precision": r["action_item_match"]["precision"],
+                    "recall": r["action_item_match"]["recall"],
+                    "f1": r["action_item_match"]["f1"],
+                }
+                for r in scored
+            ],
+        }
+        summary["extraction"] = aggregate
+
+    if thresholds is not None:
+        if aggregate is None:
+            summary["extraction_gate"] = {
+                "skipped": True,
+                "reason": (
+                    "no case carried an action-item match; the extraction gate "
+                    "cannot be evaluated"
+                ),
+                "enforce": thresholds.enforce,
+                "should_fail": False,
+            }
+        else:
+            summary["extraction_gate"] = evaluate_extraction_gate(aggregate, thresholds)
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Committed-threshold gate (#1949 — report mode; flip enforce in the manifest)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtractionThresholds:
+    """Precision/recall/F1 bars for the extraction gate (#1949 target).
+
+    ``enforce`` is the single safety switch, same contract as the FP/FN, perf,
+    and drafting gates: ``False`` (the committed value) means the gate computes
+    and reports but never fails the harness. Flip it in the manifest — data, not
+    code — once a real judged baseline confirms the bars. ``recall_min`` /
+    ``precision_min`` default to ``0.0`` (unset ⇒ not gated) so a manifest may
+    gate on F1 alone or add the axis floors independently.
+    """
+
+    f1_min: float
+    recall_min: float = 0.0
+    precision_min: float = 0.0
+    enforce: bool = False
+
+
+def load_extraction_thresholds(path: str | Path) -> ExtractionThresholds:
+    """Load the extraction-gate thresholds manifest (loud on missing/malformed)."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"extraction-gate thresholds manifest at {path} must be a JSON "
+            f"object, got {type(data).__name__}."
+        )
+    if "f1_min" not in data:
+        raise ValueError(
+            f"extraction-gate thresholds manifest at {path} is missing required "
+            "key 'f1_min'. Optional: 'recall_min', 'precision_min', 'enforce' "
+            "(default false)."
+        )
+    for key in ("f1_min", "recall_min", "precision_min"):
+        if key in data and (
+            isinstance(data[key], bool) or not isinstance(data[key], (int, float))
+        ):
+            raise ValueError(
+                f"extraction-gate threshold '{key}' in {path} must be numeric, "
+                f"got {data[key]!r}."
+            )
+    return ExtractionThresholds(
+        f1_min=float(data["f1_min"]),
+        recall_min=float(data.get("recall_min", 0.0)),
+        precision_min=float(data.get("precision_min", 0.0)),
+        enforce=bool(data.get("enforce", False)),
+    )
+
+
+# Canonical location of the committed extraction-gate thresholds manifest. The
+# single entry point CI consumes — flip 'enforce' in this file (data, not code)
+# to make CI gate on the #1949 precision/recall/F1 bars.
+_EXTRACTION_THRESHOLDS_MANIFEST = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "email"
+    / "action_items_gate_thresholds.json"
+)
+
+
+def default_extraction_thresholds_path() -> Path:
+    """Path to the committed extraction-gate thresholds manifest (#1949)."""
+    return _EXTRACTION_THRESHOLDS_MANIFEST
+
+
+def load_default_extraction_thresholds() -> ExtractionThresholds:
+    """Load the committed extraction-gate thresholds (loud if absent/malformed)."""
+    return load_extraction_thresholds(default_extraction_thresholds_path())
+
+
+def evaluate_extraction_gate(
+    aggregate: Mapping[str, Any], thresholds: ExtractionThresholds
+) -> dict[str, Any]:
+    """Compare the aggregate precision/recall/F1 to the committed bars.
+
+    Same result shape + ``should_fail`` contract as
+    :func:`gaia.eval.quality_metrics.evaluate_gate`: in report mode
+    (``enforce=False``) ``should_fail`` is always ``False`` even on a breach.
+    Only bars greater than ``0`` are checked (an unset ``recall_min`` /
+    ``precision_min`` is not gated). Fail-loud on a missing ``f1`` — a gate that
+    can't find its input must not silently pass.
+    """
+    if "f1" not in aggregate:
+        raise ValueError(
+            "extraction gate needs 'f1' in the aggregate block "
+            f"(have: {sorted(aggregate.keys())})."
+        )
+    checks = [
+        ("f1", float(aggregate["f1"]), thresholds.f1_min),
+        ("recall", float(aggregate.get("recall", 0.0)), thresholds.recall_min),
+        ("precision", float(aggregate.get("precision", 0.0)), thresholds.precision_min),
+    ]
+    breaches: list[dict[str, Any]] = []
+    for metric, value, minimum in checks:
+        if minimum > 0.0 and value < minimum:
+            breaches.append({"metric": metric, "value": value, "min": minimum})
+    passed = not breaches
+    return {
+        "f1": float(aggregate["f1"]),
+        "recall": float(aggregate.get("recall", 0.0)),
+        "precision": float(aggregate.get("precision", 0.0)),
+        "f1_min": thresholds.f1_min,
+        "recall_min": thresholds.recall_min,
+        "precision_min": thresholds.precision_min,
+        "passed": passed,
+        "breaches": breaches,
+        "enforce": thresholds.enforce,
+        "should_fail": thresholds.enforce and not passed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Optional LLM judge for borderline equivalence (minimal, injected)
+# ---------------------------------------------------------------------------
+
+
+def build_equivalence_prompt(predicted_desc: str, expected_desc: str) -> str:
+    """Render the yes/no judge prompt for one borderline (predicted, expected)
+    pair. Used ONLY when fuzzy similarity is in the gray band."""
+    return f"""You are checking whether two short descriptions refer to the SAME action a person should take from an email. Minor wording, tense, or detail differences are fine — judge the underlying task, not the phrasing.
+
+Action A (extracted by an assistant): {predicted_desc}
+Action B (the expected action): {expected_desc}
+
+Do A and B describe the same underlying action? Answer with STRICT JSON only, exactly this shape, no prose:
+{{"same_action": true}} or {{"same_action": false}}"""
+
+
+def parse_equivalence_verdict(text: str) -> bool:
+    """Parse the judge's yes/no equivalence verdict (loud on garbage)."""
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("equivalence judge reply is empty — cannot resolve the pair")
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        raise ValueError(
+            f"equivalence judge reply contains no JSON object; snippet: {text[:200]!r}"
+        )
+    try:
+        verdict = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"equivalence judge reply is not valid JSON: {exc}; snippet: {text[:200]!r}"
+        ) from exc
+    if not isinstance(verdict, dict) or not isinstance(
+        verdict.get("same_action"), bool
+    ):
+        raise ValueError(
+            'equivalence judge verdict must be {"same_action": true/false}, got '
+            f"{verdict!r}"
+        )
+    return verdict["same_action"]
+
+
+def make_claude_judge(model: str | None = None) -> Callable[[str, str], bool]:
+    """An equivalence-judge callable backed by :class:`gaia.eval.claude.ClaudeClient`.
+
+    Lazy import so the module stays importable (and unit-testable) without the
+    ``[eval]`` extras; ``ClaudeClient`` itself fails loud when the judge
+    credential is absent. The returned callable is what :func:`match_action_items`
+    consumes as ``judge_fn`` — it renders the equivalence prompt, calls the
+    judge, and parses the strict yes/no verdict.
+    """
+    from gaia.eval.claude import ClaudeClient
+
+    client = ClaudeClient(model=model)
+
+    def judge(predicted_desc: str, expected_desc: str) -> bool:
+        prompt = build_equivalence_prompt(predicted_desc, expected_desc)
+        content = client.get_completion(prompt)
+        parts = [
+            getattr(block, "text", "") for block in content if hasattr(block, "text")
+        ]
+        return parse_equivalence_verdict("".join(parts))
+
+    return judge
+
+
+# ---------------------------------------------------------------------------
+# Generation stage (live — needs Lemonade + the email agent)
+# ---------------------------------------------------------------------------
+
+
+def _incoming_payload(case_id: str, email: Mapping[str, str]) -> dict[str, Any]:
+    """A Gmail-API-shape message dict for ``FakeGmailBackend.add_message``.
+
+    Mirrors the single-part text/plain shape used by the drafting eval and the
+    fake backend, so the agent's read tools and ``decode_message_body`` handle
+    it identically.
+    """
+    body = email["body"]
+    data = base64.urlsafe_b64encode(body.encode("utf-8")).decode("ascii").rstrip("=")
+    return {
+        "id": case_id,
+        "threadId": case_id,
+        "labelIds": ["INBOX", "UNREAD"],
+        "snippet": " ".join(body.split())[:200],
+        "internalDate": "1751500000000",
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": email["from"]},
+                {"name": "To", "value": "user@example.com"},
+                {"name": "Subject", "value": email["subject"]},
+                {"name": "Message-ID", "value": f"<{case_id}@action-items.eval>"},
+            ],
+            "body": {"size": len(body.encode("utf-8")), "data": data},
+        },
+        "sizeEstimate": len(body.encode("utf-8")),
+    }
+
+
+def _extract_action_items(agent_result: Any, case_id: str) -> list[dict] | None:
+    """Harvest the action items for ``case_id`` from a triage envelope.
+
+    Reuses the triage-benchmark envelope parser: ``triage_inbox`` returns
+    ``{ok, data:{results:[{id, category, action_items, ...}]}}`` in a tool
+    message. Returns the matching result's ``action_items`` (possibly empty),
+    or ``None`` when no triage result for the case was found (an errored run).
+    """
+    from gaia.eval.benchmark import _extract_triage_results, _normalize_agent_result
+
+    result_dict = _normalize_agent_result(agent_result)
+    triage_results, _err = _extract_triage_results(result_dict.get("conversation", []))
+    for r in triage_results:
+        if r.get("id") == case_id or r.get("message_id") == case_id:
+            return list(r.get("action_items", []))
+    return None
+
+
+def generate_extractions(
+    model_id: str,
+    *,
+    corpus_path: str | Path,
+    base_url: str | None = None,
+    db_dir: str | Path | None = None,
+    limit: int | None = None,
+    agent_factory: Callable[[Any, str], Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Drive the REAL triage path per corpus case and harvest action items.
+
+    Per case: seed a fresh ``FakeGmailBackend`` with the case's email, build the
+    agent with a case-scoped SQLite ``db_path``, ask it to ``triage_inbox``, and
+    pull the extracted ``action_items`` from the triage envelope. Read-only over
+    an unchanged agent — nothing is drafted or sent.
+
+    ``agent_factory(backend, db_path)`` overrides agent construction (tests
+    inject a stub; keeps the unit path Lemonade-free). Returns
+    ``[{case_id, predicted|None, error, duration_ms}]`` for :func:`score_case`.
+    """
+    corpus = load_action_item_corpus(corpus_path)
+    cases = corpus_cases(corpus)
+    case_items = list(cases.items())
+    if limit is not None:
+        case_items = case_items[:limit]
+
+    if agent_factory is None:
+        # Lazy imports: keep `import gaia.eval.action_item_quality` free of the
+        # agent stack. EmailTriageAgent ships as the standalone
+        # gaia-agent-email wheel (#1102); the fake backend needs a checkout.
+        try:
+            from gaia_agent_email.agent import EmailTriageAgent
+            from gaia_agent_email.config import EmailAgentConfig
+        except ImportError as exc:
+            raise RuntimeError(
+                "The action-item extraction eval needs the email agent. Install "
+                "it with `pip install gaia-agent-email` (or `pip install "
+                '"amd-gaia[agents]"`). '
+                f"Original import error: {exc}"
+            ) from exc
+
+        def agent_factory(backend: Any, db_path: str) -> Any:
+            config = EmailAgentConfig(
+                model_id=model_id,
+                base_url=base_url,
+                gmail_backend=backend,
+                db_path=db_path,
+                show_stats=True,
+                silent_mode=True,
+            )
+            return EmailTriageAgent(config=config)
+
+    try:
+        from tests.fixtures.email.fake_gmail import FakeGmailBackend
+    except ImportError as exc:
+        raise RuntimeError(
+            "The action-item extraction eval must run from a GAIA repo checkout "
+            "— it drives the FakeGmailBackend in tests/fixtures/email and is not "
+            f"available in a packaged install. Original import error: {exc}"
+        ) from exc
+
+    if db_dir is None:
+        db_dir = tempfile.mkdtemp(prefix="gaia-action-item-eval-")
+    db_dir = Path(db_dir)
+    db_dir.mkdir(parents=True, exist_ok=True)
+
+    generations: list[dict[str, Any]] = []
+    for case_id, case in case_items:
+        backend = FakeGmailBackend()
+        backend.add_message(_incoming_payload(case_id, case["email"]))
+        agent = agent_factory(backend, str(db_dir / f"{case_id}.db"))
+
+        prompt = (
+            "Call triage_inbox for the one message in my inbox and extract its "
+            "action items."
+        )
+        start = time.monotonic()
+        error = ""
+        predicted: list[dict] | None = None
+        try:
+            agent_result = agent.process_query(prompt)
+            predicted = _extract_action_items(agent_result, case_id)
+        except Exception as exc:  # surfaced per-case, never swallowed silently
+            error = f"{type(exc).__name__}: {exc}"
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        if predicted is None and not error:
+            error = "triage produced no result for the case email"
+        generations.append(
+            {
+                "case_id": case_id,
+                "predicted": predicted,
+                "error": error,
+                "duration_ms": duration_ms,
+            }
+        )
+    return generations
+
+
+def score_generations(
+    corpus: Mapping[str, Any],
+    generations: list[dict],
+    *,
+    model_id: str,
+    threshold: float = DEFAULT_MATCH_THRESHOLD,
+    judge_floor: float = DEFAULT_JUDGE_FLOOR,
+    judge_fn: Callable[[str, str], bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Score :func:`generate_extractions` output into scorecard-compatible rows.
+
+    ``generations`` is ``[{case_id, predicted|None, error, duration_ms}]`` (real
+    or stubbed). A generation that carried no extraction stays ``ERRORED`` with
+    its error; everything else is matched + scored via :func:`score_case`.
+    """
+    cases = corpus_cases(corpus)
+    results: list[dict[str, Any]] = []
+    for gen in generations:
+        case_id = gen["case_id"]
+        if case_id not in cases:
+            raise ValueError(
+                f"generation references unknown case id {case_id!r} — corpus and "
+                "generations are out of sync"
+            )
+        results.append(
+            score_case(
+                case_id,
+                cases[case_id],
+                gen.get("predicted"),
+                model_id=model_id,
+                error=gen.get("error", ""),
+                duration_ms=int(gen.get("duration_ms", 0)),
+                threshold=threshold,
+                judge_floor=judge_floor,
+                judge_fn=judge_fn,
+            )
+        )
+    return results

--- a/tests/fixtures/email/action_items_gate_thresholds.json
+++ b/tests/fixtures/email/action_items_gate_thresholds.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Extraction-quality bars for the email action-item extraction eval (#1605 feature, #1949 tracking). 'f1_min' is the primary reported target (micro-averaged F1 over the labeled corpus); 'recall_min' guards against dropping real tasks; 'precision_min' guards against spurious extractions (the hard-negative false-positive case). 'enforce' is the SINGLE switch CI keys off and it ships FALSE (report mode) on purpose: NO real judged baseline exists yet (live-baseline generation is a documented #1949 follow-up on the self-hosted Lemonade runner), so these bars are PROVISIONAL placeholders, NOT measured numbers — do not treat them as a confirmed floor. Flip 'enforce' to true HERE (data, not code) once the first nightly report on Strix Halo / Gemma-4-E4B establishes a stable baseline, RE-MEASURING f1_min/recall_min/precision_min to the observed numbers at that point. Loaded by gaia.eval.action_item_quality.load_extraction_thresholds (which ignores extra keys).",
+  "f1_min": 0.70,
+  "recall_min": 0.75,
+  "precision_min": 0.70,
+  "enforce": false
+}

--- a/tests/fixtures/email/action_items_ground_truth.json
+++ b/tests/fixtures/email/action_items_ground_truth.json
@@ -1,0 +1,310 @@
+{
+  "_meta": {
+    "fixture": "action_items_ground_truth.json",
+    "fixture_kind": "hand-authored-seed",
+    "schema_version": 1,
+    "description": "Labeled seed corpus for the email action-item extraction quality eval (#1605 feature, #1949 tracking). Each case is one email whose body is hand-labeled with the action items the recipient (the principal) should actually take. Scored by gaia.eval.action_item_quality: the agent extracts action items locally (Lemonade), and the extracted set is matched against 'expected_action_items' with fuzzy-primary matching (an optional LLM judge only resolves borderline pairs). The aggregate precision / recall / F1 are compared to action_items_gate_thresholds.json in report mode. HARD NEGATIVES (expected_action_items == []) are deliberate: an email with no real task must extract nothing, and any extraction there is a false positive in the precision denominator -- the case unit tests miss most often. Expected items use the REAL ActionItem shape from gaia_agent_email.contract.ActionItem (description / due_hint / type / url); ground truth carries only what a human can confidently label from the body.",
+    "case_schema": {
+      "scenario": "str -- short label for what this email is",
+      "is_hard_negative": "bool -- true when the email has no real action items (expected_action_items is empty)",
+      "email": "{from: str, subject: str, body: str} -- the email being triaged",
+      "expected_action_items": "list[{description: str, due_hint?: str, type: 'text'|'link', url?: str}] -- the actions a careful human labels; matched on 'description' (fuzzy). Empty for hard negatives."
+    }
+  },
+  "ai-001": {
+    "scenario": "single reply-with-decision request",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Dana Kim <dana@acme.io>",
+      "subject": "Design review time change",
+      "body": "Hey Sam,\n\nCan we move Thursday's design review from 1pm to 3pm? Rachel has a conflict at the earlier time. Just let me know if that works for you.\n\nDana"
+    },
+    "expected_action_items": [
+      {
+        "description": "Reply to Dana confirming whether the 3pm Thursday design review time works",
+        "due_hint": "Thursday",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-002": {
+    "scenario": "two distinct actions in one email",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Marcus Lee <marcus@acme.io>",
+      "subject": "Onboarding flow + pricing typo",
+      "body": "Sam,\n\nTwo things before Friday: (1) please review the new onboarding flow I shared Monday and send feedback, and (2) the pricing page still says $19 instead of $29 -- can you fix that or ping whoever owns it?\n\nThanks,\nMarcus"
+    },
+    "expected_action_items": [
+      {
+        "description": "Review the new onboarding flow and send Marcus feedback",
+        "due_hint": "before Friday",
+        "type": "text"
+      },
+      {
+        "description": "Fix the pricing page typo ($19 should be $29) or escalate to the page owner",
+        "due_hint": "before Friday",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-003": {
+    "scenario": "link action -- form to fill out",
+    "is_hard_negative": false,
+    "email": {
+      "from": "People Ops <peopleops@acme.io>",
+      "subject": "Benefits enrollment closes June 30",
+      "body": "Hi all,\n\nOpen enrollment ends June 30. You must confirm or change your benefits selections in Workday before then, or your current elections roll over automatically. Complete the enrollment form here: https://workday.acme.io/enroll\n\nPeople Ops"
+    },
+    "expected_action_items": [
+      {
+        "description": "Confirm or change benefits selections in the Workday enrollment form",
+        "due_hint": "June 30",
+        "type": "link",
+        "url": "https://workday.acme.io/enroll"
+      }
+    ]
+  },
+  "ai-004": {
+    "scenario": "invoice with payment deadline",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Billing <billing@cloudhost.com>",
+      "subject": "Invoice #4471 due",
+      "body": "Dear customer,\n\nInvoice #4471 for $1,240.00 is due on July 15. Please remit payment by the due date to avoid a late fee. You can pay online at https://cloudhost.com/pay/4471.\n\nCloudHost Billing"
+    },
+    "expected_action_items": [
+      {
+        "description": "Pay invoice #4471 for $1,240.00",
+        "due_hint": "July 15",
+        "type": "link",
+        "url": "https://cloudhost.com/pay/4471"
+      }
+    ]
+  },
+  "ai-005": {
+    "scenario": "meeting with prep task",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Priya Rao <priya@acme.io>",
+      "subject": "Quarterly planning Wed 10am",
+      "body": "Hi team,\n\nReminder that quarterly planning is Wednesday at 10am. Before the meeting, please add your top three priorities to the shared planning doc so we can group them. Thanks!\n\nPriya"
+    },
+    "expected_action_items": [
+      {
+        "description": "Add your top three priorities to the shared planning doc before the meeting",
+        "due_hint": "before Wednesday 10am",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-006": {
+    "scenario": "approval request",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Tom Becker <tom@acme.io>",
+      "subject": "PTO approval needed",
+      "body": "Hi,\n\nI've requested PTO for August 4-8 in the HR system. Could you approve it when you get a chance? I'd like to book flights this week.\n\nTom"
+    },
+    "expected_action_items": [
+      {
+        "description": "Approve Tom's PTO request for August 4-8 in the HR system",
+        "due_hint": "this week",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-007": {
+    "scenario": "document review with signature",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Robert Alvarez <ralvarez@dunmorelaw.com>",
+      "subject": "Licensing agreement -- signature",
+      "body": "Dear Ms. Chen,\n\nThe licensing agreement is finalized. Please review the attached document and return a signed copy by Thursday, 12 June, so we can proceed to filing.\n\nRegards,\nRobert Alvarez"
+    },
+    "expected_action_items": [
+      {
+        "description": "Review the finalized licensing agreement and return a signed copy",
+        "due_hint": "Thursday, 12 June",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-008": {
+    "scenario": "three actions -- schedule, send, forward",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Elena Vasquez <elena@acme.io>",
+      "subject": "Customer escalation follow-ups",
+      "body": "Sam,\n\nAfter today's call with Northwind: please schedule a follow-up demo for next week, send them the updated SLA one-pager, and forward the ticket thread to the support lead so they have context. Let me know once these are done.\n\nElena"
+    },
+    "expected_action_items": [
+      {
+        "description": "Schedule a follow-up demo with Northwind for next week",
+        "due_hint": "next week",
+        "type": "text"
+      },
+      {
+        "description": "Send Northwind the updated SLA one-pager",
+        "type": "text"
+      },
+      {
+        "description": "Forward the ticket thread to the support lead",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-009": {
+    "scenario": "RSVP request",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Events <events@acme.io>",
+      "subject": "Team offsite -- headcount",
+      "body": "Hi everyone,\n\nWe're finalizing catering for the offsite. Please RSVP yes/no by Friday so we can confirm numbers. Reply to this email with your answer.\n\nEvents Team"
+    },
+    "expected_action_items": [
+      {
+        "description": "RSVP yes or no to the team offsite",
+        "due_hint": "Friday",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-010": {
+    "scenario": "bug report needing action + info request",
+    "is_hard_negative": false,
+    "email": {
+      "from": "QA <qa@acme.io>",
+      "subject": "Login regression on staging",
+      "body": "Hi Sam,\n\nWe're seeing a login regression on staging since this morning's deploy. Can you investigate and let us know root cause? Also, could you share which commit went out in that deploy?\n\nQA"
+    },
+    "expected_action_items": [
+      {
+        "description": "Investigate the staging login regression and report the root cause",
+        "type": "text"
+      },
+      {
+        "description": "Share which commit shipped in this morning's deploy",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-011": {
+    "scenario": "single link action -- password reset",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Security <no-reply@acme.io>",
+      "subject": "Action required: reset your password",
+      "body": "Your password will expire in 3 days. To keep your account active, reset it now: https://sso.acme.io/reset. If you do not reset it, you will be locked out.\n\nAcme Security"
+    },
+    "expected_action_items": [
+      {
+        "description": "Reset your account password before it expires",
+        "due_hint": "within 3 days",
+        "type": "link",
+        "url": "https://sso.acme.io/reset"
+      }
+    ]
+  },
+  "ai-012": {
+    "scenario": "scheduling with a proposed slot to confirm",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Grace Osei <grace@partnerco.com>",
+      "subject": "Intro call",
+      "body": "Hi Sam,\n\nGreat to connect. I'm free Tuesday 2pm or Thursday 11am for the intro call -- can you confirm which works and I'll send an invite?\n\nGrace"
+    },
+    "expected_action_items": [
+      {
+        "description": "Confirm whether Tuesday 2pm or Thursday 11am works for the intro call with Grace",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-013": {
+    "scenario": "expense report submission",
+    "is_hard_negative": false,
+    "email": {
+      "from": "Finance <finance@acme.io>",
+      "subject": "Q2 expenses close soon",
+      "body": "Reminder: submit any outstanding Q2 expense reports by end of day June 28. Reports submitted after the cutoff will be processed in Q3.\n\nFinance"
+    },
+    "expected_action_items": [
+      {
+        "description": "Submit outstanding Q2 expense reports",
+        "due_hint": "end of day June 28",
+        "type": "text"
+      }
+    ]
+  },
+  "ai-neg-001": {
+    "scenario": "hard negative -- newsletter, purely informational",
+    "is_hard_negative": true,
+    "email": {
+      "from": "Acme Blog <newsletter@acme.io>",
+      "subject": "This week in Acme: 5 product updates",
+      "body": "Hi there,\n\nHere's what shipped this week: dark mode, faster search, a new dashboard, CSV export, and mobile push. Read the full changelog on our blog. Thanks for being a customer!\n\nThe Acme Team"
+    },
+    "expected_action_items": []
+  },
+  "ai-neg-002": {
+    "scenario": "hard negative -- FYI status update, no ask",
+    "is_hard_negative": true,
+    "email": {
+      "from": "Priya Rao <priya@acme.io>",
+      "subject": "Deploy went out cleanly",
+      "body": "Hi all,\n\nJust letting you know the 2.4 release deployed to production this afternoon with no issues. Metrics look normal. No action needed -- sharing for visibility.\n\nPriya"
+    },
+    "expected_action_items": []
+  },
+  "ai-neg-003": {
+    "scenario": "hard negative -- receipt / order confirmation",
+    "is_hard_negative": true,
+    "email": {
+      "from": "Orders <orders@shopmart.com>",
+      "subject": "Your order #88213 has shipped",
+      "body": "Thanks for your order! Your package shipped today and should arrive by Thursday. No action is needed on your part; we'll email you when it's delivered.\n\nShopMart"
+    },
+    "expected_action_items": []
+  },
+  "ai-neg-004": {
+    "scenario": "hard negative -- thank-you note",
+    "is_hard_negative": true,
+    "email": {
+      "from": "Grace Osei <grace@partnerco.com>",
+      "subject": "Thanks!",
+      "body": "Hi Sam,\n\nJust wanted to say thanks for the great demo yesterday -- the team was impressed. No need to reply, just wanted to pass along the kind words.\n\nGrace"
+    },
+    "expected_action_items": []
+  },
+  "ai-neg-005": {
+    "scenario": "hard negative -- promotional marketing blast",
+    "is_hard_negative": true,
+    "email": {
+      "from": "Deals <deals@gadgetzone.com>",
+      "subject": "48-hour flash sale inside",
+      "body": "Our biggest sale of the summer is here! Up to 60% off everything. Shop now before it's gone. Unsubscribe anytime at the link below.\n\nGadgetZone"
+    },
+    "expected_action_items": []
+  },
+  "ai-neg-006": {
+    "scenario": "hard negative -- calendar invite auto-notification",
+    "is_hard_negative": true,
+    "email": {
+      "from": "Calendar <calendar-notification@acme.io>",
+      "subject": "Accepted: Weekly sync",
+      "body": "Marcus Lee has accepted your invitation to Weekly sync on Monday 9:00am. This is an automated notification.\n\nAcme Calendar"
+    },
+    "expected_action_items": []
+  },
+  "ai-neg-007": {
+    "scenario": "hard negative -- personal social note",
+    "is_hard_negative": true,
+    "email": {
+      "from": "Mom <mom@family.net>",
+      "subject": "Photos from the weekend",
+      "body": "Hi honey,\n\nAttaching a few photos from Sunday's picnic -- everyone had such a nice time. Hope work isn't too crazy. Love you!\n\nMom"
+    },
+    "expected_action_items": []
+  }
+}

--- a/tests/unit/email/test_action_items_corpus_integrity.py
+++ b/tests/unit/email/test_action_items_corpus_integrity.py
@@ -1,0 +1,406 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the action-item extraction eval (#1605 / #1949).
+
+Mirrors ``test_corpus_integrity.py`` for the action-item seed corpus, plus
+offline coverage of the fuzzy matcher + scorer in
+``gaia.eval.action_item_quality``:
+
+- The committed corpus loads, is the declared size, carries hard negatives, and
+  every case is schema-well-formed (the loader is the validator — fail-loud).
+- Duplicate case ids, missing required fields, and a mislabeled hard negative
+  are rejected loudly.
+- The fuzzy matcher pairs reworded descriptions, counts false positives /
+  negatives, and only consults the injected judge in the gray band.
+- The scorer runs end-to-end on hand-fed predicted-vs-expected (no backend, no
+  network): perfect extraction PASSes, a spurious extraction on a hard negative
+  is a precision-denominator false positive, and errored generations stay
+  ERRORED.
+- The committed thresholds manifest ships the #1949 bars in report mode
+  (``enforce: false``) and the gate honors the ``should_fail`` contract.
+
+Everything here runs offline: no Lemonade, no Anthropic, no live mailbox.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaia.eval import action_item_quality as aiq
+from gaia.eval.scorecard import build_scorecard
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+CORPUS_PATH = (
+    _REPO_ROOT / "tests" / "fixtures" / "email" / "action_items_ground_truth.json"
+)
+THRESHOLDS_PATH = (
+    _REPO_ROOT / "tests" / "fixtures" / "email" / "action_items_gate_thresholds.json"
+)
+
+
+@pytest.fixture(scope="module")
+def corpus() -> dict:
+    return aiq.load_action_item_corpus(CORPUS_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Corpus integrity
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_loads_and_has_seed_size(corpus):
+    """Seed corpus is committed, loadable, and in the declared 15–25 range."""
+    cases = aiq.corpus_cases(corpus)
+    assert 15 <= len(cases) <= 25, f"seed corpus size out of range: {len(cases)}"
+
+
+def test_meta_block_present_and_well_formed(corpus):
+    meta = corpus["_meta"]
+    assert meta["fixture"] == "action_items_ground_truth.json"
+    assert meta["fixture_kind"] == "hand-authored-seed"
+    assert isinstance(meta["schema_version"], int)
+
+
+def test_corpus_has_both_positives_and_hard_negatives(corpus):
+    """A precision eval is only meaningful with real extract-nothing cases."""
+    cases = aiq.corpus_cases(corpus)
+    hard = [c for c in cases.values() if aiq.is_hard_negative(c)]
+    positive = [c for c in cases.values() if not aiq.is_hard_negative(c)]
+    assert len(hard) >= 3, "need several hard negatives for the FP denominator"
+    assert len(positive) >= 3, "need several positive cases"
+
+
+def test_every_case_is_schema_well_formed(corpus):
+    """The loader already validates; assert the shape it guarantees."""
+    for case_id, case in aiq.corpus_cases(corpus).items():
+        assert not case_id.startswith("_")
+        assert case["scenario"].strip()
+        for field in ("from", "subject", "body"):
+            assert case["email"][field].strip(), f"{case_id}: email.{field}"
+        assert isinstance(case["expected_action_items"], list), case_id
+        for item in case["expected_action_items"]:
+            assert item["description"].strip(), case_id
+            assert item.get("type", "text") in {"text", "link"}, case_id
+            if item.get("type") == "link":
+                assert item.get("url", "").strip(), case_id
+
+
+def test_duplicate_case_ids_rejected(tmp_path):
+    dup = tmp_path / "dup.json"
+    dup.write_text('{"ai-001": {}, "ai-001": {}}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate case id"):
+        aiq.load_action_item_corpus(dup)
+
+
+def test_missing_required_field_rejected(tmp_path, corpus):
+    cases = aiq.corpus_cases(corpus)
+    case_id, case = next(iter(cases.items()))
+    broken = {case_id: {k: v for k, v in case.items() if k != "email"}}
+    path = tmp_path / "broken.json"
+    path.write_text(json.dumps(broken), encoding="utf-8")
+    with pytest.raises(ValueError, match="email"):
+        aiq.load_action_item_corpus(path)
+
+
+def test_mislabeled_hard_negative_rejected(tmp_path):
+    """A hard-negative flag that disagrees with the labeled set is loud."""
+    bad = {
+        "ai-x": {
+            "scenario": "mislabeled",
+            "is_hard_negative": True,
+            "email": {"from": "a@b.c", "subject": "s", "body": "b"},
+            "expected_action_items": [{"description": "do a thing", "type": "text"}],
+        }
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError, match="is_hard_negative"):
+        aiq.load_action_item_corpus(path)
+
+
+def test_link_item_without_url_rejected(tmp_path):
+    bad = {
+        "ai-x": {
+            "scenario": "link missing url",
+            "email": {"from": "a@b.c", "subject": "s", "body": "b"},
+            "expected_action_items": [{"description": "click", "type": "link"}],
+        }
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError, match="url"):
+        aiq.load_action_item_corpus(path)
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy matching
+# ---------------------------------------------------------------------------
+
+
+def test_similarity_rewards_reworded_same_action():
+    """Reordering / rewording still scores as similar (token overlap)."""
+    a = "Reply to Dana confirming the 3pm Thursday design review"
+    b = "Confirm the design review time of 3pm Thursday with Dana"
+    assert aiq.description_similarity(a, b) >= aiq.DEFAULT_MATCH_THRESHOLD
+
+
+def test_similarity_low_for_unrelated_actions():
+    a = "Pay invoice #4471 for $1,240"
+    b = "Schedule a follow-up demo for next week"
+    assert aiq.description_similarity(a, b) < aiq.DEFAULT_JUDGE_FLOOR
+
+
+def test_match_counts_tp_fp_fn():
+    expected = [
+        {"description": "Review the onboarding flow and send feedback"},
+        {"description": "Fix the pricing page typo"},
+    ]
+    predicted = [
+        {"description": "Send feedback on the onboarding flow"},  # matches #0
+        {"description": "Book a flight to Denver"},  # spurious -> FP
+    ]
+    m = aiq.match_action_items(predicted, expected)
+    assert m.tp == 1
+    assert m.fp == 1  # the spurious prediction
+    assert m.fn == 1  # the pricing typo was missed
+    assert m.matched[0]["expected_index"] == 0
+
+
+def test_match_pairs_each_side_at_most_once():
+    """One predicted item cannot satisfy two expected items."""
+    expected = [
+        {"description": "Send the SLA one-pager"},
+        {"description": "Send the pricing one-pager"},
+    ]
+    predicted = [{"description": "Send the SLA one-pager"}]
+    m = aiq.match_action_items(predicted, expected)
+    assert m.tp == 1
+    assert m.fp == 0
+    assert m.fn == 1
+
+
+def test_judge_only_consulted_in_gray_band():
+    """A borderline pair is resolved by the injected judge; a clearly-unrelated
+    pair never reaches it (no wasted LLM call)."""
+    calls = {"n": 0}
+
+    def judge(pred: str, exp: str) -> bool:
+        calls["n"] += 1
+        return True
+
+    # Borderline: partial overlap that lands in the gray band.
+    expected = [{"description": "Reset your account password before it expires"}]
+    predicted = [{"description": "reset password"}]
+    sim = aiq.description_similarity(
+        predicted[0]["description"], expected[0]["description"]
+    )
+    assert aiq.DEFAULT_JUDGE_FLOOR <= sim < aiq.DEFAULT_MATCH_THRESHOLD, sim
+    m = aiq.match_action_items(predicted, expected, judge_fn=judge)
+    assert calls["n"] == 1
+    assert m.tp == 1  # judge promoted it
+
+    # No judge → the same gray-band pair is a miss, deterministically.
+    m2 = aiq.match_action_items(predicted, expected)
+    assert m2.tp == 0
+    assert m2.fn == 1
+
+
+def test_prf_hard_negative_perfect_when_silent():
+    assert aiq.prf(0, 0, 0) == {"precision": 1.0, "recall": 1.0, "f1": 1.0}
+
+
+def test_prf_hard_negative_false_positive_tanks_precision():
+    scores = aiq.prf(0, 2, 0)  # extracted 2 items on a no-action email
+    assert scores["precision"] == 0.0
+    assert scores["f1"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Scorer on hand-fed predictions (offline end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def _predicted_from_expected(case):
+    """A 'perfect' extraction: echo the expected descriptions back."""
+    return [{"description": i["description"]} for i in case["expected_action_items"]]
+
+
+def test_score_case_perfect_extraction_passes(corpus):
+    case = aiq.corpus_cases(corpus)["ai-002"]
+    row = aiq.score_case(
+        "ai-002", case, _predicted_from_expected(case), model_id="stub-model"
+    )
+    assert row["status"] == "PASS"
+    assert row["overall_score"] == 10.0
+    assert row["action_item_match"]["f1"] == 1.0
+    assert row["category"] == "stub-model"
+
+
+def test_score_case_hard_negative_silent_passes(corpus):
+    """Correctly extracting nothing on a hard negative is a perfect case."""
+    case = aiq.corpus_cases(corpus)["ai-neg-001"]
+    assert aiq.is_hard_negative(case)
+    row = aiq.score_case("ai-neg-001", case, [], model_id="stub-model")
+    assert row["status"] == "PASS"
+    assert row["action_item_match"]["f1"] == 1.0
+
+
+def test_score_case_hard_negative_spurious_extraction_fails(corpus):
+    case = aiq.corpus_cases(corpus)["ai-neg-001"]
+    row = aiq.score_case(
+        "ai-neg-001",
+        case,
+        [{"description": "Unsubscribe from the newsletter"}],
+        model_id="stub-model",
+    )
+    assert row["status"] == "FAIL"
+    assert row["action_item_match"]["fp"] == 1
+    assert row["action_item_match"]["precision"] == 0.0
+
+
+def test_score_case_none_prediction_is_errored(corpus):
+    case = aiq.corpus_cases(corpus)["ai-001"]
+    row = aiq.score_case("ai-001", case, None, model_id="stub-model", error="boom")
+    assert row["status"] == "ERRORED"
+    assert row["error"] == "boom"
+    assert "action_item_match" not in row
+
+
+def test_summarize_micro_averages_and_scorecard(corpus):
+    """Perfect extractions on a mix of positives + hard negatives → F1 1.0 and a
+    build_scorecard-compatible summary."""
+    cases = aiq.corpus_cases(corpus)
+    results = []
+    for case_id, case in cases.items():
+        results.append(
+            aiq.score_case(
+                case_id,
+                case,
+                _predicted_from_expected(case),
+                model_id="stub-model",
+            )
+        )
+    summary = aiq.summarize_extraction(
+        results,
+        run_id="unit",
+        thresholds=aiq.ExtractionThresholds(f1_min=0.70, recall_min=0.75),
+    )
+    agg = summary["extraction"]
+    assert agg["cases_scored"] == len(cases)
+    assert agg["precision"] == 1.0
+    assert agg["recall"] == 1.0
+    assert agg["f1"] == 1.0
+    assert agg["hard_negatives_total"] >= 3
+    assert agg["hard_negative_correct_rate"] == 1.0
+    # Gate passes in report mode (perfect run).
+    assert summary["extraction_gate"]["passed"] is True
+    assert summary["extraction_gate"]["should_fail"] is False
+    # Rows also aggregate through the shared scorecard builder unchanged.
+    scorecard = build_scorecard("unit", results, {})
+    assert scorecard["summary"]["total_scenarios"] == len(cases)
+    assert scorecard["summary"]["passed"] == len(cases)
+
+
+def test_summarize_counts_hard_negative_false_positive(corpus):
+    """A spurious extraction on one hard negative shows up as an FP and drops
+    the hard-negative correct rate below 1.0."""
+    cases = aiq.corpus_cases(corpus)
+    results = []
+    for case_id, case in cases.items():
+        if case_id == "ai-neg-002":
+            predicted = [{"description": "Do something that was never asked"}]
+        else:
+            predicted = _predicted_from_expected(case)
+        results.append(aiq.score_case(case_id, case, predicted, model_id="stub-model"))
+    agg = aiq.summarize_extraction(results, run_id="unit")["extraction"]
+    assert agg["fp"] >= 1
+    assert agg["precision"] < 1.0
+    assert agg["hard_negative_correct_rate"] < 1.0
+
+
+def test_summarize_gate_skipped_when_nothing_scored():
+    """All-errored run → gate is a loud explicit skip, never a pass."""
+    results = [
+        {"id": "ai-001", "category": "m", "status": "ERRORED", "error": "x"},
+    ]
+    summary = aiq.summarize_extraction(
+        results, run_id="unit", thresholds=aiq.ExtractionThresholds(f1_min=0.70)
+    )
+    assert "extraction" not in summary
+    assert summary["extraction_gate"]["skipped"] is True
+    assert summary["extraction_gate"]["should_fail"] is False
+
+
+# ---------------------------------------------------------------------------
+# Equivalence-judge verdict parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_equivalence_verdict_happy_path_tolerates_fences():
+    assert aiq.parse_equivalence_verdict('```json\n{"same_action": true}\n```') is True
+    assert aiq.parse_equivalence_verdict('{"same_action": false}') is False
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "no json", '{"same_action": "yes"}', '{"foo": true}', "{}"],
+)
+def test_parse_equivalence_verdict_rejects_garbage(bad):
+    with pytest.raises(ValueError):
+        aiq.parse_equivalence_verdict(bad)
+
+
+# ---------------------------------------------------------------------------
+# Committed thresholds manifest + gate contract
+# ---------------------------------------------------------------------------
+
+
+def test_committed_thresholds_manifest_is_report_mode():
+    thresholds = aiq.load_extraction_thresholds(THRESHOLDS_PATH)
+    assert thresholds.f1_min == 0.70
+    assert thresholds.recall_min == 0.75
+    assert thresholds.enforce is False  # report mode — see the manifest comment
+    assert aiq.default_extraction_thresholds_path() == THRESHOLDS_PATH
+
+
+def test_malformed_thresholds_manifest_rejected(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text('{"enforce": false}', encoding="utf-8")
+    with pytest.raises(ValueError, match="f1_min"):
+        aiq.load_extraction_thresholds(path)
+
+
+def test_gate_report_mode_never_fails_the_build():
+    gate = aiq.evaluate_extraction_gate(
+        {"f1": 0.10, "recall": 0.10, "precision": 0.10},
+        aiq.ExtractionThresholds(f1_min=0.70, recall_min=0.75, enforce=False),
+    )
+    assert gate["passed"] is False
+    assert gate["breaches"]
+    assert gate["should_fail"] is False
+
+
+def test_gate_enforced_breach_fails():
+    gate = aiq.evaluate_extraction_gate(
+        {"f1": 0.10, "recall": 0.10, "precision": 0.10},
+        aiq.ExtractionThresholds(f1_min=0.70, enforce=True),
+    )
+    assert gate["should_fail"] is True
+
+
+def test_gate_only_checks_set_bars():
+    """An unset recall_min/precision_min (0.0) is not gated."""
+    gate = aiq.evaluate_extraction_gate(
+        {"f1": 0.80, "recall": 0.10, "precision": 0.10},
+        aiq.ExtractionThresholds(f1_min=0.70, enforce=True),
+    )
+    assert gate["passed"] is True
+    assert gate["should_fail"] is False
+
+
+def test_gate_missing_f1_is_loud():
+    with pytest.raises(ValueError, match="f1"):
+        aiq.evaluate_extraction_gate({}, aiq.ExtractionThresholds(f1_min=0.70))


### PR DESCRIPTION
Action-item extraction (#1605) shipped with deterministic unit tests that prove the extractor *runs* — nothing measured whether it pulls the *right* tasks, so a semantic extraction regression (dropping a real task, or inventing one on a no-action email) sails through CI today. This adds the precision/recall/F1 extraction-quality eval that closes the gap, in **report mode** (`enforce:false`) matching the triage and drafting eval conventions — a regression is scored and logged, never a build failure, until a real baseline confirms the bars.

Modeled directly on the merged drafting eval (a sibling `gaia.eval` module + committed fixture + gate manifest), so it slots into the same scorecard spine without a parallel one. Scope is offline: corpus + scorer + manifest + unit tests. Live-baseline generation on the self-hosted Lemonade runner is left as a documented follow-up (below).

- **Seed corpus** (`tests/fixtures/email/action_items_ground_truth.json`) — 20 hand-labeled cases: 13 positives (single/multi-action, link actions with due hints) and 7 **hard negatives** (newsletter, FYI, receipt, thank-you, promo, calendar auto-notice, personal note) whose expected set is empty. Expected items use the real `ActionItem` shape from `gaia_agent_email.contract` (`description`/`due_hint`/`type`/`url`) — no invented fields.
- **Scorer** (`gaia.eval.action_item_quality`) — **fuzzy-primary** matching (normalized char-ratio + content-token overlap via stdlib `difflib`, no new deps); an optional injected LLM judge (`gaia.eval.claude`) resolves only borderline gray-band pairs, so the default path is deterministic. Micro-averaged precision/recall/F1 with the **hard-negative false-positive case first-class** (a spurious extraction on a no-action email lands in the precision denominator). Emits `build_scorecard`-compatible rows and a report-mode gate. A read-only generation stage drives the real `triage_inbox` path and harvests `action_items`.
- **Gate manifest** (`action_items_gate_thresholds.json`) — `enforce:false` with a documented rationale naming the issue that flips it in *data, not code*; F1/recall/precision bars are flagged as provisional placeholders to be re-measured from the first baseline.

## Test plan

- [x] `PYTHONPATH=... pytest tests/unit/email/test_action_items_corpus_integrity.py` — 34 passed (corpus integrity, fuzzy matcher, scorer, gate; fully offline)
- [x] `pytest tests/unit/eval` — 385 passed (27 pre-existing failures in `test_scorecard_gate.py` are a Windows `cp1252` encoding bug unrelated to this change)
- [x] `python util/lint.py --all --fix` — black/isort/flake8 clean on the new files
- [x] Generation-harvest + scoring verified end-to-end offline against a synthetic `triage_inbox` envelope
- [ ] **Follow-up:** first real judged baseline + CI report-mode step in `test_email_agent_eval.yml` on the self-hosted Lemonade runner, then re-measure the manifest bars

Refs #1605.

Closes #1949
