### PR TITLE
feat(email): host the full stateful agent + query interface on the sidecar

### DIFF
--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -199,6 +199,19 @@ are exposed alongside triage/draft/send:
 Each reaches whichever calendar (Google or Microsoft) the user connected; a missing
 `calendar.events` scope fails loud with **HTTP 403** and the reconnect CTA.
 
+## Driving the full agent over HTTP (sidecar)
+
+The stateless REST endpoints above (`/v1/email/triage`, `/draft`, `/send`, …) analyze a payload you pass in — they don't run the conversational agent and have no memory. For the full experience the Agent UI shows (natural-language requests, multi-step tool use, personalization, memory), the sidecar also hosts a **stateful, session-scoped agent** under `/v1/email/agent/*`:
+
+- `POST /v1/email/agent/session` — create (or `reset`) a session; builds the agent and reports memory status.
+- `POST /v1/email/agent/query` — run one turn; streams the agent loop back as Server-Sent Events (`thinking`, `step`, `tool` usage, `permission_request`, and a terminal `run_complete` with the answer). Because this runs the real agent loop, **every** agent tool is reachable through natural language — no per-tool endpoint.
+- `POST /v1/email/agent/confirm-tool` — approve or deny a gated tool (send/forward/delete/quarantine/calendar-create). The run blocks until you respond, mirroring the in-app confirmation prompt.
+- `POST /v1/email/agent/cancel` — cooperatively cancel an in-flight run.
+- `GET /v1/email/agent/session/{id}/history` — the conversation so far.
+- `POST /v1/email/agent/memory` + `GET /v1/email/agent/memory/{id}` — the runtime memory toggle over HTTP. Enabling memory that was never initialized this session (started with `GAIA_MEMORY_DISABLED` or Lemonade unreachable) returns **409** with an actionable message rather than silently doing nothing.
+
+Each session holds one agent; one turn runs at a time (an overlapping `/query` returns **409**). This is the surface the Agent UI uses to drive the packaged email agent over the network instead of importing it in-process.
+
 ## Sending email — safety
 
 **The agent never sends email on its own. A send always requires your explicit confirmation, and this holds no matter how you drive the agent.** Drafting a reply is harmless and unconfirmed; turning a draft into a sent message is the only step that asks for your approval, and it always asks.

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -5,6 +5,26 @@ follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
 `SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
 bump is always at least a package MINOR bump with a migration note.
 
+## 0.4.0
+
+Adds a **stateful agent surface** (`/v1/email/agent/*`) so a host can drive the
+full conversational `EmailTriageAgent` over HTTP — memory, personalization, and
+every agent tool — instead of importing it in-process. This is what lets the Agent
+UI back its email experience with the packaged sidecar. No triage-contract change:
+`SCHEMA_VERSION` stays **2.1**, so `checkVersion` (MAJOR-only) is unaffected.
+
+- **New endpoints** (additive): `POST /v1/email/agent/session`,
+  `DELETE /v1/email/agent/session/{id}`, `GET /v1/email/agent/session/{id}/history`,
+  `POST /v1/email/agent/query` (SSE stream of the agent loop),
+  `POST /v1/email/agent/confirm-tool` (approve/deny a gated tool),
+  `POST /v1/email/agent/cancel`, `POST /v1/email/agent/memory` +
+  `GET /v1/email/agent/memory/{id}` (runtime memory toggle, #1666).
+- **Runtime memory toggle reachable over HTTP** — enabling memory that was never
+  initialized (started with `GAIA_MEMORY_DISABLED` or Lemonade unreachable) returns
+  **409** with an actionable message rather than silently no-opping.
+- **Frozen binary** now bundles FAISS (the memory index) — embeddings still go over
+  Lemonade HTTP, so torch/transformers stay excluded.
+
 ## 0.3.0
 
 Contract bumped to `SCHEMA_VERSION` **2.1** — additive, no triage shape change, so

--- a/hub/agents/npm/agent-email/assets/architecture.html
+++ b/hub/agents/npm/agent-email/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.3.0</span>
+      <span class="ver" id="ver">v0.4.0</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.3.0",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.3.0",
+  "agentVersion": "0.4.0",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.4.0",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.3.0
+version: 0.4.0
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/agent_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/agent_routes.py
@@ -1,0 +1,496 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Stateful agent surface for the Email Triage Agent sidecar (#1666 follow-up).
+
+The triage/draft/send routes in ``api_routes.py`` are **stateless** — each call
+runs a throwaway ``EmailTriageService`` with no memory, no conversation, and no
+agent loop. That surface can't back the Agent UI's conversational email
+experience, which today runs the full ``EmailTriageAgent`` *in-process*
+(``gaia.ui._chat_helpers`` → ``email_factory`` → ``process_query``) with SSE
+streaming, tool-confirmation, and memory.
+
+This module moves that experience behind the sidecar's HTTP boundary so the UI
+can talk to the packaged agent over the network instead of importing it. It
+hosts a real, **session-scoped** ``EmailTriageAgent`` and exposes:
+
+    POST   /v1/email/agent/query            — run a turn; SSE stream of the loop
+    POST   /v1/email/agent/confirm-tool     — approve/deny a gated tool call
+    POST   /v1/email/agent/cancel           — cancel an in-flight run
+    POST   /v1/email/agent/session          — create/reset a session
+    DELETE /v1/email/agent/session/{id}     — evict a session
+    GET    /v1/email/agent/session/{id}/history — conversation history
+    POST   /v1/email/agent/memory           — toggle memory (set_memory_enabled)
+    GET    /v1/email/agent/memory/{id}       — memory status
+
+Because ``/query`` runs the real agent loop, **every** agent tool (read,
+organize, reply, summarize, delete, calendar, preferences, profiling, phishing,
+memory) is reachable through natural language — no per-tool REST plumbing.
+
+Design commitments
+------------------
+- **Reuse, don't reinvent.** Streaming + blocking tool-confirmation reuse
+  ``gaia.ui.sse_handler.SSEOutputHandler`` (the same handler the core chat router
+  drives); the integration contract — ``agent.console = handler`` then run
+  ``process_query`` on a worker thread — mirrors ``_chat_helpers._run_agent``.
+- **Fail loudly.** A build/connection failure surfaces as an actionable HTTP
+  error, never a silent empty stream.
+- **Injectable for tests.** ``build_session_agent`` is a module-level seam tests
+  swap for a fake agent, so the surface is exercised without Lemonade or Gmail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/v1/email/agent", tags=["email-agent"])
+
+
+# ---------------------------------------------------------------------------
+# Agent construction seam (swapped by tests)
+# ---------------------------------------------------------------------------
+
+
+def build_session_agent(**config_kwargs: Any):
+    """Construct a live ``EmailTriageAgent`` for a new session.
+
+    Imported lazily so this module (and the OpenAPI export) stays dependency-light
+    until an agent session is actually created. Tests monkeypatch this attribute
+    to inject a fake agent, exercising the routes without Lemonade or Gmail.
+    """
+    from gaia_agent_email.agent import EmailTriageAgent
+    from gaia_agent_email.config import EmailAgentConfig
+
+    return EmailTriageAgent(config=EmailAgentConfig(**config_kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Session registry
+# ---------------------------------------------------------------------------
+
+
+class _AgentSession:
+    """A live agent instance plus its per-session state.
+
+    One turn runs at a time per session: ``run_lock`` rejects overlapping
+    ``/query`` calls (mirrors the core chat router's per-session lock) so a
+    second turn can't corrupt the cached agent's conversation state.
+    """
+
+    def __init__(self, session_id: str, agent: Any) -> None:
+        self.session_id = session_id
+        self.agent = agent
+        self.run_lock = threading.Lock()
+        # (user_message, assistant_answer) pairs, oldest first.
+        self.history: List[Tuple[str, str]] = []
+        # The handler for the CURRENT run — set on /query, read by /confirm-tool
+        # and /cancel, cleared when the run ends.
+        self.handler: Any = None
+
+    def is_running(self) -> bool:
+        return self.run_lock.locked()
+
+
+class _SessionRegistry:
+    """Process-local map of session_id → :class:`_AgentSession`.
+
+    In-process and single-tenant by design (the sidecar hosts one user's agent).
+    Agents are built lazily on first use and torn down on eviction.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, _AgentSession] = {}
+        self._lock = threading.Lock()
+
+    def get(self, session_id: str) -> Optional[_AgentSession]:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    def get_or_create(self, session_id: str, **config_kwargs: Any) -> _AgentSession:
+        with self._lock:
+            existing = self._sessions.get(session_id)
+            if existing is not None:
+                return existing
+        # Build outside the lock — construction is slow (memory init, backends)
+        # and must not block other sessions. A racing creator for the SAME id is
+        # resolved below by discarding the loser's agent.
+        agent = build_session_agent(**config_kwargs)
+        with self._lock:
+            existing = self._sessions.get(session_id)
+            if existing is not None:
+                _close_agent(agent)
+                return existing
+            session = _AgentSession(session_id, agent)
+            self._sessions[session_id] = session
+            return session
+
+    def delete(self, session_id: str) -> bool:
+        with self._lock:
+            session = self._sessions.pop(session_id, None)
+        if session is None:
+            return False
+        _close_agent(session.agent)
+        return True
+
+    def reset(self, session_id: str, **config_kwargs: Any) -> _AgentSession:
+        """Drop any existing session and build a fresh one (clears history+memory session)."""
+        self.delete(session_id)
+        return self.get_or_create(session_id, **config_kwargs)
+
+
+def _close_agent(agent: Any) -> None:
+    """Best-effort teardown of an agent's DB handles on eviction."""
+    close = getattr(agent, "close_db", None)
+    if callable(close):
+        try:
+            close()
+        except Exception as exc:  # pragma: no cover - teardown must not raise
+            logger.warning("agent session close_db failed: %s", exc)
+
+
+registry = _SessionRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class _Strict(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class AgentQueryRequest(_Strict):
+    """Run one conversational turn against the session's agent."""
+
+    session_id: str = Field(..., description="Opaque session id; created on first use.")
+    message: str = Field(..., description="The user's natural-language request.")
+    memory_enabled: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Optional per-turn memory override (#1666). None leaves the session's "
+            "current setting unchanged; True/False flips it before the turn runs."
+        ),
+    )
+
+
+class SessionRequest(_Strict):
+    session_id: str = Field(..., description="Session id to create or reset.")
+    reset: bool = Field(
+        default=False,
+        description="When true, tears down any existing session and starts fresh.",
+    )
+
+
+class ToolConfirmRequest(_Strict):
+    session_id: str = Field(..., description="Session with a pending confirmation.")
+    approved: bool = Field(
+        ..., description="True to allow the gated tool, False to deny."
+    )
+
+
+class CancelRequest(_Strict):
+    session_id: str = Field(..., description="Session whose in-flight run to cancel.")
+
+
+class MemoryToggleRequest(_Strict):
+    session_id: str = Field(..., description="Session to toggle memory for.")
+    enabled: bool = Field(..., description="True to enable memory, False to disable.")
+
+
+class MemoryStatusResponse(_Strict):
+    enabled: bool
+    available: bool
+    message: str
+
+
+class SessionResponse(_Strict):
+    session_id: str
+    created: bool = Field(..., description="True when a new agent was built.")
+    memory: MemoryStatusResponse
+
+
+class HistoryTurn(_Strict):
+    user: str
+    assistant: str
+
+
+class HistoryResponse(_Strict):
+    session_id: str
+    turns: List[HistoryTurn]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+def _memory_status(agent: Any) -> MemoryStatusResponse:
+    """Read the agent's memory status, tolerating agents without the toggle."""
+    status_fn = getattr(agent, "memory_status", None)
+    if callable(status_fn):
+        s = status_fn()
+        return MemoryStatusResponse(
+            enabled=bool(s.get("enabled")),
+            available=bool(s.get("available")),
+            message=str(s.get("message", "")),
+        )
+    # Agent predates the memory toggle — report unavailable rather than guess.
+    return MemoryStatusResponse(
+        enabled=False,
+        available=False,
+        message="This agent build does not expose a memory toggle.",
+    )
+
+
+@router.post("/session", response_model=SessionResponse)
+async def create_session(request: SessionRequest) -> SessionResponse:
+    """Create (or reset) a session and eagerly build its agent.
+
+    Building the agent here (rather than lazily on first /query) lets the caller
+    surface a construction failure immediately, and warms memory/backends before
+    the first turn.
+    """
+    try:
+        if request.reset:
+            session = await asyncio.to_thread(registry.reset, request.session_id)
+            created = True
+        else:
+            existing = registry.get(request.session_id)
+            session = await asyncio.to_thread(
+                registry.get_or_create, request.session_id
+            )
+            created = existing is None
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to start email agent session: {exc}",
+        ) from exc
+    return SessionResponse(
+        session_id=session.session_id,
+        created=created,
+        memory=_memory_status(session.agent),
+    )
+
+
+@router.delete("/session/{session_id}")
+async def delete_session(session_id: str) -> Dict[str, Any]:
+    """Evict a session and tear down its agent."""
+    removed = await asyncio.to_thread(registry.delete, session_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="No such session.")
+    return {"status": "ok", "deleted": True, "session_id": session_id}
+
+
+@router.get("/session/{session_id}/history", response_model=HistoryResponse)
+async def session_history(session_id: str) -> HistoryResponse:
+    """Return the session's conversation history (oldest first)."""
+    session = registry.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="No such session.")
+    return HistoryResponse(
+        session_id=session_id,
+        turns=[HistoryTurn(user=u, assistant=a) for (u, a) in session.history],
+    )
+
+
+@router.post("/memory", response_model=MemoryStatusResponse)
+async def toggle_memory(request: MemoryToggleRequest) -> MemoryStatusResponse:
+    """Enable/disable the session agent's memory at runtime (#1666).
+
+    Exposes ``EmailTriageAgent.set_memory_enabled`` over HTTP. Enabling memory
+    that was never initialized this session (started with GAIA_MEMORY_DISABLED or
+    Lemonade unreachable) cannot succeed — that is reported with an actionable
+    message and HTTP 409, never silently ignored.
+    """
+    session = registry.get(request.session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="No such session.")
+    setter = getattr(session.agent, "set_memory_enabled", None)
+    if not callable(setter):
+        raise HTTPException(
+            status_code=501,
+            detail="This agent build does not expose a memory toggle.",
+        )
+    result = setter(request.enabled)
+    status = MemoryStatusResponse(
+        enabled=bool(result.get("enabled")),
+        available=bool(result.get("available")),
+        message=str(result.get("message", "")),
+    )
+    if not result.get("ok", False):
+        # Requested state could not be applied (e.g. enable while unavailable).
+        raise HTTPException(status_code=409, detail=status.message)
+    return status
+
+
+@router.get("/memory/{session_id}", response_model=MemoryStatusResponse)
+async def memory_status(session_id: str) -> MemoryStatusResponse:
+    """Report the session agent's current memory state without changing it."""
+    session = registry.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="No such session.")
+    return _memory_status(session.agent)
+
+
+@router.post("/confirm-tool")
+async def confirm_tool(request: ToolConfirmRequest) -> Dict[str, Any]:
+    """Approve or deny a tool call the agent is blocking on.
+
+    The agent thread blocks in ``SSEOutputHandler.confirm_tool_execution()`` after
+    emitting a ``permission_request`` event; this releases it. Mirrors the core
+    chat router's ``/api/chat/confirm-tool``.
+    """
+    session = registry.get(request.session_id)
+    if session is None or session.handler is None:
+        raise HTTPException(
+            status_code=404, detail="No active run awaiting confirmation."
+        )
+    session.handler.resolve_tool_confirmation(request.approved)
+    return {"status": "ok", "approved": request.approved}
+
+
+@router.post("/cancel")
+async def cancel_run(request: CancelRequest) -> Dict[str, Any]:
+    """Request cancellation of an in-flight run (cooperative, not a kill)."""
+    session = registry.get(request.session_id)
+    if session is None or session.handler is None:
+        raise HTTPException(status_code=404, detail="No active run for this session.")
+    session.handler.cancelled.set()
+    return {"status": "ok", "cancelled": True}
+
+
+def _extract_answer(result: Any) -> str:
+    """Pull the human-readable answer from a process_query result dict."""
+    if isinstance(result, dict):
+        return (
+            result.get("answer") or result.get("response") or result.get("result") or ""
+        )
+    return str(result or "")
+
+
+@router.post("/query")
+async def query(request: AgentQueryRequest) -> StreamingResponse:
+    """Run one conversational turn and stream the agent loop as SSE.
+
+    Builds the session's agent if needed, optionally applies the per-turn memory
+    override, then runs ``process_query`` on a worker thread with an
+    ``SSEOutputHandler`` as ``agent.console`` — the same integration the core UI
+    uses. Every event the loop emits (thoughts, steps, tool usage,
+    permission requests, final answer) is relayed to the client; a terminal
+    ``run_complete`` event closes the stream.
+    """
+    from gaia.ui.sse_handler import SSEOutputHandler
+
+    try:
+        session = await asyncio.to_thread(registry.get_or_create, request.session_id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502, detail=f"Failed to start email agent session: {exc}"
+        ) from exc
+
+    # One turn at a time per session. Reject (409) rather than queue so the
+    # caller controls retry — matches the core chat router.
+    if not session.run_lock.acquire(blocking=False):
+        raise HTTPException(
+            status_code=409,
+            detail="A turn is already in progress for this session.",
+        )
+
+    # Apply the optional per-turn memory override before the run. A failed
+    # enable (memory unavailable) is surfaced as a stream event, not a hard
+    # error — the turn can still run without memory.
+    memory_note: Optional[str] = None
+    if request.memory_enabled is not None:
+        setter = getattr(session.agent, "set_memory_enabled", None)
+        if callable(setter):
+            res = setter(request.memory_enabled)
+            if not res.get("ok", False):
+                memory_note = str(res.get("message", ""))
+
+    handler = SSEOutputHandler()
+    session.handler = handler
+    session.agent.console = handler
+
+    def _run_agent() -> None:
+        try:
+            if memory_note:
+                handler._emit(
+                    {"type": "status", "status": "warning", "message": memory_note}
+                )
+            result = session.agent.process_query(request.message)
+            answer = _extract_answer(result)
+            session.history.append((request.message, answer))
+            handler._emit({"type": "run_complete", "answer": answer})
+        except Exception as exc:  # surface loudly into the stream
+            logger.exception(
+                "email agent run failed for session %s", session.session_id
+            )
+            handler._emit({"type": "error", "message": str(exc)})
+            handler._emit({"type": "run_complete", "answer": ""})
+        finally:
+            session.handler = None
+            session.run_lock.release()
+
+    thread = threading.Thread(target=_run_agent, daemon=True)
+    thread.start()
+
+    async def _sse():
+        try:
+            while True:
+                # Drain everything currently queued without blocking the loop.
+                drained = False
+                while True:
+                    try:
+                        event = handler.event_queue.get_nowait()
+                    except Exception:
+                        break
+                    drained = True
+                    yield f"data: {json.dumps(event)}\n\n"
+                    if event.get("type") == "run_complete":
+                        return
+                if not thread.is_alive() and not drained:
+                    # Thread finished and queue is empty but no terminal event
+                    # was seen (defensive) — synthesize one so the client closes.
+                    yield f'data: {json.dumps({"type": "run_complete", "answer": ""})}\n\n'
+                    return
+                await asyncio.sleep(0.05)
+        finally:
+            # If the client disconnected mid-run, ask the agent to stop; the
+            # daemon thread still tears down the lock in its finally block.
+            if session.handler is handler:
+                handler.cancelled.set()
+
+    return StreamingResponse(
+        _sse(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+__all__ = [
+    "router",
+    "registry",
+    "build_session_agent",
+    "AgentQueryRequest",
+    "SessionRequest",
+    "ToolConfirmRequest",
+    "CancelRequest",
+    "MemoryToggleRequest",
+]

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.3.0"
+AGENT_VERSION = "0.4.0"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/packaging/freeze.py
+++ b/hub/agents/python/email/packaging/freeze.py
@@ -56,12 +56,17 @@ PATHEX = [REPO_ROOT / "hub" / "agents" / "python" / "email", REPO_ROOT / "src"]
 # Heavy ML stack reached only via the lazily-imported triage import graph. Real
 # triage uses Lemonade over HTTP (no in-process torch), so these are excluded to
 # keep the binary lean (torch alone is ~2 GB).
+#
+# NOTE (#1666 follow-up): the stateful agent surface (/v1/email/agent/*) hosts the
+# full EmailTriageAgent, whose memory subsystem uses FAISS for the working-context
+# index (embeddings still go over Lemonade HTTP, so torch/transformers stay
+# excluded). ``faiss``/``faiss_cpu`` are therefore NOT excluded and are collected
+# in full below. numpy is a memory.py module-level import the analyzer already
+# follows.
 EXCLUDES = [
     "torch",
     "transformers",
     "sentence_transformers",
-    "faiss",
-    "faiss_cpu",
     "sympy",
     "tokenizers",
     "scipy",
@@ -117,6 +122,11 @@ def build(onefile: bool = False, clean: bool = True) -> Path:
         # connector provider discovery is dynamic.
         "--collect-submodules",
         "gaia.connectors",
+        # FAISS backs the stateful agent's memory index (#1666). faiss-cpu ships
+        # compiled libs + swig submodules the static analyzer misses, so collect
+        # it wholesale. Lazily imported inside gaia.agents.base.memory.
+        "--collect-all",
+        "faiss",
         # core metadata (importlib.metadata version probes).
         "--copy-metadata",
         "amd-gaia",

--- a/hub/agents/python/email/packaging/server.py
+++ b/hub/agents/python/email/packaging/server.py
@@ -54,6 +54,7 @@ def build_app():
     """
     from fastapi import FastAPI
     from gaia_agent_email import __version__ as agent_version
+    from gaia_agent_email.agent_routes import router as agent_router
     from gaia_agent_email.api_routes import router as email_router
     from gaia_agent_email.connector_routes import router as connector_router
     from gaia_agent_email.contract import SCHEMA_VERSION
@@ -76,6 +77,12 @@ def build_app():
 
     app.include_router(email_router)
     app.include_router(connector_router)
+    # Stateful agent surface (/v1/email/agent/*): hosts a session-scoped
+    # EmailTriageAgent with memory + tool-confirmation so the Agent UI can drive
+    # the full conversational agent over HTTP instead of importing it in-process.
+    # Router import is light; the heavy agent/memory imports are deferred to the
+    # first session build.
+    app.include_router(agent_router)
     return app
 
 

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.3.0"
+version = "0.4.0"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }

--- a/hub/agents/python/email/tests/test_email_agent_routes.py
+++ b/hub/agents/python/email/tests/test_email_agent_routes.py
@@ -1,0 +1,334 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for the stateful agent surface (``/v1/email/agent/*``, #1666 follow-up).
+
+These exercise the sidecar's session-scoped agent host — session lifecycle, the
+SSE ``/query`` stream, blocking tool-confirmation over HTTP, and the runtime
+memory toggle — WITHOUT Lemonade or Gmail. ``build_session_agent`` is swapped for
+a fake agent that drives the real ``SSEOutputHandler`` the routes use, so the
+streaming + confirmation machinery is genuinely exercised.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# parents[0] = tests/, [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from gaia_agent_email import agent_routes  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fake agent (drives the real SSEOutputHandler)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgent:
+    """Stand-in for EmailTriageAgent that exercises the route machinery.
+
+    ``process_query`` drives ``self.console`` (the SSEOutputHandler the route
+    assigns) exactly as the real agent loop does, so streaming + confirmation are
+    tested for real.
+    """
+
+    def __init__(self, *, memory_available: bool = True, confirm_tool=None) -> None:
+        self.console = None
+        self._memory_available = memory_available
+        self._enabled = memory_available
+        self.confirm_tool = confirm_tool  # (tool_name, args) to trigger a gate
+        self.queries: list[str] = []
+        self.closed = False
+
+    def process_query(self, message: str) -> dict:
+        self.queries.append(message)
+        if self.console is not None:
+            self.console.print_thought(f"thinking about: {message}")
+        approved = None
+        if self.confirm_tool is not None and self.console is not None:
+            approved = self.console.confirm_tool_execution(
+                self.confirm_tool[0], self.confirm_tool[1], timeout=5
+            )
+        answer = f"done: {message}" if approved is None else f"approved={approved}"
+        return {"answer": answer}
+
+    def set_memory_enabled(self, enabled: bool) -> dict:
+        if not self._memory_available:
+            return {
+                "ok": not enabled,
+                "enabled": False,
+                "available": False,
+                "message": "Memory is unavailable this session.",
+            }
+        self._enabled = enabled
+        return {
+            "ok": True,
+            "enabled": enabled,
+            "available": True,
+            "message": "Memory is enabled." if enabled else "Memory is disabled.",
+        }
+
+    def memory_status(self) -> dict:
+        enabled = self._enabled and self._memory_available
+        return {
+            "enabled": enabled,
+            "available": self._memory_available,
+            "message": "status",
+        }
+
+    def close_db(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A TestClient over an app mounting only the agent router, with a fresh
+    registry and a fake-agent factory."""
+    # Fresh registry per test — the registry is module-global.
+    monkeypatch.setattr(
+        agent_routes, "registry", agent_routes._SessionRegistry(), raising=True
+    )
+
+    built: dict = {}
+
+    def _factory(**kwargs):
+        agent = built.get("next") or _FakeAgent()
+        built["last"] = agent
+        built.pop("next", None)
+        return agent
+
+    monkeypatch.setattr(agent_routes, "build_session_agent", _factory, raising=True)
+
+    app = FastAPI()
+    app.include_router(agent_routes.router)
+    tc = TestClient(app)
+    tc.built = built  # test hook to preset / inspect the fake agent
+    tc.app_ref = app  # so tests can spin a second client for concurrent calls
+    return tc
+
+
+def _sse_events(resp) -> list[dict]:
+    """Parse an SSE response body into a list of event dicts."""
+    events = []
+    for line in resp.iter_lines():
+        if not line:
+            continue
+        text = line if isinstance(line, str) else line.decode()
+        if text.startswith("data: "):
+            events.append(json.loads(text[6:]))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSessionLifecycle:
+    def test_create_session_builds_agent(self, client):
+        r = client.post("/v1/email/agent/session", json={"session_id": "s1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["session_id"] == "s1"
+        assert body["created"] is True
+        assert body["memory"]["available"] is True
+
+    def test_create_is_idempotent(self, client):
+        client.post("/v1/email/agent/session", json={"session_id": "s1"})
+        r = client.post("/v1/email/agent/session", json={"session_id": "s1"})
+        assert r.json()["created"] is False
+
+    def test_delete_session(self, client):
+        client.post("/v1/email/agent/session", json={"session_id": "s1"})
+        r = client.request("DELETE", "/v1/email/agent/session/s1")
+        assert r.status_code == 200 and r.json()["deleted"] is True
+        # second delete → 404
+        r2 = client.request("DELETE", "/v1/email/agent/session/s1")
+        assert r2.status_code == 404
+
+    def test_history_404_without_session(self, client):
+        r = client.get("/v1/email/agent/session/nope/history")
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Query streaming
+# ---------------------------------------------------------------------------
+
+
+class TestQueryStream:
+    def test_query_streams_and_records_history(self, client):
+        with client.stream(
+            "POST",
+            "/v1/email/agent/query",
+            json={"session_id": "s1", "message": "hi"},
+        ) as resp:
+            assert resp.status_code == 200
+            events = _sse_events(resp)
+
+        types = [e["type"] for e in events]
+        assert "thinking" in types
+        final = [e for e in events if e["type"] == "run_complete"]
+        assert final and final[0]["answer"] == "done: hi"
+
+        # History is now readable on the session.
+        h = client.get("/v1/email/agent/session/s1/history").json()
+        assert h["turns"] == [{"user": "hi", "assistant": "done: hi"}]
+
+    def test_overlapping_turn_rejected(self, client):
+        # Hold the run lock as if a turn were in progress.
+        session = client_registry(client).get_or_create("s1")
+        session.run_lock.acquire()
+        try:
+            r = client.post(
+                "/v1/email/agent/query",
+                json={"session_id": "s1", "message": "hi"},
+            )
+            assert r.status_code == 409
+        finally:
+            session.run_lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Tool confirmation over HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestToolConfirmation:
+    """The blocking tool-confirmation gate, over HTTP.
+
+    TestClient buffers the SSE body until the stream completes, so a sibling
+    thread can't observe ``permission_request`` mid-run. Instead we detect the
+    pending gate by polling the registry's live handler (the agent thread is
+    blocked in ``confirm_tool_execution`` with ``_confirm_id`` set), then release
+    it via ``POST /confirm-tool`` on a SECOND client (avoids sharing one httpx
+    client across threads). Events are asserted after the stream completes.
+    """
+
+    def _run_query_in_thread(self, client, events_out):
+        def _consume():
+            with client.stream(
+                "POST",
+                "/v1/email/agent/query",
+                json={"session_id": "s1", "message": "send it"},
+            ) as resp:
+                for line in resp.iter_lines():
+                    text = line if isinstance(line, str) else (line or b"").decode()
+                    if text.startswith("data: "):
+                        events_out.append(json.loads(text[6:]))
+
+        t = threading.Thread(target=_consume, daemon=True)
+        t.start()
+        return t
+
+    def _wait_for_pending_gate(self, timeout=5.0) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            session = agent_routes.registry.get("s1")
+            handler = getattr(session, "handler", None) if session else None
+            if handler is not None and getattr(handler, "_confirm_id", None):
+                return True
+            time.sleep(0.02)
+        return False
+
+    def test_approve_releases_gated_tool(self, client):
+        client.built["next"] = _FakeAgent(confirm_tool=("send_now", {"to": "a@b.com"}))
+        events: list[dict] = []
+        t = self._run_query_in_thread(client, events)
+
+        assert self._wait_for_pending_gate(), "agent never blocked on confirmation"
+
+        confirm_client = TestClient(client.app_ref)
+        r = confirm_client.post(
+            "/v1/email/agent/confirm-tool",
+            json={"session_id": "s1", "approved": True},
+        )
+        assert r.status_code == 200 and r.json()["approved"] is True
+
+        t.join(timeout=5)
+        assert any(e["type"] == "permission_request" for e in events)
+        final = [e for e in events if e["type"] == "run_complete"]
+        assert final and final[0]["answer"] == "approved=True"
+
+    def test_deny_blocks_gated_tool(self, client):
+        client.built["next"] = _FakeAgent(confirm_tool=("send_now", {"to": "a@b.com"}))
+        events: list[dict] = []
+        t = self._run_query_in_thread(client, events)
+
+        assert self._wait_for_pending_gate(), "agent never blocked on confirmation"
+
+        confirm_client = TestClient(client.app_ref)
+        confirm_client.post(
+            "/v1/email/agent/confirm-tool",
+            json={"session_id": "s1", "approved": False},
+        )
+        t.join(timeout=5)
+        final = [e for e in events if e["type"] == "run_complete"]
+        assert final and final[0]["answer"] == "approved=False"
+
+    def test_confirm_without_active_run_404(self, client):
+        client.post("/v1/email/agent/session", json={"session_id": "s1"})
+        r = client.post(
+            "/v1/email/agent/confirm-tool",
+            json={"session_id": "s1", "approved": True},
+        )
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Memory toggle over HTTP (#1666)
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryOverHttp:
+    def test_toggle_and_status(self, client):
+        client.post("/v1/email/agent/session", json={"session_id": "s1"})
+
+        off = client.post(
+            "/v1/email/agent/memory", json={"session_id": "s1", "enabled": False}
+        )
+        assert off.status_code == 200 and off.json()["enabled"] is False
+
+        status = client.get("/v1/email/agent/memory/s1").json()
+        assert status["enabled"] is False
+
+        on = client.post(
+            "/v1/email/agent/memory", json={"session_id": "s1", "enabled": True}
+        )
+        assert on.status_code == 200 and on.json()["enabled"] is True
+
+    def test_enable_when_unavailable_conflicts(self, client):
+        client.built["next"] = _FakeAgent(memory_available=False)
+        client.post("/v1/email/agent/session", json={"session_id": "s1"})
+        r = client.post(
+            "/v1/email/agent/memory", json={"session_id": "s1", "enabled": True}
+        )
+        # Cannot enable memory that was never initialized → reported loudly.
+        assert r.status_code == 409
+
+    def test_memory_endpoints_404_without_session(self, client):
+        assert (
+            client.post(
+                "/v1/email/agent/memory", json={"session_id": "x", "enabled": True}
+            ).status_code
+            == 404
+        )
+        assert client.get("/v1/email/agent/memory/x").status_code == 404
+
+
+def client_registry(client) -> "agent_routes._SessionRegistry":
+    """The registry the client's app is bound to (monkeypatched per test)."""
+    return agent_routes.registry

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -138,9 +138,13 @@ if importlib.util.find_spec("gaia_agent_email") is None:
         "(`pip install gaia-agent-email`) to enable POST /v1/email/*."
     )
 else:
+    from gaia_agent_email.agent_routes import router as email_agent_router
     from gaia_agent_email.api_routes import router as email_router
 
     app.include_router(email_router)
+    # Stateful conversational surface (/v1/email/agent/*): session-scoped agent
+    # with memory + tool-confirmation, for hosts driving the full agent over HTTP.
+    app.include_router(email_agent_router)
 
 
 # Raw request logging middleware (debug mode only)


### PR DESCRIPTION
## Why this matters

The email sidecar was a **stateless REST facade** — it never instantiated `EmailTriageAgent`, so it had no memory, no agent loop, and no conversational query interface. It could not back the Agent UI's email experience (which today runs the full agent *in-process*). This PR makes the sidecar host the real, session-scoped agent behind an HTTP query interface, so the Agent UI can drive the packaged email agent over the network — the prerequisite for replacing the current in-process email experience with the sidecar.

Because `POST /v1/email/agent/query` runs the **real agent loop**, every agent tool (read, organize, reply, summarize, delete, calendar, preferences, profiling, phishing, memory) is exposed through natural language — no per-tool REST plumbing.

> **Stacked on #1966** (base branch = `feat/email-runtime-memory-toggle-1666`). Merge #1966 first; this diff shows only the new work. Retarget to `main` after #1966 lands.

## What's added — `/v1/email/agent/*`

- `POST /session`, `DELETE /session/{id}`, `GET /session/{id}/history` — session lifecycle (one agent per session, one turn at a time; overlap → 409).
- `POST /query` — runs a turn, streams the loop as SSE (`thinking`/`step`/`tool`/`permission_request`/terminal `run_complete`).
- `POST /confirm-tool` — the blocking confirmation gate over HTTP for destructive tools (send/forward/delete/quarantine/calendar-create).
- `POST /cancel` — cooperative cancel.
- `POST /memory` + `GET /memory/{id}` — the #1966 runtime memory toggle **now reachable over HTTP**; enabling memory that was never initialized returns **409** with an actionable message (no silent no-op).

Reuses `gaia.ui.sse_handler.SSEOutputHandler` and the `_chat_helpers` integration (`agent.console = handler`; `process_query` on a worker thread). Mounted by both the frozen sidecar (`packaging/server.py`) and `gaia api` (`openai_server.py`).

## Test plan

- [x] `pytest hub/agents/python/email/tests/test_email_agent_routes.py` — 12 cases: session lifecycle, SSE `/query` + history, blocking confirmation approve/deny over HTTP, memory toggle + status incl. the enable-unavailable **409**. Uses a fake agent driving the real `SSEOutputHandler` (no Lemonade/Gmail).
- [x] `pytest hub/agents/python/email/tests/` — 175 pass (1 pre-existing failure: `test_agent_version_matches_package_metadata`, a stale cross-worktree editable install `0.1.0` vs source `0.4.0`; unrelated).
- [x] Sidecar build smoke test — `server.build_app()` mounts all 8 agent routes.
- [x] `black`/`isort` clean.
- [ ] **Frozen-binary build (release CI):** `freeze.py` now un-excludes and `--collect-all faiss` (the memory index; embeddings stay on Lemonade HTTP so torch/transformers remain excluded). I could **not** run PyInstaller here — the frozen (user-mode) binary must be validated by `release_agent_email.yml` before shipping. The source/dev path (`gaia api`, `uvicorn server:app`) is fully covered above.

## Follow-up (Phase 2, separate PR)
Rewire the Agent UI email path from in-process `email_factory` to HTTP calls against this surface, then retire the in-process invocation. The SSE event shape mirrors the core chat router to make that frontend reuse straightforward.