### PR TITLE
ci(eval): action-item eval (Claude-judge required) — nightly + weekly + release gates (#1964)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -316,18 +316,39 @@ jobs:
       tag: ${{ needs.validate.outputs.tag_name }}
       publish_to_release: false
 
+  # ── Email eval suite (release gate, self-hosted) ────────────────────
+  # Runs the SAME triage + drafting + action-item eval suite as the nightly
+  # (test_email_agent_eval.yml) on the [self-hosted, lemonade-eval] AMD runner,
+  # so the core release exercises the email agent on its committed corpus before
+  # publish. Report mode: it runs + uploads its scorecard/gate reports and only
+  # HARD-BLOCKS the release when a tests/fixtures/email/ threshold manifest sets
+  # enforce:true (data, not code). The approval gate below waits on it; the
+  # shared `lemonade-eval` concurrency group keeps it serial with the
+  # nightly/refresh runs on the single Lemonade slot.
+  #
+  # NOTE: the general `gaia eval agent` gate is intentionally NOT wired here yet
+  # — that CI (test_eval_rag.yml) is disabled pending #1315 (nonexistent runner
+  # label + a 90-min perf ceiling), so wiring it as a blocking gate now would
+  # fail every release. Add it as a fast-follow once #1315 lands.
+  email-eval:
+    name: Email eval suite (release gate)
+    needs: validate
+    uses: ./.github/workflows/test_email_agent_eval.yml
+    secrets: inherit
+
   # ── Stage 3: Approve (single manual gate) ───────────────────────────
   # All builds must pass before the approval prompt appears.
   # Configure the "publish" GitHub environment with required reviewers.
 
   approve-publish:
     name: Approve Publishing
-    needs: [build-pypi, build-npm, build-desktop-installers]
+    needs: [build-pypi, build-npm, build-desktop-installers, email-eval]
     if: >-
       !cancelled() &&
       needs.build-pypi.result == 'success' &&
       needs.build-npm.result == 'success' &&
-      needs.build-desktop-installers.result == 'success'
+      needs.build-desktop-installers.result == 'success' &&
+      needs.email-eval.result == 'success'
     runs-on: ubuntu-latest
     environment: publish
     steps:

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -334,11 +334,26 @@ jobs:
               --scorecard hub/agents/npm/agent-email/SCORECARD.md ${BARS}
           fi
 
+  # ── Stage 1c: email eval suite (release gate, self-hosted) ─────────
+  # Runs the SAME triage + drafting + action-item eval suite as the nightly
+  # (test_email_agent_eval.yml) on the [self-hosted, lemonade-eval] AMD runner,
+  # so a release exercises the shipping agent on the committed corpus — not just
+  # the hosted-CI scorecard-presence check above. Report mode: the eval runs +
+  # uploads its scorecard/gate reports and only HARD-BLOCKS the release when a
+  # threshold manifest under tests/fixtures/email/ sets enforce:true (data, not
+  # code). `publish` gates on this job, so a release can't ship without a fresh
+  # eval; the shared `lemonade-eval` concurrency group keeps it serial with the
+  # nightly/refresh runs on the single Lemonade slot.
+  email-eval:
+    name: Email eval suite (release gate)
+    uses: ./.github/workflows/test_email_agent_eval.yml
+    secrets: inherit
+
   # ── Stage 2: publish to the hub + npm (single atomic step) ─────────
   publish:
     name: Publish to Hub + npm
     runs-on: ubuntu-latest
-    needs: [build, verify-darwin-x64-compat, scorecard-gate]
+    needs: [build, verify-darwin-x64-compat, scorecard-gate, email-eval]
     # Manual approval gate: the `agent-publish` environment is configured (repo
     # Settings → Environments) with required reviewers, so this job pauses until a
     # maintainer approves — the human backstop for an accidental/tampered release

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -434,11 +434,12 @@ jobs:
       # Precision / recall / F1 of the agent's extracted action items vs a
       # hand-labeled corpus (tests/fixtures/email/action_items_ground_truth.json,
       # hard negatives included). Generation drives the REAL triage path over a
-      # FakeGmailBackend (Lemonade — nothing is ever sent). Matching is
-      # fuzzy-primary and fully offline; the Claude equivalence judge only
-      # resolves borderline pairs and is used ONLY when ANTHROPIC_API_KEY is
-      # present — otherwise the step still runs, matching pure-fuzzy
-      # (token-overlap-only), with the mode logged and recorded in the report.
+      # FakeGmailBackend (Lemonade — nothing is ever sent). The Claude
+      # equivalence judge resolves borderline description pairs and is REQUIRED:
+      # ANTHROPIC_API_KEY MUST be present, and if the judge cannot run the step
+      # FAILS LOUDLY. There is NO fallback to fuzzy-only matching — a missing or
+      # broken judge is an error, never a silent degradation to a weaker scorer
+      # (CLAUDE.md: No Silent Fallbacks — Fail Loudly).
       # The aggregate is scored against the committed manifest
       #   tests/fixtures/email/action_items_gate_thresholds.json  (enforce:false)
       # via gaia.eval.action_item_quality — same single-source rule as the gates
@@ -453,8 +454,8 @@ jobs:
         env:
           GAIA_MEMORY_DISABLED: "1"
           EMAIL_EVAL_MODEL: ${{ inputs.model || 'Gemma-4-E4B-it-GGUF' }}
-          # Judge credential for the borderline equivalence judge. Absent -> the
-          # step still runs pure-fuzzy (never a skip, never an invented pass).
+          # Judge credential for the borderline equivalence judge — REQUIRED.
+          # Absent -> the step fails loudly (NO fuzzy-only fallback).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -e
@@ -487,16 +488,21 @@ jobs:
               f"precision_min={thresholds.precision_min} (#1949 target, REPORTED)"
           )
 
-          # The judge only resolves borderline (gray-band) pairs. Present ->
-          # judge-assisted; absent -> pure-fuzzy token-overlap. Either way the
-          # step runs; the mode is logged and written to the report.
-          if os.environ.get("ANTHROPIC_API_KEY"):
-              judge_fn = make_claude_judge()
-              match_mode = "fuzzy+judge"
-          else:
-              judge_fn = None
-              match_mode = "fuzzy-only"
-          print(f"[EXTRACT-EVAL] match mode: {match_mode}")
+          # The Claude equivalence judge is REQUIRED — no fuzzy-only fallback.
+          # If the credential is absent we FAIL LOUDLY here rather than silently
+          # scoring with a weaker matcher (CLAUDE.md: No Silent Fallbacks). A
+          # judge that errors mid-run also propagates and fails the step.
+          if not os.environ.get("ANTHROPIC_API_KEY"):
+              print(
+                  "[EXTRACT-EVAL] ERROR: ANTHROPIC_API_KEY is not set. The "
+                  "action-item extraction eval requires the Claude equivalence "
+                  "judge and does NOT fall back to fuzzy-only matching. Set the "
+                  "ANTHROPIC_API_KEY secret on this runner and re-run.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          judge_fn = make_claude_judge()
+          print("[EXTRACT-EVAL] match mode: fuzzy-primary + REQUIRED Claude judge")
 
           # Generation: drives the REAL triage/extraction path per case (Lemonade
           # — this job holds the serial lemonade-eval slot).
@@ -531,7 +537,7 @@ jobs:
               f"  Cases scored/errored    : {agg.get('cases_scored')}/"
               f"{agg.get('cases_errored')}"
           )
-          print(f"  Match mode              : {match_mode}")
+          print("  Match mode              : fuzzy-primary + REQUIRED Claude judge")
           print(
               f"  Extraction gate         : passed={gate.get('passed')} "
               f"enforce={gate.get('enforce')} "
@@ -545,7 +551,7 @@ jobs:
                   {
                       "model": model,
                       "corpus": corpus_path,
-                      "match_mode": match_mode,
+                      "match_mode": "fuzzy-primary+required-claude-judge",
                       "summary": summary,
                   },
                   indent=2,

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -399,6 +399,147 @@ jobs:
       # END voice-drafting quality eval
       # =================================================================
 
+      # =================================================================
+      # BEGIN action-item extraction eval (#1605 feature / #1949 metric /
+      # #1964 wiring) — ADDITIVE, self-contained block. Report mode.
+      #
+      # Precision / recall / F1 of the agent's extracted action items vs a
+      # hand-labeled corpus (tests/fixtures/email/action_items_ground_truth.json,
+      # hard negatives included). Generation drives the REAL triage path over a
+      # FakeGmailBackend (Lemonade — nothing is ever sent). Matching is
+      # fuzzy-primary and fully offline; the Claude equivalence judge only
+      # resolves borderline pairs and is used ONLY when ANTHROPIC_API_KEY is
+      # present — otherwise the step still runs, matching pure-fuzzy
+      # (token-overlap-only), with the mode logged and recorded in the report.
+      # The aggregate is scored against the committed manifest
+      #   tests/fixtures/email/action_items_gate_thresholds.json  (enforce:false)
+      # via gaia.eval.action_item_quality — same single-source rule as the gates
+      # above: no thresholds inlined in this YAML; flip `enforce` in the manifest
+      # (data, not code) to make this gate block once a baseline confirms the bars.
+      #
+      # Runs AFTER the triage + drafting evals in the same job, so Lemonade
+      # access stays strictly serial (CLAUDE.md: evals serial). Kept
+      # self-contained so concurrent edits to this workflow merge cleanly.
+      # =================================================================
+      - name: Action-item extraction eval (report mode)
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+          EMAIL_EVAL_MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+          # Judge credential for the borderline equivalence judge. Absent -> the
+          # step still runs pure-fuzzy (never a skip, never an invented pass).
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -e
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          from gaia.eval.action_item_quality import (
+              default_extraction_thresholds_path,
+              generate_extractions,
+              load_action_item_corpus,
+              load_default_extraction_thresholds,
+              make_claude_judge,
+              score_generations,
+              summarize_extraction,
+          )
+
+          model = os.environ["EMAIL_EVAL_MODEL"]
+          corpus_path = "tests/fixtures/email/action_items_ground_truth.json"
+          out = Path("eval-out")
+          out.mkdir(parents=True, exist_ok=True)
+
+          thresholds = load_default_extraction_thresholds()
+          print(f"[EXTRACT-EVAL] manifest: {default_extraction_thresholds_path()}")
+          print(
+              f"[EXTRACT-EVAL] enforce={thresholds.enforce} "
+              f"f1_min={thresholds.f1_min} recall_min={thresholds.recall_min} "
+              f"precision_min={thresholds.precision_min} (#1949 target, REPORTED)"
+          )
+
+          # The judge only resolves borderline (gray-band) pairs. Present ->
+          # judge-assisted; absent -> pure-fuzzy token-overlap. Either way the
+          # step runs; the mode is logged and written to the report.
+          if os.environ.get("ANTHROPIC_API_KEY"):
+              judge_fn = make_claude_judge()
+              match_mode = "fuzzy+judge"
+          else:
+              judge_fn = None
+              match_mode = "fuzzy-only"
+          print(f"[EXTRACT-EVAL] match mode: {match_mode}")
+
+          # Generation: drives the REAL triage/extraction path per case (Lemonade
+          # — this job holds the serial lemonade-eval slot).
+          generations = generate_extractions(model, corpus_path=corpus_path)
+          produced = sum(1 for g in generations if g.get("predicted") is not None)
+          print(f"[EXTRACT-EVAL] extracted for {produced}/{len(generations)} cases")
+
+          corpus = load_action_item_corpus(corpus_path)
+          results = score_generations(
+              corpus, generations, model_id=model, judge_fn=judge_fn
+          )
+          summary = summarize_extraction(
+              results,
+              run_id=f"email-action-item-eval-{model.replace('/', '-').lower()}",
+              thresholds=thresholds,
+          )
+
+          gate = summary.get("extraction_gate", {})
+          agg = summary.get("extraction", {})
+          print("\n=========== EMAIL ACTION-ITEM EVAL REPORT (report mode) ===========")
+          print(
+              f"  Precision / Recall / F1 : {agg.get('precision')} / "
+              f"{agg.get('recall')} / {agg.get('f1')}   "
+              f"(F1 target >={thresholds.f1_min} #1949, REPORTED)"
+          )
+          print(
+              f"  Hard-negative correct   : {agg.get('hard_negatives_correct')}/"
+              f"{agg.get('hard_negatives_total')} "
+              f"(rate {agg.get('hard_negative_correct_rate')})"
+          )
+          print(
+              f"  Cases scored/errored    : {agg.get('cases_scored')}/"
+              f"{agg.get('cases_errored')}"
+          )
+          print(f"  Match mode              : {match_mode}")
+          print(
+              f"  Extraction gate         : passed={gate.get('passed')} "
+              f"enforce={gate.get('enforce')} "
+              f"should_fail={gate.get('should_fail')} "
+              f"skipped={gate.get('skipped', False)}"
+          )
+          print("==================================================================\n")
+
+          (out / "action_items_report.json").write_text(
+              json.dumps(
+                  {
+                      "model": model,
+                      "corpus": corpus_path,
+                      "match_mode": match_mode,
+                      "summary": summary,
+                  },
+                  indent=2,
+                  ensure_ascii=False,
+              ),
+              encoding="utf-8",
+          )
+          print("[OUT] wrote eval-out/action_items_report.json")
+
+          # Same hook contract as the gates above: report mode never fails.
+          if gate.get("should_fail"):
+              print("[EXTRACT-EVAL] enforced gate breach — failing the build.")
+              sys.exit(1)
+          print(
+              "[EXTRACT-EVAL] report mode (or no breach) — gate does not block "
+              "the build."
+          )
+          PY
+      # =================================================================
+      # END action-item extraction eval
+      # =================================================================
+
       - name: Upload eval scorecard + gate report
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -59,6 +59,34 @@ on:
         description: 'Repeat count for variance analysis'
         required: false
         default: '1'
+  # Reusable: called as a release gate from the email-agent release
+  # (release_agent_email.yml) and the GAIA core release (publish.yml) so a
+  # release runs the same triage/drafting/action-item eval suite it runs
+  # nightly. The `lemonade-eval` concurrency group below keeps release-triggered
+  # runs strictly serial with the nightly/refresh runs on the single Lemonade
+  # slot. Report mode is preserved end-to-end (the manifests own the enforce
+  # switch), so a call only hard-blocks a release when enforce:true is set.
+  workflow_call:
+    inputs:
+      model:
+        description: 'Lemonade model id to benchmark'
+        required: false
+        type: string
+        default: 'Gemma-4-E4B-it-GGUF'
+      limit:
+        description: 'Max messages to triage from the synthetic corpus'
+        required: false
+        type: string
+        default: '50'
+      experiments:
+        description: 'Repeat count for variance analysis'
+        required: false
+        type: string
+        default: '1'
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Judge credential for the drafting + borderline action-item judge; absent → those paths log a loud skip / run judge-less.'
+        required: false
 
 concurrency:
   # Share the single Lemonade backend slot with the other self-hosted evals so
@@ -98,9 +126,9 @@ jobs:
       - name: Run email-triage benchmark over the synthetic corpus
         env:
           GAIA_MEMORY_DISABLED: "1"
-          EMAIL_EVAL_MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
-          EMAIL_EVAL_LIMIT: ${{ github.event.inputs.limit || '50' }}
-          EMAIL_EVAL_EXPERIMENTS: ${{ github.event.inputs.experiments || '1' }}
+          EMAIL_EVAL_MODEL: ${{ inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+          EMAIL_EVAL_LIMIT: ${{ inputs.limit || '50' }}
+          EMAIL_EVAL_EXPERIMENTS: ${{ inputs.experiments || '1' }}
         run: |
           set -e
           echo "================================================================"
@@ -131,9 +159,9 @@ jobs:
       - name: Evaluate committed gates (report mode — reads the threshold manifests)
         env:
           GAIA_MEMORY_DISABLED: "1"
-          EMAIL_EVAL_MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
-          EMAIL_EVAL_LIMIT: ${{ github.event.inputs.limit || '50' }}
-          EMAIL_EVAL_EXPERIMENTS: ${{ github.event.inputs.experiments || '1' }}
+          EMAIL_EVAL_MODEL: ${{ inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+          EMAIL_EVAL_LIMIT: ${{ inputs.limit || '50' }}
+          EMAIL_EVAL_EXPERIMENTS: ${{ inputs.experiments || '1' }}
         run: |
           set -e
           python - <<'PY'
@@ -282,7 +310,7 @@ jobs:
       - name: Voice-drafting quality eval (judge-scored, report mode)
         env:
           GAIA_MEMORY_DISABLED: "1"
-          EMAIL_EVAL_MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+          EMAIL_EVAL_MODEL: ${{ inputs.model || 'Gemma-4-E4B-it-GGUF' }}
           # Judge credential for gaia.eval.claude.ClaudeClient. When the
           # secret is unavailable the step logs a LOUD skip (never a pass).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -424,7 +452,7 @@ jobs:
       - name: Action-item extraction eval (report mode)
         env:
           GAIA_MEMORY_DISABLED: "1"
-          EMAIL_EVAL_MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+          EMAIL_EVAL_MODEL: ${{ inputs.model || 'Gemma-4-E4B-it-GGUF' }}
           # Judge credential for the borderline equivalence judge. Absent -> the
           # step still runs pure-fuzzy (never a skip, never an invented pass).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/weekly_eval.yml
+++ b/.github/workflows/weekly_eval.yml
@@ -1,0 +1,87 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Weekly eval sweep (#1964). Runs the email eval suite (triage + drafting +
+# action-item) once a week on the self-hosted Lemonade runner and OPENS A GITHUB
+# ISSUE if any eval fails, so a regression that the nightly report-mode run only
+# logs is escalated into the tracker once a week instead of scrolling past.
+#
+# This calls the SAME reusable workflow the nightly and the release gates use
+# (test_email_agent_eval.yml), so there is one eval definition, not a fork. The
+# shared `lemonade-eval` concurrency group keeps it strictly serial with the
+# nightly/refresh/release runs on the single Lemonade slot.
+#
+# "Failure" here is a real signal, never a silent skip: the action-item eval
+# REQUIRES the Claude judge (no fuzzy fallback), so a missing/broken judge, a
+# Lemonade/infra error, or an enforced (enforce:true) gate breach all fail the
+# job — which is exactly what files the issue.
+
+name: Weekly Eval
+
+on:
+  # Sundays 08:17 UTC — off the nightly's 07:00 slot; the concurrency group
+  # serializes them if they ever overlap.
+  schedule:
+    - cron: '17 8 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: lemonade-eval
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Reuse the one eval definition. secrets: inherit passes ANTHROPIC_API_KEY
+  # (REQUIRED by the action-item judge — the suite fails loudly without it).
+  email-eval:
+    name: Weekly email eval suite
+    uses: ./.github/workflows/test_email_agent_eval.yml
+    secrets: inherit
+
+  open-issue-on-failure:
+    name: Open an issue if the weekly eval failed
+    needs: email-eval
+    # always() so this runs even though the needed job failed; then gate on the
+    # failure result so it only fires on a real failure.
+    if: ${{ always() && needs.email-eval.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: File (or update) the eval-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          TITLE="Weekly eval failure: email eval suite"
+          # Idempotent label so --label never errors (create-or-update).
+          gh label create eval-failure --color B60205 \
+            --description "Automated weekly eval failure" --force
+          BODY="$(cat <<EOF
+          The weekly email eval suite (\`test_email_agent_eval.yml\`, called by \`weekly_eval.yml\`) failed.
+
+          - Run: ${RUN_URL}
+          - Trigger: ${EVENT_NAME}
+
+          The email eval REQUIRES the Claude equivalence judge (there is no fuzzy fallback), so a failure here is one of:
+          a Lemonade / infra error, the Claude judge being unavailable or broken, or an enforced (\`enforce: true\`) gate breach.
+          Open the run log above to see which stage failed (triage / drafting / action-item) and why.
+          EOF
+          )"
+          # One rolling issue: comment on the open one if it exists, else open it.
+          EXISTING="$(gh issue list --state open --label eval-failure \
+            --search "${TITLE} in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "${EXISTING}" ]; then
+            gh issue comment "${EXISTING}" --body "${BODY}"
+            echo "commented on existing issue #${EXISTING}"
+          else
+            gh issue create --title "${TITLE}" --body "${BODY}" --label eval-failure
+          fi

--- a/docs/plans/mcp-context-efficiency.md
+++ b/docs/plans/mcp-context-efficiency.md
@@ -26,7 +26,7 @@ This plan closes the remaining gaps that live **on the GAIA side of that line**:
 > differently. Native tool-calling models get **full JSON schemas** per tool
 > (`_build_openai_tool_schemas`) — close to the article's "~150 tokens per
 > definition." Non-native models get **one compact line** per tool
-> (`- name(params): desc`, `agent.py:771`) — far cheaper. WS1's token win is
+> (`- name(params): desc`, `agent.py:770`) — far cheaper. WS1's token win is
 > therefore largest for native tool-calling models; justify on TTFT + slope, not
 > a single headline number.
 - **WS2 — Tool results enter context verbatim.** Large MCP payloads (a Drive
@@ -51,11 +51,13 @@ selection and tool-wrapper layers — not the mechanism.
   Scores **every** registry entry by cosine similarity of the query against
   `"{name}: {description}"` (`tool_loader.py:271-278`), so MCP tools are *already
   scoreable* once the loader runs.
-- Wiring lives only in ChatAgent: `_maybe_build_tool_loader` (`agent.py:447`) gates
-  it to the **`doc` profile** with the toggle on, and `_dynamic_tools_active`
-  (`agent.py:512`) additionally requires an active memory store.
+- Wiring lives only in ChatAgent (chat wheel,
+  `hub/agents/python/chat/gaia_agent_chat/agent.py`): `_maybe_build_tool_loader`
+  (`gaia_agent_chat/agent.py:455`) gates it to the **`doc` profile** with the
+  toggle on, and `_dynamic_tools_active` (`gaia_agent_chat/agent.py:520`)
+  additionally requires an active memory store.
 - Rendering is gated in the base agent: `_format_tools_for_prompt(filter_to=)`
-  (`agent.py:738`) and `_openai_tools`/`_build_openai_tool_schemas` read
+  (`agent.py:737`) and `_openai_tools`/`_build_openai_tool_schemas` read
   `_active_tool_filter`. Execution always uses the full registry.
 - **KV-cache invariant** (`agent.py:621-647`): loaded set is monotonic + sorted,
   tool block rendered last, so non-expansion turns serialize byte-identically.
@@ -240,9 +242,9 @@ re-sent when piped into the next tool.
   scratchpad backend**: `src/gaia/scratchpad/` is oriented to SQL *tables* for
   data analysis, not opaque blobs, so "reuse" is a stretch (kept as an open
   question below, but leaning dedicated).
-- **Argument handle-resolution pass in `Agent._execute_tool`** (`agent.py:1897`)
+- **Argument handle-resolution pass in `Agent._execute_tool`** (`agent.py:1909`)
   — confirmed single dispatch site: it resolves the tool name, then calls
-  `self._tools_registry[tool_name]["function"]` at `agent.py:1983`. Scan/rehydrate
+  `self._tools_registry[tool_name]["function"]` at `agent.py:1995`. Scan/rehydrate
   handles in `tool_args` immediately before that call so it applies to **all**
   tools (a small tool can consume a large tool's artifact), MCP or not.
   - **Verify before building:** confirm the native tool-calling path also routes

--- a/docs/plans/mcp-context-efficiency.md
+++ b/docs/plans/mcp-context-efficiency.md
@@ -1,0 +1,326 @@
+# MCP Context Efficiency — Progressive Disclosure & Result Handling
+
+**Status:** Draft / not started
+**Related issues:** #688 (tool loader parent), #1449–#1451 (loader parts), #976/#1005 (MCP connectors + per-agent activation)
+**Source motivation:** [Anthropic — Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp)
+
+## TL;DR
+
+The Anthropic article bundles two ideas: (1) **progressive disclosure** of tool
+definitions, and (2) **code execution** as the calling convention (model writes
+sandboxed code that composes tool APIs). GAIA already ships (1) for in-core tools
+via the dynamic tool loader (`tool_loader.py`), and correctly avoids (2) — running
+model-authored code on a user's machine is a large attack surface and a poor fit
+for 4B–35B local models that author code unreliably.
+
+This plan closes the remaining gaps that live **on the GAIA side of that line**:
+
+- **WS1 — MCP tools bypass the loader.** `_register_mcp_tools` eagerly registers
+  every tool from every connected server into the prompt on every turn. The
+  magnitude depends on the render path (see note below) and is worst for
+  native tool-calling models, but the *slope* is the real problem: every
+  connected server taxes every turn forever. Measure before quoting a figure —
+  the existing `tool-loader.mdx` explicitly warns against fixed token estimates.
+
+> **Render-path note.** GAIA has two tool-rendering paths and they cost very
+> differently. Native tool-calling models get **full JSON schemas** per tool
+> (`_build_openai_tool_schemas`) — close to the article's "~150 tokens per
+> definition." Non-native models get **one compact line** per tool
+> (`- name(params): desc`, `agent.py:771`) — far cheaper. WS1's token win is
+> therefore largest for native tool-calling models; justify on TTFT + slope, not
+> a single headline number.
+- **WS2 — Tool results enter context verbatim.** Large MCP payloads (a Drive
+  transcript, a big query result) are dumped whole into the model's context by the
+  registration wrapper, then re-sent when passed to the next tool.
+- **WS3 — No privacy pass-through (optional/Phase 3).** Data flowing connector→
+  connector always transits the model context, even when the model never needs to
+  read it.
+
+**Explicitly out of scope:** model-authored code execution, a code sandbox, or
+presenting MCP servers as a code-API filesystem. We adopt the *outcomes*
+(fewer tokens, data-out-of-context) using GAIA's existing embedding-based
+selection and tool-wrapper layers — not the mechanism.
+
+---
+
+## Current state (what exists today)
+
+### The loader (WS1 foundation)
+- `src/gaia/agents/base/tool_loader.py` — `ToolLoader.select(query, registry, *, skill_tools=)`
+  returns a sorted tool-name subset, or `None` (fail-safe → full registry).
+  Scores **every** registry entry by cosine similarity of the query against
+  `"{name}: {description}"` (`tool_loader.py:271-278`), so MCP tools are *already
+  scoreable* once the loader runs.
+- Wiring lives only in ChatAgent: `_maybe_build_tool_loader` (`agent.py:447`) gates
+  it to the **`doc` profile** with the toggle on, and `_dynamic_tools_active`
+  (`agent.py:512`) additionally requires an active memory store.
+- Rendering is gated in the base agent: `_format_tools_for_prompt(filter_to=)`
+  (`agent.py:738`) and `_openai_tools`/`_build_openai_tool_schemas` read
+  `_active_tool_filter`. Execution always uses the full registry.
+- **KV-cache invariant** (`agent.py:621-647`): loaded set is monotonic + sorted,
+  tool block rendered last, so non-expansion turns serialize byte-identically.
+- **Coverage enforcement** — narrower than it first appears (corrected after
+  code review):
+  - `validate_registry` (`tool_loader.py:200-222`) only checks the
+    **config→registry** direction: it raises if a CORE/bundle *name* is absent
+    from the registry. An MCP tool that is *in* the registry but *not* in any
+    bundle does **not** trip it. So `validate_registry` needs **no** MCP change.
+  - The "every registry tool must be covered" rule is enforced by **one CI test**,
+    `tests/unit/test_chat_tool_bundles.py::test_core_and_bundles_cover_doc_registry_exactly`
+    (`uncovered` assertion, lines 46-54). It builds `build_doc_agent_skeleton`,
+    which registers **no** MCP tools, so it doesn't see them today.
+  - MCP tools are discovered at **runtime** with unknown names, so they can never
+    appear in static `DOC_BUNDLES`/`DOC_CORE_TOOLS`. The only change needed is to
+    the CI test *if/when* MCP tools ever enter the registry it inspects: subtract
+    `{n for n in registry if registry[n].get("_mcp_server")}` before the
+    exact-match comparison. Static-tool drift keeps the strict invariant.
+
+### MCP registration (WS1/WS2 touch point)
+- `MCPClientMixin._register_mcp_tools` (`src/gaia/mcp/mixin.py:328`) registers each
+  tool into the **global** `_TOOL_REGISTRY` with name `mcp_<prefix>_<tool>`,
+  description `[MCP:<prefix>] <desc>`, a params dict, and an `enhanced_wrapper`.
+- `MCPTool.to_gaia_format` (`src/gaia/mcp/client/mcp_client.py:154`) builds that
+  entry; descriptions and per-param descriptions are preserved from the server
+  schema — usable embedding text for WS1.
+- The `enhanced_wrapper` (`mixin.py:353-380`) wraps the **full** result dict as
+  `data` with an instruction to summarize — the WS2 problem: no size guard, the
+  entire payload lands in context.
+- `get_mcp_client_system_prompt` (`mixin.py:76`) only teaches tool-name discipline;
+  fires with ≥2 MCP tools.
+
+### Reusable infrastructure
+- Scratchpad tables backend (`src/gaia/scratchpad/`) — session-scoped SQL storage,
+  a natural home for WS2 artifacts.
+- Governance layer (`src/gaia/governance/`) — hook point for WS3 PII detection.
+- Loader escape hatch `load_tools` (Part 2) — model-driven recovery when a
+  semantic match misses; WS1 reuses this instead of inventing a new discovery tool.
+
+---
+
+## Workstream 1 — Route MCP tools through the loader (progressive disclosure)
+
+**Goal:** prompt cost scales with MCP tools *used this turn*, not MCP tools
+*connected*. Target: on a session with ≥3 connected servers, first-turn MCP tool
+tokens drop ≥60% vs. eager registration, with no recall regression.
+
+### Design
+
+1. **Tag MCP tools as dynamically-covered.** MCP registry entries already carry
+   `_mcp_server`. Treat any entry with that key as an **implicit bundle member**
+   exempt from static coverage: it participates in semantic scoring but is not
+   required to appear in `DOC_BUNDLES`, and is never in CORE (so it only surfaces
+   on a semantic/skill match or via `load_tools`). This is exactly the desired
+   progressive-disclosure behavior.
+
+2. **Coverage enforcement — no `validate_registry` change needed.** Per the
+   corrected analysis above, MCP tools uncovered by bundles do not trip
+   `validate_registry`. Only touch the CI coverage test, and only if MCP tools
+   ever enter the registry it inspects (subtract `_mcp_server`-tagged names there).
+   Static drift keeps the strict invariant.
+
+3. **Generalize loader activation beyond the doc profile — with an MCP-only
+   gating mode (critical correction).** Today the loader is `doc`-only, where
+   `DOC_CORE_TOOLS ∪ DOC_BUNDLES` cover the *entire* registry. If we simply turn
+   the loader on for a non-doc agent that has MCP tools, the loader would also
+   start gating that agent's **static** tools — but those agents define no
+   CORE/bundles, so every static tool collapses to semantic-match-only and native
+   tool recall craters. That is a regression, not a win.
+   - **Fix:** add an **MCP-only gating mode**. When the loader is activated *by
+     MCP presence* (rather than the doc-profile toggle), the effective CORE is
+     "all non-MCP registry tools" (static tools always pass through), and only
+     `_mcp_server`-tagged tools are subject to selection/eviction. The doc-profile
+     path is unchanged.
+   - Build the loader when `_mcp_manager` has ≥1 connected server *and* an embedder
+     is available, independent of `prompt_profile`. Additional trigger, not a
+     replacement for the doc toggle.
+   - `_dynamic_tools_active` currently also requires `_memory_store`. Memory gates
+     only the SKILL signal; the loader runs fine on CORE+SEMANTIC without it.
+     Decouple **only** under the MCP-present condition, to avoid perturbing the
+     doc-profile assumptions.
+
+4. **Compact "unloaded MCP tools" menu — placed in the volatile tail, NOT the
+   mixin head (critical correction).** Mirror the article's name + truncated
+   (~60 char) menu so unloaded tool *names* stay discoverable at ~1 line each.
+   **Placement matters:** mixin fragments compose at the **front** of the prompt
+   (`_compose_system_prompt`, `agent.py:611-614`) while the tool block is placed
+   **last** to keep the KV prefix warm (`agent.py:621-647`). A per-turn-changing
+   menu in `get_mcp_client_system_prompt` would sit at the front and invalidate
+   the cache on every expansion — defeating the loader. Render the menu **inside
+   the tools block region** (adjacent to the loaded-tool list, in the volatile
+   tail) so it moves with the filter, not against the cache.
+   - The instruction points only at **`load_tools`** (the Part 2 escape hatch).
+     `search_tools` does not exist in GAIA — do not reference it.
+   - **This menu is the only discovery channel for native tool-calling models:**
+     an unloaded MCP tool is absent from `_openai_tools`, so the model literally
+     cannot emit it and must `load_tools` first. Menu correctness + placement are
+     therefore load-bearing, not polish.
+   - Cap the menu (e.g. 40 tools) and `log()` truncation — no silent cap.
+
+5. **Wire embeddings.** MCP tool embedding text = `"{name}: {description}"` using
+   the existing `embed_batch_fn`. The content-keyed embed cache
+   (`tool_loader.py:177`) already handles new/removed tools across `reload()`.
+
+### Integration points
+- `src/gaia/mcp/mixin.py` — menu fragment in `get_mcp_client_system_prompt`;
+  no change to registration (tools stay in the global registry, loader gates
+  rendering only).
+- `src/gaia/agents/base/tool_loader.py` — MCP-aware `validate_registry`.
+- `hub/agents/python/chat/gaia_agent_chat/agent.py` — additional activation
+  trigger in `_maybe_build_tool_loader` / `_dynamic_tools_active`.
+- Base `Agent` — no interface change; `_select_tools_for_turn` already the hook.
+
+### Edge cases
+- MCP tools that share a bundle-like cohesion (a server's read+write pair):
+  optional follow-up — synthesize a per-server implicit bundle so a match on one
+  server tool pulls its siblings. Start without it; measure recall first.
+- Server disconnect mid-session (`reload()`): loaded set may reference a gone tool.
+  `select` already tolerates registry-absent names; confirm the menu regenerates.
+- Native tool-calling models vs. embedded-JSON models: both render paths read the
+  filter, so both are covered — but test both (see lemonade-client-patterns skill).
+
+### Tests / evals
+- Unit: extend `tests/unit/test_tool_loader_selection.py` with MCP-tagged entries
+  (uncovered by bundles) — assert they score, surface on match, and are gated
+  while static tools pass through in **MCP-only gating mode**.
+- Unit: MCP-only gating mode — static (non-`_mcp_server`) tools always render;
+  MCP tools only on match/`load_tools`. This is the regression guard for the
+  Finding-4 correction.
+- Unit: menu shape (truncation, cap, ≥2-tool gate) **and** placement — assert the
+  menu renders in the volatile tool block, so a stable turn stays byte-identical
+  (KV-cache guard).
+- Eval: extend `src/gaia/eval/tool_cost.py` / `tool_recall.py` with a fixture of
+  N connected mock MCP servers; assert token reduction and recall parity.
+- **Agent eval required** (CLAUDE.md rule — this touches prompt assembly + tool
+  schema): run `gaia eval agent` on the relevant category, compare to baseline
+  before merge.
+- No `validate_registry` test change (it doesn't gate MCP tools — see corrected
+  analysis).
+
+### Risk: **Low–Medium.** Reuses existing selection + rendering with no new
+execution surface, but the MCP-only gating mode and menu placement are genuine
+changes to loader activation and prompt composition — the KV-cache invariant and
+static-tool recall are the two things a review must protect.
+
+---
+
+## Workstream 2 — Context-efficient tool results
+
+**Goal:** large tool outputs don't transit the model context verbatim, and aren't
+re-sent when piped into the next tool.
+
+### Design
+
+1. **Size-gated result handling in the wrapper.** In `_register_mcp_tools`'s
+   `enhanced_wrapper` (`mixin.py:353`), measure serialized result size. Below a
+   threshold (e.g. ~2KB / ~500 tokens) behave exactly as today (byte-identical —
+   no regression for small results). Above it:
+   - Store the full payload in a **session-scoped artifact store** (back it with
+     the scratchpad backend, `src/gaia/scratchpad/`).
+   - Return `{status, message, artifact: "<handle>", preview: <first N + schema
+     summary>, instruction: "..."}` instead of the full `data`. The model sees a
+     preview + a handle, not the payload.
+
+2. **Handle format & resolver.** Handle e.g. `gaia://artifact/<session>/<id>`.
+   Add an argument-resolution step at tool-invocation time (in the base agent's
+   tool dispatch, or the MCP wrapper): before calling a tool, scan its arguments
+   for artifact handles and re-hydrate them from the store. This is what lets a
+   Drive transcript flow into a Salesforce/other tool **without** re-entering
+   context.
+   - **Fail loudly:** unknown/expired handle → actionable error naming the handle
+     and that the artifact expired or belongs to another session. No silent empty.
+
+3. **Preview generation.** For structured data: keys + row count + first row. For
+   text: first N chars + length. Enough for the model to reason about *whether* to
+   use the artifact and *how*, without the bulk.
+
+### Integration points
+- `src/gaia/mcp/mixin.py` — size gate + artifact write in `enhanced_wrapper`.
+- New: `src/gaia/agents/base/artifacts.py` — session-scoped store with handle
+  mint/resolve, TTL, size caps. **Prefer a small dedicated blob KV over the
+  scratchpad backend**: `src/gaia/scratchpad/` is oriented to SQL *tables* for
+  data analysis, not opaque blobs, so "reuse" is a stretch (kept as an open
+  question below, but leaning dedicated).
+- **Argument handle-resolution pass in `Agent._execute_tool`** (`agent.py:1897`)
+  — confirmed single dispatch site: it resolves the tool name, then calls
+  `self._tools_registry[tool_name]["function"]` at `agent.py:1983`. Scan/rehydrate
+  handles in `tool_args` immediately before that call so it applies to **all**
+  tools (a small tool can consume a large tool's artifact), MCP or not.
+  - **Verify before building:** confirm the native tool-calling path also routes
+    execution through `_execute_tool` (it should — `_on_tool_invoked` is recorded
+    there for both paths). If a second executor exists, the resolver must cover it.
+
+### Edge cases
+- Handle resolution must be scoped to the current session — never cross-session
+  (privacy + correctness). Store keyed by session id.
+- Artifact store growth: TTL + max-size eviction; loud log on eviction.
+- A model that pastes preview text as if it were the full payload: preview must be
+  clearly labeled `[PREVIEW — full data in artifact <handle>]`.
+
+### Tests
+- Unit: small result → unchanged path (assert byte-identical wrapper output).
+- Unit: large result → handle + preview; resolver re-hydrates on next call;
+  unknown handle raises actionable error.
+- Integration: two-tool pipe (produce large → consume by handle) never puts the
+  payload in the message list (assert on captured messages).
+
+### Risk: **Medium.** New store + dispatch hook; keep the small-result path
+byte-identical to avoid regressing every existing MCP call.
+
+---
+
+## Workstream 3 — Privacy pass-through (optional, Phase 3)
+
+**Goal:** sensitive fields flow connector→connector without ever entering model
+context. Builds directly on WS2's handle mechanism.
+
+### Design (sketch — validate before committing)
+- On result ingestion, run the governance layer's PII detection over the payload.
+- Tokenize detected fields (emails, phone numbers) into placeholders
+  (`<pii:email:1>`) in the preview/context representation; keep the real values
+  only in the artifact store.
+- On outbound tool call, the resolver substitutes real values back from the store.
+- The model orchestrates the flow seeing only placeholders.
+
+### Why Phase 3
+- Depends on WS2 landing first (shared store + resolver).
+- Depends on governance PII detection maturity.
+- Highest complexity, most speculative benefit for current local use cases.
+- Decision gate: only build if a concrete connector→connector workflow (e.g.
+  Sheets→CRM) is a real GAIA use case at that point.
+
+### Risk: **Higher.** Correctness of tokenize/resolve round-trip is critical — a
+missed substitution leaks PII into context (the exact thing it prevents). Requires
+adversarial tests.
+
+---
+
+## Phasing & sequencing
+
+| Phase | Workstream | Gate to proceed |
+|-------|-----------|-----------------|
+| 1 | WS1 (progressive disclosure for MCP) | Ship behind existing dynamic-tools toggle; eval shows token drop + recall parity |
+| 2 | WS2 (context-efficient results) | Small-result path proven byte-identical; pipe test passes |
+| 3 | WS3 (privacy pass-through) | A real connector→connector workflow exists; PII round-trip adversarially tested |
+
+WS1 and WS2 are independent and can land in either order; WS3 requires WS2.
+
+## Non-goals (the rejected half of the article)
+- No model-authored code execution.
+- No code sandbox / interpreter for agent-generated code.
+- No "MCP servers as a code-API filesystem" presentation.
+
+Rationale: GAIA's default models (Gemma-4-E4B, Qwen-4B) author orchestration code
+unreliably; running that code locally is a large security surface; and the token
+win is already captured by embedding-based selection (WS1) without either cost.
+This matches CLAUDE.md's "no silent fallbacks / fail loudly" posture — a weak model
+emitting plausible-but-wrong code is precisely the quiet-wrong-answer failure mode
+to avoid.
+
+## Open questions
+1. Should the loader's MCP activation be a new config field, or purely
+   auto-on-when-MCP-present? (Leaning auto-on, env-overridable, to match
+   `GAIA_DYNAMIC_TOOLS`.)
+2. WS2 artifact store: reuse scratchpad tables, or a dedicated lightweight KV?
+   (Leaning scratchpad to avoid a new subsystem.)
+3. WS1 per-server implicit bundles — needed for recall, or does flat semantic
+   scoring suffice? (Measure before building.)


### PR DESCRIPTION
#1962 shipped the extraction-quality eval (precision/recall/F1 over the hand-labeled action-item corpus), but nothing ran it — so a regression in *what* the agent extracts would reach a user's task list silently. This PR runs the email eval suite where it matters: **nightly**, **weekly** (with an auto-filed issue on failure), and as a **blocking gate on every release** (email-agent and GAIA core).

## Threads

- **Nightly action-item eval** — a step in `test_email_agent_eval.yml` drives the real triage/extraction path over the committed corpus, prints a precision/recall/F1 scorecard, and uploads `action_items_report.json` alongside the triage/perf/drafting reports.
- **Claude judge REQUIRED — no fuzzy fallback** — the borderline equivalence judge is mandatory. If `ANTHROPIC_API_KEY` is absent or the judge errors, the step **fails loudly** rather than degrading to fuzzy-only matching (CLAUDE.md: No Silent Fallbacks — Fail Loudly).
- **Release gate (email agent + core)** — the email eval workflow is now reusable (`workflow_call`) and is called as a blocking gate from `release_agent_email.yml` (before the hub/npm publish) and `publish.yml` (before the core publish approval). Both run on `[self-hosted, lemonade-eval]` and share the `lemonade-eval` concurrency group, so a release exercises the shipping agent on its corpus and stays strictly serial with the nightly/refresh runs.
- **Weekly sweep + auto-issue** — `weekly_eval.yml` runs the same reusable suite once a week and opens (or updates) a GitHub issue labeled `eval-failure` if any eval fails, escalating a regression the nightly only logs.

Report mode is preserved for the gate contract: the eval runs + uploads on every release, and only *hard-blocks* when a `tests/fixtures/email/` threshold manifest sets `enforce:true` (data, not code). Note this is distinct from the judge requirement above — a missing judge always fails the run regardless of `enforce`.

The general `gaia eval agent` gate is intentionally **not** wired into the core release yet: that CI (`test_eval_rag.yml`) is disabled pending #1315 (nonexistent runner label + a 90-min perf ceiling), so gating on it now would fail every release. Fast-follow once #1315 lands (noted inline in `publish.yml`).

## Test plan
- [x] All four workflow YAMLs parse (`yaml.safe_load`); every `needs:` resolves; both release gates + the weekly issue job depend on `email-eval`
- [x] Embedded step scripts compile; action-item imports from `gaia.eval.action_item_quality` resolve; no `judge_fn=None` / fuzzy-only path remains
- [x] `inputs.*` unification leaves the nightly `schedule` run unchanged; no stray `github.event.inputs` refs
- [ ] After merge: dispatch `test_email_agent_eval.yml` + `weekly_eval.yml` and confirm the action-item report uploads and (on an injected failure) an `eval-failure` issue is filed
- [ ] On the next email-agent / core release: confirm the `email-eval` gate runs on the self-hosted runner and blocks the publish approval

Closes #1964
