### PR TITLE
feat(eval): detection-quality eval for email follow-up tracking (#1950)

### DIFF
--- a/docs/plans/mcp-context-efficiency.md
+++ b/docs/plans/mcp-context-efficiency.md
@@ -26,7 +26,7 @@ This plan closes the remaining gaps that live **on the GAIA side of that line**:
 > differently. Native tool-calling models get **full JSON schemas** per tool
 > (`_build_openai_tool_schemas`) — close to the article's "~150 tokens per
 > definition." Non-native models get **one compact line** per tool
-> (`- name(params): desc`, `agent.py:771`) — far cheaper. WS1's token win is
+> (`- name(params): desc`, `agent.py:770`) — far cheaper. WS1's token win is
 > therefore largest for native tool-calling models; justify on TTFT + slope, not
 > a single headline number.
 - **WS2 — Tool results enter context verbatim.** Large MCP payloads (a Drive
@@ -51,11 +51,13 @@ selection and tool-wrapper layers — not the mechanism.
   Scores **every** registry entry by cosine similarity of the query against
   `"{name}: {description}"` (`tool_loader.py:271-278`), so MCP tools are *already
   scoreable* once the loader runs.
-- Wiring lives only in ChatAgent: `_maybe_build_tool_loader` (`agent.py:447`) gates
-  it to the **`doc` profile** with the toggle on, and `_dynamic_tools_active`
-  (`agent.py:512`) additionally requires an active memory store.
+- Wiring lives only in ChatAgent (chat wheel,
+  `hub/agents/python/chat/gaia_agent_chat/agent.py`): `_maybe_build_tool_loader`
+  (`gaia_agent_chat/agent.py:455`) gates it to the **`doc` profile** with the
+  toggle on, and `_dynamic_tools_active` (`gaia_agent_chat/agent.py:520`)
+  additionally requires an active memory store.
 - Rendering is gated in the base agent: `_format_tools_for_prompt(filter_to=)`
-  (`agent.py:738`) and `_openai_tools`/`_build_openai_tool_schemas` read
+  (`agent.py:737`) and `_openai_tools`/`_build_openai_tool_schemas` read
   `_active_tool_filter`. Execution always uses the full registry.
 - **KV-cache invariant** (`agent.py:621-647`): loaded set is monotonic + sorted,
   tool block rendered last, so non-expansion turns serialize byte-identically.
@@ -240,9 +242,9 @@ re-sent when piped into the next tool.
   scratchpad backend**: `src/gaia/scratchpad/` is oriented to SQL *tables* for
   data analysis, not opaque blobs, so "reuse" is a stretch (kept as an open
   question below, but leaning dedicated).
-- **Argument handle-resolution pass in `Agent._execute_tool`** (`agent.py:1897`)
+- **Argument handle-resolution pass in `Agent._execute_tool`** (`agent.py:1909`)
   — confirmed single dispatch site: it resolves the tool name, then calls
-  `self._tools_registry[tool_name]["function"]` at `agent.py:1983`. Scan/rehydrate
+  `self._tools_registry[tool_name]["function"]` at `agent.py:1995`. Scan/rehydrate
   handles in `tool_args` immediately before that call so it applies to **all**
   tools (a small tool can consume a large tool's artifact), MCP or not.
   - **Verify before building:** confirm the native tool-calling path also routes

--- a/docs/plans/mcp-context-efficiency.md
+++ b/docs/plans/mcp-context-efficiency.md
@@ -1,0 +1,326 @@
+# MCP Context Efficiency — Progressive Disclosure & Result Handling
+
+**Status:** Draft / not started
+**Related issues:** #688 (tool loader parent), #1449–#1451 (loader parts), #976/#1005 (MCP connectors + per-agent activation)
+**Source motivation:** [Anthropic — Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp)
+
+## TL;DR
+
+The Anthropic article bundles two ideas: (1) **progressive disclosure** of tool
+definitions, and (2) **code execution** as the calling convention (model writes
+sandboxed code that composes tool APIs). GAIA already ships (1) for in-core tools
+via the dynamic tool loader (`tool_loader.py`), and correctly avoids (2) — running
+model-authored code on a user's machine is a large attack surface and a poor fit
+for 4B–35B local models that author code unreliably.
+
+This plan closes the remaining gaps that live **on the GAIA side of that line**:
+
+- **WS1 — MCP tools bypass the loader.** `_register_mcp_tools` eagerly registers
+  every tool from every connected server into the prompt on every turn. The
+  magnitude depends on the render path (see note below) and is worst for
+  native tool-calling models, but the *slope* is the real problem: every
+  connected server taxes every turn forever. Measure before quoting a figure —
+  the existing `tool-loader.mdx` explicitly warns against fixed token estimates.
+
+> **Render-path note.** GAIA has two tool-rendering paths and they cost very
+> differently. Native tool-calling models get **full JSON schemas** per tool
+> (`_build_openai_tool_schemas`) — close to the article's "~150 tokens per
+> definition." Non-native models get **one compact line** per tool
+> (`- name(params): desc`, `agent.py:771`) — far cheaper. WS1's token win is
+> therefore largest for native tool-calling models; justify on TTFT + slope, not
+> a single headline number.
+- **WS2 — Tool results enter context verbatim.** Large MCP payloads (a Drive
+  transcript, a big query result) are dumped whole into the model's context by the
+  registration wrapper, then re-sent when passed to the next tool.
+- **WS3 — No privacy pass-through (optional/Phase 3).** Data flowing connector→
+  connector always transits the model context, even when the model never needs to
+  read it.
+
+**Explicitly out of scope:** model-authored code execution, a code sandbox, or
+presenting MCP servers as a code-API filesystem. We adopt the *outcomes*
+(fewer tokens, data-out-of-context) using GAIA's existing embedding-based
+selection and tool-wrapper layers — not the mechanism.
+
+---
+
+## Current state (what exists today)
+
+### The loader (WS1 foundation)
+- `src/gaia/agents/base/tool_loader.py` — `ToolLoader.select(query, registry, *, skill_tools=)`
+  returns a sorted tool-name subset, or `None` (fail-safe → full registry).
+  Scores **every** registry entry by cosine similarity of the query against
+  `"{name}: {description}"` (`tool_loader.py:271-278`), so MCP tools are *already
+  scoreable* once the loader runs.
+- Wiring lives only in ChatAgent: `_maybe_build_tool_loader` (`agent.py:447`) gates
+  it to the **`doc` profile** with the toggle on, and `_dynamic_tools_active`
+  (`agent.py:512`) additionally requires an active memory store.
+- Rendering is gated in the base agent: `_format_tools_for_prompt(filter_to=)`
+  (`agent.py:738`) and `_openai_tools`/`_build_openai_tool_schemas` read
+  `_active_tool_filter`. Execution always uses the full registry.
+- **KV-cache invariant** (`agent.py:621-647`): loaded set is monotonic + sorted,
+  tool block rendered last, so non-expansion turns serialize byte-identically.
+- **Coverage enforcement** — narrower than it first appears (corrected after
+  code review):
+  - `validate_registry` (`tool_loader.py:200-222`) only checks the
+    **config→registry** direction: it raises if a CORE/bundle *name* is absent
+    from the registry. An MCP tool that is *in* the registry but *not* in any
+    bundle does **not** trip it. So `validate_registry` needs **no** MCP change.
+  - The "every registry tool must be covered" rule is enforced by **one CI test**,
+    `tests/unit/test_chat_tool_bundles.py::test_core_and_bundles_cover_doc_registry_exactly`
+    (`uncovered` assertion, lines 46-54). It builds `build_doc_agent_skeleton`,
+    which registers **no** MCP tools, so it doesn't see them today.
+  - MCP tools are discovered at **runtime** with unknown names, so they can never
+    appear in static `DOC_BUNDLES`/`DOC_CORE_TOOLS`. The only change needed is to
+    the CI test *if/when* MCP tools ever enter the registry it inspects: subtract
+    `{n for n in registry if registry[n].get("_mcp_server")}` before the
+    exact-match comparison. Static-tool drift keeps the strict invariant.
+
+### MCP registration (WS1/WS2 touch point)
+- `MCPClientMixin._register_mcp_tools` (`src/gaia/mcp/mixin.py:328`) registers each
+  tool into the **global** `_TOOL_REGISTRY` with name `mcp_<prefix>_<tool>`,
+  description `[MCP:<prefix>] <desc>`, a params dict, and an `enhanced_wrapper`.
+- `MCPTool.to_gaia_format` (`src/gaia/mcp/client/mcp_client.py:154`) builds that
+  entry; descriptions and per-param descriptions are preserved from the server
+  schema — usable embedding text for WS1.
+- The `enhanced_wrapper` (`mixin.py:353-380`) wraps the **full** result dict as
+  `data` with an instruction to summarize — the WS2 problem: no size guard, the
+  entire payload lands in context.
+- `get_mcp_client_system_prompt` (`mixin.py:76`) only teaches tool-name discipline;
+  fires with ≥2 MCP tools.
+
+### Reusable infrastructure
+- Scratchpad tables backend (`src/gaia/scratchpad/`) — session-scoped SQL storage,
+  a natural home for WS2 artifacts.
+- Governance layer (`src/gaia/governance/`) — hook point for WS3 PII detection.
+- Loader escape hatch `load_tools` (Part 2) — model-driven recovery when a
+  semantic match misses; WS1 reuses this instead of inventing a new discovery tool.
+
+---
+
+## Workstream 1 — Route MCP tools through the loader (progressive disclosure)
+
+**Goal:** prompt cost scales with MCP tools *used this turn*, not MCP tools
+*connected*. Target: on a session with ≥3 connected servers, first-turn MCP tool
+tokens drop ≥60% vs. eager registration, with no recall regression.
+
+### Design
+
+1. **Tag MCP tools as dynamically-covered.** MCP registry entries already carry
+   `_mcp_server`. Treat any entry with that key as an **implicit bundle member**
+   exempt from static coverage: it participates in semantic scoring but is not
+   required to appear in `DOC_BUNDLES`, and is never in CORE (so it only surfaces
+   on a semantic/skill match or via `load_tools`). This is exactly the desired
+   progressive-disclosure behavior.
+
+2. **Coverage enforcement — no `validate_registry` change needed.** Per the
+   corrected analysis above, MCP tools uncovered by bundles do not trip
+   `validate_registry`. Only touch the CI coverage test, and only if MCP tools
+   ever enter the registry it inspects (subtract `_mcp_server`-tagged names there).
+   Static drift keeps the strict invariant.
+
+3. **Generalize loader activation beyond the doc profile — with an MCP-only
+   gating mode (critical correction).** Today the loader is `doc`-only, where
+   `DOC_CORE_TOOLS ∪ DOC_BUNDLES` cover the *entire* registry. If we simply turn
+   the loader on for a non-doc agent that has MCP tools, the loader would also
+   start gating that agent's **static** tools — but those agents define no
+   CORE/bundles, so every static tool collapses to semantic-match-only and native
+   tool recall craters. That is a regression, not a win.
+   - **Fix:** add an **MCP-only gating mode**. When the loader is activated *by
+     MCP presence* (rather than the doc-profile toggle), the effective CORE is
+     "all non-MCP registry tools" (static tools always pass through), and only
+     `_mcp_server`-tagged tools are subject to selection/eviction. The doc-profile
+     path is unchanged.
+   - Build the loader when `_mcp_manager` has ≥1 connected server *and* an embedder
+     is available, independent of `prompt_profile`. Additional trigger, not a
+     replacement for the doc toggle.
+   - `_dynamic_tools_active` currently also requires `_memory_store`. Memory gates
+     only the SKILL signal; the loader runs fine on CORE+SEMANTIC without it.
+     Decouple **only** under the MCP-present condition, to avoid perturbing the
+     doc-profile assumptions.
+
+4. **Compact "unloaded MCP tools" menu — placed in the volatile tail, NOT the
+   mixin head (critical correction).** Mirror the article's name + truncated
+   (~60 char) menu so unloaded tool *names* stay discoverable at ~1 line each.
+   **Placement matters:** mixin fragments compose at the **front** of the prompt
+   (`_compose_system_prompt`, `agent.py:611-614`) while the tool block is placed
+   **last** to keep the KV prefix warm (`agent.py:621-647`). A per-turn-changing
+   menu in `get_mcp_client_system_prompt` would sit at the front and invalidate
+   the cache on every expansion — defeating the loader. Render the menu **inside
+   the tools block region** (adjacent to the loaded-tool list, in the volatile
+   tail) so it moves with the filter, not against the cache.
+   - The instruction points only at **`load_tools`** (the Part 2 escape hatch).
+     `search_tools` does not exist in GAIA — do not reference it.
+   - **This menu is the only discovery channel for native tool-calling models:**
+     an unloaded MCP tool is absent from `_openai_tools`, so the model literally
+     cannot emit it and must `load_tools` first. Menu correctness + placement are
+     therefore load-bearing, not polish.
+   - Cap the menu (e.g. 40 tools) and `log()` truncation — no silent cap.
+
+5. **Wire embeddings.** MCP tool embedding text = `"{name}: {description}"` using
+   the existing `embed_batch_fn`. The content-keyed embed cache
+   (`tool_loader.py:177`) already handles new/removed tools across `reload()`.
+
+### Integration points
+- `src/gaia/mcp/mixin.py` — menu fragment in `get_mcp_client_system_prompt`;
+  no change to registration (tools stay in the global registry, loader gates
+  rendering only).
+- `src/gaia/agents/base/tool_loader.py` — MCP-aware `validate_registry`.
+- `hub/agents/python/chat/gaia_agent_chat/agent.py` — additional activation
+  trigger in `_maybe_build_tool_loader` / `_dynamic_tools_active`.
+- Base `Agent` — no interface change; `_select_tools_for_turn` already the hook.
+
+### Edge cases
+- MCP tools that share a bundle-like cohesion (a server's read+write pair):
+  optional follow-up — synthesize a per-server implicit bundle so a match on one
+  server tool pulls its siblings. Start without it; measure recall first.
+- Server disconnect mid-session (`reload()`): loaded set may reference a gone tool.
+  `select` already tolerates registry-absent names; confirm the menu regenerates.
+- Native tool-calling models vs. embedded-JSON models: both render paths read the
+  filter, so both are covered — but test both (see lemonade-client-patterns skill).
+
+### Tests / evals
+- Unit: extend `tests/unit/test_tool_loader_selection.py` with MCP-tagged entries
+  (uncovered by bundles) — assert they score, surface on match, and are gated
+  while static tools pass through in **MCP-only gating mode**.
+- Unit: MCP-only gating mode — static (non-`_mcp_server`) tools always render;
+  MCP tools only on match/`load_tools`. This is the regression guard for the
+  Finding-4 correction.
+- Unit: menu shape (truncation, cap, ≥2-tool gate) **and** placement — assert the
+  menu renders in the volatile tool block, so a stable turn stays byte-identical
+  (KV-cache guard).
+- Eval: extend `src/gaia/eval/tool_cost.py` / `tool_recall.py` with a fixture of
+  N connected mock MCP servers; assert token reduction and recall parity.
+- **Agent eval required** (CLAUDE.md rule — this touches prompt assembly + tool
+  schema): run `gaia eval agent` on the relevant category, compare to baseline
+  before merge.
+- No `validate_registry` test change (it doesn't gate MCP tools — see corrected
+  analysis).
+
+### Risk: **Low–Medium.** Reuses existing selection + rendering with no new
+execution surface, but the MCP-only gating mode and menu placement are genuine
+changes to loader activation and prompt composition — the KV-cache invariant and
+static-tool recall are the two things a review must protect.
+
+---
+
+## Workstream 2 — Context-efficient tool results
+
+**Goal:** large tool outputs don't transit the model context verbatim, and aren't
+re-sent when piped into the next tool.
+
+### Design
+
+1. **Size-gated result handling in the wrapper.** In `_register_mcp_tools`'s
+   `enhanced_wrapper` (`mixin.py:353`), measure serialized result size. Below a
+   threshold (e.g. ~2KB / ~500 tokens) behave exactly as today (byte-identical —
+   no regression for small results). Above it:
+   - Store the full payload in a **session-scoped artifact store** (back it with
+     the scratchpad backend, `src/gaia/scratchpad/`).
+   - Return `{status, message, artifact: "<handle>", preview: <first N + schema
+     summary>, instruction: "..."}` instead of the full `data`. The model sees a
+     preview + a handle, not the payload.
+
+2. **Handle format & resolver.** Handle e.g. `gaia://artifact/<session>/<id>`.
+   Add an argument-resolution step at tool-invocation time (in the base agent's
+   tool dispatch, or the MCP wrapper): before calling a tool, scan its arguments
+   for artifact handles and re-hydrate them from the store. This is what lets a
+   Drive transcript flow into a Salesforce/other tool **without** re-entering
+   context.
+   - **Fail loudly:** unknown/expired handle → actionable error naming the handle
+     and that the artifact expired or belongs to another session. No silent empty.
+
+3. **Preview generation.** For structured data: keys + row count + first row. For
+   text: first N chars + length. Enough for the model to reason about *whether* to
+   use the artifact and *how*, without the bulk.
+
+### Integration points
+- `src/gaia/mcp/mixin.py` — size gate + artifact write in `enhanced_wrapper`.
+- New: `src/gaia/agents/base/artifacts.py` — session-scoped store with handle
+  mint/resolve, TTL, size caps. **Prefer a small dedicated blob KV over the
+  scratchpad backend**: `src/gaia/scratchpad/` is oriented to SQL *tables* for
+  data analysis, not opaque blobs, so "reuse" is a stretch (kept as an open
+  question below, but leaning dedicated).
+- **Argument handle-resolution pass in `Agent._execute_tool`** (`agent.py:1897`)
+  — confirmed single dispatch site: it resolves the tool name, then calls
+  `self._tools_registry[tool_name]["function"]` at `agent.py:1983`. Scan/rehydrate
+  handles in `tool_args` immediately before that call so it applies to **all**
+  tools (a small tool can consume a large tool's artifact), MCP or not.
+  - **Verify before building:** confirm the native tool-calling path also routes
+    execution through `_execute_tool` (it should — `_on_tool_invoked` is recorded
+    there for both paths). If a second executor exists, the resolver must cover it.
+
+### Edge cases
+- Handle resolution must be scoped to the current session — never cross-session
+  (privacy + correctness). Store keyed by session id.
+- Artifact store growth: TTL + max-size eviction; loud log on eviction.
+- A model that pastes preview text as if it were the full payload: preview must be
+  clearly labeled `[PREVIEW — full data in artifact <handle>]`.
+
+### Tests
+- Unit: small result → unchanged path (assert byte-identical wrapper output).
+- Unit: large result → handle + preview; resolver re-hydrates on next call;
+  unknown handle raises actionable error.
+- Integration: two-tool pipe (produce large → consume by handle) never puts the
+  payload in the message list (assert on captured messages).
+
+### Risk: **Medium.** New store + dispatch hook; keep the small-result path
+byte-identical to avoid regressing every existing MCP call.
+
+---
+
+## Workstream 3 — Privacy pass-through (optional, Phase 3)
+
+**Goal:** sensitive fields flow connector→connector without ever entering model
+context. Builds directly on WS2's handle mechanism.
+
+### Design (sketch — validate before committing)
+- On result ingestion, run the governance layer's PII detection over the payload.
+- Tokenize detected fields (emails, phone numbers) into placeholders
+  (`<pii:email:1>`) in the preview/context representation; keep the real values
+  only in the artifact store.
+- On outbound tool call, the resolver substitutes real values back from the store.
+- The model orchestrates the flow seeing only placeholders.
+
+### Why Phase 3
+- Depends on WS2 landing first (shared store + resolver).
+- Depends on governance PII detection maturity.
+- Highest complexity, most speculative benefit for current local use cases.
+- Decision gate: only build if a concrete connector→connector workflow (e.g.
+  Sheets→CRM) is a real GAIA use case at that point.
+
+### Risk: **Higher.** Correctness of tokenize/resolve round-trip is critical — a
+missed substitution leaks PII into context (the exact thing it prevents). Requires
+adversarial tests.
+
+---
+
+## Phasing & sequencing
+
+| Phase | Workstream | Gate to proceed |
+|-------|-----------|-----------------|
+| 1 | WS1 (progressive disclosure for MCP) | Ship behind existing dynamic-tools toggle; eval shows token drop + recall parity |
+| 2 | WS2 (context-efficient results) | Small-result path proven byte-identical; pipe test passes |
+| 3 | WS3 (privacy pass-through) | A real connector→connector workflow exists; PII round-trip adversarially tested |
+
+WS1 and WS2 are independent and can land in either order; WS3 requires WS2.
+
+## Non-goals (the rejected half of the article)
+- No model-authored code execution.
+- No code sandbox / interpreter for agent-generated code.
+- No "MCP servers as a code-API filesystem" presentation.
+
+Rationale: GAIA's default models (Gemma-4-E4B, Qwen-4B) author orchestration code
+unreliably; running that code locally is a large security surface; and the token
+win is already captured by embedding-based selection (WS1) without either cost.
+This matches CLAUDE.md's "no silent fallbacks / fail loudly" posture — a weak model
+emitting plausible-but-wrong code is precisely the quiet-wrong-answer failure mode
+to avoid.
+
+## Open questions
+1. Should the loader's MCP activation be a new config field, or purely
+   auto-on-when-MCP-present? (Leaning auto-on, env-overridable, to match
+   `GAIA_DYNAMIC_TOOLS`.)
+2. WS2 artifact store: reuse scratchpad tables, or a dedicated lightweight KV?
+   (Leaning scratchpad to avoid a new subsystem.)
+3. WS1 per-server implicit bundles — needed for recall, or does flat semantic
+   scoring suffice? (Measure before building.)

--- a/src/gaia/eval/followup_quality.py
+++ b/src/gaia/eval/followup_quality.py
@@ -1,0 +1,669 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Detection-quality eval for the email agent's follow-up tracking
+(#1606 feature, #1950 tracking).
+
+Sibling of :mod:`gaia.eval.action_item_quality` (extraction) and
+:mod:`gaia.eval.draft_quality` (drafting): the same committed-fixture /
+report-mode conventions, applied to the follow-up path. The deterministic unit
+tests for #1606 (``test_email_followups``) prove the detector *runs*; they say
+nothing about whether the threads it flags are the ones a human actually
+considers "awaiting a reply". This module measures that — precision / recall /
+F1 of the ``awaits_reply`` flag against a hand-labeled corpus of sent threads,
+with the two failure modes treated as first-class:
+
+- **False positives** — a thanks/FYI/acknowledgment note the user sent that
+  needs no reply, but which the latest-outbound heuristic flags anyway.
+- **False negatives** — a genuine question whose latest inbound message is only
+  an out-of-office auto-reply, which the detector mistakes for a real answer.
+
+Whether a thread *awaits a reply* is a human judgment (did it actually ask for
+something / expect a response). The current detector
+(:func:`gaia_agent_email.tools.followup_tools.check_followups_impl`) is
+deterministic — latest message outbound + age past the window + an external
+recipient. This eval scores that heuristic's classification against the labels,
+surfacing exactly where the heuristic and human judgment diverge.
+
+Three separable stages, each testable on its own:
+
+1. **Generation** (:func:`generate_detections` — needs the email agent package
+   for the real detector; fully offline, NO Lemonade): per corpus case, replay
+   the thread into a ``FakeGmailBackend`` and run the REAL ``check_followups_impl``
+   over it, recording whether the case's thread was flagged.
+2. **Scoring** (:func:`score_case` — fully offline): compare the predicted flag
+   to the labeled ``awaits_reply`` and roll it into a ``build_scorecard``-compatible
+   row.
+3. **Aggregation** (:func:`summarize_followups`): reduce per-case flags into a
+   corpus-wide confusion (:class:`gaia.eval.quality_metrics.Confusion`) →
+   precision / recall / F1 / FP-rate / FN-rate, and score the committed gate
+   manifest (``followups_gate_thresholds.json``, ``enforce:false``).
+
+Fail-loud contract: a malformed corpus, an unknown case id, or a missing
+thresholds manifest raise actionable errors — nothing silently scores as a pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from gaia.eval.quality_metrics import Confusion
+
+# ---------------------------------------------------------------------------
+# Detection parameters (kept in-module so this file is importable without the
+# email agent package). window_days matches EmailAgentConfig.followup_window_days
+# / DEFAULT_FOLLOWUP_WINDOW_DAYS; the fixed clock keeps corpus ages deterministic.
+# ---------------------------------------------------------------------------
+
+DEFAULT_FOLLOWUP_WINDOW_DAYS = 3
+# Fixed "now" (epoch ms) so a case's ``age_days`` maps to a stable timestamp.
+FIXED_NOW_MS = 1_750_000_000_000
+_DAY_MS = 24 * 60 * 60 * 1000
+# The corpus principal — outbound mail is authored as coming from this address,
+# inbound replies are addressed to it. Matches FakeGmailBackend's default.
+CORPUS_USER_EMAIL = "user@example.com"
+
+# Keys that are corpus metadata, not cases (same convention as ground_truth).
+_METADATA_PREFIX = "_"
+
+_VALID_DIRECTIONS = {"outbound", "inbound"}
+
+
+# ---------------------------------------------------------------------------
+# Corpus loading (offline)
+# ---------------------------------------------------------------------------
+
+
+def _validate_message(case_id: str, idx: int, msg: Any) -> None:
+    if not isinstance(msg, dict):
+        raise ValueError(
+            f"case '{case_id}': thread[{idx}] must be an object, got "
+            f"{type(msg).__name__}."
+        )
+    direction = msg.get("direction")
+    if direction not in _VALID_DIRECTIONS:
+        raise ValueError(
+            f"case '{case_id}': thread[{idx}].direction must be one of "
+            f"{sorted(_VALID_DIRECTIONS)}, got {direction!r}."
+        )
+    for f in ("subject", "body"):
+        if not isinstance(msg.get(f), str) or not msg[f].strip():
+            raise ValueError(
+                f"case '{case_id}': thread[{idx}].{f} must be a non-empty string."
+            )
+    age = msg.get("age_days")
+    if isinstance(age, bool) or not isinstance(age, (int, float)) or age < 0:
+        raise ValueError(
+            f"case '{case_id}': thread[{idx}].age_days must be a non-negative "
+            f"number, got {age!r}."
+        )
+    # An outbound message needs a recipient; an inbound one needs a sender.
+    if direction == "outbound":
+        if not isinstance(msg.get("to"), str) or not msg["to"].strip():
+            raise ValueError(
+                f"case '{case_id}': thread[{idx}] is outbound but has no non-empty "
+                "'to' recipient."
+            )
+    else:  # inbound
+        if not isinstance(msg.get("from"), str) or not msg["from"].strip():
+            raise ValueError(
+                f"case '{case_id}': thread[{idx}] is inbound but has no non-empty "
+                "'from' sender."
+            )
+
+
+def _validate_case(case_id: str, case: Any) -> None:
+    if not isinstance(case, dict):
+        raise ValueError(
+            f"follow-up corpus case '{case_id}' must be a JSON object, got "
+            f"{type(case).__name__}."
+        )
+    scenario = case.get("scenario")
+    if not isinstance(scenario, str) or not scenario.strip():
+        raise ValueError(f"case '{case_id}': 'scenario' must be a non-empty string.")
+    awaits = case.get("awaits_reply")
+    if not isinstance(awaits, bool):
+        raise ValueError(
+            f"case '{case_id}': 'awaits_reply' must be a boolean (the label)."
+        )
+    thread = case.get("thread")
+    if not isinstance(thread, list) or not thread:
+        raise ValueError(
+            f"case '{case_id}': 'thread' must be a non-empty list of messages."
+        )
+    for idx, msg in enumerate(thread):
+        _validate_message(case_id, idx, msg)
+    # A sent thread must contain at least one outbound message, or the Sent-folder
+    # scan would never surface it — a corpus case the detector can't reach is a
+    # labeling error, not a legitimate hard negative.
+    if not any(m.get("direction") == "outbound" for m in thread):
+        raise ValueError(
+            f"case '{case_id}': thread has no outbound message; a sent-thread "
+            "corpus case must contain at least one message from the user."
+        )
+    # 'is_hard_negative' is optional metadata, but if present it must agree with
+    # the label — a mislabeled hard negative silently corrupts the FP math.
+    hard = case.get("is_hard_negative")
+    if hard is not None:
+        if not isinstance(hard, bool):
+            raise ValueError(f"case '{case_id}': 'is_hard_negative' must be a boolean.")
+        if hard != (not awaits):
+            raise ValueError(
+                f"case '{case_id}': 'is_hard_negative' is {hard} but 'awaits_reply' "
+                f"is {awaits} — the flag and the label disagree (hard negative must "
+                "be the not-awaits-reply case)."
+            )
+
+
+def _reject_duplicate_keys(pairs: list) -> dict:
+    out: dict = {}
+    for key, value in pairs:
+        if key in out:
+            raise ValueError(f"duplicate case id {key!r} in the follow-up corpus")
+        out[key] = value
+    return out
+
+
+def load_followup_corpus(path: str | Path) -> dict[str, dict]:
+    """Load + validate the follow-up corpus (loud on missing/malformed).
+
+    Returns the full mapping including the ``_meta`` block; use
+    :func:`corpus_cases` to get only the scored cases. Duplicate case ids,
+    missing required fields, or an ``is_hard_negative`` flag that disagrees with
+    ``awaits_reply`` raise ``ValueError``.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        try:
+            data = json.load(fh, object_pairs_hook=_reject_duplicate_keys)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"follow-up corpus at {path} is not valid JSON: {exc}"
+            ) from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"follow-up corpus at {path} must be a JSON object keyed by case id, "
+            f"got {type(data).__name__}."
+        )
+    cases = {k: v for k, v in data.items() if not k.startswith(_METADATA_PREFIX)}
+    if not cases:
+        raise ValueError(f"follow-up corpus at {path} contains no cases.")
+    for case_id, case in cases.items():
+        _validate_case(case_id, case)
+    return data
+
+
+def corpus_cases(corpus: Mapping[str, Any]) -> dict[str, dict]:
+    """Only the scored cases (drop ``_``-prefixed metadata blocks)."""
+    return {k: v for k, v in corpus.items() if not k.startswith(_METADATA_PREFIX)}
+
+
+def is_hard_negative(case: Mapping[str, Any]) -> bool:
+    """True when the thread does NOT await a reply (the must-not-flag case)."""
+    return not case.get("awaits_reply", False)
+
+
+# ---------------------------------------------------------------------------
+# Thread -> Gmail-API payloads (offline)
+# ---------------------------------------------------------------------------
+
+
+def _message_payload(
+    case_id: str, idx: int, msg: Mapping[str, Any], *, now_ms: int
+) -> dict[str, Any]:
+    """A Gmail-API-shape message dict for ``FakeGmailBackend.add_message``.
+
+    Outbound mail is labeled ``SENT`` (so the Sent-folder scan reaches the
+    thread) and authored as coming from the corpus principal; inbound mail is
+    labeled ``INBOX`` and addressed to the principal. ``internalDate`` is derived
+    from ``age_days`` against the injected ``now_ms`` so ages are deterministic.
+    """
+    direction = msg["direction"]
+    body = msg["body"]
+    data = base64.urlsafe_b64encode(body.encode("utf-8")).decode("ascii").rstrip("=")
+    if direction == "outbound":
+        sender = msg.get("from") or f"Me <{CORPUS_USER_EMAIL}>"
+        recipient = msg["to"]
+        label_ids = ["SENT"]
+    else:
+        sender = msg["from"]
+        recipient = msg.get("to") or CORPUS_USER_EMAIL
+        label_ids = ["INBOX", "UNREAD"]
+    internal_date = str(int(now_ms - float(msg["age_days"]) * _DAY_MS))
+    return {
+        "id": f"{case_id}-{idx}",
+        "threadId": case_id,
+        "labelIds": label_ids,
+        "snippet": " ".join(body.split())[:200],
+        "internalDate": internal_date,
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "To", "value": recipient},
+                {"name": "Subject", "value": msg["subject"]},
+                {"name": "Date", "value": f"{msg['age_days']} days ago"},
+                {"name": "Message-ID", "value": f"<{case_id}-{idx}@followups.eval>"},
+            ],
+            "body": {"size": len(body.encode("utf-8")), "data": data},
+        },
+        "sizeEstimate": len(body.encode("utf-8")),
+    }
+
+
+def thread_payloads(
+    case_id: str, case: Mapping[str, Any], *, now_ms: int = FIXED_NOW_MS
+) -> list[dict[str, Any]]:
+    """Render a case's ``thread`` into Gmail-API message payloads (chronological)."""
+    return [
+        _message_payload(case_id, idx, msg, now_ms=now_ms)
+        for idx, msg in enumerate(case["thread"])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-case scoring -> build_scorecard-compatible rows (offline)
+# ---------------------------------------------------------------------------
+
+
+def score_case(
+    case_id: str,
+    case: Mapping[str, Any],
+    predicted: bool | None,
+    *,
+    model_id: str,
+    error: str = "",
+    duration_ms: int = 0,
+) -> dict[str, Any]:
+    """Score one case into a ``build_scorecard``-compatible result row.
+
+    ``predicted`` is the detector's ``awaiting_reply`` verdict for the case's
+    thread; ``None`` means the detector produced nothing usable (``error`` says
+    why) and the row is ``ERRORED`` — never silently scored. Otherwise the row is
+    ``PASS`` when the predicted flag matches the labeled ``awaits_reply`` and
+    ``FAIL`` otherwise. ``followup_match`` carries the booleans the aggregator
+    reduces into a confusion; ``overall_score`` is 10.0 on a correct call, 0.0 on
+    a miss.
+    """
+    expected = bool(case.get("awaits_reply", False))
+    out: dict[str, Any] = {
+        "id": case_id,
+        "category": model_id,
+        "scenario": case.get("scenario", ""),
+        "awaits_reply_expected": expected,
+        "hard_negative": is_hard_negative(case),
+        "total_duration_ms": duration_ms,
+    }
+    if predicted is None:
+        out["status"] = "ERRORED"
+        out["error"] = error or "detector produced no follow-up verdict"
+        return out
+
+    predicted = bool(predicted)
+    correct = predicted == expected
+    out["followup_match"] = {
+        "predicted": predicted,
+        "expected": expected,
+        "correct": correct,
+        # 2x2 cell this case lands in, for readable per-case rows + aggregation.
+        "tp": int(predicted and expected),
+        "fp": int(predicted and not expected),
+        "fn": int((not predicted) and expected),
+        "tn": int((not predicted) and (not expected)),
+    }
+    out["overall_score"] = 10.0 if correct else 0.0
+    out["status"] = "PASS" if correct else "FAIL"
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Aggregation (offline)
+# ---------------------------------------------------------------------------
+
+
+def summarize_followups(
+    results: list[dict],
+    *,
+    run_id: str,
+    thresholds: "FollowupThresholds | None" = None,
+) -> dict[str, Any]:
+    """Aggregate per-case rows into a scorecard + follow-up-gate summary.
+
+    Reduces the per-case ``awaits_reply`` predictions into a corpus-wide
+    confusion (:class:`gaia.eval.quality_metrics.Confusion`) → precision / recall
+    / F1 / FP-rate / FN-rate / accuracy, reports the hard-negative correct rate
+    separately (the fraction of no-reply-needed threads the detector correctly
+    left unflagged — the false-positive story), and reuses
+    :func:`gaia.eval.scorecard.build_scorecard` unchanged. When ``thresholds`` is
+    given the follow-up gate runs — report mode unless the manifest sets
+    ``enforce``. When no case was scored the gate is a loud explicit skip, never
+    an invented pass.
+    """
+    from gaia.eval.scorecard import build_scorecard
+
+    scorecard = build_scorecard(
+        run_id, results, {"benchmark": "email_followup_detection"}
+    )
+    summary: dict[str, Any] = {"scorecard": scorecard}
+
+    scored = [r for r in results if isinstance(r.get("followup_match"), dict)]
+    aggregate: dict[str, Any] | None = None
+    if scored:
+        conf = Confusion()
+        hard_total = 0
+        hard_correct = 0
+        for r in scored:
+            m = r["followup_match"]
+            conf.tp += int(m["tp"])
+            conf.fp += int(m["fp"])
+            conf.fn += int(m["fn"])
+            conf.tn += int(m["tn"])
+            if r.get("hard_negative"):
+                hard_total += 1
+                # A hard negative is "correct" only when it was NOT flagged (tn).
+                if int(m["tn"]) == 1:
+                    hard_correct += 1
+        aggregate = {
+            "cases_total": len(results),
+            "cases_scored": len(scored),
+            "cases_errored": sum(1 for r in results if r.get("status") == "ERRORED"),
+            "awaits_reply_total": conf.tp + conf.fn,
+            "flagged_total": conf.tp + conf.fp,
+            "tp": conf.tp,
+            "fp": conf.fp,
+            "fn": conf.fn,
+            "tn": conf.tn,
+            "precision": conf.precision,
+            "recall": conf.recall,
+            "f1": conf.f1,
+            "false_positive_rate": conf.false_positive_rate,
+            "false_negative_rate": conf.false_negative_rate,
+            "accuracy": conf.accuracy,
+            "hard_negatives_total": hard_total,
+            "hard_negatives_correct": hard_correct,
+            "hard_negative_correct_rate": (
+                round(hard_correct / hard_total, 4) if hard_total else 0.0
+            ),
+            "per_case": [
+                {
+                    "id": r.get("id"),
+                    "status": r.get("status"),
+                    "hard_negative": r.get("hard_negative", False),
+                    "predicted": r["followup_match"]["predicted"],
+                    "expected": r["followup_match"]["expected"],
+                    "correct": r["followup_match"]["correct"],
+                }
+                for r in scored
+            ],
+        }
+        summary["followups"] = aggregate
+
+    if thresholds is not None:
+        if aggregate is None:
+            summary["followup_gate"] = {
+                "skipped": True,
+                "reason": (
+                    "no case carried a follow-up verdict; the follow-up gate "
+                    "cannot be evaluated"
+                ),
+                "enforce": thresholds.enforce,
+                "should_fail": False,
+            }
+        else:
+            summary["followup_gate"] = evaluate_followup_gate(aggregate, thresholds)
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Committed-threshold gate (#1950 — report mode; flip enforce in the manifest)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FollowupThresholds:
+    """Precision/recall/F1 bars for the follow-up gate (#1950 target).
+
+    ``enforce`` is the single safety switch, same contract as the FP/FN, perf,
+    drafting, and action-item gates: ``False`` (the committed value) means the
+    gate computes and reports but never fails the harness. Flip it in the
+    manifest — data, not code — once a real baseline confirms the bars.
+    ``recall_min`` / ``precision_min`` default to ``0.0`` (unset ⇒ not gated) so a
+    manifest may gate on F1 alone or add the axis floors independently.
+    """
+
+    f1_min: float
+    recall_min: float = 0.0
+    precision_min: float = 0.0
+    enforce: bool = False
+
+
+def load_followup_thresholds(path: str | Path) -> FollowupThresholds:
+    """Load the follow-up-gate thresholds manifest (loud on missing/malformed)."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"follow-up-gate thresholds manifest at {path} must be a JSON "
+            f"object, got {type(data).__name__}."
+        )
+    if "f1_min" not in data:
+        raise ValueError(
+            f"follow-up-gate thresholds manifest at {path} is missing required "
+            "key 'f1_min'. Optional: 'recall_min', 'precision_min', 'enforce' "
+            "(default false)."
+        )
+    for key in ("f1_min", "recall_min", "precision_min"):
+        if key in data and (
+            isinstance(data[key], bool) or not isinstance(data[key], (int, float))
+        ):
+            raise ValueError(
+                f"follow-up-gate threshold '{key}' in {path} must be numeric, "
+                f"got {data[key]!r}."
+            )
+    return FollowupThresholds(
+        f1_min=float(data["f1_min"]),
+        recall_min=float(data.get("recall_min", 0.0)),
+        precision_min=float(data.get("precision_min", 0.0)),
+        enforce=bool(data.get("enforce", False)),
+    )
+
+
+# Canonical location of the committed follow-up-gate thresholds manifest. The
+# single entry point CI consumes — flip 'enforce' in this file (data, not code)
+# to make CI gate on the #1950 precision/recall/F1 bars.
+_FOLLOWUP_THRESHOLDS_MANIFEST = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "email"
+    / "followups_gate_thresholds.json"
+)
+
+
+def default_followup_thresholds_path() -> Path:
+    """Path to the committed follow-up-gate thresholds manifest (#1950)."""
+    return _FOLLOWUP_THRESHOLDS_MANIFEST
+
+
+def load_default_followup_thresholds() -> FollowupThresholds:
+    """Load the committed follow-up-gate thresholds (loud if absent/malformed)."""
+    return load_followup_thresholds(default_followup_thresholds_path())
+
+
+def evaluate_followup_gate(
+    aggregate: Mapping[str, Any], thresholds: FollowupThresholds
+) -> dict[str, Any]:
+    """Compare the aggregate precision/recall/F1 to the committed bars.
+
+    Same result shape + ``should_fail`` contract as
+    :func:`gaia.eval.quality_metrics.evaluate_gate`: in report mode
+    (``enforce=False``) ``should_fail`` is always ``False`` even on a breach.
+    Only bars greater than ``0`` are checked (an unset ``recall_min`` /
+    ``precision_min`` is not gated). Fail-loud on a missing ``f1`` — a gate that
+    can't find its input must not silently pass.
+    """
+    if "f1" not in aggregate:
+        raise ValueError(
+            "follow-up gate needs 'f1' in the aggregate block "
+            f"(have: {sorted(aggregate.keys())})."
+        )
+    checks = [
+        ("f1", float(aggregate["f1"]), thresholds.f1_min),
+        ("recall", float(aggregate.get("recall", 0.0)), thresholds.recall_min),
+        ("precision", float(aggregate.get("precision", 0.0)), thresholds.precision_min),
+    ]
+    breaches: list[dict[str, Any]] = []
+    for metric, value, minimum in checks:
+        if minimum > 0.0 and value < minimum:
+            breaches.append({"metric": metric, "value": value, "min": minimum})
+    passed = not breaches
+    return {
+        "f1": float(aggregate["f1"]),
+        "recall": float(aggregate.get("recall", 0.0)),
+        "precision": float(aggregate.get("precision", 0.0)),
+        "f1_min": thresholds.f1_min,
+        "recall_min": thresholds.recall_min,
+        "precision_min": thresholds.precision_min,
+        "passed": passed,
+        "breaches": breaches,
+        "enforce": thresholds.enforce,
+        "should_fail": thresholds.enforce and not passed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Generation stage (drives the REAL detector — offline, no Lemonade)
+# ---------------------------------------------------------------------------
+
+
+# A detector callable: (backend, *, window_days, now_ms) -> check_followups_impl
+# result dict with an "awaiting_reply" list of {thread_id, ...}. Injectable so
+# unit tests can drive generation without the email agent package installed.
+DetectorFn = Callable[..., Mapping[str, Any]]
+
+
+def _default_detector(
+    backend: Any, *, window_days: int, now_ms: int
+) -> Mapping[str, Any]:
+    """The real follow-up detector, lazily imported.
+
+    Lazy so ``import gaia.eval.followup_quality`` stays free of the email agent
+    stack; ``check_followups_impl`` ships in the standalone gaia-agent-email
+    wheel (#1102).
+    """
+    try:
+        from gaia_agent_email.tools.followup_tools import check_followups_impl
+    except ImportError as exc:
+        raise RuntimeError(
+            "The follow-up detection eval needs the email agent. Install it with "
+            "`pip install gaia-agent-email` (or `pip install "
+            '"amd-gaia[agents]"`). '
+            f"Original import error: {exc}"
+        ) from exc
+    return check_followups_impl(backend, window_days=window_days, now_ms=now_ms)
+
+
+def generate_detections(
+    *,
+    corpus_path: str | Path,
+    window_days: int = DEFAULT_FOLLOWUP_WINDOW_DAYS,
+    now_ms: int = FIXED_NOW_MS,
+    limit: int | None = None,
+    detector_fn: DetectorFn | None = None,
+) -> list[dict[str, Any]]:
+    """Run the REAL follow-up detector per corpus case and record its verdict.
+
+    Per case: seed a fresh ``FakeGmailBackend`` with the thread's messages, run
+    the detector over its Sent folder, and record whether the case's thread was
+    flagged as awaiting a reply. Read-only over an unchanged detector — nothing
+    is drafted or sent. Detection is deterministic (no Lemonade, no network).
+
+    ``detector_fn(backend, window_days=..., now_ms=...)`` overrides the detector
+    (tests inject a stub; keeps the unit path email-package-free). Returns
+    ``[{case_id, predicted|None, error, duration_ms}]`` for :func:`score_case`.
+    """
+    corpus = load_followup_corpus(corpus_path)
+    cases = corpus_cases(corpus)
+    case_items = list(cases.items())
+    if limit is not None:
+        case_items = case_items[:limit]
+
+    detector = detector_fn or _default_detector
+
+    try:
+        from tests.fixtures.email.fake_gmail import FakeGmailBackend
+    except ImportError as exc:
+        raise RuntimeError(
+            "The follow-up detection eval must run from a GAIA repo checkout — it "
+            "drives the FakeGmailBackend in tests/fixtures/email and is not "
+            f"available in a packaged install. Original import error: {exc}"
+        ) from exc
+
+    generations: list[dict[str, Any]] = []
+    for case_id, case in case_items:
+        backend = FakeGmailBackend(user_email=CORPUS_USER_EMAIL)
+        for payload in thread_payloads(case_id, case, now_ms=now_ms):
+            backend.add_message(payload)
+
+        start = time.monotonic()
+        error = ""
+        predicted: bool | None = None
+        try:
+            result = detector(backend, window_days=window_days, now_ms=now_ms)
+            flagged = {
+                item.get("thread_id") for item in result.get("awaiting_reply", [])
+            }
+            predicted = case_id in flagged
+        except Exception as exc:  # surfaced per-case, never swallowed silently
+            error = f"{type(exc).__name__}: {exc}"
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        generations.append(
+            {
+                "case_id": case_id,
+                "predicted": predicted,
+                "error": error,
+                "duration_ms": duration_ms,
+            }
+        )
+    return generations
+
+
+def score_generations(
+    corpus: Mapping[str, Any],
+    generations: list[dict],
+    *,
+    model_id: str,
+) -> list[dict[str, Any]]:
+    """Score :func:`generate_detections` output into scorecard-compatible rows.
+
+    ``generations`` is ``[{case_id, predicted|None, error, duration_ms}]`` (real
+    or stubbed). A generation that carried no verdict stays ``ERRORED`` with its
+    error; everything else is scored via :func:`score_case`.
+    """
+    cases = corpus_cases(corpus)
+    results: list[dict[str, Any]] = []
+    for gen in generations:
+        case_id = gen["case_id"]
+        if case_id not in cases:
+            raise ValueError(
+                f"generation references unknown case id {case_id!r} — corpus and "
+                "generations are out of sync"
+            )
+        results.append(
+            score_case(
+                case_id,
+                cases[case_id],
+                gen.get("predicted"),
+                model_id=model_id,
+                error=gen.get("error", ""),
+                duration_ms=int(gen.get("duration_ms", 0)),
+            )
+        )
+    return results

--- a/tests/fixtures/email/followups_gate_thresholds.json
+++ b/tests/fixtures/email/followups_gate_thresholds.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Detection-quality bars for the email follow-up tracking eval (#1606 feature, #1950 tracking). 'f1_min' is the primary reported target (micro-averaged F1 of the awaits_reply flag over the labeled corpus of sent threads); 'recall_min' guards against silently dropping real follow-ups (false negatives, e.g. an out-of-office auto-reply masking a genuine unanswered question); 'precision_min' guards against nagging the user about mail that needs no reply (false positives, e.g. thanks/FYI/acknowledgment notes). 'enforce' is the SINGLE switch CI keys off and it ships FALSE (report mode) on purpose: NO real baseline exists yet, and the shipped detector is a deterministic latest-outbound heuristic with a KNOWN false-positive gap on courtesy/FYI notes, so these bars are PROVISIONAL placeholders, NOT measured numbers -- do not treat them as a confirmed floor. Flip 'enforce' to true HERE (data, not code) once the first report establishes a stable baseline (and, if follow-up classification gains an LLM judgment layer, re-measure against that), RE-MEASURING f1_min/recall_min/precision_min to the observed numbers at that point. Loaded by gaia.eval.followup_quality.load_followup_thresholds (which ignores extra keys).",
+  "f1_min": 0.70,
+  "recall_min": 0.80,
+  "precision_min": 0.60,
+  "enforce": false
+}

--- a/tests/fixtures/email/followups_ground_truth.json
+++ b/tests/fixtures/email/followups_ground_truth.json
@@ -1,0 +1,291 @@
+{
+  "_meta": {
+    "fixture": "followups_ground_truth.json",
+    "fixture_kind": "hand-authored-seed",
+    "schema_version": 1,
+    "description": "Labeled seed corpus for the email follow-up detection quality eval (#1606 feature, #1950 tracking). Each case is ONE sent thread (a conversation the user started) hand-labeled with whether it genuinely 'awaits_reply' -- i.e. the user asked for something / expects a response that has not arrived. Scored by gaia.eval.followup_quality: the corpus thread is replayed into a FakeGmailBackend and the REAL detector (gaia_agent_email.tools.followup_tools.check_followups_impl) is run over it; whether the thread is flagged 'awaiting_reply' is the prediction, matched against 'awaits_reply'. Detection is deterministic (latest-message-outbound + age + external-recipient) -- this eval measures where that heuristic diverges from human judgment: FALSE POSITIVES (thanks/FYI/acknowledgment notes the user sent that need no reply but get flagged) and FALSE NEGATIVES (a genuine question whose latest inbound message is only an out-of-office auto-reply, which the detector mistakes for a real answer). To isolate the CONTENT/reply-state judgment from the detector's timing grace-window, every outbound-latest case is authored past the 3-day window (age_days >= window); the only thing that varies is the content and the inbound-reply state. HARD NEGATIVES (awaits_reply == false) are deliberate and first-class: a sent note that needs no reply must NOT be flagged, and any flag there is a false positive in the precision denominator. The aggregate precision / recall / F1 over the awaits_reply flag are compared to followups_gate_thresholds.json in report mode (enforce:false).",
+    "detection_params": {
+      "window_days": 3,
+      "note": "The scorer runs check_followups_impl with window_days=3 and a fixed injected now, so ages are deterministic. A thread is flagged only when its LATEST message is the user's own outbound mail, at least window_days old, to at least one external recipient."
+    },
+    "case_schema": {
+      "scenario": "str -- short label for what this sent thread is",
+      "awaits_reply": "bool -- the human label: does this thread genuinely await an inbound reply the user is waiting on?",
+      "is_hard_negative": "bool -- true when the thread does NOT await a reply (awaits_reply == false); must agree with awaits_reply",
+      "thread": "list[{direction: 'outbound'|'inbound', from?: str, to?: str, subject: str, body: str, age_days: number}] -- the conversation in chronological order (oldest first). Outbound = the user's mail (from defaults to the user, to is the recipient); inbound = a counterparty's reply (from is the counterparty, to defaults to the user). age_days is how many days ago the message was sent, relative to the fixed eval 'now'."
+    }
+  },
+  "fu-001": {
+    "scenario": "genuine question -- confirm a meeting time, no reply",
+    "awaits_reply": true,
+    "is_hard_negative": false,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Dana Kim <dana@acme.io>",
+        "subject": "Design review time",
+        "body": "Hi Dana,\n\nCan we move Thursday's design review from 1pm to 3pm? Let me know if that works and I'll update the invite.\n\nSam",
+        "age_days": 5
+      }
+    ]
+  },
+  "fu-002": {
+    "scenario": "document review request to external counsel, no reply",
+    "awaits_reply": true,
+    "is_hard_negative": false,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Robert Alvarez <ralvarez@dunmorelaw.com>",
+        "subject": "Licensing agreement -- redline",
+        "body": "Dear Robert,\n\nI've attached our redline of the licensing agreement. Could you review sections 4 and 7 and let me know if the revised indemnity language is acceptable?\n\nThanks,\nSam",
+        "age_days": 6
+      }
+    ]
+  },
+  "fu-003": {
+    "scenario": "quote request to a vendor, no reply",
+    "awaits_reply": true,
+    "is_hard_negative": false,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Sales <sales@cloudhost.com>",
+        "subject": "Pricing for the enterprise tier",
+        "body": "Hello,\n\nWe're evaluating your enterprise plan for ~200 seats. Could you send a formal quote including volume discount and annual billing options?\n\nBest,\nSam",
+        "age_days": 4
+      }
+    ]
+  },
+  "fu-004": {
+    "scenario": "approval request to a teammate, no reply",
+    "awaits_reply": true,
+    "is_hard_negative": false,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Priya Rao <priya@acme.io>",
+        "subject": "PR #812 ready for your approval",
+        "body": "Hi Priya,\n\nThe migration PR is green and ready. Could you review and approve when you get a chance? I'd like to merge before the Friday freeze.\n\nSam",
+        "age_days": 7
+      }
+    ]
+  },
+  "fu-005": {
+    "scenario": "open question needing an answer, no reply",
+    "awaits_reply": true,
+    "is_hard_negative": false,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Marcus Lee <marcus@acme.io>",
+        "subject": "Which commit shipped in the staging deploy?",
+        "body": "Hey Marcus,\n\nQA is chasing a regression on staging. Do you know which commit went out in this morning's deploy? I need it to bisect.\n\nSam",
+        "age_days": 5
+      }
+    ]
+  },
+  "fu-006": {
+    "scenario": "false-negative trap -- genuine ask, latest inbound is only an out-of-office auto-reply",
+    "awaits_reply": true,
+    "is_hard_negative": false,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Grace Osei <grace@partnerco.com>",
+        "subject": "Intro call times",
+        "body": "Hi Grace,\n\nGreat to connect. Are you free Tuesday 2pm or Thursday 11am for a 30-minute intro call? I'll send an invite once you confirm.\n\nSam",
+        "age_days": 6
+      },
+      {
+        "direction": "inbound",
+        "from": "Grace Osei <grace@partnerco.com>",
+        "subject": "Automatic reply: Intro call times",
+        "body": "I am out of the office until Monday with limited access to email. For urgent matters contact my assistant at ops@partnerco.com. I will respond when I return.\n\nGrace",
+        "age_days": 4
+      }
+    ]
+  },
+  "fu-neg-001": {
+    "scenario": "hard negative -- thank-you note the user sent, no reply needed",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Grace Osei <grace@partnerco.com>",
+        "subject": "Thanks!",
+        "body": "Hi Grace,\n\nThanks so much for the demo yesterday -- the team was really impressed. No need to reply, just wanted to pass along the kind words.\n\nSam",
+        "age_days": 5
+      }
+    ]
+  },
+  "fu-neg-002": {
+    "scenario": "hard negative -- FYI status broadcast, explicitly no action needed",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "team@acme.io",
+        "subject": "2.4 deployed cleanly",
+        "body": "Hi all,\n\nJust letting you know the 2.4 release deployed to production this afternoon with no issues. Metrics look normal. No action needed -- sharing for visibility.\n\nSam",
+        "age_days": 5
+      }
+    ]
+  },
+  "fu-neg-003": {
+    "scenario": "hard negative -- closing acknowledgment, conversation already settled",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "inbound",
+        "from": "Dana Kim <dana@acme.io>",
+        "subject": "Design review time",
+        "body": "3pm Thursday works great on my end -- see you then.\n\nDana",
+        "age_days": 6
+      },
+      {
+        "direction": "outbound",
+        "to": "Dana Kim <dana@acme.io>",
+        "subject": "Re: Design review time",
+        "body": "Sounds good, see you Thursday at 3pm. Thanks Dana!\n\nSam",
+        "age_days": 5
+      }
+    ]
+  },
+  "fu-neg-004": {
+    "scenario": "hard negative -- shared an article for visibility, no ask",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Marcus Lee <marcus@acme.io>",
+        "subject": "Interesting read on NPU scheduling",
+        "body": "Hey Marcus,\n\nSaw this and thought of our roadmap discussion -- sharing for visibility, no need to respond.\n\nhttps://example.com/npu-scheduling\n\nSam",
+        "age_days": 6
+      }
+    ]
+  },
+  "fu-neg-005": {
+    "scenario": "hard negative -- polite decline that closes the loop, no reply needed",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "inbound",
+        "from": "Events <events@acme.io>",
+        "subject": "Team offsite -- headcount",
+        "body": "Hi all, please RSVP yes/no for the offsite by Friday.\n\nEvents",
+        "age_days": 7
+      },
+      {
+        "direction": "outbound",
+        "to": "Events <events@acme.io>",
+        "subject": "Re: Team offsite -- headcount",
+        "body": "Thanks for organizing -- I won't be able to make it this time, no worries. Have fun!\n\nSam",
+        "age_days": 5
+      }
+    ]
+  },
+  "fu-neg-006": {
+    "scenario": "hard negative -- thread answered by a substantive inbound reply",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Priya Rao <priya@acme.io>",
+        "subject": "Which commit shipped in the staging deploy?",
+        "body": "Hey Priya, do you know which commit went out in this morning's staging deploy?\n\nSam",
+        "age_days": 6
+      },
+      {
+        "direction": "inbound",
+        "from": "Priya Rao <priya@acme.io>",
+        "subject": "Re: Which commit shipped in the staging deploy?",
+        "body": "It was a1b2c3d -- the checkout refactor. That's almost certainly the regression; I'll revert it now.\n\nPriya",
+        "age_days": 4
+      }
+    ]
+  },
+  "fu-neg-007": {
+    "scenario": "hard negative -- approval granted, thread resolved by the reply",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "Tom Becker <tom@acme.io>",
+        "subject": "PTO approval",
+        "body": "Hi Tom, could you approve my PTO request for August 4-8 in the HR system?\n\nSam",
+        "age_days": 6
+      },
+      {
+        "direction": "inbound",
+        "from": "Tom Becker <tom@acme.io>",
+        "subject": "Re: PTO approval",
+        "body": "Approved -- enjoy the break!\n\nTom",
+        "age_days": 4
+      }
+    ]
+  },
+  "fu-neg-008": {
+    "scenario": "hard negative -- note-to-self, no external recipient can ever reply",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "user@example.com",
+        "subject": "Reminder: renew the domain",
+        "body": "Renew acme.io before it expires on the 22nd. Card ending 4471.",
+        "age_days": 5
+      }
+    ]
+  },
+  "fu-neg-009": {
+    "scenario": "hard negative -- FYI broadcast that got a courtesy reply, no ask outstanding",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "outbound",
+        "to": "team@acme.io",
+        "subject": "Q2 metrics recap",
+        "body": "Hi all, attaching the Q2 metrics recap for your awareness. No action needed.\n\nSam",
+        "age_days": 6
+      },
+      {
+        "direction": "inbound",
+        "from": "Elena Vasquez <elena@acme.io>",
+        "subject": "Re: Q2 metrics recap",
+        "body": "Thanks for putting this together, Sam -- really useful.\n\nElena",
+        "age_days": 4
+      }
+    ]
+  },
+  "fu-neg-010": {
+    "scenario": "hard negative -- confirmation the user sent that ends the exchange",
+    "awaits_reply": false,
+    "is_hard_negative": true,
+    "thread": [
+      {
+        "direction": "inbound",
+        "from": "Grace Osei <grace@partnerco.com>",
+        "subject": "Invite: intro call Thursday 11am",
+        "body": "Sending an invite for Thursday 11am -- let me know if that still works.\n\nGrace",
+        "age_days": 7
+      },
+      {
+        "direction": "outbound",
+        "to": "Grace Osei <grace@partnerco.com>",
+        "subject": "Re: Invite: intro call Thursday 11am",
+        "body": "Confirmed, Thursday 11am works -- accepted the invite. Talk then!\n\nSam",
+        "age_days": 5
+      }
+    ]
+  }
+}

--- a/tests/unit/email/test_followups_corpus_integrity.py
+++ b/tests/unit/email/test_followups_corpus_integrity.py
@@ -1,0 +1,411 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the follow-up detection eval (#1606 / #1950).
+
+Mirrors ``test_action_items_corpus_integrity.py`` for the follow-up seed corpus,
+plus offline coverage of the scorer + aggregation in
+``gaia.eval.followup_quality``:
+
+- The committed corpus loads, is the declared size, carries both positives and
+  hard negatives, and every case is schema-well-formed (the loader is the
+  validator — fail-loud).
+- Duplicate case ids, missing required fields, a mislabeled hard negative, a
+  thread with no outbound message, and a malformed message are rejected loudly.
+- The scorer runs end-to-end on hand-fed predicted-vs-expected flags (no
+  backend, no network): a correct flag PASSes, a spurious flag on a hard
+  negative is a precision-denominator false positive, a missed genuine follow-up
+  is a false negative, and errored generations stay ERRORED.
+- Generation is exercised with an injected stub detector (no email package) and,
+  when the email agent is installed, against the REAL ``check_followups_impl``
+  over the whole corpus — locking in that the corpus actually drives both
+  failure modes (false positives on courtesy notes, a false negative on an
+  auto-reply).
+- The committed thresholds manifest ships the #1950 bars in report mode
+  (``enforce: false``) and the gate honors the ``should_fail`` contract.
+
+Everything here runs offline: no Lemonade, no Anthropic, no live mailbox.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaia.eval import followup_quality as fq
+from gaia.eval.scorecard import build_scorecard
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+CORPUS_PATH = (
+    _REPO_ROOT / "tests" / "fixtures" / "email" / "followups_ground_truth.json"
+)
+THRESHOLDS_PATH = (
+    _REPO_ROOT / "tests" / "fixtures" / "email" / "followups_gate_thresholds.json"
+)
+
+
+@pytest.fixture(scope="module")
+def corpus() -> dict:
+    return fq.load_followup_corpus(CORPUS_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Corpus integrity
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_loads_and_has_seed_size(corpus):
+    """Seed corpus is committed, loadable, and in the declared 14–25 range."""
+    cases = fq.corpus_cases(corpus)
+    assert 14 <= len(cases) <= 25, f"seed corpus size out of range: {len(cases)}"
+
+
+def test_meta_block_present_and_well_formed(corpus):
+    meta = corpus["_meta"]
+    assert meta["fixture"] == "followups_ground_truth.json"
+    assert meta["fixture_kind"] == "hand-authored-seed"
+    assert isinstance(meta["schema_version"], int)
+    # The detection window the scorer runs at is documented in the fixture.
+    assert meta["detection_params"]["window_days"] == fq.DEFAULT_FOLLOWUP_WINDOW_DAYS
+
+
+def test_corpus_has_both_positives_and_hard_negatives(corpus):
+    """A precision/recall eval is only meaningful with both classes present."""
+    cases = fq.corpus_cases(corpus)
+    hard = [c for c in cases.values() if fq.is_hard_negative(c)]
+    positive = [c for c in cases.values() if not fq.is_hard_negative(c)]
+    assert len(hard) >= 3, "need several hard negatives for the FP denominator"
+    assert len(positive) >= 3, "need several awaits-reply positives"
+
+
+def test_every_case_is_schema_well_formed(corpus):
+    """The loader already validates; assert the shape it guarantees."""
+    for case_id, case in fq.corpus_cases(corpus).items():
+        assert not case_id.startswith("_")
+        assert case["scenario"].strip()
+        assert isinstance(case["awaits_reply"], bool)
+        assert isinstance(case["thread"], list) and case["thread"], case_id
+        has_outbound = False
+        for msg in case["thread"]:
+            assert msg["direction"] in {"outbound", "inbound"}, case_id
+            assert msg["subject"].strip(), case_id
+            assert msg["body"].strip(), case_id
+            assert isinstance(msg["age_days"], (int, float)), case_id
+            if msg["direction"] == "outbound":
+                has_outbound = True
+                assert msg["to"].strip(), case_id
+            else:
+                assert msg["from"].strip(), case_id
+        assert has_outbound, f"{case_id}: sent thread needs an outbound message"
+
+
+def test_duplicate_case_ids_rejected(tmp_path):
+    dup = tmp_path / "dup.json"
+    dup.write_text('{"fu-001": {}, "fu-001": {}}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate case id"):
+        fq.load_followup_corpus(dup)
+
+
+def test_missing_required_field_rejected(tmp_path, corpus):
+    cases = fq.corpus_cases(corpus)
+    case_id, case = next(iter(cases.items()))
+    broken = {case_id: {k: v for k, v in case.items() if k != "thread"}}
+    path = tmp_path / "broken.json"
+    path.write_text(json.dumps(broken), encoding="utf-8")
+    with pytest.raises(ValueError, match="thread"):
+        fq.load_followup_corpus(path)
+
+
+def test_mislabeled_hard_negative_rejected(tmp_path):
+    """A hard-negative flag that disagrees with the label is loud."""
+    bad = {
+        "fu-x": {
+            "scenario": "mislabeled",
+            "awaits_reply": True,
+            "is_hard_negative": True,
+            "thread": [
+                {
+                    "direction": "outbound",
+                    "to": "a@b.c",
+                    "subject": "s",
+                    "body": "b",
+                    "age_days": 5,
+                }
+            ],
+        }
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError, match="is_hard_negative"):
+        fq.load_followup_corpus(path)
+
+
+def test_thread_without_outbound_rejected(tmp_path):
+    """A sent-thread case must contain at least one outbound message."""
+    bad = {
+        "fu-x": {
+            "scenario": "no outbound",
+            "awaits_reply": False,
+            "thread": [
+                {
+                    "direction": "inbound",
+                    "from": "a@b.c",
+                    "subject": "s",
+                    "body": "b",
+                    "age_days": 5,
+                }
+            ],
+        }
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError, match="outbound"):
+        fq.load_followup_corpus(path)
+
+
+def test_outbound_without_recipient_rejected(tmp_path):
+    bad = {
+        "fu-x": {
+            "scenario": "no recipient",
+            "awaits_reply": True,
+            "thread": [
+                {"direction": "outbound", "subject": "s", "body": "b", "age_days": 5}
+            ],
+        }
+    }
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError, match="to"):
+        fq.load_followup_corpus(path)
+
+
+# ---------------------------------------------------------------------------
+# Scorer on hand-fed predictions (offline)
+# ---------------------------------------------------------------------------
+
+
+def test_score_case_correct_positive_passes(corpus):
+    case = fq.corpus_cases(corpus)["fu-001"]
+    assert case["awaits_reply"] is True
+    row = fq.score_case("fu-001", case, True, model_id="stub-detector")
+    assert row["status"] == "PASS"
+    assert row["overall_score"] == 10.0
+    assert row["followup_match"]["tp"] == 1
+    assert row["category"] == "stub-detector"
+
+
+def test_score_case_correct_hard_negative_passes(corpus):
+    """Correctly NOT flagging a no-reply-needed thread is a perfect case."""
+    case = fq.corpus_cases(corpus)["fu-neg-001"]
+    assert fq.is_hard_negative(case)
+    row = fq.score_case("fu-neg-001", case, False, model_id="stub-detector")
+    assert row["status"] == "PASS"
+    assert row["followup_match"]["tn"] == 1
+
+
+def test_score_case_false_positive_on_hard_negative_fails(corpus):
+    case = fq.corpus_cases(corpus)["fu-neg-001"]
+    row = fq.score_case("fu-neg-001", case, True, model_id="stub-detector")
+    assert row["status"] == "FAIL"
+    assert row["followup_match"]["fp"] == 1
+    assert row["overall_score"] == 0.0
+
+
+def test_score_case_false_negative_on_positive_fails(corpus):
+    case = fq.corpus_cases(corpus)["fu-006"]
+    assert case["awaits_reply"] is True
+    row = fq.score_case("fu-006", case, False, model_id="stub-detector")
+    assert row["status"] == "FAIL"
+    assert row["followup_match"]["fn"] == 1
+
+
+def test_score_case_none_prediction_is_errored(corpus):
+    case = fq.corpus_cases(corpus)["fu-001"]
+    row = fq.score_case("fu-001", case, None, model_id="stub-detector", error="boom")
+    assert row["status"] == "ERRORED"
+    assert row["error"] == "boom"
+    assert "followup_match" not in row
+
+
+def test_summarize_micro_confusion_and_scorecard(corpus):
+    """A perfect run (every predicted flag == label) → precision/recall/F1 all
+    1.0 and a build_scorecard-compatible summary."""
+    cases = fq.corpus_cases(corpus)
+    results = [
+        fq.score_case(cid, c, c["awaits_reply"], model_id="stub-detector")
+        for cid, c in cases.items()
+    ]
+    summary = fq.summarize_followups(
+        results,
+        run_id="unit",
+        thresholds=fq.FollowupThresholds(f1_min=0.70, recall_min=0.80),
+    )
+    agg = summary["followups"]
+    assert agg["cases_scored"] == len(cases)
+    assert agg["precision"] == 1.0
+    assert agg["recall"] == 1.0
+    assert agg["f1"] == 1.0
+    assert agg["fp"] == 0 and agg["fn"] == 0
+    assert agg["hard_negatives_total"] >= 3
+    assert agg["hard_negative_correct_rate"] == 1.0
+    # Gate passes in report mode (perfect run).
+    assert summary["followup_gate"]["passed"] is True
+    assert summary["followup_gate"]["should_fail"] is False
+    # Rows also aggregate through the shared scorecard builder unchanged.
+    scorecard = build_scorecard("unit", results, {})
+    assert scorecard["summary"]["total_scenarios"] == len(cases)
+    assert scorecard["summary"]["passed"] == len(cases)
+
+
+def test_summarize_counts_false_positive_and_negative(corpus):
+    """A spurious flag on a hard negative is an FP; a missed positive is an FN,
+    and both drop the corresponding rate below perfect."""
+    cases = fq.corpus_cases(corpus)
+    results = []
+    for cid, c in cases.items():
+        if cid == "fu-neg-002":
+            predicted = True  # false positive on a no-reply-needed broadcast
+        elif cid == "fu-005":
+            predicted = False  # false negative on a genuine unanswered question
+        else:
+            predicted = c["awaits_reply"]
+        results.append(fq.score_case(cid, c, predicted, model_id="stub-detector"))
+    agg = fq.summarize_followups(results, run_id="unit")["followups"]
+    assert agg["fp"] >= 1
+    assert agg["fn"] >= 1
+    assert agg["precision"] < 1.0
+    assert agg["recall"] < 1.0
+    assert agg["hard_negative_correct_rate"] < 1.0
+
+
+def test_summarize_gate_skipped_when_nothing_scored():
+    """All-errored run → gate is a loud explicit skip, never a pass."""
+    results = [{"id": "fu-001", "category": "m", "status": "ERRORED", "error": "x"}]
+    summary = fq.summarize_followups(
+        results, run_id="unit", thresholds=fq.FollowupThresholds(f1_min=0.70)
+    )
+    assert "followups" not in summary
+    assert summary["followup_gate"]["skipped"] is True
+    assert summary["followup_gate"]["should_fail"] is False
+
+
+# ---------------------------------------------------------------------------
+# Generation stage — injected stub detector (offline, no email package)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_detections_with_stub_detector(corpus):
+    """generate_detections builds a backend per case, runs the injected
+    detector, and maps its flagged thread-ids back to per-case booleans."""
+    flag = {"fu-001", "fu-neg-001"}
+
+    def stub_detector(backend, *, window_days, now_ms):
+        listing = backend.list_messages(label_ids=["SENT"], max_results=50)
+        tids = {m["threadId"] for m in listing["messages"]}
+        return {"awaiting_reply": [{"thread_id": t} for t in tids if t in flag]}
+
+    gens = fq.generate_detections(corpus_path=CORPUS_PATH, detector_fn=stub_detector)
+    by_id = {g["case_id"]: g for g in gens}
+    assert by_id["fu-001"]["predicted"] is True
+    assert by_id["fu-neg-001"]["predicted"] is True
+    assert by_id["fu-006"]["predicted"] is False
+    assert by_id["fu-neg-006"]["predicted"] is False
+    assert all(not g["error"] for g in gens)
+
+    # Score the stub run: fu-001 TP (PASS), fu-neg-001 FP (FAIL), fu-006 FN (FAIL).
+    results = fq.score_generations(corpus, gens, model_id="stub-detector")
+    by_row = {r["id"]: r for r in results}
+    assert by_row["fu-001"]["status"] == "PASS"
+    assert by_row["fu-neg-001"]["status"] == "FAIL"
+    assert by_row["fu-006"]["status"] == "FAIL"
+
+
+def test_score_generations_unknown_case_id_rejected(corpus):
+    with pytest.raises(ValueError, match="unknown case id"):
+        fq.score_generations(
+            corpus, [{"case_id": "nope", "predicted": True}], model_id="m"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Generation stage — REAL detector (offline; needs the email agent installed)
+# ---------------------------------------------------------------------------
+
+
+def test_real_detector_drives_both_failure_modes(corpus):
+    """Over the committed corpus, the REAL latest-outbound heuristic must exhibit
+    both failure modes the eval exists to catch: false positives on courtesy /
+    FYI notes and a false negative on the auto-reply trap. This locks the corpus
+    to its intended behavior against the shipped detector."""
+    pytest.importorskip("gaia_agent_email")
+
+    gens = fq.generate_detections(corpus_path=CORPUS_PATH)
+    assert all(not g["error"] for g in gens), [g for g in gens if g["error"]]
+    results = fq.score_generations(corpus, gens, model_id="check_followups")
+    agg = fq.summarize_followups(results, run_id="unit")["followups"]
+
+    # Detector flags every aged outbound-latest thread with an external
+    # recipient — so it catches the real follow-ups (recall high) but also nags
+    # on courtesy/FYI notes (precision low) and misses the auto-reply case.
+    assert agg["tp"] == 5
+    assert agg["fn"] == 1  # the out-of-office auto-reply trap (fu-006)
+    assert agg["fp"] == 6  # thanks / FYI / acknowledgment / decline notes
+    assert agg["tn"] == 4
+    assert agg["fp"] > 0 and agg["fn"] > 0
+    # The known precision gap is exactly why the committed gate ships report-mode.
+    assert agg["precision"] < 0.7
+
+
+# ---------------------------------------------------------------------------
+# Committed thresholds manifest + gate contract
+# ---------------------------------------------------------------------------
+
+
+def test_committed_thresholds_manifest_is_report_mode():
+    thresholds = fq.load_followup_thresholds(THRESHOLDS_PATH)
+    assert thresholds.f1_min == 0.70
+    assert thresholds.recall_min == 0.80
+    assert thresholds.precision_min == 0.60
+    assert thresholds.enforce is False  # report mode — see the manifest comment
+    assert fq.default_followup_thresholds_path() == THRESHOLDS_PATH
+
+
+def test_malformed_thresholds_manifest_rejected(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text('{"enforce": false}', encoding="utf-8")
+    with pytest.raises(ValueError, match="f1_min"):
+        fq.load_followup_thresholds(path)
+
+
+def test_gate_report_mode_never_fails_the_build():
+    gate = fq.evaluate_followup_gate(
+        {"f1": 0.10, "recall": 0.10, "precision": 0.10},
+        fq.FollowupThresholds(f1_min=0.70, recall_min=0.80, enforce=False),
+    )
+    assert gate["passed"] is False
+    assert gate["breaches"]
+    assert gate["should_fail"] is False
+
+
+def test_gate_enforced_breach_fails():
+    gate = fq.evaluate_followup_gate(
+        {"f1": 0.10, "recall": 0.10, "precision": 0.10},
+        fq.FollowupThresholds(f1_min=0.70, enforce=True),
+    )
+    assert gate["should_fail"] is True
+
+
+def test_gate_only_checks_set_bars():
+    """An unset recall_min/precision_min (0.0) is not gated."""
+    gate = fq.evaluate_followup_gate(
+        {"f1": 0.80, "recall": 0.10, "precision": 0.10},
+        fq.FollowupThresholds(f1_min=0.70, enforce=True),
+    )
+    assert gate["passed"] is True
+    assert gate["should_fail"] is False
+
+
+def test_gate_missing_f1_is_loud():
+    with pytest.raises(ValueError, match="f1"):
+        fq.evaluate_followup_gate({}, fq.FollowupThresholds(f1_min=0.70))


### PR DESCRIPTION
Follow-up tracking (#1606) shipped with deterministic unit tests that prove the detector *runs* but never check the thing that actually matters to users: whether the threads it flags are the ones a human considers "awaiting a reply". Before this PR that classification quality was unmeasured — so two real failure modes were invisible. **False positives** nag users about courtesy/FYI notes that need no reply; **false negatives** silently drop real follow-ups when an out-of-office auto-reply masks a genuine unanswered question. After this PR both are measured on every run in report mode, giving a baseline to tighten against.

This mirrors the just-merged action-item extraction eval (#1949/#1962): a hand-labeled seed corpus of *sent threads* (awaits-reply / not, carrying the inbound-reply state and hard negatives like thanks/FYI/auto-replies), a precision/recall/F1 scorer over the `awaits_reply` flag that replays each thread through the **real** `check_followups_impl`, a provisional gate manifest that ships `enforce:false`, and fully offline unit tests. The gate is report-mode on purpose — the shipped detector is a deterministic latest-outbound heuristic with a known precision gap, and no measured baseline exists yet, so the committed bars are placeholders to be re-measured before `enforce` is flipped (data, not code).

Scope matches the action-item sibling exactly (scorer module + corpus + thresholds + offline tests); like #1962 it does not touch `test_email_agent_eval.yml`.

## Test plan
- [x] `python -m pytest tests/unit/email/test_followups_corpus_integrity.py` — 26 passed (offline; no Lemonade, no network)
- [x] The corpus-integrity test drives the **real** `check_followups_impl` over the full corpus and asserts it exhibits both failure modes (tp=5, fn=1, fp=6, tn=4) — so the gap is measured, not assumed
- [x] `black --check` + `isort --check` clean on the new files
- [x] Scorer, gate, and threshold-manifest loaders fail loudly on malformed input (duplicate ids, missing fields, mislabeled hard negatives, threads with no outbound message, missing `f1_min`)

Closes #1950