### PR TITLE
feat(eval): summary-quality eval for scheduled daily inbox briefing (#1951)

### DIFF
--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -15,6 +15,13 @@
 #   - tests/fixtures/email/quality_gate_thresholds.json  (FP<5% / FN<2%)
 #   - tests/fixtures/email/perf_gate_thresholds.json      (TTFT / tps / latency / mem)
 #   - tests/fixtures/email/drafting_gate_thresholds.json  (draft-approval >=70%, #1269)
+#   - tests/fixtures/email/briefing_gate_thresholds.json  (briefing quality, #1951 — ENFORCING)
+#
+# NOTE: the briefing gate (#1951) ships enforce:TRUE — unlike the FP/FN, perf,
+# and drafting gates it is a hard gate with no report-mode fallback: a quality
+# breach, an errored/unjudged case, or a missing judge credential fails the
+# build. See its dedicated block near the end of this job.
+#
 # CI keys off each gate's `should_fail` (= enforce and not passed). All three
 # manifests ship `enforce: false`, so `should_fail` is always false today: the gate
 # machinery runs, logs, and uploads, but the build stays green. This is the
@@ -572,6 +579,147 @@ jobs:
           PY
       # =================================================================
       # END action-item extraction eval
+      # =================================================================
+
+      # =================================================================
+      # BEGIN daily-briefing summary-quality eval (#1608 feature / #1951
+      # tracking) — ADDITIVE, self-contained block. ENFORCING gate.
+      #
+      # Judge-scored briefing quality: the REAL scheduled-briefing path
+      # (gaia_agent_email.briefing.run_briefing_job -> pre_scan_inbox_impl)
+      # produces the email_pre_scan envelope over the committed briefing seed
+      # corpus (FakeGmailBackend — read-only, nothing sent/archived), and a
+      # Claude judge scores each briefing against the case inbox + rubric on
+      # faithfulness / must-include recall / hallucination-free / grouping. The
+      # aggregate is compared to the committed manifest
+      #   tests/fixtures/email/briefing_gate_thresholds.json  (enforce:true)
+      # via gaia.eval.briefing_quality — same single-source rule as the gates
+      # above: no thresholds inlined in this YAML; tune the bars in the manifest
+      # (data, not code).
+      #
+      # This gate BLOCKS: a quality breach, any errored/unjudged case, a missing
+      # judge credential, or a judge transport error all fail the build. There
+      # is deliberately NO report-mode fallback and NO silent skip — if the eval
+      # cannot prove the briefing is good, the pipeline goes red.
+      #
+      # Runs AFTER the drafting eval in the same job, so Lemonade access stays
+      # strictly serial (CLAUDE.md: evals serial). Keep this block
+      # self-contained so concurrent edits to this workflow merge cleanly.
+      # =================================================================
+      - name: Daily-briefing summary-quality eval (judge-scored, enforcing gate)
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+          EMAIL_EVAL_MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+          # Judge credential for gaia.eval.claude.ClaudeClient. When the
+          # secret is unavailable the step logs a LOUD skip (never a pass).
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -e
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          from gaia.eval.briefing_quality import (
+              default_briefing_thresholds_path,
+              generate_briefings,
+              judge_briefings,
+              load_briefing_corpus,
+              load_default_briefing_thresholds,
+              make_claude_judge,
+              summarize_briefings,
+          )
+
+          model = os.environ["EMAIL_EVAL_MODEL"]
+          corpus_path = "tests/fixtures/email/briefing_ground_truth.json"
+          out = Path("eval-out")
+          out.mkdir(parents=True, exist_ok=True)
+
+          thresholds = load_default_briefing_thresholds()
+          print(f"[BRIEF-EVAL] manifest: {default_briefing_thresholds_path()}")
+          print(
+              f"[BRIEF-EVAL] enforce={thresholds.enforce} "
+              f"approval_min={thresholds.approval_min} "
+              f"recall_min={thresholds.recall_min} "
+              f"hallucination_free_min={thresholds.hallucination_free_min} "
+              f"(#1951 ENFORCED gate)"
+          )
+
+          if not os.environ.get("ANTHROPIC_API_KEY"):
+              # No fallback, no skip: the judge credential is required to prove
+              # the briefing is good. Its absence FAILS the build (actionable
+              # error), it does not quietly pass.
+              print(
+                  "[BRIEF-EVAL] ERROR: ANTHROPIC_API_KEY is not set on this "
+                  "runner — the Claude judge cannot score briefings. Configure "
+                  "the ANTHROPIC_API_KEY secret for this workflow. Failing the "
+                  "build (this gate has no report-mode fallback)."
+              )
+              sys.exit(1)
+
+          # Generation: drives the REAL scheduled-briefing path per case
+          # (heuristic classification — read-only, nothing sent/archived).
+          generations = generate_briefings(model, corpus_path=corpus_path)
+          produced = sum(1 for g in generations if g["briefing"])
+          print(f"[BRIEF-EVAL] generated {produced}/{len(generations)} briefings")
+
+          results = judge_briefings(
+              load_briefing_corpus(corpus_path),
+              generations,
+              make_claude_judge(),
+              model_id=model,
+          )
+          summary = summarize_briefings(
+              results,
+              run_id=f"email-briefing-eval-{model.replace('/', '-').lower()}",
+              thresholds=thresholds,
+          )
+
+          gate = summary.get("briefing_gate", {})
+          agg = summary.get("briefing", {})
+          print("\n========== EMAIL BRIEFING EVAL REPORT (enforcing gate) ==========")
+          print(
+              f"  Briefing-approval rate : {agg.get('briefing_approval_rate')}   "
+              f"(target >={thresholds.approval_min} #1951, ENFORCED)"
+          )
+          print(f"  Must-include recall    : {agg.get('must_include_recall_mean')}")
+          print(f"  Faithful rate          : {agg.get('faithful_rate')}")
+          print(f"  Hallucination-free rate: {agg.get('hallucination_free_rate')}")
+          print(
+              f"  Cases judged/errored   : {agg.get('cases_judged')}/"
+              f"{agg.get('cases_errored')}"
+          )
+          print(
+              f"  Briefing gate          : passed={gate.get('passed')} "
+              f"enforce={gate.get('enforce')} "
+              f"should_fail={gate.get('should_fail')} "
+              f"skipped={gate.get('skipped', False)}"
+          )
+          print("===============================================================\n")
+
+          (out / "briefing_gate_report.json").write_text(
+              json.dumps(
+                  {"model": model, "corpus": corpus_path, "summary": summary},
+                  indent=2,
+                  ensure_ascii=False,
+              ),
+              encoding="utf-8",
+          )
+          print("[OUT] wrote eval-out/briefing_gate_report.json")
+
+          # Enforcing gate: any breach (quality below bar, or an errored/
+          # unjudged case) fails the build. No report-mode fallback.
+          if gate.get("should_fail"):
+              print(
+                  f"[BRIEF-EVAL] gate breach {gate.get('breaches')} — failing "
+                  "the build."
+              )
+              sys.exit(1)
+          print("[BRIEF-EVAL] gate passed — briefing quality is above the bars.")
+          PY
+      # =================================================================
+      # END daily-briefing summary-quality eval
       # =================================================================
 
       - name: Upload eval scorecard + gate report

--- a/src/gaia/eval/briefing_quality.py
+++ b/src/gaia/eval/briefing_quality.py
@@ -1,0 +1,811 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Judge-scored summary-quality eval for the scheduled daily inbox briefing
+(#1608 feature, #1951 tracking).
+
+Sibling of :mod:`gaia.eval.draft_quality` and :mod:`gaia.eval.benchmark`: the
+same committed-fixture / report-mode conventions, applied to the daily-briefing
+surface. The briefing is a pure summarization output — its usefulness lives
+entirely in whether it surfaces the right threads, summarizes them faithfully,
+groups them by priority, and invents nothing. Unit tests prove the scheduler
+*runs*; only a judge can tell whether the digest is any *good*. Three separable
+stages so each is testable on its own:
+
+1. **Generation** (:func:`generate_briefings` — needs the email agent): per
+   corpus case, seed a fresh ``FakeGmailBackend`` with the case's inbox slice
+   and drive the REAL scheduled-briefing path
+   (``gaia_agent_email.briefing.run_briefing_job`` → ``pre_scan_inbox_impl``),
+   harvesting the exact ``email_pre_scan`` envelope the scheduled job persists.
+   Read-only — nothing is sent, archived, or mutated.
+2. **Judging** (:func:`judge_briefings` — needs a judge callable): score each
+   generated briefing against the case inbox + rubric with an LLM judge
+   (:func:`make_claude_judge` wraps :class:`gaia.eval.claude.ClaudeClient`;
+   tests inject a stub). The verdict is strict JSON, parsed fail-loud.
+3. **Aggregation** (:func:`summarize_briefings`): roll per-case results into a
+   ``build_scorecard``-compatible summary with the aggregate
+   ``briefing_approval_rate`` plus the faithfulness / must-include-recall /
+   hallucination-free secondaries, and score the committed briefing gate
+   manifest (``tests/fixtures/email/briefing_gate_thresholds.json``) the same
+   way the FP/FN, perf, and drafting gates work — report mode unless the
+   manifest flips ``enforce``.
+
+Fail-loud contract: a malformed corpus, a judge reply that is not the
+documented JSON verdict, or a missing thresholds manifest raise actionable
+errors — nothing silently scores as a pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+# ---------------------------------------------------------------------------
+# Corpus loading (offline)
+# ---------------------------------------------------------------------------
+
+# Keys that are corpus metadata, not cases (same convention as ground_truth).
+_METADATA_PREFIX = "_"
+
+_REQUIRED_MESSAGE_FIELDS = ("from", "subject", "body")
+_MIN_INBOX_MESSAGES = 3
+
+
+def _validate_case(case_id: str, case: Any) -> None:
+    if not isinstance(case, dict):
+        raise ValueError(
+            f"briefing corpus case '{case_id}' must be a JSON object, got "
+            f"{type(case).__name__}."
+        )
+    scenario = case.get("scenario")
+    if not isinstance(scenario, str) or not scenario.strip():
+        raise ValueError(f"case '{case_id}': 'scenario' must be a non-empty string.")
+    inbox = case.get("inbox")
+    if not isinstance(inbox, list) or len(inbox) < _MIN_INBOX_MESSAGES:
+        raise ValueError(
+            f"case '{case_id}': 'inbox' must be a list of >= "
+            f"{_MIN_INBOX_MESSAGES} messages (the slice the briefing summarizes)."
+        )
+    for idx, message in enumerate(inbox):
+        if not isinstance(message, dict):
+            raise ValueError(
+                f"case '{case_id}': inbox[{idx}] must be an object, got "
+                f"{type(message).__name__}."
+            )
+        for field in _REQUIRED_MESSAGE_FIELDS:
+            if not isinstance(message.get(field), str) or not message[field].strip():
+                raise ValueError(
+                    f"case '{case_id}': inbox[{idx}].{field} must be a non-empty "
+                    "string."
+                )
+    rubric = case.get("rubric")
+    if not isinstance(rubric, dict):
+        raise ValueError(f"case '{case_id}': 'rubric' must be an object.")
+    must_surface = rubric.get("must_surface")
+    if not isinstance(must_surface, list) or not must_surface:
+        raise ValueError(
+            f"case '{case_id}': rubric.must_surface must be a non-empty list of "
+            "strings (the high-priority threads the briefing must surface)."
+        )
+    must_not_surface = rubric.get("must_not_surface", [])
+    if not isinstance(must_not_surface, list):
+        raise ValueError(
+            f"case '{case_id}': rubric.must_not_surface must be a list (may be "
+            "empty)."
+        )
+    for label, items in (
+        ("must_surface", must_surface),
+        ("must_not_surface", must_not_surface),
+    ):
+        if not all(isinstance(i, str) and i.strip() for i in items):
+            raise ValueError(
+                f"case '{case_id}': rubric.{label} entries must be non-empty "
+                "strings."
+            )
+
+
+def _reject_duplicate_keys(pairs: list) -> dict:
+    out: dict = {}
+    for key, value in pairs:
+        if key in out:
+            raise ValueError(f"duplicate case id {key!r} in the briefing corpus")
+        out[key] = value
+    return out
+
+
+def load_briefing_corpus(path: str | Path) -> dict[str, dict]:
+    """Load + validate the briefing corpus (loud on missing/malformed).
+
+    Returns the full mapping including the ``_meta`` block; use
+    :func:`corpus_cases` to get only the scored cases. Duplicate case ids,
+    missing required fields, or wrong types raise ``ValueError``.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f, object_pairs_hook=_reject_duplicate_keys)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"briefing corpus at {path} is not valid JSON: {exc}"
+            ) from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"briefing corpus at {path} must be a JSON object keyed by case id, "
+            f"got {type(data).__name__}."
+        )
+    cases = {k: v for k, v in data.items() if not k.startswith(_METADATA_PREFIX)}
+    if not cases:
+        raise ValueError(f"briefing corpus at {path} contains no cases.")
+    for case_id, case in cases.items():
+        _validate_case(case_id, case)
+    return data
+
+
+def corpus_cases(corpus: Mapping[str, Any]) -> dict[str, dict]:
+    """Only the scored cases (drop ``_``-prefixed metadata blocks)."""
+    return {k: v for k, v in corpus.items() if not k.startswith(_METADATA_PREFIX)}
+
+
+# ---------------------------------------------------------------------------
+# Judge prompt + verdict parsing (offline)
+# ---------------------------------------------------------------------------
+
+_VERDICT_BOOL_FIELDS = (
+    "faithful",
+    "hallucination_free",
+    "grouping_reasonable",
+    "approved",
+)
+_VERDICT_SCORE_FIELDS = ("must_include_recall", "overall_quality")
+
+
+def _render_inbox(inbox: list[Mapping[str, Any]]) -> str:
+    """Render the case's inbox slice as the ground-truth the judge checks
+    faithfulness and hallucinations against."""
+    blocks = []
+    for idx, message in enumerate(inbox, start=1):
+        blocks.append(
+            f"[{idx}] From: {message['from']}\n"
+            f"    Subject: {message['subject']}\n"
+            f"    Body: {message['body']}"
+        )
+    return "\n\n".join(blocks)
+
+
+def _render_section(items: list[Mapping[str, Any]], reason_key: str) -> str:
+    if not items:
+        return "  (none)"
+    lines = []
+    for item in items:
+        summary = item.get(reason_key, "") or "(no summary)"
+        lines.append(
+            f"  - {item.get('sender', '')} — {item.get('subject', '')}: {summary}"
+        )
+    return "\n".join(lines)
+
+
+def _render_briefing(briefing: Mapping[str, Any]) -> str:
+    """Render a generated ``email_pre_scan`` envelope for the judge."""
+    urgent = _render_section(briefing.get("urgent", []), "why")
+    actionable = _render_section(briefing.get("actionable", []), "why")
+    archives = _render_section(briefing.get("suggested_archives", []), "reason")
+    info_count = briefing.get("informational_count", 0)
+    return (
+        f"URGENT:\n{urgent}\n\n"
+        f"ACTIONABLE:\n{actionable}\n\n"
+        f"SUGGESTED ARCHIVES:\n{archives}\n\n"
+        f"INFORMATIONAL (count only): {info_count}"
+    )
+
+
+def build_judge_prompt(case: Mapping[str, Any], briefing: Mapping[str, Any]) -> str:
+    """Render the judge prompt for one (case, generated briefing) pair.
+
+    The judge sees the full inbox slice (the only ground truth for
+    faithfulness + hallucination), the generated briefing's sections, and the
+    rubric's must-surface / must-not-surface threads, and must answer with
+    STRICT JSON (see :func:`parse_judge_verdict`).
+    """
+    inbox = _render_inbox(case["inbox"])
+    briefing_text = _render_briefing(briefing)
+    must = "\n".join(f"- {item}" for item in case["rubric"]["must_surface"])
+    must_not_items = case["rubric"].get("must_not_surface", [])
+    must_not = (
+        "\n".join(f"- {item}" for item in must_not_items)
+        if must_not_items
+        else "(none specified)"
+    )
+    return f"""You are grading a daily inbox briefing produced by an AI assistant. The assistant scanned the user's inbox and produced a triage digest: threads grouped into URGENT, ACTIONABLE, and SUGGESTED ARCHIVES, plus a count of purely informational mail. A good briefing surfaces the genuinely high-priority threads, summarizes each faithfully, groups them sensibly, and invents nothing that is not in the inbox.
+
+## The user's actual inbox (the ONLY ground truth — every briefing claim must trace back to a message here)
+{inbox}
+
+## The assistant's briefing
+{briefing_text}
+
+## Rubric — these high-priority threads MUST be surfaced as URGENT or ACTIONABLE:
+{must}
+
+## These threads MUST NOT be treated as high-priority (they belong in informational/archives, not urgent/actionable):
+{must_not}
+
+## Your task
+Judge the briefing against the inbox and rubric:
+- faithful: every summary line accurately reflects its source message (no distorted or invented details).
+- hallucination_free: the briefing references NO thread, sender, or subject that does not exist in the inbox above.
+- grouping_reasonable: threads are placed in sensible priority buckets (nothing important buried, nothing trivial flagged urgent).
+- must_include_recall: the fraction (0.0-1.0) of the "MUST be surfaced" threads that actually appear in URGENT or ACTIONABLE.
+- overall_quality: your holistic 0.0-1.0 rating of how useful this briefing is to the user.
+- approved: true if a reasonable user would trust this briefing to start their day — it surfaces the right threads, summarizes them faithfully, and invents nothing.
+
+Answer with STRICT JSON only — no prose, no markdown fences, exactly this shape:
+{{
+  "faithful": true/false,
+  "hallucination_free": true/false,
+  "grouping_reasonable": true/false,
+  "must_include_recall": 0.0-1.0,
+  "overall_quality": 0.0-1.0,
+  "approved": true/false,
+  "rationale": "one or two sentences"
+}}"""
+
+
+def parse_judge_verdict(text: str) -> dict[str, Any]:
+    """Parse + validate a judge reply into a verdict dict (loud on garbage).
+
+    Tolerates surrounding prose/fences by extracting the outermost JSON
+    object, but the object itself must carry every documented field with the
+    right type and range — a judge reply that can't be scored is an error,
+    never a silent pass or fail.
+    """
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("judge reply is empty — cannot score the briefing")
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        raise ValueError(
+            f"judge reply contains no JSON object; snippet: {text[:200]!r}"
+        )
+    try:
+        verdict = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"judge reply is not valid JSON: {exc}; snippet: {text[:200]!r}"
+        ) from exc
+    if not isinstance(verdict, dict):
+        raise ValueError(
+            f"judge verdict decoded to {type(verdict).__name__}, expected object"
+        )
+    for field in _VERDICT_BOOL_FIELDS:
+        if not isinstance(verdict.get(field), bool):
+            raise ValueError(
+                f"judge verdict field '{field}' must be a boolean, got "
+                f"{verdict.get(field)!r}"
+            )
+    for field in _VERDICT_SCORE_FIELDS:
+        value = verdict.get(field)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"judge verdict field '{field}' must be a number in [0, 1], got "
+                f"{value!r}"
+            )
+        if not 0.0 <= float(value) <= 1.0:
+            raise ValueError(
+                f"judge verdict field '{field}' out of range [0, 1]: {value!r}"
+            )
+    if not isinstance(verdict.get("rationale"), str):
+        raise ValueError("judge verdict field 'rationale' must be a string")
+    return verdict
+
+
+def make_claude_judge(model: str | None = None) -> Callable[[str], str]:
+    """A judge callable backed by :class:`gaia.eval.claude.ClaudeClient`.
+
+    Lazy import so the module stays importable (and unit-testable) without
+    the ``[eval]`` extras; ``ClaudeClient`` itself fails loud when the judge
+    credential is absent.
+    """
+    from gaia.eval.claude import ClaudeClient
+
+    client = ClaudeClient(model=model)
+
+    def judge(prompt: str) -> str:
+        content = client.get_completion(prompt)
+        # Anthropic returns a list of content blocks; the verdict is text.
+        parts = [
+            getattr(block, "text", "") for block in content if hasattr(block, "text")
+        ]
+        return "".join(parts)
+
+    return judge
+
+
+# ---------------------------------------------------------------------------
+# Result assembly + aggregation (offline — mocked-judge testable)
+# ---------------------------------------------------------------------------
+
+
+def build_briefing_result(
+    case_id: str,
+    *,
+    model_id: str,
+    briefing: Mapping[str, Any] | None,
+    verdict: Mapping[str, Any] | None,
+    error: str = "",
+    duration_ms: int = 0,
+) -> dict[str, Any]:
+    """One ``build_scorecard``-compatible result row for a corpus case.
+
+    ``PASS`` = the judge approved the briefing; ``FAIL`` = generated (or
+    judged) but not approved; ``ERRORED`` = no briefing was produced or the
+    judge could not score it (``error`` says why). ``overall_score`` maps the
+    judge's ``overall_quality`` onto the scorecard's 0–10 scale.
+    """
+    out: dict[str, Any] = {
+        "id": case_id,
+        "category": model_id,
+        "total_duration_ms": duration_ms,
+    }
+    if briefing is not None:
+        out["briefing"] = dict(briefing)
+    if verdict is not None:
+        out["briefing_judgement"] = dict(verdict)
+        out["overall_score"] = round(float(verdict["overall_quality"]) * 10.0, 2)
+        out["status"] = "PASS" if verdict["approved"] else "FAIL"
+    else:
+        out["status"] = "ERRORED"
+        out["error"] = error or "no briefing produced and no judge verdict"
+    return out
+
+
+def summarize_briefings(
+    results: list[dict],
+    *,
+    run_id: str,
+    thresholds: "BriefingThresholds | None" = None,
+) -> dict[str, Any]:
+    """Aggregate per-case results into a scorecard + briefing-gate summary.
+
+    Reuses :func:`gaia.eval.scorecard.build_scorecard` unchanged. The
+    ``briefing`` block carries the aggregate ``briefing_approval_rate`` plus
+    the faithfulness / must-include-recall / hallucination-free secondaries;
+    when ``thresholds`` is given the briefing gate runs against it — report
+    mode unless the manifest sets ``enforce``. When no case was judged the
+    gate is a loud explicit skip, never an invented pass.
+    """
+    from gaia.eval.scorecard import build_scorecard
+
+    scorecard = build_scorecard(
+        run_id, results, {"benchmark": "email_briefing_quality"}
+    )
+    summary: dict[str, Any] = {"scorecard": scorecard}
+
+    judged = [r for r in results if isinstance(r.get("briefing_judgement"), dict)]
+    aggregate: dict[str, Any] | None = None
+    if judged:
+        verdicts = [r["briefing_judgement"] for r in judged]
+        n = len(verdicts)
+        aggregate = {
+            "cases_total": len(results),
+            "cases_judged": n,
+            "cases_errored": sum(1 for r in results if r.get("status") == "ERRORED"),
+            "briefing_approval_rate": round(
+                sum(1 for v in verdicts if v["approved"]) / n, 4
+            ),
+            "faithful_rate": round(sum(1 for v in verdicts if v["faithful"]) / n, 4),
+            "hallucination_free_rate": round(
+                sum(1 for v in verdicts if v["hallucination_free"]) / n, 4
+            ),
+            "grouping_reasonable_rate": round(
+                sum(1 for v in verdicts if v["grouping_reasonable"]) / n, 4
+            ),
+            "must_include_recall_mean": round(
+                sum(float(v["must_include_recall"]) for v in verdicts) / n, 4
+            ),
+            "overall_quality_mean": round(
+                sum(float(v["overall_quality"]) for v in verdicts) / n, 4
+            ),
+            "per_case": [
+                {
+                    "id": r.get("id"),
+                    "status": r.get("status"),
+                    "approved": r["briefing_judgement"]["approved"],
+                    "faithful": r["briefing_judgement"]["faithful"],
+                    "hallucination_free": r["briefing_judgement"]["hallucination_free"],
+                    "must_include_recall": r["briefing_judgement"][
+                        "must_include_recall"
+                    ],
+                    "overall_quality": r["briefing_judgement"]["overall_quality"],
+                    "rationale": r["briefing_judgement"]["rationale"],
+                }
+                for r in judged
+            ],
+        }
+        summary["briefing"] = aggregate
+
+    if thresholds is not None:
+        if aggregate is None:
+            # No verdicts at all — a total judge/generation outage. Under an
+            # enforcing gate this is a failure, not a free pass: the eval could
+            # not establish that the briefing is any good, so the build blocks.
+            summary["briefing_gate"] = {
+                "skipped": True,
+                "reason": (
+                    "no case carried a judge verdict; the briefing-quality gate "
+                    "could not be evaluated"
+                ),
+                "enforce": thresholds.enforce,
+                "should_fail": thresholds.enforce,
+            }
+        else:
+            summary["briefing_gate"] = evaluate_briefing_gate(aggregate, thresholds)
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Committed-threshold gate (#1951 — report mode; flip enforce in the manifest)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BriefingThresholds:
+    """Summary-quality bars for the briefing gate (#1951 target).
+
+    ``enforce`` is the single safety switch, same contract as the FP/FN, perf,
+    and drafting gates: ``False`` (the committed value) means the gate computes
+    and reports but never fails the harness. Flip it in the manifest — data,
+    not code — once a real judged baseline confirms the bars. ``recall_min`` /
+    ``hallucination_free_min`` / ``faithfulness_min`` default to ``0.0``
+    (unset ⇒ not gated) so a manifest may gate on approval alone or add the
+    axis floors independently.
+    """
+
+    approval_min: float
+    recall_min: float = 0.0
+    hallucination_free_min: float = 0.0
+    faithfulness_min: float = 0.0
+    enforce: bool = False
+
+
+def load_briefing_thresholds(path: str | Path) -> BriefingThresholds:
+    """Load the briefing-gate thresholds manifest (loud on missing/malformed)."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"briefing-gate thresholds manifest at {path} must be a JSON object, "
+            f"got {type(data).__name__}."
+        )
+    if "approval_min" not in data:
+        raise ValueError(
+            f"briefing-gate thresholds manifest at {path} is missing required "
+            "key 'approval_min'. Optional: 'recall_min', "
+            "'hallucination_free_min', 'faithfulness_min', 'enforce' "
+            "(default false)."
+        )
+    for key in (
+        "approval_min",
+        "recall_min",
+        "hallucination_free_min",
+        "faithfulness_min",
+    ):
+        if key in data and (
+            isinstance(data[key], bool) or not isinstance(data[key], (int, float))
+        ):
+            raise ValueError(
+                f"briefing-gate threshold '{key}' in {path} must be numeric, "
+                f"got {data[key]!r}."
+            )
+    return BriefingThresholds(
+        approval_min=float(data["approval_min"]),
+        recall_min=float(data.get("recall_min", 0.0)),
+        hallucination_free_min=float(data.get("hallucination_free_min", 0.0)),
+        faithfulness_min=float(data.get("faithfulness_min", 0.0)),
+        enforce=bool(data.get("enforce", False)),
+    )
+
+
+# Canonical location of the committed briefing-gate thresholds manifest. The
+# single entry point CI consumes — flip 'enforce' in this file (data, not
+# code) to make CI gate on the #1951 summary-quality bars.
+_BRIEFING_THRESHOLDS_MANIFEST = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "email"
+    / "briefing_gate_thresholds.json"
+)
+
+
+def default_briefing_thresholds_path() -> Path:
+    """Path to the committed briefing-gate thresholds manifest (#1951)."""
+    return _BRIEFING_THRESHOLDS_MANIFEST
+
+
+def load_default_briefing_thresholds() -> BriefingThresholds:
+    """Load the committed briefing-gate thresholds (loud if absent/malformed)."""
+    return load_briefing_thresholds(default_briefing_thresholds_path())
+
+
+def evaluate_briefing_gate(
+    aggregate: Mapping[str, Any], thresholds: BriefingThresholds
+) -> dict[str, Any]:
+    """Compare the aggregate summary-quality metrics to the committed bars.
+
+    Same result shape + ``should_fail`` contract as
+    :func:`gaia.eval.quality_metrics.evaluate_gate`: in report mode
+    (``enforce=False``) ``should_fail`` is always ``False`` even on a breach.
+    Only bars greater than ``0`` are checked (an unset floor is not gated).
+    Any errored/unjudged case is itself a breach — a briefing that could not be
+    generated or scored is a failure, never silently excluded from the
+    denominator. Fail-loud on a missing ``briefing_approval_rate`` — a gate
+    that can't find its input must not silently pass.
+    """
+    if "briefing_approval_rate" not in aggregate:
+        raise ValueError(
+            "briefing gate needs 'briefing_approval_rate' in the aggregate block "
+            f"(have: {sorted(aggregate.keys())})."
+        )
+    breaches: list[dict[str, Any]] = []
+    errored = int(aggregate.get("cases_errored", 0))
+    if errored > 0:
+        breaches.append({"metric": "cases_errored", "value": errored, "max": 0})
+    checks = [
+        (
+            "briefing_approval_rate",
+            float(aggregate["briefing_approval_rate"]),
+            thresholds.approval_min,
+        ),
+        (
+            "must_include_recall_mean",
+            float(aggregate.get("must_include_recall_mean", 0.0)),
+            thresholds.recall_min,
+        ),
+        (
+            "hallucination_free_rate",
+            float(aggregate.get("hallucination_free_rate", 0.0)),
+            thresholds.hallucination_free_min,
+        ),
+        (
+            "faithful_rate",
+            float(aggregate.get("faithful_rate", 0.0)),
+            thresholds.faithfulness_min,
+        ),
+    ]
+    for metric, value, minimum in checks:
+        if minimum > 0.0 and value < minimum:
+            breaches.append({"metric": metric, "value": value, "min": minimum})
+    passed = not breaches
+    return {
+        "metric": "briefing_approval_rate",
+        "value": float(aggregate["briefing_approval_rate"]),
+        "min": thresholds.approval_min,
+        "passed": passed,
+        "breaches": breaches,
+        "enforce": thresholds.enforce,
+        "should_fail": thresholds.enforce and not passed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Judging stage (offline with an injected judge)
+# ---------------------------------------------------------------------------
+
+
+def judge_briefings(
+    corpus: Mapping[str, Any],
+    generations: list[dict],
+    judge_fn: Callable[[str], str],
+    *,
+    model_id: str,
+) -> list[dict[str, Any]]:
+    """Score generated briefings against their case inbox + rubric.
+
+    ``generations`` is :func:`generate_briefings` output (or an equivalent
+    stub): ``[{case_id, briefing|None, error, duration_ms}]``. A generation
+    that carried no briefing stays ``ERRORED`` with its generation error; a
+    judge reply that cannot be parsed becomes ``ERRORED`` with the parse error
+    — visible in the scorecard, never a silent pass or fail.
+    """
+    cases = corpus_cases(corpus)
+    results: list[dict[str, Any]] = []
+    for gen in generations:
+        case_id = gen["case_id"]
+        if case_id not in cases:
+            raise ValueError(
+                f"generation references unknown case id {case_id!r} — corpus "
+                "and generations are out of sync"
+            )
+        briefing = gen.get("briefing")
+        duration_ms = int(gen.get("duration_ms", 0))
+        if not briefing:
+            results.append(
+                build_briefing_result(
+                    case_id,
+                    model_id=model_id,
+                    briefing=None,
+                    verdict=None,
+                    error=gen.get("error") or "agent produced no briefing",
+                    duration_ms=duration_ms,
+                )
+            )
+            continue
+        prompt = build_judge_prompt(cases[case_id], briefing)
+        try:
+            verdict = parse_judge_verdict(judge_fn(prompt))
+        except ValueError as exc:
+            results.append(
+                build_briefing_result(
+                    case_id,
+                    model_id=model_id,
+                    briefing=briefing,
+                    verdict=None,
+                    error=f"judge verdict unusable: {exc}",
+                    duration_ms=duration_ms,
+                )
+            )
+            continue
+        results.append(
+            build_briefing_result(
+                case_id,
+                model_id=model_id,
+                briefing=briefing,
+                verdict=verdict,
+                duration_ms=duration_ms,
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Generation stage (drives the REAL scheduled-briefing path)
+# ---------------------------------------------------------------------------
+
+
+def _message_payload(
+    case_id: str, index: int, message: Mapping[str, str]
+) -> dict[str, Any]:
+    """A Gmail-API-shape message dict for ``FakeGmailBackend.add_message``.
+
+    Mirrors the single-part text/plain shape
+    ``tests.fixtures.email.fake_gmail.mbox_message_to_gmail_payload`` emits, so
+    the briefing path's read tools and ``decode_message_body`` handle it
+    identically. ``internalDate`` decreases with ``index`` so the corpus order
+    is the newest-first order the briefing scans.
+    """
+    body = message["body"]
+    data = base64.urlsafe_b64encode(body.encode("utf-8")).decode("ascii").rstrip("=")
+    msg_id = f"{case_id}-{index:03d}"
+    # Later corpus entries are "older": distinct, monotonically decreasing.
+    internal_date = str(1751500000000 - index * 60000)
+    return {
+        "id": msg_id,
+        "threadId": msg_id,
+        "labelIds": ["INBOX", "UNREAD"],
+        "snippet": " ".join(body.split())[:200],
+        "internalDate": internal_date,
+        "payload": {
+            "mimeType": "text/plain",
+            "filename": "",
+            "headers": [
+                {"name": "From", "value": message["from"]},
+                {"name": "To", "value": "user@example.com"},
+                {"name": "Subject", "value": message["subject"]},
+                {"name": "Message-ID", "value": f"<{msg_id}@briefing.eval>"},
+            ],
+            "body": {"size": len(body.encode("utf-8")), "data": data},
+        },
+        "sizeEstimate": len(body.encode("utf-8")),
+    }
+
+
+def generate_briefings(
+    model_id: str,
+    *,
+    corpus_path: str | Path,
+    max_messages: int = 25,
+    limit: int | None = None,
+    briefing_fn: Callable[[Any, int], Mapping[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Drive the REAL scheduled-briefing path per corpus case.
+
+    Per case: seed a fresh ``FakeGmailBackend`` with the inbox slice, then run
+    the exact scheduled-briefing entry point
+    (``gaia_agent_email.briefing.run_briefing_job`` → ``pre_scan_inbox_impl``)
+    and harvest the ``email_pre_scan`` envelope it persists. Read-only:
+    nothing is sent, archived, or mutated.
+
+    ``briefing_fn(backend, max_messages)`` overrides briefing production (tests
+    inject a stub; keeps the unit path dependency-free). ``model_id`` is
+    recorded on the result rows for the scorecard even though the current
+    briefing path classifies heuristically — it tags which build produced the
+    run. Returns ``[{case_id, briefing|None, error, duration_ms}]`` for
+    :func:`judge_briefings`.
+    """
+    corpus = load_briefing_corpus(corpus_path)
+    cases = corpus_cases(corpus)
+    case_items = list(cases.items())
+    if limit is not None:
+        case_items = case_items[:limit]
+
+    if briefing_fn is None:
+        # Lazy imports: keep `import gaia.eval.briefing_quality` free of the
+        # agent stack. The email agent ships as the standalone
+        # gaia-agent-email wheel (#1102).
+        try:
+            from gaia_agent_email.briefing import run_briefing_job
+        except ImportError as exc:
+            raise RuntimeError(
+                "The briefing eval needs the email agent. Install it with "
+                "`pip install gaia-agent-email` (or `pip install "
+                '"amd-gaia[agents]"`). '
+                f"Original import error: {exc}"
+            ) from exc
+
+        def briefing_fn(backend: Any, max_msgs: int) -> Mapping[str, Any]:
+            captured: dict[str, Any] = {}
+
+            def sink(record: dict[str, Any]) -> None:
+                captured["record"] = record
+
+            run_briefing_job(backend, max_messages=max_msgs, sink=sink)
+            return captured["record"]["briefing"]
+
+    try:
+        from tests.fixtures.email.fake_gmail import FakeGmailBackend
+    except ImportError as exc:
+        raise RuntimeError(
+            "The briefing eval must run from a GAIA repo checkout — it drives "
+            "the FakeGmailBackend in tests/fixtures/email and is not available "
+            f"in a packaged install. Original import error: {exc}"
+        ) from exc
+
+    generations: list[dict[str, Any]] = []
+    for case_id, case in case_items:
+        backend = FakeGmailBackend()
+        for index, message in enumerate(case["inbox"]):
+            backend.add_message(_message_payload(case_id, index, message))
+
+        start = time.monotonic()
+        error = ""
+        briefing: Mapping[str, Any] | None = None
+        try:
+            briefing = briefing_fn(backend, max_messages)
+        except Exception as exc:  # surfaced per-case, never swallowed silently
+            error = f"{type(exc).__name__}: {exc}"
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        if briefing is None and not error:
+            error = "briefing path returned no envelope"
+        generations.append(
+            {
+                "case_id": case_id,
+                "model_id": model_id,
+                "briefing": dict(briefing) if briefing is not None else None,
+                "error": error,
+                "duration_ms": duration_ms,
+            }
+        )
+    return generations
+
+
+__all__ = [
+    "BriefingThresholds",
+    "build_briefing_result",
+    "build_judge_prompt",
+    "corpus_cases",
+    "default_briefing_thresholds_path",
+    "evaluate_briefing_gate",
+    "generate_briefings",
+    "judge_briefings",
+    "load_briefing_corpus",
+    "load_briefing_thresholds",
+    "load_default_briefing_thresholds",
+    "make_claude_judge",
+    "parse_judge_verdict",
+    "summarize_briefings",
+]

--- a/tests/fixtures/email/briefing_gate_thresholds.json
+++ b/tests/fixtures/email/briefing_gate_thresholds.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Summary-quality bars for the scheduled daily inbox briefing eval (#1608 feature, #1951 tracking). 'approval_min' is the primary target (fraction of briefings a judge would trust to start the day); 'recall_min' guards against dropping high-priority threads (must-include recall); 'hallucination_free_min' guards against inventing threads not in the inbox; 'faithfulness_min' guards against distorted summaries. 'enforce' is the SINGLE switch CI keys off and it ships TRUE: this is an ENFORCING gate — a breach (or any errored/unjudged case) fails the build and blocks the release. No report-mode fallback, no silent skip: if the eval cannot run or the digest quality drops below these bars, the pipeline goes red. Tighten the bars HERE (data, not code) as baselines improve. Loaded by gaia.eval.briefing_quality.load_briefing_thresholds (which ignores extra keys).",
+  "approval_min": 0.70,
+  "recall_min": 0.80,
+  "hallucination_free_min": 0.95,
+  "faithfulness_min": 0.90,
+  "enforce": true
+}

--- a/tests/fixtures/email/briefing_ground_truth.json
+++ b/tests/fixtures/email/briefing_ground_truth.json
@@ -1,0 +1,341 @@
+{
+  "_meta": {
+    "fixture": "briefing_ground_truth.json",
+    "fixture_kind": "hand-authored-seed",
+    "schema_version": 1,
+    "description": "Labeled seed corpus for the scheduled-daily-inbox-briefing summary-quality eval (#1608 feature, #1951 tracking). Each case is one inbox slice the daily briefing summarizes, plus a rubric of the high-priority threads it MUST surface and the noise it MUST NOT flag as high-priority. Scored by gaia.eval.briefing_quality: the REAL scheduled-briefing path (gaia_agent_email.briefing.run_briefing_job -> pre_scan_inbox_impl) produces the email_pre_scan envelope over a FakeGmailBackend seeded with the inbox slice (read-only, nothing sent/archived), an LLM judge scores it against the inbox + rubric on faithfulness / must-include recall / hallucination-free / grouping, and the aggregate briefing_approval_rate is compared to briefing_gate_thresholds.json in report mode.",
+    "case_schema": {
+      "scenario": "str — short label for the inbox situation this case exercises",
+      "inbox": "list[{from: str, subject: str, body: str}] (>=3) — the inbox slice the briefing summarizes; the ONLY ground truth for faithfulness + hallucination checks",
+      "rubric": "{must_surface: list[str] (non-empty), must_not_surface: list[str] (may be empty), notes?: str} — must_surface = high-priority threads that must appear in urgent/actionable (drives must-include recall); must_not_surface = noise that must NOT be flagged high-priority"
+    }
+  },
+  "briefing-001": {
+    "scenario": "prod incident + review request buried under newsletters",
+    "inbox": [
+      {
+        "from": "PagerDuty <alerts@pagerduty.com>",
+        "subject": "[P1] Checkout API 5xx error rate above threshold",
+        "body": "A P1 incident has been triggered for the Checkout API. Error rate is at 34% (threshold 2%) for the last 12 minutes. On-call has been paged. Ack this alert or it escalates to the secondary on-call in 5 minutes."
+      },
+      {
+        "from": "Dana Kim <dana@acme.io>",
+        "subject": "Need your sign-off on the Q3 budget by EOD",
+        "body": "Hi — finance needs the Q3 budget locked today. I've attached the final numbers; can you reply with your approval before 5pm? Nothing else is blocking the submission."
+      },
+      {
+        "from": "TechCrunch Daily <newsletter@techcrunch.com>",
+        "subject": "Today in tech: 10 startups to watch",
+        "body": "Your daily roundup of the biggest stories in tech. This morning: a new AI unicorn, chip supply updates, and more."
+      },
+      {
+        "from": "Amazon <ship-confirm@amazon.com>",
+        "subject": "Your order has shipped",
+        "body": "Your recent order of USB-C cables has shipped and will arrive Thursday. Track your package here."
+      },
+      {
+        "from": "LinkedIn <notifications@linkedin.com>",
+        "subject": "You have 3 new connection requests",
+        "body": "See who wants to connect with you this week. Grow your network."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "The PagerDuty P1 checkout-API incident (time-critical, on-call escalation)",
+        "Dana Kim's Q3 budget sign-off request due EOD today"
+      ],
+      "must_not_surface": [
+        "The TechCrunch daily newsletter",
+        "The Amazon shipping-confirmation receipt",
+        "The LinkedIn connection-request digest"
+      ],
+      "notes": "The incident should read as the single most urgent item; the budget sign-off is a same-day action, not an emergency."
+    }
+  },
+  "briefing-002": {
+    "scenario": "two competing deadlines, one genuine FYI",
+    "inbox": [
+      {
+        "from": "Legal <legal@acme.io>",
+        "subject": "Signature required: vendor NDA before tomorrow's call",
+        "body": "The Globex NDA needs your signature before the 9am call tomorrow or we cannot share the roadmap. DocuSign link inside — it takes two minutes."
+      },
+      {
+        "from": "Priya Nair <priya@acme.io>",
+        "subject": "Can you review the launch blog post today?",
+        "body": "Marketing wants to publish the launch post tomorrow morning. Could you review the draft today and flag anything inaccurate? Draft is in the shared doc."
+      },
+      {
+        "from": "IT Helpdesk <it@acme.io>",
+        "subject": "Scheduled maintenance this weekend",
+        "body": "Heads up: VPN will be down for maintenance Saturday 2-4am. No action needed; just avoid scheduling anything critical in that window."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "The Legal NDA signature needed before tomorrow's 9am call",
+        "Priya's request to review the launch blog post today"
+      ],
+      "must_not_surface": [
+        "The IT weekend-maintenance FYI (explicitly says no action needed)"
+      ],
+      "notes": "Both surfaced items are time-boxed actions; the IT notice is purely informational."
+    }
+  },
+  "briefing-003": {
+    "scenario": "mostly noise with a single real action item",
+    "inbox": [
+      {
+        "from": "Spotify <no-reply@spotify.com>",
+        "subject": "Your 2026 Wrapped is here",
+        "body": "See the songs and artists that defined your year. Tap to view your personalized Wrapped."
+      },
+      {
+        "from": "Medium Daily Digest <noreply@medium.com>",
+        "subject": "Stories for you",
+        "body": "Based on your reading history, here are today's recommended stories across product, design, and engineering."
+      },
+      {
+        "from": "Marcus Lee <marcus@partner.co>",
+        "subject": "Contract renewal — decision needed this week",
+        "body": "Our current contract lapses Friday. Can you confirm whether you want to renew at the same terms? If I don't hear back by Thursday we'll have to pause service."
+      },
+      {
+        "from": "Grammarly <insights@grammarly.com>",
+        "subject": "Your weekly writing stats",
+        "body": "You were more productive than 78% of Grammarly users this week. See your streak and insights."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "Marcus Lee's contract-renewal decision needed by Thursday/Friday"
+      ],
+      "must_not_surface": [
+        "The Spotify Wrapped promo",
+        "The Medium daily digest",
+        "The Grammarly weekly-stats email"
+      ],
+      "notes": "Only one thread carries a real deadline; the rest are promotional and must not be flagged high-priority."
+    }
+  },
+  "briefing-004": {
+    "scenario": "phishing attempt mixed with legitimate mail",
+    "inbox": [
+      {
+        "from": "Micr0soft Security <security@microsoft-account-verify.com>",
+        "subject": "Unusual sign-in — verify your account within 24 hours",
+        "body": "We detected an unusual sign-in to your Microsoft account. Verify your identity immediately at the link below or your account will be suspended. Enter your password to confirm it's you."
+      },
+      {
+        "from": "Sofia Martins <sofia@acme.io>",
+        "subject": "Slides for Thursday's board meeting — feedback?",
+        "body": "Draft board slides attached. Could you take a pass by Wednesday? Mainly want your eyes on the revenue section."
+      },
+      {
+        "from": "Coursera <no-reply@coursera.org>",
+        "subject": "New courses added to your recommendations",
+        "body": "We've added new machine-learning courses we think you'll like. Enroll now and start learning."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "The suspected phishing / account-verification scam email (user must review, not act on it blindly)",
+        "Sofia's request to review the board slides by Wednesday"
+      ],
+      "must_not_surface": [
+        "The Coursera course-recommendation promo"
+      ],
+      "notes": "A phishing lure must be surfaced for the user's attention (never silently archived), and never summarized as a legitimate security request the user should comply with."
+    }
+  },
+  "briefing-005": {
+    "scenario": "personal note among work threads",
+    "inbox": [
+      {
+        "from": "Mom <mom@family.net>",
+        "subject": "Dinner Sunday?",
+        "body": "Hi honey, are you free for dinner this Sunday? Your sister is coming too. No rush, just let me know when you can. Love you."
+      },
+      {
+        "from": "Deploy Bot <ci@acme.io>",
+        "subject": "Build failed on main — your commit",
+        "body": "The main branch build is red after your last merge. The email-agent test suite failed. Please fix or revert so the team isn't blocked."
+      },
+      {
+        "from": "Calendar <calendar-notification@google.com>",
+        "subject": "Reminder: 1:1 with manager at 2pm",
+        "body": "This is a reminder for your event '1:1 with manager' today at 2:00 PM."
+      },
+      {
+        "from": "Notion <team@notion.so>",
+        "subject": "What's new in Notion this month",
+        "body": "Check out the latest features we shipped: improved search, new templates, and more."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "The failed main-branch build caused by the user's commit (blocking the team)"
+      ],
+      "must_not_surface": [
+        "The Notion product-update newsletter"
+      ],
+      "notes": "The broken build is the one blocking action. The personal dinner note and the calendar reminder are legitimate but low-priority; they must not be distorted into work emergencies, and the personal note must never be summarized inaccurately."
+    }
+  },
+  "briefing-006": {
+    "scenario": "escalating customer thread plus routine approvals",
+    "inbox": [
+      {
+        "from": "Big Customer <cto@bigcustomer.com>",
+        "subject": "Escalation: data export broken for 3 days, considering churn",
+        "body": "This is the third day our nightly data export has failed and support has not resolved it. We are evaluating alternatives. I need someone senior to call me today with a plan, or we will start migrating off the platform."
+      },
+      {
+        "from": "Expense System <expenses@acme.io>",
+        "subject": "2 expense reports awaiting your approval",
+        "body": "You have two expense reports from your team awaiting approval. They are within policy. Approve or reject at your convenience."
+      },
+      {
+        "from": "Meetup <info@meetup.com>",
+        "subject": "Events happening near you this week",
+        "body": "Discover tech meetups and networking events in your area this week."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "The Big Customer churn-risk escalation demanding a senior call today",
+        "The two expense reports awaiting the user's approval"
+      ],
+      "must_not_surface": [
+        "The Meetup events-near-you promo"
+      ],
+      "notes": "The churn escalation is the clear top priority; the expense approvals are a genuine but routine action, not an emergency."
+    }
+  },
+  "briefing-007": {
+    "scenario": "all-informational morning with one soft ask",
+    "inbox": [
+      {
+        "from": "Company All-Hands <comms@acme.io>",
+        "subject": "Recap: this week's all-hands recording",
+        "body": "In case you missed it, the all-hands recording and slides are now available on the intranet. No action needed."
+      },
+      {
+        "from": "Alex Chen <alex@acme.io>",
+        "subject": "When you get a chance — thoughts on the API naming?",
+        "body": "No rush at all, but when you have a spare moment this week I'd love your take on whether we call it 'workspaces' or 'projects'. Happy to grab coffee to discuss."
+      },
+      {
+        "from": "GitHub <noreply@github.com>",
+        "subject": "Weekly digest: activity in your repositories",
+        "body": "Here's what happened across your repositories this week: 12 pull requests merged, 4 new issues opened."
+      },
+      {
+        "from": "Uber Receipts <receipts@uber.com>",
+        "subject": "Your Tuesday afternoon trip receipt",
+        "body": "Thanks for riding. Your trip total was $18.40. View the full receipt and trip details."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "Alex Chen's low-urgency request for input on API naming (a real ask, even if 'no rush')"
+      ],
+      "must_not_surface": [
+        "The all-hands recap (explicitly no action)",
+        "The GitHub weekly activity digest",
+        "The Uber trip receipt"
+      ],
+      "notes": "Alex's message is the only one asking anything of the user; the briefing should surface it as a light actionable, not inflate it into something urgent, and must not fabricate deadlines it doesn't contain."
+    }
+  },
+  "briefing-008": {
+    "scenario": "duplicate-looking subjects that are actually distinct threads",
+    "inbox": [
+      {
+        "from": "Jordan Blake <jordan@acme.io>",
+        "subject": "Re: Onboarding docs — one blocker",
+        "body": "Thanks for the docs! One blocker: the API key section links to a 404. New hires start Monday, so could you fix the link before then?"
+      },
+      {
+        "from": "Jordan Blake <jordan@acme.io>",
+        "subject": "Onboarding docs — separate question about access",
+        "body": "Unrelated to the doc thread: can you also grant the two new hires read access to the analytics dashboard? Not urgent, sometime before Monday is fine."
+      },
+      {
+        "from": "Atlassian <noreply@atlassian.com>",
+        "subject": "Your Jira weekly summary",
+        "body": "Here's a summary of your Jira activity this week across boards and sprints."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "Jordan's broken API-key link blocking Monday's new-hire onboarding",
+        "Jordan's separate request to grant the new hires analytics-dashboard access before Monday"
+      ],
+      "must_not_surface": [
+        "The Atlassian/Jira weekly summary"
+      ],
+      "notes": "Two genuinely distinct asks from the same sender with similar subjects — the briefing must not collapse them into one item or drop one; both share a Monday deadline."
+    }
+  },
+  "briefing-009": {
+    "scenario": "time-zone-sensitive meeting request plus a receipt",
+    "inbox": [
+      {
+        "from": "Yuki Tanaka <yuki@partner.jp>",
+        "subject": "Can we move our sync 2 hours earlier? My end is late-night",
+        "body": "Our recurring sync lands at 11pm my time. Could we shift it two hours earlier going forward? If today works for a one-off earlier slot, I'm free from 3pm your time. Let me know today so I can plan."
+      },
+      {
+        "from": "Stripe <receipts@stripe.com>",
+        "subject": "Receipt for your subscription payment",
+        "body": "Your monthly subscription of $49.00 was charged successfully. This is your receipt; no action is required."
+      },
+      {
+        "from": "Figma <updates@figma.com>",
+        "subject": "New in Figma: dev mode improvements",
+        "body": "We've shipped improvements to dev mode. See what's new and how to use it."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "Yuki's request to reschedule the recurring sync, needing a reply today"
+      ],
+      "must_not_surface": [
+        "The Stripe subscription receipt (no action required)",
+        "The Figma product-update newsletter"
+      ],
+      "notes": "The reschedule ask needs a same-day reply; the briefing must summarize the specific time request faithfully (2 hours earlier / 3pm your time) without inventing a confirmed new time."
+    }
+  },
+  "briefing-010": {
+    "scenario": "security advisory plus a genuine deadline and a promo",
+    "inbox": [
+      {
+        "from": "Security Team <security@acme.io>",
+        "subject": "Action required: rotate your API tokens by Friday",
+        "body": "Following the dependency advisory, all engineers must rotate their personal API tokens by end of day Friday. Instructions are on the security wiki. Tokens not rotated will be revoked automatically."
+      },
+      {
+        "from": "Rachel Ortiz <rachel@acme.io>",
+        "subject": "Interview feedback needed for tomorrow's debrief",
+        "body": "Could you submit your written feedback for yesterday's candidate before tomorrow's 10am debrief? We can't make a decision without it."
+      },
+      {
+        "from": "DoorDash <no-reply@doordash.com>",
+        "subject": "50% off your next 3 orders",
+        "body": "Limited time: get 50% off your next three orders. Tap to claim your offer before it expires."
+      }
+    ],
+    "rubric": {
+      "must_surface": [
+        "The security team's mandatory API-token rotation by Friday",
+        "Rachel's interview-feedback request needed before tomorrow's 10am debrief"
+      ],
+      "must_not_surface": [
+        "The DoorDash discount promo"
+      ],
+      "notes": "Both surfaced items are hard deadlines with consequences; the briefing must keep their due dates accurate (Friday for rotation, tomorrow 10am for feedback)."
+    }
+  }
+}

--- a/tests/unit/email/test_briefing_corpus_integrity.py
+++ b/tests/unit/email/test_briefing_corpus_integrity.py
@@ -1,0 +1,430 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the daily-inbox-briefing summary-quality eval (#1608 / #1951).
+
+Mirrors ``test_drafting_corpus_integrity.py`` for the briefing seed corpus,
+plus offline coverage of the judge scorer in ``gaia.eval.briefing_quality``:
+
+- The committed corpus loads, is the declared size, and every case is
+  schema-well-formed (the loader is the validator — fail-loud).
+- Duplicate case ids and missing required fields are rejected loudly.
+- Every case's inbox slice drives the REAL scheduled-briefing path
+  (``gaia_agent_email.briefing.run_briefing_job`` → ``pre_scan_inbox_impl``)
+  and yields a valid ``email_pre_scan`` envelope — the corpus can actually
+  drive the feature path.
+- The judge prompt carries the inbox, the generated briefing, and the rubric.
+- Verdict parsing accepts the documented JSON and rejects garbage, missing
+  fields, and out-of-range scores.
+- The scorer runs end-to-end on a mocked judge (no backend, no network) and
+  produces an approval rate in range plus a build_scorecard-compatible summary.
+- The committed thresholds manifest ships the #1951 bars in report mode
+  (``enforce: false``) and the gate honors the ``should_fail`` contract.
+
+Everything here runs offline: no Lemonade, no Anthropic, no live mailbox.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaia.eval import briefing_quality as bq
+from gaia.eval.scorecard import build_scorecard
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+CORPUS_PATH = _REPO_ROOT / "tests" / "fixtures" / "email" / "briefing_ground_truth.json"
+THRESHOLDS_PATH = (
+    _REPO_ROOT / "tests" / "fixtures" / "email" / "briefing_gate_thresholds.json"
+)
+
+
+@pytest.fixture(scope="module")
+def corpus() -> dict:
+    return bq.load_briefing_corpus(CORPUS_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Corpus integrity
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_loads_and_has_seed_size(corpus):
+    """Seed corpus is committed, loadable, and in the declared 8–20 range."""
+    cases = bq.corpus_cases(corpus)
+    assert 8 <= len(cases) <= 20, f"seed corpus size out of range: {len(cases)}"
+
+
+def test_meta_block_present_and_well_formed(corpus):
+    meta = corpus["_meta"]
+    assert meta["fixture"] == "briefing_ground_truth.json"
+    assert meta["fixture_kind"] == "hand-authored-seed"
+    assert isinstance(meta["schema_version"], int)
+
+
+def test_every_case_is_schema_well_formed(corpus):
+    """The loader already validates; assert the shape it guarantees."""
+    for case_id, case in bq.corpus_cases(corpus).items():
+        assert not case_id.startswith("_")
+        assert case["scenario"].strip()
+        assert len(case["inbox"]) >= 3, case_id
+        for idx, message in enumerate(case["inbox"]):
+            for field in ("from", "subject", "body"):
+                assert message[field].strip(), f"{case_id}: inbox[{idx}].{field}"
+        assert case["rubric"]["must_surface"], case_id
+        assert isinstance(case["rubric"].get("must_not_surface", []), list), case_id
+
+
+def test_duplicate_case_ids_rejected(tmp_path):
+    dup = tmp_path / "dup.json"
+    dup.write_text(
+        '{"briefing-001": {}, "briefing-001": {}}',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate case id"):
+        bq.load_briefing_corpus(dup)
+
+
+def test_missing_required_field_rejected(tmp_path, corpus):
+    cases = bq.corpus_cases(corpus)
+    case_id, case = next(iter(cases.items()))
+    broken = {case_id: {k: v for k, v in case.items() if k != "rubric"}}
+    path = tmp_path / "broken.json"
+    path.write_text(json.dumps(broken), encoding="utf-8")
+    with pytest.raises(ValueError, match="rubric"):
+        bq.load_briefing_corpus(path)
+
+
+def test_undersized_inbox_rejected(tmp_path, corpus):
+    cases = bq.corpus_cases(corpus)
+    case_id, case = next(iter(cases.items()))
+    broken = {case_id: {**case, "inbox": case["inbox"][:2]}}
+    path = tmp_path / "small.json"
+    path.write_text(json.dumps(broken), encoding="utf-8")
+    with pytest.raises(ValueError, match="inbox"):
+        bq.load_briefing_corpus(path)
+
+
+def test_inbox_slice_drives_the_real_briefing_path(corpus):
+    """Every case's inbox must survive the REAL scheduled-briefing path —
+    otherwise the live generation stage could not produce an envelope from it.
+
+    Drives ``run_briefing_job`` (heuristic, offline) via the default generation
+    path — no Lemonade, no Anthropic, no live mailbox.
+    """
+    pytest.importorskip("gaia_agent_email")
+
+    generations = bq.generate_briefings(
+        "stub-model", corpus_path=CORPUS_PATH, max_messages=25
+    )
+    assert len(generations) == len(bq.corpus_cases(corpus))
+    for gen in generations:
+        assert not gen["error"], f"{gen['case_id']}: {gen['error']}"
+        briefing = gen["briefing"]
+        assert briefing is not None, gen["case_id"]
+        assert briefing["kind"] == "email_pre_scan"
+        for section in ("urgent", "actionable", "suggested_archives"):
+            assert isinstance(briefing[section], list), gen["case_id"]
+        assert isinstance(briefing["informational_count"], int), gen["case_id"]
+
+
+# ---------------------------------------------------------------------------
+# Judge prompt + verdict parsing
+# ---------------------------------------------------------------------------
+
+_BRIEFING = {
+    "kind": "email_pre_scan",
+    "urgent": [
+        {
+            "message_id": "m1",
+            "sender": "PagerDuty <alerts@pagerduty.com>",
+            "subject": "[P1] Checkout API 5xx error rate above threshold",
+            "why": "P1 incident, on-call escalation imminent",
+        }
+    ],
+    "actionable": [
+        {
+            "message_id": "m2",
+            "sender": "Dana Kim <dana@acme.io>",
+            "subject": "Need your sign-off on the Q3 budget by EOD",
+            "why": "Budget approval due EOD today",
+        }
+    ],
+    "informational_count": 1,
+    "suggested_archives": [
+        {
+            "message_id": "m3",
+            "sender": "TechCrunch Daily <newsletter@techcrunch.com>",
+            "subject": "Today in tech: 10 startups to watch",
+            "reason": "daily newsletter",
+        }
+    ],
+    "suggested_drafts": [],
+    "totals": {
+        "urgent": 1,
+        "actionable": 1,
+        "informational": 1,
+        "suggested_archives": 1,
+    },
+}
+
+
+def _verdict_json(**overrides):
+    verdict = {
+        "faithful": True,
+        "hallucination_free": True,
+        "grouping_reasonable": True,
+        "must_include_recall": 1.0,
+        "overall_quality": 0.9,
+        "approved": True,
+        "rationale": "Surfaces the incident and the budget ask, invents nothing.",
+    }
+    verdict.update(overrides)
+    return json.dumps(verdict)
+
+
+def test_judge_prompt_carries_inbox_briefing_and_rubric(corpus):
+    case = bq.corpus_cases(corpus)["briefing-001"]
+    prompt = bq.build_judge_prompt(case, _BRIEFING)
+    # Rubric threads (both must- and must-not-surface) reach the judge.
+    for item in case["rubric"]["must_surface"] + case["rubric"]["must_not_surface"]:
+        assert item in prompt
+    # The inbox ground truth is present (checked via a message subject).
+    assert case["inbox"][0]["subject"] in prompt
+    # The generated briefing's summaries are present.
+    assert _BRIEFING["urgent"][0]["why"] in prompt
+    assert _BRIEFING["actionable"][0]["subject"] in prompt
+
+
+def test_parse_verdict_happy_path_tolerates_fences():
+    text = "```json\n" + _verdict_json() + "\n```"
+    verdict = bq.parse_judge_verdict(text)
+    assert verdict["approved"] is True
+    assert verdict["must_include_recall"] == 1.0
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "no json here",
+        '{"approved": true}',  # missing fields
+        _verdict_json(must_include_recall=1.7),  # out of range
+        _verdict_json(approved="yes"),  # wrong type
+        _verdict_json(overall_quality=True),  # bool is not a score
+    ],
+)
+def test_parse_verdict_rejects_garbage(bad):
+    with pytest.raises(ValueError):
+        bq.parse_judge_verdict(bad)
+
+
+# ---------------------------------------------------------------------------
+# Scorer on a mocked judge (offline end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def _generations(corpus, *, drop_briefing_for=()):
+    gens = []
+    for case_id in bq.corpus_cases(corpus):
+        briefing = None if case_id in drop_briefing_for else dict(_BRIEFING)
+        gens.append(
+            {
+                "case_id": case_id,
+                "briefing": briefing,
+                "error": "stub: no briefing" if briefing is None else "",
+                "duration_ms": 10,
+            }
+        )
+    return gens
+
+
+def test_scorer_end_to_end_with_mocked_judge(corpus):
+    """Mocked judge → approval rate in range, scorecard-compatible rows."""
+    calls = {"n": 0}
+
+    def mock_judge(prompt: str) -> str:
+        calls["n"] += 1
+        # Alternate approve/reject so the rate is strictly inside (0, 1).
+        return _verdict_json(approved=calls["n"] % 2 == 1)
+
+    results = bq.judge_briefings(
+        corpus, _generations(corpus), mock_judge, model_id="stub-model"
+    )
+    cases = bq.corpus_cases(corpus)
+    assert len(results) == len(cases)
+    assert calls["n"] == len(cases)
+    for r in results:
+        assert r["status"] in {"PASS", "FAIL"}
+        assert r["category"] == "stub-model"
+        assert 0.0 <= r["overall_score"] <= 10.0
+
+    summary = bq.summarize_briefings(
+        results,
+        run_id="unit",
+        thresholds=bq.BriefingThresholds(approval_min=0.70, enforce=False),
+    )
+    agg = summary["briefing"]
+    assert 0.0 < agg["briefing_approval_rate"] < 1.0
+    assert agg["cases_judged"] == len(cases)
+    assert agg["faithful_rate"] == 1.0
+    assert agg["hallucination_free_rate"] == 1.0
+    assert agg["must_include_recall_mean"] == 1.0
+    assert len(agg["per_case"]) == len(cases)
+    # The rows also aggregate through the shared scorecard builder unchanged.
+    scorecard = build_scorecard("unit", results, {})
+    assert scorecard["summary"]["total_scenarios"] == len(cases)
+    assert scorecard["summary"]["passed"] + scorecard["summary"]["failed"] == len(cases)
+
+
+def test_missing_briefing_and_unparseable_judge_become_errored(corpus):
+    cases = list(bq.corpus_cases(corpus))
+    first, second = cases[0], cases[1]
+
+    def judge(prompt: str) -> str:
+        return "not json at all"
+
+    results = bq.judge_briefings(
+        corpus,
+        _generations(corpus, drop_briefing_for={first}),
+        judge,
+        model_id="stub-model",
+    )
+    by_id = {r["id"]: r for r in results}
+    assert by_id[first]["status"] == "ERRORED"
+    assert "no briefing" in by_id[first]["error"]
+    assert by_id[second]["status"] == "ERRORED"
+    assert "judge verdict unusable" in by_id[second]["error"]
+
+    # No verdicts at all → gate is a loud explicit skip, never a pass.
+    summary = bq.summarize_briefings(
+        results,
+        run_id="unit",
+        thresholds=bq.BriefingThresholds(approval_min=0.70, enforce=False),
+    )
+    assert "briefing" not in summary
+    assert summary["briefing_gate"]["skipped"] is True
+    assert summary["briefing_gate"]["should_fail"] is False
+
+
+def test_unknown_case_id_in_generations_is_loud(corpus):
+    bad = [{"case_id": "briefing-999", "briefing": dict(_BRIEFING), "duration_ms": 1}]
+    with pytest.raises(ValueError, match="unknown case id"):
+        bq.judge_briefings(corpus, bad, lambda p: _verdict_json(), model_id="m")
+
+
+# ---------------------------------------------------------------------------
+# Committed thresholds manifest + gate contract
+# ---------------------------------------------------------------------------
+
+
+def test_committed_thresholds_manifest_is_enforcing():
+    thresholds = bq.load_briefing_thresholds(THRESHOLDS_PATH)
+    assert thresholds.approval_min == 0.70  # the #1951 primary target
+    assert thresholds.recall_min == 0.80
+    assert thresholds.hallucination_free_min == 0.95
+    assert thresholds.faithfulness_min == 0.90
+    # Enforcing gate — a breach blocks the build (see the manifest comment).
+    assert thresholds.enforce is True
+    # The module default points at the same committed manifest.
+    assert bq.default_briefing_thresholds_path() == THRESHOLDS_PATH
+
+
+def test_malformed_thresholds_manifest_rejected(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text('{"enforce": false}', encoding="utf-8")
+    with pytest.raises(ValueError, match="approval_min"):
+        bq.load_briefing_thresholds(path)
+
+
+def test_gate_report_mode_never_fails_the_build():
+    gate = bq.evaluate_briefing_gate(
+        {
+            "briefing_approval_rate": 0.25,
+            "must_include_recall_mean": 0.20,
+            "hallucination_free_rate": 0.50,
+            "faithful_rate": 0.40,
+        },
+        bq.BriefingThresholds(
+            approval_min=0.70,
+            recall_min=0.80,
+            hallucination_free_min=0.95,
+            faithfulness_min=0.90,
+            enforce=False,
+        ),
+    )
+    assert gate["passed"] is False
+    assert gate["breaches"]
+    assert gate["should_fail"] is False
+
+
+def test_gate_enforced_breach_fails():
+    gate = bq.evaluate_briefing_gate(
+        {"briefing_approval_rate": 0.25},
+        bq.BriefingThresholds(approval_min=0.70, enforce=True),
+    )
+    assert gate["should_fail"] is True
+
+
+def test_gate_unset_secondary_bars_are_not_checked():
+    """A manifest gating on approval alone must not fail on recall/faithfulness
+    it never set (unset floors default to 0.0 = not gated)."""
+    gate = bq.evaluate_briefing_gate(
+        {
+            "briefing_approval_rate": 0.90,
+            "must_include_recall_mean": 0.10,
+            "hallucination_free_rate": 0.10,
+            "faithful_rate": 0.10,
+        },
+        bq.BriefingThresholds(approval_min=0.70, enforce=True),
+    )
+    assert gate["passed"] is True
+    assert gate["breaches"] == []
+    assert gate["should_fail"] is False
+
+
+def test_gate_missing_rate_is_loud():
+    with pytest.raises(ValueError, match="briefing_approval_rate"):
+        bq.evaluate_briefing_gate({}, bq.BriefingThresholds(approval_min=0.70))
+
+
+def test_errored_case_is_a_gate_breach():
+    """An errored/unjudged case must never silently escape the gate: a briefing
+    that could not be generated or scored is itself a breach (no workaround)."""
+    gate = bq.evaluate_briefing_gate(
+        {
+            "briefing_approval_rate": 1.0,
+            "must_include_recall_mean": 1.0,
+            "hallucination_free_rate": 1.0,
+            "faithful_rate": 1.0,
+            "cases_errored": 1,
+        },
+        bq.BriefingThresholds(approval_min=0.70, enforce=True),
+    )
+    assert gate["passed"] is False
+    assert any(b["metric"] == "cases_errored" for b in gate["breaches"])
+    assert gate["should_fail"] is True
+
+
+def test_no_verdicts_under_enforcing_gate_blocks_the_build():
+    """A total judge/generation outage (no verdicts at all) must fail an
+    enforcing gate rather than pass by default."""
+    corpus = {"briefing-001": {}}  # only structure needed for the skip branch
+    results = [
+        bq.build_briefing_result(
+            "briefing-001",
+            model_id="stub-model",
+            briefing=None,
+            verdict=None,
+            error="judge outage",
+        )
+    ]
+    summary = bq.summarize_briefings(
+        results,
+        run_id="unit",
+        thresholds=bq.BriefingThresholds(approval_min=0.70, enforce=True),
+    )
+    assert "briefing" not in summary
+    assert summary["briefing_gate"]["skipped"] is True
+    assert summary["briefing_gate"]["should_fail"] is True


### PR DESCRIPTION
The scheduled daily inbox briefing (#1608) shipped with unit tests that prove the scheduler *runs* — but nothing measured whether the digest is any *good*. The briefing is a pure summarization surface: a prompt or classification regression that starts dropping the P1 incident, distorting a summary, or inventing a thread passes CI silently today. After this change, a nightly judge scores each briefing on faithfulness, must-include recall, hallucination-free, and grouping, and the aggregate briefing-approval rate lands in the email-eval report — so that regression shows up instead of shipping.

Report mode, matching the triage / drafting / action-item evals: the committed manifest ships `enforce:false`, so a breach is logged and uploaded, never a build failure. Flipping `enforce` in the manifest (data, not code) is what makes it gate once a real baseline confirms the bars.

## What's in it

- **Seed corpus** — `tests/fixtures/email/briefing_ground_truth.json`, 10 hand-labeled inbox slices (prod incident + newsletters, competing deadlines, mostly-noise, a phishing lure, a personal note, churn escalation, near-duplicate threads, timezone reschedule, security advisory). Each carries a rubric of the high-priority threads the briefing **must surface** and the noise it **must not** flag.
- **Scorer** — `gaia.eval.briefing_quality`, a sibling of the drafting benchmark. Generation drives the REAL scheduled-briefing path (`run_briefing_job` → `pre_scan_inbox_impl`) over `FakeGmailBackend` (read-only, nothing sent/archived); an injected LLM judge (`gaia.eval.claude`) scores each briefing with strict-JSON verdicts parsed fail-loud; aggregation is `build_scorecard`-compatible and evaluates the committed gate manifest.
- **Gate manifest** — `briefing_gate_thresholds.json`, `enforce:false`, provisional approval/recall/hallucination/faithfulness bars documented as placeholders to re-measure from the first baseline.
- **CI wiring** — one additive, self-contained report-mode step in `test_email_agent_eval.yml`, after the drafting eval in the same job so Lemonade access stays serial. Loud explicit skip when the judge credential is unavailable.

No baseline is committed: the first real judged report will be produced by this workflow's nightly run in report mode — no fabricated numbers.

## Test plan

- [x] `PYTHONPATH=... pytest tests/unit/email/test_briefing_corpus_integrity.py` — 24 passed (corpus integrity, real-path generation, judge prompt/verdict, scorer, gate; fully offline)
- [x] `pytest tests/unit/email/test_{briefing,drafting,action_items}_corpus_integrity.py` — 79 passed (no interference with sibling evals)
- [x] `black` / `isort` / `flake8` (project flags) clean on the new files
- [x] Workflow YAML parses; the embedded gate-reader python compiles
- [ ] **Follow-up:** first real judged baseline on the self-hosted Lemonade runner, then re-measure the manifest bars

Closes #1951