### PR TITLE
fix(rag): drop unnecessary sentence-transformers hard dependency

### DIFF
--- a/.github/workflows/test_rag.yml
+++ b/.github/workflows/test_rag.yml
@@ -14,6 +14,7 @@ on:
       - 'src/gaia/llm/**'
       - 'src/gaia/vlm/**'
       - 'tests/test_rag*.py'
+      - 'tests/unit/rag/**'
       - 'setup.py'
       - '.github/workflows/test_rag.yml'
   pull_request:
@@ -26,6 +27,7 @@ on:
       - 'src/gaia/llm/**'
       - 'src/gaia/vlm/**'
       - 'tests/test_rag*.py'
+      - 'tests/unit/rag/**'
       - 'setup.py'
       - '.github/workflows/test_rag.yml'
   merge_group:
@@ -65,7 +67,7 @@ jobs:
     - name: Run RAG unit tests
       run: |
         echo "Running RAG unit tests..."
-        pytest tests/test_rag.py -v -s --tb=short --cov=src/gaia/rag --cov-report=term-missing
+        pytest tests/test_rag.py tests/unit/rag/ -v -s --tb=short --cov=src/gaia/rag --cov-report=term-missing
 
     - name: Upload coverage report
       if: always()

--- a/setup.py
+++ b/setup.py
@@ -144,16 +144,18 @@ setup(
             # the OS credential store (macOS Keychain, Windows DPAPI, Linux
             # SecretService). Pinned upper bound per supply-chain advisory.
             "keyring>=24.0.0,<26.0.0",
-            # RAG runtime deps — gaia.ui.server boots faiss + sentence_transformers
-            # eagerly, and gaia.rag.sdk uses pypdf/pymupdf/numpy. See #845.
-            # Version specifiers match the standalone "rag" extra; "ui"
-            # additionally declares safetensors and a torch lower bound.
+            # RAG runtime deps — gaia.rag.sdk uses faiss/pypdf/pymupdf/numpy and
+            # embeds via Lemonade (NOT sentence-transformers). See #845.
+            # Version specifiers match the standalone "rag" extra.
             "faiss-cpu>=1.7.0",
             "numpy>=1.24.0",
             "pymupdf>=1.24.0",
             "pypdf",
             "python-pptx>=0.6.21",
             "python-docx>=1.1.0",
+            # Memory cross-encoder reranker (gaia.agents.base.memory) — optional
+            # at runtime (graceful degradation) but bundled with "ui" so the
+            # full chat experience gets reranking out of the box. NOT a RAG dep.
             "sentence-transformers",
             "safetensors",
             # torch is pinned lower-bound only. The "audio" extra caps
@@ -235,13 +237,14 @@ setup(
             "llama-index-readers-youtube-transcript",
         ],
         "rag": [
+            # RAG embeds via Lemonade, not sentence-transformers — do NOT add it
+            # here. It is only needed for the optional memory reranker (see "ui").
             "faiss-cpu>=1.7.0",
             "numpy>=1.24.0",
             "pymupdf>=1.24.0",
             "pypdf",
             "python-pptx>=0.6.21",
             "python-docx>=1.1.0",
-            "sentence-transformers",
         ],
         "lint": [
             "black",

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -30,16 +30,13 @@ except ImportError:
     except ImportError:
         PdfReader = None
 
-# Not just ImportError: a broken native dependency (e.g. torchcodec/FFmpeg
-# pulled in by sentence-transformers, or an arch-mismatched faiss build) raises
-# RuntimeError/OSError at import. Treat that the same as "not installed" so a
-# bad install can't crash every module that transitively imports RAG; the loud,
-# actionable error is deferred to RAGSDK._check_dependencies() at point of use.
-try:
-    from sentence_transformers import SentenceTransformer
-except Exception:  # pylint: disable=broad-except
-    SentenceTransformer = None
-
+# Not just ImportError: an arch-mismatched faiss build raises RuntimeError/OSError
+# at import. Treat that the same as "not installed" so a bad install can't crash
+# every module that transitively imports RAG; the loud, actionable error is
+# deferred to RAGSDK._check_dependencies() at point of use.
+# NOTE: RAG embeds via Lemonade (self.embedder.embeddings), NOT sentence-transformers.
+# sentence-transformers is intentionally NOT imported or required here — it is only
+# an optional dep of the memory cross-encoder reranker (gaia.agents.base.memory).
 try:
     import faiss
 except Exception:  # pylint: disable=broad-except
@@ -217,8 +214,6 @@ class RAGSDK:
         missing = []
         if PdfReader is None:
             missing.append("pypdf (or PyPDF2)")
-        if SentenceTransformer is None:
-            missing.append("sentence-transformers")
         if faiss is None:
             missing.append("faiss-cpu")
 
@@ -236,13 +231,8 @@ class RAGSDK:
             # skipping genuinely-missing packages (ImportError) which the
             # install instructions above already cover.
             broken = []
-            for pkg, label in (
-                ("sentence_transformers", "sentence-transformers"),
-                ("faiss", "faiss"),
-            ):
-                if (pkg == "sentence_transformers" and SentenceTransformer is None) or (
-                    pkg == "faiss" and faiss is None
-                ):
+            for pkg, label in (("faiss", "faiss"),):
+                if pkg == "faiss" and faiss is None:
                     try:
                         # Use the import statement (__import__), not
                         # importlib.import_module — the latter bypasses

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -231,24 +231,23 @@ class RAGSDK:
             # skipping genuinely-missing packages (ImportError) which the
             # install instructions above already cover.
             broken = []
-            for pkg, label in (("faiss", "faiss"),):
-                if pkg == "faiss" and faiss is None:
-                    try:
-                        # Use the import statement (__import__), not
-                        # importlib.import_module — the latter bypasses
-                        # builtins.__import__, so this path can't be exercised
-                        # by tests that intercept imports, and re-running the
-                        # real import is what re-surfaces the native cause.
-                        __import__(pkg)
-                    except ImportError:
-                        pass  # genuinely missing → covered by install instructions
-                    except Exception as exc:  # pylint: disable=broad-except
-                        broken.append(f"  {label}: {exc}")
+            if faiss is None:
+                try:
+                    # Use the import statement (__import__), not
+                    # importlib.import_module — the latter bypasses
+                    # builtins.__import__, so this path can't be exercised
+                    # by tests that intercept imports, and re-running the
+                    # real import is what re-surfaces the native cause.
+                    __import__("faiss")
+                except ImportError:
+                    pass  # genuinely missing → covered by install instructions
+                except Exception as exc:  # pylint: disable=broad-except
+                    broken.append(f"  faiss: {exc}")
             if broken:
                 error_msg += (
                     "\nThe package(s) below are installed but failed to load — "
                     "reinstalling won't help until the underlying error is fixed "
-                    "(e.g. a missing FFmpeg for torchcodec):\n"
+                    "(e.g. an arch-mismatched faiss build):\n"
                     + "\n".join(broken)
                     + "\n"
                 )

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -252,7 +252,12 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             import sys
 
             import faiss  # noqa: F401
-            import sentence_transformers  # noqa: F401
+
+            # sentence-transformers is NOT pre-imported: RAG embeds via Lemonade,
+            # and the memory cross-encoder reranker imports it lazily with graceful
+            # degradation. Eagerly importing it here pulled the fragile torch/
+            # torchcodec stack into boot and made a broken install look like a RAG
+            # failure (#RAG-embedder-switch).
 
             # Log which SWIG backend faiss actually loaded.
             # Order matters: check most-optimized first.

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -37,7 +37,6 @@ def mock_dependencies():
         patch("gaia.llm.vlm_client.VLMClient") as mock_vlm_class,
         patch("gaia.llm.lemonade_client.LemonadeClient") as mock_lemonade,
         patch("gaia.rag.sdk.PdfReader") as mock_pdf,
-        patch("gaia.rag.sdk.SentenceTransformer") as mock_st,
         patch("gaia.rag.sdk.faiss") as mock_faiss,
         patch("gaia.rag.sdk.AgentSDK") as mock_chat,
     ):
@@ -62,10 +61,6 @@ def mock_dependencies():
         )
         mock_pdf.return_value = mock_pdf_instance
 
-        mock_embedder = Mock()
-        mock_embedder.encode.return_value = np.array([[0.1, 0.2, 0.3, 0.4]])
-        mock_st.return_value = mock_embedder
-
         mock_index = Mock()
         mock_index.search.return_value = (np.array([[0.5]]), np.array([[0]]))
         mock_faiss.IndexFlatL2.return_value = mock_index
@@ -79,7 +74,6 @@ def mock_dependencies():
 
         yield {
             "pdf": mock_pdf,
-            "embedder": mock_embedder,
             "index": mock_index,
             "chat": mock_chat_instance,
             "vlm": mock_vlm_instance,
@@ -166,7 +160,6 @@ class TestRAGSDK:
             patch("gaia.llm.vlm_client.VLMClient") as mock_vlm_class,
             patch("gaia.llm.lemonade_client.LemonadeClient") as mock_lemonade,
             patch("gaia.rag.sdk.PdfReader") as mock_pdf,
-            patch("gaia.rag.sdk.SentenceTransformer") as mock_st,
             patch("gaia.rag.sdk.faiss") as mock_faiss,
             patch("gaia.rag.sdk.AgentSDK") as mock_chat,
         ):
@@ -197,9 +190,6 @@ class TestRAGSDK:
             mock_pdf.return_value = mock_pdf_instance
 
             # Mock sentence transformer
-            mock_embedder = Mock()
-            mock_embedder.encode.return_value = np.array([[0.1, 0.2, 0.3, 0.4]])
-            mock_st.return_value = mock_embedder
 
             # Mock FAISS
             mock_index = Mock()
@@ -216,7 +206,6 @@ class TestRAGSDK:
 
             yield {
                 "pdf": mock_pdf,
-                "embedder": mock_embedder,
                 "index": mock_index,
                 "chat": mock_chat_instance,
                 "vlm": mock_vlm_instance,
@@ -289,7 +278,6 @@ class TestRAGSDK:
         # Test when dependencies are missing
         with (
             patch("gaia.rag.sdk.PdfReader", None),
-            patch("gaia.rag.sdk.SentenceTransformer", None),
             patch("gaia.rag.sdk.faiss", None),
         ):
 
@@ -367,7 +355,7 @@ class TestRAGSDK:
                 # Set up mock state
                 rag.chunks = ["Sample chunk 1", "Sample chunk 2"]
                 rag.index = mock_dependencies["index"]
-                rag.embedder = mock_dependencies["embedder"]
+                rag.embedder = mock_dependencies["lemonade"]
                 rag.chat = mock_dependencies["chat"]
                 rag.chunk_to_file = {0: "test.pdf", 1: "test.pdf"}
                 rag.indexed_files = {"test.pdf"}
@@ -856,7 +844,6 @@ class TestErrorHandling:
 
         with (
             patch("gaia.rag.sdk.PdfReader", None),
-            patch("gaia.rag.sdk.SentenceTransformer", None),
             patch("gaia.rag.sdk.faiss", None),
         ):
 
@@ -908,7 +895,6 @@ class TestMemoryLimits:
             patch("gaia.llm.vlm_client.VLMClient") as mock_vlm_class,
             patch("gaia.llm.lemonade_client.LemonadeClient") as mock_lemonade,
             patch("gaia.rag.sdk.PdfReader") as mock_pdf,
-            patch("gaia.rag.sdk.SentenceTransformer") as mock_st,
             patch("gaia.rag.sdk.faiss") as mock_faiss,
             patch("gaia.rag.sdk.AgentSDK") as mock_chat,
         ):
@@ -933,10 +919,6 @@ class TestMemoryLimits:
             )
             mock_pdf.return_value = mock_pdf_instance
 
-            mock_embedder = Mock()
-            mock_embedder.encode.return_value = np.array([[0.1, 0.2, 0.3, 0.4]])
-            mock_st.return_value = mock_embedder
-
             mock_index = Mock()
             mock_index.search.return_value = (np.array([[0.5]]), np.array([[0]]))
             mock_faiss.IndexFlatL2.return_value = mock_index
@@ -950,7 +932,6 @@ class TestMemoryLimits:
 
             yield {
                 "pdf": mock_pdf,
-                "embedder": mock_embedder,
                 "index": mock_index,
                 "chat": mock_chat_instance,
                 "vlm": mock_vlm_instance,
@@ -1234,7 +1215,6 @@ class TestCacheSecurity:
             patch("gaia.llm.vlm_client.VLMClient") as mock_vlm_class,
             patch("gaia.llm.lemonade_client.LemonadeClient") as mock_lemonade,
             patch("gaia.rag.sdk.PdfReader") as mock_pdf,
-            patch("gaia.rag.sdk.SentenceTransformer") as mock_st,
             patch("gaia.rag.sdk.faiss") as mock_faiss,
             patch("gaia.rag.sdk.AgentSDK") as mock_chat,
         ):
@@ -1259,10 +1239,6 @@ class TestCacheSecurity:
             )
             mock_pdf.return_value = mock_pdf_instance
 
-            mock_embedder = Mock()
-            mock_embedder.encode.return_value = np.array([[0.1, 0.2, 0.3, 0.4]])
-            mock_st.return_value = mock_embedder
-
             mock_index = Mock()
             mock_index.search.return_value = (np.array([[0.5]]), np.array([[0]]))
             mock_faiss.IndexFlatL2.return_value = mock_index
@@ -1276,7 +1252,6 @@ class TestCacheSecurity:
 
             yield {
                 "pdf": mock_pdf,
-                "embedder": mock_embedder,
                 "index": mock_index,
                 "chat": mock_chat_instance,
                 "vlm": mock_vlm_instance,

--- a/tests/unit/rag/test_dependency_guard.py
+++ b/tests/unit/rag/test_dependency_guard.py
@@ -3,11 +3,20 @@
 
 """Unit tests for RAG dependency-import guards.
 
-A broken native dependency (e.g. torchcodec/FFmpeg under sentence-transformers,
-or an arch-mismatched faiss build) raises ``RuntimeError``/``OSError`` at import
-rather than ``ImportError``. The guard in ``gaia.rag.sdk`` must treat that the
-same as "not installed" so it cannot crash every module that transitively
-imports RAG, while still surfacing a loud, actionable error at point of use.
+RAG embeds via Lemonade, so **sentence-transformers is NOT a RAG dependency** — it
+is only an optional dep of the memory cross-encoder reranker. RAG must import and
+run even when sentence-transformers is absent or broken.
+
+Regression this file protects against (the EmbeddingGemma embedder switch, #1952):
+a broken ``torchcodec``/FFmpeg under sentence-transformers made ``import
+sentence_transformers`` raise, which — because the old dependency guard *required*
+sentence-transformers — made every RAG indexing call fail with 0 chunks even though
+the Lemonade embedder was loaded and ready.
+
+The genuine native dep (faiss) can still raise ``RuntimeError``/``OSError`` at
+import when the build is arch-mismatched; the guard must treat that as "not
+installed" so it cannot crash every module that transitively imports RAG, while
+still surfacing a loud, actionable error at point of use.
 """
 
 import builtins
@@ -28,19 +37,53 @@ def _bare_sdk():
 def test_module_imports_without_optional_deps():
     """The module is importable regardless of optional-dependency health."""
     assert hasattr(sdk, "RAGSDK")
-    assert hasattr(sdk, "SentenceTransformer")
     assert hasattr(sdk, "faiss")
 
 
-def test_broken_install_reports_actionable_cause(monkeypatch):
-    """An installed-but-broken dep surfaces the captured cause, not just 'install it'."""
-    monkeypatch.setattr(sdk, "SentenceTransformer", None)
+def test_rag_does_not_import_sentence_transformers():
+    """RAG must not even import sentence-transformers — it embeds via Lemonade.
+
+    If this fails, someone re-added a sentence-transformers import to the RAG SDK,
+    reintroducing a heavy dep (torch/torchcodec) whose broken native libs would
+    take down all RAG indexing.
+    """
+    assert not hasattr(sdk, "SentenceTransformer")
+
+
+def test_check_dependencies_passes_when_sentence_transformers_is_broken(monkeypatch):
+    """A broken/absent sentence-transformers must NOT fail the RAG dependency check.
+
+    This is the core regression: RAG indexing worked in production only because
+    sentence-transformers happened to import; on a box with broken torchcodec it
+    failed with 0 chunks. RAG does not use sentence-transformers, so the guard must
+    never list it — regardless of how broken it is.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+            raise RuntimeError("Could not load libtorchcodec (FFmpeg not found)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    try:
+        _bare_sdk()._check_dependencies()
+    except ImportError as exc:
+        # If the check raises at all (e.g. faiss genuinely missing in this env),
+        # it must never be because of sentence-transformers.
+        assert "sentence-transformers" not in str(exc).lower()
+
+
+def test_broken_faiss_reports_actionable_cause(monkeypatch):
+    """An installed-but-broken faiss surfaces the captured cause, not just 'install it'."""
+    monkeypatch.setattr(sdk, "faiss", None)
 
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "sentence_transformers":
-            raise RuntimeError("Could not load libtorchcodec (FFmpeg not found)")
+        if name == "faiss":
+            raise RuntimeError("arch-mismatched faiss build (illegal instruction)")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
@@ -49,18 +92,18 @@ def test_broken_install_reports_actionable_cause(monkeypatch):
         _bare_sdk()._check_dependencies()
     msg = str(excinfo.value)
     assert "installed but failed to load" in msg
-    assert "libtorchcodec" in msg  # the captured cause is named
+    assert "arch-mismatched faiss" in msg  # the captured cause is named
 
 
-def test_genuinely_missing_dep_omits_broken_section(monkeypatch):
+def test_genuinely_missing_faiss_omits_broken_section(monkeypatch):
     """A simply-missing dep gets install instructions, not the broken-load hint."""
-    monkeypatch.setattr(sdk, "SentenceTransformer", None)
+    monkeypatch.setattr(sdk, "faiss", None)
 
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "sentence_transformers":
-            raise ImportError("No module named 'sentence_transformers'")
+        if name == "faiss":
+            raise ImportError("No module named 'faiss'")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
@@ -68,5 +111,5 @@ def test_genuinely_missing_dep_omits_broken_section(monkeypatch):
     with pytest.raises(ImportError) as excinfo:
         _bare_sdk()._check_dependencies()
     msg = str(excinfo.value)
-    assert "sentence-transformers" in msg
+    assert "faiss-cpu" in msg
     assert "installed but failed to load" not in msg

--- a/tests/unit/rag/test_pptx_extraction.py
+++ b/tests/unit/rag/test_pptx_extraction.py
@@ -190,7 +190,13 @@ class TestPptxTextExtraction:
         assert "Remember to mention the deadline" in text
 
     def test_table_extraction(self, rag, tmp_path):
-        """Tables are extracted as markdown."""
+        """Tables are extracted as markdown by the pure-python (python-pptx) path.
+
+        The PPTX→PDF fast path (LibreOffice/PowerPoint COM) flattens tables to
+        plain text — markdown table structure is produced only by the pure-python
+        fallback. Force that fallback here so the assertion is deterministic
+        regardless of whether LibreOffice is installed on the runner.
+        """
         pptx_path = tmp_path / "table.pptx"
         _create_pptx(
             pptx_path,
@@ -206,7 +212,12 @@ class TestPptxTextExtraction:
             ],
         )
 
-        text, _, _ = rag._extract_text_from_pptx(str(pptx_path))
+        # Disable PPTX→PDF conversion so the pure-python markdown extractor runs.
+        with patch(
+            "gaia.rag.pptx_utils.convert_pptx_to_pdf",
+            side_effect=RuntimeError("PDF conversion disabled for this test"),
+        ):
+            text, _, _ = rag._extract_text_from_pptx(str(pptx_path))
 
         assert "Alice" in text
         assert "Bob" in text


### PR DESCRIPTION
## Why this matters

RAG embeds through Lemonade, yet the RAG SDK **hard-required `sentence-transformers` to import** — a heavy, fragile dependency (torch/torchcodec) it never actually uses. On any machine where `sentence-transformers` failed to import (e.g. broken `torchcodec`/FFmpeg native libs), **every RAG document-indexing call silently produced 0 chunks** even though the Lemonade EmbeddingGemma embedder was loaded and ready — a hard-to-diagnose "RAG returns nothing" failure. After this change, RAG initializes and indexes normally regardless of `sentence-transformers` health; the library is now only what it should be — an *optional* dependency of the memory cross-encoder reranker (which already degrades gracefully).

This also closes the test gap that let it through: the RAG dependency-guard test previously *encoded the wrong behavior* (it required `sentence-transformers`), and the **Test RAG** CI workflow didn't run `tests/unit/rag/` at all — so nothing exercised the guard.

## Test plan
- [ ] `pytest tests/test_rag.py tests/unit/rag/` — green (115 tests; previously 28 errors from obsolete ST mocks)
- [ ] New regression guard: RAG initializes with `sentence-transformers` forcibly unavailable (`tests/unit/rag/test_dependency_guard.py`)
- [ ] End-to-end: index a document + retrieve with ST blocked → EmbeddingGemma 768-dim embeddings, correct answer
- [ ] `black --check` / `flake8` clean on changed files
- [ ] CI **Test RAG** now runs `tests/unit/rag/` (path filter + test command updated)

## Notes
- Bundles a small pre-existing fix: `test_pptx_extraction.py::test_table_extraction` was env-dependent (failed when LibreOffice was installed, since the PPTX→PDF path flattens tables); it now forces the pure-python markdown path so the assertion is deterministic.