### PR TITLE
fix(builder): create the agent immediately when the request already names it

### DIFF
--- a/src/gaia/agents/builder/agent.py
+++ b/src/gaia/agents/builder/agent.py
@@ -38,6 +38,18 @@ _RESERVED_IDS = {"agent", "chat", "gaia", "builder"}
 # Allowed characters for a generated agent ID.
 _SAFE_ID_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,50}[a-z0-9])?$")
 
+# A one-shot creation request names the agent inline ("named X", "call it Y").
+# When it does, a greeting/question first reply is a bug — the builder should
+# call create_agent immediately (see the system prompt's Fast path).
+_NAMED_REQUEST_RE = re.compile(
+    r"\b(?:named|called|call\s+it)\s+['\"]?[\w-]", re.IGNORECASE
+)
+
+
+def _query_names_agent(query: str) -> bool:
+    """Return True if *query* already supplies an agent name to create."""
+    return bool(query) and bool(_NAMED_REQUEST_RE.search(query))
+
 
 def _name_to_class_name(name: str) -> str:
     """Convert a human name to a valid Python class name.
@@ -246,6 +258,9 @@ class BuilderAgent(Agent):
 
         final_answer: Optional[str] = None
         steps_taken = 0
+        # One-shot guard: nudge at most once if the model stalls with a
+        # greeting/question when the request already named the agent.
+        nudged_missing_tool = False
 
         while steps_taken < steps_limit and final_answer is None:
             steps_taken += 1
@@ -358,6 +373,29 @@ class BuilderAgent(Agent):
                                 "You did not actually call create_agent. "
                                 "Output ONLY the bare JSON tool call, no prose, "
                                 "no code fences."
+                            ),
+                        }
+                    )
+                    # Do not set final_answer — the loop will continue
+                elif not nudged_missing_tool and _query_names_agent(
+                    self._current_query
+                ):
+                    # The request already named the agent, yet the model greeted
+                    # or asked a question instead of calling the tool (#1428-style
+                    # stall). Nudge once to force the bare tool call, then loop.
+                    nudged_missing_tool = True
+                    logger.warning(
+                        "BuilderAgent: name present but no create_agent call; "
+                        "injecting corrective user turn"
+                    )
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": (
+                                "The request already includes the agent name and "
+                                "everything you need. Do NOT greet or ask "
+                                "questions. Output ONLY the bare create_agent JSON "
+                                "tool call now, no prose, no code fences."
                             ),
                         }
                     )

--- a/src/gaia/agents/builder/system_prompt.py
+++ b/src/gaia/agents/builder/system_prompt.py
@@ -15,12 +15,23 @@ character, but it will NOT autonomously fetch data, call APIs, or actually perfo
 task it describes (for example, it will not really pull and parse live arXiv papers) \
 until the user wires that up. Never imply otherwise.
 
-## Conversation flow
+## Fast path — if the request is already complete, act immediately
+If the user's message already gives you an agent name (e.g. "Create an agent named X", \
+"Build me a Foo agent", "call it Bar"), treat it as a complete request: do NOT greet and \
+do NOT ask any questions. Immediately call `create_agent` on your FIRST reply —
+  - infer `enable_mcp` from the message ("no tools"/"no MCP" → false; "with MCP" → true; \
+    default false when unstated),
+  - author a `system_prompt` and `conversation_starters` tailored to the name/purpose.
+A greeting or a question is the WRONG response when a name is already present — the only \
+correct first output is the bare `create_agent` JSON. Use the step-by-step flow below \
+ONLY when the message does not contain a name.
+
+## Conversation flow (only when no name has been given yet)
 1. On your very first reply, set this expectation before anything else, then ask for a \
    name — e.g. "Hi! I'm the Gaia Builder, an alpha feature. I'll scaffold a starter \
    agent *template* for you — a persona you then extend with your own tools and logic. \
    I don't create an agent that goes off and does complex tasks on its own. What would \
-   you like to call your agent?" (skip asking for the name if one is already in the message).
+   you like to call your agent?" (skip this greeting entirely if a name is already in the message).
 2. Ask for a one-sentence description of what the agent should do \
    (skip if already given).
 3. Ask whether they want MCP support — the ONLY capability question. \
@@ -39,6 +50,9 @@ until the user wires that up. Never imply otherwise.
 ## Rules
 - ALWAYS call `create_agent` once you have the name and purpose and have asked \
   about MCP. Do not describe what you would do — actually call the tool.
+- The MOMENT a name is available (in the user's message or gathered over the \
+  conversation), call `create_agent`. Never reply with only a greeting or a \
+  question when the name is already known — that is a failure.
 - ALWAYS pass a `system_prompt` and `conversation_starters` tailored to the \
   agent's purpose. Never ship a zoo/zookeeper persona or any unrelated default.
 - Do NOT ask about or offer other capabilities (document Q&A, file access, \

--- a/tests/unit/agents/test_builder_fail_loudly.py
+++ b/tests/unit/agents/test_builder_fail_loudly.py
@@ -154,3 +154,62 @@ class TestBuilderFailLoudly:
 
         assert result["answer"] == tool_result
         assert agent.chat.send_messages.call_count == 1
+
+
+class TestBuilderOneShotNudge:
+    """A one-shot request that names the agent must not stall on a greeting.
+
+    Regression for the behavior-E2E ``honest_failure`` where the model parroted
+    the Builder greeting instead of calling create_agent when the very first
+    message already contained the name.
+    """
+
+    def test_greeting_when_name_present_nudges_then_creates(self, tmp_path):
+        """Greeting on turn 1 (name present) → corrective nudge → tool call turn 2."""
+        agent = _make_agent(tmp_path)
+        agent.console = MagicMock()
+
+        greeting = (
+            "Hi! I'm the Gaia Builder, an alpha feature. I'll scaffold a starter "
+            "agent *template* for you. What would you like to call your agent?"
+        )
+        real_call = '{"tool": "create_agent", "tool_args": {"name": "test-3f6aa1b2"}}'
+        responses = iter([greeting, real_call])
+
+        agent.chat = MagicMock()
+        agent.chat.send_messages.side_effect = lambda **kwargs: _mock_chat_response(
+            next(responses)
+        )
+
+        tool_result = f"Agent 'Test Agent' created at {tmp_path}/test-3f6aa1b2/agent.py"
+        with patch.object(
+            agent, "_execute_tool", return_value=tool_result
+        ) as mock_execute:
+            result = agent._process_query_impl(
+                "Create an agent named 'test-3f6aa1b2'. No tools, no MCP. Create it now."
+            )
+
+        # The tool must have run and its confirmation returned — not the greeting.
+        mock_execute.assert_called_once()
+        assert result["answer"] == tool_result
+        assert agent.chat.send_messages.call_count == 2
+
+    def test_greeting_when_no_name_returns_greeting_without_nudge(self, tmp_path):
+        """No name in the message → normal interactive flow; ask for the name once.
+
+        The nudge must NOT fire (that would break the UI's greeting flow), and the
+        tool must not be called on a vague opener.
+        """
+        agent = _make_agent(tmp_path)
+        agent.console = MagicMock()
+
+        greeting = "Hi! I'm the Gaia Builder. What would you like to call your agent?"
+        agent.chat = MagicMock()
+        agent.chat.send_messages.return_value = _mock_chat_response(greeting)
+
+        with patch.object(agent, "_execute_tool") as mock_execute:
+            result = agent._process_query_impl("I want to build a new agent")
+
+        mock_execute.assert_not_called()
+        assert result["answer"] == greeting
+        assert agent.chat.send_messages.call_count == 1


### PR DESCRIPTION
The Agent Behavior E2E check has been red on `main` since July 6. It's not a flake — it's a real builder-agent bug. When the user's first message already names the agent (*"Create an agent named X. Create it now."*), the model parrots the Builder's canned greeting (*"Hi! I'm the Gaia Builder … What would you like to call your agent?"*) instead of calling `create_agent`, so no `agent.py` is ever written. Every one of the harness's 5 runs scored `honest_failure`. Before: a named one-shot request produced a greeting and no agent. After: it creates the agent on the first reply.

Root cause is the system prompt's conversation flow being written greeting-first ("On your very first reply … then ask for a name") — the model copies that greeting even when the name and "create it now" are already in the message.

Two fixes, defense in depth:
- **Prompt** — a dominant *Fast path*: when the message already names the agent, skip the greeting/questions and call `create_agent` on the first reply. The step-by-step flow is now explicitly for the no-name case only.
- **Loop** — if the model returns a greeting/question with no tool call *while the request already named the agent*, inject one corrective turn forcing the bare tool call (mirrors the existing fabricated-success correction). The interactive "ask for a name" flow is preserved when no name is present.

## Test plan
- [ ] `Agent Behavior E2E` (self-hosted, real model) goes green — builder writes `agent.py` for the named one-shot prompt across all 5 runs.
- [x] `pytest tests/unit/agents/test_builder_fail_loudly.py` — new tests: greeting-with-name → nudge → create (2 turns, tool runs); no-name opener → greeting returned, tool not called, single turn.
- [x] `pytest tests/unit/agents/test_builder_agent.py` (114 passed) + black/isort clean.