### PR TITLE
docs: full documentation audit (accuracy, dark-mode diagrams, persona review)

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -26,7 +26,7 @@ Included demos:
 
 ### 2. LLM Server (Lemonade)
 
-The agent connects to an OpenAI-compatible LLM server at `http://localhost:8000/api/v1` by default. The reference backend is [Lemonade Server](https://github.com/lemonade-sdk/lemonade), which runs models locally on AMD hardware.
+The agent connects to an OpenAI-compatible LLM server at `http://localhost:13305/api/v1` by default. The reference backend is [Lemonade Server](https://github.com/lemonade-sdk/lemonade), which runs models locally on AMD hardware.
 
 Download and install Lemonade Server v10.9.0, then start it:
 
@@ -179,7 +179,7 @@ The agent will:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GAIA_CPP_BASE_URL` | `http://localhost:8000/api/v1` | LLM server base URL. Overrides `AgentConfig::baseUrl`. |
+| `GAIA_CPP_BASE_URL` | `http://localhost:13305/api/v1` | LLM server base URL. Overrides `AgentConfig::baseUrl`. |
 | `LEMONADE_MODEL` | _(none)_ | Model to load. Overrides `AgentConfig::modelId`. |
 | `GAIA_CPP_CTX_SIZE` | `16384` | LLM context window size in tokens. Overrides `AgentConfig::contextSize`. |
 | `GAIA_STREAMING` | _(unset)_ | Set to `1` to enable token streaming without changing code. Overrides the default for `AgentConfig::streaming`. |
@@ -191,7 +191,7 @@ GAIA_STREAMING=1 ./build/my_agent
 
 **Example — point to a remote server:**
 ```bash
-GAIA_CPP_BASE_URL=http://192.168.1.50:8000 ./build/my_agent
+GAIA_CPP_BASE_URL=http://192.168.1.50:13305 ./build/my_agent
 ```
 
 **Example — point to Ollama's OpenAI-compatible endpoint:**
@@ -375,7 +375,7 @@ protected:
 private:
     static gaia::AgentConfig makeConfig() {
         gaia::AgentConfig cfg;
-        cfg.baseUrl = "http://localhost:8000/api/v1";
+        cfg.baseUrl = "http://localhost:13305/api/v1";
         cfg.modelId = "Qwen3-4B-GGUF";  // or any model on your server
         cfg.maxSteps = 20;
         return cfg;

--- a/cpp/examples/fetch_content_consumer/main.cpp
+++ b/cpp/examples/fetch_content_consumer/main.cpp
@@ -5,7 +5,7 @@
 // Subclasses gaia::Agent with a single get_current_time tool.
 //
 // Prerequisites:
-//   - LLM server running at http://localhost:8000/api/v1 (Lemonade) or
+//   - LLM server running at http://localhost:13305/api/v1 (Lemonade) or
 //     http://localhost:11434/v1 (Ollama-compatible)
 //
 // Build (FetchContent — no install needed):
@@ -53,7 +53,7 @@ protected:
 private:
     static gaia::AgentConfig makeConfig() {
         gaia::AgentConfig cfg;
-        cfg.baseUrl  = "http://localhost:8000/api/v1";
+        cfg.baseUrl  = "http://localhost:13305/api/v1";
         cfg.modelId  = "Qwen3-4B-GGUF";
         cfg.maxSteps = 10;
         return cfg;

--- a/cpp/examples/health_agent.cpp
+++ b/cpp/examples/health_agent.cpp
@@ -12,7 +12,7 @@
 //
 // Requirements:
 //   - Windows MCP server: uvx windows-mcp
-//   - LLM server running at http://localhost:8000/api/v1
+//   - LLM server running at http://localhost:13305/api/v1
 
 #include <algorithm>
 #include <cctype>

--- a/cpp/examples/process_agent.cpp
+++ b/cpp/examples/process_agent.cpp
@@ -15,7 +15,7 @@
 //
 // Requirements:
 //   - Windows (Win32 APIs and PowerShell for system diagnostics)
-//   - LLM server running at http://localhost:8000/api/v1
+//   - LLM server running at http://localhost:13305/api/v1
 
 #define NOMINMAX
 #include <windows.h>

--- a/cpp/examples/vlm_agent.cpp
+++ b/cpp/examples/vlm_agent.cpp
@@ -8,7 +8,7 @@
 //
 // Requires a Lemonade server running with a VLM model loaded.
 //   Environment:
-//     LEMONADE_BASE_URL   (default: http://localhost:8000/api/v1)
+//     LEMONADE_BASE_URL   (default: http://localhost:13305/api/v1)
 //     GAIA_MODEL_ID       (default: Qwen3-VL-4B-Instruct-GGUF)
 
 #include <cstdlib>

--- a/cpp/examples/wifi_agent.cpp
+++ b/cpp/examples/wifi_agent.cpp
@@ -11,7 +11,7 @@
 //
 // Requirements:
 //   - Windows (PowerShell commands for network diagnostics)
-//   - LLM server running at http://localhost:8000/api/v1
+//   - LLM server running at http://localhost:13305/api/v1
 
 #ifdef _WIN32
 #include <windows.h>

--- a/cpp/include/gaia/lemonade_client.h
+++ b/cpp/include/gaia/lemonade_client.h
@@ -25,7 +25,7 @@ using json = nlohmann::json;
 
 // ---- Constants (mirrors Python LemonadeClient defaults) ----
 
-inline constexpr const char* LEMONADE_DEFAULT_URL        = "http://localhost:8000/api/v1";
+inline constexpr const char* LEMONADE_DEFAULT_URL        = "http://localhost:13305/api/v1";
 inline constexpr const char* LEMONADE_DEFAULT_MODEL      = "Qwen3-0.6B-GGUF";
 inline constexpr int         LEMONADE_REQUEST_TIMEOUT    = 900;   // 15 min  (matches Python)
 inline constexpr int         LEMONADE_MODEL_LOAD_TIMEOUT = 12000; // ~200 min (matches Python)
@@ -93,7 +93,7 @@ public:
     /// Legacy constructor for backward compatibility.
     /// Delegates to the config-based constructor.
     ///
-    /// @param baseUrl  Server root, e.g. "http://localhost:8000"
+    /// @param baseUrl  Server root, e.g. "http://localhost:13305"
     /// @param debug    Emit extra diagnostics to stderr when true
     LemonadeClient(const std::string& baseUrl, bool debug = false);
 

--- a/cpp/include/gaia/types.h
+++ b/cpp/include/gaia/types.h
@@ -292,7 +292,7 @@ inline bool defaultStreaming() {
 /// Return the default LLM base URL, honoring the LEMONADE_BASE_URL
 /// environment variable if set (matching the Python CLI behavior).
 inline std::string defaultBaseUrl() {
-    return getEnvVar("LEMONADE_BASE_URL", "http://localhost:8000/api/v1");
+    return getEnvVar("LEMONADE_BASE_URL", "http://localhost:13305/api/v1");
 }
 
 // ---- Decision Support ----

--- a/cpp/tests/integration/test_integration_health.cpp
+++ b/cpp/tests/integration/test_integration_health.cpp
@@ -13,7 +13,7 @@
 //
 // Env vars:
 //   GAIA_CPP_TEST_MODEL  — model ID (default: Qwen3-4B-Instruct-2507-GGUF)
-//   GAIA_CPP_BASE_URL    — LLM endpoint (default: http://localhost:8000/api/v1)
+//   GAIA_CPP_BASE_URL    — LLM endpoint (default: http://localhost:13305/api/v1)
 
 #include <gtest/gtest.h>
 #include <gaia/agent.h>
@@ -53,12 +53,12 @@ static std::string testBaseUrl() {
     char* env = nullptr;
     size_t len = 0;
     _dupenv_s(&env, &len, "GAIA_CPP_BASE_URL");
-    std::string result = env ? std::string(env) : "http://localhost:8000/api/v1";
+    std::string result = env ? std::string(env) : "http://localhost:13305/api/v1";
     free(env);
     return result;
 #else
     const char* env = std::getenv("GAIA_CPP_BASE_URL");
-    return env ? std::string(env) : "http://localhost:8000/api/v1";
+    return env ? std::string(env) : "http://localhost:13305/api/v1";
 #endif
 }
 

--- a/cpp/tests/integration/test_integration_llm.cpp
+++ b/cpp/tests/integration/test_integration_llm.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 //
 // C++ GAIA agent integration tests.
-// Requires: lemonade-server running at GAIA_CPP_BASE_URL (default: http://localhost:8000/api/v1)
+// Requires: lemonade-server running at GAIA_CPP_BASE_URL (default: http://localhost:13305/api/v1)
 //           with GAIA_CPP_TEST_MODEL (default: Qwen3-4B-GGUF) loaded.
 //
 // Build:
@@ -29,7 +29,7 @@ static std::string testModel() {
 }
 
 static std::string testBaseUrl() {
-    return gaia::getEnvVar("GAIA_CPP_BASE_URL", "http://localhost:8000/api/v1");
+    return gaia::getEnvVar("GAIA_CPP_BASE_URL", "http://localhost:13305/api/v1");
 }
 
 static std::string toLower(std::string s) {

--- a/cpp/tests/integration/test_integration_mcp.cpp
+++ b/cpp/tests/integration/test_integration_mcp.cpp
@@ -11,7 +11,7 @@
 //
 // Env vars:
 //   GAIA_CPP_TEST_MODEL  — model ID (default: Qwen3-4B-Instruct-2507-GGUF)
-//   GAIA_CPP_BASE_URL    — LLM endpoint (default: http://localhost:8000/api/v1)
+//   GAIA_CPP_BASE_URL    — LLM endpoint (default: http://localhost:13305/api/v1)
 
 #include <gtest/gtest.h>
 #include <gaia/agent.h>
@@ -50,12 +50,12 @@ static std::string testBaseUrl() {
     char* env = nullptr;
     size_t len = 0;
     _dupenv_s(&env, &len, "GAIA_CPP_BASE_URL");
-    std::string result = env ? std::string(env) : "http://localhost:8000/api/v1";
+    std::string result = env ? std::string(env) : "http://localhost:13305/api/v1";
     free(env);
     return result;
 #else
     const char* env = std::getenv("GAIA_CPP_BASE_URL");
-    return env ? std::string(env) : "http://localhost:8000/api/v1";
+    return env ? std::string(env) : "http://localhost:13305/api/v1";
 #endif
 }
 

--- a/cpp/tests/integration/test_integration_vlm.cpp
+++ b/cpp/tests/integration/test_integration_vlm.cpp
@@ -3,11 +3,11 @@
 //
 // C++ GAIA VLM integration tests.
 // Requires: lemonade-server running at GAIA_CPP_BASE_URL
-//           (default: http://localhost:8000/api/v1) with a VLM model
+//           (default: http://localhost:13305/api/v1) with a VLM model
 //           (default: Qwen3-VL-4B-Instruct-GGUF) available.
 //
 // Env overrides:
-//   GAIA_CPP_BASE_URL       base URL (default http://localhost:8000/api/v1)
+//   GAIA_CPP_BASE_URL       base URL (default http://localhost:13305/api/v1)
 //   GAIA_CPP_TEST_VLM_MODEL VLM model id (default Qwen3-VL-4B-Instruct-GGUF)
 //   GAIA_CPP_TEST_VLM_CTX   context size (default 32768)
 //   GAIA_CPP_TEST_VLM_SMALL_CTX  ctx size used by the overflow test (default 2048)
@@ -41,7 +41,7 @@
 namespace {
 
 std::string testBaseUrl() {
-    return gaia::getEnvVar("GAIA_CPP_BASE_URL", "http://localhost:8000/api/v1");
+    return gaia::getEnvVar("GAIA_CPP_BASE_URL", "http://localhost:13305/api/v1");
 }
 
 std::string testVlmModel() {

--- a/cpp/tests/integration/test_integration_wifi.cpp
+++ b/cpp/tests/integration/test_integration_wifi.cpp
@@ -11,7 +11,7 @@
 //
 // Env vars:
 //   GAIA_CPP_TEST_MODEL  — model ID (default: Qwen3-4B-Instruct-2507-GGUF)
-//   GAIA_CPP_BASE_URL    — LLM endpoint (default: http://localhost:8000/api/v1)
+//   GAIA_CPP_BASE_URL    — LLM endpoint (default: http://localhost:13305/api/v1)
 
 #include <gtest/gtest.h>
 #include <gaia/agent.h>
@@ -84,12 +84,12 @@ static std::string testBaseUrl() {
     char* env = nullptr;
     size_t len = 0;
     _dupenv_s(&env, &len, "GAIA_CPP_BASE_URL");
-    std::string result = env ? std::string(env) : "http://localhost:8000/api/v1";
+    std::string result = env ? std::string(env) : "http://localhost:13305/api/v1";
     free(env);
     return result;
 #else
     const char* env = std::getenv("GAIA_CPP_BASE_URL");
-    return env ? std::string(env) : "http://localhost:8000/api/v1";
+    return env ? std::string(env) : "http://localhost:13305/api/v1";
 #endif
 }
 

--- a/cpp/tests/integration/test_main.cpp
+++ b/cpp/tests/integration/test_main.cpp
@@ -14,7 +14,7 @@
 //   tests_integration.exe --health
 //   tests_integration.exe --all
 //   tests_integration.exe --model Qwen3-4B-Instruct-2507-GGUF
-//   tests_integration.exe --url http://localhost:8000/api/v1
+//   tests_integration.exe --url http://localhost:13305/api/v1
 //
 // GTest passthrough (suppresses menu):
 //   tests_integration.exe --gtest_filter=IntegrationMCP*

--- a/cpp/tests/test_lemonade_client.cpp
+++ b/cpp/tests/test_lemonade_client.cpp
@@ -13,7 +13,7 @@ using namespace gaia;
 // ---------------------------------------------------------------------------
 
 TEST(LemonadeClientTest, ConstantsValues) {
-    EXPECT_STREQ(LEMONADE_DEFAULT_URL,   "http://localhost:8000/api/v1");
+    EXPECT_STREQ(LEMONADE_DEFAULT_URL,   "http://localhost:13305/api/v1");
     EXPECT_STREQ(LEMONADE_DEFAULT_MODEL, "Qwen3-0.6B-GGUF");
     EXPECT_EQ(LEMONADE_REQUEST_TIMEOUT,    900);
     EXPECT_EQ(LEMONADE_MODEL_LOAD_TIMEOUT, 12000);
@@ -26,7 +26,7 @@ TEST(LemonadeClientTest, ConstantsValues) {
 TEST(LemonadeClientTest, DefaultConstruction) {
     LemonadeClient client;
     // Default URL now includes /api/v1 (normalized)
-    EXPECT_EQ(client.baseUrl(), "http://localhost:8000/api/v1");
+    EXPECT_EQ(client.baseUrl(), "http://localhost:13305/api/v1");
     EXPECT_FALSE(client.debug());
     EXPECT_EQ(client.contextSize(), 0);
     EXPECT_TRUE(client.model().empty());

--- a/docs/connectors/github.mdx
+++ b/docs/connectors/github.mdx
@@ -10,8 +10,8 @@ description: "Connect GAIA agents to GitHub repos, PRs, issues, and Actions."
 
 ## What you'll need
 
-The GitHub connector is an **MCP server** — GAIA spawns the official
-[`@modelcontextprotocol/server-github`](https://github.com/github/github-mcp-server)
+The GitHub connector is an **MCP server** — GAIA spawns the
+[`@modelcontextprotocol/server-github`](https://www.npmjs.com/package/@modelcontextprotocol/server-github)
 process on demand and routes tool calls through it. It needs a single
 secret: a **GitHub Personal Access Token (PAT)** with the scopes you
 want agents to use.
@@ -89,6 +89,21 @@ gaia connectors grants grant mcp-github builtin:chat \
 ```
 
 (In the UI: open the connector tile → **Per-agent grants** section.)
+
+### Activate the tools for the agent
+
+For MCP servers, a grant alone isn't enough — the agent also needs an
+**activation** before the GitHub tools appear in its prompt. Activation
+defaults to OFF (least-privilege), so activate it explicitly:
+
+```bash
+gaia connectors activations activate mcp-github builtin:chat
+```
+
+(In the UI: the tile's **Per-agent** toggle flips both at once.) An
+agent that has a grant but no activation still can't see or call the
+tools. See the [connections security model](/security/connections) for
+why visibility and credential access are gated separately.
 
 ## Common issues
 

--- a/docs/connectors/index.mdx
+++ b/docs/connectors/index.mdx
@@ -7,10 +7,10 @@ description: "Connect GAIA agents to your accounts and external services."
 ## What connectors do
 
 Connectors give GAIA agents permission to act on your behalf — read your
-Gmail, list your GitHub issues, post to Slack, query a Postgres
-database, and so on. You configure each connector **once**, then grant
-individual agents the specific scopes they need. An agent can never see
-or use a credential you haven't granted it.
+Gmail, list your GitHub issues, search the web with Tavily, and so on.
+You configure each connector **once**, then grant individual agents the
+specific scopes they need. An agent can never see or use a credential
+you haven't granted it.
 
 There are two flavors:
 
@@ -46,27 +46,36 @@ never writes a token to a plaintext file.
   <Card title="GitHub" icon="github" href="/connectors/github">
     Repos, PRs, issues, and Actions via the official GitHub MCP server.
   </Card>
+  <Card title="Tavily" icon="globe" href="/connectors/tavily">
+    Web search and content extraction for agents via the Tavily MCP server.
+  </Card>
 </CardGroup>
 
-## Coming soon
+## Also available today
 
-The connectors below ship in the catalog and work today, but their
-setup pages are still being written. Track progress and request
-priorities at [issue #937](https://github.com/amd/gaia/issues/937).
+Two more MCP servers ship in the catalog and work now. Neither needs an
+API key, so there's no dedicated setup page — enable them per agent from
+Settings → Connections or the CLI:
 
-In the meantime, the **Configure** form for each connector includes
-inline help with where to obtain the required token or API key.
+- **Git** — `mcp-git`: `log`, `diff`, `status`, and `blame` for a local
+  repository.
+- **Memory** — `mcp-memory`: a knowledge-graph scratchpad agents can
+  persist to across a conversation.
 
-- **Calendars** — `mcp-google-calendar`
-- **Email** — `mcp-gmail`, `mcp-sendgrid`
-- **Productivity** — `mcp-notion`, `mcp-linear`, `mcp-jira`,
-  `mcp-slack`
-- **Developer tools** — `mcp-git`, `mcp-postgres`,
-  `mcp-desktop-commander`
-- **Web** — `mcp-fetch`, `mcp-brave-search`, `mcp-context7`,
-  `mcp-playwright`, `mcp-microsoft-learn`
-- **Other** — `mcp-spotify`, `mcp-stripe`, `mcp-memory`,
-  `mcp-filesystem`, `mcp-windows-automation`
+Run `gaia connectors list` to see every connector the catalog currently
+ships — it is the source of truth for what you can configure today.
+
+## On the roadmap
+
+More connectors are planned but are **not yet in the catalog**, so
+`gaia connectors list` will not show them and they can't be configured
+yet. Track progress and request priorities at
+[issue #937](https://github.com/amd/gaia/issues/937):
+
+- **Email & calendar** — dedicated Gmail / Outlook / SendGrid servers
+- **Productivity** — Notion, Linear, Jira, Slack
+- **Developer tools** — Postgres, Playwright
+- **Web** — Brave Search, Context7
 
 ## Try it: the Connectors Demo agent
 
@@ -112,6 +121,12 @@ Agents that don't have a grant for a scope they request will fail with
 `AGENT_NOT_GRANTED` and tell you exactly what scope to add. The same
 flow protects you whether the agent is built-in, custom, or installed
 from the Agent Hub.
+
+For **MCP-server** connectors (GitHub, Tavily, …) a grant isn't enough
+on its own — the agent also needs an **activation** before those tools
+appear in its prompt (`gaia connectors activations activate <id>
+<agent>`). OAuth connectors like Google don't use activations. See the
+[connections security model](/security/connections) for the full model.
 
 ## See also
 

--- a/docs/connectors/tavily.mdx
+++ b/docs/connectors/tavily.mdx
@@ -50,12 +50,19 @@ other connectors) and writes a `$keyring` reference into
 
 ## Step 3 — Use it
 
-Once configured, the `tavily-search` / `tavily-extract` MCP tools are available
-to any agent you grant them to:
+Once configured, grant **and** activate the `tavily-search` /
+`tavily-extract` MCP tools for each agent that should use them. For MCP
+servers a grant covers credential access, but the agent won't see the
+tools until you also activate them (activation defaults to OFF):
 
 ```bash
 gaia connectors grants grant mcp-tavily builtin:chat --scopes "*"
+gaia connectors activations activate mcp-tavily builtin:chat
 ```
+
+(In the UI: the tile's **Per-agent** toggle flips both at once.) See the
+[connections security model](/security/connections) for why visibility
+and credential access are gated separately.
 
 GAIA also ships a Python wrapper (`gaia.web.tavily`) used by web-research
 workflows, with response caching, a credit budget, and a CLI:

--- a/docs/cpp/api-reference.mdx
+++ b/docs/cpp/api-reference.mdx
@@ -312,9 +312,10 @@ class ToolRegistry {
 public:
     void registerTool(const std::string& name, const std::string& description,
                       ToolCallback callback, std::vector<ToolParameter> params = {},
-                      bool atomic = false);
+                      bool atomic = false,
+                      std::optional<ToolPolicy> policy = std::nullopt);
 
-    json executeTool(const std::string& name, const json& args) const;
+    json executeTool(const std::string& name, const json& args);
 
     const ToolInfo* findTool(const std::string& name) const;
     bool hasTool(const std::string& name) const;
@@ -342,9 +343,10 @@ public:
     virtual void printError(const std::string& message) = 0;
     virtual void printWarning(const std::string& message) = 0;
     virtual void printInfo(const std::string& message) = 0;
-    virtual void printFinalAnswer(const std::string& answer) = 0;
+    virtual void printFinalAnswer(const std::string& answer,
+                                  const UsageStats& usage = {}) = 0;
     virtual void printCompletion(int stepsTaken, int stepsLimit) = 0;
-    // ... plus progress indicators, debug methods
+    // ... plus printStateInfo, printPlan, startProgress/stopProgress, and debug methods
 };
 ```
 

--- a/docs/cpp/bash-agent.mdx
+++ b/docs/cpp/bash-agent.mdx
@@ -331,7 +331,7 @@ Add to OpenCode's MCP config:
       "command": "gaia-bash",
       "args": ["--mcp"],
       "env": {
-        "LEMONADE_BASE_URL": "http://localhost:8000/api/v1"
+        "LEMONADE_BASE_URL": "http://localhost:13305/api/v1"
       }
     }
   }
@@ -437,7 +437,7 @@ Claude Code> Use gaia-bash to check my deploy.sh for POSIX compliance
 
 | Variable | Default | Description |
 |---|---|---|
-| `LEMONADE_BASE_URL` | `http://localhost:8000/api/v1` | Lemonade Server URL |
+| `LEMONADE_BASE_URL` | `http://localhost:13305/api/v1` | Lemonade Server URL |
 | `LEMONADE_MODEL` | `Gemma-4-E4B-it-GGUF` | Model to load (honored by `LemonadeClient`) |
 | `GAIA_CPP_CTX_SIZE` | `16384` | Context window size (tokens) |
 | `GAIA_STREAMING` | `0` | Enable streaming (`1` = on) |

--- a/docs/cpp/bash-agent.mdx
+++ b/docs/cpp/bash-agent.mdx
@@ -42,9 +42,9 @@ icon: "terminal"
     lemonade-server serve
     ```
 
-    Ensure a coding model is loaded (Qwen3-Coder-Next recommended):
+    Ensure the default model is loaded (override with `--model` or `LEMONADE_MODEL`):
     ```bash
-    gaia download Qwen3-Coder-Next-GGUF
+    gaia download Gemma-4-E4B-it-GGUF
     ```
   </Step>
 
@@ -277,10 +277,10 @@ Health check:
 
 ```bash
 curl http://localhost:8200/health
-# {"status":"ok","model":"Gemma-4-E4B-it-GGUF","tools":10}
+# {"status":"ok","model":"Gemma-4-E4B-it-GGUF","tools":10,"port":8200}
 ```
 
-#### `GET /sessions`, `POST /sessions`, `DELETE /sessions/{id}`
+#### `GET /sessions`, `DELETE /sessions/{id}`
 
 Session management:
 
@@ -331,7 +331,7 @@ Add to OpenCode's MCP config:
       "command": "gaia-bash",
       "args": ["--mcp"],
       "env": {
-        "LEMONADE_BASE_URL": "http://localhost:13305/api/v1"
+        "LEMONADE_BASE_URL": "http://localhost:8000/api/v1"
       }
     }
   }
@@ -438,10 +438,9 @@ Claude Code> Use gaia-bash to check my deploy.sh for POSIX compliance
 | Variable | Default | Description |
 |---|---|---|
 | `LEMONADE_BASE_URL` | `http://localhost:8000/api/v1` | Lemonade Server URL |
-| `LEMONADE_MODEL` | `Qwen3-Coder-Next-GGUF` | Model to load |
+| `LEMONADE_MODEL` | `Gemma-4-E4B-it-GGUF` | Model to load (honored by `LemonadeClient`) |
 | `GAIA_CPP_CTX_SIZE` | `16384` | Context window size (tokens) |
 | `GAIA_STREAMING` | `0` | Enable streaming (`1` = on) |
-| `GAIA_DEBUG` | unset | Enable debug logging |
 
 ### CLI Flags
 
@@ -451,9 +450,11 @@ Claude Code> Use gaia-bash to check my deploy.sh for POSIX compliance
 | `--mcp` | Start as MCP stdio server |
 | `--print` | Pipe-friendly output (no TUI) |
 | `--no-tui` | Force CleanConsole even on interactive terminal |
+| `--query <text>` | Run a single query and exit (same as a positional query argument) |
 | `--resume <id>` | Resume a saved session |
 | `--list-sessions` | List saved sessions and exit |
 | `--model <name>` | Override the LLM model |
+| `--json-events` | Emit structured JSONL events on stdout (internal — used by the TUI/WebUI) |
 | `--debug` | Enable debug logging |
 
 ---

--- a/docs/cpp/custom-agent.mdx
+++ b/docs/cpp/custom-agent.mdx
@@ -322,7 +322,7 @@ static gaia::AgentConfig makeConfig() {
     gaia::AgentConfig cfg;
 
     // LLM backend
-    cfg.baseUrl = "http://localhost:8000/api/v1";   // default; override for remote server
+    cfg.baseUrl = "http://localhost:13305/api/v1";   // default; override for remote server
     cfg.modelId = "Qwen3-4B-GGUF";
 
     // Loop limits
@@ -701,7 +701,7 @@ private:
     // Step 5: tune AgentConfig
     static gaia::AgentConfig makeConfig() {
         gaia::AgentConfig cfg;
-        cfg.baseUrl              = "http://localhost:8000/api/v1";
+        cfg.baseUrl              = "http://localhost:13305/api/v1";
         cfg.modelId              = "Qwen3.5-35B-A3B-GGUF";
         cfg.maxSteps             = 15;
         cfg.maxPlanIterations    = 3;

--- a/docs/cpp/custom-agent.mdx
+++ b/docs/cpp/custom-agent.mdx
@@ -322,7 +322,7 @@ static gaia::AgentConfig makeConfig() {
     gaia::AgentConfig cfg;
 
     // LLM backend
-    cfg.baseUrl = "http://localhost:13305/api/v1";   // default; override for remote server
+    cfg.baseUrl = "http://localhost:8000/api/v1";   // default; override for remote server
     cfg.modelId = "Qwen3-4B-GGUF";
 
     // Loop limits
@@ -401,7 +401,7 @@ public:
     void printInfo(const std::string& msg) override    { log("[info] " + msg); }
     void startProgress(const std::string& msg) override { log("[progress] " + msg); }
     void stopProgress() override                        { log("[progress] done"); }
-    void printFinalAnswer(const std::string& answer) override {
+    void printFinalAnswer(const std::string& answer, const gaia::UsageStats& = {}) override {
         log("[answer] " + answer);
         finalAnswer_ = answer;
     }
@@ -511,7 +511,7 @@ public:
     void prettyPrintJson(const gaia::json& data, const std::string&) override {
         if (onToolResult) onToolResult(data);
     }
-    void printFinalAnswer(const std::string& answer) override {
+    void printFinalAnswer(const std::string& answer, const gaia::UsageStats& = {}) override {
         if (onAnswer) onAnswer(answer);
     }
     void printError(const std::string& msg) override {
@@ -606,7 +606,7 @@ public:
     void printInfo(const std::string& m)       override { log("info: " + m); }
     void startProgress(const std::string& m)   override { log("progress: " + m); }
     void stopProgress()                        override { log("progress: done"); }
-    void printFinalAnswer(const std::string& a) override {
+    void printFinalAnswer(const std::string& a, const gaia::UsageStats& = {}) override {
         std::cout << "\n=== Answer ===\n" << a << "\n";
     }
     void printCompletion(int s, int l) override {
@@ -701,7 +701,7 @@ private:
     // Step 5: tune AgentConfig
     static gaia::AgentConfig makeConfig() {
         gaia::AgentConfig cfg;
-        cfg.baseUrl              = "http://localhost:13305/api/v1";
+        cfg.baseUrl              = "http://localhost:8000/api/v1";
         cfg.modelId              = "Qwen3.5-35B-A3B-GGUF";
         cfg.maxSteps             = 15;
         cfg.maxPlanIterations    = 3;

--- a/docs/cpp/health-agent.mdx
+++ b/docs/cpp/health-agent.mdx
@@ -105,11 +105,11 @@ Full diagnostic run on a Ryzen AI PC: the agent gathers CPU, memory, disk, and p
 ## Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'16px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 graph TB
     User("User query")
     Agent("WindowsSystemHealthAgent<br/>gaia::Agent subclass")
-    LLM("LLM<br/>http://localhost:13305")
+    LLM("LLM<br/>http://localhost:8000")
     MCP("Windows MCP Server<br/>uvx windows-mcp")
 
     User --> Agent

--- a/docs/cpp/health-agent.mdx
+++ b/docs/cpp/health-agent.mdx
@@ -109,7 +109,7 @@ Full diagnostic run on a Ryzen AI PC: the agent gathers CPU, memory, disk, and p
 graph TB
     User("User query")
     Agent("WindowsSystemHealthAgent<br/>gaia::Agent subclass")
-    LLM("LLM<br/>http://localhost:8000")
+    LLM("LLM<br/>http://localhost:13305")
     MCP("Windows MCP Server<br/>uvx windows-mcp")
 
     User --> Agent

--- a/docs/cpp/integration.mdx
+++ b/docs/cpp/integration.mdx
@@ -247,7 +247,7 @@ protected:
 private:
     static gaia::AgentConfig makeConfig() {
         gaia::AgentConfig cfg;
-        cfg.baseUrl = "http://localhost:13305/api/v1";
+        cfg.baseUrl = "http://localhost:8000/api/v1";
         cfg.modelId = "Qwen3-4B-GGUF";
         cfg.maxSteps = 10;
         return cfg;
@@ -359,7 +359,7 @@ That is the entire API surface. No embeddings endpoint, no streaming (unless `cf
 
     ```cpp
     gaia::AgentConfig cfg;
-    cfg.baseUrl = "http://localhost:13305/v1";
+    cfg.baseUrl = "http://localhost:8000/v1";
     cfg.modelId = "Qwen/Qwen3-4B";
     ```
   </Tab>
@@ -374,7 +374,7 @@ That is the entire API surface. No embeddings endpoint, no streaming (unless `cf
     ```cpp
     gaia::AgentConfig cfg;
     // defaults work out of the box
-    cfg.baseUrl = "http://localhost:13305/api/v1";
+    cfg.baseUrl = "http://localhost:8000/api/v1";
     cfg.modelId = "Qwen3-4B-GGUF";
     ```
   </Tab>

--- a/docs/cpp/integration.mdx
+++ b/docs/cpp/integration.mdx
@@ -247,7 +247,7 @@ protected:
 private:
     static gaia::AgentConfig makeConfig() {
         gaia::AgentConfig cfg;
-        cfg.baseUrl = "http://localhost:8000/api/v1";
+        cfg.baseUrl = "http://localhost:13305/api/v1";
         cfg.modelId = "Qwen3-4B-GGUF";
         cfg.maxSteps = 10;
         return cfg;
@@ -359,7 +359,7 @@ That is the entire API surface. No embeddings endpoint, no streaming (unless `cf
 
     ```cpp
     gaia::AgentConfig cfg;
-    cfg.baseUrl = "http://localhost:8000/v1";
+    cfg.baseUrl = "http://localhost:13305/v1";
     cfg.modelId = "Qwen/Qwen3-4B";
     ```
   </Tab>
@@ -374,7 +374,7 @@ That is the entire API surface. No embeddings endpoint, no streaming (unless `cf
     ```cpp
     gaia::AgentConfig cfg;
     // defaults work out of the box
-    cfg.baseUrl = "http://localhost:8000/api/v1";
+    cfg.baseUrl = "http://localhost:13305/api/v1";
     cfg.modelId = "Qwen3-4B-GGUF";
     ```
   </Tab>

--- a/docs/cpp/overview.mdx
+++ b/docs/cpp/overview.mdx
@@ -39,7 +39,7 @@ The C++ framework focuses on the core agent loop and tool execution. Specialized
 ## Agent Execution Flow
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'16px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis', 'nodeSpacing': 40, 'rankSpacing': 50}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis', 'nodeSpacing': 40, 'rankSpacing': 50}}}%%
 flowchart TD
     A["&nbsp;&nbsp;User Query&nbsp;&nbsp;"] --> B["&nbsp;&nbsp;gaia::Agent&nbsp;&nbsp;<br/>processQuery()"]
     B -->|"chat/completions"| C["&nbsp;&nbsp;LLM Server&nbsp;&nbsp;<br/>(Lemonade)"]
@@ -69,7 +69,7 @@ flowchart TD
 The agent is **not a script**. After every tool execution, the LLM is called again with the full conversation so far — including the tool's output. This lets the model reason about results and change course.
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'16px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a'}, 'flowchart': {'curve': 'basis', 'nodeSpacing': 40}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis', 'nodeSpacing': 40}}}%%
 graph LR
     S["&nbsp;&nbsp;Start&nbsp;&nbsp;"] --> A["&nbsp;&nbsp;Call LLM&nbsp;&nbsp;"]
     A --> B{"&nbsp;&nbsp;Parse JSON&nbsp;&nbsp;"}
@@ -96,11 +96,11 @@ Each loop iteration: **LLM reasons → agent executes → result fed back → LL
 The `health_agent` demo is a [Windows System Health Agent](/guides/mcp/windows-system-health). It subclasses `gaia::Agent`, connects to the Windows MCP server on startup, then enters the planning loop.
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'18px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 graph TB
     User("User query")
     Agent("WindowsSystemHealthAgent<br/>gaia::Agent subclass")
-    LLM("LLM<br/>http://localhost:13305")
+    LLM("LLM<br/>http://localhost:8000")
     MCP("Windows MCP Server<br/>uvx windows-mcp")
 
     User --> Agent
@@ -240,14 +240,14 @@ All fields have sensible defaults. Override only what you need:
 
 ```cpp
 gaia::AgentConfig config;
-config.baseUrl = "http://localhost:13305/api/v1";
+config.baseUrl = "http://localhost:8000/api/v1";
 config.maxSteps = 30;
 config.debug = true;
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `baseUrl` | `std::string` | `"http://localhost:13305/api/v1"` | LLM server endpoint ([Lemonade Server](https://lemonade-server.ai) recommended; other OpenAI-compatible servers untested) |
+| `baseUrl` | `std::string` | `"http://localhost:8000/api/v1"` | LLM server endpoint ([Lemonade Server](https://lemonade-server.ai) recommended; other OpenAI-compatible servers untested) |
 | `modelId` | `std::string` | `"Qwen3-4B-GGUF"` | Model identifier sent to the server |
 | `maxSteps` | `int` | `20` | Maximum agent loop iterations per query |
 | `maxPlanIterations` | `int` | `3` | Maximum plan/replan cycles before forcing completion |
@@ -285,6 +285,9 @@ cpp/
   examples/
     health_agent.cpp        # Windows System Health Agent (MCP demo)
     wifi_agent.cpp          # Wi-Fi Troubleshooter Agent (registered tools)
+    process_agent.cpp       # Process Analyst Agent (Win32 + PowerShell tools)
+    security_demo.cpp       # Tool-policy / confirmation security demo
+    vlm_agent.cpp           # Vision-language (image) demo
   tests/
     test_agent.cpp
     test_tool_registry.cpp

--- a/docs/cpp/overview.mdx
+++ b/docs/cpp/overview.mdx
@@ -100,7 +100,7 @@ The `health_agent` demo is a [Windows System Health Agent](/guides/mcp/windows-s
 graph TB
     User("User query")
     Agent("WindowsSystemHealthAgent<br/>gaia::Agent subclass")
-    LLM("LLM<br/>http://localhost:8000")
+    LLM("LLM<br/>http://localhost:13305")
     MCP("Windows MCP Server<br/>uvx windows-mcp")
 
     User --> Agent
@@ -240,14 +240,14 @@ All fields have sensible defaults. Override only what you need:
 
 ```cpp
 gaia::AgentConfig config;
-config.baseUrl = "http://localhost:8000/api/v1";
+config.baseUrl = "http://localhost:13305/api/v1";
 config.maxSteps = 30;
 config.debug = true;
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `baseUrl` | `std::string` | `"http://localhost:8000/api/v1"` | LLM server endpoint ([Lemonade Server](https://lemonade-server.ai) recommended; other OpenAI-compatible servers untested) |
+| `baseUrl` | `std::string` | `"http://localhost:13305/api/v1"` | LLM server endpoint ([Lemonade Server](https://lemonade-server.ai) recommended; other OpenAI-compatible servers untested) |
 | `modelId` | `std::string` | `"Qwen3-4B-GGUF"` | Model identifier sent to the server |
 | `maxSteps` | `int` | `20` | Maximum agent loop iterations per query |
 | `maxPlanIterations` | `int` | `3` | Maximum plan/replan cycles before forcing completion |

--- a/docs/cpp/process-agent.mdx
+++ b/docs/cpp/process-agent.mdx
@@ -106,7 +106,7 @@ The agent auto-runs a full system scan on startup, then waits for your input. Yo
     ```bash
     lemonade-server serve
     ```
-    The agent connects to `http://localhost:13305/api/v1` by default.
+    The agent connects to `http://localhost:8000/api/v1` by default.
   </Step>
 
   <Step title="Run the agent">
@@ -181,14 +181,14 @@ The agent runs in two phases. On startup it auto-scans the system — no menu sh
 Conversation history is preserved across all actions so the LLM can reference any labeled item without re-scanning. Only **Reanalyze** clears history, because the system state has genuinely changed.
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'14px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 flowchart LR
-    START["Startup\nAuto-scan"] --> CLASS["LLM classifies\nA · B · C"]
+    START["Startup<br/>Auto-scan"] --> CLASS["LLM classifies<br/>A · B · C"]
     CLASS --> MENU["Action Menu"]
-    MENU --> ACT["Explain / Stop\nRestart / Quarantine"]
+    MENU --> ACT["Explain / Stop<br/>Restart / Quarantine"]
     ACT --> MENU
     MENU -->|"Reanalyze"| START
-    MENU -->|"Monitor"| MON["Background Thread\nSilentConsole + diff alerts"]
+    MENU -->|"Monitor"| MON["Background Thread<br/>SilentConsole + diff alerts"]
     MON -.->|"alerts before prompt"| MENU
 
     style START fill:#2d2d2d,stroke:#E2A33E,stroke-width:2px,color:#fff
@@ -510,7 +510,7 @@ These modify the system. The system prompt mandates user approval before the LLM
 ## Diagnostics Flow
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'14px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 flowchart TD
     START["Phase 1: DETECT<br/>(auto-runs on startup)"] --> SS["system_snapshot<br/>CPU, memory, disk, services"]
     SS --> LP["list_processes<br/>Top 30 memory, top 10 CPU"]
@@ -523,7 +523,7 @@ flowchart TD
     MENU -->|"[3] Restart"| CONF_R["Confirm with user"]
     MENU -->|"[4] Quarantine"| EX_Q["explain_item first"]
     MENU -->|"[5] Reanalyze"| CLEAR["clearHistory()"]
-    MENU -->|"[6] Monitor"| MTOG{"Monitor\nrunning?"}
+    MENU -->|"[6] Monitor"| MTOG{"Monitor<br/>running?"}
     MTOG -->|No| MSTART["Start background thread<br/>SilentConsole + ProcessAgent"]
     MTOG -->|Yes| MSTOP["Stop monitor thread"]
     MSTART --> MSCAN["system_snapshot +<br/>list_processes (silent)"]

--- a/docs/cpp/process-agent.mdx
+++ b/docs/cpp/process-agent.mdx
@@ -106,7 +106,7 @@ The agent auto-runs a full system scan on startup, then waits for your input. Yo
     ```bash
     lemonade-server serve
     ```
-    The agent connects to `http://localhost:8000/api/v1` by default.
+    The agent connects to `http://localhost:13305/api/v1` by default.
   </Step>
 
   <Step title="Run the agent">

--- a/docs/cpp/quickstart.mdx
+++ b/docs/cpp/quickstart.mdx
@@ -66,7 +66,7 @@ icon: "rocket"
   </Step>
 
   <Step title="Start an LLM server">
-    The agent connects to any OpenAI-compatible LLM server at `http://localhost:13305/api/v1` by default. The recommended backend is [Lemonade Server](https://lemonade-server.ai) (optimized for AMD hardware):
+    The agent connects to any OpenAI-compatible LLM server at `http://localhost:8000/api/v1` by default. The recommended backend is [Lemonade Server](https://lemonade-server.ai) (optimized for AMD hardware):
 
     ```bash
     lemonade-server serve
@@ -119,7 +119,7 @@ Verify your build with the unit test suite (no LLM server required):
   </Tab>
 </Tabs>
 
-See the [Testing Guide](/cpp/testing) for the full test suite — unit tests (12 modules), integration tests (LLM, MCP, Wi-Fi, Health), CI pipeline, and how to add new tests.
+See the [Testing Guide](/cpp/testing) for the full test suite — unit tests (20 modules), integration tests (LLM, MCP, Wi-Fi, Health, VLM), CI pipeline, and how to add new tests.
 
 ## Next Steps
 

--- a/docs/cpp/quickstart.mdx
+++ b/docs/cpp/quickstart.mdx
@@ -66,7 +66,7 @@ icon: "rocket"
   </Step>
 
   <Step title="Start an LLM server">
-    The agent connects to any OpenAI-compatible LLM server at `http://localhost:8000/api/v1` by default. The recommended backend is [Lemonade Server](https://lemonade-server.ai) (optimized for AMD hardware):
+    The agent connects to any OpenAI-compatible LLM server at `http://localhost:13305/api/v1` by default. The recommended backend is [Lemonade Server](https://lemonade-server.ai) (optimized for AMD hardware):
 
     ```bash
     lemonade-server serve

--- a/docs/cpp/testing.mdx
+++ b/docs/cpp/testing.mdx
@@ -169,7 +169,7 @@ This produces the `tests_integration` binary alongside the unit test binary.
 
 2. Set environment variables (optional — defaults shown):
    ```bat
-   set GAIA_CPP_BASE_URL=http://localhost:8000/api/v1
+   set GAIA_CPP_BASE_URL=http://localhost:13305/api/v1
    ```
    ```bat
    set GAIA_CPP_TEST_MODEL=Qwen3-4B-Instruct-2507-GGUF

--- a/docs/cpp/testing.mdx
+++ b/docs/cpp/testing.mdx
@@ -19,22 +19,34 @@ Both suites use [Google Test](https://github.com/google/googletest) (fetched aut
 
 ## Unit Tests
 
-Unit tests are built by default and run without an LLM server. They cover all twelve core modules:
+Unit tests are built by default and run without an LLM server. They cover all twenty core modules:
 
 | Module | Test file | What it covers |
 |--------|-----------|----------------|
 | Agent loop | `test_agent.cpp` | State machine, multi-step planning, error recovery |
+| Agent (VLM) | `test_agent_vlm.cpp` | `processQuery` image overloads, history stripping |
 | Tool registry | `test_tool_registry.cpp` | Registration, lookup, execution, parameter schemas |
 | Tool integration | `test_tool_integration.cpp` | End-to-end tool calling with mocked LLM |
 | JSON utilities | `test_json_utils.cpp` | Multi-strategy JSON extraction, fallback parsing |
+| JSON event handler | `test_json_event_handler.cpp` | Structured JSONL event emission (thought/goal/answer) |
 | MCP client | `test_mcp_client.cpp` | JSON-RPC protocol, stdio transport, tool discovery |
 | Console | `test_console.cpp` | TerminalConsole and SilentConsole output |
 | Clean console | `test_clean_console.cpp` | CleanConsole TUI, word-wrap, ANSI colors |
 | Types | `test_types.cpp` | AgentConfig, Message, ToolInfo, ParsedResponse |
+| Image | `test_image.cpp` | Image loading, MIME detection, base64 encoding |
 | Decision types | `test_decision.cpp` | `Decision` struct and interactive menu parsing |
 | Security | `test_security.cpp` | `ToolPolicy`, `validatePath`, shell-arg sanitisation, `AllowedToolsStore` |
 | SSE parser | `test_sse_parser.cpp` | OpenAI-style streaming-event parsing and recovery |
 | Lemonade client | `test_lemonade_client.cpp` | Lemonade HTTP surface (health, models, chat completions) |
+| Process runner | `test_process.cpp` | Cross-platform subprocess execution and pipes |
+| File tools | `test_file_tools.cpp` | `file_read`/`file_write`/`file_edit`/`file_search` |
+| Git tools | `test_git_tools.cpp` | `git_status`/`git_diff`/`git_log`/`git_show` |
+| Session store | `test_session.cpp` | Session persistence (save/list/resume) |
+| REPL | `test_repl.cpp` | Interactive REPL loop and slash-command parsing |
+
+<Note>
+  One additional module, `test_tui_console.cpp` (FTXUI TUI console), is compiled into `tests_mock` only when `GAIA_BUILD_TUI=ON` (the default).
+</Note>
 
 ### Building Unit Tests
 
@@ -129,6 +141,7 @@ Integration tests exercise the full stack — real LLM inference, live MCP serve
 | `test_integration_mcp.cpp` | MCP server connection, tool discovery, tool execution |
 | `test_integration_wifi.cpp` | Wi-Fi agent end-to-end diagnostic flow |
 | `test_integration_health.cpp` | Health agent MCP-based system diagnostics |
+| `test_integration_vlm.cpp` | Vision-language inference against a real VLM model |
 
 ### Building Integration Tests
 
@@ -156,7 +169,7 @@ This produces the `tests_integration` binary alongside the unit test binary.
 
 2. Set environment variables (optional — defaults shown):
    ```bat
-   set GAIA_CPP_BASE_URL=http://localhost:13305/api/v1
+   set GAIA_CPP_BASE_URL=http://localhost:8000/api/v1
    ```
    ```bat
    set GAIA_CPP_TEST_MODEL=Qwen3-4B-Instruct-2507-GGUF
@@ -175,7 +188,7 @@ This produces the `tests_integration` binary alongside the unit test binary.
 
 ## CI Pipeline
 
-The C++ CI workflow (`.github/workflows/build_cpp.yml`) runs four jobs on every PR that touches `cpp/`:
+The C++ CI workflow (`.github/workflows/build_cpp.yml`) runs five jobs on every PR that touches `cpp/`:
 
 | Job | Runs on | What it validates |
 |-----|---------|-------------------|
@@ -183,6 +196,7 @@ The C++ CI workflow (`.github/workflows/build_cpp.yml`) runs four jobs on every 
 | **Install Test** | Ubuntu + Windows (cloud) | `cmake --install` + `find_package` round-trip |
 | **Shared Library** | Ubuntu + Windows (cloud) | `BUILD_SHARED_LIBS=ON` compiles cleanly |
 | **Integration Tests** | STX hardware (self-hosted) | Full stack: LLM + MCP + WiFi + Health |
+| **Benchmarks** | Ubuntu + Windows (cloud) | Performance benchmarks (`benchmark_cpp.yml`), runs after Build & Test succeeds |
 
 The integration test job runs on AMD STX hardware with a real Lemonade Server and Qwen3-4B model. It is treated as non-blocking in CI (infrastructure issues on self-hosted runners don't fail the PR).
 

--- a/docs/cpp/wifi-agent.mdx
+++ b/docs/cpp/wifi-agent.mdx
@@ -91,7 +91,7 @@ Full diagnostic run on a Ryzen AI PC: the agent calls 5 tools in sequence, reads
     ```bash
     lemonade-server serve
     ```
-    The agent connects to `http://localhost:13305/api/v1` by default.
+    The agent connects to `http://localhost:8000/api/v1` by default.
   </Step>
 
   <Step title="Run the agent (run as admin for fix tools)">
@@ -115,7 +115,6 @@ Full diagnostic run on a Ryzen AI PC: the agent calls 5 tools in sequence, reads
 The agent loop is a conversation between your C++ code and the LLM:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'14px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
 sequenceDiagram
     participant U as User
     participant A as Agent (C++)
@@ -246,7 +245,7 @@ All string arguments from the LLM are validated with `isSafeShellArg()` to rejec
 The system prompt teaches the LLM this decision tree. Each fix loops back to re-verify before declaring success:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'14px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 flowchart TD
     A["1. check_adapter<br/>Wi-Fi adapter present?"] -->|Yes| B["2. check_ip_config<br/>IP address via DHCP?"]
     A -->|"Radio Off"| F4["FIX: toggle_wifi_radio"]

--- a/docs/cpp/wifi-agent.mdx
+++ b/docs/cpp/wifi-agent.mdx
@@ -91,7 +91,7 @@ Full diagnostic run on a Ryzen AI PC: the agent calls 5 tools in sequence, reads
     ```bash
     lemonade-server serve
     ```
-    The agent connects to `http://localhost:8000/api/v1` by default.
+    The agent connects to `http://localhost:13305/api/v1` by default.
   </Step>
 
   <Step title="Run the agent (run as admin for fix tools)">

--- a/docs/deployment/testing-electron.mdx
+++ b/docs/deployment/testing-electron.mdx
@@ -179,7 +179,7 @@ Edit `.github/dependabot.yml`:
 
 ### 3. Create Integration Tests
 
-Create `tests/apps/test_my_app.js`:
+Create `tests/electron/test_my_app.js` (all Electron tests live under `tests/electron/`):
 
 ```javascript
 // Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.

--- a/docs/deployment/ui.mdx
+++ b/docs/deployment/ui.mdx
@@ -200,7 +200,7 @@ Gaia Agent UI
     - AgentSDK, RAGSDK, LemonadeClient
     |
     v
-  Lemonade Server (port 8000)
+  Lemonade Server (port 13305)
 ```
 
 ## Developer Quick Start

--- a/docs/eval.mdx
+++ b/docs/eval.mdx
@@ -39,7 +39,7 @@ The benchmark runs as **two distinct processes** connected over MCP: a Python or
 ### System Overview
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     YAML(["eval/scenarios/*.yaml"]) --> RUNNER(["AgentEvalRunner\n(Python orchestrator)"])
     MANIFEST(["eval/corpus/manifest.json"]) --> RUNNER
@@ -95,7 +95,7 @@ flowchart TD
 Each `claude -p` subprocess runs a 6-phase protocol. The eval agent has access to the Agent UI MCP server tools and uses them to drive a real session:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     P1(["Phase 1 · Setup\nsystem_status()\ncreate_session()\nindex_document() ×N"]) --> P2(["Phase 2 · Simulate + Judge\n(turn loop)"])
 
@@ -160,7 +160,7 @@ effective_timeout = max(base_timeout,
 After each subprocess returns its JSON result, the runner validates and deterministically overwrites the eval agent's arithmetic before writing the trace file:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     DIM(["7 Dimension Scores per Turn\ncorrectness · tool_selection · context_retention\ncompleteness · efficiency · personality · error_recovery"]) -->|"weighted sum\n(_SCORE_WEIGHTS)"| PT(["Per-Turn Score\n(0–10)"])
 
@@ -204,7 +204,7 @@ The recomputation applies in three passes:
 When `--fix` is passed, the runner repeats a diagnose-repair-retest cycle:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A(["Phase A · Initial Eval\nall scenarios"]) --> CHK{"judged_pass_rate\n≥ target?\nno failures?"}
     CHK -->|"yes"| DONE(["Done"])

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -216,7 +216,7 @@ A fundamental mathematical operation in neural networks, crucial for AI computat
 A file format for quantized LLM models, optimized for efficient loading and inference.
 
 ### Ground Truth
-Known correct answers used to evaluate AI system performance. In GAIA, generate ground truth via `gaia groundtruth` command, then compare model outputs against it using `gaia eval`. Essential for measuring accuracy, detecting regressions, and benchmarking models. See also: Evaluation Framework, Batch Experiment.
+Known correct answers used to evaluate AI system performance. In GAIA's Agent Eval Benchmark, ground truth lives in each scenario's YAML file — per turn, the `ground_truth` block names the expected answer (a `null` answer means the agent must admit it doesn't know). The `gaia eval agent` runner judges responses against it to measure accuracy, detect regressions, and benchmark models. See also: Evaluation Framework.
 
 ### Grounding
 Anchoring LLM responses in factual data or retrieved documents to reduce hallucinations.

--- a/docs/guides/agent-ui.mdx
+++ b/docs/guides/agent-ui.mdx
@@ -411,7 +411,7 @@ The agent supports the **Model Context Protocol** in both directions — connect
 ## Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A(["Agent UI (Browser or Electron)"]) --> B(["FastAPI Backend · port 4200"])
     B --> C(["GAIA Core SDKs"])

--- a/docs/guides/blender.mdx
+++ b/docs/guides/blender.mdx
@@ -5,7 +5,7 @@ icon: "cube"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/blender/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/blender/agent.py) · [`src/gaia/mcp/blender_mcp_server.py`](https://github.com/amd/gaia/blob/main/src/gaia/mcp/blender_mcp_server.py)
+  **Source Code:** [`hub/agents/python/blender/gaia_agent_blender/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/blender/gaia_agent_blender/agent.py) · [`src/gaia/mcp/blender_mcp_server.py`](https://github.com/amd/gaia/blob/main/src/gaia/mcp/blender_mcp_server.py)
 </Info>
 
 GAIA provides a powerful Blender agent that enables natural language interaction with Blender for 3D scene creation and modification. The agent can create objects, apply materials, manipulate transformations, and manage scenes through conversational commands.
@@ -101,7 +101,7 @@ gaia blender [OPTIONS]
 |--------|------|---------|-------------|
 | `--model` | string | auto-selected by agent | Language model ID for AI processing (not a Blender 3D model). When omitted, the Blender agent picks a model based on your installed profile — typically a Qwen3 variant. Pass e.g. `--model Qwen3.5-35B-A3B-GGUF` to pin the 35B model. |
 | `--example` | int (1-6) | None | Run a specific example, if not specified run interactive mode |
-| `--steps` | int | 5 | Maximum number of steps per query |
+| `--steps` | int | global limit (50) | Maximum number of steps per query. Defaults to the global agent step limit (50, or `$GAIA_AGENT_MAX_STEPS` if set). |
 | `--output-dir` | string | "output" | Directory to save output files |
 | `--stream` | flag | False | Enable streaming mode for LLM responses |
 | `--stats` | flag | False | Enable statistics collection (stats saved to output files, not displayed) |

--- a/docs/guides/browse.mdx
+++ b/docs/guides/browse.mdx
@@ -32,31 +32,133 @@ Use interactive mode when you want to refine a web-research task over multiple t
 gaia browse
 ```
 
-## Tool Surface
+## Tools
 
-`gaia browse --list-tools` shows the exact tools available in your installed version. The focused Browser Agent exposes:
+`gaia browse --list-tools` prints the exact tools available in your installed version. The focused Browser Agent registers three:
 
-- `search_web` — run a web search for a query.
-- `fetch_page` — fetch a URL and return readable page text.
-- `download_file` — download a user-requested URL to a local file.
+| Tool | What it does | Key limits |
+|------|--------------|------------|
+| `search_web` | Runs a DuckDuckGo search and returns numbered results with titles, URLs, and snippets. | Returns up to 10 results (default 5). |
+| `fetch_page` | Fetches a URL and extracts readable content. Does **not** execute JavaScript — works best on static articles, docs, and reference pages. | Returns up to 20,000 chars (default 5,000). Can extract `text`, `html`, `links`, or `tables`. |
+| `download_file` | Saves a file from a URL to the local filesystem for later analysis. | Defaults to `~/Downloads`; capped at 100 MB per file; writes are path-validated (see below). |
 
-The Browser Agent does not register scratchpad or file-system analysis tools. Use [`gaia analyze`](/guides/analyze) for structured data work, or [`gaia chat`](/guides/chat) when you need the broader mixed tool set.
+A typical run chains them: `search_web` to find candidate sources, `fetch_page` to read the promising ones, and `download_file` only when the user needs a local copy. Binary URLs (PDFs, archives, images) that `fetch_page` hits are reported as binary with a suggestion to use `download_file` instead.
+
+### Download path validation
+
+`download_file` writes are guarded by GAIA's `PathValidator`:
+
+- **Allowlist** — by default the agent may write to `~/Downloads`. Pass `--allowed-paths` to permit additional directories. In an interactive terminal an out-of-allowlist path prompts you for confirmation; in the Agent UI / API server it is auto-denied.
+- **Blocklist** — sensitive directories (e.g. `/etc`, `~/.ssh`) and sensitive filenames (e.g. `.env`, `credentials.json`) are refused even if the allowlist would otherwise permit them; a file that resolves to a blocked name after download is deleted.
+
+```bash
+# Allow downloads into a project folder in addition to ~/Downloads
+gaia browse --allowed-paths ./research-data -q "Download the Q3 CSV from example.com and save it"
+```
+
+The Browser Agent does not register scratchpad or file-editing tools. Use [`gaia analyze`](/guides/analyze) for structured data work, or [`gaia chat`](/guides/chat) when you need the broader mixed tool set.
+
+## Flag Reference
+
+All flags are shown by `gaia browse -h`.
+
+| Flag | Description |
+|------|-------------|
+| `-q, --query QUERY` | Run a single task and exit. Omit for interactive mode. |
+| `--list-tools` | Print the agent's tools and exit. |
+| `--model MODEL` | Override the model ID (default: auto-selected). |
+| `--use-claude` | Use the Claude API instead of local Lemonade. |
+| `--use-chatgpt` | Use the ChatGPT/OpenAI API instead of local Lemonade. |
+| `--claude-model CLAUDE_MODEL` | Claude model when `--use-claude` is set (default: `claude-sonnet-4-20250514`). |
+| `--base-url BASE_URL` | Lemonade server base URL (default: `LEMONADE_BASE_URL` env or `http://localhost:13305/api/v1`). |
+| `--max-steps MAX_STEPS` | Cap the agent's tool-use steps (default: global limit 50, or `$GAIA_AGENT_MAX_STEPS`). |
+| `--allowed-paths PATH [PATH ...]` | Directories `download_file` may write to (in addition to the default `~/Downloads`). |
+| `--stats, --show-stats` | Print performance statistics after the run. |
+| `--trace` | Save a detailed JSON trace of agent execution. |
+| `--stream` | Stream raw LLM output as it is generated. |
+| `--show-prompts` | Print the prompts sent to the LLM. |
+| `--debug` | Enable debug output. |
+| `--logging-level LEVEL` | `DEBUG`, `INFO` (default), `WARNING`, `ERROR`, or `CRITICAL`. |
+| `--no-lemonade-check` | Skip the Lemonade server check (CI/testing). |
+
+## Example: a multi-step research run
+
+```bash
+gaia browse -q "What's new in the AMD Ryzen AI SDK? Find the docs and summarize the top links."
+```
+
+A representative run searches, reads a page, and reports back with citations:
+
+```
+🔍 search_web("AMD Ryzen AI SDK documentation")
+  1. Ryzen AI Software — AMD
+     https://ryzenai.docs.amd.com/
+     Documentation for the AMD Ryzen AI Software stack...
+  2. Ryzen AI SDK Release Notes
+     https://ryzenai.docs.amd.com/en/latest/relnotes.html
+     ...
+
+📄 fetch_page("https://ryzenai.docs.amd.com/en/latest/relnotes.html")
+  Page: Release Notes — Ryzen AI Software
+  Length: 12,430 chars
+
+Here are the most relevant links:
+- Ryzen AI Software docs (ryzenai.docs.amd.com) — install, quantization, and deployment guides.
+- Release Notes — the latest version adds updated NPU driver support and new example models.
+
+Sources: https://ryzenai.docs.amd.com/, https://ryzenai.docs.amd.com/en/latest/relnotes.html
+```
+
+Add `--stats` to see timing and token counts, or `--trace` to write a full JSON execution trace for debugging.
 
 ## Model and Backend Options
 
-By default, `gaia browse` uses the local Lemonade backend configured for GAIA. You can override the model or backend with the common agent flags:
+By default, `gaia browse` uses the local Lemonade backend with the agent's auto-selected default model. Override the model or switch backends with the common agent flags:
 
 ```bash
 # Use a smaller local model for lighter tasks
-gaia browse --model Qwen3-4B-Instruct-2507-GGUF -q "Fetch this page and list citations"
+gaia browse --model Qwen3-4B-Instruct-2507-GGUF -q "Fetch this page and list the citations"
 
 # Run against the Claude API instead of local inference
-gaia browse --use-claude -q "Compare these two URLs"
+gaia browse --use-claude -q "Compare the approaches described in these two URLs"
+
+# Point at a remote Lemonade server
+gaia browse --base-url https://my-host:13305/api/v1 -q "Search for recent NPU benchmarks"
 ```
 
-Other shared agent flags work here too — `--max-steps` to bound the run, `--trace` to save a JSON execution trace, `--stats` for performance metrics, and `--allowed-paths` to control where downloads may be written.
+**Choosing a model:** multi-step web research (search → read → synthesize) rewards stronger tool-calling, so the default larger model is a good starting point. Drop to a ~4B model with `--model` for simple single-fetch tasks on lighter hardware, or use `--use-claude` when you want the highest-quality synthesis and don't need everything to stay local.
 
 In the Agent UI the browser appears as a single `web` card with a model-size selector — pick **Lite (~4B)** for shorter browser tasks on lighter hardware, or **Full** for the default model. (The old `web-lite` registry ID still resolves to `web` on the lite tier for existing sessions.)
+
+## When to use browse vs. chat vs. analyze
+
+| Use | When |
+|-----|------|
+| [`gaia browse`](/guides/browse) | You want *only* web tools — search, read pages, download — with a minimal prompt and no other tooling. |
+| [`gaia chat`](/guides/chat) | You need the broader mixed tool set: RAG over local documents, file search, memory, and more, in one session. |
+| [`gaia analyze`](/guides/analyze) | You have structured rows and want reliable SQL calculations over an in-memory scratchpad table. |
+
+Keeping the tool surface small matters for smaller local models: fewer tools means a shorter system prompt and more accurate tool-calling, which is why the focused Browser Agent exists alongside the full chat agent.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="No search results / search errors">
+    `search_web` uses DuckDuckGo and can fail on rate limits or transient network issues. Retry, refine your query, or skip search entirely by giving the agent a direct URL to `fetch_page`.
+  </Accordion>
+
+  <Accordion title="A page comes back empty or truncated">
+    `fetch_page` does not run JavaScript, so JS-heavy or login-gated pages may return little content. Try a static/print version of the page, or raise the character cap via the tool's `max_length` (up to 20,000). Very long pages are truncated with a `... (truncated)` marker.
+  </Accordion>
+
+  <Accordion title="Download denied or blocked">
+    Downloads outside `~/Downloads` require `--allowed-paths`, and sensitive directories/filenames are always blocked. In the Agent UI / API server, out-of-allowlist paths are auto-denied (no interactive prompt). Pass an explicit `--allowed-paths` target and retry.
+  </Accordion>
+
+  <Accordion title="Lemonade server not reachable">
+    Ensure a model is set up (`gaia init`) and the server is running, or point at a remote one with `--base-url`. Use `--no-lemonade-check` only for CI/testing without a backend.
+  </Accordion>
+</AccordionGroup>
 
 ## Next Steps
 

--- a/docs/guides/code.mdx
+++ b/docs/guides/code.mdx
@@ -5,7 +5,7 @@ icon: "code"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/agent.py) · [`src/gaia/agents/code/tools/`](https://github.com/amd/gaia/tree/main/src/gaia/agents/code/tools)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/agent.py) · [`hub/agents/python/code/gaia_agent_code/tools/`](https://github.com/amd/gaia/tree/main/hub/agents/python/code/gaia_agent_code/tools)
 </Info>
 
 <Badge text="development" color="orange" />
@@ -411,9 +411,9 @@ Use the existing launch configurations to step through the agent when it generat
 </Accordion>
 
 **Useful breakpoint locations:**
-- `src/gaia/agents/code/agent.py` - Agent initialization and orchestration
-- `src/gaia/agents/code/tools/typescript_tools.py` - TypeScript/Next.js tooling
-- `src/gaia/agents/code/orchestration/checklist_executor.py` - Full-stack checklist workflow
+- `hub/agents/python/code/gaia_agent_code/agent.py` - Agent initialization and orchestration
+- `hub/agents/python/code/gaia_agent_code/tools/typescript_tools.py` - TypeScript/Next.js tooling
+- `hub/agents/python/code/gaia_agent_code/orchestration/checklist_executor.py` - Full-stack checklist workflow
 - `src/gaia/agents/base/agent.py` - Base agent loop
 
 ## Best Practices
@@ -449,7 +449,7 @@ Use the existing launch configurations to step through the agent when it generat
     Deep dive into how the Code Agent builds Next.js apps
   </Card>
 
-  <Card title="Features Overview" icon="stars" href="/reference/features">
+  <Card title="Features Overview" icon="wand-magic-sparkles" href="/reference/features">
     Explore all GAIA capabilities
   </Card>
 </CardGroup>

--- a/docs/guides/custom-agent.mdx
+++ b/docs/guides/custom-agent.mdx
@@ -91,7 +91,6 @@ For full control — custom tools, built-in tool mixins, MCP servers, or complex
 
 ```python
 from gaia.agents.base.agent import Agent
-from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.tools import _TOOL_REGISTRY, tool
 
 
@@ -103,31 +102,28 @@ class MyPythonAgent(Agent):
     def _get_system_prompt(self) -> str:
         return "You are a helpful assistant with a custom greet tool."
 
-    def _create_console(self) -> AgentConsole:
-        return AgentConsole()
-
     def _register_tools(self) -> None:
         _TOOL_REGISTRY.clear()
-        self._register_custom_tools()
 
-    def _register_custom_tools(self) -> None:
         @tool
         def greet(name: str) -> str:
             """Greet a person by name."""
             return f"Hello, {name}! Welcome to GAIA."
 ```
 
-The three required methods are:
+This mirrors what the Builder Agent scaffolds. The only method a subclass **must**
+implement is `_register_tools()` (it's abstract on the base `Agent`); the other two
+have sensible defaults you can override:
 
-| Method | Purpose |
-|--------|---------|
-| `_get_system_prompt()` | Returns the system prompt string |
-| `_create_console()` | Returns an `AgentConsole` instance |
-| `_register_tools()` | Registers tools into `_TOOL_REGISTRY` |
+| Method | Required? | Purpose |
+|--------|-----------|---------|
+| `_register_tools()` | **Yes** | Registers tools into `_TOOL_REGISTRY` |
+| `_get_system_prompt()` | Optional | Returns the system prompt string (defaults to `""`, i.e. mixin prompts only) |
+| `_create_console()` | Optional | Returns the console handler (defaults to `AgentConsole`, or a silent console in silent mode) |
 
 ### Adding built-in tools
 
-GAIA ships with ready-to-use tool mixins. To enable them, inherit the mixin and call its `register_*_tools()` method from `_register_tools()`:
+GAIA ships with ready-to-use tool mixins. To enable most of them, inherit the mixin and call its `register_*_tools()` method from `_register_tools()`. The `sd` and `vlm` mixins are the exception — call `init_sd()` / `init_vlm()` (which set up the client **and** register the tools in one step):
 
 | Tool | Mixin | Register call |
 |------|-------|---------------|
@@ -136,8 +132,8 @@ GAIA ships with ready-to-use tool mixins. To enable them, inherit the mixin and 
 | `file_io` | `gaia.agents.tools.file_io_tools.FileIOToolsMixin` | `self.register_file_io_tools()` |
 | `shell` | `gaia.agents.tools.shell_tools.ShellToolsMixin` | `self.register_shell_tools()` |
 | `screenshot` | `gaia.agents.tools.screenshot_tools.ScreenshotToolsMixin` | `self.register_screenshot_tools()` |
-| `sd` | `gaia.sd.mixin.SDToolsMixin` | `self.register_sd_tools()` |
-| `vlm` | `gaia.vlm.mixin.VLMToolsMixin` | `self.register_vlm_tools()` |
+| `sd` | `gaia.sd.mixin.SDToolsMixin` | `self.init_sd()` |
+| `vlm` | `gaia.vlm.mixin.VLMToolsMixin` | `self.init_vlm()` |
 
 <Tip>
   To call out to external services (Gmail, GitHub, Slack, etc.) without baking API keys into your code, use [GAIA connectors](#using-gaia-connectors) instead of writing your own auth.
@@ -381,7 +377,7 @@ The UI endpoints (`POST /api/agents/export` and `POST /api/agents/import`) are l
   </Accordion>
 
   <Accordion title="Agent fails to load">
-    Check the server logs for load errors. Ensure `AGENT_ID`, `AGENT_NAME`, and `AGENT_DESCRIPTION` are set as class attributes, and that the three required methods (`_get_system_prompt`, `_create_console`, `_register_tools`) are implemented.
+    Check the server logs for load errors. Ensure `AGENT_ID`, `AGENT_NAME`, and `AGENT_DESCRIPTION` are set as class attributes, and that the required `_register_tools()` method is implemented (`_get_system_prompt()` and `_create_console()` are optional overrides).
   </Accordion>
 
   <Accordion title="Imported agent doesn't appear or shows errors">

--- a/docs/guides/docker.mdx
+++ b/docs/guides/docker.mdx
@@ -5,7 +5,7 @@ icon: "docker"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/docker/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/docker/agent.py) · [`src/gaia/apps/docker/app.py`](https://github.com/amd/gaia/blob/main/src/gaia/apps/docker/app.py)
+  **Source Code:** [`hub/agents/python/docker/gaia_agent_docker/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/docker/gaia_agent_docker/agent.py) · [`src/gaia/apps/docker/app.py`](https://github.com/amd/gaia/blob/main/src/gaia/apps/docker/app.py)
 </Info>
 
 ## Overview
@@ -78,7 +78,7 @@ gaia docker "create a Dockerfile for my application and then build and run the c
 
 ### Key Components
 
-1. **DockerAgent** (`src/gaia/agents/docker/agent.py`)
+1. **DockerAgent** (`hub/agents/python/docker/gaia_agent_docker/agent.py`)
 
    - Core agent that processes natural language queries
    - Analyzes application structure and dependencies
@@ -198,7 +198,7 @@ For more details on the MCP bridge, see [MCP Documentation](/integrations/mcp).
 ### 1. Python API (Direct Integration)
 
 ```python
-from gaia.agents.docker.agent import DockerAgent
+from gaia_agent_docker.agent import DockerAgent
 
 # Initialize and execute
 agent = DockerAgent(model_id="Qwen3.5-35B-A3B-GGUF", silent_mode=True)
@@ -406,7 +406,7 @@ Current limitations of the Docker agent:
 
 **Quick Python Test:**
 ```python
-from gaia.agents.docker.agent import DockerAgent
+from gaia_agent_docker.agent import DockerAgent
 
 agent = DockerAgent(silent_mode=True)
 result = agent.process_query("create a Dockerfile for Flask app in: ./app")

--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -33,7 +33,7 @@ Use this integration path when you want:
 - **Your own UX and mailbox connection** — your app runs OAuth, owns the tokens, and
   forwards a connection to GAIA so the agent can read/send on the user's behalf.
 - **A structured contract** — a frozen request/response schema (`SCHEMA_VERSION`
-  `2.1`) you can code against, over REST **or** MCP stdio.
+  `2.2`) you can code against, over REST **or** MCP stdio.
 
 ## Architecture
 
@@ -205,7 +205,7 @@ token, the forwarded client credentials, and every per-agent grant.
 
 ## The triage contract
 
-*(#1262, frozen at `SCHEMA_VERSION` 2.1)* `POST /v1/email/triage` takes an email or a full
+*(#1262, frozen at `SCHEMA_VERSION` 2.2)* `POST /v1/email/triage` takes an email or a full
 thread and returns structured analysis. **No mail is read or sent** — it analyzes only the
 payload in the request, so you can build and verify triage with **zero connector setup**.
 See the full schema in the [Email Triage Contract](/spec/email-contract).
@@ -237,7 +237,7 @@ curl -s -X POST http://127.0.0.1:4200/v1/email/triage \
 
 ```json
 {
-  "schema_version": "2.1",
+  "schema_version": "2.2",
   "request_kind": "single",
   "result": {
     "category": "URGENT",
@@ -377,7 +377,7 @@ Tools exposed: `triage_email`, `triage_email_batch`, `draft_reply`, `send_email`
 ## Self-describing reference
 
 - **`GET /v1/email/spec`** — a human-readable HTML page describing every endpoint.
-- **`GET /v1/email/version`** — `{"apiVersion": "2.1", "agentVersion": "…"}`. `apiVersion`
+- **`GET /v1/email/version`** — `{"apiVersion": "2.2", "agentVersion": "…"}`. `apiVersion`
   is the frozen contract version; negotiate against its MAJOR so a breaking upgrade fails
   loudly.
 - **`GET /v1/email/health`** — liveness only (`{"status":"ok"}`). A green health check means

--- a/docs/guides/emr.mdx
+++ b/docs/guides/emr.mdx
@@ -25,7 +25,7 @@ All processing happens **100% locally** on AMD Ryzen AI hardware. No cloud APIs,
 The EMR agent combines three AI models in a sophisticated pipeline that runs entirely on your local hardware:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A[/"Intake Form"/] --> B(["VLM Extraction"])
     B --> C(["LLM Validation"])

--- a/docs/guides/eval-ci.mdx
+++ b/docs/guides/eval-ci.mdx
@@ -207,7 +207,7 @@ When a scenario exceeds its budget, it receives the `BUDGET_EXCEEDED` status and
 | Single scenario | $0.02 -- $0.10 | 30s -- 3min |
 | RAG quality category (7 scenarios) | $0.20 -- $0.70 | 5 -- 15min |
 | Context retention (4 scenarios) | $0.10 -- $0.40 | 3 -- 10min |
-| Full benchmark (54 scenarios) | $1.00 -- $5.00 | 20 -- 60min |
+| Full benchmark (all scenarios) | $1.00 -- $5.00 | 20 -- 60min |
 | Architecture audit | $0.00 | < 1min |
 
 <Note>
@@ -453,7 +453,7 @@ gaia eval agent --corpus-dir ~/my-project/eval-corpus
   </Card>
 
   <Card title="Don't" icon="xmark">
-    - Run the full 54-scenario benchmark on every commit
+    - Run the full benchmark (all scenarios) on every commit
     - Skip `--compare` -- regressions are the whole point
     - Use `--fix` in CI (patches should be reviewed by humans)
     - Ignore `BLOCKED_BY_ARCHITECTURE` -- track these as known issues

--- a/docs/guides/eval-scenarios.mdx
+++ b/docs/guides/eval-scenarios.mdx
@@ -21,12 +21,12 @@ The runner discovers scenarios automatically via recursive glob under `eval/scen
 Here is the complete schema with all fields documented:
 
 ```yaml
-# Required fields
+# Core fields (required: id, category, persona, setup, turns)
 id: my_custom_scenario           # Unique identifier (snake_case, alphanumeric + underscores)
-name: "My Custom Scenario"       # Human-readable display name
-category: rag_quality            # Category (see list below)
-severity: critical               # critical | high | medium | low
-description: |                   # Multi-line description of what this scenario tests
+name: "My Custom Scenario"       # (Optional) Human-readable display name
+category: rag_quality            # Category label (see list below)
+severity: critical               # (Optional) critical | high | medium | low
+description: |                   # (Optional) Multi-line description of what this scenario tests
   Describe the purpose and scope of this test.
 
 persona: power_user              # User persona (see Personas section below)
@@ -72,8 +72,8 @@ expected_outcome: |
 | Field | Required | Notes |
 |-------|----------|-------|
 | `id` | Yes | Unique across all scenarios. Use `snake_case`. |
-| `category` | Yes | Must be one of the 10 defined categories. |
-| `persona` | Yes | Must be one of the 5 defined personas. |
+| `category` | Yes | Free-text label for grouping and `--category` filtering; not validated against a fixed set. |
+| `persona` | Yes | Any non-empty string. The 9 built-in personas below are the documented defaults; a custom string is accepted (and logged). |
 | `setup.index_documents` | Yes | Can be empty (`[]`) for scenarios that test discovery. |
 | `turns` | Yes | At least one turn required. Numbers must be sequential starting from 1. |
 | `ground_truth` or `success_criteria` | One required per turn | Providing both gives maximum judging precision. |
@@ -95,6 +95,8 @@ eval/scenarios/
 ├── rag_quality/          # RAG retrieval and fact lookup
 ├── context_retention/    # Cross-turn context awareness
 ├── tool_selection/       # Correct tool usage and discovery
+├── mcp_reliability/      # Tool-call reliability (parameters, chains, conditionals)
+├── memory/               # Cross-session memory persistence and recall
 ├── error_recovery/       # Error handling and graceful degradation
 ├── adversarial/          # Edge cases and robustness
 ├── personality/          # GAIA voice and personality compliance
@@ -109,6 +111,8 @@ eval/scenarios/
 | `rag_quality` | Factual extraction, hallucination resistance, CSV/table parsing, cross-section synthesis |
 | `context_retention` | Pronoun resolution, remembering indexed documents, multi-document conversations |
 | `tool_selection` | Tool routing, smart document discovery, multi-step planning, knowing when NOT to use tools |
+| `mcp_reliability` | Parameter passing, conditional tool use, multi-step tool chains, no-tool-needed decisions |
+| `memory` | Cross-session persistence, fact accumulation, conflict/supersede resolution, temporal recall |
 | `error_recovery` | Missing files, empty search results, vague queries, graceful fallbacks |
 | `adversarial` | Empty files, very large documents, rapid topic switching |
 | `personality` | Conciseness, avoiding sycophancy, admitting limitations honestly |
@@ -117,11 +121,15 @@ eval/scenarios/
 | `web_system` | Clipboard, notifications, webpage fetching, system information |
 | `captured` | Replaying real user sessions as golden-path tests |
 
+<Note>
+  Category is a free-text label used for grouping and `--category` filtering — the runner does **not** validate it against a fixed enum, so you can introduce a new category simply by using it. The categories above are the ones currently in the suite.
+</Note>
+
 ---
 
 ## Personas
 
-Each scenario specifies a persona that shapes how the eval agent crafts user messages:
+Each scenario specifies a persona that shapes how the eval agent crafts user messages. Nine personas are built in (any non-empty custom string is also accepted):
 
 | Persona | Behavior | When to Use |
 |---------|----------|-------------|
@@ -130,6 +138,10 @@ Each scenario specifies a persona that shapes how the eval agent crafts user mes
 | `confused_user` | Wrong terminology, self-correcting mid-sentence | Testing error recovery and clarification |
 | `adversarial_user` | Edge cases, topic switches, impossible requests | Testing hallucination resistance and boundary handling |
 | `data_analyst` | Numbers, comparisons, aggregations, structured output expectations | Testing numerical accuracy and data synthesis |
+| `home_user` | Everyday consumer, texting-style lowercase, confused by jargon | Testing plain-language handling and simplicity |
+| `small_business_owner` | Time-pressed, ROI-focused, not deeply technical, mixes business and personal tasks | Testing practical, value-oriented interactions |
+| `student` | Academic/homework context, casual language with bursts of field jargon, appreciates step-by-step | Testing explanatory depth and research help |
+| `creative_professional` | Designer/writer/artist, project- and workflow-focused, values speed, may ask open-ended questions | Testing subjective/open-ended and impatient-with-verbosity cases |
 
 <Tip>
   Use `power_user` for straightforward RAG tests. Use `adversarial_user` for scenarios that test failure modes. Use `casual_user` to test whether the agent handles real-world ambiguity.

--- a/docs/guides/eval.mdx
+++ b/docs/guides/eval.mdx
@@ -107,7 +107,7 @@ gaia eval agent --category rag_quality
 
 ### 3. Run the Full Benchmark
 
-Run all 54 scenarios across 10 categories:
+Run all scenarios across every category (91 scenarios in 12 categories at the time of writing):
 
 ```bash
 gaia eval agent
@@ -199,19 +199,21 @@ Each turn is scored across 7 dimensions. The overall score is a weighted sum:
 
 ## Scenario Categories
 
-The benchmark includes 54 scenarios across 10 categories:
+The benchmark includes 91 scenarios across 12 categories (counts as of this writing — the runner discovers scenarios dynamically, so totals grow as new YAML is added):
 
 | Category | Count | What It Tests |
 |----------|:-----:|---------------|
-| `rag_quality` | 7 | Factual extraction, hallucination resistance, negation handling, CSV/table data |
+| `memory` | 25 | Cross-session persistence, fact accumulation, conflict resolution, temporal recall |
+| `real_world` | 19 | Real PDFs, XLSX, 10-K filings, RFC specs, datasheets |
+| `mcp_reliability` | 10 | Tool-call reliability: parameter passing, conditional tool use, multi-step chains |
+| `rag_quality` | 8 | Factual extraction, hallucination resistance, negation handling, CSV/table data |
+| `web_system` | 6 | Clipboard, desktop notifications, webpage fetching, system info |
+| `tool_selection` | 5 | Correct tool usage, smart discovery, multi-step planning |
 | `context_retention` | 4 | Cross-turn recall, pronoun resolution, multi-document context |
-| `tool_selection` | 4 | Correct tool usage, smart discovery, multi-step planning |
-| `error_recovery` | 3 | Graceful handling of missing files, empty results, vague requests |
 | `adversarial` | 3 | Empty files, large documents (>100k tokens), topic switching |
 | `personality` | 3 | Concise responses, no sycophancy, honest limitations |
 | `vision` | 3 | Screenshot capture, VLM integration |
-| `real_world` | 19 | Real PDFs, XLSX, 10-K filings, RFC specs, datasheets |
-| `web_system` | 6 | Clipboard, desktop notifications, webpage fetching, system info |
+| `error_recovery` | 3 | Graceful handling of missing files, empty results, vague requests |
 | `captured` | 2 | Golden-path replays from real user sessions |
 
 ---
@@ -299,7 +301,7 @@ gaia eval agent --output-format markdown
 
 **Typical costs:**
 - Single scenario: $0.02 -- $0.10
-- Full benchmark (54 scenarios): $1.00 -- $5.00
+- Full benchmark (all scenarios): $1.00 -- $5.00 (scenarios whose corpus files aren't on disk are skipped)
 - Architecture audit: $0.00 (no LLM calls)
 
 <Tip>

--- a/docs/guides/jira.mdx
+++ b/docs/guides/jira.mdx
@@ -83,7 +83,7 @@ The CLI (`gaia jira`) wraps **JiraApp** (`src/gaia/apps/jira/app.py`), which dri
 - **`gaia jira` CLI** — manages the agent lifecycle; supports direct queries and interactive mode.
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph LR
     User(["User Query"]) --> Agent(["JiraAgent"])
     Agent --> Discover(["Auto-Discovery"])

--- a/docs/guides/mcp/agent-ui.mdx
+++ b/docs/guides/mcp/agent-ui.mdx
@@ -32,7 +32,24 @@ Conversations initiated via MCP appear in the browser UI in real time, so you ca
 | `search_files` | Search for files by name pattern and type |
 | `preview_file` | Preview file contents or metadata |
 | `take_screenshot` | Capture the Agent UI browser window (Windows) |
+| `memory_stats` | Memory counts and breakdown by category/context/entity |
+| `memory_list` | Filtered list of knowledge rows |
+| `memory_recall` | Hybrid-search recall over the memory store |
+| `memory_get` | Fetch one knowledge row by ID |
+| `memory_get_by_entity` | All rows tagged to an entity (e.g. `person:alice`) |
+| `memory_get_conversation_turns` | Raw turn history for a session |
+| `memory_seed` | Seed knowledge rows directly (for tests/setup) |
+| `memory_clear` | Clear memory rows |
 | `open_session_in_browser` | Open a session in the default browser |
+
+<Note>
+  The `memory_*` tools are **conditional**. The read tools (`memory_stats`, `memory_list`,
+  `memory_recall`, `memory_get`, `memory_get_by_entity`, `memory_get_conversation_turns`)
+  are registered only when memory MCP access is enabled — either via the Memory Dashboard
+  toggle (`mcp_memory_enabled`) or `GAIA_MEMORY_MCP_ALWAYS=1`. The admin tools
+  (`memory_seed`, `memory_clear`) additionally require `GAIA_MEMORY_ADMIN=1` on the backend
+  process.
+</Note>
 
 ---
 
@@ -190,7 +207,7 @@ claude mcp remove gaia-agent-ui
   </Accordion>
 
   <Accordion title="'Cannot connect to GAIA backend' errors">
-    The Agent UI backend must be running before the MCP server can work. Start it with `uv run python -m gaia.ui.server` or use the startup scripts in `scripts/`.
+    The Agent UI backend must be running before the MCP server can work. Start it with `uv run python -m gaia.ui.server` or use the startup scripts in `installer/scripts/`.
   </Accordion>
 
   <Accordion title="send_message times out">

--- a/docs/guides/mcp/client.mdx
+++ b/docs/guides/mcp/client.mdx
@@ -4,13 +4,12 @@ description: "Connect GAIA agents to external MCP servers and use their tools"
 ---
 
 <Warning>
-  **CLI update (#977):** `gaia mcp add` and `gaia mcp remove` shown in this guide
-  have been removed. MCP servers are now defined as **connectors** and configured
-  with `gaia connectors configure <id> --set KEY=VALUE` (secrets are stored in the
-  OS keyring; the entry is written to `~/.gaia/mcp_servers.json`). `gaia mcp list`
-  still lists configured servers. The `gaia mcp add ...` examples below predate this
-  change and are pending a rewrite — run `gaia connectors --help` for current usage,
-  and see issue #1339.
+  **CLI update (#977):** `gaia mcp add` and `gaia mcp remove` have been removed.
+  Configure MCP servers by editing `~/.gaia/mcp_servers.json` directly (shown below),
+  or, for catalog connectors, with `gaia connectors configure <id> --set KEY=VALUE`
+  (secrets are stored in the OS keyring). `gaia mcp list`, `gaia mcp tools`, and
+  `gaia mcp test-client` still work. Run `gaia connectors --help` for connector usage;
+  see issue #1339 for the ongoing connectors migration.
 </Warning>
 
 **Connect your GAIA agent to any tool ecosystem with a single line of code.**
@@ -89,11 +88,8 @@ MCP server connected, tools auto-discovered, and the agent uses them naturally.
   </Step>
 
   <Step title="Add an MCP server">
-    Add the official [MCP Time Server](https://github.com/modelcontextprotocol/servers/tree/main/src/time):
-    ```bash
-    gaia mcp add time "uvx mcp-server-time"
-    ```
-    Or edit `~/.gaia/mcp_servers.json` directly:
+    Add the official [MCP Time Server](https://github.com/modelcontextprotocol/servers/tree/main/src/time)
+    by editing `~/.gaia/mcp_servers.json`:
     ```json
     {
       "mcpServers": {
@@ -155,7 +151,7 @@ MCP server connected, tools auto-discovered, and the agent uses them naturally.
 ## How It Works
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#E2A33E', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 flowchart TB
     User(["User Query"])
     YourAgent(["Your Agent"])
@@ -249,12 +245,10 @@ flowchart TB
     ```
   </Tab>
 
-  <Tab title="Via CLI">
+  <Tab title="Via config file">
     ```bash
-    # Add server to config
-    gaia mcp add filesystem "npx -y @modelcontextprotocol/server-filesystem /tmp"
-
-    # List configured servers
+    # Add the server by editing ~/.gaia/mcp_servers.json (see Config File Format below),
+    # then list what's configured:
     gaia mcp list
     ```
   </Tab>
@@ -347,12 +341,16 @@ This format is compatible with Claude Desktop and other Anthropic tools. The `mc
   </Step>
 
   <Step title="Add to config">
-    ```bash
-    gaia mcp add <name> "<command>"
-    ```
-    For example, to add the Memory server:
-    ```bash
-    gaia mcp add memory "npx -y @modelcontextprotocol/server-memory"
+    Add an entry to `~/.gaia/mcp_servers.json`. For example, the Memory server:
+    ```json
+    {
+      "mcpServers": {
+        "memory": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-memory"]
+        }
+      }
+    }
     ```
   </Step>
 
@@ -410,22 +408,22 @@ For detailed API usage and patterns, see the [SDK Reference](/sdk/sdks/mcp).
 
 <AccordionGroup>
   <Accordion title="CLI Commands">
-    GAIA provides CLI commands for managing MCP server configurations without writing code.
+    GAIA provides CLI commands for inspecting MCP servers without writing code.
 
     <Card title="MCP CLI Reference" icon="terminal" href="/reference/cli#mcp-client">
-      Complete documentation of all MCP CLI commands: `add`, `list`, `tools`, `test-client`, `remove`
+      Documentation for the MCP CLI commands: `list`, `tools`, `test-client`
     </Card>
 
     **Quick reference:**
     ```bash
-    gaia mcp add <name> "<command>"     # Add server to config
     gaia mcp list                        # List configured servers
-    gaia mcp tools <name>                # List tools from server
-    gaia mcp test-client <name>          # Test connection
-    gaia mcp remove <name>               # Remove server
+    gaia mcp tools <name>                # List tools from a server
+    gaia mcp test-client <name>          # Test a server connection
     ```
 
-    For detailed usage, parameters, and output examples, see the [CLI Reference](/reference/cli#mcp-client).
+    Adding and removing servers moved to the connectors framework (#977): edit
+    `~/.gaia/mcp_servers.json` directly, or use `gaia connectors configure <id> --set KEY=VALUE`
+    for catalog connectors. For detailed usage, see the [CLI Reference](/reference/cli#mcp-client).
   </Accordion>
 
   <Accordion title="Best Practices">

--- a/docs/guides/mcp/windows-system-health.mdx
+++ b/docs/guides/mcp/windows-system-health.mdx
@@ -66,7 +66,7 @@ The agent gathers metrics via PowerShell, formats a report, and pastes it into N
 ## How It Works
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'18px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 graph TB
     User("User: 'Check system health'")
     Agent("WindowsSystemHealthAgent<br/>(Agent + MCPClientMixin)")

--- a/docs/guides/memory.mdx
+++ b/docs/guides/memory.mdx
@@ -514,6 +514,7 @@ rm ~/.gaia/memory.db
 | `gaia memory bootstrap` | Run full onboarding (conversation + discovery) |
 | `gaia memory bootstrap --chat-only` | Conversational onboarding only |
 | `gaia memory bootstrap --discover` | System discovery scan only |
+| `gaia memory bootstrap --infer` | LLM-assisted profile inference from browser history and installed apps |
 | `gaia memory bootstrap --reset` | Delete discovery items (with confirmation) |
 | `gaia memory bootstrap --system` | Re-scan and refresh system context (OS, hardware, apps, versions) |
 | `gaia memory bootstrap --reset-system` | Clear system context entries and optionally disable auto-collection |

--- a/docs/guides/npu.mdx
+++ b/docs/guides/npu.mdx
@@ -4,8 +4,6 @@ description: "Run GAIA agents on AMD Ryzen AI NPU for power-efficient local infe
 icon: "bolt"
 ---
 
-# NPU Acceleration
-
 GAIA supports running agents on your AMD Ryzen AI NPU via the [FastFlowLM (FLM)](https://fastflowlm.com) backend. NPU inference is power-efficient and frees your GPU for other tasks.
 
 ## Requirements

--- a/docs/guides/routing.mdx
+++ b/docs/guides/routing.mdx
@@ -35,7 +35,7 @@ The routing agent solves these problems by:
 ## How It Works
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart LR
     A[/"REQUEST"/] --> B(["ANALYZE"])
     B --> C{"CONFIDENT?"}
@@ -242,7 +242,7 @@ gaia-code "Create an Express API with SQLite"
 For implementation details, see:
 - Source code: `hub/agents/python/routing/gaia_agent_routing/agent.py`
 - System prompt: `hub/agents/python/routing/gaia_agent_routing/system_prompt.py`
-- CLI integration: `src/gaia/cli.py` (search for "RoutingAgent")
+- CLI integration: `hub/agents/python/code/gaia_agent_code/cli.py` (search for "RoutingAgent")
 
 ## See Also
 

--- a/docs/guides/sd.mdx
+++ b/docs/guides/sd.mdx
@@ -96,7 +96,7 @@ Total: ~10GB for the complete multi-modal experience.
 ### Multi-Modal Agent Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'fontSize':'18px', 'lineColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'edgeLabelBackground':'#1a1a1a'}, 'flowchart': {'curve': 'basis'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}, 'flowchart': {'curve': 'basis'}}}%%
 graph TB
     User("User: 'create robot kitten with story'")
     Agent("SDAgent<br/>(Agent + SDToolsMixin + VLMToolsMixin)")
@@ -562,7 +562,7 @@ To see what prompt the agent uses:
 
 ```bash
 # Print final system prompt
-python -c "from gaia.agents.sd import SDAgent; agent = SDAgent(); print(agent.system_prompt)"
+python -c "from gaia_agent_sd.agent import SDAgent; agent = SDAgent(); print(agent.system_prompt)"
 
 # View just SD guidelines
 python -c "from gaia.sd import SDToolsMixin; print(SDToolsMixin.get_base_sd_guidelines())"

--- a/docs/guides/talk.mdx
+++ b/docs/guides/talk.mdx
@@ -392,7 +392,7 @@ gaia test --test-type tts-audio-file \
     Build custom voice-enabled agents
   </Card>
 
-  <Card title="Features Overview" icon="stars" href="/reference/features">
+  <Card title="Features Overview" icon="wand-magic-sparkles" href="/reference/features">
     Discover all GAIA capabilities
   </Card>
 </CardGroup>

--- a/docs/integrations/mcp.mdx
+++ b/docs/integrations/mcp.mdx
@@ -199,12 +199,13 @@ The MCP Server acts as an HTTP bridge between external applications and GAIA's n
     curl http://localhost:8765/health
     ```
 
-    Response:
+    Response (agent/tool counts vary by installation):
     ```json
     {
       "status": "healthy",
+      "service": "GAIA MCP Bridge (HTTP)",
       "agents": 4,
-      "tools": 8
+      "tools": 5
     }
     ```
   </Tab>
@@ -416,7 +417,7 @@ The MCP server exposes the following GAIA agents as tools:
 
     **Solutions**:
     - Start the Lemonade server: `lemonade-server serve`
-    - Check GAIA_BASE_URL is correct
+    - Check `LEMONADE_BASE_URL` is correct (default `http://localhost:13305/api/v1`)
     - Verify models are loaded
   </Accordion>
 

--- a/docs/integrations/vscode.mdx
+++ b/docs/integrations/vscode.mdx
@@ -103,7 +103,7 @@ The GAIA VSCode extension integrates GAIA agents as selectable language models i
 
 <Warning>
 GAIA Code requires **three services** running simultaneously:
-1. Lemonade Server (LLM backend on port 8000)
+1. Lemonade Server (LLM backend on port 13305)
 2. GAIA API Server (REST API on port 8080)
 3. VSCode Extension (installed in VSCode)
 </Warning>
@@ -465,9 +465,7 @@ src/vscode/gaia/
     4. This opens a new VSCode window (Extension Development Host) with the extension loaded
 
     <Info>
-    The launch configuration is defined in `.vscode/launch.json` and automatically compiles TypeScript before launching. There are two configurations:
-    - **GAIA VSCode Extension (API)** - For testing with the GAIA API server (port 8080)
-    - **GAIA VSCode Extension (MCP)** - For testing with the GAIA MCP server (port 8765)
+    The launch configuration is defined in `.vscode/launch.json` and automatically compiles TypeScript before launching. Use **GAIA VSCode Extension (API)** to run the extension against the GAIA API server (port 8080). A separate **MCP Bridge Debug** configuration launches the standalone MCP bridge (port 8765) for the MCP-client workflow — that path is a client integration, not a VSCode extension.
     </Info>
   </Step>
 
@@ -587,7 +585,6 @@ View > Output > Select "GAIA" from dropdown
 <Tabs>
   <Tab title="Message Flow">
     ```mermaid
-    %%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'actorBkg':'#E2A33E', 'actorTextColor':'#fff', 'actorBorder':'#A87B2D', 'signalColor':'#EFC480', 'signalTextColor':'#333', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
     sequenceDiagram
         participant User
         participant VSCode
@@ -606,7 +603,6 @@ View > Output > Select "GAIA" from dropdown
 
   <Tab title="Model Discovery">
     ```mermaid
-    %%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'actorBkg':'#E2A33E', 'actorTextColor':'#fff', 'actorBorder':'#A87B2D', 'signalColor':'#EFC480', 'signalTextColor':'#333', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
     sequenceDiagram
         participant VSCode
         participant Provider
@@ -659,7 +655,7 @@ When making changes to the extension:
 | **Exposes** | Agents as "models" | Agents as "tools" |
 | **Model Picker** | ✅ Yes | ❌ No |
 | **Setup Complexity** | Install extension | Configure MCP client |
-| **Launch Config** | "GAIA VSCode Extension (API)" | "GAIA VSCode Extension (MCP)" |
+| **Launch Config** | "GAIA VSCode Extension (API)" | "MCP Bridge Debug" (runs the bridge) |
 | **Best For** | Language model provider workflow | MCP client workflow |
 
 ---

--- a/docs/plans/autonomy-engine.mdx
+++ b/docs/plans/autonomy-engine.mdx
@@ -15,9 +15,9 @@ icon: "clock"
 > **Prerequisites:** v0.20.0 Memory & Bootstrap must ship first (MemoryStore, MemoryMixin)
 >
 > **Related plans:**
-> - [Agent UI](agent-ui.mdx) -- Phase C (autonomous infra)
-> - [Messaging Integrations](messaging-integrations-plan.mdx) -- Messaging adapters depend on this service
-> - [Security Model](security-model.mdx) -- Tool guardrails and dangerous mode
+> - [Agent UI](/plans/agent-ui) -- Phase C (autonomous infra)
+> - [Messaging Integrations](/plans/messaging-integrations-plan) -- Messaging adapters depend on this service
+> - [Security Model](/plans/security-model) -- Tool guardrails and dangerous mode
 
 ---
 
@@ -278,7 +278,7 @@ tasks:
       - auto_commit_if_ready
 ```
 
-For comprehensive security analysis, see [security-model.mdx](security-model.mdx).
+For comprehensive security analysis, see [security-model.mdx](/plans/security-model).
 
 ---
 

--- a/docs/plans/connectors.mdx
+++ b/docs/plans/connectors.mdx
@@ -18,7 +18,7 @@ icon: "plug"
 >
 > **Related issues:** [#915](https://github.com/amd/gaia/issues/915) (OAuth PKCE for Google — first concrete connector); [#735](https://github.com/amd/gaia/issues/735) / [#736](https://github.com/amd/gaia/issues/736) / [#737](https://github.com/amd/gaia/issues/737) / [#738](https://github.com/amd/gaia/issues/738) / [#740](https://github.com/amd/gaia/issues/740) (Connector Hub track — supersede-vs-children call pending @kovtcharov-amd; see #927's Coordination block).
 >
-> **Related plans:** [Agent UI](agent-ui.mdx), [Security Model](security-model.mdx).
+> **Related plans:** [Agent UI](/plans/agent-ui), [Security Model](/plans/security-model).
 >
 > **Scope:** This spec promotes the OAuth-only `gaia.connectors` library shipped in #915 into a generalized **Connectors framework** with a `Settings → Connectors` page modeled on Claude desktop's native UI. The existing 22-entry MCP server catalog (today read-only in Settings) is unified into the same surface. v1 ships the framework with two implemented types (`oauth_pkce` + `mcp_server`); other types (`api_token`, `composite_form`, `local_extension`) are framework-shaped but follow-up.
 

--- a/docs/plans/cua.mdx
+++ b/docs/plans/cua.mdx
@@ -93,7 +93,7 @@ python -m gaia.agents.cua.cli --list-tools
 ## Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'16px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph TD
     A["User CLI<br/>python -m gaia.agents.cua.cli"] --> B["ComputerUseAgent<br/>(inherits from Agent)"]
     B --> C["Lemonade Server<br/>(Qwen3.5-35B)"]
@@ -143,7 +143,6 @@ graph TD
 ### Tool Execution Flow
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'16px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
 sequenceDiagram
     participant User
     participant CLI
@@ -167,7 +166,6 @@ sequenceDiagram
 ### Connection Flow
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'16px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
 sequenceDiagram
     participant Agent as ComputerUseAgent
     participant Client as ExternalMCPClient
@@ -291,7 +289,7 @@ GAIA_FILESYSTEM_MCP_URL   # Future: File System Agent
 ## Project Structure
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'14px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph LR
     subgraph Source["src/gaia/agents/cua/"]
         A1["__init__.py"]

--- a/docs/plans/email-triage-agent.mdx
+++ b/docs/plans/email-triage-agent.mdx
@@ -14,9 +14,9 @@ icon: "inbox"
 >
 > **Related issues:** [#645](https://github.com/amd/gaia/issues/645) (Email Triage Agent), [#663](https://github.com/amd/gaia/issues/663) (Daily briefs), [#660](https://github.com/amd/gaia/issues/660) (Email & Calendar via MCP), [#634](https://github.com/amd/gaia/issues/634) (Autonomy engine), [#698](https://github.com/amd/gaia/issues/698) (Credential vault), [#542](https://github.com/amd/gaia/issues/542) (Memory system), [#701](https://github.com/amd/gaia/issues/701) (Configuration Dashboard)
 >
-> **Related plans:** [Email & Calendar](email-calendar-integration.mdx) (parent plan), [Autonomy Engine](autonomy-engine.mdx), [Security Model](security-model.mdx), [Agent UI](agent-ui.mdx), [Setup Wizard](setup-wizard.mdx)
+> **Related plans:** [Email & Calendar](/plans/email-calendar-integration) (parent plan), [Autonomy Engine](/plans/autonomy-engine), [Security Model](/plans/security-model), [Agent UI](/plans/agent-ui), [Setup Wizard](/plans/setup-wizard)
 >
-> **Scope:** This document specifies the **Email Triage Agent** as a two-phase deliverable. Phase C1 ships an on-demand inbox companion in v0.20.0. Phase C2 promotes it to a dedicated autonomous agent in v0.23.0. Integration is **auto-discovered and hands-off** — the agent detects the user's email client, picks the right adapter, and walks through OAuth with minimum friction. Users enable/disable the whole integration with a single toggle in the Agent UI. This spec complements (and does not replace) the broader [Email & Calendar plan](email-calendar-integration.mdx).
+> **Scope:** This document specifies the **Email Triage Agent** as a two-phase deliverable. Phase C1 ships an on-demand inbox companion in v0.20.0. Phase C2 promotes it to a dedicated autonomous agent in v0.23.0. Integration is **auto-discovered and hands-off** — the agent detects the user's email client, picks the right adapter, and walks through OAuth with minimum friction. Users enable/disable the whole integration with a single toggle in the Agent UI. This spec complements (and does not replace) the broader [Email & Calendar plan](/plans/email-calendar-integration).
 
 ---
 
@@ -213,7 +213,7 @@ scheduled delivery, tests) are layered on top of MVT once it's demoable.
 
 ## 2. Why This Spec Exists (Relative to the Broader Plan)
 
-The existing [Email & Calendar Integration](email-calendar-integration.mdx) plan covers
+The existing [Email & Calendar Integration](/plans/email-calendar-integration) plan covers
 the full surface — Gmail, Outlook, calendar, meeting notes, daily briefs. This spec
 drills into the **triage agent itself** with additional depth the broader plan does
 not cover:
@@ -528,7 +528,7 @@ a `normalized_body` field the classifier consumes.
 
 Email triage at scale is fundamentally a **cost-and-latency problem**. Summarizing a
 thread every 30 minutes with a 35B model burns budget and battery. Research and the
-existing [autonomy engine](autonomy-engine.mdx) both converge on cheap-first cascading.
+existing [autonomy engine](/plans/autonomy-engine) both converge on cheap-first cascading.
 
 | Tier | Model | Use | Typical warm latency | Cold-start |
 |------|-------|-----|-----------------|------------|
@@ -552,7 +552,7 @@ Design rules:
    (rule-based categorization). All cached data remains queryable.
 5. **Cold-start amortization.** Keeping T1 warm (~600 MB RAM) is the right default for
    always-on triage — pay the 3s load once. T2 and T3 load on demand. See
-   [autonomy-engine.mdx](autonomy-engine.mdx) §14 Open Question 1.
+   [autonomy-engine.mdx](/plans/autonomy-engine) §14 Open Question 1.
 
 ### 6.1 Email Content Never Routes to Cloud
 
@@ -633,7 +633,7 @@ email agent consumes that catalog rather than shipping a bespoke Settings surfac
 The agent exposes a consolidated tool surface, compatible with the GongRzhe Gmail
 convention. All tools are registered via `@tool` in
 `src/gaia/agents/base/tools.py`. Tool risk tiers follow the
-[Security Model](security-model.mdx) §4.1.
+[Security Model](/plans/security-model) §4.1.
 
 > **Prerequisite:** The `@tool` decorator currently accepts `atomic: bool` but
 > **not** a `risk_tier` parameter (see §2.5). Before C1 ships, extend the
@@ -1188,7 +1188,7 @@ triage review" button or `g`-`z` keyboard shortcut.
 
 - **Natural-language query box** ("emails from Sarah about the contract last month").
 - **Results with citations** — each hit shows the snippet that matched and the
-  surrounding context (RAG-backed; see [RAG SDK](../sdk/sdks/rag.mdx)).
+  surrounding context (RAG-backed; see [RAG SDK](/sdk/sdks/rag)).
 - **Thread preview on hover**.
 - **Filters** — sender, date range, label, has-attachment, unread, cohort —
   composable with natural-language query.
@@ -1270,7 +1270,7 @@ Desktop notifications (Electron `Notification` API; platform-native fallback via
 | New email account auto-discovered | Agent Inbox Notify | Click → connect flow |
 
 All notifications respect quiet hours (inherited from
-[autonomy engine](autonomy-engine.mdx) §4).
+[autonomy engine](/plans/autonomy-engine) §4).
 
 ### 12.15 Voice-First Synergy (C2 + v0.21.0 Voice)
 
@@ -1407,7 +1407,7 @@ users can self-diagnose:
 - "Restart server" button.
 
 This is the Agent-UI-native equivalent of reading `journalctl`. Matches the
-[observability dashboard](agent-ui.mdx) pattern rather than duplicating it.
+[observability dashboard](/plans/agent-ui) pattern rather than duplicating it.
 
 #### 12.18.5 Bulk Actions
 
@@ -1536,14 +1536,14 @@ When the brief is read aloud (§12.15), the same grammar applies:
 - Bucket names spoken ("urgent", "actionable") — emoji are display-only.
 - Thread titles truncated to first 8 words for speech.
 - Interactive — user can say "skip" to advance, "more" to get the full summary.
-- Uses [`TalkSDK`](../sdk/sdks/audio.mdx) with Kokoro TTS per §2.5.
+- Uses [`TalkSDK`](/sdk/sdks/audio) with Kokoro TTS per §2.5.
 
 ### 12.20 Slack as an Output Channel
 
 Slack is a first-class channel for the email agent to communicate with the user.
 Many users live in Slack during the workday — pushing the morning brief and
 urgent alerts there is higher-impact than an Agent-UI-only surface. This section
-aligns with [Messaging Integrations](messaging-integrations-plan.mdx)
+aligns with [Messaging Integrations](/plans/messaging-integrations-plan)
 ([#635](https://github.com/amd/gaia/issues/635)) but front-loads Slack for the
 email agent specifically.
 
@@ -1576,7 +1576,7 @@ email agent specifically.
   registered via `MCPClientMixin`.
 - User can DM GaiaAgent in Slack: "what's urgent?" → agent queries local Gmail
   MCP, classifies, replies in-thread. This reuses the messaging-adapter
-  restricted tool set ([Security Model](security-model.mdx) §12.2) — Slack DMs
+  restricted tool set ([Security Model](/plans/security-model) §12.2) — Slack DMs
   cannot trigger email sends without an explicit confirm in the Agent UI.
 
 **C2 — Interactive Approval Flow:**
@@ -1586,7 +1586,7 @@ email agent specifically.
   buttons. Approve = send via Gmail MCP. Edit = opens thread in Agent UI. Reject
   = discard.
 - Scheduled brief delivery via the autonomy engine
-  ([autonomy-engine.mdx](autonomy-engine.mdx)) — runs T0/T1/T2 cascade, posts
+  ([autonomy-engine.mdx](/plans/autonomy-engine)) — runs T0/T1/T2 cascade, posts
   structured brief to Slack.
 - Hooks into Agent Inbox (§12.6): Slack-driven approvals write to the same
   ledger as UI-driven approvals; undo works across both.
@@ -1599,7 +1599,7 @@ email agent specifically.
 - Emoji prefixes for triage buckets (🔥 urgent, 📬 actionable, ℹ️ info,
   🗃️ auto-archived).
 
-**Security (extends [Security Model](security-model.mdx) §12):**
+**Security (extends [Security Model](/plans/security-model) §12):**
 
 - **Slack token** stored in credential vault (C2) or `~/.gaia/email/slack.json`
   (chmod 600) for MVT/C1. Treated as a secret; log-redacted.
@@ -1693,7 +1693,7 @@ A red **"Stop Email Agent Now"** button is visible at all times in the tray menu
 Click → immediate pause of all email activity + pending actions cancelled + confirm
 modal to fully disable. This is the trust safety net: even if the agent is doing
 something a user didn't expect, one click stops everything. Matches the observability-
-first principle in the [Security Model](security-model.mdx).
+first principle in the [Security Model](/plans/security-model).
 
 ### 13.7 Telemetry Transparency (opt-in, off by default)
 
@@ -1757,7 +1757,7 @@ Flagged messages never trigger auto-actions; they route to the Questions inbox w
 ### 14.3 Credential Security
 
 - OAuth tokens stored in the encrypted credential vault
-  ([Security Model](security-model.mdx) §7), not environment variables, not plain JSON.
+  ([Security Model](/plans/security-model) §7), not environment variables, not plain JSON.
 - Platform-appropriate backing: DPAPI (Windows), Keychain (macOS), Secret Service
   (Linux).
 - Tokens never logged, never appear in audit trail, never sent to cloud endpoints.
@@ -1785,7 +1785,7 @@ user downgrades scope at the provider side, the agent degrades gracefully.
 
 - Agent responses are scanned for PII leakage before being returned to messaging
   adapters (Discord/Slack/Telegram). The existing PII redaction in
-  [Security Model](security-model.mdx) §12.3 applies.
+  [Security Model](/plans/security-model) §12.3 applies.
 - Email content never leaves the device for inference. If hybrid-routing sends any
   task to a cloud model, email content is explicitly blocked from that routing by
   policy — and the persistent UI privacy indicator (§12.11) flips loud if this
@@ -1822,7 +1822,7 @@ an **adversarial probabilistic problem**, not a solved one. Known residual risk:
 - **Supply chain for MCP packages.** If `taylorwilsdon/google_workspace_mcp`
   or `softeria/ms-365-mcp-server` is compromised upstream, the attacker has the
   user's tokens. Mitigated by the in-tree Gmail MCP in C2 (§7.2) and by package
-  checksum verification ([Security Model](security-model.mdx) §5.3).
+  checksum verification ([Security Model](/plans/security-model) §5.3).
 - **User confusion as attack vector.** If the UI shows a drafted reply the user
   is pressured to send quickly, the user may approve without reading. The
   confirm-before-send modal (§12.8) is necessary but not sufficient — long-term
@@ -1997,7 +1997,7 @@ Same two-column format as §16.2 (Human vs CC-assisted with parallelism).
 | 2 | `EmailTriageAgent` class with full tool surface (§8) | 2d | 0.7d | ║ (with #1) |
 | 3 | Write-side ledger + undo protocol (§9) | 2d | 0.6d | ║ (with #2) |
 | 4 | Per-cohort autonomy engine (§4) — rule-matcher + policy-evaluator + §4.6 L5 template gating | 2d | 0.7d | |
-| 5 | Scheduled triage task — heartbeat entry in [`autonomy-engine.mdx`](autonomy-engine.mdx); T0/T1/T2 cascade; batched per §5.2; escalates to Agent Inbox | 2d | 0.8d | |
+| 5 | Scheduled triage task — heartbeat entry in [`autonomy-engine.mdx`](/plans/autonomy-engine); T0/T1/T2 cascade; batched per §5.2; escalates to Agent Inbox | 2d | 0.8d | |
 | 6 | Morning & evening scheduled daily-brief with voice readout via TalkSDK | 1.5d | 0.5d | ║ (with #5) |
 | 7 | Auto-follow-up on no-reply (Superhuman Auto Drafts pattern) | 1.5d | 0.6d | (research bet; see §27.2) |
 | 8 | Writing-voice learning with per-relationship tone (Fyxer pattern) | 2d | 1.0d | (research bet; prototype first) |
@@ -2094,7 +2094,7 @@ Inbox-Zero mode, injection defense, and the full UI scope are net-new.
 | Credential vault | `~/.gaia/credentials.db` (encrypted) | OAuth tokens, refresh tokens |
 | Email ledger | `~/.gaia/email/ledger.db` (SQLite) | message_state, actions, corrections, sender_reputation |
 | Discovery cache | `~/.gaia/email/discovery.json` | Detected candidates + last-scan timestamps |
-| Audit log | `~/.gaia/audit.db` (SQLite) | Unified tool execution audit (existing — [Security Model](security-model.mdx) §6) |
+| Audit log | `~/.gaia/audit.db` (SQLite) | Unified tool execution audit (existing — [Security Model](/plans/security-model) §6) |
 | Memory | `~/.gaia/memory/memory.db` (SQLite) | Cross-session preferences, VIPs, correction patterns (v0.20.0 MemoryStore) |
 | RAG index | `~/.gaia/rag/email_index/` | Optional — message bodies + attachments indexed for semantic search |
 | MCP state | `~/.gaia/mcp_servers.json` | Server configs (tokens moved to vault in C2) |
@@ -2146,7 +2146,7 @@ gaia email slack-test                     # Send a test message to verify delive
 ## 20. OpenAI-Compatible API Surface (C2)
 
 Exposed via `ApiAgent` mixin. All endpoints localhost-only by default
-([Security Model](security-model.mdx) §3.1).
+([Security Model](/plans/security-model) §3.1).
 
 ```
 POST /v1/email/triage                { dry_run: bool, cohorts: [...] }
@@ -2287,7 +2287,7 @@ were merged; if any do merge, the MVT workarounds get simpler accordingly.
 | [#676](https://github.com/amd/gaia/issues/676) | `Shared memory database with per-agent namespaces for multi-agent architecture` | If we adopt namespaces, the email ledger becomes one namespace in a shared DB rather than a standalone SQLite file. Cleaner long-term. |
 | [#700](https://github.com/amd/gaia/issues/700) | `Meeting notes capture with speaker diarization` | Synergistic with meeting-prep assembly (§17.2 item 16). |
 | [#704](https://github.com/amd/gaia/issues/704) | `Personal CRM with AI-managed contact profiles and per-person tone matching` | Feeds per-relationship writing voice (§17.2 item 8). |
-| [#690](https://github.com/amd/gaia/issues/690) | `Messaging security: restricted default tool set and input sanitization` | Applies to our Slack bidirectional path (§12.20 C1) — Slack DMs are untrusted input per [Security Model](security-model.mdx) §12. |
+| [#690](https://github.com/amd/gaia/issues/690) | `Messaging security: restricted default tool set and input sanitization` | Applies to our Slack bidirectional path (§12.20 C1) — Slack DMs are untrusted input per [Security Model](/plans/security-model) §12. |
 | [#689](https://github.com/amd/gaia/issues/689) | `Messaging adapter rate limiting infrastructure` | Applies to §12.20 C2 interactive approval flow (Slack rate limits). |
 
 #### 22.4.4 Conflict: Two Memory PRs in Flight
@@ -2377,7 +2377,7 @@ C1 Polish.
 | 10 | Auto-unsubscribe: body-link click (via browser) or RFC 8058 one-click only? | 8058 only / both | 8058 only (body-click is prompt-injection risk) |
 | 11 | Should auto-discovery include reading Chrome/Edge cookies to detect Gmail sessions? | Yes / No / opt-in | Opt-in — requires user acknowledgment; privacy-sensitive signal |
 | 12 | Should the agent ask before the weekly re-discovery heartbeat? | Always / first time / never | First time only (with "don't ask again") |
-| 13 | Which error states get toast vs banner vs modal? | Ad-hoc / systematic | Systematic — use the [Agent UI](agent-ui.mdx) pattern library; documented in §12.12 |
+| 13 | Which error states get toast vs banner vs modal? | Ad-hoc / systematic | Systematic — use the [Agent UI](/plans/agent-ui) pattern library; documented in §12.12 |
 | 14 | How aggressive is default cohort policy on first run? (C2 — L3+ only exists in C2) | Conservative (all L2) / balanced (defaults per §4.2) / aggressive | Balanced per §4.2 in C2 — and the first scheduled triage run's archived items are all surfaced in the next morning brief so the user sees what was archived before it disappears. C1 is capped at L2 so this only applies in C2. |
 | 15 | Which Slack MCP server for C1 Polish? | `@modelcontextprotocol/server-slack` (reference) / active community alternative / in-tree build | Use Anthropic's reference server first; evaluate community forks if scope grows. Decision at C1 implementation plan stage. |
 | 16 | Slack brief content: full bodies or sender+summary redacted? | Full / redacted default with user opt-in to include bodies | **Redacted default** — Slack workspace admins may see messages; bodies stay on-device. User can opt into full-body delivery per-channel. |
@@ -2564,14 +2564,14 @@ Choices the spec implies but does not resolve:
 ## 28. References
 
 **GAIA documents:**
-- [Email & Calendar Integration](email-calendar-integration.mdx) (parent plan)
-- [Autonomy Engine](autonomy-engine.mdx)
-- [Security Model](security-model.mdx)
-- [Agent UI](agent-ui.mdx)
-- [Messaging Integrations](messaging-integrations-plan.mdx)
-- [Setup Wizard](setup-wizard.mdx)
-- [Agent System SDK](../sdk/core/agent-system.mdx)
-- [MCP Client SDK](../sdk/infrastructure/mcp.mdx)
+- [Email & Calendar Integration](/plans/email-calendar-integration) (parent plan)
+- [Autonomy Engine](/plans/autonomy-engine)
+- [Security Model](/plans/security-model)
+- [Agent UI](/plans/agent-ui)
+- [Messaging Integrations](/plans/messaging-integrations-plan)
+- [Setup Wizard](/plans/setup-wizard)
+- [Agent System SDK](/sdk/core/agent-system)
+- [MCP Client SDK](/sdk/infrastructure/mcp)
 
 **Commercial products (feature references):**
 - [Superhuman Mail AI](https://superhuman.com/products/mail/ai) — Split Inbox, Auto Labels, Auto Drafts, Ask AI

--- a/docs/plans/image-agent.mdx
+++ b/docs/plans/image-agent.mdx
@@ -50,7 +50,7 @@ An AI agent that helps users generate better Stable Diffusion images through int
 ### High-Level Overview
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'14px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph TD
     subgraph UI["User Interface"]
         CLI("CLI<br/><i>gaia sd ...</i>")

--- a/docs/plans/mcp-docs.mdx
+++ b/docs/plans/mcp-docs.mdx
@@ -194,7 +194,7 @@ List available GAIA components with descriptions.
 ## Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'16px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph TD
     A["AI Assistant<br/>(Claude, Cursor, etc.)"] -->|MCP Protocol| B["GAIA MCP Docs Server"]
     B --> C["Doc Index<br/>(Embedded)"]
@@ -302,7 +302,6 @@ gaia mcp docs clear-cache
 ### On First Run
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'16px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
 sequenceDiagram
     participant User
     participant CLI
@@ -322,7 +321,6 @@ sequenceDiagram
 ### On Query
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'16px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
 sequenceDiagram
     participant AI as AI Assistant
     participant MCP as MCP Server

--- a/docs/plans/messaging-integrations-plan.mdx
+++ b/docs/plans/messaging-integrations-plan.mdx
@@ -15,12 +15,12 @@ icon: "comments"
 > **Prerequisites:**
 > - Memory system (v0.20.0)
 > - Autonomy engine (v0.23.0 — ships alongside messaging)
-> - Agent UI foundations -- see [agent-ui.mdx](agent-ui.mdx)
+> - Agent UI foundations -- see [agent-ui.mdx](/plans/agent-ui)
 >
 > **Related plans:**
-> - [Agent UI](agent-ui.mdx) -- Settings UI, conversation history
-> - [Autonomy Engine](autonomy-engine.mdx) -- Background service, heartbeat
-> - [Security Model](security-model.mdx) -- Messaging security, tool restrictions
+> - [Agent UI](/plans/agent-ui) -- Settings UI, conversation history
+> - [Autonomy Engine](/plans/autonomy-engine) -- Background service, heartbeat
+> - [Security Model](/plans/security-model) -- Messaging security, tool restrictions
 
 ---
 
@@ -235,7 +235,7 @@ restrictive by default.
 - **Restricted default tool set.** Messaging users get read-only tools (RAG
   queries, document search, summarization) by default. File I/O and shell tools
   require explicit opt-in via configuration. See
-  [security-model.mdx](security-model.mdx) for the full tool classification and
+  [security-model.mdx](/plans/security-model) for the full tool classification and
   trust-level definitions.
 
 - **Allow-listing.** Adapters support allow-lists for guilds, channels, and
@@ -244,7 +244,7 @@ restrictive by default.
 
 - **Rate limiting.** Per-user, per-channel, and global rate limits. Defaults:
   10 RPM per user, 30 RPM per channel, 100 RPM global. See
-  [security-model.mdx](security-model.mdx) for rate limiting design.
+  [security-model.mdx](/plans/security-model) for rate limiting design.
 
 - **Input sanitization.** Strip platform formatting before passing to agents.
   Limit message length. Guard against prompt injection via messaging.
@@ -262,7 +262,7 @@ restrictive by default.
 ## 8. UI Integration
 
 The Electron UI integrates with messaging in three ways. See
-[agent-ui.mdx](agent-ui.mdx) for the broader UI framework.
+[agent-ui.mdx](/plans/agent-ui) for the broader UI framework.
 
 **Settings panel.** A "Messaging" section in Settings (following the same pattern
 as MCP Server settings) with per-platform enable/disable toggles, token

--- a/docs/plans/oem-bundling.mdx
+++ b/docs/plans/oem-bundling.mdx
@@ -21,9 +21,9 @@ icon: "box"
 > - [#615](https://github.com/amd/gaia/issues/615) -- App Store and Distribution Channel Packaging
 >
 > **Related Plans:**
-> - [desktop-installer.mdx](desktop-installer.mdx) -- NSIS desktop installer + bundled Lemonade MSI
-> - [agent-hub.mdx](agent-hub.mdx) -- Agent registry and marketplace
-> - [Agent UI](agent-ui.mdx) -- Phases A-D overview
+> - [desktop-installer](/plans/desktop-installer) -- NSIS desktop installer + bundled Lemonade MSI
+> - [agent-hub](/plans/agent-hub) -- Agent registry and marketplace
+> - [Agent UI](/plans/agent-ui) -- Phases A-D overview
 
 ---
 

--- a/docs/plans/security-model.mdx
+++ b/docs/plans/security-model.mdx
@@ -570,7 +570,7 @@ Dangerous mode CANNOT be:
 **Prerequisites for #647 (skill marketplace).**
 
 The SKILL.md format specification, permission model, security tiers, and sandboxing
-architecture are defined in [skill-format.mdx](skill-format.mdx) — the canonical
+architecture are defined in [skill-format.mdx](/plans/skill-format) — the canonical
 reference for all skill/plugin security. Key security properties:
 
 - Skills declare permissions in YAML frontmatter using domain-scoped syntax

--- a/docs/playbooks/chat-agent/part-1-getting-started.mdx
+++ b/docs/playbooks/chat-agent/part-1-getting-started.mdx
@@ -5,7 +5,7 @@ icon: "book-open-reader"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/chat/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/chat/sdk.py) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py)
+  **Source Code:** [`hub/agents/python/chat/gaia_agent_chat/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/chat/gaia_agent_chat/agent.py) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py)
 </Info>
 
 <Badge text="development" color="orange" />
@@ -48,7 +48,7 @@ A chat agent that combines:
 ## The Architecture (What You're Building)
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph TD
     A(["ChatAgent"]) --> B(["Agent Base"])
     A --> C(["Tool Mixins"])
@@ -99,11 +99,11 @@ Get a working agent running to understand the basic flow.
         cd my-chat-agent
         uv venv .venv
         source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
-        uv pip install "amd-gaia[rag]"
+        uv pip install "amd-gaia[agent-chat,rag]"
         ```
 
         <Info>
-        This is the recommended path for most users. You'll create your agent scripts in this folder.
+        This is the recommended path for most users. You'll create your agent scripts in this folder. The `agent-chat` extra pulls in the standalone `gaia-agent-chat` wheel that provides `ChatAgent`; `rag` adds the document-processing dependencies (faiss, PyMuPDF).
         </Info>
       </Tab>
 
@@ -116,10 +116,11 @@ Get a working agent running to understand the basic flow.
         uv venv .venv
         source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
         uv pip install -e ".[rag]"
+        uv pip install -e hub/agents/python/chat   # ChatAgent ships as a separate hub wheel
         ```
 
         <Info>
-        Use this path if you want to modify GAIA source code or contribute to the project.
+        Use this path if you want to modify GAIA source code or contribute to the project. `ChatAgent` lives in the standalone `gaia-agent-chat` package under `hub/agents/python/chat/`, so install it as a second editable wheel.
         </Info>
       </Tab>
     </Tabs>
@@ -203,7 +204,7 @@ Before we build step-by-step, let's understand what each piece does **under the 
 **Processing flow when you call `process_query()`:**
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A(["User Query"]) --> B(["Agent receives query"])
     B --> C{"Select tool or answer"}
@@ -312,7 +313,7 @@ flowchart TD
 **RAG pipeline:**
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A(["PDF Document"]) --> B(["Extract Text"])
     B --> C(["Split into Chunks"])

--- a/docs/playbooks/chat-agent/part-2-advanced-features.mdx
+++ b/docs/playbooks/chat-agent/part-2-advanced-features.mdx
@@ -5,7 +5,7 @@ icon: "wrench"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/chat/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/chat/sdk.py) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py)
+  **Source Code:** [`hub/agents/python/chat/gaia_agent_chat/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/chat/gaia_agent_chat/agent.py) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py)
 </Info>
 
 <Badge text="development" color="orange" />
@@ -33,6 +33,7 @@ from gaia.agents.base.console import AgentConsole
 from gaia.agents.tools import RAGToolsMixin, FileToolsMixin
 from gaia.agents.tools import FileSearchToolsMixin
 from gaia.rag.sdk import RAGSDK, RAGConfig
+from pathlib import Path
 
 class FullFeaturedAgent(
     Agent,
@@ -534,14 +535,15 @@ Extend the agent by adding domain-specific tools.
         allowed_paths=[
             "/home/user/work",
             "/home/user/research"
-        ],
-
-        # Embedding model
-        embedding_model="user.embeddinggemma-300m-GGUF"
+        ]
     )
 
     agent = ChatAgent(config)
     ```
+
+    <Note>
+    `ChatAgentConfig` does not take an `embedding_model` field — the embedding model is selected automatically based on your device (EmbeddingGemma 300M on Ryzen AI). To override it, construct a `RAGSDK` with a custom `RAGConfig(embedding_model=...)` directly.
+    </Note>
   </Tab>
 
   <Tab title="Trade-offs">

--- a/docs/playbooks/chat-agent/part-3-deployment.mdx
+++ b/docs/playbooks/chat-agent/part-3-deployment.mdx
@@ -5,7 +5,7 @@ icon: "graduation-cap"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/chat/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/chat/sdk.py) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py)
+  **Source Code:** [`hub/agents/python/chat/gaia_agent_chat/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/chat/gaia_agent_chat/agent.py) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py)
 </Info>
 
 <Badge text="development" color="orange" />
@@ -146,17 +146,18 @@ def _generate_search_keys(self, query: str) -> List[str]:
   <Tab title="Implementation">
     The `query_documents` tool searches across ALL indexed documents by default. The LLM receives chunks from multiple sources and synthesizes them.
 
-    For more control, call the RAG SDK directly (tools are also callable via
-    `agent.rag.*` — there is no public `agent.execute_tool()` on the base
-    `Agent` class):
+    For more control, call the RAG SDK directly via `agent.rag` (there is no
+    public `agent.execute_tool()` on the base `Agent` class):
 
     ```python
-    # Query a specific file via RAGSDK
-    response = agent.rag.query(
-        "safety protocols",
-        target_file="oil-manual.pdf",
-    )
+    # Query across all indexed documents
+    response = agent.rag.query("safety protocols")
+    print(response.text, response.source_files)
     ```
+
+    To target a single file, use the `query_specific_file` tool the agent
+    already exposes (`file_path` + `query`) rather than `agent.rag.query()`,
+    which searches every indexed document.
   </Tab>
 </Tabs>
 
@@ -358,7 +359,8 @@ def _generate_search_keys(self, query: str) -> List[str]:
     [project]
     name = "doc-qa-agent"
     version = "1.0.0"
-    dependencies = ["amd-gaia>=0.14.0"]
+    # gaia-agent-chat provides ChatAgent and depends on amd-gaia
+    dependencies = ["gaia-agent-chat"]
 
     [project.scripts]
     doc-qa = "my_agent.cli:main"
@@ -557,13 +559,16 @@ def _generate_search_keys(self, query: str) -> List[str]:
 
   <Tab title="Memory Management">
     ```python
-    # Limit indexed files
-    config = ChatAgentConfig(
+    # Index/file-size caps live on RAGConfig (used by the RAG SDK), not on
+    # ChatAgentConfig. Build a RAGSDK directly to tune them:
+    from gaia.rag.sdk import RAGSDK, RAGConfig
+
+    rag = RAGSDK(RAGConfig(
         max_indexed_files=100,   # Cap at 100 files
         max_file_size_mb=50      # Skip files > 50MB
-    )
+    ))
 
-    # Manual cleanup
+    # Manual cleanup on a running ChatAgent
     agent.rag.clear_cache()      # Clear cached embeddings/index
     agent.stop_watching()        # Stop file observers
     ```

--- a/docs/playbooks/code-agent/part-1-introduction.mdx
+++ b/docs/playbooks/code-agent/part-1-introduction.mdx
@@ -5,7 +5,7 @@ icon: "code"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/)
+  **Source Code:** [`hub/agents/python/code/`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/)
 </Info>
 
 <Info>
@@ -68,7 +68,7 @@ gaia-code "Build me a movie tracking app in nextjs where I can track the movie t
 ## System Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A["User Prompt"] --> B(["Code Agent"])
     B --> C["LLM Analysis"]
@@ -201,7 +201,7 @@ GAIA Code uses a **Minimum Viable Product (MVP) approach** when generating appli
 GAIA Code generates applications using modern web technologies:
 
 ### Frontend
-- **Next.js 14** with App Router
+- **Next.js 15** with App Router
 - **React** for UI components
 - **TypeScript** for type safety
 - **Tailwind CSS** for styling
@@ -305,11 +305,11 @@ Let's see GAIA Code in action:
         cd my-code-agent
         uv venv .venv
         source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
-        uv pip install "amd-gaia[dev]"
+        uv pip install "amd-gaia[agent-code]"
         ```
 
         <Info>
-        This is the recommended path for most users. The `gaia-code` command will be available after installation.
+        This is the recommended path for most users. The `agent-code` extra pulls in the standalone `gaia-agent-code` wheel, which provides the `gaia-code` command. (`gaia-code` is *not* a `gaia` subcommand — it ships as its own console script.)
         </Info>
       </Tab>
 
@@ -322,10 +322,11 @@ Let's see GAIA Code in action:
         uv venv .venv
         source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
         uv pip install -e ".[dev]"
+        uv pip install -e hub/agents/python/code   # provides the gaia-code command
         ```
 
         <Info>
-        Use this path if you want to modify GAIA source code or contribute to the project.
+        Use this path if you want to modify GAIA source code or contribute to the project. The Code agent lives in the standalone `gaia-agent-code` package under `hub/agents/python/code/`, so install it as a second editable wheel to get the `gaia-code` command.
         </Info>
       </Tab>
     </Tabs>

--- a/docs/playbooks/code-agent/part-2-app-creation.mdx
+++ b/docs/playbooks/code-agent/part-2-app-creation.mdx
@@ -5,7 +5,7 @@ icon: "puzzle-piece"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/)
+  **Source Code:** [`hub/agents/python/code/`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/)
 </Info>
 
 <Note>
@@ -40,7 +40,7 @@ The agent's first task is creating the database schema via Prisma.
 ### How Schema Generation Works
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart LR
     A["User Prompt"] --> B(["LLM Analysis"])
     B --> C["Extract Fields"]

--- a/docs/playbooks/code-agent/part-3-validation-building.mdx
+++ b/docs/playbooks/code-agent/part-3-validation-building.mdx
@@ -5,7 +5,7 @@ icon: "hammer"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/)
+  **Source Code:** [`hub/agents/python/code/`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/)
 </Info>
 
 <Note>
@@ -25,7 +25,7 @@ icon: "hammer"
 After generating code, GAIA Code doesn't just stop—it validates, builds, and fixes errors automatically until the application works.
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A["Generated Code"] --> B["TypeScript Validation"]
     B --> C{Type Errors?}

--- a/docs/playbooks/emr-agent/part-1-getting-started.mdx
+++ b/docs/playbooks/emr-agent/part-1-getting-started.mdx
@@ -34,7 +34,7 @@ Medical staff spend hours manually entering intake form data. This agent automat
 ## The Architecture (What You're Building)
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph TD
     A(["MedicalIntakeAgent"]) --> B(["Agent Base"])
     A --> C(["FileWatcherMixin"])
@@ -61,7 +61,7 @@ graph TD
 **Flow:**
 1. New form dropped in watched folder
 2. FileWatcherMixin triggers callback → `_on_file_created()`
-3. VLM extracts patient data (Qwen3-VL GGUF runs on the iGPU via llama.cpp/Vulkan)
+3. VLM extracts patient data (Gemma-4-E4B-it GGUF runs on the iGPU via llama.cpp/Vulkan)
 4. JSON parsed and validated
 5. DatabaseMixin stores structured record in SQLite
 6. Agent can now query patients via natural language
@@ -85,10 +85,10 @@ Get a working intake agent running to understand the basic flow.
         cd my-emr-agent
         uv venv .venv
         source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
-        uv pip install "amd-gaia[api,rag]"
+        uv pip install "amd-gaia[agent-emr,api,rag]"
         ```
 
-        The `api` extra provides FastAPI/uvicorn for the web dashboard. The `rag` extra provides PyMuPDF for PDF processing.
+        The `agent-emr` extra installs the standalone `gaia-agent-emr` package (which provides `gaia_agent_emr` and the `gaia-emr` command). The `api` extra provides FastAPI/uvicorn for the web dashboard. The `rag` extra provides PyMuPDF for PDF processing.
 
         <Info>
         This is the recommended path for most users. You'll create your agent scripts in this folder.
@@ -104,7 +104,10 @@ Get a working intake agent running to understand the basic flow.
         uv venv .venv
         source .venv/bin/activate  # On Windows: .\.venv\Scripts\Activate.ps1
         uv pip install -e ".[api,rag]"
+        uv pip install -e hub/agents/python/emr
         ```
+
+        The EMR agent ships as a standalone hub package, so install it separately (the second command) to make `gaia_agent_emr` and the `gaia-emr` command available.
 
         <Info>
         Use this path if you want to modify GAIA source code or contribute to the project.
@@ -120,7 +123,7 @@ Get a working intake agent running to understand the basic flow.
     ```
 
     <Info>
-    The VLM model (Qwen3-VL-4B-Instruct-GGUF) will be downloaded automatically on first use. This may take time depending on your connection.
+    The VLM model (Gemma-4-E4B-it-GGUF) will be downloaded automatically on first use. This may take time depending on your connection.
     </Info>
   </Step>
 
@@ -197,7 +200,7 @@ self.insert("patients", {"first_name": "John", "last_name": "Smith"})
 results = self.query("SELECT * FROM patients WHERE last_name = :name", {"name": "Smith"})
 
 # VLMClient - image to structured data
-vlm = VLMClient(vlm_model="Qwen3-VL-4B-Instruct-GGUF")
+vlm = VLMClient(vlm_model="Gemma-4-E4B-it-GGUF")
 json_str = vlm.extract_from_image(image_bytes, prompt="Extract as JSON: {first_name, last_name}")
 ```
 
@@ -315,7 +318,7 @@ Add VLM to extract patient data from images.
         def _get_vlm(self):
             """Lazy VLM initialization."""
             if self._vlm is None:
-                self._vlm = VLMClient(vlm_model="Qwen3-VL-4B-Instruct-GGUF")
+                self._vlm = VLMClient(vlm_model="Gemma-4-E4B-it-GGUF")
             return self._vlm
 
         def _register_tools(self):
@@ -368,7 +371,7 @@ Add VLM to extract patient data from images.
 process_intake_form("patient1.jpg")
   → Read image file as bytes
   → Send to VLM with extraction prompt
-  → VLM processes image (Qwen3-VL GGUF runs on the iGPU via llama.cpp/Vulkan)
+  → VLM processes image (Gemma-4-E4B-it GGUF runs on the iGPU via llama.cpp/Vulkan)
   → Returns JSON string: {"first_name": "John", ...}
   → Parse JSON to dict
   → Insert into database

--- a/docs/playbooks/emr-agent/part-2-dashboard.mdx
+++ b/docs/playbooks/emr-agent/part-2-dashboard.mdx
@@ -37,7 +37,7 @@ The CLI is great for developers, but healthcare staff need a visual interface. T
 ## Dashboard Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TB
     A[/"React Frontend"/]
     B(["FastAPI Server"])
@@ -375,6 +375,7 @@ curl -X DELETE "http://localhost:8080/api/database"
   "watching_directory": "./intake_forms",
   "uptime_seconds": 3600
 }
+```
 
 ---
 

--- a/docs/playbooks/emr-agent/part-3-architecture.mdx
+++ b/docs/playbooks/emr-agent/part-3-architecture.mdx
@@ -27,7 +27,7 @@ icon: "sitemap"
 ## System Architecture
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A[/"Intake Form"/] --> B(["FileWatcher"])
     B --> C(["VLM Extraction"])
@@ -50,7 +50,7 @@ flowchart TD
 | Component | Technology | Purpose |
 |-----------|------------|---------|
 | **FileWatcher** | watchdog library | Monitors directory for new intake forms |
-| **VLM Extraction** | Qwen3-VL on iGPU (Vulkan) | Extracts patient data from images/PDFs |
+| **VLM Extraction** | Gemma-4-E4B-it on iGPU (Vulkan) | Extracts patient data from images/PDFs |
 | **SQLite DB** | sqlite3 | Local storage for patients, alerts, sessions |
 | **FastAPI Server** | FastAPI + uvicorn | REST API + SSE events for real-time updates |
 | **React Dashboard** | React + Vite | Four views: Dashboard, Patients, Chat, Settings |
@@ -182,7 +182,7 @@ The agent follows a 7-step pipeline from file detection to database storage.
   </Step>
 
   <Step title="VLM Extraction">
-    **Model:** Qwen3-VL-4B-Instruct (GGUF) running on the iGPU via llama.cpp/Vulkan
+    **Model:** Gemma-4-E4B-it-GGUF running on the iGPU via llama.cpp/Vulkan
 
     ```python
     EXTRACTION_PROMPT = """Extract patient data from this medical intake form.
@@ -197,7 +197,7 @@ The agent follows a 7-step pipeline from file detection to database storage.
     Use empty string "" for fields not found on the form."""
     ```
 
-    **Why Qwen3-VL?** Best performance for document understanding on AMD hardware.
+    **Why Gemma-4-E4B-it?** A compact multimodal model that runs efficiently on AMD hardware and is the default VLM for GAIA's document-understanding agents.
   </Step>
 
   <Step title="JSON Parsing">
@@ -429,7 +429,7 @@ A form with 15 fields and ~300 characters:
 The Medical Intake Agent combines three GAIA mixins.
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 classDiagram
     class Agent {
         +process_query()

--- a/docs/playbooks/hardware-advisor/index.mdx
+++ b/docs/playbooks/hardware-advisor/index.mdx
@@ -44,7 +44,7 @@ A hardware advisor agent that combines:
 ## The Architecture (What You're Building)
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'edgeLabelBackground':'#ffffff', 'fontFamily':'system-ui, -apple-system, sans-serif'}}}%%
 graph TD
     A(["HardwareAdvisorAgent"]) --> B(["Agent Base"])
     A --> C(["LemonadeClient"])
@@ -1065,7 +1065,7 @@ get_hardware_info()
       → Returns: {"name": "AMD Radeon...", "memory_mb": 24576}
 
   → Detect NPU
-      → Query devices.npu from Lemonade response
+      → Query devices.amd_npu from Lemonade response
       → Check availability flag
       → Returns: {"name": "Ryzen AI NPU", "available": True}
 ```

--- a/docs/playbooks/index.mdx
+++ b/docs/playbooks/index.mdx
@@ -5,7 +5,7 @@ icon: "book-atlas"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/chat/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/chat/sdk.py) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py) | [`hub/agents/python/emr/`](https://github.com/amd/gaia/blob/main/hub/agents/python/emr/) | [`examples/hardware_advisor_agent.py`](https://github.com/amd/gaia/blob/main/examples/hardware_advisor_agent.py)
+  **Source Code:** [`hub/agents/python/chat/`](https://github.com/amd/gaia/blob/main/hub/agents/python/chat/) | [`hub/agents/python/code/`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/) | [`src/gaia/rag/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/rag/sdk.py) | [`hub/agents/python/emr/`](https://github.com/amd/gaia/blob/main/hub/agents/python/emr/) | [`examples/hardware_advisor_agent.py`](https://github.com/amd/gaia/blob/main/examples/hardware_advisor_agent.py)
 </Info>
 
 <Badge text="development" color="orange" />

--- a/docs/playbooks/sd-agent/index.mdx
+++ b/docs/playbooks/sd-agent/index.mdx
@@ -5,7 +5,7 @@ icon: "image"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/sd/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/sd/agent.py)
+  **Source Code:** [`hub/agents/python/sd/gaia_agent_sd/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/sd/gaia_agent_sd/agent.py)
 </Info>
 
 <Badge text="development" color="orange" />
@@ -40,6 +40,11 @@ By the end, you'll have a working multi-modal agent in ~60 lines of code and und
 
 Want to try it first before building?
 
+Install GAIA with the built-in SD agent (`gaia sd` ships in the standalone `gaia-agent-sd` package):
+```bash
+uv pip install "amd-gaia[agent-sd]"
+```
+
 Install models and start Lemonade Server:
 ```bash
 gaia init --profile sd
@@ -58,19 +63,18 @@ An `ImageStoryAgent` that generates images and creates stories about them. ~60 l
 
 When you run `agent.process_query("create a robot exploring ancient ruins")`, here's what happens:
 
-1. **LLM decides the plan**: Qwen3-8B analyzes your query and returns `{plan: [{tool: "generate_image", tool_args: {prompt: "..."}}, {tool: "create_story_from_image", tool_args: {...}}]}`
+1. **LLM decides the plan**: Gemma-4-E4B-it analyzes your query and returns `{plan: [{tool: "generate_image", tool_args: {prompt: "..."}}, {tool: "create_story_from_image", tool_args: {...}}]}`
 2. **Executes generate_image()**: Sends prompt to SDXL-Turbo (4-step diffusion model), receives PNG bytes, saves to disk (~17s)
-3. **Executes create_story_from_image()**: Calls your custom tool → sends image bytes to Qwen3-VL-4B vision model → receives 2-3 paragraph narrative (~15s)
+3. **Executes create_story_from_image()**: Calls your custom tool → sends image bytes to the Gemma-4-E4B-it vision model → receives 2-3 paragraph narrative (~15s)
 4. **Returns result**: `{"status": "success", "result": "Here's your image and story...", "conversation": [...], "steps_taken": 3}`
 
 You'll create the `create_story_from_image` tool yourself using VLM capabilities.
 
-**Three models, one agent:**
-- **Qwen3-8B-GGUF** (5GB): Reasoning engine - decides which tools to call and when
+**Two models, one agent:**
+- **Gemma-4-E4B-it-GGUF** (~3GB): Multimodal model — serves as both the reasoning engine (decides which tools to call and when) and the vision-language model (analyzes images and generates text)
 - **SDXL-Turbo** (6.5GB): Diffusion model - generates images from text prompts
-- **Qwen3-VL-4B** (3.2GB): Vision-language model - analyzes images and generates text
 
-All run locally via Lemonade Server. GGUF models use AMD Radeon iGPU (Vulkan), SDXL runs on CPU.
+All run locally via Lemonade Server. The GGUF model uses AMD Radeon iGPU (Vulkan); SDXL runs on CPU.
 
 ---
 
@@ -113,8 +117,10 @@ All run locally via Lemonade Server. GGUF models use AMD Radeon iGPU (Vulkan), S
 
   <Step title="Install GAIA">
     ```bash
-    uv pip install amd-gaia
+    uv pip install "amd-gaia[agent-sd]"
     ```
+
+    The custom agent you build below only needs the `gaia.sd` and `gaia.vlm` mixins from core `amd-gaia`. The `agent-sd` extra additionally installs the standalone `gaia-agent-sd` package so the built-in `gaia sd` command (used in the Quick Test and Troubleshooting) is available too.
   </Step>
 
   <Step title="Initialize SD profile">
@@ -126,10 +132,9 @@ All run locally via Lemonade Server. GGUF models use AMD Radeon iGPU (Vulkan), S
     1. Installs Lemonade Server (if not already installed)
     2. **Starts Lemonade Server automatically**
     3. **Configures Lemonade Server with 16K context** (required for SD agent multi-step planning)
-    4. Downloads three models (~15GB):
+    4. Downloads two models (~10GB):
        - **SDXL-Turbo** (6.5GB) - Diffusion model in safetensors format
-       - **Qwen3-8B-GGUF** (5GB) - Agent LLM in quantized GGUF format (loaded with 16K context)
-       - **Qwen3-VL-4B-Instruct-GGUF** (3.2GB) - Vision LLM in quantized GGUF format
+       - **Gemma-4-E4B-it-GGUF** (~3GB) - Multimodal GGUF model used for both agentic reasoning and vision (loaded with 16K context)
     5. Verifies models and context size
 
     **Hardware acceleration:**
@@ -162,14 +167,14 @@ class ImageStoryAgent(Agent, SDToolsMixin, VLMToolsMixin):
     """Agent that generates images and creates stories."""
 
     def __init__(self, output_dir="./generated_images"):
-        super().__init__(model_id="Qwen3-8B-GGUF")
+        super().__init__(model_id="Gemma-4-E4B-it-GGUF")
         self.init_sd(output_dir=output_dir, default_model="SDXL-Turbo")
-        self.init_vlm(model="Qwen3-VL-4B-Instruct-GGUF")
+        self.init_vlm(model="Gemma-4-E4B-it-GGUF")
 ```
 
 **What this does:**
 - `Agent, SDToolsMixin, VLMToolsMixin`: Inherits three capabilities - reasoning, image generation, vision analysis
-- `super().__init__(model_id="Qwen3-8B-GGUF")`: Sets up the reasoning LLM (downloaded by `gaia init --profile sd`)
+- `super().__init__(model_id="Gemma-4-E4B-it-GGUF")`: Sets up the multimodal reasoning LLM (downloaded by `gaia init --profile sd`)
 - `init_sd()`: Registers image generation tools (`generate_image`, `list_sd_models`, `get_generation_history`)
 - `init_vlm()`: Registers vision tools (`analyze_image`, `answer_question_about_image`)
 
@@ -208,7 +213,7 @@ The agent now has 5 tools from mixins. You'll add a 6th custom tool next.
     ```python
     analyze_image(image_path: str, focus: str = "all") -> dict
     ```
-    - Sends image bytes to Qwen3-VL-4B vision model
+    - Sends image bytes to the Gemma-4-E4B-it vision model
     - Returns: `{"status": "success", "description": "...", "focus_analysis": "..."}`
 
     ```python
@@ -279,7 +284,7 @@ Add `_register_tools()` to create `create_story_from_image`:
   - Non-atomic: multi-step tasks like "research a topic"
 - Reads image bytes from file path
 - Builds a storytelling prompt based on the style parameter
-- Calls `self.vlm_client.extract_from_image()` - sends image + prompt to Qwen3-VL-4B vision model
+- Calls `self.vlm_client.extract_from_image()` - sends image + prompt to the Gemma-4-E4B-it vision model
 - Returns structured dict with story text and metadata
 - Decorator auto-generates JSON schema from function signature and docstring
 
@@ -359,7 +364,7 @@ if __name__ == "__main__":
 <Accordion title="How the CLI works">
 
 **Quick summary:**
-- Creates output directory and initializes agent (loads Qwen3-8B, registers 6 tools)
+- Creates output directory and initializes agent (loads Gemma-4-E4B-it, registers 6 tools)
 - Loops: reads input → calls `process_query(input)` → prints result
 - `process_query()` handles LLM planning and tool execution automatically
 
@@ -368,7 +373,7 @@ if __name__ == "__main__":
 
 **Step 1 - LLM Planning:**
 ```python
-# Agent sends to Qwen3-8B
+# Agent sends to Gemma-4-E4B-it
 {
   "messages": [{"role": "user", "content": "create a robot exploring ruins"}],
   "tools": [
@@ -459,7 +464,7 @@ You: make a cyberpunk street scene and tell me a story
     **Solution:** Download missing models:
     ```bash
     lemonade-server pull SDXL-Turbo
-    lemonade-server pull Qwen3-VL-4B-Instruct-GGUF
+    lemonade-server pull Gemma-4-E4B-it-GGUF
     ```
 
     Or re-run init:

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -154,7 +154,7 @@ gaia init [OPTIONS]
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--profile, -p` | string | chat | Profile to initialize (minimal, sd, chat, code, rag, vlm, npu, all) |
+| `--profile, -p` | string | chat | Profile to initialize (minimal, sd, chat, code, rag, mcp, vlm, email, npu, all) |
 | `--minimal` | flag | false | Shortcut for `--profile minimal` |
 | `--skip-models` | flag | false | Skip model downloads (only install Lemonade) |
 | `--skip-lemonade` | flag | false | Skip Lemonade installation check (for CI with pre-installed Lemonade) |
@@ -177,8 +177,10 @@ canonical choices list):
 | `chat` | Gemma-4-E4B-it-GGUF, user.embeddinggemma-300m-GGUF | Interactive chat with RAG and vision support | ~4 GB |
 | `code` | Gemma-4-E4B-it-GGUF | Autonomous coding assistant | ~3 GB |
 | `rag` | Gemma-4-E4B-it-GGUF, user.embeddinggemma-300m-GGUF | Document Q&A with retrieval | ~4 GB |
+| `mcp` | _(none)_ | Sets up the MCP servers config (`~/.gaia/mcp_servers.json`) — no Lemonade install or model downloads | – |
 | `vlm` | Gemma-4-E4B-it-GGUF | Vision pipeline for document and image extraction | ~3 GB |
-| `npu` | gemma4-it-e2b-FLM | Ryzen AI NPU acceleration via FLM backend (requires XDNA2 NPU) | ~3 GB |
+| `email` | Gemma-4-E4B-it-GGUF | Gmail/Outlook triage with local inference | ~3 GB |
+| `npu` | gemma4-it-e2b-FLM, embed-gemma-300m-FLM | Ryzen AI NPU acceleration via FLM backend (requires XDNA2 NPU) | ~3 GB |
 | `all` | All models | All models for all agents | ~26 GB |
 
 <Note>
@@ -673,6 +675,8 @@ gaia chat [MESSAGE] [OPTIONS]
 | `--max-chunks` | integer | 3 | Maximum chunks to retrieve for RAG |
 | `--max-indexed-files` | integer | 100 | Maximum number of files to keep indexed. Evicts least-recently-accessed files when LRU eviction is enabled; rejects new files when disabled. |
 | `--max-total-chunks` | integer | 10000 | Maximum total chunks across all indexed files. Same eviction behavior as `--max-indexed-files`. |
+| `--device` | `cpu`\|`gpu`\|`npu` | gpu | Inference device — selects the model and backend for this session |
+| `--mcp-tool-limit` | integer | 50 | Maximum MCP tools to register. Larger tool sets bloat the system prompt and degrade small-model tool-calling accuracy — keep as low as your workflow allows |
 | `--allowed-paths` | path(s) | - | Restrict RAG/file tools to these directories (security sandbox) |
 | `--stats`, `--show-stats` | flag | false | Show performance statistics |
 | `--stream` | flag | false | Enable streaming responses |
@@ -801,6 +805,8 @@ gaia prompt "MESSAGE" [OPTIONS]
 |--------|------|---------|-------------|
 | `--model` | string | auto | Model ID to use (default: auto-selected by each agent). Falls back to `default_model` from config — see [Configuration](#configuration) |
 | `--max-tokens` | integer | 512 | Maximum tokens to generate |
+| `--device` | `cpu`\|`gpu`\|`npu` | gpu | Inference device (Ryzen AI for `npu`) |
+| `--config` | path | `~/.gaia/config.json` | GAIA config file used to resolve `default_model` (or `$GAIA_CONFIG_FILE`) |
 | `--stats` | flag | false | Show performance statistics |
 
 **Examples:**
@@ -934,7 +940,7 @@ Common flags at the `index` level: `--repo`, `--max-files`, `--model`, `--base-u
 | `--query` | string | – | Custom query to run instead of the built-in examples |
 | `--interactive` | flag | false | Continuously input queries in interactive mode |
 | `--example` | string | – | Run a specific built-in example (1-6); omit for interactive mode |
-| `--steps` | integer | 5 | Maximum number of steps per query |
+| `--steps` | integer | 50 | Maximum number of steps per query (defaults to the global agent step limit, or `$GAIA_AGENT_MAX_STEPS` if set) |
 | `--output-dir` | path | output | Directory to save output files |
 | `--mcp-port` | integer | 9876 | Port for the Blender MCP server |
 | `--debug-prompts` | flag | false | Show prompts sent to the LLM |
@@ -981,6 +987,8 @@ gaia email -v -q "Triage my inbox"  # verbose logs for benchmarking
 | `-i, --interactive` | flag | false | REPL loop until `/quit`. |
 | `-v, --verbose` | flag | false | Emit structured logs for every triage decision and tool call. |
 | `--debug` | flag | false | Adds full prompt + LLM-response logging (sensitive payloads in logs). |
+| `--spec` | flag | false | Generate the HTML endpoint spec page, write it to disk, and open it in a browser. No LLM or Lemonade required. |
+| `--output PATH` | path | `~/.gaia/email/endpoint-spec.html` | Where to write the HTML spec (only used with `--spec`). |
 
 **Setup:** requires the Google connector. Run `gaia connectors connect google` first; you'll be asked to grant Gmail and Calendar scopes.
 
@@ -1016,14 +1024,14 @@ gaia sd <prompt> [OPTIONS]
 
 **Examples:**
 
-Fast generation with default (SD-Turbo, ~13s):
+Fast, good-quality generation with the default (SDXL-Turbo, ~17s):
 ```bash
 gaia sd "a sunset over mountains"
 ```
 
-Better quality with SDXL-Turbo (~17s):
+Even faster (lower quality) with SD-Turbo (~13s):
 ```bash
-gaia sd "cyberpunk city at night" --sd-model SDXL-Turbo
+gaia sd "cyberpunk city at night" --sd-model SD-Turbo
 ```
 
 Photorealistic with SDXL-Base-1.0 (slow, ~9min):
@@ -1399,6 +1407,7 @@ gaia mcp test --query "Hello from GAIA MCP!"
 | `test` | Test MCP bridge functionality (optionally against a specific `--tool`) |
 | `agent` | Invoke the MCP orchestrator agent (positional `request` arg + `--domain`, `--context`) |
 | `docker` | Start the Docker MCP server (default port 8080) |
+| `serve` | Start the Agent UI MCP server (wraps the Agent UI backend) |
 
 #### `gaia mcp start` options
 
@@ -1559,7 +1568,7 @@ gaia download [OPTIONS]
 | `--timeout` | integer | 1800 | Timeout per model in seconds |
 | `--host` | string | localhost | Lemonade server host |
 | `--port` | integer | 13305 | Lemonade server port |
-| `--clear-cache` | flag | false | Remove cached download progress/metadata before running |
+| `--clear-cache` | flag | false | Delete all downloaded GAIA models to free up disk space |
 
 **Available Agents:**
 chat, code, talk, rag, blender, jira, docker, vlm, minimal, mcp
@@ -1686,7 +1695,11 @@ gaia eval agent [OPTIONS]
 | `--scenario` | string | all | Run a specific scenario by ID |
 | `--category` | string | all | Run all scenarios in a category |
 | `--backend` | string | `http://localhost:4200` | Agent UI backend URL |
+| `--agent-type` | string | backend default | Agent registration ID to target (e.g. `gaia-lite`); scenarios run against this agent |
 | `--model` | string | `claude-sonnet-4-6` | Judge/simulator model |
+| `--iterations` | integer | `1` | Run each scenario N times for reliability measurement |
+| `--keep-sessions` | flag | false | Don't delete Agent UI sessions after eval — leave them for manual inspection |
+| `--device` | `cpu`\|`gpu`\|`npu` | – | Inference device hint for the run |
 | `--budget` | string | `2.00` | Maximum USD spend per scenario |
 | `--timeout` | integer | `900` | Per-scenario timeout in seconds (auto-scaled for complex scenarios) |
 | `--audit-only` | flag | false | Run architecture audit without LLM calls (free) |

--- a/docs/reference/features.mdx
+++ b/docs/reference/features.mdx
@@ -21,7 +21,7 @@ Currently, the following capabilities are available, more will be added in the n
 | Code Agent         | AI-powered code generation and analysis  | Autonomous workflow for code generation, project scaffolding, and error fixing | Windows, Linux   |
 | Blender Agent      | 3D content creation and manipulation     | Specialized agent for Blender automation and workflow          | Windows, Linux   |
 | Summarization      | Document and transcript summarization    | AI-powered summarization with multiple output formats          | Windows, Linux   |
-| Evaluation Suite   | Model evaluation and benchmarking       | Comprehensive evaluation framework with groundtruth generation  | Windows, Linux   |
+| Evaluation Suite   | Model evaluation and benchmarking       | Scenario-based agent eval, throughput benchmarking, and reporting | Windows, Linux   |
 | Voice Interaction  | Speech-to-speech conversation           | Voice-based AI interaction with TTS and ASR                    | Windows, Linux   |
 | Web Dashboards     | Browser-based interfaces for agents      | JavaScript apps with simple configuration                       | Windows, Linux   |
 
@@ -89,7 +89,7 @@ gaia chat --show-stats
 - `/help` - Show available commands
 - `quit`, `exit`, or `bye` - End the chat session
 
-**Requirements:** Requires lemonade-server to be running. The chat agent defaults to Qwen3.5-35B-A3B-GGUF model for optimal performance.
+**Requirements:** Requires lemonade-server to be running. The chat agent defaults to the `Gemma-4-E4B-it-GGUF` model.
 
 **Platform Availability**: Windows and Linux
 
@@ -143,7 +143,7 @@ gaia summarize --list-configs
 **Key features:**
 - **Multiple Input Types**: Process transcripts, emails, and documents
 - **Flexible Output Formats**: JSON, PDF, email, or both
-- **Configurable Styles**: Executive summaries, detailed summaries, action items, key decisions, participants, and topics
+- **Configurable Styles**: Brief, detailed, bullets, executive, participants, and action items
 - **Batch Processing**: Process entire directories of documents
 - **Template Support**: Use predefined configuration templates
 - **Model Flexibility**: Support for both local (Lemonade) and cloud (OpenAI/Claude) models
@@ -170,33 +170,31 @@ gaia summarize --list-configs
 GAIA includes a comprehensive evaluation framework for testing and comparing AI model performance:
 
 ```bash
-# Generate synthetic test data
-gaia generate --meeting-transcript -o ./test_data --meeting-types standup --count-per-type 2
+# Run the agent eval benchmark (scenario-based, end-to-end)
+gaia eval agent                                 # all scenarios
+gaia eval agent --category rag_quality          # one category
+gaia eval agent --scenario simple_factual_rag   # one scenario
 
-# Create evaluation standards (ground truth)
-gaia groundtruth -d ./test_data --use-case summarization -o ./groundtruth
+# Compare a run against a saved baseline
+gaia eval agent --compare eval/results/latest/scorecard.json
 
-# Run batch experiments
-gaia batch-experiment -c config.json -i ./groundtruth -o ./experiments
+# Email-triage throughput benchmark (tokens/sec, TTFT, latency)
+gaia eval benchmark --model Gemma-4-E4B-it-GGUF --limit 50
 
-# Evaluate results
-gaia eval -d ./experiments -o ./evaluation
+# Generate a report from an evaluation results directory
+gaia report -d ./output/evaluations -o report.md
 
-# Generate reports
-gaia report -d ./evaluation -o ./reports/report.md
-
-# Launch interactive visualizer
-gaia visualize --experiments-dir ./experiments --evaluations-dir ./evaluation
+# Visualize llama.cpp server performance logs
+gaia perf-vis ./logs/llama-server.log --show
 ```
 
 **Key capabilities:**
-- **Synthetic Data Generation**: Create realistic test scenarios
-- **Ground Truth Creation**: Generate evaluation standards
-- **Batch Experimentation**: Test multiple models systematically
-- **Automated Evaluation**: Score and compare model outputs
-- **Interactive Visualization**: Web-based results explorer
-- **Cost Tracking**: Monitor API costs and token usage
-- **Performance Metrics**: Detailed timing and quality analysis
+- **Scenario-Based Agent Eval**: Multi-turn conversations judged across scoring dimensions
+- **Throughput Benchmarking**: Measure tokens/sec, time-to-first-token, and pipeline latency
+- **Baseline Comparison**: Diff a run against a saved scorecard to catch regressions
+- **Auto-Fix Mode**: `--fix` invokes Claude Code to repair failures and re-evaluate
+- **Report Generation**: Markdown/JSON/JUnit output for CI integration
+- **Performance Visualization**: Plot llama.cpp server metrics from log files
 
 **Platform Availability**: Windows and Linux
 
@@ -262,7 +260,7 @@ The following is a list of the currently supported LLMs in the generic version o
 ## Installing Additional Models
 
 GAIA uses Lemonade Server for model management. Models can be installed through:
-- **GAIA CLI**: Run `gaia init --profile <profile>` to download models for a specific use case. Valid profiles: `minimal`, `sd`, `chat`, `code`, `rag`, `mcp`, `vlm`, `all`.
+- **GAIA CLI**: Run `gaia init --profile <profile>` to download models for a specific use case. Valid profiles: `minimal`, `sd`, `chat`, `code`, `rag`, `mcp`, `vlm`, `email`, `npu`, `all`.
 - **System Tray Icon**: Access the Lemonade model manager from the system tray
 - **Web UI**: Manage models through the Lemonade web interface
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -173,7 +173,7 @@ icon: "bug"
        ```
     3. Restart Lemonade cleanly:
        ```bash
-       gaia kill && lemonade-server serve
+       gaia kill --lemonade && lemonade-server serve
        ```
     4. Close other GPU/NPU-heavy apps competing for the device (image
        generators, other LLM servers, GPU benchmarks).
@@ -381,18 +381,18 @@ icon: "bug"
 ## Evaluation Issues
 
 <AccordionGroup>
-  <Accordion title="Evaluation mode confusion" icon="scale-balanced">
-    If `gaia eval` produces inconsistent results:
-    - **Check**: Are you using Comparative Evaluation or Standalone Assessment mode?
-    - **Fix**: Ensure groundtruth data is either embedded or provided via `-g` flag
-    - **Verify**: Look for log message "Loaded ground truth data from:" vs "No ground truth file provided"
+  <Accordion title="`--compare` reports no baseline" icon="scale-balanced">
+    `gaia eval agent --compare` only *diffs* scorecards — it does not run an eval.
+    - **Fix**: Run the eval first (`gaia eval agent --category <cat>`); it prints the run dir and writes `<run-dir>/scorecard.json`.
+    - **Then**: `gaia eval agent --compare <baseline>/scorecard.json <run-dir>/scorecard.json`.
+    - **Baseline**: pick the committed baseline matching your model under `tests/fixtures/eval_baselines/` — don't rely on mtime sorting.
   </Accordion>
 
-  <Accordion title="Q&A experiments failing" icon="clipboard-question">
-    If batch-experiment fails with "No queries found":
-    - **Check**: Are you using groundtruth files as input?
-    - **Fix**: Use `gaia batch-experiment -i ./output/groundtruth/consolidated_qa_groundtruth.json`
-    - **Why**: Q&A groundtruth contains the specific questions models need to answer
+  <Accordion title="Eval runs fail with chaotic context/model errors" icon="clipboard-question">
+    Symptoms like `request exceeds the available context size`, spurious `INFRA_ERROR`, or `llama-server failed to start` usually mean two evals raced the same Lemonade server.
+    - **Rule**: run at most one `gaia eval agent` process at a time — never in parallel (`&`). Chain runs serially instead.
+    - **Backend**: the Agent UI backend must be running (`python -m gaia.ui.server --port 4200`).
+    - **Judge access**: if the run errors with `ANTHROPIC_API_KEY not found`, export the key for the judge/simulator.
   </Accordion>
 
   <Accordion title="Dependency compatibility issues" icon="cubes">

--- a/docs/sdk/agents/specialized.mdx
+++ b/docs/sdk/agents/specialized.mdx
@@ -3,7 +3,7 @@ title: "Specialized"
 ---
 
 <Info>
-  **Source Code:** [`hub/agents/python/chat/gaia_agent_chat/`](https://github.com/amd/gaia/blob/main/hub/agents/python/chat/gaia_agent_chat/), [`src/gaia/agents/docker/`](https://github.com/amd/gaia/blob/main/src/gaia/agents/docker/), [`src/gaia/agents/jira/`](https://github.com/amd/gaia/blob/main/src/gaia/agents/jira/), [`src/gaia/agents/blender/`](https://github.com/amd/gaia/blob/main/src/gaia/agents/blender/)
+  **Source Code:** [`hub/agents/python/chat/gaia_agent_chat/`](https://github.com/amd/gaia/blob/main/hub/agents/python/chat/gaia_agent_chat/), [`hub/agents/python/docker/gaia_agent_docker/`](https://github.com/amd/gaia/blob/main/hub/agents/python/docker/gaia_agent_docker/), [`hub/agents/python/jira/gaia_agent_jira/`](https://github.com/amd/gaia/blob/main/hub/agents/python/jira/gaia_agent_jira/), [`hub/agents/python/blender/gaia_agent_blender/`](https://github.com/amd/gaia/blob/main/hub/agents/python/blender/gaia_agent_blender/)
 </Info>
 
 <Note>
@@ -49,14 +49,14 @@ result = agent.process_query(
 
 ## 12.2 DockerAgent (Containerization)
 
-**Import:** `from gaia.agents.docker.agent import DockerAgent`
+**Import:** `from gaia_agent_docker.agent import DockerAgent`
 
 **Detailed Spec:** [spec/docker-agent](/spec/docker-agent)
 
 **Purpose:** Intelligent Docker assistance for containerizing applications with LLM-generated Dockerfiles.
 
 ```python
-from gaia.agents.docker.agent import DockerAgent
+from gaia_agent_docker.agent import DockerAgent
 from pathlib import Path
 
 # Create Docker agent
@@ -87,14 +87,14 @@ result = agent.process_query(
 
 ## 12.3 JiraAgent (Issue Tracking)
 
-**Import:** `from gaia.agents.jira.agent import JiraAgent`
+**Import:** `from gaia_agent_jira.agent import JiraAgent`
 
 **Detailed Spec:** [spec/jira-agent](/spec/jira-agent)
 
 **Purpose:** Natural language interface to Jira with automatic configuration discovery and JQL generation.
 
 ```python
-from gaia.agents.jira.agent import JiraAgent
+from gaia_agent_jira.agent import JiraAgent
 import os
 
 # Set credentials
@@ -132,14 +132,14 @@ result = agent.process_query(
 
 ## 12.4 BlenderAgent (3D Graphics)
 
-**Import:** `from gaia.agents.blender.agent import BlenderAgent`
+**Import:** `from gaia_agent_blender.agent import BlenderAgent`
 
 **Detailed Spec:** [spec/blender-agent](/spec/blender-agent)
 
 **Purpose:** Natural language interface for Blender 3D modeling, scene creation, and rendering.
 
 ```python
-from gaia.agents.blender.agent import BlenderAgent
+from gaia_agent_blender.agent import BlenderAgent
 
 # Create Blender agent
 agent = BlenderAgent(

--- a/docs/sdk/configuration.mdx
+++ b/docs/sdk/configuration.mdx
@@ -15,16 +15,22 @@ export LEMONADE_BASE_URL="http://localhost:13305/api/v1"
 # Required only when connecting to an authenticated remote Lemonade.
 # See https://lemonade-server.ai/docs/guide/configuration/#api-key-and-security
 export LEMONADE_API_KEY=""
-export GAIA_API_DEBUG="true"
-export GAIA_API_STREAMING="true"
+
+# API server (gaia api). These are read as the literal string "1" —
+# any other value (including "true") leaves the feature OFF.
+export GAIA_API_DEBUG="1"      # debug logging + console output
+export GAIA_API_STREAMING="1"  # stream LLM responses over the API
 
 # API Keys (for cloud providers)
 export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENAI_API_KEY="sk-..."
-
-# Logging
-export GAIA_LOG_LEVEL="INFO"
 ```
+
+<Note>
+GAIA has no `GAIA_LOG_LEVEL` environment variable. Log levels are set
+programmatically through `gaia.logger` (`set_level(name, level)`); the default
+is `INFO`.
+</Note>
 
 ---
 
@@ -35,7 +41,7 @@ import os
 
 # Read configuration
 base_url = os.getenv("LEMONADE_BASE_URL", "http://localhost:13305/api/v1")
-debug = os.getenv("GAIA_API_DEBUG", "false").lower() == "true"
+debug = os.getenv("GAIA_API_DEBUG") == "1"  # matches how gaia api reads it
 
 # Use in agent
 agent = MyAgent(

--- a/docs/sdk/core/agent-system.mdx
+++ b/docs/sdk/core/agent-system.mdx
@@ -77,7 +77,7 @@ The agent calls a weather API and returns real data.
 When you send a message to an agent, it doesn't just generate a response. It enters a **reasoning loop**:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'edgeLabelBackground':'#ffffff', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A(["RECEIVE"]) --> B(["THINK"])
     B --> C(["ACT"])
@@ -837,35 +837,33 @@ The `@tool` decorator does several things:
 
 ```python
 def tool(func):
-    # 1. Extract function signature
+    # 1. Extract the function signature
     sig = inspect.signature(func)
 
-    # 2. Build JSON schema from type hints
-    schema = {
-        "name": func.__name__,
-        "description": func.__doc__,
-        "parameters": {
-            "type": "object",
-            "properties": {},
-            "required": []
-        }
-    }
-
+    # 2. Build a minimal per-parameter map from type hints.
+    #    Each entry is just {type, required} — the whole docstring is stored
+    #    once as `description`; per-argument descriptions are NOT parsed out.
+    params = {}
     for name, param in sig.parameters.items():
-        if param.annotation != inspect.Parameter.empty:
-            schema["parameters"]["properties"][name] = {
-                "type": python_type_to_json_type(param.annotation),
-                "description": extract_arg_description(func.__doc__, name)
-            }
-        if param.default == inspect.Parameter.empty:
-            schema["parameters"]["required"].append(name)
+        params[name] = {
+            "type": python_type_to_json_type(param.annotation),  # str→string, int→integer, …
+            "required": param.default is inspect.Parameter.empty,
+        }
 
-    # 3. Register with the agent's tool registry
-    func._tool_schema = schema
-    return func
+    # 3. Register in the global _TOOL_REGISTRY under the function name.
+    _TOOL_REGISTRY[func.__name__] = {
+        "name": func.__name__,
+        "description": func.__doc__ or "",  # whole docstring, not per-arg
+        "parameters": params,
+        "function": func,
+        "atomic": False,
+    }
+    return func  # returned unchanged
 ```
 
-This schema is what the LLM sees, which is why type hints and docstrings are so important!
+The function name, type hints, and docstring are what the LLM sees, which is why
+they matter so much. See the [Tools guide](./tools) for the authoritative
+walkthrough of the registry entry.
 
 </Accordion>
 

--- a/docs/sdk/core/tools.mdx
+++ b/docs/sdk/core/tools.mdx
@@ -64,7 +64,7 @@ def get_weather(city: str, units: str = "fahrenheit") -> dict:
 ```
 
 The decorator registers an entry in the `_TOOL_REGISTRY` dictionary. Today the
-registry entry looks like this (source: `src/gaia/agents/base/tools.py:40-77`):
+registry entry looks like this (source: `src/gaia/agents/base/tools.py:79-87`):
 
 ```python
 {
@@ -76,6 +76,8 @@ registry entry looks like this (source: `src/gaia/agents/base/tools.py:40-77`):
     },
     "function": <the callable>,
     "atomic": False,
+    "display_label": None,  # optional user-facing label for UI progress strips
+    "timeout": None,        # optional per-tool timeout (seconds); None = global default
 }
 ```
 
@@ -96,7 +98,7 @@ the context it needs.
 When a user asks a question, the LLM goes through a decision process:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#A87B2D', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'edgeLabelBackground':'#ffffff', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
 flowchart TD
     A(["User Question"]) --> B(["READ TOOLS"])
     B --> C(["MATCH INTENT"])
@@ -872,7 +874,7 @@ def query_users(
 <Accordion title="How @tool Generates the Tool Entry">
 
 When you decorate a function with `@tool`, Python introspection extracts a
-minimal schema (see `src/gaia/agents/base/tools.py:19-88` for the authoritative
+minimal schema (see `src/gaia/agents/base/tools.py:19-98` for the authoritative
 implementation):
 
 ```python
@@ -880,7 +882,8 @@ import inspect
 
 _TOOL_REGISTRY = {}
 
-def tool(func=None, *, atomic: bool = False, **kwargs):
+def tool(func=None, *, atomic: bool = False, display_label: str | None = None,
+         timeout: float | None = None, **kwargs):
     """Decorator that registers a function in the global tool registry."""
 
     def decorator(f):
@@ -908,6 +911,8 @@ def tool(func=None, *, atomic: bool = False, **kwargs):
             "parameters": params,
             "function": f,
             "atomic": atomic,
+            "display_label": display_label,
+            "timeout": timeout,
         }
         return f
 
@@ -926,6 +931,9 @@ Notable implementation details:
   to a known JSON type; anything else is reported as `"unknown"`.
 - `@tool(atomic=True)` marks a tool as non-decomposable so the planner will not
   try to split it further.
+- `@tool(display_label=...)` sets a user-facing label for UI progress strips, and
+  `@tool(timeout=...)` overrides the global per-tool execution limit (seconds).
+  Both default to `None` and are stored on the registry entry.
 
 </Accordion>
 

--- a/docs/sdk/examples.mdx
+++ b/docs/sdk/examples.mdx
@@ -149,7 +149,7 @@ class DocumentQAAgent(Agent):
             """List all indexed documents."""
             status = self.rag.get_status()
             return {
-                "documents": list(self.rag.indexed_files.keys()),
+                "documents": list(self.rag.indexed_files),
                 "count": status.get("indexed_files", 0),
                 "total_chunks": status.get("total_chunks", 0),
             }

--- a/docs/sdk/mixins/code-mixins.mdx
+++ b/docs/sdk/mixins/code-mixins.mdx
@@ -4,7 +4,7 @@ icon: "code"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/)
 </Info>
 
 <Note>

--- a/docs/sdk/mixins/tool-mixins.mdx
+++ b/docs/sdk/mixins/tool-mixins.mdx
@@ -10,7 +10,7 @@ icon: "puzzle-piece"
 </Note>
 
 <Info>
-  **Source Code:** [`src/gaia/agents/tools/`](https://github.com/amd/gaia/tree/main/src/gaia/agents/tools/), [`src/gaia/agents/code/tools/`](https://github.com/amd/gaia/tree/main/src/gaia/agents/code/tools/)
+  **Source Code:** [`src/gaia/agents/tools/`](https://github.com/amd/gaia/tree/main/src/gaia/agents/tools/), [`hub/agents/python/code/gaia_agent_code/tools/`](https://github.com/amd/gaia/tree/main/hub/agents/python/code/gaia_agent_code/tools/)
 </Info>
 
 <Note>
@@ -22,6 +22,31 @@ icon: "puzzle-piece"
 **Purpose:** Reusable tool sets that can be mixed into your agents.
 
 **Available Mixins:** For complete API specifications of all 17 mixins, see [Specifications → Tool Mixins](/spec/file-tools-mixin)
+
+## Composable mixins (registry)
+
+The agent registry exposes these mixins by name in `KNOWN_TOOLS`
+([`src/gaia/agents/registry.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/registry.py)).
+A [custom agent](/guides/custom-agent) can compose any of them by listing the
+tool name — BuilderAgent's template wires the import and base class for you.
+Each row is the exact `name → module.Class` mapping the registry resolves:
+
+| Tool name | Import | Purpose |
+|-----------|--------|---------|
+| `rag` | `from gaia.agents.tools.rag_tools import RAGToolsMixin` | Document retrieval |
+| `code_index` | `from gaia.agents.tools.code_index_tools import CodeIndexToolsMixin` | Semantic code search (FAISS) |
+| `file_search` | `from gaia.agents.tools.file_tools import FileSearchToolsMixin` | Fuzzy/glob file search |
+| `file_io` | `from gaia.agents.tools.file_io_tools import FileIOToolsMixin` | Read/write/edit files |
+| `shell` | `from gaia.agents.tools.shell_tools import ShellToolsMixin` | Sandboxed shell commands |
+| `screenshot` | `from gaia.agents.tools.screenshot_tools import ScreenshotToolsMixin` | Screen capture |
+| `filesystem` | `from gaia.agents.tools.filesystem_tools import FileSystemToolsMixin` | File system navigation |
+| `scratchpad` | `from gaia.agents.tools.scratchpad_tools import ScratchpadToolsMixin` | SQL scratchpad tables for data analysis |
+| `browser` | `from gaia.agents.tools.browser_tools import BrowserToolsMixin` | Web search, page fetch, download |
+| `sd` | `from gaia.sd.mixin import SDToolsMixin` | Stable Diffusion image generation |
+| `vlm` | `from gaia.vlm.mixin import VLMToolsMixin` | Vision LLM / structured extraction |
+
+The sections below show usage patterns for the most common mixins; the
+`file_io` mixin is covered under [Code Development](./code-mixins).
 
 ## 9.1 File Watching Mixin
 

--- a/docs/sdk/packaging.mdx
+++ b/docs/sdk/packaging.mdx
@@ -99,7 +99,8 @@ my-agent = "my_package.cli:main"
 # After install, users can:
 # 1. Import: from my_package.agent import MyAgent
 # 2. CLI: my-agent "Do something"
-# 3. API: Start server with `gaia api --agent my-agent`
+# 3. API: the gaia.agents entry point makes MyAgent discoverable;
+#         start the OpenAI-compatible server with `gaia api start`
 ```
 
 ---

--- a/docs/sdk/patterns.mdx
+++ b/docs/sdk/patterns.mdx
@@ -241,14 +241,14 @@ from gaia.agents.hello.agent import HelloAgent, HelloAgentConfig
 
 def test_hello_agent_registers_now_tool(mock_lemonade_client):
     agent = HelloAgent(config=HelloAgentConfig())
-    assert "now" in agent.tools
+    assert "now" in agent._tools_registry
 
 
 def test_hello_agent_integration(require_lemonade):
     # Skips automatically when Lemonade isn't running.
     agent = HelloAgent(config=HelloAgentConfig())
     result = agent.process_query("What time is it?")
-    assert result["answer"]
+    assert result["result"]
 ```
 
 Fixtures live in `tests/conftest.py`. See [`docs/sdk/testing.mdx`](/sdk/testing) for more.

--- a/docs/sdk/sdks/agent-ui.mdx
+++ b/docs/sdk/sdks/agent-ui.mdx
@@ -1385,10 +1385,12 @@ The Agent UI server delegates to the GAIA [Agent](/sdk/core/agent-system) for LL
 ```python
 from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
 
-# The server creates a ChatAgent instance per request
+# The server creates a ChatAgent instance per request. ChatAgent derives its
+# system prompt from `prompt_profile` ("chat" | "doc" | "file" | "data" |
+# "web" | "full") — there is no `system_prompt` config field.
 config = ChatAgentConfig(
     model_id=session.get("model", "Qwen3.5-35B-A3B-GGUF"),
-    system_prompt=session.get("system_prompt"),
+    prompt_profile="doc",
     allowed_paths=["/path/to/files"],
 )
 agent = ChatAgent(config)
@@ -1435,7 +1437,7 @@ The npm package includes:
 
 | Path | Description |
 |------|-------------|
-| `bin/gaia-ui.mjs` | CLI entry point (Node.js) |
+| `bin/gaia-ui.cjs` | CLI entry point (Node.js) |
 | `dist/` | Pre-built frontend (React SPA) |
 
 ### Release Management

--- a/docs/sdk/sdks/audio.mdx
+++ b/docs/sdk/sdks/audio.mdx
@@ -34,10 +34,12 @@ audio = AudioClient(
     enable_tts=True,               # Enable text-to-speech
 )
 
-# Define message processor (sync function — callback invoked per transcription)
-def process_user_message(message: str) -> str:
+# Define message processor. It is awaited once per transcription, so it
+# MUST be `async def` — AudioClient invokes it via asyncio.run(callback(text)).
+# The return value is ignored; do your work (respond, speak, print) inside it.
+async def process_user_message(message: str) -> None:
     # Your agent logic
-    return f"You said: {message}"
+    print(f"You said: {message}")
 
 # Start voice chat (async — must be awaited)
 async def main():
@@ -100,13 +102,13 @@ while True:
 ```python
 from gaia.audio.kokoro_tts import KokoroTTS
 
-# Initialize TTS (voice defaults to "af_sarah")
+# Initialize TTS (voice defaults to "af_bella")
 tts = KokoroTTS()
 
 # List available voices
 voices = tts.list_available_voices()
 for voice_id, voice_data in voices.items():
-    print(f"{voice_id}: {voice_data.get('description', voice_id)}")
+    print(f"{voice_id}: {voice_data['name']} (quality: {voice_data['quality']})")
 
 # Select a voice (must be called before generate_speech)
 tts.set_voice("af_sarah")  # American female voice

--- a/docs/sdk/sdks/code-index.mdx
+++ b/docs/sdk/sdks/code-index.mdx
@@ -5,7 +5,7 @@ icon: "magnifying-glass-code"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/code_index/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/code_index/sdk.py), [`src/gaia/code_index/parsers.py`](https://github.com/amd/gaia/blob/main/src/gaia/code_index/parsers.py), and [`src/gaia/agents/code_index/tools/mixin.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code_index/tools/mixin.py)
+  **Source Code:** [`src/gaia/code_index/sdk.py`](https://github.com/amd/gaia/blob/main/src/gaia/code_index/sdk.py), [`src/gaia/code_index/parsers.py`](https://github.com/amd/gaia/blob/main/src/gaia/code_index/parsers.py), and [`src/gaia/agents/tools/code_index_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/tools/code_index_tools.py)
 </Info>
 
 <Note>

--- a/docs/sdk/sdks/mcp.mdx
+++ b/docs/sdk/sdks/mcp.mdx
@@ -103,9 +103,19 @@ flowchart TB
   </Step>
 
   <Step title="Add an MCP server">
-    ```bash
-    gaia mcp add time "uvx mcp-server-time"
+    Add a server entry to `~/.gaia/mcp_servers.json`:
+    ```json
+    {
+      "mcpServers": {
+        "time": { "command": "uvx", "args": ["mcp-server-time"] }
+      }
+    }
     ```
+    <Note>
+    `gaia mcp add` / `gaia mcp remove` were removed in #977 — MCP servers are
+    now configured through the connectors framework (`gaia connectors --help`)
+    or by editing `mcp_servers.json` directly.
+    </Note>
   </Step>
 
   <Step title="Use in your agent">
@@ -342,12 +352,16 @@ if "error" in result:
 ## CLI Commands
 
 ```bash
-gaia mcp add <name> "<command>"  # Add server
-gaia mcp list                    # List servers
+gaia mcp list                    # List configured servers
 gaia mcp tools <name>            # List tools from server
 gaia mcp test-client <name>      # Test connection
-gaia mcp remove <name>           # Remove server
 ```
+
+<Note>
+`gaia mcp add` and `gaia mcp remove` were removed in #977. MCP servers are now
+managed through the connectors framework (`gaia connectors --help`) or by editing
+`~/.gaia/mcp_servers.json` directly.
+</Note>
 
 ---
 
@@ -405,9 +419,13 @@ gaia mcp remove <name>           # Remove server
   </Accordion>
 
   <Accordion title="Server process hangs or times out">
-    Some servers need initialization time:
+    Requests time out after 30s by default. For servers that need a longer
+    timeout, use the lower-level `MCPClient`, which accepts `timeout` (seconds):
     ```python
-    agent.connect_mcp_server("server", config, timeout=30)
+    from gaia.mcp.client import MCPClient
+
+    client = MCPClient.from_config("server", config, timeout=60)
+    client.connect()
     ```
     Test directly: `gaia mcp test-client <server-name>`
   </Accordion>

--- a/docs/security/connections.mdx
+++ b/docs/security/connections.mdx
@@ -64,5 +64,6 @@ You can revoke access at any level:
 ## See also
 
 - [Connectors overview](/connectors)
+- [OAuth connection threat model](/security/connectors) — the deeper PKCE / refresh-token threat model and operator checklist.
 - [Connectors SDK](/sdk/infrastructure/connectors)
 - [Guarding the model endpoint](/integrations/guard-proxy)

--- a/docs/security/connectors.mdx
+++ b/docs/security/connectors.mdx
@@ -1,9 +1,8 @@
 ---
-title: "Connections — security model"
+title: "OAuth Connection Threat Model"
 description: "OAuth connection threat model, refresh-token hygiene, and what GAIA does and does not protect against."
+icon: "lock"
 ---
-
-# Connections — security model
 
 GAIA's `gaia.connectors` package implements OAuth 2.0 PKCE
 (RFC 7636/8252) for desktop authorization flows. This page describes the
@@ -136,4 +135,8 @@ the failure becomes common.
 - [ ] Sensitive-scope verification is submitted for the production
   client id (4–6 wk timeline).
 
-See also: [Google OAuth Client runbook](../runbooks/google-oauth-client.md).
+## See also
+
+- [Connections security model](/security/connections) — credential storage, the grant + activation model, and revocation across every connector type.
+- [Connectors overview](/connectors)
+- [Google OAuth Client runbook](https://github.com/amd/gaia/blob/main/docs/runbooks/google-oauth-client.md)

--- a/docs/spec/agent-base.mdx
+++ b/docs/spec/agent-base.mdx
@@ -97,7 +97,7 @@ def __init__(
     claude_model: str = "claude-sonnet-4-20250514",
     base_url: Optional[str] = None,
     model_id: str = None,
-    max_steps: int = 20,
+    max_steps: Optional[int] = None,
     debug_prompts: bool = False,
     show_prompts: bool = False,
     output_dir: str = None,
@@ -110,6 +110,7 @@ def __init__(
     max_consecutive_repeats: int = 4,
     min_context_size: int = 32768,
     skip_lemonade: bool = False,
+    device: Optional[str] = None,
 ) -> None:
     """
     Initialize the Agent.
@@ -120,7 +121,8 @@ def __init__(
         claude_model: Model to use when use_claude=True
         base_url: Local LLM server URL (default: from LEMONADE_BASE_URL or http://localhost:13305/api/v1)
         model_id: Model ID for local LLM (default: None — resolves to DEFAULT_MODEL_NAME, currently Gemma-4-E4B-it-GGUF)
-        max_steps: Maximum reasoning iterations (default: 20)
+        max_steps: Maximum reasoning iterations (default: None — resolves to the
+            global default via default_max_steps(), i.e. GAIA_AGENT_MAX_STEPS or DEFAULT_MAX_STEPS)
         debug_prompts: Include prompts in conversation history (default: False)
         show_prompts: Display prompts sent to LLM (default: False)
         output_dir: Directory for JSON output files (default: current directory)
@@ -133,6 +135,8 @@ def __init__(
         max_consecutive_repeats: Max consecutive identical tool calls before stopping (default: 4)
         min_context_size: Minimum context size required for this agent (default: 32768)
         skip_lemonade: Skip Lemonade server initialization (default: False). Use when connecting to a different OpenAI-compatible backend.
+        device: Runtime device selector ('cpu', 'gpu', 'npu') validated against detected
+            hardware at startup; an unavailable device fails loudly (default: None = no check)
     """
 ```
 
@@ -193,11 +197,18 @@ def process_query(
 
     Returns:
         dict: {
-            "answer": str,           # Final answer from agent
-            "steps": int,            # Number of reasoning steps taken
-            "tools_used": List[str], # Tools called during execution
-            "success": bool,         # Whether query completed successfully
-            "error": str             # Error message if success=False
+            "status": str,           # "success" | "failed" | "incomplete"
+            "result": str,           # Final answer from the agent
+            "system_prompt": str,    # System prompt used for this query
+            "conversation": list,    # Full step-by-step conversation trace
+            "steps_taken": int,      # Number of reasoning steps taken
+            "duration": float,       # Total processing time in seconds
+            "input_tokens": int,     # Total input tokens across all steps
+            "output_tokens": int,    # Total output tokens across all steps
+            "total_tokens": int,     # Combined token count
+            "error_count": int,      # Number of errors encountered
+            "error_history": list,   # Full error history
+            # "output_file": str     # Present only when trace=True
         }
     """
     pass
@@ -600,10 +611,10 @@ def test_end_to_end_query():
     agent = TestAgent(silent_mode=True)
     result = agent.process_query("Test query")
 
-    assert "answer" in result
-    assert "steps" in result
-    assert "tools_used" in result
-    assert "success" in result
+    assert "result" in result
+    assert "status" in result
+    assert "steps_taken" in result
+    assert "total_tokens" in result
 
 def test_multiple_tools():
     """Test agent using multiple tools."""

--- a/docs/spec/agent-ui-server.mdx
+++ b/docs/spec/agent-ui-server.mdx
@@ -53,7 +53,11 @@ src/gaia/ui/
 
 ### Routers (`src/gaia/ui/routers/`)
 
-As of v0.17.x the HTTP surface is split into focused router modules:
+As of v0.17.x the HTTP surface is split into focused router modules. Every route
+is registered under the `/api` prefix (e.g. the `chat` router serves
+`POST /api/chat/send`); the **Mount** column below names the surface, not the
+literal path prefix. Additional routers exist beyond the core set below
+(`connectors`, `goals`, `hub`, `memory`, `schedules`).
 
 | Module | Mount | Purpose |
 |---|---|---|
@@ -73,7 +77,7 @@ As of v0.17.x the HTTP surface is split into focused router modules:
 ### App Factory
 
 ```python
-def create_app(db_path: str = None) -> FastAPI:
+def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
 ```
 
 Creates a configured FastAPI application with:

--- a/docs/spec/api-agent.mdx
+++ b/docs/spec/api-agent.mdx
@@ -9,7 +9,7 @@ title: "ApiAgent"
 <Note>
 **Component:** ApiAgent
 **Module:** `gaia.agents.base.api_agent`
-**Import:** `from gaia.agents.base import ApiAgent`
+**Import:** `from gaia.agents.base.api_agent import ApiAgent`
 </Note>
 ---
 
@@ -294,7 +294,8 @@ class JiraAgent(MCPAgent, ApiAgent, Agent):
 
 ```python
 import pytest
-from gaia.agents.base import Agent, ApiAgent
+from gaia.agents.base import Agent
+from gaia.agents.base.api_agent import ApiAgent
 
 class TestApiAgent(ApiAgent, Agent):
     """Test agent for ApiAgent mixin."""
@@ -302,7 +303,7 @@ class TestApiAgent(ApiAgent, Agent):
         return "Test agent"
 
     def _create_console(self):
-        from gaia import SilentConsole
+        from gaia.agents.base.console import SilentConsole
         return SilentConsole()
 
     def _register_tools(self):
@@ -310,7 +311,7 @@ class TestApiAgent(ApiAgent, Agent):
 
 def test_api_agent_can_be_imported():
     """Verify ApiAgent can be imported."""
-    from gaia.agents.base import ApiAgent
+    from gaia.agents.base.api_agent import ApiAgent
     assert ApiAgent is not None
 
 def test_get_model_id_default():
@@ -329,7 +330,7 @@ def test_get_model_id_custom():
             return "Custom"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -358,7 +359,7 @@ def test_get_model_info_custom():
             return "Custom"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -400,7 +401,7 @@ def test_estimate_tokens_custom():
             return "Custom"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -421,7 +422,7 @@ def test_inheritance_single_protocol():
             return "Test"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -440,7 +441,7 @@ def test_inheritance_multiple_protocols():
             return "Test"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -482,7 +483,7 @@ def test_naming_conventions():
             return "Code"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -493,7 +494,7 @@ def test_naming_conventions():
             return "Jira"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -513,7 +514,8 @@ def test_naming_conventions():
 ### Example 1: Basic API Agent
 
 ```python
-from gaia.agents.base import Agent, ApiAgent
+from gaia.agents.base import Agent
+from gaia.agents.base.api_agent import ApiAgent
 from gaia import tool
 
 class MyAgent(ApiAgent, Agent):
@@ -523,7 +525,7 @@ class MyAgent(ApiAgent, Agent):
         return "You are a helpful assistant."
 
     def _create_console(self):
-        from gaia import AgentConsole
+        from gaia.agents.base.console import AgentConsole
         return AgentConsole()
 
     def _register_tools(self):
@@ -539,7 +541,8 @@ class MyAgent(ApiAgent, Agent):
 ### Example 2: Custom Model ID and Metadata
 
 ```python
-from gaia.agents.base import Agent, ApiAgent
+from gaia.agents.base import Agent
+from gaia.agents.base.api_agent import ApiAgent
 from typing import Dict, Any
 
 class CodeAgent(ApiAgent, Agent):
@@ -549,7 +552,7 @@ class CodeAgent(ApiAgent, Agent):
         return "You are an autonomous Python coding agent."
 
     def _create_console(self):
-        from gaia import AgentConsole
+        from gaia.agents.base.console import AgentConsole
         return AgentConsole()
 
     def _register_tools(self):
@@ -577,7 +580,8 @@ class CodeAgent(ApiAgent, Agent):
 ### Example 3: Custom Token Estimation
 
 ```python
-from gaia.agents.base import Agent, ApiAgent
+from gaia.agents.base import Agent
+from gaia.agents.base.api_agent import ApiAgent
 import tiktoken
 
 class PreciseAgent(ApiAgent, Agent):
@@ -592,7 +596,7 @@ class PreciseAgent(ApiAgent, Agent):
         return "Precise agent"
 
     def _create_console(self):
-        from gaia import SilentConsole
+        from gaia.agents.base.console import SilentConsole
         return SilentConsole()
 
     def _register_tools(self):
@@ -608,7 +612,8 @@ class PreciseAgent(ApiAgent, Agent):
 ### Example 4: Multi-Protocol Agent (MCP + API)
 
 ```python
-from gaia.agents.base import Agent, MCPAgent, ApiAgent
+from gaia.agents.base import Agent, MCPAgent
+from gaia.agents.base.api_agent import ApiAgent
 from typing import List, Dict, Any
 
 class JiraAgent(MCPAgent, ApiAgent, Agent):
@@ -618,7 +623,7 @@ class JiraAgent(MCPAgent, ApiAgent, Agent):
         return "You are a Jira project management assistant."
 
     def _create_console(self):
-        from gaia import AgentConsole
+        from gaia.agents.base.console import AgentConsole
         return AgentConsole()
 
     def _register_tools(self):
@@ -659,7 +664,8 @@ class JiraAgent(MCPAgent, ApiAgent, Agent):
 ### Example 5: Agent Without API Customization
 
 ```python
-from gaia.agents.base import Agent, ApiAgent
+from gaia.agents.base import Agent
+from gaia.agents.base.api_agent import ApiAgent
 
 class SimpleAgent(ApiAgent, Agent):
     """Agent using all default API behavior."""
@@ -668,7 +674,7 @@ class SimpleAgent(ApiAgent, Agent):
         return "Simple agent"
 
     def _create_console(self):
-        from gaia import AgentConsole
+        from gaia.agents.base.console import AgentConsole
         return AgentConsole()
 
     def _register_tools(self):
@@ -701,7 +707,8 @@ Add to Agent Section:
 
 **Quick Start:**
 ```python
-from gaia.agents.base import Agent, ApiAgent
+from gaia.agents.base import Agent
+from gaia.agents.base.api_agent import ApiAgent
 
 class MyAgent(ApiAgent, Agent):
     def _get_system_prompt(self):

--- a/docs/spec/audio-client.mdx
+++ b/docs/spec/audio-client.mdx
@@ -11,7 +11,12 @@ icon: "headphones"
 <Note>
 **Components:** AudioClient, WhisperAsr, KokoroTTS
 **Module:** `gaia.audio`
-**Import:** `from gaia.audio import AudioClient, WhisperAsr, KokoroTTS`
+**Import:**
+```python
+from gaia.audio.audio_client import AudioClient
+from gaia.audio.whisper_asr import WhisperAsr
+from gaia.audio.kokoro_tts import KokoroTTS
+```
 </Note>
 
 ---
@@ -61,7 +66,7 @@ The audio subsystem provides complete voice interaction capabilities including A
 ### AudioClient
 
 ```python
-from gaia.audio import AudioClient
+from gaia.audio.audio_client import AudioClient
 
 class AudioClient:
     """Handles all audio-related functionality including TTS, ASR, and voice chat."""
@@ -131,7 +136,7 @@ class AudioClient:
 ### WhisperAsr
 
 ```python
-from gaia.audio import WhisperAsr
+from gaia.audio.whisper_asr import WhisperAsr
 
 class WhisperAsr:
     """Whisper-based Automatic Speech Recognition."""
@@ -182,7 +187,7 @@ class WhisperAsr:
 ### KokoroTTS
 
 ```python
-from gaia.audio import KokoroTTS
+from gaia.audio.kokoro_tts import KokoroTTS
 
 class KokoroTTS:
     """Kokoro-based Text-to-Speech synthesis."""
@@ -264,7 +269,7 @@ talk = [
 
 ```python
 import asyncio
-from gaia.audio import AudioClient
+from gaia.audio.audio_client import AudioClient
 
 async def main():
     audio = AudioClient(
@@ -284,7 +289,7 @@ asyncio.run(main())
 ### Custom Voice Settings
 
 ```python
-from gaia.audio import AudioClient
+from gaia.audio.audio_client import AudioClient
 
 audio = AudioClient(enable_tts=True)
 audio.initialize_tts()
@@ -300,7 +305,7 @@ await audio.speak_text("Hello in a different voice")
 
 ```python
 import queue
-from gaia.audio import WhisperAsr
+from gaia.audio.whisper_asr import WhisperAsr
 
 # Create transcription queue
 transcription_queue = queue.Queue()
@@ -329,7 +334,7 @@ except KeyboardInterrupt:
 ```python
 import queue
 import threading
-from gaia.audio import KokoroTTS
+from gaia.audio.kokoro_tts import KokoroTTS
 
 tts = KokoroTTS()
 text_queue = queue.Queue()

--- a/docs/spec/blender-agent.mdx
+++ b/docs/spec/blender-agent.mdx
@@ -3,12 +3,12 @@ title: "BlenderAgent"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/blender/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/blender/agent.py)
+  **Source Code:** [`hub/agents/python/blender/gaia_agent_blender/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/blender/gaia_agent_blender/agent.py)
 </Info>
 
 <Note>
 **Component:** BlenderAgent - 3D Scene Creation via Natural Language
-**Module:** `gaia.agents.blender.agent`
+**Module:** `gaia_agent_blender.agent`
 **Inherits:** Agent
 **MCP:** BlenderMCPClient for Blender communication
 </Note>
@@ -305,9 +305,9 @@ from gaia.agents.base.agent import Agent
 from gaia.agents.base.tools import tool
 from gaia.mcp.blender_mcp_client import MCPClient
 
-# Blender core modules (separate package)
-from gaia.agents.blender.core.scene import SceneManager
-from gaia.agents.blender.core.materials import MaterialManager
+# Blender core modules (ship with the gaia-agent-blender package)
+from gaia_agent_blender.core.scene import SceneManager
+from gaia_agent_blender.core.materials import MaterialManager
 ```
 
 ---
@@ -317,7 +317,7 @@ from gaia.agents.blender.core.materials import MaterialManager
 ### Example 1: Simple Scene
 
 ```python
-from gaia.agents.blender.agent import BlenderAgent
+from gaia_agent_blender.agent import BlenderAgent
 
 agent = BlenderAgent()
 

--- a/docs/spec/chat-agent.mdx
+++ b/docs/spec/chat-agent.mdx
@@ -96,7 +96,7 @@ class ChatAgentConfig:
     claude_model: str = "claude-sonnet-4-20250514"
     # None = fall back to LEMONADE_BASE_URL env var, then the default
     base_url: Optional[str] = None
-    model_id: Optional[str] = None  # Default: Qwen3.5-35B
+    model_id: Optional[str] = None  # None = use the default model (Gemma-4-E4B-it-GGUF)
 
     # Execution
     max_steps: int = 10

--- a/docs/spec/cli-tools-mixin.mdx
+++ b/docs/spec/cli-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "CLIToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/cli_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/cli_tools.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/cli_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/cli_tools.py)
 </Info>
 
 <Note>
@@ -96,7 +96,7 @@ CLIToolsMixin provides universal CLI command execution with background process m
 ### File Location
 
 ```
-src/gaia/agents/code/tools/cli_tools.py
+hub/agents/python/code/gaia_agent_code/tools/cli_tools.py
 ```
 
 ### Public Interface
@@ -381,7 +381,7 @@ Stop all managed background processes.
 ### Example 1: Start Development Server
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 

--- a/docs/spec/code-formatting-mixin.mdx
+++ b/docs/spec/code-formatting-mixin.mdx
@@ -3,7 +3,7 @@ title: "CodeFormattingMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/code_formatting.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/code_formatting.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/code_formatting.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/code_formatting.py)
 </Info>
 
 <Note>

--- a/docs/spec/code-tools-mixin.mdx
+++ b/docs/spec/code-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "CodeToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/code_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/code_tools.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/code_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/code_tools.py)
 </Info>
 
 <Note>
@@ -86,7 +86,7 @@ CodeToolsMixin provides comprehensive code generation, analysis, and helper meth
 ### File Location
 
 ```
-src/gaia/agents/code/tools/code_tools.py
+hub/agents/python/code/gaia_agent_code/tools/code_tools.py
 ```
 
 ### Public Interface
@@ -410,7 +410,7 @@ Analyze Python code with pylint.
 ### Example 1: Generate a Function
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 

--- a/docs/spec/console.mdx
+++ b/docs/spec/console.mdx
@@ -438,7 +438,7 @@ def test_agent_execution():
     result = agent.process_query("test query")
 
     # Only structured result is returned
-    assert result.status == "success"
+    assert result["status"] == "success"
 ```
 
 ### Example 3: API Streaming with SSE

--- a/docs/spec/docker-agent.mdx
+++ b/docs/spec/docker-agent.mdx
@@ -3,12 +3,12 @@ title: "DockerAgent"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/docker/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/docker/agent.py)
+  **Source Code:** [`hub/agents/python/docker/gaia_agent_docker/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/docker/gaia_agent_docker/agent.py)
 </Info>
 
 <Note>
 **Component:** DockerAgent - Intelligent Docker Containerization
-**Module:** `gaia.agents.docker.agent`
+**Module:** `gaia_agent_docker.agent`
 **Inherits:** MCPAgent
 **Model:** Qwen3.5-35B-A3B-GGUF (default)
 </Note>
@@ -432,7 +432,7 @@ gaia docker "Containerize my Flask app in ./myapp"
 ### Example 2: Python API
 
 ```python
-from gaia.agents.docker.agent import DockerAgent
+from gaia_agent_docker.agent import DockerAgent
 
 # Initialize agent
 agent = DockerAgent(
@@ -452,7 +452,7 @@ print(result["result"])
 
 ```python
 from gaia.mcp.agent_mcp_server import AgentMCPServer
-from gaia.agents.docker.agent import DockerAgent
+from gaia_agent_docker.agent import DockerAgent
 
 # Start MCP server
 server = AgentMCPServer(

--- a/docs/spec/email-contract.mdx
+++ b/docs/spec/email-contract.mdx
@@ -10,7 +10,7 @@ title: "Email Triage Contract Schema"
 **Component:** Email request/response contract (issue #1262)
 **Module:** `gaia_agent_email.contract`
 **Validation:** pydantic v2
-**Schema version:** `1.0`
+**Schema version:** `2.2`
 </Note>
 
 ---
@@ -28,33 +28,59 @@ stable shape.
 
 - **One schema, two surfaces.** REST and MCP stdio import the same pydantic
   models, guaranteeing identical structured output for a fixed input.
-- **Single email *and* full thread.** The input is a discriminated union on a
-  `kind` field (`"single"` / `"thread"`); a consumer branches deterministically.
+- **Single email *and* full thread.** The triage input is a discriminated union
+  on a `kind` field (`"single"` / `"thread"`); a consumer branches
+  deterministically.
 - **Dependency-light.** `gaia_agent_email.contract` imports only pydantic — no
   Gmail or connector backends — so either surface can import it without pulling
   live-mail machinery into the process. (A regression test enforces this.)
 - **Fail loudly.** Every model forbids unknown fields (`extra="forbid"`). An
   off-contract payload raises a `ValidationError` naming the offending field,
   never a silently coerced result.
-- **Versioned.** `SCHEMA_VERSION` (`"1.0"`) is pinned in the module and echoed in
-  both request and response so a consumer can detect a breaking change.
+- **Versioned.** `SCHEMA_VERSION` (`"2.2"`) is pinned in the module and echoed in
+  every request and response so a consumer can detect a breaking change.
+
+### Version history
+
+`SCHEMA_VERSION` bumps only on a breaking change; additive surfaces keep older
+consumers working.
+
+| Version | Change |
+|---|---|
+| `1.0` | First frozen revision — single-email + thread triage. |
+| `2.0` | Five-bucket taxonomy (#1615); batch triage (#1887). |
+| `2.1` | Additive REST surfaces: inbox search (#1781), archive + phishing-quarantine and their undo (#1779), calendar view/create/respond (#1780), inbox pre-scan (#1778). |
+| `2.2` | Additive attachment handling (#1542): `EmailMessage` / `EmailTriageResult` / `DraftReply` gain an `attachments` metadata list; draft/send accept `OutgoingAttachment` payloads. |
+
+---
+
+## Category taxonomy
+
+`EmailCategory` is the **five-bucket** triage taxonomy (schema 2.0, #1615). The
+string values mirror the agent's `triage_heuristics.ALL_CATEGORIES`; a contract
+test asserts byte-for-byte equality, so drift in either place fails CI.
+
+| Value | Meaning |
+|---|---|
+| `URGENT` | Time-critical; needs attention now. |
+| `NEEDS_RESPONSE` | Actionable; a reply/action is expected. |
+| `FYI` | Informational; no action required. |
+| `PROMOTIONAL` | Marketing / bulk mail. |
+| `PERSONAL` | Personal correspondence. |
 
 ---
 
 ## Request schema (input)
 
-`EmailTriageRequest` — top-level envelope.
+`EmailTriageRequest` — top-level triage envelope.
 
 | Field | Type | Notes |
 |---|---|---|
-| `schema_version` | string | Contract version. Defaults to `"1.0"`. |
+| `schema_version` | string | Contract version. Defaults to `"2.2"`. |
 | `payload` | `SingleEmailInput` \| `ThreadInput` | Discriminated on `kind`. |
+| `context` | `TriageContext` \| null | Optional; biases categorization/summary. |
 
-### Shared input fields
-
-Both payload shapes carry a **principal** — the recipient the agent acts on
-behalf of (the inbox owner). This is distinct from a message's `to`: in a thread
-the principal is not necessarily a recipient of every message.
+### Shared value objects
 
 `EmailAddress`:
 
@@ -62,6 +88,23 @@ the principal is not necessarily a recipient of every message.
 |---|---|---|
 | `name` | string \| null | Display name. Optional. |
 | `email` | string | Required. Rejected loudly if it lacks `@` or a dotted domain. |
+
+`AttachmentMeta` (schema 2.2 — metadata only, no content):
+
+| Field | Type | Notes |
+|---|---|---|
+| `filename` | string | Required, non-empty. |
+| `mime_type` | string | MIME type as reported by the provider. |
+| `size_bytes` | int | Decoded size, `>= 0`. |
+| `attachment_id` | string \| null | Provider handle to fetch bytes (Gmail `body.attachmentId`); null when none. |
+
+`OutgoingAttachment` (schema 2.2 — content travels inline on draft/send):
+
+| Field | Type | Notes |
+|---|---|---|
+| `filename` | string | Required; rejects CRLF/null/quote (header-injection safe). |
+| `mime_type` | string | Must match `type/subtype`. |
+| `content_base64` | string | Standard (RFC 4648) base64. Must decode, be non-empty, and be ≤ `MAX_ATTACHMENT_BYTES` (25 MB). |
 
 `EmailMessage`:
 
@@ -76,13 +119,23 @@ the principal is not necessarily a recipient of every message.
 | `date` | string \| null | ISO-8601 timestamp. |
 | `subject` | string | Subject line. |
 | `body` | string | Plain-text body to analyze. Required. |
+| `attachments` | `AttachmentMeta[]` | Attachment metadata (schema 2.2). Content never travels here. |
+
+`TriageContext` (optional caller-supplied bias, #1541):
+
+| Field | Type | Notes |
+|---|---|---|
+| `people` | string[] | Important people whose mail weighs higher. |
+| `projects` | string[] | Active projects the principal cares about. |
+| `tone` | string \| null | Preferred summary tone, e.g. `"concise"`. |
+| `self_email` | string \| null | The principal's own address, so the model knows who "I" is. |
 
 ### `SingleEmailInput` (`kind: "single"`)
 
 | Field | Type | Notes |
 |---|---|---|
 | `kind` | `"single"` | Discriminator. |
-| `principal` | `EmailAddress` | Inbox owner. Required. |
+| `principal` | `EmailAddress` | Inbox owner the agent acts on behalf of. Required. |
 | `message` | `EmailMessage` | The one message to analyze. Required. |
 
 ### `ThreadInput` (`kind: "thread"`)
@@ -94,11 +147,14 @@ the principal is not necessarily a recipient of every message.
 | `thread_id` | string | Conversation id. Required. |
 | `messages` | `EmailMessage[]` | **Non-empty**, oldest-first. An empty thread is rejected loudly. |
 
+The principal is the account owner — distinct from a message's `to`: in a thread
+the principal is not necessarily a recipient of every message.
+
 ---
 
 ## Response schema (output)
 
-`EmailTriageResponse` — top-level envelope.
+`EmailTriageResponse` — top-level triage response envelope.
 
 | Field | Type | Notes |
 |---|---|---|
@@ -110,12 +166,16 @@ the principal is not necessarily a recipient of every message.
 
 | Field | Type | Notes |
 |---|---|---|
-| `category` | enum | One of `urgent`, `actionable`, `informational`, `low priority`. Matches the agent's frozen four-bucket taxonomy. |
+| `category` | `EmailCategory` | One of the five taxonomy buckets. |
 | `is_spam` | bool | Spam signal, scored independently of `category`. |
 | `is_phishing` | bool | Phishing signal, independent of `is_spam`. |
 | `summary` | string | Plain-text summary of the email / thread. Required. |
 | `action_items` | `ActionItem[]` | Extracted actions. May be empty. |
 | `draft` | `DraftReply` \| null | Proposed reply, or `null` when none is suggested. Never sent without explicit confirmation (#1264). |
+| `suggested_action` | `"reply"` \| `"none"` \| `"archive"` | Derived next action (reply for URGENT/NEEDS_RESPONSE, archive for PROMOTIONAL, none otherwise). Defaults to `"none"`. |
+| `message_id` | string \| null | Echoes the request message-id when available; null for raw Gmail-API-sourced results. |
+| `usage` | `TriageUsage` \| null | LLM token/throughput metrics. Null on the heuristic-only path (no LLM call). |
+| `attachments` | `AttachmentMeta[]` | Attachment metadata of the analyzed message(s), echoed for downstream processing (schema 2.2). |
 
 `ActionItem`:
 
@@ -123,6 +183,8 @@ the principal is not necessarily a recipient of every message.
 |---|---|---|
 | `description` | string | Imperative action. Required, non-empty. |
 | `due_hint` | string \| null | Free-text due hint as written (`"Friday"`); not parsed into a date. |
+| `type` | `"text"` \| `"link"` | Discriminator; defaults to `"text"`. |
+| `url` | string \| null | Required and non-empty when `type="link"`; must be `null` when `type="text"`. |
 
 `DraftReply`:
 
@@ -131,101 +193,16 @@ the principal is not necessarily a recipient of every message.
 | `to` | `EmailAddress[]` | **Non-empty** proposed recipients. |
 | `subject` | string | Proposed subject. |
 | `body` | string | Proposed body. |
+| `attachments` | `AttachmentMeta[]` | Metadata of proposed attachments (schema 2.2). Content stays in the caller's `OutgoingAttachment` payload. |
 
----
-
-## Batch endpoint (`POST /v1/email/triage/batch`)
-
-Added in agent `0.3.0` (#1887) **beside** the single-email endpoint — the single
-`POST /v1/email/triage` and its schema above are unchanged, and `SCHEMA_VERSION`
-stays `"2.0"`. The batch endpoint triages up to **100** emails or threads in one
-request: an `items` array in, a parallel `results` array out, order-preserved.
-
-`BatchTriageRequest` — top-level envelope:
+`TriageUsage`:
 
 | Field | Type | Notes |
 |---|---|---|
-| `schema_version` | string | Contract version. Defaults to `"2.0"`. |
-| `items` | `(SingleEmailInput \| ThreadInput)[]` | 1–100 inputs, discriminated on `kind` — the same item shapes the single endpoint's `payload` accepts. Over 100 → `422`. |
-| `context` | `TriageContext` \| null | Optional; applied to **all** items. |
-
-`BatchTriageResponse` — top-level envelope:
-
-| Field | Type | Notes |
-|---|---|---|
-| `schema_version` | string | Echoes the contract version. |
-| `results` | `BatchItemResult[]` | One entry per request item, order-preserved, 1:1 with `items`. |
-
-`BatchItemResult` — exactly one of `result` / `error` is set:
-
-| Field | Type | Notes |
-|---|---|---|
-| `index` | int | 0-based position in the request `items` array. |
-| `result` | `EmailTriageResult` \| null | Set when the item succeeded (same shape as the single response's `result`). |
-| `error` | `BatchItemError` \| null | Set when the item failed; `BatchItemError` carries a `message`. |
-
-**Per-item isolation — read the results, not the status.** A failure on one item
-sets that entry's `error` and the rest still run, so **HTTP 200 with every item
-errored is a valid response**. Consumers MUST inspect each `results[].error`, never
-just the HTTP status. A `502` means the local LLM was unreachable before any item
-was processed — the whole batch fails.
-
-### Example — batch request
-
-```json
-{
-  "schema_version": "2.0",
-  "items": [
-    {
-      "kind": "single",
-      "principal": { "email": "alice@example.com" },
-      "message": {
-        "message_id": "msg-1",
-        "from": { "email": "bob@vendor.com" },
-        "subject": "Q2 invoice",
-        "body": "Please review the attached invoice by Friday."
-      }
-    },
-    {
-      "kind": "single",
-      "principal": { "email": "alice@example.com" },
-      "message": {
-        "message_id": "msg-2",
-        "from": { "email": "promo@shop.example" },
-        "subject": "50% off this weekend",
-        "body": "Limited-time offer — shop now."
-      }
-    }
-  ]
-}
-```
-
-### Example — batch response (one item errored)
-
-```json
-{
-  "schema_version": "2.0",
-  "results": [
-    {
-      "index": 0,
-      "result": {
-        "category": "NEEDS_RESPONSE",
-        "is_spam": false,
-        "is_phishing": false,
-        "summary": "Vendor invoice needs review by Friday.",
-        "action_items": [{ "description": "Review the Q2 invoice", "due_hint": "Friday" }]
-      }
-    },
-    {
-      "index": 1,
-      "error": { "message": "local LLM triage failed for this item" }
-    }
-  ]
-}
-```
-
-The MCP surface mirrors this with a `triage_email_batch` tool (the single
-`triage_email` tool is unchanged).
+| `prompt_tokens` | int | Sum of input tokens across the LLM calls. |
+| `completion_tokens` | int | Sum of output tokens. |
+| `total_tokens` | int | Sum of input + output. |
+| `tokens_per_second` | float | Aggregate decode throughput. |
 
 ---
 
@@ -235,7 +212,7 @@ The MCP surface mirrors this with a `triage_email_batch` tool (the single
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "2.2",
   "payload": {
     "kind": "single",
     "principal": { "name": "Alice Example", "email": "alice@example.com" },
@@ -257,10 +234,10 @@ The MCP surface mirrors this with a `triage_email_batch` tool (the single
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "2.2",
   "request_kind": "single",
   "result": {
-    "category": "actionable",
+    "category": "NEEDS_RESPONSE",
     "is_spam": false,
     "is_phishing": false,
     "summary": "Vendor invoice needs review by Friday.",
@@ -271,7 +248,8 @@ The MCP surface mirrors this with a `triage_email_batch` tool (the single
       "to": [{ "name": "Bob Sender", "email": "bob@vendor.com" }],
       "subject": "Re: Q2 invoice attached",
       "body": "Thanks Bob, I'll review and confirm by Friday."
-    }
+    },
+    "suggested_action": "reply"
   }
 }
 ```
@@ -284,7 +262,7 @@ The MCP surface mirrors this with a `triage_email_batch` tool (the single
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "2.2",
   "payload": {
     "kind": "thread",
     "principal": { "name": "Alice Example", "email": "alice@example.com" },
@@ -317,18 +295,178 @@ The MCP surface mirrors this with a `triage_email_batch` tool (the single
 
 ```json
 {
-  "schema_version": "1.0",
+  "schema_version": "2.2",
   "request_kind": "thread",
   "result": {
-    "category": "actionable",
+    "category": "NEEDS_RESPONSE",
     "is_spam": false,
     "is_phishing": false,
     "summary": "Bob wants a renewal call; Alice proposed Thursday 2pm.",
     "action_items": [{ "description": "Confirm Thursday 2pm call" }],
-    "draft": null
+    "draft": null,
+    "suggested_action": "reply"
   }
 }
 ```
+
+---
+
+## Batch endpoint (`POST /v1/email/triage/batch`)
+
+Added in agent `0.3.0` (#1887) **beside** the single-email endpoint — the single
+`POST /v1/email/triage` and its schema above are unchanged. The batch endpoint
+triages up to `MAX_BATCH_SIZE` (**100**) emails or threads in one request: an
+`items` array in, a parallel `results` array out, order-preserved.
+
+`BatchTriageRequest` — top-level envelope:
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Contract version. Defaults to `"2.2"`. |
+| `items` | `(SingleEmailInput \| ThreadInput)[]` | 1–100 inputs, discriminated on `kind` — the same item shapes the single endpoint's `payload` accepts. Over 100 → `422`. |
+| `context` | `TriageContext` \| null | Optional; applied to **all** items. |
+
+`BatchTriageResponse` — top-level envelope:
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Echoes the contract version. |
+| `results` | `BatchItemResult[]` | One entry per request item, order-preserved, 1:1 with `items`. |
+
+`BatchItemResult` — exactly one of `result` / `error` is set:
+
+| Field | Type | Notes |
+|---|---|---|
+| `index` | int | 0-based position in the request `items` array. |
+| `result` | `EmailTriageResult` \| null | Set when the item succeeded (same shape as the single response's `result`). |
+| `error` | `BatchItemError` \| null | Set when the item failed; `BatchItemError` carries a `message`. |
+
+**Per-item isolation — read the results, not the status.** A failure on one item
+sets that entry's `error` and the rest still run, so **HTTP 200 with every item
+errored is a valid response**. Consumers MUST inspect each `results[].error`, never
+just the HTTP status. A `502` means the local LLM was unreachable before any item
+was processed — the whole batch fails.
+
+The MCP surface mirrors this with a `triage_email_batch` tool (the single
+`triage_email` tool is unchanged).
+
+### Example — batch request
+
+```json
+{
+  "schema_version": "2.2",
+  "items": [
+    {
+      "kind": "single",
+      "principal": { "email": "alice@example.com" },
+      "message": {
+        "message_id": "msg-1",
+        "from": { "email": "bob@vendor.com" },
+        "subject": "Q2 invoice",
+        "body": "Please review the attached invoice by Friday."
+      }
+    },
+    {
+      "kind": "single",
+      "principal": { "email": "alice@example.com" },
+      "message": {
+        "message_id": "msg-2",
+        "from": { "email": "promo@shop.example" },
+        "subject": "50% off this weekend",
+        "body": "Limited-time offer — shop now."
+      }
+    }
+  ]
+}
+```
+
+### Example — batch response (one item errored)
+
+```json
+{
+  "schema_version": "2.2",
+  "results": [
+    {
+      "index": 0,
+      "result": {
+        "category": "NEEDS_RESPONSE",
+        "is_spam": false,
+        "is_phishing": false,
+        "summary": "Vendor invoice needs review by Friday.",
+        "action_items": [{ "description": "Review the Q2 invoice", "due_hint": "Friday" }],
+        "suggested_action": "reply"
+      }
+    },
+    {
+      "index": 1,
+      "error": { "message": "local LLM triage failed for this item" }
+    }
+  ]
+}
+```
+
+---
+
+## Additional REST surfaces
+
+Schema 2.1 (#1778–#1781) restored several agent capabilities on the REST
+contract, all under the `/v1/email` prefix. They are **additive**: triage
+consumers are unaffected. Every model still echoes `schema_version` and forbids
+unknown fields. Only the triage and batch-triage shapes are mirrored on MCP; the
+surfaces below are REST-only.
+
+### Inbox search — `POST /v1/email/search` (#1781)
+
+Read-only mailbox search by Gmail-style query and/or labels. `EmailSearchRequest`
+carries `query`, `labels`, `max_results` (1–100, default 25), and a `page_token`
+cursor. `EmailSearchResponse` returns `count`, a list of `EmailSearchResultItem`
+(inbox-list metadata — raw header strings, `snippet`, `label_ids`, not parsed
+`EmailAddress` objects), and `next_page_token`. Fetch the full body via the triage
+path.
+
+### Mailbox actions — archive & phishing-quarantine (#1779)
+
+Mutating actions are gated by a single-use confirmation-token handshake, mirroring
+draft→send (#1264):
+
+1. `POST /v1/email/confirm` (`EmailActionConfirmRequest`) mints a
+   `confirmation_token` bound to one `(action, message_id)` — `action` is
+   `"archive"` or `"quarantine"`.
+2. `POST /v1/email/archive` / `POST /v1/email/quarantine` echoes the token; a
+   call without a valid matching token is rejected (`403`).
+
+Both are reversible inside an undo window via **ungated** reversal endpoints
+(`/v1/email/unarchive`, `/v1/email/unquarantine`) — reversal restores, never
+destroys. Archive returns the `batch_id` undo handle **and** `post_archive_id`
+(folder-based backends like Outlook mint a new id on the move). Quarantine applies
+the `GAIA_PHISHING_QUARANTINE` label + archives, records `prior_labels` for undo,
+and is **Gmail-only** (a request resolving to an Outlook mailbox is rejected
+`400`); it also refuses a message not flagged `is_phishing`.
+
+### Calendar — view / create / respond (#1780)
+
+- `GET /v1/email/calendar/events` → `CalendarEventsResponse` (read-only view;
+  `CalendarEvent` flattens provider start/end strings).
+- `POST /v1/email/calendar/events/preview` → `CalendarEventPreviewResponse` mints
+  a confirmation token bound to the event.
+- `POST /v1/email/calendar/events` (`CalendarCreateEventRequest`) creates the
+  event — confirmation-gated (`403` without a valid token) — returning
+  `CalendarEventResponse`.
+- `POST /v1/email/calendar/events/respond` (`CalendarRespondRequest`) RSVPs
+  (`accepted` / `declined` / `tentative`); not token-gated (explicit user action).
+
+`CalendarEventDateTime` requires **exactly one** of `date_time` (RFC 3339 timed)
+or `date` (`YYYY-MM-DD` all-day). The Outlook backend defaults a missing
+`time_zone` to `UTC` on timed events.
+
+### Inbox pre-scan — `POST /v1/email/prescan` (#1778)
+
+A read-only, lightweight triage over recent inbox messages, reshaped into the
+scannable card the Agent UI renders. `EmailPreScanRequest` carries `max_messages`
+(1–100, default 25). `EmailPreScanResponse.result` is an `EmailPreScanResult`
+(`kind == "email_pre_scan"`) with capped `urgent` / `actionable` /
+`suggested_archives` lists of `PreScanItem`, an `informational_count`,
+`preferences_applied`, and pre-cap `totals`.
 
 ---
 
@@ -352,10 +490,11 @@ response = parse_response(raw_response_dict)  # -> EmailTriageResponse
 
 ## Stability contract
 
-- **Frozen at `1.0`.** Additive, backward-compatible changes (new optional
-  fields) keep the version. Any breaking change (renamed/removed field, new
-  required field, taxonomy change) bumps `SCHEMA_VERSION` so consumers detect it.
-- **Categories never drift.** The four-bucket taxonomy is mirrored from the
+- **Versioned additively.** Additive, backward-compatible changes (new optional
+  fields, new endpoints) keep older consumers working; `SCHEMA_VERSION` bumps only
+  on a breaking change (renamed/removed field, new required field, taxonomy
+  change) so consumers detect it. See the [version history](#version-history).
+- **Categories never drift.** The five-bucket taxonomy is mirrored from the
   agent's `triage_heuristics.ALL_CATEGORIES`; a unit test asserts byte-for-byte
   equality, so a taxonomy change in either place fails CI.
 - **Unknown fields are errors**, not warnings — there is no silent forward-compat

--- a/docs/spec/error-fixing-mixin.mdx
+++ b/docs/spec/error-fixing-mixin.mdx
@@ -3,7 +3,7 @@ title: "ErrorFixingMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/error_fixing.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/error_fixing.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/error_fixing.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/error_fixing.py)
 </Info>
 
 <Note>
@@ -254,7 +254,7 @@ into an ordered plan of tool invocations the agent then executes.
 ### Example 1: Auto-Fix Syntax Errors
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 

--- a/docs/spec/external-tools-mixin.mdx
+++ b/docs/spec/external-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "ExternalToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/external_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/external_tools.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/external_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/external_tools.py)
 </Info>
 
 <Note>

--- a/docs/spec/file-io-tools-mixin.mdx
+++ b/docs/spec/file-io-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "FileIOToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/file_io.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/file_io.py)
+  **Source Code:** [`src/gaia/agents/tools/file_io_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/tools/file_io_tools.py)
 </Info>
 
 <Note>
@@ -266,7 +266,7 @@ what it's building.
 ### Example 1: Read and Analyze Python File
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 

--- a/docs/spec/file-search-mixin.mdx
+++ b/docs/spec/file-search-mixin.mdx
@@ -46,6 +46,7 @@ class FileSearchToolsMixin:
     - read_file: Type-aware file reading with analysis
     - search_file_content: Grep-like content search
     - write_file: Generic file writer
+    - edit_file: Partial string replacement in an existing file
     - browse_directory: List directory contents with metadata
     - get_file_info: Inspect a single file's metadata
     - analyze_data_file: Summarise CSV / JSON / XLSX / log files
@@ -216,6 +217,38 @@ class FileSearchToolsMixin:
                 "file_path": str,
                 "bytes_written": int,
                 "line_count": int
+            }
+        """
+        pass
+
+    @tool
+    def edit_file(
+        file_path: str,
+        old_content: str,
+        new_content: str,
+    ) -> Dict[str, Any]:
+        """
+        Edit a file by replacing old content with new content.
+
+        Partial string replacement (first occurrence only) rather than a full
+        overwrite — like Claude Code's Edit tool. Runs the same security
+        guardrails as write_file (PathValidator allowlist, blocked-dir and
+        sensitive-file checks, backup creation, audit logging). The target file
+        must already exist and contain old_content verbatim.
+
+        Args:
+            file_path: File to edit
+            old_content: Exact text to find and replace
+            new_content: Replacement text
+
+        Returns:
+            {
+                "status": "success",
+                "file_path": str,
+                "old_size": int,   # chars before edit
+                "new_size": int,   # chars after edit
+                "diff": str,       # unified diff
+                "backup_path": str # only when a backup was created
             }
         """
         pass

--- a/docs/spec/file-tools-mixin.mdx
+++ b/docs/spec/file-tools-mixin.mdx
@@ -245,7 +245,7 @@ class MockChatAgent(Agent, FileToolsMixin):
         return "Test agent"
 
     def _create_console(self):
-        from gaia import SilentConsole
+        from gaia.agents.base.console import SilentConsole
         return SilentConsole()
 
     def _register_tools(self):

--- a/docs/spec/jira-agent.mdx
+++ b/docs/spec/jira-agent.mdx
@@ -3,12 +3,12 @@ title: "JiraAgent"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/jira/agent.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/jira/agent.py)
+  **Source Code:** [`hub/agents/python/jira/gaia_agent_jira/agent.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/jira/gaia_agent_jira/agent.py)
 </Info>
 
 <Note>
 **Component:** JiraAgent - Natural Language Jira Interface
-**Module:** `gaia.agents.jira.agent`
+**Module:** `gaia_agent_jira.agent`
 **Inherits:** Agent
 **Model:** Qwen3.5-35B-A3B-GGUF (default)
 </Note>
@@ -69,10 +69,7 @@ class JiraAgent(Agent):
     def __init__(
         self,
         jira_config: Dict[str, Any] = None,
-        max_steps: int = 10,
-        model_id: str = "Qwen3.5-35B-A3B-GGUF",
-        silent_mode: bool = False,
-        **kwargs
+        **kwargs,
     ):
         """
         Initialize Jira agent.
@@ -84,6 +81,9 @@ class JiraAgent(Agent):
                 "statuses": ["To Do", "In Progress", "Done"],
                 "priorities": ["Highest", "High", "Medium", "Low"]
             }
+            **kwargs: Forwarded to the base Agent — e.g. max_steps
+                (default: the global default), model_id (default:
+                Qwen3.5-35B-A3B-GGUF), silent_mode, debug, show_prompts.
         """
         pass
 
@@ -349,7 +349,7 @@ gaia jira "Show me high priority bugs assigned to me"
 ### Example 2: Python API
 
 ```python
-from gaia.agents.jira.agent import JiraAgent
+from gaia_agent_jira.agent import JiraAgent
 
 # Initialize and discover
 agent = JiraAgent()

--- a/docs/spec/llm-client.mdx
+++ b/docs/spec/llm-client.mdx
@@ -382,7 +382,7 @@ class LemonadeProvider(LLMClient):
         Initialize Lemonade provider.
 
         Args:
-            model: Model name (defaults to "Qwen3-0.6B-GGUF")
+            model: Model name (defaults to DEFAULT_MODEL_NAME, currently "Gemma-4-E4B-it-GGUF")
             base_url: Base URL for Lemonade server (overrides LEMONADE_BASE_URL env var)
             host: Server host (alternative to base_url)
             port: Server port (alternative to base_url)
@@ -398,7 +398,7 @@ class LemonadeProvider(LLMClient):
             LEMONADE_MODEL: Default model name if not specified
 
         Note:
-            Default model is "Qwen3-0.6B-GGUF" for CPU-only inference.
+            Default model is DEFAULT_MODEL_NAME (currently "Gemma-4-E4B-it-GGUF").
             All methods use temperature=0.1 by default for deterministic responses.
         """
 
@@ -809,7 +809,7 @@ from .exceptions import NotSupportedError
 from typing import Iterator, Optional, Union
 from ..base_client import LLMClient
 from ..lemonade_client import LemonadeClient, DEFAULT_MODEL_NAME
-# DEFAULT_MODEL_NAME = "Qwen3-0.6B-GGUF"
+# DEFAULT_MODEL_NAME = "Gemma-4-E4B-it-GGUF"
 ```
 
 **OpenAIProvider (`providers/openai_provider.py`):**

--- a/docs/spec/mcp-agent.mdx
+++ b/docs/spec/mcp-agent.mdx
@@ -398,7 +398,7 @@ class TestMCPAgent(MCPAgent, Agent):
         return "Test MCP agent"
 
     def _create_console(self):
-        from gaia import SilentConsole
+        from gaia.agents.base.console import SilentConsole
         return SilentConsole()
 
     def _register_tools(self):
@@ -437,7 +437,7 @@ def test_mcp_agent_is_abstract():
             def _get_system_prompt(self):
                 return "Test"
             def _create_console(self):
-                from gaia import SilentConsole
+                from gaia.agents.base.console import SilentConsole
                 return SilentConsole()
             def _register_tools(self):
                 pass
@@ -556,7 +556,7 @@ def test_multiple_tools():
             return "Multi-tool agent"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -584,14 +584,14 @@ def test_multiple_tools():
 
 def test_inheritance_with_api_agent():
     """Test multiple inheritance with ApiAgent."""
-    from gaia.agents.base import ApiAgent
+    from gaia.agents.base.api_agent import ApiAgent
 
     class DualAgent(MCPAgent, ApiAgent, Agent):
         def _get_system_prompt(self):
             return "Dual agent"
 
         def _create_console(self):
-            from gaia import SilentConsole
+            from gaia.agents.base.console import SilentConsole
             return SilentConsole()
 
         def _register_tools(self):
@@ -635,7 +635,7 @@ class FileAgent(MCPAgent, Agent):
         return "You are a file management agent."
 
     def _create_console(self):
-        from gaia import AgentConsole
+        from gaia.agents.base.console import AgentConsole
         return AgentConsole()
 
     def _register_tools(self):
@@ -695,7 +695,7 @@ class ProjectAgent(MCPAgent, Agent):
         return "You are a project management agent."
 
     def _create_console(self):
-        from gaia import AgentConsole
+        from gaia.agents.base.console import AgentConsole
         return AgentConsole()
 
     def _register_tools(self):
@@ -742,7 +742,8 @@ class ProjectAgent(MCPAgent, Agent):
 ### Example 3: Multi-Protocol Agent
 
 ```python
-from gaia.agents.base import Agent, MCPAgent, ApiAgent
+from gaia.agents.base import Agent, MCPAgent
+from gaia.agents.base.api_agent import ApiAgent
 from typing import List, Dict, Any
 
 class CodeAgent(MCPAgent, ApiAgent, Agent):
@@ -752,7 +753,7 @@ class CodeAgent(MCPAgent, ApiAgent, Agent):
         return "You are an autonomous coding agent."
 
     def _create_console(self):
-        from gaia import AgentConsole
+        from gaia.agents.base.console import AgentConsole
         return AgentConsole()
 
     def _register_tools(self):

--- a/docs/spec/mcp-client.mdx
+++ b/docs/spec/mcp-client.mdx
@@ -1105,6 +1105,7 @@ def to_gaia_format(self, server_name: str) -> Dict[str, Any]:
 ### Connection Flow
 
 ```mermaid
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#E2A33E', 'primaryTextColor':'#1a1a1a', 'primaryBorderColor':'#A87B2D', 'lineColor':'#EFC480', 'secondaryColor':'#2d2d2d', 'tertiaryColor':'#f5f5f5', 'fontSize':'16px', 'fontFamily': 'system-ui, -apple-system, sans-serif'}}}%%
 sequenceDiagram
     participant Agent
     participant Mixin as MCPClientMixin

--- a/docs/spec/mcp-server.mdx
+++ b/docs/spec/mcp-server.mdx
@@ -76,6 +76,8 @@ class AgentMCPServer:
         host: str = None,
         verbose: bool = False,
         agent_params: Dict[str, Any] = None,
+        transport: Transport = "streamable-http",
+        register_typed_tools: bool = False,
     ):
         """
         Initialize MCP server for an agent.
@@ -83,21 +85,28 @@ class AgentMCPServer:
         Args:
             agent_class: MCPAgent subclass to wrap
             name: Display name (default: "GAIA {AgentName} MCP")
-            port: Port to listen on (default: 8080)
-            host: Host to bind to (default: localhost)
+            port: Port to listen on (default: 8080). Ignored for stdio.
+            host: Host to bind to (default: localhost). Ignored for stdio.
             verbose: Enable verbose logging
             agent_params: Parameters for agent __init__
+            transport: Default transport for start() — "streamable-http"
+                (binds a port) or "stdio" (JSON-RPC over stdin/stdout)
+            register_typed_tools: When True, register each tool with an explicit
+                typed signature derived from its inputSchema. When False (default),
+                use the legacy **kwargs wrapper that tolerates VSCode/Copilot's
+                {"kwargs": ...} envelope.
 
         Raises:
             TypeError: If agent_class doesn't inherit MCPAgent
         """
         pass
 
-    def start(self):
+    def start(self, transport: Transport = None):
         """
-        Start MCP server with streamable-http transport.
+        Start the MCP server.
 
-        Prints startup banner and blocks until Ctrl+C.
+        Uses the transport passed here, or the instance default from __init__.
+        Prints the startup banner and blocks until Ctrl+C.
         """
         pass
 
@@ -274,7 +283,7 @@ def _print_startup_info(self):
 
 def test_server_initialization():
     """Test AgentMCPServer initializes."""
-    from gaia.agents.docker.agent import DockerAgent
+    from gaia_agent_docker.agent import DockerAgent
 
     server = AgentMCPServer(
         agent_class=DockerAgent,
@@ -294,7 +303,7 @@ def test_server_rejects_non_mcp_agent():
 
 def test_tool_registration():
     """Test tools are registered from agent."""
-    from gaia.agents.docker.agent import DockerAgent
+    from gaia_agent_docker.agent import DockerAgent
 
     server = AgentMCPServer(
         agent_class=DockerAgent,
@@ -310,7 +319,7 @@ def test_tool_registration():
 @pytest.mark.asyncio
 async def test_parameter_mapping():
     """Test VSCode parameter unwrapping."""
-    from gaia.agents.docker.agent import DockerAgent
+    from gaia_agent_docker.agent import DockerAgent
 
     server = AgentMCPServer(
         agent_class=DockerAgent,
@@ -367,7 +376,7 @@ from gaia.logger import get_logger
 
 ```python
 from gaia.mcp.agent_mcp_server import AgentMCPServer
-from gaia.agents.docker.agent import DockerAgent
+from gaia_agent_docker.agent import DockerAgent
 
 # Create server
 server = AgentMCPServer(
@@ -385,19 +394,49 @@ server = AgentMCPServer(
 server.start()
 ```
 
-### Example 2: Start Jira MCP Server
+### Example 2: Wrap a Custom MCPAgent
+
+Any subclass of `MCPAgent` can be served — `agent_class` is validated against
+`MCPAgent` at construction, so the agent must implement
+`get_mcp_tool_definitions()` and `execute_mcp_tool()`.
 
 ```python
-from gaia.agents.jira.agent import JiraAgent
+from typing import Any, Dict, List
+from gaia.agents.base.mcp_agent import MCPAgent
+from gaia.agents.base.console import SilentConsole
+from gaia.mcp.agent_mcp_server import AgentMCPServer
+
+class GreeterAgent(MCPAgent):
+    def _get_system_prompt(self) -> str:
+        return "You greet users."
+
+    def _create_console(self):
+        return SilentConsole()
+
+    def _register_tools(self):
+        pass
+
+    def get_mcp_tool_definitions(self) -> List[Dict[str, Any]]:
+        return [{
+            "name": "greet",
+            "description": "Greet a person by name",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        }]
+
+    def execute_mcp_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        if tool_name == "greet":
+            return {"message": f"Hello, {arguments['name']}!"}
+        raise ValueError(f"Unknown tool: {tool_name}")
 
 server = AgentMCPServer(
-    agent_class=JiraAgent,
+    agent_class=GreeterAgent,
     port=8081,
     verbose=False,
-    agent_params={
-        "jira_config": discovered_config,  # Pre-discovered config
-        "silent_mode": True
-    }
+    agent_params={"silent_mode": True},
 )
 
 server.start()
@@ -409,7 +448,7 @@ server.start()
 # src/gaia/mcp/start_docker_mcp.py
 import argparse
 from gaia.mcp.agent_mcp_server import AgentMCPServer
-from gaia.agents.docker.agent import DockerAgent
+from gaia_agent_docker.agent import DockerAgent
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--port", type=int, default=8080)
@@ -434,9 +473,8 @@ python -m gaia.mcp.start_docker_mcp --port 8080 --verbose
 
 ## Related Specifications
 
-- [agent-base](/spec/agent-base) - MCPAgent interface
+- [mcp-agent](/spec/mcp-agent) - MCPAgent interface
 - [docker-agent](/spec/docker-agent) - Example agent using MCP
-- [jira-agent](/spec/jira-agent) - Another MCP-enabled agent
 - [electron-integration](/spec/electron-integration) - Electron MCP client
 
 ---

--- a/docs/spec/prisma-tools-mixin.mdx
+++ b/docs/spec/prisma-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "PrismaToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/prisma_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/prisma_tools.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/prisma_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/prisma_tools.py)
 </Info>
 
 <Note>

--- a/docs/spec/project-management-mixin.mdx
+++ b/docs/spec/project-management-mixin.mdx
@@ -3,7 +3,7 @@ title: "ProjectManagementMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/project_management.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/project_management.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/project_management.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/project_management.py)
 </Info>
 
 <Note>

--- a/docs/spec/rag-sdk.mdx
+++ b/docs/spec/rag-sdk.mdx
@@ -60,6 +60,9 @@ class RAGConfig:
     max_file_size_mb: int = 100
     warn_file_size_mb: int = 50
 
+    # Chunking strategy
+    use_llm_chunking: bool = False
+
     # VLM settings
     vlm_model: str = "Qwen3-VL-4B-Instruct-GGUF"
 

--- a/docs/spec/routing-agent.mdx
+++ b/docs/spec/routing-agent.mdx
@@ -196,8 +196,8 @@ def test_api_mode_defaults():
 
 ## Dependencies
 
-RoutingAgent stays in the core framework and depends only on the LLM client.
-CodeAgent ships as the standalone `gaia-agent-code` wheel (#1397, #1102);
+RoutingAgent ships as the standalone `gaia-agent-routing` wheel and depends only
+on the LLM client. CodeAgent ships as the standalone `gaia-agent-code` wheel (#1397, #1102);
 RoutingAgent resolves it lazily at runtime through the agent registry
 (`AgentRegistry().create_agent("code", ...)`) and raises an actionable error
 if the wheel is not installed — it does **not** hard-depend on the package.

--- a/docs/spec/summarizer-app.mdx
+++ b/docs/spec/summarizer-app.mdx
@@ -71,7 +71,7 @@ SUMMARY_STYLES = {
 ### SummarizerApp
 
 `SummarizerApp` is a **thin wrapper** that delegates to
-[`SummarizerAgent`](https://github.com/amd/gaia/blob/main/src/gaia/agents/summarize/agent.py)
+[`SummarizerAgent`](https://github.com/amd/gaia/blob/main/hub/agents/python/summarize/gaia_agent_summarize/agent.py)
 for the actual prompt construction, retry logic, and multi-style generation.
 The app class itself exposes just four public methods:
 
@@ -286,14 +286,20 @@ print(f"Recipients: {participants.get('recipients')}")
 
 ```python
 def test_content_type_detection():
-    """Test auto-detection of content type."""
-    app = SummarizerApp()
+    """Test auto-detection of content type.
+
+    detect_content_type lives on SummarizerAgent (see note above), not on the
+    thin SummarizerApp wrapper.
+    """
+    from gaia_agent_summarize.agent import SummarizerAgent
+
+    agent = SummarizerAgent()
 
     transcript = "Alice: Hello\nBob: Hi there"
-    assert app.detect_content_type(transcript) == "transcript"
+    assert agent.detect_content_type(transcript) == "transcript"
 
     email = "From: alice@test.com\nTo: bob@test.com\nSubject: Test"
-    assert app.detect_content_type(email) == "email"
+    assert agent.detect_content_type(email) == "email"
 
 def test_single_style_summarization():
     """Test single style summary."""

--- a/docs/spec/testing-mixin.mdx
+++ b/docs/spec/testing-mixin.mdx
@@ -3,7 +3,7 @@ title: "TestingMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/testing.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/testing.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/testing.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/testing.py)
 </Info>
 
 <Note>
@@ -131,7 +131,7 @@ else:
 ### Example 1: Execute Python Script
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 

--- a/docs/spec/tool-decorator.mdx
+++ b/docs/spec/tool-decorator.mdx
@@ -264,7 +264,7 @@ def search_users(
 }
 ```
 
-### Example 3: Tool with Complex Types
+### Example 4: Tool with Complex Types
 
 ```python
 from typing import Dict, List
@@ -303,7 +303,7 @@ def batch_process(
 }
 ```
 
-### Example 4: Tool in Agent Context
+### Example 5: Tool in Agent Context
 
 ```python
 from gaia.agents.base.agent import Agent
@@ -351,7 +351,7 @@ class MyAgent(Agent):
             return {"tables": tables}
 ```
 
-### Example 5: Both Decorator Syntaxes
+### Example 6: Both Decorator Syntaxes
 
 ```python
 # Syntax 1: No parentheses (recommended)

--- a/docs/spec/typescript-tools-mixin.mdx
+++ b/docs/spec/typescript-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "TypeScriptToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/typescript_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/typescript_tools.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/typescript_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/typescript_tools.py)
 </Info>
 
 <Note>
@@ -72,7 +72,7 @@ Validate TypeScript code compilation and linting.
 ### Example 1: Basic Validation
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 

--- a/docs/spec/validation-tools-mixin.mdx
+++ b/docs/spec/validation-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "ValidationToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/validation_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/validation_tools.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/validation_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/validation_tools.py)
 </Info>
 
 <Note>
@@ -231,7 +231,7 @@ str  # Tool command (e.g., 'manage_react_component(variant="form", ...)')
 ### Example 1: Test CRUD API
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 

--- a/docs/spec/vlm-client.mdx
+++ b/docs/spec/vlm-client.mdx
@@ -34,7 +34,7 @@ VLMClient provides Vision-Language Model capabilities for extracting text from i
 ### Functional Requirements
 
 1. **Model Management**
-   - Load VLM model (Qwen3-VL-4B-Instruct-GGUF)
+   - Load VLM model (Gemma-4-E4B-it-GGUF)
    - Automatic model download via Lemonade
    - Model availability checking
    - State tracking (loaded/unloaded)
@@ -105,7 +105,7 @@ class VLMClient:
     VLM client for extracting text from images using Lemonade server.
 
     Handles:
-    - Model loading (Qwen3-VL-4B-Instruct-GGUF)
+    - Model loading (Gemma-4-E4B-it-GGUF)
     - Image-to-markdown conversion
     - State tracking for VLM processing
 
@@ -122,7 +122,7 @@ class VLMClient:
 
     def __init__(
         self,
-        vlm_model: str = "Qwen3-VL-4B-Instruct-GGUF",
+        vlm_model: str = "Gemma-4-E4B-it-GGUF",
         base_url: Optional[str] = None,
         auto_load: bool = True,
     ):
@@ -158,10 +158,10 @@ class VLMClient:
             >>> vlm = VLMClient()
             >>> if not vlm.check_availability():
             ...     print("Model not available")
-            ❌ VLM model not found: Qwen3-VL-4B-Instruct-GGUF
+            ❌ VLM model not found: Gemma-4-E4B-it-GGUF
             📥 To download this model:
                1. Open Lemonade Model Manager (http://localhost:13305)
-               2. Search for: Qwen3-VL-4B-Instruct-GGUF
+               2. Search for: Gemma-4-E4B-it-GGUF
                3. Click 'Download' to install the model
         """
         pass
@@ -452,7 +452,7 @@ def test_initialize_vlm_client():
     """Test VLM client initialization."""
     with patch('gaia.llm.vlm_client.LemonadeClient'):
         vlm = VLMClient()
-        assert vlm.vlm_model == "Qwen3-VL-4B-Instruct-GGUF"
+        assert vlm.vlm_model == "Gemma-4-E4B-it-GGUF"
         assert vlm.auto_load is True
         assert vlm.vlm_loaded is False
 
@@ -477,7 +477,7 @@ def test_check_availability_success():
         vlm = VLMClient()
         vlm.client.list_models = Mock(return_value={
             "data": [
-                {"id": "Qwen3-VL-4B-Instruct-GGUF"},
+                {"id": "Gemma-4-E4B-it-GGUF"},
                 {"id": "Other-Model"}
             ]
         })

--- a/docs/spec/web-tools-mixin.mdx
+++ b/docs/spec/web-tools-mixin.mdx
@@ -3,7 +3,7 @@ title: "WebToolsMixin"
 ---
 
 <Info>
-  **Source Code:** [`src/gaia/agents/code/tools/web_dev_tools.py`](https://github.com/amd/gaia/blob/main/src/gaia/agents/code/tools/web_dev_tools.py)
+  **Source Code:** [`hub/agents/python/code/gaia_agent_code/tools/web_dev_tools.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/code/gaia_agent_code/tools/web_dev_tools.py)
 </Info>
 
 <Note>
@@ -438,7 +438,7 @@ if model_info["success"]:
 ### Example 1: Build Complete CRUD App
 
 ```python
-from gaia import CodeAgent
+from gaia_agent_code import CodeAgent
 
 agent = CodeAgent()
 


### PR DESCRIPTION
## Why this matters

A full audit of the published documentation against `main`. It fixes reader-facing breakage across the whole docs surface: mermaid diagrams that were unreadable in dark mode (sequence-message and flowchart edge-label text rendered dark-on-dark — e.g. the flagged Wi-Fi agent diagram); CLI/feature reference pages that documented **removed** commands; a connectors page that described a **fictional** catalog; a Browser Agent guide too thin to use; SDK examples that would **crash on copy-paste**; and the C++ framework defaulting to a Lemonade port (`8000`) that the server doesn't use (`13305`). After: diagrams are legible in both themes, documented commands/APIs match the code, and examples run.

Every change was verified against the latest `main`: CLI reconciled via actual `-h` output, Python/C++ examples checked against `src/gaia/` + `hub/agents/python/` + `cpp/` (with import smoke tests), links checked against `docs/docs.json`, and each page reviewed through developer / end-user / enterprise / ISV personas. The dark-mode mermaid fix was validated by rendering both themes.

## Scope (7 commits)

- **guides + C++ + reference + connectors/security + integrations/deployment** — accuracy, dark-mode diagrams, persona gaps; Browser Agent guide expanded.
- **SDK reference** — runtime-correct examples (fixed `indexed_files` set/dict bug, async audio callback, agent-ui `system_prompt` TypeError, removed `gaia mcp add`).
- **Python Specifications** — class/method/signature drift, stale module paths (agents now in `hub/agents/python/<id>/`), tool-mixins aligned to `registry.KNOWN_TOOLS`.
- **Playbooks** — step-by-step tutorials verified runnable in order.
- **Roadmap plans + release notes** — link + dark-mode-diagram fixes only; historical release content left intact; roadmap design docs not rewritten (shipped/stale items flagged, not edited).
- **fix(cpp)** — default Lemonade URL `8000` → `13305` in the C++ source, tests, examples, and README (this is what the C++ integration CI already uses). Python-CLI CI keeps `8000` because it uses `lemonade-server-dev`, which binds there.

## Notable correctness fixes

- Reference/feature docs referenced ~5 removed eval commands (`gaia generate`, `groundtruth`, `batch-experiment`, `eval -d`, `visualize`) → current commands.
- `cli.mdx`: added `mcp serve`, eval flags (`--agent-type/--iterations/--keep-sessions/--device`); connectors doc reflects `gaia mcp add/remove` removal.
- Invalid FontAwesome icon `stars` (rendered blank) → `wand-magic-sparkles`.
- email-integration contract version `2.1` → `2.2`.

## Test plan

- [ ] Preview docs and confirm mermaid diagrams are readable in **dark mode** (spot-check `cpp/wifi-agent`, `guides/sd`, `guides/routing`, `sdk/sdks/rag`).
- [ ] `PYTHONPATH=src python -m gaia.cli -h` and spot-check `reference/cli.mdx` matches (incl. `schedule`, `config`, `uninstall`, `knowledge`, `mcp serve`).
- [ ] C++ build/tests green with the `13305` default (`build_cpp.yml` integration job already targets 13305).
- [ ] No broken internal links (all targets in `docs/docs.json`).
- [ ] `docs/browse` reads completely; its flag table matches `gaia browse -h`.

## Follow-ups flagged (not changed here)

- Stale "supported LLMs" model tables in `faq.mdx`/`features.mdx` (Phi-3.5, Llama-2 …).
- Roadmap docs describing already-shipped work (e.g. `agent-hub-ui` Phase 0, `image-agent`/`vision-sdk` supersets) — maintainer call.
- `plans/docker-containers` Dockerfile `EXPOSE` list includes `8000`, inconsistent with its own port table.