### PR TITLE
docs: fix maintainer-flagged staleness (model tables, shipped plans, ports)

### DIFF
--- a/docs/plans/agent-hub-ui.mdx
+++ b/docs/plans/agent-hub-ui.mdx
@@ -34,6 +34,10 @@ The Agent Hub is a centralized platform for discovering, installing, and managin
 
 ## Phase 0: Restructure — `hub/agents/` Directory
 
+<Note>
+✅ **Shipped.** Production agents (chat, doc, file, code, analyst, browser, email, jira, docker, sd, emr, docqa, routing, …) already live as standalone packages under `hub/agents/python/<id>/`; `src/gaia/agents/` retains only the framework (base classes, shared tool mixins, registry). The remainder of this document is the still-in-progress hub platform plan.
+</Note>
+
 ### Directory structure
 
 ```

--- a/docs/plans/docker-containers.mdx
+++ b/docs/plans/docker-containers.mdx
@@ -124,7 +124,7 @@ ENV SHELL=/bin/zsh
 RUN chsh -s /bin/zsh
 
 # Expose standard GAIA ports
-EXPOSE 3000 5174 8000 9229 9222
+EXPOSE 3000 5174 8080 13305 9229 9222
 
 # Keep container running
 CMD ["tail", "-f", "/dev/null"]
@@ -179,7 +179,7 @@ RUN C:\git-installer.exe /VERYSILENT /NORESTART && \
 RUN pip install --no-cache-dir amd-gaia
 
 # Expose standard GAIA ports
-EXPOSE 3000 5174 8000 9229 9222
+EXPOSE 3000 5174 8080 13305 9229 9222
 
 # Keep container running
 CMD ["powershell", "-NoExit", "-Command", "while ($true) { Start-Sleep -Seconds 3600 }"]
@@ -291,7 +291,7 @@ RUN chsh -s /bin/zsh
 RUN mkdir -p /src
 
 # Expose standard GAIA ports
-EXPOSE 3000 5174 8000 9229 9222
+EXPOSE 3000 5174 8080 13305 9229 9222
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/docs/plans/email-calendar-integration.mdx
+++ b/docs/plans/email-calendar-integration.mdx
@@ -359,7 +359,7 @@ Phase 3 (v0.23.0+):
 
 | Task | Effort | Output |
 |------|--------|--------|
-| EmailTriageAgent class (extends Agent + MemoryMixin) | 2-3 days | New agent in src/gaia/agents/email/ |
+| EmailTriageAgent class (extends Agent + MemoryMixin) | 2-3 days | ✅ Shipped — agent lives in `hub/agents/python/email/` |
 | IMAP/OAuth email source (Gmail + Outlook) | 3-4 days | Direct protocol access |
 | Triage engine (categorize, prioritize, summarize) | 2-3 days | AI-learned categories |
 | Draft response generation | 1-2 days | Agent drafts, user approves |

--- a/docs/plans/image-agent.mdx
+++ b/docs/plans/image-agent.mdx
@@ -6,7 +6,7 @@ description: Intelligent Stable Diffusion assistant that optimizes prompts and p
 # SD Agent
 
 <Info>
-**Status:** Planning
+**Status:** Partially shipped — a Stable Diffusion agent already ships today (`gaia sd`, [SD guide](/guides/sd); source in `hub/agents/python/sd/`). This document describes the aspirational superset (VLM-driven iterative refinement, gallery UI, task queue) and its `PromptAgent`/`src/gaia/agents/sd/` references are design-time names, not the shipped layout.
 **Priority:** Medium
 [Vote with 👍 on GitHub Issue #272](https://github.com/amd/gaia/issues/272)
 </Info>

--- a/docs/plans/vision-sdk.mdx
+++ b/docs/plans/vision-sdk.mdx
@@ -6,7 +6,7 @@ description: Unified document processing pipeline with VLM-powered OCR for AMD A
 # Vision SDK - Document Processing Pipeline
 
 <Info>
-**Status:** Planning
+**Status:** Partially shipped — the core VLM SDK already exists today (`src/gaia/vlm/`, `VLMClient` with `Qwen3-VL-4B-Instruct-GGUF`; see the [VLM SDK](/sdk/sdks/vlm)). This document describes the broader unified document-processing pipeline still on the roadmap.
 **Timeline:** Q2-Q3 2026
 [Vote with 👍](https://github.com/amd/gaia/issues/325)
 </Info>

--- a/docs/reference/faq.mdx
+++ b/docs/reference/faq.mdx
@@ -71,8 +71,10 @@ icon: "circle-question"
     Run the installer from command-line with parameters for CI/CD or silent installations:
 
     ```bash
-    gaia-windows-setup.exe /S
+    gaia-agent-ui-<version>-x64-setup.exe /S
     ```
+
+    (The Windows installer is an NSIS package named `gaia-agent-ui-<version>-<arch>-setup.exe`, downloaded from [GitHub Releases](https://github.com/amd/gaia/releases).)
 
     **Available parameters:**
     - `/S` - Silent installation (no UI)
@@ -145,17 +147,16 @@ Discover the capabilities of Ryzen AI with GAIA - an innovative generative AI ap
   </Accordion>
 
   <Accordion title="What LLMs are supported?" icon="list">
-    GAIA supports various local LLMs optimized for Ryzen AI NPU hardware, including:
+    GAIA runs models locally through [Lemonade Server](https://lemonade-server.ai), so any model in the Lemonade catalog works — GGUF models via llama.cpp on GPU/CPU, and FLM models on the Ryzen AI NPU. The models GAIA agents use by default:
 
-    **Hybrid Mode (NPU + iGPU) - Ryzen AI 300 series:**
-    - Phi-3.5 Mini Instruct
-    - Phi-3 Mini Instruct
-    - Llama-2 7B Chat
-    - Llama-3.2 1B/3B Instruct
-    - Qwen 1.5 7B Chat
-    - Mistral 7B Instruct
+    - **Gemma-4-E4B-it-GGUF** — default chat/coding/vision model (multimodal)
+    - **Qwen3.5-35B-A3B-GGUF** — default for the specialized agents (analyst, browser, file I/O, code, jira, docker, routing)
+    - **Qwen3-4B-Instruct-2507-GGUF** — summarization
+    - **Qwen3-VL-4B-Instruct-GGUF** — alternate vision model
+    - **embeddinggemma-300m-GGUF** — embeddings for RAG/document Q&A
+    - **NPU (FLM):** `gemma4-it-e2b-FLM` + `embed-gemma-300m-FLM` (via `gaia init --profile npu`)
 
-    These models are tailored for different use cases like Q&A, summarization, and complex reasoning tasks.
+    Download them per use case with `gaia init --profile <profile>` (e.g. `minimal`, `chat`, `code`, `vlm`, `npu`).
 
     [→ Full Model List](/reference/features#supported-llms)
   </Accordion>

--- a/docs/reference/features.mdx
+++ b/docs/reference/features.mdx
@@ -239,23 +239,20 @@ For available applications and setup instructions, see the [Desktop UI](/deploym
 
 ## Supported LLMs
 
-The following is a list of the currently supported LLMs with GAIA using Ryzen AI Hybrid (NPU+iGPU) mode using `gaia-windows-setup.exe`. To request support for a new LLM, please contact the [AMD GAIA team](mailto:gaia@amd.com).
+GAIA runs models locally through [Lemonade Server](https://lemonade-server.ai), so **any model in the Lemonade catalog is supported** — GGUF models run via llama.cpp on GPU/CPU, and FLM models run on the Ryzen AI NPU (XDNA2). To request support for a new model, contact the [AMD GAIA team](mailto:gaia@amd.com).
 
-| LLM                    | Checkpoint                                                            | Backend            | Data Type |
-| -----------------------|-----------------------------------------------------------------------|--------------------|-----------|
-| Phi-3.5 Mini Instruct  | amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid         | oga                | int4      |
-| Phi-3 Mini Instruct    | amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid        | oga                | int4      |
-| Llama-2 7B Chat        | amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid            | oga                | int4      |
-| Llama-3.2 1B Instruct  | amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid         | oga                | int4      |
-| Llama-3.2 3B Instruct  | amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid         | oga                | int4      |
-| Qwen 1.5 7B Chat       | amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid               | oga                | int4      |
-| Mistral 7B Instruct    | amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid      | oga                | int4      |
+The models GAIA agents use by default (pulled by `gaia init --profile <profile>`):
 
-The following is a list of the currently supported LLMs in the generic version of GAIA (GAIA_Installer.exe). To request support for a new LLM, please contact the [AMD GAIA team](mailto:gaia@amd.com).
-| LLM                    | Checkpoint                                                            | Device   | Backend            | Data Type |
-| -----------------------|-----------------------------------------------------------------------|----------|--------------------|-----------|
-
-* oga - [Onnx Runtime GenAI](https://github.com/microsoft/onnxruntime-genai)
+| Model | Format / Backend | Used by |
+| ----- | ---------------- | ------- |
+| `Gemma-4-E4B-it-GGUF` | GGUF (llama.cpp) | Default chat, coding, and vision (multimodal) |
+| `Qwen3.5-35B-A3B-GGUF` | GGUF (llama.cpp) | Specialized agents (analyst, browser, file I/O, code, jira, docker, routing, doc Q&A) |
+| `Qwen3-4B-Instruct-2507-GGUF` | GGUF (llama.cpp) | Summarization |
+| `Qwen3-VL-4B-Instruct-GGUF` | GGUF (llama.cpp) | Alternate vision model |
+| `embeddinggemma-300m-GGUF` | GGUF (llama.cpp) | Embeddings for RAG / document Q&A |
+| `gemma4-it-e2b-FLM` | FLM (NPU) | Chat on Ryzen AI NPU (`--profile npu`) |
+| `embed-gemma-300m-FLM` | FLM (NPU) | Embeddings on Ryzen AI NPU (`--profile npu`) |
+| `SDXL-Turbo` | Stable Diffusion | Image generation (also `SDXL-Base-1.0`, `SD-Turbo`, `SD-1.5`) |
 
 ## Installing Additional Models
 


### PR DESCRIPTION
## Why this matters

Follow-up to the documentation audit (#1982), fixing the three items that were flagged for a maintainer decision. Before: the "Supported LLMs" reference listed pre-Lemonade OGA/ONNX-hybrid models (Phi-3.5, Llama-2, Mistral) and dead installer names — actively misleading for anyone choosing a model today; several roadmap docs described already-shipped features as "Planning"; and a container plan's `EXPOSE` list contradicted its own port table. After: model docs match what GAIA actually runs (Lemonade GGUF/FLM), shipped work is marked shipped, and ports are consistent.

## What changed

- **`reference/features.mdx` + `reference/faq.mdx`** — replaced the stale OGA hybrid model tables (and empty "generic installer" table) with the current Lemonade model set, verified against source (`lemonade_client.py`, `init_command.py` profiles): `Gemma-4-E4B-it-GGUF` (default), `Qwen3.5-35B-A3B-GGUF` (agents), `Qwen3-4B-Instruct-2507-GGUF` (summarize), `Qwen3-VL-4B-Instruct-GGUF` (VLM), `embeddinggemma-300m-GGUF` (RAG), FLM NPU models, `SDXL-Turbo`. Fixed the silent-install example from the dead `gaia-windows-setup.exe` to the current NSIS artifact name.
- **Roadmap plans** — status corrected to reflect reality: `agent-hub-ui` Phase 0 (agents already in `hub/agents/python/`), `image-agent` (SD ships as `gaia sd`), `vision-sdk` (VLM SDK ships in `src/gaia/vlm/`), and the email agent row in `email-calendar-integration` (now `hub/agents/python/email/`). Designs left intact — only status/paths corrected.
- **`plans/docker-containers.mdx`** — `EXPOSE` lines had a stale `8000` and omitted `8080`; aligned to the doc's own port table → `3000 5174 8080 13305 9229 9222`.

## Test plan

- [ ] `reference/features` "Supported LLMs" matches `src/gaia/llm/lemonade_client.py` + `src/gaia/installer/init_command.py` profiles.
- [ ] No remaining `gaia-windows-setup.exe` / `GAIA_Installer.exe` / `onnx-hybrid` references in reference docs.
- [ ] `docs/plans/docker-containers` EXPOSE list matches its port table.
- [ ] Roadmap status notes render and read correctly.