### PR TITLE
ci(email): gate releases on the full eval suite + all email tests

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -88,7 +88,12 @@ jobs:
         uses: ./.github/actions/setup-venv
         with:
           python-version: '3.12'
-          install-package: '.[dev,eval,api]'
+          # The email agent ships as the standalone gaia-agent-email wheel (#1102),
+          # so it is NOT pulled by [dev,eval,api]. `gaia eval benchmark` imports
+          # gaia_agent_email.agent — install the LOCAL editable hub package (this
+          # branch's agent code, not the published PyPI wheel) or the benchmark
+          # dies with ModuleNotFoundError on a clean venv.
+          install-package: '.[dev,eval,api] -e hub/agents/python/email'
 
       - name: Install Lemonade Server
         uses: ./.github/actions/install-lemonade

--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -158,9 +158,24 @@ jobs:
             --output-dir eval-out
           if ($LASTEXITCODE -ne 0) { throw "gaia eval benchmark failed" }
 
+      - name: Voice-drafting quality eval (judge-scored) — for the scorecard metric
+        env:
+          # eval_drafting_report.py reads EMAIL_EVAL_MODEL; reuse the refresh model.
+          EMAIL_EVAL_MODEL: ${{ env.MODEL }}
+          # Judge credential. Absent -> loud skip (report says so); the metric is
+          # then simply omitted from the card (gen_scorecard never invents one).
+          # With drafting_gate_thresholds.json enforce:true, a real breach fails
+          # here and the refresh does not commit a regressed card.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python hub/agents/python/email/packaging/eval_drafting_report.py
+          if ($LASTEXITCODE -ne 0) { throw "drafting eval failed" }
+
       - name: Regenerate SCORECARD.md from the real run
         run: |
-          python hub/agents/python/email/packaging/gen_scorecard.py --benchmark-dir eval-out --limit "$env:LIMIT"
+          # --drafting-report folds draft_approval_rate into the card as a
+          # reported metric (weight 0); a loud-skip report omits it cleanly.
+          python hub/agents/python/email/packaging/gen_scorecard.py --benchmark-dir eval-out --limit "$env:LIMIT" --drafting-report eval-out/drafting_gate_report.json
           if ($LASTEXITCODE -ne 0) { throw "gen_scorecard failed" }
 
       - name: Same-version regression check (reject a worse re-run)

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -49,6 +49,12 @@
 #                              as an ENVIRONMENT secret on `agent-publish` (NOT a
 #                              repo secret) so it's unreadable until the gate is
 #                              approved.
+#     ANTHROPIC_API_KEY      — Claude judge credential for the eval-gate's
+#                              voice-drafting eval. REQUIRED: the eval-gate asserts
+#                              it and FAILS the release if absent, so a release
+#                              never ships an un-judged drafting eval. A repo (or
+#                              org) secret — the eval-gate runs before the approval
+#                              gate, on the self-hosted stx pool.
 #   Variables:
 #     GAIA_HUB_BASE_URL      — public Worker origin for downloads + the lock
 #                              baseUrl, default https://hub.amd-gaia.ai.
@@ -349,11 +355,22 @@ jobs:
     uses: ./.github/workflows/test_email_agent_eval.yml
     secrets: inherit
 
+  # ── Stage 1d: email test suite (release gate, hosted) ──────────────
+  # The full email test suite — unit + connectors + eval-framework tests AND the
+  # REST-sidecar contract + OpenAPI-conformance (spec) tests — must pass before a
+  # release publishes. Fully mocked (no Lemonade / network), so it runs on hosted
+  # CI. `publish` gates on it, so a spec/contract or unit regression blocks the
+  # release, not just a PR.
+  email-tests:
+    name: Email test suite (release gate)
+    uses: ./.github/workflows/test_email_agent_unit.yml
+    secrets: inherit
+
   # ── Stage 2: publish to the hub + npm (single atomic step) ─────────
   publish:
     name: Publish to Hub + npm
     runs-on: ubuntu-latest
-    needs: [build, verify-darwin-x64-compat, scorecard-gate, email-eval]
+    needs: [build, verify-darwin-x64-compat, scorecard-gate, email-eval, email-tests]
     # Manual approval gate: the `agent-publish` environment is configured (repo
     # Settings → Environments) with required reviewers, so this job pauses until a
     # maintainer approves — the human backstop for an accidental/tampered release

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -51,9 +51,12 @@
 name: Email Agent Eval (offline, report mode)
 
 on:
-  # Nightly — 07:00 UTC daily.
+  # Weekly — Mondays 07:17 UTC. Was nightly; moved to weekly because the run now
+  # includes the judge-scored voice-drafting eval, which spends Claude tokens.
+  # (The release itself re-runs the full suite as a hard gate — see
+  # release_agent_email.yml eval-gate — so daily cadence here is unnecessary.)
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '17 7 * * 1'
   # Manual trigger, with a knob for repeat experiments (variance).
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -139,8 +139,12 @@ jobs:
           python-version: '3.12'
           # [dev] + [eval] for the benchmark + quality/perf gate machinery and
           # the Anthropic/scikit-learn judge deps; [api] for the connectors
-          # layer the email agent boots.
-          install-package: '.[dev,eval,api]'
+          # layer the email agent boots. The email agent ships as the standalone
+          # gaia-agent-email wheel (#1102) and is NOT pulled by those extras —
+          # `gaia eval benchmark` imports gaia_agent_email.agent, so install the
+          # LOCAL editable hub package (this branch's code, not the PyPI wheel)
+          # or the benchmark dies with ModuleNotFoundError on a clean venv.
+          install-package: '.[dev,eval,api] -e hub/agents/python/email'
 
       - name: Install Lemonade Server
         uses: ./.github/actions/install-lemonade

--- a/.github/workflows/test_email_agent_unit.yml
+++ b/.github/workflows/test_email_agent_unit.yml
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 # Fast PR gate for the email-triage agent (#1112).
-# Runs the email-agent unit suite plus the connectors and eval unit tests it
-# depends on, fully mocked — no Lemonade server, no network, no live mailbox.
-# Target: well under ~2 minutes (the local suite runs in ~10s).
+# Runs the email-agent unit suite plus the connectors + eval unit tests it
+# depends on, AND the REST-sidecar contract + OpenAPI-conformance tests (spec
+# validation) — all fully mocked, no Lemonade server, no network, no live
+# mailbox. Also called by release_agent_email.yml as a hard release gate, so a
+# spec/contract regression blocks a release, not just a PR.
+# Target: a couple of minutes (the mocked suite runs in seconds).
 
 name: Email Agent Unit Tests
 
@@ -23,6 +26,7 @@ on:
       - 'tests/unit/connectors/**'
       - 'tests/unit/eval/**'
       - 'tests/fixtures/email/**'
+      - 'tests/test_email_openapi_conformance.py'
       - 'setup.py'
       - 'pyproject.toml'
       - '.github/workflows/test_email_agent_unit.yml'
@@ -40,6 +44,7 @@ on:
       - 'tests/unit/connectors/**'
       - 'tests/unit/eval/**'
       - 'tests/fixtures/email/**'
+      - 'tests/test_email_openapi_conformance.py'
       - 'setup.py'
       - 'pyproject.toml'
       - '.github/workflows/test_email_agent_unit.yml'
@@ -88,8 +93,11 @@ jobs:
           # respx, keyring, httpx). [api] adds fastapi/uvicorn, which the
           # tests/unit/connectors/ router tests import via the UI connectors
           # router. The in-memory keyring backend in tests/conftest.py avoids
-          # the SecretService daemon prerequisite on Linux runners.
-          uv pip install --system -e ".[dev,api]"
+          # the SecretService daemon prerequisite on Linux runners. The email
+          # hub package is installed so the REST-contract + OpenAPI-conformance
+          # tests can import gaia_agent_email (they build the app in-process and
+          # mock Lemonade — no server needed).
+          uv pip install --system -e ".[dev,api]" -e hub/agents/python/email
 
       - name: Run email-agent unit tests
         env:
@@ -101,16 +109,20 @@ jobs:
           echo "                  EMAIL AGENT UNIT TESTS"
           echo "================================================================"
           echo "Scope (fast, fully mocked — no Lemonade, no live mailbox):"
-          echo "  - tests/unit/agents/email/   contract schema"
-          echo "  - tests/unit/email/          gmail client, triage heuristics, corpus integrity"
-          echo "  - tests/unit/connectors/     OAuth/MCP connector plumbing (email uses it)"
-          echo "  - tests/unit/eval/           benchmark / quality + perf gate machinery"
+          echo "  - tests/unit/agents/email/         contract schema"
+          echo "  - tests/unit/email/                gmail client, triage heuristics, corpus integrity"
+          echo "  - tests/unit/connectors/           OAuth/MCP connector plumbing (email uses it)"
+          echo "  - tests/unit/eval/                 benchmark / quality + perf gate machinery"
+          echo "  - hub/agents/python/email/tests/   REST sidecar contract"
+          echo "  - tests/test_email_openapi_conformance.py  OpenAPI spec conformance"
           echo ""
           python -m pytest \
             tests/unit/agents/email/ \
             tests/unit/email/ \
             tests/unit/connectors/ \
             tests/unit/eval/ \
+            hub/agents/python/email/tests/ \
+            tests/test_email_openapi_conformance.py \
             -v --tb=short
 
       - name: Test summary

--- a/.github/workflows/test_email_agent_unit.yml
+++ b/.github/workflows/test_email_agent_unit.yml
@@ -100,10 +100,14 @@ jobs:
           uv pip install --system -e ".[dev,api]" -e hub/agents/python/email
 
       - name: Run email-agent unit tests
-        env:
-          # Skip memory init — Lemonade isn't available in this CI job; the
-          # email-agent unit tests don't exercise memory functionality.
-          GAIA_MEMORY_DISABLED: "1"
+        # NOTE: do NOT set GAIA_MEMORY_DISABLED here. The hub/agents/python/email
+        # memory / inbox-profiling / behavioral-learning / preferences suites DO
+        # exercise memory: they mock the Lemonade embedder per-test (so no server
+        # is needed) and toggle GAIA_MEMORY_DISABLED themselves where a test wants
+        # the disabled path. A process-wide GAIA_MEMORY_DISABLED=1 would force the
+        # memory store to None for every agent, skip memory-tool registration, and
+        # fail those tests. Agents that don't mock the embedder just get a
+        # store=None fast (connection refused), so nothing here needs the flag.
         run: |
           echo "================================================================"
           echo "                  EMAIL AGENT UNIT TESTS"

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -230,11 +230,32 @@ def _compute_breakdown(judged: list) -> Optional[dict]:
     return {"per_category": per_category, "top_confusions": top_confusions}
 
 
+def _load_draft_approval_rate(drafting_report: Path) -> Optional[float]:
+    """Read ``summary.drafting.draft_approval_rate`` from a drafting gate report.
+
+    Returns ``None`` when the report is a loud-skip (no judge credential) so the
+    scorecard simply omits the metric rather than inventing a value. Fails loud if
+    the file exists but is malformed — a judged run must yield a real rate.
+    """
+    data = json.loads(drafting_report.read_text(encoding="utf-8"))
+    if data.get("skipped"):
+        return None
+    rate = data.get("summary", {}).get("drafting", {}).get("draft_approval_rate")
+    if rate is None:
+        raise ValueError(
+            f"No summary.drafting.draft_approval_rate in {drafting_report} "
+            f"(judged run expected). Re-run eval_drafting_report.py with "
+            f"ANTHROPIC_API_KEY set."
+        )
+    return float(rate)
+
+
 def build_payload(
     benchmark_dir: Path,
     ground_truth_path: Path,
     limit=None,
     environment=None,
+    drafting_report=None,
 ):
     """Build a :class:`~gaia.eval.release_scorecard.ResultPayload` from benchmark output.
 
@@ -379,6 +400,20 @@ def build_payload(
             "weight": 0.0,
         },
     ]
+    # Fold the judge-scored voice-drafting result in as a REPORTED metric
+    # (weight 0) when a drafting report is supplied — visible on the card without
+    # changing the aggregate (still 100 x within_one). Blocking on a drafting
+    # regression is the drafting gate's job (enforce:true), not the aggregate's.
+    if drafting_report is not None:
+        draft_rate = _load_draft_approval_rate(Path(drafting_report))
+        if draft_rate is not None:
+            metrics.append(
+                {
+                    "name": "draft_approval_rate",
+                    "value": float(draft_rate),
+                    "weight": 0.0,
+                }
+            )
     compute_aggregate(
         metrics
     )  # validate metrics; aggregate embedded in render_scorecard
@@ -591,6 +626,17 @@ def main(argv=None) -> int:
         default=None,
         help="Sampling temperature used for the eval run, if applicable.",
     )
+    parser.add_argument(
+        "--drafting-report",
+        default=None,
+        help=(
+            "Path to eval-out/drafting_gate_report.json (from "
+            "eval_drafting_report.py). When given and not a loud-skip, folds "
+            "draft_approval_rate into the scorecard as a reported metric "
+            "(weight 0). Blocking on a drafting regression is the drafting "
+            "gate's job (enforce:true), not the aggregate's."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -636,7 +682,11 @@ def main(argv=None) -> int:
 
     try:
         payload = build_payload(
-            benchmark_dir, gt_path, limit=args.limit, environment=environment
+            benchmark_dir,
+            gt_path,
+            limit=args.limit,
+            environment=environment,
+            drafting_report=args.drafting_report,
         )
     except (ValueError, FileNotFoundError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/tests/fixtures/email/drafting_gate_thresholds.json
+++ b/tests/fixtures/email/drafting_gate_thresholds.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Draft-approval bar for the voice/style drafting eval (#1607 feature, #1269 metric, #1948 tracking). 'approval_min' is the REPORTED target from #1269 (draft-approval >= 70%), NOT an enforced gate: 'enforce' is the SINGLE switch CI keys off and it ships FALSE (report mode) on purpose — no real judged baseline exists yet, so the bar is not yet confirmed meaningful on hardware. Flip 'enforce' to true HERE (data, not code) once the nightly report establishes a stable baseline. Loaded by gaia.eval.draft_quality.load_drafting_thresholds.",
+  "_comment": "Draft-approval bar for the voice/style drafting eval (#1607 feature, #1269 metric, #1948 tracking). 'approval_min' is the target from #1269 (draft-approval >= 70%). 'enforce' is the SINGLE switch CI keys off; it is now TRUE — the judge-scored drafting eval is a hard release gate (release_agent_email.yml eval-gate). A draft-approval regression below approval_min blocks the release; a missing ANTHROPIC_API_KEY also blocks it (the eval-gate asserts the key before running). Loaded by gaia.eval.draft_quality.load_drafting_thresholds.",
   "approval_min": 0.70,
-  "enforce": false
+  "enforce": true
 }

--- a/tests/fixtures/email/perf_gate_thresholds.json
+++ b/tests/fixtures/email/perf_gate_thresholds.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "Strix Halo perf bars for the email-triage benchmark (#1277). These are the AC targets; 'enforce' is the SINGLE switch CI (#1112) keys off. It ships FALSE (report mode) on purpose: the bars only become gating once they are confirmed on actual Ryzen AI / Strix Halo hardware in the nightly self-hosted job. #1112 flips 'enforce' to true HERE (data, not code) to make the harness fail on a missed gating bar. Loaded by gaia.eval.performance.load_perf_thresholds.",
+  "_comment": "Strix Halo perf bars for the email-triage benchmark (#1277). These are the AC targets; 'enforce' is the SINGLE switch CI (#1112) keys off. It is now TRUE — a missed gating bar (ttft/tps/pipeline/mem) blocks the release (release_agent_email.yml eval-gate runs on the stx pool). NOTE: these bars are not yet independently hardware-confirmed; if the stx pool proves noisy, widen the bars HERE (data, not code) rather than reverting to report mode. Loaded by gaia.eval.performance.load_perf_thresholds.",
   "_gating": "ttft_max_s, throughput_min_tps, pipeline_max_s, peak_memory_max_gb are GATING bars when enforced. NPU utilization is REPORTED-ONLY (no bar) — it is observed and exported but never gates the build.",
   "ttft_max_s": 5.0,
   "throughput_min_tps": 10.0,
   "pipeline_max_s": 300.0,
   "peak_memory_max_gb": 8.0,
-  "enforce": false
+  "enforce": true
 }

--- a/tests/unit/email/test_briefing_corpus_integrity.py
+++ b/tests/unit/email/test_briefing_corpus_integrity.py
@@ -17,8 +17,9 @@ plus offline coverage of the judge scorer in ``gaia.eval.briefing_quality``:
   fields, and out-of-range scores.
 - The scorer runs end-to-end on a mocked judge (no backend, no network) and
   produces an approval rate in range plus a build_scorecard-compatible summary.
-- The committed thresholds manifest ships the #1951 bars in report mode
-  (``enforce: false``) and the gate honors the ``should_fail`` contract.
+- The committed thresholds manifest ships the #1951 bars as a hard gate
+  (``enforce: true`` — release_agent_email.yml eval-gate) and the gate
+  honors the ``should_fail`` contract.
 
 Everything here runs offline: no Lemonade, no Anthropic, no live mailbox.
 """

--- a/tests/unit/email/test_drafting_corpus_integrity.py
+++ b/tests/unit/email/test_drafting_corpus_integrity.py
@@ -17,8 +17,9 @@ offline coverage of the judge scorer in ``gaia.eval.draft_quality``:
 - The scorer runs end-to-end on a mocked judge (no backend, no network)
   and produces an approval rate in range plus a build_scorecard-compatible
   summary.
-- The committed thresholds manifest ships the #1269 bar in report mode
-  (``enforce: false``) and the gate honors the ``should_fail`` contract.
+- The committed thresholds manifest ships the #1269 bar as a hard gate
+  (``enforce: true`` — release_agent_email.yml eval-gate) and the gate
+  honors the ``should_fail`` contract.
 
 Everything here runs offline: no Lemonade, no Anthropic, no live mailbox.
 """
@@ -258,10 +259,12 @@ def test_missing_draft_and_unparseable_judge_become_errored(corpus):
 # ---------------------------------------------------------------------------
 
 
-def test_committed_thresholds_manifest_is_report_mode():
+def test_committed_thresholds_manifest_is_enforcing():
     thresholds = dq.load_drafting_thresholds(THRESHOLDS_PATH)
-    assert thresholds.approval_min == 0.70  # the #1269 reported target
-    assert thresholds.enforce is False  # report mode — see the manifest comment
+    assert thresholds.approval_min == 0.70  # the #1269 target
+    # Enforcing gate (#1990) — a draft-approval breach blocks the release
+    # (release_agent_email.yml eval-gate). See the manifest comment.
+    assert thresholds.enforce is True
     # The module default points at the same committed manifest.
     assert dq.default_drafting_thresholds_path() == THRESHOLDS_PATH
 

--- a/tests/unit/eval/test_benchmark.py
+++ b/tests/unit/eval/test_benchmark.py
@@ -454,7 +454,11 @@ class TestAcceptanceMetrics:
 
 
 class TestPerfGateInBenchmark:
-    """The perf gate (#1277) added alongside #1278's quality gate — report mode."""
+    """The perf gate (#1277) added alongside #1278's quality gate.
+
+    The committed manifest is enforcing (#1990); the report-mode cases below
+    exercise the gate logic with inline ``enforce=False`` thresholds.
+    """
 
     def _results(self, *, total_duration_ms=2000):
         return [
@@ -534,16 +538,18 @@ class TestPerfGateInBenchmark:
         assert "quality_gate" in summary
         assert "perf_gate" in summary
 
-    def test_committed_perf_manifest_loads_in_report_mode(self):
-        # #1112 contract: the shipped perf manifest must exist, parse, and default
-        # to report mode until the Strix Halo bars are ratified on hardware.
+    def test_committed_perf_manifest_is_enforcing(self):
+        # #1990 contract: the shipped perf manifest is a hard release gate — a
+        # missed Strix Halo bar blocks the build (release_agent_email.yml runs
+        # it on the stx pool). If the pool proves noisy, widen the bars in the
+        # manifest (data) rather than reverting to report mode.
         assert default_perf_thresholds_path().exists()
         pth = load_default_perf_thresholds()
         assert pth.ttft_max_s == 5.0
         assert pth.throughput_min_tps == 10.0
         assert pth.pipeline_max_s == 300.0
         assert pth.peak_memory_max_gb == 8.0
-        assert pth.enforce is False
+        assert pth.enforce is True
 
 
 if __name__ == "__main__":

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -690,6 +690,58 @@ class TestEmailAdapter:
         assert "gen_scorecard.py" in payload.reproduction_command
         assert "PYTHON_KEYRING_BACKEND" in payload.reproduction_command
 
+    def _bench_and_gt(self, tmp_path):
+        benchmark_dir = tmp_path / "benchmark"
+        benchmark_dir.mkdir()
+        (benchmark_dir / "email_benchmark_scorecard.json").write_text(
+            EMAIL_BENCHMARK_FIXTURE.read_text()
+        )
+        gt_path = tmp_path / "ground_truth.json"
+        gt_path.write_text(json.dumps({"_meta": {}, "a": {"label": "x"}}))
+        return benchmark_dir, gt_path
+
+    def test_drafting_report_folds_reported_metric(self, tmp_path):
+        # A judged drafting report adds draft_approval_rate as a REPORTED metric
+        # (weight 0) without changing the aggregate (still 100 x within_one).
+        from gaia.eval.release_scorecard import compute_aggregate
+
+        mod = self._load_gen_scorecard()
+        bench, gt = self._bench_and_gt(tmp_path)
+        report = tmp_path / "drafting_gate_report.json"
+        report.write_text(
+            json.dumps({"summary": {"drafting": {"draft_approval_rate": 0.73}}})
+        )
+
+        base = mod.build_payload(bench, gt)
+        withd = mod.build_payload(bench, gt, drafting_report=str(report))
+
+        names = {m["name"]: m["weight"] for m in withd.metrics}
+        assert names.get("draft_approval_rate") == 0.0
+        draft = next(m for m in withd.metrics if m["name"] == "draft_approval_rate")
+        assert draft["value"] == pytest.approx(0.73)
+        # Aggregate unchanged — drafting is reported, not weighted.
+        assert compute_aggregate(withd.metrics)[1] == compute_aggregate(base.metrics)[1]
+
+    def test_drafting_report_skip_omits_metric(self, tmp_path):
+        # A loud-skip report (no ANTHROPIC_API_KEY) must NOT invent a metric.
+        mod = self._load_gen_scorecard()
+        bench, gt = self._bench_and_gt(tmp_path)
+        report = tmp_path / "drafting_gate_report.json"
+        report.write_text(json.dumps({"skipped": True, "reason": "no key"}))
+
+        payload = mod.build_payload(bench, gt, drafting_report=str(report))
+        assert not any(m["name"] == "draft_approval_rate" for m in payload.metrics)
+
+    def test_drafting_report_malformed_fails_loud(self, tmp_path):
+        # A non-skip report missing the rate is a hard error, never a silent omit.
+        mod = self._load_gen_scorecard()
+        bench, gt = self._bench_and_gt(tmp_path)
+        report = tmp_path / "drafting_gate_report.json"
+        report.write_text(json.dumps({"summary": {"drafting": {}}}))
+
+        with pytest.raises(ValueError, match="draft_approval_rate"):
+            mod.build_payload(bench, gt, drafting_report=str(report))
+
 
 # ---------------------------------------------------------------------------
 # 11. Task 1: breakdown round-trip (release_scorecard core)


### PR DESCRIPTION
## Why this matters

An email-agent release could previously ship even if the judge-based evals regressed, the perf bars were missed, or the unit/spec tests were red. #1983 wired the eval suite (triage / drafting / action-item / briefing) into the release as a gate, but the drafting + perf gates were **report-only**, and the release did **not** run the unit or spec/contract tests at all.

After this change, a release of `@amd-gaia/agent-email` is blocked unless, at the release commit:
- **Every eval passes** — triage acceptance bar, **drafting** approval, **perf** bars, plus the already-enforcing action-item + briefing judge evals.
- **A missing `ANTHROPIC_API_KEY` blocks** — the action-item + briefing evals hard-require the judge and fail loudly (no fuzzy-only fallback), so a release can't ship an un-judged suite.
- **All email tests pass**, including the **REST-sidecar contract** and **OpenAPI-conformance (spec)** tests — now part of the release gate, not just PR CI.
- The **judge-scored drafting result is folded into `SCORECARD.md`** (`draft_approval_rate`, reported metric).

## What changed

- **Enforce drafting + perf gates** (`tests/fixtures/email/{drafting,perf}_gate_thresholds.json` → `enforce: true`). ⚠️ The perf bars are not yet independently hardware-confirmed — if the stx pool proves noisy, widen them in the manifest (data, not code) rather than reverting to report mode.
- **`release_agent_email.yml`**: `publish` now also needs a new `email-tests` gate (`uses: test_email_agent_unit.yml`).
- **`test_email_agent_unit.yml`**: installs the email hub package and also runs `hub/agents/python/email/tests/` (REST contract) + `tests/test_email_openapi_conformance.py` (spec) — fully mocked, no Lemonade.
- **`gen_scorecard.py`**: new `--drafting-report`; folds `draft_approval_rate` as a reported metric (weight 0) so the aggregate stays `100 × within_one_bucket_accuracy`. Loud-skip report → metric omitted; malformed non-skip → hard error.
- **`email_scorecard_refresh.yml`**: runs the drafting eval and passes `--drafting-report`, so the committed/shipped scorecard carries the drafting metric.
- **`test_email_agent_eval.yml`**: nightly → **weekly** (Mondays 07:17 UTC) — the run now spends Claude judge tokens, and the release re-runs the suite as a hard gate.

## Design note (deviation from the original plan preview)

The approved preview envisioned a bespoke `eval-gate` job that regenerates + ships a runner-fresh scorecard. #1983 had already landed a reusable `email-eval` gate, so this adapts to that structure instead: the eval runs (and now enforces) via `email-eval`; the committed scorecard is kept honest — and gains the drafting metric — by `email_scorecard_refresh.yml`. Net effect matches the requirement.

## Test plan

- [x] `pytest tests/unit/eval/test_release_scorecard.py` — 76 pass (3 new: drafting metric folded/reported/aggregate-unchanged; loud-skip omits; malformed fails loud). *Windows: `PYTHONUTF8=1`.*
- [x] `black --check` / `isort --check` clean on the changed Python.
- [x] All four edited workflows YAML-parse; both manifests are valid JSON with `enforce: true`.
- [ ] **CI-only (cannot run locally):** the `email-eval` gate + `email_scorecard_refresh` run on the self-hosted **stx** pool with Lemonade + `ANTHROPIC_API_KEY`. Verify via a `workflow_dispatch` dry-run on hardware before cutting a real tag — especially that the newly-enforced **perf** bars pass on the pool.

## Dependency
Overlaps PR #1989 (docs) on `gen_scorecard.py`. Trivial to resolve; recommend landing #1989 first.
