### PR TITLE
perf(ci): halve weekly-audit token burn — Opus 4.8 default + serialized dimensions

### DIFF
--- a/.claude/skills/weekly-audit-patterns/SKILL.md
+++ b/.claude/skills/weekly-audit-patterns/SKILL.md
@@ -53,8 +53,13 @@ route promotions through `bug` unless you deliberately widen the auto-fix `if`.
 
 ## Cost & safety invariants
 
-- **Model** is `AUDIT_MODEL` (top-level env, `claude-fable-5`). One place to change it;
-  swap to `claude-opus-4-8` if Fable isn't on the subscription tier.
+- **Model** is `AUDIT_MODEL` (top-level env, `claude-opus-4-8` — ~half the token burn of
+  Fable for comparable static-review quality). One place to change it; swap to
+  `claude-fable-5` for maximum depth at ~2x cost. A measured Fable deep run was ~$45 of
+  API-equivalent subscription usage; Opus roughly halves that.
+- **Serialized dimensions**: the matrix runs `max-parallel: 1` so the run is a steady
+  drip, not a 5-job burst — this keeps it under the Max subscription's rolling (5-hour)
+  rate limit. If you re-parallelize, expect a token spike that can trip that limit.
 - **Skip-if-empty**: normal mode exits in `preflight` before any Claude call on a
   no-change week. Deep mode never skips.
 - **Modes**: `normal` = last N days' diff; `deep` = whole codebase, auto-selected on the

--- a/.github/workflows/claude-weekly-audit.yml
+++ b/.github/workflows/claude-weekly-audit.yml
@@ -35,20 +35,22 @@
 # A synthesis job collects the five structured outputs, dedupes against already-open
 # `weekly-audit` issues via a stable per-finding key, ranks by severity, and files output.
 #
-# MODEL: claude-fable-5 (Claude Fable 5) — Anthropic's most capable model, chosen for
-# the deep-review quality this proactive lens needs. NOTE: Fable is premium-priced
-# ($10/$50 per MTok) and its safety classifiers auto-route ~<5% of sessions to Opus
-# 4.8; both are expected. If Fable is not selectable on the CLAUDE_CODE_OAUTH_TOKEN
-# subscription tier, the action errors and the per-job verify step surfaces it — change
-# AUDIT_MODEL below to claude-opus-4-8 in that case.
+# MODEL: claude-opus-4-8 (Claude Opus 4.8) — excellent for static review at half the
+# token burn of Fable ($5/$25 vs $10/$50 per MTok). A measured deep run on Fable cost
+# ~$45 of API-equivalent subscription usage; Opus roughly halves that. Swap AUDIT_MODEL
+# below to claude-fable-5 for maximum depth if you accept ~2x the cost (Fable also
+# auto-routes ~<5% of sessions to Opus 4.8 via its safety classifiers).
 #
 # AUTH: same OAuth-preferred / API-key-fallback wiring as every claude.yml job
 # (CLAUDE_CODE_OAUTH_TOKEN, covered by the monthly claude-auth-canary.yml). Runs on the
 # Claude Max subscription pool, so there is no per-run dollar cost — only shared quota.
 #
 # COST CEILING: 5 dimension jobs (--max-turns 30) + 1 synthesis job (--max-turns 25) =
-# a known per-run ceiling. skip-if-empty exits before any Claude call on a no-change
-# week. The concurrency group prevents two scheduled runs from overlapping.
+# a known per-run ceiling. The dimension matrix runs `max-parallel: 1` (serialized) so
+# the run is a steady drip rather than a 5-job burst — this keeps it under the Max
+# subscription's rolling (5-hour) rate limit, at the cost of a longer wall-clock.
+# skip-if-empty exits before any Claude call on a no-change week. The concurrency group
+# prevents two scheduled runs from overlapping.
 #
 # NO REPO-CODE EXECUTION: the jobs read and report only (--allowedTools Read,Grep,Glob,Bash
 # with no Edit/Write) — they never `pip install` / run GAIA / execute checked-out code,
@@ -83,9 +85,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Single source of truth for the model. Swap to claude-opus-4-8 if Fable is
-  # unavailable on the subscription tier (see the MODEL note in the file header).
-  AUDIT_MODEL: claude-fable-5
+  # Single source of truth for the model. Opus 4.8 by default — half the token burn of
+  # Fable for comparable static-review quality (see the MODEL note in the file header).
+  AUDIT_MODEL: claude-opus-4-8
 
 jobs:
   # Resolve mode (auto → deep/normal) and short-circuit a no-change week.
@@ -142,6 +144,10 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      # Serialize the dimensions so the run is a steady drip, not a 5-job burst —
+      # keeps it under the Max subscription's rolling (5-hour) rate limit. Trades
+      # wall-clock (~5 sequential Claude jobs) for a smoother token profile.
+      max-parallel: 1
       matrix:
         dimension: [security, correctness, docs, tests, features]
     steps:

--- a/docs/plans/weekly-claude-audit.md
+++ b/docs/plans/weekly-claude-audit.md
@@ -57,7 +57,9 @@ A synthesis job collects the five structured outputs, dedupes against already-op
   `findings-security.json`; the public issue shows a count + run-log pointer + `@kovtcharov-amd`.
 - **Skip-if-empty**: normal mode exits before any Claude call on a no-change week.
 - **Read-only**: `--allowedTools Read,Grep,Glob,Bash`; never install or run repo code.
-- **Model** `claude-fable-5` via the top-level `AUDIT_MODEL` env (one place to change).
+- **Model** `claude-opus-4-8` via the top-level `AUDIT_MODEL` env (one place to change);
+  `claude-fable-5` for max depth at ~2x cost. Dimensions run `max-parallel: 1` (serialized)
+  to stay under the Max subscription's rolling rate limit.
 
 ## Non-goals
 


### PR DESCRIPTION
The first `deep` run of the weekly audit worked well — it filed ~20 genuinely useful findings (real correctness bugs, doc/code drift, coverage gaps). But it also cost **~$45 of API‑equivalent Max‑subscription usage in one shot** (measured per‑job: correctness $14.96, tests $13.39, docs $6.01, security $3.62, features $3.37), and fired all five dimension jobs **concurrently** — a burst that can trip the subscription's rolling 5‑hour rate limit. This PR cuts that roughly in half and smooths the profile, with no change to what the audit does.

**Two levers:**
- **`AUDIT_MODEL` → `claude-opus-4-8`** ($5/$25 vs Fable $10/$50 per MTok). Opus 4.8 is excellent for static review; one‑line swap back to `claude-fable-5` for maximum depth at ~2x cost.
- **`max-parallel: 1`** on the dimension matrix — the run is now a steady drip instead of a 5‑job spike, keeping it under the rolling rate limit (trades wall‑clock for a smoother token profile).

Skill (`weekly-audit-patterns`) and the design doc updated to match the new default.

## Test plan

- [ ] Merge, then **Actions → Claude Weekly Audit → Run workflow → `mode: deep`**.
- [ ] Confirm dimension jobs run **one at a time** (serialized), not all at once.
- [ ] Sum `total_cost_usd` across jobs and compare to the ~$45 Fable baseline — expect **~$20–24**.
- [ ] Confirm the audit still files a `weekly-audit` triage issue + child issues (quality parity vs the Fable run).

> Comparison will be done once this is merged and I re-run `deep` on Opus — same repo, same prompts, so per‑job cost is directly comparable to the Fable numbers above.
