### PR TITLE
feat(hub): add Evaluation tab to the hub agent page (EVALUATION.md)

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -47,6 +47,10 @@ on:
       - main
     paths:
       - 'hub/agents/python/email/**'
+      # Publishing/upload plumbing is not LLM- or eval-affecting, so a change to
+      # it must NOT re-run the 90-min real eval. publish_to_r2.py only POSTs the
+      # already-built artifacts + docs to the Hub Worker.
+      - '!hub/agents/python/email/packaging/publish_to_r2.py'
       - 'tests/fixtures/email/**'
       - 'src/gaia/eval/release_scorecard.py'
       - 'src/gaia/eval/scorecard_gate.py'

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -547,6 +547,14 @@ jobs:
           if [ -f "${SCORECARD}" ]; then
             scorecard_args+=(--eval-scorecard "${SCORECARD}")
           fi
+          # EVALUATION.md (evaluation guide) renders as its own hub doc tab. It
+          # only lands with PR #1989 — guard on presence so releases cut before it
+          # merges still publish cleanly.
+          evaluation_args=()
+          EVALUATION="hub/agents/npm/agent-email/EVALUATION.md"
+          if [ -f "${EVALUATION}" ]; then
+            evaluation_args+=(--evaluation "${EVALUATION}")
+          fi
           python hub/agents/python/email/packaging/publish_to_r2.py \
             --base-url "${GAIA_HUB_PUBLISH_URL:-${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}}" \
             --manifest "${MANIFEST}" \
@@ -555,6 +563,7 @@ jobs:
             --spec "${SPEC}" \
             --skill "${SKILL}" \
             "${scorecard_args[@]}" \
+            "${evaluation_args[@]}" \
             "${args[@]}" \
             --summary-out published.json
           echo "=== publish summary ==="

--- a/hub/agents/python/email/packaging/publish_to_r2.py
+++ b/hub/agents/python/email/packaging/publish_to_r2.py
@@ -129,6 +129,7 @@ def publish_one(
     changelog_bytes: bytes | None = None,
     spec_bytes: bytes | None = None,
     skill_bytes: bytes | None = None,
+    evaluation_bytes: bytes | None = None,
     eval_scorecard_bytes: bytes | None = None,
     package_files_bytes: bytes | None = None,
 ) -> dict:
@@ -173,6 +174,10 @@ def publish_one(
             files["spec"] = ("SPEC.md", spec_bytes, "text/markdown")
         if skill_bytes is not None:
             files["skill"] = ("SKILL.md", skill_bytes, "text/markdown")
+        # EVALUATION.md rides along the same way — it becomes the catalog entry's
+        # `evaluation`, rendered as its own doc tab on the hub page.
+        if evaluation_bytes is not None:
+            files["evaluation"] = ("EVALUATION.md", evaluation_bytes, "text/markdown")
         # The eval scorecard rides along with the first platform binary and becomes
         # the catalog entry's `eval_score` and `eval_scorecard_url`.
         if eval_scorecard_bytes is not None:
@@ -277,6 +282,12 @@ def main(argv=None) -> int:
         "(POSTed as the multipart 'skill' part the Worker accepts).",
     )
     parser.add_argument(
+        "--evaluation",
+        type=Path,
+        help="Path to EVALUATION.md to publish as the agent's catalog evaluation "
+        "(POSTed as the multipart 'evaluation' part the Worker accepts).",
+    )
+    parser.add_argument(
         "--eval-scorecard",
         type=Path,
         help="Path to the eval scorecard markdown (e.g. SCORECARD.md) to "
@@ -354,6 +365,20 @@ def main(argv=None) -> int:
             flush=True,
         )
 
+    evaluation_bytes = None
+    if args.evaluation is not None:
+        if not args.evaluation.exists():
+            raise SystemExit(
+                f"error: --evaluation path not found: {args.evaluation}. Pass the "
+                "agent's EVALUATION.md, or omit --evaluation to publish without one."
+            )
+        evaluation_bytes = args.evaluation.read_bytes()
+        print(
+            f"[publish] attaching evaluation: {args.evaluation} "
+            f"({len(evaluation_bytes)} bytes)",
+            flush=True,
+        )
+
     eval_scorecard_bytes = None
     if args.eval_scorecard is not None:
         if not args.eval_scorecard.exists():
@@ -404,6 +429,7 @@ def main(argv=None) -> int:
                 changelog_bytes=changelog_bytes,
                 spec_bytes=spec_bytes,
                 skill_bytes=skill_bytes,
+                evaluation_bytes=evaluation_bytes,
                 eval_scorecard_bytes=eval_scorecard_bytes,
                 package_files_bytes=package_files_bytes,
             )

--- a/website/src/data/catalog.ts
+++ b/website/src/data/catalog.ts
@@ -57,6 +57,10 @@ export interface Agent {
   // published. Optional for the same older-index.json resilience as `changelog`.
   spec?: string;
   skill?: string;
+  // EVALUATION.md (evaluation guide) markdown of the latest version, rendered as its
+  // own doc tab. "" / absent if none was published. Optional for the same
+  // older-index.json resilience as `spec`/`skill`.
+  evaluation?: string;
   // Eval-scorecard markdown (SCORECARD.md body, YAML front matter already stripped
   // by the hub Worker), rendered as its own doc tab. "" / absent if none was
   // published. Same older-index.json resilience as `spec`/`skill`.

--- a/website/src/pages/hub/[id].astro
+++ b/website/src/pages/hub/[id].astro
@@ -44,6 +44,7 @@ const readmeHtml = renderMarkdown(agent.readme);
 const changelogHtml = agent.changelog ? renderMarkdown(agent.changelog) : '';
 const specHtml = agent.spec ? renderMarkdown(agent.spec) : '';
 const skillHtml = agent.skill ? renderMarkdown(agent.skill) : '';
+const evaluationHtml = agent.evaluation ? renderMarkdown(agent.evaluation) : '';
 // Eval scorecard: the Worker embeds the SCORECARD.md body (front matter already
 // stripped) as `scorecard`, and the aggregate as `eval_score`. Render the body as
 // a tab; the sidebar badge links out to the canonical source (eval_scorecard_url).
@@ -86,6 +87,7 @@ const docTabs = [
   ...(specHtml ? [{ key: 'spec', label: 'Spec' }] : []),
   ...(skillHtml ? [{ key: 'skill', label: 'Skill' }] : []),
   ...(scorecardHtml ? [{ key: 'scorecard', label: 'Scorecard' }] : []),
+  ...(evaluationHtml ? [{ key: 'evaluation', label: 'Evaluation' }] : []),
   ...(changelogHtml ? [{ key: 'changelog', label: 'Changelog' }] : []),
   ...(packageFiles.length ? [{ key: 'files', label: 'Files' }] : []),
 ];
@@ -154,7 +156,7 @@ const terminalLines = [
       </div>
     </section>
 
-    <!-- Body: tabbed docs (README / Spec / Skill / Scorecard / Changelog / Files) + cards -->
+    <!-- Body: tabbed docs (README / Spec / Skill / Scorecard / Evaluation / Changelog / Files) + cards -->
     <div class="mt-12 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-12">
       <div class="min-w-0" data-doc-tabs>
         {docTabs.length > 1 && (
@@ -199,6 +201,11 @@ const terminalLines = [
               </p>
             )}
             <div set:html={scorecardHtml} />
+          </article>
+        )}
+        {evaluationHtml && (
+          <article role="tabpanel" id="docpanel-evaluation" aria-labelledby="doctab-evaluation" data-doc-panel="evaluation" class="doc max-w-[70ch]" hidden>
+            <div set:html={evaluationHtml} />
           </article>
         )}
         {changelogHtml && (
@@ -714,7 +721,7 @@ const terminalLines = [
   .file-tree-chevron { transition: transform 0.15s ease; }
   .file-tree details[open] > summary .file-tree-chevron { transform: rotate(90deg); }
 
-  /* Doc tabs (README / Spec / Skill / Scorecard / Changelog / Files) */
+  /* Doc tabs (README / Spec / Skill / Scorecard / Evaluation / Changelog / Files) */
   .doc-tab {
     @apply -mb-px border-b-2 border-transparent px-4 py-2 text-sm font-medium text-g-muted transition-colors hover:text-g-text;
   }

--- a/workers/agent-hub/schemas/index.schema.json
+++ b/workers/agent-hub/schemas/index.schema.json
@@ -146,6 +146,10 @@
           "type": "string",
           "description": "SKILL.md (AI-integration playbook) markdown of the latest version; empty string if none was published."
         },
+        "evaluation": {
+          "type": "string",
+          "description": "EVALUATION.md (evaluation guide) markdown of the latest version; empty string if none was published."
+        },
         "scorecard": {
           "type": "string",
           "description": "Eval-scorecard markdown (SCORECARD.md body, YAML front matter stripped) of the latest version, rendered as its own doc tab; empty string if none was published."

--- a/workers/agent-hub/src/catalog.ts
+++ b/workers/agent-hub/src/catalog.ts
@@ -14,6 +14,7 @@ import {
   readAgentManifest,
   readChangelog,
   readEvalScorecard,
+  readEvaluation,
   readPackageFiles,
   readReadme,
   readSkill,
@@ -147,6 +148,7 @@ export function toIndexEntry(
   packageFiles: { files: { name: string; size_bytes: number }[] } | null,
   spec = "",
   skill = "",
+  evaluation = "",
   evalScorecard: string | null = null,
   baseUrl = "https://hub.amd-gaia.ai"
 ): IndexEntry {
@@ -192,6 +194,7 @@ export function toIndexEntry(
     changelog,
     spec,
     skill,
+    evaluation,
     // Render-ready scorecard body (front matter stripped); "" when none published.
     scorecard: evalScorecard !== null ? stripFrontMatter(evalScorecard) : "",
     // undefined serializes to "key absent" — only present when the manifest set it.
@@ -224,8 +227,11 @@ export async function rebuildIndex(
     const packageFiles = await readPackageFiles(bucket, id, agent.latest_version);
     const spec = await readSpec(bucket, id, agent.latest_version);
     const skill = await readSkill(bucket, id, agent.latest_version);
+    const evaluation = await readEvaluation(bucket, id, agent.latest_version);
     const evalScorecard = await readEvalScorecard(bucket, id, agent.latest_version);
-    entries.push(toIndexEntry(agent, readme, changelog, packageFiles, spec, skill, evalScorecard, baseUrl));
+    entries.push(
+      toIndexEntry(agent, readme, changelog, packageFiles, spec, skill, evaluation, evalScorecard, baseUrl)
+    );
   }
   entries.sort((a, b) => a.id.localeCompare(b.id));
 

--- a/workers/agent-hub/src/publish.ts
+++ b/workers/agent-hub/src/publish.ts
@@ -7,8 +7,9 @@
  * Flow: authenticate -> parse multipart -> validate manifest -> enforce
  * publisher scope -> enforce version immutability -> generate server-side
  * SHA-256 -> store artifact + raw manifest + optional README + optional
- * CHANGELOG + per-agent manifest -> rebuild index.json. Every guard fails
- * loudly with a structured error.
+ * CHANGELOG + optional SPEC + optional SKILL + optional EVALUATION +
+ * per-agent manifest -> rebuild index.json. Every guard fails loudly with a
+ * structured error.
  */
 
 import { assertAuthorAllowed, authenticate } from "./auth";
@@ -19,6 +20,7 @@ import {
   artifactKey,
   changelogKey,
   evalScorecardKey,
+  evaluationKey,
   packageFilesKey,
   rawManifestKey,
   readAgentManifest,
@@ -174,6 +176,9 @@ export async function handlePublish(
   // semantics as README/CHANGELOG.
   const specText = await optionalMarkdownPart(form, "spec", "SPEC.md");
   const skillText = await optionalMarkdownPart(form, "skill", "SKILL.md");
+  // Optional EVALUATION.md (evaluation guide), rendered as its own doc tab on the
+  // hub page. Same per-version, first-POST semantics as SPEC/SKILL.
+  const evaluationText = await optionalMarkdownPart(form, "evaluation", "EVALUATION.md");
   // Optional eval scorecard markdown (the agent's benchmark results, rendered on
   // the hub listing as an aggregate score + link). Per-version, first-POST semantics.
   const evalScorecardText = await optionalMarkdownPart(form, "eval_scorecard", "SCORECARD.md");
@@ -277,6 +282,11 @@ export async function handlePublish(
     }
     if (skillText != null) {
       await env.BUCKET.put(skillKey(manifest.id, manifest.version), skillText, {
+        httpMetadata: { contentType: "text/markdown; charset=utf-8" },
+      });
+    }
+    if (evaluationText != null) {
+      await env.BUCKET.put(evaluationKey(manifest.id, manifest.version), evaluationText, {
         httpMetadata: { contentType: "text/markdown; charset=utf-8" },
       });
     }

--- a/workers/agent-hub/src/storage.ts
+++ b/workers/agent-hub/src/storage.ts
@@ -12,6 +12,7 @@
  *   agents/<id>/<version>/CHANGELOG.md      changelog markdown, per version (optional)
  *   agents/<id>/<version>/SPEC.md           spec/reference markdown, per version (optional)
  *   agents/<id>/<version>/SKILL.md          AI-integration playbook markdown (optional)
+ *   agents/<id>/<version>/EVALUATION.md     evaluation guide markdown, per version (optional)
  *   agents/<id>/<version>/<filename>        the artifact (wheel or binary)
  */
 
@@ -50,6 +51,10 @@ export function specKey(id: string, version: string): string {
 
 export function skillKey(id: string, version: string): string {
   return `${versionDir(id, version)}SKILL.md`;
+}
+
+export function evaluationKey(id: string, version: string): string {
+  return `${versionDir(id, version)}EVALUATION.md`;
 }
 
 export function evalScorecardKey(id: string, version: string): string {
@@ -114,6 +119,20 @@ export async function readSkill(
   version: string
 ): Promise<string> {
   const obj = await bucket.get(skillKey(id, version));
+  if (!obj) return "";
+  return obj.text();
+}
+
+/**
+ * Read the EVALUATION.md (evaluation guide) markdown for one version. Returns ""
+ * when none was published — the `evaluation` form part on POST /publish is optional.
+ */
+export async function readEvaluation(
+  bucket: R2Bucket,
+  id: string,
+  version: string
+): Promise<string> {
+  const obj = await bucket.get(evaluationKey(id, version));
   if (!obj) return "";
   return obj.text();
 }

--- a/workers/agent-hub/src/types.ts
+++ b/workers/agent-hub/src/types.ts
@@ -195,6 +195,8 @@ export interface IndexEntry {
   spec: string;
   /** SKILL.md (AI-integration playbook) markdown of the latest version; "" if none was published. */
   skill: string;
+  /** EVALUATION.md (evaluation guide) markdown of the latest version; "" if none was published. */
+  evaluation: string;
   /**
    * Eval-scorecard markdown (SCORECARD.md body, YAML front matter stripped) of the
    * latest version, rendered as its own doc tab on the hub page; "" if none was

--- a/workers/agent-hub/test/fake-r2.ts
+++ b/workers/agent-hub/test/fake-r2.ts
@@ -159,6 +159,7 @@ export function publishRequest(opts: {
   changelog?: string;
   spec?: string;
   skill?: string;
+  evaluation?: string;
   evalScorecard?: string;
   packageFiles?: string;
 }): Request {
@@ -168,6 +169,7 @@ export function publishRequest(opts: {
   if (opts.changelog !== undefined) form.set("changelog", opts.changelog);
   if (opts.spec !== undefined) form.set("spec", opts.spec);
   if (opts.skill !== undefined) form.set("skill", opts.skill);
+  if (opts.evaluation !== undefined) form.set("evaluation", opts.evaluation);
   if (opts.evalScorecard !== undefined) form.set("eval_scorecard", opts.evalScorecard);
   if (opts.packageFiles !== undefined) form.set("package_files", opts.packageFiles);
   const bytes = typeof opts.artifact === "string" ? new TextEncoder().encode(opts.artifact) : opts.artifact;

--- a/workers/agent-hub/test/publish.test.ts
+++ b/workers/agent-hub/test/publish.test.ts
@@ -591,6 +591,7 @@ describe("POST /publish — SPEC & SKILL doc tabs", () => {
     const env = makeEnv();
     const spec = "# Spec\n\nThe wire contract is 2.0.\n";
     const skill = "# Skill\n\nSpawn the sidecar, then call triage.\n";
+    const evaluation = "# Evaluation\n\nRun the eval, compare to baseline.\n";
     const res = await publish(env, {
       token: "tok_amd",
       manifestYaml: sampleManifest(),
@@ -598,10 +599,12 @@ describe("POST /publish — SPEC & SKILL doc tabs", () => {
       filename: "gaia_agent_chat-0.1.0-py3-none-any.whl",
       spec,
       skill,
+      evaluation,
     });
     expect(res.status).toBe(201);
     expect(env.bucket.keys()).toContain("agents/chat/0.1.0/SPEC.md");
     expect(env.bucket.keys()).toContain("agents/chat/0.1.0/SKILL.md");
+    expect(env.bucket.keys()).toContain("agents/chat/0.1.0/EVALUATION.md");
 
     // Served by the existing GET /agents/... download route, as markdown.
     const getSpec = await worker.fetch(
@@ -612,10 +615,19 @@ describe("POST /publish — SPEC & SKILL doc tabs", () => {
     expect(getSpec.headers.get("content-type")).toContain("text/markdown");
     expect(await getSpec.text()).toBe(spec);
 
+    const getEvaluation = await worker.fetch(
+      new Request("https://hub.amd-gaia.ai/agents/chat/0.1.0/EVALUATION.md"),
+      env as never
+    );
+    expect(getEvaluation.status).toBe(200);
+    expect(getEvaluation.headers.get("content-type")).toContain("text/markdown");
+    expect(await getEvaluation.text()).toBe(evaluation);
+
     const index = (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex;
     const entry = index.agents.find((a) => a.id === "chat")!;
     expect(entry.spec).toBe(spec);
     expect(entry.skill).toBe(skill);
+    expect(entry.evaluation).toBe(evaluation);
   });
 
   it('defaults spec + skill to "" in index.json when none are published', async () => {
@@ -627,11 +639,13 @@ describe("POST /publish — SPEC & SKILL doc tabs", () => {
       filename: "gaia_agent_chat-0.1.0-py3-none-any.whl",
     });
     expect(env.bucket.keys()).not.toContain("agents/chat/0.1.0/SPEC.md");
+    expect(env.bucket.keys()).not.toContain("agents/chat/0.1.0/EVALUATION.md");
     const entry = (
       (await (await env.bucket.get("index.json"))!.json()) as CatalogIndex
     ).agents.find((a) => a.id === "chat")!;
     expect(entry.spec).toBe("");
     expect(entry.skill).toBe("");
+    expect(entry.evaluation).toBe("");
   });
 
   it("rejects an empty spec part (400) — omit it instead", async () => {


### PR DESCRIPTION
The email agent ships an `EVALUATION.md` eval guide (added in #1989) and links it from its README via github.com URLs, but the hub page only renders readme/changelog/spec/skill/scorecard from the catalog — so **EVALUATION.md never appears on amd-gaia.ai/hub/email**. This adds a new catalog `evaluation` field carrying the agent's EVALUATION.md markdown and surfaces it as its own **Evaluation** tab. It mirrors the existing spec/skill doc-field pipeline exactly — plain embedded markdown, no front matter, no score, no URL (unlike the score-carrying scorecard field).

**Dependency:** `hub/agents/npm/agent-email/EVALUATION.md` currently exists only on the #1989 branch (`docs/email-scorecard-repro`), not on main. The release workflow's `--evaluation` flag is guarded by a file-presence check, so releases cut before #1989 merges still publish cleanly; the tab lights up once EVALUATION.md lands on main and the next email release republishes.

## Test plan

- [x] Worker: `cd workers/agent-hub && npx vitest run` → **70 passed** (incl. new evaluation store/serve/index assertions + the `entry.evaluation === ""` default) and `npx tsc --noEmit` clean.
- [x] Website: `cd website && npx vitest run` → **26 passed**; `HUB_CATALOG_URL=https://hub.amd-gaia.ai npm run build` (astro check + build) clean.
- [x] **Render proof**: injected `"evaluation": "# Eval Guide\n\nHello **newcomer**.\n"` into a local copy of the live catalog, served it on a non-4001 port, rebuilt, and grepped `dist/hub/email/index.html`:
  - Tab button → `data-doc-tab="evaluation" ...>Evaluation<`
  - Panel → `data-doc-panel="evaluation"`
  - Rendered body → `Eval Guide</h1>` and `<strong>newcomer</strong>`
- [x] Python: `publish_to_r2.py` parses and `--evaluation` appears in `--help`; the `hub/` packaging dir is outside `util/lint.py`'s scope (`src/gaia` + `tests` only), and the new line is black-clean regardless.