### PR TITLE
fix(email-eval): drafting eval hard-fails on missing judge key (no silent skip)

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -167,10 +167,11 @@ jobs:
         env:
           # eval_drafting_report.py reads EMAIL_EVAL_MODEL; reuse the refresh model.
           EMAIL_EVAL_MODEL: ${{ env.MODEL }}
-          # Judge credential. Absent -> loud skip (report says so); the metric is
-          # then simply omitted from the card (gen_scorecard never invents one).
-          # With drafting_gate_thresholds.json enforce:true, a real breach fails
-          # here and the refresh does not commit a regressed card.
+          # Judge credential — REQUIRED. Absent -> eval_drafting_report.py exits 1
+          # (fail-loudly, no silent skip), so this step throws and the refresh
+          # never commits a card with a silently-omitted drafting metric. With
+          # drafting_gate_thresholds.json enforce:true a real breach also fails
+          # here, so the refresh does not commit a regressed card.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           python hub/agents/python/email/packaging/eval_drafting_report.py
@@ -179,7 +180,9 @@ jobs:
       - name: Regenerate SCORECARD.md from the real run
         run: |
           # --drafting-report folds draft_approval_rate into the card as a
-          # reported metric (weight 0); a loud-skip report omits it cleanly.
+          # reported metric (weight 0). The drafting eval above hard-fails on a
+          # missing key, so a report here is always a real judged run; a missing
+          # or unjudged report makes gen_scorecard fail loudly (never omits).
           python hub/agents/python/email/packaging/gen_scorecard.py --benchmark-dir eval-out --limit "$env:LIMIT" --drafting-report eval-out/drafting_gate_report.json
           if ($LASTEXITCODE -ne 0) { throw "gen_scorecard failed" }
 

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -50,9 +50,10 @@
 #                              repo secret) so it's unreadable until the gate is
 #                              approved.
 #     ANTHROPIC_API_KEY      — Claude judge credential for the eval-gate's
-#                              voice-drafting eval. REQUIRED: the eval-gate asserts
-#                              it and FAILS the release if absent, so a release
-#                              never ships an un-judged drafting eval. A repo (or
+#                              voice-drafting eval. REQUIRED: eval_drafting_report.py
+#                              exits 1 when it is absent (no silent skip — CLAUDE.md
+#                              fail-loudly), so the eval-gate step FAILS the release
+#                              and never ships an un-judged drafting eval. A repo (or
 #                              org) secret — the eval-gate runs before the approval
 #                              gate, on the self-hosted stx pool.
 #   Variables:

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -9,27 +9,29 @@
 # / 50-email latency / peak memory, #1277) gates and the categorization-accuracy
 # / phishing-precision numbers, logs them, and uploads the full gate report.
 #
-# REPORT MODE. The gate bars + the single on/off switch live in ONE committed
+# MIXED MODE. The gate bars + the single on/off switch live in ONE committed
 # source each — the threshold manifests under tests/fixtures/email/, read here
 # only through the harness loaders (no thresholds are hardcoded in this YAML):
-#   - tests/fixtures/email/quality_gate_thresholds.json  (FP<5% / FN<2%)
-#   - tests/fixtures/email/perf_gate_thresholds.json      (TTFT / tps / latency / mem)
-#   - tests/fixtures/email/drafting_gate_thresholds.json  (draft-approval >=70%, #1269)
+#   - tests/fixtures/email/quality_gate_thresholds.json  (FP<5% / FN<2% — report mode)
+#   - tests/fixtures/email/perf_gate_thresholds.json      (TTFT / tps / latency / mem — ENFORCING)
+#   - tests/fixtures/email/drafting_gate_thresholds.json  (draft-approval >=70%, #1269 — ENFORCING)
 #   - tests/fixtures/email/briefing_gate_thresholds.json  (briefing quality, #1951 — ENFORCING)
 #
-# NOTE: the briefing gate (#1951) ships enforce:TRUE — unlike the FP/FN, perf,
-# and drafting gates it is a hard gate with no report-mode fallback: a quality
-# breach, an errored/unjudged case, or a missing judge credential fails the
-# build. See its dedicated block near the end of this job.
+# NOTE: the perf (#1277), drafting (#1269) and briefing (#1951) gates now ship
+# enforce:TRUE — a bar/quality breach fails the build (no report-mode fallback).
+# Only the FP/FN quality gate remains report mode. The judged evals (drafting,
+# briefing) hard-require ANTHROPIC_API_KEY: a missing key fails the build (exit 1,
+# no silent skip — CLAUDE.md fail-loudly), never an un-judged pass. See the
+# briefing block near the end of this job.
 #
-# CI keys off each gate's `should_fail` (= enforce and not passed). All three
-# manifests ship `enforce: false`, so `should_fail` is always false today: the gate
-# machinery runs, logs, and uploads, but the build stays green. This is the
-# honest posture — categorization accuracy is still ~0.40, so the FP/FN bars are
-# not yet meaningful and the Strix Halo perf bars are not yet confirmed on
-# hardware. Flipping `enforce: true` IN THE MANIFEST (data, not this workflow) is
-# what makes the build start failing on a breach, once #1266 (categorization),
-# #1271 (phishing) and the perf bars land. No edit to this file is needed then.
+# CI keys off each gate's `should_fail` (= enforce and not passed). The perf,
+# drafting, and briefing manifests now ship `enforce: true`, so a breach in any
+# of them fails the build. The FP/FN quality manifest still ships
+# `enforce: false` — its gate machinery runs, logs, and uploads, but a breach
+# stays green (categorization accuracy is still ~0.40, so the FP/FN bars are not
+# yet meaningful). Enforcement is toggled IN THE MANIFEST (data, not this
+# workflow); flip the FP/FN manifest to `enforce: true` once #1266
+# (categorization) / #1271 (phishing) land. No edit to this file is needed then.
 #
 # NOTE on accuracy gates: categorization >=85% (#1266) and phishing precision
 # >=90% (#1271) do not yet have committed threshold manifests (they are owned by
@@ -38,8 +40,10 @@
 # committed bar to read, and inventing one in YAML would violate the single-source
 # rule above. They become gating once their manifests land and this gate-reader is
 # pointed at them. Draft-approval >=70% (#1269) DOES now have a committed manifest
-# (tests/fixtures/email/drafting_gate_thresholds.json, enforce:false) — it is
-# scored by the voice-drafting eval step below (#1607 / #1948), report mode.
+# (tests/fixtures/email/drafting_gate_thresholds.json, enforce:true) — it is
+# scored by the voice-drafting eval step below (#1607 / #1948) and now enforcing:
+# a draft-approval breach fails the build, and a missing judge credential also
+# fails it (eval_drafting_report.py exits 1 — no silent skip).
 #
 # Self-hosted: this needs a running Lemonade Server on AMD hardware, so it runs
 # on the [self-hosted, Windows, stx] pool. The install-lemonade action pins the
@@ -98,7 +102,7 @@ on:
         default: '1'
     secrets:
       ANTHROPIC_API_KEY:
-        description: 'Judge credential for the drafting + borderline action-item judge; absent → those paths log a loud skip / run judge-less.'
+        description: 'Judge credential for the drafting / action-item / briefing judged evals — REQUIRED; absent → those evals fail loudly (exit 1), never a skip.'
         required: false
 
 concurrency:
@@ -200,22 +204,25 @@ jobs:
 
       # =================================================================
       # BEGIN voice-drafting quality eval (#1607 feature / #1269 metric /
-      # #1948 tracking) — ADDITIVE, self-contained block. Report mode.
+      # #1948 tracking) — ADDITIVE, self-contained block. Enforcing.
       #
       # Judge-scored draft quality over the committed drafting seed corpus with
       # the #1607 voice profile active (Lemonade, FakeGmailBackend — drafting
       # only, nothing is ever sent); a Claude judge scores each draft against
       # the case rubric. The aggregate draft_approval_rate is compared to the
       # committed manifest tests/fixtures/email/drafting_gate_thresholds.json
-      # (enforce:false) — same single-source rule as the gates above.
+      # (enforce:true) — same single-source rule as the gates above. A breach
+      # fails the build; a missing judge credential ALSO fails it
+      # (eval_drafting_report.py exits 1 — no silent skip, CLAUDE.md fail-loudly).
       #
       # Runs AFTER the triage benchmark in the same job, so Lemonade access stays
       # strictly serial (CLAUDE.md: evals serial).
       # =================================================================
-      - name: Voice-drafting quality eval (judge-scored, report mode)
+      - name: Voice-drafting quality eval (judge-scored)
         env:
-          # Judge credential for gaia.eval.claude.ClaudeClient. When the secret
-          # is unavailable the script logs a LOUD skip (never a pass).
+          # Judge credential for gaia.eval.claude.ClaudeClient — REQUIRED. When the
+          # secret is absent eval_drafting_report.py exits 1 (fail-loudly, never a
+          # skip), so this step throws rather than shipping an un-judged gate.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           python hub/agents/python/email/packaging/eval_drafting_report.py
@@ -316,8 +323,8 @@ jobs:
           Write-Host "(FP/FN) and performance gates from the committed threshold"
           Write-Host "manifests under tests/fixtures/email/."
           Write-Host ""
-          Write-Host "Report mode: while the manifests ship enforce:false, a breach is"
-          Write-Host "logged + uploaded but does NOT fail the build. Flip enforce:true in"
-          Write-Host "the manifest (data, not this workflow) to make CI block - see the"
-          Write-Host "header of this workflow file."
+          Write-Host "Perf gate: ENFORCING (enforce:true) - a breach fails the build."
+          Write-Host "FP/FN quality gate: report mode (enforce:false) - a breach is logged"
+          Write-Host "+ uploaded but does NOT fail the build. Enforcement is toggled in the"
+          Write-Host "manifest (data, not this workflow) - see the header of this file."
           Write-Host "================================================================"

--- a/hub/agents/python/email/packaging/eval_drafting_report.py
+++ b/hub/agents/python/email/packaging/eval_drafting_report.py
@@ -1,23 +1,26 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""Voice-drafting quality eval (judge-scored, report mode) — CI helper.
+"""Voice-drafting quality eval (judge-scored, enforcing) — CI helper.
 
 Drives the #1607 voice-profile drafting path over the committed drafting seed
 corpus (Lemonade + FakeGmailBackend — drafting only, nothing is ever sent) and
 scores each draft with a Claude judge against the case rubric. The aggregate
 ``draft_approval_rate`` is compared to the committed manifest
-``tests/fixtures/email/drafting_gate_thresholds.json`` (enforce:false) via
+``tests/fixtures/email/drafting_gate_thresholds.json`` (enforce:true) via
 ``gaia.eval.draft_quality`` — same single-source rule as the other gates: no
-thresholds inlined here. Flip ``enforce`` in the manifest (data, not code) to
-make this gate block.
+thresholds inlined here. The manifest owns the enforce switch (data, not code).
 
-When ``ANTHROPIC_API_KEY`` is absent the judge cannot score drafts, so this
-writes a LOUD, explicit skip report (never an invented pass) and exits 0.
+``ANTHROPIC_API_KEY`` is REQUIRED — the Claude judge cannot score drafts without
+it, and per CLAUDE.md's fail-loudly rule there is NO silent skip: its absence is
+a HARD FAILURE (exit 1), never a skip report and never an invented pass. The
+workflows that run this (release_agent_email.yml, test_email_agent_eval.yml,
+email_scorecard_refresh.yml) inject the key from ``secrets.ANTHROPIC_API_KEY``
+and never run on fork PRs, so the key is always present in a legitimate run.
 
 Config comes from the environment (shell-agnostic):
   EMAIL_EVAL_MODEL   Lemonade model id (required)
-  ANTHROPIC_API_KEY  Claude judge credential (optional; absence -> loud skip)
+  ANTHROPIC_API_KEY  Claude judge credential (REQUIRED; absence -> exit 1)
 
 Extracted verbatim from the former inline ``python - <<'PY'`` step so the eval
 can run on the Windows ``stx`` runner pool (PowerShell, no heredocs).
@@ -54,25 +57,23 @@ def main() -> int:
     )
 
     if not os.environ.get("ANTHROPIC_API_KEY"):
-        # Loud, explicit skip — the judge credential is absent, so no draft can
-        # be scored. Never invents a pass; the report says so.
-        report = {
-            "skipped": True,
-            "reason": (
-                "ANTHROPIC_API_KEY not available on this runner — the Claude "
-                "judge cannot score drafts"
-            ),
-            "enforce": thresholds.enforce,
-            "should_fail": False,
-        }
-        (out / "drafting_gate_report.json").write_text(
-            json.dumps(report, indent=2), encoding="utf-8"
-        )
+        # Fail loudly (CLAUDE.md: No Silent Fallbacks — Fail Loudly). The judge
+        # credential is REQUIRED to score drafts; its absence is a hard failure,
+        # never a skip — regardless of the manifest's enforce flag. No skip report
+        # is written and no pass is invented, so the release / nightly cannot ship
+        # a silently un-judged drafting gate.
         print(
-            "[DRAFT-EVAL] SKIPPED: no judge credential — wrote "
-            "eval-out/drafting_gate_report.json"
+            "[DRAFT-EVAL] ERROR: ANTHROPIC_API_KEY is not set — the Claude judge "
+            "cannot score the voice-drafting eval.\n"
+            "  What to do: set ANTHROPIC_API_KEY on this runner. The workflow step "
+            "injects it from secrets.ANTHROPIC_API_KEY; add/repair that repo (or "
+            "org) secret.\n"
+            "  Where: the 'Voice-drafting quality eval' step in "
+            ".github/workflows/{release_agent_email,test_email_agent_eval,"
+            "email_scorecard_refresh}.yml.",
+            file=sys.stderr,
         )
-        return 0
+        return 1
 
     # Generation: drives the #1607 voice-profile drafting path per case
     # (Lemonade — this job holds the serial lemonade-eval slot).
@@ -94,7 +95,7 @@ def main() -> int:
 
     gate = summary.get("drafting_gate", {})
     agg = summary.get("drafting", {})
-    print("\n============ EMAIL DRAFTING EVAL REPORT (report mode) ============")
+    print("\n============ EMAIL DRAFTING EVAL REPORT (enforcing) ============")
     print(
         f"  Draft-approval rate : {agg.get('draft_approval_rate')}   "
         f"(target >={thresholds.approval_min} #1269, REPORTED)"
@@ -123,11 +124,11 @@ def main() -> int:
     )
     print("[OUT] wrote eval-out/drafting_gate_report.json")
 
-    # Same hook contract as the other gates: report mode never fails.
+    # Same hook contract as the other gates: with enforce:true a breach blocks.
     if gate.get("should_fail"):
         print("[DRAFT-EVAL] enforced gate breach — failing the build.")
         return 1
-    print("[DRAFT-EVAL] report mode (or no breach) — gate does not block the build.")
+    print("[DRAFT-EVAL] drafting gate passed — no breach.")
     return 0
 
 

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -269,16 +269,23 @@ def _build_reproduction_command(model, ground_truth_rel: str, limit=None) -> str
     )
 
 
-def _load_draft_approval_rate(drafting_report: Path) -> Optional[float]:
+def _load_draft_approval_rate(drafting_report: Path) -> float:
     """Read ``summary.drafting.draft_approval_rate`` from a drafting gate report.
 
-    Returns ``None`` when the report is a loud-skip (no judge credential) so the
-    scorecard simply omits the metric rather than inventing a value. Fails loud if
-    the file exists but is malformed — a judged run must yield a real rate.
+    A drafting report passed here must be a real judged run — ``eval_drafting_report.py``
+    hard-fails (exit 1) rather than emitting a skip report, so there is no silent
+    "skipped" path (CLAUDE.md: No Silent Fallbacks). Fails loud on a legacy
+    ``skipped`` marker or any report missing the rate — never silently omits the
+    metric.
     """
     data = json.loads(drafting_report.read_text(encoding="utf-8"))
     if data.get("skipped"):
-        return None
+        raise ValueError(
+            f"Drafting report {drafting_report} is marked skipped, but the judged "
+            f"drafting eval must not skip (ANTHROPIC_API_KEY is required and "
+            f"eval_drafting_report.py exits 1 when it is absent). Re-run "
+            f"eval_drafting_report.py with ANTHROPIC_API_KEY set."
+        )
     rate = data.get("summary", {}).get("drafting", {}).get("draft_approval_rate")
     if rate is None:
         raise ValueError(
@@ -444,15 +451,16 @@ def build_payload(
     # changing the aggregate (still 100 x within_one). Blocking on a drafting
     # regression is the drafting gate's job (enforce:true), not the aggregate's.
     if drafting_report is not None:
+        # A judged run always yields a real rate; _load_draft_approval_rate raises
+        # loudly otherwise (no silent omit).
         draft_rate = _load_draft_approval_rate(Path(drafting_report))
-        if draft_rate is not None:
-            metrics.append(
-                {
-                    "name": "draft_approval_rate",
-                    "value": float(draft_rate),
-                    "weight": 0.0,
-                }
-            )
+        metrics.append(
+            {
+                "name": "draft_approval_rate",
+                "value": float(draft_rate),
+                "weight": 0.0,
+            }
+        )
     compute_aggregate(
         metrics
     )  # validate metrics; aggregate embedded in render_scorecard
@@ -649,10 +657,11 @@ def main(argv=None) -> int:
         default=None,
         help=(
             "Path to eval-out/drafting_gate_report.json (from "
-            "eval_drafting_report.py). When given and not a loud-skip, folds "
-            "draft_approval_rate into the scorecard as a reported metric "
-            "(weight 0). Blocking on a drafting regression is the drafting "
-            "gate's job (enforce:true), not the aggregate's."
+            "eval_drafting_report.py, a judged run). Folds draft_approval_rate "
+            "into the scorecard as a reported metric (weight 0); a missing/"
+            "unjudged report fails loudly, never silently omits. Blocking on a "
+            "drafting regression is the drafting gate's job (enforce:true), not "
+            "the aggregate's."
         ),
     )
 

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -728,15 +728,17 @@ class TestEmailAdapter:
         # Aggregate unchanged — drafting is reported, not weighted.
         assert compute_aggregate(withd.metrics)[1] == compute_aggregate(base.metrics)[1]
 
-    def test_drafting_report_skip_omits_metric(self, tmp_path):
-        # A loud-skip report (no ANTHROPIC_API_KEY) must NOT invent a metric.
+    def test_drafting_report_skip_marker_fails_loud(self, tmp_path):
+        # No silent skip (CLAUDE.md fail-loudly): the judged drafting eval now
+        # hard-fails on a missing key instead of emitting a skip report, so a
+        # legacy `skipped` marker must raise — never silently omit the metric.
         mod = self._load_gen_scorecard()
         bench, gt = self._bench_and_gt(tmp_path)
         report = tmp_path / "drafting_gate_report.json"
         report.write_text(json.dumps({"skipped": True, "reason": "no key"}))
 
-        payload = mod.build_payload(bench, gt, drafting_report=str(report))
-        assert not any(m["name"] == "draft_approval_rate" for m in payload.metrics)
+        with pytest.raises(ValueError, match="skipped"):
+            mod.build_payload(bench, gt, drafting_report=str(report))
 
     def test_drafting_report_malformed_fails_loud(self, tmp_path):
         # A non-skip report missing the rate is a hard error, never a silent omit.
@@ -747,6 +749,38 @@ class TestEmailAdapter:
 
         with pytest.raises(ValueError, match="draft_approval_rate"):
             mod.build_payload(bench, gt, drafting_report=str(report))
+
+    def _load_eval_drafting_report(self):
+        path = (
+            Path(__file__).parents[3]
+            / "hub"
+            / "agents"
+            / "python"
+            / "email"
+            / "packaging"
+            / "eval_drafting_report.py"
+        )
+        spec = importlib.util.spec_from_file_location("eval_drafting_report", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_drafting_eval_missing_key_hard_fails(self, tmp_path, monkeypatch, capsys):
+        # No silent skip (CLAUDE.md fail-loudly): a missing ANTHROPIC_API_KEY makes
+        # the judged drafting eval exit 1 with an actionable error naming the key —
+        # it must NOT write a skip report or return 0.
+        mod = self._load_eval_drafting_report()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("EMAIL_EVAL_MODEL", "test-model")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        rc = mod.main()
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "ANTHROPIC_API_KEY" in err
+        # Never emits a skip report the scorecard could silently omit.
+        assert not (tmp_path / "eval-out" / "drafting_gate_report.json").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

Follow-up to #1990 (already merged), which flipped the drafting + perf gates to `enforce:true` but left two accuracy defects on main:

1. **A fail-loudly violation.** `eval_drafting_report.py` still *silently loud-skipped* when `ANTHROPIC_API_KEY` was absent — it wrote `{"skipped": true, "should_fail": false}` and returned 0, and `gen_scorecard.py` then quietly dropped the `draft_approval_rate` metric. So a keyless run shipped an **un-judged drafting gate** while the manifest claimed `enforce:true`. That contradicts CLAUDE.md's "No Silent Fallbacks — Fail Loudly" hard rule. Now a missing key is a hard failure (exit 1) with an actionable error naming the key; there is no skip report and no invented pass.

2. **Stale docs from the enforce flip.** `test_email_agent_eval.yml`, `release_agent_email.yml`, and the drafting-eval docstrings still described the perf/drafting gates as `enforce:false` / "report mode" / "loud-skip". Swept to match shipped behavior: perf + drafting + briefing enforce; only the FP/FN quality gate remains report-mode.

No gating **logic** changed beyond the missing-key path — the manifests still own the enforce switch (data, not code).

**Fork/nightly safety:** the three workflows that run the judged eval trigger only on `schedule` / `workflow_call` / tag-push / base-branch push — never `pull_request` from a fork — so `secrets.ANTHROPIC_API_KEY` is always present in a legitimate run and the hard-fail can't spuriously break CI.

## Test plan

- [x] `pytest tests/unit/eval tests/unit/email -q` → 605 passed
- [x] New: missing key → `main()` returns 1 + stderr names `ANTHROPIC_API_KEY`, writes no skip report (`test_drafting_eval_missing_key_hard_fails`)
- [x] Changed: a `skipped`-marked report now raises instead of silently omitting the metric (`test_drafting_report_skip_marker_fails_loud`)
- [x] `python util/lint.py --all` clean; all three workflow YAMLs parse
- [x] `gen_scorecard.py` retains #1989's `_build_reproduction_command` alongside the fail-loudly change (clean 3-way merge)