### PR TITLE
ci(email-eval): fix broken triage benchmark — PYTHONPATH + tool-timeout + keyring

### DIFF
--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -133,6 +133,13 @@ env:
   # `ModuleNotFoundError: No module named 'tests'`. Set job-wide so every eval
   # step is covered — mirrors email_scorecard_refresh.yml.
   PYTHONPATH: ${{ github.workspace }}
+  # The benchmark triages the whole corpus in ONE `triage_inbox` tool call
+  # (~20s/email on a 4B local model), so the default 180s tool timeout abandons
+  # it mid-run. Match the scorecard refresh's 30-min budget.
+  GAIA_AGENT_TOOL_TIMEOUT: "1800"
+  # The agent's calendar-connector resolution blocks on the OS keyring in a
+  # headless runner — disable it so agent construction/triage doesn't hang.
+  PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
 
 jobs:
   email-eval:

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -127,6 +127,12 @@ env:
   # Bare host (no /api/v1): the LemonadeClient normalizes the suffix itself.
   LEMONADE_BASE_URL: "http://127.0.0.1:13305"
   NO_PROXY: "localhost,127.0.0.1"
+  # `gaia eval benchmark` is the installed console script; it imports the
+  # synthetic-corpus backend via `from tests.fixtures.email.fake_gmail import
+  # FakeGmailBackend`. The repo root must be on sys.path or it dies with
+  # `ModuleNotFoundError: No module named 'tests'`. Set job-wide so every eval
+  # step is covered — mirrors email_scorecard_refresh.yml.
+  PYTHONPATH: ${{ github.workspace }}
 
 jobs:
   email-eval:


### PR DESCRIPTION
The report-mode email eval workflow (`test_email_agent_eval.yml`) has **never actually run** — and when forced to, it fails instantly. Every scheduled nightly (07-04 → 07-10) was `cancelled` by the shared `lemonade-eval` concurrency mutex *before* reaching the benchmark step, so a latent bug stayed hidden: the step runs `gaia eval benchmark` (the installed console script) with **no `PYTHONPATH`**, so `from tests.fixtures.email.fake_gmail import FakeGmailBackend` blows up:

```
ModuleNotFoundError: No module named 'tests'
RuntimeError: The email throughput benchmark must run from a GAIA repo checkout …
```

`email_scorecard_refresh.yml` already sets `PYTHONPATH: ${{ github.workspace }}` on the same step — that's why the scorecard path works and this one didn't. This adds it job-wide so the benchmark **and** all three judge-scored eval steps (voice-drafting, action-item, briefing) are covered.

Surfaced while validating the 0.4.0 email release: after clearing the mutex, the first real run of this workflow (run 29127878665) reproduced the failure exactly.

## Test plan
- [x] YAML parses; `env.PYTHONPATH == ${{ github.workspace }}`
- [ ] Re-dispatch `test_email_agent_eval.yml` on this branch → benchmark imports the corpus and the eval runs to completion (green)