### PR TITLE
fix(email-eval): survive Windows temp-db cleanup lock in the triage benchmark

### DIFF
--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -4358,7 +4358,14 @@ Let me know your answer!
                     "quality scoring skipped"
                 )
 
-            with tempfile.TemporaryDirectory(prefix="gaia-bench-") as tmp:
+            # ignore_cleanup_errors: the benchmark's per-email SQLite state.db can
+            # still hold a Windows file lock when the block exits (WinError 32 on
+            # rmtree). `results` is already captured, and the temp dir is a
+            # throwaway in the OS temp space, so a failed cleanup must not fail an
+            # otherwise-successful eval.
+            with tempfile.TemporaryDirectory(
+                prefix="gaia-bench-", ignore_cleanup_errors=True
+            ) as tmp:
                 results = run_benchmark(
                     args.model,
                     mbox_path=mbox_path,

--- a/src/gaia/eval/benchmark.py
+++ b/src/gaia/eval/benchmark.py
@@ -617,6 +617,14 @@ def run_benchmark(
                 )
             )
 
+            # Release the agent's SQLite state.db before the next experiment and
+            # the caller's temp-dir cleanup — an open connection locks the file on
+            # Windows. Best-effort: a stub agent_factory agent may lack close_db.
+            try:
+                agent.close_db()
+            except Exception:
+                pass
+
         return results
     finally:
         if _prev_ceiling is None:


### PR DESCRIPTION
The email eval benchmark **runs to completion** (logs `✨ Processing complete!`) but then crashes on the Windows `stx` runner during temp-dir teardown:

```
✨ Processing complete!
PermissionError: [WinError 32] The process cannot access the file because it is
being used by another process: 'C:\WINDOWS\TEMP\gaia-bench-…\state.db'
  … self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)
```

The per-email task-store (#1605) keeps a SQLite connection to `state.db` open (the log shows it re-initialising every ~30s), so `TemporaryDirectory` cleanup can't `rmtree` it on Windows. The eval **result is already captured** before the `with` block exits — a throwaway temp dir failing to delete must not fail an otherwise-green eval.

- `cli.py`: `TemporaryDirectory(prefix="gaia-bench-", ignore_cleanup_errors=True)`.
- `benchmark.py`: close the agent's `state.db` after each experiment (proper hygiene).

This is the last blocker for `test_email_agent_eval.yml` (the release's `email-eval` gate) to go green on Windows. Surfaced validating the 0.4.0 release: after #2024 fixed the env, the benchmark ran the full triage but died here at ~26 min.

## Test plan
- [x] `py_compile` clean; `ignore_cleanup_errors` is py3.10+ (repo min)
- [ ] Re-dispatch `test_email_agent_eval.yml` → benchmark completes AND the run goes green