### PR TITLE
fix(email-eval): pin eval workflows to Windows stx runners

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -79,7 +79,12 @@ env:
 jobs:
   refresh:
     name: Re-run eval, refresh-or-reject scorecard
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Require the WINDOWS stx runners: the bare 'stx' label also matches a
+    # Linux box (xsj-aimlab-stxp-04), and this eval is Windows-only (PowerShell
+    # steps + LemonadeServer.exe) — landing on Linux dies instantly with
+    # 'powershell: command not found'. fromJSON(...) yields a label ARRAY so the
+    # runner must have Windows AND the stx/stx-test label.
+    runs-on: ${{ fromJSON(contains(github.event.pull_request.labels.*.name, 'stx-test') && '["self-hosted","Windows","stx-test"]' || '["self-hosted","Windows","stx"]') }}
     # The refresh triages the full ~220-email corpus in one call (~38s/email
     # -> ~2.3h) to regenerate a representative card, so the job needs a wide
     # budget. (Faster triage is tracked separately; until then the refresh is

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -147,7 +147,12 @@ env:
 jobs:
   email-eval:
     name: Email Triage Eval (synthetic corpus, report mode)
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # Require the WINDOWS stx runners: the bare 'stx' label also matches a
+    # Linux box (xsj-aimlab-stxp-04), and this eval is Windows-only (PowerShell
+    # steps + LemonadeServer.exe) — landing on Linux dies instantly with
+    # 'powershell: command not found'. fromJSON(...) yields a label ARRAY so the
+    # runner must have Windows AND the stx/stx-test label.
+    runs-on: ${{ fromJSON(contains(github.event.pull_request.labels.*.name, 'stx-test') && '["self-hosted","Windows","stx-test"]' || '["self-hosted","Windows","stx"]') }}
     timeout-minutes: 90
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why

The email scorecard-refresh (run 29280701253) failed in **9 s** at *Install Lemonade Server* with **`powershell: command not found`** — the job landed on the **Linux** stx runner (`xsj-aimlab-stxp-04`, labeled `stx,stx-test,Linux`). `runs-on: 'stx'` matches that box as well as the Windows stx runners, but these evals are **Windows-only** (PowerShell steps + `LemonadeServer.exe`). Landing on Linux dies instantly, and it **intermittently threatens the release gate** (same `runs-on`).

## Fix

`runs-on` now uses `fromJSON(...)` to yield a label **array** requiring `[self-hosted, Windows, stx]` (or `stx-test`), so the job can only land on a Windows stx runner. The existing `stx-test` PR-label override is preserved.

## Test plan
- [x] Both workflows YAML-parse.
- [ ] Dispatch `test_email_agent_eval.yml` (limit=20) on this branch → confirm it lands on a Windows stx runner and runs end-to-end (validates this fix **and**, on top of the merged #2043, the thresholds-path + timeout fixes).