### PR TITLE
ci(email): pin stx eval jobs to Windows runners

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -79,7 +79,12 @@ env:
 jobs:
   refresh:
     name: Re-run eval, refresh-or-reject scorecard
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # OS-qualified like the other STX workflows (#1975): the stx/stx-test pools
+    # include a Linux box, and this job's install-lemonade steps are PowerShell.
+    runs-on:
+      - self-hosted
+      - Windows
+      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
     # The refresh triages the full ~220-email corpus in one call (~38s/email
     # -> ~2.3h) to regenerate a representative card, so the job needs a wide
     # budget. (Faster triage is tracked separately; until then the refresh is

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -147,7 +147,12 @@ env:
 jobs:
   email-eval:
     name: Email Triage Eval (synthetic corpus, report mode)
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
+    # OS-qualified like the other STX workflows (#1975): the stx/stx-test pools
+    # include a Linux box, and this job's install-lemonade steps are PowerShell.
+    runs-on:
+      - self-hosted
+      - Windows
+      - ${{ contains(github.event.pull_request.labels.*.name, 'stx-test') && 'stx-test' || 'stx' }}
     timeout-minutes: 90
     steps:
       - name: Checkout


### PR DESCRIPTION
Email-branch pushes were going randomly red: the two email eval workflows request the bare `stx` pool label but run PowerShell-only steps (`install-lemonade`), so whenever the pool's Linux box won the job it failed in ~9 seconds with `powershell: command not found`. After this change both jobs only match Windows stx runners, same as every other STX workflow since #1975.

Fixes #2051

## Test plan
- [x] YAML parses; `runs-on` resolves to `[self-hosted, Windows, stx]` (or `stx-test` with the label) — same list form #1975 applied to the other nine STX workflows, where existing Windows stx runners already match
- [x] `git grep` over `.github/workflows/` confirms no other workflow still uses an unqualified `stx` `runs-on` (`strix-halo` is a separate, intentionally-Linux label)
- [ ] Next push to an email branch schedules these jobs on a Windows runner and gets past "Install Lemonade Server"

<details>
<summary>🔍 Details</summary>

- Failing job: https://github.com/amd/gaia/actions/runs/29280701253/job/86922813976 — died at "Install Lemonade Server" on a Linux runner; same failure on three other email branches the same day.
- These two workflows were missed by #1975 because they joined the stx pool in #1983 around the same time; `email_scorecard_refresh.yml`'s own header already documents the intended pool as `[self-hosted, Windows, stx]`.
- Org-side, the runner registration could also drop `stx` from the Linux box, but the workflow-side guard is the durable fix.
</details>