### PR TITLE
feat(daemon): headless custody daemon skeleton — single instance, client auth, gaia daemon CLI

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2115,6 +2115,35 @@ gaia youtube \
 
 ---
 
+### Daemon Command
+
+Manage the headless custody daemon — the always-on, single-instance background
+process that later Agent UI v2 phases (sidecar supervision, `/host/v1/*` custody,
+the model-slot broker, the scheduler clock) mount into. This Phase-1 skeleton
+provides single-instance identity, client-token auth, and lifecycle control.
+
+Requires the daemon extras (`fastapi`/`uvicorn`/`psutil`) — install with
+`pip install "amd-gaia[ui]"` (or `[api]`/`[dev]`). Running it on a base install
+fails loudly with that instruction.
+
+```bash
+gaia daemon start      # start the daemon, or attach if one is already running
+gaia daemon status     # show pid, port, and uptime
+gaia daemon stop       # graceful shutdown (tree-kills the instance)
+gaia daemon restart    # stop then start
+gaia daemon logs [--lines N] [--follow]   # tail the daemon log
+```
+
+| Action | Options | Description |
+|--------|---------|-------------|
+| `start` | — | Start the daemon or attach to the running one (two callers → one daemon). |
+| `status` | — | Print pid / port / uptime, or report if no daemon is running. |
+| `stop` | — | Shut the daemon down and release `~/.gaia/host/instance.json`. |
+| `restart` | — | `stop` followed by `start`. |
+| `logs` | `--lines`, `--follow` | Print (or stream) the daemon log tail. |
+
+---
+
 ### Cache Command
 
 Inspect or clear GAIA's on-disk caches (document-Q7 metadata, chat history,

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "gaia.audio",
         "gaia.chat",
         "gaia.schedule",
+        "gaia.daemon",
         "gaia.ui",
         "gaia.ui.routers",
         "gaia.ui.email_sidecar",

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -6959,8 +6959,6 @@ def _handle_daemon_logs(args):
     lines = getattr(args, "lines", 100)
     if getattr(args, "follow", False):
         # Simple follow loop: print the tail, then stream appended bytes.
-        import time as _time
-
         with open(log_file, "r", encoding="utf-8", errors="replace") as f:
             existing = f.readlines()
             for line in existing[-lines:]:
@@ -6971,7 +6969,7 @@ def _handle_daemon_logs(args):
                     if chunk:
                         print(chunk, end="")
                     else:
-                        _time.sleep(0.3)
+                        time.sleep(0.3)
             except KeyboardInterrupt:
                 return
         return

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -2757,6 +2757,42 @@ Examples:
     )
     mcp_test_client_parser.add_argument("name", help="Name of the MCP server to test")
 
+    # Daemon command (headless custody daemon lifecycle)
+    daemon_parser = subparsers.add_parser(
+        "daemon",
+        help="Manage the headless GAIA daemon (single machine-wide custody process)",
+    )
+    daemon_subparsers = daemon_parser.add_subparsers(
+        dest="daemon_action", help="Daemon action to perform"
+    )
+    daemon_subparsers.add_parser(
+        "start", help="Start the daemon (or attach if one is already running)"
+    )
+    daemon_subparsers.add_parser(
+        "status", help="Show daemon pid / port / uptime"
+    )
+    daemon_subparsers.add_parser("stop", help="Stop the running daemon")
+    daemon_subparsers.add_parser(
+        "restart", help="Restart the daemon (stop if running, then start)"
+    )
+    daemon_logs_parser = daemon_subparsers.add_parser(
+        "logs", help="Show the daemon log"
+    )
+    daemon_logs_parser.add_argument(
+        "-n",
+        "--lines",
+        type=int,
+        default=100,
+        help="Number of trailing log lines to show (default: 100)",
+    )
+    daemon_logs_parser.add_argument(
+        "-f",
+        "--follow",
+        action="store_true",
+        help="Follow the log (like tail -f); Ctrl-C to stop",
+    )
+    daemon_parser.set_defaults(action="daemon")
+
     # Cache command (for Context7 cache management)
     cache_parser = subparsers.add_parser(
         "cache", help="Manage Context7 API cache and rate limiting"
@@ -4477,6 +4513,10 @@ Let me know your answer!
     # Handle MCP command
     if args.action == "mcp":
         handle_mcp_command(args)
+        return
+
+    if args.action == "daemon":
+        handle_daemon_command(args)
         return
 
     # Handle Config command
@@ -6796,6 +6836,146 @@ def handle_agent_import(args):
     if result.errors:
         print(f"Errors: {', '.join(result.errors)}", file=sys.stderr)
         sys.exit(1)
+
+
+def handle_daemon_command(args):
+    """Handle `gaia daemon status|stop|restart|logs|start`."""
+    action = getattr(args, "daemon_action", None)
+    if action is None:
+        print(
+            "❌ No daemon action specified. Use 'gaia daemon --help' to see "
+            "available actions (start, status, stop, restart, logs)."
+        )
+        return
+    if action == "start":
+        _handle_daemon_start()
+    elif action == "status":
+        _handle_daemon_status()
+    elif action == "stop":
+        _handle_daemon_stop()
+    elif action == "restart":
+        _handle_daemon_restart()
+    elif action == "logs":
+        _handle_daemon_logs(args)
+    else:
+        print(f"❌ Unknown daemon action: {action}")
+
+
+def _fmt_uptime(seconds: float) -> str:
+    seconds = int(max(0, seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h {m}m {s}s"
+    if m:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
+def _handle_daemon_start():
+    from gaia.daemon import client
+    from gaia.daemon.errors import DaemonError
+
+    try:
+        inst = client.start_or_attach()
+    except DaemonError as e:
+        print(f"❌ {e}")
+        sys.exit(1)
+    print(f"✅ GAIA daemon running (pid {inst.pid}, port {inst.port})")
+
+
+def _handle_daemon_status():
+    from gaia.daemon import client, paths
+
+    report = client.status_report()
+    state = report["state"]
+    if state == "not_running":
+        print("GAIA daemon: not running")
+        print("  Start it with `gaia daemon start`.")
+        return
+    inst = report["instance"]
+    if state == "stale":
+        reason = {
+            "pid_dead": "recorded pid is not alive",
+            "unresponsive": "process is alive but not answering the client API",
+        }.get(report.get("reason"), report.get("reason"))
+        print(f"GAIA daemon: stale ({reason})")
+        print(f"  Registry: {paths.instance_path()} (pid {inst.pid}, port {inst.port})")
+        print("  Reclaim it with `gaia daemon restart`.")
+        return
+    body = report["status"]
+    print("GAIA daemon: running")
+    print(f"  pid:        {inst.pid}")
+    print(f"  port:       {inst.port}")
+    print(f"  uptime:     {_fmt_uptime(body.get('uptime_seconds', 0))}")
+    print(f"  api:        v{body.get('api_version')}")
+    print(f"  url:        {inst.base_url}")
+
+
+def _handle_daemon_stop():
+    from gaia.daemon import client
+    from gaia.daemon.errors import DaemonError
+    from gaia.daemon.instance import pid_alive, read_instance, remove_instance, terminate_instance
+
+    inst = read_instance()
+    if inst is None:
+        print("GAIA daemon: not running (nothing to stop)")
+        return
+    if not pid_alive(inst.pid):
+        remove_instance(only_pid=inst.pid)
+        print(f"GAIA daemon: cleared stale registry (pid {inst.pid} was already dead)")
+        return
+    # Prefer a graceful, authed shutdown; escalate to terminate if it won't answer.
+    try:
+        client.request_shutdown(inst)
+    except DaemonError as e:
+        print(f"⚠️  graceful shutdown failed ({e}); terminating pid {inst.pid}")
+        terminate_instance(inst)
+    if client.wait_until_gone(inst, timeout=10.0):
+        remove_instance(only_pid=inst.pid)
+        print(f"✅ GAIA daemon stopped (pid {inst.pid})")
+    else:
+        print(f"⚠️  daemon pid {inst.pid} did not exit; terminating")
+        terminate_instance(inst)
+        remove_instance(only_pid=inst.pid)
+        print(f"✅ GAIA daemon terminated (pid {inst.pid})")
+
+
+def _handle_daemon_restart():
+    _handle_daemon_stop()
+    _handle_daemon_start()
+
+
+def _handle_daemon_logs(args):
+    from gaia.daemon import paths
+
+    log_file = paths.log_path()
+    if not log_file.exists():
+        print(f"No daemon log at {log_file} (the daemon has not started yet).")
+        return
+    lines = getattr(args, "lines", 100)
+    if getattr(args, "follow", False):
+        # Simple follow loop: print the tail, then stream appended bytes.
+        import time as _time
+
+        with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+            existing = f.readlines()
+            for line in existing[-lines:]:
+                print(line, end="")
+            try:
+                while True:
+                    chunk = f.readline()
+                    if chunk:
+                        print(chunk, end="")
+                    else:
+                        _time.sleep(0.3)
+            except KeyboardInterrupt:
+                return
+        return
+    with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+        tail = f.readlines()[-lines:]
+    for line in tail:
+        print(line, end="")
 
 
 def handle_mcp_command(args):

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -2768,9 +2768,7 @@ Examples:
     daemon_subparsers.add_parser(
         "start", help="Start the daemon (or attach if one is already running)"
     )
-    daemon_subparsers.add_parser(
-        "status", help="Show daemon pid / port / uptime"
-    )
+    daemon_subparsers.add_parser("status", help="Show daemon pid / port / uptime")
     daemon_subparsers.add_parser("stop", help="Stop the running daemon")
     daemon_subparsers.add_parser(
         "restart", help="Restart the daemon (stop if running, then start)"
@@ -6915,7 +6913,12 @@ def _handle_daemon_status():
 def _handle_daemon_stop():
     from gaia.daemon import client
     from gaia.daemon.errors import DaemonError
-    from gaia.daemon.instance import pid_alive, read_instance, remove_instance, terminate_instance
+    from gaia.daemon.instance import (
+        pid_alive,
+        read_instance,
+        remove_instance,
+        terminate_instance,
+    )
 
     inst = read_instance()
     if inst is None:

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -6836,6 +6836,36 @@ def handle_agent_import(args):
         sys.exit(1)
 
 
+def _check_daemon_deps():
+    """Fail loud if the daemon's runtime deps (extras-only) are missing.
+
+    ``gaia daemon`` is a base console command but the daemon process needs
+    ``fastapi``/``uvicorn``/``psutil``, which live in the ``[ui]``/``[api]``/
+    ``[dev]`` extras. On a base install the spawned daemon would die on
+    ``ModuleNotFoundError`` and surface a cryptic "process exited early"; name
+    the real cause and the fix instead.
+    """
+    import importlib.util
+
+    missing = [
+        pkg
+        for mod, pkg in (
+            ("fastapi", "fastapi"),
+            ("uvicorn", "uvicorn"),
+            ("psutil", "psutil"),
+        )
+        if importlib.util.find_spec(mod) is None
+    ]
+    if missing:
+        print(
+            "❌ `gaia daemon` needs packages not in the base install: "
+            + ", ".join(missing)
+            + '.\n   Install the daemon extras:  pip install "amd-gaia[ui]"'
+            "  (or [api]/[dev])."
+        )
+        sys.exit(1)
+
+
 def handle_daemon_command(args):
     """Handle `gaia daemon status|stop|restart|logs|start`."""
     action = getattr(args, "daemon_action", None)
@@ -6845,6 +6875,7 @@ def handle_daemon_command(args):
             "available actions (start, status, stop, restart, logs)."
         )
         return
+    _check_daemon_deps()
     if action == "start":
         _handle_daemon_start()
     elif action == "status":

--- a/src/gaia/daemon/__init__.py
+++ b/src/gaia/daemon/__init__.py
@@ -18,6 +18,8 @@ two concurrent callers yield exactly one daemon.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from gaia.daemon.constants import DAEMON_API_VERSION, SERVICE_ID
 from gaia.daemon.errors import (
     DaemonError,
@@ -32,6 +34,11 @@ from gaia.daemon.instance import (
     read_instance,
     write_instance,
 )
+
+if TYPE_CHECKING:
+    # Declared for static analysis / `__all__`; resolved lazily at runtime via
+    # __getattr__ so importing gaia.daemon doesn't pull in the client machinery.
+    from gaia.daemon.client import attach, request_shutdown, start_or_attach
 
 __all__ = [
     "DAEMON_API_VERSION",

--- a/src/gaia/daemon/__init__.py
+++ b/src/gaia/daemon/__init__.py
@@ -1,0 +1,61 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GAIA headless custody daemon (Agent UI v2, Phase 1 skeleton).
+
+The daemon is the always-on machine-wide custody/supervisor process. This package
+is the SKELETON: single-instance identity, client-token auth, and the
+``gaia daemon`` lifecycle CLI. Sidecar supervision, ``/host/v1/*`` custody, the
+model broker, and the scheduler clock each land in their own later issue and are
+deliberately NOT implemented here.
+
+Public surface used by clients (the web UI and the ``gaia <agent>`` CLIs):
+
+    from gaia.daemon import start_or_attach, read_instance, DaemonInstance
+
+``start_or_attach()`` starts a daemon or attaches to the one already running —
+two concurrent callers yield exactly one daemon.
+"""
+
+from __future__ import annotations
+
+from gaia.daemon.constants import DAEMON_API_VERSION, SERVICE_ID
+from gaia.daemon.errors import (
+    DaemonError,
+    DaemonLockError,
+    DaemonStartError,
+    DaemonVersionError,
+)
+from gaia.daemon.instance import (
+    DaemonInstance,
+    is_live,
+    probe,
+    read_instance,
+    write_instance,
+)
+
+__all__ = [
+    "DAEMON_API_VERSION",
+    "SERVICE_ID",
+    "DaemonError",
+    "DaemonLockError",
+    "DaemonStartError",
+    "DaemonVersionError",
+    "DaemonInstance",
+    "is_live",
+    "probe",
+    "read_instance",
+    "write_instance",
+    "start_or_attach",
+    "attach",
+    "request_shutdown",
+]
+
+
+def __getattr__(name: str):
+    # Lazy re-export of client helpers so importing gaia.daemon does not pull in
+    # the client/subprocess machinery until a caller actually needs it.
+    if name in ("start_or_attach", "attach", "request_shutdown"):
+        from gaia.daemon import client
+
+        return getattr(client, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/gaia/daemon/__main__.py
+++ b/src/gaia/daemon/__main__.py
@@ -1,0 +1,10 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``python -m gaia.daemon`` -> run the daemon process."""
+
+from __future__ import annotations
+
+from gaia.daemon.server import run
+
+if __name__ == "__main__":
+    run()

--- a/src/gaia/daemon/app.py
+++ b/src/gaia/daemon/app.py
@@ -1,0 +1,131 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The daemon's versioned client API surface (``/daemon/v1/*``).
+
+Skeleton scope: a token-guarded ``status`` route and a ``shutdown`` route. Later
+issues mount the custody API (``/host/v1/*``), the model broker, and the scheduler
+into this same app.
+
+Every ``/daemon/v1`` route requires the client token minted at startup. A request
+without a valid token gets a 401 whose detail names what failed, what to do, and
+where to look — no silent fallback to an unauthenticated response.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from contextlib import asynccontextmanager
+from typing import Callable, Optional
+
+from gaia.daemon.constants import (
+    API_PREFIX,
+    AUTH_SCHEME,
+    DAEMON_API_VERSION,
+    SERVICE_ID,
+)
+from gaia.daemon.paths import instance_path
+
+
+def create_app(
+    *,
+    token: str,
+    port: int,
+    pid: int,
+    started_at: float,
+    on_startup: Optional[Callable[[], None]] = None,
+    on_shutdown: Optional[Callable[[], None]] = None,
+):
+    """Build the FastAPI app bound to this daemon's identity.
+
+    *token*, *port*, *pid*, *started_at* are captured in the closure so the status
+    payload and the auth check need no shared global state. *on_startup* /
+    *on_shutdown* run inside the app lifespan — the daemon registers instance.json
+    on startup (once the port is bound) and deregisters on shutdown.
+    """
+    from fastapi import Depends, FastAPI, Header, HTTPException
+
+    @asynccontextmanager
+    async def lifespan(_app):
+        if on_startup is not None:
+            on_startup()
+        try:
+            yield
+        finally:
+            if on_shutdown is not None:
+                on_shutdown()
+
+    app = FastAPI(
+        title="GAIA Daemon",
+        version=DAEMON_API_VERSION,
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+        lifespan=lifespan,
+    )
+
+    def require_token(authorization: Optional[str] = Header(default=None)) -> None:
+        where = f"the client token in {instance_path()}"
+        if not authorization:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    "Missing client token. Send the header "
+                    f"'Authorization: {AUTH_SCHEME} <token>' using {where}. "
+                    "If the daemon was restarted the token rotated — re-attach with "
+                    "`gaia daemon status`."
+                ),
+                headers={"WWW-Authenticate": AUTH_SCHEME},
+            )
+        scheme, _, credential = authorization.partition(" ")
+        if scheme.lower() != AUTH_SCHEME.lower() or not credential:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    f"Malformed Authorization header. Expected "
+                    f"'{AUTH_SCHEME} <token>' using {where}."
+                ),
+                headers={"WWW-Authenticate": AUTH_SCHEME},
+            )
+        if not secrets.compare_digest(credential, token):
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    "Invalid client token. The token must match "
+                    f"{where}. If the daemon restarted, re-read it via "
+                    "`gaia daemon status`, or run `gaia daemon restart`."
+                ),
+                headers={"WWW-Authenticate": AUTH_SCHEME},
+            )
+
+    @app.get(f"{API_PREFIX}/status")
+    def status(_: None = Depends(require_token)) -> dict:
+        now = time.time()
+        return {
+            "service": SERVICE_ID,
+            "api_version": DAEMON_API_VERSION,
+            "pid": pid,
+            "port": port,
+            "host": "127.0.0.1",
+            "started_at": started_at,
+            "uptime_seconds": max(0.0, now - started_at),
+        }
+
+    @app.post(f"{API_PREFIX}/shutdown")
+    def shutdown(_: None = Depends(require_token)) -> dict:
+        # uvicorn polls should_exit in its serving loop; setting it triggers a
+        # graceful drain + shutdown. The server object is attached in server.run().
+        server = getattr(app.state, "server", None)
+        if server is None:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Daemon shutdown is unavailable: no server handle attached. "
+                    "Stop it with `gaia daemon stop` (which will terminate the pid), "
+                    "or inspect `gaia daemon logs`."
+                ),
+            )
+        server.should_exit = True
+        return {"service": SERVICE_ID, "status": "stopping", "pid": pid}
+
+    return app

--- a/src/gaia/daemon/client.py
+++ b/src/gaia/daemon/client.py
@@ -1,0 +1,187 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Client-side daemon helpers: start-or-attach, attach, shutdown request.
+
+``start_or_attach()`` is the entry point every client (the web UI and the
+``gaia <agent>`` CLIs) calls. It returns the running daemon, starting one only if
+needed — and does so under an exclusive start lock so two concurrent callers yield
+exactly ONE daemon (the second attaches to the first's instance.json).
+
+Recovery follows §0.25: a recorded instance is trusted only when its pid is alive
+AND a token-authed probe succeeds. A dead pid → reclaim by spawning fresh; a
+live-but-unresponsive pid → terminate it, then spawn fresh.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from typing import Optional
+
+from gaia.daemon import paths
+from gaia.daemon.constants import API_PREFIX, AUTH_SCHEME, DAEMON_API_VERSION
+from gaia.daemon.errors import DaemonError, DaemonStartError, DaemonVersionError
+from gaia.daemon.instance import (
+    DaemonInstance,
+    is_live,
+    pid_alive,
+    probe,
+    read_instance,
+    terminate_instance,
+)
+from gaia.daemon.lock import StartLock
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+_START_TIMEOUT = 30.0
+
+
+def _major(version: str) -> int:
+    try:
+        return int(str(version).split(".")[0])
+    except (ValueError, IndexError) as e:
+        raise DaemonVersionError(
+            f"cannot parse a MAJOR daemon API version from '{version}'"
+        ) from e
+
+
+def _check_version(inst: DaemonInstance) -> None:
+    """Fail loudly on a daemon↔client MAJOR skew (§0.25) — no silent stale attach."""
+    if _major(inst.api_version) != _major(DAEMON_API_VERSION):
+        raise DaemonVersionError(
+            f"the running daemon speaks host API v{inst.api_version} but this client "
+            f"speaks v{DAEMON_API_VERSION}. An app update replaced the client while the "
+            "old daemon kept running. Restart it with `gaia daemon restart`, then retry."
+        )
+
+
+def attach(timeout: float = 1.5) -> Optional[DaemonInstance]:
+    """Return the running daemon if one is live and version-compatible, else None."""
+    inst = read_instance()
+    if inst is None or not is_live(inst, timeout=timeout):
+        return None
+    _check_version(inst)
+    return inst
+
+
+def start_or_attach(timeout: float = _START_TIMEOUT) -> DaemonInstance:
+    """Return the running daemon, starting one if needed. Single-instance guaranteed."""
+    inst = attach()
+    if inst is not None:
+        return inst
+
+    with StartLock(timeout=timeout):
+        # Re-check under the lock: a concurrent caller may have just started it.
+        inst = read_instance()
+        if inst is not None and is_live(inst):
+            _check_version(inst)
+            return inst
+        # Stale registry. If the pid is alive but unresponsive, it is our own
+        # daemon gone bad — terminate it before reclaiming (§0.25).
+        if inst is not None and pid_alive(inst.pid):
+            logger.warning(
+                "daemon: instance pid=%s is alive but unresponsive; reclaiming",
+                inst.pid,
+            )
+            terminate_instance(inst)
+        return _spawn_and_wait(timeout)
+
+
+def _spawn_and_wait(timeout: float) -> DaemonInstance:
+    """Spawn the daemon detached, wait until it registers a live instance.json."""
+    paths.ensure_host_dir()
+    log_file = open(paths.log_path(), "ab")
+    creationflags = 0
+    start_new_session = False
+    if sys.platform == "win32":
+        # DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP: outlive the launcher.
+        creationflags = 0x00000008 | 0x00000200
+    else:
+        start_new_session = True
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "gaia.daemon"],
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=start_new_session,
+            creationflags=creationflags,
+        )
+    except OSError as e:
+        log_file.close()
+        raise DaemonStartError(
+            f"failed to launch the daemon ({sys.executable} -m gaia.daemon): {e}. "
+            f"Check the Python environment and `gaia daemon logs` at {paths.log_path()}."
+        ) from e
+    finally:
+        # The child inherits the fd; the parent no longer needs it.
+        log_file.close()
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        rc = proc.poll()
+        if rc is not None:
+            raise DaemonStartError(
+                f"the daemon process exited early (code {rc}) before registering. "
+                f"See the daemon log at {paths.log_path()}."
+            )
+        inst = read_instance()
+        # Trust only OUR child's registration (pid match), and only once live.
+        if inst is not None and inst.pid == proc.pid and is_live(inst):
+            _check_version(inst)
+            logger.info("daemon: started pid=%s port=%s", inst.pid, inst.port)
+            return inst
+        time.sleep(0.1)
+
+    raise DaemonStartError(
+        f"the daemon did not become healthy within {timeout}s. It may be stuck "
+        f"binding a port or importing. Inspect the daemon log at {paths.log_path()}."
+    )
+
+
+def request_shutdown(inst: DaemonInstance, timeout: float = 5.0) -> bool:
+    """Ask the daemon to shut down gracefully via its authed shutdown route.
+
+    Returns True if the daemon accepted the request. Raises DaemonError on a
+    transport failure so the caller can decide whether to escalate to a kill.
+    """
+    import requests
+
+    url = f"{inst.base_url}{API_PREFIX}/shutdown"
+    try:
+        r = requests.post(
+            url,
+            headers={"Authorization": f"{AUTH_SCHEME} {inst.token}"},
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as e:
+        raise DaemonError(
+            f"could not reach the daemon at {inst.base_url} to request shutdown: {e}. "
+            "It may already be dead; `gaia daemon status` will confirm."
+        ) from e
+    return r.status_code == 200
+
+
+def wait_until_gone(inst: DaemonInstance, timeout: float = 10.0) -> bool:
+    """Poll until the daemon pid is no longer alive. Returns True if it exited."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not pid_alive(inst.pid):
+            return True
+        time.sleep(0.1)
+    return not pid_alive(inst.pid)
+
+
+def status_report() -> dict:
+    """Structured status for the CLI: running/stale/absent + identity + uptime."""
+    inst = read_instance()
+    if inst is None:
+        return {"state": "not_running"}
+    if not pid_alive(inst.pid):
+        return {"state": "stale", "reason": "pid_dead", "instance": inst}
+    body = probe(inst)
+    if body is None:
+        return {"state": "stale", "reason": "unresponsive", "instance": inst}
+    return {"state": "running", "instance": inst, "status": body}

--- a/src/gaia/daemon/constants.py
+++ b/src/gaia/daemon/constants.py
@@ -1,0 +1,27 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Daemon-wide constants (identity, versioning, network binding)."""
+
+from __future__ import annotations
+
+# The daemon binds loopback only. NEVER 4001 (repo-wide reserved port).
+HOST = "127.0.0.1"
+RESERVED_PORT = 4001
+
+# Stable service identifier stamped into instance.json and returned by
+# /daemon/v1/status. A client probing the recorded port trusts the process only
+# if it answers with THIS id and the recorded pid — a foreign server that grabbed
+# the freed port after a crash cannot impersonate the daemon.
+SERVICE_ID = "gaia-daemon"
+
+# MAJOR contract version of the UI/CLI <-> daemon boundary (design §0.25 skew
+# rule). An app update replaces the client while an old daemon keeps running; a
+# differing MAJOR means the client cannot speak the running daemon's API and must
+# restart it rather than silently attach to a stale host.
+DAEMON_API_VERSION = "1"
+
+# Client-token auth: header name and scheme.
+AUTH_SCHEME = "Bearer"
+
+# Route prefix for the versioned client API surface.
+API_PREFIX = "/daemon/v1"

--- a/src/gaia/daemon/errors.py
+++ b/src/gaia/daemon/errors.py
@@ -1,0 +1,33 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Loud, actionable daemon errors (no silent fallbacks — CLAUDE.md).
+
+Each message names what failed, what to do, and where to look.
+"""
+
+from __future__ import annotations
+
+
+class DaemonError(Exception):
+    """Base for all daemon lifecycle/client failures."""
+
+
+class DaemonLockError(DaemonError):
+    """The single-instance start lock could not be acquired.
+
+    Raised when another process holds the start lock longer than the timeout —
+    surfaced loudly instead of racing to spawn a rival daemon.
+    """
+
+
+class DaemonStartError(DaemonError):
+    """The daemon subprocess could not be launched or never became healthy."""
+
+
+class DaemonVersionError(DaemonError):
+    """The running daemon speaks a different MAJOR host-API version than this client.
+
+    An app update replaced the client while the old daemon kept running (§0.25).
+    Restart the daemon so the new client can attach — never silently talk a stale
+    contract.
+    """

--- a/src/gaia/daemon/instance.py
+++ b/src/gaia/daemon/instance.py
@@ -1,0 +1,229 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``instance.json`` — the daemon's single-instance registry, plus liveness/probe.
+
+The file records the running daemon's ``pid``, loopback ``port``, and a minted
+client-auth ``token``. It is written mode ``0600`` via temp-file-then-rename so a
+crash mid-write can never leave a half-written (and therefore trusted) file — the
+same atomic-write discipline the email sidecar manager uses.
+
+Trusting the file requires TWO checks (design §0.25): the recorded pid must be
+alive AND a ``/daemon/v1/status`` probe on the recorded port must answer with our
+service id, matching pid, and the recorded token. After SIGKILL/OOM/power-loss the
+file points at a dead pid or a freed port some unrelated process now owns — either
+check fails, and the caller reclaims the lock.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+from gaia.daemon import paths
+from gaia.daemon.constants import DAEMON_API_VERSION, HOST, SERVICE_ID
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Fields persisted to instance.json. Kept explicit so a future field addition is a
+# deliberate contract change, not an accidental leak of internal state.
+_PERSISTED = ("pid", "port", "token", "host", "api_version", "service", "started_at")
+
+# Default timeout for the status probe. Short: a live daemon answers loopback in
+# milliseconds; a longer wait just delays reclaim of a dead one.
+_PROBE_TIMEOUT = 1.5
+
+
+@dataclass(frozen=True)
+class DaemonInstance:
+    """Immutable snapshot of the running daemon's identity."""
+
+    pid: int
+    port: int
+    token: str
+    host: str = HOST
+    api_version: str = DAEMON_API_VERSION
+    service: str = SERVICE_ID
+    started_at: float = field(default=0.0)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in asdict(self).items() if k in _PERSISTED}
+
+
+def write_instance(inst: DaemonInstance) -> None:
+    """Atomically persist *inst* to instance.json at mode 0600.
+
+    Writes a uniquely-named temp file in the same directory (so ``os.replace`` is a
+    same-filesystem atomic rename), fsyncs it, then renames it over the target. The
+    temp file is created ``O_EXCL`` at 0600 so it is never briefly world-readable.
+    """
+    d = paths.ensure_host_dir()
+    target = paths.instance_path()
+    tmp = d / f".instance.{os.getpid()}.tmp"
+    payload = json.dumps(inst.to_dict(), indent=2)
+    # O_EXCL: a leftover temp from a prior crashed writer must not be reused.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
+    if tmp.exists():
+        tmp.unlink()
+    fd = os.open(str(tmp), flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    os.replace(str(tmp), str(target))
+    # os.replace preserves the temp's 0600 mode; re-assert defensively for
+    # platforms where the source mode is not carried across the rename.
+    try:
+        os.chmod(str(target), 0o600)
+    except OSError:
+        pass
+
+
+def read_instance() -> Optional[DaemonInstance]:
+    """Load instance.json, or ``None`` if absent/corrupt.
+
+    A corrupt or truncated file is treated as "no trustworthy instance" and logged
+    (not silently ignored) — the caller then reclaims via a fresh start.
+    """
+    path = paths.instance_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        logger.warning("daemon: cannot read %s: %s", path, e)
+        return None
+    try:
+        data = json.loads(raw)
+        return DaemonInstance(
+            pid=int(data["pid"]),
+            port=int(data["port"]),
+            token=str(data["token"]),
+            host=str(data.get("host", HOST)),
+            api_version=str(data.get("api_version", DAEMON_API_VERSION)),
+            service=str(data.get("service", SERVICE_ID)),
+            started_at=float(data.get("started_at", 0.0)),
+        )
+    except (ValueError, KeyError, TypeError) as e:
+        logger.warning(
+            "daemon: %s is present but malformed (%s); treating as stale", path, e
+        )
+        return None
+
+
+def remove_instance(*, only_pid: Optional[int] = None) -> None:
+    """Delete instance.json.
+
+    When *only_pid* is given, delete only if the file still records that pid — so a
+    shutting-down daemon never clobbers the registry of a newer daemon that already
+    reclaimed the slot.
+    """
+    path = paths.instance_path()
+    if only_pid is not None:
+        inst = read_instance()
+        if inst is not None and inst.pid != only_pid:
+            return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.warning("daemon: could not remove %s: %s", path, e)
+
+
+def pid_alive(pid: int) -> bool:
+    """True if *pid* refers to a running process (cross-platform via psutil)."""
+    import psutil
+
+    try:
+        return psutil.pid_exists(pid) and psutil.Process(pid).status() not in (
+            psutil.STATUS_ZOMBIE,
+            psutil.STATUS_DEAD,
+        )
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        # AccessDenied means the pid exists but is owned by another user — from our
+        # perspective that is "not our daemon"; the probe below is the real check.
+        return psutil.pid_exists(pid)
+
+
+def probe(inst: DaemonInstance, timeout: float = _PROBE_TIMEOUT) -> Optional[dict]:
+    """Probe the recorded port with the recorded token.
+
+    Returns the status payload only if the server answers 200 with our service id
+    and the pid recorded in the file — otherwise ``None`` (an unrelated process
+    grabbed the freed port, or the daemon is unresponsive). Never raises.
+    """
+    import requests
+
+    from gaia.daemon.constants import API_PREFIX, AUTH_SCHEME
+
+    url = f"{inst.base_url}{API_PREFIX}/status"
+    try:
+        r = requests.get(
+            url,
+            headers={"Authorization": f"{AUTH_SCHEME} {inst.token}"},
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException:
+        return None
+    if r.status_code != 200:
+        return None
+    try:
+        body = r.json()
+    except ValueError:
+        return None
+    if body.get("service") != SERVICE_ID:
+        return None
+    if int(body.get("pid", -1)) != inst.pid:
+        return None
+    return body
+
+
+def is_live(inst: DaemonInstance, timeout: float = _PROBE_TIMEOUT) -> bool:
+    """True only if the pid is alive AND the token-authed probe succeeds."""
+    return pid_alive(inst.pid) and probe(inst, timeout=timeout) is not None
+
+
+def terminate_instance(inst: DaemonInstance, timeout: float = 5.0) -> None:
+    """Best-effort tree-kill of a stale-but-alive daemon so its slot can be reclaimed.
+
+    Used when the recorded pid is alive but unresponsive to the probe (§0.25). The
+    pid comes from our own registry file, so terminating it is legitimate reclaim,
+    not killing an arbitrary process.
+    """
+    import psutil
+
+    try:
+        proc = psutil.Process(inst.pid)
+    except psutil.NoSuchProcess:
+        return
+    procs = []
+    try:
+        procs = proc.children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+    procs.append(proc)
+    for p in procs:
+        try:
+            p.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    _, alive = psutil.wait_procs(procs, timeout=timeout)
+    for p in alive:
+        try:
+            p.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass

--- a/src/gaia/daemon/instance.py
+++ b/src/gaia/daemon/instance.py
@@ -200,15 +200,21 @@ def is_live(inst: DaemonInstance, timeout: float = _PROBE_TIMEOUT) -> bool:
 def terminate_instance(inst: DaemonInstance, timeout: float = 5.0) -> None:
     """Best-effort tree-kill of a stale-but-alive daemon so its slot can be reclaimed.
 
-    Used when the recorded pid is alive but unresponsive to the probe (§0.25). The
-    pid comes from our own registry file, so terminating it is legitimate reclaim,
-    not killing an arbitrary process.
+    Used when the recorded pid is alive but unresponsive to the probe (§0.25).
+    The pid comes from our own registry file, but after a hard crash (SIGKILL /
+    OOM / power-loss) the OS may have reused it for an unrelated process, so we
+    verify the pid is still *our* daemon (cmdline references ``gaia.daemon``)
+    before killing it — same skepticism ``probe`` applies before trusting it.
     """
     import psutil
 
     try:
         proc = psutil.Process(inst.pid)
-    except psutil.NoSuchProcess:
+        cmdline = " ".join(proc.cmdline())
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return
+    if "gaia.daemon" not in cmdline:
+        # PID was reused by an unrelated process — do not kill it.
         return
     procs = []
     try:

--- a/src/gaia/daemon/lock.py
+++ b/src/gaia/daemon/lock.py
@@ -1,0 +1,85 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Cross-platform advisory file lock serializing daemon start.
+
+Only ONE process may be in the "decide + spawn" critical section at a time, so two
+concurrent ``start_or_attach()`` callers spawn exactly one daemon (the loser waits,
+then attaches to the winner's instance.json). An OS advisory lock is used rather
+than an ``O_EXCL`` create-lock because the OS releases it automatically when the
+holder dies — a create-lock would strand a stale lock file after SIGKILL.
+
+POSIX uses ``fcntl.flock``; Windows uses ``msvcrt.locking``. Acquisition is a
+bounded non-blocking retry so an abandoned attempt fails loudly with an actionable
+error instead of hanging forever.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+from gaia.daemon import paths
+from gaia.daemon.errors import DaemonLockError
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
+
+class StartLock:
+    """Context manager holding the exclusive daemon-start lock."""
+
+    def __init__(self, timeout: float = 30.0, poll: float = 0.1):
+        self._timeout = timeout
+        self._poll = poll
+        self._fd: Optional[int] = None
+        self._path = paths.lock_path()
+
+    def _try_acquire(self) -> bool:
+        if os.name == "nt":
+            try:
+                msvcrt.locking(self._fd, msvcrt.LK_NBLCK, 1)
+                return True
+            except OSError:
+                return False
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+    def __enter__(self) -> "StartLock":
+        paths.ensure_host_dir()
+        # 0600: the lock file lives beside the token-bearing instance.json.
+        self._fd = os.open(str(self._path), os.O_RDWR | os.O_CREAT, 0o600)
+        deadline = time.monotonic() + self._timeout
+        while True:
+            if self._try_acquire():
+                return self
+            if time.monotonic() >= deadline:
+                os.close(self._fd)
+                self._fd = None
+                raise DaemonLockError(
+                    f"could not acquire the daemon start lock at {self._path} within "
+                    f"{self._timeout}s — another process is starting the daemon and "
+                    "did not finish. Check for a stuck `gaia daemon`/UI start, then "
+                    "retry; if it persists inspect the daemon log via `gaia daemon logs`."
+                )
+            time.sleep(self._poll)
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._fd is None:
+            return
+        try:
+            if os.name == "nt":
+                try:
+                    msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+        finally:
+            os.close(self._fd)
+            self._fd = None

--- a/src/gaia/daemon/paths.py
+++ b/src/gaia/daemon/paths.py
@@ -1,0 +1,46 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""On-disk locations for the daemon's single-instance state (design §0.26).
+
+Everything lives under ``~/.gaia/host/``. ``GAIA_DAEMON_HOME`` overrides the
+directory (used by tests so a run never clobbers the user's real daemon, and so
+concurrent tests stay isolated). The override is read on every call — not cached —
+so a subprocess spawned with a different env resolves its own directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ENV_HOME = "GAIA_DAEMON_HOME"
+
+
+def host_dir() -> Path:
+    """Directory holding instance.json, the start lock, and the daemon log."""
+    override = os.environ.get(_ENV_HOME)
+    if override:
+        return Path(override)
+    return Path.home() / ".gaia" / "host"
+
+
+def instance_path() -> Path:
+    """The single-instance registry file (pid + port + client token)."""
+    return host_dir() / "instance.json"
+
+
+def lock_path() -> Path:
+    """Advisory lock serializing daemon start (so two callers spawn one daemon)."""
+    return host_dir() / "instance.lock"
+
+
+def log_path() -> Path:
+    """Daemon stdout/stderr log (what ``gaia daemon logs`` tails)."""
+    return host_dir() / "daemon.log"
+
+
+def ensure_host_dir() -> Path:
+    """Create ``host_dir()`` if missing and return it."""
+    d = host_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d

--- a/src/gaia/daemon/server.py
+++ b/src/gaia/daemon/server.py
@@ -1,0 +1,85 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Daemon process entrypoint: bind loopback port, mint token, serve, register.
+
+Run as ``python -m gaia.daemon`` (the client spawns it detached). This process IS
+the daemon — its pid is what instance.json records — so ``start_or_attach`` can
+assert the file it reads back belongs to the child it launched.
+
+Order matters: uvicorn binds the port during its startup phase; instance.json is
+written from a startup hook so the registry only appears once the port is actually
+accepting. On shutdown the registry is removed (guarded by pid so a newer daemon's
+file is never clobbered).
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import socket
+import time
+
+from gaia.daemon.app import create_app
+from gaia.daemon.constants import HOST, RESERVED_PORT
+from gaia.daemon.errors import DaemonStartError
+from gaia.daemon.instance import DaemonInstance, remove_instance, write_instance
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _find_free_port(host: str = HOST) -> int:
+    """OS-assigned free loopback port. Never returns the reserved 4001."""
+    for _ in range(50):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((host, 0))
+            port = s.getsockname()[1]
+        if port != RESERVED_PORT:
+            return port
+    raise DaemonStartError(
+        "could not find a free loopback port for the daemon after 50 attempts — "
+        "the ephemeral port range may be exhausted; check `gaia daemon logs`."
+    )
+
+
+def run(host: str = HOST) -> None:
+    """Start the daemon and serve until shutdown. Blocks."""
+    import uvicorn
+
+    port = _find_free_port(host)
+    token = secrets.token_urlsafe(32)
+    pid = os.getpid()
+    started_at = time.time()
+
+    def _register() -> None:
+        write_instance(
+            DaemonInstance(
+                pid=pid, port=port, token=token, host=host, started_at=started_at
+            )
+        )
+        logger.info("daemon: registered instance pid=%s port=%s", pid, port)
+
+    def _deregister() -> None:
+        remove_instance(only_pid=pid)
+        logger.info("daemon: deregistered instance pid=%s", pid)
+
+    app = create_app(
+        token=token,
+        port=port,
+        pid=pid,
+        started_at=started_at,
+        on_startup=_register,
+        on_shutdown=_deregister,
+    )
+
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    # Give the shutdown route a handle to trigger a graceful exit.
+    app.state.server = server
+
+    logger.info("daemon: starting on http://%s:%s (pid=%s)", host, port, pid)
+    server.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via `python -m gaia.daemon`
+    run()

--- a/tests/integration/test_daemon.py
+++ b/tests/integration/test_daemon.py
@@ -1,0 +1,289 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Integration tests for the headless custody daemon skeleton (issue #2018).
+
+These spawn a real daemon subprocess, issue live HTTP requests, send SIGKILL,
+and invoke the actual `gaia daemon` CLI — cross-system behavior, so they live in
+tests/integration/ (the pure instance.json logic tests stay in tests/unit/).
+
+Covers the acceptance criteria:
+  * two concurrent start-or-attach callers yield ONE daemon (the second attaches).
+  * kill -9 the daemon then restart → the stale lock is reclaimed cleanly.
+  * a request without the client token → 401 with an actionable detail.
+  * `gaia daemon status` reports pid / port / uptime.
+
+The daemon binds an ephemeral loopback port (never 4001); every test isolates
+state under a tmp ``GAIA_DAEMON_HOME`` and tears the daemon down in a finally.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+uvicorn = pytest.importorskip("uvicorn")
+
+from gaia.daemon import client, instance  # noqa: E402
+from gaia.daemon.constants import API_PREFIX, RESERVED_PORT, SERVICE_ID  # noqa: E402
+from gaia.daemon.instance import DaemonInstance  # noqa: E402
+
+_REPO_SRC = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "src"
+)
+
+
+@pytest.fixture()
+def daemon_home(tmp_path, monkeypatch):
+    """Isolate all daemon on-disk state under a tmp dir for one test."""
+    home = tmp_path / "host"
+    monkeypatch.setenv("GAIA_DAEMON_HOME", str(home))
+    return home
+
+
+def _child_env(home) -> dict:
+    """Env for a spawned client subprocess: isolated home + importable src."""
+    env = os.environ.copy()
+    env["GAIA_DAEMON_HOME"] = str(home)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = _REPO_SRC + (os.pathsep + existing if existing else "")
+    return env
+
+
+def _stop(inst):
+    """Best-effort teardown of a running daemon."""
+    if inst is None:
+        return
+    try:
+        client.request_shutdown(inst)
+        client.wait_until_gone(inst, timeout=5.0)
+    except Exception:
+        pass
+    try:
+        if instance.pid_alive(inst.pid):
+            instance.terminate_instance(inst)
+    except Exception:
+        pass
+
+
+def test_probe_rejects_pid_mismatch(daemon_home):
+    # A live daemon, but the recorded pid does not match what it reports → not trusted.
+    real = None
+    try:
+        real = client.start_or_attach()
+        forged = DaemonInstance(
+            pid=real.pid + 1,
+            port=real.port,
+            token=real.token,
+            started_at=real.started_at,
+        )
+        assert instance.probe(forged) is None
+    finally:
+        _stop(real)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: start, attach, token auth (401), status shape
+# ---------------------------------------------------------------------------
+
+
+def test_start_binds_loopback_never_4001_and_authed_status(daemon_home):
+    import requests
+
+    inst = None
+    try:
+        inst = client.start_or_attach()
+        assert inst.host == "127.0.0.1"
+        assert inst.port != RESERVED_PORT
+        assert instance.pid_alive(inst.pid)
+        assert instance.is_live(inst)
+
+        # 200 with the token; payload carries pid/port/uptime.
+        r = requests.get(
+            f"{inst.base_url}{API_PREFIX}/status",
+            headers={"Authorization": f"Bearer {inst.token}"},
+            timeout=5,
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["service"] == SERVICE_ID
+        assert body["pid"] == inst.pid
+        assert body["port"] == inst.port
+        assert "uptime_seconds" in body
+    finally:
+        _stop(inst)
+
+
+def test_missing_token_returns_actionable_401(daemon_home):
+    import requests
+
+    inst = None
+    try:
+        inst = client.start_or_attach()
+        r = requests.get(f"{inst.base_url}{API_PREFIX}/status", timeout=5)
+        assert r.status_code == 401
+        detail = r.json()["detail"]
+        # Actionable: what failed + what to do + where to look.
+        assert "token" in detail.lower()
+        assert "Authorization" in detail
+        assert "instance.json" in detail
+    finally:
+        _stop(inst)
+
+
+def test_wrong_token_returns_401(daemon_home):
+    import requests
+
+    inst = None
+    try:
+        inst = client.start_or_attach()
+        r = requests.get(
+            f"{inst.base_url}{API_PREFIX}/status",
+            headers={"Authorization": "Bearer definitely-wrong"},
+            timeout=5,
+        )
+        assert r.status_code == 401
+        assert "Invalid client token" in r.json()["detail"]
+    finally:
+        _stop(inst)
+
+
+# ---------------------------------------------------------------------------
+# Single-instance guarantee + stale-lock reclaim
+# ---------------------------------------------------------------------------
+
+
+def _spawn_start_or_attach(home) -> subprocess.Popen:
+    """Run start_or_attach() in a subprocess, printing the resulting pid."""
+    code = textwrap.dedent("""
+        from gaia.daemon.client import start_or_attach
+        inst = start_or_attach()
+        print("PID=%d" % inst.pid)
+        """)
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        env=_child_env(home),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _read_pid(proc: subprocess.Popen, timeout: float = 40.0) -> int:
+    out, err = proc.communicate(timeout=timeout)
+    assert proc.returncode == 0, f"start_or_attach subprocess failed: {err}\n{out}"
+    for line in out.splitlines():
+        if line.startswith("PID="):
+            return int(line.split("=", 1)[1])
+    raise AssertionError(f"no PID in subprocess output: {out!r} / {err!r}")
+
+
+def test_two_concurrent_callers_yield_one_daemon(daemon_home):
+    """Two concurrent start_or_attach invocations → one daemon (second attaches)."""
+    inst_for_teardown = None
+    a = _spawn_start_or_attach(daemon_home)
+    b = _spawn_start_or_attach(daemon_home)
+    try:
+        pid_a = _read_pid(a)
+        pid_b = _read_pid(b)
+        assert pid_a == pid_b, "concurrent callers started rival daemons"
+        # Exactly one live registry pointing at that pid.
+        reg = instance.read_instance()
+        assert reg is not None and reg.pid == pid_a and instance.is_live(reg)
+        inst_for_teardown = reg
+    finally:
+        for p in (a, b):
+            if p.poll() is None:
+                p.kill()
+        _stop(inst_for_teardown)
+
+
+def test_kill9_then_restart_reclaims_stale_lock(daemon_home):
+    """kill -9 the daemon, leave the stale registry, then restart → clean reclaim."""
+    import psutil
+
+    first = client.start_or_attach()
+    first_pid = first.pid
+    try:
+        # Hard-kill (SIGKILL / TerminateProcess) — no chance to deregister.
+        psutil.Process(first_pid).kill()
+        psutil.Process(first_pid).wait(timeout=10)
+
+        # Stale registry still on disk, pointing at the dead pid.
+        stale = instance.read_instance()
+        assert stale is not None and stale.pid == first_pid
+        assert not instance.pid_alive(first_pid)
+        assert not instance.is_live(stale)
+
+        # Restart reclaims: a fresh, live daemon with a different pid.
+        second = client.start_or_attach()
+        assert second.pid != first_pid
+        assert instance.is_live(second)
+        assert instance.read_instance().pid == second.pid
+    finally:
+        cur = instance.read_instance()
+        _stop(cur)
+
+
+# ---------------------------------------------------------------------------
+# Actual CLI (`gaia daemon ...`) — per CLAUDE.md, exercise the real command
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(home, *cli_args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "gaia.cli", "daemon", *cli_args],
+        env=_child_env(home),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_cli_start_status_stop_roundtrip(daemon_home):
+    started = False
+    try:
+        r = _run_cli(daemon_home, "status")
+        assert r.returncode == 0
+        assert "not running" in r.stdout
+
+        r = _run_cli(daemon_home, "start")
+        assert r.returncode == 0, r.stderr
+        assert "running" in r.stdout
+        started = True
+
+        r = _run_cli(daemon_home, "status")
+        assert r.returncode == 0
+        assert "running" in r.stdout
+        assert "pid:" in r.stdout
+        assert "port:" in r.stdout
+        assert "uptime:" in r.stdout
+
+        r = _run_cli(daemon_home, "stop")
+        assert r.returncode == 0
+        assert "stopped" in r.stdout or "terminated" in r.stdout
+        started = False
+    finally:
+        if started:
+            _stop(instance.read_instance())
+
+
+def test_cli_status_reports_stale_after_kill9(daemon_home):
+    import psutil
+
+    inst = client.start_or_attach()
+    try:
+        psutil.Process(inst.pid).kill()
+        psutil.Process(inst.pid).wait(timeout=10)
+        r = _run_cli(daemon_home, "status")
+        assert r.returncode == 0
+        assert "stale" in r.stdout
+        assert "restart" in r.stdout
+    finally:
+        cur = instance.read_instance()
+        _stop(cur)
+        instance.remove_instance()

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -1,0 +1,347 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the headless custody daemon skeleton (issue #2018).
+
+Covers the acceptance criteria:
+  * instance.json is written atomically at mode 0600 and round-trips.
+  * two concurrent start-or-attach callers yield ONE daemon (the second attaches).
+  * kill -9 the daemon then restart → the stale lock is reclaimed cleanly.
+  * a request without the client token → 401 with an actionable detail.
+  * `gaia daemon status` reports pid / port / uptime.
+
+The daemon binds an ephemeral loopback port (never 4001); every test isolates
+state under a tmp ``GAIA_DAEMON_HOME`` and tears the daemon down in a finally.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+uvicorn = pytest.importorskip("uvicorn")
+
+from gaia.daemon import client, instance, paths  # noqa: E402
+from gaia.daemon.constants import API_PREFIX, RESERVED_PORT, SERVICE_ID  # noqa: E402
+from gaia.daemon.instance import DaemonInstance  # noqa: E402
+
+_REPO_SRC = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "src"
+)
+
+
+@pytest.fixture()
+def daemon_home(tmp_path, monkeypatch):
+    """Isolate all daemon on-disk state under a tmp dir for one test."""
+    home = tmp_path / "host"
+    monkeypatch.setenv("GAIA_DAEMON_HOME", str(home))
+    return home
+
+
+def _child_env(home) -> dict:
+    """Env for a spawned client subprocess: isolated home + importable src."""
+    env = os.environ.copy()
+    env["GAIA_DAEMON_HOME"] = str(home)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = _REPO_SRC + (os.pathsep + existing if existing else "")
+    return env
+
+
+def _stop(inst):
+    """Best-effort teardown of a running daemon."""
+    if inst is None:
+        return
+    try:
+        client.request_shutdown(inst)
+        client.wait_until_gone(inst, timeout=5.0)
+    except Exception:
+        pass
+    try:
+        if instance.pid_alive(inst.pid):
+            instance.terminate_instance(inst)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# instance.json: atomic write, mode, round-trip, corruption handling
+# ---------------------------------------------------------------------------
+
+
+def test_write_instance_atomic_mode_and_roundtrip(daemon_home):
+    inst = DaemonInstance(pid=1234, port=55555, token="tok-abc", started_at=100.0)
+    instance.write_instance(inst)
+
+    path = paths.instance_path()
+    assert path.exists()
+
+    # 0600 is only meaningful on POSIX; Windows does not honor the mode bits.
+    if os.name != "nt":
+        assert (os.stat(path).st_mode & 0o777) == 0o600
+
+    # No temp file left behind (temp-then-rename completed).
+    leftovers = list(daemon_home.glob(".instance.*.tmp"))
+    assert leftovers == []
+
+    back = instance.read_instance()
+    assert back is not None
+    assert back.pid == 1234
+    assert back.port == 55555
+    assert back.token == "tok-abc"
+    assert back.service == SERVICE_ID
+    assert back.base_url == f"http://127.0.0.1:{back.port}"
+
+
+def test_write_instance_overwrites_atomically(daemon_home):
+    instance.write_instance(DaemonInstance(pid=1, port=2, token="a"))
+    instance.write_instance(DaemonInstance(pid=9, port=8, token="z"))
+    back = instance.read_instance()
+    assert back.pid == 9 and back.port == 8 and back.token == "z"
+    # The overwrite is a single rename — the target is always complete JSON.
+    data = json.loads(paths.instance_path().read_text())
+    assert set(("pid", "port", "token", "service", "api_version")).issubset(data)
+
+
+def test_read_instance_missing_returns_none(daemon_home):
+    assert instance.read_instance() is None
+
+
+def test_read_instance_corrupt_returns_none(daemon_home):
+    paths.ensure_host_dir()
+    paths.instance_path().write_text("{ not valid json ", encoding="utf-8")
+    # A corrupt registry is treated as "no trustworthy instance", not an exception.
+    assert instance.read_instance() is None
+
+
+def test_remove_instance_only_pid_guard(daemon_home):
+    instance.write_instance(DaemonInstance(pid=42, port=1, token="t"))
+    # Wrong pid → must NOT delete a newer daemon's registry.
+    instance.remove_instance(only_pid=99)
+    assert instance.read_instance() is not None
+    # Matching pid → deletes.
+    instance.remove_instance(only_pid=42)
+    assert instance.read_instance() is None
+
+
+def test_probe_rejects_pid_mismatch(daemon_home):
+    # A live daemon, but the recorded pid does not match what it reports → not trusted.
+    real = None
+    try:
+        real = client.start_or_attach()
+        forged = DaemonInstance(
+            pid=real.pid + 1,
+            port=real.port,
+            token=real.token,
+            started_at=real.started_at,
+        )
+        assert instance.probe(forged) is None
+    finally:
+        _stop(real)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: start, attach, token auth (401), status shape
+# ---------------------------------------------------------------------------
+
+
+def test_start_binds_loopback_never_4001_and_authed_status(daemon_home):
+    import requests
+
+    inst = None
+    try:
+        inst = client.start_or_attach()
+        assert inst.host == "127.0.0.1"
+        assert inst.port != RESERVED_PORT
+        assert instance.pid_alive(inst.pid)
+        assert instance.is_live(inst)
+
+        # 200 with the token; payload carries pid/port/uptime.
+        r = requests.get(
+            f"{inst.base_url}{API_PREFIX}/status",
+            headers={"Authorization": f"Bearer {inst.token}"},
+            timeout=5,
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["service"] == SERVICE_ID
+        assert body["pid"] == inst.pid
+        assert body["port"] == inst.port
+        assert "uptime_seconds" in body
+    finally:
+        _stop(inst)
+
+
+def test_missing_token_returns_actionable_401(daemon_home):
+    import requests
+
+    inst = None
+    try:
+        inst = client.start_or_attach()
+        r = requests.get(f"{inst.base_url}{API_PREFIX}/status", timeout=5)
+        assert r.status_code == 401
+        detail = r.json()["detail"]
+        # Actionable: what failed + what to do + where to look.
+        assert "token" in detail.lower()
+        assert "Authorization" in detail
+        assert "instance.json" in detail
+    finally:
+        _stop(inst)
+
+
+def test_wrong_token_returns_401(daemon_home):
+    import requests
+
+    inst = None
+    try:
+        inst = client.start_or_attach()
+        r = requests.get(
+            f"{inst.base_url}{API_PREFIX}/status",
+            headers={"Authorization": "Bearer definitely-wrong"},
+            timeout=5,
+        )
+        assert r.status_code == 401
+        assert "Invalid client token" in r.json()["detail"]
+    finally:
+        _stop(inst)
+
+
+# ---------------------------------------------------------------------------
+# Single-instance guarantee + stale-lock reclaim
+# ---------------------------------------------------------------------------
+
+
+def _spawn_start_or_attach(home) -> subprocess.Popen:
+    """Run start_or_attach() in a subprocess, printing the resulting pid."""
+    code = textwrap.dedent("""
+        from gaia.daemon.client import start_or_attach
+        inst = start_or_attach()
+        print("PID=%d" % inst.pid)
+        """)
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        env=_child_env(home),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _read_pid(proc: subprocess.Popen, timeout: float = 40.0) -> int:
+    out, err = proc.communicate(timeout=timeout)
+    assert proc.returncode == 0, f"start_or_attach subprocess failed: {err}\n{out}"
+    for line in out.splitlines():
+        if line.startswith("PID="):
+            return int(line.split("=", 1)[1])
+    raise AssertionError(f"no PID in subprocess output: {out!r} / {err!r}")
+
+
+def test_two_concurrent_callers_yield_one_daemon(daemon_home):
+    """Two concurrent start_or_attach invocations → one daemon (second attaches)."""
+    inst_for_teardown = None
+    a = _spawn_start_or_attach(daemon_home)
+    b = _spawn_start_or_attach(daemon_home)
+    try:
+        pid_a = _read_pid(a)
+        pid_b = _read_pid(b)
+        assert pid_a == pid_b, "concurrent callers started rival daemons"
+        # Exactly one live registry pointing at that pid.
+        reg = instance.read_instance()
+        assert reg is not None and reg.pid == pid_a and instance.is_live(reg)
+        inst_for_teardown = reg
+    finally:
+        for p in (a, b):
+            if p.poll() is None:
+                p.kill()
+        _stop(inst_for_teardown)
+
+
+def test_kill9_then_restart_reclaims_stale_lock(daemon_home):
+    """kill -9 the daemon, leave the stale registry, then restart → clean reclaim."""
+    import psutil
+
+    first = client.start_or_attach()
+    first_pid = first.pid
+    try:
+        # Hard-kill (SIGKILL / TerminateProcess) — no chance to deregister.
+        psutil.Process(first_pid).kill()
+        psutil.Process(first_pid).wait(timeout=10)
+
+        # Stale registry still on disk, pointing at the dead pid.
+        stale = instance.read_instance()
+        assert stale is not None and stale.pid == first_pid
+        assert not instance.pid_alive(first_pid)
+        assert not instance.is_live(stale)
+
+        # Restart reclaims: a fresh, live daemon with a different pid.
+        second = client.start_or_attach()
+        assert second.pid != first_pid
+        assert instance.is_live(second)
+        assert instance.read_instance().pid == second.pid
+    finally:
+        cur = instance.read_instance()
+        _stop(cur)
+
+
+# ---------------------------------------------------------------------------
+# Actual CLI (`gaia daemon ...`) — per CLAUDE.md, exercise the real command
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(home, *cli_args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "gaia.cli", "daemon", *cli_args],
+        env=_child_env(home),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_cli_start_status_stop_roundtrip(daemon_home):
+    started = False
+    try:
+        r = _run_cli(daemon_home, "status")
+        assert r.returncode == 0
+        assert "not running" in r.stdout
+
+        r = _run_cli(daemon_home, "start")
+        assert r.returncode == 0, r.stderr
+        assert "running" in r.stdout
+        started = True
+
+        r = _run_cli(daemon_home, "status")
+        assert r.returncode == 0
+        assert "running" in r.stdout
+        assert "pid:" in r.stdout
+        assert "port:" in r.stdout
+        assert "uptime:" in r.stdout
+
+        r = _run_cli(daemon_home, "stop")
+        assert r.returncode == 0
+        assert "stopped" in r.stdout or "terminated" in r.stdout
+        started = False
+    finally:
+        if started:
+            _stop(instance.read_instance())
+
+
+def test_cli_status_reports_stale_after_kill9(daemon_home):
+    import psutil
+
+    inst = client.start_or_attach()
+    try:
+        psutil.Process(inst.pid).kill()
+        psutil.Process(inst.pid).wait(timeout=10)
+        r = _run_cli(daemon_home, "status")
+        assert r.returncode == 0
+        assert "stale" in r.stdout
+        assert "restart" in r.stdout
+    finally:
+        cur = instance.read_instance()
+        _stop(cur)
+        instance.remove_instance()

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -2,37 +2,22 @@
 # SPDX-License-Identifier: MIT
 """Unit tests for the headless custody daemon skeleton (issue #2018).
 
-Covers the acceptance criteria:
-  * instance.json is written atomically at mode 0600 and round-trips.
-  * two concurrent start-or-attach callers yield ONE daemon (the second attaches).
-  * kill -9 the daemon then restart → the stale lock is reclaimed cleanly.
-  * a request without the client token → 401 with an actionable detail.
-  * `gaia daemon status` reports pid / port / uptime.
-
-The daemon binds an ephemeral loopback port (never 4001); every test isolates
-state under a tmp ``GAIA_DAEMON_HOME`` and tears the daemon down in a finally.
+Pure instance.json logic — atomic write, mode, round-trip, corruption handling,
+and the pid-guarded remove. No subprocesses, no network: those cross-system
+lifecycle tests (start/attach, 401 auth, kill-9 reclaim, the `gaia daemon` CLI)
+live in tests/integration/test_daemon.py.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import subprocess
-import sys
-import textwrap
 
 import pytest
 
-fastapi = pytest.importorskip("fastapi")
-uvicorn = pytest.importorskip("uvicorn")
-
-from gaia.daemon import client, instance, paths  # noqa: E402
-from gaia.daemon.constants import API_PREFIX, RESERVED_PORT, SERVICE_ID  # noqa: E402
-from gaia.daemon.instance import DaemonInstance  # noqa: E402
-
-_REPO_SRC = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "src"
-)
+from gaia.daemon import instance, paths
+from gaia.daemon.constants import SERVICE_ID
+from gaia.daemon.instance import DaemonInstance
 
 
 @pytest.fixture()
@@ -41,31 +26,6 @@ def daemon_home(tmp_path, monkeypatch):
     home = tmp_path / "host"
     monkeypatch.setenv("GAIA_DAEMON_HOME", str(home))
     return home
-
-
-def _child_env(home) -> dict:
-    """Env for a spawned client subprocess: isolated home + importable src."""
-    env = os.environ.copy()
-    env["GAIA_DAEMON_HOME"] = str(home)
-    existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = _REPO_SRC + (os.pathsep + existing if existing else "")
-    return env
-
-
-def _stop(inst):
-    """Best-effort teardown of a running daemon."""
-    if inst is None:
-        return
-    try:
-        client.request_shutdown(inst)
-        client.wait_until_gone(inst, timeout=5.0)
-    except Exception:
-        pass
-    try:
-        if instance.pid_alive(inst.pid):
-            instance.terminate_instance(inst)
-    except Exception:
-        pass
 
 
 # ---------------------------------------------------------------------------
@@ -126,222 +86,3 @@ def test_remove_instance_only_pid_guard(daemon_home):
     # Matching pid → deletes.
     instance.remove_instance(only_pid=42)
     assert instance.read_instance() is None
-
-
-def test_probe_rejects_pid_mismatch(daemon_home):
-    # A live daemon, but the recorded pid does not match what it reports → not trusted.
-    real = None
-    try:
-        real = client.start_or_attach()
-        forged = DaemonInstance(
-            pid=real.pid + 1,
-            port=real.port,
-            token=real.token,
-            started_at=real.started_at,
-        )
-        assert instance.probe(forged) is None
-    finally:
-        _stop(real)
-
-
-# ---------------------------------------------------------------------------
-# Lifecycle: start, attach, token auth (401), status shape
-# ---------------------------------------------------------------------------
-
-
-def test_start_binds_loopback_never_4001_and_authed_status(daemon_home):
-    import requests
-
-    inst = None
-    try:
-        inst = client.start_or_attach()
-        assert inst.host == "127.0.0.1"
-        assert inst.port != RESERVED_PORT
-        assert instance.pid_alive(inst.pid)
-        assert instance.is_live(inst)
-
-        # 200 with the token; payload carries pid/port/uptime.
-        r = requests.get(
-            f"{inst.base_url}{API_PREFIX}/status",
-            headers={"Authorization": f"Bearer {inst.token}"},
-            timeout=5,
-        )
-        assert r.status_code == 200
-        body = r.json()
-        assert body["service"] == SERVICE_ID
-        assert body["pid"] == inst.pid
-        assert body["port"] == inst.port
-        assert "uptime_seconds" in body
-    finally:
-        _stop(inst)
-
-
-def test_missing_token_returns_actionable_401(daemon_home):
-    import requests
-
-    inst = None
-    try:
-        inst = client.start_or_attach()
-        r = requests.get(f"{inst.base_url}{API_PREFIX}/status", timeout=5)
-        assert r.status_code == 401
-        detail = r.json()["detail"]
-        # Actionable: what failed + what to do + where to look.
-        assert "token" in detail.lower()
-        assert "Authorization" in detail
-        assert "instance.json" in detail
-    finally:
-        _stop(inst)
-
-
-def test_wrong_token_returns_401(daemon_home):
-    import requests
-
-    inst = None
-    try:
-        inst = client.start_or_attach()
-        r = requests.get(
-            f"{inst.base_url}{API_PREFIX}/status",
-            headers={"Authorization": "Bearer definitely-wrong"},
-            timeout=5,
-        )
-        assert r.status_code == 401
-        assert "Invalid client token" in r.json()["detail"]
-    finally:
-        _stop(inst)
-
-
-# ---------------------------------------------------------------------------
-# Single-instance guarantee + stale-lock reclaim
-# ---------------------------------------------------------------------------
-
-
-def _spawn_start_or_attach(home) -> subprocess.Popen:
-    """Run start_or_attach() in a subprocess, printing the resulting pid."""
-    code = textwrap.dedent("""
-        from gaia.daemon.client import start_or_attach
-        inst = start_or_attach()
-        print("PID=%d" % inst.pid)
-        """)
-    return subprocess.Popen(
-        [sys.executable, "-c", code],
-        env=_child_env(home),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-
-def _read_pid(proc: subprocess.Popen, timeout: float = 40.0) -> int:
-    out, err = proc.communicate(timeout=timeout)
-    assert proc.returncode == 0, f"start_or_attach subprocess failed: {err}\n{out}"
-    for line in out.splitlines():
-        if line.startswith("PID="):
-            return int(line.split("=", 1)[1])
-    raise AssertionError(f"no PID in subprocess output: {out!r} / {err!r}")
-
-
-def test_two_concurrent_callers_yield_one_daemon(daemon_home):
-    """Two concurrent start_or_attach invocations → one daemon (second attaches)."""
-    inst_for_teardown = None
-    a = _spawn_start_or_attach(daemon_home)
-    b = _spawn_start_or_attach(daemon_home)
-    try:
-        pid_a = _read_pid(a)
-        pid_b = _read_pid(b)
-        assert pid_a == pid_b, "concurrent callers started rival daemons"
-        # Exactly one live registry pointing at that pid.
-        reg = instance.read_instance()
-        assert reg is not None and reg.pid == pid_a and instance.is_live(reg)
-        inst_for_teardown = reg
-    finally:
-        for p in (a, b):
-            if p.poll() is None:
-                p.kill()
-        _stop(inst_for_teardown)
-
-
-def test_kill9_then_restart_reclaims_stale_lock(daemon_home):
-    """kill -9 the daemon, leave the stale registry, then restart → clean reclaim."""
-    import psutil
-
-    first = client.start_or_attach()
-    first_pid = first.pid
-    try:
-        # Hard-kill (SIGKILL / TerminateProcess) — no chance to deregister.
-        psutil.Process(first_pid).kill()
-        psutil.Process(first_pid).wait(timeout=10)
-
-        # Stale registry still on disk, pointing at the dead pid.
-        stale = instance.read_instance()
-        assert stale is not None and stale.pid == first_pid
-        assert not instance.pid_alive(first_pid)
-        assert not instance.is_live(stale)
-
-        # Restart reclaims: a fresh, live daemon with a different pid.
-        second = client.start_or_attach()
-        assert second.pid != first_pid
-        assert instance.is_live(second)
-        assert instance.read_instance().pid == second.pid
-    finally:
-        cur = instance.read_instance()
-        _stop(cur)
-
-
-# ---------------------------------------------------------------------------
-# Actual CLI (`gaia daemon ...`) — per CLAUDE.md, exercise the real command
-# ---------------------------------------------------------------------------
-
-
-def _run_cli(home, *cli_args) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [sys.executable, "-m", "gaia.cli", "daemon", *cli_args],
-        env=_child_env(home),
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-
-
-def test_cli_start_status_stop_roundtrip(daemon_home):
-    started = False
-    try:
-        r = _run_cli(daemon_home, "status")
-        assert r.returncode == 0
-        assert "not running" in r.stdout
-
-        r = _run_cli(daemon_home, "start")
-        assert r.returncode == 0, r.stderr
-        assert "running" in r.stdout
-        started = True
-
-        r = _run_cli(daemon_home, "status")
-        assert r.returncode == 0
-        assert "running" in r.stdout
-        assert "pid:" in r.stdout
-        assert "port:" in r.stdout
-        assert "uptime:" in r.stdout
-
-        r = _run_cli(daemon_home, "stop")
-        assert r.returncode == 0
-        assert "stopped" in r.stdout or "terminated" in r.stdout
-        started = False
-    finally:
-        if started:
-            _stop(instance.read_instance())
-
-
-def test_cli_status_reports_stale_after_kill9(daemon_home):
-    import psutil
-
-    inst = client.start_or_attach()
-    try:
-        psutil.Process(inst.pid).kill()
-        psutil.Process(inst.pid).wait(timeout=10)
-        r = _run_cli(daemon_home, "status")
-        assert r.returncode == 0
-        assert "stale" in r.stdout
-        assert "restart" in r.stdout
-    finally:
-        cur = instance.read_instance()
-        _stop(cur)
-        instance.remove_instance()


### PR DESCRIPTION
Closes #2018. Part of the Agent UI v2 epic (#2014), Phase 1.

Today the UI backend owns everything in-process and dies with the browser session: CLI-only use has no callback target and scheduled jobs (the email agent's briefing/snooze clocks) die when the UI closes. This adds the always-on custody process everything in Phase 2 (custody API, model broker, scheduler clock) will mount into. Skeleton only — no sidecar supervision, custody routes, broker, or scheduler yet (each is its own issue).

Introduces `src/gaia/daemon/` (loopback FastAPI app), `~/.gaia/host/instance.json` (pid + port + minted client token, `0600`, atomic temp-then-rename), stale-lock recovery (liveness-check pid + probe port/token before trusting; atomic reclaim), an auto-start-or-attach client helper, a versioned `/daemon/v1/*` surface, and `gaia daemon status|stop|restart|logs`.

**Test plan**
- [ ] `python -m pytest tests/unit/test_daemon.py -q` (lock atomicity + stale-lock reclaim + 401 path).
- [ ] Two concurrent invocations yield one daemon (second attaches).
- [ ] `kill -9` then restart reclaims the lock; request without the client token → 401 with actionable detail.
- [ ] `gaia daemon status` shows pid/port/uptime.