### PR TITLE
ci(docs): skip t.me links in the external URL checker

### DIFF
--- a/util/check_doc_links.py
+++ b/util/check_doc_links.py
@@ -75,6 +75,7 @@ SKIP_PATTERNS = [
     r"github\.com/amd/gaia/compare/",  # Release compare URLs (tags may not exist yet)
     r"github\.com/amd/gaia/(blob|tree)/main/",  # Same-repo links (may 404 during PRs before merge)
     r"https?://(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)",  # RFC1918 private IPs (example URLs in docs)
+    r"^https?://t\.me/",  # Telegram deep-links (e.g. BotFather) — valid but unresolvable from CI runners
 ]
 
 


### PR DESCRIPTION
The external-URL doc check fails on every PR with a DNS error on `https://t.me/BotFather` (in `docs/guides/telegram-adapter.mdx`). The link is **valid** — it's Telegram's canonical BotFather deep-link — but `t.me` is unresolvable from GitHub Actions runners, so a correct URL turns the check red for unrelated PRs (surfaced on #2057/#2058). This skips the `t.me` host the same way other CI-unreachable-but-valid domains already are, so the checker stops flagging a good link.

The pattern is anchored to scheme+host (`^https?://t\.me/`) rather than a bare `t.me` substring, so lookalike hosts that merely contain the substring (e.g. `content.medium.com`) are not falsely skipped.

Note: this is only the CI-noise fix. The real follow-up — that the Telegram adapter has no end-to-end/live test proving it works — is tracked in #2062.

**Test plan**
- [x] `should_skip("https://t.me/BotFather")` / `http://t.me/somebot` → `True`.
- [x] `should_skip("https://content.medium.com/foo")` and `https://example.org/t.me/x` → `False` (no false-positive from the substring).
- [ ] `Verify external URLs` check passes on this PR.