### PR TITLE
feat(email-eval): surface versioned perf metrics on the scorecard (hub)

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -197,13 +197,33 @@ jobs:
           python hub/agents/python/email/packaging/eval_drafting_report.py
           if ($LASTEXITCODE -ne 0) { throw "drafting eval failed" }
 
+      - name: Action-item extraction eval (judge-scored) — for the scorecard metric
+        env:
+          EMAIL_EVAL_MODEL: ${{ env.MODEL }}
+          # Judge credential — REQUIRED (fail-loudly, no silent skip), same as
+          # drafting. Runs the small committed action-item corpus, not the mbox.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python hub/agents/python/email/packaging/eval_action_item_report.py
+          if ($LASTEXITCODE -ne 0) { throw "action-item eval failed" }
+
+      - name: Briefing quality eval (judge-scored) — for the scorecard metric
+        env:
+          EMAIL_EVAL_MODEL: ${{ env.MODEL }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python hub/agents/python/email/packaging/eval_briefing_report.py
+          if ($LASTEXITCODE -ne 0) { throw "briefing eval failed" }
+
       - name: Regenerate SCORECARD.md from the real run
         run: |
-          # --drafting-report folds draft_approval_rate into the card as a
-          # reported metric (weight 0). The drafting eval above hard-fails on a
+          # Fold every capability's judged result into the card as report-only
+          # metrics: drafting -> draft_approval_rate (weight-0 metric); spam (from
+          # the benchmark quality block, no flag needed) + action-item + briefing
+          # -> the Capability quality section. Each eval above hard-fails on a
           # missing key, so a report here is always a real judged run; a missing
           # or unjudged report makes gen_scorecard fail loudly (never omits).
-          python hub/agents/python/email/packaging/gen_scorecard.py --benchmark-dir eval-out --limit "$env:LIMIT" --drafting-report eval-out/drafting_gate_report.json
+          python hub/agents/python/email/packaging/gen_scorecard.py --benchmark-dir eval-out --limit "$env:LIMIT" --drafting-report eval-out/drafting_gate_report.json --action-item-report eval-out/action_items_report.json --briefing-report eval-out/briefing_gate_report.json
           if ($LASTEXITCODE -ne 0) { throw "gen_scorecard failed" }
 
       - name: Same-version regression check (reject a worse re-run)

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -215,6 +215,105 @@ def _compute_performance(judged: list) -> Optional[dict]:
     return perf or None
 
 
+def _mean_nested_metric(judged: list, group: str, key: str) -> Optional[float]:
+    """Mean of ``quality[group][key]`` across judged runs (None if absent).
+
+    Unlike :func:`_mean_scenario_metric`, this reads a nested confusion sub-dict
+    such as ``quality.spam.{precision,recall,f1}`` (from
+    ``confusion_for_flag(...).to_dict()`` in the benchmark quality block).
+    """
+    vals = [
+        float(s["quality"][group][key])
+        for s in judged
+        if isinstance(s.get("quality"), dict)
+        and isinstance(s["quality"].get(group), dict)
+        and isinstance(s["quality"][group].get(key), (int, float))
+        and not isinstance(s["quality"][group][key], bool)
+    ]
+    return round(sum(vals) / len(vals), 4) if vals else None
+
+
+def _load_report_metrics(report_path, group: str, mapping: dict) -> dict:
+    """Read ``summary.<group>.<src_key>`` from a judged gate report → ``{dst: value}``.
+
+    ``mapping`` is ``{dst_key: src_key}``. Fails loud on a report marked skipped or
+    any missing source key — a judged run always yields real values, so a gap means
+    the report was not a real judged run (CLAUDE.md: No Silent Fallbacks). Never
+    silently omits a metric.
+    """
+    data = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    if data.get("skipped"):
+        raise ValueError(
+            f"Report {report_path} is marked skipped, but a judged eval must not "
+            f"skip (ANTHROPIC_API_KEY is required). Re-run it with the key set."
+        )
+    section = data.get("summary", {}).get(group, {})
+    out: dict = {}
+    for dst, src in mapping.items():
+        val = section.get(src)
+        if val is None:
+            raise ValueError(
+                f"No summary.{group}.{src} in {report_path} (judged run expected). "
+                f"Re-run the eval with ANTHROPIC_API_KEY set."
+            )
+        out[dst] = round(float(val), 4)
+    return out
+
+
+def _compute_capability_quality(
+    judged: list, action_item_report=None, briefing_report=None
+) -> Optional[dict]:
+    """Fold the agent's non-triage capability evals onto the versioned scorecard.
+
+    Beyond the headline triage accuracy, the email agent has three other evaluated
+    capabilities whose scores otherwise live only in transient CI artifacts:
+
+    * **spam** — is_spam precision/recall/F1 from the benchmark quality block
+      (already in the benchmark output; no extra report needed).
+    * **action_items** — precision/recall/F1 from a judged action-item report.
+    * **briefing** — approval / must-include recall / faithfulness /
+      hallucination-free rates from a judged briefing report.
+
+    Report-only: these never feed the aggregate (blocking on a regression is each
+    capability's own gate's job, ``enforce:true`` under ``tests/fixtures/email/``).
+    Returns ``None`` when no capability has data.
+    """
+    capq: dict = {}
+
+    spam = {
+        k: v
+        for k, v in (
+            ("precision", _mean_nested_metric(judged, "spam", "precision")),
+            ("recall", _mean_nested_metric(judged, "spam", "recall")),
+            ("f1", _mean_nested_metric(judged, "spam", "f1")),
+        )
+        if v is not None
+    }
+    if spam:
+        capq["spam"] = spam
+
+    if action_item_report is not None:
+        capq["action_items"] = _load_report_metrics(
+            action_item_report,
+            "extraction",
+            {"precision": "precision", "recall": "recall", "f1": "f1"},
+        )
+
+    if briefing_report is not None:
+        capq["briefing"] = _load_report_metrics(
+            briefing_report,
+            "briefing",
+            {
+                "approval": "briefing_approval_rate",
+                "must_include_recall": "must_include_recall_mean",
+                "faithful": "faithful_rate",
+                "hallucination_free": "hallucination_free_rate",
+            },
+        )
+
+    return capq or None
+
+
 def _compute_breakdown(judged: list) -> Optional[dict]:
     """Aggregate per-category accuracy and top confusion pairs across judged scenarios.
 
@@ -350,6 +449,8 @@ def build_payload(
     limit=None,
     environment=None,
     drafting_report=None,
+    action_item_report=None,
+    briefing_report=None,
 ):
     """Build a :class:`~gaia.eval.release_scorecard.ResultPayload` from benchmark output.
 
@@ -526,6 +627,11 @@ def build_payload(
 
     breakdown = _compute_breakdown(judged)
     performance = _compute_performance(judged)
+    capability_quality = _compute_capability_quality(
+        judged,
+        action_item_report=action_item_report,
+        briefing_report=briefing_report,
+    )
 
     return ResultPayload(
         agent_name="Email Triage",
@@ -575,6 +681,7 @@ def build_payload(
         breakdown=breakdown,
         environment=environment,
         performance=performance,
+        capability_quality=capability_quality,
     )
 
 
@@ -714,6 +821,27 @@ def main(argv=None) -> int:
             "the aggregate's."
         ),
     )
+    parser.add_argument(
+        "--action-item-report",
+        default=None,
+        help=(
+            "Path to the judged action-item extraction report (from "
+            "eval_action_item_report.py). Folds precision/recall/F1 into the "
+            "scorecard's Capability quality section (report-only). A skipped or "
+            "incomplete report fails loudly, never silently omits."
+        ),
+    )
+    parser.add_argument(
+        "--briefing-report",
+        default=None,
+        help=(
+            "Path to the judged briefing-quality report (from "
+            "eval_briefing_report.py). Folds approval / must-include recall / "
+            "faithfulness / hallucination-free rates into the scorecard's "
+            "Capability quality section (report-only). A skipped or incomplete "
+            "report fails loudly, never silently omits."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -764,6 +892,8 @@ def main(argv=None) -> int:
             limit=args.limit,
             environment=environment,
             drafting_report=args.drafting_report,
+            action_item_report=args.action_item_report,
+            briefing_report=args.briefing_report,
         )
     except (ValueError, FileNotFoundError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -208,7 +208,10 @@ def _compute_performance(judged: list) -> Optional[dict]:
         # Same corpus per run; record the sample size so the numbers are read in
         # context (TTFT/throughput are per-token, but pipeline scales with it).
         perf["emails_per_run"] = max(emails)
-    perf = {k: v for k, v in perf.items() if v is not None}
+    # Drop absent (None) AND zero values: peak_memory_gb is 0.0 when the runner's
+    # /stats omits memory (see performance.py), and a 0 for any of these means
+    # "not measured", not a real reading — showing "0.0" on the hub is misleading.
+    perf = {k: v for k, v in perf.items() if v}
     return perf or None
 
 

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -167,6 +167,51 @@ def _mean_scenario_metric(judged: list, key: str) -> Optional[float]:
     return round(sum(vals) / len(vals), 4) if vals else None
 
 
+def _compute_performance(judged: list) -> Optional[dict]:
+    """Mean of the key perf metrics across judged scenarios' performance_summary.
+
+    Each judged scenario is one run over the same corpus, so the cross-run mean is
+    the representative figure (same convention as the quality metrics). These are
+    surfaced on the versioned scorecard (and thus the hub) so the perf numbers are
+    visible per release, not just buried in a CI artifact. Returns ``None`` when no
+    scenario carries a ``performance_summary`` (older benchmark output).
+    """
+    summaries = [
+        s["performance_summary"]
+        for s in judged
+        if isinstance(s.get("performance_summary"), dict)
+    ]
+    if not summaries:
+        return None
+
+    def _mean(key: str) -> Optional[float]:
+        vals = [
+            float(ps[key])
+            for ps in summaries
+            if isinstance(ps.get(key), (int, float)) and not isinstance(ps[key], bool)
+        ]
+        return round(sum(vals) / len(vals), 3) if vals else None
+
+    perf = {
+        "ttft_s": _mean("avg_time_to_first_token"),
+        "throughput_tps": _mean("avg_tokens_per_second"),
+        "pipeline_s": _mean("pipeline_latency_s"),
+        "peak_memory_gb": _mean("peak_memory_gb"),
+    }
+    emails = [
+        int(ps["total_emails"])
+        for ps in summaries
+        if isinstance(ps.get("total_emails"), (int, float))
+        and not isinstance(ps["total_emails"], bool)
+    ]
+    if emails:
+        # Same corpus per run; record the sample size so the numbers are read in
+        # context (TTFT/throughput are per-token, but pipeline scales with it).
+        perf["emails_per_run"] = max(emails)
+    perf = {k: v for k, v in perf.items() if v is not None}
+    return perf or None
+
+
 def _compute_breakdown(judged: list) -> Optional[dict]:
     """Aggregate per-category accuracy and top confusion pairs across judged scenarios.
 
@@ -477,6 +522,7 @@ def build_payload(
     reproduction_command = _build_reproduction_command(model, ground_truth_rel, limit)
 
     breakdown = _compute_breakdown(judged)
+    performance = _compute_performance(judged)
 
     return ResultPayload(
         agent_name="Email Triage",
@@ -525,6 +571,7 @@ def build_payload(
         reproduction_command=reproduction_command,
         breakdown=breakdown,
         environment=environment,
+        performance=performance,
     )
 
 

--- a/src/gaia/eval/release_scorecard.py
+++ b/src/gaia/eval/release_scorecard.py
@@ -91,6 +91,7 @@ class ResultPayload:
     breakdown: Optional[dict] = None
     environment: Optional[dict] = None
     performance: Optional[dict] = None
+    capability_quality: Optional[dict] = None
 
 
 def _md_cell(value) -> str:
@@ -187,6 +188,11 @@ def render_scorecard(payload: ResultPayload) -> str:
             ],
             **({"breakdown": payload.breakdown} if payload.breakdown else {}),
             **({"performance": payload.performance} if payload.performance else {}),
+            **(
+                {"capability_quality": payload.capability_quality}
+                if payload.capability_quality
+                else {}
+            ),
         },
         "aggregate": {
             "name": payload.aggregate_name,
@@ -321,6 +327,26 @@ matter alone — no eval-harness access needed.
             "not pass/fail bars (see `tests/fixtures/email/perf_gate_thresholds.json`)._\n\n"
             f"| Metric | Value |\n|--------|-------|\n{perf_rows}\n"
         )
+
+    if payload.capability_quality:
+        capq_rows = "\n".join(
+            f"| {_md_cell(cap)} | {_md_cell(metric)} | {value:.4f} |"
+            for cap, metrics in payload.capability_quality.items()
+            if isinstance(metrics, dict)
+            for metric, value in metrics.items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        )
+        if capq_rows:
+            body += (
+                "\n## Capability quality\n\n"
+                "_Beyond the headline triage accuracy, these are the agent's other "
+                "capabilities scored by their own evals (spam detection, action-item "
+                "extraction, briefing quality). Report-only — they don't feed the "
+                "aggregate above; see the per-capability gate thresholds under "
+                "`tests/fixtures/email/`._\n\n"
+                f"| Capability | Metric | Value |\n|------------|--------|-------|\n"
+                f"{capq_rows}\n"
+            )
 
     if payload.inherited_from:
         body += f"\n> **Inherited from {payload.inherited_from}** — results carried forward verbatim (patch release).\n"
@@ -552,6 +578,7 @@ def carry_forward(prev_scorecard_path: Path, new_version: str) -> ResultPayload:
     breakdown = results.get("breakdown")
     environment = recipe.get("environment")
     performance = results.get("performance")
+    capability_quality = results.get("capability_quality")
 
     import datetime
 
@@ -571,4 +598,5 @@ def carry_forward(prev_scorecard_path: Path, new_version: str) -> ResultPayload:
         breakdown=breakdown,
         environment=environment,
         performance=performance,
+        capability_quality=capability_quality,
     )

--- a/src/gaia/eval/release_scorecard.py
+++ b/src/gaia/eval/release_scorecard.py
@@ -90,6 +90,7 @@ class ResultPayload:
     reproduction_command: Optional[str] = None
     breakdown: Optional[dict] = None
     environment: Optional[dict] = None
+    performance: Optional[dict] = None
 
 
 def _md_cell(value) -> str:
@@ -185,6 +186,7 @@ def render_scorecard(payload: ResultPayload) -> str:
                 for m in payload.metrics
             ],
             **({"breakdown": payload.breakdown} if payload.breakdown else {}),
+            **({"performance": payload.performance} if payload.performance else {}),
         },
         "aggregate": {
             "name": payload.aggregate_name,
@@ -307,6 +309,18 @@ matter alone — no eval-harness access needed.
             )
             breakdown_section += f"\n**Top confusions:**\n\n{conf_lines}\n"
         body += breakdown_section
+
+    if payload.performance:
+        perf_rows = "\n".join(
+            f"| {_md_cell(k)} | {_md_cell(v)} |" for k, v in payload.performance.items()
+        )
+        body += (
+            "\n## Performance\n\n"
+            "_Measured on the run environment above (model / hardware / gaia_commit / "
+            "corpus size); the perf gate is report-only, so these are observed values, "
+            "not pass/fail bars (see `tests/fixtures/email/perf_gate_thresholds.json`)._\n\n"
+            f"| Metric | Value |\n|--------|-------|\n{perf_rows}\n"
+        )
 
     if payload.inherited_from:
         body += f"\n> **Inherited from {payload.inherited_from}** — results carried forward verbatim (patch release).\n"
@@ -537,6 +551,7 @@ def carry_forward(prev_scorecard_path: Path, new_version: str) -> ResultPayload:
     # promise "carried forward verbatim").
     breakdown = results.get("breakdown")
     environment = recipe.get("environment")
+    performance = results.get("performance")
 
     import datetime
 
@@ -555,4 +570,5 @@ def carry_forward(prev_scorecard_path: Path, new_version: str) -> ResultPayload:
         inherited_from=prev_version,
         breakdown=breakdown,
         environment=environment,
+        performance=performance,
     )

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -955,6 +955,69 @@ class TestPerformanceRoundTrip:
         assert result.performance["throughput_tps"] == 12.1
 
 
+class TestCapabilityQualityRoundTrip:
+    """capability_quality: render→parse round-trip, absence, validate invariant."""
+
+    def _make_capq(self):
+        return {
+            "spam": {"precision": 0.92, "recall": 0.88, "f1": 0.9},
+            "action_items": {"precision": 0.8, "recall": 0.75, "f1": 0.77},
+            "briefing": {
+                "approval": 0.95,
+                "must_include_recall": 0.9,
+                "faithful": 1.0,
+                "hallucination_free": 1.0,
+            },
+        }
+
+    def test_capq_present_in_front_matter(self):
+        payload = _make_payload()
+        payload.capability_quality = self._make_capq()
+        parsed = parse_scorecard(render_scorecard(payload))
+        assert "capability_quality" in parsed.get("results", {})
+        assert parsed["results"]["capability_quality"]["spam"]["f1"] == 0.9
+
+    def test_capq_absent_when_none(self):
+        parsed = parse_scorecard(render_scorecard(_make_payload()))
+        assert "capability_quality" not in parsed.get("results", {})
+
+    def test_capq_body_section_rendered_when_present(self):
+        payload = _make_payload()
+        payload.capability_quality = self._make_capq()
+        text = render_scorecard(payload)
+        assert "## Capability quality" in text
+        assert "spam" in text and "action_items" in text and "briefing" in text
+        assert "0.9200" in text  # spam precision rendered with 4dp
+
+    def test_capq_body_section_absent_when_none(self):
+        assert "## Capability quality" not in render_scorecard(_make_payload())
+
+    def test_capq_not_in_required_fields(self):
+        assert "capability_quality" not in REQUIRED_FIELDS
+
+    def test_capq_validate_still_passes(self):
+        payload = _make_payload()
+        payload.capability_quality = self._make_capq()
+        parsed = parse_scorecard(render_scorecard(payload))
+        assert validate_scorecard(parsed) == []
+
+    def test_capq_does_not_affect_aggregate(self):
+        base = parse_scorecard(render_scorecard(_make_payload(accuracy=0.46)))
+        withq = _make_payload(accuracy=0.46)
+        withq.capability_quality = self._make_capq()
+        withq_parsed = parse_scorecard(render_scorecard(withq))
+        assert base["aggregate"]["value"] == withq_parsed["aggregate"]["value"]
+
+    def test_carry_forward_preserves_capq(self, tmp_path):
+        src = _make_payload(version="0.2.3", accuracy=0.75)
+        src.capability_quality = self._make_capq()
+        card = tmp_path / "SCORECARD.md"
+        card.write_text(render_scorecard(src))
+        result = carry_forward(card, "0.2.4")
+        assert result.capability_quality is not None
+        assert result.capability_quality["briefing"]["approval"] == 0.95
+
+
 class TestEnvironmentRoundTrip:
     """environment field: render→parse round-trip, absence, validate invariant."""
 
@@ -1375,6 +1438,121 @@ class TestBreakdownAdapter:
         bd = self._make_benchmark_dir(tmp_path, scorecard)
         payload = mod.build_payload(bd, self._make_gt(tmp_path))
         assert payload.performance is None
+
+    def _scorecard_with_spam(self, precision, recall, f1):
+        return {
+            "run_id": "spam",
+            "scenarios": [
+                {
+                    "category": "Gemma-4-E4B-it-GGUF",
+                    "status": "PASS",
+                    "total_emails": 20,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                        "spam": {
+                            "precision": precision,
+                            "recall": recall,
+                            "f1": f1,
+                        },
+                    },
+                }
+            ],
+        }
+
+    def test_spam_folded_into_capability_quality(self, tmp_path):
+        """is_spam P/R/F1 from the benchmark quality block reaches the card."""
+        mod = self._load_gen_scorecard()
+        bd = self._make_benchmark_dir(
+            tmp_path, self._scorecard_with_spam(0.9, 0.8, 0.85)
+        )
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.capability_quality is not None
+        assert payload.capability_quality["spam"] == {
+            "precision": 0.9,
+            "recall": 0.8,
+            "f1": 0.85,
+        }
+        assert "## Capability quality" in render_scorecard(payload)
+
+    def test_capability_quality_none_without_spam_or_reports(self, tmp_path):
+        """No spam block and no report args -> capability_quality omitted."""
+        mod = self._load_gen_scorecard()
+        scorecard = {
+            "run_id": "nocapq",
+            "scenarios": [
+                {
+                    "category": "m",
+                    "status": "PASS",
+                    "total_emails": 10,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                    },
+                }
+            ],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.capability_quality is None
+
+    def test_action_item_and_briefing_reports_folded(self, tmp_path):
+        """--action-item-report and --briefing-report metrics reach the card."""
+        mod = self._load_gen_scorecard()
+        ai = tmp_path / "ai.json"
+        ai.write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "extraction": {"precision": 0.8, "recall": 0.7, "f1": 0.75}
+                    }
+                }
+            )
+        )
+        br = tmp_path / "br.json"
+        br.write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "briefing": {
+                            "briefing_approval_rate": 0.95,
+                            "must_include_recall_mean": 0.9,
+                            "faithful_rate": 1.0,
+                            "hallucination_free_rate": 1.0,
+                        }
+                    }
+                }
+            )
+        )
+        bd = self._make_benchmark_dir(
+            tmp_path, self._scorecard_with_spam(0.9, 0.8, 0.85)
+        )
+        payload = mod.build_payload(
+            bd,
+            self._make_gt(tmp_path),
+            action_item_report=str(ai),
+            briefing_report=str(br),
+        )
+        capq = payload.capability_quality
+        assert capq["action_items"] == {"precision": 0.8, "recall": 0.7, "f1": 0.75}
+        assert capq["briefing"]["approval"] == 0.95
+        assert capq["briefing"]["hallucination_free"] == 1.0
+
+    def test_report_fails_loud_on_skipped(self, tmp_path):
+        """A report marked skipped raises rather than silently omitting the metric."""
+        mod = self._load_gen_scorecard()
+        rep = tmp_path / "skipped.json"
+        rep.write_text(json.dumps({"skipped": True}))
+        with pytest.raises(ValueError, match="skipped"):
+            mod._load_report_metrics(rep, "extraction", {"f1": "f1"})
+
+    def test_report_fails_loud_on_missing_key(self, tmp_path):
+        """A judged report missing a mapped source key raises (no silent omit)."""
+        mod = self._load_gen_scorecard()
+        rep = tmp_path / "partial.json"
+        rep.write_text(json.dumps({"summary": {"extraction": {"precision": 0.8}}}))
+        with pytest.raises(ValueError, match="summary.extraction.f1"):
+            mod._load_report_metrics(rep, "extraction", {"f1": "f1"})
 
     def test_per_category_accuracy_fyi(self, tmp_path):
         """fyi: 6+10=16 total, 6+10=16 correct in scenario1+2 combined."""

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -1325,6 +1325,36 @@ class TestBreakdownAdapter:
         # It reaches the rendered card so it shows on the hub.
         assert "## Performance" in render_scorecard(payload)
 
+    def test_performance_drops_unmeasured_memory(self, tmp_path):
+        """peak_memory_gb=0.0 (runner /stats omits it) is dropped, not shown as 0."""
+        mod = self._load_gen_scorecard()
+        scorecard = {
+            "run_id": "nomem",
+            "scenarios": [
+                {
+                    "category": "m",
+                    "status": "PASS",
+                    "total_emails": 20,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                    },
+                    "performance_summary": {
+                        "avg_time_to_first_token": 8.5,
+                        "avg_tokens_per_second": 12.1,
+                        "pipeline_latency_s": 760.0,
+                        "peak_memory_gb": 0.0,
+                        "total_emails": 20,
+                    },
+                }
+            ],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.performance is not None
+        assert "peak_memory_gb" not in payload.performance
+        assert payload.performance["throughput_tps"] == 12.1
+
     def test_performance_none_when_no_summary(self, tmp_path):
         """No performance_summary in any scenario -> perf block omitted."""
         mod = self._load_gen_scorecard()

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -894,6 +894,67 @@ class TestBreakdownRoundTrip:
 # ---------------------------------------------------------------------------
 
 
+class TestPerformanceRoundTrip:
+    """performance field: render→parse round-trip, absence, validate invariant."""
+
+    def _make_perf(self):
+        return {
+            "ttft_s": 8.541,
+            "throughput_tps": 12.1,
+            "pipeline_s": 1894.0,
+            "peak_memory_gb": 6.2,
+            "emails_per_run": 20,
+        }
+
+    def test_performance_present_in_front_matter(self):
+        payload = _make_payload()
+        payload.performance = self._make_perf()
+        parsed = parse_scorecard(render_scorecard(payload))
+        assert "performance" in parsed.get(
+            "results", {}
+        ), "'performance' must appear under results in front matter when set"
+        assert parsed["results"]["performance"]["throughput_tps"] == 12.1
+
+    def test_performance_absent_when_none(self):
+        parsed = parse_scorecard(render_scorecard(_make_payload()))
+        assert "performance" not in parsed.get("results", {})
+
+    def test_performance_body_section_rendered_when_present(self):
+        payload = _make_payload()
+        payload.performance = self._make_perf()
+        text = render_scorecard(payload)
+        assert "## Performance" in text
+        assert "throughput_tps" in text and "8.541" in text
+
+    def test_performance_body_section_absent_when_none(self):
+        assert "## Performance" not in render_scorecard(_make_payload())
+
+    def test_performance_not_in_required_fields(self):
+        assert "performance" not in REQUIRED_FIELDS
+
+    def test_performance_validate_still_passes(self):
+        payload = _make_payload()
+        payload.performance = self._make_perf()
+        parsed = parse_scorecard(render_scorecard(payload))
+        assert validate_scorecard(parsed) == []
+
+    def test_performance_does_not_affect_aggregate(self):
+        base = parse_scorecard(render_scorecard(_make_payload(accuracy=0.46)))
+        withp = _make_payload(accuracy=0.46)
+        withp.performance = self._make_perf()
+        withp_parsed = parse_scorecard(render_scorecard(withp))
+        assert base["aggregate"]["value"] == withp_parsed["aggregate"]["value"]
+
+    def test_carry_forward_preserves_performance(self, tmp_path):
+        src = _make_payload(version="0.2.3", accuracy=0.75)
+        src.performance = self._make_perf()
+        card = tmp_path / "SCORECARD.md"
+        card.write_text(render_scorecard(src))
+        result = carry_forward(card, "0.2.4")
+        assert result.performance is not None
+        assert result.performance["throughput_tps"] == 12.1
+
+
 class TestEnvironmentRoundTrip:
     """environment field: render→parse round-trip, absence, validate invariant."""
 
@@ -1228,6 +1289,62 @@ class TestBreakdownAdapter:
         gt_path = tmp_path / "ground_truth.json"
         gt_path.write_text(json.dumps(gt))
         return gt_path
+
+    def test_performance_extracted_from_summary(self, tmp_path):
+        """build_payload folds performance_summary into a versioned perf block."""
+        mod = self._load_gen_scorecard()
+        scorecard = {
+            "run_id": "perf",
+            "scenarios": [
+                {
+                    "category": "Gemma-4-E4B-it-GGUF",
+                    "status": "PASS",
+                    "total_emails": 20,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                    },
+                    "performance_summary": {
+                        "avg_time_to_first_token": 8.5,
+                        "avg_tokens_per_second": 12.1,
+                        "pipeline_latency_s": 760.0,
+                        "peak_memory_gb": 6.2,
+                        "total_emails": 20,
+                    },
+                }
+            ],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.performance is not None
+        assert payload.performance["ttft_s"] == 8.5
+        assert payload.performance["throughput_tps"] == 12.1
+        assert payload.performance["pipeline_s"] == 760.0
+        assert payload.performance["peak_memory_gb"] == 6.2
+        assert payload.performance["emails_per_run"] == 20
+        # It reaches the rendered card so it shows on the hub.
+        assert "## Performance" in render_scorecard(payload)
+
+    def test_performance_none_when_no_summary(self, tmp_path):
+        """No performance_summary in any scenario -> perf block omitted."""
+        mod = self._load_gen_scorecard()
+        scorecard = {
+            "run_id": "noperf",
+            "scenarios": [
+                {
+                    "category": "m",
+                    "status": "PASS",
+                    "total_emails": 10,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                    },
+                }
+            ],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.performance is None
 
     def test_per_category_accuracy_fyi(self, tmp_path):
         """fyi: 6+10=16 total, 6+10=16 correct in scenario1+2 combined."""


### PR DESCRIPTION
## Why

The email eval measures **TTFT / throughput / pipeline latency / peak memory** every run, but those numbers only lived in the CI **gate-report artifact** — invisible on the hub and not versioned. This surfaces them on the agent's hub page, **properly versioned**.

## What

- **`release_scorecard.py`**: new optional `performance` block — front-matter `results.performance` + a rendered **`## Performance`** section (mirrors the existing `environment` / `breakdown` optional sections). `carry_forward` preserves it; it's **excluded from the aggregate** (observed values, not a weighted metric).
- **`gen_scorecard.py`**: `_compute_performance()` means the key perf fields across judged scenarios' `performance_summary` → `ttft_s`, `throughput_tps`, `pipeline_s`, `peak_memory_gb`, `emails_per_run`. Returns `None` (section omitted) when a run doesn't carry them.

**Versioning:** the perf block lives in the per-version `SCORECARD.md`, next to the environment block (`gaia_commit`, `lemonade_version`, `model`, `hardware`) and corpus size — so each release's numbers are tied to the exact commit/hardware/sample they were measured on.

**Hub:** no hub-side change needed — the worker already serves `SCORECARD.md` as the Scorecard tab, so the `## Performance` section renders automatically.

This also makes the (currently report-only) perf gate's numbers **publicly visible + trend-trackable per release**, addressing the "report-only is invisible" concern. The section populates on the next eval run; #2063 tracks the per-email speedups.

## Test plan
- [x] `pytest tests/unit/eval/test_release_scorecard.py` — 87 pass (new: performance round-trip, front-matter/body render, absence, not-required, validate, aggregate-unchanged, carry-forward; adapter extracts perf from `performance_summary` and omits when absent).
- [x] `black` / `isort` clean.
- [ ] Renders on the hub after the next release/refresh regenerates the card with perf data.
