### PR TITLE
feat(email-eval): fold spam / action-item / briefing scores onto the scorecard

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -197,13 +197,33 @@ jobs:
           python hub/agents/python/email/packaging/eval_drafting_report.py
           if ($LASTEXITCODE -ne 0) { throw "drafting eval failed" }
 
+      - name: Action-item extraction eval (judge-scored) — for the scorecard metric
+        env:
+          EMAIL_EVAL_MODEL: ${{ env.MODEL }}
+          # Judge credential — REQUIRED (fail-loudly, no silent skip), same as
+          # drafting. Runs the small committed action-item corpus, not the mbox.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python hub/agents/python/email/packaging/eval_action_item_report.py
+          if ($LASTEXITCODE -ne 0) { throw "action-item eval failed" }
+
+      - name: Briefing quality eval (judge-scored) — for the scorecard metric
+        env:
+          EMAIL_EVAL_MODEL: ${{ env.MODEL }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python hub/agents/python/email/packaging/eval_briefing_report.py
+          if ($LASTEXITCODE -ne 0) { throw "briefing eval failed" }
+
       - name: Regenerate SCORECARD.md from the real run
         run: |
-          # --drafting-report folds draft_approval_rate into the card as a
-          # reported metric (weight 0). The drafting eval above hard-fails on a
+          # Fold every capability's judged result into the card as report-only
+          # metrics: drafting -> draft_approval_rate (weight-0 metric); spam (from
+          # the benchmark quality block, no flag needed) + action-item + briefing
+          # -> the Capability quality section. Each eval above hard-fails on a
           # missing key, so a report here is always a real judged run; a missing
           # or unjudged report makes gen_scorecard fail loudly (never omits).
-          python hub/agents/python/email/packaging/gen_scorecard.py --benchmark-dir eval-out --limit "$env:LIMIT" --drafting-report eval-out/drafting_gate_report.json
+          python hub/agents/python/email/packaging/gen_scorecard.py --benchmark-dir eval-out --limit "$env:LIMIT" --drafting-report eval-out/drafting_gate_report.json --action-item-report eval-out/action_items_report.json --briefing-report eval-out/briefing_gate_report.json
           if ($LASTEXITCODE -ne 0) { throw "gen_scorecard failed" }
 
       - name: Same-version regression check (reject a worse re-run)

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -215,6 +215,105 @@ def _compute_performance(judged: list) -> Optional[dict]:
     return perf or None
 
 
+def _mean_nested_metric(judged: list, group: str, key: str) -> Optional[float]:
+    """Mean of ``quality[group][key]`` across judged runs (None if absent).
+
+    Unlike :func:`_mean_scenario_metric`, this reads a nested confusion sub-dict
+    such as ``quality.spam.{precision,recall,f1}`` (from
+    ``confusion_for_flag(...).to_dict()`` in the benchmark quality block).
+    """
+    vals = [
+        float(s["quality"][group][key])
+        for s in judged
+        if isinstance(s.get("quality"), dict)
+        and isinstance(s["quality"].get(group), dict)
+        and isinstance(s["quality"][group].get(key), (int, float))
+        and not isinstance(s["quality"][group][key], bool)
+    ]
+    return round(sum(vals) / len(vals), 4) if vals else None
+
+
+def _load_report_metrics(report_path, group: str, mapping: dict) -> dict:
+    """Read ``summary.<group>.<src_key>`` from a judged gate report → ``{dst: value}``.
+
+    ``mapping`` is ``{dst_key: src_key}``. Fails loud on a report marked skipped or
+    any missing source key — a judged run always yields real values, so a gap means
+    the report was not a real judged run (CLAUDE.md: No Silent Fallbacks). Never
+    silently omits a metric.
+    """
+    data = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    if data.get("skipped"):
+        raise ValueError(
+            f"Report {report_path} is marked skipped, but a judged eval must not "
+            f"skip (ANTHROPIC_API_KEY is required). Re-run it with the key set."
+        )
+    section = data.get("summary", {}).get(group, {})
+    out: dict = {}
+    for dst, src in mapping.items():
+        val = section.get(src)
+        if val is None:
+            raise ValueError(
+                f"No summary.{group}.{src} in {report_path} (judged run expected). "
+                f"Re-run the eval with ANTHROPIC_API_KEY set."
+            )
+        out[dst] = round(float(val), 4)
+    return out
+
+
+def _compute_capability_quality(
+    judged: list, action_item_report=None, briefing_report=None
+) -> Optional[dict]:
+    """Fold the agent's non-triage capability evals onto the versioned scorecard.
+
+    Beyond the headline triage accuracy, the email agent has three other evaluated
+    capabilities whose scores otherwise live only in transient CI artifacts:
+
+    * **spam** — is_spam precision/recall/F1 from the benchmark quality block
+      (already in the benchmark output; no extra report needed).
+    * **action_items** — precision/recall/F1 from a judged action-item report.
+    * **briefing** — approval / must-include recall / faithfulness /
+      hallucination-free rates from a judged briefing report.
+
+    Report-only: these never feed the aggregate (blocking on a regression is each
+    capability's own gate's job, ``enforce:true`` under ``tests/fixtures/email/``).
+    Returns ``None`` when no capability has data.
+    """
+    capq: dict = {}
+
+    spam = {
+        k: v
+        for k, v in (
+            ("precision", _mean_nested_metric(judged, "spam", "precision")),
+            ("recall", _mean_nested_metric(judged, "spam", "recall")),
+            ("f1", _mean_nested_metric(judged, "spam", "f1")),
+        )
+        if v is not None
+    }
+    if spam:
+        capq["spam"] = spam
+
+    if action_item_report is not None:
+        capq["action_items"] = _load_report_metrics(
+            action_item_report,
+            "extraction",
+            {"precision": "precision", "recall": "recall", "f1": "f1"},
+        )
+
+    if briefing_report is not None:
+        capq["briefing"] = _load_report_metrics(
+            briefing_report,
+            "briefing",
+            {
+                "approval": "briefing_approval_rate",
+                "must_include_recall": "must_include_recall_mean",
+                "faithful": "faithful_rate",
+                "hallucination_free": "hallucination_free_rate",
+            },
+        )
+
+    return capq or None
+
+
 def _compute_breakdown(judged: list) -> Optional[dict]:
     """Aggregate per-category accuracy and top confusion pairs across judged scenarios.
 
@@ -350,6 +449,8 @@ def build_payload(
     limit=None,
     environment=None,
     drafting_report=None,
+    action_item_report=None,
+    briefing_report=None,
 ):
     """Build a :class:`~gaia.eval.release_scorecard.ResultPayload` from benchmark output.
 
@@ -526,6 +627,11 @@ def build_payload(
 
     breakdown = _compute_breakdown(judged)
     performance = _compute_performance(judged)
+    capability_quality = _compute_capability_quality(
+        judged,
+        action_item_report=action_item_report,
+        briefing_report=briefing_report,
+    )
 
     return ResultPayload(
         agent_name="Email Triage",
@@ -575,6 +681,7 @@ def build_payload(
         breakdown=breakdown,
         environment=environment,
         performance=performance,
+        capability_quality=capability_quality,
     )
 
 
@@ -714,6 +821,27 @@ def main(argv=None) -> int:
             "the aggregate's."
         ),
     )
+    parser.add_argument(
+        "--action-item-report",
+        default=None,
+        help=(
+            "Path to the judged action-item extraction report (from "
+            "eval_action_item_report.py). Folds precision/recall/F1 into the "
+            "scorecard's Capability quality section (report-only). A skipped or "
+            "incomplete report fails loudly, never silently omits."
+        ),
+    )
+    parser.add_argument(
+        "--briefing-report",
+        default=None,
+        help=(
+            "Path to the judged briefing-quality report (from "
+            "eval_briefing_report.py). Folds approval / must-include recall / "
+            "faithfulness / hallucination-free rates into the scorecard's "
+            "Capability quality section (report-only). A skipped or incomplete "
+            "report fails loudly, never silently omits."
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -764,6 +892,8 @@ def main(argv=None) -> int:
             limit=args.limit,
             environment=environment,
             drafting_report=args.drafting_report,
+            action_item_report=args.action_item_report,
+            briefing_report=args.briefing_report,
         )
     except (ValueError, FileNotFoundError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/src/gaia/eval/release_scorecard.py
+++ b/src/gaia/eval/release_scorecard.py
@@ -91,6 +91,7 @@ class ResultPayload:
     breakdown: Optional[dict] = None
     environment: Optional[dict] = None
     performance: Optional[dict] = None
+    capability_quality: Optional[dict] = None
 
 
 def _md_cell(value) -> str:
@@ -187,6 +188,11 @@ def render_scorecard(payload: ResultPayload) -> str:
             ],
             **({"breakdown": payload.breakdown} if payload.breakdown else {}),
             **({"performance": payload.performance} if payload.performance else {}),
+            **(
+                {"capability_quality": payload.capability_quality}
+                if payload.capability_quality
+                else {}
+            ),
         },
         "aggregate": {
             "name": payload.aggregate_name,
@@ -321,6 +327,26 @@ matter alone — no eval-harness access needed.
             "not pass/fail bars (see `tests/fixtures/email/perf_gate_thresholds.json`)._\n\n"
             f"| Metric | Value |\n|--------|-------|\n{perf_rows}\n"
         )
+
+    if payload.capability_quality:
+        capq_rows = "\n".join(
+            f"| {_md_cell(cap)} | {_md_cell(metric)} | {value:.4f} |"
+            for cap, metrics in payload.capability_quality.items()
+            if isinstance(metrics, dict)
+            for metric, value in metrics.items()
+            if isinstance(value, (int, float)) and not isinstance(value, bool)
+        )
+        if capq_rows:
+            body += (
+                "\n## Capability quality\n\n"
+                "_Beyond the headline triage accuracy, these are the agent's other "
+                "capabilities scored by their own evals (spam detection, action-item "
+                "extraction, briefing quality). Report-only — they don't feed the "
+                "aggregate above; see the per-capability gate thresholds under "
+                "`tests/fixtures/email/`._\n\n"
+                f"| Capability | Metric | Value |\n|------------|--------|-------|\n"
+                f"{capq_rows}\n"
+            )
 
     if payload.inherited_from:
         body += f"\n> **Inherited from {payload.inherited_from}** — results carried forward verbatim (patch release).\n"
@@ -552,6 +578,7 @@ def carry_forward(prev_scorecard_path: Path, new_version: str) -> ResultPayload:
     breakdown = results.get("breakdown")
     environment = recipe.get("environment")
     performance = results.get("performance")
+    capability_quality = results.get("capability_quality")
 
     import datetime
 
@@ -571,4 +598,5 @@ def carry_forward(prev_scorecard_path: Path, new_version: str) -> ResultPayload:
         breakdown=breakdown,
         environment=environment,
         performance=performance,
+        capability_quality=capability_quality,
     )

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -955,6 +955,69 @@ class TestPerformanceRoundTrip:
         assert result.performance["throughput_tps"] == 12.1
 
 
+class TestCapabilityQualityRoundTrip:
+    """capability_quality: render→parse round-trip, absence, validate invariant."""
+
+    def _make_capq(self):
+        return {
+            "spam": {"precision": 0.92, "recall": 0.88, "f1": 0.9},
+            "action_items": {"precision": 0.8, "recall": 0.75, "f1": 0.77},
+            "briefing": {
+                "approval": 0.95,
+                "must_include_recall": 0.9,
+                "faithful": 1.0,
+                "hallucination_free": 1.0,
+            },
+        }
+
+    def test_capq_present_in_front_matter(self):
+        payload = _make_payload()
+        payload.capability_quality = self._make_capq()
+        parsed = parse_scorecard(render_scorecard(payload))
+        assert "capability_quality" in parsed.get("results", {})
+        assert parsed["results"]["capability_quality"]["spam"]["f1"] == 0.9
+
+    def test_capq_absent_when_none(self):
+        parsed = parse_scorecard(render_scorecard(_make_payload()))
+        assert "capability_quality" not in parsed.get("results", {})
+
+    def test_capq_body_section_rendered_when_present(self):
+        payload = _make_payload()
+        payload.capability_quality = self._make_capq()
+        text = render_scorecard(payload)
+        assert "## Capability quality" in text
+        assert "spam" in text and "action_items" in text and "briefing" in text
+        assert "0.9200" in text  # spam precision rendered with 4dp
+
+    def test_capq_body_section_absent_when_none(self):
+        assert "## Capability quality" not in render_scorecard(_make_payload())
+
+    def test_capq_not_in_required_fields(self):
+        assert "capability_quality" not in REQUIRED_FIELDS
+
+    def test_capq_validate_still_passes(self):
+        payload = _make_payload()
+        payload.capability_quality = self._make_capq()
+        parsed = parse_scorecard(render_scorecard(payload))
+        assert validate_scorecard(parsed) == []
+
+    def test_capq_does_not_affect_aggregate(self):
+        base = parse_scorecard(render_scorecard(_make_payload(accuracy=0.46)))
+        withq = _make_payload(accuracy=0.46)
+        withq.capability_quality = self._make_capq()
+        withq_parsed = parse_scorecard(render_scorecard(withq))
+        assert base["aggregate"]["value"] == withq_parsed["aggregate"]["value"]
+
+    def test_carry_forward_preserves_capq(self, tmp_path):
+        src = _make_payload(version="0.2.3", accuracy=0.75)
+        src.capability_quality = self._make_capq()
+        card = tmp_path / "SCORECARD.md"
+        card.write_text(render_scorecard(src))
+        result = carry_forward(card, "0.2.4")
+        assert result.capability_quality is not None
+        assert result.capability_quality["briefing"]["approval"] == 0.95
+
+
 class TestEnvironmentRoundTrip:
     """environment field: render→parse round-trip, absence, validate invariant."""
 
@@ -1375,6 +1438,121 @@ class TestBreakdownAdapter:
         bd = self._make_benchmark_dir(tmp_path, scorecard)
         payload = mod.build_payload(bd, self._make_gt(tmp_path))
         assert payload.performance is None
+
+    def _scorecard_with_spam(self, precision, recall, f1):
+        return {
+            "run_id": "spam",
+            "scenarios": [
+                {
+                    "category": "Gemma-4-E4B-it-GGUF",
+                    "status": "PASS",
+                    "total_emails": 20,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                        "spam": {
+                            "precision": precision,
+                            "recall": recall,
+                            "f1": f1,
+                        },
+                    },
+                }
+            ],
+        }
+
+    def test_spam_folded_into_capability_quality(self, tmp_path):
+        """is_spam P/R/F1 from the benchmark quality block reaches the card."""
+        mod = self._load_gen_scorecard()
+        bd = self._make_benchmark_dir(
+            tmp_path, self._scorecard_with_spam(0.9, 0.8, 0.85)
+        )
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.capability_quality is not None
+        assert payload.capability_quality["spam"] == {
+            "precision": 0.9,
+            "recall": 0.8,
+            "f1": 0.85,
+        }
+        assert "## Capability quality" in render_scorecard(payload)
+
+    def test_capability_quality_none_without_spam_or_reports(self, tmp_path):
+        """No spam block and no report args -> capability_quality omitted."""
+        mod = self._load_gen_scorecard()
+        scorecard = {
+            "run_id": "nocapq",
+            "scenarios": [
+                {
+                    "category": "m",
+                    "status": "PASS",
+                    "total_emails": 10,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                    },
+                }
+            ],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.capability_quality is None
+
+    def test_action_item_and_briefing_reports_folded(self, tmp_path):
+        """--action-item-report and --briefing-report metrics reach the card."""
+        mod = self._load_gen_scorecard()
+        ai = tmp_path / "ai.json"
+        ai.write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "extraction": {"precision": 0.8, "recall": 0.7, "f1": 0.75}
+                    }
+                }
+            )
+        )
+        br = tmp_path / "br.json"
+        br.write_text(
+            json.dumps(
+                {
+                    "summary": {
+                        "briefing": {
+                            "briefing_approval_rate": 0.95,
+                            "must_include_recall_mean": 0.9,
+                            "faithful_rate": 1.0,
+                            "hallucination_free_rate": 1.0,
+                        }
+                    }
+                }
+            )
+        )
+        bd = self._make_benchmark_dir(
+            tmp_path, self._scorecard_with_spam(0.9, 0.8, 0.85)
+        )
+        payload = mod.build_payload(
+            bd,
+            self._make_gt(tmp_path),
+            action_item_report=str(ai),
+            briefing_report=str(br),
+        )
+        capq = payload.capability_quality
+        assert capq["action_items"] == {"precision": 0.8, "recall": 0.7, "f1": 0.75}
+        assert capq["briefing"]["approval"] == 0.95
+        assert capq["briefing"]["hallucination_free"] == 1.0
+
+    def test_report_fails_loud_on_skipped(self, tmp_path):
+        """A report marked skipped raises rather than silently omitting the metric."""
+        mod = self._load_gen_scorecard()
+        rep = tmp_path / "skipped.json"
+        rep.write_text(json.dumps({"skipped": True}))
+        with pytest.raises(ValueError, match="skipped"):
+            mod._load_report_metrics(rep, "extraction", {"f1": "f1"})
+
+    def test_report_fails_loud_on_missing_key(self, tmp_path):
+        """A judged report missing a mapped source key raises (no silent omit)."""
+        mod = self._load_gen_scorecard()
+        rep = tmp_path / "partial.json"
+        rep.write_text(json.dumps({"summary": {"extraction": {"precision": 0.8}}}))
+        with pytest.raises(ValueError, match="summary.extraction.f1"):
+            mod._load_report_metrics(rep, "extraction", {"f1": "f1"})
 
     def test_per_category_accuracy_fyi(self, tmp_path):
         """fyi: 6+10=16 total, 6+10=16 correct in scenario1+2 combined."""


### PR DESCRIPTION
The email agent has four evaluated capabilities, but before this PR only triage accuracy and voice-drafting made it onto the versioned `SCORECARD.md` (and thus the hub). Spam detection, action-item extraction, and briefing quality were scored on every CI run — yet their numbers lived only in throwaway CI artifacts. So a user comparing agents on the hub saw a headline triage score and nothing about how well the agent actually detects spam, extracts action items, or writes faithful briefings; #1911's promise of `is_spam` metrics on the card was never actually delivered. After this PR, all four capabilities are visible per release, side by side, in a new **Capability quality** section.

Report-only by design: these are weight-0 / non-aggregate, so the headline aggregate score is unchanged (blocking on a regression stays each capability's own gate's job under `tests/fixtures/email/`). Spam folds in for free from the benchmark output (no extra eval); action-item and briefing come from their judged reports via new `--action-item-report` / `--briefing-report` flags, and the refresh workflow now runs those two evals (small committed corpora, cheap next to the 2.3h triage benchmark). Missing or skipped reports fail loudly — never a silently-omitted metric.

> **Stacked on #2067** (perf-on-scorecard) — both add an optional block to the same spots in `release_scorecard.py`/`gen_scorecard.py`, so this is based on that branch to avoid conflicts. Rebase onto `main` once #2067 merges.

## Test plan

- [x] `pytest tests/unit/eval/test_release_scorecard.py` — 101 pass (13 new: core round-trip/absence/validate/carry-forward for `capability_quality`; adapter spam-fold, report-fold, and fail-loud-on-skipped/missing-key)
- [x] `black --check` + `isort` clean on all changed files
- [x] Rendered a sample card locally — **Capability quality** table renders spam/action_items/briefing rows with a report-only note
- [x] `email_scorecard_refresh.yml` YAML validates; new action-item + briefing eval steps ordered before scorecard regeneration
- [ ] Next scheduled/manual `email_scorecard_refresh` run regenerates a committed card carrying the new section (on-hardware)