### PR TITLE
feat(hub): POST /reindex to rebuild the catalog without a re-publish

### DIFF
--- a/workers/agent-hub/src/index.ts
+++ b/workers/agent-hub/src/index.ts
@@ -12,6 +12,7 @@
  *   GET  /health                               liveness probe
  */
 
+import { rebuildIndex } from "./catalog";
 import { errorResponse, HttpError, json } from "./http";
 import { handlePublish } from "./publish";
 import { AGENTS_PREFIX, INDEX_KEY } from "./storage";
@@ -42,6 +43,30 @@ async function route(request: Request, env: Env): Promise<Response> {
       throw new HttpError(405, "method_not_allowed", "Use POST to /publish.");
     }
     return handlePublish(request, env);
+  }
+
+  if (path === "/reindex") {
+    if (method !== "POST") {
+      throw new HttpError(405, "method_not_allowed", "Use POST to /reindex.");
+    }
+    // Maintainer-only rebuild of index.json from the immutable R2 objects.
+    // rebuildIndex is idempotent + non-destructive — it re-derives the catalog
+    // from the stored artifacts, so a Worker schema change (e.g. the scorecard /
+    // evaluation fields) can be backfilled without re-publishing a version.
+    // Guarded by REINDEX_TOKEN, a secret separate from the CI PUBLISH_TOKENS.
+    if (!env.REINDEX_TOKEN) {
+      throw new HttpError(
+        500,
+        "config_error",
+        "REINDEX_TOKEN is not set. Run `wrangler secret put REINDEX_TOKEN`."
+      );
+    }
+    if (request.headers.get("Authorization") !== `Bearer ${env.REINDEX_TOKEN}`) {
+      throw new HttpError(401, "unauthorized", "Missing or invalid reindex token.");
+    }
+    const baseUrl = new URL(request.url).origin;
+    const index = await rebuildIndex(env.BUCKET, new Date(), baseUrl);
+    return json({ status: "reindexed", agents: index.agents.length });
   }
 
   if (method === "GET" || method === "HEAD") {

--- a/workers/agent-hub/src/types.ts
+++ b/workers/agent-hub/src/types.ts
@@ -21,6 +21,14 @@ export interface Env {
    * An author entry of "*" grants publishing for any author value.
    */
   PUBLISH_TOKENS?: string;
+
+  /**
+   * Bearer token for the maintainer-only `POST /reindex` endpoint, which
+   * rebuilds index.json from the immutable R2 objects (idempotent). Separate
+   * from PUBLISH_TOKENS so a reindex never needs a publish credential.
+   * Set with `wrangler secret put REINDEX_TOKEN`.
+   */
+  REINDEX_TOKEN?: string;
   /** Max artifact size in bytes (string in wrangler vars). */
   MAX_ARTIFACT_BYTES?: string;
 }


### PR DESCRIPTION
The hub `index.json` is only regenerated on `POST /publish`. So when the Worker's catalog schema gains fields (e.g. `scorecard`/`evaluation`) or a doc is added to R2, the live catalog can't pick them up without cutting a new agent version — the doc tabs render empty even though the markdown is in R2.

This adds a maintainer-only **`POST /reindex`** that calls the existing, idempotent `rebuildIndex()` over the immutable R2 objects, guarded by a new **`REINDEX_TOKEN`** secret (separate from `PUBLISH_TOKENS`).

**Concrete fix it enabled:** the email **0.4.0** hub page was missing its **Scorecard** and **Evaluation** tabs — `SCORECARD.md` was in R2 (and `EVALUATION.md` backfilled), but the stored `index.json` (built by an older Worker) had no `scorecard`/`evaluation` fields. Deploying this + one `/reindex` call rebuilt the catalog; both tabs now render live on amd-gaia.ai/hub/email.

## Test plan
- [x] `wrangler deploy --dry-run` typechecks
- [x] Deployed; `POST /reindex` with the token returns `{status:reindexed}` and repopulates `scorecard`/`evaluation` in index.json
- [x] 401 without the token; 405 on non-POST
- [ ] Reviewer: confirm `REINDEX_TOKEN` secret is set on the Worker (already done in prod)