### PR TITLE
docs(email): human-first rewrite of README, CHANGELOG & EVALUATION

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -1,336 +1,100 @@
 # Changelog
 
-All notable changes to `@amd-gaia/agent-email` are documented here. The package
-follows [SemVer](https://semver.org/): the **MAJOR** of the on-the-wire
-`SCHEMA_VERSION` is what `checkVersion` enforces at startup, so a contract MAJOR
-bump is always at least a package MINOR bump with a migration note.
+What's new in `@amd-gaia/agent-email`, in plain language. For the technical detail
+behind any entry — API shapes, endpoints, and version semantics — see
+[`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md).
 
 ## 0.4.0
 
-Contract bumped to `SCHEMA_VERSION` **2.3**. `checkVersion` is MAJOR-only, so the
-2.x MAJOR is unchanged and existing clients keep connecting.
-
-### Changed
-
-- **Triage returns a reply *scaffold*, not an empty draft (`SCHEMA_VERSION` 2.2 →
-  2.3).** `EmailTriageResult.draft` is now a `DraftScaffold` (`{ to, subject }`)
-  instead of a `DraftReply` — triage classifies and summarizes but never composes
-  reply prose, so the `draft.body` it used to return was *always* `""`
-  regardless of model or provider. That empty field read as a bug ("the model
-  failed to draft"), so it is dropped from the triage shape entirely. `DraftReply`
-  (with `body` + `attachments`) is **unchanged** and remains the `draft()` /
-  `send()` shape: to send a reply, compose the body yourself and call `draft()`
-  for a full `DraftReply` + confirmation token. MAJOR is unchanged (the removed
-  field carried no data), so `checkVersion` does not flag existing integrations;
-  TypeScript consumers that destructured `result.draft.body` will see it typed
-  away and should read the body from `draft()` instead.
-
-### Security
-
-- **Caller authentication for the local sidecar API (#1706).** The sidecar binds
-  `127.0.0.1` and can send mail as the user, but its REST API had **no caller
-  authentication** — any other local process, or a web page in the user's browser
-  (via DNS-rebinding), could reach draft/send. `spawnSidecar` / `startSidecar` now
-  mint a cryptographically-random **per-session bearer token**, hand it to the
-  sidecar over the private `GAIA_EMAIL_SIDECAR_TOKEN` env channel, and bind it to
-  `sidecar.client`; every `/v1/email/*` request must present `Authorization:
-  Bearer <token>` or it is **401**. A non-loopback `Host` is **400** and a
-  non-loopback browser `Origin` is **403**, closing DNS-rebinding / drive-by
-  access. The draft→send confirmation-token gate is unchanged (it is
-  payload-integrity, not caller-auth). `EmailClient` gains an `authToken` option;
-  `sidecar.authToken` and `generateSessionToken` are exported for the
-  construct-your-own-client / renderer-over-IPC paths. Wire-compatible: no
-  contract change, `SCHEMA_VERSION` stays `2.2`.
-
-### Added
-
-- **Code-derived capability matrix (#2013).** New committed
-  [`CAPABILITY_MATRIX.md`](https://github.com/amd/gaia/blob/main/hub/agents/python/email/CAPABILITY_MATRIX.md)
-  inventories every capability surface (52 internal agent-loop tools, 16
-  functional REST verbs, 4 MCP tools, 6 eval suites) with per-op eval
-  coverage; a CI drift test regenerates and byte-compares it so the surfaces
-  can no longer silently diverge. Doc-only for this package (referenced from
-  README/SPEC); no wire or client change.
-- **Readiness preflight — `GET /v1/email/init` (#1795).** A green `/health` never
-  meant "ready to triage": on a fresh host the binary boots fine but the first
-  `triage` 502s until Lemonade is up and the model is pulled. The new endpoint
-  probes the whole triage stack — Lemonade reachable **and** version-compatible
-  **and** the triage model downloaded — and returns `200` when ready, `503` with
-  an actionable `hint` when not (same `InitResponse` envelope either way).
-  Read-only: no model pull. The companion `POST /v1/email/init` asks the running
-  Lemonade to download the model and streams `text/plain` progress (it can't
-  install Lemonade itself — a host prerequisite — so an unreachable server is a
-  loud `503`, not a silent no-op). New exported types: `InitResponse`,
-  `InitLemonadeStatus`, `InitModelStatus`; no client wrapper yet (call with
-  `fetch`). `SCHEMA_VERSION` stays `2.2`.
-- **Voice / style-matched drafting (#1607).** The agent can now draft replies in
-  the user's **own voice** instead of a neutral scaffold. `build_voice_profile`
-  samples the user's Sent mail into a local style profile — top greetings /
-  sign-offs, typical length, contraction & exclamation rate (derived features
-  only, never raw content, stored on-device) — and the agent's system prompt
-  injects that guidance every turn so `draft_reply` bodies match how the user
-  writes; `clear_voice_profile` forgets it. **Agent-loop only** (chat / Agent UI /
-  `gaia email`) — no REST endpoint, no npm client method, `SCHEMA_VERSION` stays
-  `2.2`.
-- **Content-based spam detection (#1911).** Spam detection previously keyed
-  entirely off Gmail's own `SPAM` label — so it did nothing for Outlook or any
-  non-Gmail mailbox and wasn't real detection. It's now provider-agnostic: a
-  narrow mechanical prefilter (auto-generated sender addresses, freemail-domain
-  impersonation) handles the clear-cut cases, and the local LLM makes the real
-  content-vs-legitimate-marketing call on the rest. The `is_spam` signal on
-  `triage()` keeps its shape — only its derivation changed — so `SCHEMA_VERSION`
-  stays `2.2`. The eval corpus was expanded to exercise it (spam examples 7 →
-  57, corpus → 299 messages) and the scorecard gains `is_spam` recall /
-  precision / F1 as the primary spam metrics (plain accuracy is misleading on a
-  minority class this size).
-- **Stateful agent surface (`/v1/email/agent/*`, #1666).** A session-scoped,
-  conversational surface so a host can drive the full `EmailTriageAgent` over HTTP —
-  memory, personalization, and every agent tool — instead of importing it in-process.
-  This is what lets the Agent UI back its email experience with the packaged sidecar.
-  Additive and **not part of the frozen triage contract** (it runs the agent loop, not
-  the stateless `EmailTriageService`), so it does not itself move `SCHEMA_VERSION`. New
-  endpoints: `POST /v1/email/agent/session`, `DELETE /v1/email/agent/session/{id}`,
-  `GET /v1/email/agent/session/{id}/history`, `POST /v1/email/agent/query` (SSE stream
-  of the agent loop), `POST /v1/email/agent/confirm-tool` (approve/deny a gated tool),
-  `POST /v1/email/agent/cancel`, and the runtime memory toggle `POST /v1/email/agent/memory`
-  + `GET /v1/email/agent/memory/{id}`. Not wrapped by the typed npm client yet.
-- **Runtime memory enable/disable (#1666).** `EmailAgentConfig.memory_enabled` (startup)
-  and `EmailTriageAgent.set_memory_enabled()` (runtime, no restart) turn the agent's
-  memory — inbox profiling, behavioral learning, preference persistence, and
-  working-context injection — on or off, superseding the startup-only
-  `GAIA_MEMORY_DISABLED` env var. Reachable over HTTP via the agent surface above;
-  enabling memory that was never initialized (started with `GAIA_MEMORY_DISABLED` or
-  Lemonade unreachable) returns **409** with an actionable message, never a silent
-  no-op. The frozen binary now bundles FAISS (the memory index); embeddings still go
-  over Lemonade HTTP, so torch/transformers stay excluded.
-- **Follow-up tracking (#1606).** The agent gains a read-only `check_followups`
-  tool that scans the Sent folder of every connected mailbox and flags threads
-  whose latest message is still the user's own outbound mail past a
-  configurable window (default 3 days) — surfacing message id, recipient,
-  subject, and age, most overdue first. Detection only: it never sends a
-  nudge (any send stays confirmation-gated). The scan caps how many Sent
-  messages it enumerates per mailbox (default 50, max 200); the result now
-  also carries `scan_truncated: true` when a mailbox has more sent mail than
-  that cap, so the caller knows older threads weren't checked. Agent-loop
-  surface (chat / Agent UI / `gaia email`); the sidecar REST/MCP surface is
-  unchanged and `SCHEMA_VERSION` stays `2.2`.
-- **Attachment handling (#1542).** Real email has attachments; triage and replies
-  that ignored them were incomplete. Read/triage now exposes attachment metadata —
-  `EmailMessage` (request) and `EmailTriageResult` / `DraftReply` (response) carry
-  an `attachments` array of `{ filename, mime_type, size_bytes, attachment_id? }`
-  — and `draft` / `send` accept an `attachments` array of
-  `{ filename, mime_type, content_base64 }` (standard base64, ≤ 25 MB decoded
-  each) that reaches the mailbox as real MIME/Graph file attachments. The
-  draft→send confirmation token binds each attachment's filename, MIME type, and
-  content digest, so a confirmed payload can't have files swapped in or smuggled
-  past the user. Fail-loud validation throughout: bad base64 / MIME / oversize →
-  `422`, mismatched attachment set → `403`, Outlook > 3 MB (Graph simple-attach
-  limit) → a loud error, never truncation. The agent's in-loop `draft_reply` /
-  `send_now` tools gain an optional comma-separated `attachments` file-path
-  parameter with the same fail-loud checks.
-- **Scheduled send + snooze in the agent tool loop** (#1609): the agent can now
-  schedule a send for a future time ("send this tomorrow at 9am") and snooze a
-  message out of the inbox until a chosen time. A scheduled send is
-  user-confirmed **at creation** (literal recipient/subject/body + fire time),
-  stored as a regular mailbox draft plus a persistent one-shot job, and fired
-  at/after its time by the agent's scheduler; snooze archives now and re-adds
-  INBOX at the chosen time. Both are cancellable before they fire, and a firing
-  failure is recorded on the job and logged — never silently swallowed.
-  **Agent-loop only — no runtime/contract change**: no new REST endpoints, no
-  new npm surface in this package (see SPEC "Agent-loop capabilities not on the
-  contract").
-- **Triage action items now persist as a task list** (#1605): `triage()` /
-  `triageBatch()` write each extracted action item to the sidecar's local SQLite
-  (`~/.gaia/email/state.db`), linked back to the source `message_id` (or
-  `thread_id` for a thread) and de-duplicated per message on the normalized
-  description — re-triaging a message never duplicates tasks. Side-effect only:
-  the wire response, contract, and `SCHEMA_VERSION` are unchanged, and results
-  without a `message_id` are not persisted. Read/complete surfaces arrive with
-  GAIA's cross-agent task store (amd/gaia#1521); until then the store is the
-  email-local `email_tasks` table.
-- **Scheduled daily inbox briefing** (#1608): the sidecar can now run the inbox
-  pre-scan on a daily timer — no prompt, no live caller — and expose the result on
-  the new `GET /v1/email/briefing` (additive). The
-  briefing payload is the same `email_pre_scan` envelope as `POST /v1/email/prescan`,
-  produced by the agent's own `pre_scan_inbox` path, plus a `generated_at` stamp.
-  **Off by default**: opt in by launching the sidecar with
-  `GAIA_EMAIL_BRIEFING_ENABLED=true` (fire time `GAIA_EMAIL_BRIEFING_TIME`, 24h local
-  `HH:MM`, default `08:00`; scan size `GAIA_EMAIL_BRIEFING_MAX_MESSAGES`, 1–100,
-  default 25), e.g. via `startSidecar({ env: {...} })`. An invalid value fails sidecar
-  startup loudly; the endpoint returns `404` until the first scheduled run. REST-only
-  for now — no npm client wrapper method yet.
-
-### Fixed
-
-- **MCP `serverInfo.version` now reports the real package version.** The stdio MCP
-  server's `get_mcp_server_info` had a hardcoded `"1.0.0"` placeholder; it now sources
-  `AGENT_VERSION` from `gaia_agent_email.version`, so all three version surfaces (wheel
-  metadata, `GET /v1/email/version` `agentVersion`, MCP server info) agree.
-- **Hub manifest `tools_count` corrected 6 → 52** (`gaia-agent.yaml` + the in-code agent
-  registration): the agent registers 52 `@tool` functions; the stale `6` under-reported
-  the surface on the hub page and the Agent UI card.
+- **Reply drafts come back as a ready-to-fill scaffold** (recipient + subject)
+  instead of an always-empty body. Triage sorts and summarizes but doesn't write
+  the reply text — so compose the body yourself and send it with `draft()` +
+  `send()`.
+- **The local agent now checks who's calling it.** Because it can send mail as you,
+  it now requires a private per-session key that your app gets automatically — so
+  another program on your machine, or a web page in your browser, can't quietly
+  reach it to draft or send.
+- **Draft in your own voice.** The agent can learn your writing style locally from
+  your Sent mail (top greetings, sign-offs, typical length — never the raw
+  content, and it stays on your device) and match it when drafting replies.
+- **Better spam detection that works beyond Gmail.** Spam is now judged by the
+  content itself, on-device, so it works for Outlook and any mailbox — not just
+  Gmail's own spam label.
+- **Follow-up tracking.** The agent can flag threads where you're still waiting on
+  a reply past a window you choose (default 3 days), most overdue first. It points
+  them out; it never sends a nudge for you.
+- **Schedule a send or snooze a message.** Ask the agent to "send this tomorrow at
+  9am" or push a message out of the inbox until a chosen time. Both are confirmed
+  up front and can be cancelled before they fire.
+- **Attachments.** Triage now sees attachments, and drafts and sends can include
+  files (up to 25 MB each). When you confirm a send, the attachments are locked to
+  what you approved — nothing can be swapped in or added after.
+- **Action items become a task list.** Items pulled from an email are saved
+  locally and linked back to the message, so re-triaging never creates duplicates.
+- **Daily inbox briefing.** The agent can produce a morning inbox summary on a
+  schedule with no prompt. Off by default; turn it on when you launch the agent.
+- **A readiness check before your first triage.** Ask the agent whether the local
+  model is actually up and get a clear yes/no with a hint on what to fix, instead
+  of hitting an error on the first request.
+- **Runtime memory toggle.** Turn the agent's memory (inbox profiling, learned
+  preferences) on or off without restarting it.
+- **Conversational agent surface.** The agent can now be driven as a stateful,
+  streaming conversation over its local API — the same thing the GAIA Agent UI
+  uses to power its email experience.
 
 ## 0.3.0
 
-Contract bumped to `SCHEMA_VERSION` **2.1** — additive, no triage shape change, so
-`checkVersion` (MAJOR-only) keeps accepting 2.0 clients.
-
-- **Eval scorecard now measures acceptance, and the release gate enforces it** (#1437,
-  #1894): the `SCORECARD.md` aggregate is now **within-one-bucket acceptance accuracy**
-  (triage priority is ordinal, so exact-or-adjacent buckets are credited — what users
-  feel) instead of exact 4-way match. Measured **0.834** (3-run mean on Strix Halo /
-  Gemma-4-E4B, 95% CI [0.821, 0.847]) vs the **0.80** bar (#1437); exact 4-way stays a
-  reported secondary (0.77). The card now carries run-to-run variance/CI, and the
-  release gate enforces the 0.80 bar plus an anti-gaming URGENT-recall floor and a
-  variance-aware regression check. No runtime/contract change — eval + packaging only.
-- **Batch triage endpoint** (#1887): new `POST /v1/email/triage/batch` /
-  `client.triageBatch(req)` beside the single-email endpoint, so a caller can triage
-  up to 100 emails or threads in one request instead of one HTTP round-trip per
-  message. The body carries an `items` array; the response carries a parallel
-  `results` array, order-preserved, each entry holding exactly one of `result` or
-  `error`. Per-item failures are isolated: HTTP 200 with every item errored is a
-  valid response, so consumers MUST inspect each `results[].error`, not just the
-  HTTP status. New npm surface: `client.triageBatch()`, the `BatchTriageRequest` /
-  `BatchTriageResponse` / `BatchItemResult` / `BatchItemError` types, and the
-  `MAX_BATCH_SIZE` constant. New MCP tool `triage_email_batch`. Purely additive —
-  the single `triage()` / `POST /v1/email/triage` / MCP `triage_email` are unchanged.
-- **Inbox search on the REST contract** (#1781): new read-only `POST /v1/email/search`
-  / `client.search(req)`. The Agent UI lost live inbox search in the in-process
-  agent rip-out (#1653); this restores it through the package. Lists messages
-  matching a Gmail-style `query`/`labels` from the connected mailbox and returns
-  metadata only (id, subject, sender, snippet, labels) — no body, no confirmation
-  token. Needs a connected mailbox (`503` if none, `400` if 2+).
-- **Archive + phishing-quarantine are now on the REST contract (#1779).** The Agent
-  UI lost these in the #1653 in-process rip-out — they ran only in the agent loop.
-  They're back **through the package**: `POST /v1/email/{archive,quarantine}` (and
-  their `unarchive`/`unquarantine` reversals), plus `POST /v1/email/confirm` to mint
-  the gate token. Both mutating actions are confirmation-token-gated exactly like
-  `send` (a missing/invalid token → **403** before any backend call); both are
-  reversible inside the 30s undo window (the reversal endpoints are ungated — they
-  restore). Archive returns a `batch_id` undo handle and the `post_archive_id` so
-  Outlook undo survives the folder-move id change (#1738). Quarantine is
-  Gmail-only — an Outlook mailbox is refused with 400 rather than shipping a
-  folder-move its label-based undo can't reverse. New client methods:
-  `confirmAction`, `archive`, `unarchive`, `quarantine`, `unquarantine`.
-  Contract `SCHEMA_VERSION` bumps `2.0` → `2.1` (additive — triage-shape unchanged).
-- **Calendar surface on the REST contract (`SCHEMA_VERSION` 2.0 → 2.1, #1780).**
-  Restores view / create / respond for calendar events through the packaged
-  sidecar so the Agent UI gets it back without the in-process agent. New client
-  methods: `listCalendarEvents`, `previewCalendarEvent`, `createCalendarEvent`,
-  `respondToCalendarEvent` (+ `Calendar*` types). Create is confirmation-gated
-  exactly like `send` — mint a token with `previewCalendarEvent`, echo it to
-  `createCalendarEvent`; without a valid payload-bound token the create is
-  rejected (403). Additive and same-major (2.x), so a 2.0 client keeps working.
-- **Inbox pre-scan over REST** (#1778): new `prescan(req?)` client method →
-  `POST /v1/email/prescan`. Reads recent inbox messages from the connected
-  mailbox and returns the triage-card envelope (`kind: "email_pre_scan"` —
-  urgent / actionable / suggested-archive rows + an informational count) the
-  Agent UI's pre-scan card renders. Read-only; reuses the agent's own
-  `pre_scan_inbox` classification path. Contract `SCHEMA_VERSION` → `2.1`.
-
-**Verified before release:** the `darwin-arm64` binary was frozen with
-`packaging/freeze.py`, passed the no-Python `smoke_test.py` (OpenAPI surface +
-`/version` + `/v1/email/triage` all PASS), and was driven end-to-end through the
-published `EmailClient`/`checkVersion` — single `triage()` and `triageBatch()`
-both returned real, correctly-categorized Lemonade inference results. Full
-transcript in the release PR.
+- **The eval score now measures what users feel.** Triage priority is ranked
+  (urgent > needs-reply > FYI), so the score credits an exact *or* one-off bucket
+  — a "needs-reply" called "urgent" is close, not a total miss. It measures 83.4 /
+  100, and every release has to clear the bar to ship.
+- **Triage many emails in one call.** New `triageBatch()` handles up to 100 emails
+  or threads at once instead of one request each; each item succeeds or fails on
+  its own, so check every result, not just the overall status.
+- **Search your inbox, view your calendar, and file messages — through the
+  package.** Read-only inbox search, calendar view/create/RSVP, and archive plus
+  phishing-quarantine (both reversible within 30 seconds) are now available to
+  apps embedding the agent, matching what the GAIA Agent UI can do.
+- **Inbox pre-scan.** Get the triage card (urgent / needs-action /
+  suggested-archive rows) for your recent inbox in one call.
 
 ## 0.2.5
 
-Sending from a mailbox connected with identity-only scopes now returns an
-actionable 4xx (naming the missing `installed:email` grant) instead of an opaque
-HTTP 500, so the playground no longer points users at Lemonade for what is really
-an OAuth-scope problem. The playground's mailbox connect now requests mail-send
-scopes (so connect → send works), and the send panel keeps every connected
-mailbox selectable while marking ones that lack mail-send access. No agent
-wire-contract change — `SCHEMA_VERSION` stays `2.0`.
+Sending from a mailbox connected with view-only permissions now gives a clear
+error naming the missing mail-send permission, instead of a confusing server
+error. The playground's connect flow now asks for send access up front, so
+connect → send just works.
 
 ## 0.2.4
 
-First fully-published release of this feature set. The whole-package zip download
-(#1843) is temporarily disabled: the ~177 MB all-platforms zip exceeds Cloudflare's
-edge upload limit, so the publish step rejected it (413) and blocked every prior
-attempt (0.2.1–0.2.3). The worker-side streaming approach was reverted; 0.2.4 ships
-the per-platform binaries + this npm client without the combined zip. Per-platform
-binaries remain individually downloadable from the Hub. No agent wire-contract
-change — `SCHEMA_VERSION` stays `2.0`.
+First fully-published release of this feature set. Ships the per-platform agent
+downloads plus this client. (The combined all-platforms download is temporarily
+disabled — it exceeded a hosting size limit; the individual downloads work.)
 
 ## 0.2.3
 
-Re-cut of 0.2.2 after the Agent Hub worker was redeployed with the large-artifact
-streaming fix. 0.2.2 published its per-platform binaries but its whole-package zip
-and npm publish never completed (the live worker hadn't yet picked up the fix);
-0.2.3 is the first fully-published release of this feature set. No agent
-wire-contract change — `SCHEMA_VERSION` stays `2.0`.
+Re-cut of 0.2.2 after a publishing-infrastructure fix — the first fully-published
+release of this feature set.
 
 ## 0.2.2
 
-Release-reliability fix. The 0.2.1 tag published the per-platform binaries to the
-Agent Hub but its npm publish never completed: the Hub Worker buffered the entire
-upload in memory, so the new ~177 MB whole-package zip exceeded Cloudflare's
-128 MB per-Worker memory limit and the publish step 502'd before npm. 0.2.2 fixes
-that and is the first complete publish of the 0.2.1 feature set. No agent
-wire-contract change — `SCHEMA_VERSION` stays `2.0` and the client + REST/MCP
-surface are unchanged.
-
-### Fixed
-
-- **Whole-package zip + npm publish now complete.** The Agent Hub Worker
-  (`POST /publish`) streams large `application/octet-stream` uploads straight to
-  R2 with server-side SHA-256 verification instead of reading the whole body into
-  memory, so the ~177 MB whole-package zip publishes without OOMing the Worker.
+Publishing-reliability fix so the download and npm publish complete. No change to
+how the agent behaves.
 
 ## 0.2.1
 
-Adds the one-command `playground` launcher and automatic sidecar cleanup, and
-makes this README the single canonical agent README (hub + npm). No wire-contract
-change (`SCHEMA_VERSION` stays `2.0`).
-
-### Added
-
-- **`npx @amd-gaia/agent-email playground` — one-command launcher.** Fetches the
-  binary, starts the sidecar, and opens the browser to `/v1/email/playground`,
-  running until Ctrl+C. `--port <n>` to bind elsewhere, `--no-open` to skip the
-  browser, `--out <dir>` to choose the binary cache. Makes "try the agent" a single
-  command instead of fetch → spawn → find-the-URL.
-- **Automatic sidecar cleanup (`autoCleanup`, default on).** `startSidecar` /
-  `spawnSidecar` now reap the frozen sidecar's detached process tree when the host
-  process exits, crashes (`uncaughtException` / `unhandledRejection`), or is
-  interrupted (`SIGINT` / `SIGTERM` / `SIGHUP`) — so a skipped or missed
-  `shutdown()` no longer leaves the binary running and holding its port. Pass
-  `autoCleanup: false` to manage the lifecycle yourself; `shutdown()` stays the
-  graceful, awaited path. A hard `SIGKILL` of the host process is the one case no
-  in-process handler can catch.
-
-### Changed
-
-- **This README is now the single canonical agent README** (hub + npm). The
-  release workflow publishes it to both, so the hub page and the npm listing no
-  longer drift — the architecture diagram and the GAIA/npm install flow show up on
-  `hub.amd-gaia.ai/hub/email`.
-- **Architecture diagram loads from an in-repo raw image** instead of a
-  version-pinned hub URL that the publish pipeline didn't populate, so it renders on
-  GitHub and npm before the binaries are uploaded.
-- **Agent version is shown on the hub cards** (listing + featured + detail).
+- **One-command playground.** `npx @amd-gaia/agent-email playground` fetches the
+  agent, starts it, and opens a browser page to try it — no setup.
+- **Automatic cleanup.** The agent now shuts itself down when your app exits,
+  crashes, or is interrupted, so it never lingers holding a port.
 
 ## 0.2.0
 
-### Changed (breaking)
-
-- **Contract `SCHEMA_VERSION` 1.0 → 2.0.** The TS client and the frozen binary now
-  agree on `"2.0"`. A 0.1.x client against a 2.0 binary (or vice-versa) fails loudly
-  at `startSidecar` with `VersionMismatchError` — upgrade both together. No
-  `expectedApiVersion` override is needed once client and binary match.
-
-### Added
-
-- **Browser-safe `./client` subpath export.** `import { EmailClient } from
-  "@amd-gaia/agent-email/client"` exposes only zero-Node-dependency symbols, so the
-  client bundles for a browser or Electron renderer. The `.` entry (binary fetch +
-  sidecar spawn) stays Node-only.
+- **Browser-safe client.** A separate `@amd-gaia/agent-email/client` import works
+  in a browser or Electron renderer (the main import stays Node-only, since it
+  downloads and launches the agent).
 
 ## 0.1.0
 
-- Initial release: typed `EmailClient`, build-time `fetch` CLI (download +
-  SHA-256 verify), and sidecar lifecycle helpers (`spawnSidecar`, `waitForHealth`,
-  `checkVersion`, `shutdown`, `startSidecar`).
+- Initial release: the typed email client, the build-time downloader, and the
+  helpers to launch and shut down the local agent.

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 What's new in `@amd-gaia/agent-email`, in plain language. For the technical detail
 behind any entry — API shapes, endpoints, and version semantics — see
-[`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md).
+[`SPEC.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SPEC.md).
 
 ## 0.4.0
 

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 What's new in `@amd-gaia/agent-email`, in plain language. For the technical detail
 behind any entry — API shapes, endpoints, and version semantics — see
-[`SPEC.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SPEC.md).
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SPEC.md).
 
 ## 0.4.0
 

--- a/hub/agents/npm/agent-email/EVALUATION.md
+++ b/hub/agents/npm/agent-email/EVALUATION.md
@@ -3,7 +3,7 @@
 Short version: we measure how reliably the agent sorts email into the right
 priority, using a fixed set of labeled emails and comparing its answer to the
 correct one. The current result is on the
-[**Scorecard**](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md)
+[**Scorecard**](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md)
 tab. This page explains what that number means and how it's measured — in plain
 terms first, with the technical recipe at the end.
 
@@ -57,7 +57,7 @@ changes.
 You need a source checkout of [amd/gaia](https://github.com/amd/gaia) and **AMD
 Ryzen AI hardware** (the npm package ships neither the test corpus nor the eval
 harness). The exact, version-stamped command lives in the
-[Scorecard's *Reproduction* section](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md#reproduction)
+[Scorecard's *Reproduction* section](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md#reproduction)
 — it's auto-generated so it always matches the published number. Run that block;
 it installs the eval tools, starts a local model server, rebuilds the test emails
 from the committed seed, and runs the benchmark (~17 minutes on a 4B model).

--- a/hub/agents/npm/agent-email/EVALUATION.md
+++ b/hub/agents/npm/agent-email/EVALUATION.md
@@ -3,7 +3,7 @@
 Short version: we measure how reliably the agent sorts email into the right
 priority, using a fixed set of labeled emails and comparing its answer to the
 correct one. The current result is on the
-[**Scorecard**](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md)
+[**Scorecard**](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md)
 tab. This page explains what that number means and how it's measured — in plain
 terms first, with the technical recipe at the end.
 
@@ -57,7 +57,7 @@ changes.
 You need a source checkout of [amd/gaia](https://github.com/amd/gaia) and **AMD
 Ryzen AI hardware** (the npm package ships neither the test corpus nor the eval
 harness). The exact, version-stamped command lives in the
-[Scorecard's *Reproduction* section](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md#reproduction)
+[Scorecard's *Reproduction* section](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md#reproduction)
 — it's auto-generated so it always matches the published number. Run that block;
 it installs the eval tools, starts a local model server, rebuilds the test emails
 from the committed seed, and runs the benchmark (~17 minutes on a 4B model).

--- a/hub/agents/npm/agent-email/EVALUATION.md
+++ b/hub/agents/npm/agent-email/EVALUATION.md
@@ -1,177 +1,89 @@
-# Email Triage Agent — Evaluation Guide
+# How the Email Triage agent is evaluated
 
-How the Email Triage agent is evaluated, what the dataset is, and how to
-reproduce the numbers yourself. For the **latest results**, see
-[`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md);
-this document is the background and reproduction recipe behind them.
+Short version: we measure how reliably the agent sorts email into the right
+priority, using a fixed set of labeled emails and comparing its answer to the
+correct one. The current result is on the
+[**Scorecard**](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md)
+tab. This page explains what that number means and how it's measured — in plain
+terms first, with the technical recipe at the end.
 
-## What this measures
+## What we measure
 
-The **Email Triage** agent sorts a Gmail inbox into priority/category buckets —
-`URGENT`, `NEEDS_RESPONSE`, `FYI`, `PROMOTIONAL`, `PERSONAL` — so nothing
-important gets buried. It runs **100% locally** on AMD Ryzen AI: no cloud, no
-mail leaving the device.
+The agent sorts each email into one of five buckets — **urgent**,
+**needs-reply**, **FYI**, **promotional**, or **personal** — so nothing important
+gets buried. The eval checks how often it puts an email in the **right bucket, or
+a close one**.
 
-This scorecard measures triage **quality** on a fixed, labelled corpus. The
-agent triages every email through a **`FakeGmailBackend`** (a synthetic inbox
-loaded from an mbox file — never a live mailbox), and each prediction is compared
-to a human/vendor label. **The triage scoring is deterministic label-matching —
-not LLM-judged** (`predicted == expected`; see
-[`quality_metrics.py`](https://github.com/amd/gaia/blob/main/src/gaia/eval/quality_metrics.py)),
-so these numbers are stable, cheap, and need **no Claude/`ANTHROPIC_API_KEY`**.
+Why "or a close one"? Priority is a ranking (urgent > needs-reply > FYI >
+promotional). Calling a *needs-reply* email *urgent* is a near miss, not a
+disaster — you still see it. Calling it *promotional* is a real miss — it gets
+buried. So the headline score gives full credit for the exact bucket **or** the
+one next to it, and no credit for anything further off. That's what the
+**83.4 / 100** headline means: on most emails, the agent lands on the right
+priority or right next to it.
 
-> The agent *itself* uses a **local** LLM to classify each email; "not
-> LLM-judged" refers to the *scoring*, which is exact label comparison.
+Alongside the headline we also report the stricter "exact bucket" rate, how many
+truly-urgent emails it catches (so a model can't cheat by calling everything
+urgent), and a couple of others. Only the headline counts toward the published
+score; the rest are there for transparency.
 
-The harness is [`gaia eval benchmark`](https://github.com/amd/gaia/blob/main/src/gaia/eval/benchmark.py)
-(`src/gaia/eval/benchmark.py`); it drives the unchanged agent and reuses the
-shared scorecard renderer.
+## What it's tested on
 
-### A second eval that *does* use an LLM judge
+- A **balanced set of ~250 labeled emails** drawn from a real vendor mailbox
+  dataset — not emails we made up to make the agent look good, and balanced across
+  the five buckets so every category (including the rare *personal* one) is
+  measured fairly.
+- **No real personal data** ever enters the test set — that's a deliberate policy.
+- The whole run is **on-device**: the agent uses a local AI model to classify each
+  email, and the scoring is a simple, exact comparison to the known-correct label
+  (no cloud, no second AI "judge", no API key). That keeps the numbers stable and
+  cheap to re-run.
 
-The email agent also ships a separate **voice-drafting quality** eval (#1269):
-a **Claude judge** ([`eval_drafting_report.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/email/packaging/eval_drafting_report.py),
-requires `ANTHROPIC_API_KEY`) scores each generated draft against a rubric. It is
-**report-mode and independent** of this scorecard — the 83.4 triage aggregate
-does not depend on it. If you only want to reproduce the scorecard below, you do
-**not** need the judge; if you want to run the drafting eval too, you do.
+There's also a separate, optional check that rates how well the agent drafts
+replies *in your voice* — that one uses an AI judge and is reported on its own; it
+does not affect the 83.4 triage score.
 
-## The dataset
+## Can you trust the number?
 
-The corpus is **vendor-derived, not GAIA-synthesised**, and fully reproducible
-from a single committed source of truth.
+Yes, and you can re-run it yourself. Every published score is stamped with the
+exact command, model, and dataset that produced it, and the test emails are
+rebuilt deterministically from one committed source file — so the score is
+reproducible, not a one-off. Each release has to clear a minimum bar before it can
+ship, and the score is re-measured whenever the agent's behavior or the dataset
+changes.
 
-| File | Role |
-|------|------|
-| [`vendor_corpus_seed.jsonl`](https://github.com/amd/gaia/blob/main/tests/fixtures/email/vendor_corpus_seed.jsonl) | **Source of truth** (committed) — a deterministic, category-balanced subset of the vendor's labelled mailbox dataset, already in the schema-2.0 taxonomy |
-| `synthetic_inbox.mbox` | **Generated** (gitignored) — the mbox the eval loads via `FakeGmailBackend` |
-| `ground_truth.json` | **Generated** (gitignored) — per-email labels, keyed by the Gmail-derived id `sha256(Message-ID)[:16]` so labels align 1:1 with `FakeGmailBackend` |
-| [`_schema.md`](https://github.com/amd/gaia/blob/main/tests/fixtures/email/_schema.md) | Full corpus schema, provenance chain, PII policy, and category split |
+## Reproducing it yourself
 
-The two generated files are rebuilt from the seed on demand — never a live mailbox:
+You need a source checkout of [amd/gaia](https://github.com/amd/gaia) and **AMD
+Ryzen AI hardware** (the npm package ships neither the test corpus nor the eval
+harness). The exact, version-stamped command lives in the
+[Scorecard's *Reproduction* section](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md#reproduction)
+— it's auto-generated so it always matches the published number. Run that block;
+it installs the eval tools, starts a local model server, rebuilds the test emails
+from the committed seed, and runs the benchmark (~17 minutes on a 4B model).
 
-```sh
-python tests/fixtures/email/generate_mbox.py           # seed -> mbox + ground_truth
-python tests/fixtures/email/generate_mbox.py --verify   # check the two are in sync
-```
+<details>
+<summary>Technical detail (for maintainers)</summary>
 
-**Provenance chain (all reproducible):**
-
-```
-vendor mailbox JSONL  --select_vendor_subset.py-->  vendor_corpus_seed.jsonl
-                      --generate_mbox.py-->          synthetic_inbox.mbox + ground_truth.json
-```
-
-The corpus is category-balanced on purpose so per-category accuracy is meaningful
-and the scarce `PERSONAL` bucket stays measurable. Selection excludes real-person
-corpora (no personal PII enters a committed fixture); see `_schema.md` for the
-exact policy and counts.
-
-## A worked example (one labeled email)
-
-**1. Input — a seed record (source of truth):**
-
-```json
-{
-  "id": "004d89d1-cba8-4045-b94b-b6cab756529b",
-  "sender": "Hugo Petit <hugo.petit@lenovo.com>",
-  "subject": "Ryzen AI Adoption Trends Across ThinkPad Lineup - Data Request",
-  "category": "NEEDS_RESPONSE",
-  "suggestedAction": "reply",
-  "is_phishing": false,
-  "source_dataset": "spamassassin"
-}
-```
-
-`generate_mbox.py` writes this into the mbox and emits the matching
-**ground-truth** entry, keyed by the Gmail-derived id:
-
-```json
-"<gmail-id>": {
-  "category": "NEEDS_RESPONSE",
-  "priority": "normal",
-  "is_spam": false,
-  "is_phishing": false,
-  "suggested_action": "reply",
-  "source_dataset": "spamassassin"
-}
-```
-
-**2. Output — the agent's prediction.** At eval time the agent triages the email
-and returns a structured result (shape from
-[`llm_triage.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/email/gaia_agent_email/tools/llm_triage.py);
-the values below are illustrative for this email):
-
-```json
-{
-  "category": "NEEDS_RESPONSE",
-  "is_spam": false,
-  "confidence": 0.82,
-  "reasoning": "Direct data request from a partner; expects a reply.",
-  "suggested_action": "reply"
-}
-```
-
-**3. Scoring.** The scorer compares the predicted `category` to the ground-truth
-`category` and records one row:
-
-```json
-{ "id": "<gmail-id>", "predicted": "NEEDS_RESPONSE", "expected": "NEEDS_RESPONSE", "category_correct": true }
-```
-
-Because triage priority is **ordinal** (`URGENT > NEEDS_RESPONSE > FYI >
-PROMOTIONAL`), the headline metric credits an exact match **or** an adjacent
-bucket. For this email, predicting `URGENT` or `FYI` still counts toward the
-aggregate, while `PROMOTIONAL` (two buckets away) does not.
-
-## Understanding the metrics
-
-| Metric | In aggregate? | Meaning |
-|--------|:---:|---------|
-| **within_one_bucket_accuracy** | ✅ headline | Share of emails whose predicted priority is exact or one bucket off — what a user feels: nothing urgent buried. The only metric in the aggregate. |
-| **category_accuracy** | reported | Strict exact-match rate on the category label. Always lower than the headline; the harder bar. |
-| **urgent_recall** | reported (anti-gaming floor) | Fraction of truly urgent emails caught. Keeps a model from inflating the headline by calling everything urgent. |
-| **urgent_vs_not_accuracy** | reported | Binary urgent-vs-everything-else accuracy. |
-| **personal_recall** | reported | Recall on the scarce `PERSONAL` bucket. |
-
-Only `within_one_bucket_accuracy` carries weight; the rest are shown with weight
-0, so the published aggregate is recomputable as
-`100 × within_one_bucket_accuracy`. The exact formula and a worked recomputation
-are in [`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md).
-
-## Reproducing the scorecard
-
-The **exact, version-stamped command** that produced the current numbers lives in
-[`SCORECARD.md` → *Reproduction*](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md#reproduction).
-It is auto-generated with that run's model, corpus, and limit, so it always matches
-the published score — this guide deliberately does **not** duplicate it (a hand-copy
-would drift). Run that block from a source checkout of
-[`amd/gaia`](https://github.com/amd/gaia); it installs the eval extras, starts a
-Lemonade Server, and builds the corpus from the committed seed before running the
-benchmark. You need **AMD Ryzen AI hardware** (Strix Halo recommended) — the npm
-package alone ships neither the corpus nor the harness.
-
-A few things worth knowing before you run it:
-
-- **`GAIA_AGENT_TOOL_TIMEOUT=1800`** — full-corpus triage is one long tool call
-  (~17 min on a 4B local model); a lower timeout abandons it mid-run and scores 0
-  emails.
-- **Run evals serially.** Never run two `gaia eval` processes against one Lemonade
-  Server — they race-evict each other's model. Use `--experiments N` for
-  run-to-run variance instead of parallel runs.
-- **Variance:** `--experiments 3` repeats the run and records mean / stdev / 95%
-  CI (surfaced in the scorecard's `acceptance_variance`).
-
-## CI
-
-- **Nightly** (`.github/workflows/test_email_agent_eval.yml`) — runs the triage
-  benchmark over the synthetic corpus on the self-hosted AMD (`stx`) pool, then the
-  judge-scored **voice-drafting** eval (which needs `ANTHROPIC_API_KEY`; absent →
-  loud skip, never a pass), and uploads a gate report. It is **report mode**: the
-  quality / perf / drafting gates log and upload but do not fail the build (the
-  threshold manifests under `tests/fixtures/email/` ship `enforce: false`). Flip
-  `enforce: true` in a manifest — data, not workflow — to start blocking on a
-  breach.
-- **Scorecard refresh** (`.github/workflows/email_scorecard_refresh.yml`) — when
-  the agent's LLM-affecting code or the corpus changes, re-runs the real eval,
-  regenerates `SCORECARD.md`, and runs a same-version regression check.
+- **Harness:** `gaia eval benchmark` (`src/gaia/eval/benchmark.py`) drives the
+  unchanged agent over a `FakeGmailBackend` synthetic inbox; scoring is exact
+  label-matching in `src/gaia/eval/quality_metrics.py` (no LLM judge, no
+  `ANTHROPIC_API_KEY`).
+- **Dataset:** committed source of truth is
+  `tests/fixtures/email/vendor_corpus_seed.jsonl`; `generate_mbox.py` builds the
+  gitignored `synthetic_inbox.mbox` + `ground_truth.json` from it
+  (`--verify` checks they're in sync). Full schema/provenance/PII policy in
+  `tests/fixtures/email/_schema.md`.
+- **Metrics:** the aggregate is `within_one_bucket_accuracy` (weight 1.0);
+  `category_accuracy`, `urgent_recall`, `urgent_vs_not_accuracy`, and
+  `personal_recall` are reported at weight 0. Formula + worked recomputation are in
+  `SCORECARD.md`.
+- **Running it:** set `GAIA_AGENT_TOOL_TIMEOUT=1800` (full-corpus triage is one
+  long tool call); run evals **serially** (two `gaia eval` runs against one
+  Lemonade server race-evict each other's model); use `--experiments 3` for
+  run-to-run variance (mean/stdev/95% CI).
+- **CI:** `test_email_agent_eval.yml` (nightly, report-mode on the self-hosted AMD
+  `stx` pool) and `email_scorecard_refresh.yml` (regenerates `SCORECARD.md` on
+  agent/corpus changes). The drafting eval needs `ANTHROPIC_API_KEY`; absent → loud
+  skip, never a pass.
+</details>

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -11,7 +11,7 @@ by a local AI model (via AMD's Lemonade runtime); message content is never sent 
 a cloud service, and that's enforced when the agent starts up.
 
 > Using an AI coding assistant? This package ships a
-> [`SKILL.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SKILL.md)
+> [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SKILL.md)
 > — load it into Claude Code (or similar) for a copy-paste integration playbook.
 
 ## What it can do
@@ -102,20 +102,20 @@ Three pieces, all on your own machine — no cloud, no separate GAIA install:
   machine's local network only.
 
 Full architecture, the complete API, authentication, and every endpoint are in
-[`SPEC.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SPEC.md).
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SPEC.md).
 
 ## How good is the triage?
 
 Scores **83.4 / 100** on a labeled benchmark inbox — see the **Scorecard** tab (or
-[`SCORECARD.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md))
+[`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md))
 for the full breakdown, and the **Evaluation** tab for how it's measured.
 
 ## Reference
 
-- [`SPEC.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
-- [`SKILL.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SKILL.md) — integration playbook for AI coding assistants.
-- [`SCORECARD.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md) / [`EVALUATION.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/EVALUATION.md) — eval results and how they're measured.
-- [`CHANGELOG.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/CHANGELOG.md) — what's new in each version.
+- [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
+- [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SKILL.md) — integration playbook for AI coding assistants.
+- [`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md) / [`EVALUATION.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/EVALUATION.md) — eval results and how they're measured.
+- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/CHANGELOG.md) — what's new in each version.
 
 ## License
 

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -1,66 +1,46 @@
 # @amd-gaia/agent-email
 
-[![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email) · contract `SCHEMA_VERSION` **2.3** · last updated **2026-07-10**
+[![npm version](https://img.shields.io/npm/v/@amd-gaia/agent-email?label=version)](https://www.npmjs.com/package/@amd-gaia/agent-email)
 
-**Eval scorecard (v0.3.0): aggregate 83.4 / 100** — within-one-bucket **acceptance** accuracy (3-run mean, 95% CI [82.1, 84.7]) over the full 249-email labeled corpus ([`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md)). Triage priority is ordinal, so the bar (#1437) credits exact-or-adjacent buckets — what users feel — not exact 4-way match (reported as a secondary, 0.77). The linked scorecard carries the full recipe, metrics + reported secondaries, run-to-run variance/CI, a per-category breakdown, the run environment, and a worked recomputation; [`EVALUATION.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/EVALUATION.md) is the companion guide — what's measured, the dataset, a worked example, and step-by-step reproduction.
+Sorts your Gmail or Outlook inbox into urgent / needs-reply / FYI, pulls out
+action items, and drafts replies — all running **locally on your machine**, so no
+email content ever leaves it.
 
-Embed the **GAIA email agent** in your JS/TS app. It triages, organizes, replies
-to, and schedules from Gmail and Outlook — with every email body analyzed
-**locally on AMD Ryzen AI** via Lemonade. No message content is sent to a cloud
-LLM; local-only inference is enforced at startup.
+You embed it in a JavaScript or TypeScript app. Every email is analyzed on-device
+by a local AI model (via AMD's Lemonade runtime); message content is never sent to
+a cloud service, and that's enforced when the agent starts up.
 
-This package is the **client**: a typed `EmailClient`, a build-time fetcher that
-downloads and SHA-256-verifies the right native binary for your platform, and
-helpers to spawn, health-check, and shut down the sidecar. It ships **no Python** —
-the agent runs as a frozen, self-contained REST sidecar your app launches and owns.
+> Using an AI coding assistant? This package ships a
+> [`SKILL.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SKILL.md)
+> — load it into Claude Code (or similar) for a copy-paste integration playbook.
 
-> Using an AI coding assistant? This package ships a [`SKILL.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SKILL.md) — load
-> it into Claude Code (or similar) for a focused, copy-paste integration playbook.
+## What it can do
 
-## What the agent does
-
-- **Triage** — classify each message (urgent / needs-response / FYI / promotional /
-  personal), summarize a thread, and extract action items and phishing signals.
-  Extracted action items also persist as a local task list linked back to the
-  source message, de-duplicated on re-triage.
-- **Organize** — archive, label, move, mark read/unread — one message or in batches.
-- **Reply & send** — draft context-aware replies and forwards, then send —
-  attachments included (schema 2.2): triage exposes attachment metadata, and
-  draft/send accept base64 file payloads. In the agent tool loop it can also
-  draft in the user's **own voice** (a local style profile learned from Sent
-  mail, #1607), schedule a confirmed send for a future time, and snooze messages
-  out of the inbox — agent-loop capabilities today, not yet on this package's
-  REST surface.
-- **Track** — flag sent mail still awaiting a reply past a configurable window
-  (follow-up tracking, #1606; detection only — it never auto-sends a nudge) and
-  run a scheduled daily inbox briefing.
-- **Calendar** — detect meeting requests, flag conflicts, RSVP, and create events
+- **Triage** — sort each message into urgent, needs-reply, FYI, promotional, or
+  personal; summarize a thread; and extract the action items and any phishing or
+  spam signals.
+- **Organize** — archive, label, and move messages, one at a time or in batches.
+- **Reply & send** — draft context-aware replies (optionally in your own writing
+  style, learned locally from your Sent mail) and send them — with attachments.
+  Anything that leaves your mailbox asks for confirmation first.
+- **Calendar** — spot meeting requests, flag conflicts, RSVP, and create events
   from an email.
-- **Safe by construction** — email bodies are treated as untrusted **data, never
-  instructions**, and anything that leaves the mailbox (send, delete, RSVP) asks for
-  confirmation.
+- **Track follow-ups** — flag replies you're still waiting on past a window you
+  choose (it points them out; it never nudges anyone for you).
+- **Daily briefing** — generate a morning inbox summary on a schedule, no prompt
+  needed.
 
-Triage and draft analyze the content you pass and need only the local LLM. Reading
-or acting on a live mailbox (send, archive, label, calendar) goes through the
-**Google or Microsoft connector** (OAuth, configured in GAIA).
+## Prerequisites
 
-## How it works
+A local AI model has to be running before triage or drafting works:
 
-![@amd-gaia/agent-email architecture — your Node code spawns and drives a frozen email-agent sidecar (127.0.0.1:8131) over HTTP, which runs triage inference on a local Lemonade Server; a browser/Electron renderer drives the same sidecar over HTTP via the ./client entry.](https://raw.githubusercontent.com/amd/gaia/main/hub/agents/npm/agent-email/assets/architecture.webp)
+1. Install and start it with **`gaia init`** (downloads the default model) and
+   **`lemonade-server serve`**.
+2. On a fresh machine the agent still starts, but triage won't return results
+   until that local model is up. Call `client.init()` to check readiness.
 
-Three tiers, all on the user's machine — no cloud, no separate GAIA install:
-
-- **Your app** (Node) fetches and spawns the sidecar via the `.` entry and owns its
-  lifecycle (`shutdown()` tears it down).
-- **The sidecar** is a frozen `email-agent` binary serving the email REST API — no
-  Python on the host.
-- **Lemonade Server** is the one runtime dependency: the sidecar calls a **local**
-  Lemonade for inference. With none reachable, `triage` returns HTTP 502.
-
-Once it's running, any Node process can drive it over local HTTP. A browser or
-Electron **renderer** reaches it through your app's main process — the sidecar is
-same-origin only (no CORS), so a renderer can't call it cross-origin directly (see
-[Browser / Electron](#browser--electron-renderer)).
+You'll need about 8 GB of RAM for the default model, and one of: Windows x64,
+Linux x64, or macOS Apple Silicon.
 
 ## Install
 
@@ -68,22 +48,22 @@ same-origin only (no CORS), so a renderer can't call it cross-origin directly (s
 npm install @amd-gaia/agent-email
 ```
 
-> **Corporate TLS:** if install fails with `UNABLE_TO_GET_ISSUER_CERT` behind a
-> proxy, use Node's system CA store: `NODE_OPTIONS=--use-system-ca npm install`
-> (Node ≥ 22).
+> **Behind a corporate proxy?** If install fails with `UNABLE_TO_GET_ISSUER_CERT`,
+> reinstall with `NODE_OPTIONS=--use-system-ca npm install` (Node ≥ 22).
 
 ## Quick start
+
+Triage one email — get back a category and a summary:
 
 ```ts
 import { fetchBinary, startSidecar, shutdown } from "@amd-gaia/agent-email";
 
-// Build-time: download + SHA-256-verify the binary for this platform.
+// Once, at build time: download and verify the agent for your platform.
 const { binaryPath } = await fetchBinary({ outDir: "resources" });
 
-// Runtime: spawn -> wait for /health -> version-check.
+// At startup: launch the local agent and hold onto the handle.
 const sidecar = await startSidecar({ binaryPath, port: 8131 });
 
-// Drive it with the typed client.
 const res = await sidecar.client.triage({
   payload: {
     kind: "single",
@@ -96,326 +76,46 @@ const res = await sidecar.client.triage({
     },
   },
 });
+
 console.log(res.result.category, res.result.summary);
+// e.g. "NEEDS_RESPONSE  Sarah asks you to review the report and reply by Friday."
 
-await shutdown(sidecar); // kills the whole process tree
+await shutdown(sidecar);
 ```
 
-### Triage many at once
+Triage classifies and drafts using only the local model — no mailbox connection
+needed. Reading or acting on a live inbox (search, send, archive, calendar) uses
+the **Google or Microsoft connector** you set up in GAIA under
+*Settings → Connectors*.
 
-`triageBatch` sends up to 100 emails or threads in a single request and returns a
-parallel `results` array (one entry per item, order-preserved). It's additive — the
-single `triage()` above is unchanged. Per-item failures are isolated, so an HTTP 200
-can still carry errored items: inspect each `results[].error`, never just the status.
+Want to try it without writing code? Run `npx @amd-gaia/agent-email playground`
+for a local page to test triage, drafting, and a live send.
 
-```ts
-const batch = await sidecar.client.triageBatch({
-  items: [
-    {
-      kind: "single",
-      principal: { email: "me@example.com" },
-      message: { message_id: "m1", from: { email: "sarah@example.com" },
-        subject: "Prod incident", body: "Reply by Friday." },
-    },
-    {
-      kind: "single",
-      principal: { email: "me@example.com" },
-      message: { message_id: "m2", from: { email: "promo@shop.example" },
-        subject: "Sale", body: "Shop now." },
-    },
-  ],
-});
-for (const item of batch.results) {
-  if (item.error) console.warn(`item ${item.index} failed: ${item.error.message}`);
-  else console.log(`item ${item.index}:`, item.result!.category);
-}
-```
+## How it works
 
-### Browser / Electron renderer
+Three pieces, all on your own machine — no cloud, no separate GAIA install:
 
-The `.` entry uses Node built-ins, so it can't be bundled for a browser or an
-Electron renderer. The sidecar also serves **same-origin only — it sends no CORS
-headers** — so a renderer on a different origin (`file://`, a dev server, an
-`app://` scheme) **cannot call `http://127.0.0.1:8131` directly**; the browser
-blocks it. Don't design around a direct renderer→sidecar fetch.
+- **Your app** launches the agent and owns its lifetime.
+- **The agent** is a single self-contained program (~30–45 MB, no Python) that
+  serves a small local API.
+- **The local model** does the actual thinking; the agent talks to it over your
+  machine's local network only.
 
-**Recommended (Electron):** spawn and own the sidecar in your **main** process via
-the `.` entry, and expose `triage`/`draft` to the renderer over your own IPC. The
-renderer never touches the sidecar.
+Full architecture, the complete API, authentication, and every endpoint are in
+[`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md).
 
-The browser-safe `./client` entry (zero Node built-ins, so it bundles for a
-renderer) is for the case where the renderer *does* have a same-origin or
-app-proxied path to the sidecar:
+## How good is the triage?
 
-```ts
-import { EmailClient } from "@amd-gaia/agent-email/client";
-
-// Only from a same-origin page, or behind a proxy you control — not a
-// cross-origin fetch straight at 127.0.0.1:8131. Pass the sidecar's session
-// token (see Authentication) — get it from your main process via IPC; the
-// renderer never spawns the sidecar itself.
-const client = new EmailClient({
-  baseUrl: "http://127.0.0.1:8131",
-  authToken, // from sidecar.authToken in the main process
-});
-const res = await client.triage({ payload: { /* … */ } });
-```
-
-## Authentication
-
-The sidecar binds `127.0.0.1` and can **send mail as the user**, so it
-authenticates its **caller** (#1706). This is separate from the draft→send
-`confirmation_token`, which binds a send to one exact message but does not
-identify who is calling.
-
-- **Per-session bearer token.** `spawnSidecar` / `startSidecar` mint a
-  cryptographically-random token, hand it to the sidecar over the private
-  `GAIA_EMAIL_SIDECAR_TOKEN` env channel, and bind it to `sidecar.client`. Every
-  `/v1/email/*` request must carry `Authorization: Bearer <token>` or the sidecar
-  returns **HTTP 401**. Using `sidecar.client` you get this for free; a client you
-  construct yourself must pass `authToken` (read it from `sidecar.authToken`).
-- **Host / Origin allowlist.** A non-loopback `Host` header → **400**
-  (DNS-rebinding); a non-loopback browser `Origin` → **403** (drive-by web page).
-  No permissive CORS is ever sent.
-
-```ts
-const sidecar = await startSidecar({ binaryPath, port: 8131 });
-sidecar.authToken; // the per-session token, if you need to forward it (e.g. IPC)
-await sidecar.client.draft({ to: [{ email: "a@b.com" }], subject: "Re: x", body: "hi" });
-// A raw client without the token is refused:
-new EmailClient({ baseUrl: sidecar.baseUrl }).send(/* … */); // → HttpError 401
-```
-
-Liveness/version probes (`/health`, `/version`) and the HTML pages
-(`/v1/email/spec`, `/v1/email/playground`) are exempt from the token.
-
-## Prerequisites
-
-The package fetches and spawns the binary, but it does **not** provision the model.
-Before any LLM call succeeds, the host needs:
-
-1. **A running Lemonade Server** — `lemonade-server serve`.
-2. **The model pulled** — via `gaia init` (installs Lemonade and downloads the
-   default model, `Gemma-4-E4B-it-GGUF`).
-
-On a fresh machine the binary boots fine, but the first `triage` returns **HTTP
-502** until Lemonade and the model are in place. `health()` is **liveness-only** — a
-green `/health` means the REST surface is up, not that triage will work.
-
-To check *actual* readiness before your first `triage`, call **`client.init()`**
-(`GET /v1/email/init`, #1795) — it probes Lemonade reachability + version + the
-triage model and returns the `InitResponse` on both the ready (`200`) and
-not-ready (`503`) paths, so branch on `.ready` / read `.hint` instead of catching an
-error. As a client method it attaches the per-session bearer token for you (a raw
-`fetch` would have to add `Authorization: Bearer ${sidecar.authToken}` itself).
-`POST /v1/email/init` can then ask the running Lemonade to pull the model, streaming
-progress. See [`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md) → *Readiness vs liveness*.
-
-## Interface
-
-You drive everything through the typed `EmailClient` — `sidecar.client` after
-`startSidecar`, or constructed directly against a running sidecar (see the renderer
-example above). Every non-2xx response throws `HttpError` (with `status`, `url`,
-`bodyText`) — never a silent null.
-
-| Call | Needs | Does |
-|------|-------|------|
-| `triage(req)` | Local LLM only | Classifies the message you pass, summarizes it, and extracts action items + spam/phishing signals. No mailbox is read. Action items also persist to the sidecar's local task list, linked to the `message_id` and de-duplicated per message — the response shape is unchanged. |
-| `triageBatch(req)` | Local LLM only | Same as `triage`, but for an `items` array (1–100). Returns a parallel `results` array; per-item failures isolate (HTTP 200 can carry errored items — inspect `results[].error`). |
-| `search(req)` | A connected Gmail/Outlook mailbox | Searches the connected inbox (**read-only**) by Gmail-style `query`/`labels` and returns message metadata — id, subject, sender, snippet, labels. No message is read in full or modified; no confirmation token needed. |
-| `prescan(req?)` | A connected Gmail/Outlook mailbox | Reads recent inbox messages and returns the triage-card envelope (urgent / needs-response / suggested-archive rows + an informational count). Read-only — nothing is archived, marked, or sent. |
-| `draft(req)` | Nothing external | Proposes a reply (`to` is a list of `{ email }` objects, not strings) and returns a single-use confirmation token. Optional `attachments` (schema 2.2): `{ filename, mime_type, content_base64 }` each, ≤ 25 MB decoded — the token binds to their content digests. |
-| `send(req)` | A connected Gmail/Outlook mailbox + the token | Actually transmits the mail, attachments included. Must carry the exact attachment set the token was minted for — a swapped file or a smuggled extra is rejected with **403**. |
-| `confirmAction(req)` | Nothing external | Mints a single-use token for a destructive action (`"archive"` / `"quarantine"`), bound to that exact `(action, message_id)`. |
-| `archive(req)` | A connected mailbox + the token | Removes the message from the inbox. Returns a `batch_id` undo handle. |
-| `unarchive(req)` | A connected mailbox | Restores an archived message within the 30s window (ungated — pass the `batch_id`). |
-| `quarantine(req)` | A connected **Gmail** mailbox + the token | Applies the `GAIA_PHISHING_QUARANTINE` label + archives a phishing message. Refuses `is_phishing: false`; Gmail-only (an Outlook mailbox → 400, since label-undo can't reverse a folder move). |
-| `unquarantine(req)` | A connected mailbox | Restores a quarantined message's prior labels within the 30s window (ungated — pass the `action_id`). |
-| `listCalendarEvents(opts?)` | A connected mailbox + calendar scope | Views events on the primary calendar (read-only). Optional `timeMin`/`timeMax` RFC 3339 bounds; `provider` only when >1 account is connected. |
-| `previewCalendarEvent(req)` | Nothing external | Mints a single-use confirmation token bound to a proposed event — the calendar analogue of `draft`. |
-| `createCalendarEvent(req)` | A connected mailbox + calendar scope + the token | Creates the event. Requires the token from `previewCalendarEvent`; a missing/invalid token is rejected with **403** before any backend call. |
-| `respondToCalendarEvent(req)` | A connected mailbox + calendar scope | RSVPs `accepted`/`declined`/`tentative` to an existing invite. |
-
-**`triage`, `draft`, `confirmAction`, and `previewCalendarEvent` are standalone** — you
-can build and verify those flows with zero connector setup. The read-only `search` and
-`prescan` need a connected mailbox (they read the live inbox) but **no** confirmation
-token (`503` with none connected, `400` with two). The mutating calls — `send`,
-`archive`, `quarantine`, and `createCalendarEvent` — are different on two counts: each
-requires a single-use confirmation token (call `draft` for `send`, `confirmAction` for
-`archive`/`quarantine`, or `previewCalendarEvent` for `createCalendarEvent`; a
-missing/invalid token is rejected with **403** before anything else), and each acts on
-the mailbox **connected in GAIA on the host** (under *Settings → Connectors*) — so even
-with a valid token, a headless server returns **HTTP 503** until a mailbox is connected.
-
-### Scheduled daily briefing (#1608)
-
-The sidecar can generate the `prescan` triage card on a daily schedule — no prompt,
-no caller. **Off by default**; opt in with env vars when launching:
-
-```ts
-const sidecar = await startSidecar({
-  binaryPath,
-  env: {
-    GAIA_EMAIL_BRIEFING_ENABLED: "true",
-    GAIA_EMAIL_BRIEFING_TIME: "08:00", // 24h local HH:MM (default 08:00)
-    GAIA_EMAIL_BRIEFING_MAX_MESSAGES: "25", // 1–100 (default 25)
-  },
-});
-```
-
-Each run persists the `email_pre_scan` envelope with a `generated_at` stamp; pull the
-latest one from `GET /v1/email/briefing` (plain `fetch` — no client wrapper yet, so
-attach the per-session bearer token yourself). It
-returns **404** until the first scheduled run has happened, and an invalid env value
-fails sidecar startup loudly rather than guessing a schedule.
-`archive`/`quarantine` are reversible within a 30-second window via
-`unarchive`/`unquarantine` (which are *not* gated — they restore, never destroy); the
-calendar actions additionally need the account's calendar scope (a missing scope fails
-loud with **403** and the reconnect CTA). For a server integration, treat the standalone
-calls as your surface and handle the mailbox/calendar-mutating calls where a connector is
-available.
-
-### Lifecycle
-
-`startSidecar({ binaryPath, port })` runs spawn → health-check → version-check in
-one call and cleans up if any step fails (so a failed start never leaks a process).
-When you need finer control, the steps are exported individually:
-
-| Helper | Purpose |
-|--------|---------|
-| `fetchBinary(opts)` | Download + SHA-256-verify the platform binary (build time). |
-| `spawnSidecar(opts)` | Launch the binary on `127.0.0.1:<port>` (default `8131`). |
-| `waitForHealth(baseUrl)` | Poll `/health` until live; throws on timeout. |
-| `checkVersion(client)` | Throw if the sidecar's contract MAJOR differs from the client's. |
-| `shutdown(sidecar)` | Kill the whole process tree. |
-
-As of `SCHEMA_VERSION` 2.2 this package exposes inbox **search** (read-only),
-the **archive** / phishing-**quarantine** mailbox actions (+ their undo),
-calendar **view / create / respond**, and **attachments** (#1542: triage
-exposes metadata, draft/send accept files). The remaining mailbox **actions**
-(label, move, mark read/unread) are part of the full agent but not yet exposed
-through this package — see
-[`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md) for the complete surface.
-
-### Stateful agent surface (`/v1/email/agent/*`, 0.4.0)
-
-The typed client above is **stateless** — each call analyzes the payload you pass,
-with no memory and no conversation. As of 0.4.0 the sidecar *also* hosts a
-**session-scoped, conversational agent** (`/v1/email/agent/*`) that runs the full
-`EmailTriageAgent` — memory, personalization, and every agent tool — over HTTP,
-streaming each turn back as Server-Sent Events. Create a session, `POST
-/v1/email/agent/query` to run a turn, approve gated tools via `/confirm-tool`, and
-toggle memory at runtime via `/memory`. This is the surface the Agent UI uses; it is
-**not wrapped by the typed client yet** — drive it with `fetch`. See
-[`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md)
-and [`SKILL.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SKILL.md)
-for the endpoint table and a streaming example.
-
-## Running in production
-
-This is a long-lived local resource, not a per-request one. Wire it like this:
-
-- **Fetch at build time, not per request.** `fetchBinary` does network I/O and
-  SHA-256 verification — run it once in your build / postinstall step, ship the
-  verified binary, then `resolveBinaryPath` at runtime.
-- **Spawn once at boot.** Call `startSidecar` during app startup and hold the
-  `Sidecar` handle for the process lifetime. Never spawn per request.
-- **Keep concurrency low.** The sidecar accepts concurrent HTTP requests, but
-  inference runs on a **single local Lemonade model slot** — parallel `triage`
-  calls queue behind one another. Cap inflight calls (a small queue / concurrency
-  limit) rather than fanning out.
-- **Pick a port you own.** `port` is yours to choose; if it's already taken,
-  `startSidecar` fails its health wait (`HealthTimeoutError`) — run with
-  `DEBUG=agent-email` to see the bind error.
-- **Supervise it yourself.** The package does not restart a crashed sidecar. If you
-  need resilience, watch `sidecar.child` for `exit` and re-`startSidecar`.
-- **Cleanup is automatic.** By default the sidecar is reaped when your process
-  goes away — normal exit, `process.exit()`, an uncaught exception, or
-  `SIGINT`/`SIGTERM`/`SIGHUP` (Ctrl+C) — so the frozen binary's detached child
-  never leaks and never keeps holding its port. No signal wiring required. For a
-  graceful, *awaited* shutdown that lets in-flight work finish, call
-  `shutdown(sidecar)` (the automatic reaper is a `SIGKILL` backstop on top of it):
-
-```ts
-const sidecar = await startSidecar({ binaryPath, port: 8131 });
-// … use sidecar.client …
-await shutdown(sidecar); // optional & graceful; auto-cleanup also runs on exit
-```
-
-  To own the lifecycle yourself, pass `autoCleanup: false` and wire the signals.
-  (A hard `SIGKILL` of your process can't be intercepted by anyone, so the safest
-  guarantee is the default in-process reaper.)
-
-```ts
-const sidecar = await startSidecar({ binaryPath, port: 8131, autoCleanup: false });
-const reap = (code = 0) => shutdown(sidecar).finally(() => process.exit(code));
-for (const sig of ["SIGTERM", "SIGINT"]) process.once(sig, () => reap(0));
-```
-
-### Errors & retries
-
-Every non-2xx throws `HttpError` (`status`, `url`, `bodyText`); a network failure or
-timeout surfaces as `HttpError` with `status === 0` (not an HTTP code).
-
-| Failure | Meaning | Retry? |
-|---------|---------|--------|
-| `HttpError` 502 (from `triage`) | Lemonade is down or the model is cold/missing | **Yes** — transient; back off and retry |
-| `HttpError` 0 (network/timeout) | Sidecar not reachable / crashed | **Yes** — after re-spawning the sidecar |
-| `HttpError` 403 (from `send` / `archive` / `quarantine`) | Missing/invalid confirmation token | **No** — call `draft` (for `send`) or `confirmAction` (for `archive`/`quarantine`) first and pass its token |
-| `HttpError` 503 (from `send` / `archive` / `quarantine`) | No mailbox connected on the host | **No** — configuration, not transient |
-| `HttpError` 409 (from `unarchive` / `unquarantine`) | Undo window expired or handle unknown | **No** — past the 30s window; restore manually in the mail client |
-| `HttpError` 400 | Bad request, 2+ mailboxes connected without a provider, or `quarantine` with `is_phishing: false` | **No** — fix the call/config |
-| `HealthTimeoutError` / `VersionMismatchError` / `IntegrityError` | Startup faults (port taken, contract mismatch, bad binary) | **No** — fail fast at boot |
-
-## Playground
-
-One command fetches the binary, starts the sidecar, and opens the playground:
-
-```bash
-npx @amd-gaia/agent-email playground
-```
-
-It serves a zero-setup, **localhost-only** page at
-[http://127.0.0.1:8131/v1/email/playground](http://127.0.0.1:8131/v1/email/playground)
-— a stack-health check, live triage and draft, and a Connectors panel to connect
-Gmail/Outlook and try a live send. It's served same-origin under a strict CSP, so
-the page can only ever reach your local sidecar: triage and draft stay on-device,
-while a `send` transmits to your mail provider by definition. Press Ctrl+C to stop
-(`--port <n>` to bind elsewhere, `--no-open` to skip auto-opening the browser,
-`--out <dir>` to choose where the binary is cached).
-
-## Requirements
-
-- **Platforms:** Windows x64, Linux x64, macOS Apple Silicon (`darwin-arm64`).
-- **Memory:** 8 GB RAM — sized for the default local model (`Gemma-4-E4B-it-GGUF`)
-  running in Lemonade, not the sidecar itself.
-- **Lemonade:** the sidecar calls a local Lemonade endpoint (default
-  `http://localhost:13305`); cloud hosts are rejected at startup.
-- **Footprint:** one self-contained native binary (~30–45 MB depending on
-  platform), no Python runtime. (Model weights are downloaded and managed
-  separately by Lemonade.)
-
-## Troubleshooting
-
-| Symptom | Cause & fix |
-|---------|-------------|
-| `triage()` returns **HTTP 502** | Lemonade isn't running or the model isn't pulled. Start it (`lemonade-server serve`) and provision the model (`gaia init`). Not a bug in this package. |
-| `/health` is green but `triage` fails | `health()` is **liveness-only** — it doesn't check Lemonade or the model. Use `GET /v1/email/init` for real readiness (it probes Lemonade + the model; `503` + `hint` when not ready). |
-| `npm install` fails with `UNABLE_TO_GET_ISSUER_CERT` | Corporate TLS proxy. Reinstall with Node's system CA store: `NODE_OPTIONS=--use-system-ca npm install` (Node ≥ 22). |
-| `require(...)` throws `ERR_REQUIRE_ESM` | The package is ESM-only. Use `import`, or `await import("@amd-gaia/agent-email")` from CommonJS. |
-| Sidecar process lingers after exit | Auto-cleanup reaps it on exit/crash/signal by default; a lingering sidecar means `autoCleanup: false` (call `shutdown(sidecar)` yourself) or a hard `SIGKILL` of the host. |
-| `IntegrityError` / `VersionMismatchError` on start | The downloaded binary failed its SHA-256 check, or its contract MAJOR differs from the client. Clear `resources/` and re-`fetchBinary`, and make sure the package version matches the binary. |
-
-Set `DEBUG=agent-email` for verbose spawn/fetch/health logs (on stderr).
+Scores **83.4 / 100** on a labeled benchmark inbox — see the **Scorecard** tab (or
+[`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md))
+for the full breakdown, and the **Evaluation** tab for how it's measured.
 
 ## Reference
 
-- [`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md) — full API, lifecycle helpers, connectors, module format, and platforms.
-- [`CAPABILITY_MATRIX.md`](https://github.com/amd/gaia/blob/main/hub/agents/python/email/CAPABILITY_MATRIX.md) — code-derived, CI-guarded inventory of every capability surface (internal tools, REST, MCP, eval coverage).
-- [`SKILL.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SKILL.md) — load into Claude Code (or similar) for a step-by-step integration playbook.
-- [`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md) — latest eval results (score, metrics, per-category breakdown, run environment).
-- [`EVALUATION.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/EVALUATION.md) — evaluation guide: what's measured, the dataset, a worked example, and how to reproduce the scorecard.
-- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/CHANGELOG.md) — version history.
+- [`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
+- [`SKILL.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SKILL.md) — integration playbook for AI coding assistants.
+- [`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md) / [`EVALUATION.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/EVALUATION.md) — eval results and how they're measured.
+- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/CHANGELOG.md) — what's new in each version.
 
 ## License
 

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -11,7 +11,7 @@ by a local AI model (via AMD's Lemonade runtime); message content is never sent 
 a cloud service, and that's enforced when the agent starts up.
 
 > Using an AI coding assistant? This package ships a
-> [`SKILL.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SKILL.md)
+> [`SKILL.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SKILL.md)
 > — load it into Claude Code (or similar) for a copy-paste integration playbook.
 
 ## What it can do
@@ -102,20 +102,20 @@ Three pieces, all on your own machine — no cloud, no separate GAIA install:
   machine's local network only.
 
 Full architecture, the complete API, authentication, and every endpoint are in
-[`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md).
+[`SPEC.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SPEC.md).
 
 ## How good is the triage?
 
 Scores **83.4 / 100** on a labeled benchmark inbox — see the **Scorecard** tab (or
-[`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md))
+[`SCORECARD.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md))
 for the full breakdown, and the **Evaluation** tab for how it's measured.
 
 ## Reference
 
-- [`SPEC.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
-- [`SKILL.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SKILL.md) — integration playbook for AI coding assistants.
-- [`SCORECARD.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/SCORECARD.md) / [`EVALUATION.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/EVALUATION.md) — eval results and how they're measured.
-- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/main/hub/agents/npm/agent-email/CHANGELOG.md) — what's new in each version.
+- [`SPEC.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
+- [`SKILL.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SKILL.md) — integration playbook for AI coding assistants.
+- [`SCORECARD.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/SCORECARD.md) / [`EVALUATION.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/EVALUATION.md) — eval results and how they're measured.
+- [`CHANGELOG.md`](https://hub.amd-gaia.ai/agents/email/0.4.0/CHANGELOG.md) — what's new in each version.
 
 ## License
 

--- a/hub/agents/python/email/packaging/stamp_version.py
+++ b/hub/agents/python/email/packaging/stamp_version.py
@@ -139,15 +139,17 @@ def build_rules() -> list[Rule]:
             re.compile(r'(<span[^>]*id="ver"[^>]*>v)([^<]+)(</span>)'),
             'id="ver" badge',
         ),
-        # Versioned hub doc links (https://hub.amd-gaia.ai/agents/email/<v>/<file>)
-        # in the npm markdown docs — they pin cross-references to the R2 copy of
-        # the shipping version instead of the mutable GitHub main blob.
+        # Version-pinned doc links (github.com/amd/gaia/blob/agent-pkg-email-v<v>/…)
+        # in the npm markdown docs — they pin cross-references to the release tag's
+        # rendered copy instead of the mutable GitHub main blob. The tag is created
+        # at release time on the stamped commit, so the links resolve once the
+        # release that ships them is published.
         *(
             Rule(
-                f"npm {name} hub doc links",
+                f"npm {name} pinned doc links",
                 NPM_ROOT / name,
-                re.compile(r"(https://hub\.amd-gaia\.ai/agents/email/)([^\"/\s)]+)(/)"),
-                "hub doc link version",
+                re.compile(r"(/amd/gaia/blob/agent-pkg-email-v)([^\"/\s)]+)(/)"),
+                "pinned doc link version",
             )
             for name in ("README.md", "CHANGELOG.md", "EVALUATION.md")
         ),

--- a/hub/agents/python/email/packaging/stamp_version.py
+++ b/hub/agents/python/email/packaging/stamp_version.py
@@ -139,6 +139,18 @@ def build_rules() -> list[Rule]:
             re.compile(r'(<span[^>]*id="ver"[^>]*>v)([^<]+)(</span>)'),
             'id="ver" badge',
         ),
+        # Versioned hub doc links (https://hub.amd-gaia.ai/agents/email/<v>/<file>)
+        # in the npm markdown docs — they pin cross-references to the R2 copy of
+        # the shipping version instead of the mutable GitHub main blob.
+        *(
+            Rule(
+                f"npm {name} hub doc links",
+                NPM_ROOT / name,
+                re.compile(r"(https://hub\.amd-gaia\.ai/agents/email/)([^\"/\s)]+)(/)"),
+                "hub doc link version",
+            )
+            for name in ("README.md", "CHANGELOG.md", "EVALUATION.md")
+        ),
     ]
 
 

--- a/hub/agents/python/email/tests/test_stamp_version.py
+++ b/hub/agents/python/email/tests/test_stamp_version.py
@@ -73,18 +73,15 @@ def _build_tree(root: Path, version: str, *, include_optional: bool = True) -> N
             f"![play](https://hub.amd-gaia.ai/agents/email/{version}/playground.webp)\n",
             encoding="utf-8",
         )
+        base = f"https://github.com/amd/gaia/blob/agent-pkg-email-v{version}/hub/agents/npm/agent-email"
         (npm / "README.md").write_text(
             f"![arch](https://hub.amd-gaia.ai/agents/email/{version}/architecture.webp)\n"
-            f"[SPEC](https://hub.amd-gaia.ai/agents/email/{version}/SPEC.md)\n",
+            f"[SPEC]({base}/SPEC.md)\n",
             encoding="utf-8",
         )
-        (npm / "CHANGELOG.md").write_text(
-            f"[SPEC](https://hub.amd-gaia.ai/agents/email/{version}/SPEC.md)\n",
-            encoding="utf-8",
-        )
+        (npm / "CHANGELOG.md").write_text(f"[SPEC]({base}/SPEC.md)\n", encoding="utf-8")
         (npm / "EVALUATION.md").write_text(
-            f"[Scorecard](https://hub.amd-gaia.ai/agents/email/{version}/SCORECARD.md#reproduction)\n",
-            encoding="utf-8",
+            f"[Scorecard]({base}/SCORECARD.md#reproduction)\n", encoding="utf-8"
         )
         (npm / "assets").mkdir()
         (npm / "assets" / "architecture.html").write_text(
@@ -155,13 +152,13 @@ def test_check_passes_on_consistent_tree(tree):
         ),
         (
             "hub/agents/npm/agent-email/README.md",
-            "/agents/email/1.2.3/SPEC.md",
-            "/agents/email/9.9.9/SPEC.md",
+            "blob/agent-pkg-email-v1.2.3/",
+            "blob/agent-pkg-email-v9.9.9/",
         ),
         (
             "hub/agents/npm/agent-email/EVALUATION.md",
-            "/agents/email/1.2.3/SCORECARD.md",
-            "/agents/email/9.9.9/SCORECARD.md",
+            "blob/agent-pkg-email-v1.2.3/",
+            "blob/agent-pkg-email-v9.9.9/",
         ),
     ],
 )

--- a/hub/agents/python/email/tests/test_stamp_version.py
+++ b/hub/agents/python/email/tests/test_stamp_version.py
@@ -74,7 +74,16 @@ def _build_tree(root: Path, version: str, *, include_optional: bool = True) -> N
             encoding="utf-8",
         )
         (npm / "README.md").write_text(
-            f"![arch](https://hub.amd-gaia.ai/agents/email/{version}/architecture.webp)\n",
+            f"![arch](https://hub.amd-gaia.ai/agents/email/{version}/architecture.webp)\n"
+            f"[SPEC](https://hub.amd-gaia.ai/agents/email/{version}/SPEC.md)\n",
+            encoding="utf-8",
+        )
+        (npm / "CHANGELOG.md").write_text(
+            f"[SPEC](https://hub.amd-gaia.ai/agents/email/{version}/SPEC.md)\n",
+            encoding="utf-8",
+        )
+        (npm / "EVALUATION.md").write_text(
+            f"[Scorecard](https://hub.amd-gaia.ai/agents/email/{version}/SCORECARD.md#reproduction)\n",
             encoding="utf-8",
         )
         (npm / "assets").mkdir()
@@ -143,6 +152,16 @@ def test_check_passes_on_consistent_tree(tree):
             "hub/agents/npm/agent-email/assets/architecture.html",
             'id="ver">v1.2.3',
             'id="ver">v9.9.9',
+        ),
+        (
+            "hub/agents/npm/agent-email/README.md",
+            "/agents/email/1.2.3/SPEC.md",
+            "/agents/email/9.9.9/SPEC.md",
+        ),
+        (
+            "hub/agents/npm/agent-email/EVALUATION.md",
+            "/agents/email/1.2.3/SCORECARD.md",
+            "/agents/email/9.9.9/SCORECARD.md",
         ),
     ],
 )


### PR DESCRIPTION
The email agent's hub page (amd-gaia.ai/hub/email) read like internal engineering docs — **~15,000 words** across the tabs, written for a maintainer/machine rather than someone deciding whether to use it. The README opened with confidence intervals and issue numbers; the CHANGELOG was a wall of `SCHEMA_VERSION`/type-migration prose; every entry leaked internal symbols and HTTP codes.

This rewrites the three **user-facing** docs to lead with what the agent does, in plain language, and pushes the machine detail into SPEC (where developers look for it). Nothing accurate is lost — SPEC already carries the contract/type/auth/endpoint/eval-internals detail.

| Doc | Before → After | Change |
|---|---|---|
| **README** | 3,592 → ~690 words | Leads with "sorts your inbox into urgent/needs-reply/FYI and drafts replies, all local"; tiny quick-start; plain capability list; detail → SPEC |
| **CHANGELOG** | 2,953 → ~825 words | User-facing "what's new" per version — no `SCHEMA_VERSION`, symbols, issue #s, or status codes in the entries |
| **EVALUATION** | dense recipe → plain guide | Explains what the 83.4 score *means* and the dataset in plain terms; reproduction/harness detail collapsed into a maintainer `<details>` |

**Doc cross-links are now version-pinned.** The SPEC/SKILL/SCORECARD/EVALUATION/CHANGELOG links used to point at the mutable GitHub `main` blob — a 0.4.0 user would read docs for whatever is in development. They now point at the release tag (`blob/agent-pkg-email-v0.4.0/…`) — rendered on GitHub *and* immutable — and `stamp_version.py` gains a rule per markdown doc so the version segment is stamped from `AGENT_VERSION` at release and gated by the existing `--check`, so the links can never go stale.

**Left intentionally technical:** `SPEC.md` (the reference — correct home for the moved detail) and `SKILL.md` (the AI-assistant integration playbook). `SCORECARD.md` is generated (untouched).

**Before/after (worst offender):**
- Before: *"Contract bumped to `SCHEMA_VERSION` 2.3. `checkVersion` is MAJOR-only, so the 2.x MAJOR is unchanged and existing clients keep connecting."*
- After: *"Reply drafts come back as a ready-to-fill scaffold (recipient + subject) instead of an always-empty body — compose the reply text yourself and send it."*

Every claim was checked against the code (categories, client API, capability list, install name). Now merged with latest `main`: the `/v1/email/query` agent loop (#2061) is absorbed in plain language — a "plain-language requests" capability bullet in the README and a lead CHANGELOG entry (streams progress, cancellable, send still routes to draft-and-confirm) — with the SSE vocabulary/`run_id`/contract detail staying in SPEC/SKILL where #2061 put it. Renders live once the agent republishes (or via the catalog reindex).

## Test plan
- [x] Word counts cut ~75% on README, ~72% on CHANGELOG
- [x] Claims verified against `src/*.ts` + `api_routes.py`/`contract.py`
- [x] All 10 pinned links return 200 (`curl github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/.../{SPEC,SKILL,SCORECARD,EVALUATION,CHANGELOG}.md`)
- [x] `pytest hub/agents/python/email/tests/test_stamp_version.py` (12 pass) + `stamp_version.py --check` green on the tree
- [ ] Reviewer: confirm no user-facing capability was dropped


