### PR TITLE
chore(agent-email): cut 0.5.0

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 What's new in `@amd-gaia/agent-email`, in plain language. For the technical detail
 behind any entry — API shapes, endpoints, and version semantics — see
-[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SPEC.md).
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SPEC.md).
 
-## 0.4.0
+## 0.5.0
 
 - **Ask the agent in plain language.** Send a free-form request ("find today's
   urgent mail and archive the promotions") to a new streaming endpoint and the
@@ -12,6 +12,12 @@ behind any entry — API shapes, endpoints, and version semantics — see
   goes; a run can be cancelled mid-way. Anything that would actually send mail
   still stops and routes you to the explicit draft-and-confirm flow. Not yet
   wrapped by the typed client — call the endpoint directly (see `SPEC.md`).
+- **Docs rewritten for humans.** The README, this changelog, and the evaluation
+  guide now lead with what the agent does in plain language; the deep technical
+  reference lives in `SPEC.md`.
+
+## 0.4.0
+
 - **Reply drafts come back as a ready-to-fill scaffold** (recipient + subject)
   instead of an always-empty body. Triage sorts and summarizes but doesn't write
   the reply text — so compose the body yourself and send it with `draft()` +

--- a/hub/agents/npm/agent-email/EVALUATION.md
+++ b/hub/agents/npm/agent-email/EVALUATION.md
@@ -3,7 +3,7 @@
 Short version: we measure how reliably the agent sorts email into the right
 priority, using a fixed set of labeled emails and comparing its answer to the
 correct one. The current result is on the
-[**Scorecard**](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md)
+[**Scorecard**](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SCORECARD.md)
 tab. This page explains what that number means and how it's measured — in plain
 terms first, with the technical recipe at the end.
 
@@ -57,7 +57,7 @@ changes.
 You need a source checkout of [amd/gaia](https://github.com/amd/gaia) and **AMD
 Ryzen AI hardware** (the npm package ships neither the test corpus nor the eval
 harness). The exact, version-stamped command lives in the
-[Scorecard's *Reproduction* section](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md#reproduction)
+[Scorecard's *Reproduction* section](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SCORECARD.md#reproduction)
 — it's auto-generated so it always matches the published number. Run that block;
 it installs the eval tools, starts a local model server, rebuilds the test emails
 from the committed seed, and runs the benchmark (~17 minutes on a 4B model).

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -11,7 +11,7 @@ by a local AI model (via AMD's Lemonade runtime); message content is never sent 
 a cloud service, and that's enforced when the agent starts up.
 
 > Using an AI coding assistant? This package ships a
-> [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SKILL.md)
+> [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SKILL.md)
 > — load it into Claude Code (or similar) for a copy-paste integration playbook.
 
 ## What it can do
@@ -105,20 +105,20 @@ Three pieces, all on your own machine — no cloud, no separate GAIA install:
   machine's local network only.
 
 Full architecture, the complete API, authentication, and every endpoint are in
-[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SPEC.md).
+[`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SPEC.md).
 
 ## How good is the triage?
 
 Scores **83.4 / 100** on a labeled benchmark inbox — see the **Scorecard** tab (or
-[`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md))
+[`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SCORECARD.md))
 for the full breakdown, and the **Evaluation** tab for how it's measured.
 
 ## Reference
 
-- [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
-- [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SKILL.md) — integration playbook for AI coding assistants.
-- [`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/SCORECARD.md) / [`EVALUATION.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/EVALUATION.md) — eval results and how they're measured.
-- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.4.0/hub/agents/npm/agent-email/CHANGELOG.md) — what's new in each version.
+- [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SPEC.md) — full API, authentication, lifecycle, connectors, and platforms.
+- [`SKILL.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SKILL.md) — integration playbook for AI coding assistants.
+- [`SCORECARD.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SCORECARD.md) / [`EVALUATION.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/EVALUATION.md) — eval results and how they're measured.
+- [`CHANGELOG.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/CHANGELOG.md) — what's new in each version.
 
 ## License
 

--- a/hub/agents/npm/agent-email/assets/architecture.html
+++ b/hub/agents/npm/agent-email/assets/architecture.html
@@ -83,7 +83,7 @@
   <div class="card" id="card">
     <div class="head">
       <span class="pkg">@amd-gaia/agent-email</span>
-      <span class="ver" id="ver">v0.4.0</span>
+      <span class="ver" id="ver">v0.5.0</span>
       <span class="tag">architecture</span>
     </div>
     <div class="install"><span class="p mono">$</span><code>npm i @amd-gaia/agent-email</code></div>

--- a/hub/agents/npm/agent-email/binaries.lock.json
+++ b/hub/agents/npm/agent-email/binaries.lock.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
-  "agentVersion": "0.4.0",
-  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.4.0",
+  "agentVersion": "0.5.0",
+  "baseUrl": "https://hub.amd-gaia.ai/agents/email/0.5.0",
   "binaries": {
     "win32-x64": {
       "filename": "email-agent-win32-x64.exe",

--- a/hub/agents/npm/agent-email/package.json
+++ b/hub/agents/npm/agent-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Thin JS/TS client + build-time binary fetcher + sidecar lifecycle helpers for the GAIA email agent (frozen, no-Python REST sidecar). Runs 100% locally on AMD Ryzen AI.",
   "author": "AMD AI Group",

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -1,6 +1,6 @@
 id: email
 name: Email Triage
-version: 0.4.0
+version: 0.5.0
 description: "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 author: AMD
 license: MIT

--- a/hub/agents/python/email/gaia_agent_email/version.py
+++ b/hub/agents/python/email/gaia_agent_email/version.py
@@ -28,7 +28,7 @@ from gaia_agent_email.contract import SCHEMA_VERSION
 # Package build version. Keep in sync with ``pyproject.toml``'s ``version`` —
 # ``test_rest_contract.test_agent_version_matches_package_metadata`` asserts the
 # installed distribution metadata agrees with this literal so the two never drift.
-AGENT_VERSION = "0.4.0"
+AGENT_VERSION = "0.5.0"
 
 # REST/contract version exposed to hosts. Aliased to the frozen contract's
 # SCHEMA_VERSION so a contract bump is an API bump — no second number to forget.

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaia-agent-email"
-version = "0.4.0"
+version = "0.5.0"
 description = "GAIA email triage agent — read, triage, organize, and reply to Gmail/Outlook locally"
 authors = [{ name = "AMD" }]
 license = { text = "MIT" }


### PR DESCRIPTION
npm 0.4.0 shipped ~6 hours before #2061 merged, so the published package doesn't contain the `/v1/email/query` streaming agent loop its changelog claims. 0.5.0 is the release that actually ships it (contract 2.3→2.4, a feature ⇒ minor bump), together with the human-first docs rewrite (#2071) — which also fixes the hub page, since the catalog snapshots docs at publish time.

- CHANGELOG: the `/query` bullet moves from 0.4.0 → a new 0.5.0 section (matching what each npm version really contains) + a docs-rewrite line.
- All other changes are mechanical: `stamp_version.py` propagated 0.4.0→0.5.0 to package.json, binaries.lock, the architecture badge, and the version-pinned doc links (`--check` green).

## Test plan
- [x] `pytest hub/agents/python/email/tests/test_stamp_version.py` (12 pass); `stamp_version.py --check` green
- [x] `npm ci && npm run build && npm test` (69 pass); `npm pack --dry-run` ships README/CHANGELOG/EVALUATION at 0.5.0
- [ ] After merge: tag `agent-pkg-email-v0.5.0` from main → release workflow (freeze → publish gate → npm OIDC → website deploy)