### PR TITLE
feat(email): real tokens-per-triage accounting + scorecard metric (#1891)

### DIFF
--- a/docs/reference/eval-scorecard.mdx
+++ b/docs/reference/eval-scorecard.mdx
@@ -140,7 +140,7 @@ These blocks are **optional and additive** — a scorecard is valid with or with
 | Row | Definition |
 |-----|------------|
 | `total_input_tokens` / `total_output_tokens` | Run totals: outer agent-loop turns **plus** the triage tool's per-email classify calls. |
-| `llm_classified_count` | How many emails were classified by the LLM (the rest took the heuristic fast path). |
+| `llm_classified_count` | Classify calls whose usage was measurable — on the shipped Lemonade path this equals the number of emails classified by the LLM (the rest took the heuristic fast path). |
 | `tokens_per_triage` | **Pinned definition:** triage classify-call tokens ÷ `llm_classified_count` — classify tokens over *LLM-classified emails only*, so the figure is invariant to the heuristic/LLM mix and to outer-turn measurement races. Comparisons across releases are only meaningful with the corpus held fixed. |
 
 <Note>

--- a/docs/reference/eval-scorecard.mdx
+++ b/docs/reference/eval-scorecard.mdx
@@ -127,12 +127,25 @@ A scorecard missing any of these is **invalid** and will be rejected by the rele
 
 ### Optional fields
 
-Two blocks are **optional and additive** — a scorecard is valid with or without them, and neither ever affects `aggregate.value`. They add reviewer-facing detail about *how* the number was produced and *where* the misses are:
+These blocks are **optional and additive** — a scorecard is valid with or without them, and none of them ever affects `aggregate.value`. They add reviewer-facing detail about *how* the number was produced and *where* the misses are:
 
 | Field | Description |
 |-------|-------------|
 | `recipe.environment` | What produced the numbers: `gaia_commit`, `lemonade_version`, `model`, `hardware` (a class descriptor — never a hostname), and an optional `temperature`. |
 | `results.breakdown` | Where the score comes from: `per_category` (per-label `total` / `correct` / `accuracy`) and `top_confusions` (the most frequent `expected → predicted` mistakes). |
+| `results.performance` | Observed perf figures, mean across the run's scenarios: `ttft_s`, `throughput_tps`, `pipeline_s`, `peak_memory_gb`, `emails_per_run`, and the token-accounting rows below. Rendered as the `## Performance` table. Every row here is **reported, never gated**. |
+
+**Token accounting rows** (`results.performance`, issue #1891) — real LLM token counts including the nested per-email classify calls the outer-turn stats used to miss:
+
+| Row | Definition |
+|-----|------------|
+| `total_input_tokens` / `total_output_tokens` | Run totals: outer agent-loop turns **plus** the triage tool's per-email classify calls. |
+| `llm_classified_count` | How many emails were classified by the LLM (the rest took the heuristic fast path). |
+| `tokens_per_triage` | **Pinned definition:** triage classify-call tokens ÷ `llm_classified_count` — classify tokens over *LLM-classified emails only*, so the figure is invariant to the heuristic/LLM mix and to outer-turn measurement races. Comparisons across releases are only meaningful with the corpus held fixed. |
+
+<Note>
+  `tokens_per_triage` is **reported, not gated**: do not add a release-gate bar for it without a committed, ctx-stamped baseline scorecard to compare against (see `_tokens_per_triage_comment` in `tests/fixtures/email/quality_gate_thresholds.json`).
+</Note>
 
 ```yaml
 recipe:

--- a/hub/agents/python/email/CONTRACT.md
+++ b/hub/agents/python/email/CONTRACT.md
@@ -553,7 +553,17 @@ ships to, and numbers measured there do not transfer.
 `usage` block reports `prompt_tokens` / `completion_tokens` /
 `total_tokens` for the LLM calls behind the result — compare
 `prompt_tokens` against the envelope to see how much of the window a
-payload consumed. `GET /v1/email/init` additionally reports the *currently
+payload consumed. The agent-loop bulk triage (the `triage_inbox` tool
+behind natural-language requests like "triage my inbox", including
+`POST /v1/email/query`) reports the same accounting at the result level
+([#1891](https://github.com/amd/gaia/issues/1891)): the tool's result
+data carries a `usage` object (same four fields as `TriageUsage`,
+aggregated across every LLM classify call in the run, all mailboxes)
+plus `llm_classified_count` — the number of emails that were classified
+by the LLM rather than the heuristic fast path. Both keys are **absent**
+(never zeroed) on a heuristic-only run where no LLM call was made; a
+present-but-zero `usage` means classify calls happened but their
+per-call measurements were unavailable. `GET /v1/email/init` additionally reports the *currently
 loaded* `ctx_size` on `model` when the triage model is loaded and the
 server exposes it — null otherwise (no config echo, no guessing).
 `ctx_size` reflects `/health`'s loaded state specifically, so it can be set

--- a/hub/agents/python/email/CONTRACT.md
+++ b/hub/agents/python/email/CONTRACT.md
@@ -559,8 +559,10 @@ behind natural-language requests like "triage my inbox", including
 ([#1891](https://github.com/amd/gaia/issues/1891)): the tool's result
 data carries a `usage` object (same four fields as `TriageUsage`,
 aggregated across every LLM classify call in the run, all mailboxes)
-plus `llm_classified_count` — the number of emails that were classified
-by the LLM rather than the heuristic fast path. Both keys are **absent**
+plus `llm_classified_count` — the number of classify calls whose usage
+was measurable (on the shipped Lemonade path this equals the number of
+emails classified by the LLM rather than the heuristic fast path; a
+provider exposing no per-call usage/stats undercounts). Both keys are **absent**
 (never zeroed) on a heuristic-only run where no LLM call was made; a
 present-but-zero `usage` means classify calls happened but their
 per-call measurements were unavailable. `GET /v1/email/init` additionally reports the *currently

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -752,12 +752,23 @@ class EmailTriageAgent(
             triage_inbox_impl,
         )
         from gaia_agent_email.tools.triage_heuristics import group_by_category
+        from gaia_agent_email.tools.usage import aggregate_usage_stats
 
         # Reference the factory via the read_tools module so the existing
         # ``read_tools.make_llm_classifier`` test seam (the pre-scan canary)
         # keeps intercepting the expensive triage path.
+        #
+        # One shared list across ALL backends (#1891) — the classifier is
+        # built ONCE here and reused across the per-backend loop below, so
+        # every classify call across every mailbox lands in the same list
+        # for a single post-loop aggregation.
         chat = getattr(self, "chat", None)
-        classifier = read_tools.make_llm_classifier(chat) if chat is not None else None
+        call_stats: list[dict] = []
+        classifier = (
+            read_tools.make_llm_classifier(chat, collect_stats=call_stats)
+            if chat is not None
+            else None
+        )
         prefs = getattr(self, "_session_preferences", None)
         force_llm = bool(getattr(self.config, "force_llm", False))
         debug_flag = bool(getattr(self.config, "debug", False))
@@ -815,6 +826,17 @@ class EmailTriageAgent(
         result: dict = {"results": merged, "grouped": group_by_category(merged)}
         if mailbox_errors:
             result["mailbox_errors"] = mailbox_errors
+        # #1891: fix the bulk-triage token undercount — nested classify calls
+        # previously discarded their stats entirely (no collect_stats threaded
+        # through). usage is a PLAIN DICT (never a pydantic object) since this
+        # result is serialized via ``json.dumps(..., default=str)``, which
+        # would silently stringify a pydantic model instead of erroring.
+        # Absent (never zeroed) on the heuristic-only path — no LLM call means
+        # no usage to report.
+        usage = aggregate_usage_stats(call_stats)
+        if usage is not None:
+            result["usage"] = usage
+            result["llm_classified_count"] = len(call_stats)
         return result
 
     def _apply_behavioral_promotions(self) -> None:

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -107,6 +107,7 @@ from gaia_agent_email.tools.triage_heuristics import (
     classify_category_heuristic,
     default_action_for,
 )
+from gaia_agent_email.tools.usage import aggregate_usage_stats
 from gaia_agent_email.version import AGENT_VERSION, API_VERSION
 from pydantic import BaseModel, ConfigDict, Field
 from starlette.concurrency import iterate_in_threadpool
@@ -447,39 +448,19 @@ def _split_sentences(text: str) -> List[str]:
 
 
 def _aggregate_usage(call_stats: List[dict]) -> Optional[TriageUsage]:
-    """Sum the per-call ``AgentResponse.stats`` (#1277/#1278) across the
-    classify + summarize LLM calls into a single :class:`TriageUsage`.
+    """Sum the per-call usage/stats entries across the classify + summarize
+    LLM calls into a single :class:`TriageUsage`.
 
-    prompt_tokens = Σ input_tokens; total_tokens = Σ(input + output);
-    tokens_per_second = Σ output / Σ decode_time, where each call's decode time
-    is output_tokens / tokens_per_second (so the aggregate is total output
-    tokens over total decode time, not a naive TPS average). Returns ``None``
-    when no LLM call produced stats (the heuristic-only path).
+    Thin wrapper around :func:`gaia_agent_email.tools.usage.aggregate_usage_stats`
+    (#1891) — the pure aggregation logic is shared with the tool-call triage
+    path (``EmailTriageAgent._triage_all_backends``) so both surfaces report
+    the same numbers from the same math. Returns ``None`` when no LLM call
+    produced usage/stats (the heuristic-only path).
     """
-    if not call_stats:
+    agg = aggregate_usage_stats(call_stats)
+    if agg is None:
         return None
-    total_input = 0
-    total_output = 0
-    decode_output = 0  # output only from calls with a usable TPS (>0)
-    total_decode_time = 0.0
-    for s in call_stats:
-        inp = int(s.get("input_tokens") or 0)
-        out = int(s.get("output_tokens") or 0)
-        tps = float(s.get("tokens_per_second") or 0.0)
-        total_input += inp
-        total_output += out
-        if out and tps > 0:
-            decode_output += out
-            total_decode_time += out / tps
-    # Numerator excludes output from tps==0 calls so they can't inflate the
-    # aggregate (they add nothing to the decode-time denominator).
-    agg_tps = decode_output / total_decode_time if total_decode_time > 0 else 0.0
-    return TriageUsage(
-        prompt_tokens=total_input,
-        completion_tokens=total_output,
-        total_tokens=total_input + total_output,
-        tokens_per_second=agg_tps,
-    )
+    return TriageUsage(**agg)
 
 
 class EmailTriageService:

--- a/hub/agents/python/email/gaia_agent_email/tools/llm_triage.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/llm_triage.py
@@ -255,9 +255,13 @@ def classify_email_llm(
     ``send_messages(messages, system_prompt=...) -> response`` with a ``.text``
     attribute).
 
-    When ``collect_stats`` is a list, the response's ``.stats`` dict (the reused
-    ``AgentResponse.stats`` measurement, #1277/#1278) is appended to it so a
-    caller can aggregate usage across calls — no new measurement path.
+    When ``collect_stats`` is a list, one usage/stats entry is appended to it
+    so a caller can aggregate usage across calls (``aggregate_usage_stats``,
+    #1891). The response's ``.usage`` dict (the Lemonade chat-completion
+    response's ``usage`` field, surfaced as an additive ``AgentResponse``
+    field — exact per-call token counts, no extra HTTP round-trip) is
+    preferred when present; falls back to the polled ``.stats`` dict
+    (#1277/#1278) for providers that don't expose ``.usage``.
 
     ``context`` is an optional ``TriageContext`` (#1541): when supplied, a short
     context block is prepended to the user prompt so the model factors in the
@@ -281,9 +285,13 @@ def classify_email_llm(
         ) from exc
 
     if collect_stats is not None:
-        stats = getattr(response, "stats", None)
-        if stats:
-            collect_stats.append(stats)
+        usage = getattr(response, "usage", None)
+        if isinstance(usage, dict) and usage:
+            collect_stats.append(usage)
+        else:
+            stats = getattr(response, "stats", None)
+            if isinstance(stats, dict) and stats:
+                collect_stats.append(stats)
 
     text = getattr(response, "text", None)
     if text is None:
@@ -298,12 +306,19 @@ def classify_email_llm(
     return result
 
 
-def make_llm_classifier(chat: Any) -> Callable[..., Mapping[str, Any]]:
+def make_llm_classifier(
+    chat: Any, collect_stats: Optional[List[dict]] = None
+) -> Callable[..., Mapping[str, Any]]:
     """Build a classifier callable bound to ``chat`` for ``triage_inbox_impl``.
 
     The returned callable has signature
     ``(*, subject, sender, body, message_id="") -> Mapping`` and raises
-    ``LLMTriageError`` on failure.
+    ``LLMTriageError`` on failure — unchanged by ``collect_stats``.
+
+    ``collect_stats`` (#1891), when provided, is threaded through to every
+    ``classify_email_llm`` call this classifier makes, so a caller can build
+    it ONCE, reuse the classifier across a whole triage run, and aggregate
+    the accumulated list afterwards via ``aggregate_usage_stats``.
     """
 
     def _classifier(
@@ -315,6 +330,7 @@ def make_llm_classifier(chat: Any) -> Callable[..., Mapping[str, Any]]:
             sender=sender,
             body=body,
             message_id=message_id,
+            collect_stats=collect_stats,
         )
 
     return _classifier

--- a/hub/agents/python/email/gaia_agent_email/tools/usage.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/usage.py
@@ -1,0 +1,72 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Pure LLM usage aggregation for triage (#1891).
+
+Lifted out of ``api_routes._aggregate_usage`` so both the REST triage path
+(``EmailTriageService``) and the tool-call triage path
+(``EmailTriageAgent._triage_all_backends``) share ONE aggregation
+implementation instead of two copies drifting apart.
+
+Per-call entries can arrive in either shape a chat backend may produce:
+
+- the Lemonade chat-completion response's ``usage`` shape (preferred,
+  #1891): ``prompt_tokens`` / ``completion_tokens`` / ``total_tokens`` /
+  ``tokens_per_second``
+- the legacy ``/stats``-polled shape (#1277/#1278): ``input_tokens`` /
+  ``output_tokens`` / ``tokens_per_second``
+
+``aggregate_usage_stats`` normalizes both into ONE output shape, in one
+place, so callers never need to know which mechanism produced a given entry.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def aggregate_usage_stats(call_stats: List[Any]) -> Optional[Dict[str, Any]]:
+    """Sum per-call usage/stats entries into one aggregate dict.
+
+    ``prompt_tokens`` = Σ input tokens; ``total_tokens`` = Σ(input + output);
+    ``tokens_per_second`` = Σ output / Σ decode_time, where each call's decode
+    time is output_tokens / tokens_per_second (so the aggregate is total
+    output tokens over total decode time, not a naive TPS average). Calls
+    with no usable TPS (missing or <= 0) don't contribute to the decode-time
+    denominator, so they can't inflate the aggregate.
+
+    Entries that aren't a dict (e.g. a stray ``MagicMock()`` from an
+    under-configured test double, or ``None``) are skipped rather than
+    raising — malformed per-call data must never crash aggregation.
+
+    Returns ``None`` only when ``call_stats`` itself is empty (no LLM call
+    was made — the heuristic-only path). A non-empty list containing only
+    malformed/unusable entries still returns the all-zero aggregate dict,
+    never ``None`` — ``None`` specifically means "no LLM call happened",
+    not "the LLM call's stats were unusable".
+    """
+    if not call_stats:
+        return None
+    total_input = 0
+    total_output = 0
+    decode_output = 0  # output only from calls with a usable TPS (>0)
+    total_decode_time = 0.0
+    for s in call_stats:
+        if not isinstance(s, dict):
+            continue
+        inp = int(s.get("input_tokens") or s.get("prompt_tokens") or 0)
+        out = int(s.get("output_tokens") or s.get("completion_tokens") or 0)
+        tps = float(s.get("tokens_per_second") or 0.0)
+        total_input += inp
+        total_output += out
+        if out and tps > 0:
+            decode_output += out
+            total_decode_time += out / tps
+    # Numerator excludes output from tps==0 calls so they can't inflate the
+    # aggregate (they add nothing to the decode-time denominator).
+    agg_tps = decode_output / total_decode_time if total_decode_time > 0 else 0.0
+    return {
+        "prompt_tokens": total_input,
+        "completion_tokens": total_output,
+        "total_tokens": total_input + total_output,
+        "tokens_per_second": agg_tps,
+    }

--- a/hub/agents/python/email/packaging/gen_scorecard.py
+++ b/hub/agents/python/email/packaging/gen_scorecard.py
@@ -197,6 +197,16 @@ def _compute_performance(judged: list) -> Optional[dict]:
         "throughput_tps": _mean("avg_tokens_per_second"),
         "pipeline_s": _mean("pipeline_latency_s"),
         "peak_memory_gb": _mean("peak_memory_gb"),
+        # Token accounting (#1891). REPORTED only — do NOT gate
+        # tokens_per_triage without a committed baseline (#1894 trust model);
+        # see _tokens_per_triage_comment in quality_gate_thresholds.json.
+        # tokens_per_triage = triage classify-call tokens / LLM-classified
+        # emails ONLY (pinned in gaia.eval.benchmark.build_result), so
+        # cross-release comparisons must hold the corpus fixed.
+        "total_input_tokens": _mean("total_input_tokens"),
+        "total_output_tokens": _mean("total_output_tokens"),
+        "tokens_per_triage": _mean("tokens_per_triage"),
+        "llm_classified_count": _mean("llm_classified_count"),
     }
     emails = [
         int(ps["total_emails"])

--- a/hub/agents/python/email/tests/test_email_agent.py
+++ b/hub/agents/python/email/tests/test_email_agent.py
@@ -128,6 +128,65 @@ def test_triage_service_uses_llm():
     assert response.result.message_id == "msg-001"
 
 
+def _fake_chat_with_usage(
+    category="NEEDS_RESPONSE",
+    summary="Alice invites Bob to lunch.",
+    usage=None,
+):
+    """Like ``_fake_chat`` but the classify call's response also carries a
+    Lemonade chat-completion-shaped ``.usage`` dict -- exercises the REST
+    path's real ``_aggregate_usage`` -> ``aggregate_usage_stats`` delegation
+    (#1891). The summarize call's response deliberately carries NO usage/stats
+    (plain ``.text`` only, like the original ``_fake_chat``) so the expected
+    aggregate is deterministic regardless of whether ``summarize_email_llm``
+    itself is ever updated to also prefer ``.usage``.
+    """
+    import json
+    import types
+
+    usage = usage or {
+        "prompt_tokens": 120,
+        "completion_tokens": 30,
+        "total_tokens": 150,
+        "tokens_per_second": 25.0,
+    }
+
+    class _FakeChat:
+        def send_messages(self, messages, system_prompt="", **kwargs):
+            resp = types.SimpleNamespace()
+            content = messages[0].get("content", "") if messages else ""
+            if "Classify" in content:
+                resp.text = json.dumps(
+                    {"category": category, "confidence": 0.9, "reasoning": "test"}
+                )
+                resp.usage = dict(usage)
+            else:
+                resp.text = summary
+            return resp
+
+    return _FakeChat()
+
+
+def test_triage_service_usage_uses_response_usage_shape():
+    """REST path: the classify call's ``response.usage`` (Lemonade
+    chat-completion shape) must be aggregated into a correct, non-None
+    ``EmailTriageResult.usage`` after ``_aggregate_usage`` is refactored to
+    delegate to ``aggregate_usage_stats`` (#1891)."""
+    from gaia_agent_email.api_routes import EmailTriageService
+
+    service = EmailTriageService()
+    request = _make_single_request()
+    chat = _fake_chat_with_usage()
+
+    response = service.triage_request(request, chat=chat)
+
+    assert response.result.usage is not None
+    assert response.result.usage.prompt_tokens == 120
+    assert response.result.usage.completion_tokens == 30
+    assert response.result.usage.total_tokens == 150
+    assert response.result.usage.tokens_per_second == pytest.approx(25.0)
+
+
 def test_body_not_clipped_by_llm_triage():
     """_build_user_prompt must pass the FULL body to the model (no 4 000-char cap)."""
     from gaia_agent_email.tools.llm_triage import _build_user_prompt

--- a/hub/agents/python/email/tests/test_llm_triage_usage.py
+++ b/hub/agents/python/email/tests/test_llm_triage_usage.py
@@ -1,0 +1,315 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Failing (red-phase) coverage for the tokens-per-triage usage aggregation
+increment (#1891, Increment 1).
+
+Two things land together in this increment:
+
+1. A new pure aggregation leaf, ``gaia_agent_email.tools.usage.aggregate_usage_stats``,
+   that normalizes BOTH the Lemonade chat-completion "usage" shape and the
+   legacy "/stats" shape into one summed dict -- shared by the REST path's
+   ``_aggregate_usage`` (refactored to delegate to it) and the new tool-path
+   wiring in ``EmailTriageAgent._triage_all_backends``.
+2. ``make_llm_classifier`` gains an additive ``collect_stats`` kwarg that
+   threads through to ``classify_email_llm``, whose own stats-collection now
+   prefers ``response.usage`` over ``response.stats`` (falling back to
+   ``.stats`` for providers that don't expose usage).
+
+Neither exists yet in this worktree -- every test in the first section fails
+with an ImportError until ``tools/usage.py`` is added; every ``collect_stats``
+test in the second section fails with a TypeError until ``make_llm_classifier``
+gains the kwarg.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# aggregate_usage_stats
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_usage_stats_empty_list_returns_none():
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    assert aggregate_usage_stats([]) is None
+
+
+def test_aggregate_usage_stats_single_usage_shape():
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    call_stats = [
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+            "tokens_per_second": 25.0,
+        }
+    ]
+    agg = aggregate_usage_stats(call_stats)
+    assert agg == {
+        "prompt_tokens": 100,
+        "completion_tokens": 20,
+        "total_tokens": 120,
+        "tokens_per_second": 25.0,
+    }
+
+
+def test_aggregate_usage_stats_single_legacy_stats_shape():
+    """The old ``/stats`` shape (``input_tokens``/``output_tokens``) must
+    normalize to the same output keys as the usage shape."""
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    call_stats = [{"input_tokens": 50, "output_tokens": 10, "tokens_per_second": 20.0}]
+    agg = aggregate_usage_stats(call_stats)
+    assert agg == {
+        "prompt_tokens": 50,
+        "completion_tokens": 10,
+        "total_tokens": 60,
+        "tokens_per_second": 20.0,
+    }
+
+
+def test_aggregate_usage_stats_sums_mixed_shapes():
+    """One usage-shape call + one legacy-stats-shape call in the SAME list
+    must normalize and sum together (mixed shapes, #1891)."""
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    call_stats = [
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+            "tokens_per_second": 25.0,
+        },
+        {"input_tokens": 50, "output_tokens": 10, "tokens_per_second": 20.0},
+    ]
+    agg = aggregate_usage_stats(call_stats)
+    assert agg["prompt_tokens"] == 150
+    assert agg["completion_tokens"] == 30
+    assert agg["total_tokens"] == 180
+    # Aggregate decode throughput = total output / total decode time, not a
+    # naive per-call average: (20+10) / (20/25 + 10/20) == 30 / 1.3.
+    assert agg["tokens_per_second"] == pytest.approx(30 / 1.3)
+
+
+def test_aggregate_usage_stats_excludes_zero_tps_calls_from_decode_time():
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    call_stats = [
+        {
+            "prompt_tokens": 30,
+            "completion_tokens": 15,
+            "total_tokens": 45,
+            "tokens_per_second": 0.0,
+        },
+        {
+            "prompt_tokens": 5,
+            "completion_tokens": 5,
+            "total_tokens": 10,
+            "tokens_per_second": 10.0,
+        },
+    ]
+    agg = aggregate_usage_stats(call_stats)
+    # Token counts still include the zero-tps call...
+    assert agg["prompt_tokens"] == 35
+    assert agg["completion_tokens"] == 20
+    assert agg["total_tokens"] == 55
+    # ...but its output can't inflate the decode-time denominator: only the
+    # tps>0 call contributes, so the aggregate equals that call's own tps.
+    assert agg["tokens_per_second"] == pytest.approx(10.0)
+
+
+def test_aggregate_usage_stats_zero_when_no_call_has_usable_tps():
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    call_stats = [
+        {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        {
+            "prompt_tokens": 20,
+            "completion_tokens": 8,
+            "total_tokens": 28,
+            "tokens_per_second": 0.0,
+        },
+    ]
+    agg = aggregate_usage_stats(call_stats)
+    assert agg["prompt_tokens"] == 30
+    assert agg["completion_tokens"] == 13
+    assert agg["total_tokens"] == 43
+    assert agg["tokens_per_second"] == 0.0
+
+
+def test_aggregate_usage_stats_skips_malformed_entries_without_raising():
+    """A non-dict item (e.g. a stray ``MagicMock()`` or ``None``) mixed in
+    with valid entries must be skipped, not crash the aggregation."""
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    call_stats = [
+        {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "tokens_per_second": 5.0,
+        },
+        MagicMock(),
+        None,
+        "not-a-dict",
+    ]
+    agg = aggregate_usage_stats(call_stats)
+    assert agg == {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+        "tokens_per_second": 5.0,
+    }
+
+
+def test_aggregate_usage_stats_all_malformed_returns_zero_dict_not_none():
+    """A non-empty ``call_stats`` list of ONLY malformed entries must return
+    the all-zero aggregation dict -- never ``None``, since ``call_stats``
+    itself was non-empty. Only a genuinely EMPTY list returns ``None``
+    (#1891 exact-edge-case requirement)."""
+    from gaia_agent_email.tools.usage import aggregate_usage_stats
+
+    agg = aggregate_usage_stats([object(), None])
+    assert agg == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "tokens_per_second": 0.0,
+    }
+    assert agg is not None
+
+
+# ---------------------------------------------------------------------------
+# make_llm_classifier(chat, collect_stats=...)
+# ---------------------------------------------------------------------------
+
+
+def _fake_chat_for_classify(*, usage=None, stats=None, category="FYI"):
+    """Chat stub returning a valid classify JSON body plus optional
+    Lemonade-usage / legacy-stats attributes on the response -- exercises
+    ``classify_email_llm``'s collect_stats preference (usage over stats).
+
+    Uses ``types.SimpleNamespace`` so an attribute that isn't passed is
+    simply ABSENT (not an auto-vivified Mock) -- required to exercise the
+    "no .usage at all" fallback case honestly.
+    """
+
+    class _FakeChat:
+        def send_messages(self, messages, system_prompt="", **kwargs):
+            resp = types.SimpleNamespace()
+            resp.text = json.dumps(
+                {"category": category, "confidence": 0.9, "reasoning": "t"}
+            )
+            if usage is not None:
+                resp.usage = usage
+            if stats is not None:
+                resp.stats = stats
+            return resp
+
+    return _FakeChat()
+
+
+def test_make_llm_classifier_accepts_collect_stats_kwarg():
+    """``make_llm_classifier(chat, collect_stats=list)`` must not raise a
+    TypeError for an unexpected keyword -- this is the additive-kwarg wiring
+    Increment 1 adds, and the appended entry must be the usage-shape dict."""
+    from gaia_agent_email.tools.llm_triage import make_llm_classifier
+
+    stats: list = []
+    usage = {
+        "prompt_tokens": 40,
+        "completion_tokens": 8,
+        "total_tokens": 48,
+        "tokens_per_second": 15.0,
+    }
+    chat = _fake_chat_for_classify(usage=usage)
+    classifier = make_llm_classifier(chat, collect_stats=stats)
+
+    result = classifier(subject="S", sender="a@example.com", body="b", message_id="m1")
+
+    assert result["category"] == "FYI"
+    assert stats == [usage]
+
+
+def test_make_llm_classifier_default_collect_stats_is_optional():
+    """Omitting ``collect_stats`` must keep working exactly as before -- the
+    returned classifier callable's own signature is unchanged."""
+    from gaia_agent_email.tools.llm_triage import make_llm_classifier
+
+    chat = _fake_chat_for_classify(category="URGENT")
+    classifier = make_llm_classifier(chat)
+
+    result = classifier(subject="S", sender="a@example.com", body="b", message_id="m1")
+    assert result["category"] == "URGENT"
+
+
+def test_make_llm_classifier_appends_one_entry_per_call():
+    """N classifier calls -> N entries appended, in call order."""
+    from gaia_agent_email.tools.llm_triage import make_llm_classifier
+
+    stats: list = []
+    usage = {
+        "prompt_tokens": 10,
+        "completion_tokens": 2,
+        "total_tokens": 12,
+        "tokens_per_second": 5.0,
+    }
+    chat = _fake_chat_for_classify(usage=usage)
+    classifier = make_llm_classifier(chat, collect_stats=stats)
+
+    for i in range(3):
+        classifier(subject="S", sender="a@example.com", body="b", message_id=f"m{i}")
+
+    assert len(stats) == 3
+    assert stats == [usage, usage, usage]
+
+
+def test_make_llm_classifier_prefers_usage_over_stats_when_both_present():
+    """When the response carries BOTH ``.usage`` and ``.stats``, the
+    Lemonade-usage shape must win -- the legacy ``.stats`` values must not
+    leak into ``collect_stats``."""
+    from gaia_agent_email.tools.llm_triage import make_llm_classifier
+
+    usage = {
+        "prompt_tokens": 90,
+        "completion_tokens": 15,
+        "total_tokens": 105,
+        "tokens_per_second": 30.0,
+    }
+    legacy_stats = {"input_tokens": 999, "output_tokens": 999, "tokens_per_second": 1.0}
+    chat = _fake_chat_for_classify(usage=usage, stats=legacy_stats)
+    stats: list = []
+    classifier = make_llm_classifier(chat, collect_stats=stats)
+
+    classifier(subject="S", sender="a@example.com", body="b", message_id="m1")
+
+    assert len(stats) == 1
+    assert stats[0] == usage
+    assert stats[0] != legacy_stats
+
+
+def test_make_llm_classifier_falls_back_to_stats_when_no_usage():
+    """Backward compat: a provider response that exposes ONLY ``.stats`` (no
+    ``.usage`` attribute at all) must still be collected via the fallback."""
+    from gaia_agent_email.tools.llm_triage import make_llm_classifier
+
+    legacy_stats = {"input_tokens": 33, "output_tokens": 7, "tokens_per_second": 12.0}
+    chat = _fake_chat_for_classify(stats=legacy_stats)
+    stats: list = []
+    classifier = make_llm_classifier(chat, collect_stats=stats)
+
+    classifier(subject="S", sender="a@example.com", body="b", message_id="m1")
+
+    assert len(stats) == 1
+    assert stats[0] == legacy_stats

--- a/src/gaia/chat/sdk.py
+++ b/src/gaia/chat/sdk.py
@@ -49,6 +49,11 @@ class AgentResponse:
     history: Optional[List[str]] = None
     stats: Optional[Dict[str, Any]] = None
     is_complete: bool = True
+    # Token usage from the provider's completion response, when it carried
+    # one (#1891) — additive field alongside ``stats``, which stays exactly
+    # as it was (the polled ``/stats`` measurement). ``None`` for providers/
+    # calls that don't expose per-call usage.
+    usage: Optional[Dict[str, Any]] = None
 
 
 class AgentSDK:
@@ -243,7 +248,12 @@ class AgentSDK:
             if self.config.show_stats:
                 stats = self.get_stats()
 
-            return AgentResponse(text=response, stats=stats, is_complete=True)
+            # Additive (#1891) — no extra call, just an attribute read.
+            usage = self.llm_client.get_last_usage()
+
+            return AgentResponse(
+                text=response, stats=stats, usage=usage, is_complete=True
+            )
 
         except ConnectionError as e:
             # Re-raise connection errors with additional context

--- a/src/gaia/eval/benchmark.py
+++ b/src/gaia/eval/benchmark.py
@@ -128,6 +128,30 @@ def _extract_triage_results(conversation: list) -> tuple[list[dict], str]:
     return [], ""
 
 
+def _extract_triage_usage(conversation: list) -> tuple[dict | None, int]:
+    """Find the triage tool result's LLM usage block (#1891).
+
+    Sibling of :func:`_extract_triage_results`: walks the same tool messages
+    and reads ``data.usage`` / ``data.llm_classified_count`` off the first ok
+    triage envelope. Returns ``(usage_dict, llm_classified_count)``, or
+    ``(None, 0)`` when the envelope carries no usage block (a heuristic-only
+    run, or a pre-#1891 agent) — absence is the normal, non-error shape.
+    """
+    for msg in conversation:
+        if msg.get("role") != "tool" or not msg.get("content"):
+            continue
+        envelope = _maybe_parse_tool_envelope(msg["content"])
+        if not isinstance(envelope, dict):
+            continue
+        data = envelope.get("data")
+        if envelope.get("ok") and isinstance(data, dict) and "results" in data:
+            usage = data.get("usage")
+            if isinstance(usage, dict):
+                return usage, int(data.get("llm_classified_count") or 0)
+            return None, 0
+    return None, 0
+
+
 def _extract_tools_called(agent_result: dict) -> list[str]:
     """Ordered, de-duplicated list of tool names used in the conversation."""
     seen: set[str] = set()
@@ -194,9 +218,38 @@ def build_result(
         is_cold_start=is_cold_start,
     )
 
+    # #1891: merge the triage tool's nested classify-call usage into the run
+    # totals BEFORE serialization / cost — the outer-turn stats above never
+    # saw those calls, so totals (and cost_estimate) were undercounting.
+    # avg_tokens_per_second / TTFT stay outer-turn-derived on purpose (the
+    # usage block has no per-call TTFT and its decode rate is already the
+    # aggregate the tool computed). Bounded caveat: when the outer turn's own
+    # stats dict is falsy, the base agent falls back to a GET /stats that can
+    # capture the LAST nested classify call as the outer turn — merging then
+    # double-counts that one call (~0.3% worst case); tokens_per_triage below
+    # is immune (classify tokens over classify count only).
+    triage_usage, llm_classified_count = _extract_triage_usage(conversation)
+    triage_llm_tokens = 0
+    if triage_usage is not None:
+        t_in = int(triage_usage.get("prompt_tokens") or 0)
+        t_out = int(triage_usage.get("completion_tokens") or 0)
+        triage_llm_tokens = int(triage_usage.get("total_tokens") or 0) or (t_in + t_out)
+        perf_run.total_input_tokens += t_in
+        perf_run.total_output_tokens += t_out
+        perf_run.total_tokens += t_in + t_out
+
     out = performance.run_to_dict(perf_run)
     out["tools_called"] = _extract_tools_called(result_dict)
     out["performance_summary"] = performance.to_performance_summary(perf_run)
+    if triage_usage is not None:
+        # Pinned metric (#1891): tokens_per_triage = classify-call tokens over
+        # LLM-classified emails ONLY — invariant to the heuristic/batch mix
+        # and to the outer-turn fallback race noted above.
+        ps = out["performance_summary"]
+        ps["triage_llm_tokens"] = triage_llm_tokens
+        ps["llm_classified_count"] = llm_classified_count
+        if llm_classified_count > 0:
+            ps["tokens_per_triage"] = round(triage_llm_tokens / llm_classified_count, 1)
     out["cost_estimate"] = {
         "estimated_usd": quality_metrics.compute_cost(
             perf_run.total_input_tokens,

--- a/src/gaia/llm/base_client.py
+++ b/src/gaia/llm/base_client.py
@@ -53,6 +53,14 @@ class LLMClient(ABC):
     def get_performance_stats(self) -> dict:
         raise NotSupportedError(self.provider_name, "get_performance_stats")
 
+    def get_last_usage(self) -> Optional[dict]:
+        """Token-usage dict from the most recent ``chat()`` call, when the
+        provider's response carried one (#1891). ``None`` by default —
+        unlike ``get_performance_stats``, absence is a normal, silent case
+        (most providers/streaming calls simply don't have one) rather than
+        an unsupported-operation error."""
+        return None
+
     def load_model(self, model_name: str, **kwargs) -> None:
         raise NotSupportedError(self.provider_name, "load_model")
 

--- a/src/gaia/llm/providers/lemonade.py
+++ b/src/gaia/llm/providers/lemonade.py
@@ -244,6 +244,11 @@ class LemonadeProvider(LLMClient):
         self._backend = LemonadeClient(**backend_kwargs)
         self._model = model
         self._system_prompt = system_prompt
+        # Token usage from the most recent non-streaming ``chat()`` call
+        # (#1891) — the OpenAI-compatible ``/chat/completions`` response's
+        # ``usage`` field, captured here since ``chat()`` itself returns
+        # just the message content/tool-call envelope as ``str``.
+        self._last_usage: Optional[dict] = None
 
     @property
     def provider_name(self) -> str:
@@ -272,6 +277,11 @@ class LemonadeProvider(LLMClient):
         tools: Optional[List[dict]] = None,
         **kwargs,
     ) -> Union[str, dict, Iterator[str]]:
+        # Reset from any previous call — usage is per-call, not cumulative,
+        # and the streaming branch below never populates it (no non-streaming
+        # JSON body to read a ``usage`` field from).
+        self._last_usage = None
+
         # Use provided model, instance model, or default CPU model
         effective_model = model or self._model or DEFAULT_MODEL_NAME
         tool_capable = is_tool_calling_model(effective_model)
@@ -349,6 +359,24 @@ class LemonadeProvider(LLMClient):
                 payload=response if isinstance(response, dict) else {"raw": response},
             )
 
+        # Capture usage before the choice-shaping logic below discards the
+        # raw response dict (#1891) — enriched with the decode-rate timing
+        # llama.cpp reports alongside ``usage`` (absent from the OpenAI-shape
+        # ``usage`` object itself) so downstream aggregation gets equal-or-
+        # better fidelity than the polled ``/stats`` endpoint, with no extra
+        # HTTP round-trip and no last-request race.
+        usage = response.get("usage")
+        if isinstance(usage, dict):
+            timings = response.get("timings")
+            self._last_usage = {
+                "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+                "completion_tokens": int(usage.get("completion_tokens") or 0),
+                "total_tokens": int(usage.get("total_tokens") or 0),
+                "tokens_per_second": float(
+                    (timings or {}).get("predicted_per_second") or 0.0
+                ),
+            }
+
         if not response["choices"] or len(response["choices"]) == 0:
             raise ValueError("Empty choices in response from Lemonade Server")
 
@@ -411,6 +439,12 @@ class LemonadeProvider(LLMClient):
 
     def get_performance_stats(self) -> dict:
         return self._backend.get_stats() or {}
+
+    def get_last_usage(self) -> Optional[dict]:
+        """Token-usage dict from the most recent non-streaming ``chat()``
+        call (#1891), or ``None`` when unavailable (a streaming call, or the
+        server's response didn't include a ``usage`` field)."""
+        return self._last_usage
 
     def load_model(self, model_name: str, **kwargs) -> None:
         self._backend.load_model(model_name, **kwargs)

--- a/tests/fixtures/email/quality_gate_thresholds.json
+++ b/tests/fixtures/email/quality_gate_thresholds.json
@@ -9,5 +9,6 @@
   "urgent_recall_floor": 0.90,
   "acceptance_enforce": true,
   "_ctx_comment": "Ctx-window envelope (#1892): when require_ctx_match is true, release_agent_email.yml passes --require-ctx-match to the scorecard gate so a candidate SCORECARD.md that does not record recipe.environment.ctx_size (the window it was measured under) hard-fails. Same data-not-code switch pattern as acceptance_enforce. Ships FALSE for now: no committed SCORECARD carries a ctx stamp yet, so enforcing would break CI on merge. Flip to true when the consolidated eval pass (#1319/#1892) commits the first ctx-stamped SCORECARD — email_scorecard_refresh.yml already pins --ctx-size 16384, so the next organic refresh produces a stamped card.",
-  "require_ctx_match": false
+  "require_ctx_match": false,
+  "_tokens_per_triage_comment": "Token accounting (#1891): the scorecard's tokens_per_triage / total_input_tokens / total_output_tokens / llm_classified_count rows (gen_scorecard._compute_performance) are REPORTED only. Do NOT add a gate (bar/floor) for tokens_per_triage without a committed, ctx-stamped baseline SCORECARD to compare against (#1894 trust model) — and comparisons are only meaningful with the corpus held fixed, since the metric is classify-call tokens over LLM-classified emails only (pinned in gaia.eval.benchmark.build_result). No enforce switch exists for it yet on purpose; add one here (data, not code) when a baseline lands."
 }

--- a/tests/unit/agents/email/test_triage_usage_metric.py
+++ b/tests/unit/agents/email/test_triage_usage_metric.py
@@ -1,0 +1,210 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tokens-per-triage usage metric on the tool (chat-agent) bulk-triage path
+(#1891, Increment 1).
+
+Before this increment, ``EmailTriageAgent._triage_all_backends`` built its
+classifier via ``read_tools.make_llm_classifier(chat)`` -- no ``collect_stats``
+threaded through -- so per-call LLM token stats for the tool path were
+silently discarded even though the REST path (``EmailTriageService``) already
+aggregates and reports them (#1540). This increment wires the SAME shared
+``call_stats`` list through a classifier built ONCE and reused across every
+connected mailbox, then attaches ``usage`` (a plain dict) and
+``llm_classified_count`` to the ``triage_inbox`` tool's JSON envelope --
+present ONLY when at least one LLM classify call actually happened.
+
+None of this exists yet in this worktree -- every test here is expected to
+fail (missing ``usage``/``llm_classified_count`` keys) until the increment
+lands.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")  # noqa: E402
+
+from unittest.mock import MagicMock, patch
+
+from gaia_agent_email.agent import EmailTriageAgent
+from gaia_agent_email.config import EmailAgentConfig
+
+# ---------------------------------------------------------------------------
+# In-test spy backend (Gmail-API-shape) -- same minimal pattern as
+# test_multi_inbox_triage.py, but the default message is deliberately
+# NEUTRAL (no system-category label, no promo/automated-sender keyword) so
+# the heuristic returns confident=False and the LLM classifier IS invoked --
+# these tests exercise the usage-metric wiring, not classification itself.
+# ---------------------------------------------------------------------------
+
+
+def _msg(message_id: str, *, subject="Hi there", sender=None, label_ids=None):
+    return {
+        "id": message_id,
+        "threadId": f"t-{message_id}",
+        "labelIds": label_ids if label_ids is not None else ["INBOX"],
+        "snippet": subject,
+        "internalDate": "1000",
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": subject},
+                {"name": "From", "value": sender or "alice@example.com"},
+            ],
+            "body": {"data": ""},
+        },
+    }
+
+
+class SpyBackend:
+    """Minimal GmailBackend-shaped fake holding a fixed message list."""
+
+    def __init__(self, name: str, messages: list[dict]):
+        self.name = name
+        self._messages = {m["id"]: m for m in messages}
+
+    def list_messages(
+        self, *, query=None, label_ids=None, max_results=25, page_token=None
+    ):
+        ids = list(self._messages)[:max_results]
+        return {"messages": [{"id": m, "threadId": f"t-{m}"} for m in ids]}
+
+    def get_message(self, message_id: str):
+        return self._messages[message_id]
+
+    def get_thread(self, thread_id: str):
+        return {"id": thread_id, "messages": list(self._messages.values())}
+
+
+_USAGE = {
+    "prompt_tokens": 50,
+    "completion_tokens": 10,
+    "total_tokens": 60,
+    "tokens_per_second": 20.0,
+}
+
+
+def _classify_response_text() -> str:
+    return json.dumps(
+        {"category": "FYI", "is_spam": False, "confidence": 0.9, "reasoning": "t"}
+    )
+
+
+def _build_agent(tmp_path, monkeypatch, *, google_messages, usage=None):
+    """Construct an ``EmailTriageAgent`` with ONE connected (google) backend
+    whose mocked chat's ``send_messages`` response carries a Lemonade
+    chat-completion-shaped ``.usage`` dict -- the shape this increment threads
+    through to ``result['usage']``.
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    spy = SpyBackend("google", google_messages)
+    cfg = EmailAgentConfig(
+        gmail_backend=spy,
+        calendar_backend=object(),
+        db_path=str(tmp_path / "state.db"),
+        silent_mode=True,
+        mail_provider="google",
+    )
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        response = MagicMock()
+        response.text = _classify_response_text()
+        response.usage = dict(usage or _USAGE)
+        mock_sdk.return_value.send_messages.return_value = response
+        agent = EmailTriageAgent(config=cfg)
+    return agent
+
+
+def _registered_tool(name):
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    return _TOOL_REGISTRY[name]["function"]
+
+
+class TestTriageUsageMetric:
+    def test_triage_inbox_attaches_usage_when_llm_classifies(
+        self, tmp_path, monkeypatch
+    ):
+        """One message needing LLM escalation -> one classify call -> usage
+        + llm_classified_count attached to the triage_inbox JSON envelope."""
+        agent = _build_agent(tmp_path, monkeypatch, google_messages=[_msg("m1")])
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            assert envelope["ok"] is True, envelope
+            data = envelope["data"]
+            assert data["usage"] == _USAGE
+            assert data["llm_classified_count"] == 1
+        finally:
+            agent.close_db()
+
+    def test_triage_inbox_usage_total_tokens_is_json_int(self, tmp_path, monkeypatch):
+        """``usage`` must round-trip through the JSON envelope as a plain
+        int -- proving it is a plain dict, not a pydantic model that the
+        envelope's ``default=str`` fallback would have stringified."""
+        agent = _build_agent(tmp_path, monkeypatch, google_messages=[_msg("m1")])
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            total = envelope["data"]["usage"]["total_tokens"]
+            assert isinstance(total, int)
+            assert not isinstance(total, str)
+            assert total == 60
+        finally:
+            agent.close_db()
+
+    def test_triage_inbox_llm_classified_count_sums_across_backends(
+        self, tmp_path, monkeypatch
+    ):
+        """Two backends, one message each needing LLM escalation -> the
+        classifier must be built ONCE and its shared call_stats list reused
+        (not rebuilt per backend), so llm_classified_count == 2, not 1, and
+        usage sums across BOTH backends' calls."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        spy_g = SpyBackend("google", [_msg("g1")])
+        spy_m = SpyBackend("microsoft", [_msg("m1")])
+        cfg = EmailAgentConfig(
+            gmail_backend=spy_g,
+            outlook_backend=spy_m,
+            calendar_backend=object(),
+            db_path=str(tmp_path / "state.db"),
+            silent_mode=True,
+            mail_provider=None,
+        )
+        with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+            response = MagicMock()
+            response.text = _classify_response_text()
+            response.usage = dict(_USAGE)
+            mock_sdk.return_value.send_messages.return_value = response
+            agent = EmailTriageAgent(config=cfg)
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            assert envelope["ok"] is True, envelope
+            data = envelope["data"]
+            assert data["llm_classified_count"] == 2
+            assert data["usage"]["total_tokens"] == _USAGE["total_tokens"] * 2
+            assert data["usage"]["prompt_tokens"] == _USAGE["prompt_tokens"] * 2
+            assert data["usage"]["completion_tokens"] == _USAGE["completion_tokens"] * 2
+        finally:
+            agent.close_db()
+
+    def test_triage_inbox_no_usage_when_heuristic_confident_only(
+        self, tmp_path, monkeypatch
+    ):
+        """Heuristic-confident-only run (no LLM call at all, out of scope for
+        pre_scan too per #1891) -> neither 'usage' nor 'llm_classified_count'
+        is present in the envelope data -- absent, not zero/null."""
+        # CATEGORY_UPDATES -> category=FYI, confident=True, and (since the
+        # category resolves non-PROMOTIONAL) spam_confident=True too, so
+        # needs_llm is False and the classifier is never invoked.
+        confident_msg = _msg(
+            "m1", subject="Weekly digest", label_ids=["INBOX", "CATEGORY_UPDATES"]
+        )
+        agent = _build_agent(tmp_path, monkeypatch, google_messages=[confident_msg])
+        try:
+            envelope = json.loads(_registered_tool("triage_inbox")(20))
+            assert envelope["ok"] is True, envelope
+            data = envelope["data"]
+            assert "usage" not in data
+            assert "llm_classified_count" not in data
+        finally:
+            agent.close_db()

--- a/tests/unit/eval/test_benchmark.py
+++ b/tests/unit/eval/test_benchmark.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Unit tests for gaia.eval.benchmark (offline — no Lemonade)."""
 
+import copy
 import json
 import os
 
@@ -10,6 +11,7 @@ import pytest
 from gaia.eval.benchmark import (
     _extract_tools_called,
     _extract_triage_results,
+    _extract_triage_usage,
     _maybe_parse_tool_envelope,
     _normalize_agent_result,
     build_result,
@@ -21,7 +23,7 @@ from gaia.eval.benchmark import (
     summarize_benchmark,
 )
 from gaia.eval.performance import PerfThresholds
-from gaia.eval.quality_metrics import QualityThresholds
+from gaia.eval.quality_metrics import QualityThresholds, compute_cost
 
 GT = {
     "_meta": {"note": "skip me"},
@@ -85,6 +87,28 @@ def _agent_result():
     }
 
 
+def _agent_result_with_usage(
+    usage=None,
+    llm_classified_count=4,
+):
+    """Deep-copied variant of ``_agent_result()`` whose triage envelope's
+    ``data`` also carries ``usage`` + ``llm_classified_count`` (Increment 1
+    shape). Never mutates the shared ``TRIAGE_ENVELOPE`` constant."""
+    if usage is None:
+        usage = {
+            "prompt_tokens": 5000,
+            "completion_tokens": 800,
+            "total_tokens": 5800,
+            "tokens_per_second": 40.0,
+        }
+    ar = _agent_result()
+    envelope = copy.deepcopy(TRIAGE_ENVELOPE)
+    envelope["data"]["usage"] = usage
+    envelope["data"]["llm_classified_count"] = llm_classified_count
+    ar["conversation"][2]["content"] = json.dumps(envelope)
+    return ar
+
+
 class TestFailLoud:
     """The upstream fork swallowed malformed tool JSON; we must raise."""
 
@@ -135,6 +159,45 @@ class TestExtractToolsCalled:
         assert _extract_tools_called(_agent_result()) == ["triage_inbox"]
 
 
+class TestExtractTriageUsage:
+    """``_extract_triage_usage`` (Increment 2): sibling walk of
+    ``_extract_triage_results`` that reads ``data.usage`` /
+    ``data.llm_classified_count`` off the first ok triage envelope."""
+
+    def test_extracts_usage_and_count_from_envelope(self):
+        ar = _agent_result_with_usage(
+            usage={
+                "prompt_tokens": 5000,
+                "completion_tokens": 800,
+                "total_tokens": 5800,
+                "tokens_per_second": 40.0,
+            },
+            llm_classified_count=4,
+        )
+        usage, count = _extract_triage_usage(ar["conversation"])
+        assert usage == {
+            "prompt_tokens": 5000,
+            "completion_tokens": 800,
+            "total_tokens": 5800,
+            "tokens_per_second": 40.0,
+        }
+        assert count == 4
+
+    def test_plain_envelope_without_usage_returns_none_zero(self):
+        # TRIAGE_ENVELOPE (the existing/absence-tolerant shape) carries no
+        # usage or llm_classified_count at all.
+        ar = _agent_result()
+        usage, count = _extract_triage_usage(ar["conversation"])
+        assert usage is None
+        assert count == 0
+
+    def test_no_triage_envelope_returns_none_zero(self):
+        convo = [{"role": "assistant", "content": "I refuse."}]
+        usage, count = _extract_triage_usage(convo)
+        assert usage is None
+        assert count == 0
+
+
 class TestBuildResult:
     def test_scorecard_compatible_and_perf(self):
         out = build_result(
@@ -180,6 +243,106 @@ class TestBuildResult:
         )
         assert out["status"] == "ERRORED"
         assert out["error"] == "backend down"
+
+
+class TestBuildResultUsageMerge:
+    """Increment 2: ``build_result`` merges the triage-classify ``usage`` block
+    into the run's token totals + adds ``tokens_per_triage`` to
+    ``performance_summary``. Absence-tolerant — a plain (no-usage) envelope
+    must leave every existing number exactly as today."""
+
+    _USAGE = {
+        "prompt_tokens": 5000,
+        "completion_tokens": 800,
+        "total_tokens": 5800,
+        "tokens_per_second": 40.0,
+    }
+
+    def _build_with_usage(self, model_id="Gemma-4-E4B-it-GGUF"):
+        return build_result(
+            _agent_result_with_usage(usage=self._USAGE, llm_classified_count=4),
+            run_id="r1",
+            timestamp="t",
+            model_id=model_id,
+            total_duration_ms=2000,
+            ground_truth=GT,
+        )
+
+    def test_merged_totals_in_performance_summary_and_top_level(self):
+        # Fixture note: _agent_result()'s top-level aggregates are
+        # input=1000/output=200/total=1200 (preferred over step sums by
+        # performance.extract_from_agent_result). Merged with the usage block
+        # (prompt=5000/completion=800/total=5800):
+        #   total_input_tokens  = 1000 + 5000 = 6000
+        #   total_output_tokens =  200 +  800 = 1000
+        #   total_tokens        = 1200 + 5800 = 7000... but per the spec the
+        #   merge adds (prompt + completion) to total_tokens, i.e. 1200 + 5800
+        #   = 7000. However total input+output alone would be 7000 too
+        #   (6000+1000); both derivations agree.
+        out = self._build_with_usage()
+        ps = out["performance_summary"]
+        assert ps["total_input_tokens"] == 6000
+        assert ps["total_output_tokens"] == 1000
+        assert ps["total_tokens"] == 7000
+        # run_to_dict output (top-level keys) reflects the same merge.
+        assert out["total_input_tokens"] == 6000
+        assert out["total_output_tokens"] == 1000
+        assert out["total_tokens"] == 7000
+
+    def test_new_performance_summary_fields_exact_values(self):
+        out = self._build_with_usage()
+        ps = out["performance_summary"]
+        assert ps["triage_llm_tokens"] == 5800
+        assert ps["llm_classified_count"] == 4
+        assert ps["tokens_per_triage"] == 1450.0
+
+    def test_avg_tps_and_ttft_unchanged_by_merge(self):
+        # avg_tokens_per_second / avg_time_to_first_token stay outer-turn
+        # derived (same values as the no-usage baseline).
+        out = self._build_with_usage()
+        ps = out["performance_summary"]
+        assert ps["avg_tokens_per_second"] == 50.0
+        assert ps["avg_time_to_first_token"] == 0.1
+
+    def test_cost_estimate_rises_with_merged_totals(self):
+        # Use a priced model so compute_cost isn't 0.0-clamped for local ids.
+        out_no_usage = build_result(
+            _agent_result(),
+            run_id="r0",
+            timestamp="t",
+            model_id="claude-sonnet-4",
+            total_duration_ms=2000,
+            ground_truth=GT,
+        )
+        out_with_usage = self._build_with_usage(model_id="claude-sonnet-4")
+
+        baseline_cost = compute_cost(1000, 200, model="claude-sonnet-4")
+        merged_cost = compute_cost(6000, 1000, model="claude-sonnet-4")
+
+        assert out_no_usage["cost_estimate"]["estimated_usd"] == baseline_cost
+        assert out_with_usage["cost_estimate"]["estimated_usd"] == merged_cost
+        assert merged_cost > baseline_cost
+
+    def test_no_usage_envelope_leaves_new_keys_absent_and_totals_unchanged(self):
+        # Plain TRIAGE_ENVELOPE (today's shape, no usage/llm_classified_count).
+        out = build_result(
+            _agent_result(),
+            run_id="r1",
+            timestamp="t",
+            model_id="Gemma-4-E4B-it-GGUF",
+            total_duration_ms=2000,
+            ground_truth=GT,
+        )
+        ps = out["performance_summary"]
+        assert "triage_llm_tokens" not in ps
+        assert "llm_classified_count" not in ps
+        assert "tokens_per_triage" not in ps
+        assert ps["total_input_tokens"] == 1000
+        assert ps["total_output_tokens"] == 200
+        assert ps["total_tokens"] == 1200
+        assert out["total_input_tokens"] == 1000
+        assert out["total_output_tokens"] == 200
+        assert out["total_tokens"] == 1200
 
 
 class TestRunBenchmarkOffline:

--- a/tests/unit/eval/test_release_scorecard.py
+++ b/tests/unit/eval/test_release_scorecard.py
@@ -1418,6 +1418,110 @@ class TestBreakdownAdapter:
         assert "peak_memory_gb" not in payload.performance
         assert payload.performance["throughput_tps"] == 12.1
 
+    def test_performance_folds_triage_token_metrics(self, tmp_path):
+        """Increment 2: tokens_per_triage / llm_classified_count / token totals
+        are meaned into payload.performance alongside the existing perf keys."""
+        mod = self._load_gen_scorecard()
+        scorecard = {
+            "run_id": "tokens",
+            "scenarios": [
+                {
+                    "category": "Gemma-4-E4B-it-GGUF",
+                    "status": "PASS",
+                    "total_emails": 20,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                    },
+                    "performance_summary": {
+                        "avg_time_to_first_token": 8.5,
+                        "avg_tokens_per_second": 12.1,
+                        "pipeline_latency_s": 760.0,
+                        "peak_memory_gb": 6.2,
+                        "total_emails": 20,
+                        "tokens_per_triage": 1450.0,
+                        "llm_classified_count": 4,
+                        "total_input_tokens": 6000,
+                        "total_output_tokens": 1000,
+                    },
+                }
+            ],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.performance is not None
+        assert payload.performance["tokens_per_triage"] == 1450.0
+        assert payload.performance["llm_classified_count"] == 4
+        assert payload.performance["total_input_tokens"] == 6000.0
+        assert payload.performance["total_output_tokens"] == 1000.0
+
+    def test_performance_drops_unmeasured_triage_token_metrics(self, tmp_path):
+        """No triage-token keys in performance_summary -> none of the four new
+        keys appear in payload.performance (drop-if-absent, mirrors the
+        existing peak_memory_gb=0.0 drop test)."""
+        mod = self._load_gen_scorecard()
+        scorecard = {
+            "run_id": "no-tokens",
+            "scenarios": [
+                {
+                    "category": "m",
+                    "status": "PASS",
+                    "total_emails": 20,
+                    "quality": {
+                        "category_accuracy": 0.5,
+                        "within_one_bucket_accuracy": 0.8,
+                    },
+                    "performance_summary": {
+                        "avg_time_to_first_token": 8.5,
+                        "avg_tokens_per_second": 12.1,
+                        "pipeline_latency_s": 760.0,
+                        "peak_memory_gb": 6.2,
+                        "total_emails": 20,
+                    },
+                }
+            ],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.performance is not None
+        assert "tokens_per_triage" not in payload.performance
+        assert "llm_classified_count" not in payload.performance
+        assert "total_input_tokens" not in payload.performance
+        assert "total_output_tokens" not in payload.performance
+        assert payload.performance["throughput_tps"] == 12.1
+
+    def test_performance_means_tokens_per_triage_across_scenarios(self, tmp_path):
+        """Two judged scenarios with different tokens_per_triage -> the mean."""
+        mod = self._load_gen_scorecard()
+
+        def _scenario(tpt):
+            return {
+                "category": "Gemma-4-E4B-it-GGUF",
+                "status": "PASS",
+                "total_emails": 20,
+                "quality": {
+                    "category_accuracy": 0.5,
+                    "within_one_bucket_accuracy": 0.8,
+                },
+                "performance_summary": {
+                    "avg_time_to_first_token": 8.5,
+                    "avg_tokens_per_second": 12.1,
+                    "pipeline_latency_s": 760.0,
+                    "peak_memory_gb": 6.2,
+                    "total_emails": 20,
+                    "tokens_per_triage": tpt,
+                    "llm_classified_count": 4,
+                },
+            }
+
+        scorecard = {
+            "run_id": "tokens-mean",
+            "scenarios": [_scenario(1400.0), _scenario(1500.0)],
+        }
+        bd = self._make_benchmark_dir(tmp_path, scorecard)
+        payload = mod.build_payload(bd, self._make_gt(tmp_path))
+        assert payload.performance["tokens_per_triage"] == 1450.0
+
     def test_performance_none_when_no_summary(self, tmp_path):
         """No performance_summary in any scenario -> perf block omitted."""
         mod = self._load_gen_scorecard()


### PR DESCRIPTION
Part of #1891 (stacked on #2072 — diff shows only this branch's changes). The issue stays open: before/after numbers and the eval-gated prompt cuts land with the consolidated eval pass ([#1319 plan](https://github.com/amd/gaia/issues/1319)).

Before this change, every token number the email benchmark and scorecard reported was wrong in the same direction: the N per-email classify calls inside a bulk `triage_inbox` discarded their usage, so published totals reflected only the agent's outer planning turns — a fraction of the real LLM cost. After it, per-call usage is captured from the completion response itself (zero extra HTTP — the [#1890 spike](https://github.com/amd/gaia/issues/1890#issuecomment-4970677985) measured the old `/stats`-poll approach and this is strictly better), aggregated across all mailboxes, surfaced on the triage tool result (`usage` + `llm_classified_count`), merged into benchmark totals, and reported as a first-class scorecard metric: `tokens_per_triage = triage_llm_tokens / llm_classified_count` (reported-only — gating a new metric with no committed baseline would violate the #1894 trust model; a `_comment` guard in `quality_gate_thresholds.json` says so).

**This PR deliberately ships zero prompt changes.** The spike ranked every meaningful reduction HIGH/MEDIUM-HIGH accuracy-risk (and the one "safe" trim saves ~5 tokens/call — noise); all cuts are gated on the eval pass measuring their accuracy-delta.

Reviewer-visible consequences (intended):
- **`cost_estimate` rises** — it was undercounting; classify tokens now merge into totals before cost.
- **`avg_tokens_per_second`/TTFT stay outer-turn-derived** while totals now include classify calls — internally inconsistent by design, acknowledged here rather than silently.
- A present-but-**zero** `usage` block means calls happened but measurement was unavailable; **absent** means no LLM call at all (documented in CONTRACT.md).

## Test plan

- [x] Widened suite (hub tests + `tests/unit/{email,eval,agents/email}` + openapi conformance): **1748 passed, 1 failed** — the failure is the pre-existing `test_claude_judge::test_raises_on_missing_api_key` ambient-auth artifact (stash-verified identical without this branch; passes in CI)
- [x] TDD throughout: red-first test commits (`4e85c53d`, `22bd945d`) precede each implementation commit; the chain-locking test proves collect→aggregate→tool-envelope→`build_result`→scorecard end-to-end hermetically
- [x] Mechanism verified live against Lemonade 10.7.0: completion response carries `usage` (+ `timings.predicted_per_second`, which preserves REST `tokens_per_second` parity); real classify call round-tripped `{prompt_tokens: 1050, completion_tokens: 469, total_tokens: 1519, tokens_per_second: 70.8}`
- [x] `util/lint.py --all` ALL PASSED · `stamp_version.py --check` @ 0.5.0 · capability matrix up to date · `tsc --noEmit` clean

<details>
<summary>Additional disclosures</summary>

- **Double-count bound:** if an outer turn's stats read comes back falsy, the base agent's `/stats` fallback can capture the last nested classify call as the outer turn's; merging then double-counts that one call (~0.3% worst case). The `tokens_per_triage` definition is immune (tool-aggregate only); a core-agent fix is out of scope and documented at the merge site in `benchmark.py`.
- **SSE/UI:** the usage block does not appear in the live Agent UI (the SSE translation allowlist excludes it); contract-compliant per the frozen /query spec, just invisible live. Surfacing it later is an allowlist + render change.
- **Non-Lemonade providers:** `get_last_usage()` defaults to None → falls back to `.stats`; providers with neither report usage as absent (never zeros).
- **Pre-existing, untouched:** 18 `tests/test_sdk.py` failures (unrelated `gaia.apps.summarize.app.LLMClient` patch-target drift, stash-verified) and one black quote-style debt in `llm_triage.py` (present on base; deliberately not reformatted).
- **Forward notes:** #1912 (wave 3) may grow the spam prompt — this metric is the instrument that will show it. The npm CHANGELOG's next version cut should name the new tool-envelope fields (npm prose untouched here, post-#2071).
</details>
