### PR TITLE
feat(email): auto-select gemma4-it-e2b-FLM on NPU hardware (#1439)

### DIFF
--- a/docs/guides/npu.mdx
+++ b/docs/guides/npu.mdx
@@ -91,6 +91,17 @@ gaia eval agent --compare eval/results/run1/scorecard.json eval/results/run2/sco
 - **Explicit `--device npu`:** fails immediately if NPU not available
 - **Default (no `--device`):** uses GPU; falls back to CPU with a warning if no GPU detected
 
+### Email agent: no `--device` flag — auto-detected instead
+
+The email triage agent doesn't take a `--device` flag. When it isn't given
+an explicit model, it probes the Lemonade Server it's configured against and
+picks `gemma4-it-e2b-FLM` automatically if an NPU is available there and the
+model is already downloaded — otherwise it falls back to
+`Gemma-4-E4B-it-GGUF`, the same GPU/CPU default above. `GET /v1/email/init`
+reports which one was resolved. See the [email agent
+contract](https://github.com/amd/gaia/blob/main/hub/agents/python/email/CONTRACT.md#default-model-selection)
+for the full resolution order.
+
 ## Troubleshooting
 
 ### NPU not detected

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -4,6 +4,17 @@ What's new in `@amd-gaia/agent-email`, in plain language. For the technical deta
 behind any entry — API shapes, endpoints, and version semantics — see
 [`SPEC.md`](https://github.com/amd/gaia/blob/agent-pkg-email-v0.5.0/hub/agents/npm/agent-email/SPEC.md).
 
+## 0.6.0
+
+- **On NPU-capable machines, triage now runs on the NPU by default.** When
+  you haven't pinned a specific model, the agent checks whether the
+  Lemonade Server it's talking to has an AMD NPU and the NPU-optimized
+  model ready — if so, it uses that automatically for lower power draw;
+  otherwise it keeps using the existing GPU/CPU model, exactly as before.
+  `GET /v1/email/init` reports which one was picked. Accuracy/throughput
+  numbers for the NPU model aren't published yet — that measurement lands
+  in a follow-up release.
+
 ## 0.5.0
 
 - **Ask the agent in plain language.** Send a free-form request ("find today's

--- a/hub/agents/python/email/CONTRACT.md
+++ b/hub/agents/python/email/CONTRACT.md
@@ -584,3 +584,50 @@ slot. An agent instance with an exact ctx pin (`EmailAgentConfig.ctx_size` /
 same model will fight over the loaded ctx — visible as the reported ctx
 flapping between values across successive `GET /v1/email/init` calls. Do not
 enable `ctx_size` against a Lemonade instance shared with other traffic.
+
+---
+
+## Default model selection
+
+When `EmailAgentConfig.model_id` is unset, the agent no longer defaults
+unconditionally to the GGUF model — it resolves against the Lemonade Server
+it will actually talk to
+([#1439](https://github.com/amd/gaia/issues/1439),
+[`gaia_agent_email/model_select.py`](gaia_agent_email/model_select.py)):
+
+1. Probe that server's `/system-info` for `devices.amd_npu.available`
+   (a short-timeout raw probe — never the SDK's `get_system_info()`, which
+   has no timeout knob and would hang the whole resolution on an
+   unreachable server).
+2. If an AMD NPU is available **and** the NPU-native triage model
+   (`gemma4-it-e2b-FLM`) is already downloaded on that server, resolve to
+   it.
+3. Otherwise — no NPU, NPU present but the model not downloaded, or either
+   probe failing/timing out — resolve to the GGUF default
+   (`Gemma-4-E4B-it-GGUF`).
+
+The resolved id is always exactly one of those two literals; nothing from
+the server response is ever interpolated into it. A successful resolution
+is cached per Lemonade base URL for the life of the process (so a hot REST
+path doesn't re-probe on every request); a failed/timeout probe is never
+cached, so a server that comes up later is picked up on the next call
+rather than being stuck on a cold-start failure.
+
+An explicit `model_id` (`EmailAgentConfig.model_id`, or a caller-supplied
+value) always wins — auto-select only fills in when no preference was
+given. `GET /v1/email/init`'s `model.id` and the model actually used by
+`POST /v1/email/triage` are guaranteed to be the resolved model for the
+same request's `base_url` (both read through the same resolver).
+
+**Auto-selecting the NPU model also switches the agent's memory embedder**
+(`gaia.agents.registry.get_embedding_model_for_device`) to the FLM-native
+embedder when the resolver picks `gemma4-it-e2b-FLM`, so the chat model and
+the embedder stay co-resident on the NPU backend — mixing an NPU chat model
+with the default GGUF/Vulkan embedder would otherwise evict and reload the
+chat model on every turn on shared-memory hardware. Any other resolved
+model keeps the unchanged GGUF embedder default.
+
+**Merge-gate note:** this auto-select is not yet backed by an FLM-variant
+triage-accuracy baseline (`baseline_accuracy_e2b.json` was recorded on the
+GGUF build) — the measurement lands with the consolidated eval pass
+([#1319](https://github.com/amd/gaia/issues/1319)).

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -38,11 +38,15 @@ from typing import Any, ClassVar, List, Optional
 
 from gaia_agent_email import action_store, schedule_store
 from gaia_agent_email.config import ConfigurationError, EmailAgentConfig
-from gaia_agent_email.scheduler import EmailJobScheduler
+from gaia_agent_email.model_select import (
+    NPU_EMAIL_MODEL_ID,
+    resolve_default_email_model,
+)
 from gaia_agent_email.outlook_scopes import (
     OUTLOOK_CALENDAR_SCOPES,
     OUTLOOK_MAIL_SCOPES,
 )
+from gaia_agent_email.scheduler import EmailJobScheduler
 from gaia_agent_email.scopes import (
     AGENT_NAMESPACED_ID,
     ALL_SCOPES,
@@ -71,11 +75,11 @@ from gaia.agents.base.agent import Agent
 from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.memory import MemoryMixin
 from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.agents.registry import get_embedding_model_for_device
 from gaia.connectors.errors import ConnectorsError
 from gaia.connectors.formatting import format_connector_error
 from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.database.mixin import DatabaseMixin
-from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -346,13 +350,43 @@ class EmailTriageAgent(
         action_store.init_schema(self)
         schedule_store.init_schema(self)
 
+        # LLM connection. Default to Lemonade — the config's base_url
+        # allowlist guarantees the host is local. Resolved BEFORE init_memory()
+        # (below) so the memory embedder can be threaded to match an
+        # NPU auto-select (#1439) — see the embedder note there.
+        effective_base_url = (
+            config.base_url
+            if config.base_url is not None
+            else os.getenv("LEMONADE_BASE_URL", "http://localhost:13305/api/v1")
+        )
+        effective_model_id = config.model_id or resolve_default_email_model(
+            effective_base_url
+        )
+
         # Memory subsystem. Must be called BEFORE super().__init__() because
         # Agent.__init__() calls _register_tools(), and register_memory_tools()
         # needs _memory_store to be set. Default path: ~/.gaia/email/memory.db
         # (namespaced so it coexists with state.db without conflict).
+        #
+        # Embedder thrash guard (#1439, #1744/#1676/#1746 pattern): triaging
+        # on the FLM-native NPU model while the memory embedder stays on the
+        # GGUF/Vulkan default makes Lemonade evict and reload the chat model
+        # on every turn (NPU <-> Vulkan). When the resolved model is the NPU
+        # candidate, thread the device-appropriate embedder into init_memory
+        # the same way ChatAgent does (hub/agents/python/chat/gaia_agent_chat/
+        # agent.py, get_embedding_model_for_device) so chat + embeddings stay
+        # co-resident on the NPU backend. Any other resolved model keeps the
+        # unchanged default (embedding_model=None -> GGUF nomic).
+        embedding_model = (
+            get_embedding_model_for_device("npu")
+            if effective_model_id == NPU_EMAIL_MODEL_ID
+            else None
+        )
         memory_db = Path(config.resolved_memory_db_path())
         memory_db.parent.mkdir(parents=True, exist_ok=True)
-        self.init_memory(db_path=memory_db, context="email")
+        self.init_memory(
+            db_path=memory_db, context="email", embedding_model=embedding_model
+        )
 
         # Runtime memory toggle (#1666). init_memory() sets _incognito=False when
         # the store is live; honor an explicit memory_enabled=False by starting in
@@ -365,15 +399,6 @@ class EmailTriageAgent(
         # init_memory() (so _memory_store is set) and after
         # _session_preferences is set (done above).
         self._load_persisted_preferences()
-
-        # LLM connection. Default to Lemonade — the config's base_url
-        # allowlist guarantees the host is local.
-        effective_model_id = config.model_id or DEFAULT_MODEL_NAME
-        effective_base_url = (
-            config.base_url
-            if config.base_url is not None
-            else os.getenv("LEMONADE_BASE_URL", "http://localhost:13305/api/v1")
-        )
 
         self.response_mode = "conversational"
         super().__init__(

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -220,32 +220,24 @@ _MAX_SUMMARY_CHARS = 300
 # it also governs the TCP connect, so an unreachable server blocks on the OS
 # SYN timeout (~30s) before erroring. A short connect timeout turns "server
 # down" into a prompt 502 instead of a 30s hang.
-_LEMONADE_PROBE_CONNECT_TIMEOUT = 2.0
-_LEMONADE_PROBE_READ_TIMEOUT = 3.0
+#
+# _resolve_probe_base / _probe_model_present / the two timeout constants live
+# in gaia_agent_email.model_select (#1439) — that module is the NPU-aware
+# default-model resolver's home and must stay import-light (never pulls in
+# this FastAPI router), so the shared probe helpers moved there and are
+# re-imported here rather than duplicated.
+from gaia_agent_email.model_select import (  # noqa: E402
+    _LEMONADE_PROBE_CONNECT_TIMEOUT,
+    _LEMONADE_PROBE_READ_TIMEOUT,
+    _probe_model_present,
+    _resolve_probe_base,
+    resolve_default_email_model,
+)
 
 # A model pull is a first-download of multi-GB weights — minutes, not seconds.
 # Generous ceiling so a slow link doesn't abort a real download; the connect
 # leg stays short so an unreachable server still fails fast.
 _LEMONADE_PULL_TIMEOUT = (5.0, 1800.0)
-
-
-def _resolve_probe_base(base_url: Optional[str]) -> str:
-    """Resolve the Lemonade ``/api/v1`` base URL for a health/model probe.
-
-    An explicit ``base_url`` is normalised to end in ``/api/v1`` (callers often
-    omit it); ``None`` falls back to the env-derived default via
-    ``_get_lemonade_config``. Shared by the reachability probe and the
-    model-presence probe so both target the exact same server.
-    """
-    from gaia.llm.lemonade_client import _get_lemonade_config
-
-    if base_url:
-        probe_base = base_url.rstrip("/")
-        if not probe_base.endswith("/api/v1"):
-            probe_base = f"{probe_base}/api/v1"
-        return probe_base
-    _, _, probe_base = _get_lemonade_config()
-    return probe_base
 
 
 def _probe_lemonade_health(
@@ -325,43 +317,6 @@ def _probe_lemonade_reachable(base_url: Optional[str] = None) -> Tuple[bool, str
     return reachable, probe_base
 
 
-def _probe_model_present(probe_base: str, model_id: str) -> bool:
-    """Cheaply check whether ``model_id`` is downloaded on the Lemonade server.
-
-    Queries the model list (downloaded models only) with the same short
-    timeout as the reachability probe and matches on the ``id`` field using
-    the core tolerant comparison (``user.``-prefixed registrations are listed
-    under the stripped id). Sends the resolved Lemonade auth header so an
-    authenticated server answers instead of 401-ing. Raises
-    ``requests.RequestException`` on a transport failure — the caller turns
-    that into an actionable readiness hint rather than silently reporting
-    "absent".
-
-    "Present" is intentionally cheap (a list lookup, no model load). Whether
-    the model actually *loads* (``loadable``) is not probed in v1 — forcing a
-    load is heavy, so the readiness response reports ``loadable=null``.
-    """
-    import requests
-
-    from gaia.llm.lemonade_client import (
-        _model_ids_match,
-        lemonade_auth_headers,
-        resolve_lemonade_api_key,
-    )
-
-    resp = requests.get(
-        f"{probe_base}/models",
-        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
-        timeout=(_LEMONADE_PROBE_CONNECT_TIMEOUT, _LEMONADE_PROBE_READ_TIMEOUT),
-    )
-    resp.raise_for_status()
-    payload = resp.json()
-    data = payload.get("data", []) if isinstance(payload, dict) else []
-    return any(
-        isinstance(m, dict) and _model_ids_match(m.get("id"), model_id) for m in data
-    )
-
-
 def _pull_model(probe_base: str, model_id: str) -> None:
     """Tell a RUNNING Lemonade Server to download ``model_id``.
 
@@ -392,18 +347,19 @@ def _pull_model(probe_base: str, model_id: str) -> None:
     resp.raise_for_status()
 
 
-def _resolve_email_model_id() -> str:
+def _resolve_email_model_id(base_url: Optional[str] = None) -> str:
     """Resolve the Lemonade model id the email agent triages with.
 
     Mirrors the agent's own resolution (``config.model_id or
-    DEFAULT_MODEL_NAME``) so the readiness probe reports the exact model the
-    triage path will load.
+    resolve_default_email_model(base_url)``, #1439) so the readiness probe
+    reports the exact model the triage path will load — including the
+    NPU-aware auto-select, and against the SAME ``base_url`` the caller is
+    probing (a caller with an explicit non-default ``base_url`` must not
+    silently fall back to resolving against the default server).
     """
     from gaia_agent_email.config import EmailAgentConfig
 
-    from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
-
-    return EmailAgentConfig().model_id or DEFAULT_MODEL_NAME
+    return EmailAgentConfig().model_id or resolve_default_email_model(base_url)
 
 
 def _parse_version(version: Optional[str]) -> Optional[Tuple[int, ...]]:
@@ -572,8 +528,18 @@ class EmailTriageService:
         # with the fix beats a generic chat-time failure with no URL/model.
         self._assert_model_present(base_url)
 
+        # #1439: the resolved model id (explicit config.model_id, or the
+        # NPU-aware auto-select) MUST reach the chat client. Omitting `model=`
+        # here would make the resolution cosmetic — /v1/email/init could
+        # report the FLM model while the real triage call silently ran the
+        # SDK's own default instead. resolve_default_email_model() is cached
+        # per probe_base, so this second resolution (the first happened
+        # inside _assert_model_present above) is not a second network probe.
+        model_id = _resolve_email_model_id(base_url)
+
         sdk_cfg = AgentConfig(
             base_url=base_url,
+            model=model_id,
             use_local_llm=True,
             use_claude=False,
             use_chatgpt=False,
@@ -631,7 +597,7 @@ class EmailTriageService:
         import requests
 
         probe_base = _resolve_probe_base(base_url)
-        model_id = _resolve_email_model_id()
+        model_id = _resolve_email_model_id(base_url)
 
         try:
             present = _probe_model_present(probe_base, model_id)
@@ -2616,7 +2582,10 @@ def _compute_init_status(base_url: Optional[str] = None) -> InitResponse:
     import requests
     from gaia_agent_email.version import MIN_LEMONADE_VERSION
 
-    model_id = _resolve_email_model_id()
+    # #1439: pass base_url through — this used to call _resolve_email_model_id()
+    # with no argument, silently resolving against the DEFAULT server even when
+    # this readiness probe targets a different one.
+    model_id = _resolve_email_model_id(base_url)
     reachable, probe_base, version, loaded_models = _probe_lemonade_health(base_url)
     compatible = (
         _version_meets_min(version, MIN_LEMONADE_VERSION) if reachable else None

--- a/hub/agents/python/email/gaia_agent_email/model_select.py
+++ b/hub/agents/python/email/gaia_agent_email/model_select.py
@@ -1,0 +1,211 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""NPU-aware default model selection for the email triage agent (#1439).
+
+Auto-selects the FLM-native triage model (``gemma4-it-e2b-FLM``) when the
+Lemonade Server the agent will talk to reports an available AMD NPU AND
+already serves that model; falls back to the GGUF default
+(``DEFAULT_MODEL_NAME``, currently ``Gemma-4-E4B-it-GGUF``) in every other
+case — no NPU, NPU present but the FLM model not downloaded, or the probe
+itself failing/timing out.
+
+This module is a LEAF: it must never import ``gaia_agent_email.api_routes``
+(that would drag the whole FastAPI router into every CLI/agent
+construction). ``api_routes.py`` imports the shared probe helpers back FROM
+here instead — this module used to live inline in ``api_routes.py``; the
+probe helpers (:func:`_resolve_probe_base`, :func:`_probe_model_present`,
+the two timeout constants) were moved here verbatim so this module and
+``api_routes.py`` share one implementation.
+
+Timeout trap (#1677): NEVER call ``LemonadeClient.get_system_info()`` here
+— it has no timeout knob of its own and inherits
+``DEFAULT_REQUEST_TIMEOUT`` (900s). This module always uses a raw
+``requests.get`` with the same short probe-timeout tuple ``api_routes.py``
+already uses for its ``/health`` and ``/models`` probes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Fast pre-flight timeouts (mirrors the api_routes.py probe timeouts,
+# #1677): a short connect timeout turns "server down" into a prompt
+# fallback instead of hanging on the OS SYN timeout.
+_LEMONADE_PROBE_CONNECT_TIMEOUT = 2.0
+_LEMONADE_PROBE_READ_TIMEOUT = 3.0
+
+# The two-literal candidate set (security-panel-mandated): the value
+# resolve_default_email_model() returns is ALWAYS one of these two hardcoded
+# strings — never anything interpolated from a server response.
+NPU_EMAIL_MODEL_ID = "gemma4-it-e2b-FLM"
+
+# Module-level SUCCESS-ONLY memo, keyed by the resolved probe_base string. A
+# failed/timeout probe is NEVER cached here — a cold-start caller (e.g. the
+# import-time construction of a service singleton) must not bake in a
+# "Lemonade wasn't up yet" failure for the life of the process. See
+# _reset_model_select_cache() for the test-only reset hook.
+_resolution_cache: Dict[str, str] = {}
+
+
+def _resolve_probe_base(base_url: Optional[str]) -> str:
+    """Resolve the Lemonade ``/api/v1`` base URL for a health/model probe.
+
+    An explicit ``base_url`` is normalised to end in ``/api/v1`` (callers
+    often omit it); ``None`` falls back to the env-derived default via
+    ``_get_lemonade_config``. Shared by every probe in this module (and, via
+    the re-export in ``api_routes.py``, its reachability/model-presence
+    probes) so they all target the exact same server.
+    """
+    from gaia.llm.lemonade_client import _get_lemonade_config
+
+    if base_url:
+        probe_base = base_url.rstrip("/")
+        if not probe_base.endswith("/api/v1"):
+            probe_base = f"{probe_base}/api/v1"
+        return probe_base
+    _, _, probe_base = _get_lemonade_config()
+    return probe_base
+
+
+def _probe_model_present(probe_base: str, model_id: str) -> bool:
+    """Cheaply check whether ``model_id`` is downloaded on the Lemonade server.
+
+    Queries the model list (downloaded models only) with the short probe
+    timeout and matches on the ``id`` field using the core tolerant
+    comparison (``user.``-prefixed registrations are listed under the
+    stripped id). Sends the resolved Lemonade auth header so an
+    authenticated server answers instead of 401-ing. Raises
+    ``requests.RequestException`` on a transport failure — the caller turns
+    that into an actionable readiness hint (or, here, a fallback decision)
+    rather than silently reporting "absent".
+
+    "Present" is intentionally cheap (a list lookup, no model load).
+    """
+    import requests
+
+    from gaia.llm.lemonade_client import (
+        _model_ids_match,
+        lemonade_auth_headers,
+        resolve_lemonade_api_key,
+    )
+
+    resp = requests.get(
+        f"{probe_base}/models",
+        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        timeout=(_LEMONADE_PROBE_CONNECT_TIMEOUT, _LEMONADE_PROBE_READ_TIMEOUT),
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    data = payload.get("data", []) if isinstance(payload, dict) else []
+    return any(
+        isinstance(m, dict) and _model_ids_match(m.get("id"), model_id) for m in data
+    )
+
+
+def _probe_npu_available(probe_base: str) -> bool:
+    """Raw ``/system-info`` probe for ``devices.amd_npu.available`` (#1677).
+
+    Never uses ``LemonadeClient.get_system_info()`` — that has no timeout
+    knob and inherits the 900s ``DEFAULT_REQUEST_TIMEOUT``. Raises
+    ``requests.RequestException`` on a transport failure/timeout; the caller
+    treats that as "can't tell, fall back to E4B" and does NOT cache it.
+    """
+    import requests
+
+    from gaia.llm.lemonade_client import lemonade_auth_headers, resolve_lemonade_api_key
+
+    resp = requests.get(
+        f"{probe_base}/system-info",
+        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        timeout=(_LEMONADE_PROBE_CONNECT_TIMEOUT, _LEMONADE_PROBE_READ_TIMEOUT),
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    devices = payload.get("devices", {}) if isinstance(payload, dict) else {}
+    npu = devices.get("amd_npu", {}) if isinstance(devices, dict) else {}
+    return bool(npu.get("available")) if isinstance(npu, dict) else False
+
+
+def resolve_default_email_model(base_url: Optional[str] = None) -> str:
+    """Resolve the default Lemonade model id for email triage (#1439).
+
+    NPU available AND the FLM triage model already servable on that
+    server -> ``NPU_EMAIL_MODEL_ID``. Every other case (no NPU, NPU present
+    but the model isn't downloaded there, or either probe
+    failing/timing out) -> ``DEFAULT_MODEL_NAME`` (GGUF). Callers that
+    already have an explicit model id (``EmailAgentConfig.model_id`` or an
+    end-user-supplied model) must not call this — it is the "no explicit
+    preference" fallback path only.
+
+    Successful resolutions are cached per resolved ``probe_base`` so a hot
+    path (e.g. a REST route probing on every request) doesn't re-probe
+    Lemonade every call. A failed/timed-out probe is NEVER cached — see the
+    module docstring.
+    """
+    import requests
+
+    from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
+
+    probe_base = _resolve_probe_base(base_url)
+
+    cached = _resolution_cache.get(probe_base)
+    if cached is not None:
+        return cached
+
+    try:
+        npu_available = _probe_npu_available(probe_base)
+    except requests.exceptions.RequestException as exc:
+        logger.info(
+            "NPU auto-select: /system-info probe failed at %s (%s: %s) — "
+            "defaulting to %s.",
+            probe_base,
+            type(exc).__name__,
+            exc,
+            DEFAULT_MODEL_NAME,
+        )
+        return DEFAULT_MODEL_NAME  # NOT cached — retry on the next call.
+
+    if not npu_available:
+        _resolution_cache[probe_base] = DEFAULT_MODEL_NAME
+        return DEFAULT_MODEL_NAME
+
+    try:
+        servable = _probe_model_present(probe_base, NPU_EMAIL_MODEL_ID)
+    except requests.exceptions.RequestException as exc:
+        logger.info(
+            "NPU auto-select: could not read the model list at %s/models "
+            "(%s: %s) — defaulting to %s.",
+            probe_base,
+            type(exc).__name__,
+            exc,
+            DEFAULT_MODEL_NAME,
+        )
+        return DEFAULT_MODEL_NAME  # NOT cached — retry on the next call.
+
+    if not servable:
+        logger.info(
+            "NPU detected at %s but %s is not downloaded there — defaulting "
+            "to %s. Run `gaia init --profile npu` to pull it.",
+            probe_base,
+            NPU_EMAIL_MODEL_ID,
+            DEFAULT_MODEL_NAME,
+        )
+        _resolution_cache[probe_base] = DEFAULT_MODEL_NAME
+        return DEFAULT_MODEL_NAME
+
+    _resolution_cache[probe_base] = NPU_EMAIL_MODEL_ID
+    return NPU_EMAIL_MODEL_ID
+
+
+def _reset_model_select_cache() -> None:
+    """Test-only: clear the success-only resolution memo.
+
+    Tests that monkeypatch ``requests.get`` across multiple probe_base
+    values (or re-probe the same one under a different fake) must call this
+    between cases — otherwise a cached success from an earlier case silently
+    short-circuits a later one instead of re-probing.
+    """
+    _resolution_cache.clear()

--- a/hub/agents/python/email/tests/conftest.py
+++ b/hub/agents/python/email/tests/conftest.py
@@ -1,0 +1,26 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Shared fixtures for the gaia-agent-email package's own test suite.
+
+Resets ``gaia_agent_email.model_select``'s success-only cache before AND
+after every test in this directory, so a cached resolution from one test
+can never silently short-circuit another test's fake ``requests.get``
+(order-dependent flakiness).
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_select_cache_between_tests():
+    # ``model_select`` does not exist yet at RED time (#1439) -- this
+    # autouse fixture must not break every OTHER already-passing test in
+    # this directory by erroring at setup before the module lands.
+    try:
+        from gaia_agent_email.model_select import _reset_model_select_cache
+    except ImportError:
+        yield
+        return
+    _reset_model_select_cache()
+    yield
+    _reset_model_select_cache()

--- a/hub/agents/python/email/tests/test_email_agent.py
+++ b/hub/agents/python/email/tests/test_email_agent.py
@@ -310,6 +310,12 @@ def test_llm_chat_respects_lemonade_base_url_override_env(monkeypatch):
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"version": "10.2.0"}
             return resp
+        if url == "http://127.0.0.1:9555/api/v1/system-info":
+            # No NPU here — this test is about base_url redirection, not
+            # NPU auto-select (#1439); keep the resolved model unchanged.
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
+            return resp
         if url == "http://127.0.0.1:9555/api/v1/models":
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"data": [{"id": resolved_model_id}]}
@@ -343,6 +349,12 @@ def test_llm_chat_respects_lemonade_base_url_explicit_param(monkeypatch):
         if url == "http://127.0.0.1:9555/api/v1/health":
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"version": "10.2.0"}
+            return resp
+        if url == "http://127.0.0.1:9555/api/v1/system-info":
+            # No NPU here — this test is about base_url redirection, not
+            # NPU auto-select (#1439); keep the resolved model unchanged.
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
             return resp
         if url == "http://127.0.0.1:9555/api/v1/models":
             resp = MagicMock(status_code=200)
@@ -381,6 +393,12 @@ def test_wrong_model_raises_llm_triage_error(monkeypatch):
         if url == f"{probe_base}/health":
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"version": "10.2.0"}
+            return resp
+        if url == f"{probe_base}/system-info":
+            # No NPU — this test is about the model-absent path (AC2), not
+            # NPU auto-select (#1439); keep the resolved model unchanged.
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
             return resp
         if url == f"{probe_base}/models":
             resp = MagicMock(status_code=200)
@@ -424,6 +442,12 @@ def test_wrong_model_check_transport_failure_is_loud(monkeypatch):
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"version": "10.2.0"}
             return resp
+        if url == f"{probe_base}/system-info":
+            # No NPU — this test is about a /models transport failure, not
+            # NPU auto-select (#1439); keep the resolved model unchanged.
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
+            return resp
         if url == f"{probe_base}/models":
             raise requests.ConnectionError("reset by peer")
         raise AssertionError(f"unexpected probe URL: {url}")
@@ -466,6 +490,12 @@ def test_model_present_check_tolerant_of_user_dot_prefix(monkeypatch):
         if url == f"{probe_base}/health":
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"version": "10.2.0"}
+            return resp
+        if url == f"{probe_base}/system-info":
+            # No NPU — this test is about the user.-prefix tolerant match,
+            # not NPU auto-select (#1439); keep the resolved model unchanged.
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
             return resp
         if url == f"{probe_base}/models":
             resp = MagicMock(status_code=200)

--- a/hub/agents/python/email/tests/test_init_ctx.py
+++ b/hub/agents/python/email/tests/test_init_ctx.py
@@ -38,10 +38,17 @@ pytest.importorskip("gaia_agent_email")
 
 
 def _fake_get_factory(*, health_body, models_present):
-    """Build a ``requests.get`` stub serving ``/health`` and ``/models``.
+    """Build a ``requests.get`` stub serving ``/health``, ``/system-info``,
+    and ``/models``.
 
     ``models_present`` controls whether ``/models`` lists the resolved model
     id (mirrors the existing pattern in test_email_agent.py:197-263).
+
+    ``/system-info`` reports the NPU as unavailable (#1439's auto-select
+    resolver short-circuits to the GGUF default on that answer) so every
+    test in this file keeps resolving to its existing implicit
+    ``model_id == DEFAULT_MODEL_NAME`` expectation -- this file is about
+    ``ctx_size`` reporting, not NPU model selection.
     """
 
     def _fake_get(url, *args, **kwargs):
@@ -50,6 +57,10 @@ def _fake_get_factory(*, health_body, models_present):
         if url.endswith("/health"):
             resp = MagicMock(status_code=200)
             resp.json.return_value = health_body
+            return resp
+        if url.endswith("/system-info"):
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
             return resp
         if url.endswith("/models"):
             model_id = _resolve_email_model_id()

--- a/hub/agents/python/email/tests/test_model_select.py
+++ b/hub/agents/python/email/tests/test_model_select.py
@@ -1,0 +1,397 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""RED-first tests for the NPU auto-select resolver (#1439).
+
+``resolve_default_email_model`` decides, per Lemonade server, whether the
+email agent's default model should be the NPU-native ``gemma4-it-e2b-FLM``
+or the existing GGUF default (``gaia.llm.lemonade_client.DEFAULT_MODEL_NAME``).
+It probes Lemonade's raw ``/system-info`` (never
+``LemonadeClient.get_system_info()`` -- that call carries a 900s default
+timeout, the #1677 hang class) and, only when an NPU is reported available,
+the ``/models`` catalog for FLM presence.
+
+The two-literal guarantee is the security-relevant property under test: the
+function must NEVER echo any field from the Lemonade response back as the
+resolved model id -- it always returns one of exactly two hardcoded
+constants.
+
+``gaia_agent_email.model_select`` does not exist yet (a teammate implements
+it after this file lands) -- every test here is expected to fail collection
+with ``ModuleNotFoundError`` until then. That is the correct RED state.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+import requests  # noqa: E402
+from gaia_agent_email.model_select import (  # noqa: E402
+    NPU_EMAIL_MODEL_ID,
+    _LEMONADE_PROBE_CONNECT_TIMEOUT,
+    _LEMONADE_PROBE_READ_TIMEOUT,
+    _reset_model_select_cache,
+    resolve_default_email_model,
+)
+
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME  # noqa: E402
+
+
+def _system_info_body(*, npu_available, extra_npu_fields=None):
+    amd_npu = {"available": npu_available}
+    if extra_npu_fields:
+        amd_npu.update(extra_npu_fields)
+    return {"devices": {"amd_npu": amd_npu}}
+
+
+def _models_body(*, present):
+    return {"data": [{"id": NPU_EMAIL_MODEL_ID}] if present else []}
+
+
+def _fake_get_factory(
+    probe_base,
+    *,
+    system_info_body=None,
+    system_info_raises=None,
+    models_body=None,
+    models_raises=None,
+):
+    """Strict ``requests.get`` stub serving ``/system-info`` and ``/models``
+    rooted at ``probe_base``. Any other URL raises loudly instead of
+    silently returning something plausible -- a resolver bug that queries
+    the wrong endpoint (or the wrong server) must fail the test, not pass
+    on a lucky mock. Returns ``(fake_get, calls)`` where ``calls`` is a
+    mutable list of ``(url, kwargs)`` the caller can inspect after use.
+    """
+    calls: list = []
+
+    def _fake_get(url, *args, **kwargs):
+        calls.append((url, kwargs))
+        if url == f"{probe_base}/system-info":
+            if system_info_raises is not None:
+                raise system_info_raises
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = system_info_body
+            return resp
+        if url == f"{probe_base}/models":
+            if models_raises is not None:
+                raise models_raises
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = models_body
+            return resp
+        raise AssertionError(f"unexpected probe URL: {url}")
+
+    return _fake_get, calls
+
+
+# ---------------------------------------------------------------------------
+# Behavior matrix
+# ---------------------------------------------------------------------------
+
+
+def test_npu_available_and_flm_servable_selects_npu_model(monkeypatch):
+    probe_base = "http://127.0.0.1:9601/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base,
+        system_info_body=_system_info_body(npu_available=True),
+        models_body=_models_body(present=True),
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    result = resolve_default_email_model("http://127.0.0.1:9601")
+
+    assert result == NPU_EMAIL_MODEL_ID
+    assert any(url == f"{probe_base}/models" for url, _ in calls)
+
+
+def test_npu_available_but_flm_not_servable_falls_back_and_logs(monkeypatch, caplog):
+    probe_base = "http://127.0.0.1:9602/api/v1"
+    fake, _calls = _fake_get_factory(
+        probe_base,
+        system_info_body=_system_info_body(npu_available=True),
+        models_body=_models_body(present=False),
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    with caplog.at_level(logging.INFO):
+        result = resolve_default_email_model("http://127.0.0.1:9602")
+
+    assert result == DEFAULT_MODEL_NAME
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(info_records) == 1
+    assert "gaia init --profile npu" in info_records[0].getMessage()
+
+
+@pytest.mark.parametrize(
+    "system_info_body",
+    [
+        _system_info_body(npu_available=False),
+        {},
+        {"devices": {}},
+    ],
+    ids=["npu_unavailable", "devices_missing", "amd_npu_missing"],
+)
+def test_npu_unavailable_short_circuits_without_models_probe(
+    monkeypatch, system_info_body
+):
+    probe_base = "http://127.0.0.1:9603/api/v1"
+    fake, calls = _fake_get_factory(probe_base, system_info_body=system_info_body)
+    monkeypatch.setattr(requests, "get", fake)
+
+    result = resolve_default_email_model("http://127.0.0.1:9603")
+
+    assert result == DEFAULT_MODEL_NAME
+    assert not any(url == f"{probe_base}/models" for url, _ in calls)
+
+
+# ---------------------------------------------------------------------------
+# Transport failures -- always DEFAULT_MODEL_NAME, always logged, never cached
+# ---------------------------------------------------------------------------
+
+
+def test_system_info_connection_error_falls_back_and_logs(monkeypatch, caplog):
+    probe_base = "http://127.0.0.1:9620/api/v1"
+    fake, _calls = _fake_get_factory(
+        probe_base, system_info_raises=requests.exceptions.ConnectionError("refused")
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    with caplog.at_level(logging.INFO):
+        result = resolve_default_email_model("http://127.0.0.1:9620")
+
+    assert result == DEFAULT_MODEL_NAME
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(info_records) == 1
+
+
+def test_system_info_timeout_falls_back_and_logs(monkeypatch, caplog):
+    probe_base = "http://127.0.0.1:9621/api/v1"
+    fake, _calls = _fake_get_factory(
+        probe_base, system_info_raises=requests.exceptions.Timeout("timed out")
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    with caplog.at_level(logging.INFO):
+        result = resolve_default_email_model("http://127.0.0.1:9621")
+
+    assert result == DEFAULT_MODEL_NAME
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(info_records) == 1
+
+
+def test_system_info_transport_failure_is_not_cached(monkeypatch):
+    probe_base = "http://127.0.0.1:9622/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base, system_info_raises=requests.exceptions.ConnectionError("refused")
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    resolve_default_email_model("http://127.0.0.1:9622")
+    first_count = sum(1 for url, _ in calls if url == f"{probe_base}/system-info")
+
+    resolve_default_email_model("http://127.0.0.1:9622")
+    second_count = sum(1 for url, _ in calls if url == f"{probe_base}/system-info")
+
+    assert second_count == first_count + 1
+
+
+def test_models_probe_transport_failure_falls_back_and_logs(monkeypatch, caplog):
+    probe_base = "http://127.0.0.1:9623/api/v1"
+    fake, _calls = _fake_get_factory(
+        probe_base,
+        system_info_body=_system_info_body(npu_available=True),
+        models_raises=requests.exceptions.ConnectionError("reset by peer"),
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    with caplog.at_level(logging.INFO):
+        result = resolve_default_email_model("http://127.0.0.1:9623")
+
+    assert result == DEFAULT_MODEL_NAME
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(info_records) == 1
+
+
+def test_models_probe_transport_failure_is_not_cached(monkeypatch):
+    probe_base = "http://127.0.0.1:9624/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base,
+        system_info_body=_system_info_body(npu_available=True),
+        models_raises=requests.exceptions.ConnectionError("reset by peer"),
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    resolve_default_email_model("http://127.0.0.1:9624")
+    first_count = sum(1 for url, _ in calls if url == f"{probe_base}/system-info")
+
+    resolve_default_email_model("http://127.0.0.1:9624")
+    second_count = sum(1 for url, _ in calls if url == f"{probe_base}/system-info")
+
+    assert second_count == first_count + 1
+
+
+# ---------------------------------------------------------------------------
+# Success-only caching
+# ---------------------------------------------------------------------------
+
+
+def test_successful_flm_resolution_is_cached(monkeypatch):
+    probe_base = "http://127.0.0.1:9610/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base,
+        system_info_body=_system_info_body(npu_available=True),
+        models_body=_models_body(present=True),
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    first = resolve_default_email_model("http://127.0.0.1:9610")
+    count_after_first = len(calls)
+    second = resolve_default_email_model("http://127.0.0.1:9610")
+    count_after_second = len(calls)
+
+    assert first == NPU_EMAIL_MODEL_ID
+    assert second == NPU_EMAIL_MODEL_ID
+    assert count_after_second == count_after_first
+
+
+def test_successful_e4b_resolution_is_cached_npu_unavailable(monkeypatch):
+    probe_base = "http://127.0.0.1:9611/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base, system_info_body=_system_info_body(npu_available=False)
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    first = resolve_default_email_model("http://127.0.0.1:9611")
+    count_after_first = len(calls)
+    second = resolve_default_email_model("http://127.0.0.1:9611")
+    count_after_second = len(calls)
+
+    assert first == DEFAULT_MODEL_NAME
+    assert second == DEFAULT_MODEL_NAME
+    assert count_after_second == count_after_first
+
+
+def test_reset_model_select_cache_clears_cache(monkeypatch):
+    probe_base = "http://127.0.0.1:9612/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base,
+        system_info_body=_system_info_body(npu_available=True),
+        models_body=_models_body(present=True),
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    resolve_default_email_model("http://127.0.0.1:9612")
+    count_before_reset = len(calls)
+
+    _reset_model_select_cache()
+
+    resolve_default_email_model("http://127.0.0.1:9612")
+    count_after_reset = len(calls)
+
+    assert count_after_reset > count_before_reset
+
+
+def test_different_base_urls_get_independent_cache_entries(monkeypatch):
+    base_a = "http://127.0.0.1:9613"
+    base_b = "http://127.0.0.1:9614"
+    probe_base_a = f"{base_a}/api/v1"
+    probe_base_b = f"{base_b}/api/v1"
+    calls: list = []
+
+    def _fake_get(url, *args, **kwargs):
+        calls.append((url, kwargs))
+        if url == f"{probe_base_a}/system-info":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = _system_info_body(npu_available=True)
+            return resp
+        if url == f"{probe_base_a}/models":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = _models_body(present=True)
+            return resp
+        if url == f"{probe_base_b}/system-info":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = _system_info_body(npu_available=False)
+            return resp
+        raise AssertionError(f"unexpected probe URL: {url}")
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+
+    result_a = resolve_default_email_model(base_a)
+    result_b = resolve_default_email_model(base_b)
+
+    assert result_a == NPU_EMAIL_MODEL_ID
+    assert result_b == DEFAULT_MODEL_NAME
+    # base_b must have been genuinely probed, not short-circuited by
+    # base_a's already-cached entry.
+    assert any(url == f"{probe_base_b}/system-info" for url, _ in calls)
+
+
+# ---------------------------------------------------------------------------
+# Two-literal guarantee + timeout pin + default probe base
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_value_is_always_exactly_one_of_two_literals(monkeypatch):
+    probe_base = "http://127.0.0.1:9615/api/v1"
+    injected_fields = {
+        "name": "'; DROP TABLE models;--",
+        "some_id_field": "not-a-real-model",
+    }
+    fake, _calls = _fake_get_factory(
+        probe_base,
+        system_info_body=_system_info_body(
+            npu_available=True, extra_npu_fields=injected_fields
+        ),
+        models_body=_models_body(present=True),
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    result = resolve_default_email_model("http://127.0.0.1:9615")
+
+    assert result in (NPU_EMAIL_MODEL_ID, DEFAULT_MODEL_NAME)
+    assert result == NPU_EMAIL_MODEL_ID
+    for injected_value in injected_fields.values():
+        assert injected_value not in result
+
+
+def test_system_info_probe_uses_pinned_timeout_tuple(monkeypatch):
+    probe_base = "http://127.0.0.1:9616/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base, system_info_body=_system_info_body(npu_available=False)
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    resolve_default_email_model("http://127.0.0.1:9616")
+
+    system_info_calls = [
+        kwargs for url, kwargs in calls if url == f"{probe_base}/system-info"
+    ]
+    assert len(system_info_calls) == 1
+    assert system_info_calls[0].get("timeout") == (
+        _LEMONADE_PROBE_CONNECT_TIMEOUT,
+        _LEMONADE_PROBE_READ_TIMEOUT,
+    )
+
+
+def test_resolve_default_email_model_with_no_args_uses_default_probe_base(
+    monkeypatch,
+):
+    monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+    probe_base = "http://localhost:13305/api/v1"
+    fake, calls = _fake_get_factory(
+        probe_base, system_info_body=_system_info_body(npu_available=False)
+    )
+    monkeypatch.setattr(requests, "get", fake)
+
+    result = resolve_default_email_model()
+
+    assert result == DEFAULT_MODEL_NAME
+    assert any(url == f"{probe_base}/system-info" for url, _ in calls)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/hub/agents/python/email/tests/test_model_select.py
+++ b/hub/agents/python/email/tests/test_model_select.py
@@ -31,9 +31,9 @@ pytest.importorskip("gaia_agent_email")
 
 import requests  # noqa: E402
 from gaia_agent_email.model_select import (  # noqa: E402
-    NPU_EMAIL_MODEL_ID,
     _LEMONADE_PROBE_CONNECT_TIMEOUT,
     _LEMONADE_PROBE_READ_TIMEOUT,
+    NPU_EMAIL_MODEL_ID,
     _reset_model_select_cache,
     resolve_default_email_model,
 )

--- a/hub/agents/python/email/tests/test_npu_model_wiring.py
+++ b/hub/agents/python/email/tests/test_npu_model_wiring.py
@@ -187,11 +187,10 @@ def test_agent_explicit_model_id_skips_resolver(tmp_path, monkeypatch):
     monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
     cfg = _make_config(tmp_path, model_id="SomeExplicitModel-GGUF")
 
-    with patch.object(
-        LemonadeManager, "ensure_ready", return_value=True
-    ), patch(
-        "gaia_agent_email.agent.resolve_default_email_model"
-    ) as mock_resolve:
+    with (
+        patch.object(LemonadeManager, "ensure_ready", return_value=True),
+        patch("gaia_agent_email.agent.resolve_default_email_model") as mock_resolve,
+    ):
         agent = EmailTriageAgent(config=cfg)
     try:
         mock_resolve.assert_not_called()
@@ -202,16 +201,15 @@ def test_agent_explicit_model_id_skips_resolver(tmp_path, monkeypatch):
 
 def test_agent_resolver_called_with_explicit_base_url(tmp_path, monkeypatch):
     monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
-    cfg = _make_config(
-        tmp_path, base_url="http://127.0.0.1:9640", model_id=None
-    )
+    cfg = _make_config(tmp_path, base_url="http://127.0.0.1:9640", model_id=None)
 
-    with patch.object(
-        LemonadeManager, "ensure_ready", return_value=True
-    ), patch(
-        "gaia_agent_email.agent.resolve_default_email_model",
-        return_value="sentinel-model",
-    ) as mock_resolve:
+    with (
+        patch.object(LemonadeManager, "ensure_ready", return_value=True),
+        patch(
+            "gaia_agent_email.agent.resolve_default_email_model",
+            return_value="sentinel-model",
+        ) as mock_resolve,
+    ):
         agent = EmailTriageAgent(config=cfg)
     try:
         mock_resolve.assert_called_once_with("http://127.0.0.1:9640")
@@ -225,12 +223,13 @@ def test_agent_resolver_called_with_env_default_base_url(tmp_path, monkeypatch):
     monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
     cfg = _make_config(tmp_path, base_url=None, model_id=None)
 
-    with patch.object(
-        LemonadeManager, "ensure_ready", return_value=True
-    ), patch(
-        "gaia_agent_email.agent.resolve_default_email_model",
-        return_value="sentinel-model",
-    ) as mock_resolve:
+    with (
+        patch.object(LemonadeManager, "ensure_ready", return_value=True),
+        patch(
+            "gaia_agent_email.agent.resolve_default_email_model",
+            return_value="sentinel-model",
+        ) as mock_resolve,
+    ):
         agent = EmailTriageAgent(config=cfg)
     try:
         mock_resolve.assert_called_once_with("http://localhost:13305/api/v1")
@@ -246,12 +245,14 @@ def test_agent_threads_npu_embedder_when_flm_resolved(tmp_path, monkeypatch):
     expected_embedder = get_embedding_model_for_device("npu")
     cfg = _make_config(tmp_path, model_id=None)
 
-    with patch.object(
-        LemonadeManager, "ensure_ready", return_value=True
-    ), patch(
-        "gaia_agent_email.agent.resolve_default_email_model",
-        return_value=NPU_EMAIL_MODEL_ID,
-    ), patch.object(EmailTriageAgent, "init_memory") as mock_init_memory:
+    with (
+        patch.object(LemonadeManager, "ensure_ready", return_value=True),
+        patch(
+            "gaia_agent_email.agent.resolve_default_email_model",
+            return_value=NPU_EMAIL_MODEL_ID,
+        ),
+        patch.object(EmailTriageAgent, "init_memory") as mock_init_memory,
+    ):
         agent = EmailTriageAgent(config=cfg)
     try:
         mock_init_memory.assert_called_once()
@@ -269,12 +270,14 @@ def test_agent_leaves_default_embedder_when_e4b_resolved(tmp_path, monkeypatch):
     (None -> GGUF nomic embedder)."""
     cfg = _make_config(tmp_path, model_id=None)
 
-    with patch.object(
-        LemonadeManager, "ensure_ready", return_value=True
-    ), patch(
-        "gaia_agent_email.agent.resolve_default_email_model",
-        return_value=DEFAULT_MODEL_NAME,
-    ), patch.object(EmailTriageAgent, "init_memory") as mock_init_memory:
+    with (
+        patch.object(LemonadeManager, "ensure_ready", return_value=True),
+        patch(
+            "gaia_agent_email.agent.resolve_default_email_model",
+            return_value=DEFAULT_MODEL_NAME,
+        ),
+        patch.object(EmailTriageAgent, "init_memory") as mock_init_memory,
+    ):
         agent = EmailTriageAgent(config=cfg)
     try:
         mock_init_memory.assert_called_once()
@@ -290,9 +293,10 @@ def test_agent_leaves_default_embedder_with_explicit_non_flm_model(
     consulted) also must not thread the NPU embedder."""
     cfg = _make_config(tmp_path, model_id="SomeExplicitModel-GGUF")
 
-    with patch.object(
-        LemonadeManager, "ensure_ready", return_value=True
-    ), patch.object(EmailTriageAgent, "init_memory") as mock_init_memory:
+    with (
+        patch.object(LemonadeManager, "ensure_ready", return_value=True),
+        patch.object(EmailTriageAgent, "init_memory") as mock_init_memory,
+    ):
         agent = EmailTriageAgent(config=cfg)
     try:
         mock_init_memory.assert_called_once()

--- a/hub/agents/python/email/tests/test_npu_model_wiring.py
+++ b/hub/agents/python/email/tests/test_npu_model_wiring.py
@@ -1,0 +1,361 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""RED-first tests: NPU auto-select is actually WIRED, not cosmetic (#1439).
+
+``gaia_agent_email.model_select.resolve_default_email_model`` (see
+``test_model_select.py``) decides FLM vs the GGUF default per Lemonade
+server. This file locks in that the resolver's answer actually reaches
+every surface that loads a model for the email agent:
+
+- ``api_routes._resolve_email_model_id`` (readiness probe + trap test below)
+- ``api_routes._compute_init_status`` (``GET /v1/email/init``)
+- ``api_routes.EmailTriageService._build_llm_chat`` (the REAL triage call --
+  THE most important regression: today ``_build_llm_chat`` builds its
+  ``AgentConfig`` with no ``model=`` kwarg, so ``/v1/email/init`` could
+  report FLM selected while the actual triage call silently runs the SDK's
+  default model instead)
+- ``agent.EmailTriageAgent.__init__`` (CLI / agent-loop path), including the
+  device-aware embedder threaded into ``init_memory(embedding_model=...)``
+  so an FLM chat model doesn't get evicted by a GGUF (Vulkan) embedder.
+
+``gaia_agent_email.model_select`` does not exist yet -- every test in this
+file is expected to fail collection with ``ModuleNotFoundError`` until a
+teammate implements it. That is the correct RED state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+import requests  # noqa: E402
+from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
+from gaia_agent_email.api_routes import (  # noqa: E402
+    EmailTriageService,
+    _compute_init_status,
+    _resolve_email_model_id,
+)
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+from gaia_agent_email.model_select import (  # noqa: E402
+    NPU_EMAIL_MODEL_ID,
+    _reset_model_select_cache,
+)
+
+from gaia.agents.registry import get_embedding_model_for_device  # noqa: E402
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME  # noqa: E402
+from gaia.llm.lemonade_manager import LemonadeManager  # noqa: E402
+
+
+class _MinimalMailBackend:
+    """Satisfies the GmailBackend protocol just enough to construct."""
+
+
+class _MinimalCalendarBackend:
+    """Satisfies the CalendarBackend protocol just enough to construct."""
+
+
+def _make_config(tmp_path, **overrides):
+    kwargs = dict(
+        gmail_backend=_MinimalMailBackend(),
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+    )
+    kwargs.update(overrides)
+    return EmailAgentConfig(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# (a) api_routes wiring
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_email_model_id_delegates_to_resolver_with_base_url():
+    with patch(
+        "gaia_agent_email.api_routes.resolve_default_email_model",
+        return_value="sentinel-model",
+    ) as mock_resolve:
+        result = _resolve_email_model_id("http://127.0.0.1:9631")
+
+    mock_resolve.assert_called_once_with("http://127.0.0.1:9631")
+    assert result == "sentinel-model"
+
+
+def test_resolve_email_model_id_default_base_url_is_none():
+    with patch(
+        "gaia_agent_email.api_routes.resolve_default_email_model",
+        return_value="sentinel-default",
+    ) as mock_resolve:
+        result = _resolve_email_model_id()
+
+    mock_resolve.assert_called_once_with(None)
+    assert result == "sentinel-default"
+
+
+def test_compute_init_status_threads_non_default_base_url(monkeypatch):
+    """Regression: today ``_compute_init_status`` calls
+    ``_resolve_email_model_id()`` with no args, silently ignoring its own
+    ``base_url`` parameter. It must thread that same base_url through.
+    """
+
+    def _fake_get(url, *args, **kwargs):
+        raise requests.exceptions.ConnectionError("refused")
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+
+    with patch(
+        "gaia_agent_email.api_routes._resolve_email_model_id",
+        return_value="sentinel-model",
+    ) as mock_resolve:
+        _compute_init_status(base_url="http://127.0.0.1:9632")
+
+    mock_resolve.assert_called_once_with("http://127.0.0.1:9632")
+
+
+def test_build_llm_chat_uses_resolved_model_id_the_trap_test(monkeypatch):
+    """THE regression guard: a resolver that exists but never reaches the
+    real ``AgentConfig(model=...)`` is cosmetic. Fake the reachability +
+    model-presence preflight to succeed, patch the resolver to a known
+    sentinel, and assert the constructed chat client actually carries it.
+    """
+    probe_base = "http://127.0.0.1:9633/api/v1"
+    sentinel_model = "sentinel-resolved-model"
+
+    def _fake_get(url, *args, **kwargs):
+        if url == f"{probe_base}/health":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"version": "10.10.0"}
+            return resp
+        if url == f"{probe_base}/models":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"data": [{"id": sentinel_model}]}
+            return resp
+        raise AssertionError(f"unexpected probe URL: {url}")
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+
+    with patch(
+        "gaia_agent_email.api_routes.resolve_default_email_model",
+        return_value=sentinel_model,
+    ):
+        chat = EmailTriageService()._build_llm_chat(base_url="http://127.0.0.1:9633")
+
+    assert chat.config.model == sentinel_model
+
+
+def test_build_llm_chat_uses_default_model_when_npu_unavailable_inverse(monkeypatch):
+    """Inverse of the trap test: with the REAL resolver running (not
+    patched) and the NPU reported unavailable, the chat client lands on
+    ``DEFAULT_MODEL_NAME`` -- proving the wiring isn't hardcoded to always
+    equal whatever the resolver happens to return.
+    """
+    probe_base = "http://127.0.0.1:9634/api/v1"
+
+    def _fake_get(url, *args, **kwargs):
+        if url == f"{probe_base}/health":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"version": "10.10.0"}
+            return resp
+        if url == f"{probe_base}/system-info":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
+            return resp
+        if url == f"{probe_base}/models":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"data": [{"id": DEFAULT_MODEL_NAME}]}
+            return resp
+        raise AssertionError(f"unexpected probe URL: {url}")
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+
+    chat = EmailTriageService()._build_llm_chat(base_url="http://127.0.0.1:9634")
+
+    assert chat.config.model == DEFAULT_MODEL_NAME
+
+
+# ---------------------------------------------------------------------------
+# (b) agent.py wiring
+# ---------------------------------------------------------------------------
+
+
+def test_agent_explicit_model_id_skips_resolver(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    cfg = _make_config(tmp_path, model_id="SomeExplicitModel-GGUF")
+
+    with patch.object(
+        LemonadeManager, "ensure_ready", return_value=True
+    ), patch(
+        "gaia_agent_email.agent.resolve_default_email_model"
+    ) as mock_resolve:
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        mock_resolve.assert_not_called()
+        assert agent.model_id == "SomeExplicitModel-GGUF"
+    finally:
+        agent.close_db()
+
+
+def test_agent_resolver_called_with_explicit_base_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    cfg = _make_config(
+        tmp_path, base_url="http://127.0.0.1:9640", model_id=None
+    )
+
+    with patch.object(
+        LemonadeManager, "ensure_ready", return_value=True
+    ), patch(
+        "gaia_agent_email.agent.resolve_default_email_model",
+        return_value="sentinel-model",
+    ) as mock_resolve:
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        mock_resolve.assert_called_once_with("http://127.0.0.1:9640")
+        assert agent.model_id == "sentinel-model"
+    finally:
+        agent.close_db()
+
+
+def test_agent_resolver_called_with_env_default_base_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+    cfg = _make_config(tmp_path, base_url=None, model_id=None)
+
+    with patch.object(
+        LemonadeManager, "ensure_ready", return_value=True
+    ), patch(
+        "gaia_agent_email.agent.resolve_default_email_model",
+        return_value="sentinel-model",
+    ) as mock_resolve:
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        mock_resolve.assert_called_once_with("http://localhost:13305/api/v1")
+        assert agent.model_id == "sentinel-model"
+    finally:
+        agent.close_db()
+
+
+def test_agent_threads_npu_embedder_when_flm_resolved(tmp_path, monkeypatch):
+    """FLM resolved -> ``init_memory`` gets the device-aware NPU embedder
+    (never the FLM-chat literal hardcoded here -- call the real helper).
+    """
+    expected_embedder = get_embedding_model_for_device("npu")
+    cfg = _make_config(tmp_path, model_id=None)
+
+    with patch.object(
+        LemonadeManager, "ensure_ready", return_value=True
+    ), patch(
+        "gaia_agent_email.agent.resolve_default_email_model",
+        return_value=NPU_EMAIL_MODEL_ID,
+    ), patch.object(EmailTriageAgent, "init_memory") as mock_init_memory:
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        mock_init_memory.assert_called_once()
+        assert (
+            mock_init_memory.call_args.kwargs.get("embedding_model")
+            == expected_embedder
+        )
+    finally:
+        agent.close_db()
+
+
+def test_agent_leaves_default_embedder_when_e4b_resolved(tmp_path, monkeypatch):
+    """Regression: resolver landing on DEFAULT_MODEL_NAME must NOT thread
+    the NPU embedder -- ``embedding_model`` stays the unchanged default
+    (None -> GGUF nomic embedder)."""
+    cfg = _make_config(tmp_path, model_id=None)
+
+    with patch.object(
+        LemonadeManager, "ensure_ready", return_value=True
+    ), patch(
+        "gaia_agent_email.agent.resolve_default_email_model",
+        return_value=DEFAULT_MODEL_NAME,
+    ), patch.object(EmailTriageAgent, "init_memory") as mock_init_memory:
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        mock_init_memory.assert_called_once()
+        assert mock_init_memory.call_args.kwargs.get("embedding_model") is None
+    finally:
+        agent.close_db()
+
+
+def test_agent_leaves_default_embedder_with_explicit_non_flm_model(
+    tmp_path, monkeypatch
+):
+    """Regression: an explicit non-FLM ``model_id`` (resolver never
+    consulted) also must not thread the NPU embedder."""
+    cfg = _make_config(tmp_path, model_id="SomeExplicitModel-GGUF")
+
+    with patch.object(
+        LemonadeManager, "ensure_ready", return_value=True
+    ), patch.object(EmailTriageAgent, "init_memory") as mock_init_memory:
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        mock_init_memory.assert_called_once()
+        assert mock_init_memory.call_args.kwargs.get("embedding_model") is None
+    finally:
+        agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# (c) Cross-surface agreement at a non-default base_url
+# ---------------------------------------------------------------------------
+
+
+def test_cross_surface_agreement_at_nondefault_base_url(tmp_path, monkeypatch):
+    """Agent, readiness probe, init status, and the real triage chat client
+    must all agree on the SAME resolved model at the SAME non-default
+    Lemonade base_url -- and the resolver must actually have reached that
+    port (9555), never silently falling back to the default (13305).
+    """
+    _reset_model_select_cache()
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+
+    probe_base = "http://127.0.0.1:9555/api/v1"
+    captured_urls: list = []
+
+    def _fake_get(url, *args, **kwargs):
+        captured_urls.append(url)
+        if url == f"{probe_base}/health":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"version": "10.10.0"}
+            return resp
+        if url == f"{probe_base}/system-info":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": True}}}
+            return resp
+        if url == f"{probe_base}/models":
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"data": [{"id": NPU_EMAIL_MODEL_ID}]}
+            return resp
+        raise AssertionError(f"unexpected probe URL: {url}")
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+
+    cfg = _make_config(tmp_path, base_url="http://127.0.0.1:9555", model_id=None)
+    with patch.object(LemonadeManager, "ensure_ready", return_value=True):
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        assert agent.model_id == NPU_EMAIL_MODEL_ID
+    finally:
+        agent.close_db()
+
+    assert _resolve_email_model_id("http://127.0.0.1:9555") == NPU_EMAIL_MODEL_ID
+
+    status = _compute_init_status("http://127.0.0.1:9555")
+    assert status.model.id == NPU_EMAIL_MODEL_ID
+
+    chat = EmailTriageService()._build_llm_chat(base_url="http://127.0.0.1:9555")
+    assert chat.config.model == NPU_EMAIL_MODEL_ID
+
+    assert any("9555" in url for url in captured_urls)
+    assert not any("13305" in url for url in captured_urls)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/agents/email/conftest.py
+++ b/tests/unit/agents/email/conftest.py
@@ -1,0 +1,27 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Shared fixtures for tests/unit/agents/email.
+
+Resets ``gaia_agent_email.model_select``'s success-only cache before AND
+after every test in this directory (e.g. ``test_init_endpoint.py`` exercises
+``_resolve_email_model_id`` / ``_probe_model_present`` repeatedly across many
+test functions in the same file), so a cached resolution from one test can
+never silently short-circuit another test's fake ``requests.get``.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_select_cache_between_tests():
+    # ``model_select`` does not exist yet at RED time (#1439) -- this
+    # autouse fixture must not break every OTHER already-passing test in
+    # this directory by erroring at setup before the module lands.
+    try:
+        from gaia_agent_email.model_select import _reset_model_select_cache
+    except ImportError:
+        yield
+        return
+    _reset_model_select_cache()
+    yield
+    _reset_model_select_cache()

--- a/tests/unit/agents/email/test_init_endpoint.py
+++ b/tests/unit/agents/email/test_init_endpoint.py
@@ -439,6 +439,12 @@ def test_init_endpoint_tracks_lemonade_base_url_override(monkeypatch, client):
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"version": MIN_LEMONADE_VERSION}
             return resp
+        if url == f"{probe_base}/system-info":
+            # No NPU — this test is about base_url tracking (AC3), not
+            # NPU auto-select (#1439); keep the resolved model unchanged.
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {"devices": {"amd_npu": {"available": False}}}
+            return resp
         if url == f"{probe_base}/models":
             resp = MagicMock(status_code=200)
             resp.json.return_value = {"data": [{"id": resolved_model_id}]}


### PR DESCRIPTION
Part of #1439 — implements NPU detection + auto-select (checkboxes 1–2). The accuracy/throughput measurement (checkbox 3) is deferred to the consolidated eval pass ([#1319](https://github.com/amd/gaia/issues/1319); relates to #1283/#1912) and is intentionally not addressed here. Stacked on #2072.

**Merge-gate recommendation:** merge after the eval pass measures FLM triage accuracy on the production path — no FLM-variant baseline exists today (`baseline_accuracy_e2b.json` was recorded on the GGUF build), so this changes NPU users' default to a model whose triage accuracy is not yet measured. The code is ready; the evidence gate is deliberate.

Before this change, NPU users got the heavier E4B GGUF default unless they hand-picked a model. After it, when no model is configured, the agent asks the Lemonade **server** (never local hardware sniffing — the server may be remote per #1888) whether `amd_npu` is available and `gemma4-it-e2b-FLM` is installed, and defaults to it; otherwise E4B, with one INFO log naming why. Explicit `model_id` always wins and is the opt-out.

Three traps the adversarial review caught in the naive design, all closed with named regression tests:
- The REST triage call never consumed the resolved model (`_build_llm_chat` passed no `model=` — resolution would have been cosmetic). Now wired and asserted on `chat.config.model`.
- The obvious probe API (`LemonadeClient.get_system_info()`) has a 900-second default timeout; the resolver uses the package's raw 2s/3s probe pattern instead.
- Auto-selecting FLM while the memory embedder stayed GGUF/Vulkan would reproduce the open P0 thrash pattern (#1676/#1746) — the agent now threads `get_embedding_model_for_device("npu")` into `init_memory` whenever FLM is the resolved model (the ChatAgent precedent, #1744).

Resolution is cached per server (success-only — a Lemonade-not-up-yet probe is never baked in), and all four surfaces (agent, `_resolve_email_model_id`, `/v1/email/init`, `_build_llm_chat`) are pinned to agree by a test at a non-default base_url.

## Test plan

- [x] Targeted suite: **1300 passed** (29 new, 0 broken; stable under xdist and reordering) · `util/lint.py --all` green · hub files hand-linted (the linter is hub-blind) · `stamp_version.py --check` green · capability matrix green
- [x] Real-world 4-step smoke (below)

## Evidence — live smoke on AMD Strix Halo (NPU) + macOS control

```
STEP 1  GET /v1/email/init          (NPU box, no model configured)
→ ready: true, model.id: "gemma4-it-e2b-FLM", present: true      # resolver picked FLM

STEP 2  POST /v1/email/triage       (schema-2.x single message, live inference)
→ category: "URGENT", usage: {prompt_tokens: 1258, completion_tokens: 91,
  total_tokens: 1349, tokens_per_second: 22.2}                    # 19s incl. FLM load
Lemonade /health after the call:
→ [('gemma4-it-e2b-FLM', recipe='flm', ctx_size=32768)]           # the completion RAN the auto-selected model

STEP 3  explicit model_id="Gemma-4-E4B-it-GGUF" on the same NPU box
→ resolver spy: called=False                                       # explicit choice honored, resolver bypassed

STEP 4  non-NPU control (macOS, live local Lemonade)
→ resolver picks: "Gemma-4-E4B-it-GGUF"                            # no NPU → unchanged default
```

Step 2 is the one that would expose a cosmetic-resolver regression: the health readback proves the completion executed on the FLM/NPU build, not the default.

<details>
<summary>Notes</summary>

- Pre-existing, not this PR's bug: the unpinned agent floor (32768) under-serves E4B's registry `min_ctx_size` (65536) — flagged for awareness.
- Every measurement path (integration baseline test, `gaia eval benchmark`'s CLI default, the CI scorecard workflows) pins `--model` explicitly, so committed baselines cannot false-alarm from this default change.
- #1282's "hardware-validated" means *serves on NPU*; triage accuracy on the production path is exactly what the eval pass measures before this merges.
- `model.ctx_size: null` in step 1 is correct honest semantics (#1892): FLM wasn't loaded yet at probe time.
</details>
