### PR TITLE
fix(hub): platform-aware artifact selection for binary hub agents

### DIFF
--- a/src/gaia/hub/compatibility.py
+++ b/src/gaia/hub/compatibility.py
@@ -20,7 +20,9 @@ silently passes as if the requirement were met.
 
 from __future__ import annotations
 
+import platform as _platform
 import shutil
+import sys as _sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -114,6 +116,38 @@ def detect_free_disk_gb(path: Path) -> Optional[float]:
     except OSError as exc:
         logger.debug("compatibility: could not read disk usage for %s: %s", probe, exc)
         return None
+
+
+def current_platform_key(plat: Optional[str] = None, arch: Optional[str] = None) -> str:
+    """Resolve the host's platform key in the artifact-filename namespace.
+
+    Distinct from :func:`current_platform`'s ``{os}-{arch}`` hub-triple
+    vocabulary (``win-x64``) used for ``requirements.platforms`` gates — this
+    is the npm-package namespace (``win32-x64``, ``darwin-arm64``) used to
+    select an entry from a manifest's ``versions[v].artifacts[]`` by filename
+    suffix. Mirrors ``gaia.ui.email_sidecar.platform.current_platform_key()``
+    exactly (parity-tested); duplicated rather than imported because
+    ``gaia.hub`` must never import ``gaia.ui.*``. Never raises — an
+    unrecognized OS/arch passes through as-is so the artifact-selection loud
+    error can name it, rather than crashing here.
+    """
+    raw_os = plat if plat is not None else _sys.platform
+    if raw_os.startswith("win"):
+        os_key = "win32"
+    elif raw_os == "darwin":
+        os_key = "darwin"
+    elif raw_os.startswith("linux"):
+        os_key = "linux"
+    else:
+        os_key = raw_os
+    raw_arch = (arch if arch is not None else _platform.machine()).lower()
+    if raw_arch in ("x86_64", "amd64", "x64"):
+        arch_key = "x64"
+    elif raw_arch in ("arm64", "aarch64"):
+        arch_key = "arm64"
+    else:
+        arch_key = raw_arch
+    return f"{os_key}-{arch_key}"
 
 
 def _coerce_requirements(requirements: Any) -> Requirements:

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -418,11 +418,12 @@ def _install_binary_artifact(
 
 
 def _filename_matches_platform(filename: str, platform_key: str) -> bool:
-    """Whether *filename* is the artifact published for *platform_key*."""
-    if filename.endswith(platform_key):
-        return True
-    # win32-x64 binaries carry a .exe suffix after the platform key.
-    return platform_key == "win32-x64" and filename.endswith(platform_key + ".exe")
+    """Whether *filename* is the artifact published for *platform_key*.
+
+    Windows binaries carry a ``.exe`` after the platform key; accept it for
+    any key (win32-arm64 binaries are planned, #1898).
+    """
+    return filename.endswith(platform_key) or filename.endswith(platform_key + ".exe")
 
 
 def _generic_binary_name(filename: str, platform_key: str) -> str:
@@ -432,10 +433,9 @@ def _generic_binary_name(filename: str, platform_key: str) -> str:
     (``gaia.ui.email_sidecar.platform`` / ``binaries.lock.json``) so a
     same-version install primes it.
     """
-    if platform_key == "win32-x64":
-        suffix = f"-{platform_key}.exe"
-        if filename.endswith(suffix):
-            return filename[: -len(suffix)] + ".exe"
+    suffix = f"-{platform_key}.exe"
+    if filename.endswith(suffix):
+        return filename[: -len(suffix)] + ".exe"
     suffix = f"-{platform_key}"
     if filename.endswith(suffix):
         return filename[: -len(suffix)]
@@ -483,14 +483,18 @@ def _resolve_version(
     working. *artifact* is a copy of the manifest entry with an added
     ``artifact_kind`` key (``"wheel"`` | ``"binary"`` | ``"cpp"``):
 
-    * ``versions[v].artifacts[]`` present (non-empty): select the entry whose
-      filename matches *platform_key*; no match is a loud error — a wheel
-      elsewhere in the same list is never substituted.
+    * ``language: cpp`` — classified first: the singular ``artifact`` is used
+      exactly as before this fix, regardless of any ``artifacts[]``.
+    * ``versions[v].artifacts[]`` present: classify the SET. The hub worker
+      writes ``artifacts: [artifact]`` on every publish, so its mere presence
+      must not imply binaries — only entries whose filenames don't look like a
+      wheel/sdist do. Any binary-like entries → platform-match among those
+      only; no match is a loud error (a wheel elsewhere in the same list is
+      never substituted). Wheel/sdist-only → the wheel, pip route.
     * No ``artifacts[]`` (legacy shape): the singular ``artifact`` is used.
-      For a Python-language agent whose filename doesn't look like a wheel
-      (e.g. a bare platform executable, pre-#1648 published shape), it must
-      match *platform_key* or raise; a genuine wheel/sdist filename is
-      unaffected (pip route, unchanged from before this fix).
+      A bare platform executable (pre-#1648 published shape) must match
+      *platform_key* or raise; a genuine wheel/sdist filename is unaffected
+      (pip route, unchanged from before this fix).
     """
     versions = manifest.get("versions") or {}
     if not versions:
@@ -512,29 +516,41 @@ def _resolve_version(
     effective_key = platform_key or current_platform_key()
 
     artifacts = entry.get("artifacts") or []
-    if artifacts:
-        match = _select_platform_artifact(artifacts, effective_key)
+    binary_like = [a for a in artifacts if not _looks_like_wheel(a.get("filename", ""))]
+    if language == "cpp":
+        artifact = dict(entry.get("artifact") or {})
+        artifact["artifact_kind"] = ARTIFACT_KIND_CPP
+    elif binary_like:
+        match = _select_platform_artifact(binary_like, effective_key)
         if match is None:
-            available = ", ".join(sorted(a.get("filename", "?") for a in artifacts))
+            available = ", ".join(sorted(a.get("filename", "?") for a in binary_like))
             raise InstallError(
-                f"No published artifact for '{agent_id}' matches this "
-                f"platform ('{effective_key}'). Available: {available}."
+                f"No published artifact for version '{version}' of "
+                f"'{agent_id}' matches this platform ('{effective_key}'). "
+                f"Available: {available}."
             )
         artifact = dict(match)
         artifact["artifact_kind"] = ARTIFACT_KIND_BINARY
+    elif artifacts:
+        # Wheel/sdist-only artifacts[] (the hub worker writes artifacts:
+        # [artifact] on every publish) — pip route, platform-independent.
+        wheels = sorted(
+            artifacts,
+            key=lambda a: not a.get("filename", "").lower().endswith(".whl"),
+        )
+        artifact = dict(wheels[0])
+        artifact["artifact_kind"] = ARTIFACT_KIND_WHEEL
     else:
         artifact = dict(entry.get("artifact") or {})
         filename = artifact.get("filename", "")
-        if language == "cpp":
-            artifact["artifact_kind"] = ARTIFACT_KIND_CPP
-        elif _looks_like_wheel(filename):
+        if _looks_like_wheel(filename):
             artifact["artifact_kind"] = ARTIFACT_KIND_WHEEL
         else:
             if not _filename_matches_platform(filename, effective_key):
                 raise InstallError(
-                    f"'{agent_id}' has no binary for this platform "
-                    f"('{effective_key}'); the published artifact is "
-                    f"'{filename}'."
+                    f"Version '{version}' of '{agent_id}' has no binary for "
+                    f"this platform ('{effective_key}'); the published "
+                    f"artifact is '{filename}'."
                 )
             artifact["artifact_kind"] = ARTIFACT_KIND_BINARY
 

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -28,7 +28,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -43,7 +45,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from gaia.agents.registry import _RESERVED_BUILTIN_IDS
 from gaia.hub import catalog as catalog_mod
-from gaia.hub.compatibility import check_compatibility
+from gaia.hub.compatibility import check_compatibility, current_platform_key
 from gaia.logger import get_logger
 
 logger = get_logger(__name__)
@@ -57,6 +59,12 @@ BACKUP_DIRNAME = ".backup"
 
 # Where Python wheels get installed (``uv pip install --target``).
 SITE_PACKAGES_DIRNAME = "site-packages"
+
+# ``artifact_kind`` values recorded in the sentinel. A sentinel written before
+# this field existed reads as "wheel" (the only kind installed pre-#2084).
+ARTIFACT_KIND_WHEEL = "wheel"
+ARTIFACT_KIND_BINARY = "binary"
+ARTIFACT_KIND_CPP = "cpp"
 
 # The only security tier whose native agents install without an explicit trust
 # opt-in. ``community`` / ``experimental`` C++ agents require ``trust_native``.
@@ -146,6 +154,7 @@ class InstalledAgent:
     installed_at: str
     artifact_sha256: str = ""
     path: Optional[Path] = None
+    artifact_kind: str = ARTIFACT_KIND_WHEEL
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -155,6 +164,7 @@ class InstalledAgent:
             "installed_at": self.installed_at,
             "artifact_sha256": self.artifact_sha256,
             "path": str(self.path) if self.path else None,
+            "artifact_kind": self.artifact_kind,
         }
 
 
@@ -177,6 +187,9 @@ def read_sentinel(
         installed_at=data.get("installed_at", ""),
         artifact_sha256=data.get("artifact_sha256", ""),
         path=agent_install_dir(agent_id, install_root),
+        # Missing key = a pre-#2084 sentinel; every kind installed back then
+        # was a wheel.
+        artifact_kind=data.get("artifact_kind", ARTIFACT_KIND_WHEEL),
     )
 
 
@@ -370,12 +383,115 @@ def _install_cpp_artifact(
     return install_dir
 
 
+def _install_binary_artifact(
+    artifact_bytes: bytes, generic_name: str, install_dir: Path
+) -> Path:
+    """Write a checksum-verified platform binary as ``install_dir/generic_name``.
+
+    Writes atomically (temp file + ``os.replace``) so a crash mid-write never
+    leaves a half-written executable. Unlike a wheel/cpp install, this never
+    goes through :func:`_snapshot_backup` — the caller must skip that for
+    binary kinds — because a dir-level move would relocate a live sidecar's
+    own cache dir out from under it.
+    """
+    install_dir.mkdir(parents=True, exist_ok=True)
+    target = install_dir / generic_name
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=str(install_dir), prefix=".gaia-hub-tmp-")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(tmp_fd, "wb") as f:
+            f.write(artifact_bytes)
+        os.replace(str(tmp_path), str(target))
+    except PermissionError as exc:
+        tmp_path.unlink(missing_ok=True)
+        raise InstallError(
+            f"Could not write {target.name} to {install_dir}: {exc}. The agent "
+            f"appears to be running — close it and retry."
+        ) from exc
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    if os.name != "nt":
+        mode = target.stat().st_mode
+        target.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return target
+
+
+def _filename_matches_platform(filename: str, platform_key: str) -> bool:
+    """Whether *filename* is the artifact published for *platform_key*."""
+    if filename.endswith(platform_key):
+        return True
+    # win32-x64 binaries carry a .exe suffix after the platform key.
+    return platform_key == "win32-x64" and filename.endswith(platform_key + ".exe")
+
+
+def _generic_binary_name(filename: str, platform_key: str) -> str:
+    """Strip the platform suffix: ``email-agent-win32-x64.exe`` -> ``email-agent.exe``.
+
+    Must match the executable name the sidecar's own cache uses
+    (``gaia.ui.email_sidecar.platform`` / ``binaries.lock.json``) so a
+    same-version install primes it.
+    """
+    if platform_key == "win32-x64":
+        suffix = f"-{platform_key}.exe"
+        if filename.endswith(suffix):
+            return filename[: -len(suffix)] + ".exe"
+    suffix = f"-{platform_key}"
+    if filename.endswith(suffix):
+        return filename[: -len(suffix)]
+    return filename
+
+
+def _looks_like_wheel(filename: str) -> bool:
+    return filename.lower().endswith((".whl", ".tar.gz", ".tgz"))
+
+
+def _sanitize_artifact_filename(filename: str, agent_id: Optional[str]) -> None:
+    """Refuse a filename that could escape the install dir on path-join."""
+    if not filename or "/" in filename or "\\" in filename or ".." in filename:
+        raise InstallError(
+            f"Artifact filename {filename!r} for '{agent_id}' is unsafe (nested "
+            f"path or path traversal). Refusing to install; report this hub "
+            f"manifest as corrupt."
+        )
+
+
+def _select_platform_artifact(
+    artifacts: List[Dict[str, Any]], platform_key: str
+) -> Optional[Dict[str, Any]]:
+    for candidate in artifacts:
+        if _filename_matches_platform(candidate.get("filename", ""), platform_key):
+            return candidate
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Version resolution
 # ---------------------------------------------------------------------------
 
 
-def _resolve_version(manifest: Dict[str, Any], version: Optional[str]):
+def _resolve_version(
+    manifest: Dict[str, Any],
+    version: Optional[str],
+    *,
+    platform_key: Optional[str] = None,
+):
+    """Resolve *version* and select its artifact, honest about the artifact's kind.
+
+    Returns ``(resolved_version, artifact)`` — an unchanged 2-tuple so
+    :func:`_artifact_size` (the setup executor's ordering helper) keeps
+    working. *artifact* is a copy of the manifest entry with an added
+    ``artifact_kind`` key (``"wheel"`` | ``"binary"`` | ``"cpp"``):
+
+    * ``versions[v].artifacts[]`` present (non-empty): select the entry whose
+      filename matches *platform_key*; no match is a loud error — a wheel
+      elsewhere in the same list is never substituted.
+    * No ``artifacts[]`` (legacy shape): the singular ``artifact`` is used.
+      For a Python-language agent whose filename doesn't look like a wheel
+      (e.g. a bare platform executable, pre-#1648 published shape), it must
+      match *platform_key* or raise; a genuine wheel/sdist filename is
+      unaffected (pip route, unchanged from before this fix).
+    """
     versions = manifest.get("versions") or {}
     if not versions:
         raise InstallError(
@@ -391,12 +507,43 @@ def _resolve_version(manifest: Dict[str, Any], version: Optional[str]):
             f"Available: {', '.join(sorted(versions))}."
         )
     entry = versions[version]
-    artifact = entry.get("artifact") or {}
+    agent_id = manifest.get("id")
+    language = manifest.get("language", "python")
+    effective_key = platform_key or current_platform_key()
+
+    artifacts = entry.get("artifacts") or []
+    if artifacts:
+        match = _select_platform_artifact(artifacts, effective_key)
+        if match is None:
+            available = ", ".join(sorted(a.get("filename", "?") for a in artifacts))
+            raise InstallError(
+                f"No published artifact for '{agent_id}' matches this "
+                f"platform ('{effective_key}'). Available: {available}."
+            )
+        artifact = dict(match)
+        artifact["artifact_kind"] = ARTIFACT_KIND_BINARY
+    else:
+        artifact = dict(entry.get("artifact") or {})
+        filename = artifact.get("filename", "")
+        if language == "cpp":
+            artifact["artifact_kind"] = ARTIFACT_KIND_CPP
+        elif _looks_like_wheel(filename):
+            artifact["artifact_kind"] = ARTIFACT_KIND_WHEEL
+        else:
+            if not _filename_matches_platform(filename, effective_key):
+                raise InstallError(
+                    f"'{agent_id}' has no binary for this platform "
+                    f"('{effective_key}'); the published artifact is "
+                    f"'{filename}'."
+                )
+            artifact["artifact_kind"] = ARTIFACT_KIND_BINARY
+
     if not artifact.get("path") or not artifact.get("sha256"):
         raise InstallError(
             f"Hub manifest version '{version}' of '{manifest.get('id')}' is "
             f"missing its artifact path or checksum."
         )
+    _sanitize_artifact_filename(artifact.get("filename", ""), agent_id)
     return version, artifact
 
 
@@ -531,6 +678,7 @@ def install(
     registry: Any = None,
     skip_compatibility_check: bool = False,
     trust_native: bool = False,
+    platform_key: Optional[str] = None,
 ) -> InstallResult:
     """Download, verify, and install an agent from the hub.
 
@@ -545,6 +693,9 @@ def install(
         skip_compatibility_check: Skip the platform/disk gate (tests/forced).
         trust_native: Explicit opt-in to install a non-verified native (C++)
             agent. Required for ``community``/``experimental`` C++ packages.
+        platform_key: Artifact-filename platform key (``win32-x64`` etc.) used
+            to select among ``versions[v].artifacts[]``; defaults to the real
+            host's key (injectable for tests).
 
     Raises:
         InstallInProgressError, ChecksumError, DiskSpaceError,
@@ -580,7 +731,11 @@ def install(
                     agent_id,
                 )
 
-            resolved_version, artifact = _resolve_version(manifest, version)
+            resolved_version, artifact = _resolve_version(
+                manifest, version, platform_key=platform_key
+            )
+            artifact_kind = artifact.get("artifact_kind", ARTIFACT_KIND_WHEEL)
+            effective_platform_key = platform_key or current_platform_key()
 
             # --- compatibility / disk gate ---
             _set_progress(
@@ -624,14 +779,22 @@ def install(
             )
 
             # --- backup before update ---
+            # Binary installs skip the dir-level snapshot: a move would
+            # relocate a live sidecar's own cache dir out from under it. The
+            # replace happens in place instead (see _install_binary_artifact).
             updated = read_sentinel(agent_id, root) is not None
-            if updated:
+            if updated and artifact_kind != ARTIFACT_KIND_BINARY:
                 _snapshot_backup(agent_id, root)
 
             install_dir = agent_install_dir(agent_id, root)
             try:
                 install_dir.mkdir(parents=True, exist_ok=True)
-                if language == "python":
+                if artifact_kind == ARTIFACT_KIND_BINARY:
+                    generic_name = _generic_binary_name(
+                        artifact["filename"], effective_platform_key
+                    )
+                    _install_binary_artifact(artifact_bytes, generic_name, install_dir)
+                elif language == "python":
                     _install_python_artifact(
                         artifact_bytes, artifact["filename"], install_dir, run_pip
                     )
@@ -648,6 +811,7 @@ def install(
                     language,
                     artifact["sha256"],
                     install_dir,
+                    artifact_kind=artifact_kind,
                 )
             except Exception:
                 # Install failed mid-write — restore the backup if we made one so
@@ -663,7 +827,13 @@ def install(
                 percent=90,
                 version=resolved_version,
             )
-            hot = _hot_register(agent_id, install_dir, language, registry)
+            # Binary installs have no site-packages to scan (nothing to
+            # hot-register), regardless of the manifest's declared language.
+            hot = (
+                False
+                if artifact_kind == ARTIFACT_KIND_BINARY
+                else _hot_register(agent_id, install_dir, language, registry)
+            )
 
             # NOTE: the backup snapshot is intentionally retained after a
             # successful update so rollback() can restore the prior version. It
@@ -705,6 +875,8 @@ def _write_sentinel(
     language: str,
     sha256: str,
     install_dir: Path,
+    *,
+    artifact_kind: str = ARTIFACT_KIND_WHEEL,
 ) -> None:
     sentinel = InstalledAgent(
         id=agent_id,
@@ -713,6 +885,7 @@ def _write_sentinel(
         installed_at=datetime.now(timezone.utc).isoformat(),
         artifact_sha256=sha256,
         path=install_dir,
+        artifact_kind=artifact_kind,
     )
     (install_dir / SENTINEL_NAME).write_text(
         json.dumps(sentinel.to_dict(), indent=2), encoding="utf-8"
@@ -767,7 +940,13 @@ def uninstall(
         raise NotInstalledError(
             f"'{agent_id}' is not installed (no {SENTINEL_NAME} at {install_dir})."
         )
-    shutil.rmtree(install_dir)
+    try:
+        shutil.rmtree(install_dir)
+    except PermissionError as exc:
+        raise InstallError(
+            f"Could not remove '{agent_id}': {exc}. It appears to be running — "
+            f"close it and retry."
+        ) from exc
     _discard_backup(agent_id, root)
     if registry is not None:
         _deregister(agent_id, registry)
@@ -791,6 +970,13 @@ def rollback(
         InstallError: If there is no backup to restore.
     """
     root = install_root or default_install_root()
+    current = read_sentinel(agent_id, root)
+    if current is not None and current.artifact_kind == ARTIFACT_KIND_BINARY:
+        raise InstallError(
+            f"Rollback is not supported for '{agent_id}' (a binary install) — "
+            f"no backup is kept, to avoid disturbing a running sidecar. "
+            f"Re-install the version you want instead."
+        )
     backup = _backup_dir(agent_id, root)
     if not backup.exists():
         raise InstallError(

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -155,6 +155,9 @@ class InstalledAgent:
     artifact_sha256: str = ""
     path: Optional[Path] = None
     artifact_kind: str = ARTIFACT_KIND_WHEEL
+    # Generic executable filename for binary-kind installs (health checks
+    # probe it); empty for wheel/cpp kinds.
+    executable: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -165,6 +168,7 @@ class InstalledAgent:
             "artifact_sha256": self.artifact_sha256,
             "path": str(self.path) if self.path else None,
             "artifact_kind": self.artifact_kind,
+            "executable": self.executable,
         }
 
 
@@ -190,6 +194,7 @@ def read_sentinel(
         # Missing key = a pre-#2084 sentinel; every kind installed back then
         # was a wheel.
         artifact_kind=data.get("artifact_kind", ARTIFACT_KIND_WHEEL),
+        executable=data.get("executable", ""),
     )
 
 
@@ -803,6 +808,7 @@ def install(
                 _snapshot_backup(agent_id, root)
 
             install_dir = agent_install_dir(agent_id, root)
+            generic_name = ""
             try:
                 install_dir.mkdir(parents=True, exist_ok=True)
                 if artifact_kind == ARTIFACT_KIND_BINARY:
@@ -828,6 +834,7 @@ def install(
                     artifact["sha256"],
                     install_dir,
                     artifact_kind=artifact_kind,
+                    executable=generic_name,
                 )
             except Exception:
                 # Install failed mid-write — restore the backup if we made one so
@@ -893,6 +900,7 @@ def _write_sentinel(
     install_dir: Path,
     *,
     artifact_kind: str = ARTIFACT_KIND_WHEEL,
+    executable: str = "",
 ) -> None:
     sentinel = InstalledAgent(
         id=agent_id,
@@ -902,6 +910,7 @@ def _write_sentinel(
         artifact_sha256=sha256,
         path=install_dir,
         artifact_kind=artifact_kind,
+        executable=executable,
     )
     (install_dir / SENTINEL_NAME).write_text(
         json.dumps(sentinel.to_dict(), indent=2), encoding="utf-8"

--- a/src/gaia/hub/lifecycle.py
+++ b/src/gaia/hub/lifecycle.py
@@ -26,6 +26,7 @@ message instead of pretending the agent is fine.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -217,6 +218,62 @@ def _default_loader(agent_id: str, registry: Any) -> List[str]:
     )
 
 
+def _binary_health(
+    agent_id: str,
+    sentinel: "installer_mod.InstalledAgent",
+    install_root: Optional[Path],
+    warnings: List[str],
+) -> HealthStatus:
+    """Health for a binary-kind install: the executable exists (+x on POSIX).
+
+    Binary agents ship no site-packages / entry point, so the wheel loader
+    probe would always report them broken; presence of the runnable executable
+    IS the health signal.
+    """
+    install_dir = installer_mod.agent_install_dir(agent_id, install_root)
+    if not sentinel.executable:
+        return HealthStatus(
+            id=agent_id,
+            state=HEALTH_ERROR,
+            detail=(
+                f"'{agent_id}' is a binary install but its sentinel records no "
+                f"executable name; re-install it from the Hub."
+            ),
+            warnings=warnings,
+        )
+    exe = install_dir / sentinel.executable
+    if not exe.is_file():
+        return HealthStatus(
+            id=agent_id,
+            state=HEALTH_ERROR,
+            detail=(
+                f"'{agent_id}' executable is missing at {exe}; "
+                f"re-install it from the Hub."
+            ),
+            warnings=warnings,
+        )
+    if os.name != "nt" and not os.access(exe, os.X_OK):
+        return HealthStatus(
+            id=agent_id,
+            state=HEALTH_ERROR,
+            detail=(
+                f"'{agent_id}' executable at {exe} is not executable "
+                f"(chmod +x it, or re-install from the Hub)."
+            ),
+            warnings=warnings,
+        )
+    if warnings:
+        return HealthStatus(
+            id=agent_id,
+            state=HEALTH_DEGRADED,
+            detail=f"'{agent_id}' loads but has {len(warnings)} warning(s).",
+            warnings=warnings,
+        )
+    return HealthStatus(
+        id=agent_id, state=HEALTH_HEALTHY, detail=f"'{agent_id}' is healthy."
+    )
+
+
 def health_check(
     agent_id: str,
     *,
@@ -233,10 +290,15 @@ def health_check(
     * ``degraded`` — loads, but something optional is off (e.g. a corrupt config
       or an optional warning from the loader probe).
     * ``healthy`` — loads cleanly with no warnings.
+
+    Binary-kind installs (sentinel ``artifact_kind: binary``) are probed by
+    executable presence instead of the entry-point loader — they have no
+    entry point by design.
     """
     loader = loader or _default_loader
 
-    installed = installer_mod.read_sentinel(agent_id, install_root) is not None
+    sentinel = installer_mod.read_sentinel(agent_id, install_root)
+    installed = sentinel is not None
     is_builtin = installer_mod.is_builtin(agent_id)
     registered = registry is not None and registry.get(agent_id) is not None
 
@@ -255,6 +317,12 @@ def health_check(
         read_config(agent_id, install_root)
     except LifecycleError as exc:
         warnings.append(str(exc))
+
+    if (
+        sentinel is not None
+        and sentinel.artifact_kind == installer_mod.ARTIFACT_KIND_BINARY
+    ):
+        return _binary_health(agent_id, sentinel, install_root, warnings)
 
     try:
         warnings.extend(loader(agent_id, registry) or [])

--- a/src/gaia/ui/routers/hub.py
+++ b/src/gaia/ui/routers/hub.py
@@ -55,6 +55,23 @@ def _require_ui_header(request: Request) -> None:
         raise HTTPException(status_code=403, detail="missing X-Gaia-UI header")
 
 
+def _shutdown_email_sidecar(request: Request, agent_id: str) -> None:
+    """Stop a running email sidecar before mutating its install directory.
+
+    The email agent's install dir doubles as the sidecar's own binary cache,
+    and the warm manager holds the executable open — install/uninstall/rollback
+    would hit a locked file (Windows) or mutate a live process's dir. Only the
+    router may bridge the two layers (``gaia.hub`` never imports ``gaia.ui``).
+    """
+    if agent_id != "email":
+        return
+    manager = getattr(request.app.state, "email_sidecar_manager", None)
+    if manager is None or not manager.is_running:
+        return
+    logger.info("hub: stopping the running email sidecar before mutating its dir")
+    manager.shutdown()
+
+
 class InstallRequest(BaseModel):
     """Body for ``POST /api/agents/install``."""
 
@@ -170,6 +187,8 @@ async def install_agent(
     except installer_mod.TrustRequiredError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
 
+    _shutdown_email_sidecar(request, body.id)
+
     installer_mod.clear_progress(body.id)
     installer_mod._set_progress(  # noqa: SLF001 - seed state for the poller
         body.id, status="queued", phase="queued", percent=0, version=body.version
@@ -208,6 +227,7 @@ async def install_status(agent_id: str):
 async def uninstall_agent(agent_id: str, request: Request):
     """Uninstall a hub-installed agent. Refuses builtins (400)."""
     registry = _registry(request)
+    _shutdown_email_sidecar(request, agent_id)
     try:
         installer_mod.uninstall(agent_id, registry=registry)
     except installer_mod.NotInstalledError as exc:
@@ -229,6 +249,7 @@ async def uninstall_agent(agent_id: str, request: Request):
 async def rollback_agent(agent_id: str, request: Request):
     """Roll an agent back to its pre-update snapshot in ``.backup/``."""
     registry = _registry(request)
+    _shutdown_email_sidecar(request, agent_id)
     try:
         restored = installer_mod.rollback(agent_id, registry=registry)
     except installer_mod.InstallError as exc:

--- a/tests/unit/test_hub_compatibility.py
+++ b/tests/unit/test_hub_compatibility.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 """Unit tests for gaia.hub.compatibility — the system-requirements checker."""
 
+import pytest
+
 from gaia.hub import compatibility
 from gaia.hub.compatibility import check_compatibility
 
@@ -82,3 +84,39 @@ def test_report_to_dict_round_trips(monkeypatch):
     assert set(
         ["compatible", "platform_ok", "memory_ok", "disk_ok", "warnings", "blockers"]
     ).issubset(d)
+
+
+# ---------------------------------------------------------------------------
+# current_platform_key: npm/artifact-filename style keys (#2084)
+#
+# Distinct from detect_platform()/current_platform()'s hub-triple vocabulary
+# ("win-x64", "darwin-arm64") used for requirements.platforms gates — this is
+# the npm-namespace vocabulary ("win32-x64", "darwin-arm64") used to select an
+# entry from a manifest's versions[v].artifacts[] by filename suffix.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "plat,arch,expected",
+    [
+        ("win32", "AMD64", "win32-x64"),
+        ("win32", "amd64", "win32-x64"),
+        ("win32", "x86_64", "win32-x64"),
+        ("win64", "x64", "win32-x64"),
+        ("darwin", "arm64", "darwin-arm64"),
+        ("darwin", "aarch64", "darwin-arm64"),
+        ("darwin", "x86_64", "darwin-x64"),
+        ("darwin", "amd64", "darwin-x64"),
+        ("linux", "x86_64", "linux-x64"),
+        ("linux2", "amd64", "linux-x64"),
+        ("linux", "aarch64", "linux-arm64"),
+    ],
+)
+def test_current_platform_key_mapping(plat, arch, expected):
+    assert compatibility.current_platform_key(plat, arch) == expected
+
+
+def test_current_platform_key_no_override_returns_nonempty_string():
+    key = compatibility.current_platform_key()
+    assert isinstance(key, str)
+    assert key

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -736,6 +736,98 @@ def test_install_wheel_only_manifest_unaffected_by_platform_selection(tmp_path):
     assert sentinel.artifact_kind == "wheel"
 
 
+# --- T4b: modern worker shape — wheel-only artifacts[] still routes to pip --
+
+
+def test_install_modern_wheel_only_artifacts_routes_to_pip(tmp_path):
+    # The hub worker writes artifacts: [artifact] for EVERY publish, so a modern
+    # wheel-only agent has an artifacts[] containing exactly one .whl entry (the
+    # same dict as the singular artifact). artifacts[] presence must NOT imply
+    # binary: a wheel/sdist-only artifacts[] selects the wheel and takes pip
+    # regardless of platform_key.
+    manifest = _manifest()
+    version = manifest["latest_version"]
+    manifest["versions"][version]["artifacts"] = [
+        manifest["versions"][version]["artifact"]
+    ]
+    pip_calls = []
+    install(
+        "demo",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_make_fetcher(manifest),
+        run_pip=lambda args: pip_calls.append(args),
+        install_root=tmp_path,
+        platform_key="win32-x64",
+    )
+    assert pip_calls and "--target" in pip_calls[0]
+    assert any(str(a).endswith(".whl") for a in pip_calls[0])
+    sentinel = read_sentinel("demo", tmp_path)
+    assert sentinel.artifact_kind == "wheel"
+
+
+# --- T4c: cpp agents with an artifacts[] list behave like the legacy route --
+
+
+def test_install_cpp_with_artifacts_list_uses_singular_zip(tmp_path):
+    # cpp is classified FIRST, before any artifacts[] logic — a cpp manifest that
+    # also carries artifacts[] extracts the singular zip exactly like the legacy
+    # cpp route (mirror of test_install_cpp_artifact_extracted).
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("bin/demo", "binary")
+    archive = buf.getvalue()
+    sha = hashlib.sha256(archive).hexdigest()
+    path = "agents/native/1.0.0/native.zip"
+    artifact = {
+        "filename": "native.zip",
+        "path": path,
+        "size_bytes": len(archive),
+        "sha256": sha,
+        "content_type": "application/zip",
+    }
+    manifest = {
+        "id": "native",
+        "language": "cpp",
+        "latest_version": "1.0.0",
+        "requirements": {"platforms": []},
+        "versions": {
+            "1.0.0": {
+                "version": "1.0.0",
+                "artifact": artifact,
+                "artifacts": [artifact],
+            }
+        },
+    }
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: native\n"
+        if url == f"{BASE}/{path}":
+            return archive
+        raise AssertionError(url)
+
+    pip_calls = []
+    result = install(
+        "native",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=fetcher,
+        run_pip=lambda args: pip_calls.append(args),
+        install_root=tmp_path,
+        platform_key="linux-x64",
+        trust_native=True,
+    )
+    assert result.language == "cpp"
+    assert (tmp_path / "native" / "bin" / "demo").exists()
+    assert pip_calls == []
+    sentinel = read_sentinel("native", tmp_path)
+    assert sentinel.artifact_kind == "cpp"
+
+
 # --- T5: binaries-only manifest, no artifact for platform_key --------------
 
 

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -7,6 +7,8 @@ All HTTP and pip work is mocked; no live network, no real ``uv``.
 
 import hashlib
 import json
+import os
+import stat
 
 import pytest
 
@@ -473,4 +475,599 @@ def test_run_setup_rejects_bad_concurrency(tmp_path):
             install_root=tmp_path,
             state_path=tmp_path / "s.json",
             installer_fn=lambda agent_id, **kwargs: None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Platform-selection binary installs (#2084)
+#
+# The hub installer only read the manifest's legacy singular ``artifact``
+# field (always the first-published macOS binary), so Windows/Linux hosts got
+# fed a macOS executable into ``uv pip install``. These tests exercise the
+# fix: selecting the right per-platform entry from ``versions[v].artifacts[]``
+# via the new ``install(..., platform_key=...)`` DI seam. Manifest shapes
+# mirror the real ``hub.amd-gaia.ai/agents/email/manifest.json``.
+# ---------------------------------------------------------------------------
+
+_PLATFORM_FILENAMES = {
+    "win32-x64": "email-agent-win32-x64.exe",
+    "darwin-arm64": "email-agent-darwin-arm64",
+    "darwin-x64": "email-agent-darwin-x64",
+    "linux-x64": "email-agent-linux-x64",
+}
+
+_FILENAME_BYTES = {
+    "email-agent-win32-x64.exe": b"win32-x64-binary-bytes",
+    "email-agent-darwin-arm64": b"darwin-arm64-binary-bytes",
+    "email-agent-darwin-x64": b"darwin-x64-binary-bytes",
+    "email-agent-linux-x64": b"linux-x64-binary-bytes",
+}
+
+
+def _artifact_entry(filename, data, path_prefix):
+    return {
+        "filename": filename,
+        "path": f"{path_prefix}/{filename}",
+        "size_bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "content_type": "application/octet-stream",
+    }
+
+
+def _binary_manifest(
+    agent_id="email",
+    version="0.1.0",
+    platform_keys=("win32-x64", "darwin-arm64", "darwin-x64", "linux-x64"),
+    filename_bytes=None,
+    singular_key="darwin-arm64",
+    extra_wheel=False,
+):
+    """Live-shape manifest: singular ``artifact`` is the macOS-first entry the
+    pre-fix installer always used, plus a full ``artifacts[]`` array."""
+    merged_bytes = {**_FILENAME_BYTES, **(filename_bytes or {})}
+    prefix = f"agents/{agent_id}/{version}"
+    artifacts = [
+        _artifact_entry(
+            _PLATFORM_FILENAMES[k], merged_bytes[_PLATFORM_FILENAMES[k]], prefix
+        )
+        for k in platform_keys
+    ]
+    if extra_wheel:
+        wheel_filename = f"{agent_id}-{version}-py3-none-any.whl"
+        artifacts.append(
+            _artifact_entry(wheel_filename, b"wheel-bytes-in-artifacts", prefix)
+        )
+    singular_filename = _PLATFORM_FILENAMES[singular_key]
+    singular = next(a for a in artifacts if a["filename"] == singular_filename)
+    return {
+        "id": agent_id,
+        "language": "python",
+        "latest_version": version,
+        "requirements": {"platforms": []},
+        "versions": {
+            version: {
+                "version": version,
+                "artifact": singular,
+                "artifacts": artifacts,
+            }
+        },
+    }
+
+
+def _legacy_binary_manifest(
+    agent_id="email",
+    version="0.1.0",
+    filename="email-agent-darwin-arm64",
+    data=b"legacy-binary-bytes",
+):
+    """Old manifest shape: a bare-executable singular ``artifact``, no
+    ``artifacts[]`` array at all (pre-#1648 published versions)."""
+    sha = hashlib.sha256(data).hexdigest()
+    path = f"agents/{agent_id}/{version}/{filename}"
+    return {
+        "id": agent_id,
+        "language": "python",
+        "latest_version": version,
+        "requirements": {"platforms": []},
+        "versions": {
+            version: {
+                "version": version,
+                "artifact": {
+                    "filename": filename,
+                    "path": path,
+                    "size_bytes": len(data),
+                    "sha256": sha,
+                    "content_type": "application/octet-stream",
+                },
+            }
+        },
+    }
+
+
+def _binary_fetcher(manifest, filename_bytes=None):
+    merged_bytes = {**_FILENAME_BYTES, **(filename_bytes or {})}
+    version = manifest["latest_version"]
+    entry = manifest["versions"][version]
+    by_path = {
+        a["path"]: merged_bytes.get(a["filename"], b"")
+        for a in entry.get("artifacts") or []
+    }
+    singular = entry["artifact"]
+    by_path.setdefault(singular["path"], merged_bytes.get(singular["filename"], b""))
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: email\nname: Email\n"
+        for path, data in by_path.items():
+            if url == f"{BASE}/{path}":
+                return data
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    return fetcher
+
+
+def _refuse_pip(args):
+    raise AssertionError(f"run_pip must not be called for a binary install: {args}")
+
+
+# --- T1: platform_key picks the matching per-platform binary, never pip ----
+
+
+def test_install_binary_selects_win32_and_skips_pip(tmp_path):
+    manifest = _binary_manifest()
+    downloaded_urls = []
+    inner_fetcher = _binary_fetcher(manifest)
+
+    def tracking_fetcher(url):
+        downloaded_urls.append(url)
+        return inner_fetcher(url)
+
+    result = install(
+        "email",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=tracking_fetcher,
+        run_pip=_refuse_pip,
+        install_root=tmp_path,
+        platform_key="win32-x64",
+    )
+
+    assert any(u.endswith("email-agent-win32-x64.exe") for u in downloaded_urls)
+    exe_path = tmp_path / "email" / "email-agent.exe"
+    assert exe_path.exists()
+    sentinel = read_sentinel("email", tmp_path)
+    assert sentinel is not None
+    assert sentinel.artifact_kind == "binary"
+    assert result.hot_registered is False
+
+
+# --- T2: correct artifact + generic name per platform; +x bit on POSIX -----
+
+
+@pytest.mark.parametrize(
+    "platform_key,expected_filename,expected_generic",
+    [
+        ("win32-x64", "email-agent-win32-x64.exe", "email-agent.exe"),
+        ("darwin-arm64", "email-agent-darwin-arm64", "email-agent"),
+        ("linux-x64", "email-agent-linux-x64", "email-agent"),
+    ],
+)
+def test_install_binary_platform_selection(
+    tmp_path, platform_key, expected_filename, expected_generic
+):
+    manifest = _binary_manifest()
+    downloaded_urls = []
+    inner_fetcher = _binary_fetcher(manifest)
+
+    def tracking_fetcher(url):
+        downloaded_urls.append(url)
+        return inner_fetcher(url)
+
+    install(
+        "email",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=tracking_fetcher,
+        run_pip=_refuse_pip,
+        install_root=tmp_path,
+        platform_key=platform_key,
+    )
+    assert any(u.endswith(expected_filename) for u in downloaded_urls)
+    installed_path = tmp_path / "email" / expected_generic
+    assert installed_path.exists()
+    if platform_key != "win32-x64" and os.name == "posix":
+        mode = installed_path.stat().st_mode
+        assert mode & stat.S_IXUSR
+
+
+# --- T3: artifacts[] with both a wheel and binaries; never falls back ------
+
+
+def test_install_binary_prefers_binary_over_wheel_in_artifacts(tmp_path):
+    manifest = _binary_manifest(extra_wheel=True)
+    pip_calls = []
+    install(
+        "email",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_binary_fetcher(manifest),
+        run_pip=lambda args: pip_calls.append(args),
+        install_root=tmp_path,
+        platform_key="linux-x64",
+    )
+    assert pip_calls == []
+    assert (tmp_path / "email" / "email-agent").exists()
+
+
+def test_install_binary_no_match_never_falls_back_to_wheel(tmp_path):
+    manifest = _binary_manifest(extra_wheel=True)
+    pip_calls = []
+    with pytest.raises(InstallError):
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_binary_fetcher(manifest),
+            run_pip=lambda args: pip_calls.append(args),
+            install_root=tmp_path,
+            platform_key="freebsd-riscv64",
+        )
+    assert pip_calls == []
+
+
+# --- T4: wheel-only manifest is unaffected (regression guard) --------------
+
+
+def test_install_wheel_only_manifest_unaffected_by_platform_selection(tmp_path):
+    manifest = _manifest()
+    pip_calls = []
+    install(
+        "demo",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_make_fetcher(manifest),
+        run_pip=lambda args: pip_calls.append(args),
+        install_root=tmp_path,
+        platform_key="linux-x64",
+    )
+    # Byte-identical to test_install_happy_path's pip-args assertion.
+    assert pip_calls and "--target" in pip_calls[0]
+    sentinel = read_sentinel("demo", tmp_path)
+    assert sentinel.artifact_kind == "wheel"
+
+
+# --- T5: binaries-only manifest, no artifact for platform_key --------------
+
+
+def test_install_binary_missing_platform_raises_loud_error(tmp_path):
+    manifest = _binary_manifest(
+        platform_keys=("win32-x64", "linux-x64"), singular_key="win32-x64"
+    )
+
+    with pytest.raises(InstallError) as excinfo:
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_binary_fetcher(manifest),
+            run_pip=_refuse_pip,
+            install_root=tmp_path,
+            platform_key="darwin-x64",
+        )
+    message = str(excinfo.value)
+    assert "email" in message
+    assert "darwin-x64" in message
+    assert "email-agent-win32-x64.exe" in message
+    assert "email-agent-linux-x64" in message
+    assert installer.get_install_status("email")["status"] == "failed"
+    install_dir = tmp_path / "email"
+    assert not install_dir.exists() or list(install_dir.iterdir()) == []
+
+
+# --- T6: old-manifest shape (singular artifact IS a binary, no artifacts[]) -
+
+
+def test_install_legacy_singular_binary_matches_platform(tmp_path):
+    manifest = _legacy_binary_manifest(
+        filename="email-agent-darwin-arm64", data=b"legacy-bytes"
+    )
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: email\n"
+        if url.endswith("email-agent-darwin-arm64"):
+            return b"legacy-bytes"
+        raise AssertionError(url)
+
+    pip_calls = []
+    install(
+        "email",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=fetcher,
+        run_pip=lambda args: pip_calls.append(args),
+        install_root=tmp_path,
+        platform_key="darwin-arm64",
+    )
+    assert pip_calls == []
+    assert (tmp_path / "email" / "email-agent").exists()
+    sentinel = read_sentinel("email", tmp_path)
+    assert sentinel.artifact_kind == "binary"
+
+
+def test_install_legacy_singular_binary_mismatch_raises(tmp_path):
+    manifest = _legacy_binary_manifest(
+        filename="email-agent-darwin-arm64", data=b"legacy-bytes"
+    )
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: email\n"
+        if url.endswith("email-agent-darwin-arm64"):
+            return b"legacy-bytes"
+        raise AssertionError(url)
+
+    pip_calls = []
+    with pytest.raises(InstallError):
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=fetcher,
+            run_pip=lambda args: pip_calls.append(args),
+            install_root=tmp_path,
+            platform_key="win32-x64",
+        )
+    assert pip_calls == []
+
+
+# --- T7: checksum mismatch on the platform-matched binary -------------------
+
+
+def test_install_binary_checksum_mismatch(tmp_path):
+    manifest = _binary_manifest()
+    good_fetcher = _binary_fetcher(manifest)
+
+    def tampered_fetcher(url):
+        if url.endswith("email-agent-linux-x64"):
+            return b"tampered-bytes"
+        return good_fetcher(url)
+
+    with pytest.raises(ChecksumError):
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=tampered_fetcher,
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+            platform_key="linux-x64",
+        )
+    assert read_sentinel("email", tmp_path) is None
+
+
+# --- T8: update-in-place, locked-file errors, rollback/uninstall on binary --
+
+
+def test_install_binary_update_replaces_without_backup_dir(tmp_path):
+    manifest_v1 = _binary_manifest(version="0.1.0")
+    install(
+        "email",
+        manifest=manifest_v1,
+        base_url=BASE,
+        fetcher=_binary_fetcher(manifest_v1),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+        platform_key="linux-x64",
+    )
+    v2_bytes = {fn: data + b"-v2" for fn, data in _FILENAME_BYTES.items()}
+    manifest_v2 = _binary_manifest(version="0.2.0", filename_bytes=v2_bytes)
+    result = install(
+        "email",
+        manifest=manifest_v2,
+        base_url=BASE,
+        fetcher=_binary_fetcher(manifest_v2, filename_bytes=v2_bytes),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+        platform_key="linux-x64",
+    )
+    assert result.updated is True
+    assert not (tmp_path / installer.BACKUP_DIRNAME / "email").exists()
+    assert read_sentinel("email", tmp_path).version == "0.2.0"
+
+
+def test_install_binary_locked_file_raises_actionable_error(tmp_path, monkeypatch):
+    manifest = _binary_manifest()
+
+    def boom(*_a, **_k):
+        raise PermissionError("file in use")
+
+    monkeypatch.setattr("os.replace", boom)
+    with pytest.raises(InstallError) as excinfo:
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_binary_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+            platform_key="linux-x64",
+        )
+    message = str(excinfo.value).lower()
+    assert "running" in message or "close" in message
+
+
+def test_rollback_binary_kind_raises_clean_error(tmp_path):
+    manifest = _binary_manifest()
+    install(
+        "email",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_binary_fetcher(manifest),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+        platform_key="linux-x64",
+    )
+    with pytest.raises(InstallError) as excinfo:
+        rollback("email", install_root=tmp_path)
+    message = str(excinfo.value).lower()
+    assert "rollback" in message or "backup" in message
+
+
+def test_uninstall_binary_locked_raises_actionable_error(tmp_path, monkeypatch):
+    manifest = _binary_manifest()
+    install(
+        "email",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_binary_fetcher(manifest),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+        platform_key="linux-x64",
+    )
+
+    def boom(*_a, **_k):
+        raise PermissionError("in use")
+
+    monkeypatch.setattr(installer.shutil, "rmtree", boom)
+    with pytest.raises(InstallError):
+        uninstall("email", install_root=tmp_path)
+
+
+# --- T9: sentinel back-compat + filename sanitization -----------------------
+
+
+def test_read_sentinel_missing_artifact_kind_defaults_to_wheel(tmp_path):
+    install_dir = installer.agent_install_dir("legacy", tmp_path)
+    install_dir.mkdir(parents=True, exist_ok=True)
+    sentinel_data = {
+        "id": "legacy",
+        "version": "1.0.0",
+        "language": "python",
+        "installed_at": "2026-01-01T00:00:00+00:00",
+        "artifact_sha256": "deadbeef",
+        # No "artifact_kind" key at all — simulates a pre-fix install.
+    }
+    (install_dir / installer.SENTINEL_NAME).write_text(
+        json.dumps(sentinel_data), encoding="utf-8"
+    )
+    sentinel = read_sentinel("legacy", tmp_path)
+    assert sentinel.artifact_kind == "wheel"
+
+
+@pytest.mark.parametrize(
+    "bad_filename",
+    ["../evil-binary", "sub/email-agent-win32-x64.exe", "sub\\evil.exe"],
+)
+def test_install_rejects_path_traversal_filename_in_singular_artifact(
+    tmp_path, bad_filename
+):
+    manifest = _legacy_binary_manifest(filename=bad_filename, data=b"evil-bytes")
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: email\n"
+        return b"evil-bytes"
+
+    with pytest.raises(InstallError):
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=fetcher,
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+            platform_key="win32-x64",
+        )
+    install_dir = tmp_path / "email"
+    assert not install_dir.exists() or list(install_dir.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "bad_filename", ["../evil-win32-x64.exe", "sub/email-agent-win32-x64.exe"]
+)
+def test_install_rejects_path_traversal_filename_in_artifacts_array(
+    tmp_path, bad_filename
+):
+    manifest = _binary_manifest()
+    version = manifest["latest_version"]
+    manifest["versions"][version]["artifacts"][0]["filename"] = bad_filename
+    manifest["versions"][version]["artifacts"][0][
+        "path"
+    ] = f"agents/email/{version}/{bad_filename}"
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: email\n"
+        return b"evil-bytes"
+
+    with pytest.raises(InstallError):
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=fetcher,
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+            platform_key="win32-x64",
+        )
+    install_dir = tmp_path / "email"
+    assert not install_dir.exists() or list(install_dir.iterdir()) == []
+
+
+# --- T10: parity + drift guards ---------------------------------------------
+
+
+def test_generic_executable_names_match_binaries_lock(tmp_path):
+    from gaia.ui.email_sidecar import platform as sidecar_platform
+
+    lock = sidecar_platform.load_lock()
+    for platform_key in sidecar_platform.SUPPORTED_PLATFORMS:
+        root = tmp_path / platform_key
+        manifest = _binary_manifest(singular_key=platform_key)
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_binary_fetcher(manifest),
+            run_pip=_refuse_pip,
+            install_root=root,
+            platform_key=platform_key,
+        )
+        expected = lock.binaries[platform_key].executable
+        assert (root / "email" / expected).exists()
+
+
+@pytest.mark.parametrize(
+    "plat,arch",
+    [
+        ("win32", "AMD64"),
+        ("win32", "x86_64"),
+        ("darwin", "arm64"),
+        ("darwin", "x86_64"),
+        ("linux", "x86_64"),
+        ("linux2", "aarch64"),
+        ("freebsd", "riscv64"),
+    ],
+)
+def test_current_platform_key_parity_with_email_sidecar(plat, arch):
+    from gaia.hub import compatibility
+    from gaia.ui.email_sidecar import platform as sidecar_platform
+
+    assert compatibility.current_platform_key(plat, arch) == (
+        sidecar_platform.current_platform_key(plat, arch)
+    )
+
+
+def test_install_unsupported_platform_key_hits_loud_error_not_crash(tmp_path):
+    manifest = _binary_manifest()
+    with pytest.raises(InstallError):
+        install(
+            "email",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_binary_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+            platform_key="freebsd-riscv64",
         )

--- a/tests/unit/test_hub_lifecycle.py
+++ b/tests/unit/test_hub_lifecycle.py
@@ -6,7 +6,10 @@ No live network, no real agent imports: health probes are injected so the tests
 assert state transitions (healthy/degraded/error/not_installed) deterministically.
 """
 
+import hashlib
 import json
+import os
+import stat
 
 import pytest
 
@@ -208,3 +211,103 @@ def test_status_all_covers_installed_and_registered(tmp_path):
     assert set(all_status) == {"demo", "chat"}
     assert all_status["demo"].installed_version is not None
     assert all_status["chat"].installed_version is None  # builtin, no semver
+
+
+# ---------------------------------------------------------------------------
+# health_check: binary-kind agents (#2084 — platform-selection installer fix)
+#
+# Binary-kind agents (e.g. email) have no site-packages / entry point to scan;
+# health is "does the generic executable file exist" instead. These tests
+# drive a real installer.install() binary flow so the on-disk sentinel shape
+# matches whatever the fix actually writes, rather than hand-guessing it.
+# ---------------------------------------------------------------------------
+
+_BASE = "https://hub.test"
+
+
+def _binary_manifest_single(
+    agent_id="email", version="0.1.0", platform_key="linux-x64", data=b"binary-bytes"
+):
+    filename = f"{agent_id}-agent-{platform_key}"
+    sha = hashlib.sha256(data).hexdigest()
+    path = f"agents/{agent_id}/{version}/{filename}"
+    artifact = {
+        "filename": filename,
+        "path": path,
+        "size_bytes": len(data),
+        "sha256": sha,
+        "content_type": "application/octet-stream",
+    }
+    manifest = {
+        "id": agent_id,
+        "language": "python",
+        "latest_version": version,
+        "requirements": {"platforms": []},
+        "versions": {
+            version: {
+                "version": version,
+                "artifact": artifact,
+                "artifacts": [artifact],
+            }
+        },
+    }
+    return manifest, data
+
+
+def _install_binary_agent(tmp_path, agent_id="email", platform_key="linux-x64"):
+    """Install a real binary-kind agent so its sentinel matches the fix's shape."""
+    manifest, data = _binary_manifest_single(
+        agent_id=agent_id, platform_key=platform_key
+    )
+    version = manifest["latest_version"]
+    artifact_path = manifest["versions"][version]["artifact"]["path"]
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return f"id: {agent_id}\n".encode()
+        if url == f"{_BASE}/{artifact_path}":
+            return data
+        raise AssertionError(url)
+
+    def refuse_pip(args):
+        raise AssertionError(f"run_pip must not be called for a binary install: {args}")
+
+    installer.install(
+        agent_id,
+        manifest=manifest,
+        base_url=_BASE,
+        fetcher=fetcher,
+        run_pip=refuse_pip,
+        install_root=tmp_path,
+        platform_key=platform_key,
+    )
+    return installer.agent_install_dir(agent_id, tmp_path) / f"{agent_id}-agent"
+
+
+def test_health_binary_kind_healthy_without_entrypoint_probe(tmp_path):
+    exe_path = _install_binary_agent(
+        tmp_path, agent_id="email", platform_key="linux-x64"
+    )
+    assert exe_path.exists()  # sanity: the install actually wrote the executable
+    if os.name == "posix":
+        assert exe_path.stat().st_mode & stat.S_IXUSR
+
+    def exploding_loader(agent_id, registry):
+        raise AssertionError("entry-point loader must not run for a binary-kind agent")
+
+    result = health_check("email", install_root=tmp_path, loader=exploding_loader)
+    assert result.state == HEALTH_HEALTHY
+
+
+def test_health_binary_kind_missing_executable_is_not_healthy(tmp_path):
+    exe_path = _install_binary_agent(
+        tmp_path, agent_id="email", platform_key="linux-x64"
+    )
+    exe_path.unlink()
+
+    def exploding_loader(agent_id, registry):
+        raise AssertionError("entry-point loader must not run for a binary-kind agent")
+
+    result = health_check("email", install_root=tmp_path, loader=exploding_loader)
+    assert result.state in (HEALTH_DEGRADED, HEALTH_ERROR)
+    assert result.detail

--- a/tests/unit/test_hub_router.py
+++ b/tests/unit/test_hub_router.py
@@ -372,3 +372,157 @@ def test_setup_status_not_swallowed_by_agents_route(client, monkeypatch):
     resp = client.get("/api/agents/setup-status")
     assert resp.status_code == 200
     assert resp.json()["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Platform-selection binary installs (#2084)
+# ---------------------------------------------------------------------------
+
+
+def test_install_error_surfaces_via_install_status(client, monkeypatch):
+    # Real InstallError from the platform-selection path (no artifact on this
+    # host's platform) must flow through the existing progress-tracking
+    # machinery unmodified — this drives the REAL installer.install(), not a
+    # mock, so it also proves the new error path wires into _set_progress.
+    bad_artifact = {
+        "filename": "email-agent-nonexistent-plat",
+        "path": "agents/email/0.1.0/email-agent-nonexistent-plat",
+        "size_bytes": 4,
+        "sha256": "0" * 64,
+        "content_type": "application/octet-stream",
+    }
+    manifest = {
+        "id": "email",
+        "language": "python",
+        "latest_version": "0.1.0",
+        "requirements": {"platforms": []},
+        "versions": {
+            "0.1.0": {
+                "version": "0.1.0",
+                "artifact": bad_artifact,
+                "artifacts": [bad_artifact],
+            }
+        },
+    }
+    monkeypatch.setattr(catalog_mod, "fetch_manifest", lambda *a, **k: manifest)
+
+    resp = client.post("/api/agents/install", json={"id": "email"}, headers=UI)
+    assert resp.status_code == 202
+
+    status_resp = client.get("/api/agents/email/install-status")
+    assert status_resp.status_code == 200
+    body = status_resp.json()
+    assert body["status"] == "failed"
+    assert body["error"]
+    assert "email" in body["error"]
+
+
+class _FakeSidecarManager:
+    def __init__(self, is_running=True):
+        self.is_running = is_running
+        self.shutdown_calls = 0
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+
+
+def test_email_install_shuts_down_running_sidecar_first(client, app, monkeypatch):
+    fake = _FakeSidecarManager(is_running=True)
+    app.state.email_sidecar_manager = fake
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {"id": "email", "language": "python"},
+    )
+    monkeypatch.setattr(installer_mod, "install", lambda agent_id, **k: None)
+    resp = client.post("/api/agents/install", json={"id": "email"}, headers=UI)
+    assert resp.status_code == 202
+    assert fake.shutdown_calls == 1
+
+
+def test_email_uninstall_shuts_down_running_sidecar_first(client, app, monkeypatch):
+    fake = _FakeSidecarManager(is_running=True)
+    app.state.email_sidecar_manager = fake
+    monkeypatch.setattr(installer_mod, "uninstall", lambda *a, **k: None)
+    resp = client.delete("/api/agents/email", headers=UI)
+    assert resp.status_code == 200
+    assert fake.shutdown_calls == 1
+
+
+def test_email_rollback_shuts_down_running_sidecar_first(client, app, monkeypatch):
+    fake = _FakeSidecarManager(is_running=True)
+    app.state.email_sidecar_manager = fake
+    restored = InstalledAgent(
+        id="email", version="1.0.0", language="python", installed_at="now"
+    )
+    monkeypatch.setattr(installer_mod, "rollback", lambda *a, **k: restored)
+    resp = client.post("/api/agents/email/rollback", headers=UI)
+    assert resp.status_code == 200
+    assert fake.shutdown_calls == 1
+
+
+def test_email_install_noop_when_sidecar_not_running(client, app, monkeypatch):
+    fake = _FakeSidecarManager(is_running=False)
+    app.state.email_sidecar_manager = fake
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {"id": "email", "language": "python"},
+    )
+    called = {}
+    monkeypatch.setattr(
+        installer_mod, "install", lambda agent_id, **k: called.update(id=agent_id)
+    )
+    resp = client.post("/api/agents/install", json={"id": "email"}, headers=UI)
+    assert resp.status_code == 202
+    assert fake.shutdown_calls == 0
+    assert called.get("id") == "email"
+
+
+def test_email_install_noop_when_sidecar_manager_none(client, app, monkeypatch):
+    app.state.email_sidecar_manager = None
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {"id": "email", "language": "python"},
+    )
+    called = {}
+    monkeypatch.setattr(
+        installer_mod, "install", lambda agent_id, **k: called.update(id=agent_id)
+    )
+    resp = client.post("/api/agents/install", json={"id": "email"}, headers=UI)
+    assert resp.status_code == 202
+    assert called.get("id") == "email"
+
+
+def test_email_install_noop_when_sidecar_manager_attribute_absent(
+    client, app, monkeypatch
+):
+    if hasattr(app.state, "email_sidecar_manager"):
+        del app.state.email_sidecar_manager
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {"id": "email", "language": "python"},
+    )
+    called = {}
+    monkeypatch.setattr(
+        installer_mod, "install", lambda agent_id, **k: called.update(id=agent_id)
+    )
+    resp = client.post("/api/agents/install", json={"id": "email"}, headers=UI)
+    assert resp.status_code == 202
+    assert called.get("id") == "email"
+
+
+def test_non_email_install_does_not_shutdown_sidecar(client, app, monkeypatch):
+    fake = _FakeSidecarManager(is_running=True)
+    app.state.email_sidecar_manager = fake
+    monkeypatch.setattr(
+        catalog_mod,
+        "fetch_manifest",
+        lambda *a, **k: {"id": "demo", "language": "python"},
+    )
+    monkeypatch.setattr(installer_mod, "install", lambda agent_id, **k: None)
+    resp = client.post("/api/agents/install", json={"id": "demo"}, headers=UI)
+    assert resp.status_code == 202
+    assert fake.shutdown_calls == 0


### PR DESCRIPTION
Closes #2084

Installing the Email Triage agent from the Agent UI hub failed on **every platform**: the hub manifest's legacy singular `artifact` field always points at the first-published platform binary (`email-agent-darwin-arm64`), the installer read only that field, and `language: python` routed the macOS executable into `uv pip install` — the exit-2 error in #2084. The installer now selects the right entry from `versions[v].artifacts[]` for the host platform and installs a binary *as a binary* (checksum-verified, atomic, `chmod +x`), so the only agent in the live hub catalog actually installs — verified end-to-end on a Windows 11 + Radeon machine (the reporter's environment class) and on macOS.

Also in the change, because the email install dir doubles as the running sidecar's own binary cache: the UI shuts a running sidecar down before install/uninstall/rollback, a Windows locked-file failure becomes an actionable error instead of a stack trace, updates replace the binary in place (no dir-level backup that would yank a live process's directory), and health/status report a correct binary install as healthy instead of demanding the `gaia.agent` entry point binaries don't ship. Wheel- and C++-agent behavior is byte-identical (regression-tested). Deferred follow-ups (binary-agent trust gate, wheel-publishing hazards, small install hardening) are tracked in #2085 with the full analysis.

## Test plan

- [x] `python -m pytest tests/unit/test_hub_installer.py tests/unit/test_hub_router.py tests/unit/test_hub_lifecycle.py tests/unit/test_hub_compatibility.py -q` → **121 passed** (includes the new T1–T14 contract: platform selection, wheel/cpp regression guards, loud no-match errors, sentinel back-compat, locked-file/update paths, sidecar-shutdown hook, kind-aware health, platform-key parity with the sidecar's own mapping)
- [x] Regression net: `tests/unit/test_hub_catalog.py tests/unit/test_agent_hub_api.py` → 21 passed, 4 skipped
- [x] `python util/lint.py --all` → ALL QUALITY CHECKS PASSED
- [x] Real-world before→after on Windows 11 + Radeon and on macOS (evidence below)

## Evidence (real hub, cold state — `~/.gaia/agents/email` deleted before each phase)

**Before — main (`a02ae714`), Windows 11:** `POST /api/agents/install {"id":"email"}` → install-status:

```json
{"id":"email","status":"failed","error":"'uv pip install' failed (exit 2): error: Failed to parse: `...\\gaia-hub-k1pdt_rr\\email-agent-darwin-arm64` ... Expected path to end in a supported file extension: `.whl`, ..."}
```

**After — this branch (`924c8449`), same box, cold:** same request →

```json
{"id":"email","status":"completed","phase":"completed","percent":100,"version":"0.4.0","error":null}
```

`email-agent.exe` SHA-256 = `206a9c12…93f8` — exact match with the live manifest's `win32-x64` artifact; `GET /api/agents/email/health` → `{"state":"healthy"}`.

<details>
<summary>🔍 More evidence: locked-file error, update-in-place, macOS</summary>

**Windows, install while the agent binary is running** (holds the exe open) — actionable error instead of a stack trace, and no `.backup/` dir is created:

```json
{"status":"failed","error":"Could not write email-agent.exe to C:\\Users\\...\\agents\\email: [WinError 5] Access is denied ... The agent appears to be running — close it and retry."}
```

After closing the process, the same request completes and replaces the binary in place (SHA re-verified).

**macOS (darwin-arm64), cold:** same install → `completed`, `~/.gaia/agents/email/email-agent` written with `-rwx--x--x`, SHA-256 = `26bcf05b…bf` (exact manifest match), health `healthy`, `./email-agent --help` runs.

Tested by driving the real `POST /api/agents/install` / `install-status` / `health` endpoints of `gaia.ui.server` against the live hub on both machines.
</details>
