### PR TITLE
fix(email): eval-pass follow-ups — ctx-stamped baseline, refresh limit, usage aggregate

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -37,7 +37,10 @@ on:
       limit:
         description: 'Messages to triage (smaller = faster; regen a card at this sample size)'
         required: false
-        default: '60'
+        # 25 (~12.8K tokens: ~8K fixed aggregation turn + ~190/email) fits the
+        # #1892 16384 ctx window; 60 guarantees context_length_exceeded (#2087).
+        # Restore a larger limit once #2087's chunking lands.
+        default: '25'
       model:
         description: 'Lemonade model id'
         required: false
@@ -67,7 +70,8 @@ permissions:
 env:
   SCORECARD: hub/agents/npm/agent-email/SCORECARD.md
   MANIFEST: hub/agents/python/email/gaia-agent.yaml
-  LIMIT: ${{ github.event.inputs.limit || '60' }}
+  # 25 fits the pinned 16384 ctx window; 60 overflows it (#2087).
+  LIMIT: ${{ github.event.inputs.limit || '25' }}
   MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
   PYTHONIOENCODING: "utf-8"
   # JOB-WIDE so EVERY eval step (benchmark AND the drafting eval) can import the
@@ -95,10 +99,10 @@ jobs:
     # 'powershell: command not found'. fromJSON(...) yields a label ARRAY so the
     # runner must have Windows AND the stx/stx-test label.
     runs-on: ${{ fromJSON(contains(github.event.pull_request.labels.*.name, 'stx-test') && '["self-hosted","Windows","stx-test"]' || '["self-hosted","Windows","stx"]') }}
-    # The refresh triages ~60 emails in one call (~38s/email -> ~40min); the
-    # limit was cut from 220 (~2.3h) because that hogged the serial
-    # lemonade-eval slot. Per-email speedups that would let it go back up are
-    # tracked in #2063.
+    # The refresh triages ~25 emails in one call (~38s/email -> ~16min); the
+    # limit was cut from 220 (~2.3h), then from 60 to 25 because 60 overflows
+    # the pinned 16384 ctx window (#2087). Per-email speedups that would let
+    # it go back up are tracked in #2063.
     timeout-minutes: 90
     steps:
       - name: Checkout (the pushed branch)
@@ -170,8 +174,8 @@ jobs:
           # The agent's calendar-connector resolution blocks on the OS keyring in
           # a headless context — disable it so construction doesn't hang.
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-          # Triage of the ~60-email corpus is ONE tool call at ~38s/email
-          # (measured on the stx pool for Gemma-4-E4B) -> ~40min. A too-low
+          # Triage of the ~25-email corpus is ONE tool call at ~38s/email
+          # (measured on the stx pool for Gemma-4-E4B) -> ~16min. A too-low
           # timeout abandons it mid-run -> 0 triage results -> Category acc 0.0.
           # 3600s (1h) covers it with margin. Per-email speedups: #2063.
           GAIA_AGENT_TOOL_TIMEOUT: '3600'

--- a/src/gaia/eval/benchmark.py
+++ b/src/gaia/eval/benchmark.py
@@ -430,6 +430,49 @@ def _acceptance_variance(aggregate_quality: dict) -> dict[str, Any]:
     return block
 
 
+def _aggregate_triage_usage(results: list[dict]) -> dict[str, Any] | None:
+    """Mean triage-usage token accounting across runs (#1891 gap fix).
+
+    ``build_scorecard`` (``gaia.eval.scorecard``) is shared by every eval
+    category (RAG quality, tool selection, drafting, briefing, …) and has no
+    notion of email's ``triage_llm_tokens`` / ``llm_classified_count`` /
+    ``tokens_per_triage`` — those live only in each run's
+    ``performance_summary`` (stamped by :func:`build_result`), so the
+    scorecard's aggregate ``performance`` block silently omitted them even on
+    a fully-passing run. Mean-of-runs mirrors gen_scorecard.py's
+    ``_compute_performance`` convention (each run scores the same corpus, so
+    the cross-run mean is the representative figure). Returns ``None`` when no
+    run carries these fields (a heuristic-only run, or a pre-#1891 agent).
+    """
+    llm_tokens_vals: list[float] = []
+    classified_vals: list[float] = []
+    per_triage_vals: list[float] = []
+    for r in results:
+        ps = r.get("performance_summary")
+        if not isinstance(ps, dict):
+            continue
+        if isinstance(ps.get("triage_llm_tokens"), (int, float)):
+            llm_tokens_vals.append(float(ps["triage_llm_tokens"]))
+        if isinstance(ps.get("llm_classified_count"), (int, float)):
+            classified_vals.append(float(ps["llm_classified_count"]))
+        if isinstance(ps.get("tokens_per_triage"), (int, float)):
+            per_triage_vals.append(float(ps["tokens_per_triage"]))
+
+    if not (llm_tokens_vals or classified_vals or per_triage_vals):
+        return None
+
+    out: dict[str, Any] = {}
+    if llm_tokens_vals:
+        out["triage_llm_tokens"] = round(sum(llm_tokens_vals) / len(llm_tokens_vals), 1)
+    if classified_vals:
+        out["llm_classified_count"] = round(
+            sum(classified_vals) / len(classified_vals), 1
+        )
+    if per_triage_vals:
+        out["tokens_per_triage"] = round(sum(per_triage_vals) / len(per_triage_vals), 1)
+    return out
+
+
 def _aggregate_perf(results: list[dict]) -> dict[str, Any] | None:
     """Roll per-run ``performance_summary`` blocks into one perf block for the gate.
 
@@ -532,6 +575,13 @@ def summarize_benchmark(
     run_ctx = next(iter(ctx_values), None)
     if run_ctx is not None:
         summary["scorecard"]["ctx_size"] = run_ctx
+
+    # #1891 gap fix: build_scorecard's generic performance block (shared across
+    # every eval category) has no notion of email's triage-usage fields — merge
+    # them in here, same post-build_scorecard enrichment pattern as ctx_size above.
+    triage_usage_agg = _aggregate_triage_usage(results)
+    if triage_usage_agg is not None:
+        summary["scorecard"]["performance"].update(triage_usage_agg)
 
     aggregate_quality = _aggregate_quality(results)
     if aggregate_quality is not None:

--- a/tests/fixtures/email/baseline_accuracy.json
+++ b/tests/fixtures/email/baseline_accuracy.json
@@ -1,26 +1,27 @@
 {
   "model": "Gemma-4-E4B-it-GGUF",
+  "ctx_size": 16384,
   "fixture": "synthetic_inbox.mbox",
-  "category_accuracy": 0.8094,
+  "category_accuracy": 0.796,
   "category_breakdown": {
     "URGENT": 0.9259,
     "NEEDS_RESPONSE": 1.0,
-    "FYI": 0.8148,
-    "PROMOTIONAL": 0.7885,
-    "PERSONAL": 0.3636
+    "FYI": 0.8519,
+    "PROMOTIONAL": 0.7404,
+    "PERSONAL": 0.3333
   },
-  "is_spam_accuracy": 0.8896,
-  "is_spam_precision": 0.6765,
-  "is_spam_recall": 0.807,
-  "is_spam_f1": 0.736,
-  "is_spam_tp": 46,
-  "is_spam_fp": 22,
-  "is_spam_fn": 11,
+  "is_spam_accuracy": 0.8796,
+  "is_spam_precision": 0.6567,
+  "is_spam_recall": 0.7719,
+  "is_spam_f1": 0.7097,
+  "is_spam_tp": 44,
+  "is_spam_fp": 23,
+  "is_spam_fn": 13,
   "is_phishing_accuracy": 0.6789,
   "scored": 299,
-  "correct": 242,
+  "correct": 238,
   "tolerance_pp": 5,
-  "_recorded_on": "2026-06-30",
+  "_recorded_on": "2026-07-14",
   "_recorded_by": "real measurement on Gemma-4-E4B-it-GGUF via production heuristic + LLM-assist triage path (#1107); is_spam now content-based detection with precision/recall/F1 (#1906)",
   "_misses": [
     {
@@ -60,6 +61,12 @@
       "source": "llm"
     },
     {
+      "id": "125717a5b5ed123f",
+      "predicted": "NEEDS_RESPONSE",
+      "expected": "FYI",
+      "source": "llm"
+    },
+    {
       "id": "166e34f9d48b5b26",
       "predicted": "NEEDS_RESPONSE",
       "expected": "PERSONAL",
@@ -72,9 +79,15 @@
       "source": "llm"
     },
     {
-      "id": "21f22f402abbe49a",
-      "predicted": "PROMOTIONAL",
-      "expected": "URGENT",
+      "id": "1b59d4c756dc46df",
+      "predicted": "NEEDS_RESPONSE",
+      "expected": "PROMOTIONAL",
+      "source": "llm"
+    },
+    {
+      "id": "1b5aea9fa6daa6d9",
+      "predicted": "URGENT",
+      "expected": "PROMOTIONAL",
       "source": "llm"
     },
     {
@@ -135,6 +148,12 @@
       "id": "4157882a94b83dab",
       "predicted": "NEEDS_RESPONSE",
       "expected": "PERSONAL",
+      "source": "llm"
+    },
+    {
+      "id": "41db79347af5a0bc",
+      "predicted": "URGENT",
+      "expected": "PROMOTIONAL",
       "source": "llm"
     },
     {
@@ -211,7 +230,7 @@
     },
     {
       "id": "a1511668f14aa9a4",
-      "predicted": "URGENT",
+      "predicted": "NEEDS_RESPONSE",
       "expected": "PROMOTIONAL",
       "source": "llm"
     },
@@ -246,6 +265,18 @@
       "source": "llm"
     },
     {
+      "id": "af726c46ca50bf42",
+      "predicted": "NEEDS_RESPONSE",
+      "expected": "PERSONAL",
+      "source": "llm"
+    },
+    {
+      "id": "afcf0d7e59e03c7b",
+      "predicted": "NEEDS_RESPONSE",
+      "expected": "URGENT",
+      "source": "llm"
+    },
+    {
       "id": "b04f5b2541b0196d",
       "predicted": "NEEDS_RESPONSE",
       "expected": "URGENT",
@@ -255,6 +286,12 @@
       "id": "b155905a1c9b9f38",
       "predicted": "NEEDS_RESPONSE",
       "expected": "FYI",
+      "source": "llm"
+    },
+    {
+      "id": "b1de250d853b9df7",
+      "predicted": "NEEDS_RESPONSE",
+      "expected": "PERSONAL",
       "source": "llm"
     },
     {
@@ -270,21 +307,15 @@
       "source": "llm"
     },
     {
-      "id": "ba0f911e9fd56d36",
-      "predicted": "FYI",
-      "expected": "PERSONAL",
+      "id": "bb62e71a243fe62e",
+      "predicted": "PERSONAL",
+      "expected": "PROMOTIONAL",
       "source": "llm"
     },
     {
       "id": "c44231570ae76a19",
       "predicted": "URGENT",
       "expected": "PROMOTIONAL",
-      "source": "llm"
-    },
-    {
-      "id": "c6d1c3352562c979",
-      "predicted": "NEEDS_RESPONSE",
-      "expected": "FYI",
       "source": "llm"
     },
     {
@@ -306,14 +337,14 @@
       "source": "llm"
     },
     {
-      "id": "dab15c22c83b3729",
-      "predicted": "NEEDS_RESPONSE",
-      "expected": "FYI",
+      "id": "db5997e092a925e1",
+      "predicted": "URGENT",
+      "expected": "PROMOTIONAL",
       "source": "llm"
     },
     {
-      "id": "db5997e092a925e1",
-      "predicted": "URGENT",
+      "id": "dc27ba17720e604f",
+      "predicted": "FYI",
       "expected": "PROMOTIONAL",
       "source": "llm"
     },
@@ -328,12 +359,6 @@
       "predicted": "FYI",
       "expected": "PROMOTIONAL",
       "source": "heuristic"
-    },
-    {
-      "id": "e31d74a62bc24a73",
-      "predicted": "NEEDS_RESPONSE",
-      "expected": "FYI",
-      "source": "llm"
     },
     {
       "id": "e99af3dcd6970171",

--- a/tests/unit/eval/test_benchmark.py
+++ b/tests/unit/eval/test_benchmark.py
@@ -491,6 +491,52 @@ class TestSummarizeBenchmark:
         assert perf["scenarios_with_data"] == 3
         assert "Gemma-4-E4B-it-GGUF" in summary["variance"]
 
+    def test_scorecard_perf_section_carries_triage_usage(self):
+        """#1891 gap: build_scorecard's generic performance block has no notion
+        of email's triage-usage fields — they must be merged in from each run's
+        performance_summary, not silently dropped (live-shape regression pin;
+        was found None on real, fully-passing hardware runs)."""
+        results = [
+            build_result(
+                _agent_result_with_usage(),
+                run_id=f"r{i}",
+                timestamp="t",
+                model_id="Gemma-4-E4B-it-GGUF",
+                total_duration_ms=2000,
+            )
+            for i in range(3)
+        ]
+        # Precondition: the per-run performance_summary DOES carry the fields
+        # (build_result's own extraction, tested separately) — this test is
+        # about the AGGREGATE scorecard block, not the per-run one.
+        assert results[0]["performance_summary"]["triage_llm_tokens"] == 5800
+        assert results[0]["performance_summary"]["llm_classified_count"] == 4
+
+        summary = summarize_benchmark(results, run_id="bench-run")
+        perf = summary["scorecard"]["performance"]
+        assert perf["triage_llm_tokens"] == 5800
+        assert perf["llm_classified_count"] == 4
+        assert perf["tokens_per_triage"] == 1450.0
+
+    def test_scorecard_perf_section_omits_triage_usage_when_absent(self):
+        # Plain TRIAGE_ENVELOPE (no usage/llm_classified_count) must not
+        # fabricate the keys — absence is the normal, non-error shape.
+        results = [
+            build_result(
+                _agent_result(),
+                run_id=f"r{i}",
+                timestamp="t",
+                model_id="Gemma-4-E4B-it-GGUF",
+                total_duration_ms=2000,
+            )
+            for i in range(3)
+        ]
+        summary = summarize_benchmark(results, run_id="bench-run")
+        perf = summary["scorecard"]["performance"]
+        assert "triage_llm_tokens" not in perf
+        assert "llm_classified_count" not in perf
+        assert "tokens_per_triage" not in perf
+
     def test_quality_gate_block_present_with_thresholds(self):
         results = [
             build_result(


### PR DESCRIPTION
Follow-ups from the #1319 consolidated eval pass, cherry-picked onto main after the #2072 train merged (the commits raced the merge). Three small, independent threads:

- **Ctx-stamped baseline (#1892's last deliverable):** `baseline_accuracy.json` re-recorded on AMD Strix Halo hardware at the pinned 16K window — `category_accuracy` 0.8094 → **0.796** with the new `ctx_size: 16384` stamp. The old number was measured at the silent 64K default; this is the honest pinned-window figure the release gate can now compare against.
- **Scorecard-refresh workflow limit 60 → 25 (#2087 interim):** the eval pass measured the agent-loop's post-tool aggregation turn at ~8K fixed + ~190 tokens/email, so limit 60 at the workflow's pinned 16K is a guaranteed `context_length_exceeded`. Limit 25 fits (~12.8K); restore a larger limit when #2087's chunking lands.
- **Triage usage in the aggregate scorecard (#1891 live gap):** per-scenario `performance_summary` carried `tokens_per_triage` correctly on real runs (measured: **1,952 tokens per LLM-classified email** on the E4B 32K leg) but the shared `build_scorecard` aggregate's field whitelist silently dropped it. Fixed via the same post-build enrichment pattern `ctx_size` already uses, with presence + no-fabrication tests.

## Test plan
- [x] `tests/unit/eval tests/unit/email`: 689 passed (single failure is the known pre-existing `test_claude_judge` machine-`.env` artifact — passes in CI)
- [x] Full widened suite on the identical pre-merge content: 1819 passed · lint clean · YAML validated
- [x] The baseline number itself is real hardware evidence (299/299 scored at pinned ctx on Strix Halo; run artifacts retained)
