### PR TITLE
fix(ui): spawn hub-installed email binary before consulting the placeholder lock

### DIFF
--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -331,9 +331,12 @@ self-contained HTTP service the Python backend spawns, health-checks, proxies to
 and tree-kills. No Node.js is involved. Two modes, selected by
 `GAIA_EMAIL_AGENT_MODE`:
 
-- `user` (default) — runs the published frozen binary, fetched on first email use
-  and verified against `binaries.lock.json` (SHA-256 is the integrity gate). A
-  tampered or unpublished binary fails loudly; there is no fallback to dev mode.
+- `user` (default) — runs the published frozen binary. An Agent Hub install is
+  used first (its SHA-256 was verified against the hub manifest at install time
+  and is re-checked before every spawn); otherwise the binary is fetched on
+  first email use and verified against `binaries.lock.json`. Either way SHA-256
+  is the integrity gate: a tampered or unpublished binary fails loudly; there is
+  no fallback to dev mode.
 - `dev` — runs the agent from your local source with hot reload, so prompt/tool
   edits show up live without a freeze → publish cycle:
 

--- a/src/gaia/ui/email_sidecar/fetch.py
+++ b/src/gaia/ui/email_sidecar/fetch.py
@@ -2,11 +2,17 @@
 # SPDX-License-Identifier: MIT
 """Verified binary fetch (port of fetch.ts) — the security boundary.
 
-Resolves the host platform -> looks up the artifact in binaries.lock.json ->
-downloads it -> **verifies its SHA-256 against the lock and raises loudly on any
-mismatch** -> writes it atomically into the cache -> chmod +x on POSIX. A
-tampered/truncated download is rejected before it can ever be spawned. There is
-NO 'use it anyway' path.
+Two verified sources, checked in order; there is NO 'use it anyway' path:
+
+1. **Agent Hub install** — a binary the Hub installer already verified against
+   the hub manifest's server-computed SHA-256 and recorded in its ``.installed``
+   sentinel (#2086). Re-checked against that sentinel here before every spawn.
+2. **Lock fetch** — resolve the host platform -> look up the artifact in
+   binaries.lock.json -> download -> **verify its SHA-256 against the lock and
+   raise loudly on any mismatch** -> write atomically into the cache -> chmod +x
+   on POSIX.
+
+A tampered/truncated binary is rejected before it can ever be spawned.
 """
 
 from __future__ import annotations
@@ -67,6 +73,47 @@ def _join_url(base: str, name: str) -> str:
     return f"{base.rstrip('/')}/{name.lstrip('/')}"
 
 
+def _hub_installed_binary(cache: Path, platform_key: str) -> Optional[FetchResult]:
+    """Return the Hub-installed binary in *cache* if its sentinel verifies it.
+
+    The Agent Hub installer verifies every artifact against the hub manifest's
+    server-computed SHA-256 and records it in a ``.installed`` sentinel next to
+    the binary (#2086) — an equivalent integrity guarantee to the lock's, so it
+    must not be re-gated on binaries.lock.json (whose SHAs may still be
+    placeholders, #2095). Returns ``None`` when no verified install exists;
+    raises :class:`IntegrityError` if the installed file no longer matches its
+    recorded SHA.
+    """
+    from gaia.hub import installer
+
+    sentinel = installer.read_sentinel(cache.name, cache.parent)
+    if (
+        sentinel is None
+        or sentinel.artifact_kind != installer.ARTIFACT_KIND_BINARY
+        or not sentinel.executable
+        or not sentinel.artifact_sha256
+    ):
+        return None
+    binary_path = cache / sentinel.executable
+    actual = file_sha256(binary_path)
+    if actual is None:
+        return None
+    if actual.lower() != sentinel.artifact_sha256.lower():
+        raise IntegrityError(
+            f"hub-installed email agent binary at {binary_path} does not match the "
+            f"SHA-256 its install sentinel recorded:\n"
+            f"  expected {sentinel.artifact_sha256}\n  actual   {actual}\n"
+            "The install is corrupt or was tampered with — reinstall the email "
+            "agent from the Agent Hub."
+        )
+    logger.info(
+        "email sidecar: using hub-installed verified binary %s (v%s)",
+        binary_path,
+        sentinel.version,
+    )
+    return FetchResult(binary_path, platform_key, actual, url="", cached=True)
+
+
 def fetch_binary(
     *,
     out_dir: Optional[Path] = None,
@@ -79,13 +126,23 @@ def fetch_binary(
 ) -> FetchResult:
     """Fetch + verify + cache the email-agent binary for the current platform.
 
+    A Hub-installed, sentinel-verified binary short-circuits BEFORE the lock is
+    consulted (#2095) — unless ``force`` explicitly asks for a lock re-fetch.
+
     Raises:
         PlatformError: unsupported platform / incomplete or placeholder lock entry.
-        IntegrityError: SHA-256 mismatch (tampered/truncated download).
+        IntegrityError: SHA-256 mismatch (tampered install or download).
         RuntimeError: download/network failure (HTTP status surfaced).
     """
-    lock = plat.load_lock(lock_path)
     key = platform_key or plat.current_platform_key()
+    cache = Path(out_dir) if out_dir is not None else default_cache_dir()
+
+    if not force:
+        installed = _hub_installed_binary(cache, key)
+        if installed is not None:
+            return installed
+
+    lock = plat.load_lock(lock_path)
     entry = plat.resolve_entry(lock, key)
     resolved_base = base_url or os.environ.get("ASSETS_BASE_URL") or lock.base_url
     if not resolved_base:
@@ -97,12 +154,11 @@ def fetch_binary(
         raise PlatformError(
             f"binaries.lock.json has a placeholder sha256 for '{key}' "
             f"({entry.sha256}); no binary is published for it in this build. Fetch is "
-            "blocked so a bad binary can never be trusted. Publish the email agent "
-            "(release_agent_email.yml) to populate the real SHA, or run dev mode "
-            "(GAIA_EMAIL_AGENT_MODE=dev)."
+            "blocked so a bad binary can never be trusted. Install the email agent "
+            "from the Agent Hub, publish it (release_agent_email.yml) to populate "
+            "the real SHA, or run dev mode (GAIA_EMAIL_AGENT_MODE=dev)."
         )
 
-    cache = Path(out_dir) if out_dir is not None else default_cache_dir()
     cache.mkdir(parents=True, exist_ok=True)
     binary_path = cache / entry.executable
     url = _join_url(resolved_base, entry.filename)

--- a/src/gaia/ui/email_sidecar/manager.py
+++ b/src/gaia/ui/email_sidecar/manager.py
@@ -4,7 +4,8 @@
 lifecycle.ts), Node-free.
 
 Modes (``GAIA_EMAIL_AGENT_MODE``):
-  user (default) — spawn the cached frozen binary (lazy-fetched on first use).
+  user (default) — spawn the verified frozen binary: a Hub-installed one when
+                   present (#2095), else lazy-fetched via binaries.lock.json.
   dev            — spawn ``uvicorn server:app --reload --app-dir <email>/packaging``
                    from source. The file is loaded as the TOP-LEVEL module
                    ``server`` (NOT ``packaging.server:app``, which would resolve

--- a/tests/unit/test_email_sidecar_fetch.py
+++ b/tests/unit/test_email_sidecar_fetch.py
@@ -152,3 +152,125 @@ def test_fetch_base_url_override(tmp_path):
 def test_default_cache_dir():
     p = fetchmod.default_cache_dir()
     assert p.parts[-3:] == (".gaia", "agents", "email")
+
+
+# ---------------------------------------------------------------------------
+# Hub-installed binary short-circuit (#2095)
+# ---------------------------------------------------------------------------
+
+
+def _hub_install(cache: Path, data: bytes = REAL_BYTES, **overrides) -> Path:
+    """Simulate a Hub install (#2086): verified binary + .installed sentinel."""
+    cache.mkdir(parents=True, exist_ok=True)
+    sentinel = {
+        "id": "email",
+        "version": "0.5.0",
+        "language": "python",
+        "installed_at": "2026-07-15T00:00:00+00:00",
+        "artifact_sha256": hashlib.sha256(data).hexdigest(),
+        "artifact_kind": "binary",
+        "executable": "email-agent",
+        **overrides,
+    }
+    binary = cache / (sentinel["executable"] or "email-agent")
+    binary.write_bytes(data)
+    (cache / ".installed").write_text(json.dumps(sentinel))
+    return binary
+
+
+def test_hub_installed_binary_spawns_despite_placeholder_lock(tmp_path):
+    out = tmp_path / "email"
+    binary = _hub_install(out)
+    sess = _FakeSession(b"SHOULD-NOT-BE-USED")
+    res = fetchmod.fetch_binary(
+        out_dir=out,
+        platform_key="darwin-arm64",
+        lock_path=_lock(tmp_path, "PENDING-1648-replace"),
+        session=sess,
+    )
+    assert res.cached is True
+    assert Path(res.binary_path) == binary
+    assert res.sha256 == REAL_SHA
+    assert sess.calls == []
+
+
+def test_hub_installed_short_circuit_precedes_lock(tmp_path):
+    # Pin the ordering: a verified Hub install is returned BEFORE the lock is
+    # consulted at all — an unreadable lock must not block the spawn.
+    out = tmp_path / "email"
+    binary = _hub_install(out)
+    res = fetchmod.fetch_binary(
+        out_dir=out,
+        platform_key="darwin-arm64",
+        lock_path=tmp_path / "does-not-exist.lock.json",
+        session=_FakeSession(b"SHOULD-NOT-BE-USED"),
+    )
+    assert Path(res.binary_path) == binary
+
+
+def test_placeholder_still_refuses_without_hub_install(tmp_path):
+    out = tmp_path / "email"
+    out.mkdir()
+    with pytest.raises(PlatformError, match="binaries.lock.json.*placeholder"):
+        fetchmod.fetch_binary(
+            out_dir=out,
+            platform_key="darwin-arm64",
+            lock_path=_lock(tmp_path, "PENDING-1648-replace"),
+            session=_FakeSession(REAL_BYTES),
+        )
+
+
+def test_hub_installed_binary_tampered_raises(tmp_path):
+    out = tmp_path / "email"
+    _hub_install(out)
+    (out / "email-agent").write_bytes(b"tampered-after-install")
+    with pytest.raises(IntegrityError, match="reinstall"):
+        fetchmod.fetch_binary(
+            out_dir=out,
+            platform_key="darwin-arm64",
+            lock_path=_lock(tmp_path, "PENDING-1648-replace"),
+            session=_FakeSession(REAL_BYTES),
+        )
+
+
+def test_hub_sentinel_without_binary_kind_is_ignored(tmp_path):
+    # A wheel-kind sentinel (pre-#2084 email install) vouches for no binary.
+    out = tmp_path / "email"
+    _hub_install(out, artifact_kind="wheel", executable="")
+    with pytest.raises(PlatformError, match="placeholder"):
+        fetchmod.fetch_binary(
+            out_dir=out,
+            platform_key="darwin-arm64",
+            lock_path=_lock(tmp_path, "PENDING-1648-replace"),
+            session=_FakeSession(REAL_BYTES),
+        )
+
+
+def test_hub_sentinel_missing_binary_file_falls_through(tmp_path):
+    out = tmp_path / "email"
+    _hub_install(out)
+    (out / "email-agent").unlink()
+    with pytest.raises(PlatformError, match="placeholder"):
+        fetchmod.fetch_binary(
+            out_dir=out,
+            platform_key="darwin-arm64",
+            lock_path=_lock(tmp_path, "PENDING-1648-replace"),
+            session=_FakeSession(REAL_BYTES),
+        )
+
+
+def test_force_refetches_past_hub_install(tmp_path):
+    # force=True is an explicit "re-fetch from the lock" — the short-circuit
+    # must not mask it. With real lock SHAs that means a fresh download.
+    out = tmp_path / "email"
+    _hub_install(out, artifact_sha256="0" * 64)
+    sess = _FakeSession(REAL_BYTES)
+    res = fetchmod.fetch_binary(
+        out_dir=out,
+        platform_key="darwin-arm64",
+        lock_path=_lock(tmp_path, REAL_SHA),
+        session=sess,
+        force=True,
+    )
+    assert res.cached is False
+    assert sess.calls == ["https://r2.example/email-agent-darwin-arm64"]

--- a/tests/unit/test_email_sidecar_manager.py
+++ b/tests/unit/test_email_sidecar_manager.py
@@ -61,6 +61,57 @@ def test_user_mode_fetch_failure_raises_with_remedy(monkeypatch):
         m.build_spawn_command(port=9123)
 
 
+def test_user_mode_spawns_hub_installed_binary_despite_placeholder_lock(
+    monkeypatch, tmp_path
+):
+    # #2095: a Hub-installed, checksum-verified binary must spawn even while
+    # binaries.lock.json still ships placeholder SHAs. Real fetch, no mocks.
+    import hashlib
+    import json
+
+    monkeypatch.setenv("GAIA_EMAIL_AGENT_MODE", "user")
+    cache = tmp_path / "email"
+    cache.mkdir()
+    data = b"hub-verified-binary"
+    binary = cache / "email-agent"
+    binary.write_bytes(data)
+    (cache / ".installed").write_text(
+        json.dumps(
+            {
+                "id": "email",
+                "version": "0.5.0",
+                "language": "python",
+                "installed_at": "2026-07-15T00:00:00+00:00",
+                "artifact_sha256": hashlib.sha256(data).hexdigest(),
+                "artifact_kind": "binary",
+                "executable": "email-agent",
+            }
+        )
+    )
+    lock = tmp_path / "binaries.lock.json"
+    lock.write_text(
+        json.dumps(
+            {
+                "schemaVersion": "1.0",
+                "agentVersion": "0.5.0",
+                "baseUrl": "https://r2.example",
+                "binaries": {
+                    "darwin-arm64": {
+                        "filename": "email-agent-darwin-arm64",
+                        "executable": "email-agent",
+                        "sha256": "PENDING-1648-replace-with-real-sha256",
+                        "size": 0,
+                    }
+                },
+            }
+        )
+    )
+    m = mgr.EmailSidecarManager(cache_dir=cache, lock_path=lock)
+    argv, kwargs = m.build_spawn_command(port=9126)
+    assert argv[0] == str(binary)
+    assert "--port" in argv and "9126" in argv
+
+
 def test_dev_mode_spawn_command_is_uvicorn_app_dir(monkeypatch, tmp_path):
     monkeypatch.setenv("GAIA_EMAIL_AGENT_MODE", "dev")
     src = tmp_path / "email"


### PR DESCRIPTION
Installing the email agent from the Agent Hub currently produces a binary the UI refuses to run: #2086 puts a checksum-verified `email-agent` exactly where `EmailSidecarManager` looks, but the user-mode spawn path gates on `binaries.lock.json`'s placeholder SHAs *before* checking what's installed, so the first email chat dies with a "placeholder sha256" error. Now `fetch_binary` short-circuits to the Hub-installed binary first — re-verified against the SHA-256 its install sentinel recorded from the hub manifest — so Hub install → email chat just works in user mode, no env overrides. With no installed binary, the placeholder lock still fails loudly naming the lock, and a sentinel/file mismatch raises `IntegrityError` with a reinstall remedy instead of silently falling back.

Fixes #2095

## Test plan

- [ ] `python -m pytest tests/unit/test_email_sidecar_fetch.py tests/unit/test_email_sidecar_manager.py tests/unit/test_hub_installer.py -q` — includes new tests pinning the ordering (installed-binary short-circuit before the lock is consulted), the loud placeholder failure without an install, the tampered-install `IntegrityError`, and the manager-level spawn with the placeholder lock
- [ ] `python util/lint.py --all`
- [ ] Manual golden path: fresh `~/.gaia/agents/email`, install the email agent from the Agent Hub panel, open an email chat — the sidecar spawns the installed binary (log: `using hub-installed verified binary`)