### PR TITLE
feat(ui): proxy /v1/email/init (readiness + provisioning) through the sidecar router

### DIFF
--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -169,10 +169,10 @@ the endpoint returns **503** with a `hint` naming exactly what to fix.
 
 <Note>
   **Migration note:** triage no longer auto-downloads the model on its first call.
-  On a fresh server, provision once — `POST /v1/email/init` directly on the
-  sidecar (the GAIA backend proxies only the readiness `GET /v1/email/init`, not
-  the provisioning `POST`), or pull the model on your Lemonade — before the first
-  triage request; until then triage returns **502** with the fix in the error.
+  On a fresh server, provision once — `POST /v1/email/init` (the GAIA backend
+  streams the sidecar's provisioning progress through), or pull the model on
+  your Lemonade — before the first triage request; until then triage returns
+  **502** with the fix in the error.
   The target server's catalog must list the model that `GET /v1/email/init`
   reports as `model.id` (`user.`-prefixed registrations match tolerantly).
 </Note>
@@ -475,6 +475,10 @@ Tools exposed: `triage_email`, `triage_email_batch`, `draft_reply`, `send_email`
   `model.id`, and a **503** with an actionable `hint` when not ready. This is how you
   confirm a [`LEMONADE_BASE_URL` override](#pointing-the-sidecar-at-an-existing-embedded-lemonade)
   took effect.
+- **`POST /v1/email/init`** — provisioning: tells a running Lemonade to download the
+  triage model, streaming newline-delimited `text/plain` progress (`curl -N`). Once the
+  stream commits **200**, the final `✓`/`✗` line is the authoritative outcome; a **503**
+  means Lemonade itself is unreachable.
 - **`GET /v1/email/health`** — liveness only (`{"status":"ok"}`). A green health check means
   the REST surface is up, **not** that Lemonade is reachable — the readiness signal is
   `GET /v1/email/init`.

--- a/src/gaia/ui/email_sidecar/proxy.py
+++ b/src/gaia/ui/email_sidecar/proxy.py
@@ -5,7 +5,8 @@
 Forwards the full schema-2.1 ``/v1/email/*`` contract (triage, batch triage,
 search, inbox pre-scan, draft/send + confirm, archive/unarchive,
 quarantine/unquarantine, calendar view/preview/create/respond, health, version,
-readiness init) and returns the sidecar's envelopes **unchanged** so the
+readiness init + streamed provisioning) and returns the sidecar's envelopes
+**unchanged** so the
 existing SSE card pipeline (``pre_scan_inbox`` → ``email_pre_scan``) keeps
 working byte-for-byte.
 
@@ -25,6 +26,10 @@ from gaia.logger import get_logger
 from gaia.ui.email_sidecar.errors import SidecarHTTPError
 
 logger = get_logger(__name__)
+
+# POST /init can stay silent for the whole model pull — the read timeout must
+# outlast the sidecar's own 30-min pull read timeout (_LEMONADE_PULL_TIMEOUT).
+_PROVISION_READ_TIMEOUT = 1830.0
 
 
 def _extract_detail(resp) -> str:
@@ -170,3 +175,35 @@ class EmailSidecarProxy:
         if resp.status_code not in (200, 503):
             self._raise_for_status(resp, path)
         return resp.status_code, resp.json()
+
+    def provision(self) -> tuple:
+        """Provisioning verb — ``POST /v1/email/init``, streamed passthrough.
+
+        Returns ``(status_code, media_type, chunk_iterator)``. The sidecar
+        streams newline-delimited ``text/plain`` progress: a committed **200**
+        whose final ``✓``/``✗`` line is the authoritative outcome, or a **503**
+        (Lemonade unreachable) whose actionable lines are equally contract —
+        both pass through verbatim. A model pull can take many minutes, so the
+        body is never buffered; anything outside 200/503 keeps the loud
+        :class:`SidecarHTTPError` boundary, raised before any chunk is yielded.
+        """
+        path = "/v1/email/init"
+        resp = self._session.post(
+            f"{self.base_url}{path}",
+            stream=True,
+            timeout=(self.timeout, max(self.timeout, _PROVISION_READ_TIMEOUT)),
+        )
+        if resp.status_code not in (200, 503):
+            try:
+                self._raise_for_status(resp, path)
+            finally:
+                resp.close()
+        media_type = resp.headers.get("Content-Type", "text/plain; charset=utf-8")
+
+        def _chunks():
+            try:
+                yield from resp.iter_content(chunk_size=None)
+            finally:
+                resp.close()
+
+        return resp.status_code, media_type, _chunks()

--- a/src/gaia/ui/email_sidecar/router.py
+++ b/src/gaia/ui/email_sidecar/router.py
@@ -6,9 +6,9 @@ This router is the **single** ``/v1/email`` surface: the UI server mounts it
 instead of importing the email wheel in-process (#1768 / design decision 4). It
 forwards the full schema-2.1 data contract (triage, batch triage, search, inbox
 pre-scan, draft/send + confirm, archive/unarchive, quarantine/unquarantine,
-calendar view/preview/create/respond, health, version, readiness init) to the
-out-of-process sidecar, preserving the sidecar's own status codes and
-actionable error detail.
+calendar view/preview/create/respond, health, version, readiness init +
+streamed provisioning) to the out-of-process sidecar, preserving the sidecar's
+own status codes and actionable error detail.
 
 Each request lazily starts the sidecar (off the event loop) and forwards to it.
 
@@ -24,7 +24,7 @@ from typing import Optional
 
 import requests
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.concurrency import run_in_threadpool
 
 from gaia.logger import get_logger
@@ -201,11 +201,20 @@ async def health(request: Request):
 @router.get("/init")
 async def init(request: Request):
     # Readiness (#1795): pass the sidecar's 200/503 + InitResponse body through
-    # verbatim. POST /init (streamed provisioning) is deliberately not proxied
-    # for now — call it on the sidecar directly.
+    # verbatim.
     proxy = await _get_proxy(request)
     status_code, body = await _forward(proxy.init)
     return JSONResponse(status_code=status_code, content=body)
+
+
+@router.post("/init")
+async def init_provision(request: Request):
+    # Provisioning (#2054): stream the sidecar's text/plain progress through
+    # chunk-by-chunk — a multi-minute model pull must never buffer in memory.
+    # StreamingResponse iterates the sync chunk iterator in a threadpool.
+    proxy = await _get_proxy(request)
+    status_code, media_type, chunks = await _forward(proxy.provision)
+    return StreamingResponse(chunks, media_type=media_type, status_code=status_code)
 
 
 @router.get("/version")

--- a/tests/unit/test_email_sidecar_proxy.py
+++ b/tests/unit/test_email_sidecar_proxy.py
@@ -159,6 +159,106 @@ def test_init_unexpected_status_still_raises_loudly():
     assert "bearer token" in ei.value.detail.lower()
 
 
+class _StreamResp:
+    """Fake ``requests`` streamed response (``stream=True`` shape)."""
+
+    def __init__(self, chunks, status=200, *, payload=None):
+        self.status_code = status
+        self.headers = {"Content-Type": "text/plain; charset=utf-8"}
+        self._chunks = chunks
+        self._payload = payload
+        self.text = str(payload) if payload is not None else ""
+        self.closed = False
+        self.pulled = 0  # chunks consumed from the source so far
+
+    def iter_content(self, chunk_size=None):
+        for c in self._chunks:
+            self.pulled += 1
+            yield c
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("not json")
+        return self._payload
+
+    def close(self):
+        self.closed = True
+
+
+class _StreamSession:
+    def __init__(self, resp):
+        self._resp = resp
+        self.posts = []  # (url, kwargs)
+
+    def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        return self._resp
+
+
+def test_provision_streams_chunks_incrementally_on_200():
+    # #2054: POST /v1/email/init must stream through — a multi-minute model
+    # pull cannot be buffered to completion in memory.
+    resp = _StreamResp([b"line 1\n", b"line 2\n", b"done\n"])
+    sess = _StreamSession(resp)
+    proxy = EmailSidecarProxy("http://127.0.0.1:9100", session=sess)
+    status, media_type, chunks = proxy.provision()
+    assert status == 200
+    assert media_type == "text/plain; charset=utf-8"
+    # Lazy passthrough: pulling one chunk consumes exactly one from the source.
+    assert next(chunks) == b"line 1\n"
+    assert resp.pulled == 1
+    assert list(chunks) == [b"line 2\n", b"done\n"]
+    assert resp.closed  # underlying response released once the stream ends
+    url, kwargs = sess.posts[0]
+    assert url == "http://127.0.0.1:9100/v1/email/init"
+    assert kwargs["stream"] is True
+
+
+def test_provision_read_timeout_outlasts_model_pull():
+    # The sidecar's stream can stay silent for the whole pull (its own pull
+    # read timeout is 1800s) — the proxy's read timeout must outlast it even
+    # when the general sidecar timeout is short.
+    resp = _StreamResp([b"ok\n"])
+    sess = _StreamSession(resp)
+    proxy = EmailSidecarProxy("http://127.0.0.1:9100", session=sess, timeout=60.0)
+    proxy.provision()
+    connect, read = sess.posts[0][1]["timeout"]
+    assert connect == 60.0
+    assert read >= 1800.0
+
+
+def test_provision_503_unreachable_streams_body_through():
+    # 503 (Lemonade unreachable) is contract — the actionable streamed lines
+    # must pass through verbatim, not be flattened into a SidecarHTTPError.
+    resp = _StreamResp(
+        [
+            b"Lemonade Server is not reachable\n",
+            b"Start it with lemonade-server serve\n",
+        ],
+        status=503,
+    )
+    sess = _StreamSession(resp)
+    proxy = EmailSidecarProxy("http://127.0.0.1:9100", session=sess)
+    status, _media_type, chunks = proxy.provision()
+    assert status == 503
+    assert b"".join(chunks) == (
+        b"Lemonade Server is not reachable\nStart it with lemonade-server serve\n"
+    )
+
+
+def test_provision_unexpected_status_raises_loudly_and_closes():
+    # Anything outside the 200/503 contract keeps the loud SidecarHTTPError
+    # boundary — raised BEFORE any chunk is handed out.
+    resp = _StreamResp([], status=401, payload={"detail": "Missing bearer token"})
+    sess = _StreamSession(resp)
+    proxy = EmailSidecarProxy("http://127.0.0.1:9100", session=sess)
+    with pytest.raises(SidecarHTTPError) as ei:
+        proxy.provision()
+    assert ei.value.status_code == 401
+    assert "bearer token" in ei.value.detail.lower()
+    assert resp.closed
+
+
 def test_non_2xx_with_json_detail_raises_actionable_error():
     # The sidecar's actionable detail (e.g. Lemonade down) must survive, not be
     # flattened into a generic HTTPError.

--- a/tests/unit/test_email_sidecar_router.py
+++ b/tests/unit/test_email_sidecar_router.py
@@ -12,11 +12,16 @@ from gaia.ui.email_sidecar.router import router as email_router
 
 
 class _FakeProxy:
-    def __init__(self, *, error=None, init_result=None):
+    def __init__(self, *, error=None, init_result=None, provision_result=None):
         self._error = error
         self._init_result = init_result or (
             200,
             {"ready": True, "lemonade": {"base_url": "http://127.0.0.1:8000/api/v1"}},
+        )
+        self._provision_result = provision_result or (
+            200,
+            "text/plain; charset=utf-8",
+            iter([b"provisioning\n", b"done\n"]),
         )
 
     def triage(self, body):
@@ -55,14 +60,27 @@ class _FakeProxy:
             raise self._error
         return self._init_result
 
+    def provision(self):
+        if self._error:
+            raise self._error
+        return self._provision_result
+
 
 class _FakeManager:
-    def __init__(self, *, start_error=None, proxy_error=None, init_result=None):
+    def __init__(
+        self,
+        *,
+        start_error=None,
+        proxy_error=None,
+        init_result=None,
+        provision_result=None,
+    ):
         self.started = 0
         self._running = False
         self._start_error = start_error
         self._proxy_error = proxy_error
         self._init_result = init_result
+        self._provision_result = provision_result
 
     @property
     def is_running(self):
@@ -76,7 +94,11 @@ class _FakeManager:
         return "http://127.0.0.1:9999"
 
     def proxy(self, **kwargs):
-        return _FakeProxy(error=self._proxy_error, init_result=self._init_result)
+        return _FakeProxy(
+            error=self._proxy_error,
+            init_result=self._init_result,
+            provision_result=self._provision_result,
+        )
 
 
 def _client(manager) -> TestClient:
@@ -137,6 +159,97 @@ def test_init_not_ready_503_body_passthrough():
     r = client.get("/v1/email/init")
     assert r.status_code == 503
     assert r.json() == not_ready_body
+
+
+def test_init_post_streams_provisioning_output_200():
+    # #2054: POST /v1/email/init forwards the sidecar's streamed provisioning
+    # progress through chunk-by-chunk (not buffered to completion). TestClient
+    # coalesces body chunks, so drive the ASGI app directly and capture the raw
+    # http.response.body messages — one per chunk proves it streamed.
+    import asyncio
+
+    chunks = [
+        "→ Pulling Gemma-4-E4B-it-GGUF via Lemonade…\n".encode(),
+        "✓ Provisioning complete. Re-run GET /v1/email/init to confirm readiness.\n".encode(),
+    ]
+    mgr = _FakeManager(
+        provision_result=(200, "text/plain; charset=utf-8", iter(list(chunks)))
+    )
+    app = FastAPI()
+    app.state.email_sidecar_manager = mgr
+    app.include_router(email_router)
+
+    messages = []
+    body_sent = False
+
+    async def receive():
+        # First call delivers the (empty) request body; later calls block so
+        # starlette's disconnect-listener parks instead of spinning, and gets
+        # cancelled cleanly when the stream finishes.
+        nonlocal body_sent
+        if not body_sent:
+            body_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await asyncio.get_running_loop().create_future()
+
+    async def send(message):
+        messages.append(message)
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/email/init",
+        "raw_path": b"/v1/email/init",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 4200),
+    }
+    asyncio.run(app(scope, receive, send))
+
+    start = messages[0]
+    assert start["type"] == "http.response.start"
+    assert start["status"] == 200
+    headers = {k.decode(): v.decode() for k, v in start["headers"]}
+    assert headers["content-type"].startswith("text/plain")
+    bodies = [
+        m["body"] for m in messages if m["type"] == "http.response.body" and m["body"]
+    ]
+    assert bodies == chunks  # chunk boundaries survive — proof it streamed
+
+
+def test_init_post_503_unreachable_streamed_body_passthrough():
+    # Lemonade-unreachable is a contract 503 with actionable streamed lines —
+    # status and body must pass through unchanged.
+    client = _client(
+        _FakeManager(
+            provision_result=(
+                503,
+                "text/plain; charset=utf-8",
+                iter(["✗ Local Lemonade Server is not reachable\n".encode()]),
+            )
+        )
+    )
+    r = client.post("/v1/email/init")
+    assert r.status_code == 503
+    assert "not reachable" in r.text
+
+
+def test_init_post_sidecar_http_error_passthrough():
+    # Outside the 200/503 contract the loud SidecarHTTPError boundary holds.
+    client = _client(
+        _FakeManager(
+            proxy_error=SidecarHTTPError(
+                401, "Missing bearer token", path="/v1/email/init"
+            )
+        )
+    )
+    r = client.post("/v1/email/init")
+    assert r.status_code == 401
+    assert "bearer token" in r.json()["detail"].lower()
 
 
 def test_prescan_route_forwards_and_preserves_card_envelope():


### PR DESCRIPTION
Before, a consumer on the recommended backend surface whose Lemonade model wasn't downloaded hit a dead-end **502** on first triage — the backend proxied only the readiness `GET /v1/email/init`, and the integration guide had to say "POST /v1/email/init directly on the sidecar", undercutting the backend as the single `/v1/email` surface. Now the provisioning verb works through the backend: `curl -N -X POST …:4200/v1/email/init` streams the sidecar's model-pull progress live (never buffered — the read timeout outlasts the sidecar's 30-min pull window), the contract 200/503 statuses and terminal "re-run GET /v1/email/init" guidance pass through verbatim, and the guide's sidecar-direct caveat is gone. Anything outside 200/503 keeps the loud `SidecarHTTPError` boundary, raised before the first chunk.

Closes #2054

## Test plan

- [x] `pytest tests/unit/test_email_sidecar_proxy.py tests/unit/test_email_sidecar_router.py` — 49 passed, including a raw-ASGI streaming assertion (chunk boundaries survive, proving no buffering) and 200/503/non-contract status passthrough on both layers
- [x] Adjacent guards: `tests/test_email_openapi_conformance.py`, `tests/unit/test_email_sidecar_server_wiring.py`, `tests/unit/agents/email/` — 574 passed
- [x] Live e2e (dev-mode sidecar via `python -m gaia.ui.server`): `curl -N -X POST /v1/email/init` through the backend streamed `→ …pulling… ✓ Provisioning complete. Re-run GET /v1/email/init…` with HTTP 200 `text/plain`
- [x] Fresh-state e2e with `LEMONADE_BASE_URL` pointed at a dead port: streamed **503** with the sidecar's actionable `✗` lines verbatim
- [x] `python util/lint.py --all --fix` clean