### PR TITLE
feat(agent-email/npm): /v1/email/query SSE streaming client + contract 2.4

### DIFF
--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -6,6 +6,19 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## 0.6.0
 
+- **The plain-language agent loop is now part of the typed client.** 0.5.0's
+  streaming endpoint required hand-rolled `fetch` + SSE parsing; now
+  `client.query()` returns an async iterator of typed events (`status`, `token`,
+  `tool_call`, `tool_result`, `needs_confirmation`, `final`, `error` — plus a
+  visible `unknown` placeholder for event types added by a newer agent, never a
+  silent drop), and `client.cancelQuery(runId)` stops a run mid-way. You mint
+  `run_id`, so a run is cancellable from the instant you send it. A stream that
+  breaks mid-run throws instead of looking like success.
+- **The client now speaks contract 2.4.** `SCHEMA_VERSION` moved 2.3 → 2.4
+  (additive — every 2.3 request/response shape is unchanged). The startup
+  version handshake accepts any 2.x sidecar, so a 2.3-pinned client keeps
+  working against a 2.4 sidecar exactly as before; only the new `query()` /
+  `cancelQuery()` calls need a 2.4 (0.5.0+) agent binary.
 - **On NPU-capable machines, triage now runs on the NPU by default.** When
   you haven't pinned a specific model, the agent checks whether the
   Lemonade Server it's talking to has an AMD NPU and the NPU-optimized

--- a/hub/agents/npm/agent-email/README.md
+++ b/hub/agents/npm/agent-email/README.md
@@ -86,6 +86,22 @@ console.log(res.result.category, res.result.summary);
 await shutdown(sidecar);
 ```
 
+Or hand the agent a plain-language request and watch it work — `query()` streams
+typed progress events (`status`, `tool_call`, `tool_result`, …) and ends with the
+answer; `cancelQuery()` stops a run mid-way:
+
+```ts
+const runId = crypto.randomUUID(); // yours to mint — it's also the cancel handle
+for await (const ev of sidecar.client.query({
+  query: "Find today's urgent mail and archive the promotions.",
+  run_id: runId,
+  context: [],
+})) {
+  if (ev.type === "status") console.log(ev.message);
+  if (ev.type === "final") console.log(ev.answer); // last event
+}
+```
+
 Triage classifies and drafts using only the local model — no mailbox connection
 needed. Reading or acting on a live inbox (search, send, archive, calendar) uses
 the **Google or Microsoft connector** you set up in GAIA under

--- a/hub/agents/npm/agent-email/SKILL.md
+++ b/hub/agents/npm/agent-email/SKILL.md
@@ -112,6 +112,8 @@ The interface:
 | `previewCalendarEvent(req)` | Nothing external | Mints a single-use confirmation token bound to the event (calendar analogue of `draft`). |
 | `createCalendarEvent(req)` | Preview token + connected calendar | Token gate fires first: no/invalid token → 403, then the calendar checks. |
 | `respondToCalendarEvent(req)` | Connected calendar | RSVP `accepted`/`declined`/`tentative` to an existing invite. |
+| `query(req)` | A connected mailbox (for mailbox tools) | The agent loop (schema 2.4): async iterator of the seven typed SSE events. You mint `run_id`; push the transcript slice in `context`. See "Canonical agent-loop query" below. |
+| `cancelQuery(runId)` | Nothing external | Cancel an in-flight `query()` run between steps (pass the `run_id` you minted). Not in flight → 404. |
 
 **Build the standalone surface (`triage`, `draft`, `confirmAction`,
 `previewCalendarEvent`) with zero connector setup.** The read-only `search` and
@@ -156,40 +158,46 @@ The v2 keystone (#2016): NL request in, the agent reasons and chains its tools, 
 `tool_result` / `needs_confirmation` / `final` / `error`, terminated by exactly one
 `final` or `error`. This is the one loop every v2 front-door relays to. The **host
 mints `run_id`** and **pushes** the transcript slice in `context`, so the sidecar
-stays stateless; cancel a run mid-flight with `POST /v1/email/query/{run_id}/cancel`
-(stops tool execution between steps). Not wrapped by the typed client yet — call it
-directly:
+stays stateless. The typed client wraps it (#2097): `query()` returns an async
+iterator of typed `QueryEvent`s; `cancelQuery(runId)` stops the run between steps:
 
-```js
-const base = "http://127.0.0.1:8131";
-const run_id = crypto.randomUUID(); // host-minted; also the cancel handle
-const res = await fetch(`${base}/v1/email/query`, {
-  method: "POST",
-  headers: {
-    "content-type": "application/json",
-    accept: "text/event-stream",
-    authorization: `Bearer ${authToken}`, // per-session bearer (#1980)
-  },
-  body: JSON.stringify({ query: "Triage my inbox", run_id, context: [] }),
-});
-const reader = res.body.getReader(); const dec = new TextDecoder(); let buf = "";
-for (;;) {
-  const { value, done } = await reader.read();
-  if (done) break;
-  buf += dec.decode(value, { stream: true });
-  let i;
-  while ((i = buf.indexOf("\n\n")) !== -1) {
-    const frame = buf.slice(0, i); buf = buf.slice(i + 2);
-    const line = frame.split("\n").find((l) => l.startsWith("data:"));
-    if (!line) continue;
-    const ev = JSON.parse(line.slice(5).trim());
-    // ev.type ∈ status|token|tool_call|tool_result|needs_confirmation|final|error
-    if (ev.type === "final" || ev.type === "error") { /* terminal */ }
+```ts
+const runId = crypto.randomUUID(); // host-minted; also the cancel handle
+for await (const ev of sidecar.client.query({
+  query: "Triage my inbox",
+  run_id: runId,
+  context: [], // pushed transcript slice; [] for a fresh conversation
+})) {
+  switch (ev.type) {
+    case "status":       console.log(ev.message); break;
+    case "token":        process.stdout.write(ev.delta); break;
+    case "tool_call":    console.log(`→ ${ev.tool}`, ev.args); break;
+    case "tool_result":  console.log(`← ${ev.tool}`, ev.data); break;
+    case "needs_confirmation": break; // run then ends with a final refusal (D1)
+    case "final":        console.log(ev.answer); break;   // terminal
+    case "error":        console.error(ev.detail); break; // terminal, verbatim
+    default:             console.warn("unsupported event", ev); // future additive type
   }
 }
-// To cancel: await fetch(`${base}/v1/email/query/${run_id}/cancel`, { method: "POST",
-//   headers: { authorization: `Bearer ${authToken}` } });
+// Mid-run, from anywhere that knows runId:
+// await sidecar.client.cancelQuery(runId);
 ```
+
+Rules an integration must respect:
+
+- **Mint `run_id` yourself** (`crypto.randomUUID()`) and keep it — it is the cancel
+  handle, valid from the instant the request is sent.
+- **Exactly one terminal event.** A terminal `error` is *yielded* (surface `detail`
+  verbatim); transport/contract failures *throw* (`HttpError` non-2xx,
+  `QueryStreamError` for a non-SSE response / malformed event / stream that closes
+  without a terminal). Never treat iterator completion without a `final` as success —
+  the client already throws for you.
+- **Handle the `default` branch.** A `type` outside the frozen seven arrives as
+  `{ type: "unknown", eventType, raw }` — render an "unsupported event" placeholder or
+  log it; it is never silently dropped.
+- **Long runs are normal.** `timeoutMs` bounds time-to-first-response only. To abort
+  from the client side pass `query(req, { signal })` AND call `cancelQuery` so the
+  sidecar stops the loop, not just the socket.
 
 A confirmation-requiring step (a destructive tool such as `send_now`) emits
 `needs_confirmation` then ends with a `final` refusal pointing at the fixed-function

--- a/hub/agents/npm/agent-email/SPEC.md
+++ b/hub/agents/npm/agent-email/SPEC.md
@@ -95,8 +95,8 @@ result.
 | `POST /v1/email/calendar/events/preview` | `previewCalendarEvent()` | **Standalone** | Nothing external — mints a single-use confirmation token bound to the event (calendar analogue of `draft`). |
 | `POST /v1/email/calendar/events` | `createCalendarEvent()` | **Connector** | A valid `preview` token **and** a connected calendar. Token gate fires first: no/invalid token → `403`; then the calendar-scope / account checks. |
 | `POST /v1/email/calendar/events/respond` | `respondToCalendarEvent()` | **Connector** | A connected calendar. RSVPs `accepted`/`declined`/`tentative` to an existing invite. |
-| `POST /v1/email/query` | — (SSE; no wrapper yet) | **Connector** | Canonical agent-loop query (schema 2.4, #2016). NL request in, seven canonical SSE event types out (`status`/`token`/`tool_call`/`tool_result`/`needs_confirmation`/`final`/`error`), terminated by one `final`/`error`. Host mints `run_id`; context is pushed. See "Canonical agent-loop query" below. |
-| `POST /v1/email/query/{run_id}/cancel` | — (no wrapper yet) | **Standalone** | Cancel an in-flight `/query` run — stops tool execution between steps. `404` if no run with that id is in flight. |
+| `POST /v1/email/query` | `query()` | **Connector** | Canonical agent-loop query (schema 2.4, #2016). NL request in, seven canonical SSE event types out (`status`/`token`/`tool_call`/`tool_result`/`needs_confirmation`/`final`/`error`), terminated by one `final`/`error`. `query()` returns an async iterator of typed `QueryEvent`s. Host mints `run_id`; context is pushed. See "Canonical agent-loop query" below. |
+| `POST /v1/email/query/{run_id}/cancel` | `cancelQuery()` | **Standalone** | Cancel an in-flight `/query` run — stops tool execution between steps. `404` if no run with that id is in flight. |
 | `GET /v1/email/init` | `init()` | **Standalone** | **Readiness preflight** (#1795): probes the whole triage stack — Lemonade reachable **and** version-compatible **and** the triage model downloaded. Returns `200` when ready, `503` when not, with an actionable `hint` either way (same `InitResponse` envelope). Read-only — no model pull. Unlike `/health` (liveness only), this verifies "ready to triage," not just "process up." |
 | `POST /v1/email/init` | — (streaming; no wrapper yet) | **Standalone** | **Provisioning** (#1795): tells the *running* local Lemonade to download the configured triage model, streaming `text/plain` progress line-by-line. Lemonade unreachable → real `503` (pulls nothing); once a pull starts the `200` is committed, so the trailing `✓`/`✗` line carries the true outcome. Not in the OpenAPI JSON — a streaming operational verb (like `GET /spec`), so `include_in_schema=False`. |
 | `GET /health` | `health()` | **Standalone** | Liveness only — does **not** check Lemonade/model. |
@@ -153,8 +153,42 @@ The stream ends with **exactly one `final` or `error`**.
 destructive/external tool such as `send_now`) emits `needs_confirmation` and then the run
 ends with a `final` refusal pointing at the deterministic fixed-function route — mint a
 token via `draft()`/`POST /v1/email/draft`, then `send()`/`POST /v1/email/send`.
-Server-side resume is not wired yet, so `confirm_url` is omitted. Not wrapped by the typed
-npm client yet — call it directly (e.g. `fetch` with `Accept: text/event-stream`).
+Server-side resume is not wired yet, so `confirm_url` is omitted.
+
+**Typed client:** `query()` wraps the stream as an async iterator of typed `QueryEvent`s
+(discriminated on `type`); `cancelQuery(runId)` wraps the cancel route.
+
+```ts
+const runId = crypto.randomUUID(); // host-minted (spec §2.3); also the cancel handle
+for await (const ev of sidecar.client.query({
+  query: "Triage my inbox and draft replies to anything urgent.",
+  run_id: runId,
+  context: [], // pushed transcript slice; [] for a fresh conversation
+})) {
+  switch (ev.type) {
+    case "status":       spinner.text = ev.message; break;
+    case "token":        answer += ev.delta; break;
+    case "tool_call":    console.log(`→ ${ev.tool}`, ev.args); break;
+    case "tool_result":  renderCard(ev.render, ev.data); break;
+    case "needs_confirmation": /* run then ends with a final refusal (D1) */ break;
+    case "final":        console.log(ev.answer); break;        // terminal
+    case "error":        console.error(ev.detail); break;      // terminal, verbatim
+    default:             console.warn("unsupported event", ev); // additive future type
+  }
+}
+// Mid-run, from anywhere that knows runId:
+// await sidecar.client.cancelQuery(runId);
+```
+
+Semantics: exactly one terminal `final`/`error` ends the iterator — a terminal `error`
+event is **yielded** (its `detail` is the actionable message), while transport/contract
+failures **throw** (`HttpError` on a non-2xx; `QueryStreamError` on a non-SSE response,
+a malformed event, or a stream that closes with no terminal event). An event `type`
+outside the frozen seven is yielded as `{ type: "unknown", eventType, raw }` — surfaced,
+never silently dropped (contract §7). The client's `timeoutMs` bounds time-to-first-response
+only; a healthy run streams as long as the agent works (pass an `AbortSignal` via
+`query(req, { signal })` to abort the transport — and also call `cancelQuery` so the
+sidecar stops the loop, not just the socket).
 
 ### Stateful agent surface (`/v1/email/agent/*`, 0.4.0)
 
@@ -528,11 +562,15 @@ TypeScript types in `src/types.ts` mirror two Python sources of truth:
 - `contract.py` — the triage request/response contract plus the schema-2.1
   additions (inbox search, mailbox actions, calendar, pre-scan), the schema-2.2
   attachment models (`AttachmentMeta` / `OutgoingAttachment`), and the schema-2.3
-  triage draft scaffold (`DraftScaffold`; `SCHEMA_VERSION = "2.3"`).
+  triage draft scaffold (`DraftScaffold`; `SCHEMA_VERSION = "2.4"`).
 - `api_routes.py` — the local draft/send confirmation handshake models, the
   readiness-preflight envelope (`InitResponse` / `InitLemonadeStatus` /
   `InitModelStatus`, #1795), and the scheduled-briefing response
   (`EmailBriefingResponse`, #1608).
+- `query_routes.py` + the frozen `/query` SSE contract
+  (`docs/spec/agent-ui-query-sse-contract.md`) — the schema-2.4 agent-loop query:
+  `EmailQueryRequest` / `QueryContextItem`, the seven `QueryEvent` shapes (plus
+  the `unknown` placeholder for additive future types), and `QueryCancelResponse`.
 
 They are hand-written (vs. generated from `/openapi.json`) because the contract is
 small and version-gated, keeping the published package free of a typegen build

--- a/hub/agents/npm/agent-email/package-lock.json
+++ b/hub/agents/npm/agent-email/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amd-gaia/agent-email",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amd-gaia/agent-email",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "bin": {
         "agent-email": "dist/cli.js"

--- a/hub/agents/npm/agent-email/src/client-entry.ts
+++ b/hub/agents/npm/agent-email/src/client-entry.ts
@@ -30,6 +30,7 @@ export {
   HealthTimeoutError,
   VersionMismatchError,
   BinaryNotFoundError,
+  QueryStreamError,
 } from "./errors.js";
 
 export { SCHEMA_VERSION } from "./types.js";

--- a/hub/agents/npm/agent-email/src/client.ts
+++ b/hub/agents/npm/agent-email/src/client.ts
@@ -18,6 +18,8 @@
  *   POST /v1/email/calendar/events/preview     (mint a calendar confirmation token)
  *   POST /v1/email/calendar/events             (create — gated on a valid token)
  *   POST /v1/email/calendar/events/respond     (RSVP accept/decline/tentative)
+ *   POST /v1/email/query                       (agent loop — SSE stream, schema 2.4)
+ *   POST /v1/email/query/{run_id}/cancel       (cancel an in-flight /query run)
  *   GET  /v1/email/init       (readiness preflight — Lemonade + model probe)
  *   GET  /health              (root liveness — what the standalone sidecar serves)
  *   GET  /version             (root apiVersion / agentVersion)
@@ -38,8 +40,9 @@
  * `HttpError` carrying the status and body — no silent empty/null fallback.
  */
 
-import { HttpError } from "./errors.js";
+import { HttpError, QueryStreamError } from "./errors.js";
 import { createLogger } from "./logger.js";
+import { SseDataParser } from "./sse.js";
 import { stripTrailingSlashes } from "./url.js";
 import type {
   BatchTriageRequest,
@@ -58,6 +61,7 @@ import type {
   EmailDraftResponse,
   EmailPreScanRequest,
   EmailPreScanResponse,
+  EmailQueryRequest,
   EmailQuarantineRequest,
   EmailQuarantineResponse,
   EmailSearchRequest,
@@ -73,6 +77,8 @@ import type {
   HealthResponse,
   InitResponse,
   OpenApiDocument,
+  QueryCancelResponse,
+  QueryEvent,
   VersionResponse,
 } from "./types.js";
 
@@ -287,6 +293,192 @@ export class EmailClient {
     return this.post<CalendarRespondResponse>(
       "/v1/email/calendar/events/respond",
       request,
+    );
+  }
+
+  /**
+   * Run the agent loop for one natural-language request and stream the seven
+   * canonical SSE events (POST /v1/email/query — schema 2.4, #2016/#2097).
+   *
+   * Returns an async iterator of typed {@link QueryEvent}s. YOU mint `run_id`
+   * (e.g. `crypto.randomUUID()`) — spec §2.3 — and keep it: `cancelQuery(runId)`
+   * keys off it, so the run is cancellable from the instant the request is sent.
+   * The transcript slice is pushed in `request.context` (spec §2.4); the sidecar
+   * stays stateless.
+   *
+   * Stream semantics (spec §3–§4):
+   *   - events interleave freely; exactly one terminal `final` OR `error` ends
+   *     the run, after which the iterator completes. A terminal `error` event is
+   *     YIELDED (its `detail` is the actionable message, surfaced verbatim), not
+   *     thrown — transport/contract failures throw instead.
+   *   - an event `type` outside the frozen seven is yielded as
+   *     `{ type: "unknown", eventType, raw }` — surfaced, never silently dropped
+   *     (spec §7). Handle it in your `default` branch.
+   *   - a gated step emits `needs_confirmation`, then (stateless model, epic
+   *     decision D1) the run ends with a `final` refusal pointing at the
+   *     fixed-function route (`draft()` → `send()`).
+   *
+   * Failures throw: non-2xx → `HttpError`; a non-SSE response, a malformed
+   * event payload, or a stream that closes without a terminal event →
+   * `QueryStreamError`. The client's `timeoutMs` bounds time-to-first-response
+   * only — a healthy run streams as long as the agent works; pass
+   * `opts.signal` to abort the transport (and also call `cancelQuery` so the
+   * sidecar stops the loop, not just the socket).
+   */
+  async *query(
+    request: EmailQueryRequest,
+    opts?: { signal?: AbortSignal },
+  ): AsyncGenerator<QueryEvent, void, undefined> {
+    const url = `${this.baseUrl}/v1/email/query`;
+    const ctrl = new AbortController();
+    // timeoutMs bounds the time to response HEADERS only (cleared below) —
+    // the stream itself must run as long as the agent loop does.
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    const onCallerAbort = (): void => ctrl.abort();
+    opts?.signal?.addEventListener("abort", onCallerAbort, { once: true });
+    log.debug(`POST ${url} (SSE)`);
+    const authHeaders: Record<string, string> = this.authToken
+      ? { authorization: `Bearer ${this.authToken}` }
+      : {};
+
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        method: "POST",
+        signal: ctrl.signal,
+        headers: {
+          accept: "text/event-stream",
+          "content-type": "application/json",
+          ...authHeaders,
+        },
+        body: JSON.stringify(request),
+      });
+    } catch (e) {
+      clearTimeout(timer);
+      opts?.signal?.removeEventListener("abort", onCallerAbort);
+      if (e instanceof Error && e.name === "AbortError") {
+        if (opts?.signal?.aborted) throw e; // caller-initiated — propagate as-is
+        throw new HttpError(
+          0,
+          url,
+          `request timed out after ${this.timeoutMs}ms — is the sidecar running at ${this.baseUrl}?`,
+        );
+      }
+      throw new HttpError(
+        0,
+        url,
+        `network error: ${(e as Error).message} — is the sidecar running at ${this.baseUrl}?`,
+      );
+    }
+    clearTimeout(timer); // headers received — the stream is unbounded from here
+
+    try {
+      if (!res.ok) {
+        const text = await res.text();
+        log.debug(`POST ${url} -> ${res.status}`);
+        throw new HttpError(res.status, url, text);
+      }
+      const contentType = res.headers.get("content-type") ?? "";
+      if (!contentType.includes("text/event-stream")) {
+        throw new QueryStreamError(
+          `expected a text/event-stream response from ${url} but got ` +
+            `'${contentType || "(no content-type)"}' — is this a /v1/email/query-capable ` +
+            "(apiVersion >= 2.4) sidecar?",
+        );
+      }
+      if (!res.body) {
+        throw new QueryStreamError(`response from ${url} has no body to stream`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      const parser = new SseDataParser();
+      let sawTerminal = false;
+
+      const toEvent = (payload: string): QueryEvent => {
+        let raw: unknown;
+        try {
+          raw = JSON.parse(payload);
+        } catch (e) {
+          throw new QueryStreamError(
+            `malformed /query event — not valid JSON: ${(e as Error).message} ` +
+              `(payload: ${payload.slice(0, 200)})`,
+          );
+        }
+        if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+          throw new QueryStreamError(
+            `malformed /query event — expected a JSON object, got: ${payload.slice(0, 200)}`,
+          );
+        }
+        const obj = raw as Record<string, unknown>;
+        const type = obj.type;
+        if (typeof type !== "string" || type.length === 0) {
+          throw new QueryStreamError(
+            `malformed /query event — missing string 'type': ${payload.slice(0, 200)}`,
+          );
+        }
+        switch (type) {
+          case "status":
+          case "token":
+          case "tool_call":
+          case "tool_result":
+          case "needs_confirmation":
+          case "final":
+          case "error":
+            return obj as unknown as QueryEvent;
+          default:
+            // Additive future type (spec §7): surface it, never drop it.
+            return { type: "unknown", eventType: type, raw: obj };
+        }
+      };
+
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          // At EOF flush the decoder (a multibyte char can straddle the last
+          // chunk) before flushing the parser's pending event.
+          const payloads = done
+            ? [...parser.push(decoder.decode()), ...parser.end()]
+            : parser.push(decoder.decode(value, { stream: true }));
+          for (const payload of payloads) {
+            const event = toEvent(payload);
+            yield event;
+            if (event.type === "final" || event.type === "error") {
+              sawTerminal = true;
+              return;
+            }
+          }
+          if (done) break;
+        }
+      } finally {
+        // Consumer break / terminal / throw: release the connection.
+        reader.cancel().catch(() => undefined);
+      }
+
+      if (!sawTerminal) {
+        throw new QueryStreamError(
+          `the /query stream from ${url} closed without a terminal 'final' or ` +
+            "'error' event — the run's outcome is unknown (contract requires exactly one).",
+        );
+      }
+    } finally {
+      opts?.signal?.removeEventListener("abort", onCallerAbort);
+    }
+  }
+
+  /**
+   * Cancel an in-flight `query()` run (POST /v1/email/query/{run_id}/cancel).
+   * Cooperative, not a kill: the agent loop stops tool execution at its next
+   * step boundary. 404 (`HttpError`) if no run with that id is in flight —
+   * including a run that already finished.
+   */
+  async cancelQuery(runId: string): Promise<QueryCancelResponse> {
+    if (!runId) {
+      throw new TypeError("cancelQuery requires the run_id the query was sent with");
+    }
+    return this.post<QueryCancelResponse>(
+      `/v1/email/query/${encodeURIComponent(runId)}/cancel`,
+      undefined,
     );
   }
 

--- a/hub/agents/npm/agent-email/src/errors.ts
+++ b/hub/agents/npm/agent-email/src/errors.ts
@@ -39,3 +39,10 @@ export class VersionMismatchError extends AgentEmailError {}
 
 /** A binary could not be located on disk for spawning. */
 export class BinaryNotFoundError extends AgentEmailError {}
+
+/**
+ * The `/query` SSE stream violated the frozen contract — a malformed event
+ * payload, a non-SSE response, or a stream that closed without the mandated
+ * terminal `final`/`error` event.
+ */
+export class QueryStreamError extends AgentEmailError {}

--- a/hub/agents/npm/agent-email/src/index.ts
+++ b/hub/agents/npm/agent-email/src/index.ts
@@ -65,6 +65,7 @@ export {
   HealthTimeoutError,
   VersionMismatchError,
   BinaryNotFoundError,
+  QueryStreamError,
 } from "./errors.js";
 
 export { SCHEMA_VERSION, MAX_BATCH_SIZE } from "./types.js";

--- a/hub/agents/npm/agent-email/src/lifecycle.ts
+++ b/hub/agents/npm/agent-email/src/lifecycle.ts
@@ -313,7 +313,7 @@ function majorOf(version: string): number {
 }
 
 export interface VersionCheckOptions {
-  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("2.3"). */
+  /** The apiVersion the client was built against. Default SCHEMA_VERSION ("2.4"). */
   expectedApiVersion?: string;
 }
 

--- a/hub/agents/npm/agent-email/src/sse.ts
+++ b/hub/agents/npm/agent-email/src/sse.ts
@@ -1,0 +1,76 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+/**
+ * Minimal incremental Server-Sent-Events parser for the `/query` stream.
+ *
+ * Feed it decoded text chunks in whatever framing the transport delivers
+ * (an event may arrive split across chunks, or many events in one chunk);
+ * it returns each completed event's `data` payload as one string. Handles:
+ *   - events separated by a blank line (LF or CRLF line endings)
+ *   - multi-line `data:` fields (joined with "\n", per the SSE spec)
+ *   - the optional single space after "data:"
+ *   - comment lines (":...") and non-data fields (event:/id:/retry:) — SSE
+ *     framing the /query contract doesn't use; skipped as transport chrome.
+ *     (The no-silent-fallback rule applies to the JSON `type` vocabulary,
+ *     which the client surfaces as QueryUnknownEvent — not to SSE framing.)
+ *
+ * The parser never interprets the payload — JSON parsing (and the fail-loud
+ * behavior on malformed payloads) lives with the caller in client.ts.
+ */
+
+export class SseDataParser {
+  private buffer = "";
+  private dataLines: string[] = [];
+
+  /** Feed one decoded chunk; returns the data payloads completed by it. */
+  push(chunk: string): string[] {
+    this.buffer += chunk;
+    const out: string[] = [];
+    let idx: number;
+    // Consume only COMPLETE lines; a partial line stays buffered for the next chunk.
+    while ((idx = this.buffer.indexOf("\n")) !== -1) {
+      let line = this.buffer.slice(0, idx);
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      const payload = this.consumeLine(line);
+      if (payload !== undefined) out.push(payload);
+    }
+    return out;
+  }
+
+  /**
+   * Signal end-of-stream; returns the final payload if the stream closed with
+   * a pending event (no trailing blank line), else an empty array.
+   */
+  end(): string[] {
+    // A trailing partial line without "\n" still counts at EOF.
+    if (this.buffer) {
+      let line = this.buffer;
+      this.buffer = "";
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      this.consumeLine(line);
+    }
+    if (this.dataLines.length === 0) return [];
+    const payload = this.dataLines.join("\n");
+    this.dataLines = [];
+    return [payload];
+  }
+
+  /** Process one complete line; returns a payload when a blank line dispatches. */
+  private consumeLine(line: string): string | undefined {
+    if (line === "") {
+      if (this.dataLines.length === 0) return undefined; // stray blank line
+      const payload = this.dataLines.join("\n");
+      this.dataLines = [];
+      return payload;
+    }
+    if (line.startsWith(":")) return undefined; // SSE comment
+    if (line.startsWith("data:")) {
+      let value = line.slice("data:".length);
+      if (value.startsWith(" ")) value = value.slice(1);
+      this.dataLines.push(value);
+    }
+    // Other SSE fields (event:/id:/retry:) are transport framing — skipped.
+    return undefined;
+  }
+}

--- a/hub/agents/npm/agent-email/src/types.ts
+++ b/hub/agents/npm/agent-email/src/types.ts
@@ -34,10 +34,15 @@
  * DraftScaffold (recipient + subject only) instead of a DraftReply — triage
  * never composed a body, so the always-empty draft.body is dropped. DraftReply
  * (with body) is unchanged and remains the draft()/send() shape.
+ * Schema 2.4 (additive over 2.3, #2016/#2097): the canonical agent-loop query —
+ * POST /v1/email/query (SSE stream of the seven frozen event types, spec
+ * docs/spec/agent-ui-query-sse-contract.md) + POST /v1/email/query/{run_id}/cancel.
+ * Mirrored from `query_routes.py` (QueryRequest / QueryCancelResponse) and the
+ * frozen #2057 event vocabulary.
  */
 
 /** Frozen contract version echoed by the server's `/version` endpoint. */
-export const SCHEMA_VERSION = "2.3" as const;
+export const SCHEMA_VERSION = "2.4" as const;
 
 /**
  * The five-bucket triage taxonomy (schema 2.0 — contract.py: EmailCategory).
@@ -642,6 +647,173 @@ export interface CalendarRespondResponse {
   status: CalendarRsvpStatus;
   /** Always true on success. */
   responded: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical agent-loop query (query_routes.py — schema 2.4, #2016/#2097). A
+// natural-language request in, the seven frozen SSE event types out (the #2057
+// wire contract, docs/spec/agent-ui-query-sse-contract.md), terminated by
+// exactly one `final` or `error`. The HOST mints `run_id` (spec §2.3) so the
+// run is cancellable from the instant the request is sent; the transcript
+// slice is PUSHED in `context` (spec §2.4) so the sidecar stays stateless.
+// ---------------------------------------------------------------------------
+
+/** Transcript role of one pushed context turn (query_routes.py: QueryContextItem). */
+export type QueryRole = "user" | "assistant" | "system" | "tool";
+
+/** One prior turn pushed in the request body (query_routes.py: QueryContextItem). */
+export interface QueryContextItem {
+  /** Transcript role for this turn. */
+  role: QueryRole;
+  /** The message text for this turn. */
+  content: string;
+}
+
+/** `POST /v1/email/query` request body (query_routes.py: QueryRequest, spec §2.2). */
+export interface EmailQueryRequest {
+  /** The natural-language request driving the agent loop. Non-empty. */
+  query: string;
+  /**
+   * Host-minted streaming-run handle (UUIDv4) — mint it yourself (e.g.
+   * `crypto.randomUUID()`) and keep it: cancellation (`cancelQuery(runId)`)
+   * keys off it, so the run is cancellable from the instant the request is sent.
+   */
+  run_id: string;
+  /**
+   * The relevant transcript slice, pushed in the body. May be an empty array
+   * for a fresh conversation, but the field must be present (spec §2.4).
+   */
+  context: QueryContextItem[];
+  /** Model id override. Omitted → the sidecar's default. */
+  model?: string;
+  /**
+   * LLM provider override. The email agent runs local inference only, so only
+   * "lemonade" is accepted; any other value is rejected (400).
+   */
+  provider?: string;
+  /** Agent-loop step ceiling (≥ 1). Omitted → the agent's configured default. */
+  max_steps?: number;
+}
+
+/** Progress narration (also carries folded step/thinking/plan lines). */
+export interface QueryStatusEvent {
+  type: "status";
+  /** The progress line to show. */
+  message: string;
+}
+
+/** An incremental chunk of assistant answer text. */
+export interface QueryTokenEvent {
+  type: "token";
+  /** The next chunk of assistant text to append. */
+  delta: string;
+}
+
+/** The agent is invoking a tool. */
+export interface QueryToolCallEvent {
+  type: "tool_call";
+  /** Tool name, e.g. "triage_inbox". */
+  tool: string;
+  /** Tool arguments; `{}` when the tool takes none. */
+  args: Record<string, unknown>;
+}
+
+/** A tool returned a result. */
+export interface QueryToolResultEvent {
+  type: "tool_result";
+  /** Tool name the result belongs to. */
+  tool: string;
+  /** Optional typed-card key (e.g. "email_pre_scan"); unknown keys degrade to a generic card. */
+  render?: string;
+  /** Structured result; shape is render-specific. */
+  data: unknown;
+}
+
+/**
+ * A gated (destructive/external) step is awaiting approval. Under the current
+ * stateless confirmation model (epic decision D1) the run then ends with a
+ * `final` refusal pointing at the fixed-function route (draft() → send());
+ * `confirm_url` is omitted until server-side resume is wired.
+ */
+export interface QueryNeedsConfirmationEvent {
+  type: "needs_confirmation";
+  /** The run this pause belongs to (correlate with your minted run_id). */
+  run_id: string;
+  /** The gated action, e.g. "send", "archive", "input". */
+  action: string;
+  /** The literal text the user would approve. */
+  summary: string;
+  /** Resume endpoint — only present under the (not yet wired) resume model. */
+  confirm_url?: string;
+}
+
+/** Run usage metrics on the terminal `final` event (all fields optional). */
+export interface QueryUsage {
+  /** Agent-loop steps taken. */
+  steps?: number;
+  /** Tools invoked during the run. */
+  tools_used?: number;
+  /** Wall-clock seconds for the run. */
+  elapsed?: number;
+  /** Token counts, when the backend reports them. */
+  tokens?: number;
+  [key: string]: unknown;
+}
+
+/** Terminal: the assistant's final answer. Exactly one `final` OR `error` ends a run. */
+export interface QueryFinalEvent {
+  type: "final";
+  /** The assistant's answer text. */
+  answer: string;
+  /** Optional usage metrics for the run. */
+  usage?: QueryUsage;
+}
+
+/** Terminal: an actionable failure — surface `detail` verbatim. */
+export interface QueryErrorEvent {
+  type: "error";
+  /** Actionable message, surfaced verbatim. */
+  detail: string;
+  /** HTTP-style status code for the failure class. */
+  status: number;
+}
+
+/**
+ * A wire event whose `type` is outside the frozen seven. Per the contract's
+ * evolution rule (spec §7) a newer sidecar may add event types additively; the
+ * client surfaces them as this placeholder — visibly, never silently dropped.
+ * Render an "unsupported event" affordance (or log it) in your default branch.
+ */
+export interface QueryUnknownEvent {
+  type: "unknown";
+  /** The unrecognized wire `type` value. */
+  eventType: string;
+  /** The full raw event object as received. */
+  raw: Record<string, unknown>;
+}
+
+/**
+ * One canonical `/query` SSE event, discriminated on `type`. The seven frozen
+ * types (spec §4) plus the `unknown` placeholder for additive future types.
+ */
+export type QueryEvent =
+  | QueryStatusEvent
+  | QueryTokenEvent
+  | QueryToolCallEvent
+  | QueryToolResultEvent
+  | QueryNeedsConfirmationEvent
+  | QueryFinalEvent
+  | QueryErrorEvent
+  | QueryUnknownEvent;
+
+/** Result of `POST /v1/email/query/{run_id}/cancel` (query_routes.py: QueryCancelResponse). */
+export interface QueryCancelResponse {
+  /** The run that was signalled to cancel. */
+  run_id: string;
+  /** True once the cancel was delivered to the run. */
+  cancelled: boolean;
+  /** Always "ok" on success. */
+  status: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/hub/agents/npm/agent-email/test/browser-entry.test.ts
+++ b/hub/agents/npm/agent-email/test/browser-entry.test.ts
@@ -58,7 +58,7 @@ describe("browser entry (./client)", () => {
 
   it("client-entry exports SCHEMA_VERSION and request/response types (runtime const)", async () => {
     const mod = await import("../src/client-entry.js");
-    expect(mod.SCHEMA_VERSION).toBe("2.3");
+    expect(mod.SCHEMA_VERSION).toBe("2.4");
   });
 
   it("client-entry does NOT export spawnSidecar (Node-only)", async () => {

--- a/hub/agents/npm/agent-email/test/fixtures/query_test_server.py
+++ b/hub/agents/npm/agent-email/test/fixtures/query_test_server.py
@@ -1,0 +1,147 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Dev-mode sidecar for the npm client's /query integration test (#2097).
+
+Boots the REAL packaging/server.py app (real routes, real SSEOutputHandler,
+real CanonicalTranslator, real caller-auth gate) with ONE swap: the
+``query_routes.build_query_agent`` seam returns a scripted fake agent instead
+of a live EmailTriageAgent, so the canonical wire is exercised end-to-end over
+real HTTP without Lemonade or Gmail — the same seam the Python-side
+``test_query_route.py`` acceptance harness swaps.
+
+The fake picks its script from the query text:
+  - a query containing "wait between steps" runs multi-step, parking on the
+    run's cancel event between steps (so the Node test can cancel mid-run);
+  - anything else drives one happy triage turn: status -> tool_call ->
+    tool_result -> final.
+
+Usage (spawned by test/query-integration.test.ts via startSidecar):
+    python query_test_server.py --host 127.0.0.1 --port <port>
+    python query_test_server.py --check   # import probe only; exits 0/1
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+_FIXTURES = Path(__file__).resolve().parent
+# parents: [0]=test [1]=agent-email [2]=npm [3]=agents [4]=hub [5]=repo root
+_REPO_ROOT = _FIXTURES.parents[5]
+
+# First-party code comes from THIS checkout; third-party deps from the interpreter.
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+sys.path.insert(0, str(_REPO_ROOT / "hub" / "agents" / "python" / "email"))
+
+
+def _load_server_module():
+    server_py = (
+        _REPO_ROOT / "hub" / "agents" / "python" / "email" / "packaging" / "server.py"
+    )
+    spec = importlib.util.spec_from_file_location("server", server_py)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {server_py}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _HappyFakeAgent:
+    """One happy triage turn: status -> tool_call -> tool_result -> final."""
+
+    def __init__(self) -> None:
+        self.conversation_history = []
+        self.console = None
+        self._cancel_event = None
+
+    def process_query(self, query, max_steps=None):
+        self.console.print_processing_start(query, 20, "fake-model")
+        self.console.print_tool_usage("triage_inbox")
+        self.console.pretty_print_json({"max_messages": 10}, title="Arguments")
+        self.console.pretty_print_json({"ok": True, "count": 5})
+        self.console.print_tool_complete()
+        self.console.print_final_answer("Triaged 5 emails.", streaming=False)
+        return {"answer": "Triaged 5 emails."}
+
+
+class _CancelFakeAgent:
+    """Multi-step run that parks on the cancel event BETWEEN steps."""
+
+    def __init__(self) -> None:
+        self.conversation_history = []
+        self.console = None
+        self._cancel_event = None
+
+    def process_query(self, query, max_steps=None):
+        self.console.print_processing_start(query, 5, "fake-model")
+        for step in range(1, 4):
+            if self._cancel_event is not None and self._cancel_event.is_set():
+                self.console.print_final_answer(
+                    "Stopped between steps.", streaming=False
+                )
+                return {"answer": "Stopped between steps."}
+            self.console.print_tool_usage(f"tool_{step}")
+            self.console.pretty_print_json({}, title="Arguments")
+            self.console.pretty_print_json({"ok": True})
+            self.console.print_tool_complete()
+            if self._cancel_event is not None:
+                # Bounded park so the Node test can cancel between steps; a
+                # hung test still terminates.
+                self._cancel_event.wait(timeout=10)
+        self.console.print_final_answer("Completed all steps.", streaming=False)
+        return {"answer": "Completed all steps."}
+
+
+def _fake_build_query_agent(**_config_kwargs):
+    # The scripted behavior is selected per-run inside process_query via the
+    # query text, but agent construction happens before the text is known —
+    # so return a dispatcher that picks the script on first process_query.
+    class _Dispatcher:
+        def __init__(self) -> None:
+            self.conversation_history = []
+            self.console = None
+            self._cancel_event = None
+
+        def process_query(self, query, max_steps=None):
+            cls = _CancelFakeAgent if "wait between steps" in query else _HappyFakeAgent
+            inner = cls()
+            inner.conversation_history = self.conversation_history
+            inner.console = self.console
+            inner._cancel_event = self._cancel_event
+            return inner.process_query(query, max_steps=max_steps)
+
+    return _Dispatcher()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8131)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Probe that every import resolves, then exit 0 (no server).",
+    )
+    args = parser.parse_args()
+
+    if args.port == 4001:
+        raise SystemExit("port 4001 is reserved and must never be used")
+
+    import uvicorn  # noqa: F401 — part of the --check probe
+    from gaia_agent_email import query_routes
+
+    server = _load_server_module()
+
+    if args.check:
+        print("ok")
+        return 0
+
+    query_routes.build_query_agent = _fake_build_query_agent
+    uvicorn.run(server.app, host=args.host, port=args.port, log_level="warning")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hub/agents/npm/agent-email/test/query-integration.test.ts
+++ b/hub/agents/npm/agent-email/test/query-integration.test.ts
@@ -1,0 +1,170 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+/**
+ * /query integration test (#2097): startSidecar spawns the REAL Python sidecar
+ * (dev mode — packaging/server.py with the scripted fake-agent seam from
+ * test/fixtures/query_test_server.py), then drives the typed client end-to-end
+ * over real HTTP: the 2.4 version handshake, the bearer gate, the canonical
+ * status -> tool_call -> tool_result -> final sequence, and mid-run cancel.
+ *
+ * Needs a Python interpreter that can import the email agent's deps (fastapi,
+ * uvicorn, and the gaia/gaia_agent_email sources of THIS checkout). Resolution
+ * order: $GAIA_EMAIL_TEST_PYTHON, then <repo>/.venv, then python3 on PATH.
+ * Skips (visibly) when none can — and on Windows (the spawn shim is POSIX).
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { HttpError } from "../src/errors.js";
+import { startSidecar, shutdown, type Sidecar } from "../src/lifecycle.js";
+import type { QueryEvent } from "../src/types.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..", "..", "..");
+const FIXTURE = path.join(HERE, "fixtures", "query_test_server.py");
+const PORT = 8200 + Math.floor(Math.random() * 500); // never 4001
+
+function resolvePython(): string | null {
+  const candidates = [
+    process.env.GAIA_EMAIL_TEST_PYTHON,
+    path.join(REPO_ROOT, ".venv", "bin", "python"),
+    "python3",
+  ].filter((c): c is string => Boolean(c));
+  for (const py of candidates) {
+    if (py.includes(path.sep) && !fs.existsSync(py)) continue;
+    const probe = spawnSync(py, [FIXTURE, "--check"], { timeout: 60_000 });
+    if (probe.status === 0) return py;
+  }
+  return null;
+}
+
+const python = process.platform === "win32" ? null : resolvePython();
+if (!python) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[query-integration] SKIPPED: no Python interpreter can import the email " +
+      "sidecar (set GAIA_EMAIL_TEST_PYTHON to a venv python with the repo installed).",
+  );
+}
+
+async function collect(iter: AsyncIterable<QueryEvent>): Promise<QueryEvent[]> {
+  const out: QueryEvent[] = [];
+  for await (const ev of iter) out.push(ev);
+  return out;
+}
+
+describe.skipIf(!python)("query() against the real sidecar (dev mode)", () => {
+  let sidecar: Sidecar;
+  let wrapperDir: string;
+
+  beforeAll(async () => {
+    // startSidecar spawns `binaryPath --host H --port P`; a python interpreter
+    // can't take those before its script, so shim it with an exec wrapper.
+    wrapperDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-email-query-"));
+    const wrapper = path.join(wrapperDir, "email-agent-dev");
+    fs.writeFileSync(wrapper, `#!/bin/sh\nexec "${python}" "${FIXTURE}" "$@"\n`, {
+      mode: 0o755,
+    });
+    // verifyVersion defaults ON: this IS the 2.4-handshake acceptance — the
+    // client (SCHEMA_VERSION 2.4) must accept the sidecar's reported apiVersion.
+    sidecar = await startSidecar({
+      binaryPath: wrapper,
+      port: PORT,
+      healthTimeoutMs: 90_000,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (sidecar) await shutdown(sidecar);
+    if (wrapperDir) fs.rmSync(wrapperDir, { recursive: true, force: true });
+  });
+
+  it("reports apiVersion 2.4 (the handshake already accepted it at startup)", async () => {
+    const v = await sidecar.client.version();
+    expect(v.apiVersion).toBe("2.4");
+  });
+
+  it("streams the canonical status -> tool_call -> tool_result -> final sequence", async () => {
+    const runId = crypto.randomUUID();
+    const events = await collect(
+      sidecar.client.query({
+        query: "Triage my inbox.",
+        run_id: runId,
+        context: [{ role: "user", content: "earlier turn" }],
+      }),
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      "status",
+      "tool_call",
+      "tool_result",
+      "final",
+    ]);
+    const call = events[1];
+    if (call?.type !== "tool_call") throw new Error("expected tool_call");
+    expect(call.tool).toBe("triage_inbox");
+    expect(call.args).toEqual({ max_messages: 10 });
+    const result = events[2];
+    if (result?.type !== "tool_result") throw new Error("expected tool_result");
+    expect(result.tool).toBe("triage_inbox");
+    const final = events[3];
+    if (final?.type !== "final") throw new Error("expected final");
+    expect(final.answer).toBe("Triaged 5 emails.");
+  }, 60_000);
+
+  it("cancelQuery stops an in-flight run between steps", async () => {
+    const runId = crypto.randomUUID();
+    const events: QueryEvent[] = [];
+    let cancelled = false;
+
+    for await (const ev of sidecar.client.query({
+      query: "Do a long task and wait between steps.",
+      run_id: runId,
+      context: [],
+    })) {
+      events.push(ev);
+      if (!cancelled && ev.type === "tool_result") {
+        // First step done, agent parked on the cancel event — cancel mid-run.
+        const res = await sidecar.client.cancelQuery(runId);
+        expect(res.cancelled).toBe(true);
+        expect(res.run_id).toBe(runId);
+        cancelled = true;
+      }
+    }
+
+    expect(cancelled).toBe(true);
+    const final = events[events.length - 1];
+    if (final?.type !== "final") throw new Error("expected a terminal final");
+    expect(final.answer).toBe("Stopped between steps.");
+    // Only the first step's tool ran — steps 2 and 3 never started.
+    const tools = events.filter((e) => e.type === "tool_call");
+    expect(tools).toHaveLength(1);
+  }, 60_000);
+
+  it("rejects a /query without the per-session bearer (401)", async () => {
+    const res = await fetch(`${sidecar.baseUrl}/v1/email/query`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "text/event-stream" },
+      body: JSON.stringify({
+        query: "Triage my inbox.",
+        run_id: crypto.randomUUID(),
+        context: [],
+      }),
+    });
+    expect(res.status).toBe(401);
+  }, 30_000);
+
+  it("cancel of a run that is not in flight is a loud 404", async () => {
+    const err = await sidecar.client
+      .cancelQuery(crypto.randomUUID())
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+  }, 30_000);
+});

--- a/hub/agents/npm/agent-email/test/query.test.ts
+++ b/hub/agents/npm/agent-email/test/query.test.ts
@@ -1,0 +1,351 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+/**
+ * EmailClient.query() / cancelQuery() unit tests against a fake fetch — the
+ * typed client surface of the frozen /query SSE contract (schema 2.4, #2097).
+ * Asserts the OUTGOING call shape (path, headers, bearer, body) as well as the
+ * parsed event stream, so a contract-violating request can't hide behind a
+ * stubbed 200.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { EmailClient } from "../src/client.js";
+import { HttpError, QueryStreamError } from "../src/errors.js";
+import type { QueryCancelResponse, QueryEvent } from "../src/types.js";
+
+const RUN_ID = "0f9c2b6e-2c4a-4b1e-9d6a-1e2f3a4b5c6d";
+
+function sseResponse(text: string, status = 200): Response {
+  return new Response(text, {
+    status,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function sse(events: Array<Record<string, unknown>>): string {
+  return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+}
+
+async function collect(iter: AsyncIterable<QueryEvent>): Promise<QueryEvent[]> {
+  const out: QueryEvent[] = [];
+  for await (const ev of iter) out.push(ev);
+  return out;
+}
+
+const HAPPY_WIRE = sse([
+  { type: "status", message: "Processing..." },
+  { type: "tool_call", tool: "triage_inbox", args: { max_messages: 10 } },
+  { type: "tool_result", tool: "triage_inbox", data: { ok: true, count: 5 } },
+  { type: "final", answer: "Triaged 5 emails.", usage: { steps: 1 } },
+]);
+
+describe("EmailClient.query", () => {
+  it("sends the spec-shaped request (path, SSE accept, bearer, body) and yields the typed sequence", async () => {
+    const fetchImpl = vi.fn(async (url, init) => {
+      expect(String(url)).toBe("http://127.0.0.1:8131/v1/email/query");
+      expect(init?.method).toBe("POST");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.accept).toBe("text/event-stream");
+      expect(headers["content-type"]).toBe("application/json");
+      expect(headers.authorization).toBe("Bearer session-token");
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({
+        query: "Triage my inbox",
+        run_id: RUN_ID,
+        context: [{ role: "user", content: "earlier turn" }],
+        max_steps: 5,
+      });
+      return sseResponse(HAPPY_WIRE);
+    }) as unknown as typeof fetch;
+
+    const client = new EmailClient({
+      baseUrl: "http://127.0.0.1:8131",
+      fetchImpl,
+      authToken: "session-token",
+    });
+    const events = await collect(
+      client.query({
+        query: "Triage my inbox",
+        run_id: RUN_ID,
+        context: [{ role: "user", content: "earlier turn" }],
+        max_steps: 5,
+      }),
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      "status",
+      "tool_call",
+      "tool_result",
+      "final",
+    ]);
+    expect(events[0]).toEqual({ type: "status", message: "Processing..." });
+    const call = events[1];
+    if (call.type !== "tool_call") throw new Error("expected tool_call");
+    expect(call.tool).toBe("triage_inbox");
+    expect(call.args).toEqual({ max_messages: 10 });
+    const final = events[3];
+    if (final.type !== "final") throw new Error("expected final");
+    expect(final.answer).toBe("Triaged 5 emails.");
+    expect(final.usage?.steps).toBe(1);
+  });
+
+  it("reassembles events split across arbitrary transport chunks", async () => {
+    // Deliver the happy wire in 7-byte chunks — framing must not matter.
+    const bytes = new TextEncoder().encode(HAPPY_WIRE);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < bytes.length; i += 7) {
+          controller.enqueue(bytes.slice(i, i + 7));
+        }
+        controller.close();
+      },
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+    const events = await collect(
+      client.query({ query: "q", run_id: RUN_ID, context: [] }),
+    );
+    expect(events.map((e) => e.type)).toEqual([
+      "status",
+      "tool_call",
+      "tool_result",
+      "final",
+    ]);
+  });
+
+  it("reassembles a multibyte character split across chunk boundaries", async () => {
+    const wire = sse([
+      { type: "token", delta: "café ☕" },
+      { type: "final", answer: "done ✓" },
+    ]);
+    const bytes = new TextEncoder().encode(wire);
+    // 3-byte chunks guarantee the multibyte sequences are split mid-character.
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < bytes.length; i += 3) {
+          controller.enqueue(bytes.slice(i, i + 3));
+        }
+        controller.close();
+      },
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+    const events = await collect(
+      client.query({ query: "q", run_id: RUN_ID, context: [] }),
+    );
+    expect(events[0]).toEqual({ type: "token", delta: "café ☕" });
+    expect(events[1]).toEqual({ type: "final", answer: "done ✓" });
+  });
+
+  it("surfaces an unknown event type as {type:'unknown'} instead of dropping it", async () => {
+    const wire = sse([
+      { type: "status", message: "working" },
+      { type: "reasoning_trace", text: "a future additive event" },
+      { type: "final", answer: "done" },
+    ]);
+    const fetchImpl = vi.fn(async () => sseResponse(wire)) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    const events = await collect(
+      client.query({ query: "q", run_id: RUN_ID, context: [] }),
+    );
+    expect(events.map((e) => e.type)).toEqual(["status", "unknown", "final"]);
+    const unknown = events[1];
+    if (unknown.type !== "unknown") throw new Error("expected unknown");
+    expect(unknown.eventType).toBe("reasoning_trace");
+    expect(unknown.raw).toEqual({
+      type: "reasoning_trace",
+      text: "a future additive event",
+    });
+  });
+
+  it("yields a terminal error event (surfaced verbatim, not thrown) and ends the stream", async () => {
+    const wire = sse([
+      { type: "status", message: "working" },
+      { type: "error", detail: "Lemonade Server is not reachable", status: 502 },
+    ]);
+    const fetchImpl = vi.fn(async () => sseResponse(wire)) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    const events = await collect(
+      client.query({ query: "q", run_id: RUN_ID, context: [] }),
+    );
+    expect(events.map((e) => e.type)).toEqual(["status", "error"]);
+    const err = events[1];
+    if (err.type !== "error") throw new Error("expected error");
+    expect(err.detail).toContain("not reachable");
+    expect(err.status).toBe(502);
+  });
+
+  it("stops iterating after the terminal event even if more data follows", async () => {
+    const wire = sse([
+      { type: "final", answer: "done" },
+      { type: "status", message: "should never be seen" },
+    ]);
+    const fetchImpl = vi.fn(async () => sseResponse(wire)) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    const events = await collect(
+      client.query({ query: "q", run_id: RUN_ID, context: [] }),
+    );
+    expect(events.map((e) => e.type)).toEqual(["final"]);
+  });
+
+  it("throws QueryStreamError when the stream closes without a terminal event", async () => {
+    const wire = sse([{ type: "status", message: "working" }]);
+    const fetchImpl = vi.fn(async () => sseResponse(wire)) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    await expect(
+      collect(client.query({ query: "q", run_id: RUN_ID, context: [] })),
+    ).rejects.toThrow(QueryStreamError);
+  });
+
+  it("throws QueryStreamError on a malformed (non-JSON) event payload", async () => {
+    const fetchImpl = vi.fn(async () =>
+      sseResponse("data: not-json{\n\n"),
+    ) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    await expect(
+      collect(client.query({ query: "q", run_id: RUN_ID, context: [] })),
+    ).rejects.toThrow(QueryStreamError);
+  });
+
+  it("throws QueryStreamError on an event missing its type discriminator", async () => {
+    const fetchImpl = vi.fn(async () =>
+      sseResponse('data: {"message":"no type"}\n\n'),
+    ) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    await expect(
+      collect(client.query({ query: "q", run_id: RUN_ID, context: [] })),
+    ).rejects.toThrow(QueryStreamError);
+  });
+
+  it("throws HttpError (with the body) on a non-2xx response", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ detail: "run_id 'x' is already in flight." }), {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    const err = await collect(
+      client.query({ query: "q", run_id: RUN_ID, context: [] }),
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(409);
+    expect((err as HttpError).bodyText).toContain("already in flight");
+  });
+
+  it("throws QueryStreamError when the response is not text/event-stream", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    await expect(
+      collect(client.query({ query: "q", run_id: RUN_ID, context: [] })),
+    ).rejects.toThrow(QueryStreamError);
+  });
+
+  it("cancels the transport when the consumer breaks out early", async () => {
+    const cancelled = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode('data: {"type":"status","message":"1"}\n\n'),
+        );
+        // Stream intentionally left open — only a consumer break releases it.
+      },
+      cancel: cancelled,
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+    ) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    for await (const ev of client.query({ query: "q", run_id: RUN_ID, context: [] })) {
+      expect(ev.type).toBe("status");
+      break; // consumer walks away mid-run
+    }
+    expect(cancelled).toHaveBeenCalled();
+  });
+});
+
+describe("EmailClient.cancelQuery", () => {
+  it("POSTs to /v1/email/query/{run_id}/cancel with the bearer and parses the result", async () => {
+    const cancelResponse: QueryCancelResponse = {
+      run_id: RUN_ID,
+      cancelled: true,
+      status: "ok",
+    };
+    const fetchImpl = vi.fn(async (url, init) => {
+      expect(String(url)).toBe(
+        `http://127.0.0.1:8131/v1/email/query/${RUN_ID}/cancel`,
+      );
+      expect(init?.method).toBe("POST");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.authorization).toBe("Bearer session-token");
+      return new Response(JSON.stringify(cancelResponse), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const client = new EmailClient({
+      baseUrl: "http://127.0.0.1:8131",
+      fetchImpl,
+      authToken: "session-token",
+    });
+    const res = await client.cancelQuery(RUN_ID);
+    expect(res.cancelled).toBe(true);
+    expect(res.run_id).toBe(RUN_ID);
+  });
+
+  it("throws HttpError 404 for a run that is not in flight", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ detail: "No in-flight run" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl });
+
+    const err = await client.cancelQuery(RUN_ID).catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+  });
+
+  it("refuses an empty run_id loudly", async () => {
+    const client = new EmailClient({ baseUrl: "http://x", fetchImpl: vi.fn() as never });
+    await expect(client.cancelQuery("")).rejects.toThrow(TypeError);
+  });
+});

--- a/hub/agents/npm/agent-email/test/sse.test.ts
+++ b/hub/agents/npm/agent-email/test/sse.test.ts
@@ -1,0 +1,93 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+/**
+ * SseDataParser unit tests — the incremental SSE framing under `query()`.
+ * The hard cases: events split across arbitrary chunk boundaries, multi-line
+ * data fields, CRLF endings, and end-of-stream flushing.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { SseDataParser } from "../src/sse.js";
+
+describe("SseDataParser", () => {
+  it("parses one complete event", () => {
+    const p = new SseDataParser();
+    expect(p.push('data: {"type":"status","message":"hi"}\n\n')).toEqual([
+      '{"type":"status","message":"hi"}',
+    ]);
+  });
+
+  it("parses many events in a single chunk", () => {
+    const p = new SseDataParser();
+    const out = p.push('data: {"a":1}\n\ndata: {"b":2}\n\ndata: {"c":3}\n\n');
+    expect(out).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
+  });
+
+  it("reassembles an event split across arbitrary chunk boundaries", () => {
+    const wire = 'data: {"type":"final","answer":"done"}\n\n';
+    // Split at EVERY possible boundary — the parser must be framing-agnostic.
+    for (let split = 1; split < wire.length; split++) {
+      const p = new SseDataParser();
+      const first = p.push(wire.slice(0, split));
+      const second = p.push(wire.slice(split));
+      expect([...first, ...second]).toEqual(['{"type":"final","answer":"done"}']);
+    }
+  });
+
+  it("reassembles an event arriving one byte at a time", () => {
+    const p = new SseDataParser();
+    const wire = 'data: {"type":"token","delta":"x"}\n\n';
+    const out: string[] = [];
+    for (const ch of wire) out.push(...p.push(ch));
+    expect(out).toEqual(['{"type":"token","delta":"x"}']);
+  });
+
+  it("joins multi-line data fields with newlines (SSE spec)", () => {
+    const p = new SseDataParser();
+    const out = p.push("data: line one\ndata: line two\ndata: line three\n\n");
+    expect(out).toEqual(["line one\nline two\nline three"]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const p = new SseDataParser();
+    const out = p.push('data: {"a":1}\r\n\r\ndata: {"b":2}\r\n\r\n');
+    expect(out).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it("tolerates a missing space after the data: prefix", () => {
+    const p = new SseDataParser();
+    expect(p.push('data:{"a":1}\n\n')).toEqual(['{"a":1}']);
+  });
+
+  it("skips SSE comments and non-data framing fields", () => {
+    const p = new SseDataParser();
+    const out = p.push(
+      ': keepalive\nevent: message\nid: 7\nretry: 100\ndata: {"a":1}\n\n',
+    );
+    expect(out).toEqual(['{"a":1}']);
+  });
+
+  it("ignores stray blank lines between events", () => {
+    const p = new SseDataParser();
+    expect(p.push('\n\n\ndata: {"a":1}\n\n\n\n')).toEqual(['{"a":1}']);
+  });
+
+  it("end() flushes a final event that had no trailing blank line", () => {
+    const p = new SseDataParser();
+    expect(p.push('data: {"type":"final","answer":"eof"}\n')).toEqual([]);
+    expect(p.end()).toEqual(['{"type":"final","answer":"eof"}']);
+  });
+
+  it("end() flushes even a final event missing its trailing newline entirely", () => {
+    const p = new SseDataParser();
+    expect(p.push('data: {"a":1}')).toEqual([]);
+    expect(p.end()).toEqual(['{"a":1}']);
+  });
+
+  it("end() returns nothing after a cleanly terminated stream", () => {
+    const p = new SseDataParser();
+    p.push('data: {"a":1}\n\n');
+    expect(p.end()).toEqual([]);
+  });
+});


### PR DESCRIPTION
A Node integrator (and the #1653 dogfood) couldn't reach the sidecar's streaming agent loop through `@amd-gaia/agent-email` — the 2.4 endpoints landed Python-side in #2061 but the package's answer was "hand-roll `fetch` + SSE parsing". Now `client.query()` streams the seven typed canonical events (frozen #2057 contract) as an async iterator and `client.cancelQuery(runId)` stops a run mid-flight, with bearer auth and host-minted `run_id` semantics handled for you. The client speaks contract 2.4 (`SCHEMA_VERSION` 2.3 → 2.4, additive — every 2.3 shape unchanged), and streams fail loud: a malformed event, a non-SSE response, or a stream that dies without the mandated terminal `final`/`error` throws, while an unknown event type is surfaced as a visible placeholder, never dropped.

Closes #2097

## Test plan

- [ ] `cd hub/agents/npm/agent-email && npm ci && npm run build && npm test` — 101 tests: SSE parser (chunk splits at every boundary, multi-line data, CRLF, multibyte flush), client call-shape + event-stream unit tests, and the existing suite.
- [ ] Integration (needs a venv with the repo installed): `GAIA_EMAIL_TEST_PYTHON=<repo-venv>/bin/python npm test` — `startSidecar` spawns the real Python sidecar in dev mode (scripted fake-agent seam, the same one `test_query_route.py` swaps) and asserts the 2.4 version handshake, the `status→tool_call→tool_result→final` sequence, mid-run cancel via `cancelQuery`, the 401 bearer gate, and the 404 cancel. Skips visibly on npm CI (no capable interpreter there).
- [ ] Docs updated together per #1841 — `grep -rn 'no wrapper yet' hub/agents/npm/agent-email/{README,SPEC,SKILL}.md` no longer matches the `/query` rows.