### PR TITLE
fix(ui): unblock email chat on consumer installs (registry guard, Metal, ctx floor)

### DIFF
--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -298,6 +298,12 @@ class LemonadeManager:
                             if k in item:
                                 detected.add(str(item[k]))
                                 break
+        # Lemonade on Apple Silicon reports the llama.cpp Metal backend as
+        # 'metal' in system_info while its health payload calls the same device
+        # 'gpu' — normalize to the generic GPU tier so a default device='gpu'
+        # request validates on macOS instead of falling through to cpu.
+        if "metal" in detected:
+            detected.add("amd_dgpu")
         # Find highest-capability detected device
         highest = None
         for dev in _DEVICE_PRIORITY:
@@ -394,6 +400,8 @@ class LemonadeManager:
 
         This is the main entry point for both CLI and SDK flows.
         Safe to call multiple times - validates context size on each call.
+        An explicit ``min_context_size=None`` (callers threading through an
+        unset config value) means "the default floor", never a crash.
 
         Args:
             min_context_size: Minimum context size required (default: 32768).
@@ -422,6 +430,10 @@ class LemonadeManager:
             The Lemonade server must be running before calling this method.
             Start it with: lemonade-server serve --ctx-size 32768
         """
+        # Callers thread config values through verbatim — an unset (None)
+        # floor means the default, never a TypeError at the ctx comparison.
+        if min_context_size is None:
+            min_context_size = DEFAULT_CONTEXT_SIZE
         # Map high-level device selector to required_min_device when the
         # caller didn't pass an explicit required_min_device.
         if device and not required_min_device:

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -106,6 +106,25 @@ def get_agent_registry():
     return _agent_registry
 
 
+# Agent types served by an out-of-process sidecar with a dedicated dispatch
+# branch below. They are never registry-loadable: a binary-only hub install
+# ships no importable wheel, so registry.get() is None even when the agent is
+# installed and healthy.
+_SIDECAR_AGENT_TYPES = frozenset({"email"})
+
+
+def _agent_type_unknown(agent_type: str, registry) -> bool:
+    """True when *agent_type* must be rejected as unknown before dispatch.
+
+    ``chat`` is the built-in default and sidecar types have their own dispatch
+    branch — neither goes through the registry. Everything else must resolve
+    in the registry or the caller returns the unavailable-agent error.
+    """
+    if agent_type == "chat" or agent_type in _SIDECAR_AGENT_TYPES:
+        return False
+    return bool(registry) and not registry.get(agent_type)
+
+
 # ── Per-session agent cache ───────────────────────────────────────────────────
 # Constructing a fresh ChatAgent on every message is expensive: it initialises
 # RAGSDK, MCPClientManager, runs LemonadeManager.ensure_ready() (HTTP calls),
@@ -969,15 +988,20 @@ def _build_email_proxy_agent(
     """
     from gaia.ui.email_sidecar.proxy_agent import EmailProxyAgent
 
+    kwargs = {}
+    # A None device_ctx (device config with no ctx entry) must not clobber
+    # EmailProxyAgent's own 32K minimum — omit and let its default apply.
+    if device_ctx is not None:
+        kwargs["min_context_size"] = device_ctx
     return EmailProxyAgent(
         model_id=model_id,
         mail_provider=mail_provider,
         device=device,
-        min_context_size=device_ctx,
         streaming=streaming,
         # Match the chat agent: a streaming session drives the SSE console; a
         # non-streaming one is silent (JSON-only).
         silent_mode=not streaming,
+        **kwargs,
     )
 
 
@@ -1198,8 +1222,9 @@ async def _get_chat_response(
         agent_type = request.agent_type or stored_agent_type
 
         # Validate requested agent_type exists in the registry before persisting
+        # (chat + sidecar types are exempt — they never live in the registry).
         registry = _agent_registry
-        if agent_type != "chat" and registry and not registry.get(agent_type):
+        if _agent_type_unknown(agent_type, registry):
             logger.warning(
                 "chat: Session %s requested unknown agent_type '%s'; "
                 "returning unavailable-agent error",
@@ -1593,8 +1618,9 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
         agent_type = request.agent_type or stored_agent_type
 
         # Validate requested agent_type exists in the registry before persisting
+        # (chat + sidecar types are exempt — they never live in the registry).
         registry = _agent_registry
-        if agent_type != "chat" and registry and not registry.get(agent_type):
+        if _agent_type_unknown(agent_type, registry):
             logger.warning(
                 "chat: Session %s requested unknown agent_type '%s' (streaming); "
                 "returning unavailable-agent error",

--- a/tests/fixtures/hardware/metal_mac.json
+++ b/tests/fixtures/hardware/metal_mac.json
@@ -1,0 +1,6 @@
+{
+  "devices": {
+    "cpu": { "cores": 12, "ram_gb": 32, "available": true },
+    "metal": { "name": "Apple M-series GPU", "available": true }
+  }
+}

--- a/tests/unit/test_chat_agent_type_guard.py
+++ b/tests/unit/test_chat_agent_type_guard.py
@@ -1,0 +1,49 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The agent-type registry pre-check must not reject sidecar-backed agents.
+
+The email agent ships as an out-of-process sidecar: a binary-only Hub install
+has no importable wheel, so ``registry.get("email")`` is ``None`` even when the
+agent is installed and healthy. The chat guard must exempt sidecar types (like
+``chat``) or the email chat is unreachable on exactly the consumer machines the
+Hub install targets — dev boxes mask this because they pip-install the wheel.
+"""
+
+from gaia.ui._chat_helpers import _SIDECAR_AGENT_TYPES, _agent_type_unknown
+
+
+class _Registry:
+    """Registry double: knows only the agent ids it is given."""
+
+    def __init__(self, known=()):
+        self._known = set(known)
+
+    def get(self, agent_id):
+        return object() if agent_id in self._known else None
+
+
+def test_email_allowed_without_registry_entry():
+    # The consumer-machine state: binary hub install, no importable wheel.
+    assert _agent_type_unknown("email", _Registry(known=())) is False
+
+
+def test_chat_always_allowed():
+    assert _agent_type_unknown("chat", _Registry(known=())) is False
+
+
+def test_unknown_type_still_rejected():
+    assert _agent_type_unknown("nonexistent-agent", _Registry(known=())) is True
+
+
+def test_registry_agent_allowed_when_known():
+    assert _agent_type_unknown("jira", _Registry(known={"jira"})) is False
+
+
+def test_no_registry_preserves_permissive_behavior():
+    # Registry not initialized -> guard never fired historically; keep that.
+    assert _agent_type_unknown("anything", None) is False
+
+
+def test_email_is_declared_sidecar_type():
+    # Pins the constant so a rename/refactor can't silently drop the exemption.
+    assert "email" in _SIDECAR_AGENT_TYPES

--- a/tests/unit/test_hardware_selection.py
+++ b/tests/unit/test_hardware_selection.py
@@ -65,6 +65,22 @@ def test_requirement_not_satisfied_cpu_only(monkeypatch):
         LemonadeManager.ensure_ready(required_min_device="amd_igpu")
 
 
+def test_metal_satisfies_gpu_requirement(monkeypatch):
+    # Apple Silicon: Lemonade's system_info reports 'metal' (its health payload
+    # calls the same device 'gpu') — the generic gpu tier must validate, or the
+    # UI's default device='gpu' request fails on every Mac.
+    patch_lemonade(monkeypatch, "metal_mac.json")
+    assert LemonadeManager.ensure_ready(required_min_device="amd_dgpu") is True
+
+
+def test_metal_does_not_satisfy_npu_requirement(monkeypatch):
+    # The normalization maps metal to the GPU tier only — an NPU floor must
+    # still fail loudly on a Mac.
+    patch_lemonade(monkeypatch, "metal_mac.json")
+    with pytest.raises(HardwareRequirementError):
+        LemonadeManager.ensure_ready(required_min_device="amd_npu")
+
+
 def test_list_shaped_devices(monkeypatch):
     # Use the fixture helper so get_status is patched too
     patch_lemonade(monkeypatch, "hardware_list.json")
@@ -132,3 +148,10 @@ def test_agent_init_passes_none_when_no_requirement(monkeypatch):
 
     assert "kwargs" in calls
     assert calls["kwargs"].get("required_min_device") is None
+
+
+def test_ensure_ready_none_min_context_uses_default(monkeypatch):
+    # Callers thread config values through verbatim; an unset (None) ctx floor
+    # must mean "the default", not TypeError at the >= comparison (#2096 E2E).
+    patch_lemonade(monkeypatch, "metal_mac.json")
+    assert LemonadeManager.ensure_ready(min_context_size=None) is True


### PR DESCRIPTION
Live E2E for the demo (#2096) on a clean macOS machine found three consecutive blockers between "Hub install succeeded" and "email chat works" — all invisible on dev boxes. Before: a consumer who hub-installs the email agent gets **"I couldn't load the agent 'email'"** (dev machines pip-install the wheel, so the registry pre-check only fails on binary-only installs), then Mac users get **"Requested device 'gpu' is not available"** (Lemonade reports Metal as `metal` in system_info but `gpu` in health; GAIA's tier list knew neither), then a **TypeError** ('>=' int vs None) from an unset ctx floor. After: hub install → user-mode spawn → agent loop on Gemma-4/Metal → `pre_scan_inbox` → the designed actionable stop ("connect Google or Microsoft in Settings → Connectors") — verified live on macOS end-to-end.

## Test plan
- [ ] `python -m pytest tests/unit/test_chat_agent_type_guard.py tests/unit/test_hardware_selection.py -q` — new: sidecar-type guard exemption (5 cases), Metal-satisfies-GPU, Metal-fails-NPU, None-ctx-floor default
- [ ] Affected suites: 150 passed / 5 skipped (chat guard, hardware, multi-device, all four email-sidecar suites, chat preflight)
- [ ] On a Mac with Lemonade tray running: hub-install email → open email chat → reaches the sidecar and stops at the connect-mailbox message (no wheel installed)

Closes #2096's blocking findings; the E2E issue itself stays open for the scripted golden-path harness.