### PR TITLE
ci(email): derive the scorecard-refresh budget from measured times, guard the published basis

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -22,9 +22,10 @@
 # never existed in practice, so removing it costs nothing real, and it stops
 # every push to an email branch from silently queueing for the single serial
 # `lemonade-eval` slot. Regression duty on LLM behavior remains with the
-# weekly `test_email_agent_eval.yml` (itself red as of #2093 -- a separate,
-# already-tracked issue) and the release-time `scorecard-gate` job in
-# `release_agent_email.yml` (parses committed files only, no eval).
+# weekly `test_email_agent_eval.yml` (whose own last scheduled run --
+# 2026-07-13, run 29235382831 -- failed; separate and out of scope here) and
+# the release-time `scorecard-gate` job in `release_agent_email.yml` (parses
+# committed files only, no eval).
 #
 # `workflow_dispatch` now supports TWO profiles, selected by `limit` AND
 # `experiments` together:

--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -1,33 +1,101 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-# Email agent eval-scorecard refresh + regression gate (#1862).
+# Email agent eval-scorecard refresh + regression gate (#1862, #2094).
 #
-# Answers "how does a PR that changes the agent keep the scorecard honest?":
-# when the email agent's LLM-affecting code (or the eval corpus) changes, this
-# re-runs the REAL eval, regenerates the scorecard, and then:
-#   - score IMPROVED or held  -> commits the refreshed SCORECARD.md to the branch
-#   - score REGRESSED          -> fails the job (the worse card is NOT committed)
+# Answers "how does a change to the agent keep the published scorecard honest?":
+# re-run the REAL eval, regenerate the scorecard, then either commit a
+# refreshed card or reject a regressed/sub-bar one.
+#
+# HISTORY (#2094): this workflow had NEVER completed a single run in its first
+# 100 dispatches. Root cause: a hand-typed `timeout-minutes: 90` against a
+# measured ~2h workload (run 29433392568, limit 60): benchmark 41:24 + drafting
+# judge 21:00 + action-item judge killed at 90:00 mid-eval + briefing judge
+# never ran + gen_scorecard/gates/commit never ran. Lowering the sample count
+# does not fix this — the three judge evals cost more than the benchmark
+# itself and are fixed-size (19/21/11 cases), so the workflow died at every
+# limit ever tried. See the Budget derivation comment on the job below for the
+# real numbers this rewrite is sized against.
+#
+# The `push:` trigger is GONE (previously: push to any non-main branch
+# touching the email agent). 0/100 successes means per-push refresh coverage
+# never existed in practice, so removing it costs nothing real, and it stops
+# every push to an email branch from silently queueing for the single serial
+# `lemonade-eval` slot. Regression duty on LLM behavior remains with the
+# weekly `test_email_agent_eval.yml` (itself red as of #2093 -- a separate,
+# already-tracked issue) and the release-time `scorecard-gate` job in
+# `release_agent_email.yml` (parses committed files only, no eval).
+#
+# `workflow_dispatch` now supports TWO profiles, selected by `limit` AND
+# `experiments` together:
+#   - FULL (limit >= 249 AND experiments >= the committed card's n_runs,
+#     defaults 250 / 3): reproduces the committed card's methodology
+#     (250 x 3). This is the ONLY profile allowed to commit a refreshed card.
+#     ~10.5h wall-clock -- dispatch deliberately, and check `gh run list`
+#     first (see the slot-occupancy warning below).
+#   - SUBSET (limit < 249): an end-to-end smoke/dry-run. Runs the benchmark,
+#     all three judge evals, gen_scorecard, and (skipped by `if:`, not just
+#     printed) the two regression-gate steps, then NEVER commits -- it
+#     restores the committed SCORECARD.md and prints a loud "SUBSET RUN"
+#     notice. A subset-sized card is not a valid stand-in for the published
+#     figure (at few-case samples a single flip swings the metric double
+#     digits), so it is never given the chance to overwrite the real one.
+#
+# Fail-fast basis guard (in the `pre` step, before any eval spend): a
+# full-profile run whose `ctx_size` does not match the committed card's
+# `recipe.environment.ctx_size` stamp (or where the committed card has NO
+# stamp at all -- the current state), or whose `experiments` is below the
+# committed card's `n_runs`, fails immediately naming both bases and the exact
+# re-dispatch command -- unless `rebaseline=true` (with a required
+# `rebaseline_reason`) marks the basis change deliberate. This is what stops a
+# fast/lucky run from silently overwriting the real 250x3 card with a weaker
+# one; subset runs skip this guard entirely (they can never commit). Dispatch
+# also refuses to auto-commit against `main` -- `workflow_dispatch` has no
+# `branches:` restriction, so a careless full dispatch against `main` would
+# otherwise push straight to it.
 #
 # `gaia eval benchmark` needs Lemonade on AMD hardware, so this runs on the
-# self-hosted [self-hosted, Windows, stx] pool — GitHub-hosted runners cannot run
-# it. The install-lemonade action pins the runner to the expected LEMONADE_VERSION
-# (installs if missing, reconciles if drifted) and ensure-lemonade-running.ps1
-# starts + warms the server before the eval. Serial execution across the eval
-# workflows is enforced by the shared `lemonade-eval` concurrency group (below),
-# NOT by the runner label. The release-time `scorecard-gate` job in
-# release_agent_email.yml is the hosted-CI backstop (it parses committed files
-# only, no eval).
+# self-hosted [self-hosted, Windows, stx] pool -- GitHub-hosted runners cannot
+# run it. The install-lemonade action pins the runner to the expected
+# LEMONADE_VERSION (installs if missing, reconciles if drifted) and
+# ensure-lemonade-running.ps1 starts + warms the server before the eval.
+# Serial execution across the eval workflows is enforced by the shared
+# `lemonade-eval` concurrency group (below), NOT by the runner label. The
+# release-time `scorecard-gate` job in release_agent_email.yml is the
+# hosted-CI backstop (it parses committed files only, no eval).
 #
-# Two regression checks run here:
-#   1. SAME-VERSION: fresh aggregate vs the currently-committed SCORECARD.md —
-#      stops a noisy/worse re-run from silently overwriting a good score.
-#   2. CROSS-VERSION (best-effort): fresh SCORECARD.md vs the prior version tag
-#      via --baseline-ref.
+# SLOT-OCCUPANCY WARNING: a FULL run holds the serial `lemonade-eval`
+# concurrency slot for ~10h. Six sibling workflows (test_api, test_embeddings,
+# test_lemonade_server, test_rag, build_cpp, test_examples) share the same
+# [self-hosted, Windows, stx] runner LABEL *outside* that concurrency group --
+# they are not blocked by it, but most of them run
+# installer/scripts/cleanup-lemonade.ps1, which force-kills whatever owns port
+# 13305. That means an unrelated PR landing mid-run can kill a 10h eval, and
+# conversely those six workflows queue behind a full run for hours if it grabs
+# the box first. Before dispatching a FULL run: check `gh run list` for
+# in-flight/queued stx work, and expect (do not "fix" by restarting the
+# runner) hours of queuing elsewhere. Widening the concurrency group to cover
+# those six workflows is the right structural fix but is out of scope here --
+# file a follow-up issue rather than silently absorbing it.
 #
-# Auto-commit needs `contents: write` and only works on the repo's own branches;
-# a fork PR's GITHUB_TOKEN is read-only — for forks, run the eval locally / on AMD
-# hardware and commit the scorecard by hand (the release gate still enforces it).
+# Two regression checks run here (FULL profile only):
+#   1. SAME-VERSION: fresh aggregate vs the currently-committed SCORECARD.md,
+#      via gaia.eval.scorecard_gate --baseline-file (variance-aware,
+#      ctx-comparability-aware -- do not hand-roll this comparison).
+#   2. CROSS-VERSION (best-effort): fresh SCORECARD.md vs the prior version
+#      tag via --baseline-ref. Both gate calls also enforce the absolute
+#      acceptance bar / urgent-recall floor from
+#      tests/fixtures/email/quality_gate_thresholds.json (mirrors
+#      release_agent_email.yml's derivation) -- a sub-bar card must never
+#      reach the published surface, even from a "clean" refresh.
+#
+# Auto-commit needs `contents: write` and only works on the repo's own
+# branches; a fork PR's GITHUB_TOKEN is read-only -- for forks, run the eval
+# locally / on AMD hardware and commit the scorecard by hand (the release gate
+# still enforces it).
+#
+# KNOWN RESIDUAL GAP: this workflow can only govern what IT commits. A human
+# hand-editing SCORECARD.md in an unrelated PR bypasses every guard here.
 
 name: Email Agent Eval — scorecard refresh
 
@@ -35,32 +103,34 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: 'Messages to triage (smaller = faster; regen a card at this sample size)'
+        description: >-
+          Messages to triage. full profile (>=249, with experiments >=
+          the committed card's n_runs) reproduces the committed card's
+          methodology (~10.5h serial-slot occupancy -- dispatch
+          deliberately); smaller = smoke run that never commits.
         required: false
-        # Stays at 25 even though #2087's ctx overflow is fixed: the 60-email
-        # limit had TWO independent blockers and this PR only removes one.
-        # The ctx one is gone (condense_triage_result keeps the envelope in
-        # budget at any batch size — measured at 300). The other is this job's
-        # 90-minute budget: at 60 the benchmark + judge evals overrun it (run
-        # 29433392568 was killed mid-action-item eval at exactly 90:00). Raise
-        # the limit when #2063's per-email speedups land, not before.
-        default: '25'
+        default: '250'
+      experiments:
+        description: 'Repeated full-eval runs (matches the committed card''s n_runs methodology; must be >= the committed n_runs for a full-profile run to be allowed to commit)'
+        required: false
+        default: '3'
       model:
         description: 'Lemonade model id'
         required: false
         default: 'Gemma-4-E4B-it-GGUF'
-  push:
-    branches-ignore:
-      - main
-    paths:
-      - 'hub/agents/python/email/**'
-      # Publishing/upload plumbing is not LLM- or eval-affecting, so a change to
-      # it must NOT re-run the 90-min real eval. publish_to_r2.py only POSTs the
-      # already-built artifacts + docs to the Hub Worker.
-      - '!hub/agents/python/email/packaging/publish_to_r2.py'
-      - 'tests/fixtures/email/**'
-      - 'src/gaia/eval/release_scorecard.py'
-      - 'src/gaia/eval/scorecard_gate.py'
+      ctx_size:
+        description: 'Context window to pin the benchmark run at (the card records the window it was measured under, #1892)'
+        required: false
+        default: '16384'
+      rebaseline:
+        description: 'Commit a card whose basis (ctx_size or experiments/n_runs) differs from the committed card''s; skips the numeric regression comparison for this one deliberate run (absolute bars still enforced)'
+        type: boolean
+        default: false
+      rebaseline_reason:
+        description: 'REQUIRED when rebaseline=true -- why this basis change is deliberate (threaded into the commit message so git history can tell an approved migration from a careless flip)'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   # Share the single Lemonade backend slot with the other self-hosted evals so two
@@ -74,10 +144,17 @@ permissions:
 env:
   SCORECARD: hub/agents/npm/agent-email/SCORECARD.md
   MANIFEST: hub/agents/python/email/gaia-agent.yaml
-  # 25, not 60 — bounded by this job's 90-min budget, not by ctx (#2087 fixed
-  # that). See the workflow_dispatch input above.
-  LIMIT: ${{ github.event.inputs.limit || '25' }}
-  MODEL: ${{ github.event.inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+  THRESHOLDS: tests/fixtures/email/quality_gate_thresholds.json
+  LIMIT: ${{ inputs.limit || '250' }}
+  EXPERIMENTS: ${{ inputs.experiments || '3' }}
+  MODEL: ${{ inputs.model || 'Gemma-4-E4B-it-GGUF' }}
+  CTX_SIZE: ${{ inputs.ctx_size || '16384' }}
+  REBASELINE: ${{ inputs.rebaseline }}
+  REBASELINE_REASON: ${{ inputs.rebaseline_reason || '' }}
+  # Single source of truth for the full/subset split (#2094, Reflection A1/S1)
+  # -- every downstream ternary and the `pre` step read THIS, never re-derive
+  # the >=249 threshold themselves.
+  IS_FULL: ${{ fromJSON(inputs.limit || '250') >= 249 }}
   PYTHONIOENCODING: "utf-8"
   # JOB-WIDE so EVERY eval step (benchmark AND the drafting eval) can import the
   # tests.fixtures.email FakeGmailBackend — eval_drafting_report.py died with
@@ -104,13 +181,30 @@ jobs:
     # 'powershell: command not found'. fromJSON(...) yields a label ARRAY so the
     # runner must have Windows AND the stx/stx-test label.
     runs-on: ${{ fromJSON(contains(github.event.pull_request.labels.*.name, 'stx-test') && '["self-hosted","Windows","stx-test"]' || '["self-hosted","Windows","stx"]') }}
-    # The refresh triages ~25 emails in one call (~38s/email -> ~16min), then
-    # runs three judge evals; that whole chain has to fit the budget below.
-    # History: 220 (~2.3h) hogged the serial lemonade-eval slot -> 60 -> 25
-    # (#2089) when 60 overflowed the pinned 16384 ctx window. #2087 fixed the
-    # ctx half, but 60 still overruns this budget (run 29433392568 died at
-    # 90:00 mid-judge-eval), so 25 stands. Per-email speedups: #2063.
-    timeout-minutes: 90
+    # Budget derivation (#2094) — measured against run 29433392568 (limit 60,
+    # killed at the old flat 90-min job timeout mid action-item judge eval).
+    # Judge-step ceilings are profile-independent: their corpora are fixed
+    # size (drafting 19, action-item 21, briefing 11 cases) regardless of the
+    # triage `limit`.
+    #   benchmark full:    3 experiments x 249 emails x 45s (41.4 measured
+    #                        + margin) ~= 560min                          -> 620
+    #   benchmark subset:  25 emails x 45s ~= 19min + model-load variance -> 45
+    #   drafting judge:    measured 21:00 (19 cases ~= 66s/case)          -> 35
+    #   action-item judge: measured >=27:05 (21 cases)                   -> 45
+    #   briefing judge:    est. 11 cases x ~75s ~= 14min                 -> 25
+    #   setup (checkout + venv + install-lemonade + start; the "start" step
+    #     already carries its own 15-min cap)                            -> 35
+    #   FIVE short steps (pre, gen_scorecard, same-version gate,
+    #     cross-version gate, commit) @ 10 each                          -> 50
+    #   job full:   620+35+45+25+35+50 = 810 -> timeout-minutes 840 (margin)
+    #   job subset:  45+35+45+25+35+50 = 235 -> timeout-minutes 240 (margin)
+    # These are CEILINGS, not expectations — expected wall-clock is ~10.5h
+    # full, ~100min subset. The job timeout is only the backstop: every step
+    # above the "short steps" bucket carries its OWN timeout-minutes so an
+    # overrun fails at a NAMED step, never a silent job-level `cancelled`
+    # (this is the root fix for #2094 — the old value, 90, wasn't even
+    # derived from a measurement).
+    timeout-minutes: ${{ fromJSON(inputs.limit || '250') >= 249 && 840 || 240 }}
     steps:
       - name: Checkout (the pushed branch)
         uses: actions/checkout@v7
@@ -147,8 +241,9 @@ jobs:
           powershell -ExecutionPolicy Bypass -File installer\scripts\ensure-lemonade-running.ps1 -WarmModel "$env:MODEL"
           if ($LASTEXITCODE -ne 0) { throw "Lemonade server not ready" }
 
-      - name: Resolve version + capture currently-committed aggregate
+      - name: Resolve version, committed basis, and fail fast on a basis mismatch
         id: pre
+        timeout-minutes: 10
         run: |
           $ErrorActionPreference = "Stop"
 
@@ -156,8 +251,16 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "could not read version from $env:MANIFEST" }
           "version=$VERSION" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-          # Aggregate of the SCORECARD.md as committed on this branch (empty if new).
+          # Read the committed card's basis (aggregate, ctx_size, n_runs,
+          # limit) BEFORE any eval spend, so a basis-incompatible dispatch can
+          # be rejected cheaply. ctx_size lives at recipe.environment.ctx_size,
+          # NOT recipe.config -- reuse the existing reference implementation
+          # (env_ctx_size) rather than re-deriving the path.
           $COMMITTED = ""
+          $COMMITTED_CTX = ""
+          $COMMITTED_N = ""
+          $COMMITTED_LIMIT = ""
+          $committedPath = ""
           git cat-file -e "HEAD:$env:SCORECARD" 2>$null
           if ($LASTEXITCODE -eq 0) {
             $committedPath = Join-Path $env:RUNNER_TEMP "committed_scorecard.md"
@@ -165,48 +268,118 @@ jobs:
             [System.IO.File]::WriteAllLines($committedPath, (git show "HEAD:$env:SCORECARD"))
             $committedForPy = $committedPath -replace '\\', '/'
             $COMMITTED = python -c "from gaia.eval.release_scorecard import parse_scorecard; import pathlib; print(parse_scorecard(pathlib.Path('$committedForPy'))['aggregate']['value'])"
-            if ($LASTEXITCODE -ne 0) { throw "could not parse committed scorecard" }
+            if ($LASTEXITCODE -ne 0) { throw "could not parse committed scorecard aggregate" }
+            $COMMITTED_CTX = python -c "from gaia.eval.release_scorecard import parse_scorecard; from gaia.eval.scorecard_gate import env_ctx_size; import pathlib; v = env_ctx_size(parse_scorecard(pathlib.Path('$committedForPy'))); print('' if v is None else v)"
+            if ($LASTEXITCODE -ne 0) { throw "could not read committed ctx_size" }
+            $COMMITTED_N = python -c "from gaia.eval.release_scorecard import parse_scorecard; import pathlib; v = parse_scorecard(pathlib.Path('$committedForPy'))['recipe']['config'].get('n_runs'); print('' if v is None else v)"
+            if ($LASTEXITCODE -ne 0) { throw "could not read committed n_runs" }
+            $COMMITTED_LIMIT = python -c "from gaia.eval.release_scorecard import parse_scorecard; import pathlib; v = parse_scorecard(pathlib.Path('$committedForPy'))['recipe']['config'].get('limit'); print('' if v is None else v)"
+            if ($LASTEXITCODE -ne 0) { throw "could not read committed limit" }
           }
           "committed=$COMMITTED" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "committed_ctx=$COMMITTED_CTX" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "committed_n=$COMMITTED_N" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "committed_limit=$COMMITTED_LIMIT" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "committed_path=$committedPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
           # Resolve the previous release tag for the cross-version check.
           $PREV = (git describe --tags --abbrev=0 --match 'agent-pkg-email-*' "HEAD^" 2>$null)
           if (-not $PREV) { $PREV = "" }
           "prev_tag=$PREV" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-          Write-Host "Version $VERSION; committed aggregate: $(if ($COMMITTED) { $COMMITTED } else { '<none>' }); prev tag: $(if ($PREV) { $PREV } else { '<none>' })"
+          # Absolute acceptance bar + urgent-recall floor (#1437), data-driven
+          # from the same thresholds manifest release_agent_email.yml reads --
+          # never hardcode 80.0/0.90 here.
+          $ENFORCE = python -c "import json; print(json.load(open('$env:THRESHOLDS')).get('acceptance_enforce', False))"
+          $MINAGG = ""
+          $MINURGENT = ""
+          if ($ENFORCE -eq "True") {
+            $TARGET = python -c "import json; print(json.load(open('$env:THRESHOLDS'))['acceptance_target'])"
+            $FLOOR = python -c "import json; print(json.load(open('$env:THRESHOLDS'))['urgent_recall_floor'])"
+            $MINAGG = python -c "print(round(float('$TARGET') * 100, 2))"
+            $MINURGENT = $FLOOR
+          }
+          "min_aggregate=$MINAGG" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "min_urgent_recall=$MINURGENT" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          "is_full=$env:IS_FULL" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          # commit_allowed == is_full: a subset run can never commit; a full
+          # run that fails one of the checks below exits 1 and never reaches
+          # the commit step at all.
+          "commit_allowed=$env:IS_FULL" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          # Display-only fallbacks (computed unconditionally so the PROFILE
+          # banner below is correct on BOTH profiles, not just full).
+          $committedCtxDisplay = if ($COMMITTED_CTX) { $COMMITTED_CTX } else { "<unstamped>" }
+          $committedAggDisplay = if ($COMMITTED) { $COMMITTED } else { "<none>" }
+
+          # --- Fail-fast basis guard (full profile only; subset can't commit) ---
+          if ($env:IS_FULL -eq "true") {
+            # Refuse to auto-commit to a protected branch. workflow_dispatch has
+            # no branches: restriction, and github.head_ref is empty on
+            # dispatch, so both checkout and push resolve to the dispatched
+            # ref -- including main.
+            if ($env:GITHUB_REF_NAME -eq "main") {
+              Write-Host "::error::Refuse to auto-commit to main via workflow_dispatch. Dispatch this workflow against a feature branch and open a PR with the refreshed card instead."
+              exit 1
+            }
+
+            if ($env:REBASELINE -eq "true" -and [string]::IsNullOrWhiteSpace($env:REBASELINE_REASON)) {
+              Write-Host "::error::rebaseline=true requires a non-empty rebaseline_reason -- it is recorded in the commit message so git history can tell an approved basis migration from a careless flip."
+              exit 1
+            }
+
+            $ctxMismatch = ($COMMITTED_CTX -eq "") -or ($COMMITTED_CTX -ne $env:CTX_SIZE)
+            if ($ctxMismatch -and ($env:REBASELINE -ne "true")) {
+              Write-Host "::error::Basis mismatch -- committed card ctx_size=$committedCtxDisplay vs requested ctx_size=$env:CTX_SIZE. Re-dispatch at the committed ctx_size to compare apples-to-apples, or pass rebaseline=true with a rebaseline_reason to move the basis deliberately. Re-dispatch command: gh workflow run email_scorecard_refresh.yml --ref $env:GITHUB_REF_NAME -f limit=$env:LIMIT -f experiments=$env:EXPERIMENTS -f ctx_size=$env:CTX_SIZE -f rebaseline=true -f rebaseline_reason=`"...`""
+              exit 1
+            }
+
+            if (($COMMITTED_N -ne "") -and ([int]$env:EXPERIMENTS -lt [int]$COMMITTED_N) -and ($env:REBASELINE -ne "true")) {
+              Write-Host "::error::Basis mismatch -- committed card n_runs=$COMMITTED_N vs requested experiments=$env:EXPERIMENTS. A lower experiments count would silently downgrade the published sample-size basis. Re-dispatch with experiments >= $COMMITTED_N, or pass rebaseline=true with a rebaseline_reason to move the basis deliberately. Re-dispatch command: gh workflow run email_scorecard_refresh.yml --ref $env:GITHUB_REF_NAME -f limit=$env:LIMIT -f experiments=$COMMITTED_N -f ctx_size=$env:CTX_SIZE -f rebaseline=true -f rebaseline_reason=`"...`""
+              exit 1
+            }
+          }
+
+          $profileName = if ($env:IS_FULL -eq "true") { "FULL" } else { "SUBSET" }
+          Write-Host "PROFILE: $profileName -- limit=$env:LIMIT experiments=$env:EXPERIMENTS ctx_size=$env:CTX_SIZE rebaseline=$env:REBASELINE | committed: limit=$COMMITTED_LIMIT n_runs=$COMMITTED_N ctx_size=$committedCtxDisplay aggregate=$committedAggDisplay | prev_tag=$PREV"
 
       - name: Run the email-triage benchmark (real eval)
+        timeout-minutes: ${{ fromJSON(inputs.limit || '250') >= 249 && 620 || 45 }}
         env:
           # The agent's calendar-connector resolution blocks on the OS keyring in
           # a headless context — disable it so construction doesn't hang.
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-          # Triage of the ~25-email corpus is ONE tool call at ~38s/email
-          # (measured on the stx pool for Gemma-4-E4B) -> ~16min. A too-low
-          # timeout abandons it mid-run -> 0 triage results -> Category acc 0.0.
-          # 3600s (1h) covers it with margin. Per-email speedups: #2063.
-          GAIA_AGENT_TOOL_TIMEOUT: '3600'
+          # Bounds ONE tool call (agent.py _call_tool_bounded), and benchmark.py
+          # builds a fresh agent per experiment, so this need only cover a
+          # single experiment's triage call, not the whole run. Full-corpus:
+          # ~249 emails x 41.4s measured -> ~2h52m per experiment -> 14400s (4h)
+          # margin. Subset (~25 emails): 3600s (1h) covers it with margin.
+          GAIA_AGENT_TOOL_TIMEOUT: ${{ fromJSON(inputs.limit || '250') >= 249 && '14400' || '3600' }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
           Remove-Item -Recurse -Force eval-out -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force eval-out | Out-Null
-          # mbox + ground_truth are generated artifacts (not committed) — build
+          # mbox + ground_truth are generated artifacts (not committed) -- build
           # them from the committed seed before the eval reads them.
           python tests/fixtures/email/generate_mbox.py
           if ($LASTEXITCODE -ne 0) { throw "generate_mbox failed" }
-          # --ctx-size 16384: pin the run to the #1892 envelope target so the
-          # refreshed card records the window it was measured under
-          # (gen_scorecard.py refuses to build an unstamped card).
+          # --ctx-size / --experiments come from the dispatch inputs (job env)
+          # so the refreshed card records the window and repeat-count it was
+          # actually measured under (gen_scorecard.py refuses to build an
+          # unstamped card).
           gaia eval benchmark `
             --model "$env:MODEL" `
             --mbox-path tests/fixtures/email/synthetic_inbox.mbox `
             --ground-truth tests/fixtures/email/ground_truth.json `
             --limit "$env:LIMIT" `
-            --ctx-size 16384 `
+            --experiments "$env:EXPERIMENTS" `
+            --ctx-size "$env:CTX_SIZE" `
             --output-dir eval-out
           if ($LASTEXITCODE -ne 0) { throw "gaia eval benchmark failed" }
 
       - name: Voice-drafting quality eval (judge-scored) — for the scorecard metric
+        timeout-minutes: 35
         env:
           # eval_drafting_report.py reads EMAIL_EVAL_MODEL; reuse the refresh model.
           EMAIL_EVAL_MODEL: ${{ env.MODEL }}
@@ -221,6 +394,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "drafting eval failed" }
 
       - name: Action-item extraction eval (judge-scored) — for the scorecard metric
+        timeout-minutes: 45
         env:
           EMAIL_EVAL_MODEL: ${{ env.MODEL }}
           # Judge credential — REQUIRED (fail-loudly, no silent skip), same as
@@ -231,6 +405,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "action-item eval failed" }
 
       - name: Briefing quality eval (judge-scored) — for the scorecard metric
+        timeout-minutes: 25
         env:
           EMAIL_EVAL_MODEL: ${{ env.MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -239,6 +414,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "briefing eval failed" }
 
       - name: Regenerate SCORECARD.md from the real run
+        timeout-minutes: 10
         run: |
           # Fold every capability's judged result into the card as report-only
           # metrics: drafting -> draft_approval_rate (weight-0 metric); spam (from
@@ -250,36 +426,63 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "gen_scorecard failed" }
 
       - name: Same-version regression check (reject a worse re-run)
+        # Subset runs can never commit, so comparing them is not just
+        # unnecessary but actively misleading (#2094, Reflection A2): an
+        # "informational" printed comparison at 25 emails still reads as
+        # signal to a human. Skip the step entirely for subset.
+        if: steps.pre.outputs.is_full == 'true'
+        timeout-minutes: 10
         run: |
-          $inv = [System.Globalization.CultureInfo]::InvariantCulture
-          $COMMITTED = "${{ steps.pre.outputs.committed }}"
-          $scorecardForPy = "$env:SCORECARD" -replace '\\', '/'
-          $FRESH = python -c "from gaia.eval.release_scorecard import parse_scorecard; import pathlib; print(parse_scorecard(pathlib.Path('$scorecardForPy'))['aggregate']['value'])"
-          if ($LASTEXITCODE -ne 0) { throw "could not parse fresh scorecard" }
-          Write-Host "fresh aggregate: $FRESH | committed: $(if ($COMMITTED) { $COMMITTED } else { '<none>' })"
-          if ($COMMITTED) {
-            $freshVal = [double]::Parse($FRESH, $inv)
-            $committedVal = [double]::Parse($COMMITTED, $inv)
-            if ($freshVal -lt $committedVal) {
-              Write-Host "::error::Scorecard regression: re-run scored $FRESH < committed $COMMITTED. Not committing the worse card. Investigate, or override intentionally via --allow-regression in a manual commit."
-              git checkout -- "$env:SCORECARD"
-              exit 1
-            }
+          # Reuse gaia.eval.scorecard_gate instead of hand-rolling this
+          # comparison (#2094, Reflection C4) -- it is already tested and
+          # already implements the variance-aware regression band
+          # (--regression-k) that a strict '<' lacks (it would reject a fresh
+          # 0.833 against a committed 0.834 despite stdev 0.0116).
+          $gateArgs = @("--scorecard", "$env:SCORECARD")
+          if ("${{ steps.pre.outputs.committed_path }}") {
+            $gateArgs += @("--baseline-file", "${{ steps.pre.outputs.committed_path }}")
           }
-          Write-Host "No same-version regression -- fresh score is >= committed."
+          if ("${{ steps.pre.outputs.min_aggregate }}") {
+            $gateArgs += @("--min-aggregate", "${{ steps.pre.outputs.min_aggregate }}")
+          }
+          if ("${{ steps.pre.outputs.min_urgent_recall }}") {
+            $gateArgs += @("--min-urgent-recall", "${{ steps.pre.outputs.min_urgent_recall }}")
+          }
+          if ("$env:REBASELINE" -eq "true") {
+            $gateArgs += "--allow-ctx-mismatch"
+          }
+          python -m gaia.eval.scorecard_gate @gateArgs
+          if ($LASTEXITCODE -ne 0) { throw "scorecard_gate (same-version) failed" }
 
       - name: Cross-version gate (fresh SCORECARD.md vs prior version tag, best-effort)
+        if: steps.pre.outputs.is_full == 'true'
+        timeout-minutes: 10
         run: |
           $PREV = "${{ steps.pre.outputs.prev_tag }}"
+          $gateArgs = @("--scorecard", "$env:SCORECARD")
           if ($PREV) {
-            python -m gaia.eval.scorecard_gate --scorecard "$env:SCORECARD" --baseline-ref "$PREV"
-          } else {
-            python -m gaia.eval.scorecard_gate --scorecard "$env:SCORECARD"
+            $gateArgs += @("--baseline-ref", "$PREV")
           }
-          if ($LASTEXITCODE -ne 0) { throw "scorecard_gate failed" }
+          if ("${{ steps.pre.outputs.min_aggregate }}") {
+            $gateArgs += @("--min-aggregate", "${{ steps.pre.outputs.min_aggregate }}")
+          }
+          if ("${{ steps.pre.outputs.min_urgent_recall }}") {
+            $gateArgs += @("--min-urgent-recall", "${{ steps.pre.outputs.min_urgent_recall }}")
+          }
+          if ("$env:REBASELINE" -eq "true") {
+            $gateArgs += "--allow-ctx-mismatch"
+          }
+          python -m gaia.eval.scorecard_gate @gateArgs
+          if ($LASTEXITCODE -ne 0) { throw "scorecard_gate (cross-version) failed" }
 
-      - name: Commit the refreshed SCORECARD.md (only if it changed for the better/equal)
+      - name: Commit the refreshed SCORECARD.md (full profile only)
+        timeout-minutes: 10
         run: |
+          if ("${{ steps.pre.outputs.commit_allowed }}" -ne "true") {
+            Write-Host "SUBSET RUN -- card NOT committed (basis limit=$env:LIMIT experiments=$env:EXPERIMENTS is smaller than the committed limit=${{ steps.pre.outputs.committed_limit }} n_runs=${{ steps.pre.outputs.committed_n }} basis). Restoring the committed SCORECARD.md."
+            git checkout -- "$env:SCORECARD"
+            exit 0
+          }
           git diff --quiet -- "$env:SCORECARD"
           if ($LASTEXITCODE -eq 0) {
             Write-Host "SCORECARD.md unchanged -- nothing to commit."
@@ -288,7 +491,11 @@ jobs:
           git config user.name  "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add "$env:SCORECARD"
-          git commit -m "eval(email): refresh v${{ steps.pre.outputs.version }} scorecard from benchmark run"
+          $commitMsg = "eval(email): refresh v${{ steps.pre.outputs.version }} scorecard from benchmark run"
+          if ("$env:REBASELINE" -eq "true") {
+            $commitMsg = "eval(email): re-baseline v${{ steps.pre.outputs.version }} scorecard at ctx=$env:CTX_SIZE from full-corpus run`n`n$env:REBASELINE_REASON"
+          }
+          git commit -m "$commitMsg"
           if ($LASTEXITCODE -ne 0) { throw "git commit failed" }
           git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
           if ($LASTEXITCODE -ne 0) { throw "git push failed" }

--- a/docs/reference/eval-scorecard.mdx
+++ b/docs/reference/eval-scorecard.mdx
@@ -326,11 +326,13 @@ The scorecard must move with the agent: when LLM-affecting code changes, the eva
 Two enforcement points work together:
 
 1. **Reject-on-worse (always on, GitHub-hosted).** The `scorecard-gate` job in `release_agent_<id>.yml` runs on every release. It only parses committed files (no eval), so it runs on a standard runner and **fails the build** if the committed scorecard regressed below the prior version or is missing. This is the hard gate.
-2. **Run-and-refresh (self-hosted AMD).** `gaia eval benchmark` needs Lemonade on AMD hardware, so it cannot run on GitHub-hosted runners — it runs on the `[self-hosted, lemonade-eval]` pool. The `Email Agent Eval — scorecard refresh` workflow (`.github/workflows/email_scorecard_refresh.yml`) runs on demand (and on pushes touching the email agent), re-runs the eval, regenerates `SCORECARD.md`, then:
-   - **score ≥ committed** → commits the refreshed scorecard back to the branch (the PR carries the improved number);
-   - **score < committed** → fails loudly (the regression must be investigated, or consciously overridden with `--allow-regression`).
+2. **Run-and-refresh (self-hosted AMD, manual dispatch).** `gaia eval benchmark` needs Lemonade on AMD hardware, so it cannot run on GitHub-hosted runners — it runs on the `[self-hosted, Windows, stx]` pool, serialized against the other evals by the shared `lemonade-eval` concurrency group. The `Email Agent Eval — scorecard refresh` workflow (`.github/workflows/email_scorecard_refresh.yml`) is **`workflow_dispatch`-only** (#2094 — it previously also ran on pushes touching the email agent, but a full eval costs ~10.5h and that trigger never once completed a run), and takes two profiles:
+   - **full** (`limit ≥ 249` **and** `experiments ≥` the committed card's `n_runs`) — reproduces the committed card's methodology and is the **only** profile allowed to commit a refreshed card;
+   - **subset** (`limit < 249`) — an end-to-end smoke run that exercises every step and then **never commits** (a small-sample number is not a valid stand-in for the published figure).
 
-So a PR that changes the agent gets its scorecard refreshed (better) or rejected (worse) automatically on the AMD runner, and the release gate is the backstop on hosted CI. Locally, `gen_scorecard.py` + `scorecard_gate.py` reproduce both steps (see the **`adding-eval-scorecard` skill**).
+   A full run then either **commits** the refreshed card (score clears the absolute bar and shows no regression beyond the recorded noise band) or **fails loudly** (regression, or a card below the acceptance bar / urgent-recall floor from `tests/fixtures/email/quality_gate_thresholds.json`). Before any eval spend, the run also fails fast if its basis (`ctx_size`, `experiments`) differs from the committed card's — unless `rebaseline=true` (with a required `rebaseline_reason`) marks the basis change deliberate.
+
+So the published number always traces to a full-corpus run, and the release gate is the backstop on hosted CI. Locally, `gen_scorecard.py` + `scorecard_gate.py` reproduce both steps (see the **`adding-eval-scorecard` skill**).
 
 <Warning>
   The refresh job needs `contents: write` and runs only on the repo's own branches — a fork PR's `GITHUB_TOKEN` is read-only and cannot auto-commit. For a fork PR, run the eval locally/on AMD hardware and commit the scorecard manually; the release gate still enforces no-regression.

--- a/hub/agents/npm/agent-email/EVALUATION.md
+++ b/hub/agents/npm/agent-email/EVALUATION.md
@@ -83,7 +83,8 @@ from the committed seed, and runs the benchmark (~17 minutes on a 4B model).
   Lemonade server race-evict each other's model); use `--experiments 3` for
   run-to-run variance (mean/stdev/95% CI).
 - **CI:** `test_email_agent_eval.yml` (nightly, report-mode on the self-hosted AMD
-  `stx` pool) and `email_scorecard_refresh.yml` (regenerates `SCORECARD.md` on
-  agent/corpus changes). The drafting eval needs `ANTHROPIC_API_KEY`; absent → loud
-  skip, never a pass.
+  `stx` pool) and `email_scorecard_refresh.yml` (manual dispatch only; a full-corpus
+  run regenerates `SCORECARD.md`, a subset run smoke-tests the pipeline without
+  committing). The drafting eval needs `ANTHROPIC_API_KEY`; absent → loud skip,
+  never a pass.
 </details>

--- a/hub/agents/npm/agent-email/SCORECARD.md
+++ b/hub/agents/npm/agent-email/SCORECARD.md
@@ -2,7 +2,7 @@
 schema_version: 1
 agent:
   name: Email Triage
-  version: 0.3.0
+  version: 0.5.0
 recipe:
   dataset:
     reference: tests/fixtures/email/ground_truth.json
@@ -10,56 +10,56 @@ recipe:
       (FakeGmailBackend, schema-2.0 triage taxonomy: urgent / needs_response / fyi
       / promotional / personal); a deterministic, category-balanced subset of the
       vendor mailbox dataset'
-    size: 249
+    size: 299
   methodology: 'gaia eval benchmark over the vendor-derived labelled corpus via FakeGmailBackend;
-    no LLM judge. The full 249-email corpus is scored (GAIA_EMAIL_TRIAGE_MAX_MESSAGES
-    lifts the interactive per-call scan cap for the eval so the whole balanced corpus
-    is covered). Aggregate = within-one-bucket ACCEPTANCE accuracy (#1437): triage
-    priority is ordinal (URGENT>NEEDS_RESPONSE>FYI>PROMOTIONAL), so a prediction is
-    credited when it is exact or an adjacent bucket (|rank diff|<=1) — what users
-    feel (nothing urgent buried). Reported secondaries (not in the aggregate): urgent-vs-not
-    binary accuracy, urgent recall (anti-gaming floor), and exact 4-way category_accuracy.
+    no LLM judge. The full corpus is scored — see dataset_size (GAIA_EMAIL_TRIAGE_MAX_MESSAGES
+    lifts the interactive per-call scan cap for the eval so the whole corpus is covered).
+    Aggregate = within-one-bucket ACCEPTANCE accuracy (#1437): triage priority is
+    ordinal (URGENT>NEEDS_RESPONSE>FYI>PROMOTIONAL), so a prediction is credited when
+    it is exact or an adjacent bucket (|rank diff|<=1) — what users feel (nothing
+    urgent buried). Reported secondaries (not in the aggregate): urgent-vs-not binary
+    accuracy, urgent recall (anti-gaming floor), and exact 4-way category_accuracy.
     The corpus uses the schema-2.0 taxonomy aligned with the agent''s output labels
     (#1874); averaged over 3 run(s) for run-to-run variance/CI (#1894)'
   config:
     harness: gaia eval benchmark
     model: Gemma-4-E4B-it-GGUF
     corpus: tests/fixtures/email/synthetic_inbox.mbox
-    ground_truth: tests/fixtures/email/ground_truth.json
+    ground_truth: tests\fixtures\email\ground_truth.json
     limit: 250
     n_runs: 3
     acceptance_variance:
       n_runs: 3
       within_one_bucket_accuracy:
         n: 3
-        mean: 0.834
-        stdev: 0.0116
-        min: 0.8273
-        max: 0.8474
-        cv_pct: 1.39
-        ci95_half_width: 0.0131
-        ci95_low: 0.8209
-        ci95_high: 0.8471
+        mean: 0.8453
+        stdev: 0.0023
+        min: 0.844
+        max: 0.848
+        cv_pct: 0.27
+        ci95_half_width: 0.0026
+        ci95_low: 0.8427
+        ci95_high: 0.8479
       urgent_vs_not_accuracy:
         n: 3
-        mean: 0.7845
-        stdev: 0.0129
-        min: 0.7751
-        max: 0.7992
-        cv_pct: 1.65
-        ci95_half_width: 0.0146
-        ci95_low: 0.7699
-        ci95_high: 0.7991
+        mean: 0.7987
+        stdev: 0.0046
+        min: 0.796
+        max: 0.804
+        cv_pct: 0.58
+        ci95_half_width: 0.0052
+        ci95_low: 0.7934
+        ci95_high: 0.8039
       urgent_recall:
         n: 3
-        mean: 0.9938
-        stdev: 0.0054
-        min: 0.9907
+        mean: 1.0
+        stdev: 0.0
+        min: 1.0
         max: 1.0
-        cv_pct: 0.54
-        ci95_half_width: 0.0061
-        ci95_low: 0.9877
-        ci95_high: 0.9999
+        cv_pct: 0.0
+        ci95_half_width: 0.0
+        ci95_low: 1.0
+        ci95_high: 1.0
       personal_recall:
         n: 3
         mean: 0.3636
@@ -72,43 +72,47 @@ recipe:
         ci95_high: 0.3636
       category_accuracy:
         n: 3
-        mean: 0.7684
-        stdev: 0.0129
-        min: 0.759
-        max: 0.7831
-        cv_pct: 1.68
-        ci95_half_width: 0.0146
-        ci95_low: 0.7538
-        ci95_high: 0.783
+        mean: 0.7813
+        stdev: 0.0023
+        min: 0.78
+        max: 0.784
+        cv_pct: 0.3
+        ci95_half_width: 0.0026
+        ci95_low: 0.7787
+        ci95_high: 0.7839
   environment:
-    gaia_commit: 8dad5985
-    lemonade_version: 10.7.0
+    gaia_commit: eca42a0e
+    lemonade_version: 10.10.0
     model: Gemma-4-E4B-it-GGUF
+    ctx_size: 16384
     hardware: AMD Ryzen AI MAX+ (Strix Halo)
 results:
-  test_cases_run: 249
+  test_cases_run: 250
   metrics:
   - name: within_one_bucket_accuracy
-    value: 0.834
+    value: 0.8453
     weight: 1.0
   - name: urgent_vs_not_accuracy
-    value: 0.7845
+    value: 0.7987
     weight: 0.0
   - name: urgent_recall
-    value: 0.9938
+    value: 1.0
     weight: 0.0
   - name: personal_recall
     value: 0.3636
     weight: 0.0
   - name: category_accuracy
-    value: 0.7684
+    value: 0.7813
+    weight: 0.0
+  - name: draft_approval_rate
+    value: 0.6111
     weight: 0.0
   breakdown:
     per_category:
     - category: fyi
       total: 162
-      correct: 125
-      accuracy: 0.7716
+      correct: 124
+      accuracy: 0.7654
     - category: needs_response
       total: 162
       correct: 162
@@ -118,55 +122,81 @@ results:
       correct: 36
       accuracy: 0.3636
     - category: promotional
-      total: 162
-      correct: 103
-      accuracy: 0.6358
+      total: 165
+      correct: 112
+      accuracy: 0.6788
     - category: urgent
       total: 162
-      correct: 148
-      accuracy: 0.9136
+      correct: 152
+      accuracy: 0.9383
     top_confusions:
+    - expected: personal
+      predicted: needs_response
+      count: 44
     - expected: promotional
       predicted: urgent
-      count: 48
-    - expected: personal
-      predicted: needs_response
-      count: 48
+      count: 40
     - expected: fyi
       predicted: needs_response
-      count: 37
+      count: 38
     - expected: personal
       predicted: urgent
-      count: 15
-    - expected: urgent
+      count: 16
+    - expected: promotional
       predicted: needs_response
-      count: 12
+      count: 13
+  performance:
+    ttft_s: 24.673
+    throughput_tps: 23.767
+    pipeline_s: 6926.411
+    total_input_tokens: 316983.667
+    total_output_tokens: 169056.667
+    tokens_per_triage: 1906.033
+    llm_classified_count: 250.0
+    emails_per_run: 250
+  capability_quality:
+    spam:
+      precision: 0.1078
+      recall: 0.3333
+      f1: 0.1629
+    action_items:
+      precision: 0.0
+      recall: 0.0
+      f1: 0.0
+    briefing:
+      approval: 0.0
+      must_include_recall: 0.05
+      faithful: 1.0
+      hallucination_free: 1.0
 aggregate:
   name: weighted_accuracy
   formula: round(100 * sum(weight_i * value_i) / sum(weight_i), 2)
   components:
   - metric: within_one_bucket_accuracy
-    value: 0.834
+    value: 0.8453
     weight: 1.0
   - metric: urgent_vs_not_accuracy
-    value: 0.7845
+    value: 0.7987
     weight: 0.0
   - metric: urgent_recall
-    value: 0.9938
+    value: 1.0
     weight: 0.0
   - metric: personal_recall
     value: 0.3636
     weight: 0.0
   - metric: category_accuracy
-    value: 0.7684
+    value: 0.7813
     weight: 0.0
-  value: 83.4
-generated_at: '2026-06-30T12:20:57.795513+00:00'
+  - metric: draft_approval_rate
+    value: 0.6111
+    weight: 0.0
+  value: 84.53
+generated_at: '2026-07-16T07:54:50.556072+00:00'
 inherited_from: null
 ---
-# Email Triage — Eval Scorecard v0.3.0
+# Email Triage — Eval Scorecard v0.5.0
 
-**Aggregate score: 83.4** (out of 100)
+**Aggregate score: 84.53** (out of 100)
 
 ## Recipe
 
@@ -174,17 +204,18 @@ inherited_from: null
 |-------|-------|
 | Dataset | [tests/fixtures/email/ground_truth.json](tests/fixtures/email/ground_truth.json) |
 | Description | Vendor-derived labelled email corpus for GAIA email-triage evaluation (FakeGmailBackend, schema-2.0 triage taxonomy: urgent / needs_response / fyi / promotional / personal); a deterministic, category-balanced subset of the vendor mailbox dataset |
-| Dataset size | 249 labeled examples |
-| Test cases run | 249 |
-| Methodology | gaia eval benchmark over the vendor-derived labelled corpus via FakeGmailBackend; no LLM judge. The full 249-email corpus is scored (GAIA_EMAIL_TRIAGE_MAX_MESSAGES lifts the interactive per-call scan cap for the eval so the whole balanced corpus is covered). Aggregate = within-one-bucket ACCEPTANCE accuracy (#1437): triage priority is ordinal (URGENT>NEEDS_RESPONSE>FYI>PROMOTIONAL), so a prediction is credited when it is exact or an adjacent bucket (|rank diff|<=1) — what users feel (nothing urgent buried). Reported secondaries (not in the aggregate): urgent-vs-not binary accuracy, urgent recall (anti-gaming floor), and exact 4-way category_accuracy. The corpus uses the schema-2.0 taxonomy aligned with the agent's output labels (#1874); averaged over 3 run(s) for run-to-run variance/CI (#1894) |
+| Dataset size | 299 labeled examples |
+| Test cases run | 250 |
+| Methodology | gaia eval benchmark over the vendor-derived labelled corpus via FakeGmailBackend; no LLM judge. The full corpus is scored — see dataset_size (GAIA_EMAIL_TRIAGE_MAX_MESSAGES lifts the interactive per-call scan cap for the eval so the whole corpus is covered). Aggregate = within-one-bucket ACCEPTANCE accuracy (#1437): triage priority is ordinal (URGENT>NEEDS_RESPONSE>FYI>PROMOTIONAL), so a prediction is credited when it is exact or an adjacent bucket (|rank diff|<=1) — what users feel (nothing urgent buried). Reported secondaries (not in the aggregate): urgent-vs-not binary accuracy, urgent recall (anti-gaming floor), and exact 4-way category_accuracy. The corpus uses the schema-2.0 taxonomy aligned with the agent's output labels (#1874); averaged over 3 run(s) for run-to-run variance/CI (#1894) |
 
 ## Metrics
 
-  - **within_one_bucket_accuracy**: 0.8340 × 1.0
-  - **urgent_vs_not_accuracy**: 0.7845 × 0.0
-  - **urgent_recall**: 0.9938 × 0.0
+  - **within_one_bucket_accuracy**: 0.8453 × 1.0
+  - **urgent_vs_not_accuracy**: 0.7987 × 0.0
+  - **urgent_recall**: 1.0000 × 0.0
   - **personal_recall**: 0.3636 × 0.0
-  - **category_accuracy**: 0.7684 × 0.0
+  - **category_accuracy**: 0.7813 × 0.0
+  - **draft_approval_rate**: 0.6111 × 0.0
 
 ## Aggregate score recomputation
 
@@ -193,7 +224,7 @@ Formula: `round(100 × Σ(weightᵢ × valueᵢ) / Σ(weightᵢ), 2)`
 Worked example:
 
 ```
-round(100 × ((0.8340 × 1.0) + (0.7845 × 0.0) + (0.9938 × 0.0) + (0.3636 × 0.0) + (0.7684 × 0.0)) / 1.0, 2) = 83.4
+round(100 × ((0.8453 × 1.0) + (0.7987 × 0.0) + (1.0000 × 0.0) + (0.3636 × 0.0) + (0.7813 × 0.0) + (0.6111 × 0.0)) / 1.0, 2) = 84.53
 ```
 
 A reader can reproduce this value from the `aggregate.components` in the front
@@ -222,7 +253,7 @@ PYTHONPATH="$(pwd)" \
 gaia eval benchmark \
     --model Gemma-4-E4B-it-GGUF \
     --mbox-path tests/fixtures/email/synthetic_inbox.mbox \
-    --ground-truth tests/fixtures/email/ground_truth.json \
+    --ground-truth tests\fixtures\email\ground_truth.json \
     --limit 250 \
     --output-dir /tmp/email-eval
 
@@ -230,7 +261,7 @@ gaia eval benchmark \
 PYTHONPATH="$(pwd)" \
 python hub/agents/python/email/packaging/gen_scorecard.py \
     --benchmark-dir /tmp/email-eval \
-    --ground-truth tests/fixtures/email/ground_truth.json \
+    --ground-truth tests\fixtures\email\ground_truth.json \
     --limit 250
 
 # Background, dataset details, a worked example, and metric
@@ -243,27 +274,60 @@ See [eval-scorecard docs](https://amd-gaia.ai/docs/reference/eval-scorecard) and
 
 | Field | Value |
 |-------|-------|
-| gaia_commit | 8dad5985 |
-| lemonade_version | 10.7.0 |
+| gaia_commit | eca42a0e |
+| lemonade_version | 10.10.0 |
 | model | Gemma-4-E4B-it-GGUF |
+| ctx_size | 16384 |
 | hardware | AMD Ryzen AI MAX+ (Strix Halo) |
 
 ## Category breakdown (pooled across all 3 runs)
 
-_Each of the 249 test cases is scored once per run, so the totals below sum to test_cases_run × 3._
+_Each of the 250 test cases is scored once per run, so the totals below sum to test_cases_run × 3._
 
 | Category | Total | Correct | Accuracy |
 |----------|-------|---------|----------|
-| fyi | 162 | 125 | 0.7716 |
+| fyi | 162 | 124 | 0.7654 |
 | needs_response | 162 | 162 | 1.0000 |
 | personal | 99 | 36 | 0.3636 |
-| promotional | 162 | 103 | 0.6358 |
-| urgent | 162 | 148 | 0.9136 |
+| promotional | 165 | 112 | 0.6788 |
+| urgent | 162 | 152 | 0.9383 |
 
 **Top confusions:**
 
-  - promotional → urgent: 48
-  - personal → needs_response: 48
-  - fyi → needs_response: 37
-  - personal → urgent: 15
-  - urgent → needs_response: 12
+  - personal → needs_response: 44
+  - promotional → urgent: 40
+  - fyi → needs_response: 38
+  - personal → urgent: 16
+  - promotional → needs_response: 13
+
+## Performance
+
+_Measured on the run environment above (model / hardware / gaia_commit / corpus size); the perf gate is report-only, so these are observed values, not pass/fail bars (see `tests/fixtures/email/perf_gate_thresholds.json`)._
+
+| Metric | Value |
+|--------|-------|
+| ttft_s | 24.673 |
+| throughput_tps | 23.767 |
+| pipeline_s | 6926.411 |
+| total_input_tokens | 316983.667 |
+| total_output_tokens | 169056.667 |
+| tokens_per_triage | 1906.033 |
+| llm_classified_count | 250.0 |
+| emails_per_run | 250 |
+
+## Capability quality
+
+_Beyond the headline triage accuracy, these are the agent's other capabilities scored by their own evals (spam detection, action-item extraction, briefing quality). Report-only — they don't feed the aggregate above; see the per-capability gate thresholds under `tests/fixtures/email/`._
+
+| Capability | Metric | Value |
+|------------|--------|-------|
+| spam | precision | 0.1078 |
+| spam | recall | 0.3333 |
+| spam | f1 | 0.1629 |
+| action_items | precision | 0.0000 |
+| action_items | recall | 0.0000 |
+| action_items | f1 | 0.0000 |
+| briefing | approval | 0.0000 |
+| briefing | must_include_recall | 0.0500 |
+| briefing | faithful | 1.0000 |
+| briefing | hallucination_free | 1.0000 |

--- a/src/gaia/eval/action_item_quality.py
+++ b/src/gaia/eval/action_item_quality.py
@@ -712,7 +712,8 @@ def make_claude_judge(model: str | None = None) -> Callable[[str, str], bool]:
     """
     from gaia.eval.claude import ClaudeClient
 
-    client = ClaudeClient(model=model)
+    # Judge determinism: generation is temp-0, the judge must be too (#2094).
+    client = ClaudeClient(model=model, temperature=0.0)
 
     def judge(predicted_desc: str, expected_desc: str) -> bool:
         prompt = build_equivalence_prompt(predicted_desc, expected_desc)

--- a/src/gaia/eval/briefing_quality.py
+++ b/src/gaia/eval/briefing_quality.py
@@ -312,7 +312,8 @@ def make_claude_judge(model: str | None = None) -> Callable[[str], str]:
     """
     from gaia.eval.claude import ClaudeClient
 
-    client = ClaudeClient(model=model)
+    # Judge determinism: generation is temp-0, the judge must be too (#2094).
+    client = ClaudeClient(model=model, temperature=0.0)
 
     def judge(prompt: str) -> str:
         content = client.get_completion(prompt)

--- a/src/gaia/eval/claude.py
+++ b/src/gaia/eval/claude.py
@@ -27,7 +27,7 @@ load_dotenv()
 class ClaudeClient:
     log = get_logger(__name__)
 
-    def __init__(self, model=None, max_tokens=1024, max_retries=3):
+    def __init__(self, model=None, max_tokens=1024, max_retries=3, temperature=None):
         """
         Initialize Claude client with retry support.
 
@@ -35,6 +35,10 @@ class ClaudeClient:
             model: Claude model to use (defaults to DEFAULT_CLAUDE_MODEL)
             max_tokens: Maximum tokens in response (default: 1024)
             max_retries: Maximum number of retry attempts for API calls with exponential backoff (default: 3)
+            temperature: Sampling temperature forwarded to every completion call.
+                Left as None (the default), no temperature is sent and the API
+                default applies — generation callers depend on that diversity.
+                Judges pass 0.0 explicitly (#2094).
         """
         # Check for required dependencies
         if anthropic is None:
@@ -86,9 +90,20 @@ class ClaudeClient:
         self.model = model
         self.max_tokens = max_tokens
         self.max_retries = max_retries
+        self.temperature = temperature
         self.log.info(
             f"Initialized ClaudeClient with model: {model}, max_retries: {max_retries}"
         )
+
+    def _sampling_kwargs(self):
+        """Sampling kwargs for a completion call: ``temperature`` only if pinned.
+
+        Omitting the kwarg entirely (rather than passing None) preserves the
+        API default for callers that never asked for a pin.
+        """
+        if self.temperature is None:
+            return {}
+        return {"temperature": self.temperature}
 
     def calculate_cost(self, input_tokens, output_tokens):
         """
@@ -123,6 +138,7 @@ class ClaudeClient:
                 model=self.model,
                 max_tokens=self.max_tokens,
                 messages=[{"role": "user", "content": prompt}],
+                **self._sampling_kwargs(),
             )
             return message.content
         except Exception as e:
@@ -145,6 +161,7 @@ class ClaudeClient:
                 model=self.model,
                 max_tokens=self.max_tokens,
                 messages=[{"role": "user", "content": prompt}],
+                **self._sampling_kwargs(),
             )
 
             # Extract usage information
@@ -252,6 +269,7 @@ class ClaudeClient:
                             "content": f"Document content:\n\n{text_content}\n\n{prompt}",
                         }
                     ],
+                    **self._sampling_kwargs(),
                 )
                 self.log.info("Successfully analyzed HTML content")
                 return message.content[0].text
@@ -293,6 +311,7 @@ class ClaudeClient:
                         ],
                     }
                 ],
+                **self._sampling_kwargs(),
             )
             self.log.info("Successfully analyzed file")
             return message.content[0].text
@@ -348,6 +367,7 @@ class ClaudeClient:
                             "content": f"Document content:\n\n{text_content}\n\n{prompt}",
                         }
                     ],
+                    **self._sampling_kwargs(),
                 )
                 self.log.info(f"Successfully analyzed text content ({ext} file)")
 
@@ -405,6 +425,7 @@ class ClaudeClient:
                         ],
                     }
                 ],
+                **self._sampling_kwargs(),
             )
             self.log.info("Successfully analyzed file")
 

--- a/src/gaia/eval/draft_quality.py
+++ b/src/gaia/eval/draft_quality.py
@@ -274,7 +274,8 @@ def make_claude_judge(model: str | None = None) -> Callable[[str], str]:
     """
     from gaia.eval.claude import ClaudeClient
 
-    client = ClaudeClient(model=model)
+    # Judge determinism: generation is temp-0, the judge must be too (#2094).
+    client = ClaudeClient(model=model, temperature=0.0)
 
     def judge(prompt: str) -> str:
         content = client.get_completion(prompt)

--- a/src/gaia/eval/scorecard_gate.py
+++ b/src/gaia/eval/scorecard_gate.py
@@ -88,11 +88,16 @@ def _within_one_stdev(parsed: dict) -> float | None:
     return None
 
 
-def _env_ctx_size(parsed: dict) -> int | None:
+def env_ctx_size(parsed: dict) -> int | None:
     """The ctx window a card was measured under (#1892), or ``None``.
 
     Lives in ``recipe.environment.ctx_size`` — absent on cards produced
     before the envelope landed (implicitly the model's 64K registry floor).
+
+    Public (#2094): the ``email_scorecard_refresh.yml`` ``pre`` step imports
+    this directly to read the committed card's ctx stamp before spending any
+    eval budget, rather than re-deriving the ``recipe.environment.ctx_size``
+    path in ad-hoc PowerShell/Python.
     """
     env = parsed.get("recipe", {}).get("environment")
     if not isinstance(env, dict):
@@ -291,7 +296,7 @@ def main(argv=None) -> int:
         return 1
 
     # --- Step 1a: ctx-stamp requirement (#1892) ---
-    cand_ctx = _env_ctx_size(candidate_parsed)
+    cand_ctx = env_ctx_size(candidate_parsed)
     if args.require_ctx_match and cand_ctx is None:
         print(
             f"ERROR: --require-ctx-match is set but the candidate SCORECARD.md "
@@ -419,7 +424,7 @@ def main(argv=None) -> int:
     # comparable to one measured at another; when the windows differ (or the
     # baseline predates stamping) the regression comparison is SKIPPED, never
     # run-and-annotated. Absolute bars already ran at Step 1b regardless.
-    base_ctx = _env_ctx_size(prev_parsed)
+    base_ctx = env_ctx_size(prev_parsed)
     cand_version_ctx = candidate_parsed.get("agent", {}).get("version", "?")
     prev_version_ctx = prev_parsed.get("agent", {}).get("version", "?")
     if cand_ctx is not None and base_ctx is not None and cand_ctx != base_ctx:

--- a/tests/unit/eval/test_claude_judge.py
+++ b/tests/unit/eval/test_claude_judge.py
@@ -24,6 +24,24 @@ def _make_mock_anthropic():
     return mock_module
 
 
+def _build_client(monkeypatch, temperature=None, model="claude-sonnet-4-6"):
+    """Construct a ClaudeClient with mocked anthropic/bs4 deps.
+
+    ``temperature`` is only forwarded to the constructor when not ``None`` so
+    tests can exercise the true default-argument path (no kwarg at all), not
+    just an explicit ``temperature=None``.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("gaia.eval.claude.anthropic", _make_mock_anthropic())
+    monkeypatch.setattr("gaia.eval.claude.BeautifulSoup", MagicMock())
+    from gaia.eval.claude import ClaudeClient
+
+    kwargs = {"model": model}
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    return ClaudeClient(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Initialization
 # ---------------------------------------------------------------------------
@@ -200,3 +218,233 @@ class TestCountTokens:
             model="claude-sonnet-4-6",
             messages=[{"role": "user", "content": "test prompt"}],
         )
+
+
+# ---------------------------------------------------------------------------
+# Judge sampling temperature (#2094 AC-5)
+#
+# The judge's own sampling must be pinnable via a `temperature` constructor
+# kwarg, forwarded to every `messages.create` call site *only* when set —
+# leaving it unset must reproduce today's behavior exactly (no `temperature`
+# kwarg at all), since a non-judge caller (pdf_document_generator.py) relies
+# on the API default for fixture-generation diversity.
+# ---------------------------------------------------------------------------
+
+
+class TestTemperatureStored:
+    def test_default_temperature_is_none(self, monkeypatch):
+        client = _build_client(monkeypatch)
+        assert client.temperature is None
+
+    def test_explicit_temperature_is_stored(self, monkeypatch):
+        client = _build_client(monkeypatch, temperature=0.0)
+        assert client.temperature == 0.0
+
+
+class TestGetCompletionTemperature:
+    def test_temperature_pinned_when_set(self, monkeypatch):
+        client = _build_client(monkeypatch, temperature=0.0)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")]
+        )
+        client.get_completion("prompt")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.0
+
+    def test_temperature_omitted_by_default(self, monkeypatch):
+        client = _build_client(monkeypatch)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")]
+        )
+        client.get_completion("prompt")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+
+    def test_non_default_temperature_is_forwarded(self, monkeypatch):
+        """Distinguishes "reads self.temperature" from "hardcodes 0.0 at each
+        call site" — both satisfy AC-5's wording, only the former survives a
+        future default change."""
+        client = _build_client(monkeypatch, temperature=0.7)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")]
+        )
+        client.get_completion("prompt")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.7
+
+
+class TestGetCompletionWithUsageTemperature:
+    def test_temperature_pinned_when_set(self, monkeypatch):
+        client = _build_client(monkeypatch, temperature=0.0)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.get_completion_with_usage("prompt")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.0
+
+    def test_temperature_omitted_by_default(self, monkeypatch):
+        client = _build_client(monkeypatch)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.get_completion_with_usage("prompt")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+
+
+class TestAnalyzeFileHtmlTemperature:
+    """analyze_file's HTML branch (claude.py:246)."""
+
+    @pytest.fixture()
+    def html_file(self, tmp_path):
+        path = tmp_path / "doc.html"
+        path.write_text("<html><body>hello</body></html>", encoding="utf-8")
+        return path
+
+    def test_temperature_pinned_when_set(self, monkeypatch, html_file):
+        client = _build_client(monkeypatch, temperature=0.0)
+        monkeypatch.setattr(client, "_convert_html_to_text", lambda *a, **kw: "hello")
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")]
+        )
+        client.analyze_file(str(html_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.0
+
+    def test_temperature_omitted_by_default(self, monkeypatch, html_file):
+        client = _build_client(monkeypatch)
+        monkeypatch.setattr(client, "_convert_html_to_text", lambda *a, **kw: "hello")
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")]
+        )
+        client.analyze_file(str(html_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+
+
+class TestAnalyzeFileBinaryTemperature:
+    """analyze_file's base64/document branch (claude.py:277)."""
+
+    @pytest.fixture()
+    def pdf_file(self, tmp_path):
+        path = tmp_path / "doc.pdf"
+        path.write_bytes(b"%PDF-1.4 fake pdf content")
+        return path
+
+    def test_temperature_pinned_when_set(self, monkeypatch, pdf_file):
+        client = _build_client(monkeypatch, temperature=0.0)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")]
+        )
+        client.analyze_file(str(pdf_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.0
+
+    def test_temperature_omitted_by_default(self, monkeypatch, pdf_file):
+        client = _build_client(monkeypatch)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")]
+        )
+        client.analyze_file(str(pdf_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+
+
+class TestAnalyzeFileWithUsageTextTemperature:
+    """analyze_file_with_usage's text branch (claude.py:342)."""
+
+    @pytest.fixture()
+    def txt_file(self, tmp_path):
+        path = tmp_path / "doc.txt"
+        path.write_text("hello world", encoding="utf-8")
+        return path
+
+    def test_temperature_pinned_when_set(self, monkeypatch, txt_file):
+        client = _build_client(monkeypatch, temperature=0.0)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.analyze_file_with_usage(str(txt_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.0
+
+    def test_temperature_omitted_by_default(self, monkeypatch, txt_file):
+        client = _build_client(monkeypatch)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.analyze_file_with_usage(str(txt_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+
+
+class TestAnalyzeFileWithUsageBinaryTemperature:
+    """analyze_file_with_usage's binary/PDF branch (claude.py:389)."""
+
+    @pytest.fixture()
+    def pdf_file(self, tmp_path):
+        path = tmp_path / "doc.pdf"
+        path.write_bytes(b"%PDF-1.4 fake pdf content")
+        return path
+
+    def test_temperature_pinned_when_set(self, monkeypatch, pdf_file):
+        client = _build_client(monkeypatch, temperature=0.0)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.analyze_file_with_usage(str(pdf_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert kwargs["temperature"] == 0.0
+
+    def test_temperature_omitted_by_default(self, monkeypatch, pdf_file):
+        client = _build_client(monkeypatch)
+        client.client.messages.create.return_value = SimpleNamespace(
+            content=[SimpleNamespace(text="analysis")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        client.analyze_file_with_usage(str(pdf_file), "summarize")
+        kwargs = client.client.messages.create.call_args.kwargs
+        assert "temperature" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Judge factories pin temperature=0.0 (#2094 AC-5)
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeFactoryTemperature:
+    def test_action_item_quality_pins_temperature_zero(self, monkeypatch):
+        spy = MagicMock()
+        monkeypatch.setattr("gaia.eval.claude.ClaudeClient", spy)
+
+        from gaia.eval.action_item_quality import make_claude_judge
+
+        make_claude_judge(model="claude-sonnet-4-6")
+
+        spy.assert_called_once_with(model="claude-sonnet-4-6", temperature=0.0)
+
+    def test_briefing_quality_pins_temperature_zero(self, monkeypatch):
+        spy = MagicMock()
+        monkeypatch.setattr("gaia.eval.claude.ClaudeClient", spy)
+
+        from gaia.eval.briefing_quality import make_claude_judge
+
+        make_claude_judge(model="claude-sonnet-4-6")
+
+        spy.assert_called_once_with(model="claude-sonnet-4-6", temperature=0.0)
+
+    def test_draft_quality_pins_temperature_zero(self, monkeypatch):
+        spy = MagicMock()
+        monkeypatch.setattr("gaia.eval.claude.ClaudeClient", spy)
+
+        from gaia.eval.draft_quality import make_claude_judge
+
+        make_claude_judge(model="claude-sonnet-4-6")
+
+        spy.assert_called_once_with(model="claude-sonnet-4-6", temperature=0.0)

--- a/tests/unit/eval/test_scorecard_gate.py
+++ b/tests/unit/eval/test_scorecard_gate.py
@@ -10,9 +10,10 @@ import yaml
 from gaia.eval.release_scorecard import (
     ResultPayload,
     compute_aggregate,
+    parse_scorecard,
     render_scorecard,
 )
-from gaia.eval.scorecard_gate import main
+from gaia.eval.scorecard_gate import env_ctx_size, main
 
 # ---------------------------------------------------------------------------
 # Helper
@@ -588,3 +589,42 @@ class TestCtxSizeMismatch:
             tmp_path / "SCORECARD.md", version="0.3.1", within_one=0.85
         )
         assert main(["--scorecard", str(cand), "--require-ctx-match"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# env_ctx_size — public helper (#2094): email_scorecard_refresh.yml's `pre`
+# step imports this directly to read the committed card's ctx stamp before
+# any eval spend, so it must be importable without the leading underscore.
+# ---------------------------------------------------------------------------
+
+
+class TestEnvCtxSizePublicHelper:
+    def test_stamped_card_returns_ctx_size(self, tmp_path):
+        cand = _make_acceptance_card(
+            tmp_path / "SCORECARD.md",
+            version="0.3.1",
+            within_one=0.85,
+            environment={"ctx_size": 16384},
+        )
+        parsed = parse_scorecard(cand)
+        assert env_ctx_size(parsed) == 16384
+
+    def test_legacy_unstamped_card_returns_none(self, tmp_path):
+        # The current real state of hub/agents/npm/agent-email/SCORECARD.md
+        # (#2094): committed before #1892's ctx envelope landed, so it carries
+        # no recipe.environment.ctx_size at all.
+        cand = _make_acceptance_card(
+            tmp_path / "SCORECARD.md", version="0.3.0", within_one=0.834
+        )
+        parsed = parse_scorecard(cand)
+        assert env_ctx_size(parsed) is None
+
+    def test_environment_present_without_ctx_size_key_returns_none(self):
+        # Defensive: an environment block that carries other keys but not
+        # ctx_size must not be mistaken for a stamped card.
+        parsed = {"recipe": {"environment": {"gpu": "stx-halo"}}}
+        assert env_ctx_size(parsed) is None
+
+    def test_non_dict_environment_returns_none(self):
+        parsed = {"recipe": {"environment": None}}
+        assert env_ctx_size(parsed) is None


### PR DESCRIPTION
Closes #2094

## Why this matters

The email agent's published quality card — the accuracy figure integrators rely on — is refreshed by an automated workflow that was supposed to reject any change making quality worse. Two hours ago that workflow did the opposite: it auto-committed a card claiming **100% accuracy measured on 25 emails in a single run**, silently replacing the real figure (83.4%, measured over 249 emails, repeated 3 times). Its regression check approved the swap *because 1.0 beats 0.834* — it compares only the number, never the basis the number was measured on, so a small lucky sample reads as an improvement. That card is sitting on an open, merge-ready PR right now (flagged in #2060); `main` is still clean.

That incident reframes this issue. #2094 was filed because the workflow had never once completed — a hand-typed `timeout-minutes: 90` against a ~2h workload. #2089's interim limit cut (60→25) made it fast enough to finish, which means the failure mode changed rather than went away: **a workflow that reliably died became one that reliably publishes a meaningless number.** The loud failure was the safer bug.

After this PR: a subset-sized run physically cannot commit a card, a run that would downgrade the published basis (fewer emails, fewer repeats, or a different context window) is rejected in seconds before spending any eval time, a sub-bar card can never reach the published surface, and an overrun fails at a named step instead of a silent job-level `cancelled`. The per-push trigger — which fired the incident above, unasked, from an unrelated refactor branch merging `main` — is gone; refresh is now a deliberate dispatch, and the budget is derived from measured step times with the arithmetic recorded in the workflow.

## Evidence

**1. The bug this prevents, firing in production** — [run 29457164041](https://github.com/amd/gaia/actions/runs/29457164041) (old workflow, `main`'s version) auto-committed [`2e21edb9`](https://github.com/amd/gaia/commit/2e21edb9):

| | before | after the auto-commit |
|---|---|---|
| corpus / repeats | 250 / 3 | **25 / 1** |
| within-one accuracy | 0.834 (stdev 0.0116) | **1.0 (stdev 0.0)** |

Under this PR that run is a SUBSET profile: it evaluates, prints `SUBSET RUN -- card NOT committed`, restores the card, and exits 0.

**2. Basis guard rejects a downgrade before spending eval time** — [run 29458595361](https://github.com/amd/gaia/actions/runs/29458595361), dispatched `limit=250 experiments=3 ctx_size=16384 rebaseline=false`:

```
##[error]Basis mismatch -- committed card ctx_size=<unstamped> vs requested ctx_size=16384.
Re-dispatch at the committed ctx_size to compare apples-to-apples, or pass rebaseline=true
with a rebaseline_reason to move the basis deliberately.
Re-dispatch command: gh workflow run email_scorecard_refresh.yml --ref ... -f rebaseline=true ...
```

Failed at the **named step** `Resolve version, committed basis, and fail fast on a basis mismatch` in **6 seconds** — the whole run cost ~2 minutes instead of ~2 hours. This is AC-3 (loud, step-named failure) and the AC-4 guard in one artifact.

**3. Subset end-to-end + 4. full-corpus terminal step** — dispatched; posted as a follow-up comment.

<details>
<summary>Budget derivation (AC-2) — measured, not guessed</summary>

Ceilings derive from [run 29433392568](https://github.com/amd/gaia/actions/runs/29433392568) and are recorded in the workflow header beside the arithmetic. The judge legs are fixed-size (19/21/11 cases) and don't shrink with `limit`, so they dominate a subset run: tonight's 50-minute run spent 34:25 of it in judges.

| step | ceiling (full / subset) |
|---|---|
| benchmark | 620 / 45 |
| drafting · action-item · briefing judges | 35 · 45 · 25 (both profiles) |
| setup | 35 |
| five short steps @10 | 50 |
| **job** | **840 (sum 810) / 240 (sum 235)** |

The old value, 90, was never derived from a measurement. The job timeout is now only a backstop — every long step carries its own ceiling so an overrun names itself.
</details>

## Tests

- [x] Unit: `python -m pytest tests/unit/eval/ -q` → **471 passed, 1 deselected** (pre-existing worktree `.env` failure, reproduced identically at `origin/main`)
- [x] Judge pin (AC-5): `python -m pytest tests/unit/eval/test_claude_judge.py -v` → **28 passed**; 18 new tests cover all 6 `messages.create` sites across 4 public methods. Tests were authored against the acceptance criteria before the implementation existed, and pin the judge to `temperature=0.0` — with agent generation already at temp 0, the judge's own sampling was the last uncontrolled variance source
- [x] Lint: `python util/lint.py --all` → Black / isort / Pylint / Flake8 OK
- [x] Static: `actionlint` → 31→30 findings, **zero new** (remainder are pre-existing PowerShell-parsed-as-bash false positives already on `main`). Static only — it cannot prove the ternaries evaluate correctly or that PS 5.1 survives the string encoding; the dispatched runs above are the real validation
- [x] Real-world: basis-guard fail-fast (evidence 2) ✅
- [ ] Real-world: subset end-to-end, terminal = NOT-COMMITTED
- [ ] Real-world: full-corpus, terminal = commit or loud rejection

## Notes for the reviewer

- **The full-corpus run is expected to *reject*, not commit.** Prior measurement puts 16K at ~0.796 against the enforced 0.80 floor. That is the guard working: the card stays at its current basis and the measured number goes back for a decision (adjacent to #2090). The bar does not move to make the run pass.
- **Known residual gap:** this workflow can only govern what *it* commits. A human hand-editing `SCORECARD.md` in an unrelated PR bypasses every guard here.
- **Follow-up owed, deliberately not absorbed:** six sibling workflows (`test_api`, `test_embeddings`, `test_lemonade_server`, `test_rag`, `build_cpp`, `test_examples`) share the `stx` runner label *outside* the `lemonade-eval` concurrency group, and most run `cleanup-lemonade.ps1`, which force-kills port 13305 — so an unrelated PR can kill a long eval mid-run. Widening the group is the right fix and needs its own issue.
- **Unrelated anomaly spotted in the incident data:** the briefing judge finished in 36s against a ~11-15 min estimate — possibly a silent no-op. Noted on #2094, not fixed here.
- `scorecard_gate.py` is touched additively only: `_env_ctx_size` → public `env_ctx_size` (+4 tests), because the guard must read the ctx stamp from `recipe.environment`, and re-deriving that path in workflow PowerShell is how this class of bug gets written twice. No gate semantics, thresholds, or flags changed.
