### PR TITLE
feat(webui): render→component map + generic render primitives (V2-9)

### DIFF
--- a/docs/spec/agent-ui-query-sse-contract.md
+++ b/docs/spec/agent-ui-query-sse-contract.md
@@ -234,6 +234,42 @@ injection is deleted. Each `render` type still needs a frontend component; per
 §0.15 a **custom `render` type is first-party / AMD-verified only in v1**, and an
 unknown `render` degrades to the generic result card (see §7).
 
+### 4.3 Generic render primitives (#2108)
+
+Beyond agent-specific keys like `email_pre_scan`, the Agent UI registers five
+**generic primitives** any agent can emit on `tool_result.render` without
+shipping its own frontend component. `data` must match the schema for the key:
+
+| `render` | `data` schema |
+|---|---|
+| `table` | `{ title?: string, columns: string[], rows: Array<Array<string\|number\|boolean\|null>> }` |
+| `key_value` | `{ title?: string, items: Array<{key: string, value: string\|number\|boolean\|null}> }` |
+| `list` | `{ title?: string, ordered?: boolean, items: Array<string\|number> }` |
+| `image` | `{ src: string, alt?: string, caption?: string }` |
+| `diff` | `{ title?: string, unified: string }` — a unified-diff text; lines are styled by their `+` / `-` / `@@` prefix |
+
+Rules every receiver implements and every producer can rely on:
+
+- **Fallback, never nothing.** An unknown `render` key renders an explicit
+  `Unsupported card type: "<render>"` card; a payload that fails its schema
+  renders `Invalid <render> payload`. Both include a collapsible dump of the
+  raw `data` so the turn stays debuggable. A card is never silently dropped
+  and a bad card never blanks the message.
+- **`image.src` accepts only inline base64 raster data** matching
+  `^data:image/(png|jpe?g|gif|webp);base64,` — SVG is deliberately excluded
+  (it can carry script), and remote URLs (`http(s)://`) are rejected. Anything
+  else is an invalid payload.
+- **500-item render cap.** `table` rows, `list` items, and `key_value` items
+  render at most 500 entries; the card shows a visible `+N more (truncated)`
+  row when capped. Producers should pre-trim to what the user actually needs.
+- **Values are rendered as plain text** — markdown/HTML inside cell, item, or
+  key/value strings is NOT interpreted.
+
+**Author guidance:** default to these primitives — they need zero frontend
+work and render consistently. A custom `render` key requires a first-party /
+AMD-verified frontend component in v1 (§0.15); until yours ships, emitting it
+degrades to the unsupported-card fallback.
+
 ---
 
 ## 5. `needs_confirmation` and the confirmation model

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -11,7 +11,7 @@ import * as api from '../services/api';
 import { log } from '../utils/logger';
 import { bugReportUrl } from './UnsupportedFeature';
 import { getAgentIcon } from './agentIcons';
-import type { Message, StreamEvent, AgentStep, Attachment, Session, AgentInfo } from '../types';
+import type { Message, StreamEvent, AgentStep, Attachment, Session, AgentInfo, RenderCardData } from '../types';
 
 import './ChatView.css';
 import DashboardProgress from './DashboardProgress';
@@ -171,6 +171,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         sessions, messages, setMessages, addMessage, removeMessage, removeMessagesFrom, updateSessionInList,
         isStreaming, streamingContent, setStreaming, setStreamContent, clearStreamContent,
         agentSteps, addAgentStep, updateLastAgentStep, appendThinkingContent, updateLastToolStep, clearAgentSteps,
+        cards, appendCard, clearCards,
         documents, setDocuments, setShowDocLibrary, setShowFileBrowser, setShowMemoryDashboard, isLoadingMessages, setLoadingMessages,
         systemStatus,
         agents, activeAgentId, setActiveAgentId,
@@ -251,6 +252,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
     const [streamEnding, setStreamEnding] = useState(false);
     const lastStreamContentRef = useRef('');
     const lastAgentStepsRef = useRef<AgentStep[]>([]);
+    const lastCardsRef = useRef<RenderCardData[]>([]);
     const prevStreamingRef = useRef(false);
     // Continuously snapshot the streaming state so we have it when streaming ends
     useEffect(() => {
@@ -260,12 +262,16 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         if (agentSteps.length > 0) lastAgentStepsRef.current = agentSteps.map(s => ({ ...s, active: false }));
     }, [agentSteps]);
     useEffect(() => {
+        if (cards.length > 0) lastCardsRef.current = [...cards];
+    }, [cards]);
+    useEffect(() => {
         if (!isStreaming && prevStreamingRef.current) {
             setStreamEnding(true);
             const timer = setTimeout(() => {
                 setStreamEnding(false);
                 lastStreamContentRef.current = '';
                 lastAgentStepsRef.current = [];
+                lastCardsRef.current = [];
             }, 350);
             return () => clearTimeout(timer);
         }
@@ -492,6 +498,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         if (content) {
             log.stream.info(`Saving partial response (${content.length} chars)`);
             const currentSteps = storeState.agentSteps;
+            const currentCards = storeState.cards;
             const assistantMsg: Message = {
                 id: Date.now() + 1,
                 session_id: sessionId,
@@ -500,6 +507,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 created_at: new Date().toISOString(),
                 rag_sources: null,
                 agentSteps: currentSteps.length > 0 ? [...currentSteps] : undefined,
+                cards: currentCards.length > 0 ? [...currentCards] : undefined,
             };
             addMessage(assistantMsg);
         }
@@ -508,7 +516,8 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         clearStreamContent();
         setCompletedSteps([]);
         clearAgentSteps();
-    }, [sessionId, addMessage, setStreaming, clearStreamContent, clearAgentSteps]);
+        clearCards();
+    }, [sessionId, addMessage, setStreaming, clearStreamContent, clearAgentSteps, clearCards]);
 
     // Global keyboard shortcuts: Escape → stop streaming, Ctrl+K → focus sidebar search
     useEffect(() => {
@@ -711,6 +720,9 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
         setStreaming(true);
         clearStreamContent();
         clearAgentSteps();
+        // Also covers attach-replay dedupe — attachToRun replays all events
+        // from the start, so stale cards would double up without this.
+        clearCards();
         setCompletedSteps([]);
         stepIdRef.current = 0;
         toolOccurredRef.current = false;
@@ -879,6 +891,11 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                     return;
                 }
                 if (event.type === 'tool_result') {
+                    // Structured card (#2108): a non-empty render key mounts a
+                    // registered card component against event.data.
+                    if (typeof event.render === 'string' && event.render.length > 0) {
+                        appendCard({ render: event.render, data: event.data });
+                    }
                     const updates: Partial<AgentStep> = {
                         result: event.summary || event.title || 'Done',
                         active: false,
@@ -1017,6 +1034,8 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 const stepsSnapshot = useChatStore.getState().agentSteps.map((s) => ({
                     ...s, active: false,
                 }));
+                // Snapshot streaming cards (#2108) — same lifecycle as steps.
+                const cardsSnapshot = [...useChatStore.getState().cards];
 
                 const hasPolicyAlert = stepsSnapshot.some((s) => s.type === 'policy_alert');
                 if (content || hasPolicyAlert) {
@@ -1031,6 +1050,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                         rag_sources: null,
                         agentSteps: stepsSnapshot.length > 0 ? stepsSnapshot : undefined,
                         stats: event.stats || undefined,
+                        cards: cardsSnapshot.length > 0 ? cardsSnapshot : undefined,
                     };
                     addMessage(assistantMsg);
                 }
@@ -1039,6 +1059,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 setStreaming(false);
                 clearStreamContent();
                 clearAgentSteps();
+                clearCards();
 
                 // Refocus input so user can immediately type the next message
                 if (inputRef.current) inputRef.current.focus();
@@ -1051,11 +1072,21 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                     api.getMessages(sessionId)
                         .then((data) => {
                             if (isStale()) return;
+                            // The backend doesn't persist cards, so this replace
+                            // would drop them — merge from the pre-refetch
+                            // in-memory messages by id, else role+content.
+                            // #2109 replaces this merge with steps-derived hydration.
+                            const prevWithCards = useChatStore.getState().messages
+                                .filter((m) => m.cards && m.cards.length > 0);
                             const msgs: Message[] = (data.messages || []).map((m: any) => {
+                                const prev = prevWithCards.find(
+                                    (p) => p.id === m.id || (p.role === m.role && p.content === m.content),
+                                );
                                 return {
                                     ...m,
                                     agentSteps: m.agentSteps || m.agent_steps || undefined,
                                     stats: m.stats || m.inference_stats || undefined,
+                                    cards: prev?.cards,
                                 };
                             });
                             setMessages(msgs);
@@ -1126,6 +1157,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 setStreaming(false);
                 clearStreamContent();
                 clearAgentSteps();
+                clearCards();
             },
             onAgentCreated: () => {
                 // A new agent was created — refresh the list so it appears
@@ -1141,7 +1173,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
             : api.sendMessageStream(sessionId, messageText, streamCallbacks, undefined, undefined, activeAgentId);
 
         abortRef.current = controller;
-    }, [input, attachments, isStreaming, sessionId, session, addMessage, setMessages, setStreaming, flushStreamBuffer, clearStreamContent, updateSessionInList, addAgentStep, updateLastAgentStep, appendThinkingContent, updateLastToolStep, clearAgentSteps, activeAgentId, addNotification, isStale]);
+    }, [input, attachments, isStreaming, sessionId, session, addMessage, setMessages, setStreaming, flushStreamBuffer, clearStreamContent, updateSessionInList, addAgentStep, updateLastAgentStep, appendThinkingContent, updateLastToolStep, clearAgentSteps, appendCard, clearCards, activeAgentId, addNotification, isStale]);
 
     // Keep ref in sync so event listeners always call the latest sendMessage
     sendMessageRef.current = sendMessage;
@@ -1670,6 +1702,7 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                             showTerminalCursor={streamEnding}
                             agentSteps={isStreaming ? agentSteps : lastAgentStepsRef.current}
                             agentStepsActive={isStreaming && agentSteps.some(s => s.active)}
+                            cards={isStreaming ? cards : lastCardsRef.current}
                             agentName={activeAgentName}
                         />
                     </div>

--- a/src/gaia/apps/webui/src/components/MessageBubble.tsx
+++ b/src/gaia/apps/webui/src/components/MessageBubble.tsx
@@ -9,10 +9,11 @@ import remarkGfm from 'remark-gfm';
 import { AgentActivity } from './AgentActivity';
 import { EmailConnectCta, isAuthRequiredMessage } from './email/EmailConnectCta';
 import { EmailPreScanCard, isPreScanPayload } from './email/EmailPreScanCard';
+import { RenderCard } from './render/RenderCard';
 import * as api from '../services/api';
 import { log } from '../utils/logger';
 import gaiaRobot from '../assets/gaia-robot.png';
-import type { Message, AgentStep } from '../types';
+import type { Message, AgentStep, RenderCardData } from '../types';
 import './MessageBubble.css';
 
 interface MessageBubbleProps {
@@ -24,6 +25,10 @@ interface MessageBubbleProps {
     agentSteps?: AgentStep[];
     /** Whether agent steps are currently active (streaming). */
     agentStepsActive?: boolean;
+    /** Live-streaming cards (issue #2108). `message.cards` wins when set —
+     *  this prop carries in-flight cards for the synthetic streaming bubble,
+     *  mirroring how `agentSteps` reaches it. */
+    cards?: RenderCardData[];
     /** Called when user clicks the delete button. */
     onDelete?: (messageId: number) => void;
     /** Called when user clicks the resend button (user messages only). */
@@ -354,7 +359,7 @@ function formatLatency(ms: number): string {
     return `${(ms / 1000).toFixed(1)}s`;
 }
 
-export function MessageBubble({ message, isStreaming, showTerminalCursor, agentSteps, agentStepsActive, onDelete, onResend, latencyMs, agentName }: MessageBubbleProps) {
+export function MessageBubble({ message, isStreaming, showTerminalCursor, agentSteps, agentStepsActive, cards, onDelete, onResend, latencyMs, agentName }: MessageBubbleProps) {
     const isError = message.role === 'assistant' && isErrorContent(message.content);
     // Memoize the expensive LLM content cleaning (brace-depth parser) so it
     // doesn't re-run on every render — only when message content changes.
@@ -505,6 +510,12 @@ export function MessageBubble({ message, isStreaming, showTerminalCursor, agentS
                             <span>Something went wrong</span>
                         </div>
                     )}
+                    {/* Structured cards (#2108) — finalized message.cards wins;
+                        the prop is the live-streaming path. Always above the
+                        markdown content. */}
+                    {(message.cards ?? cards)?.map((card, i) => (
+                        <RenderCard key={i} render={card.render} data={card.data} />
+                    ))}
                     <RenderedContent content={cleanedContent} showCursor={(isStreaming || showTerminalCursor) && !!cleanedContent && !agentStepsActive} />
                     {message.role === 'assistant'
                         && !isStreaming

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.cards.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.cards.test.tsx
@@ -1,0 +1,285 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Contract tests for the streaming-cards wiring in ChatView (issue #2108):
+ * `tool_result` events with a non-empty `render` field append a card to the
+ * store, the live streaming bubble shows cards mid-stream, and cards survive
+ * onDone / handleStop / resetStreaming / onError in the ways #1580's
+ * session-switch guard already established for agent steps.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatView } from '../ChatView';
+import { useChatStore } from '../../stores/chatStore';
+import type { AgentInfo, Session, StreamEvent } from '../../types';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+const mockedApi = vi.mocked(api);
+
+const SESSION: Session = {
+    id: 'session-1',
+    // Deliberately NOT 'New Task' — skips onDone's auto-title branch entirely.
+    title: 'Existing chat',
+    created_at: '2026-06-10T00:00:00Z',
+    updated_at: '2026-06-10T00:00:00Z',
+    model: 'qwen',
+    system_prompt: null,
+    message_count: 0,
+    document_ids: [],
+    agent_type: 'doc',
+};
+
+const DOC_AGENT: AgentInfo = {
+    id: 'doc',
+    name: 'Doc Agent',
+    description: 'Search and answer questions from indexed documents.',
+    source: 'builtin',
+    conversation_starters: ['Find contract clauses'],
+    models: [],
+    tags: ['rag', 'files'],
+    icon: 'file-text',
+    tools_count: 3,
+};
+
+const preScanPayload = {
+    kind: 'email_pre_scan',
+    urgent: [{ message_id: 'm1', sender: 'Alice <alice@example.com>', subject: 'Server down' }],
+    actionable: [],
+    informational_count: 2,
+    suggested_archives: [],
+    suggested_drafts: [],
+};
+
+const toolResultWithRender = {
+    type: 'tool_result',
+    tool: 'pre_scan_inbox',
+    summary: 'Scanned',
+    render: 'email_pre_scan',
+    data: preScanPayload,
+} as unknown as StreamEvent;
+
+const toolResultWithoutRender = {
+    type: 'tool_result',
+    tool: 'search_documents',
+    summary: 'ok',
+} as unknown as StreamEvent;
+
+let capturedCallbacks: api.StreamCallbacks | null = null;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCallbacks = null;
+
+    mockedApi.getMessages.mockResolvedValue({ messages: [], total: 0 });
+    mockedApi.getActiveRuns.mockResolvedValue({ session_ids: [] });
+    mockedApi.listDocuments.mockResolvedValue({
+        documents: [],
+        total: 0,
+        total_size_bytes: 0,
+        total_chunks: 0,
+    });
+    mockedApi.cancelStream.mockResolvedValue(undefined as never);
+    mockedApi.updateSession.mockResolvedValue(undefined as never);
+    mockedApi.sendMessageStream.mockImplementation((_sid, _msg, cbs) => {
+        capturedCallbacks = cbs as api.StreamCallbacks;
+        return new AbortController();
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: vi.fn(),
+    });
+
+    useChatStore.setState({
+        agents: [DOC_AGENT],
+        activeAgentId: 'doc',
+        sessions: [SESSION],
+        currentSessionId: SESSION.id,
+        messages: [],
+        documents: [],
+        isStreaming: false,
+        streamingContent: '',
+        agentSteps: [],
+        cards: [],
+        isLoadingMessages: false,
+        pendingPrompt: null,
+        systemStatus: null,
+    });
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+/** Type/render + click Send, and wait for sendMessageStream to be invoked. */
+async function driveSend() {
+    render(<ChatView sessionId={SESSION.id} />);
+
+    await act(async () => {
+        fireEvent.change(screen.getByLabelText('Message input'), {
+            target: { value: 'scan my inbox' },
+        });
+        fireEvent.click(screen.getByLabelText('Send message'));
+    });
+
+    expect(capturedCallbacks).not.toBeNull();
+}
+
+describe('ChatView streaming cards (#2108)', () => {
+    it('appends a card on tool_result.render and shows it in the live streaming bubble', async () => {
+        await driveSend();
+
+        act(() => {
+            capturedCallbacks!.onAgentEvent({ type: 'tool_start', tool: 'pre_scan_inbox' } as unknown as StreamEvent);
+        });
+        act(() => {
+            capturedCallbacks!.onAgentEvent(toolResultWithRender);
+        });
+
+        const cards = useChatStore.getState().cards;
+        expect(cards).toHaveLength(1);
+        expect(cards[0].render).toBe('email_pre_scan');
+
+        // Live bubble renders the card mid-stream, before any onDone.
+        expect(screen.getByText('Server down')).toBeInTheDocument();
+    });
+
+    it('does not append a card for a tool_result without a render field', async () => {
+        await driveSend();
+
+        act(() => {
+            capturedCallbacks!.onAgentEvent(toolResultWithoutRender);
+        });
+
+        expect(useChatStore.getState().cards).toEqual([]);
+        expect(document.querySelector('.render-card')).toBeNull();
+    });
+
+    it('onDone transfers cards onto the finalized message and clears the store', async () => {
+        vi.useFakeTimers();
+        try {
+            await driveSend();
+
+            act(() => {
+                capturedCallbacks!.onAgentEvent({ type: 'tool_start', tool: 'pre_scan_inbox' } as unknown as StreamEvent);
+            });
+            act(() => {
+                capturedCallbacks!.onAgentEvent(toolResultWithRender);
+            });
+
+            // The backend's view of getMessages does NOT return a cards field —
+            // the refetch-merge must reattach cards from the pre-refetch message.
+            mockedApi.getMessages.mockResolvedValue({
+                messages: [
+                    {
+                        id: 10,
+                        session_id: SESSION.id,
+                        role: 'user',
+                        content: 'scan my inbox',
+                        created_at: '2026-07-16T00:00:00.000Z',
+                        rag_sources: null,
+                    },
+                    {
+                        id: 11,
+                        session_id: SESSION.id,
+                        role: 'assistant',
+                        content: 'Here is your inbox summary.',
+                        created_at: '2026-07-16T00:00:01.000Z',
+                        rag_sources: null,
+                    },
+                ],
+                total: 2,
+            });
+
+            act(() => {
+                capturedCallbacks!.onDone({ type: 'done', content: 'Here is your inbox summary.' } as unknown as StreamEvent);
+            });
+
+            // Advance past the 350ms streamEnding window (the 300ms refetch fires
+            // inside this same window), then flush the resolved-promise microtasks.
+            act(() => {
+                vi.advanceTimersByTime(400);
+            });
+            await act(async () => {});
+
+            expect(screen.getByText('Server down')).toBeInTheDocument();
+            expect(useChatStore.getState().cards).toEqual([]);
+
+            const assistantMsg = useChatStore.getState().messages.find((m) => m.role === 'assistant');
+            expect(assistantMsg?.cards).toHaveLength(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('handleStop transfers in-flight cards onto the partial message', async () => {
+        vi.useFakeTimers();
+        try {
+            await driveSend();
+
+            // handleStop only saves a partial message when content is non-empty.
+            act(() => {
+                capturedCallbacks!.onChunk({ type: 'chunk', content: 'partial answer text' } as unknown as StreamEvent);
+            });
+            act(() => {
+                capturedCallbacks!.onAgentEvent({ type: 'tool_start', tool: 'pre_scan_inbox' } as unknown as StreamEvent);
+            });
+            act(() => {
+                capturedCallbacks!.onAgentEvent(toolResultWithRender);
+            });
+
+            act(() => {
+                fireEvent.click(screen.getByLabelText('Stop generating'));
+            });
+
+            // Stay under the 3s message-poll interval so a stray poll doesn't
+            // clobber the partial message while still clearing the 350ms
+            // streamEnding window.
+            act(() => {
+                vi.advanceTimersByTime(400);
+            });
+            await act(async () => {});
+
+            const assistantMsg = useChatStore.getState().messages.find((m) => m.role === 'assistant');
+            expect(assistantMsg?.cards).toHaveLength(1);
+            expect(screen.getByText('Server down')).toBeInTheDocument();
+            expect(useChatStore.getState().cards).toEqual([]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('resetStreaming (session switch) wipes in-flight cards', async () => {
+        await driveSend();
+
+        act(() => {
+            capturedCallbacks!.onAgentEvent(toolResultWithRender);
+        });
+        expect(useChatStore.getState().cards).toHaveLength(1);
+
+        act(() => {
+            useChatStore.getState().resetStreaming();
+        });
+
+        expect(useChatStore.getState().cards).toEqual([]);
+    });
+
+    it('onError clears cards', async () => {
+        await driveSend();
+
+        act(() => {
+            capturedCallbacks!.onAgentEvent(toolResultWithRender);
+        });
+        expect(useChatStore.getState().cards).toHaveLength(1);
+
+        act(() => {
+            capturedCallbacks!.onError(new Error('boom'));
+        });
+
+        expect(useChatStore.getState().cards).toEqual([]);
+    });
+});

--- a/src/gaia/apps/webui/src/components/__tests__/MessageBubble.cards.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/MessageBubble.cards.test.tsx
@@ -1,0 +1,92 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Contract tests for MessageBubble's `cards` rendering (issue #2108):
+ * `message.cards` (finalized) wins over the `cards` prop (live-streaming),
+ * both render via RenderCard, and they are positioned ABOVE the markdown
+ * content in DOM order.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MessageBubble } from '../MessageBubble';
+import type { Message, RenderCardData } from '../../types';
+
+const minimalMessage: Message = {
+    id: 1,
+    session_id: 'sess-1',
+    role: 'assistant',
+    content: 'hello world',
+    created_at: '2026-07-16T00:00:00.000Z',
+    rag_sources: null,
+};
+
+// A `table` card whose rendered cell text is unique and unambiguous —
+// success is `getByText('cell-val')` / `getByRole('table')`.
+const messageTableCard: RenderCardData = {
+    render: 'table',
+    data: { columns: ['Col1'], rows: [['cell-val']] },
+};
+
+// A second, distinct table card so the "message wins over prop" test can
+// prove which payload actually rendered.
+const propTableCard: RenderCardData = {
+    render: 'table',
+    data: { columns: ['Col1'], rows: [['prop-only-val']] },
+};
+
+describe('MessageBubble cards rendering (#2108)', () => {
+    it('renders message.cards above the markdown content', () => {
+        const { container } = render(
+            <MessageBubble message={{ ...minimalMessage, cards: [messageTableCard] }} />
+        );
+
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByText('cell-val')).toBeInTheDocument();
+
+        const card = container.querySelector('.render-card');
+        const mdContent = container.querySelector('.md-content');
+        expect(card).not.toBeNull();
+        expect(mdContent).not.toBeNull();
+
+        // card precedes md-content in DOM order: md-content must FOLLOW the card.
+        const position = card!.compareDocumentPosition(mdContent!);
+        expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('renders the cards prop when message.cards is undefined (live-streaming path)', () => {
+        render(<MessageBubble message={minimalMessage} cards={[messageTableCard]} />);
+
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByText('cell-val')).toBeInTheDocument();
+    });
+
+    it('message.cards wins when both message.cards and the cards prop are set', () => {
+        render(
+            <MessageBubble
+                message={{ ...minimalMessage, cards: [messageTableCard] }}
+                cards={[propTableCard]}
+            />
+        );
+
+        expect(screen.getByText('cell-val')).toBeInTheDocument();
+        expect(screen.queryByText('prop-only-val')).not.toBeInTheDocument();
+    });
+
+    it('renders no card when neither message.cards nor the cards prop are set', () => {
+        const { container } = render(<MessageBubble message={minimalMessage} />);
+
+        expect(container.querySelector('.render-card')).toBeNull();
+    });
+
+    it('falls back to the Unsupported card for an unknown render key in message.cards', () => {
+        render(
+            <MessageBubble
+                message={{ ...minimalMessage, cards: [{ render: 'not_a_real_card', data: {} }] }}
+            />
+        );
+
+        expect(screen.getByText('Unsupported card type: "not_a_real_card"')).toBeInTheDocument();
+    });
+});

--- a/src/gaia/apps/webui/src/components/__tests__/MessageBubble.fence.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/MessageBubble.fence.test.tsx
@@ -1,0 +1,80 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Characterization tests for MessageBubble's fenced ``email_pre_scan``
+ * code-block path: STRUCTURED_FENCE_RE, promoteStructuredPayloads, and the
+ * EmailPreScanCard mount.
+ *
+ * These pin TODAY's behavior as a baseline for issue #2109, which is
+ * expected to delete/replace this path with the render-registry system
+ * (see render-registry.test.tsx). All three tests must pass against the
+ * current, unmodified codebase — if this path changes intentionally in the
+ * future, update these tests to match the new reality; never edit
+ * MessageBubble.tsx to satisfy an assertion written against a stale
+ * understanding of it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MessageBubble } from '../MessageBubble';
+import type { Message } from '../../types';
+
+const minimalMessage: Message = {
+    id: 1,
+    session_id: 'sess-1',
+    role: 'assistant',
+    content: '',
+    created_at: '2026-07-16T00:00:00.000Z',
+    rag_sources: null,
+};
+
+// Minimal payload satisfying EmailPreScanCard's isPreScanPayload(). The
+// angle-bracket sender email is deliberate: it is the reason RenderedContent
+// bypasses ReactMarkdown for this fence in the first place (remark-gfm's
+// autolink handling of `<email@domain>` corrupts fence detection), so this
+// fixture exercises the exact shape the bypass exists for.
+const payload = {
+    kind: 'email_pre_scan',
+    urgent: [{ message_id: 'm1', sender: 'Alice <alice@example.com>', subject: 'Server down' }],
+    actionable: [],
+    informational_count: 2,
+    suggested_archives: [],
+    suggested_drafts: [],
+};
+
+describe('MessageBubble fenced email_pre_scan characterization', () => {
+    it('renders EmailPreScanCard for a fenced email_pre_scan block', () => {
+        const content = '```email_pre_scan\n' + JSON.stringify(payload) + '\n```';
+
+        render(<MessageBubble message={{ ...minimalMessage, content }} />);
+
+        expect(screen.getByText('Server down')).toBeInTheDocument();
+    });
+
+    it('renders EmailPreScanCard identically for bare leading JSON (promoteStructuredPayloads)', () => {
+        // No fence markers at all — promoteStructuredPayloads must wrap this
+        // in a fence itself before RenderedContent's STRUCTURED_FENCE_RE runs.
+        const content = JSON.stringify(payload);
+
+        render(<MessageBubble message={{ ...minimalMessage, content }} />);
+
+        expect(screen.getByText('Server down')).toBeInTheDocument();
+    });
+
+    it('falls through to a plain code block for an invalid payload, without crashing', () => {
+        // Deliberately missing the required array fields (urgent, actionable,
+        // suggested_archives, suggested_drafts, informational_count), so
+        // isPreScanPayload returns false. No sender/email field here — this
+        // case is isolated from the autolink concern above.
+        const invalidPayload = { kind: 'email_pre_scan' };
+        const content = '```email_pre_scan\n' + JSON.stringify(invalidPayload) + '\n```';
+
+        // A successful render() call below (no uncaught exception) is itself
+        // the proof this does not crash.
+        const { container } = render(<MessageBubble message={{ ...minimalMessage, content }} />);
+
+        expect(screen.queryByRole('region', { name: 'Inbox pre-scan' })).toBeNull();
+        expect(container.querySelector('.code-block')).not.toBeNull();
+    });
+});

--- a/src/gaia/apps/webui/src/components/__tests__/render-primitives.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/render-primitives.test.tsx
@@ -60,6 +60,17 @@ describe('table primitive', () => {
 
         expect(screen.getByText('Invalid table payload')).toBeInTheDocument();
     });
+
+    it('caps columns at 500 and appends one truncation header cell', () => {
+        const columns = Array.from({ length: 501 }, (_, i) => `col-${i}`);
+        const { container } = render(<RenderCard render="table" data={{ columns, rows: [] }} />);
+
+        const headers = container.querySelectorAll('thead th');
+        expect(headers).toHaveLength(501);
+        expect(screen.getByText('col-499')).toBeInTheDocument();
+        expect(screen.queryByText('col-500')).not.toBeInTheDocument();
+        expect(screen.getByText('+1 more (truncated)')).toBeInTheDocument();
+    });
 });
 
 describe('key_value primitive', () => {
@@ -196,6 +207,28 @@ describe('diff primitive', () => {
         render(<RenderCard render="diff" data={{ unified: 42 }} />);
 
         expect(screen.getByText('Invalid diff payload')).toBeInTheDocument();
+    });
+
+    it('styles unified-diff file header lines as neutral, not added/removed', () => {
+        const unified = '--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new';
+        const { container } = render(<RenderCard render="diff" data={{ unified }} />);
+
+        const lines = Array.from(container.querySelectorAll('.render-diff__line'));
+
+        const minusHeader = lines.find((el) => el.textContent === '--- a/x');
+        const plusHeader = lines.find((el) => el.textContent === '+++ b/x');
+        const removedLine = lines.find((el) => el.textContent === '-old');
+        const addedLine = lines.find((el) => el.textContent === '+new');
+
+        expect(minusHeader).toBeTruthy();
+        expect(minusHeader?.className).toBe('render-diff__line');
+        expect(plusHeader).toBeTruthy();
+        expect(plusHeader?.className).toBe('render-diff__line');
+
+        expect(removedLine).toBeTruthy();
+        expect(removedLine?.classList.contains('render-diff__line--removed')).toBe(true);
+        expect(addedLine).toBeTruthy();
+        expect(addedLine?.classList.contains('render-diff__line--added')).toBe(true);
     });
 });
 

--- a/src/gaia/apps/webui/src/components/__tests__/render-primitives.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/render-primitives.test.tsx
@@ -1,0 +1,209 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Contract tests for the five generic render primitives added in issue
+ * #2108, Increment 2: `table`, `key_value`, `list`, `image`, `diff`.
+ *
+ * None of these render keys are registered yet — `CARD_REGISTRY` (see
+ * ../render/registry.tsx) only knows `email_pre_scan` as of Increment 1.
+ * Every assertion below that expects real card output is EXPECTED TO FAIL
+ * right now: RenderCard falls back to UnsupportedCard, so e.g.
+ * `screen.getByRole('table')` will not find anything. That is correct TDD —
+ * this file pins the frozen contract the Increment 2 implementer must
+ * conform to; do not loosen these assertions to match a different shape
+ * without confirming it against the plan in issue #2108.
+ *
+ * Only test #18 (oversized payload notice) is expected to pass today — it
+ * exercises UnsupportedCard behavior that already shipped in Increment 1.
+ *
+ * Everything is driven through the public `<RenderCard render data />`
+ * surface; the primitive components' file/module layout is the
+ * implementer's choice and is deliberately not imported here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RenderCard } from '../render/RenderCard';
+
+describe('table primitive', () => {
+    it('renders a real table with headers and cell text, wrapped in .render-table', () => {
+        const { container } = render(
+            <RenderCard render="table" data={{ columns: ['A', 'B'], rows: [[1, 'x']] }} />,
+        );
+
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByText('A')).toBeInTheDocument();
+        expect(screen.getByText('B')).toBeInTheDocument();
+        expect(screen.getByText('1')).toBeInTheDocument();
+        expect(screen.getByText('x')).toBeInTheDocument();
+        expect(container.querySelector('.render-table')).not.toBeNull();
+    });
+
+    it('renders an optional title', () => {
+        render(<RenderCard render="table" data={{ title: 'My Table', columns: ['A'], rows: [['v']] }} />);
+
+        expect(screen.getByText('My Table')).toBeInTheDocument();
+    });
+
+    it('caps rows at 500 and shows a truncation notice', () => {
+        const rows = Array.from({ length: 501 }, (_, i) => [`row-${i}`]);
+        render(<RenderCard render="table" data={{ columns: ['Name'], rows }} />);
+
+        expect(screen.getByText('row-499')).toBeInTheDocument();
+        expect(screen.queryByText('row-500')).not.toBeInTheDocument();
+        expect(screen.getByText('+1 more (truncated)')).toBeInTheDocument();
+    });
+
+    it('renders the invalid-payload fallback for a malformed payload', () => {
+        render(<RenderCard render="table" data={{ columns: 'nope' }} />);
+
+        expect(screen.getByText('Invalid table payload')).toBeInTheDocument();
+    });
+});
+
+describe('key_value primitive', () => {
+    it('renders each item key and value as visible text', () => {
+        render(<RenderCard render="key_value" data={{ items: [{ key: 'Status', value: 'ok' }] }} />);
+
+        expect(screen.getByText('Status')).toBeInTheDocument();
+        expect(screen.getByText('ok')).toBeInTheDocument();
+    });
+
+    it('renders the invalid-payload fallback for a malformed payload', () => {
+        render(<RenderCard render="key_value" data={{ items: [{ wrong: true }] }} />);
+
+        expect(screen.getByText('Invalid key_value payload')).toBeInTheDocument();
+    });
+});
+
+describe('list primitive', () => {
+    it('renders an <ol> with exactly the given <li> items when ordered', () => {
+        const { container } = render(
+            <RenderCard render="list" data={{ ordered: true, items: ['first', 'second'] }} />,
+        );
+
+        const ol = container.querySelector('ol');
+        expect(ol).not.toBeNull();
+        expect(ol?.querySelectorAll('li')).toHaveLength(2);
+        expect(screen.getByText('first')).toBeInTheDocument();
+        expect(screen.getByText('second')).toBeInTheDocument();
+    });
+
+    it('renders a <ul> (not <ol>) when ordered is omitted', () => {
+        const { container } = render(<RenderCard render="list" data={{ items: ['only'] }} />);
+
+        expect(container.querySelector('ul')).not.toBeNull();
+        expect(container.querySelector('ol')).toBeNull();
+    });
+
+    it('caps items at 500 and shows a truncation notice', () => {
+        const items = Array.from({ length: 501 }, (_, i) => `item-${i}`);
+        render(<RenderCard render="list" data={{ items }} />);
+
+        expect(screen.getByText('item-499')).toBeInTheDocument();
+        expect(screen.queryByText('item-500')).not.toBeInTheDocument();
+        expect(screen.getByText('+1 more (truncated)')).toBeInTheDocument();
+    });
+
+    it('renders the invalid-payload fallback for a malformed payload', () => {
+        render(<RenderCard render="list" data={{ items: 'nope' }} />);
+
+        expect(screen.getByText('Invalid list payload')).toBeInTheDocument();
+    });
+});
+
+describe('image primitive', () => {
+    it('renders an <img> with the exact src and alt attributes for a valid base64 PNG', () => {
+        const { container } = render(
+            <RenderCard render="image" data={{ src: 'data:image/png;base64,iVBORw0KGgo=', alt: 'chart' }} />,
+        );
+
+        const img = container.querySelector('img');
+        expect(img).not.toBeNull();
+        expect(img?.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=');
+        expect(img?.getAttribute('alt')).toBe('chart');
+    });
+
+    it('rejects a remote https:// URL — no <img>, invalid-payload fallback', () => {
+        const { container } = render(<RenderCard render="image" data={{ src: 'https://example.com/x.png' }} />);
+
+        expect(container.querySelector('img')).toBeNull();
+        expect(screen.getByText('Invalid image payload')).toBeInTheDocument();
+    });
+
+    it('rejects data:image/svg+xml (deliberately excluded) — no <img>, invalid-payload fallback', () => {
+        const { container } = render(
+            <RenderCard render="image" data={{ src: 'data:image/svg+xml;base64,PHN2Zz4=' }} />,
+        );
+
+        expect(container.querySelector('img')).toBeNull();
+        expect(screen.getByText('Invalid image payload')).toBeInTheDocument();
+    });
+
+    it('rejects a javascript: scheme — no <img>, invalid-payload fallback', () => {
+        const { container } = render(<RenderCard render="image" data={{ src: 'javascript:alert(1)' }} />);
+
+        expect(container.querySelector('img')).toBeNull();
+        expect(screen.getByText('Invalid image payload')).toBeInTheDocument();
+    });
+
+    it('renders an optional caption as visible text', () => {
+        render(
+            <RenderCard
+                render="image"
+                data={{ src: 'data:image/png;base64,iVBORw0KGgo=', caption: 'Q3 numbers' }}
+            />,
+        );
+
+        expect(screen.getByText('Q3 numbers')).toBeInTheDocument();
+    });
+});
+
+describe('diff primitive', () => {
+    it('applies per-line classes by +/-/@@ prefix, with plain context lines carrying only the base class', () => {
+        const unified = '@@ -1,2 +1,2 @@\n context\n-old line\n+new line';
+        const { container } = render(<RenderCard render="diff" data={{ unified }} />);
+
+        const lines = Array.from(container.querySelectorAll('.render-diff__line'));
+        expect(lines.length).toBeGreaterThan(0);
+
+        const hunkLine = lines.find((el) => el.textContent?.includes('@@ -1,2 +1,2 @@'));
+        const removedLine = lines.find((el) => el.textContent?.includes('old line'));
+        const addedLine = lines.find((el) => el.textContent?.includes('new line'));
+        const contextLine = lines.find(
+            (el) => el.textContent?.includes('context') && !el.textContent?.includes('old line') && !el.textContent?.includes('new line'),
+        );
+
+        expect(hunkLine).toBeTruthy();
+        expect(hunkLine?.classList.contains('render-diff__line--hunk')).toBe(true);
+
+        expect(removedLine).toBeTruthy();
+        expect(removedLine?.classList.contains('render-diff__line')).toBe(true);
+        expect(removedLine?.classList.contains('render-diff__line--removed')).toBe(true);
+
+        expect(addedLine).toBeTruthy();
+        expect(addedLine?.classList.contains('render-diff__line--added')).toBe(true);
+
+        expect(contextLine).toBeTruthy();
+        expect(contextLine?.classList.contains('render-diff__line')).toBe(true);
+        expect(contextLine?.classList.contains('render-diff__line--added')).toBe(false);
+        expect(contextLine?.classList.contains('render-diff__line--removed')).toBe(false);
+        expect(contextLine?.classList.contains('render-diff__line--hunk')).toBe(false);
+    });
+
+    it('renders the invalid-payload fallback for a malformed payload', () => {
+        render(<RenderCard render="diff" data={{ unified: 42 }} />);
+
+        expect(screen.getByText('Invalid diff payload')).toBeInTheDocument();
+    });
+});
+
+describe('UnsupportedCard — oversized payload notice (Increment 1 behavior, should already pass)', () => {
+    it('shows a byte-count notice instead of the JSON dump for a payload over 2,000,000 chars', () => {
+        const data = { blob: 'x'.repeat(2_000_001) };
+        render(<RenderCard render="nonexistent_widget" data={data} />);
+
+        expect(screen.getByText(/^Payload too large to display \(\d+ bytes\)$/)).toBeInTheDocument();
+    });
+});

--- a/src/gaia/apps/webui/src/components/__tests__/render-registry.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/render-registry.test.tsx
@@ -1,0 +1,135 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Contract tests for the render->component card registry (issue #2108,
+ * Increment 1). The modules under test do not exist yet:
+ *
+ *   - src/components/render/RenderCard.tsx
+ *   - src/components/render/UnsupportedCard.tsx
+ *   - src/components/render/CardErrorBoundary.tsx
+ *
+ * These tests are EXPECTED to fail right now — that is correct TDD. They
+ * pin the frozen API surface the implementer must conform to; do not treat
+ * a future failure here as license to change the assertions to match a
+ * different implementation shape without confirming it against the plan.
+ *
+ * Only `email_pre_scan` is registered as of this increment. Do not add
+ * assertions for `table` / `key_value` / `list` / `image` / `diff` (present
+ * or absent) — those land in Increment 2.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RenderCard } from '../render/RenderCard';
+import { CardErrorBoundary } from '../render/CardErrorBoundary';
+import { UnsupportedCard } from '../render/UnsupportedCard';
+
+const preScanPayload = {
+    kind: 'email_pre_scan',
+    urgent: [{ message_id: 'm1', sender: 'Alice <alice@example.com>', subject: 'Server down' }],
+    actionable: [],
+    informational_count: 2,
+    suggested_archives: [],
+    suggested_drafts: [],
+};
+
+describe('UnsupportedCard module', () => {
+    // Deliberately minimal: the plan names this as its own module but does
+    // not freeze its prop shape (unlike RenderCard/CardErrorBoundary below),
+    // so this only pins "the module and export exist" — its rendered output
+    // is pinned via RenderCard, which is its only specified public surface.
+    it('is exported from render/UnsupportedCard', () => {
+        expect(UnsupportedCard).toBeDefined();
+    });
+});
+
+describe('RenderCard — unregistered render key', () => {
+    it('wraps output in a .render-card div', () => {
+        const { container } = render(
+            <RenderCard render="nonexistent_widget" data={{ marker: 'unregistered-payload-marker' }} />,
+        );
+
+        expect(container.querySelector('.render-card')).not.toBeNull();
+    });
+
+    it('renders the exact "Unsupported card type" fallback text for an unregistered key', () => {
+        // A deliberately nonsense render key — not one of the real card
+        // types (table/list/etc.) landing in Increment 2, so this stays
+        // valid across increments.
+        render(<RenderCard render="nonexistent_widget" data={{ marker: 'unregistered-payload-marker' }} />);
+
+        expect(screen.getByText('Unsupported card type: "nonexistent_widget"')).toBeInTheDocument();
+    });
+
+    it('renders a <details> element with a JSON dump of the unregistered payload', () => {
+        const { container } = render(
+            <RenderCard render="nonexistent_widget" data={{ marker: 'unregistered-payload-marker' }} />,
+        );
+
+        const details = container.querySelector('details');
+        expect(details).not.toBeNull();
+        expect(details?.textContent).toContain('unregistered-payload-marker');
+    });
+});
+
+describe('RenderCard — email_pre_scan registry entry', () => {
+    it('renders the real EmailPreScanCard for the bare/target payload shape', () => {
+        render(<RenderCard render="email_pre_scan" data={preScanPayload} />);
+
+        expect(screen.getByText('Server down')).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: 'Inbox pre-scan' })).toBeInTheDocument();
+    });
+
+    it('renders identically for the { ok, data } envelope shape', () => {
+        render(<RenderCard render="email_pre_scan" data={{ ok: true, data: preScanPayload }} />);
+
+        expect(screen.getByText('Server down')).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: 'Inbox pre-scan' })).toBeInTheDocument();
+    });
+
+    it('renders the invalid-payload fallback (with JSON dump) for a payload matching neither shape', () => {
+        const { container } = render(<RenderCard render="email_pre_scan" data={{ foo: 'bar' }} />);
+
+        expect(screen.getByText('Invalid email_pre_scan payload')).toBeInTheDocument();
+
+        const details = container.querySelector('details');
+        expect(details).not.toBeNull();
+        expect(details?.textContent).toContain('bar');
+    });
+});
+
+describe('CardErrorBoundary', () => {
+    it('renders children normally when nothing throws', () => {
+        render(
+            <CardErrorBoundary>
+                <div>safe content</div>
+            </CardErrorBoundary>,
+        );
+
+        expect(screen.getByText('safe content')).toBeInTheDocument();
+    });
+
+    it('catches a throwing child and renders the fallback alert instead of propagating', () => {
+        function ThrowingComponent() {
+            throw new Error('boom');
+        }
+
+        // React logs caught render errors to console.error; mock it so the
+        // expected failure doesn't pollute test output, and so we can assert
+        // the boundary actually caught something.
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        render(
+            <CardErrorBoundary>
+                <ThrowingComponent />
+            </CardErrorBoundary>,
+        );
+
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText('Card failed to render')).toBeInTheDocument();
+        expect(consoleErrorSpy).toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+    });
+});

--- a/src/gaia/apps/webui/src/components/__tests__/render-registry.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/render-registry.test.tsx
@@ -111,7 +111,7 @@ describe('CardErrorBoundary', () => {
     });
 
     it('catches a throwing child and renders the fallback alert instead of propagating', () => {
-        function ThrowingComponent() {
+        function ThrowingComponent(): never {
             throw new Error('boom');
         }
 

--- a/src/gaia/apps/webui/src/components/render/CardErrorBoundary.tsx
+++ b/src/gaia/apps/webui/src/components/render/CardErrorBoundary.tsx
@@ -1,0 +1,44 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { Component } from 'react';
+import type { ReactNode } from 'react';
+
+interface CardErrorBoundaryProps {
+    children: ReactNode;
+}
+
+interface CardErrorBoundaryState {
+    hasError: boolean;
+}
+
+/**
+ * Error boundary wrapping every registered render card (see RenderCard.tsx).
+ * A bug in one card must never blank the whole assistant message — no
+ * boundary exists anywhere else in the app, so this is the first one.
+ */
+export class CardErrorBoundary extends Component<CardErrorBoundaryProps, CardErrorBoundaryState> {
+    constructor(props: CardErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): CardErrorBoundaryState {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: unknown): void {
+        console.error('[CardErrorBoundary] card render failed:', error);
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <div role="alert" className="render-card-error">
+                    Card failed to render
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/src/gaia/apps/webui/src/components/render/DiffCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/DiffCard.tsx
@@ -1,0 +1,43 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { UnsupportedCard } from './UnsupportedCard';
+import { isOptionalString } from './primitiveShared';
+
+interface DiffPayload {
+    title?: string;
+    unified: string;
+}
+
+function isDiffPayload(value: unknown): value is DiffPayload {
+    if (!value || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return isOptionalString(v.title) && typeof v.unified === 'string';
+}
+
+/** FIXED prefix -> class lookup — classes must never be derived from
+ *  line content (content is untrusted). */
+function lineClass(line: string): string {
+    if (line.startsWith('@@')) return 'render-diff__line render-diff__line--hunk';
+    if (line.startsWith('+')) return 'render-diff__line render-diff__line--added';
+    if (line.startsWith('-')) return 'render-diff__line render-diff__line--removed';
+    return 'render-diff__line';
+}
+
+export function DiffCard({ data }: { data: unknown }) {
+    if (!isDiffPayload(data)) {
+        return <UnsupportedCard variant="invalid" render="diff" data={data} />;
+    }
+    return (
+        <div className="render-diff">
+            {data.title && <div className="render-diff__title">{data.title}</div>}
+            <pre className="render-diff__body">
+                {data.unified.split('\n').map((line, i) => (
+                    <div className={lineClass(line)} key={i}>
+                        {line}
+                    </div>
+                ))}
+            </pre>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/render/DiffCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/DiffCard.tsx
@@ -19,6 +19,13 @@ function isDiffPayload(value: unknown): value is DiffPayload {
  *  line content (content is untrusted). */
 function lineClass(line: string): string {
     if (line.startsWith('@@')) return 'render-diff__line render-diff__line--hunk';
+    if (
+        line.startsWith('+++') ||
+        line.startsWith('---') ||
+        line.startsWith('diff ') ||
+        line.startsWith('index ')
+    )
+        return 'render-diff__line';
     if (line.startsWith('+')) return 'render-diff__line render-diff__line--added';
     if (line.startsWith('-')) return 'render-diff__line render-diff__line--removed';
     return 'render-diff__line';

--- a/src/gaia/apps/webui/src/components/render/ImageCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/ImageCard.tsx
@@ -1,0 +1,45 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { UnsupportedCard } from './UnsupportedCard';
+import { isOptionalString } from './primitiveShared';
+
+/**
+ * Inline base64 raster images only — SVG is deliberately excluded (it can
+ * carry script), and remote/other schemes are rejected outright. There is
+ * no CSP in this app, so this allowlist is the actual security boundary.
+ */
+const DATA_IMAGE_RE = /^data:image\/(png|jpe?g|gif|webp);base64,/;
+
+interface ImagePayload {
+    src: string;
+    alt?: string;
+    caption?: string;
+}
+
+function isImagePayload(value: unknown): value is ImagePayload {
+    if (!value || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return (
+        typeof v.src === 'string' &&
+        DATA_IMAGE_RE.test(v.src) &&
+        isOptionalString(v.alt) &&
+        isOptionalString(v.caption)
+    );
+}
+
+export function ImageCard({ data }: { data: unknown }) {
+    if (!isImagePayload(data)) {
+        return <UnsupportedCard variant="invalid" render="image" data={data} />;
+    }
+    // SECURITY: `src` binds ONLY to this <img> attribute — never to
+    // window.open, location, an anchor href, or any electronAPI.invoke.
+    return (
+        <figure className="render-image">
+            <img className="render-image__img" src={data.src} alt={data.alt ?? ''} />
+            {data.caption && (
+                <figcaption className="render-image__caption">{data.caption}</figcaption>
+            )}
+        </figure>
+    );
+}

--- a/src/gaia/apps/webui/src/components/render/KeyValueCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/KeyValueCard.tsx
@@ -1,0 +1,51 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { UnsupportedCard } from './UnsupportedCard';
+import { MAX_ITEMS, isScalar, isOptionalString, scalarText, truncationLabel } from './primitiveShared';
+import type { Scalar } from './primitiveShared';
+
+interface KeyValuePayload {
+    title?: string;
+    items: Array<{ key: string; value: Scalar }>;
+}
+
+function isKeyValuePayload(value: unknown): value is KeyValuePayload {
+    if (!value || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return (
+        isOptionalString(v.title) &&
+        Array.isArray(v.items) &&
+        v.items.every(
+            (item) =>
+                item &&
+                typeof item === 'object' &&
+                typeof (item as Record<string, unknown>).key === 'string' &&
+                isScalar((item as Record<string, unknown>).value),
+        )
+    );
+}
+
+export function KeyValueCard({ data }: { data: unknown }) {
+    if (!isKeyValuePayload(data)) {
+        return <UnsupportedCard variant="invalid" render="key_value" data={data} />;
+    }
+    const truncated = data.items.length > MAX_ITEMS;
+    const items = truncated ? data.items.slice(0, MAX_ITEMS) : data.items;
+    return (
+        <div className="render-kv">
+            {data.title && <div className="render-kv__title">{data.title}</div>}
+            <dl className="render-kv__list">
+                {items.map((item, i) => (
+                    <div className="render-kv__row" key={i}>
+                        <dt className="render-kv__key">{item.key}</dt>
+                        <dd className="render-kv__value">{scalarText(item.value)}</dd>
+                    </div>
+                ))}
+            </dl>
+            {truncated && (
+                <div className="render-truncation">{truncationLabel(data.items.length)}</div>
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/render/ListCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/ListCard.tsx
@@ -1,0 +1,44 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { UnsupportedCard } from './UnsupportedCard';
+import { MAX_ITEMS, isOptionalString, truncationLabel } from './primitiveShared';
+
+interface ListPayload {
+    title?: string;
+    ordered?: boolean;
+    items: Array<string | number>;
+}
+
+function isListPayload(value: unknown): value is ListPayload {
+    if (!value || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return (
+        isOptionalString(v.title) &&
+        (v.ordered === undefined || typeof v.ordered === 'boolean') &&
+        Array.isArray(v.items) &&
+        v.items.every((item) => typeof item === 'string' || typeof item === 'number')
+    );
+}
+
+export function ListCard({ data }: { data: unknown }) {
+    if (!isListPayload(data)) {
+        return <UnsupportedCard variant="invalid" render="list" data={data} />;
+    }
+    const truncated = data.items.length > MAX_ITEMS;
+    const items = truncated ? data.items.slice(0, MAX_ITEMS) : data.items;
+    const entries = items.map((item, i) => <li key={i}>{String(item)}</li>);
+    return (
+        <div className="render-list">
+            {data.title && <div className="render-list__title">{data.title}</div>}
+            {data.ordered ? (
+                <ol className="render-list__items">{entries}</ol>
+            ) : (
+                <ul className="render-list__items">{entries}</ul>
+            )}
+            {truncated && (
+                <div className="render-truncation">{truncationLabel(data.items.length)}</div>
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/render/RenderCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/RenderCard.tsx
@@ -1,0 +1,34 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { CARD_REGISTRY } from './registry';
+import { CardErrorBoundary } from './CardErrorBoundary';
+import { UnsupportedCard } from './UnsupportedCard';
+import './render.css';
+
+export interface RenderCardProps {
+    /** The `tool_result.render` key naming which card to mount. */
+    render: string;
+    /** The `tool_result.data` payload, handed to the resolved card as-is. */
+    data: unknown;
+}
+
+/**
+ * Resolves a `render` key against the card registry and mounts the result.
+ * Unknown keys fall back to UnsupportedCard; registered cards are wrapped in
+ * CardErrorBoundary so one bad card can never blank the whole message.
+ */
+export function RenderCard({ render, data }: RenderCardProps) {
+    const Card = CARD_REGISTRY[render];
+    return (
+        <div className="render-card">
+            {Card ? (
+                <CardErrorBoundary>
+                    <Card data={data} />
+                </CardErrorBoundary>
+            ) : (
+                <UnsupportedCard variant="unknown" render={render} data={data} />
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/render/TableCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/TableCard.tsx
@@ -1,0 +1,60 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { UnsupportedCard } from './UnsupportedCard';
+import { MAX_ITEMS, isScalar, isOptionalString, scalarText, truncationLabel } from './primitiveShared';
+import type { Scalar } from './primitiveShared';
+
+interface TablePayload {
+    title?: string;
+    columns: string[];
+    rows: Scalar[][];
+}
+
+function isTablePayload(value: unknown): value is TablePayload {
+    if (!value || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return (
+        isOptionalString(v.title) &&
+        Array.isArray(v.columns) &&
+        v.columns.every((c) => typeof c === 'string') &&
+        Array.isArray(v.rows) &&
+        v.rows.every((r) => Array.isArray(r) && r.every(isScalar))
+    );
+}
+
+export function TableCard({ data }: { data: unknown }) {
+    if (!isTablePayload(data)) {
+        return <UnsupportedCard variant="invalid" render="table" data={data} />;
+    }
+    const truncated = data.rows.length > MAX_ITEMS;
+    const rows = truncated ? data.rows.slice(0, MAX_ITEMS) : data.rows;
+    return (
+        <div className="render-table-card">
+            {data.title && <div className="render-table-card__title">{data.title}</div>}
+            <div className="render-table">
+                <table>
+                    <thead>
+                        <tr>
+                            {data.columns.map((col, i) => (
+                                <th key={i}>{col}</th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map((row, ri) => (
+                            <tr key={ri}>
+                                {row.map((cell, ci) => (
+                                    <td key={ci}>{scalarText(cell)}</td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+            {truncated && (
+                <div className="render-truncation">{truncationLabel(data.rows.length)}</div>
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/render/TableCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/TableCard.tsx
@@ -27,8 +27,10 @@ export function TableCard({ data }: { data: unknown }) {
     if (!isTablePayload(data)) {
         return <UnsupportedCard variant="invalid" render="table" data={data} />;
     }
-    const truncated = data.rows.length > MAX_ITEMS;
-    const rows = truncated ? data.rows.slice(0, MAX_ITEMS) : data.rows;
+    const rowsTruncated = data.rows.length > MAX_ITEMS;
+    const rows = rowsTruncated ? data.rows.slice(0, MAX_ITEMS) : data.rows;
+    const columnsTruncated = data.columns.length > MAX_ITEMS;
+    const columns = columnsTruncated ? data.columns.slice(0, MAX_ITEMS) : data.columns;
     return (
         <div className="render-table-card">
             {data.title && <div className="render-table-card__title">{data.title}</div>}
@@ -36,15 +38,16 @@ export function TableCard({ data }: { data: unknown }) {
                 <table>
                     <thead>
                         <tr>
-                            {data.columns.map((col, i) => (
+                            {columns.map((col, i) => (
                                 <th key={i}>{col}</th>
                             ))}
+                            {columnsTruncated && <th>{truncationLabel(data.columns.length)}</th>}
                         </tr>
                     </thead>
                     <tbody>
                         {rows.map((row, ri) => (
                             <tr key={ri}>
-                                {row.map((cell, ci) => (
+                                {row.slice(0, columns.length).map((cell, ci) => (
                                     <td key={ci}>{scalarText(cell)}</td>
                                 ))}
                             </tr>
@@ -52,7 +55,7 @@ export function TableCard({ data }: { data: unknown }) {
                     </tbody>
                 </table>
             </div>
-            {truncated && (
+            {rowsTruncated && (
                 <div className="render-truncation">{truncationLabel(data.rows.length)}</div>
             )}
         </div>

--- a/src/gaia/apps/webui/src/components/render/UnsupportedCard.tsx
+++ b/src/gaia/apps/webui/src/components/render/UnsupportedCard.tsx
@@ -1,0 +1,62 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/** Above this length (JSON.stringify(data).length), skip the pretty-printed
+ *  dump and show a size notice instead — a malformed/huge payload must not
+ *  freeze the tab rendering a multi-megabyte <pre>. */
+const MAX_PAYLOAD_JSON_LENGTH = 2_000_000;
+
+export interface UnsupportedCardProps {
+    /** 'unknown' = no card registered for this render key; 'invalid' = the
+     *  registered card rejected this data's shape. */
+    variant: 'unknown' | 'invalid';
+    /** The render key that failed to produce a card. */
+    render: string;
+    /** The raw payload — shown as a collapsible JSON dump either way, so
+     *  the user (and whoever's debugging) can still see what arrived. */
+    data: unknown;
+}
+
+/**
+ * Explicit fallback card — the loud path for a render key with no
+ * registered component, or a registered component whose payload validation
+ * failed. Never renders nothing: an unrecognized card must be visible and
+ * debuggable, not silently dropped.
+ */
+export function UnsupportedCard({ variant, render, data }: UnsupportedCardProps) {
+    let rawJson: string;
+    try {
+        rawJson = JSON.stringify(data);
+    } catch {
+        rawJson = String(data);
+    }
+    const tooLarge = rawJson.length > MAX_PAYLOAD_JSON_LENGTH;
+    let pretty = rawJson;
+    if (!tooLarge) {
+        try {
+            pretty = JSON.stringify(data, null, 2);
+        } catch {
+            pretty = rawJson;
+        }
+    }
+
+    const message = variant === 'unknown'
+        ? `Unsupported card type: "${render}"`
+        : `Invalid ${render} payload`;
+
+    return (
+        <div className="render-unsupported">
+            <p className="render-unsupported__message">{message}</p>
+            <details className="render-unsupported__details">
+                <summary>Raw payload</summary>
+                {tooLarge ? (
+                    <p className="render-unsupported__too-large">
+                        Payload too large to display ({rawJson.length} bytes)
+                    </p>
+                ) : (
+                    <pre className="render-unsupported__json">{pretty}</pre>
+                )}
+            </details>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/render/primitiveShared.ts
+++ b/src/gaia/apps/webui/src/components/render/primitiveShared.ts
@@ -1,0 +1,32 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/** Shared helpers for the generic render primitives (issue #2108). */
+
+/** Render cap for table rows, list items, and key_value items. */
+export const MAX_ITEMS = 500;
+
+export type Scalar = string | number | boolean | null;
+
+export function isScalar(value: unknown): value is Scalar {
+    return (
+        value === null ||
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+    );
+}
+
+/** Render a scalar payload value as plain text. */
+export function scalarText(value: Scalar): string {
+    return value === null ? '' : String(value);
+}
+
+export function isOptionalString(value: unknown): value is string | undefined {
+    return value === undefined || typeof value === 'string';
+}
+
+/** The visible `+N more (truncated)` row shown when a cap kicks in. */
+export function truncationLabel(total: number): string {
+    return `+${total - MAX_ITEMS} more (truncated)`;
+}

--- a/src/gaia/apps/webui/src/components/render/registry.tsx
+++ b/src/gaia/apps/webui/src/components/render/registry.tsx
@@ -11,6 +11,11 @@
 import type { ComponentType } from 'react';
 import { EmailPreScanCard, isPreScanPayload } from '../email/EmailPreScanCard';
 import { UnsupportedCard } from './UnsupportedCard';
+import { TableCard } from './TableCard';
+import { KeyValueCard } from './KeyValueCard';
+import { ListCard } from './ListCard';
+import { ImageCard } from './ImageCard';
+import { DiffCard } from './DiffCard';
 
 export type CardComponent = ComponentType<{ data: unknown }>;
 
@@ -44,4 +49,9 @@ function EmailPreScanAdapter({ data }: { data: unknown }) {
 
 export const CARD_REGISTRY: Record<string, CardComponent> = {
     email_pre_scan: EmailPreScanAdapter,
+    table: TableCard,
+    key_value: KeyValueCard,
+    list: ListCard,
+    image: ImageCard,
+    diff: DiffCard,
 };

--- a/src/gaia/apps/webui/src/components/render/registry.tsx
+++ b/src/gaia/apps/webui/src/components/render/registry.tsx
@@ -1,0 +1,47 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Card registry — maps a `render` key (the `tool_result.render` field on
+ * the frozen /query SSE contract, see docs/spec/agent-ui-query-sse-contract.md
+ * §4.3) to the component that renders its `data` payload. RenderCard.tsx
+ * resolves this map and falls back to UnsupportedCard for unknown keys.
+ */
+
+import type { ComponentType } from 'react';
+import { EmailPreScanCard, isPreScanPayload } from '../email/EmailPreScanCard';
+import { UnsupportedCard } from './UnsupportedCard';
+
+export type CardComponent = ComponentType<{ data: unknown }>;
+
+/** Unwrap the `{ok, data}` envelope form, if present; otherwise pass the
+ *  payload through unchanged. */
+function resolveEmailPreScanPayload(data: unknown): unknown {
+    if (data && typeof data === 'object' && (data as Record<string, unknown>).kind === 'email_pre_scan') {
+        return data;
+    }
+    const enveloped = (data as { data?: unknown } | null | undefined)?.data;
+    if (enveloped && typeof enveloped === 'object' && (enveloped as Record<string, unknown>).kind === 'email_pre_scan') {
+        return enveloped;
+    }
+    return data;
+}
+
+/**
+ * Adapter for the `email_pre_scan` render key. Contract-TARGET shapes only:
+ * today's live wire still emits a {summary, success} stub for
+ * `pre_scan_inbox` until #2109 lands the `result_data` population fix, so
+ * this tolerates both the bare target shape and the `{ok, data}` envelope
+ * without needing to change again once #2109 ships.
+ */
+function EmailPreScanAdapter({ data }: { data: unknown }) {
+    const payload = resolveEmailPreScanPayload(data);
+    if (!isPreScanPayload(payload)) {
+        return <UnsupportedCard variant="invalid" render="email_pre_scan" data={data} />;
+    }
+    return <EmailPreScanCard payload={payload} />;
+}
+
+export const CARD_REGISTRY: Record<string, CardComponent> = {
+    email_pre_scan: EmailPreScanAdapter,
+};

--- a/src/gaia/apps/webui/src/components/render/render.css
+++ b/src/gaia/apps/webui/src/components/render/render.css
@@ -49,3 +49,164 @@
     font-style: italic;
     margin: 6px 0 0;
 }
+
+/* ── Shared primitive chrome ─────────────────────────────────────────── */
+
+.render-truncation {
+    color: var(--text-secondary, #666666);
+    font-size: 12px;
+    font-style: italic;
+    padding: 4px 0 0;
+}
+
+/* ── table ───────────────────────────────────────────────────────────── */
+
+.render-table-card {
+    background: var(--bg-card, #ffffff);
+    border: 1px solid var(--border-light, #e2e2e2);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 13px;
+}
+
+.render-table-card__title {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+/* Wide tables scroll inside the card, never the page. */
+.render-table {
+    overflow-x: auto;
+}
+
+.render-table table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.render-table th,
+.render-table td {
+    text-align: left;
+    padding: 4px 10px 4px 0;
+    border-bottom: 1px solid var(--border-light, #e2e2e2);
+    white-space: nowrap;
+}
+
+.render-table th {
+    font-weight: 600;
+    color: var(--text-secondary, #666666);
+}
+
+/* ── key_value ───────────────────────────────────────────────────────── */
+
+.render-kv {
+    background: var(--bg-card, #ffffff);
+    border: 1px solid var(--border-light, #e2e2e2);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 13px;
+}
+
+.render-kv__title {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.render-kv__list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.render-kv__row {
+    display: flex;
+    gap: 12px;
+}
+
+.render-kv__key {
+    color: var(--text-secondary, #666666);
+    min-width: 120px;
+    flex-shrink: 0;
+}
+
+.render-kv__value {
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+/* ── list ────────────────────────────────────────────────────────────── */
+
+.render-list {
+    background: var(--bg-card, #ffffff);
+    border: 1px solid var(--border-light, #e2e2e2);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 13px;
+}
+
+.render-list__title {
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.render-list__items {
+    margin: 0;
+    padding-left: 20px;
+}
+
+/* ── image ───────────────────────────────────────────────────────────── */
+
+.render-image {
+    margin: 0;
+}
+
+.render-image__img {
+    max-width: 100%;
+    border-radius: 8px;
+    display: block;
+}
+
+.render-image__caption {
+    color: var(--text-secondary, #666666);
+    font-size: 12px;
+    padding-top: 4px;
+}
+
+/* ── diff ────────────────────────────────────────────────────────────── */
+
+.render-diff {
+    background: var(--bg-card, #ffffff);
+    border: 1px solid var(--border-light, #e2e2e2);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 12px;
+}
+
+.render-diff__title {
+    font-weight: 600;
+    margin-bottom: 6px;
+    font-size: 13px;
+}
+
+.render-diff__body {
+    margin: 0;
+    overflow-x: auto;
+    font-family: var(--font-mono, monospace);
+}
+
+.render-diff__line {
+    white-space: pre;
+}
+
+.render-diff__line--added {
+    background: var(--diff-added-bg, rgba(46, 160, 67, 0.15));
+}
+
+.render-diff__line--removed {
+    background: var(--diff-removed-bg, rgba(248, 81, 73, 0.15));
+}
+
+.render-diff__line--hunk {
+    color: var(--text-secondary, #666666);
+}

--- a/src/gaia/apps/webui/src/components/render/render.css
+++ b/src/gaia/apps/webui/src/components/render/render.css
@@ -1,0 +1,51 @@
+/* Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved. */
+/* SPDX-License-Identifier: MIT */
+/* Card registry primitives (issue #2108). Every selector is prefixed
+ * `render-` — this stylesheet is global, so unprefixed names would collide
+ * silently with other components. */
+
+.render-card {
+    margin: 8px 0;
+}
+
+.render-card-error {
+    background: var(--bg-card, #ffffff);
+    border: 1px solid var(--border-error, #e5484d);
+    border-radius: 8px;
+    padding: 10px 12px;
+    color: var(--text-error, #c92a2a);
+    font-size: 13px;
+}
+
+.render-unsupported {
+    background: var(--bg-card, #ffffff);
+    border: 1px solid var(--border-light, #e2e2e2);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 13px;
+    color: var(--text-primary, #1a1a1a);
+}
+
+.render-unsupported__message {
+    margin: 0 0 6px;
+    font-weight: 500;
+}
+
+.render-unsupported__details summary {
+    cursor: pointer;
+    color: var(--text-secondary, #666666);
+    font-size: 12px;
+}
+
+.render-unsupported__json {
+    overflow-x: auto;
+    font-size: 12px;
+    white-space: pre;
+    margin: 6px 0 0;
+}
+
+.render-unsupported__too-large {
+    color: var(--text-secondary, #666666);
+    font-style: italic;
+    margin: 6px 0 0;
+}

--- a/src/gaia/apps/webui/src/stores/__tests__/chatStore.cards.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/chatStore.cards.test.ts
@@ -1,0 +1,85 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from '../chatStore';
+import type { AgentStep, RenderCardData } from '../../types';
+
+const step = (id: number, label: string): AgentStep => ({
+    id,
+    type: 'thinking',
+    label,
+    active: true,
+    timestamp: id,
+});
+
+const tableCard: RenderCardData = { render: 'table', data: { columns: ['A'], rows: [] } };
+const listCard: RenderCardData = { render: 'list', data: { items: [] } };
+
+describe('chatStore streaming cards (#2108)', () => {
+    // NOTE: deliberately NOT resetting `cards` here. If the beforeEach preset
+    // `cards: []` on every test, the "starts with an empty cards array" test
+    // below would trivially pass off that preset rather than off the store's
+    // real default — masking the exact `cards ?? []`-style softening this
+    // suite exists to catch. Each test that needs a clean starting point
+    // resets `cards` itself, explicitly, at the top of its own body.
+    beforeEach(() => {
+        useChatStore.setState({
+            isStreaming: false,
+            streamingContent: '',
+            agentSteps: [],
+        });
+    });
+
+    it('starts with an empty cards array', () => {
+        // Must be the first test in this file (before any cards mutation) so
+        // this reads the store's real default, not a beforeEach override.
+        expect(useChatStore.getState().cards).toEqual([]);
+    });
+
+    it('appendCard appends cards in insertion order', () => {
+        useChatStore.setState({ cards: [] });
+        useChatStore.getState().appendCard(tableCard);
+        useChatStore.getState().appendCard(listCard);
+
+        const cards = useChatStore.getState().cards;
+        expect(cards).toHaveLength(2);
+        expect(cards[0]).toEqual(tableCard);
+        expect(cards[1]).toEqual(listCard);
+    });
+
+    it('clearCards empties the cards array', () => {
+        useChatStore.setState({ cards: [] });
+        useChatStore.getState().appendCard(tableCard);
+        expect(useChatStore.getState().cards).toHaveLength(1);
+
+        useChatStore.getState().clearCards();
+        expect(useChatStore.getState().cards).toEqual([]);
+    });
+
+    it('resetStreaming clears cards along with the existing streaming state (#1580 guard)', () => {
+        useChatStore.setState({ cards: [] });
+        const s = useChatStore.getState();
+        s.setStreaming(true);
+        s.setStreamContent('partial answer from previous session');
+        s.addAgentStep(step(1, 'analyzing'));
+        s.appendCard(tableCard);
+
+        // Sanity: state is populated as if a stream were in flight, cards included.
+        expect(useChatStore.getState().isStreaming).toBe(true);
+        expect(useChatStore.getState().streamingContent).not.toBe('');
+        expect(useChatStore.getState().agentSteps).toHaveLength(1);
+        expect(useChatStore.getState().cards).toHaveLength(1);
+
+        // Switching sessions must wipe all of it — including in-flight cards —
+        // so the new view never mirrors the previous session's stream
+        // (issue #1580's session-switch leak guard, extended to cards by #2108).
+        useChatStore.getState().resetStreaming();
+
+        const after = useChatStore.getState();
+        expect(after.isStreaming).toBe(false);
+        expect(after.streamingContent).toBe('');
+        expect(after.agentSteps).toEqual([]);
+        expect(after.cards).toEqual([]);
+    });
+});

--- a/src/gaia/apps/webui/src/stores/chatStore.ts
+++ b/src/gaia/apps/webui/src/stores/chatStore.ts
@@ -4,7 +4,7 @@
 /** Zustand store for GAIA Agent UI state. */
 
 import { create } from 'zustand';
-import type { Session, Message, Document, AgentStep, SystemStatus, AgentInfo } from '../types';
+import type { Session, Message, Document, AgentStep, SystemStatus, AgentInfo, RenderCardData } from '../types';
 
 interface ChatState {
     // Agents
@@ -71,6 +71,14 @@ interface ChatState {
     /** Update the last tool step (not the absolute last step). */
     updateLastToolStep: (updates: Partial<AgentStep>) => void;
     clearAgentSteps: () => void;
+
+    // Structured cards from tool_result.render events (issue #2108).
+    // Accumulated during the stream, transferred onto the finalized
+    // Message by ChatView (onDone/handleStop), then cleared — mirroring
+    // the agentSteps lifecycle exactly.
+    cards: RenderCardData[];
+    appendCard: (card: RenderCardData) => void;
+    clearCards: () => void;
 
     // Documents
     documents: Document[];
@@ -210,7 +218,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         set((state) => ({ streamingContent: state.streamingContent + content })),
     setStreamContent: (content) => set({ streamingContent: content }),
     clearStreamContent: () => set({ streamingContent: '' }),
-    resetStreaming: () => set({ isStreaming: false, streamingContent: '', agentSteps: [] }),
+    resetStreaming: () => set({ isStreaming: false, streamingContent: '', agentSteps: [], cards: [] }),
 
     // Agent activity
     agentSteps: [],
@@ -257,6 +265,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
             return state;
         }),
     clearAgentSteps: () => set({ agentSteps: [] }),
+
+    // Streaming cards (#2108)
+    cards: [],
+    appendCard: (card) =>
+        set((state) => ({ cards: [...state.cards, card] })),
+    clearCards: () => set({ cards: [] }),
 
     // Documents
     documents: [],

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -314,6 +314,15 @@ export interface Message {
     agentSteps?: AgentStep[];
     /** Inference performance stats from the LLM backend. */
     stats?: InferenceStats;
+    /** Structured cards emitted via tool_result.render during this turn
+     *  (issue #2108). Rendered by RenderCard above the markdown content. */
+    cards?: RenderCardData[];
+}
+
+/** One card instance transferred onto a finalized Message (issue #2108). */
+export interface RenderCardData {
+    render: string;
+    data: unknown;
 }
 
 export interface SourceInfo {
@@ -703,4 +712,12 @@ export interface StreamEvent {
         files?: Array<Record<string, unknown>>;
         total?: number;
     };
+    /**
+     * Card render key (issue #2108, additive on `tool_result`). Non-empty
+     * string means the frontend should mount a registered card via
+     * RenderCard against `data`. Absent on every other event type.
+     */
+    render?: string;
+    /** Card payload for `render` (issue #2108, additive on `tool_result`). */
+    data?: unknown;
 }


### PR DESCRIPTION
Closes #2108 (epic #2014, Phase 1 / V2-9).

Before: the Agent UI can render exactly one structured card (`email_pre_scan`), and only by parsing a fenced code block the backend injects into the answer text — every future agent card would need its own hack. After: cards mount from the frozen /query contract's `tool_result.render` key via a card registry, any agent gets five generic primitives (table / key_value / list / image / diff) with zero frontend work, and an unknown or malformed card always shows an explicit fallback instead of silently rendering nothing. This is the frontend prerequisite for #2109, which makes the backend emit these events; it ships inert (no producer emits `render` yet) and does not touch the existing fence path.

## Evidence

All eight card states rendered live in the browser (vite dev server on this branch, every card driven through the public `RenderCard` surface — the same seam `tool_result` events hit):

![render cards](https://raw.githubusercontent.com/amd/gaia/evidence/2108-render-map/2108-render-cards-full.png)

## Tests

- [x] Vitest: 19 files / 155 tests green (110 baseline + 45 new, authored test-first); `npm run build` green
- [x] `email_pre_scan` renders from a `tool_result` event in both contract data forms (component + ChatView-integration DOM proof)
- [x] Unknown `render` → `Unsupported card type: "<key>"`; invalid payload → `Invalid <key> payload`; error boundary keeps a throwing card from blanking the message
- [x] Security rails pinned by tests: `image.src` limited to `data:image/(png|jpe?g|gif|webp);base64` (SVG excluded — no CSP exists), src binds only to `<img>`, 500-item caps with a visible truncation row, no `dangerouslySetInnerHTML`
- [x] Card state clears on session switch (#1580 guard), new send, attach replay, and error; transfers on both done and user-stop; survives the post-turn refetch
- [x] 3 characterization tests pin today's fence behavior as the deletion baseline for #2109
- [x] Spec §4.3 documents the primitive schemas for agent authors (additive; frozen sections untouched)

<details>
<summary>Scope notes / disclosures</summary>

- Cards are live-session-only in this PR: a page reload drops them until #2109 lands steps-derived hydration (the post-turn refetch merge is in-memory and commented as #2109-replaceable).
- The `email_pre_scan` adapter targets the contract shapes; today's live wire emits a stub payload for `pre_scan_inbox` until #2109 fixes `result_data` population in the shared SSE handler (plan-known gap, assigned there).
- Cards mirror the `agentSteps` finalize gate: a hypothetical cards-only turn with empty content would drop them — zero live impact now; #2109 may widen the gate.
- Frozen §4.2's "generic result card" wording vs §4.3's concrete fallback copy: reconciled at the #2109 cutover.
- The `evidence/2108-render-map` branch holds the screenshot; purge it after merge.
</details>
