### PR TITLE
feat(memory): adaptive, review-gated onboarding conversation (#1955)

### DIFF
--- a/docs/guides/memory.mdx
+++ b/docs/guides/memory.mdx
@@ -132,6 +132,8 @@ Everything is stored in a single file at `~/.gaia/memory.db` (SQLite with WAL mo
     gaia memory bootstrap --discover     # System scan only
     ```
 
+    The questions adapt to your answers -- say you are a student and the follow-up asks about coursework, not deployment pipelines. When the questions are done, everything the agent learned is shown back as a list and stored one item at a time on your approval (`[Y] store · [n] skip · [q] stop`). Nothing reaches the database unreviewed.
+
     <Tip>
       Bootstrap is repeatable. Run it again anytime to refresh the agent's understanding. New discoveries will not overwrite items you have manually edited.
     </Tip>
@@ -144,7 +146,7 @@ Everything is stored in a single file at `~/.gaia/memory.db` (SQLite with WAL mo
     gaia memory status
     ```
 
-    This shows counts by category (fact, preference, error, skill, note, reminder), context (work, personal, global), total conversations, tool call stats, and database size.
+    This shows counts by category (fact, preference, error, skill, note, reminder, profile, system, permission), context (work, personal, global), total conversations, tool call stats, and database size.
   </Step>
 
   <Step title="Start chatting">

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1903,6 +1903,8 @@ Manage agent memory: run day-zero onboarding and view memory statistics.
     gaia memory bootstrap --chat-only
     ```
 
+    The questions adapt to your answers (a student is asked about coursework, an engineer about their deployment workflow), and everything they produce is shown for approval (`[Y/n/q]`) before it is stored. `--chat-only` needs no LLM and no Lemonade Server -- it writes plain rows, which are embedded the next time an agent starts.
+
     Re-run system discovery:
     ```bash
     gaia memory bootstrap --discover

--- a/docs/sdk/sdks/memory.mdx
+++ b/docs/sdk/sdks/memory.mdx
@@ -100,7 +100,9 @@ def init_memory(
 9. Generate session UUID
 
 <Warning>
-  Embedding is a hard requirement in v2. If the Lemonade embedding service is unavailable, `init_memory()` raises `RuntimeError("Lemonade embedding service required for memory system")`. There is no silent degradation to keyword-only search.
+  Embedding is a hard requirement in v2 — there is no silent degradation to keyword-only search. If the Lemonade embedding service is unreachable at startup, `init_memory()` logs a warning and disables memory for that session (`memory_store` becomes `None`) rather than running with a half-built index. It does **not** raise: an agent must still start on a machine where Lemonade is not installed yet. `GAIA_MEMORY_DISABLED=1` disables memory the same way.
+
+  Callers that need a live store must check `memory_store is None` and fail with an actionable message — `run_bootstrap_conversation()` does exactly that.
 </Warning>
 
 ### get_memory_system_prompt()
@@ -204,6 +206,54 @@ def set_memory_context(self, context: str) -> None
 agent.set_memory_context("work")      # Switch to work context
 agent.set_memory_context("personal")  # Switch to personal context
 ```
+
+### run_bootstrap_conversation()
+
+Run the adaptive day-zero onboarding conversation and store the approved answers. This is the entry point for populating an empty memory — the CLI's `gaia memory bootstrap --chat-only` runs the same engine.
+
+```python
+def run_bootstrap_conversation(
+    self,
+    *,
+    prompt_fn: Callable[[str], str],
+    output_fn: Callable[[str], None],
+) -> BootstrapResult
+```
+
+All IO is injected, so the same flow works over stdio, a chat transport, or a test script:
+
+```python
+from gaia.agents.base.bootstrap import BootstrapCancelled
+
+def ask(question: str) -> str:
+    try:
+        return input(f"  {question} ")
+    except (EOFError, KeyboardInterrupt) as e:
+        raise BootstrapCancelled("user cancelled onboarding") from e
+
+result = agent.run_bootstrap_conversation(prompt_fn=ask, output_fn=print)
+print(f"{result.stored} stored, {result.rejected} rejected, {result.skipped} skipped")
+```
+
+The questions branch on the role answer (a student is asked about coursework, an engineer about their deployment workflow). Every entry the answers produce is shown for approval (`[Y/n/q]`) before it is written, with `source="user"` and `confidence=0.8` — identity answers as `profile`/`global`, work answers as `fact`/`work` with an `entity` link (e.g. `app:vscode`). Only `Y` or a bare Enter stores an entry; an answer that is not `Y`, `n`, or `q` is re-asked rather than treated as approval. Each stored entry is embedded immediately on this path.
+
+Returns a `BootstrapResult`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stored` | `int` | Rows written. Can be below the number of approvals — `store()` dedups near-identical content within the same category/context/entity |
+| `skipped` | `int` | Questions answered with an empty line |
+| `rejected` | `int` | Entries declined at review |
+| `unreviewed` | `int` | Entries never shown (the user quit the review or cancelled) |
+| `cancelled` | `bool` | The user aborted; entries approved before the abort are still stored |
+| `answers` | `dict[str, str]` | Question id → the user's raw answer |
+| `knowledge_ids` | `list[str]` | Ids of the stored rows, in approval order |
+
+Raises `RuntimeError` if memory is disabled for the session (embedding service unreachable, or `GAIA_MEMORY_DISABLED=1`) — use `gaia memory bootstrap --chat-only`, which onboards without an embedder — or if an approved entry cannot be stored or embedded. A `prompt_fn` may raise `BootstrapCancelled` to abort; entries approved before the abort remain stored.
+
+<Note>
+  The engine lives in `gaia.agents.base.bootstrap` as a pure function over an injected `MemoryStore` plus injected IO — no LLM, no console. `run_bootstrap_conversation(store, prompt_fn=..., output_fn=..., on_stored=None)` is how the CLI drives onboarding on a machine with no embedding backend.
+</Note>
 
 ### reset_memory_session()
 
@@ -921,7 +971,7 @@ These map to CRUD operations: `remember` = create, `recall` = read, `update_memo
 | `tool` | LLM called `remember()` | 0.5 |
 | `llm_extract` | Auto-extracted by LLM from conversation, Mem0-style | 0.4 |
 | `error_auto` | Auto-stored from tool failure | 0.5 |
-| `user` | Manually created via dashboard | 0.8 |
+| `user` | Manually created via dashboard, or answered during bootstrap onboarding | 0.8 |
 | `discovery` | System scan during bootstrap | 0.4 |
 | `consolidation` | Distilled from old conversation sessions | 0.5 |
 
@@ -941,6 +991,7 @@ These map to CRUD operations: `remember` = create, `recall` = read, `update_memo
 | `get_memory_system_prompt()` | Stable frozen prefix for system prompt (includes Skills section) |
 | `get_memory_dynamic_context()` | Per-turn time + upcoming items |
 | `register_memory_tools()` | Register 5 LLM-facing tools |
+| `run_bootstrap_conversation(prompt_fn, output_fn)` | Adaptive day-zero onboarding; stores approved answers as `source="user"` |
 | `set_memory_context(context)` | Switch active context |
 | `reset_memory_session()` | New session ID + confidence decay |
 | `_get_embedder()` | Lazy-init Lemonade embedding provider |

--- a/docs/spec/agent-memory-architecture.md
+++ b/docs/spec/agent-memory-architecture.md
@@ -308,7 +308,7 @@ Source is visible in the dashboard and helps users understand why the agent "kno
 
 ### Embed
 
-After storage, the item is immediately embedded via Lemonade (`user.embeddinggemma-300m-GGUF`, 768-dim) and the embedding BLOB is written back. Embedding is a hard requirement — `init_memory()` validates Lemonade connectivity at startup and raises `RuntimeError` if the embedding endpoint is unreachable. All knowledge items must have embeddings; items without embeddings (e.g., from a schema migration) are backfilled on startup before the system becomes operational.
+After storage, the item is embedded via Lemonade (`user.embeddinggemma-300m-GGUF`, 768-dim) and the embedding BLOB is written back. `init_memory()` validates Lemonade connectivity at startup; if the endpoint is unreachable it disables memory for the session rather than raising (see [Hard Requirements](#hard-requirements)). All knowledge items must end up with embeddings; items without one -- from a schema migration, or from a `--chat-only` bootstrap run on a machine with no embedder -- are backfilled at the next agent start.
 
 The embedder switched from `nomic-embed-text-v2-moe-GGUF` to `user.embeddinggemma-300m-GGUF` because the current llama.cpp server cannot load the nomic MOE embedder. Both are 768-dim, so the embedding schema is unchanged — but old nomic vectors are not comparable to EmbeddingGemma vectors, so the changed model name invalidates the stored embeddings and existing stores are re-embedded automatically on the next run.
 
@@ -416,11 +416,12 @@ def _classify_query_complexity(query: str) -> int:
 ### Hard Requirements
 
 Embedding is not optional. If the Lemonade embedding service is unavailable:
-- `init_memory()` raises `RuntimeError("Lemonade embedding service required for memory system")`
-- `search_hybrid()` raises `RuntimeError` rather than silently returning BM25-only results
-- `store()` raises `RuntimeError` if it cannot embed the new item
+- `init_memory()` logs a WARNING and **disables memory for that session** (`memory_store` is `None`). It does *not* raise -- an agent must still start on a machine where Lemonade is not installed yet, on a cloud backend, or under `GAIA_MEMORY_DISABLED=1` in CI. Every caller that needs a live store checks `memory_store is None` and fails with an actionable message (see `MemoryMixin.run_bootstrap_conversation()`).
+- `search_hybrid()` raises `RuntimeError` rather than silently returning BM25-only results.
 
-This is a deliberate design choice. Silent degradation to keyword-only search produces inconsistent result quality, masks configuration problems, and makes performance benchmarking unreliable. The user should always know when the system is not fully operational.
+This is a deliberate design choice. Silent degradation to keyword-only *search* produces inconsistent result quality, masks configuration problems, and makes performance benchmarking unreliable. The user should always know when the system is not fully operational -- which is why memory switches off loudly rather than running at half strength.
+
+**Storing is not embedding.** `store()` writes the row; embedding is a separate step (`store_embedding()` + the FAISS add). A row stored without one is not lost: `_backfill_embeddings()` picks it up at the next agent start. That separation is what lets `gaia memory bootstrap --chat-only` onboard a user on a machine that has no embedding backend at all.
 
 ### FAISS Index Lifecycle
 
@@ -1331,36 +1332,50 @@ Agent: "Hi! I'm your GAIA assistant. Let me learn a bit about you so I can
         be helpful from the start. You can skip any question."
 
 Agent: "What's your name?"
--> remember(fact="User's name is Alex", category="fact", context="global")
+-> store(content="User's name is Alex", category="profile", context="global")
 
 Agent: "What do you do? (e.g., software engineer, student, designer)"
--> remember(fact="Alex is a senior software engineer", category="fact", context="global")
+-> store(content="User's role/profession: senior software engineer",
+        category="profile", context="global")
 
 Agent: "What are you mainly going to use me for?"
   User: "Work coding, personal task management, and learning"
--> remember(fact="Primary use cases: work coding, personal tasks, learning",
-           category="fact", context="global")
--> Suggests creating contexts: "work", "personal", "learning"
+-> store(content="User's primary use cases for GAIA: Work coding, personal task management, and learning",
+        category="profile", context="global")
+-> Suggests creating contexts: "work", "personal", "learning" -- when the answer
+   names 2+ of them, that suggestion is proposed as its own entry:
+   store(content="Uses GAIA across these contexts: work, personal, learning",
+         category="profile", context="global")
 
 Agent: "Any preferences for how I communicate? (concise vs detailed, formal vs casual)"
--> remember(fact="Prefers concise, casual communication", category="preference",
-           context="global")
+-> store(content="Preferred communication style: concise, casual",
+        category="preference", context="global")
 
 Agent: "What's your timezone?"
--> remember(fact="Timezone: America/Los_Angeles (PST/PDT)", category="fact",
-           context="global")
+-> store(content="Timezone: America/Los_Angeles", category="profile",
+        context="global")
 
 Agent: "What tools/languages do you use most for work?"
   User: "Python, TypeScript, VS Code, git"
--> remember(fact="Primary stack: Python, TypeScript", category="fact",
-           context="work", entity="app:vscode")
--> remember(fact="Uses VS Code as primary IDE", category="fact",
-           context="work", entity="app:vscode")
+-> store(content="User's primary tools and languages: Python, TypeScript, VS Code, git",
+        category="profile", context="global")
+-> store(content="Primary stack: Python, TypeScript, VS Code, git", category="fact",
+        context="work", entity="app:vscode")
+-> store(content="Uses VS Code as primary IDE", category="fact",
+        context="work", entity="app:vscode")
 ```
 
-**Implementation:** A predefined question flow in `memory.py` -- a method like `run_bootstrap_conversation()` that the agent or CLI can invoke. Not a separate agent -- just a structured conversation using the existing memory tools.
+**Why the stack is stored twice:** the `work`-context rows are the entity-linked, context-scoped truth. But a default chat session runs in the `global` context, and the prompt builder selects *only* `global` rows there -- so a `work`-only stack would never reach the system prompt and the agent would look like it had forgotten the user's tools. The `profile`/`global` row is the one the agent actually sees day one; the `work` rows are what an agent working in the `work` context recalls, and what entity search (`app:vscode`) finds.
 
-The questions are adaptive -- if the user says "I'm a student," follow-up questions shift to coursework and study habits, not deployment pipelines.
+**Why `profile` and not `fact` for identity:** `profile` is a *privileged* category (`_PRIVILEGED_CATEGORIES` in `memory_store.py`). Only explicit user action may write one -- the LLM conversation extractor cannot mint one from a chat turn -- and profile entries render into their own "User profile:" section of the system prompt, always in the `global` context. Identity answers therefore stay `profile`; only the work-shaped answers (stack, IDE, engineering workflow) are `fact` in the `work` context. First-boot detection also keys on a `profile`/`global` entry existing, so demoting these to `fact` would re-offer onboarding forever.
+
+**Why `store(source="user")` and not the `remember` tool:** `remember` writes `source="tool"`, and Reset Safety (below) requires onboarding answers to be `source="user"` so that a discovery reset never deletes them. Onboarding writes through `MemoryStore.store()` directly with `source="user"` and `confidence=0.8`.
+
+**Nothing is stored unreviewed:** the collected answers are shown back as a numbered list and stored one by one on approval (`[Y/n/q]`), the same show-before-store gate System Discovery uses.
+
+**Implementation:** `MemoryMixin.run_bootstrap_conversation()` (`memory.py`) is the entry point the agent or CLI invokes. Not a separate agent -- just a structured conversation. The engine itself is a pure core in `agents/base/bootstrap.py`: it takes an injected `MemoryStore` plus injected IO callables, so `gaia memory bootstrap --chat-only` runs it with no LLM and no embedding backend, while an agent runs it with an embedding hook that indexes each approved entry immediately.
+
+The questions are adaptive -- if the user says "I'm a student," follow-up questions shift to coursework and study habits, not deployment pipelines. Branching is keyword-based (`student`, `engineer`, `designer`, `researcher`, `manager`, plus a generic fallback), which keeps onboarding usable on a machine where no model is loaded yet.
 
 ### System Discovery
 
@@ -1424,7 +1439,7 @@ Agent: "I can learn more about your setup by looking at your system.
 class SystemDiscovery:
     """Local system scanner for bootstrap. No agent dependencies.
     Each method returns a list of DiscoveredFact dicts, NOT stored directly.
-    The caller (MemoryMixin.run_bootstrap) presents them for user review."""
+    The caller (`gaia memory bootstrap --discover`) presents them for review."""
 
     def scan_file_system(self, paths: List[Path] = None) -> List[Dict]
         """Walk project directories. Returns project names + languages."""

--- a/docs/spec/agent-memory-architecture.md
+++ b/docs/spec/agent-memory-architecture.md
@@ -86,7 +86,7 @@ The working memory tier is bounded by the LLM's context window. The stable prefi
 
 ### Single Database: `~/.gaia/memory.db`
 
-One file, three tables. WAL mode for concurrent reads. Schema version 2.
+One file, six tables. WAL mode for concurrent reads. Schema version 3.
 
 ### Timestamps
 
@@ -102,7 +102,7 @@ Stored via Python: `datetime.now().astimezone().isoformat()` (local time with UT
 
 **Important caveat:** SQLite's built-in `datetime()` function does NOT understand timezone offsets. The temporal queries (`get_upcoming`, etc.) must compare against a Python-generated "now" string passed as a parameter, not `datetime('now')` in SQL. This is handled in the implementation -- all time comparisons use parameterized queries with Python-computed boundaries.
 
-### Complete v2 Schema
+### Complete v3 Schema
 
 ```sql
 -- Schema version tracking (for migrations)
@@ -110,14 +110,14 @@ CREATE TABLE IF NOT EXISTS schema_version (
     version     INTEGER NOT NULL,
     migrated_at TEXT NOT NULL         -- ISO 8601
 );
--- Initialize: INSERT INTO schema_version VALUES (2, <now>);
+-- Initialize: INSERT INTO schema_version VALUES (3, <now>);
 
 
 -- Table 1: knowledge
 -- Persistent facts, preferences, learnings -- the "second brain"
 CREATE TABLE knowledge (
     id          TEXT PRIMARY KEY,     -- UUID
-    category    TEXT NOT NULL,        -- 'fact' | 'preference' | 'error' | 'skill' | 'note' | 'reminder'
+    category    TEXT NOT NULL,        -- 'fact' | 'preference' | 'error' | 'skill' | 'note' | 'reminder' | 'system' | 'profile' | 'permission'
     content     TEXT NOT NULL,        -- Human-readable description
     domain      TEXT,                 -- Optional sub-type (e.g., 'journal', 'meeting:standup', 'deployment')
     source      TEXT NOT NULL DEFAULT 'tool',  -- 'tool' | 'llm_extract' | 'error_auto' | 'user' | 'discovery' | 'consolidation'
@@ -203,14 +203,49 @@ CREATE INDEX idx_tool_name ON tool_history(tool_name);
 CREATE INDEX idx_tool_session ON tool_history(session_id);
 CREATE INDEX idx_tool_success ON tool_history(success);
 CREATE INDEX idx_tool_ts ON tool_history(timestamp DESC);
+
+
+-- Table 4: procedures
+-- Synthesized procedural memory -- learned workflows (#887)
+CREATE TABLE IF NOT EXISTS procedures (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,              -- kebab-case (-> SKILL.md name)
+    when_to_use     TEXT NOT NULL,              -- trigger; embedded for recall (-> description)
+    markdown_body   TEXT NOT NULL,              -- full procedure incl. edge cases inline
+    tools_required  TEXT,                       -- JSON array -- the tool-loader recipe contract
+    tool_sequence   TEXT,                       -- JSON -- the distilled step pattern
+    success_count   INTEGER NOT NULL DEFAULT 0,
+    attempt_count   INTEGER NOT NULL DEFAULT 0, -- success_count / attempt_count = success rate
+    provenance      TEXT,                       -- JSON {source:'synthesized', from_sessions:[...]}
+    version         TEXT NOT NULL DEFAULT '1.0.0',
+    enabled         INTEGER NOT NULL DEFAULT 1, -- disable without delete (blocks recall)
+    embedding       BLOB,                       -- over when_to_use; its OWN FAISS index
+    superseded_by   TEXT,                       -- set on supersede (higher success rate)
+    created_at      TEXT NOT NULL,
+    last_used_at    TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_proc_name ON procedures(name);
+CREATE INDEX IF NOT EXISTS idx_proc_enabled ON procedures(enabled)
+    WHERE enabled = 1;
+CREATE INDEX IF NOT EXISTS idx_proc_superseded ON procedures(superseded_by)
+    WHERE superseded_by IS NOT NULL;
+
+
+-- Table 5: meta
+-- Internal key/value bookkeeping (consolidation cursors, etc.)
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+);
 ```
 
 ### Schema Migrations
 
-Schema version 2 adds two columns vs. v1. Migrations run automatically in `MemoryStore.__init__()`:
+Migrations run automatically in `MemoryStore.__init__()`. Fresh installs are stamped
+at the current version directly and skip the migration ladder.
 
 ```sql
--- Migration: schema_version 1 -> 2
+-- Migration: schema_version 1 -> 2 (embeddings + consolidation tracking)
 ALTER TABLE knowledge ADD COLUMN embedding BLOB;
 ALTER TABLE conversations ADD COLUMN consolidated_at TEXT;
 
@@ -220,13 +255,20 @@ CREATE INDEX IF NOT EXISTS idx_conv_not_consolidated
     ON conversations(session_id) WHERE consolidated_at IS NULL;
 
 UPDATE schema_version SET version = 2, migrated_at = <now>;
+
+
+-- Migration: schema_version 2 -> 3 (procedures table, #887)
+-- Additive only. The table and its indexes are created by the CREATE TABLE
+-- IF NOT EXISTS above (which runs for fresh and migrating databases alike),
+-- so this step only advances the version marker. No existing row is touched.
+UPDATE schema_version SET version = 3, migrated_at = <now>;
 ```
 
 ---
 
 ## Knowledge Categories & Domain Conventions
 
-### 6 Categories
+### 9 Categories
 
 | Category | What it stores | Example |
 |---|---|---|
@@ -236,6 +278,15 @@ UPDATE schema_version SET version = 2, migrated_at = <now>;
 | `skill` | Learned workflows and patterns | "To deploy: run tests -> build -> push to staging -> verify -> promote" |
 | `note` | Observations, journal entries, meeting notes | "Standup 2026-04-01: API migration complete" |
 | `reminder` | Time-sensitive items with `due_at` | "Q2 report due April 15" |
+| `system` | Discovered machine/environment facts | "Machine has an AMD Ryzen AI 9 HX 370 with NPU" |
+| `profile` | Who the user is (set by bootstrap onboarding) | "User is a software engineer in America/Los_Angeles" |
+| `permission` | Standing approvals for agent-inferred goals | "Always accept routine maintenance tasks" |
+
+**Privileged categories.** `system`, `profile`, and `permission` are writable only by an
+explicit memory tool or the system -- never by the LLM conversation extractor. A chat
+turn must not be able to mint a permission grant or a profile entry by emitting that
+category, so the extraction and consolidation paths validate against
+`EXTRACTABLE_CATEGORIES` (the other six), not `VALID_CATEGORIES`.
 
 ### Recommended Domain Naming
 

--- a/src/gaia/agents/base/bootstrap.py
+++ b/src/gaia/agents/base/bootstrap.py
@@ -1,0 +1,784 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Adaptive day-zero onboarding: the bootstrap conversation core.
+
+A pure engine — it walks a question graph, proposes memory entries, shows them
+for approval, and stores the approved ones through an injected ``MemoryStore``.
+It has no LLM dependency and no console dependency: all IO enters as the
+injected ``prompt_fn`` / ``output_fn`` callables, so the CLI can drive it over
+stdio while an agent drives it over a chat transport.
+
+That injection is what keeps ``gaia memory bootstrap --chat-only`` working on a
+machine with no Lemonade Server: the CLI passes a bare ``MemoryStore`` and no
+``on_stored`` hook, so no embedding is attempted. Agents pass an ``on_stored``
+hook (see ``MemoryMixin.run_bootstrap_conversation``) and get embeddings inline.
+The stored rows are identical either way — the CLI path's embeddings are
+backfilled at the next agent start.
+
+Adaptivity is rule-based (keyword branching), not LLM-driven — an LLM branch
+would re-introduce the Lemonade dependency this flow deliberately avoids.
+
+Spec: docs/spec/agent-memory-architecture.md ("Bootstrap: Day-Zero Onboarding")
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+from gaia.agents.base.memory_store import VALID_CATEGORIES, MemoryStore
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+#: Onboarding answers come straight from the user, so they are stored with
+#: ``source="user"`` — the source the reset path preserves (spec: "New
+#: discoveries don't overwrite user-edited memories") and the dedup merge
+#: refuses to downgrade (memory_store.py, ``CASE WHEN source = 'user'``).
+BOOTSTRAP_SOURCE: str = "user"
+
+#: Confidence for a fact the user stated about themselves.
+BOOTSTRAP_CONFIDENCE: float = 0.8
+
+#: The first question of the flow.
+START_ID: str = "name"
+
+#: How many distinct use-case contexts must be detected before onboarding
+#: suggests creating them (spec: "Suggests creating contexts").
+_MIN_CONTEXTS_FOR_SUGGESTION: int = 2
+
+#: The review question, and the three answers it accepts.
+_REVIEW_PROMPT: str = "Store this? [Y/n/q]:"
+_APPROVE: str = "approve"
+_DECLINE: str = "decline"
+_QUIT: str = "quit"
+
+#: How many times to re-ask when the review answer isn't Y, n, or q. After
+#: this, the entry is left out — an unparsed answer must never mean "store".
+_MAX_REVIEW_ATTEMPTS: int = 3
+
+
+class BootstrapCancelled(Exception):
+    """Raised by a caller's ``prompt_fn`` to abort onboarding.
+
+    The stdio adapter raises it on EOF / Ctrl-C. The engine catches only this
+    exception: it stops asking, keeps whatever the user already approved, and
+    returns a result with ``cancelled=True``.
+    """
+
+
+@dataclass(frozen=True)
+class ProposedEntry:
+    """One memory entry proposed by onboarding — the unit of user review.
+
+    Nothing reaches the database until the user approves the entry it came from.
+    """
+
+    content: str
+    category: str
+    context: str = "global"
+    entity: Optional[str] = None
+    confidence: float = BOOTSTRAP_CONFIDENCE
+
+
+@dataclass(frozen=True)
+class BootstrapQuestion:
+    """A node in the onboarding question graph.
+
+    Attributes:
+        id: Node id; must match the key it is registered under.
+        prompt: The question shown to the user.
+        category: Memory category for the entry built from the answer.
+        context: Memory context for that entry ("global", "work", ...).
+        template: Content template; ``{answer}`` is substituted.
+        branches: Keyword pattern -> next node id. Patterns are pipe-separated
+            alternatives matched case-insensitively on word boundaries, in
+            insertion order (first match wins).
+        next_id: Next node when no branch matches (and when the answer is
+            skipped). ``None`` ends the flow.
+        builder: Optional override that turns an answer into one or more
+            entries. Defaults to a single entry from ``template``.
+    """
+
+    id: str
+    prompt: str
+    category: str = "profile"
+    context: str = "global"
+    template: str = "{answer}"
+    branches: Dict[str, str] = field(default_factory=dict)
+    next_id: Optional[str] = None
+    builder: Optional[Callable[["BootstrapQuestion", str], List[ProposedEntry]]] = None
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Outcome of one onboarding run.
+
+    Attributes:
+        stored: Rows written to the database. Can be lower than the number of
+            approvals: ``store()`` dedups near-identical content within the
+            same category/context/entity.
+        skipped: Questions the user answered with an empty line.
+        rejected: Proposed entries the user declined at the review step.
+        unreviewed: Proposed entries never shown, because the user quit the
+            review or cancelled. Not stored, not rejected — just unseen.
+        cancelled: True when the user aborted (EOF / Ctrl-C). Entries approved
+            before the abort are still stored.
+        answers: Question id -> the user's raw answer.
+        knowledge_ids: Ids of the stored rows, in approval order.
+    """
+
+    stored: int
+    skipped: int
+    rejected: int
+    unreviewed: int
+    cancelled: bool
+    answers: Dict[str, str]
+    knowledge_ids: List[str]
+
+
+# ============================================================================
+# Keyword maps — the rule-based adaptivity
+# ============================================================================
+
+#: IDE keyword -> (entity id, display name). Ordered: the first match wins, so
+#: longer names precede the shorter names they contain.
+_ENTITY_MAP: Tuple[Tuple[str, Tuple[str, str]], ...] = (
+    ("visual studio code", ("app:vscode", "VS Code")),
+    ("vs code", ("app:vscode", "VS Code")),
+    ("vscode", ("app:vscode", "VS Code")),
+    ("pycharm", ("app:pycharm", "PyCharm")),
+    ("intellij", ("app:intellij", "IntelliJ IDEA")),
+    ("cursor", ("app:cursor", "Cursor")),
+    ("neovim", ("app:neovim", "Neovim")),
+    ("vim", ("app:vim", "Vim")),
+    ("sublime", ("app:sublime", "Sublime Text")),
+    ("emacs", ("app:emacs", "Emacs")),
+    ("xcode", ("app:xcode", "Xcode")),
+    ("figma", ("app:figma", "Figma")),
+)
+
+#: Context -> keywords that imply the user works in it.
+_CONTEXT_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "work": ("work", "job", "coding", "professional"),
+    "personal": ("personal", "home", "family", "hobby"),
+    "learning": ("learning", "study", "school", "course", "university"),
+}
+
+
+def _matches(keyword: str, text: str) -> bool:
+    """True when *keyword* occurs in *text* as a whole word (case-insensitive).
+
+    Word boundaries matter: a naive substring match would route "I build
+    things" to the designer branch because "build" contains "ui".
+    """
+    return (
+        re.search(rf"\b{re.escape(keyword)}\b", text, flags=re.IGNORECASE) is not None
+    )
+
+
+def _detect_ide(answer: str) -> Tuple[Optional[str], Optional[str]]:
+    """Find the first IDE named in *answer*.
+
+    Args:
+        answer: The user's raw tools/languages answer.
+
+    Returns:
+        ``(entity, display_name)`` for the first IDE matched, else
+        ``(None, None)``.
+    """
+    for keyword, (entity, display) in _ENTITY_MAP:
+        if _matches(keyword, answer):
+            return entity, display
+    return None, None
+
+
+def _detect_contexts(answer: str) -> List[str]:
+    """Return the memory contexts implied by *answer*, in canonical order.
+
+    Args:
+        answer: The user's raw use-cases answer.
+
+    Returns:
+        A list of context names (subset of ``_CONTEXT_KEYWORDS``), possibly
+        empty.
+    """
+    return [
+        context
+        for context, keywords in _CONTEXT_KEYWORDS.items()
+        if any(_matches(keyword, answer) for keyword in keywords)
+    ]
+
+
+# ============================================================================
+# Entry builders
+# ============================================================================
+
+
+def _default_builder(question: BootstrapQuestion, answer: str) -> List[ProposedEntry]:
+    """Build the single entry a question proposes by default.
+
+    Args:
+        question: The question that was answered.
+        answer: The user's raw answer (already stripped, non-empty).
+
+    Returns:
+        A one-element list holding the templated entry.
+    """
+    return [
+        ProposedEntry(
+            content=question.template.format(answer=answer),
+            category=question.category,
+            context=question.context,
+        )
+    ]
+
+
+def _tools_builder(question: BootstrapQuestion, answer: str) -> List[ProposedEntry]:
+    """Build the work-scoped stack facts, plus a global mirror of the stack.
+
+    The spec scopes the stack to ``context="work"`` with an ``entity`` link, and
+    emits a dedicated IDE fact alongside it. But a default chat runs in the
+    ``global`` context, and the prompt builder selects *only* global rows there
+    (``get_by_category_contexts``) — so work-scoped rows alone would never reach
+    the system prompt, and the user's stack would go quiet on day one. The
+    global ``profile`` mirror is what keeps it visible; the work rows are what
+    make it entity-linked and context-scoped.
+
+    Args:
+        question: The tools question.
+        answer: The user's raw tools/languages answer.
+
+    Returns:
+        The global stack entry and the work-scoped stack entry, plus the IDE
+        entry when an IDE was recognised.
+    """
+    entity, display = _detect_ide(answer)
+    entries = [
+        ProposedEntry(
+            content=f"User's primary tools and languages: {answer}",
+            category="profile",
+            context="global",
+        ),
+        ProposedEntry(
+            content=question.template.format(answer=answer),
+            category=question.category,
+            context=question.context,
+            entity=entity,
+        ),
+    ]
+    if entity is not None:
+        entries.append(
+            ProposedEntry(
+                content=f"Uses {display} as primary IDE",
+                category=question.category,
+                context=question.context,
+                entity=entity,
+            )
+        )
+    return entries
+
+
+def _use_cases_builder(question: BootstrapQuestion, answer: str) -> List[ProposedEntry]:
+    """Build the use-cases fact, plus the contexts the answer implies.
+
+    The second entry is what the spec calls "suggests creating contexts": the
+    user sees it in the review list and approves it. It is phrased as a fact
+    about the user, not as a note to the assistant, because profile rows are
+    injected verbatim into the "User profile:" block of the system prompt.
+
+    Args:
+        question: The use-cases question.
+        answer: The user's raw use-cases answer.
+
+    Returns:
+        One entry, or two when the answer names at least
+        ``_MIN_CONTEXTS_FOR_SUGGESTION`` distinct contexts.
+    """
+    entries = _default_builder(question, answer)
+    contexts = _detect_contexts(answer)
+    if len(contexts) >= _MIN_CONTEXTS_FOR_SUGGESTION:
+        entries.append(
+            ProposedEntry(
+                content=f"Uses GAIA across these contexts: {', '.join(contexts)}",
+                category="profile",
+                context="global",
+            )
+        )
+    return entries
+
+
+# ============================================================================
+# The question graph
+# ============================================================================
+
+#: Spine: name -> role -> <role follow-up> -> use_cases -> comms_style ->
+#: timezone -> tools -> interests -> extra.  The role answer picks the
+#: follow-up: a student is asked about coursework, an engineer about their
+#: deployment workflow (spec: "The questions are adaptive").
+BOOTSTRAP_GRAPH: Dict[str, BootstrapQuestion] = {
+    "name": BootstrapQuestion(
+        id="name",
+        prompt="What's your name?",
+        template="User's name is {answer}",
+        next_id="role",
+    ),
+    "role": BootstrapQuestion(
+        id="role",
+        prompt="What do you do? (role, profession, or student)",
+        template="User's role/profession: {answer}",
+        branches={
+            "student": "coursework",
+            "engineer|developer|programmer|software": "eng_workflow",
+            "designer|ux|ui": "design_tools",
+            "researcher|scientist|phd|academic": "research_area",
+            "manager|lead|pm|founder": "team_context",
+        },
+        next_id="generic_focus",
+    ),
+    # --- role follow-ups -------------------------------------------------
+    "coursework": BootstrapQuestion(
+        id="coursework",
+        prompt="What are you studying, and how do you like to study?",
+        template="User's coursework and study habits: {answer}",
+        next_id="use_cases",
+    ),
+    "eng_workflow": BootstrapQuestion(
+        id="eng_workflow",
+        prompt="What does your day-to-day engineering workflow look like? "
+        "(stack, testing, deployment)",
+        category="fact",
+        context="work",
+        template="User's engineering workflow: {answer}",
+        next_id="use_cases",
+    ),
+    "design_tools": BootstrapQuestion(
+        id="design_tools",
+        prompt="What does your design process look like? (tools, handoff)",
+        category="fact",
+        context="work",
+        template="User's design process: {answer}",
+        next_id="use_cases",
+    ),
+    "research_area": BootstrapQuestion(
+        id="research_area",
+        prompt="What's your research area, and what are you working on now?",
+        template="User's research area: {answer}",
+        next_id="use_cases",
+    ),
+    "team_context": BootstrapQuestion(
+        id="team_context",
+        prompt="What does your team build, and how big is it?",
+        category="fact",
+        context="work",
+        template="User's team context: {answer}",
+        next_id="use_cases",
+    ),
+    "generic_focus": BootstrapQuestion(
+        id="generic_focus",
+        prompt="What kinds of tasks do you most want help with?",
+        template="User's main focus areas: {answer}",
+        next_id="use_cases",
+    ),
+    # --- shared spine ----------------------------------------------------
+    "use_cases": BootstrapQuestion(
+        id="use_cases",
+        prompt="What will you mainly use GAIA for?",
+        template="User's primary use cases for GAIA: {answer}",
+        builder=_use_cases_builder,
+        next_id="comms_style",
+    ),
+    "comms_style": BootstrapQuestion(
+        id="comms_style",
+        prompt="How should I communicate with you? "
+        "(concise/detailed, casual/formal)",
+        category="preference",
+        template="Preferred communication style: {answer}",
+        next_id="timezone",
+    ),
+    "timezone": BootstrapQuestion(
+        id="timezone",
+        prompt="What timezone are you in? (e.g. America/Los_Angeles)",
+        template="Timezone: {answer}",
+        next_id="tools",
+    ),
+    "tools": BootstrapQuestion(
+        id="tools",
+        prompt="What programming languages or tools do you use most?",
+        category="fact",
+        context="work",
+        template="Primary stack: {answer}",
+        builder=_tools_builder,
+        next_id="interests",
+    ),
+    "interests": BootstrapQuestion(
+        id="interests",
+        prompt="What are your interests or hobbies outside of work?",
+        template="User's interests and hobbies: {answer}",
+        next_id="extra",
+    ),
+    "extra": BootstrapQuestion(
+        id="extra",
+        prompt="Anything else you'd like me to know about you?",
+        template="Additional user context: {answer}",
+        next_id=None,
+    ),
+}
+
+
+# ============================================================================
+# Validation — the store does not validate categories, so we must
+# ============================================================================
+
+
+def _validate_category(category: str, where: str) -> None:
+    """Raise if *category* is not a category MemoryStore recognises.
+
+    ``MemoryStore.store()`` accepts any string, so an unknown category would be
+    written silently and then never render into a system prompt.
+
+    Args:
+        category: The category to check.
+        where: Human-readable origin, used in the error message.
+
+    Raises:
+        ValueError: If the category is outside ``VALID_CATEGORIES``.
+    """
+    if category not in VALID_CATEGORIES:
+        raise ValueError(
+            f"Bootstrap {where} uses category '{category}', which is not a "
+            f"MemoryStore category. Valid categories: {sorted(VALID_CATEGORIES)} "
+            "(see VALID_CATEGORIES in src/gaia/agents/base/memory_store.py). "
+            "MemoryStore.store() does not validate categories, so this row "
+            "would be stored and then never recalled — fix the category in "
+            "BOOTSTRAP_GRAPH (src/gaia/agents/base/bootstrap.py)."
+        )
+
+
+def _validate_graph(graph: Dict[str, BootstrapQuestion], start: str) -> None:
+    """Check a question graph before asking anything.
+
+    Args:
+        graph: Node id -> question.
+        start: Id of the first question.
+
+    Raises:
+        ValueError: If the graph is empty, the start node is missing, a node id
+            disagrees with its key, a category is invalid, or an edge points at
+            an unknown node.
+    """
+    if not graph:
+        raise ValueError(
+            "Bootstrap question graph is empty — pass BOOTSTRAP_GRAPH "
+            "(src/gaia/agents/base/bootstrap.py) or a non-empty graph."
+        )
+    if start not in graph:
+        raise ValueError(
+            f"Bootstrap start node '{start}' is not in the question graph. "
+            f"Known nodes: {sorted(graph)}."
+        )
+    for node_id, question in graph.items():
+        if question.id != node_id:
+            raise ValueError(
+                f"Bootstrap question registered under '{node_id}' declares "
+                f"id='{question.id}'. The key and the id must match."
+            )
+        _validate_category(question.category, f"question '{node_id}'")
+        targets = list(question.branches.values())
+        if question.next_id is not None:
+            targets.append(question.next_id)
+        for target in targets:
+            if target not in graph:
+                raise ValueError(
+                    f"Bootstrap question '{node_id}' points at unknown node "
+                    f"'{target}'. Known nodes: {sorted(graph)}."
+                )
+
+
+# ============================================================================
+# Engine
+# ============================================================================
+
+
+def next_question_id(question: BootstrapQuestion, answer: str) -> Optional[str]:
+    """Pick the next question from *answer* — this is the adaptive branch.
+
+    Public so a step-wise driver (an onboarding wizard in the UI, say) can walk
+    the same graph one request at a time instead of re-deriving the branching.
+
+    Args:
+        question: The question that was just answered.
+        answer: The user's raw answer.
+
+    Returns:
+        The next question's id, ``question.next_id`` when no branch matches, or
+        ``None`` at the end of the flow.
+    """
+    for patterns, target in question.branches.items():
+        if any(_matches(keyword, answer) for keyword in patterns.split("|")):
+            return target
+    return question.next_id
+
+
+def build_entries(question: BootstrapQuestion, answer: str) -> List[ProposedEntry]:
+    """Turn one answer into the entries it proposes — nothing is stored here.
+
+    Public for the same reason as ``next_question_id``: a step-wise driver needs
+    the proposals to render its own review UI.
+
+    Args:
+        question: The question that was answered.
+        answer: The user's raw answer (non-empty).
+
+    Returns:
+        The proposed entries, each with a category the store recognises.
+
+    Raises:
+        ValueError: If a builder emits a category outside ``VALID_CATEGORIES``.
+    """
+    builder = question.builder or _default_builder
+    entries = builder(question, answer)
+    for entry in entries:
+        _validate_category(entry.category, f"entry from '{question.id}'")
+    return entries
+
+
+def _render(entry: ProposedEntry) -> str:
+    """Format a proposed entry for the review list."""
+    line = f"[{entry.category}/{entry.context}] {entry.content}"
+    if entry.entity:
+        line += f" (entity: {entry.entity})"
+    return line
+
+
+def _ask_approval(
+    prompt_fn: Callable[[str], str],
+    output_fn: Callable[[str], None],
+) -> str:
+    """Ask whether to store one entry, and insist on an answer we understand.
+
+    Only an explicit yes (or a bare Enter, the documented default) stores the
+    entry. An unrecognised reply — "no", "nope", a typo — is re-asked rather
+    than taken as approval: treating it as a yes would write data the user was
+    trying to decline.
+
+    Args:
+        prompt_fn: Asks the user one question and returns the raw reply.
+        output_fn: Shows one line of narration to the user.
+
+    Returns:
+        ``_APPROVE``, ``_DECLINE``, or ``_QUIT``.
+
+    Raises:
+        BootstrapCancelled: Propagated from *prompt_fn* when the user aborts.
+    """
+    for _ in range(_MAX_REVIEW_ATTEMPTS):
+        choice = prompt_fn(_REVIEW_PROMPT).strip().lower()
+        if choice in ("", "y", "yes"):
+            return _APPROVE
+        if choice in ("n", "no"):
+            return _DECLINE
+        if choice in ("q", "quit"):
+            return _QUIT
+        output_fn(f"  '{choice}' isn't Y, n, or q — please answer again.")
+
+    output_fn("  Still not Y, n, or q — leaving this one out to be safe.")
+    return _DECLINE
+
+
+def _db_hint(store: MemoryStore) -> str:
+    """Return a ' (database: ...)' fragment for error messages, or ''."""
+    db_path = getattr(store, "_db_path", None)
+    return f" (database: {db_path})" if db_path else ""
+
+
+def _store_entry(
+    store: MemoryStore,
+    entry: ProposedEntry,
+    on_stored: Optional[Callable[[str, str], None]],
+) -> str:
+    """Write one approved entry and run the caller's post-store hook.
+
+    Args:
+        store: The ``MemoryStore`` to write to.
+        entry: The approved entry.
+        on_stored: Optional hook called with ``(knowledge_id, content)`` after
+            the write — agents use it to embed the new row.
+
+    Returns:
+        The knowledge id of the stored entry.
+
+    Raises:
+        RuntimeError: If the write fails, or if *on_stored* fails.
+    """
+    try:
+        knowledge_id = store.store(
+            category=entry.category,
+            content=entry.content,
+            context=entry.context,
+            entity=entry.entity,
+            source=BOOTSTRAP_SOURCE,
+            confidence=entry.confidence,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Onboarding could not store '{entry.content[:60]}' "
+            f"(category={entry.category}, context={entry.context})"
+            f"{_db_hint(store)}: {e}. Check that the memory database is "
+            "writable and not held by another GAIA process (`gaia kill` "
+            "clears stale ones), then re-run `gaia memory bootstrap "
+            "--chat-only`."
+        ) from e
+
+    if on_stored is not None:
+        try:
+            on_stored(knowledge_id, entry.content)
+        except Exception as e:
+            raise RuntimeError(
+                f"Onboarding stored entry {knowledge_id} but could not embed "
+                f"it: {e}. The row itself is safe and will be embedded at the "
+                "next agent start. To finish onboarding now, start "
+                "lemonade-server, or run `gaia memory bootstrap --chat-only`, "
+                "which needs no embedder."
+            ) from e
+
+    logger.debug("[bootstrap] stored %s (%s)", knowledge_id, entry.category)
+    return knowledge_id
+
+
+def run_bootstrap_conversation(
+    store: MemoryStore,
+    *,
+    prompt_fn: Callable[[str], str],
+    output_fn: Callable[[str], None],
+    on_stored: Optional[Callable[[str, str], None]] = None,
+    questions: Optional[Dict[str, BootstrapQuestion]] = None,
+    start: str = START_ID,
+) -> BootstrapResult:
+    """Run the adaptive onboarding conversation and store the approved answers.
+
+    Walks the question graph (the role answer selects the follow-up), turns the
+    answers into proposed entries, shows every entry for approval, and stores
+    only the approved ones with ``source="user"``.
+
+    Args:
+        store: An open ``MemoryStore`` to write approved entries to.
+        prompt_fn: Asks the user one question and returns the raw reply. Raise
+            ``BootstrapCancelled`` from it to abort (the stdio adapter does this
+            on EOF / Ctrl-C).
+        output_fn: Shows one line of narration to the user.
+        on_stored: Optional hook called with ``(knowledge_id, content)`` after
+            each write. Pass ``None`` (the CLI does) to store without embedding
+            — the rows are embedded at the next agent start.
+        questions: Question graph. Defaults to ``BOOTSTRAP_GRAPH``.
+        start: Id of the first question. Defaults to ``START_ID``.
+
+    Returns:
+        A ``BootstrapResult`` with the stored/skipped/rejected/unreviewed
+        counts, whether the user cancelled, the raw answers, and the ids of the
+        stored rows.
+
+    Raises:
+        ValueError: If the question graph is malformed — unknown category,
+            dangling edge, missing start node, or a cycle.
+        RuntimeError: If an approved entry cannot be stored or embedded.
+    """
+    graph = BOOTSTRAP_GRAPH if questions is None else questions
+    _validate_graph(graph, start)
+
+    answers: Dict[str, str] = {}
+    proposed: List[ProposedEntry] = []
+    skipped = 0
+
+    try:
+        node_id: Optional[str] = start
+        visited: List[str] = []
+        while node_id is not None:
+            if node_id in visited:
+                raise ValueError(
+                    f"Bootstrap question graph loops back to '{node_id}' "
+                    f"(path: {' -> '.join(visited)}). Onboarding would re-ask "
+                    "the same question forever — remove the cycle from the "
+                    "branches/next_id edges."
+                )
+            visited.append(node_id)
+
+            question = graph[node_id]
+            answer = prompt_fn(question.prompt).strip()
+            if not answer:
+                skipped += 1
+                node_id = question.next_id
+                continue
+
+            answers[question.id] = answer
+            proposed.extend(build_entries(question, answer))
+            node_id = next_question_id(question, answer)
+    except BootstrapCancelled:
+        logger.info("[bootstrap] cancelled by the user before the review step")
+        return BootstrapResult(
+            stored=0,
+            skipped=skipped,
+            rejected=0,
+            unreviewed=len(proposed),
+            cancelled=True,
+            answers=answers,
+            knowledge_ids=[],
+        )
+
+    if not proposed:
+        output_fn("\nNothing to store — every question was skipped.")
+        return BootstrapResult(
+            stored=0,
+            skipped=skipped,
+            rejected=0,
+            unreviewed=0,
+            cancelled=False,
+            answers=answers,
+            knowledge_ids=[],
+        )
+
+    # Show before store — nothing is written without explicit approval.
+    output_fn(f"\nHere's what I learned ({len(proposed)} items):")
+    output_fn("  [Y] = store (default)   [n] = skip   [q] = stop review\n")
+
+    knowledge_ids: List[str] = []
+    rejected = 0
+    unreviewed = 0
+    cancelled = False
+
+    for index, entry in enumerate(proposed, 1):
+        output_fn(f"  ({index}/{len(proposed)}) {_render(entry)}")
+        try:
+            choice = _ask_approval(prompt_fn, output_fn)
+        except BootstrapCancelled:
+            logger.info("[bootstrap] cancelled by the user during review")
+            cancelled = True
+            unreviewed = len(proposed) - index + 1
+            break
+
+        if choice == _QUIT:
+            unreviewed = len(proposed) - index + 1
+            output_fn(
+                f"  Review stopped — the remaining {unreviewed} "
+                "item(s) were not stored."
+            )
+            break
+        if choice == _DECLINE:
+            rejected += 1
+            continue
+
+        knowledge_id = _store_entry(store, entry, on_stored)
+        # store() dedups within (category, context, entity), so two approved
+        # entries can merge into one row — count rows, not approvals.
+        if knowledge_id not in knowledge_ids:
+            knowledge_ids.append(knowledge_id)
+
+    return BootstrapResult(
+        stored=len(knowledge_ids),
+        skipped=skipped,
+        rejected=rejected,
+        unreviewed=unreviewed,
+        cancelled=cancelled,
+        answers=answers,
+        knowledge_ids=knowledge_ids,
+    )

--- a/src/gaia/agents/base/discovery.py
+++ b/src/gaia/agents/base/discovery.py
@@ -630,7 +630,7 @@ class SystemDiscovery:
     """Local system scanner for bootstrap. No agent dependencies.
 
     Each method returns a list of discovered fact dicts, NOT stored directly.
-    The caller (MemoryMixin.run_bootstrap) presents them for user review.
+    The caller (`gaia memory bootstrap --discover`) presents them for user review.
 
     All methods catch exceptions internally and return partial results.
     """

--- a/src/gaia/agents/base/memory.py
+++ b/src/gaia/agents/base/memory.py
@@ -41,7 +41,7 @@ import re
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from uuid import uuid4
 
 import numpy as np
@@ -53,6 +53,9 @@ from gaia.agents.base.memory_store import (
 )
 from gaia.agents.base.procedural_memory import ProceduralMemoryMixin
 from gaia.llm.lemonade_client import DEFAULT_EMBEDDING_MODEL
+
+if TYPE_CHECKING:
+    from gaia.agents.base.bootstrap import BootstrapResult
 
 logger = logging.getLogger(__name__)
 
@@ -337,11 +340,13 @@ class MemoryMixin(ProceduralMemoryMixin):
                 The embedding dimension is derived from the live embedder, not
                 this id, so a model with a different dim works without changes.
 
-        Raises:
-            RuntimeError: If Lemonade embedding service is unreachable
-                (unless ``GAIA_MEMORY_DISABLED=1`` is set, in which case
-                memory is skipped entirely — used by security tests and CI
-                environments that don't need memory but instantiate agents).
+        Does not raise when the embedding service is unreachable: it logs a
+        warning and degrades to a memory-disabled session (``memory_store`` is
+        ``None``), so an agent still starts on a machine without Lemonade.
+        ``GAIA_MEMORY_DISABLED=1`` skips init the same way — used by security
+        tests and CI environments that instantiate agents without memory.
+        Callers that need a live store must check ``memory_store is None`` and
+        fail with an actionable message.
         """
         # Explicit opt-out for environments that don't need memory (security
         # tests, lint-time imports, etc.).  This is NOT a silent fallback —
@@ -619,6 +624,73 @@ class MemoryMixin(ProceduralMemoryMixin):
             logger.info("[MemoryMixin] stored %d system context items", stored)
 
         return {"stored": stored}
+
+    # ------------------------------------------------------------------
+    # Bootstrap: day-zero conversational onboarding
+    # ------------------------------------------------------------------
+
+    def run_bootstrap_conversation(
+        self,
+        *,
+        prompt_fn: Callable[[str], str],
+        output_fn: Callable[[str], None],
+    ) -> "BootstrapResult":
+        """Run the adaptive onboarding conversation and store the answers.
+
+        The spec'd entry point for day-zero onboarding: asks a branching set of
+        questions (a student is asked about coursework, an engineer about their
+        deployment workflow), shows every proposed entry for approval, and
+        stores the approved ones with ``source="user"``. Each stored entry is
+        embedded immediately, so it is searchable in this same session.
+
+        The CLI drives the same engine directly against a bare ``MemoryStore``
+        (``gaia memory bootstrap --chat-only``), which is why onboarding still
+        works with no embedding backend.
+
+        Args:
+            prompt_fn: Asks the user one question and returns the raw reply.
+                Raise ``BootstrapCancelled`` from it to abort onboarding.
+            output_fn: Shows one line of narration to the user.
+
+        Returns:
+            A ``BootstrapResult`` with the stored/skipped/rejected counts,
+            whether the user cancelled, the raw answers, and the stored ids.
+
+        Raises:
+            RuntimeError: If memory is disabled for this session, or if an
+                approved entry cannot be stored or embedded.
+        """
+        from gaia.agents.base.bootstrap import (
+            run_bootstrap_conversation as _run_bootstrap_conversation,
+        )
+
+        store = self.memory_store  # raises if init_memory() was never called
+        if store is None:
+            raise RuntimeError(
+                "Cannot run onboarding: memory is disabled for this session "
+                "(the embedding service was unreachable at agent start, or "
+                "GAIA_MEMORY_DISABLED=1 is set). Start lemonade-server and "
+                "re-create the agent, or run `gaia memory bootstrap "
+                "--chat-only`, which onboards without an embedder. See "
+                "docs/guides/memory.mdx."
+            )
+
+        return _run_bootstrap_conversation(
+            store,
+            prompt_fn=prompt_fn,
+            output_fn=output_fn,
+            on_stored=self._embed_bootstrap_entry,
+        )
+
+    def _embed_bootstrap_entry(self, knowledge_id: str, content: str) -> None:
+        """Embed one stored onboarding entry and index it for search.
+
+        Failures propagate — the bootstrap core turns them into an actionable
+        RuntimeError naming the row that was stored but not embedded.
+        """
+        vec = self._embed_text(content)
+        self.memory_store.store_embedding(knowledge_id, _embedding_to_blob(vec))
+        self._faiss_add(knowledge_id, vec)
 
     # ------------------------------------------------------------------
     # Properties

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -768,7 +768,11 @@ async def async_main(action, **kwargs):
 
                 return 0 if result["status"] == "success" else 1
 
-            # First-boot: if no profile entries exist, offer onboarding intro
+            # First-boot: offer the onboarding intro until the user has either
+            # stored a profile entry or been through the conversation once.
+            # Both signals are needed: the review gate means a user can answer
+            # every question and approve nothing, and being re-asked forever
+            # after declining is worse than not asking.
             from gaia.agents.base.memory_store import MemoryStore as _BootMS
 
             _boot_store = _BootMS()
@@ -778,18 +782,28 @@ async def async_main(action, **kwargs):
                 )
             finally:
                 _boot_store.close()
-            if not _has_profile:
+            if not _has_profile and not _onboarding_completed():
                 print("\n" + "=" * 60)
                 print("  First time with GAIA? Let's set up your profile.")
                 print("=" * 60)
                 try:
                     run_first_boot = (
-                        input("  Quick intro? Takes ~1 minute. [Y/n]: ").strip().lower()
+                        input("  Quick intro? Takes ~3 minutes. [Y/n]: ")
+                        .strip()
+                        .lower()
                     )
                 except (EOFError, KeyboardInterrupt):
                     run_first_boot = "n"
                 if run_first_boot != "n":
-                    _bootstrap_chat()
+                    # Onboarding is optional; chat is not. A failure to store
+                    # must not cost the user their chat session.
+                    try:
+                        _bootstrap_chat()
+                    except RuntimeError as e:
+                        print(f"⚠ Onboarding could not finish: {e}")
+                        print(
+                            "  Continuing to chat — run `gaia memory bootstrap` later."
+                        )
                     print()
 
             # Interactive mode
@@ -5770,8 +5784,10 @@ def _handle_memory_bootstrap(args):
         elif getattr(args, "infer", False):
             _bootstrap_infer()
         else:
-            # Default: run both phases
-            _bootstrap_chat()
+            # Default: run both phases — but a cancelled conversation means the
+            # user wants out, not a second round of prompts from discovery.
+            if _bootstrap_chat().cancelled:
+                return
             print()
             _bootstrap_discover()
     except RuntimeError as e:
@@ -5781,87 +5797,95 @@ def _handle_memory_bootstrap(args):
 
 # ---- Bootstrap: conversational onboarding ----
 
-_BOOTSTRAP_QUESTIONS = [
-    {
-        "prompt": "What's your name?",
-        "category": "profile",
-        "template": "User's name is {answer}",
-    },
-    {
-        "prompt": "What do you do? (role, profession, or student)",
-        "category": "profile",
-        "template": "User's role/profession: {answer}",
-    },
-    {
-        "prompt": "What will you mainly use GAIA for?",
-        "category": "profile",
-        "template": "User's primary use cases for GAIA: {answer}",
-    },
-    {
-        "prompt": "What programming languages or tools do you use most?",
-        "category": "profile",
-        "template": "User's primary tools and languages: {answer}",
-    },
-    {
-        "prompt": "What are your interests or hobbies outside of work?",
-        "category": "profile",
-        "template": "User's interests and hobbies: {answer}",
-    },
-    {
-        "prompt": "How should I communicate with you? (concise/detailed, casual/formal)",
-        "category": "preference",
-        "template": "Preferred communication style: {answer}",
-    },
-    {
-        "prompt": "Anything else you'd like me to know about you?",
-        "category": "profile",
-        "template": "Additional user context: {answer}",
-    },
-]
+
+#: Marks that the user has been through the onboarding conversation, whatever
+#: they chose to store. Keyed in ~/.gaia/memory_settings.json so first-boot does
+#: not have to infer completion from the presence of a memory row.
+_ONBOARDING_COMPLETED_KEY = "onboarding_completed_at"
+
+
+def _onboarding_completed() -> bool:
+    """True once the user has finished the onboarding conversation at least once."""
+    from gaia.agents.base.memory import _load_memory_settings
+
+    return bool(_load_memory_settings().get(_ONBOARDING_COMPLETED_KEY))
+
+
+def _mark_onboarding_completed() -> None:
+    """Record that onboarding ran to the end, so first-boot stops offering it."""
+    from datetime import datetime
+
+    from gaia.agents.base.memory import _save_memory_settings
+
+    _save_memory_settings(
+        {_ONBOARDING_COMPLETED_KEY: datetime.now().astimezone().isoformat()}
+    )
+
+
+def _bootstrap_prompt(question: str) -> str:
+    """Ask *question* on stdio for the bootstrap conversation core.
+
+    Translates EOF / Ctrl-C into ``BootstrapCancelled`` so the core can stop
+    asking, keep what the user already approved, and report the cancellation.
+    """
+    from gaia.agents.base.bootstrap import BootstrapCancelled
+
+    try:
+        return input(f"  {question} ")
+    except (EOFError, KeyboardInterrupt) as e:
+        raise BootstrapCancelled("user cancelled onboarding") from e
 
 
 def _bootstrap_chat():
-    """Phase 1: Conversational onboarding — ask questions, store answers."""
+    """Phase 1: Conversational onboarding — adaptive questions, reviewed answers.
+
+    Drives the bootstrap core against a bare MemoryStore with no ``on_stored``
+    hook, so onboarding needs no embedding backend — the stored rows are
+    embedded at the next agent start.
+
+    Returns the BootstrapResult so callers can honour a cancellation.
+    """
+    from gaia.agents.base.bootstrap import run_bootstrap_conversation
     from gaia.agents.base.memory_store import MemoryStore
 
     print("\n=== Welcome to GAIA — Your Personal AI Assistant ===")
     print("I run locally on your AMD hardware, so everything stays private.")
     print("Let me get to know you so I can be more helpful from the start.")
-    print("(Press Enter to skip any question)\n")
+    print(
+        "(Press Enter to skip any question. Nothing is stored without your approval.)\n"
+    )
 
     try:
         store = MemoryStore()
     except Exception as e:
         raise RuntimeError(f"Error opening memory database: {e}") from e
 
-    stored_count = 0
     try:
-        for q in _BOOTSTRAP_QUESTIONS:
-            try:
-                answer = input(f"  {q['prompt']} ").strip()
-            except (EOFError, KeyboardInterrupt):
-                print("\n\nBootstrap cancelled.")
-                return
-
-            if not answer:
-                continue
-
-            content = q["template"].format(answer=answer)
-            try:
-                store.store(
-                    category=q["category"],
-                    content=content,
-                    source="user",
-                    context="global",
-                    confidence=0.8,
-                )
-                stored_count += 1
-            except Exception as e:
-                print(f"  ⚠ Failed to store: {e}")
-
-        print(f"\n✅ Stored {stored_count} memory entries from onboarding.")
+        result = run_bootstrap_conversation(
+            store,
+            prompt_fn=_bootstrap_prompt,
+            output_fn=print,
+            on_stored=None,
+        )
     finally:
         store.close()
+
+    if result.cancelled:
+        print("\n\nBootstrap cancelled.")
+        if result.stored:
+            print(f"Kept the {result.stored} entries you already approved.")
+        return result
+
+    _mark_onboarding_completed()
+
+    summary = (
+        f"\n✅ Stored {result.stored} memory entries from onboarding "
+        f"({result.rejected} rejected, {result.skipped} skipped"
+    )
+    if result.unreviewed:
+        summary += f", {result.unreviewed} not reviewed"
+    print(summary + ").")
+    return result
 
 
 # ---- Bootstrap: LLM-assisted profile inference ----

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -768,43 +768,7 @@ async def async_main(action, **kwargs):
 
                 return 0 if result["status"] == "success" else 1
 
-            # First-boot: offer the onboarding intro until the user has either
-            # stored a profile entry or been through the conversation once.
-            # Both signals are needed: the review gate means a user can answer
-            # every question and approve nothing, and being re-asked forever
-            # after declining is worse than not asking.
-            from gaia.agents.base.memory_store import MemoryStore as _BootMS
-
-            _boot_store = _BootMS()
-            try:
-                _has_profile = bool(
-                    _boot_store.get_by_category("profile", context="global", limit=1)
-                )
-            finally:
-                _boot_store.close()
-            if not _has_profile and not _onboarding_completed():
-                print("\n" + "=" * 60)
-                print("  First time with GAIA? Let's set up your profile.")
-                print("=" * 60)
-                try:
-                    run_first_boot = (
-                        input("  Quick intro? Takes ~3 minutes. [Y/n]: ")
-                        .strip()
-                        .lower()
-                    )
-                except (EOFError, KeyboardInterrupt):
-                    run_first_boot = "n"
-                if run_first_boot != "n":
-                    # Onboarding is optional; chat is not. A failure to store
-                    # must not cost the user their chat session.
-                    try:
-                        _bootstrap_chat()
-                    except RuntimeError as e:
-                        print(f"⚠ Onboarding could not finish: {e}")
-                        print(
-                            "  Continuing to chat — run `gaia memory bootstrap` later."
-                        )
-                    print()
+            _offer_first_boot_onboarding()
 
             # Interactive mode
             interactive_mode(agent)
@@ -5820,6 +5784,47 @@ def _mark_onboarding_completed() -> None:
     _save_memory_settings(
         {_ONBOARDING_COMPLETED_KEY: datetime.now().astimezone().isoformat()}
     )
+
+
+def _offer_first_boot_onboarding() -> None:
+    """Offer the onboarding intro on first `gaia chat`, at most once.
+
+    Gated on a stored profile entry OR the completion marker. Both signals are
+    needed: the review gate means a user can answer every question and approve
+    nothing, and being re-asked forever after declining is worse than not asking.
+    """
+    from gaia.agents.base.memory_store import MemoryStore
+
+    store = MemoryStore()
+    try:
+        has_profile = bool(store.get_by_category("profile", context="global", limit=1))
+    finally:
+        store.close()
+
+    if has_profile or _onboarding_completed():
+        return
+
+    print("\n" + "=" * 60)
+    print("  First time with GAIA? Let's set up your profile.")
+    print("=" * 60)
+    try:
+        answer = input("  Quick intro? Takes ~3 minutes. [Y/n]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        answer = "n"
+
+    if answer in ("n", "no"):
+        # Declining is an answer — record it so the intro is not re-offered.
+        _mark_onboarding_completed()
+        return
+
+    # Onboarding is optional; chat is not. A failure to store must not cost
+    # the user their chat session.
+    try:
+        _bootstrap_chat()
+    except RuntimeError as e:
+        print(f"⚠ Onboarding could not finish: {e}")
+        print("  Continuing to chat — run `gaia memory bootstrap` later.")
+    print()
 
 
 def _bootstrap_prompt(question: str) -> str:

--- a/tests/integration/test_memory_integration.py
+++ b/tests/integration/test_memory_integration.py
@@ -54,7 +54,7 @@ def _past_iso(days: int = 1) -> str:
 
 @pytest.fixture
 def memory_store(tmp_path):
-    """Real SQLite MemoryStore with v2 schema in a temp directory."""
+    """Real SQLite MemoryStore at the current schema, in a temp directory."""
     store = MemoryStore(db_path=tmp_path / "test_memory.db")
     yield store
     store.close()
@@ -1369,16 +1369,16 @@ class TestPruningPipeline:
 
 
 class TestSchemaMigration:
-    """Test that v2 schema features work on fresh databases."""
+    """Test that the current schema features work on fresh databases."""
 
-    def test_fresh_install_gets_v2_schema(self, memory_store):
-        """Fresh install creates schema version 2."""
+    def test_fresh_install_gets_current_schema(self, memory_store):
+        """Fresh install creates schema version 3 (procedures table, #887)."""
         with memory_store._lock:
             cursor = memory_store._conn.execute(
                 "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1"
             )
             version = cursor.fetchone()[0]
-        assert version == 2
+        assert version == 3
 
     def test_embedding_column_exists(self, memory_store):
         """The embedding BLOB column exists in the knowledge table."""

--- a/tests/unit/test_memory_bootstrap.py
+++ b/tests/unit/test_memory_bootstrap.py
@@ -1,0 +1,731 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Unit tests for the adaptive bootstrap conversation (issue #1955).
+
+Covers the day-zero onboarding core in ``gaia.agents.base.bootstrap``: role
+branching, timezone capture, entity linking, work-context scoping, context
+suggestion, the show-before-store review gate, cancellation, and the fail-loud
+paths — plus the ``MemoryMixin.run_bootstrap_conversation`` wrapper.
+
+Every storage assertion runs against a real ``MemoryStore`` on a temp sqlite
+file, so they assert the shape of the rows that were actually written, not that
+a mock was called.
+
+No Lemonade and no mocked LLM: the conversation core takes an injected store and
+injected IO by design, which is exactly what keeps ``gaia memory bootstrap
+--chat-only`` working with no embedding backend. The filename must keep its
+``test_memory_`` prefix — tests/unit/conftest.py keys on it to clear
+``GAIA_MEMORY_DISABLED``.
+"""
+
+import sqlite3
+
+import numpy as np
+import pytest
+
+from gaia.agents.base.bootstrap import (
+    BOOTSTRAP_GRAPH,
+    BootstrapCancelled,
+    BootstrapQuestion,
+    ProposedEntry,
+    run_bootstrap_conversation,
+)
+from gaia.agents.base.memory_store import MemoryStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REVIEW_PREFIX = "Store this?"
+
+#: A complete engineer run: name, role, engineering follow-up, use cases,
+#: communication style, timezone, tools, interests, extra.
+_ENGINEER_ANSWERS = [
+    "Alex",
+    "senior software engineer",
+    "Python monorepo, pytest, GitHub Actions",
+    "Work coding, personal task management, and learning",
+    "concise and casual",
+    "America/Los_Angeles",
+    "Python, TypeScript, VS Code, git",
+    "hiking and chess",
+    "I prefer metric units",
+]
+
+#: Entries the answers above propose: one per question (9), plus the context
+#: suggestion, plus the tools answer's global mirror and its IDE fact.
+_ENGINEER_ENTRY_COUNT = 12
+
+
+class ScriptedIO:
+    """Scripted ``prompt_fn``/``output_fn`` pair standing in for a human.
+
+    Answers questions from *answers* in order (an exhausted queue means "skip"),
+    and review prompts from *reviews* (an exhausted queue means "approve", the
+    default). Raises ``BootstrapCancelled`` when the configured cancel point is
+    reached, mimicking the CLI adapter's EOF / Ctrl-C translation.
+    """
+
+    def __init__(
+        self, answers, reviews=None, cancel_at_question=None, cancel_at_review=None
+    ):
+        self._answers = list(answers)
+        self._reviews = list(reviews or [])
+        self._cancel_at_question = cancel_at_question
+        self._cancel_at_review = cancel_at_review
+        self.questions_asked: list[str] = []
+        self.reviews_shown: int = 0
+        self.output: list[str] = []
+
+    def prompt(self, text: str) -> str:
+        if text.startswith(_REVIEW_PREFIX):
+            self.reviews_shown += 1
+            if self.reviews_shown == self._cancel_at_review:
+                raise BootstrapCancelled("cancelled at review")
+            return self._reviews.pop(0) if self._reviews else ""
+
+        self.questions_asked.append(text)
+        if len(self.questions_asked) == self._cancel_at_question:
+            raise BootstrapCancelled("cancelled at question")
+        return self._answers.pop(0) if self._answers else ""
+
+    def out(self, line: str) -> None:
+        self.output.append(line)
+
+
+def _rows(store: MemoryStore) -> list[dict]:
+    """Every active knowledge row, newest first."""
+    return store.get_all_knowledge(limit=100)["items"]
+
+
+def _contents(store: MemoryStore) -> list[str]:
+    return [row["content"] for row in _rows(store)]
+
+
+def _prompt_of(node_id: str) -> str:
+    return BOOTSTRAP_GRAPH[node_id].prompt
+
+
+@pytest.fixture
+def store(tmp_path):
+    """A real MemoryStore on a temp sqlite file — no Lemonade needed."""
+    db = MemoryStore(db_path=tmp_path / "memory.db")
+    yield db
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path — stored row shape (contract-shape assert)
+# ---------------------------------------------------------------------------
+
+
+def test_full_flow_stores_rows_with_the_documented_shape(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    rows = _rows(store)
+    assert result.stored == len(rows) > 0
+    assert result.skipped == 0
+    assert result.rejected == 0
+    assert result.cancelled is False
+    assert result.answers["name"] == "Alex"
+
+    # Every onboarding row is user-sourced (reset-safety) and high-confidence.
+    for row in rows:
+        assert row["source"] == "user"
+        assert row["confidence"] == pytest.approx(0.8)
+
+    by_content = {row["content"]: row for row in rows}
+
+    name_row = by_content["User's name is Alex"]
+    assert (name_row["category"], name_row["context"]) == ("profile", "global")
+
+    style_row = by_content["Preferred communication style: concise and casual"]
+    assert (style_row["category"], style_row["context"]) == ("preference", "global")
+
+    stack_row = by_content["Primary stack: Python, TypeScript, VS Code, git"]
+    assert (stack_row["category"], stack_row["context"]) == ("fact", "work")
+    assert stack_row["entity"] == "app:vscode"
+
+
+# ---------------------------------------------------------------------------
+# 2. Role branching (AC #1)
+# ---------------------------------------------------------------------------
+
+
+def test_student_role_branches_to_coursework_not_engineering(store):
+    io = ScriptedIO(["Ana", "I'm a student"])
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert _prompt_of("coursework") in io.questions_asked
+    assert _prompt_of("eng_workflow") not in io.questions_asked
+
+
+def test_engineer_role_branches_to_engineering_workflow(store):
+    io = ScriptedIO(["Alex", "senior software engineer"])
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert _prompt_of("eng_workflow") in io.questions_asked
+    assert _prompt_of("coursework") not in io.questions_asked
+
+
+def test_unmatched_role_branches_to_the_generic_follow_up(store):
+    io = ScriptedIO(["Sam", "I run a bakery"])
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert _prompt_of("generic_focus") in io.questions_asked
+
+
+def test_role_keywords_match_on_word_boundaries(store):
+    """'I build things' must not route to the designer branch via 'ui' in 'build'."""
+    io = ScriptedIO(["Sam", "I build things"])
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert _prompt_of("design_tools") not in io.questions_asked
+    assert _prompt_of("generic_focus") in io.questions_asked
+
+
+# ---------------------------------------------------------------------------
+# 3. Timezone
+# ---------------------------------------------------------------------------
+
+
+def test_timezone_is_asked_and_stored(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert _prompt_of("timezone") in io.questions_asked
+    tz_rows = [
+        r for r in _rows(store) if r["content"] == "Timezone: America/Los_Angeles"
+    ]
+    assert len(tz_rows) == 1
+    assert (tz_rows[0]["category"], tz_rows[0]["context"]) == ("profile", "global")
+
+
+# ---------------------------------------------------------------------------
+# 4. Entity linking — the tools answer emits two facts
+# ---------------------------------------------------------------------------
+
+
+def test_tools_answer_emits_stack_fact_and_ide_fact_with_entity(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    ide_rows = [r for r in _rows(store) if r["entity"] == "app:vscode"]
+    assert len(ide_rows) == 2
+    assert {r["content"] for r in ide_rows} == {
+        "Primary stack: Python, TypeScript, VS Code, git",
+        "Uses VS Code as primary IDE",
+    }
+    for row in ide_rows:
+        assert (row["category"], row["context"]) == ("fact", "work")
+
+
+def test_tools_answer_also_mirrors_the_stack_into_the_global_profile(store):
+    """A work-only stack would never reach the system prompt (global context)."""
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    # This is exactly what the prompt builder reads for a default chat session.
+    profile = store.get_by_category_contexts("profile", "global", limit=20)
+    assert "User's primary tools and languages: Python, TypeScript, VS Code, git" in [
+        row["content"] for row in profile
+    ]
+
+
+def test_tools_answer_without_an_ide_emits_no_entity_and_no_ide_fact(store):
+    answers = list(_ENGINEER_ANSWERS)
+    answers[6] = "Python, TypeScript, git"
+    io = ScriptedIO(answers)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert [r for r in _rows(store) if r["entity"]] == []
+    assert "Primary stack: Python, TypeScript, git" in _contents(store)
+    assert "Uses VS Code as primary IDE" not in _contents(store)
+
+
+# ---------------------------------------------------------------------------
+# 5. Context scoping (AC #2)
+# ---------------------------------------------------------------------------
+
+
+def test_work_facts_are_scoped_to_work_and_identity_stays_global(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    contexts = {row["content"]: row["context"] for row in _rows(store)}
+    assert contexts["Primary stack: Python, TypeScript, VS Code, git"] == "work"
+    assert (
+        contexts["User's engineering workflow: Python monorepo, pytest, GitHub Actions"]
+        == "work"
+    )
+    assert contexts["User's name is Alex"] == "global"
+    assert contexts["Timezone: America/Los_Angeles"] == "global"
+
+
+# ---------------------------------------------------------------------------
+# 6. Context suggestion
+# ---------------------------------------------------------------------------
+
+
+def test_multi_context_use_cases_propose_a_context_suggestion(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    suggestions = [
+        r for r in _rows(store) if r["content"].startswith("Uses GAIA across")
+    ]
+    assert len(suggestions) == 1
+    assert suggestions[0]["content"] == (
+        "Uses GAIA across these contexts: work, personal, learning"
+    )
+    assert (suggestions[0]["category"], suggestions[0]["context"]) == (
+        "profile",
+        "global",
+    )
+
+
+def test_single_context_use_cases_propose_no_suggestion(store):
+    answers = list(_ENGINEER_ANSWERS)
+    answers[3] = "work coding"
+    io = ScriptedIO(answers)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert not [r for r in _rows(store) if r["content"].startswith("Uses GAIA across")]
+
+
+# ---------------------------------------------------------------------------
+# 7. Review gate — nothing is stored without approval
+# ---------------------------------------------------------------------------
+
+
+def test_rejected_entry_is_not_stored(store):
+    # First proposed entry is the name; reject it, approve the rest.
+    io = ScriptedIO(_ENGINEER_ANSWERS, reviews=["n"])
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert result.rejected == 1
+    assert "User's name is Alex" not in _contents(store)
+    assert "Timezone: America/Los_Angeles" in _contents(store)
+
+
+def test_quit_stops_the_review_but_keeps_earlier_approvals(store):
+    # Approve the first entry, then quit.
+    io = ScriptedIO(_ENGINEER_ANSWERS, reviews=["y", "q"])
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert result.stored == 1
+    assert _contents(store) == ["User's name is Alex"]
+    assert result.cancelled is False
+    # The entries that were never shown are reported, not silently dropped.
+    assert result.unreviewed == _ENGINEER_ENTRY_COUNT - 1
+    assert result.stored + result.rejected + result.unreviewed == _ENGINEER_ENTRY_COUNT
+
+
+def test_spelled_out_no_declines_and_never_stores(store):
+    """'no' must not be read as approval — only Y / Enter stores."""
+    io = ScriptedIO(_ENGINEER_ANSWERS, reviews=["no"])
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert result.rejected == 1
+    assert "User's name is Alex" not in _contents(store)
+
+
+def test_unrecognised_review_answer_is_re_asked_then_declined(store):
+    """A typo is never taken as a yes; after re-asking, the entry is left out."""
+    io = ScriptedIO(["Alex"], reviews=["huh", "wat", "zzz"])
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert result.stored == 0
+    assert result.rejected == 1
+    assert _rows(store) == []
+    assert any("isn't Y, n, or q" in line for line in io.output)
+
+
+# ---------------------------------------------------------------------------
+# 8. Empty answers
+# ---------------------------------------------------------------------------
+
+
+def test_all_questions_skipped_stores_nothing(store):
+    io = ScriptedIO([])
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert result.stored == 0
+    assert result.skipped == len(io.questions_asked) > 0
+    assert result.knowledge_ids == []
+    assert _rows(store) == []
+    assert io.reviews_shown == 0
+
+
+# ---------------------------------------------------------------------------
+# 9. Cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_during_questions_stores_nothing(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS, cancel_at_question=3)
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert result.cancelled is True
+    assert result.stored == 0
+    assert result.knowledge_ids == []
+    assert _rows(store) == []
+    assert io.reviews_shown == 0
+
+
+def test_cancel_during_review_keeps_earlier_approvals(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS, cancel_at_review=2)
+
+    result = run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert result.cancelled is True
+    assert result.stored == 1
+    assert _contents(store) == ["User's name is Alex"]
+
+
+# ---------------------------------------------------------------------------
+# 10. Cold / no-embedder contract — the CLI path
+# ---------------------------------------------------------------------------
+
+
+def test_without_an_on_stored_hook_rows_are_stored_but_never_embedded(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    result = run_bootstrap_conversation(
+        store, prompt_fn=io.prompt, output_fn=io.out, on_stored=None
+    )
+
+    coverage = store.get_embedding_coverage()
+    assert result.stored > 0
+    assert coverage["total_items"] == result.stored
+    assert coverage["with_embedding"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 11. Fail loudly
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_graph_category_raises_before_asking_anything(store):
+    graph = {
+        "only": BootstrapQuestion(
+            id="only", prompt="Anything?", category="not-a-category"
+        )
+    }
+    io = ScriptedIO(["something"])
+
+    with pytest.raises(ValueError, match="not a MemoryStore category"):
+        run_bootstrap_conversation(
+            store,
+            prompt_fn=io.prompt,
+            output_fn=io.out,
+            questions=graph,
+            start="only",
+        )
+
+    assert io.questions_asked == []
+
+
+def test_dangling_graph_edge_raises(store):
+    graph = {
+        "only": BootstrapQuestion(id="only", prompt="Anything?", next_id="nowhere")
+    }
+    io = ScriptedIO(["something"])
+
+    with pytest.raises(ValueError, match="unknown node 'nowhere'"):
+        run_bootstrap_conversation(
+            store,
+            prompt_fn=io.prompt,
+            output_fn=io.out,
+            questions=graph,
+            start="only",
+        )
+
+
+def test_builder_emitting_an_invalid_category_raises(store):
+    def _bad_builder(question, answer):  # pylint: disable=unused-argument
+        return [ProposedEntry(content="bad", category="not-a-category")]
+
+    graph = {
+        "only": BootstrapQuestion(id="only", prompt="Anything?", builder=_bad_builder)
+    }
+    io = ScriptedIO(["something"])
+
+    with pytest.raises(ValueError, match="not a MemoryStore category"):
+        run_bootstrap_conversation(
+            store,
+            prompt_fn=io.prompt,
+            output_fn=io.out,
+            questions=graph,
+            start="only",
+        )
+
+
+def test_cyclic_graph_raises_instead_of_looping_forever(store):
+    graph = {
+        "a": BootstrapQuestion(id="a", prompt="A?", next_id="b"),
+        "b": BootstrapQuestion(id="b", prompt="B?", next_id="a"),
+    }
+    io = ScriptedIO(["one", "two", "three", "four"])
+
+    with pytest.raises(ValueError, match="loops back to 'a'"):
+        run_bootstrap_conversation(
+            store, prompt_fn=io.prompt, output_fn=io.out, questions=graph, start="a"
+        )
+
+
+def test_store_failure_raises_runtime_error_with_context():
+    class _BrokenStore:
+        _db_path = "/tmp/broken.db"
+
+        def store(self, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    io = ScriptedIO(["Alex"])
+
+    with pytest.raises(RuntimeError, match="Onboarding could not store") as excinfo:
+        run_bootstrap_conversation(
+            _BrokenStore(), prompt_fn=io.prompt, output_fn=io.out
+        )
+
+    assert isinstance(excinfo.value.__cause__, sqlite3.OperationalError)
+    assert "/tmp/broken.db" in str(excinfo.value)
+
+
+def test_embedding_failure_raises_runtime_error_naming_the_stored_row(store):
+    def _broken_hook(knowledge_id, content):  # pylint: disable=unused-argument
+        raise ConnectionError("lemonade-server not reachable")
+
+    io = ScriptedIO(["Alex"])
+
+    with pytest.raises(RuntimeError, match="could not embed") as excinfo:
+        run_bootstrap_conversation(
+            store, prompt_fn=io.prompt, output_fn=io.out, on_stored=_broken_hook
+        )
+
+    assert isinstance(excinfo.value.__cause__, ConnectionError)
+    # The row itself is safe — the error says so, and the DB agrees.
+    assert "User's name is Alex" in _contents(store)
+
+
+# ---------------------------------------------------------------------------
+# 12. The MemoryMixin wrapper
+# ---------------------------------------------------------------------------
+
+
+def _memory_host():
+    """A bare MemoryMixin host — no Agent, no LLM."""
+    from gaia.agents.base.memory import MemoryMixin
+
+    class _Host(MemoryMixin):
+        pass
+
+    return _Host()
+
+
+def test_mixin_wrapper_fails_loudly_when_memory_is_disabled(monkeypatch):
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    host = _memory_host()
+    host.init_memory()
+    assert host.memory_store is None
+
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    with pytest.raises(RuntimeError, match="memory is disabled") as excinfo:
+        host.run_bootstrap_conversation(prompt_fn=io.prompt, output_fn=io.out)
+
+    message = str(excinfo.value)
+    assert "GAIA_MEMORY_DISABLED" in message
+    assert "gaia memory bootstrap --chat-only" in message
+
+
+def test_mixin_wrapper_embeds_every_stored_entry(store, monkeypatch):
+    host = _memory_host()
+    host._memory_store = store
+    monkeypatch.setattr(
+        type(host),
+        "_embed_text",
+        lambda self, text: np.zeros(768, dtype=np.float32),
+    )
+    monkeypatch.setattr(type(host), "_faiss_add", lambda self, kid, vec: None)
+
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+    result = host.run_bootstrap_conversation(prompt_fn=io.prompt, output_fn=io.out)
+
+    coverage = store.get_embedding_coverage()
+    assert result.stored > 0
+    assert coverage["with_embedding"] == result.stored
+    assert coverage["without_embedding"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 13. First-boot invariant — cli.py detects onboarding via profile/global
+# ---------------------------------------------------------------------------
+
+
+def test_onboarding_writes_a_profile_row_in_the_global_context(store):
+    io = ScriptedIO(_ENGINEER_ANSWERS)
+
+    run_bootstrap_conversation(store, prompt_fn=io.prompt, output_fn=io.out)
+
+    assert store.get_by_category("profile", context="global", limit=1)
+
+
+# ---------------------------------------------------------------------------
+# 14. The CLI adapter — stdio in, BootstrapCancelled out
+# ---------------------------------------------------------------------------
+
+
+def _raise(exc):
+    def _boom(*_args, **_kwargs):
+        raise exc
+
+    return _boom
+
+
+@pytest.mark.parametrize("interrupt", [EOFError, KeyboardInterrupt])
+def test_cli_prompt_translates_an_interrupt_into_bootstrap_cancelled(
+    monkeypatch, interrupt
+):
+    from gaia.cli import _bootstrap_prompt
+
+    monkeypatch.setattr("builtins.input", _raise(interrupt()))
+
+    with pytest.raises(BootstrapCancelled):
+        _bootstrap_prompt("What's your name?")
+
+
+def test_cli_bootstrap_chat_reports_cancellation_and_stores_nothing(
+    monkeypatch, tmp_path, capsys
+):
+    import gaia.agents.base.memory_store as memory_store_module
+    from gaia import cli
+
+    db_path = tmp_path / "memory.db"
+    monkeypatch.setattr(
+        memory_store_module, "MemoryStore", lambda *a, **k: MemoryStore(db_path=db_path)
+    )
+    monkeypatch.setattr("builtins.input", _raise(EOFError()))
+
+    result = cli._bootstrap_chat()
+
+    out = capsys.readouterr().out
+    assert result.cancelled is True
+    assert "Bootstrap cancelled" in out
+    assert "✅" not in out  # no success line on an abort
+
+    after = MemoryStore(db_path=db_path)
+    try:
+        assert after.get_all_knowledge(limit=10)["items"] == []
+    finally:
+        after.close()
+
+
+def test_cli_marks_onboarding_completed_even_when_the_user_stores_nothing(
+    monkeypatch, tmp_path
+):
+    """Declining every entry must not re-offer the intro on every `gaia chat`.
+
+    First-boot keys on a profile row OR this marker; the review gate means a
+    user can answer everything and approve nothing.
+    """
+    import gaia.agents.base.memory as memory_module
+    import gaia.agents.base.memory_store as memory_store_module
+    from gaia import cli
+
+    monkeypatch.setattr(
+        memory_store_module,
+        "MemoryStore",
+        lambda *a, **k: MemoryStore(db_path=tmp_path / "memory.db"),
+    )
+    monkeypatch.setattr(
+        memory_module, "_MEMORY_SETTINGS_PATH", tmp_path / "memory_settings.json"
+    )
+    answers = iter(_ENGINEER_ANSWERS)
+    # Answer every question, then decline every proposed entry.
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt: "n" if "Store this?" in prompt else next(answers, ""),
+    )
+
+    assert cli._onboarding_completed() is False
+
+    result = cli._bootstrap_chat()
+
+    assert result.stored == 0
+    assert result.rejected == _ENGINEER_ENTRY_COUNT
+    assert cli._onboarding_completed() is True
+
+
+def test_cli_does_not_mark_onboarding_completed_when_cancelled(monkeypatch, tmp_path):
+    import gaia.agents.base.memory as memory_module
+    import gaia.agents.base.memory_store as memory_store_module
+    from gaia import cli
+
+    monkeypatch.setattr(
+        memory_store_module,
+        "MemoryStore",
+        lambda *a, **k: MemoryStore(db_path=tmp_path / "memory.db"),
+    )
+    monkeypatch.setattr(
+        memory_module, "_MEMORY_SETTINGS_PATH", tmp_path / "memory_settings.json"
+    )
+    monkeypatch.setattr("builtins.input", _raise(EOFError()))
+
+    cli._bootstrap_chat()
+
+    # Cancelling is not completing — the intro should still be offered.
+    assert cli._onboarding_completed() is False
+
+
+def test_cli_default_bootstrap_skips_discovery_when_the_chat_is_cancelled(monkeypatch):
+    from types import SimpleNamespace
+
+    from gaia import cli
+    from gaia.agents.base.bootstrap import BootstrapResult
+
+    discovered: list[str] = []
+    cancelled_result = BootstrapResult(
+        stored=0,
+        skipped=0,
+        rejected=0,
+        unreviewed=0,
+        cancelled=True,
+        answers={},
+        knowledge_ids=[],
+    )
+    monkeypatch.setattr(cli, "_bootstrap_chat", lambda: cancelled_result)
+    monkeypatch.setattr(cli, "_bootstrap_discover", lambda: discovered.append("ran"))
+
+    cli._handle_memory_bootstrap(
+        SimpleNamespace(
+            reset=False,
+            chat_only=False,
+            discover=False,
+            infer=False,
+            system=False,
+            reset_system=False,
+        )
+    )
+
+    assert discovered == []

--- a/tests/unit/test_memory_bootstrap.py
+++ b/tests/unit/test_memory_bootstrap.py
@@ -698,6 +698,127 @@ def test_cli_does_not_mark_onboarding_completed_when_cancelled(monkeypatch, tmp_
     assert cli._onboarding_completed() is False
 
 
+def _first_boot_env(monkeypatch, tmp_path):
+    """Point first-boot at a tmp store + settings file, with no profile row."""
+    import gaia.agents.base.memory as memory_module
+    import gaia.agents.base.memory_store as memory_store_module
+
+    monkeypatch.setattr(
+        memory_store_module,
+        "MemoryStore",
+        lambda *a, **k: MemoryStore(db_path=tmp_path / "memory.db"),
+    )
+    monkeypatch.setattr(
+        memory_module, "_MEMORY_SETTINGS_PATH", tmp_path / "memory_settings.json"
+    )
+
+
+@pytest.mark.parametrize("decline", ["n", "no", "N", "  No  "])
+def test_first_boot_declining_is_remembered_and_not_re_offered(
+    monkeypatch, tmp_path, decline
+):
+    """Declining the intro must not re-offer it on every `gaia chat`.
+
+    Regression: the decline path set neither first-boot signal (no profile row,
+    no marker), so the gate stayed open forever. 'no' must also decline — the
+    review gate accepts ('n', 'no'), so the two prompts must agree.
+    """
+    from gaia import cli
+
+    _first_boot_env(monkeypatch, tmp_path)
+
+    ran: list[str] = []
+    monkeypatch.setattr(cli, "_bootstrap_chat", lambda: ran.append("ran"))
+    monkeypatch.setattr("builtins.input", lambda prompt: decline)
+
+    assert cli._onboarding_completed() is False
+
+    cli._offer_first_boot_onboarding()
+
+    assert ran == []  # declining must not start the conversation
+    assert cli._onboarding_completed() is True
+
+    # Second launch: the intro is not offered again.
+    monkeypatch.setattr("builtins.input", _raise(AssertionError("re-offered")))
+    cli._offer_first_boot_onboarding()
+    assert ran == []
+
+
+@pytest.mark.parametrize("consent", ["", "y", "yes", "Y"])
+def test_first_boot_accepting_runs_the_conversation(monkeypatch, tmp_path, consent):
+    from gaia import cli
+
+    _first_boot_env(monkeypatch, tmp_path)
+
+    ran: list[str] = []
+    monkeypatch.setattr(cli, "_bootstrap_chat", lambda: ran.append("ran"))
+    monkeypatch.setattr("builtins.input", lambda prompt: consent)
+
+    cli._offer_first_boot_onboarding()
+
+    assert ran == ["ran"]
+
+
+def test_first_boot_eof_declines_without_running(monkeypatch, tmp_path):
+    """A non-interactive stdin must decline, not hang or start onboarding."""
+    from gaia import cli
+
+    _first_boot_env(monkeypatch, tmp_path)
+
+    ran: list[str] = []
+    monkeypatch.setattr(cli, "_bootstrap_chat", lambda: ran.append("ran"))
+    monkeypatch.setattr("builtins.input", _raise(EOFError()))
+
+    cli._offer_first_boot_onboarding()
+
+    assert ran == []
+    assert cli._onboarding_completed() is True
+
+
+def test_first_boot_is_skipped_when_a_profile_already_exists(monkeypatch, tmp_path):
+    from gaia import cli
+
+    _first_boot_env(monkeypatch, tmp_path)
+
+    store = MemoryStore(db_path=tmp_path / "memory.db")
+    try:
+        store.store(
+            category="profile",
+            content="User is a software engineer",
+            context="global",
+            source="user",
+        )
+    finally:
+        store.close()
+
+    monkeypatch.setattr("builtins.input", _raise(AssertionError("offered")))
+    monkeypatch.setattr(
+        cli, "_bootstrap_chat", _raise(AssertionError("ran onboarding"))
+    )
+
+    cli._offer_first_boot_onboarding()
+
+
+def test_first_boot_onboarding_failure_does_not_block_chat(
+    monkeypatch, tmp_path, capsys
+):
+    """Onboarding is optional; chat is not. A store failure must not propagate."""
+    from gaia import cli
+
+    _first_boot_env(monkeypatch, tmp_path)
+
+    monkeypatch.setattr("builtins.input", lambda prompt: "y")
+    monkeypatch.setattr(
+        cli, "_bootstrap_chat", _raise(RuntimeError("memory database is locked"))
+    )
+
+    cli._offer_first_boot_onboarding()
+
+    out = capsys.readouterr().out
+    assert "memory database is locked" in out
+    assert "gaia memory bootstrap" in out
+
+
 def test_cli_default_bootstrap_skips_discovery_when_the_chat_is_cancelled(monkeypatch):
     from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary

Day-zero onboarding now adapts to who you are and shows you every memory before it stores it. `gaia memory bootstrap --chat-only` and the first-boot intro in `gaia chat` run the spec'd `run_bootstrap_conversation()`, and still work on a machine with no LLM and no embedder.

## Why

Onboarding shipped in #606 as a static 7-question stub: it asked a student about deployment pipelines, never asked your timezone, filed every answer as `context="global"` with no entity links, and wrote all of it to the database **unreviewed** — the one thing the spec's "Nothing stored without explicit approval" rule forbids. Failures were swallowed with a `print`, so a locked database looked like success. Now the questions branch on your role (say "I'm a student" and the follow-up asks about coursework, not deployment), your tools get linked to the app you named (`entity="app:vscode"`) and scoped to `work`, and nothing reaches the database until you approve it item by item — with a loud, actionable error if a write genuinely fails.

## Linked issue

Closes #1955

## Changes

- **The conversation engine is a pure core** (`agents/base/bootstrap.py`) over an injected `MemoryStore` + injected IO callables, mirroring the existing `discovery.py` + CLI-driver split. This is load-bearing, not stylistic: `init_memory()` degrades to `_memory_store = None` on three live paths (Lemonade not installed, cloud backend, `GAIA_MEMORY_DISABLED=1`), so a naive `self.memory_store` call would break `--chat-only` for exactly the new users onboarding targets. `MemoryMixin.run_bootstrap_conversation()` is the spec'd entry point; the CLI passes `on_stored=None` (no embedding), agents pass a hook and get embeddings inline. Same rows either way — the CLI's are backfilled at next agent start.
- **Adaptivity is rule-based, not LLM-driven.** The spec's own example is keyword-shaped, and an LLM branch would re-introduce a Lemonade dependency into a flow that today has none. An optional `classify_fn`-style seam (`questions=` / public `build_entries` / `next_question_id`) is left for a future upgrade and for a step-wise UI wizard.
- **Fail-loudly throughout.** The core catches only `BootstrapCancelled`; store/embed failures `raise RuntimeError(...) from e` naming what failed, what to do, and the DB path — replacing the swallow at the old `cli.py:5859`. Categories are validated against `VALID_CATEGORIES` in our code, because `MemoryStore.store()` does **not** validate (only `seed_bulk` does), so a bad category would be stored and then never recalled.
- **Two first-boot guards, both bug-driven.** The review gate lets a user answer everything and approve nothing → no `profile` row → the intro would re-offer forever; an `onboarding_completed_at` marker (via the existing `memory_settings.json` mechanism) closes that. Declining with "no" now also counts as an answer and is recorded. Onboarding failure no longer costs you the chat session.
- **Spec aligned to code where they disagreed** (see Deviations) — plus the memory spec's schema section, stale at v2 since #1794, updated to v3.

## Deviations from the plan / spec — all flagged

| # | Spec / plan said | Shipped | Why |
|---|---|---|---|
| 1 | Onboarding stores `category="fact"` for identity (spec :1334-1351) | **`category="profile"`**; spec updated | ⚠️ **Needs a maintainer call.** `profile` is a real *privileged* category: it renders into its own "User profile:" prompt section (`limit=15`, always-global) and drives first-boot detection. Renaming would demote identity out of that section, re-fire the intro forever, and let a chat turn forge identity. Reversal is a one-line category-map edit if you disagree. |
| 2 | Flow lives "in `memory.py`" (:1361) | Core in new `bootstrap.py`; **the spec'd entry point still lives on `MemoryMixin`** | `memory.py` is 2600+ lines; the no-LLM constraint forces the pure-core split. Substance met, file placement differs. |
| 3 | Use the existing `remember()` tool (:1361) | `MemoryStore.store(source="user")` directly | `remember` writes `source="tool"`, which the spec's *own* reset-safety rule (:1322/:1484) forbids for onboarding. Also keeps the LLM tool surface out of the diff. |
| 4 | `remember()` implies an immediate embed | CLI: no embed (**unchanged**); mixin: embeds via `on_stored` | Preserves the cold-start path. Identical rows. |
| 5 | Timezone → `category="fact"` (:1350) | `profile` @ `global` | Consistency with #1. |
| 6 | "Show before store" written under *discovery* (:1320) | Batch review added to the chat flow | The issue's explicit ask. |
| 7 | tools → 2 entries, `fact`@`work` only | **3 entries** — adds a `profile`@`global` mirror | Found in review and verified: `set_memory_context()` has **zero** non-test callers, and `get_by_category_contexts` selects *only* global rows when the active context is `global`. Work-only rows would never reach the system prompt — a day-one regression vs. today. The `work` rows keep the spec's scoping + entity link; the mirror keeps the stack visible. |
| 8 | first-boot hook **unchanged** | Marker + `RuntimeError` guard + "~3 minutes" | The review gate broke the plan's own "fires once and only once" invariant. |

**Known trade-off:** `_get_context_items` returns active-context + global, and the default context is `global`, so the `work`-scoped stack rows surface only in the `work` context. That's what the spec (:1355) and the AC demand; the global mirror (#7) is the mitigation.

**Deliberately out of scope:** the two inlined `[Y/n/q]` review loops in `_bootstrap_discover` / `_bootstrap_infer` are not refactored into a shared helper — that would regress-risk those paths for no AC gain. Note that discovery's gate still treats an unrecognized answer as *approve*, which now disagrees with the chat gate in the same command; worth a follow-up.

## #1955 Acceptance Criteria — Proof

All evidence below is from real runs on this branch (details + raw output in `GAIA-1955-verification.md`).

| AC | Proof |
|---|---|
| **#1 — Adaptive questions** | Cold run answering "I'm a student" asked *"What are you studying, and how do you like to study?"*; the engineering/deployment question was never asked. Tests: `test_student_role_branches_to_coursework_not_engineering`, `..._engineer_role_branches_to_engineering_workflow`, `..._unmatched_role_branches_to_the_generic_follow_up`, `..._role_keywords_match_on_word_boundaries` ("I build things" must not route to the *designer* branch via "ui" in "build"). |
| **#2 — Category/context conformance** | Cold-DB `gaia memory status`: `fact: 2, preference: 1, profile: 9` · `global: 10, work: 2` · `user: 12` · avg confidence `0.80`. Direct sqlite: `('Primary stack: …', 'app:vscode')`, `('Uses VS Code as primary IDE', 'app:vscode')`, both `fact`/`work`. |
| **Entity linking** (spec :1355-1358) | The tools answer emits the stack fact **and** a dedicated IDE fact, both carrying `entity="app:vscode"`. |
| **Timezone** (spec :1350) | Asked and stored: `Timezone: America/Los_Angeles` (`profile`/`global`). |
| **Context suggestion** (spec :1343) | ≥2 use-case keywords → `Uses GAIA across these contexts: work, personal, learning`. |
| **Show before store** (spec :1320/:1504) | 12 items listed with `[Y/n/q]` before any write. Declining leaves the row out of the DB; `q` stops the review and reports what went unreviewed; only `Y`/Enter stores — `"no"`, `"nope"` or a typo is re-asked, never taken as approval. |
| **Reset safety** (spec :1322/:1484) | Every stored row is `source="user"` (`sources: ['user']`), protected by #1958's `CASE WHEN source = 'user'` dedup guard. |
| **First-boot invariant** | Run 1 of `gaia chat` on a cold DB offered the intro and stored 12 rows (`profile@global=9`); run 2 went straight to interactive mode, intro not offered. |
| **No-LLM / no-embedder contract** | `--chat-only` stored 11 rows with **0 embedding BLOBs** both with the embedder unreachable (`LEMONADE_BASE_URL=http://127.0.0.1:9`) *and* with Lemonade genuinely up on `:13305` — proving the CLI path never reaches for an embedder. |

## Test plan

- [x] `python -m pytest tests/unit/test_memory_bootstrap.py -q` → **46 passed**. Needs no Lemonade and no mocked LLM by design; asserts stored-row *shape* in a real sqlite DB, not "the mock was called". (The `test_memory_` filename prefix is load-bearing — `tests/unit/conftest.py:29` keys on it to clear `GAIA_MEMORY_DISABLED`, so a file named `test_bootstrap.py` would pass vacuously in CI.)
- [x] `python -m pytest tests/unit/test_memory_mixin.py tests/unit/test_memory_store.py tests/unit/test_memory_discovery.py -q` → **580 passed** — proves `remember`, the store, and discovery are untouched.
- [x] `python -m pytest tests/integration/test_memory_integration.py -q` → **74 passed** (was `1 failed` on `main`: `test_fresh_install_gets_v2_schema` asserted schema v2 while fresh installs have stamped **v3** since #1794 — the assertion was never updated. Verified pre-existing on a pristine worktree at `ec2cb5ae`).
- [x] `python util/lint.py --all` → `[SUCCESS] ALL QUALITY CHECKS PASSED!`
- [x] **Cold state** (the maintainer's explicit ask on #1955): from an empty memory DB, `gaia memory bootstrap --chat-only`. Answer "I'm a student" → coursework follow-up fires. Answer "Python, TypeScript, VS Code, git" → review list shows a `work` fact with `entity=app:vscode`. Then `gaia memory status` → `profile` + `preference` + `fact`, all `source=user`.
- [x] **No-embedder contract:** with `lemonade-server` down, `gaia memory bootstrap --chat-only` still completes and stores. Any embedder error here means the mixin coupling leaked into the CLI path.
- [x] **First-boot:** from a cleared DB, `gaia chat` offers the intro; complete it; `gaia chat` again → not offered.

### Eval

`gaia eval agent --category memory` on this branch vs. `main`, same machine, memory enabled, one eval process at a time (6-scenario subset; the full category is ~3h/side). **No regression:** pass rate **83% both sides**, avg **9.25 (branch) vs 9.0 (main)**.

<details>
<summary>Scenario detail + the one flagged regression (a web-search flake)</summary>

| Scenario | main | branch |
|---|---|---|
| memory_conflict_resolution | PASS 9.7 | PASS 9.8 |
| memory_cross_session_persistence | PASS 8.9 | PASS 9.8 |
| memory_multi_fact_accumulation | PASS 9.9 | PASS 9.9 |
| memory_preference_application | PASS 9.7 | FAIL 7.0 → **PASS 8.3 on re-run** |
| memory_store_and_recall | PASS 9.9 | PASS 9.9 |
| memory_stress_retrieval_under_noise | FAIL 8.3 | FAIL 8.0 (**also fails on `main`** — pre-existing) |

`memory_preference_application` failed only on **turn 3**, where the agent chose `search_web` for a general-knowledge question, the search errored (`TAVILY_API_KEY` is unset on this machine), and it gave up. Turns 1–2 — the actual memory behaviour — passed. Re-running the identical scenario against identical branch code: **PASS 8.3**. This change touches no tool, no tool schema, and no system prompt, so it has no mechanism to affect `search_web`.

There is **no committed `scorecard_memory.json` baseline**, so this is an A/B against `main`, not a baseline comparison. The `main` side was served from a detached worktree at `ec2cb5ae` (verified: `bootstrap.py` and `run_bootstrap_conversation` absent).

**Honest framing:** none of CLAUDE.md's enumerated eval triggers strictly fire — no system-prompt, tool-registration, error-classification, model-default, or tool-call-parsing changes. `memory.py` is in the diff and onboarding's rows feed `_build_stable_memory_prompt`, so this was run as a regression guard.
</details>

<details>
<summary>Two environment findings from the eval work (neither is a bug in this change) — worth follow-ups</summary>

1. **`memory_enabled` defaults to `false`** (beta flag in the UI DB under `HOME`), so a clean/isolated `HOME` yields a memory-*disabled* agent — every `remember` returns *"Memory is paused — this is a private session."* My first A/B scored cleanly and symmetrically while measuring an agent that could not remember anything. The runner's preflight checks `GAIA_MEMORY_ADMIN` but never checks memory is actually on; it should fail loudly when a `memory`-category scenario runs against `memory_enabled=false`.
2. **`OMP: Error #15`** on macOS once memory is enabled (faiss and torch each link their own `libomp.dylib`) crashes the backend; `KMP_DUPLICATE_LIB_OK=TRUE` works around it. Means memory evals can't run on a Mac without that env var.
</details>

## Checklist

- [x] I have linked a GitHub issue above (`Closes #1955`).
- [x] I have described **why** this change is being made, not just what changed.
- [x] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
- [x] I have updated documentation if user-visible behavior changed — spec, SDK reference, user guide, and CLI reference updated together; no `docs.json` entry needed (`guides/memory` is already registered, no new page).
