### PR TITLE
fix(ui): propagate cancel to the email sidecar on relay timeout/crash (#2158)

### DIFF
--- a/src/gaia/ui/email_sidecar/relay.py
+++ b/src/gaia/ui/email_sidecar/relay.py
@@ -414,6 +414,12 @@ def relay_query(
         if not terminated:
             handler._emit({"type": "status", "message": "Cancelled."})
     elif crashed or not terminated:
+        # No terminal event arrived — the sidecar generation is still decoding
+        # on the single GPU slot; stop it or later queries death-spiral.
+        try:
+            proxy.cancel_query(rid)
+        except SidecarError as exc:
+            logger.info("email relay: cancel_query for run_id=%s: %s", rid, exc)
         handler._emit({"type": "agent_error", "content": crash_message})
 
 

--- a/tests/unit/test_email_sidecar_relay.py
+++ b/tests/unit/test_email_sidecar_relay.py
@@ -569,6 +569,86 @@ class TestStreamFailureHandling:
         relay.relay_query(handler, proxy, query="q", context=[])
 
 
+# --- Orphaned-generation cleanup (#2158) -------------------------------------
+
+
+class TestOrphanCancelOnCrash:
+    """A run that ends without a terminal sidecar event (read-timeout, dropped
+    connection, exhausted stream) leaves the sidecar's ``/v1/email/query``
+    generation decoding on the single GPU slot unless the relay cancels it —
+    #2158's multi-query death-spiral."""
+
+    def test_stream_raise_without_terminal_event_calls_cancel_query(self):
+        handler = _FakeHandler()
+
+        def _source():
+            yield {"type": "status", "message": "hi"}
+            raise RuntimeError("read timed out")
+
+        proxy = _ScriptedProxy(_source)
+        relay.relay_query(handler, proxy, query="q", context=[], run_id="rid-t1")
+        assert proxy.cancel_calls == ["rid-t1"]
+
+    def test_stream_raise_with_zero_events_calls_cancel_query(self):
+        handler = _FakeHandler()
+        proxy = _ScriptedProxy(
+            lambda: _RaisingIterator(RuntimeError("connection reset"))
+        )
+        relay.relay_query(handler, proxy, query="q", context=[], run_id="rid-t2")
+        assert proxy.cancel_calls == ["rid-t2"]
+
+    def test_stream_exhausted_without_terminal_event_calls_cancel_query(self):
+        handler = _FakeHandler()
+
+        def _source():
+            yield {"type": "status", "message": "hi"}
+            # Generator ends -- no final/error was ever yielded.
+
+        proxy = _ScriptedProxy(_source)
+        relay.relay_query(handler, proxy, query="q", context=[], run_id="rid-t3")
+        assert proxy.cancel_calls == ["rid-t3"]
+
+    def test_terminal_final_does_not_call_cancel_query(self):
+        handler = _FakeHandler()
+        proxy = _ScriptedProxy(_events({"type": "final", "answer": "done"}))
+        relay.relay_query(handler, proxy, query="q", context=[], run_id="rid-t4")
+        assert proxy.cancel_calls == []
+
+    def test_terminal_error_does_not_call_cancel_query(self):
+        handler = _FakeHandler()
+        proxy = _ScriptedProxy(
+            _events({"type": "error", "detail": "Lemonade down", "status": 500})
+        )
+        relay.relay_query(handler, proxy, query="q", context=[], run_id="rid-t5")
+        assert proxy.cancel_calls == []
+
+    def test_user_cancel_still_calls_cancel_query_exactly_once(self):
+        handler = _FakeHandler()
+
+        def _source():
+            yield {"type": "tool_call", "tool": "pre_scan_inbox", "args": {}}
+            handler.cancelled.set()
+
+        proxy = _ScriptedProxy(_source)
+        relay.relay_query(handler, proxy, query="q", context=[], run_id="rid-t6")
+        assert proxy.cancel_calls == ["rid-t6"]
+
+    def test_crash_path_swallows_cancel_query_error_and_still_emits(self):
+        handler = _FakeHandler()
+
+        def _source():
+            yield {"type": "status", "message": "hi"}
+            raise RuntimeError("read timed out")
+
+        proxy = _ScriptedProxy(_source, cancel_raises=SidecarError("cancel failed"))
+        # Must not raise even though proxy.cancel_query raises SidecarError.
+        relay.relay_query(handler, proxy, query="q", context=[], run_id="rid-t7")
+        assert proxy.cancel_calls == ["rid-t7"]
+        agent_errors = [e for e in handler.events if e["type"] == "agent_error"]
+        assert len(agent_errors) == 1
+        assert agent_errors[0]["content"] == relay.STREAM_ENDED_UNEXPECTEDLY
+
+
 # --- Cancellation mid-stream -------------------------------------------------
 
 


### PR DESCRIPTION
Fixes #2158.

In a multi-query email UI session, one run hitting the 300s read-timeout (or any mid-stream crash) silently orphaned its sidecar generation: the relay emitted an agent_error but never told the sidecar to stop, so the dead run kept decoding on the single GPU slot and every later query got slower until all of them timed out — a session death-spiral. The relay now cancels the sidecar run whenever the stream ends without a terminal `final`/`error` event (and it wasn't a user-cancel, which already cancelled), so a timed-out run frees the slot immediately. A clean terminal event still skips the cancel, and the user-cancel path is unchanged — no double-cancel.

## Test plan

- [x] New unit tests: stream raise / zero-event raise / exhausted-without-terminal all call `cancel_query(rid)`; terminal `final`/`error` do NOT; user-cancel still cancels exactly once; a `SidecarError` from the cancel is swallowed and the agent_error still emits
- [x] `pytest tests/unit/test_email_sidecar_relay.py` — 48 passed, including the real-uvicorn read-timeout integration test now exercising the new cancel against the live sidecar app
- [x] `pytest tests/unit/chat/ui/test_email_relay_fidelity.py tests/unit/chat/ui/test_email_query_dispatch.py tests/unit/chat/ui/test_sse_handler.py` — 276 passed
- [x] `python util/lint.py --all --fix` clean on touched files