### PR TITLE
fix(email): raise amd-gaia floor to match get_embedding_model_for_device (#2112)

### DIFF
--- a/hub/agents/python/chat/gaia-agent.yaml
+++ b/hub/agents/python/chat/gaia-agent.yaml
@@ -11,14 +11,14 @@ icon: message-circle
 tools_count: 0
 
 language: python
-min_gaia_version: "0.20.0"
+min_gaia_version: "0.22.0"
 models: []
 
 python:
   entry_module: gaia_agent_chat
   entry_class: ChatAgent
   dependencies:
-    - "amd-gaia>=0.20.0"
+    - "amd-gaia>=0.22.0"
 
 requirements:
   min_memory_gb: 8

--- a/hub/agents/python/chat/pyproject.toml
+++ b/hub/agents/python/chat/pyproject.toml
@@ -10,7 +10,10 @@ authors = [{ name = "AMD" }]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["amd-gaia>=0.20.0"]
+# Floor: 0.22.0 is the first core release shipping
+# gaia.agents.registry.get_embedding_model_for_device, imported at agent
+# start (#2112).
+dependencies = ["amd-gaia>=0.22.0"]
 
 [project.entry-points."gaia.agent"]
 chat = "gaia_agent_chat:build_chat"

--- a/hub/agents/python/email/gaia-agent.yaml
+++ b/hub/agents/python/email/gaia-agent.yaml
@@ -22,14 +22,14 @@ icon: mail
 tools_count: 52
 
 language: python
-min_gaia_version: "0.20.0"
+min_gaia_version: "0.22.0"
 models: [Gemma-4-E4B-it-GGUF]
 
 python:
   entry_module: gaia_agent_email
   entry_class: EmailTriageAgent
   dependencies:
-    - "amd-gaia>=0.20.0"
+    - "amd-gaia>=0.22.0"
 
 requirements:
   min_memory_gb: 8

--- a/hub/agents/python/email/pyproject.toml
+++ b/hub/agents/python/email/pyproject.toml
@@ -13,9 +13,11 @@ requires-python = ">=3.10"
 # `pip install gaia-agent-email` pulls the REST-server deps (fastapi/uvicorn)
 # AND keyring automatically — the email REST router's import chain needs keyring
 # at module load and at request time (connected_mailbox_providers). Closes the
-# "consumer forgot [api]" half of #1617. Raise the floor to >=0.21.0 once that
-# release ships keyring-in-[api] for a hard version guarantee.
-dependencies = ["amd-gaia[api]>=0.20.0"]
+# "consumer forgot [api]" half of #1617.
+# Floor: 0.22.0 is the first core release shipping
+# gaia.agents.registry.get_embedding_model_for_device, imported at agent
+# start (#2112). tests/test_dependency_floor.py guards this floor.
+dependencies = ["amd-gaia[api]>=0.22.0"]
 
 # Agent registration temporarily disabled: with the entry point commented out,
 # `AgentRegistry.discover()` no longer surfaces the in-process email agent (it's

--- a/hub/agents/python/email/tests/test_dependency_floor.py
+++ b/hub/agents/python/email/tests/test_dependency_floor.py
@@ -1,0 +1,68 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Guards the amd-gaia dependency floor against the agent's real core needs.
+
+The email agent imports ``get_embedding_model_for_device`` from
+``gaia.agents.registry`` at module load; that symbol first shipped in core
+v0.22.0. With a lower floor a fresh resolver may legally select an older
+core and the agent dies at startup with ImportError (#2112). These tests
+pin the floor to the symbol so the two can't silently drift apart again:
+if the floor is lowered, or the agent grows an import the declared floor
+doesn't cover, one of these fails.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+EMAIL_ROOT = Path(__file__).resolve().parents[1]
+
+# First core release shipping gaia.agents.registry.get_embedding_model_for_device
+# (introduced by commit 89db99d6, first tagged in v0.22.0).
+REQUIRED_FLOOR = (0, 22, 0)
+
+
+def _floor_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in version.strip().split(".")[:3])
+
+
+def test_agent_module_imports_and_registry_symbol_exists():
+    """The exact import chain that crashed fresh installs in #2112."""
+    import gaia_agent_email.agent  # noqa: F401
+    from gaia.agents.registry import get_embedding_model_for_device
+
+    assert callable(get_embedding_model_for_device)
+
+
+def test_pyproject_floor_covers_registry_symbol():
+    pyproject = (EMAIL_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'"amd-gaia\[api\]>=([0-9.]+)"', pyproject)
+    assert match, "pyproject.toml must declare an amd-gaia[api]>=X.Y.Z floor"
+    assert _floor_tuple(match.group(1)) >= REQUIRED_FLOOR, (
+        f"amd-gaia floor {match.group(1)} predates "
+        "gaia.agents.registry.get_embedding_model_for_device (first shipped in "
+        "0.22.0); a fresh resolver may select a core that ImportErrors at "
+        "agent start (#2112)"
+    )
+
+
+def test_manifest_floors_match_pyproject():
+    """gaia-agent.yaml repeats the floor twice; both must stay in lock-step."""
+    manifest = (EMAIL_ROOT / "gaia-agent.yaml").read_text(encoding="utf-8")
+    min_gaia = re.search(r'min_gaia_version:\s*"([0-9.]+)"', manifest)
+    dep = re.search(r'"amd-gaia>=([0-9.]+)"', manifest)
+    assert min_gaia, "gaia-agent.yaml must declare min_gaia_version"
+    assert dep, "gaia-agent.yaml must declare an amd-gaia>=X.Y.Z dependency"
+
+    pyproject = (EMAIL_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    pyproject_floor = re.search(r'"amd-gaia\[api\]>=([0-9.]+)"', pyproject)
+    assert pyproject_floor
+
+    assert (
+        min_gaia.group(1) == dep.group(1) == pyproject_floor.group(1)
+    ), (
+        "amd-gaia floor drift: pyproject.toml "
+        f"({pyproject_floor.group(1)}) vs gaia-agent.yaml min_gaia_version "
+        f"({min_gaia.group(1)}) / python dependency ({dep.group(1)})"
+    )


### PR DESCRIPTION
Fresh installs of `gaia-agent-email` could crash at agent start: the declared floor `amd-gaia[api]>=0.20.0` let a fresh pip/uv resolver pick a core without `gaia.agents.registry.get_embedding_model_for_device`, so `/v1/email/query` died with ImportError (#2112). Core v0.22.0 — the first release shipping the symbol — is now on PyPI, so the floor is raised to it in both the pyproject and the hub manifest; the chat agent carried the identical under-declared floor (same import, flagged in the issue thread) and is fixed in the same pass. A new test pins the floor to the symbol so lowering it, or letting the manifest drift from the pyproject, fails CI.

Fixes #2112

## Test plan

- [x] `pytest hub/agents/python/email/tests/` — 599 passed (includes the new `test_dependency_floor.py`)
- [x] `pytest hub/agents/python/chat/tests/` — 7 passed
- [x] Mutation check: lowering the floor back to 0.20.0 makes the new tests fail
- [x] Acceptance (issue's criterion): scratch venv with PyPI `amd-gaia[api]==0.22.0` (the new minimum) + this package → `import gaia_agent_email.agent` and the registry symbol import clean
- [x] All package imports audited: every `gaia.*` symbol imported by `gaia_agent_email` and `gaia_agent_chat` exists in the `v0.22.0` tag, so 0.22.0 is a sufficient floor, not just for this one symbol
- [x] `python util/lint.py --all --fix` — clean

A follow-up could add the issue's suggested CI job that installs each hub agent against its declared floor from PyPI to catch this class generically; the new test pins the known symbol/floor pair in the meantime.