### PR TITLE
fix(email): normalize date operators in search_messages (#2161)

### DIFF
--- a/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/python/email/gaia_agent_email/tools/read_tools.py
@@ -18,6 +18,8 @@ module because every read tool that returns body bytes needs to honor it.
 from __future__ import annotations
 
 import os
+import re
+from datetime import date
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from gaia_agent_email.gmail_backend import decode_message_body
@@ -494,6 +496,114 @@ def summarize_thread_impl(
         return result
 
 
+# Gmail's after:/before:/older:/newer: operators only accept YYYY/MM/DD (or
+# epoch seconds). Anything else — e.g. the model's `after:July 1` — is treated
+# as a free-text content match, silently returning 0 results (#2161).
+_MONTH_NAMES = {
+    "jan": 1, "january": 1,
+    "feb": 2, "february": 2,
+    "mar": 3, "march": 3,
+    "apr": 4, "april": 4,
+    "may": 5,
+    "jun": 6, "june": 6,
+    "jul": 7, "july": 7,
+    "aug": 8, "august": 8,
+    "sep": 9, "sept": 9, "september": 9,
+    "oct": 10, "october": 10,
+    "nov": 11, "november": 11,
+    "dec": 12, "december": 12,
+}  # fmt: skip
+
+_MONTH_ALT = "|".join(sorted(_MONTH_NAMES, key=len, reverse=True))
+
+# Value grammar: quoted string, "July 1[, 2026]", "1 July[, 2026]", or a
+# single token. `older_than:`/`newer_than:` never match — the op name must be
+# followed immediately by a colon.
+_DATE_OP_RE = re.compile(
+    rf"""
+    \b(?P<op>after|before|older|newer):
+    (?P<val>
+        "[^"]*"
+      | (?:{_MONTH_ALT})\s+\d{{1,2}}(?:st|nd|rd|th)?(?:,?\s*\d{{4}}\b)?
+      | \d{{1,2}}\s+(?:{_MONTH_ALT})\b(?:,?\s*\d{{4}}\b)?
+      | \S+
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_ORDINAL_RE = re.compile(r"^(\d{1,2})(?:st|nd|rd|th)?$", re.IGNORECASE)
+
+
+def _parse_gmail_date_value(raw: str, *, op: str) -> str:
+    """Parse one date-operator value into Gmail's ``YYYY/MM/DD`` form.
+
+    Accepts the formats the model actually produces: ``2026/07/01``,
+    ``2026-07-01``, ``7/1/2026`` (US month-first), ``July 1[, 2026]``,
+    ``1 July [2026]``. Epoch values (all digits, >= 8 chars) pass through —
+    Gmail accepts them natively. Anything else raises ``ValueError``.
+    """
+    value = raw.strip().strip('"').strip()
+    if value.isdigit() and len(value) >= 8:
+        return value
+
+    y = mo = d = None
+    m = re.fullmatch(r"(\d{4})[/-](\d{1,2})[/-](\d{1,2})", value)
+    if m:
+        y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+    else:
+        m = re.fullmatch(r"(\d{1,2})/(\d{1,2})/(\d{4})", value)
+        if m:
+            mo, d, y = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        else:
+            tokens = [t for t in re.split(r"[\s,]+", value) if t]
+            if len(tokens) in (2, 3):
+                a, b = tokens[0].lower(), tokens[1].lower()
+                day_tok = None
+                if a in _MONTH_NAMES and _ORDINAL_RE.fullmatch(b):
+                    mo, day_tok = _MONTH_NAMES[a], b
+                elif b in _MONTH_NAMES and _ORDINAL_RE.fullmatch(a):
+                    mo, day_tok = _MONTH_NAMES[b], a
+                if day_tok is not None:
+                    d = int(_ORDINAL_RE.fullmatch(day_tok).group(1))
+                    if len(tokens) == 3:
+                        if not re.fullmatch(r"\d{4}", tokens[2]):
+                            mo = d = None
+                        else:
+                            y = int(tokens[2])
+                    else:
+                        y = date.today().year
+
+    if y is None or mo is None or d is None:
+        raise ValueError(
+            f"search_messages: cannot parse date value {raw!r} for the "
+            f"'{op}:' operator. Use Gmail date format {op}:YYYY/MM/DD "
+            f"(e.g. {op}:2026/07/01)."
+        )
+    try:
+        date(y, mo, d)
+    except ValueError as exc:
+        raise ValueError(
+            f"search_messages: {raw!r} is not a valid calendar date for the "
+            f"'{op}:' operator ({exc}). Use {op}:YYYY/MM/DD "
+            f"(e.g. {op}:2026/07/01)."
+        ) from exc
+    return f"{y:04d}/{mo:02d}/{d:02d}"
+
+
+def normalize_gmail_date_operators(query: str) -> str:
+    """Rewrite date-operator values in ``query`` to Gmail's ``YYYY/MM/DD``.
+
+    Raises ``ValueError`` on an unparseable value — a loud error beats
+    passing it through as free text and returning a false zero-result.
+    """
+    def _sub(m: "re.Match[str]") -> str:
+        op = m.group("op").lower()
+        return f"{op}:{_parse_gmail_date_value(m.group('val'), op=op)}"
+
+    return _DATE_OP_RE.sub(_sub, query)
+
+
 def search_messages_impl(
     gmail,
     *,
@@ -501,6 +611,7 @@ def search_messages_impl(
     max_results: int = 25,
     debug: bool = False,
 ) -> Dict[str, Any]:
+    query = normalize_gmail_date_operators(query)
     with log_tool_call(
         "search_messages",
         {"query": query, "max_results": max_results},
@@ -1151,7 +1262,9 @@ class ReadToolsMixin:
             downstream tools route actions without re-asking.
 
             ``query`` uses Gmail search syntax (e.g.
-            ``"from:boss@example.com is:unread newer_than:7d"``).
+            ``"from:boss@example.com is:unread newer_than:7d"``). Date
+            operators require ``YYYY/MM/DD`` — e.g. ``after:2026/07/01
+            before:2026/07/08``, never ``after:July 1``.
             """
             try:
                 max_results = max(1, min(int(max_results or 25), 100))

--- a/hub/agents/python/email/tests/test_search_date_normalization.py
+++ b/hub/agents/python/email/tests/test_search_date_normalization.py
@@ -1,0 +1,143 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Date-operator normalization tests for ``search_messages`` (#2161).
+
+Gmail requires ``after:``/``before:``/``older:``/``newer:`` values in
+``YYYY/MM/DD`` form. The model routinely emits natural-language dates
+(``after:July 1 before:July 8``), which Gmail treats as free-text content
+matches — silently returning 0 results and letting the agent confidently
+assert no messages exist in the range.
+
+Covered:
+
+- mixed-format query normalizes to ``after:YYYY/MM/DD before:YYYY/MM/DD``
+  in the outgoing Gmail query string (asserted via FakeGmailBackend's
+  recorded transport call)
+- the common formats the model produces parse: ``July 1``, ``July 1 2026``,
+  ``July 1, 2026``, ``1 July 2026``, ``2026-07-01``, ``7/1/2026``,
+  ``2026/7/1`` (zero-padded)
+- non-date operators (``newer_than:7d``) and epoch values pass through
+  untouched
+- an unparseable or invalid date raises ``ValueError`` loudly BEFORE any
+  backend call — never a silent zero-result
+
+All tests are hermetic: FakeGmailBackend only, no Lemonade, no network.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+# parents[0] = tests/,  [1] = email/,  [2] = python/,  [3] = agents/,
+# [4] = hub/,  [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.tools.read_tools import (  # noqa: E402
+    normalize_gmail_date_operators,
+    search_messages_impl,
+)
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through search_messages_impl: outgoing query is normalized
+# ---------------------------------------------------------------------------
+
+
+def test_impl_normalizes_mixed_format_dates_in_outgoing_query():
+    gmail = FakeGmailBackend(user_email="user@example.com")
+    search_messages_impl(
+        gmail, query="invoice after:July 1, 2026 before:2026-07-08"
+    )
+    listed = [c for c in gmail.transport.calls if c[0] == "list_messages"]
+    assert len(listed) == 1
+    assert listed[0][1]["query"] == "invoice after:2026/07/01 before:2026/07/08"
+
+
+def test_impl_rejects_unparseable_date_before_any_backend_call():
+    gmail = FakeGmailBackend(user_email="user@example.com")
+    with pytest.raises(ValueError, match=r"YYYY/MM/DD"):
+        search_messages_impl(gmail, query="after:sometime")
+    assert gmail.transport.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Normalizer unit coverage: formats the model actually produces
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("after:2026-07-01", "after:2026/07/01"),
+        ("after:7/1/2026", "after:2026/07/01"),
+        ("after:July 1 2026", "after:2026/07/01"),
+        ("after:July 1, 2026", "after:2026/07/01"),
+        ("before:1 July 2026", "before:2026/07/01"),
+        ('before:"July 8, 2026"', "before:2026/07/08"),
+        ("after:jul 1st 2026", "after:2026/07/01"),
+        ("older:2026-12-31", "older:2026/12/31"),
+        ("newer:2026-01-02", "newer:2026/01/02"),
+        # Already-Gmail values normalize idempotently (zero-padded).
+        ("after:2026/7/1", "after:2026/07/01"),
+        ("after:2026/07/01", "after:2026/07/01"),
+        # Multiple operators plus surrounding free text.
+        (
+            "from:boss@example.com after:July 1 2026 before:July 8 2026 is:unread",
+            "from:boss@example.com after:2026/07/01 before:2026/07/08 is:unread",
+        ),
+    ],
+)
+def test_normalizes_common_model_formats(query, expected):
+    assert normalize_gmail_date_operators(query) == expected
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "newer_than:7d",
+        "older_than:2m",
+        "from:boss@example.com is:unread",
+        "after:1751328000",  # epoch seconds are valid Gmail date values
+        "",
+    ],
+)
+def test_non_date_operators_and_epoch_pass_through_untouched(query):
+    assert normalize_gmail_date_operators(query) == query
+
+
+def test_yearless_date_defaults_to_current_year():
+    year = date.today().year
+    assert (
+        normalize_gmail_date_operators("after:July 1")
+        == f"after:{year}/07/01"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loud failure: unparseable / impossible dates never pass through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "after:sometime",
+        "before:next week",
+        "after:2026-02-30",  # impossible calendar date
+        "after:13/45/2026",
+    ],
+)
+def test_unparseable_date_raises_actionable_error(query):
+    with pytest.raises(ValueError, match=r"YYYY/MM/DD"):
+        normalize_gmail_date_operators(query)


### PR DESCRIPTION
Fixes #2161.

Date-ranged email searches silently returned false "no messages found" answers: the model emits `after:July 1 before:July 8`, Gmail requires `after:YYYY/MM/DD` and treats anything else as a free-text content match, so the search returned 0 results and the agent confidently asserted no mail existed in a range that had messages — a silent wrong answer, found live via the UI→/query cutover (matrix N4). Now `search_messages` normalizes the date formats the model actually produces (`July 1[, 2026]`, `1 July 2026`, `2026-07-01`, `7/1/2026`, zero-pads `2026/7/1`) into Gmail's form before the backend call, and raises an actionable error on an unparseable value instead of passing it through — the agent gets a loud, retryable failure, never a false zero. Epoch values and relative operators (`newer_than:7d`) pass through untouched.

One line of `YYYY/MM/DD` guidance was added to the tool docstring — that's tool-schema text, so it's LLM-affecting; flagging per repo policy (pairs with the operator-guidance half of #2114).

## Test plan

- [x] `pytest hub/agents/python/email/tests/test_search_date_normalization.py` — mixed-format query asserts the outgoing Gmail query string is exactly `after:2026/07/01 before:2026/07/08` (via FakeGmailBackend transport recording); unparseable/impossible dates raise `ValueError` before any backend call
- [x] `pytest hub/agents/python/email/tests/` — 619 passed (1 pre-existing env-only failure, `test_agent_version_matches_package_metadata`, fails identically on clean main)
- [x] `python util/lint.py --all --fix` — Black/isort/Pylint/Flake8 pass (Import Validation + Dependabot failures pre-exist on clean main)