### PR TITLE
fix(webui): pin explicitly-set session titles — stop auto-retitle churn (#2165)

### DIFF
--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -1116,7 +1116,9 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
                 // hand and the run's lifecycle already titles server-side, #1580).
                 if (!attach && session && session.title === 'New Task') {
                     const autoTitle = text.slice(0, 50) + (text.length > 50 ? '...' : '');
-                    api.updateSession(sessionId, { title: autoTitle })
+                    // Not a user choice — leave unpinned so the server-side
+                    // LLM titler can still replace it (#2165).
+                    api.updateSession(sessionId, { title: autoTitle, title_is_custom: false })
                         .then(() => updateSessionInList(sessionId, { title: autoTitle }))
                         .catch((err) => log.chat.error('Auto-title failed', err));
                 }
@@ -1321,7 +1323,8 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
 
     const saveTitle = async () => {
         if (titleDraft.trim() && titleDraft !== session?.title) {
-            await api.updateSession(sessionId, { title: titleDraft.trim() });
+            // Explicit rename — pin against the auto-retitler (#2165).
+            await api.updateSession(sessionId, { title: titleDraft.trim(), title_is_custom: true });
             updateSessionInList(sessionId, { title: titleDraft.trim() });
         }
         setEditingTitle(false);

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.autotitle.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.autotitle.test.tsx
@@ -1,0 +1,131 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// #2165: explicit renames must PIN the session title (title_is_custom: true)
+// while the client-side first-message auto-title must NOT pin it
+// (title_is_custom: false) so the server-side LLM titler can still improve it.
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatView } from '../ChatView';
+import { useChatStore } from '../../stores/chatStore';
+import type { AgentInfo, Session } from '../../types';
+import * as api from '../../services/api';
+import type { StreamEvent } from '../../types';
+
+vi.mock('../../services/api');
+
+const mockedApi = vi.mocked(api);
+
+const SESSION: Session = {
+    id: 'session-1',
+    title: 'New Task',
+    created_at: '2026-06-10T00:00:00Z',
+    updated_at: '2026-06-10T00:00:00Z',
+    model: 'qwen',
+    system_prompt: null,
+    message_count: 0,
+    document_ids: [],
+    agent_type: 'doc',
+};
+
+const DOC_AGENT: AgentInfo = {
+    id: 'doc',
+    name: 'Doc Agent',
+    description: 'Search and answer questions from indexed documents.',
+    source: 'builtin',
+    conversation_starters: [],
+    models: [],
+    tags: ['rag', 'files'],
+    icon: 'file-text',
+    tools_count: 3,
+};
+
+let capturedCallbacks: api.StreamCallbacks | null = null;
+
+function setSession(session: Session) {
+    useChatStore.setState({
+        agents: [DOC_AGENT],
+        activeAgentId: 'doc',
+        sessions: [session],
+        currentSessionId: session.id,
+        messages: [],
+        documents: [],
+        isStreaming: false,
+        streamingContent: '',
+        agentSteps: [],
+        cards: [],
+        isLoadingMessages: false,
+        pendingPrompt: null,
+        systemStatus: null,
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCallbacks = null;
+
+    mockedApi.getMessages.mockResolvedValue({ messages: [], total: 0 });
+    mockedApi.getActiveRuns.mockResolvedValue({ session_ids: [] });
+    mockedApi.listDocuments.mockResolvedValue({
+        documents: [],
+        total: 0,
+        total_size_bytes: 0,
+        total_chunks: 0,
+    });
+    mockedApi.updateSession.mockResolvedValue(undefined as never);
+    mockedApi.sendMessageStream.mockImplementation((_sid, _msg, cbs) => {
+        capturedCallbacks = cbs as api.StreamCallbacks;
+        return new AbortController();
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: vi.fn(),
+    });
+
+    setSession(SESSION);
+});
+
+describe('ChatView title pinning (#2165)', () => {
+    it('client-side auto-title on first message does NOT pin the title', async () => {
+        render(<ChatView sessionId={SESSION.id} />);
+
+        await act(async () => {
+            fireEvent.change(screen.getByLabelText('Message input'), {
+                target: { value: 'what is the capital of france' },
+            });
+            fireEvent.click(screen.getByLabelText('Send message'));
+        });
+        expect(capturedCallbacks).not.toBeNull();
+
+        await act(async () => {
+            capturedCallbacks!.onDone({
+                type: 'done',
+                content: 'Paris.',
+            } as unknown as StreamEvent);
+        });
+
+        expect(mockedApi.updateSession).toHaveBeenCalledWith(SESSION.id, {
+            title: 'what is the capital of france',
+            title_is_custom: false,
+        });
+    });
+
+    it('manual rename pins the title', async () => {
+        setSession({ ...SESSION, title: 'Auto Generated Title' });
+        render(<ChatView sessionId={SESSION.id} />);
+
+        fireEvent.click(screen.getByLabelText('Rename task'));
+        const input = screen.getByLabelText('Edit task title');
+        await act(async () => {
+            fireEvent.change(input, { target: { value: 'My Research Project' } });
+            fireEvent.keyDown(input, { key: 'Enter' });
+        });
+
+        expect(mockedApi.updateSession).toHaveBeenCalledWith(SESSION.id, {
+            title: 'My Research Project',
+            title_is_custom: true,
+        });
+    });
+});

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -378,7 +378,7 @@ export async function getSession(id: string): Promise<Session> {
     return apiFetch('GET', `/sessions/${id}`);
 }
 
-export async function updateSession(id: string, data: { title?: string; system_prompt?: string; private?: boolean; agent_type?: string }): Promise<Session> {
+export async function updateSession(id: string, data: { title?: string; title_is_custom?: boolean; system_prompt?: string; private?: boolean; agent_type?: string }): Promise<Session> {
     return apiFetch('PUT', `/sessions/${id}`, data);
 }
 

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -6,6 +6,9 @@
 export interface Session {
     id: string;
     title: string;
+    /** True when the title was explicitly set (rename/API) and is pinned
+     *  against auto-retitling (#2165). */
+    title_is_custom?: boolean;
     created_at: string;
     updated_at: string;
     model: string;

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -25,7 +25,7 @@ from typing import Optional
 
 from fastapi import HTTPException
 
-from .database import SESSION_DEFAULT_MODEL, ChatDatabase
+from .database import PLACEHOLDER_TITLES, SESSION_DEFAULT_MODEL, ChatDatabase
 from .models import ChatRequest
 from .sse_handler import (
     _ANSWER_JSON_SUB_RE,
@@ -278,19 +278,15 @@ def _classify_chat_exception(exc: BaseException):
 #     (≥ 25 chars) — topic-shift pass
 #
 # Skipped when:
+#   * The session's title_is_custom flag is set — an explicit user/API title
+#     is pinned forever (#2165); only auto-generated titles may be replaced
 #   * Title starts with "Eval:" — those are owned by the eval framework
 #   * Title was last updated < 30 s ago — prevents thrash mid-conversation
 #   * No agent / no Lemonade base URL available
 #
 # Throttled by a per-session timestamp dict so concurrent fire-and-forget
 # tasks don't pile up.
-_AUTO_TITLE_DEFAULTS = {
-    "new chat",
-    "new task",
-    "untitled",
-    "untitled session",
-    "chat",
-}
+_AUTO_TITLE_DEFAULTS = PLACEHOLDER_TITLES
 _AUTO_TITLE_LOCK = threading.Lock()
 _AUTO_TITLE_LAST_AT: dict[str, float] = {}  # session_id -> monotonic ts
 _AUTO_TITLE_THROTTLE_S = 30.0
@@ -304,12 +300,16 @@ def _title_word_set(s: str) -> set[str]:
     return {w for w in cleaned.split() if len(w) > 1}
 
 
-def _should_retitle(current_title: str, last_user_msg: str) -> bool:
+def _should_retitle(
+    current_title: str, last_user_msg: str, title_is_custom: bool = False
+) -> bool:
     """Decide whether the session deserves a fresh title.
 
     See module-level comment for the rule set.  Returns True/False; pure
     function so it's easy to unit-test in isolation.
     """
+    if title_is_custom:
+        return False  # explicit user/API title — pinned (#2165)
     title = (current_title or "").strip()
     title_lower = title.lower()
     if title.startswith("Eval:"):
@@ -413,7 +413,8 @@ async def _maybe_update_session_title(
     if not session:
         return
     current_title = session.get("title") or ""
-    if not _should_retitle(current_title, user_msg):
+    title_is_custom = bool(session.get("title_is_custom"))
+    if not _should_retitle(current_title, user_msg, title_is_custom):
         return
 
     # Throttle: don't re-title if we updated within the last 30 s.

--- a/src/gaia/ui/database.py
+++ b/src/gaia/ui/database.py
@@ -24,6 +24,23 @@ DEFAULT_DB_PATH = Path.home() / ".gaia" / "chat" / "gaia_chat.db"
 # any code that reads session["model"] and falls back when the field is NULL.
 SESSION_DEFAULT_MODEL = "Gemma-4-E4B-it-GGUF"
 
+# Auto-generated placeholder titles the auto-retitler may replace (#2165).
+# Anything else is treated as explicitly chosen and pinned via title_is_custom.
+PLACEHOLDER_TITLES = {
+    "",
+    "new chat",
+    "new task",
+    "untitled",
+    "untitled session",
+    "chat",
+}
+
+
+def is_placeholder_title(title: str | None) -> bool:
+    """True when the title is an auto-generated default, not a user choice."""
+    return (title or "").strip().lower() in PLACEHOLDER_TITLES
+
+
 # Sentinel used by update_document_status to distinguish "caller passed None to clear
 # last_error" from "caller did not pass last_error at all" (leaving it unchanged).
 _UNSET = object()
@@ -50,6 +67,8 @@ CREATE TABLE IF NOT EXISTS documents (
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
     title TEXT NOT NULL DEFAULT 'New Chat',
+    -- 1 = explicitly set by the user/API caller; auto-retitler must not touch (#2165)
+    title_is_custom INTEGER NOT NULL DEFAULT 0,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     model TEXT NOT NULL DEFAULT 'Gemma-4-E4B-it-GGUF',
@@ -294,6 +313,30 @@ class ChatDatabase:
         except Exception as e:
             logger.debug("Migration check for mail_provider column: %s", e)
 
+        # Add title_is_custom column so the auto-retitler can tell explicit
+        # titles from its own (#2165). Backfill: existing non-placeholder
+        # titles could be user-set or auto-generated — pin them all, since
+        # wrongly renaming a user's title is worse than never renaming.
+        try:
+            sess_cols = [
+                row[1]
+                for row in self._conn.execute("PRAGMA table_info(sessions)").fetchall()
+            ]
+            if "title_is_custom" not in sess_cols:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN title_is_custom INTEGER NOT NULL DEFAULT 0"
+                )
+                placeholders = ", ".join("?" for _ in PLACEHOLDER_TITLES)
+                self._conn.execute(
+                    f"UPDATE sessions SET title_is_custom = 1 "
+                    f"WHERE LOWER(TRIM(COALESCE(title, ''))) NOT IN ({placeholders})",
+                    tuple(PLACEHOLDER_TITLES),
+                )
+                self._conn.commit()
+                logger.info("Migrated sessions table: added title_is_custom column")
+        except Exception as e:
+            logger.debug("Migration check for title_is_custom column: %s", e)
+
     def close(self):
         """Close database connection."""
         if self._conn:
@@ -334,6 +377,9 @@ class ChatDatabase:
         session_id = str(uuid.uuid4())
         now = self._now()
         model = model or SESSION_DEFAULT_MODEL
+        # A non-placeholder title at creation is an explicit caller choice —
+        # pin it so the auto-retitler never overwrites it (#2165).
+        title_is_custom = 0 if is_placeholder_title(title) else 1
         title = title or "New Chat"
         agent_type = agent_type or "chat"
         device = device or "gpu"
@@ -342,11 +388,12 @@ class ChatDatabase:
 
         with self._transaction():
             self._conn.execute(
-                """INSERT INTO sessions (id, title, created_at, updated_at, model, system_prompt, private, agent_type, device, mail_provider)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT INTO sessions (id, title, title_is_custom, created_at, updated_at, model, system_prompt, private, agent_type, device, mail_provider)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     title,
+                    title_is_custom,
                     now,
                     now,
                     model,
@@ -435,14 +482,23 @@ class ChatDatabase:
         device: str | None = None,
         model: str | None = None,
         mail_provider: str | None = None,
+        title_is_custom: bool | None = None,
     ) -> Optional[Dict[str, Any]]:
-        """Update session title, system prompt, agent_type, device, model, mail_provider, private flag, and/or document_ids."""
+        """Update session title, system prompt, agent_type, device, model, mail_provider, private flag, and/or document_ids.
+
+        ``title_is_custom`` pins/unpins the title against auto-retitling
+        (#2165); omit it (None) to leave the pin unchanged — the backend
+        auto-titler relies on that so its own updates never pin.
+        """
         updates: list[str] = []
         params: list[Any] = []
 
         if title is not None:
             updates.append("title = ?")
             params.append(title)
+        if title_is_custom is not None:
+            updates.append("title_is_custom = ?")
+            params.append(1 if title_is_custom else 0)
         if model is not None:
             updates.append("model = ?")
             params.append(model)

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -280,6 +280,10 @@ class UpdateSessionRequest(BaseModel):
     """Request to update a session."""
 
     title: Optional[str] = None
+    # Pin state for the title (#2165). Omitted + title set → the server pins
+    # (a rename is explicit). The webui's client-side auto-title sends False
+    # so the server-side LLM titler can still improve the title later.
+    title_is_custom: Optional[bool] = None
     system_prompt: Optional[str] = None
     document_ids: Optional[List[str]] = None
     private: Optional[bool] = None
@@ -293,6 +297,9 @@ class SessionResponse(BaseModel):
 
     id: str
     title: str
+    # True when the title was explicitly set (user rename / API caller) and
+    # is therefore pinned against auto-retitling (#2165).
+    title_is_custom: bool = False
     created_at: str
     updated_at: str
     model: str

--- a/src/gaia/ui/routers/sessions.py
+++ b/src/gaia/ui/routers/sessions.py
@@ -14,7 +14,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from .._chat_helpers import evict_session_agent, resolve_device_model
-from ..database import SESSION_DEFAULT_MODEL, ChatDatabase
+from ..database import SESSION_DEFAULT_MODEL, ChatDatabase, is_placeholder_title
 from ..dependencies import get_db
 from ..models import (
     AttachDocumentRequest,
@@ -187,9 +187,18 @@ async def update_session(
             if resolved != current_model and (is_default_model or device_is_explicit):
                 device_model = resolved
 
+    # A PUT that sets the title is an explicit rename → pin it against the
+    # auto-retitler (#2165), unless the caller says otherwise (the webui's
+    # client-side auto-title sends title_is_custom=false) or the new title
+    # is itself a placeholder (renaming to "New Chat" re-enables auto-title).
+    title_is_custom = request.title_is_custom
+    if request.title is not None and title_is_custom is None:
+        title_is_custom = not is_placeholder_title(request.title)
+
     session = db.update_session(
         session_id,
         title=request.title,
+        title_is_custom=title_is_custom,
         system_prompt=request.system_prompt,
         document_ids=request.document_ids,
         private=request.private,

--- a/src/gaia/ui/utils.py
+++ b/src/gaia/ui/utils.py
@@ -134,6 +134,7 @@ def session_to_response(session: dict) -> SessionResponse:
     return SessionResponse(
         id=session["id"],
         title=session["title"],
+        title_is_custom=bool(session.get("title_is_custom", 0)),
         created_at=session["created_at"],
         updated_at=session["updated_at"],
         model=session["model"],

--- a/tests/unit/chat/ui/test_chat_helpers.py
+++ b/tests/unit/chat/ui/test_chat_helpers.py
@@ -12,7 +12,7 @@ Tests the pure helper functions in gaia.ui._chat_helpers:
 
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -853,3 +853,105 @@ class TestStreamingEmailBranchReturnsBeforeSharedTrunk:
             "agent.process_query on a non-existent in-process agent. "
             f"Last line was: {lines[-1]!r}"
         )
+
+
+# ── Auto-title pinning (#2165) ───────────────────────────────────────────────
+#
+# Explicitly-set session titles (user rename or API caller) must NEVER be
+# replaced by the auto-retitler; placeholder titles ("New Task"/"New Chat"/
+# empty) must still be auto-titled on the first substantive message.
+
+# Long + zero word-overlap with any title used below → would trigger the
+# topic-shift pass if the pin didn't hold.
+_SHIFT_MSG = "please summarize quarterly revenue figures across all the divisions"
+
+
+class TestShouldRetitle:
+    """Tests for _should_retitle() with the title_is_custom pin."""
+
+    @pytest.mark.parametrize(
+        "placeholder", ["New Chat", "New Task", "", "  ", "Untitled", "chat"]
+    )
+    def test_placeholder_titles_are_retitled(self, placeholder):
+        from gaia.ui._chat_helpers import _should_retitle
+
+        assert _should_retitle(placeholder, "hi") is True
+
+    def test_custom_title_never_retitled(self):
+        from gaia.ui._chat_helpers import _should_retitle
+
+        assert (
+            _should_retitle("My Research Project", _SHIFT_MSG, title_is_custom=True)
+            is False
+        )
+
+    def test_custom_flag_pins_across_multiple_turns(self):
+        from gaia.ui._chat_helpers import _should_retitle
+
+        turns = [
+            _SHIFT_MSG,
+            "now write me a haiku about mountains and rivers flowing",
+            "explain the difference between tcp and udp networking protocols",
+        ]
+        for msg in turns:
+            assert (
+                _should_retitle("Weekly Standup Notes", msg, title_is_custom=True)
+                is False
+            )
+
+    def test_custom_flag_pins_even_placeholder_lookalike(self):
+        """A pinned title wins even if its text happens to be a placeholder."""
+        from gaia.ui._chat_helpers import _should_retitle
+
+        assert _should_retitle("New Chat", _SHIFT_MSG, title_is_custom=True) is False
+
+    def test_auto_generated_title_still_topic_shifts(self):
+        """Non-pinned (auto-generated) titles keep the topic-shift pass."""
+        from gaia.ui._chat_helpers import _should_retitle
+
+        assert (
+            _should_retitle("Python Sorting Help", _SHIFT_MSG, title_is_custom=False)
+            is True
+        )
+
+    def test_eval_titles_never_retitled(self):
+        from gaia.ui._chat_helpers import _should_retitle
+
+        assert _should_retitle("Eval: rag_quality run 3", _SHIFT_MSG) is False
+
+
+class TestMaybeUpdateSessionTitleHonorsPin:
+    """_maybe_update_session_title must read the session's title_is_custom
+    flag and skip pinned sessions without calling the LLM or the DB."""
+
+    def _run(self, session, msg=_SHIFT_MSG):
+        from gaia.ui import _chat_helpers as ch
+
+        db = MagicMock()
+        db.get_session.return_value = session
+        gen = AsyncMock(return_value="LLM Title")
+        with (
+            patch.object(ch, "_generate_session_title", gen),
+            patch(
+                "gaia.llm.lemonade_manager.LemonadeManager.get_base_url",
+                return_value="http://localhost:13305/api/v1",
+            ),
+        ):
+            asyncio.run(
+                ch._maybe_update_session_title(
+                    db, session["id"], msg, "assistant reply", "model-x"
+                )
+            )
+        return db, gen
+
+    def test_pinned_session_is_skipped(self):
+        db, gen = self._run(
+            {"id": "pin-1", "title": "My Research Project", "title_is_custom": 1}
+        )
+        gen.assert_not_awaited()
+        db.update_session.assert_not_called()
+
+    def test_placeholder_session_is_retitled(self):
+        db, gen = self._run({"id": "auto-1", "title": "New Task", "title_is_custom": 0})
+        gen.assert_awaited_once()
+        db.update_session.assert_called_once_with("auto-1", title="LLM Title")

--- a/tests/unit/chat/ui/test_database.py
+++ b/tests/unit/chat/ui/test_database.py
@@ -174,6 +174,80 @@ class TestMailProviderMigration:
             database.close()
 
 
+class TestTitleIsCustom:
+    """Sessions must record whether their title was explicitly set (#2165)
+    so the auto-retitler never overwrites a user/API-chosen title."""
+
+    def test_explicit_title_marks_custom(self, db):
+        session = db.create_session(title="My Research Project")
+        assert session["title_is_custom"] == 1
+
+    @pytest.mark.parametrize("title", [None, "New Chat", "New Task", "Untitled"])
+    def test_placeholder_or_default_title_not_custom(self, db, title):
+        session = db.create_session(title=title)
+        assert session["title_is_custom"] == 0
+
+    def test_rename_pins_title(self, db):
+        session = db.create_session()
+        updated = db.update_session(
+            session["id"], title="Pinned Name", title_is_custom=True
+        )
+        assert updated["title"] == "Pinned Name"
+        assert updated["title_is_custom"] == 1
+
+    def test_auto_title_update_leaves_flag_alone(self, db):
+        """The backend auto-titler updates title WITHOUT the flag — the
+        session must stay non-custom so later auto-titles still apply."""
+        session = db.create_session()
+        updated = db.update_session(session["id"], title="LLM Generated Title")
+        assert updated["title_is_custom"] == 0
+
+    def test_unrelated_update_preserves_pin(self, db):
+        session = db.create_session(title="Pinned")
+        updated = db.update_session(session["id"], device="npu")
+        assert updated["title_is_custom"] == 1
+
+
+class TestTitleIsCustomMigration:
+    """Pre-#2165 DBs get the title_is_custom column; existing rows with a
+    non-placeholder title are backfilled as pinned (can't tell user-set from
+    auto-generated, so err on never renaming)."""
+
+    def test_migration_adds_and_backfills_column(self, tmp_path):
+        db_path = str(tmp_path / "old.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT, "
+            "created_at TEXT, updated_at TEXT, model TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO sessions (id, title, created_at, updated_at, model) "
+            "VALUES (?, ?, '2025-01-01', '2025-01-01', 'm')",
+            [
+                ("s1", "Quarterly Report Analysis"),
+                ("s2", "New Chat"),
+                ("s3", "New Task"),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        database = ChatDatabase(db_path)
+        try:
+            cols = [
+                r[1]
+                for r in database._conn.execute(
+                    "PRAGMA table_info(sessions)"
+                ).fetchall()
+            ]
+            assert "title_is_custom" in cols
+            assert database.get_session("s1")["title_is_custom"] == 1
+            assert database.get_session("s2")["title_is_custom"] == 0
+            assert database.get_session("s3")["title_is_custom"] == 0
+        finally:
+            database.close()
+
+
 class TestMessages:
     def test_add_and_get_messages(self, db):
         session = db.create_session()

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -922,6 +922,34 @@ class TestSessionEndpoints:
         assert resp.status_code == 200
         assert resp.json()["title"] == "Updated"
 
+    def test_create_with_explicit_title_pins_it(self, client):
+        """#2165: a title passed by an API caller is explicit → pinned."""
+        resp = client.post("/api/sessions", json={"title": "My Research Project"})
+        assert resp.json()["title_is_custom"] is True
+
+    def test_create_with_placeholder_title_not_pinned(self, client):
+        """The webui creates sessions titled 'New Task' — still auto-titlable."""
+        resp = client.post("/api/sessions", json={"title": "New Task"})
+        assert resp.json()["title_is_custom"] is False
+
+    def test_rename_pins_title(self, client):
+        """#2165: a PUT rename is explicit → pinned."""
+        sid = client.post("/api/sessions", json={}).json()["id"]
+        resp = client.put(f"/api/sessions/{sid}", json={"title": "Pinned Name"})
+        assert resp.status_code == 200
+        assert resp.json()["title_is_custom"] is True
+
+    def test_put_can_opt_out_of_pinning(self, client):
+        """The webui's client-side auto-title sends title_is_custom=false so
+        the server-side LLM titler can still improve it later."""
+        sid = client.post("/api/sessions", json={}).json()["id"]
+        resp = client.put(
+            f"/api/sessions/{sid}",
+            json={"title": "what is the capital of fr...", "title_is_custom": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title_is_custom"] is False
+
     def test_update_session_system_prompt(self, client):
         create_resp = client.post("/api/sessions", json={})
         session_id = create_resp.json()["id"]


### PR DESCRIPTION
## Why this matters

Naming a session — via the UI rename or `POST /api/sessions {"title": ...}` — didn't stick: the background auto-titler silently renamed it on essentially every assistant reply, with one session cycling through 3+ names in a single run (#2165). Explicit titles are now pinned via a persisted `title_is_custom` flag and are never touched by the auto-titler, while fresh "New Task"/"New Chat" sessions still get auto-titled on the first substantive message exactly as before. An additive migration backfills existing non-placeholder titles as pinned, so already-renamed sessions stop churning too.

## Test plan

- [x] `python -m pytest tests/unit/chat/` — 798 passed (includes new pin/placeholder/migration cases in `test_chat_helpers.py`, `test_database.py`, `test_server.py`)
- [x] webui `vitest run` — 182 passed (new `ChatView.autotitle.test.tsx`: rename pins, client auto-title doesn't) + `tsc --noEmit` clean
- [x] `python util/lint.py --all` — clean
- [x] Live server on a scratch DB: created a session with an explicit title, drove the retitler across 3 low-overlap turns (LLM stubbed) — pinned title untouched; a default "New Chat" session was auto-titled once and stayed unpinned