### PR TITLE
fix(email): error on an explicitly-targeted unconnected mailbox instead of substituting (#2164)

### DIFF
--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -427,6 +427,10 @@ contract yet.
 
 Your Google connection predates the email agent and lacks `gmail.modify`. Open Settings → Connections → Google → Reconnect to grant the missing scopes.
 
+### "NOT_CONNECTED: microsoft is not currently connected"
+
+You asked about a specific provider's mailbox (e.g. *"check my Outlook inbox"*) that isn't connected. The agent refuses rather than silently answering from a different mailbox. Connect that provider in Settings → Connections, or rephrase without naming a provider to scan every connected mailbox.
+
 ### "Gmail API returned 401"
 
 The access token has expired or scopes were revoked. Reconnect Google in Settings → Connections.

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -33,8 +33,9 @@ Phase I prompt-injection defense:
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
-from typing import Any, ClassVar, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from gaia_agent_email import action_store, schedule_store
 from gaia_agent_email.config import ConfigurationError, EmailAgentConfig
@@ -76,7 +77,7 @@ from gaia.agents.base.console import AgentConsole
 from gaia.agents.base.memory import MemoryMixin
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.registry import get_embedding_model_for_device
-from gaia.connectors.errors import ConnectorsError
+from gaia.connectors.errors import AuthRequiredError, ConnectorsError
 from gaia.connectors.formatting import format_connector_error
 from gaia.connectors.providers.base import ConnectorRequirement
 from gaia.database.mixin import DatabaseMixin
@@ -100,6 +101,50 @@ class _UnavailableCalendarBackend:
 
     def __getattr__(self, name: str):
         raise ConfigurationError(self._message)
+
+
+# ---------------------------------------------------------------------------
+# Provider-intent detection (#2164)
+# ---------------------------------------------------------------------------
+
+# Conservative mailbox-targeting detection: a query that explicitly names a
+# provider's MAILBOX ("check my Outlook inbox", "search gmail for ...") must
+# never be silently answered from a different mailbox. Precision over recall —
+# a missed detection falls back to the (prompt-guarded) default scan, while a
+# false positive would block a legitimate query. Deliberately NOT matched:
+# provider words inside email addresses (bob@outlook.com) and sender phrasing
+# ("the email from Microsoft").
+_PROVIDER_TERMS = {
+    "google": r"(?:gmail|google)",
+    "microsoft": r"(?:outlook|hotmail|microsoft)",
+}
+# "in google drive" / "in microsoft teams" name another product, not a mailbox.
+_NON_MAILBOX_PRODUCTS = r"(?!\s+(?:drive|docs|sheets|maps|teams|word|excel|office))"
+_MAILBOX_NOUNS = r"(?:inbox|mail(?:box)?|e-?mails?|messages?|account|folders?)"
+_MAILBOX_VERBS = r"(?:in|via|check|open|scan|triage|search)"
+
+_MAILBOX_TARGET_PATTERNS: Dict[str, "re.Pattern[str]"] = {
+    provider: re.compile(
+        "|".join(
+            (
+                rf"\bmy\s+{term}{_NON_MAILBOX_PRODUCTS}\b",
+                rf"(?<![@.\w-]){term}\s+{_MAILBOX_NOUNS}\b",
+                rf"\b{_MAILBOX_VERBS}\s+{term}{_NON_MAILBOX_PRODUCTS}\b",
+            )
+        ),
+        re.IGNORECASE,
+    )
+    for provider, term in _PROVIDER_TERMS.items()
+}
+
+
+def _detect_targeted_mailboxes(query: str) -> set:
+    """Return the mailbox providers a query explicitly targets (possibly empty)."""
+    return {
+        provider
+        for provider, pattern in _MAILBOX_TARGET_PATTERNS.items()
+        if pattern.search(query)
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +218,14 @@ write ONE short framing sentence (e.g. "Here's your inbox pre-scan — 5
 actionable, 1 suggested archive.") and stop. The user can see the card;
 do not re-state its contents in prose. For follow-up questions about
 specific items, refer to the message_id values from the card.
+
+MAILBOX TARGETING:
+Read/triage tools scan only CONNECTED mailboxes, and every result item is
+tagged with its source mailbox (google or microsoft). If the user asks
+about a specific provider's mailbox and the results carry only a different
+provider's tag, that provider is not connected — say so plainly and stop.
+NEVER present one mailbox's data as if it came from the provider the user
+asked for.
 
 OUTPUT:
 Tool results come back as JSON envelopes ``{"ok": true, "data": ...}``
@@ -582,12 +635,66 @@ class EmailTriageAgent(
             return ""
         return super().get_memory_dynamic_context()
 
-    def process_query(self, *args, **kwargs):
+    def process_query(self, user_input: str, *args, **kwargs):
         # Zero the batch-organize counter per turn so a long-lived instance
         # can't carry a prior turn's count into the batch-confirm threshold.
         # Only the batch counter resets here; session preferences persist.
         self._reset_organize_counter()
-        return super().process_query(*args, **kwargs)
+        guard = self._mailbox_target_guard(user_input)
+        if guard is not None:
+            return guard
+        return super().process_query(user_input, *args, **kwargs)
+
+    def _mailbox_target_guard(self, user_input: str) -> Optional[Dict[str, Any]]:
+        """Reject a request that explicitly targets an unavailable mailbox (#2164).
+
+        With only Google connected, "check my Outlook inbox" used to run the
+        inbox tool against Gmail and present that as the answer. When the query
+        names a provider that is not connected (or is filtered out by the
+        session's mailbox selection), surface the connectors framework's
+        actionable error BEFORE any tool runs — never substitute another
+        mailbox. Queries naming no provider keep the default
+        every-connected-mailbox behavior untouched.
+        """
+        targeted = _detect_targeted_mailboxes(user_input or "")
+        if not targeted:
+            return None
+        available = set(self.config.available_mailbox_providers())
+        selected_filter = (self.config.mail_provider or "").strip().lower()
+        problems: List[str] = []
+        for provider in sorted(targeted):
+            if provider not in available:
+                problems.append(
+                    format_connector_error(
+                        AuthRequiredError(
+                            AuthRequiredError.Reason.NOT_CONNECTED,
+                            provider=provider,
+                        )
+                    )
+                )
+            elif selected_filter and provider != selected_filter:
+                problems.append(
+                    f"This session is pinned to the {selected_filter!r} mailbox, "
+                    f"but the request targets {provider!r}. Clear the mailbox "
+                    f"selection (or switch it to {provider!r}) to use that "
+                    "mailbox."
+                )
+        if not problems:
+            return None
+        message = "\n".join(problems)
+        # The SSE surfaces render console events, not the return value — emit
+        # a terminal error event so the chat stream carries the message too.
+        self.console.print_error(message)
+        result = {
+            "status": "failed",
+            "result": message,
+            "conversation": [{"role": "user", "content": user_input}],
+            "steps_taken": 0,
+            "error_count": len(problems),
+            "error_history": list(problems),
+        }
+        self.last_result = result
+        return result
 
     def _register_tools(self) -> None:
         # Mirror BuilderAgent / ConnectorsDemoAgent: clear the

--- a/hub/agents/python/email/gaia_agent_email/config.py
+++ b/hub/agents/python/email/gaia_agent_email/config.py
@@ -287,6 +287,28 @@ class EmailAgentConfig:
             "Expected 'google' or 'microsoft'."
         )
 
+    def available_mailbox_providers(self) -> List[str]:
+        """Return the UNFILTERED available mailbox providers, registry order.
+
+        The eval seam rules apply exactly as in ``resolve_mail_backends``:
+        when a fake backend is injected, the injected set FULLY defines
+        availability (the live keyring is not consulted); otherwise the
+        available set is the connected mailboxes. Unlike
+        ``resolve_mail_backends``, the ``mail_provider`` filter is NOT
+        applied — callers that need to distinguish "not connected" from
+        "connected but filtered out by the session selection" (the #2164
+        provider-intent guard) read this.
+        """
+        injected = set()
+        if self.gmail_backend is not None:
+            injected.add("google")
+        if self.outlook_backend is not None:
+            injected.add("microsoft")
+        available = injected if injected else set(connected_mailbox_providers())
+        # Canonical registry order (google before microsoft) — deterministic
+        # regardless of keyring vs injection ordering.
+        return [p for p in ("google", "microsoft") if p in available]
+
     def resolve_mail_backends(self) -> List[Tuple[str, Any]]:
         """Return ``[(provider, backend), ...]`` for every admitted mailbox.
 
@@ -319,15 +341,7 @@ class EmailAgentConfig:
         # available set — the live keyring is not consulted at all, so an
         # injected-fake run stays hermetic regardless of the host's real OAuth
         # connections. Otherwise the available set is the connected mailboxes.
-        injected = set()
-        if self.gmail_backend is not None:
-            injected.add("google")
-        if self.outlook_backend is not None:
-            injected.add("microsoft")
-        available = injected if injected else set(connected_mailbox_providers())
-        # Canonical registry order (google before microsoft) — deterministic
-        # regardless of keyring vs injection ordering.
-        connected = [p for p in ("google", "microsoft") if p in available]
+        connected = self.available_mailbox_providers()
         selected_filter = (self.mail_provider or "").strip().lower()
         if selected_filter:
             selected = [p for p in connected if p == selected_filter]

--- a/hub/agents/python/email/tests/test_mailbox_target_guard.py
+++ b/hub/agents/python/email/tests/test_mailbox_target_guard.py
@@ -1,0 +1,197 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Provider-intent guard (#2164): a request explicitly naming an unconnected
+mailbox provider must fail with the connectors framework's NOT_CONNECTED
+message BEFORE any tool runs — never silently answer from a different mailbox.
+
+The default behavior (no provider named → scan every connected mailbox) must
+stay intact, as must requests naming a provider that IS connected.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from gaia_agent_email.agent import _detect_targeted_mailboxes
+
+
+# ---------------------------------------------------------------------------
+# Detector — pure-function intent extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        # The live repro from #2164 (matrix N7).
+        ("check my Outlook inbox", {"microsoft"}),
+        ("check my outlook", {"microsoft"}),
+        ("what's new in Outlook?", {"microsoft"}),
+        ("triage my hotmail inbox", {"microsoft"}),
+        ("summarize my gmail", {"google"}),
+        ("search gmail for the invoice", {"google"}),
+        ("scan my Google mailbox", {"google"}),
+        ("check my gmail and my outlook", {"google", "microsoft"}),
+        # No provider named — default multi-mailbox scan must be untouched.
+        ("what's in my inbox", set()),
+        ("run a pre-scan", set()),
+        ("summarize my unread emails", set()),
+        # Provider words as an email-address domain are NOT mailbox targeting.
+        ("forward this to bob@outlook.com", set()),
+        ("reply to alice@gmail.com", set()),
+        # Provider words as a SENDER are NOT mailbox targeting.
+        ("summarize the email from Microsoft about security", set()),
+        ("archive the newsletter from Google", set()),
+    ],
+)
+def test_detect_targeted_mailboxes(query, expected):
+    assert _detect_targeted_mailboxes(query) == expected
+
+
+# ---------------------------------------------------------------------------
+# process_query guard — with only Google connected (injected fake backend)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingMailBackend:
+    """GmailBackend-protocol fake that records every method invocation."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, name):
+        def _record(*args, **kwargs):
+            self.calls.append(name)
+            return {}
+
+        return _record
+
+
+class _MinimalCalendarBackend:
+    """Satisfies the CalendarBackend protocol just enough to construct."""
+
+
+def _build_agent(tmp_path, monkeypatch, gmail_backend):
+    from gaia_agent_email.agent import EmailTriageAgent
+    from gaia_agent_email.config import EmailAgentConfig
+
+    cfg = EmailAgentConfig(
+        gmail_backend=gmail_backend,
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        start_scheduler=False,
+    )
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        return EmailTriageAgent(config=cfg)
+
+
+@pytest.fixture
+def google_only_agent(tmp_path, monkeypatch):
+    backend = _RecordingMailBackend()
+    agent = _build_agent(tmp_path, monkeypatch, backend)
+    try:
+        yield agent, backend
+    finally:
+        agent.close_db()
+
+
+def test_outlook_target_with_only_google_errors_before_any_tool(
+    google_only_agent, monkeypatch
+):
+    """#2164: 'check my Outlook inbox' with only Google connected must return
+    the connectors NOT_CONNECTED error — and never touch the Gmail backend or
+    enter the agent loop."""
+    from gaia.agents.base.agent import Agent
+
+    agent, backend = google_only_agent
+
+    def _loop_must_not_run(self, *args, **kwargs):
+        raise AssertionError(
+            "agent loop ran for an unconnected-provider request — the "
+            "pre-flight guard did not fire"
+        )
+
+    monkeypatch.setattr(Agent, "process_query", _loop_must_not_run)
+
+    result = agent.process_query("check my Outlook inbox")
+
+    assert result["status"] == "failed"
+    assert "NOT_CONNECTED" in result["result"]
+    assert "microsoft" in result["result"]
+    # The misleading substitution: no Gmail call may have happened.
+    assert backend.calls == []
+
+
+def test_no_provider_request_still_reaches_the_loop(google_only_agent, monkeypatch):
+    """No provider named → the guard must NOT fire; the normal loop (which
+    scans every connected mailbox) runs."""
+    from gaia.agents.base.agent import Agent
+
+    agent, _ = google_only_agent
+    sentinel = {"status": "success", "result": "loop ran"}
+    monkeypatch.setattr(Agent, "process_query", lambda self, *a, **k: sentinel)
+
+    assert agent.process_query("what's in my inbox") is sentinel
+
+
+def test_connected_provider_target_passes_through(google_only_agent, monkeypatch):
+    """Naming a provider that IS connected must not trip the guard."""
+    from gaia.agents.base.agent import Agent
+
+    agent, _ = google_only_agent
+    sentinel = {"status": "success", "result": "loop ran"}
+    monkeypatch.setattr(Agent, "process_query", lambda self, *a, **k: sentinel)
+
+    assert agent.process_query("check my gmail inbox") is sentinel
+
+
+def test_guard_error_is_surfaced_on_the_console(google_only_agent, monkeypatch):
+    """The message must reach the console (the SSE stream renders console
+    events, not the return value)."""
+    agent, _ = google_only_agent
+    printed = []
+    monkeypatch.setattr(
+        agent.console, "print_error", lambda msg: printed.append(msg), raising=False
+    )
+
+    agent.process_query("check my Outlook inbox")
+
+    assert len(printed) == 1
+    assert "NOT_CONNECTED" in printed[0]
+    assert "microsoft" in printed[0]
+
+
+def test_session_pinned_to_other_mailbox_errors(tmp_path, monkeypatch):
+    """Both providers available but the session is pinned to google →
+    targeting microsoft must error (not silently serve Gmail), with a
+    clear-the-selection remediation instead of a bogus 'connect' one."""
+    from gaia_agent_email.agent import EmailTriageAgent
+    from gaia_agent_email.config import EmailAgentConfig
+
+    gmail = _RecordingMailBackend()
+    outlook = _RecordingMailBackend()
+    cfg = EmailAgentConfig(
+        gmail_backend=gmail,
+        outlook_backend=outlook,
+        mail_provider="google",
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        start_scheduler=False,
+    )
+    monkeypatch.setenv("GAIA_MEMORY_DISABLED", "1")
+    with patch("gaia.agents.base.agent.AgentSDK") as mock_sdk:
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    try:
+        result = agent.process_query("check my Outlook inbox")
+        assert result["status"] == "failed"
+        assert "pinned" in result["result"]
+        assert gmail.calls == []
+        assert outlook.calls == []
+    finally:
+        agent.close_db()


### PR DESCRIPTION
With only Google connected, asking the email agent to *"check my Outlook inbox"* silently ran the inbox tool against **Gmail** and presented that as the answer — 111 s of misleading provider substitution instead of a clean "Microsoft isn't connected" error (#2164, found live in matrix N7). Now a pre-flight guard in `process_query` catches a query that explicitly targets an unconnected provider and returns the connectors framework's `NOT_CONNECTED` message before any tool runs; the default no-provider-named behavior (scan every connected mailbox) is untouched, and a mailbox-tagging system-prompt rule backstops phrasings the detector misses. Detection is precision-biased: provider words inside email addresses (`bob@outlook.com`) or sender phrasing ("the email from Microsoft") never trip it.

Closes #2164.

## Test plan

- [x] `python -m pytest hub/agents/python/email/tests/test_mailbox_target_guard.py -q` — 20 new tests: Outlook-targeted request with only Google connected returns the NOT_CONNECTED error with **zero** Gmail backend calls and no agent-loop entry; no-provider and connected-provider requests still reach the loop; session pinned to google + Outlook target errors with a clear-the-selection message; detector precision cases (addresses, sender phrasing) stay untripped
- [x] `python -m pytest hub/agents/python/email/tests/ -q` — 635 passed (1 pre-existing env failure: stale `gaia-agent-email` 0.3.0 dist vs 0.5.0 source, fails on a clean checkout of main too)
- [x] `python util/lint.py --all --fix` — clean on touched files