### PR TITLE
refactor(ui): extract _best_effort_cancel helper for the relay cancel paths

### DIFF
--- a/src/gaia/ui/email_sidecar/relay.py
+++ b/src/gaia/ui/email_sidecar/relay.py
@@ -315,6 +315,13 @@ def _dispatch_one(handler: Any, event: Dict[str, Any]) -> bool:
     return False
 
 
+def _best_effort_cancel(proxy: Any, rid: str) -> None:
+    try:
+        proxy.cancel_query(rid)
+    except SidecarError as exc:
+        logger.info("email relay: cancel_query for run_id=%s: %s", rid, exc)
+
+
 def relay_query(
     handler: Any,
     proxy: Any,
@@ -407,19 +414,13 @@ def relay_query(
         handler.active_relay_response = None
 
     if handler.cancelled.is_set():
-        try:
-            proxy.cancel_query(rid)
-        except SidecarError as exc:
-            logger.info("email relay: cancel_query for run_id=%s: %s", rid, exc)
+        _best_effort_cancel(proxy, rid)
         if not terminated:
             handler._emit({"type": "status", "message": "Cancelled."})
     elif crashed or not terminated:
         # No terminal event arrived — the sidecar generation is still decoding
         # on the single GPU slot; stop it or later queries death-spiral.
-        try:
-            proxy.cancel_query(rid)
-        except SidecarError as exc:
-            logger.info("email relay: cancel_query for run_id=%s: %s", rid, exc)
+        _best_effort_cancel(proxy, rid)
         handler._emit({"type": "agent_error", "content": crash_message})
 
 


### PR DESCRIPTION
Review follow-up to #2167 (merged before this landed): the `SidecarError`-tolerant cancel block was duplicated verbatim across the user-cancel and crash/timeout branches in `relay_query` — this folds both into one `_best_effort_cancel` helper so the next edit can't drift them apart. No behavior change.

## Test plan

- [x] `pytest tests/unit/test_email_sidecar_relay.py` — 48 passed (includes the cancel-path and swallow-`SidecarError` tests pinning both branches)
- [x] `python util/lint.py` black/isort/flake8 clean