### PR TITLE
test(chat): mirror the amd-gaia floor guard from #2169; harden version parsing

### DIFF
--- a/hub/agents/python/chat/pyproject.toml
+++ b/hub/agents/python/chat/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 # Floor: 0.22.0 is the first core release shipping
 # gaia.agents.registry.get_embedding_model_for_device, imported at agent
-# start (#2112).
+# start (#2112). tests/test_chat_dependency_floor.py guards this floor.
 dependencies = ["amd-gaia>=0.22.0"]
 
 [project.entry-points."gaia.agent"]

--- a/hub/agents/python/chat/tests/test_chat_dependency_floor.py
+++ b/hub/agents/python/chat/tests/test_chat_dependency_floor.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: MIT
 """Guards the amd-gaia dependency floor against the agent's real core needs.
 
-The email agent imports ``get_embedding_model_for_device`` from
+The chat agent imports ``get_embedding_model_for_device`` from
 ``gaia.agents.registry`` at module load; that symbol first shipped in core
 v0.22.0. With a lower floor a fresh resolver may legally select an older
 core and the agent dies at startup with ImportError (#2112). These tests
 pin the floor to the symbol so the two can't silently drift apart again:
 if the floor is lowered, or the agent grows an import the declared floor
-doesn't cover, one of these fails.
+doesn't cover, one of these fails. Mirrors the email agent's
+tests/test_dependency_floor.py (distinct basename: pytest can't collect
+two same-named modules from __init__-less tests dirs in one run).
 """
 
 from __future__ import annotations
@@ -16,11 +18,15 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-EMAIL_ROOT = Path(__file__).resolve().parents[1]
+CHAT_ROOT = Path(__file__).resolve().parents[1]
 
 # First core release shipping gaia.agents.registry.get_embedding_model_for_device
 # (introduced by commit 89db99d6, first tagged in v0.22.0).
 REQUIRED_FLOOR = (0, 22, 0)
+
+# Matches the version in "amd-gaia>=X.Y.Z" with or without an extras suffix
+# (e.g. "amd-gaia[api]>=X.Y.Z") — the extras are #1617's concern, not the floor's.
+_AMD_GAIA_FLOOR_RE = r'"amd-gaia(?:\[[^\]]*\])?>=([0-9.]+)"'
 
 
 def _floor_tuple(version: str) -> tuple[int, ...]:
@@ -30,16 +36,16 @@ def _floor_tuple(version: str) -> tuple[int, ...]:
 
 def test_agent_module_imports_and_registry_symbol_exists():
     """The exact import chain that crashed fresh installs in #2112."""
-    import gaia_agent_email.agent  # noqa: F401
+    import gaia_agent_chat.agent  # noqa: F401
     from gaia.agents.registry import get_embedding_model_for_device
 
     assert callable(get_embedding_model_for_device)
 
 
 def test_pyproject_floor_covers_registry_symbol():
-    pyproject = (EMAIL_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    match = re.search(r'"amd-gaia\[api\]>=([0-9.]+)"', pyproject)
-    assert match, "pyproject.toml must declare an amd-gaia[api]>=X.Y.Z floor"
+    pyproject = (CHAT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(_AMD_GAIA_FLOOR_RE, pyproject)
+    assert match, "pyproject.toml must declare an amd-gaia>=X.Y.Z floor"
     assert _floor_tuple(match.group(1)) >= REQUIRED_FLOOR, (
         f"amd-gaia floor {match.group(1)} predates "
         "gaia.agents.registry.get_embedding_model_for_device (first shipped in "
@@ -50,14 +56,14 @@ def test_pyproject_floor_covers_registry_symbol():
 
 def test_manifest_floors_match_pyproject():
     """gaia-agent.yaml repeats the floor twice; both must stay in lock-step."""
-    manifest = (EMAIL_ROOT / "gaia-agent.yaml").read_text(encoding="utf-8")
+    manifest = (CHAT_ROOT / "gaia-agent.yaml").read_text(encoding="utf-8")
     min_gaia = re.search(r'min_gaia_version:\s*"([0-9.]+)"', manifest)
-    dep = re.search(r'"amd-gaia>=([0-9.]+)"', manifest)
+    dep = re.search(_AMD_GAIA_FLOOR_RE, manifest)
     assert min_gaia, "gaia-agent.yaml must declare min_gaia_version"
     assert dep, "gaia-agent.yaml must declare an amd-gaia>=X.Y.Z dependency"
 
-    pyproject = (EMAIL_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    pyproject_floor = re.search(r'"amd-gaia\[api\]>=([0-9.]+)"', pyproject)
+    pyproject = (CHAT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    pyproject_floor = re.search(_AMD_GAIA_FLOOR_RE, pyproject)
     assert pyproject_floor
 
     assert (


### PR DESCRIPTION
Follow-ups from the #2169 review (it merged before they could ride along): the chat agent got the same 0.20.0→0.22.0 floor bump as email but no guard test, so its floor could silently regress below `get_embedding_model_for_device`'s first release and re-introduce #2112 with green CI. This mirrors the email guard into `hub/agents/python/chat/tests/` — symbol import, pyproject floor ≥ 0.22.0, manifest in lock-step with pyproject — which `test_chat_agent.yml` already runs. Also normalizes `_floor_tuple` in both guards so a shortened floor like `"0.22"` compares as `(0, 22, 0)` instead of failing spuriously.

The guard intentionally compares version numbers only, not the `[api]` extra — the email manifest's dropped `[api]` is #1617's concern.

## Test plan

- [x] `pytest hub/agents/python/chat/tests/ hub/agents/python/email/tests/` — all pass in a single run (distinct basename avoids the pytest same-module collision from `__init__`-less tests dirs)
- [x] Mutation check: lowering the chat floor to 0.20.0 fails both new guard tests
- [x] `_floor_tuple('0.22') == (0, 22, 0)` in both guards
- [x] `python util/lint.py --all --fix` — clean