### PR TITLE
feat(daemon): deliver sidecar launch secret via 0600 file, not bare env (#2149)

### DIFF
--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -187,7 +187,10 @@ identify who is calling.
 - **Per-session bearer token.** Every `/v1/email/*` request to the sidecar must
   carry `Authorization: Bearer <token>` or it is rejected with **HTTP 401**. The
   token is a cryptographically-random per-session secret the spawning parent hands
-  to the sidecar over the private `GAIA_EMAIL_SIDECAR_TOKEN` env channel.
+  to the sidecar — preferably as a `0600` owner-only file whose path arrives in
+  `GAIA_EMAIL_SIDECAR_TOKEN_FILE` (the GAIA daemon does this for 0.6.0+ binaries,
+  so the secret never sits in the process environment), or directly in the
+  `GAIA_EMAIL_SIDECAR_TOKEN` env var (npm lifecycle and older binaries).
 - **Host / Origin allowlist.** A non-loopback `Host` header → **HTTP 400**
   (DNS-rebinding); a non-loopback browser `Origin` → **HTTP 403** (drive-by web
   page). No permissive CORS is ever sent.
@@ -206,9 +209,12 @@ How this maps to the entry points above:
   after the backend exits; stop it with `gaia daemon stop-agent email` or
   `gaia daemon stop`.
 - **Direct-to-sidecar for local dev** — if you launch the frozen binary yourself,
-  set `GAIA_EMAIL_SIDECAR_TOKEN` and send the matching bearer header. Running it
-  **without** the env var disables the token check (local development only, logged
-  loudly) — the Host/Origin controls still apply.
+  set `GAIA_EMAIL_SIDECAR_TOKEN` (or point `GAIA_EMAIL_SIDECAR_TOKEN_FILE` at a
+  file holding the token) and send the matching bearer header. Running it with
+  **neither** variable disables the token check (local development only, logged
+  loudly) — the Host/Origin controls still apply. A set
+  `GAIA_EMAIL_SIDECAR_TOKEN_FILE` whose file is missing or empty fails startup
+  loudly rather than silently disabling auth.
 
 ```ts
 // npm path — the bound client carries the token for you.

--- a/hub/agents/npm/agent-email/CHANGELOG.md
+++ b/hub/agents/npm/agent-email/CHANGELOG.md
@@ -6,6 +6,13 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## 0.6.0
 
+- **The launch secret no longer sits in the sidecar's environment.** The
+  per-session auth token used to be handed to the sidecar as a bare environment
+  variable, visible to any local process that can inspect process environments.
+  A 0.6.0+ sidecar spawned by the GAIA daemon now receives it as an owner-only
+  (`0600`) file that is removed when the sidecar stops; the env channel
+  (`GAIA_EMAIL_SIDECAR_TOKEN`) keeps working for older binaries and for the npm
+  lifecycle, exactly as before.
 - **Asking "what's on my calendar?" no longer digs up years-old meetings.**
   Listing calendar events without a date range used to return the oldest
   instances of recurring series — events from years ago narrated as if they

--- a/hub/agents/npm/agent-email/SPEC.md
+++ b/hub/agents/npm/agent-email/SPEC.md
@@ -49,6 +49,13 @@ binds a send to one exact message but does not identify the caller.
   `generateSessionToken()` is exported for advanced flows. Exempt: `/health`,
   `/version`, `/v1/email/health`, `/v1/email/version`, `/v1/email/spec`,
   `/v1/email/playground`.
+  Sidecar binaries **0.6.0+** also accept `GAIA_EMAIL_SIDECAR_TOKEN_FILE` — the
+  path of a `0600`, owner-only file holding the token, so the secret never sits
+  in the process environment (readable via `/proc/<pid>/environ` / `ps eww`).
+  The GAIA daemon delivers the secret this way and treats the env channel as a
+  logged, deprecated compatibility leg for older binaries; a set path var whose
+  file is missing or empty fails sidecar startup loudly. The npm lifecycle
+  currently uses the env channel.
 - **Host allowlist** — non-loopback `Host` → **400** (DNS-rebinding).
 - **Origin rejection** — non-loopback browser `Origin` → **403** (drive-by page).
   Non-browser clients send no `Origin` and are unaffected. No CORS is ever sent.

--- a/hub/agents/python/email/gaia_agent_email/api_routes.py
+++ b/hub/agents/python/email/gaia_agent_email/api_routes.py
@@ -154,9 +154,10 @@ async def require_caller_token(request: Request) -> None:
     the same router without this dependency, so their posture is unchanged. The
     policy is read from :mod:`gaia_agent_email.caller_auth`:
 
-    - No policy configured, or a policy with ``token is None`` (a dev running the
-      sidecar by hand without ``GAIA_EMAIL_SIDECAR_TOKEN``) → allowed. The Host/
-      Origin controls in ``HostOriginMiddleware`` still apply.
+    - No policy configured, or a policy with ``token is None`` (a dev running
+      the sidecar by hand with neither ``GAIA_EMAIL_SIDECAR_TOKEN_FILE`` nor
+      ``GAIA_EMAIL_SIDECAR_TOKEN``) → allowed. The Host/Origin controls in
+      ``HostOriginMiddleware`` still apply.
     - Liveness/version probes and the HTML pages are exempt (:data:`caller_auth.
       EXEMPT_PATHS`) so the readiness handshake works before a token is in play.
     - Otherwise a missing/malformed/wrong ``Authorization: Bearer <token>`` is a
@@ -173,10 +174,12 @@ async def require_caller_token(request: Request) -> None:
             detail=(
                 "Unauthorized: this email sidecar endpoint requires the "
                 "per-session bearer token. Send 'Authorization: Bearer "
-                "<token>' using the token the sidecar was started with "
-                f"(the parent process passes it via the {caller_auth.TOKEN_ENV_VAR} "
-                "env var on spawn). Requests without a valid token are refused so "
-                "no other local process or web page can act on your mailbox."
+                "<token>' using the token the sidecar was started with (the "
+                "parent process delivers it on spawn via the "
+                f"{caller_auth.TOKEN_FILE_ENV_VAR} secret file, or the legacy "
+                f"{caller_auth.TOKEN_ENV_VAR} env var). Requests without a "
+                "valid token are refused so no other local process or web page "
+                "can act on your mailbox."
             ),
         )
 

--- a/hub/agents/python/email/gaia_agent_email/caller_auth.py
+++ b/hub/agents/python/email/gaia_agent_email/caller_auth.py
@@ -16,11 +16,13 @@ untouched.
 
 Three controls, all keyed on a single :class:`CallerAuthConfig` set at app build:
 
-1. **Per-session bearer token** — the spawning parent (npm ``lifecycle.ts`` or the
-   Python ``EmailSidecarManager``) generates a cryptographically-random token and
-   hands it to the sidecar over the private ``GAIA_EMAIL_SIDECAR_TOKEN`` env
-   channel. Every non-exempt request must present ``Authorization: Bearer
-   <token>`` or it is rejected with 401. This authenticates the *caller*.
+1. **Per-session bearer token** — the spawning parent (npm ``lifecycle.ts`` or
+   the daemon's ``AgentSidecarManager``) generates a cryptographically-random
+   token and hands it to the sidecar either as a 0600 file whose path arrives in
+   ``GAIA_EMAIL_SIDECAR_TOKEN_FILE`` (preferred, #2149 — the secret never sits
+   in the environment) or directly in ``GAIA_EMAIL_SIDECAR_TOKEN`` (legacy).
+   Every non-exempt request must present ``Authorization: Bearer <token>`` or it
+   is rejected with 401. This authenticates the *caller*.
 2. **Host allowlist** — the ``Host`` header must be a loopback host
    (127.0.0.1 / localhost / ::1). This closes DNS-rebinding, where a victim's
    browser is tricked into resolving ``evil.com`` → 127.0.0.1 and posting to the
@@ -43,6 +45,7 @@ import hmac
 import os
 import secrets
 from dataclasses import dataclass
+from pathlib import Path
 from typing import FrozenSet, Optional
 from urllib.parse import urlsplit
 
@@ -53,9 +56,18 @@ from gaia.logger import get_logger
 
 logger = get_logger(__name__)
 
-# The private channel the spawning parent uses to hand the sidecar its token.
-# An env var (not argv) so the secret never shows up in a `ps`/Task Manager
-# process listing the way command-line arguments do.
+# Preferred channel (#2149): the spawning parent writes the token to a 0600,
+# owner-only file and passes its PATH here — the secret itself never sits in the
+# process environment (which any local process can read via /proc/<pid>/environ
+# or `ps eww`). MUST equal the daemon's mirrored literal in
+# gaia.daemon.sidecars.spec (kept as plain strings so core never imports this
+# wheel).
+TOKEN_FILE_ENV_VAR = "GAIA_EMAIL_SIDECAR_TOKEN_FILE"
+
+# Legacy channel: the token directly in the environment. Still honored for
+# older spawning parents and bare integrators; deprecated for daemon spawns
+# (#2149). An env var (not argv) so the secret at least never shows up in a
+# `ps`/Task Manager process listing the way command-line arguments do.
 TOKEN_ENV_VAR = "GAIA_EMAIL_SIDECAR_TOKEN"
 
 # Hosts the sidecar is allowed to be reached as. The sidecar only ever binds a
@@ -125,11 +137,44 @@ def get_config() -> Optional[CallerAuthConfig]:
 
 
 def config_from_env() -> CallerAuthConfig:
-    """Build a policy from the environment (``GAIA_EMAIL_SIDECAR_TOKEN``).
+    """Build a policy from the environment.
 
-    A missing/empty env var yields ``token=None`` — the token check is then
-    skipped (dev mode) but Host/Origin protection still applies.
+    Preferred (#2149): ``GAIA_EMAIL_SIDECAR_TOKEN_FILE`` names a 0600 file the
+    spawning parent wrote the token into — the secret never sits in the
+    environment. A set path var whose file is missing/unreadable/empty is a
+    LOUD startup error, never a silent auth-off skip. Legacy:
+    ``GAIA_EMAIL_SIDECAR_TOKEN`` carries the token directly. Neither set →
+    ``token=None`` — the token check is skipped (dev mode) but Host/Origin
+    protection still applies.
     """
+    token_path = os.environ.get(TOKEN_FILE_ENV_VAR) or None
+    if token_path:
+        if os.environ.get(TOKEN_ENV_VAR):
+            logger.warning(
+                "Both %s and %s are set; using the secret file (%s) and "
+                "ignoring the bare env token.",
+                TOKEN_FILE_ENV_VAR,
+                TOKEN_ENV_VAR,
+                token_path,
+            )
+        try:
+            token = Path(token_path).read_text(encoding="utf-8").strip()
+        except OSError as e:
+            raise RuntimeError(
+                f"{TOKEN_FILE_ENV_VAR} points at '{token_path}' but the "
+                f"launch-secret file cannot be read: {e}. The spawning parent "
+                "creates this file on spawn and removes it on sidecar exit — "
+                "do not set the variable by hand unless the file exists. Unset "
+                "it to run without caller auth (local development only)."
+            ) from e
+        if not token:
+            raise RuntimeError(
+                f"{TOKEN_FILE_ENV_VAR} points at '{token_path}' but the file "
+                "is empty — refusing to start with an empty caller-auth token. "
+                "Unset the variable to run without caller auth (local "
+                "development only)."
+            )
+        return CallerAuthConfig(token=token)
     token = os.environ.get(TOKEN_ENV_VAR) or None
     return CallerAuthConfig(token=token)
 
@@ -234,6 +279,7 @@ class HostOriginMiddleware:
 
 __all__ = [
     "TOKEN_ENV_VAR",
+    "TOKEN_FILE_ENV_VAR",
     "LOOPBACK_HOSTS",
     "EXEMPT_PATHS",
     "CallerAuthConfig",

--- a/hub/agents/python/email/gaia_agent_email/spec_html.py
+++ b/hub/agents/python/email/gaia_agent_email/spec_html.py
@@ -870,10 +870,13 @@ def render_endpoint_spec_html() -> str:
 </p>
 <ul class="desc">
   <li><strong>Per-session bearer token.</strong> The parent process that spawns
-    the sidecar (the <code>@amd-gaia/agent-email</code> lifecycle or the GAIA UI
-    sidecar manager) generates a cryptographically-random token and hands it to
-    the sidecar over the private <code>GAIA_EMAIL_SIDECAR_TOKEN</code> env
-    channel. Every <code>/v1/email/*</code> request must carry
+    the sidecar (the <code>@amd-gaia/agent-email</code> lifecycle or the GAIA
+    daemon's sidecar manager) generates a cryptographically-random token and
+    hands it to the sidecar either as a <code>0600</code> owner-only file whose
+    path arrives in <code>GAIA_EMAIL_SIDECAR_TOKEN_FILE</code> (preferred —
+    the secret never sits in the process environment) or directly in the
+    <code>GAIA_EMAIL_SIDECAR_TOKEN</code> env var (legacy parents). Every
+    <code>/v1/email/*</code> request must carry
     <code>Authorization: Bearer &lt;token&gt;</code> or it is rejected with
     <strong>HTTP 401</strong>. Liveness/version probes
     (<code>/health</code>, <code>/version</code>) and these HTML pages are exempt.</li>

--- a/hub/agents/python/email/packaging/README.md
+++ b/hub/agents/python/email/packaging/README.md
@@ -60,14 +60,24 @@ if there is none it returns **HTTP 502 (`local LLM triage failed`)**.
 
 ### Caller authentication (#1706)
 
-The sidecar can send mail as the user, so it authenticates its caller. Set
-`GAIA_EMAIL_SIDECAR_TOKEN` in the environment (the `@amd-gaia/agent-email`
-lifecycle and the GAIA UI sidecar manager do this automatically on spawn) and
-every `/v1/email/*` request must send `Authorization: Bearer <token>` or it is
+The sidecar can send mail as the user, so it authenticates its caller. The
+spawning parent hands over a per-session token through one of two channels:
+
+- **`GAIA_EMAIL_SIDECAR_TOKEN_FILE`** (preferred) — the path of a `0600`,
+  owner-only file holding the token. The GAIA daemon's sidecar manager writes
+  it on spawn and removes it on sidecar exit, so the secret never sits in the
+  process environment. If the variable is set but the file is missing or
+  empty, startup fails loudly (never a silent auth-off).
+- **`GAIA_EMAIL_SIDECAR_TOKEN`** (legacy) — the token directly in the
+  environment. Still honored for older spawning parents (e.g. the
+  `@amd-gaia/agent-email` lifecycle) and bare integrators; if both are set,
+  the file wins.
+
+Every `/v1/email/*` request must send `Authorization: Bearer <token>` or it is
 rejected with **401**. A non-loopback `Host` → **400** (DNS-rebinding) and a
 non-loopback browser `Origin` → **403** (drive-by page); `/health`, `/version`,
 `/v1/email/spec`, and `/v1/email/playground` are exempt from the token. Launching
-by hand without the env var disables the token check (local dev only, logged
+by hand with neither variable disables the token check (local dev only, logged
 loudly) — Host/Origin protection still applies.
 
 ## Smoke test

--- a/hub/agents/python/email/packaging/server.py
+++ b/hub/agents/python/email/packaging/server.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 
 logging.basicConfig(
@@ -88,25 +89,33 @@ def build_app():
     # Caller authentication (#1706). The sidecar binds 127.0.0.1 and exposes
     # draft/send, so it MUST authenticate its caller — a no-auth localhost API is
     # reachable by any other local process and (via DNS-rebinding) by the user's
-    # browser. The spawning parent passes a per-session bearer token over the
-    # private GAIA_EMAIL_SIDECAR_TOKEN env channel; the Host/Origin middleware
-    # closes rebinding / drive-by-webpage access regardless. This is wired ONLY
-    # here — the product server (gaia.api.openai_server) mounts the same router
+    # browser. The spawning parent hands over a per-session bearer token — via a
+    # 0600 secret file (GAIA_EMAIL_SIDECAR_TOKEN_FILE, preferred #2149) or the
+    # legacy GAIA_EMAIL_SIDECAR_TOKEN env var; the Host/Origin middleware closes
+    # rebinding / drive-by-webpage access regardless. This is wired ONLY here —
+    # the product server (gaia.api.openai_server) mounts the same router
     # unchanged.
     auth_config = caller_auth.config_from_env()
     caller_auth.configure(auth_config)
     app.add_middleware(caller_auth.HostOriginMiddleware)
     if auth_config.token:
+        channel = (
+            f"0600 secret file ({caller_auth.TOKEN_FILE_ENV_VAR})"
+            if os.environ.get(caller_auth.TOKEN_FILE_ENV_VAR)
+            else f"{caller_auth.TOKEN_ENV_VAR} env var (legacy delivery)"
+        )
         log.info(
-            "Email sidecar: caller authentication ENABLED "
-            "(per-session bearer token required on /v1/email/* requests)."
+            "Email sidecar: caller authentication ENABLED via %s "
+            "(per-session bearer token required on /v1/email/* requests).",
+            channel,
         )
     else:
         log.warning(
-            "Email sidecar: caller authentication DISABLED — no %s in the "
-            "environment. This is intended for LOCAL DEVELOPMENT only; the "
-            "shipped product spawns the sidecar with a per-session token. "
-            "Host/Origin protection is still enforced.",
+            "Email sidecar: caller authentication DISABLED — neither %s nor %s "
+            "is in the environment. This is intended for LOCAL DEVELOPMENT "
+            "only; the shipped product spawns the sidecar with a per-session "
+            "token. Host/Origin protection is still enforced.",
+            caller_auth.TOKEN_FILE_ENV_VAR,
             caller_auth.TOKEN_ENV_VAR,
         )
 

--- a/hub/agents/python/email/specification.html
+++ b/hub/agents/python/email/specification.html
@@ -180,10 +180,13 @@ td:nth-child(3) {
 </p>
 <ul class="desc">
   <li><strong>Per-session bearer token.</strong> The parent process that spawns
-    the sidecar (the <code>@amd-gaia/agent-email</code> lifecycle or the GAIA UI
-    sidecar manager) generates a cryptographically-random token and hands it to
-    the sidecar over the private <code>GAIA_EMAIL_SIDECAR_TOKEN</code> env
-    channel. Every <code>/v1/email/*</code> request must carry
+    the sidecar (the <code>@amd-gaia/agent-email</code> lifecycle or the GAIA
+    daemon's sidecar manager) generates a cryptographically-random token and
+    hands it to the sidecar either as a <code>0600</code> owner-only file whose
+    path arrives in <code>GAIA_EMAIL_SIDECAR_TOKEN_FILE</code> (preferred —
+    the secret never sits in the process environment) or directly in the
+    <code>GAIA_EMAIL_SIDECAR_TOKEN</code> env var (legacy parents). Every
+    <code>/v1/email/*</code> request must carry
     <code>Authorization: Bearer &lt;token&gt;</code> or it is rejected with
     <strong>HTTP 401</strong>. Liveness/version probes
     (<code>/health</code>, <code>/version</code>) and these HTML pages are exempt.</li>

--- a/hub/agents/python/email/tests/test_caller_auth.py
+++ b/hub/agents/python/email/tests/test_caller_auth.py
@@ -198,6 +198,56 @@ def test_host_and_origin_apply_even_to_exempt_paths():
 
 
 # ---------------------------------------------------------------------------
+# Secret-file delivery (#2149) — the preferred channel: the spawning parent
+# writes the token to a 0600 file and passes its PATH, so the secret never
+# sits in the sidecar's environment.
+# ---------------------------------------------------------------------------
+
+
+def test_config_from_env_reads_token_from_secret_file(tmp_path, monkeypatch):
+    secret = tmp_path / "launch-secret"
+    secret.write_text(_TOKEN + "\n", encoding="utf-8")  # trailing newline is ok
+    monkeypatch.setenv(caller_auth.TOKEN_FILE_ENV_VAR, str(secret))
+    monkeypatch.delenv(caller_auth.TOKEN_ENV_VAR, raising=False)
+    assert caller_auth.config_from_env().token == _TOKEN
+
+
+def test_config_from_env_missing_secret_file_is_a_loud_error(tmp_path, monkeypatch):
+    # Path var set but no file: that is a broken spawn, NOT dev-mode auth-off.
+    # A silent token=None here would disable auth exactly when the parent
+    # believed it was enabled.
+    monkeypatch.setenv(caller_auth.TOKEN_FILE_ENV_VAR, str(tmp_path / "gone"))
+    monkeypatch.delenv(caller_auth.TOKEN_ENV_VAR, raising=False)
+    with pytest.raises(RuntimeError, match="cannot be read"):
+        caller_auth.config_from_env()
+
+
+def test_config_from_env_empty_secret_file_is_a_loud_error(tmp_path, monkeypatch):
+    secret = tmp_path / "launch-secret"
+    secret.write_text("  \n", encoding="utf-8")
+    monkeypatch.setenv(caller_auth.TOKEN_FILE_ENV_VAR, str(secret))
+    monkeypatch.delenv(caller_auth.TOKEN_ENV_VAR, raising=False)
+    with pytest.raises(RuntimeError, match="empty"):
+        caller_auth.config_from_env()
+
+
+def test_config_from_env_secret_file_wins_over_bare_env_token(tmp_path, monkeypatch):
+    secret = tmp_path / "launch-secret"
+    secret.write_text(_TOKEN, encoding="utf-8")
+    monkeypatch.setenv(caller_auth.TOKEN_FILE_ENV_VAR, str(secret))
+    monkeypatch.setenv(caller_auth.TOKEN_ENV_VAR, "stale-env-token")
+    assert caller_auth.config_from_env().token == _TOKEN
+
+
+def test_config_from_env_bare_env_leg_still_works(monkeypatch):
+    # Older spawning parents (and bare integrators) still hand the token over
+    # the env channel — explicitly supported, negotiated by the daemon.
+    monkeypatch.delenv(caller_auth.TOKEN_FILE_ENV_VAR, raising=False)
+    monkeypatch.setenv(caller_auth.TOKEN_ENV_VAR, _TOKEN)
+    assert caller_auth.config_from_env().token == _TOKEN
+
+
+# ---------------------------------------------------------------------------
 # The real sidecar app wiring (packaging/server.py) — guards against the
 # middleware/dependency not actually being installed on the shipped app.
 # ---------------------------------------------------------------------------
@@ -228,6 +278,36 @@ def test_shipped_sidecar_app_enforces_token(monkeypatch):
     assert ok.status_code == 200
     # Root liveness probe stays open (readiness handshake needs it pre-token).
     assert client.get("/health").status_code == 200
+
+
+def test_shipped_sidecar_app_enforces_token_delivered_via_file(
+    tmp_path, monkeypatch
+):
+    # The full boundary for the #2149 file leg: token delivered as a file path,
+    # enforced by the real app over HTTP — missing/wrong bearer → 401, the
+    # delivered token → 200. No mocks between the request and the check.
+    secret = tmp_path / "launch-secret"
+    secret.write_text(_TOKEN, encoding="utf-8")
+    monkeypatch.setenv(caller_auth.TOKEN_FILE_ENV_VAR, str(secret))
+    monkeypatch.delenv(caller_auth.TOKEN_ENV_VAR, raising=False)
+    server = _load_sidecar_server()
+    client = TestClient(server.build_app(), base_url=_BASE_URL)
+
+    assert client.post("/v1/email/draft", json=_DRAFT_BODY).status_code == 401
+    assert (
+        client.post(
+            "/v1/email/draft",
+            json=_DRAFT_BODY,
+            headers={"Authorization": "Bearer wrong"},
+        ).status_code
+        == 401
+    )
+    ok = client.post(
+        "/v1/email/draft",
+        json=_DRAFT_BODY,
+        headers={"Authorization": f"Bearer {_TOKEN}"},
+    )
+    assert ok.status_code == 200
 
 
 def test_shipped_app_gates_connector_and_agent_routers(monkeypatch):

--- a/src/gaia/daemon/sidecars/fetch.py
+++ b/src/gaia/daemon/sidecars/fetch.py
@@ -72,6 +72,9 @@ class FetchResult:
     sha256: str
     url: str
     cached: bool
+    # Installed binary version (hub sentinel / lock agentVersion). The manager
+    # negotiates secret delivery off this BEFORE spawn (#2149).
+    version: Optional[str] = None
 
 
 def _join_url(base: str, name: str) -> str:
@@ -116,7 +119,14 @@ def _hub_installed_binary(cache: Path, platform_key: str) -> Optional[FetchResul
         binary_path,
         sentinel.version,
     )
-    return FetchResult(binary_path, platform_key, actual, url="", cached=True)
+    return FetchResult(
+        binary_path,
+        platform_key,
+        actual,
+        url="",
+        cached=True,
+        version=sentinel.version or None,
+    )
 
 
 def fetch_binary(
@@ -173,7 +183,14 @@ def fetch_binary(
         existing = file_sha256(binary_path)
         if existing and existing.lower() == entry.sha256.lower():
             logger.info("sidecar fetch: cache hit %s matches lock sha256", binary_path)
-            return FetchResult(binary_path, key, existing, url, cached=True)
+            return FetchResult(
+                binary_path,
+                key,
+                existing,
+                url,
+                cached=True,
+                version=lock.agent_version or None,
+            )
 
     if session is None:
         import requests
@@ -206,4 +223,11 @@ def fetch_binary(
             binary_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
     logger.info("sidecar fetch: installed verified binary -> %s", binary_path)
-    return FetchResult(binary_path, key, sha, url, cached=False)
+    return FetchResult(
+        binary_path,
+        key,
+        sha,
+        url,
+        cached=False,
+        version=lock.agent_version or None,
+    )

--- a/src/gaia/daemon/sidecars/manager.py
+++ b/src/gaia/daemon/sidecars/manager.py
@@ -36,8 +36,10 @@ import atexit
 import os
 import secrets
 import socket
+import stat
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -71,6 +73,20 @@ def find_free_port(host: str = _HOST) -> int:
         if port != RESERVED_PORT:
             return port
     raise SidecarSpawnError("could not find a free ephemeral port for the sidecar")
+
+
+def _version_tuple(version: str) -> tuple:
+    """Parse a dotted version into a comparable int tuple; loud on garbage."""
+    parts = str(version).strip().lstrip("v").split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError as e:
+        raise SidecarSpawnError(
+            f"cannot parse sidecar binary version '{version}' for secret-delivery "
+            "negotiation. Expected a dotted numeric version (e.g. '0.6.0') — "
+            "reinstall the agent from the Agent Hub if its install metadata is "
+            "corrupt."
+        ) from e
 
 
 def _major(version: str) -> int:
@@ -138,9 +154,16 @@ class AgentSidecarManager:
         # already running" must compare against this, not a moving target.
         self.resolved_mode: Optional[str] = None
         # Per-session caller-auth token handed to the sidecar on spawn (#1706).
-        # Generated once per manager instance and passed over the private env
-        # channel; the proxy replays it as a bearer token on every request.
+        # Generated once per manager instance; the proxy replays it as a bearer
+        # token on every request. Delivered via a 0600 file (#2149) when the
+        # sidecar supports it, else the deprecated bare-env leg.
         self.auth_token: str = secrets.token_urlsafe(32)
+        # Installed binary version captured by build_spawn_command (user mode) —
+        # the pre-spawn key for secret-delivery negotiation (#2149).
+        self.installed_binary_version: Optional[str] = None
+        # The leg actually used at spawn time: "file" | "env".
+        self.secret_delivery: Optional[str] = None
+        self._secret_path: Optional[Path] = None
 
     @property
     def mode(self) -> str:
@@ -183,9 +206,11 @@ class AgentSidecarManager:
                     f"mode: {e} Set {self.spec.mode_env_var}=dev to run from "
                     "source, or publish the agent so the binary + real SHA exist."
                 ) from e
+            self.installed_binary_version = result.version
             argv = [str(result.binary_path), "--host", self.host, "--port", str(port)]
             return argv, {}
         # dev mode — load packaging/server.py as the top-level module `server`.
+        self.installed_binary_version = None
         if self.spec.dev_src_dir is None:
             raise SidecarSpawnError(
                 f"dev mode needs a source dir but {self.spec.agent_id}'s spec has "
@@ -262,12 +287,13 @@ class AgentSidecarManager:
             creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
         else:
             start_new_session = True  # own process group for tree-kill
-        log_handle = self._open_log(port)
-        # Hand the sidecar its per-session caller-auth token over the private env
-        # channel (#1706). Merge over the inherited env / any cwd already in
-        # popen_kwargs — never clobber them.
+        # Hand the sidecar its per-session caller-auth token (#1706). Merge over
+        # the inherited env / any cwd already in popen_kwargs — never clobber
+        # them. Delivery leg (0600 file vs deprecated bare env) is negotiated
+        # pre-spawn (#2149), before the log opens so a refusal leaks nothing.
         spawn_env = {**os.environ, **(popen_kwargs.pop("env", None) or {})}
-        spawn_env[self.spec.token_env_var] = self.auth_token
+        self._apply_secret_delivery(spawn_env)
+        log_handle = self._open_log(port)
         try:
             self._proc = subprocess.Popen(
                 argv,
@@ -280,6 +306,7 @@ class AgentSidecarManager:
             )
         except OSError as e:
             self._close_log()
+            self._cleanup_secret_file()
             raise SidecarSpawnError(
                 f"failed to launch the {self.spec.agent_id} sidecar ({argv[0]}): {e}"
             ) from e
@@ -293,6 +320,133 @@ class AgentSidecarManager:
         if not self._atexit_registered:
             atexit.register(self.shutdown)
             self._atexit_registered = True
+
+    def _resolve_secret_delivery(self) -> "tuple[str, str]":
+        """Pick the delivery leg ("file" | "env") BEFORE spawn, plus the reason.
+
+        Keyed off what the parent already knows — the resolved mode and the
+        installed binary's version from the install manifest / lock. NOT the
+        runtime /version probe: that answers only after spawn, which is too late
+        to choose how the secret is delivered (#2149).
+        """
+        spec = self.spec
+        if not spec.token_file_env_var or not spec.secret_file_min_version:
+            return "env", f"the {spec.agent_id} spec declares no file-delivery contract"
+        mode = self.resolved_mode or self.mode
+        if mode == "dev":
+            return "file", "dev mode runs from source, which reads the secret file"
+        version = self.installed_binary_version
+        if not version:
+            raise SidecarSpawnError(
+                f"cannot negotiate secret delivery for the {spec.agent_id} "
+                "sidecar: the installed binary's version is unknown (no version "
+                "in the hub install sentinel or binaries.lock.json). Refusing to "
+                "guess which leg the binary understands — reinstall the agent "
+                "from the Agent Hub so its install metadata records a version."
+            )
+        if _version_tuple(version) >= _version_tuple(spec.secret_file_min_version):
+            return (
+                "file",
+                f"installed binary {version} >= {spec.secret_file_min_version}",
+            )
+        return (
+            "env",
+            f"installed binary {version} predates file delivery "
+            f"(< {spec.secret_file_min_version})",
+        )
+
+    def _apply_secret_delivery(self, spawn_env: dict) -> None:
+        """Inject the launch secret into *spawn_env* via the negotiated leg."""
+        leg, reason = self._resolve_secret_delivery()
+        self.secret_delivery = leg
+        if leg == "file":
+            secret_path = self._write_secret_file()
+            spawn_env[self.spec.token_file_env_var] = str(secret_path)
+            # Never let a stale inherited token env var ride into the child.
+            spawn_env.pop(self.spec.token_env_var, None)
+            logger.info(
+                "%s sidecar: delivering launch secret via 0600 file %s (%s)",
+                self.spec.agent_id,
+                secret_path,
+                reason,
+            )
+        else:
+            spawn_env[self.spec.token_env_var] = self.auth_token
+            logger.warning(
+                "%s sidecar: DEPRECATED bare-env secret delivery via %s (%s). "
+                "The secret is visible to local process inspection "
+                "(/proc/<pid>/environ, ps eww); upgrade the installed sidecar "
+                "binary to get 0600-file delivery. Removal of this leg is "
+                "tracked in #2149.",
+                self.spec.agent_id,
+                self.spec.token_env_var,
+                reason,
+            )
+
+    def _write_secret_file(self) -> Path:
+        """Create the owner-only launch-secret file; loud error, no env fallback.
+
+        A fresh ``mkdtemp`` dir (0700) + ``O_CREAT|O_EXCL`` at 0600 means the
+        secret never exists on disk with looser permissions, even mid-write.
+        """
+        secret_dir: Optional[Path] = None
+        try:
+            secret_dir = Path(
+                tempfile.mkdtemp(prefix=f"gaia-{self.spec.agent_id}-secret-")
+            )
+            path = secret_dir / "launch-secret"
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                os.write(fd, self.auth_token.encode("utf-8"))
+            finally:
+                os.close(fd)
+            if os.name != "nt":
+                mode = stat.S_IMODE(os.stat(path).st_mode)
+                if mode != 0o600:
+                    raise SidecarSpawnError(
+                        f"launch-secret file {path} came out mode {oct(mode)}, "
+                        "not 0600 — refusing to spawn with a secret other local "
+                        "users could read. The temp filesystem is ignoring POSIX "
+                        "permissions; point TMPDIR at one that honors them."
+                    )
+        except OSError as e:
+            self._remove_secret_dir(secret_dir)
+            raise SidecarSpawnError(
+                f"could not create the {self.spec.agent_id} sidecar's 0600 "
+                f"launch-secret file: {e}. There is no env fallback — fix the "
+                "temp directory (TMPDIR) permissions/space and retry."
+            ) from e
+        except SidecarSpawnError:
+            self._remove_secret_dir(secret_dir)
+            raise
+        self._secret_path = path
+        return path
+
+    @staticmethod
+    def _remove_secret_dir(secret_dir: Optional[Path]) -> None:
+        if secret_dir is None:
+            return
+        try:
+            (secret_dir / "launch-secret").unlink(missing_ok=True)
+            secret_dir.rmdir()
+        except OSError:
+            pass
+
+    def _cleanup_secret_file(self) -> None:
+        path = self._secret_path
+        if path is None:
+            return
+        self._secret_path = None
+        try:
+            path.unlink(missing_ok=True)
+            path.parent.rmdir()
+        except OSError as e:
+            logger.warning(
+                "%s sidecar: could not remove launch-secret file %s: %s",
+                self.spec.agent_id,
+                path,
+                e,
+            )
 
     def start(self, max_attempts: int = 3) -> str:
         """Spawn + health-check + version-handshake the sidecar; return base_url.
@@ -461,10 +615,12 @@ class AgentSidecarManager:
         proc = self._proc
         if proc is None:
             self._close_log()
+            self._cleanup_secret_file()
             return
         if proc.poll() is not None:
             self._proc = None
             self._close_log()
+            self._cleanup_secret_file()
             self._fire_reaped()
             return
         pid = proc.pid
@@ -501,6 +657,7 @@ class AgentSidecarManager:
         leader_gone = proc.poll() is not None
         self._proc = None
         self._close_log()
+        self._cleanup_secret_file()
         if leader_gone:
             self._fire_reaped()
         logger.info("%s sidecar: shut down", self.spec.agent_id)

--- a/src/gaia/daemon/sidecars/spec.py
+++ b/src/gaia/daemon/sidecars/spec.py
@@ -21,6 +21,14 @@ class AgentSidecarSpec:
     ``token_env_var`` is a cross-repo literal contract: for the email spec it
     MUST equal ``gaia_agent_email.caller_auth.TOKEN_ENV_VAR``. Kept as a plain
     string (not imported from the hub wheel) so the daemon never depends on it.
+
+    ``token_file_env_var`` is the file-delivery leg of the same contract
+    (#2149): the manager writes the launch secret to a 0600 file and hands the
+    sidecar its PATH via this variable, so the secret itself never sits in the
+    child's environment. ``secret_file_min_version`` is the first agent version
+    whose binary reads that file; older installed binaries keep the (deprecated,
+    loudly logged) bare-env leg. Both unset → the spec has no file contract and
+    delivery stays env-based.
     """
 
     agent_id: str
@@ -30,6 +38,8 @@ class AgentSidecarSpec:
     token_env_var: str
     mode_env_var: str
     cache_dir_name: str
+    token_file_env_var: Optional[str] = None
+    secret_file_min_version: Optional[str] = None
     dev_src_dir: Optional[Path] = None
     dev_app_dir: str = "packaging"
     dev_module: str = "server:app"
@@ -40,6 +50,14 @@ class AgentSidecarSpec:
 # gaia_agent_email.caller_auth.TOKEN_ENV_VAR — kept a literal so core never
 # imports the hub wheel.
 _EMAIL_TOKEN_ENV_VAR = "GAIA_EMAIL_SIDECAR_TOKEN"
+
+# File-delivery leg (#2149). MUST equal
+# gaia_agent_email.caller_auth.TOKEN_FILE_ENV_VAR — literal for the same reason.
+_EMAIL_TOKEN_FILE_ENV_VAR = "GAIA_EMAIL_SIDECAR_TOKEN_FILE"
+
+# First gaia-agent-email version whose binary reads the token file. Keep in
+# lock-step with the release cut that first ships caller_auth's file leg.
+_EMAIL_SECRET_FILE_MIN_VERSION = "0.6.0"
 
 
 def _default_email_src_dir() -> Path:
@@ -56,6 +74,8 @@ def builtin_specs() -> "dict[str, AgentSidecarSpec]":
             display_name="Email",
             expected_api_major="2",
             token_env_var=_EMAIL_TOKEN_ENV_VAR,
+            token_file_env_var=_EMAIL_TOKEN_FILE_ENV_VAR,
+            secret_file_min_version=_EMAIL_SECRET_FILE_MIN_VERSION,
             mode_env_var="GAIA_EMAIL_AGENT_MODE",
             cache_dir_name="email",
             dev_src_dir=_default_email_src_dir(),

--- a/tests/unit/test_agent_sidecar_manager.py
+++ b/tests/unit/test_agent_sidecar_manager.py
@@ -7,6 +7,9 @@ mechanics (#2142 T1)."""
 
 import dataclasses
 import importlib.util
+import logging
+import os
+import stat as _stat
 import sys
 import threading
 import time as _t
@@ -54,6 +57,23 @@ def test_builtin_email_spec_token_env_var_matches_the_hub_wheel_contract():
     # Never silently drift — this env var is how the daemon hands the sidecar
     # its per-session auth token.
     assert builtin_specs()["email"].token_env_var == "GAIA_EMAIL_SIDECAR_TOKEN"
+
+
+def test_builtin_email_spec_token_file_env_var_matches_the_hub_wheel_contract():
+    # File-delivery leg (#2149): same mirror rule as the token env var — must
+    # equal gaia_agent_email.caller_auth.TOKEN_FILE_ENV_VAR.
+    email = builtin_specs()["email"]
+    assert email.token_file_env_var == "GAIA_EMAIL_SIDECAR_TOKEN_FILE"
+    assert email.secret_file_min_version == "0.6.0"
+
+
+def test_email_spec_literals_match_the_installed_caller_auth_module():
+    # When the hub wheel is importable, assert the mirrored literals for real —
+    # the drift the plain-string contract cannot catch by itself.
+    caller_auth = pytest.importorskip("gaia_agent_email.caller_auth")
+    email = builtin_specs()["email"]
+    assert email.token_env_var == caller_auth.TOKEN_ENV_VAR
+    assert email.token_file_env_var == caller_auth.TOKEN_FILE_ENV_VAR
 
 
 def test_builtin_email_spec_mode_env_var():
@@ -163,6 +183,7 @@ def test_user_mode_spawn_command_uses_fetched_binary(monkeypatch, tmp_path):
 
     class _Res:
         binary_path = fake_binary
+        version = "0.6.0"
 
     monkeypatch.setattr(mgr.fetch, "fetch_binary", lambda **kw: _Res())
     m = mgr.AgentSidecarManager(builtin_specs()["email"])
@@ -352,19 +373,140 @@ def test_start_registers_atexit_reaper(monkeypatch, tmp_path):
     assert m.shutdown in captured["atexit"]
 
 
-def test_spawn_passes_per_session_token_via_env(monkeypatch, tmp_path):
-    # #1706: the sidecar's caller-auth token is handed over the private env
-    # channel on spawn (never argv), so no other local process sees it in a
-    # process listing. Now keyed by spec.token_env_var, not a hardcoded literal.
+def test_dev_mode_delivers_secret_via_0600_file_never_env(monkeypatch, tmp_path):
+    # #2149: dev mode runs from source (which reads the secret file), so the
+    # token reaches the sidecar as a 0600 owner-only file — its PATH is in the
+    # env, the secret itself is not, and it never appears on the command line.
+    spec = builtin_specs()["email"]
+    monkeypatch.delenv(spec.token_env_var, raising=False)
     m, captured = _install_fake_spawn(monkeypatch, tmp_path)
     m.start()
     env = captured["popen_kwargs"]["env"]
-    assert m.auth_token  # a real random token was generated
-    assert env[builtin_specs()["email"].token_env_var] == m.auth_token
+    assert m.secret_delivery == "file"
+    secret_path = Path(env[spec.token_file_env_var])
+    assert secret_path.read_text(encoding="utf-8") == m.auth_token
+    if os.name != "nt":
+        assert _stat.S_IMODE(secret_path.stat().st_mode) == 0o600
+        assert _stat.S_IMODE(secret_path.parent.stat().st_mode) == 0o700
+    # The secret VALUE is absent from the spawn env and argv.
+    assert spec.token_env_var not in env
+    assert m.auth_token not in env.values()
+    assert all(m.auth_token not in str(a) for a in captured["argv"])
     # The inherited environment is preserved (merged, not replaced).
     assert "PATH" in env or "Path" in env
-    # The token must never appear on the command line.
-    assert all(m.auth_token not in str(a) for a in captured["argv"])
+    m.shutdown()
+
+
+def test_secret_file_is_removed_on_shutdown(monkeypatch, tmp_path):
+    # The 0600 file must not outlive the sidecar — removal hangs off the same
+    # shutdown/reap path that tree-kills the process (atexit covers crashes).
+    spec = builtin_specs()["email"]
+    m, captured = _install_fake_spawn(monkeypatch, tmp_path)
+    m.start()
+    secret_path = Path(captured["popen_kwargs"]["env"][spec.token_file_env_var])
+    assert secret_path.exists()
+    m.shutdown()
+    assert not secret_path.exists()
+    assert not secret_path.parent.exists()  # the private 0700 dir goes too
+
+
+def _install_fake_user_spawn(monkeypatch, tmp_path, *, version):
+    """User-mode twin of _install_fake_spawn: fake fetched binary at *version*."""
+    monkeypatch.setenv("GAIA_EMAIL_AGENT_MODE", "user")
+    fake_binary = tmp_path / "email-agent"
+    fake_binary.write_bytes(b"x")
+
+    class _Res:
+        binary_path = fake_binary
+
+    _Res.version = version
+    monkeypatch.setattr(mgr.fetch, "fetch_binary", lambda **kw: _Res())
+    captured = {}
+
+    def _fake_popen(argv, **kwargs):
+        captured["popen_kwargs"] = kwargs
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(mgr.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(mgr.atexit, "register", lambda fn: None)
+    monkeypatch.setattr(mgr.atexit, "unregister", lambda fn: None)
+    m = mgr.AgentSidecarManager(
+        builtin_specs()["email"], cache_dir=tmp_path, log_dir=tmp_path / "logs"
+    )
+    monkeypatch.setattr(
+        m,
+        "_http_get",
+        lambda url, timeout: _FakeResp(
+            {"status": "ok", "service": "gaia-agent-email"}
+            if url.endswith("/health")
+            else {"apiVersion": "2.0", "agentVersion": version or "?"}
+        ),
+    )
+    return m, captured
+
+
+def test_user_mode_new_binary_negotiates_file_delivery(monkeypatch, tmp_path):
+    # Negotiation is keyed off the INSTALLED binary's version (known pre-spawn),
+    # not the runtime /version probe (which answers only after spawn).
+    m, captured = _install_fake_user_spawn(monkeypatch, tmp_path, version="0.6.0")
+    m.start()
+    spec = builtin_specs()["email"]
+    env = captured["popen_kwargs"]["env"]
+    assert m.secret_delivery == "file"
+    assert spec.token_file_env_var in env
+    assert spec.token_env_var not in env
+    m.shutdown()
+
+
+def test_user_mode_old_binary_keeps_env_leg_with_loud_deprecation(
+    monkeypatch, tmp_path, caplog
+):
+    # Explicit, versioned compatibility: a published binary that predates file
+    # delivery still spawns and authenticates via the env leg — loudly.
+    m, captured = _install_fake_user_spawn(monkeypatch, tmp_path, version="0.5.0")
+    with caplog.at_level(logging.WARNING, logger="gaia.daemon.sidecars.manager"):
+        m.start()
+    spec = builtin_specs()["email"]
+    env = captured["popen_kwargs"]["env"]
+    assert m.secret_delivery == "env"
+    assert env[spec.token_env_var] == m.auth_token
+    assert spec.token_file_env_var not in env
+    assert any("DEPRECATED" in r.getMessage() for r in caplog.records)
+    m.shutdown()
+
+
+def test_user_mode_unknown_binary_version_fails_loudly(monkeypatch, tmp_path):
+    # No version in the install metadata → the manager cannot know which leg
+    # the binary understands. Refuse loudly; never guess a delivery channel.
+    m, captured = _install_fake_user_spawn(monkeypatch, tmp_path, version=None)
+    with pytest.raises(SidecarSpawnError, match="version is unknown"):
+        m.start()
+    assert captured.get("popen_kwargs") is None  # never spawned
+
+
+def test_secret_file_creation_failure_is_spawn_error_not_env_fallback(
+    monkeypatch, tmp_path
+):
+    # Fail-loudly rule: if the 0600 file cannot be created, that is a startup
+    # error — the manager must NOT quietly fall back to bare-env delivery.
+    m, captured = _install_fake_spawn(monkeypatch, tmp_path)
+
+    def _boom(prefix=None):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mgr.tempfile, "mkdtemp", _boom)
+    with pytest.raises(SidecarSpawnError, match="launch-secret"):
+        m.start()
+    assert captured.get("popen_kwargs") is None  # never spawned, no env leg
+
+
+def test_version_tuple_parses_and_rejects_garbage():
+    assert mgr._version_tuple("0.6.0") == (0, 6, 0)
+    assert mgr._version_tuple("v1.2") == (1, 2)
+    assert mgr._version_tuple("0.10.0") > mgr._version_tuple("0.6.0")
+    with pytest.raises(SidecarSpawnError, match="cannot parse"):
+        mgr._version_tuple("not-a-version")
 
 
 def test_start_captures_version(monkeypatch, tmp_path):
@@ -667,6 +809,7 @@ def test_resolved_mode_captures_spawn_time_mode_not_live_env(monkeypatch, tmp_pa
 )
 def test_dev_mode_real_spawn_health_and_treekill(monkeypatch):
     monkeypatch.setenv("GAIA_EMAIL_AGENT_MODE", "dev")
+    monkeypatch.delenv("GAIA_EMAIL_SIDECAR_TOKEN", raising=False)
     m = mgr.AgentSidecarManager(builtin_specs()["email"], health_timeout=60.0)
     base = m.start()
     try:
@@ -674,6 +817,32 @@ def test_dev_mode_real_spawn_health_and_treekill(monkeypatch):
 
         assert requests.get(f"{base}/health", timeout=5).json()["status"] == "ok"
         assert m.is_running
+        # #2149: the secret must be absent from the live child's environment.
+        # Linux exposes the real spawn-time record via /proc.
+        if sys.platform.startswith("linux"):
+            environ = Path(f"/proc/{m.pid}/environ").read_bytes()
+            assert m.auth_token.encode() not in environ
+        # Real HTTP boundary (no mocks): the file-delivered token gates the
+        # surface — missing/wrong bearer → 401, the delivered token → 200.
+        draft = {"to": [{"email": "a@b.com"}], "subject": "x", "body": "y"}
+        url = f"{base}/v1/email/draft"
+        assert requests.post(url, json=draft, timeout=10).status_code == 401
+        assert (
+            requests.post(
+                url,
+                json=draft,
+                timeout=10,
+                headers={"Authorization": "Bearer wrong"},
+            ).status_code
+            == 401
+        )
+        ok = requests.post(
+            url,
+            json=draft,
+            timeout=10,
+            headers={"Authorization": f"Bearer {m.auth_token}"},
+        )
+        assert ok.status_code == 200
     finally:
         m.shutdown()
     assert not m.is_running


### PR DESCRIPTION
Closes #2149 (milestone 55, V2-3 — unblocks #2153 / #2154).

The email sidecar's per-session bearer secret was delivered as a bare environment variable, so any local process that can read `/proc/<pid>/environ` or `ps eww` output learned a credential that can send mail as the user. The daemon now writes the secret to an owner-only `0600` file (inside a fresh `0700` tempdir) and passes only its path; the file is removed on sidecar stop/reap, and a file that can't be created with correct permissions fails the spawn loudly — no silent env fallback. Published binaries that predate file delivery keep working: the leg is negotiated **before spawn** off the installed binary's version (install sentinel / `binaries.lock.json`), per the #2014 audit guardrail — the env leg logs a loud deprecation line, and an unknown installed version refuses to guess.

The read side prefers the new `GAIA_EMAIL_SIDECAR_TOKEN_FILE` path var (mirrored as a plain literal in `spec.py` — core still never imports the hub wheel); a set path var whose file is missing/empty is a loud startup error, never a silent auth-off. File support ships with the 0.6.0 cut — `secret_file_min_version` is pinned to it, so today's 0.5.0 binaries negotiate the env leg until then.

## Test plan

- [x] `tests/unit/test_agent_sidecar_manager.py` — 56 pass, including the live dev-mode spawn: real HTTP 401 (no/wrong bearer) and 200 (delivered token), secret file `0600` + removed on shutdown, env leg for a 0.5.0 binary with deprecation log, loud failure on unknown version and on file-creation failure; Linux-gated `/proc/<pid>/environ` assertion that the secret is absent
- [x] `hub/agents/python/email/tests/` — 653 pass, including the new secret-file `config_from_env` matrix and the shipped-app boundary test (file-delivered token → 401/401/200 through the real app)
- [x] Daemon/sidecar/proxy suites (`test_daemon*.py`, `test_email_sidecar_*.py`) — pass
- [x] `python util/lint.py --all` — clean; `specification.html` regenerated (drift guard green)

Pre-existing failures, unrelated and untouched: `test_email_sidecar_proxy.py`'s two live tests import `gaia.ui.email_sidecar.manager`, removed by the #2144 relocation (they skip in CI where `gaia_agent_email` isn't installed); `test_agent_version_matches_package_metadata` fails on machines with a stale 0.3.0 editable install.