### PR TITLE
feat(daemon): streaming SSE reverse-proxy for agent routes (#2150)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2132,6 +2132,14 @@ daemon *client*: it asks the daemon to ensure a sidecar and talks to the
 sidecar directly, so **closing the UI leaves the sidecar running** — stopping
 is a daemon command.
 
+The daemon also serves a streaming **data plane**: `ANY /v1/<agent>/*` (e.g.
+`POST /v1/email/query`) is reverse-proxied to that agent's running sidecar,
+SSE relayed unbuffered, with cancel propagated on client disconnect and a
+synthetic terminal `error` event if the sidecar crashes mid-stream. Clients
+authenticate every route — control plane and data plane alike — with the
+daemon client token from `~/.gaia/host/instance.json`; the per-sidecar bearer
+is injected by the daemon and never leaves it for relayed traffic.
+
 Requires the daemon extras (`fastapi`/`uvicorn`/`psutil`) — install with
 `pip install "amd-gaia[ui]"` (or `[api]`/`[dev]`). Running it on a base install
 fails loudly with that instruction.

--- a/src/gaia/daemon/app.py
+++ b/src/gaia/daemon/app.py
@@ -87,7 +87,8 @@ def create_app(
     *on_shutdown* run inside the app lifespan — the daemon registers instance.json
     on startup (once the port is bound) and deregisters on shutdown. *registry*
     (a :class:`gaia.daemon.sidecars.registry.SidecarRegistry`) mounts the
-    ``/daemon/v1/agents`` control plane; ``None`` leaves it unmounted.
+    ``/daemon/v1/agents`` control plane and the ``/v1/<agent>/*`` streaming
+    relay (#2150); ``None`` leaves both unmounted.
     """
     from fastapi import Depends, FastAPI, HTTPException
 
@@ -143,8 +144,12 @@ def create_app(
         return {"service": SERVICE_ID, "status": "stopping", "pid": pid}
 
     if registry is not None:
+        from gaia.daemon.relay import build_relay_router
         from gaia.daemon.sidecars.routes import build_agents_router
 
         app.include_router(build_agents_router(token, registry))
+        # Data plane (#2150): ANY /v1/<agent>/* relays to the agent's sidecar
+        # behind the SAME client-token guard as the control plane above.
+        app.include_router(build_relay_router(token, registry))
 
     return app

--- a/src/gaia/daemon/relay.py
+++ b/src/gaia/daemon/relay.py
@@ -1,0 +1,450 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Streaming reverse-proxy for agent routes — the daemon's data plane
+(``ANY /v1/<agent>/*``, issue #2150 / V2-7).
+
+Clients present only the DAEMON client token; the daemon swaps it for the
+per-agent sidecar bearer server-side (via ``SidecarRegistry.connection``), so
+sidecar credentials never leave the daemon for relayed traffic. The
+``/daemon/v1/*`` control plane is untouched — this router is the second,
+data-plane mount over the same registry.
+
+Behavior by upstream response type:
+
+- ``text/event-stream`` — relayed UNBUFFERED (``httpx.AsyncClient(stream=True)``
+  chunks → ``StreamingResponse``): each upstream chunk is forwarded the moment
+  it arrives. A passive :class:`_SSEWatcher` observes the bytes (never altering
+  them) to learn the ``run_id`` and whether the frozen 7-event contract's
+  single terminal ``final``/``error`` event has passed.
+- anything else — buffered passthrough with status, headers, and body
+  preserved (fixed-function routes; per V2-7 the buffered path is fine there).
+
+Crash semantics (§0.13): if the stream ends — EOF or transport error — WITHOUT
+a terminal event, the relay appends one synthetic terminal error frame::
+
+    data: {"type": "error", "detail": "<actionable message>", "source": "daemon_relay"}
+
+and ends the response cleanly. The shape is the canonical contract's own
+``error`` event plus an additive ``source`` marker so downstream front-doors
+(V2-8 CLI, V2-17 ``gaia api``) can tell a relay-synthesized terminal from a
+sidecar-authored one.
+
+Cancel semantics: a client disconnect (or a non-terminal stream end) triggers a
+best-effort ``POST /v1/<agent>/query/<run_id>/cancel`` upstream — mirroring
+``gaia.ui.email_sidecar.relay``'s crash/cancel handling — so an abandoned run
+stops occupying the single-tenant LLM slot. Best-effort by design: the sidecar
+may already be dead, so transport failures are logged, never raised.
+
+Loud errors, no silent fallbacks: unknown agent → 404 naming the registered
+ids; registered-but-not-running → 503 naming the ensure remedy; upstream
+unreachable mid-flight → 502 carrying the transport error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Optional
+
+# Module-level on purpose (matches sidecars/routes.py): this module is itself
+# imported lazily from create_app, and the endpoint annotations below must be
+# resolvable from module globals under PEP 563 (`request: Request`).
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse
+
+from gaia.daemon.sidecars.errors import SidecarNotRunningError, UnknownAgentError
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+#: Connect timeout — a dead sidecar should fail fast on TCP connect.
+CONNECT_TIMEOUT = 10.0
+#: Read timeout between upstream chunks — spans a whole agent-loop step, so it
+#: matches the sidecar proxy's long per-request budget, not the connect one.
+READ_TIMEOUT = 300.0
+#: Cancel POST timeout — best-effort cleanup must never wait out READ_TIMEOUT.
+CANCEL_TIMEOUT = 10.0
+
+#: Canonical event types that terminate a ``/query`` stream (frozen 7-event
+#: contract, spec #2015/#2016 — mirrors ``gaia_agent_email.sse_translation``).
+TERMINAL_TYPES = frozenset({"final", "error"})
+
+#: Methods the relay accepts — everything a sidecar route can serve.
+RELAY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+
+# Hop-by-hop headers never forwarded in either direction (RFC 9110 §7.6.1).
+_HOP_BY_HOP = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+# Request headers the relay owns: host (rewritten by httpx), authorization
+# (client token swapped for the sidecar bearer), content-length (recomputed),
+# accept-encoding (forced to identity so relayed bytes stay uncompressed and
+# the SSE watcher can read them).
+_REQUEST_DROP = _HOP_BY_HOP | {
+    "host",
+    "authorization",
+    "content-length",
+    "accept-encoding",
+}
+# Response headers the relay owns: length/encoding are recomputed for the
+# (decoded) body; date/server would duplicate uvicorn's own.
+_RESPONSE_DROP = _HOP_BY_HOP | {"content-length", "content-encoding", "date", "server"}
+
+# Cap on the watcher's partial-frame buffer: a stream that never frames (not
+# SSE-shaped after all) must not grow memory without bound. Far above any
+# plausible single canonical event — a frame this size means the stream is not
+# SSE-shaped, and the watcher degrades to "terminal unknown" rather than
+# misclassifying a valid oversized final as a crash.
+_WATCHER_BUFFER_CAP = 16 << 20
+
+# Strong refs to fire-and-forget cancel tasks spawned from a cancelled response
+# generator (asyncio only weak-refs pending tasks).
+_background_tasks: "set[asyncio.Task]" = set()
+
+
+def _spawn_background(coro) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # Loop already gone (server teardown): cleanup cannot run, so the
+        # upstream response/client leak until GC — name it instead of hiding it.
+        logger.warning(
+            "daemon relay: no running loop for background cancel/cleanup task; "
+            "upstream connection will be reclaimed by GC"
+        )
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+def stream_ended_unexpectedly_detail(agent_id: str) -> str:
+    """Actionable detail for the synthetic terminal error frame (§0.13)."""
+    return (
+        f"agent '{agent_id}' stream ended unexpectedly without a terminal "
+        "event — the sidecar may have crashed mid-run. Check its log under "
+        f"~/.gaia/agents/{agent_id}/logs/, re-ensure it "
+        f"(POST /daemon/v1/agents/{agent_id}/ensure), and retry."
+    )
+
+
+def _synthetic_error_frame(detail: str, *, terminate_partial: bool) -> bytes:
+    """One canonical terminal ``error`` SSE frame, relay-authored.
+
+    *terminate_partial* prepends a frame separator so a half-forwarded upstream
+    frame can never concatenate with (and corrupt) the synthetic one.
+    """
+    frame = (
+        b"data: "
+        + json.dumps(
+            {"type": "error", "detail": detail, "source": "daemon_relay"}
+        ).encode("utf-8")
+        + b"\n\n"
+    )
+    return (b"\n\n" + frame) if terminate_partial else frame
+
+
+def _run_id_from_body(body: bytes) -> Optional[str]:
+    """``run_id`` from a JSON request body, if it carries one (host-minted per
+    the /query contract). A non-JSON or run_id-less body legitimately has none."""
+    if not body:
+        return None
+    try:
+        payload = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if isinstance(payload, dict):
+        rid = payload.get("run_id")
+        if isinstance(rid, str) and rid:
+            return rid
+    return None
+
+
+class _SSEWatcher:
+    """Passive observer of the relayed SSE byte stream.
+
+    Feeds on the exact bytes forwarded to the client (never altering them) and
+    tracks two facts the crash/cancel semantics depend on: whether a terminal
+    ``final``/``error`` event has passed, and the current ``run_id`` (seeded
+    from the request body, updated from any event that carries one). A
+    malformed ``data:`` payload is logged loudly but does not fail the relay —
+    the bytes reach the client verbatim either way; only the daemon-side
+    crash classification would degrade.
+    """
+
+    def __init__(self, run_id: Optional[str] = None):
+        self._buf = b""
+        self._pending_cr = b""
+        self._overflowed = False
+        # Sticky: once bytes were dropped on overflow, a terminal event may
+        # have passed unseen — terminal classification is unknown from then on.
+        self.degraded = False
+        self.terminal_seen = False
+        self.run_id = run_id
+
+    @property
+    def mid_frame(self) -> bool:
+        """True when the last forwarded byte was inside an unterminated frame."""
+        return bool(self._buf) or bool(self._pending_cr) or self._overflowed
+
+    def feed(self, chunk: bytes) -> None:
+        # Normalize CRLF incrementally (a trailing '\r' may pair with the next
+        # chunk's '\n') so '\r\n\r\n'-framed streams still detect frames. The
+        # normalization is watcher-internal — forwarded bytes are untouched.
+        data = self._pending_cr + chunk
+        self._pending_cr = b""
+        if data.endswith(b"\r"):
+            self._pending_cr = b"\r"
+            data = data[:-1]
+        self._buf += data.replace(b"\r\n", b"\n")
+        while True:
+            frame, sep, rest = self._buf.partition(b"\n\n")
+            if not sep:
+                break
+            self._buf = rest
+            self._overflowed = False
+            self._scan_frame(frame)
+        if len(self._buf) > _WATCHER_BUFFER_CAP:
+            if not self._overflowed:
+                logger.warning(
+                    "daemon relay: SSE watcher buffer exceeded %d bytes without "
+                    "a frame separator — upstream is not emitting SSE frames; "
+                    "terminal-event detection is degraded for this stream",
+                    _WATCHER_BUFFER_CAP,
+                )
+            self._overflowed = True
+            self.degraded = True
+            self._buf = b""
+
+    def _scan_frame(self, frame: bytes) -> None:
+        for raw_line in frame.split(b"\n"):
+            line = raw_line.strip(b"\r")
+            if not line.startswith(b"data:"):
+                continue
+            payload = line[len(b"data:") :].strip()
+            if not payload:
+                continue
+            try:
+                event = json.loads(payload)
+            except (ValueError, UnicodeDecodeError):
+                logger.warning(
+                    "daemon relay: unparseable SSE data payload (%.120r) — "
+                    "forwarded verbatim, but terminal/run_id tracking cannot "
+                    "read it",
+                    payload,
+                )
+                continue
+            if not isinstance(event, dict):
+                continue
+            rid = event.get("run_id")
+            if isinstance(rid, str) and rid:
+                self.run_id = rid
+            if event.get("type") in TERMINAL_TYPES:
+                self.terminal_seen = True
+
+
+def build_relay_router(token: str, registry):
+    """Token-guarded APIRouter relaying ``ANY /v1/{agent_id}/*`` to the
+    agent's running sidecar (same guard as the ``/daemon/v1/*`` control
+    plane — ``build_require_token`` — so the 401 contract never forks)."""
+    from gaia.daemon.app import build_require_token
+
+    require_token = build_require_token(token)
+    router = APIRouter(dependencies=[Depends(require_token)])
+
+    @router.api_route("/v1/{agent_id}/{path:path}", methods=RELAY_METHODS)
+    async def relay(agent_id: str, path: str, request: Request):
+        try:
+            base_url, bearer = registry.connection(agent_id)
+        except UnknownAgentError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        except SidecarNotRunningError as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+
+        body = await request.body()
+        upstream_headers = {
+            k: v for k, v in request.headers.items() if k.lower() not in _REQUEST_DROP
+        }
+        upstream_headers["Authorization"] = f"Bearer {bearer}"
+        upstream_headers["Accept-Encoding"] = "identity"
+        url = f"{base_url}/v1/{agent_id}/{path}"
+
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(READ_TIMEOUT, connect=CONNECT_TIMEOUT)
+        )
+        try:
+            upstream = await client.send(
+                client.build_request(
+                    request.method,
+                    url,
+                    content=body,
+                    headers=upstream_headers,
+                    params=request.url.query or None,
+                ),
+                stream=True,
+            )
+        except httpx.HTTPError as e:
+            await client.aclose()
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"sidecar for agent '{agent_id}' at {base_url} did not "
+                    f"answer ({e.__class__.__name__}: {e}). It may have died "
+                    "after registration — re-ensure it (POST "
+                    f"/daemon/v1/agents/{agent_id}/ensure) and retry."
+                ),
+            ) from e
+
+        content_type = upstream.headers.get("content-type", "")
+        response_headers = {
+            k: v for k, v in upstream.headers.items() if k.lower() not in _RESPONSE_DROP
+        }
+
+        if not content_type.lower().startswith("text/event-stream"):
+            # Fixed-function route: buffered passthrough, verbatim envelope.
+            try:
+                payload = await upstream.aread()
+            except httpx.HTTPError as e:
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        f"sidecar for agent '{agent_id}' dropped the "
+                        f"connection mid-response on /v1/{agent_id}/{path} "
+                        f"({e.__class__.__name__}: {e}). Re-ensure it (POST "
+                        f"/daemon/v1/agents/{agent_id}/ensure) and retry."
+                    ),
+                ) from e
+            finally:
+                await upstream.aclose()
+                await client.aclose()
+            return Response(
+                content=payload,
+                status_code=upstream.status_code,
+                headers=response_headers,
+            )
+
+        watcher = _SSEWatcher(run_id=_run_id_from_body(body))
+
+        async def _finalize(reason: str) -> None:
+            """Propagate cancel upstream if the run never terminated, then
+            close the upstream response + client. Cancel is best-effort by
+            design (the sidecar may be the thing that just died)."""
+            try:
+                if not watcher.terminal_seen:
+                    rid = watcher.run_id
+                    if rid:
+                        cancel_url = f"{base_url}/v1/{agent_id}/query/{rid}/cancel"
+                        try:
+                            resp = await client.post(
+                                cancel_url,
+                                headers={"Authorization": f"Bearer {bearer}"},
+                                timeout=CANCEL_TIMEOUT,
+                            )
+                            logger.info(
+                                "daemon relay: %s — cancel for agent '%s' "
+                                "run_id=%s answered HTTP %s",
+                                reason,
+                                agent_id,
+                                rid,
+                                resp.status_code,
+                            )
+                        except httpx.HTTPError as exc:
+                            logger.warning(
+                                "daemon relay: %s — best-effort cancel for "
+                                "agent '%s' run_id=%s failed at transport "
+                                "level: %s",
+                                reason,
+                                agent_id,
+                                rid,
+                                exc,
+                            )
+                    else:
+                        logger.warning(
+                            "daemon relay: %s for agent '%s' with no run_id "
+                            "observed — cannot propagate cancel upstream",
+                            reason,
+                            agent_id,
+                        )
+            finally:
+                await upstream.aclose()
+                await client.aclose()
+
+        async def _relay_sse():
+            disconnected = False
+            try:
+                try:
+                    async for chunk in upstream.aiter_bytes():
+                        watcher.feed(chunk)
+                        yield chunk
+                except (GeneratorExit, asyncio.CancelledError):
+                    # Client went away mid-stream. This generator is being
+                    # torn down and can no longer await safely, so cleanup +
+                    # cancel-propagation move to a detached task.
+                    disconnected = True
+                    _spawn_background(_finalize("client disconnected"))
+                    raise
+                except httpx.HTTPError as exc:
+                    # Upstream transport died mid-stream (crash/reset/timeout).
+                    if not watcher.terminal_seen:
+                        logger.warning(
+                            "daemon relay: agent '%s' stream broke before its "
+                            "terminal event (%s: %s) — emitting synthetic "
+                            "terminal error",
+                            agent_id,
+                            exc.__class__.__name__,
+                            exc,
+                        )
+                        yield _synthetic_error_frame(
+                            stream_ended_unexpectedly_detail(agent_id),
+                            terminate_partial=watcher.mid_frame,
+                        )
+                else:
+                    # Clean EOF — but the contract requires exactly one
+                    # terminal event; a silent early EOF is a crash (§0.13).
+                    # A degraded watcher (buffer overflow dropped bytes) cannot
+                    # know whether a terminal passed — appending a synthetic
+                    # error then could double-terminate a completed run, so it
+                    # only logs; cancel below stays best-effort either way.
+                    if not watcher.terminal_seen:
+                        if watcher.degraded:
+                            logger.warning(
+                                "daemon relay: agent '%s' stream hit EOF with "
+                                "terminal state UNKNOWN (watcher buffer "
+                                "overflowed earlier) — not appending a "
+                                "synthetic error; propagating best-effort "
+                                "cancel only",
+                                agent_id,
+                            )
+                        else:
+                            logger.warning(
+                                "daemon relay: agent '%s' stream hit EOF "
+                                "before its terminal event — emitting "
+                                "synthetic terminal error",
+                                agent_id,
+                            )
+                            yield _synthetic_error_frame(
+                                stream_ended_unexpectedly_detail(agent_id),
+                                terminate_partial=watcher.mid_frame,
+                            )
+            finally:
+                if not disconnected:
+                    await _finalize("stream finished")
+
+        return StreamingResponse(
+            _relay_sse(),
+            status_code=upstream.status_code,
+            headers=response_headers,
+        )
+
+    return router

--- a/src/gaia/daemon/sidecars/errors.py
+++ b/src/gaia/daemon/sidecars/errors.py
@@ -72,6 +72,10 @@ class ModeConflictError(SidecarError):
     """The sidecar is running in a different mode than the ensure requested."""
 
 
+class SidecarNotRunningError(SidecarError):
+    """The agent is registered but has no running sidecar to talk to."""
+
+
 class CapacityError(SidecarError):
     """Starting another sidecar would exceed the live-sidecar cap."""
 

--- a/src/gaia/daemon/sidecars/registry.py
+++ b/src/gaia/daemon/sidecars/registry.py
@@ -18,6 +18,7 @@ import psutil
 from gaia.daemon.sidecars.errors import (
     CapacityError,
     ModeConflictError,
+    SidecarNotRunningError,
     StopFailedError,
     UnknownAgentError,
 )
@@ -143,6 +144,27 @@ class SidecarRegistry:
     @staticmethod
     def _manager_mode(manager) -> str:
         return manager.mode
+
+    def connection(self, agent_id: str) -> "tuple[str, str]":
+        """``(base_url, bearer token)`` for *agent_id*'s RUNNING sidecar.
+
+        The relay's single server-side token source (#2150): the sidecar bearer
+        never has to travel through a client to reach proxied calls. Raises
+        :class:`UnknownAgentError` (unregistered id) or
+        :class:`SidecarNotRunningError` (registered but not running) so the
+        HTTP layer can map them to distinct loud 404/503 responses.
+        """
+        self._spec(agent_id)
+        with self._lock:
+            holder = self._managers.get(agent_id)
+        manager = holder[0] if holder is not None else None
+        if manager is None or not manager.is_running or not manager.base_url:
+            raise SidecarNotRunningError(
+                f"agent '{agent_id}' has no running sidecar to relay to. "
+                f"Start it first (`gaia daemon start-agent {agent_id}` or "
+                f"POST /daemon/v1/agents/{agent_id}/ensure), then retry."
+            )
+        return manager.base_url, manager.auth_token
 
     def list_agents(self) -> "list[dict]":
         """One entry per registered spec, running or not. NEVER includes tokens."""

--- a/tests/unit/test_daemon_relay.py
+++ b/tests/unit/test_daemon_relay.py
@@ -1,0 +1,726 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Deterministic suite for the daemon's streaming SSE reverse-proxy
+(``gaia.daemon.relay``, issue #2150 / V2-7).
+
+Part 1 (unit): the passive ``_SSEWatcher`` (terminal/run_id tracking across
+arbitrary chunk boundaries), body run_id extraction, and the synthetic
+terminal frame shape.
+
+Part 2 (unit): ``SidecarRegistry.connection`` — the relay's single server-side
+source for the sidecar bearer.
+
+Part 3 (routes): TestClient over ``create_app`` with a stub registry — the
+401/404/503 loud-error contract, no upstream involved.
+
+Part 4 (integration): a REAL uvicorn fake sidecar + a REAL uvicorn daemon app
+on ephemeral ports (never 4001 — ``find_free_port`` excludes it). The fake
+sidecar's stream is gated on explicit events, never wall-clock timing, so the
+load-bearing assertions are deterministic:
+
+  (a) no buffering — the first SSE event reaches the client while the
+      upstream body is provably still open,
+  (b) cancel-on-disconnect — closing the client connection mid-stream makes
+      the relay POST ``/v1/email/query/{run_id}/cancel`` upstream with the
+      SIDECAR bearer,
+  (c) sidecar crash mid-stream (EOF, no terminal event) — the client receives
+      a synthetic terminal ``error`` event and a cleanly-ended response,
+  (d) buffered passthrough for fixed-function routes — status, headers, and
+      body preserved; the daemon token never reaches the sidecar, the sidecar
+      bearer never left the daemon.
+"""
+
+# NO `from __future__ import annotations` here: the fake sidecar's FastAPI
+# endpoints annotate `request: Request` with Request imported inside
+# build_app(); stringified annotations could not resolve it (PEP 563).
+
+import importlib.util
+import json
+import threading
+import time
+
+import pytest
+
+from gaia.daemon.relay import (
+    TERMINAL_TYPES,
+    _run_id_from_body,
+    _SSEWatcher,
+    _synthetic_error_frame,
+    stream_ended_unexpectedly_detail,
+)
+from gaia.daemon.sidecars.errors import SidecarNotRunningError, UnknownAgentError
+
+_HAS_FASTAPI = importlib.util.find_spec("fastapi") is not None
+_HAS_UVICORN = importlib.util.find_spec("uvicorn") is not None
+_HAS_HTTPX = importlib.util.find_spec("httpx") is not None
+_HAS_REQUESTS = importlib.util.find_spec("requests") is not None
+
+needs_fastapi = pytest.mark.skipif(
+    not (_HAS_FASTAPI and _HAS_HTTPX),
+    reason="fastapi + httpx must be importable for relay route tests",
+)
+needs_live_servers = pytest.mark.skipif(
+    not (_HAS_FASTAPI and _HAS_HTTPX and _HAS_UVICORN and _HAS_REQUESTS),
+    reason=(
+        "fastapi, httpx, uvicorn, and requests must all be importable for the "
+        "real-server relay integration tests"
+    ),
+)
+
+_DAEMON_TOKEN = "daemon-client-tok"
+_SIDECAR_TOKEN = "sidecar-bearer-tok"
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — _SSEWatcher / helpers (pure unit, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _frame(event: dict) -> bytes:
+    return b"data: " + json.dumps(event).encode() + b"\n\n"
+
+
+def test_terminal_types_match_frozen_contract():
+    assert TERMINAL_TYPES == frozenset({"final", "error"})
+
+
+def test_watcher_sees_terminal_final():
+    w = _SSEWatcher()
+    w.feed(_frame({"type": "status", "message": "hi"}))
+    assert not w.terminal_seen
+    w.feed(_frame({"type": "final", "answer": "done"}))
+    assert w.terminal_seen
+
+
+def test_watcher_sees_terminal_error():
+    w = _SSEWatcher()
+    w.feed(_frame({"type": "error", "detail": "boom"}))
+    assert w.terminal_seen
+
+
+def test_watcher_handles_arbitrary_chunk_boundaries():
+    """A frame split mid-line across feeds must still be recognized."""
+    w = _SSEWatcher()
+    raw = _frame({"type": "status", "message": "x"}) + _frame(
+        {"type": "final", "answer": "y"}
+    )
+    for i in range(0, len(raw), 3):
+        w.feed(raw[i : i + 3])
+    assert w.terminal_seen
+    assert not w.mid_frame
+
+
+def test_watcher_captures_run_id_from_events():
+    w = _SSEWatcher()
+    w.feed(_frame({"type": "needs_confirmation", "run_id": "run-77"}))
+    assert w.run_id == "run-77"
+
+
+def test_watcher_seeded_run_id_survives_events_without_one():
+    w = _SSEWatcher(run_id="seed-run")
+    w.feed(_frame({"type": "status", "message": "no run id here"}))
+    assert w.run_id == "seed-run"
+
+
+def test_watcher_mid_frame_true_for_partial_frame():
+    w = _SSEWatcher()
+    w.feed(b'data: {"type": "tok')
+    assert w.mid_frame
+
+
+def test_watcher_malformed_data_payload_does_not_raise():
+    w = _SSEWatcher()
+    w.feed(b"data: {not json}\n\n")
+    assert not w.terminal_seen
+
+
+def test_watcher_ignores_non_data_lines_and_crlf():
+    w = _SSEWatcher()
+    w.feed(
+        b": keep-alive\r\n\r\ndata: "
+        + json.dumps({"type": "final"}).encode()
+        + b"\r\n\r\n"
+    )
+    # \r\n\r\n framing: the \n\n split leaves \r remnants that must be stripped.
+    assert w.terminal_seen
+
+
+def test_watcher_buffer_overflow_capped_without_crash(monkeypatch):
+    from gaia.daemon import relay as relay_mod
+
+    monkeypatch.setattr(relay_mod, "_WATCHER_BUFFER_CAP", 1024)
+    w = _SSEWatcher()
+    w.feed(b"x" * 4096)  # exceeds the (patched) cap, no frame separator
+    assert w.mid_frame
+    assert w.degraded  # sticky: terminal classification is unknown from here
+    assert not w.terminal_seen
+    # A later well-formed terminal is still recognized...
+    w.feed(b"\n\n" + _frame({"type": "final", "answer": "y"}))
+    assert w.terminal_seen
+    # ...but degradation never resets (bytes were dropped earlier).
+    assert w.degraded
+
+
+def test_watcher_not_degraded_below_cap():
+    w = _SSEWatcher()
+    w.feed(_frame({"type": "status", "message": "x"}))
+    assert not w.degraded
+
+
+def test_run_id_from_body_extracts_string_run_id():
+    assert _run_id_from_body(b'{"query": "q", "run_id": "r-1"}') == "r-1"
+
+
+@pytest.mark.parametrize(
+    "body", [b"", b"not json", b'{"run_id": 7}', b'{"query": "no id"}', b'["r-1"]']
+)
+def test_run_id_from_body_returns_none_when_absent(body):
+    assert _run_id_from_body(body) is None
+
+
+def test_synthetic_error_frame_shape():
+    raw = _synthetic_error_frame("it broke", terminate_partial=False)
+    assert raw.startswith(b"data: ") and raw.endswith(b"\n\n")
+    event = json.loads(raw[len(b"data: ") : -2])
+    assert event == {"type": "error", "detail": "it broke", "source": "daemon_relay"}
+
+
+def test_synthetic_error_frame_terminates_partial_frame_first():
+    raw = _synthetic_error_frame("it broke", terminate_partial=True)
+    assert raw.startswith(b"\n\ndata: ")
+
+
+def test_stream_ended_detail_is_actionable():
+    detail = stream_ended_unexpectedly_detail("email")
+    assert "email" in detail
+    assert "ensure" in detail  # names the remedy
+    assert "logs" in detail  # names where to look
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — SidecarRegistry.connection
+# ---------------------------------------------------------------------------
+
+
+class _FakeManager:
+    def __init__(self, spec, mode=None, **kwargs):
+        self.spec = spec
+        self._running = False
+        self.port = None
+        self.base_url = None
+        self.api_version = "1.0"
+        self.agent_version = "0.1.0"
+        self.resolved_mode = None
+        self.auth_token = f"tok-{spec.agent_id}"
+        self.pid = None
+        self.started_at = None
+
+    @property
+    def is_running(self):
+        return self._running
+
+    def start(self):
+        self.resolved_mode = "user"
+        self.pid = 4321
+        self.port = 54321
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        self.started_at = time.time()
+        self._running = True
+        return self.base_url
+
+    def shutdown(self):
+        self._running = False
+
+
+def _toy_registry():
+    from gaia.daemon.sidecars.registry import SidecarRegistry
+    from gaia.daemon.sidecars.spec import AgentSidecarSpec
+
+    spec = AgentSidecarSpec(
+        agent_id="toy",
+        service_id="gaia-agent-toy",
+        display_name="Toy Agent",
+        expected_api_major="1",
+        token_env_var="GAIA_TOY_SIDECAR_TOKEN",
+        mode_env_var="GAIA_TOY_AGENT_MODE",
+        cache_dir_name="toy",
+    )
+    reg = SidecarRegistry({"toy": spec})
+    reg._manager_factory = _FakeManager
+    return reg
+
+
+def test_connection_unknown_agent_raises_listing_registered_ids():
+    reg = _toy_registry()
+    with pytest.raises(UnknownAgentError) as exc_info:
+        reg.connection("bogus")
+    assert "toy" in str(exc_info.value)
+
+
+def test_connection_not_running_raises_with_ensure_remedy():
+    reg = _toy_registry()
+    with pytest.raises(SidecarNotRunningError) as exc_info:
+        reg.connection("toy")
+    msg = str(exc_info.value)
+    assert "toy" in msg
+    assert "ensure" in msg  # names the remedy
+
+
+def test_connection_running_returns_base_url_and_bearer():
+    reg = _toy_registry()
+    ensured = reg.ensure("toy")
+    base_url, bearer = reg.connection("toy")
+    assert base_url == ensured["base_url"]
+    assert bearer == ensured["token"]
+
+
+def test_connection_stopped_after_running_raises_again():
+    reg = _toy_registry()
+    reg.ensure("toy")
+    reg.stop("toy")
+    with pytest.raises(SidecarNotRunningError):
+        reg.connection("toy")
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — route-level loud errors (TestClient, stub registry, no upstream)
+# ---------------------------------------------------------------------------
+
+
+class _StubRegistry:
+    """connection()-only registry stub for route tests."""
+
+    def __init__(self, base_url=None, bearer=_SIDECAR_TOKEN, known=("email",)):
+        self._base_url = base_url
+        self._bearer = bearer
+        self._known = set(known)
+
+    def connection(self, agent_id):
+        if agent_id not in self._known:
+            raise UnknownAgentError(
+                f"unknown agent '{agent_id}'; registered agents: "
+                + ", ".join(sorted(self._known))
+            )
+        if self._base_url is None:
+            raise SidecarNotRunningError(
+                f"agent '{agent_id}' has no running sidecar to relay to. "
+                f"Start it first (`gaia daemon start-agent {agent_id}` or "
+                f"POST /daemon/v1/agents/{agent_id}/ensure), then retry."
+            )
+        return self._base_url, self._bearer
+
+    # create_app's agents router probes these; keep them inert.
+    def list_agents(self):
+        return []
+
+    def ensure(self, agent_id, mode=None):  # pragma: no cover - unused
+        raise AssertionError("relay tests must not call ensure()")
+
+    def stop(self, agent_id):  # pragma: no cover - unused
+        raise AssertionError("relay tests must not call stop()")
+
+
+def _daemon_test_client(registry):
+    from fastapi.testclient import TestClient
+
+    from gaia.daemon.app import create_app
+
+    app = create_app(
+        token=_DAEMON_TOKEN,
+        port=55555,
+        pid=1,
+        started_at=time.time(),
+        registry=registry,
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _auth(token=_DAEMON_TOKEN):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@needs_fastapi
+def test_relay_requires_daemon_client_token():
+    client = _daemon_test_client(_StubRegistry())
+    r = client.post("/v1/email/query", json={"query": "hi"})  # no auth header
+    assert r.status_code == 401
+    assert "Authorization" in r.json()["detail"]
+
+
+@needs_fastapi
+def test_relay_rejects_wrong_daemon_client_token():
+    client = _daemon_test_client(_StubRegistry())
+    r = client.post(
+        "/v1/email/query", json={"query": "hi"}, headers=_auth("wrong-token")
+    )
+    assert r.status_code == 401
+
+
+@needs_fastapi
+def test_relay_unknown_agent_maps_to_404_listing_registered_ids():
+    client = _daemon_test_client(_StubRegistry())
+    r = client.post("/v1/bogus/query", json={"query": "hi"}, headers=_auth())
+    assert r.status_code == 404
+    assert "email" in r.json()["detail"]
+
+
+@needs_fastapi
+def test_relay_not_running_sidecar_maps_to_503_with_ensure_remedy():
+    client = _daemon_test_client(_StubRegistry(base_url=None))
+    r = client.post("/v1/email/query", json={"query": "hi"}, headers=_auth())
+    assert r.status_code == 503
+    detail = r.json()["detail"]
+    assert "email" in detail
+    assert "ensure" in detail
+
+
+@needs_fastapi
+def test_relay_dead_upstream_maps_to_502_with_reensure_remedy():
+    # Registered + "running" per the registry, but nothing listens on the port
+    # (the sidecar died after registration): connect refused → loud 502.
+    from gaia.daemon.sidecars.manager import find_free_port
+
+    dead_port = find_free_port()
+    client = _daemon_test_client(
+        _StubRegistry(base_url=f"http://127.0.0.1:{dead_port}")
+    )
+    r = client.post("/v1/email/query", json={"query": "hi"}, headers=_auth())
+    assert r.status_code == 502
+    detail = r.json()["detail"]
+    assert "email" in detail
+    assert "ensure" in detail
+
+
+# ---------------------------------------------------------------------------
+# Part 4 — real-server integration: fake sidecar + daemon relay over TCP
+# ---------------------------------------------------------------------------
+
+
+class _FakeSidecar:
+    """Scripted stand-in for a sidecar agent server.
+
+    ``/v1/email/query`` streams SSE gated on explicit events (never sleeps for
+    effect): one ``status`` event, then — mode ``hold`` — waits for
+    ``release`` before the terminal ``final``; mode ``crash`` — returns with
+    NO terminal event (EOF mid-contract). ``stream_body_done`` is set only
+    when the stream generator has fully exited, which is what makes the
+    no-buffering assertion deterministic.
+    """
+
+    def __init__(self):
+        self.release = threading.Event()
+        self.stream_body_done = threading.Event()
+        self.mode = "hold"
+        self.cancels = []  # (run_id, authorization header)
+        self.seen = []  # (path, authorization header, extra header)
+
+    def build_app(self):
+        import asyncio
+
+        from fastapi import FastAPI, Request
+        from fastapi.responses import JSONResponse, StreamingResponse
+
+        app = FastAPI()
+        sidecar = self
+
+        @app.post("/v1/email/query")
+        async def query(request: Request):
+            body = await request.json()
+            sidecar.seen.append(
+                (
+                    "/v1/email/query",
+                    request.headers.get("authorization"),
+                    request.headers.get("x-client-extra"),
+                )
+            )
+            run_id = body.get("run_id", "")
+
+            async def _events():
+                try:
+                    if sidecar.mode == "giant_final":
+                        # ONE valid terminal frame far larger than the (test-
+                        # patched) watcher cap, split so the first piece
+                        # overflows the watcher BEFORE the frame can complete
+                        # (the tail is release-gated → deterministic).
+                        full = _frame({"type": "final", "answer": "x" * 4096})
+                        yield full[:3000]
+                        while not sidecar.release.is_set():
+                            await asyncio.sleep(0.02)
+                        yield full[3000:]
+                        return
+                    yield _frame(
+                        {"type": "status", "message": "starting", "run_id": run_id}
+                    )
+                    if sidecar.mode == "crash":
+                        return  # EOF without a terminal event
+                    while not sidecar.release.is_set():
+                        await asyncio.sleep(0.02)
+                    yield _frame({"type": "final", "answer": "done"})
+                finally:
+                    sidecar.stream_body_done.set()
+
+            return StreamingResponse(_events(), media_type="text/event-stream")
+
+        @app.post("/v1/email/query/{run_id}/cancel")
+        async def cancel(run_id: str, request: Request):
+            sidecar.cancels.append((run_id, request.headers.get("authorization")))
+            sidecar.release.set()  # a held stream ends on cancel
+            return {"status": "cancelled", "run_id": run_id}
+
+        @app.post("/v1/email/triage")
+        async def triage(request: Request):
+            body = await request.json()
+            sidecar.seen.append(
+                (
+                    "/v1/email/triage",
+                    request.headers.get("authorization"),
+                    request.headers.get("x-client-extra"),
+                )
+            )
+            return JSONResponse(
+                {"result": {"echo": body}},
+                headers={"X-Sidecar-Custom": "yes"},
+            )
+
+        return app
+
+
+def _serve(app):
+    """Run *app* under uvicorn on an ephemeral port (never 4001) in a
+    background thread. Returns (server, thread, base_url)."""
+    import uvicorn
+
+    from gaia.daemon.sidecars.manager import find_free_port
+
+    port = find_free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10.0
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.02)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=5)
+        raise RuntimeError("test uvicorn server never started")
+    return server, thread, f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture()
+def live_relay():
+    """A live fake sidecar + a live daemon app relaying to it."""
+    if not (_HAS_FASTAPI and _HAS_HTTPX and _HAS_UVICORN and _HAS_REQUESTS):
+        pytest.skip("fastapi/httpx/uvicorn/requests not importable")
+
+    from gaia.daemon.app import create_app
+
+    sidecar = _FakeSidecar()
+    sc_server, sc_thread, sc_url = _serve(sidecar.build_app())
+    daemon_app = create_app(
+        token=_DAEMON_TOKEN,
+        port=55555,
+        pid=1,
+        started_at=time.time(),
+        registry=_StubRegistry(base_url=sc_url),
+    )
+    d_server, d_thread, d_url = _serve(daemon_app)
+
+    yield sidecar, d_url
+
+    sidecar.release.set()  # unblock any still-held stream
+    d_server.should_exit = True
+    sc_server.should_exit = True
+    d_thread.join(timeout=10)
+    sc_thread.join(timeout=10)
+
+
+def _iter_data_events(resp):
+    """Yield parsed ``data:`` payloads from a requests streaming response."""
+    for raw_line in resp.iter_lines():
+        if not raw_line:
+            continue
+        line = raw_line.decode() if isinstance(raw_line, bytes) else raw_line
+        if not line.startswith("data:"):
+            continue
+        yield json.loads(line[len("data:") :].strip())
+
+
+def _wait_for(predicate, timeout=5.0, message="condition never became true"):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError(message)
+
+
+@needs_live_servers
+def test_sse_relayed_unbuffered_first_event_before_upstream_completes(live_relay):
+    import requests
+
+    sidecar, daemon_url = live_relay
+    with requests.post(
+        f"{daemon_url}/v1/email/query",
+        json={"query": "q", "run_id": "run-nobuf", "context": []},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    ) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        events = _iter_data_events(resp)
+        first = next(events)
+        assert first["type"] == "status"
+        # THE no-buffering assertion: the first event has reached the client
+        # while the upstream stream body is provably still open (the fake
+        # only completes after `release`, which has not been set).
+        assert not sidecar.stream_body_done.is_set()
+
+        sidecar.release.set()
+        rest = list(events)
+    assert [e["type"] for e in rest] == ["final"]
+    _wait_for(sidecar.stream_body_done.is_set)
+    # Terminal event arrived → no cancel must have been propagated upstream.
+    assert sidecar.cancels == []
+
+
+@needs_live_servers
+def test_client_disconnect_propagates_cancel_upstream(live_relay):
+    import requests
+
+    sidecar, daemon_url = live_relay
+    resp = requests.post(
+        f"{daemon_url}/v1/email/query",
+        json={"query": "q", "run_id": "run-cancel", "context": []},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    )
+    events = _iter_data_events(resp)
+    assert next(events)["type"] == "status"
+    resp.close()  # client walks away mid-stream
+
+    _wait_for(
+        lambda: sidecar.cancels,
+        message="relay never POSTed the upstream cancel after client disconnect",
+    )
+    run_id, auth = sidecar.cancels[0]
+    assert run_id == "run-cancel"
+    # The cancel carries the SIDECAR bearer (injected server-side), never the
+    # daemon client token.
+    assert auth == f"Bearer {_SIDECAR_TOKEN}"
+
+
+@needs_live_servers
+def test_sidecar_crash_mid_stream_yields_synthetic_terminal_error(live_relay):
+    import requests
+
+    sidecar, daemon_url = live_relay
+    sidecar.mode = "crash"
+    with requests.post(
+        f"{daemon_url}/v1/email/query",
+        json={"query": "q", "run_id": "run-crash", "context": []},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    ) as resp:
+        assert resp.status_code == 200
+        events = list(_iter_data_events(resp))  # stream must end CLEANLY
+
+    assert [e["type"] for e in events] == ["status", "error"]
+    synthetic = events[-1]
+    assert synthetic["source"] == "daemon_relay"
+    assert synthetic["detail"] == stream_ended_unexpectedly_detail("email")
+    # The abandoned run is cancelled upstream too (single-tenant LLM slot).
+    _wait_for(
+        lambda: sidecar.cancels,
+        message="relay never cancelled the crashed run upstream",
+    )
+    assert sidecar.cancels[0][0] == "run-crash"
+
+
+@needs_live_servers
+def test_oversized_terminal_frame_relayed_verbatim_without_synthetic_error(
+    live_relay, monkeypatch
+):
+    """W1 guard: a single valid terminal frame larger than the watcher cap
+    degrades terminal DETECTION only — the bytes still relay verbatim and no
+    spurious synthetic error may double-terminate the completed run."""
+    import requests
+
+    from gaia.daemon import relay as relay_mod
+
+    monkeypatch.setattr(relay_mod, "_WATCHER_BUFFER_CAP", 1024)
+    sidecar, daemon_url = live_relay
+    sidecar.mode = "giant_final"
+    with requests.post(
+        f"{daemon_url}/v1/email/query",
+        json={"query": "q", "run_id": "run-giant", "context": []},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    ) as resp:
+        assert resp.status_code == 200
+        chunks = []
+        for chunk in resp.iter_content(chunk_size=None):
+            chunks.append(chunk)
+            if not sidecar.release.is_set() and sum(map(len, chunks)) >= 2048:
+                # The oversized head (past the patched cap) has arrived —
+                # now let the sidecar finish the frame.
+                sidecar.release.set()
+        raw = b"".join(chunks)
+
+    frames = [f for f in raw.split(b"\n\n") if f]
+    assert len(frames) == 1  # the giant final only — nothing appended
+    event = json.loads(frames[0][len(b"data: ") :])
+    assert event["type"] == "final"
+    assert event["answer"] == "x" * 4096
+    assert b"daemon_relay" not in raw  # no synthetic error frame
+
+
+@needs_live_servers
+def test_fixed_function_route_buffered_passthrough(live_relay):
+    import requests
+
+    sidecar, daemon_url = live_relay
+    r = requests.post(
+        f"{daemon_url}/v1/email/triage",
+        json={"subject": "hello"},
+        headers={**_auth(), "X-Client-Extra": "abc"},
+        timeout=10,
+    )
+    assert r.status_code == 200
+    assert r.json() == {"result": {"echo": {"subject": "hello"}}}
+    assert r.headers["X-Sidecar-Custom"] == "yes"  # upstream headers preserved
+
+    path, auth, extra = sidecar.seen[-1]
+    assert path == "/v1/email/triage"
+    # Bearer swap: the sidecar sees ITS token; the daemon client token never
+    # crosses the relay boundary.
+    assert auth == f"Bearer {_SIDECAR_TOKEN}"
+    assert f"Bearer {_DAEMON_TOKEN}" not in (auth or "")
+    assert extra == "abc"  # non-auth client headers pass through
+
+
+@needs_live_servers
+def test_upstream_non_2xx_passes_through_with_body(live_relay):
+    import requests
+
+    _, daemon_url = live_relay
+    r = requests.get(
+        f"{daemon_url}/v1/email/no-such-route", headers=_auth(), timeout=10
+    )
+    # The SIDECAR's own 404 envelope, not the daemon's unknown-agent 404.
+    assert r.status_code == 404
+    assert r.json() == {"detail": "Not Found"}
+
+
+@needs_live_servers
+def test_control_plane_status_route_unchanged(live_relay):
+    import requests
+
+    _, daemon_url = live_relay
+    r = requests.get(f"{daemon_url}/daemon/v1/status", headers=_auth(), timeout=10)
+    assert r.status_code == 200
+    assert r.json()["service"]


### PR DESCRIPTION
Closes #2150 (V2-7).

Every client of a sidecar agent has had to receive the sidecar's port **and its bearer token**, then stream to the sidecar directly — the opposite of the thin-host model, and a blocker for #2152 and `gaia api`. With this PR the daemon is the one front door: `ANY /v1/<agent>/*` (e.g. `POST /v1/email/query`) relays to the agent's running sidecar behind the same daemon client token as `/daemon/v1/*`, with the sidecar bearer injected server-side — sidecar credentials stop leaving the daemon for relayed traffic. SSE streams unbuffered end-to-end; a client that disconnects mid-run gets its run cancelled upstream; a sidecar that crashes mid-stream yields a synthetic terminal `error` event (`{"type": "error", "detail": ..., "source": "daemon_relay"}` — additive to the frozen 7-event contract) instead of a hung or silently-truncated stream. The UI's existing direct-stream path and the `/daemon/v1/*` control plane are untouched, so the app stays shippable at every step.

## Test plan

- [x] `pytest tests/unit/test_daemon_relay.py` — 36 deterministic tests: no-buffering (first SSE event reaches the client while the upstream body is provably still open), cancel-on-disconnect (relay POSTs `/v1/email/query/{run_id}/cancel` with the sidecar bearer), synthetic terminal `error` on mid-stream crash, oversized-terminal degraded mode, buffered passthrough (status/headers/body + bearer-swap assertions), 401/404/503/502 loud-error mapping — real uvicorn servers on ephemeral ports, event-gated fake sidecar, ran 3× stable
- [x] `pytest tests/unit/test_daemon.py tests/unit/test_daemon_agents_routes.py tests/unit/test_daemon_sidecar_*.py tests/unit/test_email_sidecar_daemon_client.py tests/unit/test_schedule_daemon.py` — all pass (control plane unchanged)
- [x] Manual golden path: `curl -N` through a live daemon → fake sidecar shows incremental arrival (first event +0.06s, terminal +4.79s) and the synthetic terminal `error` transcript on crash
- [x] `python util/lint.py --all` clean
- [ ] Freeze spike (§0.23 item 2): golden-path `curl -N` through daemon → **PyInstaller-frozen** email binary on real hardware