### PR TITLE
docs(connectors): rewrite the Google client-ID walkthrough for the current console

### DIFF
--- a/docs/connectors/google.mdx
+++ b/docs/connectors/google.mdx
@@ -13,12 +13,30 @@ description: "Connect GAIA to Gmail, Calendar, Drive, and other Google Workspace
 Google requires every desktop app — including GAIA running locally — to
 identify itself with an **OAuth client** that you create in your own
 Google Cloud project. This sounds heavy, but for a single-developer
-machine it takes about three minutes and is free.
+machine it takes about five minutes and is free.
 
-You will create one OAuth client and paste two values into the GAIA
-Agent UI: a **Client ID** and a **Client Secret**. After that, GAIA
-stores them encrypted in your OS keyring and you never need to think
-about them again.
+You will do three things in the Google Cloud Console — **enable the APIs**
+you want GAIA to call, **register yourself as a test user**, and **create
+an OAuth client** — then paste two values into the GAIA Agent UI: a
+**Client ID** and a **Client Secret**. After that, GAIA stores them
+encrypted in your OS keyring and you never need to think about them again.
+
+<Note>
+  **Bringing your own OAuth client is a temporary step.** A future GAIA
+  release ([#2104](https://github.com/amd/gaia/issues/2104)) ships a
+  verified AMD-managed client so end users skip the Cloud Console entirely
+  and just click **Connect**. Until then, the steps below are required for
+  personal accounts.
+</Note>
+
+<Warning>
+  **Google restructured this console in 2024–2025.** The OAuth settings
+  that used to live under **APIs & Services → OAuth consent screen** and
+  **→ Credentials** now live under **Google Auth Platform**, split across
+  three tabs: **Branding**, **Audience**, and **Clients**. This guide uses
+  the new layout with direct links; the old menu path is noted only as a
+  fallback in case Google shifts the UI again.
+</Warning>
 
 ## Step 1 — Create a Google Cloud project
 
@@ -28,51 +46,86 @@ Otherwise:
 1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
 2. Click the project dropdown at the top → **New project**.
 3. Name it something like `gaia-personal` and click **Create**.
+4. Make sure the new project is selected in the dropdown before
+   continuing — every step below applies to the **selected** project.
 
 ## Step 2 — Enable the APIs you want to use
 
-GAIA only sees the Google APIs you explicitly enable on the project.
-For a typical setup enable at least:
+<Warning>
+  **This step is mandatory, not optional.** GAIA can only call the Google
+  APIs you have explicitly enabled on the project. If you skip it, the
+  OAuth flow still succeeds — but the **first mailbox call fails** with a
+  raw Google `403` (`Gmail API has not been used in project … or it is
+  disabled`), which is confusing because the connection looks healthy
+  ([#2116](https://github.com/amd/gaia/issues/2116)).
+</Warning>
 
-- **Gmail API** — to read/send mail
-- **Google Calendar API** — to read/create events
-- **Google Drive API** — to read/manage files
+Enable each API you plan to use:
 
-In the Cloud Console, go to **APIs & Services → Library**, search for
-each API by name, click it, and click **Enable**.
+- **[Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com)** — to read/send mail (required for the Email Triage agent)
+- **[Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)** — to read/create events
+- **[Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com)** — to read/manage files
 
-## Step 3 — Configure the OAuth consent screen
+For each one, open the link (with your project selected), then click
+**Enable**. You can also reach these from **APIs & Services → Library**
+and search by name.
+
+<Tip>
+  Enabling an API takes **1–2 minutes to propagate**. If your first
+  request 403s right after enabling, wait a minute and retry before
+  assuming something else is wrong.
+</Tip>
+
+## Step 3 — Configure the consent screen (Branding + Audience)
 
 Google requires you to fill in a consent-screen form before it will
-issue OAuth credentials, even for personal-use apps.
+issue OAuth credentials, even for personal-use apps. In the new console
+this is the **Google Auth Platform**.
 
-1. Go to **APIs & Services → OAuth consent screen**.
-2. Pick **External** as the user type and click **Create**.
-3. Fill in the required fields:
+1. Go to [**Google Auth Platform**](https://console.cloud.google.com/auth/overview)
+   (old path: **APIs & Services → OAuth consent screen**). On a fresh
+   project you'll see a **Get started** button — click it to enter the
+   short setup wizard.
+2. **Branding** — fill in the required fields:
    - **App name**: `GAIA Personal` (or whatever)
    - **User support email**: your email
    - **Developer contact email**: your email
-4. Click **Save and Continue** through the Scopes and Test users
-   pages — leave them empty for now. You'll add yourself as a test
-   user in the next step.
+3. **Audience** — pick **External**.
+
+<Note>
+  A personal `@gmail.com` account has **no "Internal" option** — Internal
+  is only available to Google Workspace organizations. **External** is the
+  correct (and only) choice for a personal account. An External app starts
+  in **Testing** publishing status, which is exactly what you want for
+  personal use.
+</Note>
 
 ### Add yourself as a test user
 
 While the app is in **Testing** publishing status (the default), only
-test users can authenticate. Add your own Google account:
+listed test users can authenticate. Add your own Google account:
 
-1. **OAuth consent screen → Test users → Add users**.
+1. On the **Google Auth Platform → Audience** tab, scroll to
+   **Test users → Add users**.
 2. Enter your Google email and **Save**.
 
 You can stay in Testing mode indefinitely if you only use this for
 yourself — there's no need to verify the app for personal use.
 
+<Warning>
+  **Test-mode refresh tokens expire after ~7 days.** While the app stays
+  in Testing status, Google expires the refresh token roughly a week after
+  consent, so GAIA will eventually prompt you to reconnect. This is a
+  Google policy for unverified test apps, not a GAIA bug — just reconnect
+  when it happens (see [Common issues](#error-400-invalid_grant-after-a-long-while)).
+</Warning>
+
 ## Step 4 — Create the OAuth client
 
 This is the credential GAIA uses.
 
-1. Go to **APIs & Services → Credentials → Create credentials → OAuth
-   client ID**.
+1. Go to [**Google Auth Platform → Clients**](https://console.cloud.google.com/auth/clients)
+   (old path: **APIs & Services → Credentials**) → **Create client**.
 2. **Application type**: **Desktop app**. <Tooltip tip="GAIA is a
    desktop application that runs a temporary loopback web server on
    127.0.0.1 to receive the OAuth callback. The 'Desktop app' type is
@@ -107,26 +160,84 @@ GAIA will:
 4. Exchange the auth code for a refresh token (also stored in the
    keyring).
 
+<Note>
+  During authorization you'll hit a **"Google hasn't verified this app"**
+  interstitial. This is expected for a personal test app — click
+  **Advanced → Continue** (or **Go to GAIA Personal (unsafe)**) to
+  proceed. The warning only appears because your app is unverified, not
+  because anything is wrong.
+</Note>
+
 The tile flips to **Connected as your.email@gmail.com** once the flow
 completes.
+
+<Note>
+  **Prefer the CLI?** The whole flow works headless without opening the
+  Agent UI — `gaia connectors configure google --client-id … --client-secret …`
+  then `gaia connectors connect google`. See the [Email Triage guide's CLI
+  tab](/guides/email#setup) for the exact commands.
+</Note>
 
 ## Step 6 — Grant scopes to specific agents
 
 Connecting Google doesn't automatically give every agent access to
-your inbox. Each agent must be granted the specific scopes it needs.
-You can do this in the UI or the CLI:
+your inbox. **Each agent must be granted the specific scopes it needs** —
+connecting alone is not enough. You can do this in the UI (open the Google
+tile → **Per-agent grants**) or the CLI.
+
+**Chat agent — read-only Gmail:**
 
 ```bash
-# Grant the chat agent read-only Gmail access
 gaia connectors grants grant google builtin:chat \
   --scopes https://www.googleapis.com/auth/gmail.readonly
 ```
+
+**Email Triage agent — the full mailbox + calendar scope set** it needs
+to read, organize, draft/send, and manage events:
+
+```bash
+gaia connectors grants grant google installed:email \
+  --scopes https://www.googleapis.com/auth/gmail.modify \
+           https://www.googleapis.com/auth/gmail.send \
+           https://www.googleapis.com/auth/calendar.events \
+           https://www.googleapis.com/auth/calendar.readonly
+```
+
+<Note>
+  The Agent UI's **Connect** / **Reconnect** flow for the Email Triage
+  agent grants these scopes for you. The CLI command above is the explicit
+  equivalent for headless setups — and the fix when you hit the
+  `AGENT_NOT_GRANTED` error below.
+</Note>
 
 The default scopes a connection is established with are listed in the
 spec at
 [`src/gaia/connectors/catalog/google.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/catalog/google.py).
 
 ## Common issues
+
+### `Gmail API has not been used in project … or it is disabled` (403)
+
+You skipped **Step 2**, or the enablement hasn't propagated yet. Enable
+the [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com)
+(and [Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)
+if you use calendar) on the **selected** project, wait 1–2 minutes, and
+retry. The OAuth connection itself is fine — only the API call is blocked
+([#2116](https://github.com/amd/gaia/issues/2116)).
+
+### `AGENT_NOT_GRANTED` — an agent can't use your connection
+
+Connecting Google is not the same as granting a specific agent access to
+it (**Step 6**). Until the per-agent grant lands, the agent surfaces:
+
+```
+AGENT_NOT_GRANTED: this agent isn't granted these scopes on google: …
+Open Settings → Connections → google → Per-agent grants and grant them.
+```
+
+Fix it in the UI (Google tile → **Per-agent grants**) or run the
+`gaia connectors grants grant google installed:email …` command from
+Step 6.
 
 ### `redirect_uri_mismatch`
 
@@ -167,6 +278,10 @@ Two places — both work:
 ## See also
 
 - [Connectors overview](/connectors)
-- [Google Cloud Console — OAuth 2.0 credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
-- [Google APIs Explorer](https://developers.google.com/apis-explorer)
+- [Email Triage agent](/guides/email) — the agent that uses these Gmail scopes
+- [Google OAuth client runbook](https://github.com/amd/gaia/blob/main/docs/runbooks/google-oauth-client.md) — the AMD-internal client + rotation procedure (maintainers)
+- [Manage OAuth Clients — Google Cloud Console Help](https://support.google.com/cloud/answer/15549257)
+- [Get started with the Google Auth Platform — Google Cloud Console Help](https://support.google.com/cloud/answer/15544987)
 - [Connectors security model](/security/connections)
+</content>
+</invoke>

--- a/docs/connectors/google.mdx
+++ b/docs/connectors/google.mdx
@@ -205,9 +205,12 @@ gaia connectors grants grant google installed:email \
 
 <Note>
   The Agent UI's **Connect** / **Reconnect** flow for the Email Triage
-  agent grants these scopes for you. The CLI command above is the explicit
-  equivalent for headless setups — and the fix when you hit the
-  `AGENT_NOT_GRANTED` error below.
+  agent both authorizes these scopes with Google **and** grants them to the
+  agent for you. On the CLI you do both steps yourself — authorize the
+  scopes with `gaia connectors connect google --scopes …`, then run the
+  `grants grant` above. The [Email Triage guide's CLI tab](/guides/email#setup)
+  has the full sequence; the grant is also the fix when you hit
+  `AGENT_NOT_GRANTED`.
 </Note>
 
 The default scopes a connection is established with are listed in the

--- a/docs/connectors/google.mdx
+++ b/docs/connectors/google.mdx
@@ -286,5 +286,3 @@ Two places — both work:
 - [Manage OAuth Clients — Google Cloud Console Help](https://support.google.com/cloud/answer/15549257)
 - [Get started with the Google Auth Platform — Google Cloud Console Help](https://support.google.com/cloud/answer/15544987)
 - [Connectors security model](/security/connections)
-</content>
-</invoke>

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -43,7 +43,8 @@ There are two ways to connect Google depending on how you use GAIA.
   ([#2116](https://github.com/amd/gaia/issues/2116)). The
   [Google connector walkthrough](/connectors/google) covers the full,
   verified sequence (enable APIs → add yourself as a test user → create the
-  client). Come back here for the agent-specific grant in step 3 below.
+  client). The email agent also needs a per-agent grant: the Agent UI does
+  it for you, while the CLI flow needs it as the explicit Step 3 below.
   A future release ([#2104](https://github.com/amd/gaia/issues/2104)) ships
   an AMD-managed client that removes this bring-your-own step.
 </Note>
@@ -79,21 +80,26 @@ There are two ways to connect Google depending on how you use GAIA.
 
     Both flags are required together — Google rejects token requests that omit the secret even for Desktop-app PKCE clients.
 
-    **Step 2 — Sign in and authorize:**
+    **Step 2 — Sign in and authorize the mailbox scopes.** Pass the email
+    agent's scopes explicitly with `--scopes` — the bare
+    `gaia connectors connect google` requests only the default
+    `openid`/`email`/`profile` and your mailbox calls would later fail with a
+    scope error:
 
     ```bash
-    gaia connectors connect google
+    gaia connectors connect google \
+      --scopes https://www.googleapis.com/auth/gmail.modify \
+               https://www.googleapis.com/auth/gmail.send \
+               https://www.googleapis.com/auth/calendar.events \
+               https://www.googleapis.com/auth/calendar.readonly
     ```
 
-    The command prints an authorization URL. Open it in a browser, complete the OAuth consent screen, and paste the resulting code back into the terminal. The scopes requested are the same as the Agent UI flow:
+    The command prints an authorization URL. Open it in a browser, complete the OAuth consent screen (grant every requested scope), and paste the resulting code back into the terminal.
 
-    - `gmail.modify`, `gmail.send`
-    - `calendar.events`, `calendar.readonly`
-
-    **Step 3 — Grant the scopes to the email agent.** Connecting stores the
-    credentials, but the email agent has no access until you grant it the
-    scopes explicitly. In the CLI flow this is a **separate, required step**
-    (the Agent UI does it for you):
+    **Step 3 — Grant the same scopes to the email agent.** Authorizing the
+    connection stores the credentials, but the email agent has no access
+    until you grant it those scopes explicitly. In the CLI flow this is a
+    **separate, required step** (the Agent UI does it for you):
 
     ```bash
     gaia connectors grants grant google installed:email \

--- a/docs/guides/email.mdx
+++ b/docs/guides/email.mdx
@@ -35,6 +35,19 @@ The Email Triage Agent connects to your Gmail account through GAIA's connectors 
 
 There are two ways to connect Google depending on how you use GAIA.
 
+<Note>
+  **First time connecting a personal Google account?** You need to create
+  your own OAuth client in the Google Cloud Console and — crucially —
+  **enable the Gmail and Calendar APIs on that project** first, or the
+  first mailbox call 403s even though the connection looks healthy
+  ([#2116](https://github.com/amd/gaia/issues/2116)). The
+  [Google connector walkthrough](/connectors/google) covers the full,
+  verified sequence (enable APIs → add yourself as a test user → create the
+  client). Come back here for the agent-specific grant in step 3 below.
+  A future release ([#2104](https://github.com/amd/gaia/issues/2104)) ships
+  an AMD-managed client that removes this bring-your-own step.
+</Note>
+
 <Tabs>
   <Tab title="Agent UI (recommended)">
     The Agent UI is the primary way to connect Google. It walks you through the OAuth consent screen and stores your credentials securely in the OS keyring.
@@ -47,12 +60,14 @@ There are two ways to connect Google depending on how you use GAIA.
        - `calendar.events` / `calendar.readonly` — read and update calendar events
     4. After approval, the browser redirects back and the connector shows as **Connected**.
 
+    The Agent UI's **Connect** / **Reconnect** flow grants the Email Triage agent these scopes for you, so no separate grant step is needed here.
+
     If you have an existing Google connection that predates GAIA v0.23, click **Reconnect** to grant the additional Gmail and Calendar scopes.
   </Tab>
   <Tab title="CLI (developer flow)">
     The CLI connector flow is fully self-contained — you do **not** need to open the Agent UI to set your OAuth client credentials. It is intended for developers and headless environments.
 
-    First, create an OAuth **Desktop-app** client in the Google Cloud Console and note its Client ID and Client Secret. See the [Google OAuth client runbook](https://github.com/amd/gaia/blob/main/docs/runbooks/google-oauth-client.md) for step-by-step instructions.
+    First, create an OAuth **Desktop-app** client in the Google Cloud Console and note its Client ID and Client Secret, **and enable the Gmail + Calendar APIs on the project** — see the [Google connector walkthrough](/connectors/google) for the full step-by-step (the [runbook](https://github.com/amd/gaia/blob/main/docs/runbooks/google-oauth-client.md) covers the AMD-internal client instead).
 
     **Step 1 — Configure the OAuth client credentials** (persists them to your OS keyring, encrypted at rest):
 
@@ -74,6 +89,23 @@ There are two ways to connect Google depending on how you use GAIA.
 
     - `gmail.modify`, `gmail.send`
     - `calendar.events`, `calendar.readonly`
+
+    **Step 3 — Grant the scopes to the email agent.** Connecting stores the
+    credentials, but the email agent has no access until you grant it the
+    scopes explicitly. In the CLI flow this is a **separate, required step**
+    (the Agent UI does it for you):
+
+    ```bash
+    gaia connectors grants grant google installed:email \
+      --scopes https://www.googleapis.com/auth/gmail.modify \
+               https://www.googleapis.com/auth/gmail.send \
+               https://www.googleapis.com/auth/calendar.events \
+               https://www.googleapis.com/auth/calendar.readonly
+    ```
+
+    Skip this and the first email tool call fails with
+    `AGENT_NOT_GRANTED` — see [Troubleshooting](#troubleshooting).
+    This explicit grant step is required until [#2117](https://github.com/amd/gaia/issues/2117) lands.
 
     If you connected Google before GAIA v0.23, run `gaia connectors connect google --force` to trigger a fresh consent screen with the updated scope list.
 
@@ -425,7 +457,18 @@ contract yet.
 
 ### "AGENT_NOT_GRANTED — Email agent needs additional Google permissions"
 
-Your Google connection predates the email agent and lacks `gmail.modify`. Open Settings → Connections → Google → Reconnect to grant the missing scopes.
+The email agent hasn't been granted the mailbox scopes on your Google connection — either you connected Google without granting the agent (common on the CLI flow), or your connection predates the email agent and lacks `gmail.modify`.
+
+- **Agent UI:** open Settings → Connections → Google → **Reconnect** to grant the missing scopes.
+- **CLI:** run the explicit grant (required until [#2117](https://github.com/amd/gaia/issues/2117) lands):
+
+  ```bash
+  gaia connectors grants grant google installed:email \
+    --scopes https://www.googleapis.com/auth/gmail.modify \
+             https://www.googleapis.com/auth/gmail.send \
+             https://www.googleapis.com/auth/calendar.events \
+             https://www.googleapis.com/auth/calendar.readonly
+  ```
 
 ### "NOT_CONNECTED: microsoft is not currently connected"
 

--- a/docs/runbooks/google-oauth-client.md
+++ b/docs/runbooks/google-oauth-client.md
@@ -38,15 +38,16 @@ export GAIA_GOOGLE_CLIENT_SECRET="<client-secret>"
 ```
 
 The connections layer reads these at first use (`gaia.connectors.providers.get("google")`).
-Missing → the layer raises `ConfigurationError`; the AgentUI surfaces a
-503 on `/api/connections/*`, but the rest of the AgentUI keeps working
-(per plan amendment A3).
+A missing **client id** raises `ConfigurationError` immediately — the
+AgentUI surfaces a 503 on `/api/connections/*`, but the rest of the AgentUI
+keeps working (per plan amendment A3). A missing **secret** is not caught
+here; Google's token endpoint rejects the exchange later, so set both.
 
 For development against personal Google accounts, register your own
-desktop client in Google Cloud Console and set the env var to its id.
-Do NOT commit the id into the repository. (Personal-account users should
-follow [`docs/connectors/google.mdx`](../connectors/google.mdx), which
-covers the same steps from the BYO-client angle.)
+desktop client in Google Cloud Console and set the env vars to its id and
+secret. Do NOT commit either into the repository. (Personal-account users
+should follow [`docs/connectors/google.mdx`](../connectors/google.mdx),
+which covers the same steps from the BYO-client angle.)
 
 ## Cloud Console setup
 

--- a/docs/runbooks/google-oauth-client.md
+++ b/docs/runbooks/google-oauth-client.md
@@ -7,44 +7,85 @@ This runbook documents how the Google OAuth client used by
 `gaia.connectors` is created, rotated, and consumed. It is **not**
 user-facing — end users never need to know the `client_id`.
 
+> **Scope:** this runbook covers the **AMD-managed** client (the shared
+> `GAIA_GOOGLE_CLIENT_ID`) and its rotation. If you are an end user
+> bringing **your own** OAuth client for a personal Google account, follow
+> the user-facing walkthrough at
+> [`docs/connectors/google.mdx`](../connectors/google.mdx) instead — it
+> covers the same console steps from the BYO-client angle.
+>
+> **End state:** [#2104](https://github.com/amd/gaia/issues/2104) ships a
+> verified AMD-managed client so end users skip the Cloud Console entirely
+> and just click **Connect**. Until it lands, both this runbook (AMD
+> client) and the user guide (BYO client) apply.
+
 ## What this client is
 
 A "Desktop app" OAuth 2.0 client registered in a Google Cloud project owned
-by AMD. PKCE is used for the authorization code flow (no client secret).
-Tokens are stored in the user's OS keychain by `gaia.connectors.store`;
-nothing about the client travels with the user's data.
+by AMD. PKCE protects the authorization code flow, but Google's token
+endpoint still requires the `client_secret` to be present in every exchange
+even for Desktop-app clients — so both the client id **and** secret must be
+configured. Tokens are stored in the user's OS keychain by
+`gaia.connectors.store`; nothing about the client travels with the user's data.
 
 ## Configuration
 
-Set the environment variable before any GAIA process starts:
+Set the environment variables before any GAIA process starts:
 
 ```bash
 export GAIA_GOOGLE_CLIENT_ID="<numeric-id>.apps.googleusercontent.com"
+export GAIA_GOOGLE_CLIENT_SECRET="<client-secret>"
 ```
 
-The connections layer reads this at first use (`gaia.connectors.providers.get("google")`).
+The connections layer reads these at first use (`gaia.connectors.providers.get("google")`).
 Missing → the layer raises `ConfigurationError`; the AgentUI surfaces a
 503 on `/api/connections/*`, but the rest of the AgentUI keeps working
 (per plan amendment A3).
 
 For development against personal Google accounts, register your own
 desktop client in Google Cloud Console and set the env var to its id.
-Do NOT commit the id into the repository.
+Do NOT commit the id into the repository. (Personal-account users should
+follow [`docs/connectors/google.mdx`](../connectors/google.mdx), which
+covers the same steps from the BYO-client angle.)
 
 ## Cloud Console setup
 
-1. Visit [https://console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials).
-2. Create a new project (or use an existing AMD-owned one).
-3. **APIs & Services → OAuth consent screen**:
-   - User Type: Internal (AMD-only) or External (broader).
-   - Add the scopes you intend to support: `gmail.readonly`,
-     `gmail.send`, `calendar.readonly`, `drive.readonly`, etc.
+> **Console layout changed (2024–2025).** Google moved the OAuth settings
+> that used to live under **APIs & Services → OAuth consent screen** and
+> **→ Credentials** into the **Google Auth Platform**, split across three
+> tabs: **Branding**, **Audience**, and **Clients**. The steps below use
+> the new layout with direct links; old menu paths are noted as fallbacks.
+
+1. Create a new project (or use an existing AMD-owned one) and make sure it
+   is selected in the project dropdown.
+2. **Enable the required APIs — mandatory.** GAIA can only call APIs
+   explicitly enabled on the project; skip this and the OAuth flow succeeds
+   but the first mailbox call returns a raw Google `403`
+   ([#2116](https://github.com/amd/gaia/issues/2116)). Enable each API you
+   support, then wait 1–2 minutes for propagation:
+   - [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com)
+   - [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)
+   - [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com)
+3. **Google Auth Platform → Branding + Audience** (old path:
+   **APIs & Services → OAuth consent screen**):
+   - **Audience → User type**: Internal (AMD Workspace org only) or
+     External (broader / personal accounts — a personal `@gmail.com` has
+     no Internal option).
+   - **Branding**: app name, support email, developer contact.
    - For "External" + sensitive scopes, submit for verification (4–6 wk).
-4. **Credentials → Create Credentials → OAuth client ID**:
+     The scopes GAIA supports (`gmail.readonly`, `gmail.send`,
+     `gmail.modify`, `calendar.readonly`, `calendar.events`,
+     `drive.readonly`, …) are declared in
+     [`src/gaia/connectors/catalog/google.py`](../../src/gaia/connectors/catalog/google.py).
+   - **Audience → Test users**: while the app is in Testing status, only
+     listed test users can authorize — add internal QA accounts here.
+4. **Google Auth Platform → Clients** (old path:
+   **APIs & Services → Credentials**) → **Create client**:
    - Application type: **Desktop app**.
    - Name: `GAIA Desktop` (or similar).
-5. Copy the resulting client ID. There is no client secret in the desktop
-   flow — PKCE replaces it.
+5. Copy the resulting client ID. Google issues a client secret alongside
+   it; the Desktop-app PKCE flow still requires the secret to be present in
+   every token exchange, so store both.
 
 ## Rotation procedure
 
@@ -76,21 +117,31 @@ Sensitive scopes (`gmail.*`, `drive.*`, etc.) require Google's
 verification before unverified users can authorize. Until then, only
 test users listed on the consent screen can complete the OAuth flow.
 
-- **In-Cloud-Console flow:** OAuth consent screen → "PUBLISH APP" →
-  follow the form. Provide a privacy policy URL, demo video, and
-  scope justification.
+- **In-Cloud-Console flow:** Google Auth Platform → **Audience** →
+  "Publish app" (old path: OAuth consent screen → "PUBLISH APP") → follow
+  the form. Provide a privacy policy URL, demo video, and scope
+  justification.
 - **Timeline:** 4–6 weeks typical.
 - **Until verified:** add internal QA accounts as test users so they
-  can complete the flow without seeing the "unverified app" warning.
+  can complete the flow.
+- **Test-mode token expiry:** while the app stays in Testing status,
+  Google expires each test user's refresh token roughly **7 days** after
+  consent, so testers must periodically reconnect. This is a Google policy
+  for unverified test apps, not a GAIA bug.
 
 ## Local development without a published client
 
 For day-to-day development:
 1. Create a personal/test Google Cloud project.
-2. Add your own Google account as a test user on the consent screen.
-3. Use that project's desktop client id in `GAIA_GOOGLE_CLIENT_ID`.
-4. The "unverified app" warning appears once per user; click "Continue"
-   to proceed.
+2. Enable the Gmail / Calendar / Drive APIs you'll exercise (mandatory —
+   see [Cloud Console setup](#cloud-console-setup)).
+3. Add your own Google account as a test user (Google Auth Platform →
+   Audience → Test users).
+4. Use that project's desktop client id + secret in
+   `GAIA_GOOGLE_CLIENT_ID` / `GAIA_GOOGLE_CLIENT_SECRET`.
+5. The "Google hasn't verified this app" warning appears during
+   authorization; click **Advanced → Continue** to proceed. Expect to
+   reconnect about weekly while in Testing mode (7-day token expiry).
 
 ## Diagnostics
 

--- a/util/check_doc_links.py
+++ b/util/check_doc_links.py
@@ -61,6 +61,9 @@ SKIP_DOMAINS = {
     "www.npmjs.com",  # Returns 403 to automated requests
     "support.microsoft.com",  # Intermittently 400s/429s datacenter IPs
     "www.xda-developers.com",  # Drops connections from datacenter IPs
+    "console.cloud.google.com",  # Redirects unauthenticated requests to sign-in (302)
+    "support.google.com",  # Locale/UA-gated help pages; 404s automated requests
+    "myaccount.google.com",  # Redirects unauthenticated requests to sign-in (302)
 }
 
 # URL patterns to skip


### PR DESCRIPTION
## Why this matters

Following our own connect-your-Gmail docs live, a maintainer hit four undocumented walls — because the walkthrough had drifted from both the current Google Cloud Console and the real connector flow. Before: the docs sent users to **APIs & Services → Credentials** (a menu Google removed), never mentioned enabling the Gmail/Calendar APIs (so the first mailbox call 403s with a raw Google error even though the connection looks healthy, #2116), didn't cover the personal-account path (External consent + test user, ~7-day token expiry, the "unverified app" interstitial), and implied that connecting was enough. After: a verified step-by-step that matches the live **Google Auth Platform** (Branding/Audience/Clients) layout, treats API enablement as the hard prerequisite it is, and documents the required **per-agent grant** (`gaia connectors grants grant google installed:email …`) plus the exact `AGENT_NOT_GRANTED` error that signals it.

All three doc surfaces are updated together per the CLAUDE.md multi-surface rule: the user-facing BYO-client walkthrough ([`connectors/google`](https://github.com/amd/gaia/blob/docs/google-client-id-walkthrough-2120/docs/connectors/google.mdx)), the email guide's connect section + `AGENT_NOT_GRANTED` troubleshooting entry, and the AMD-internal runbook. The runbook stays focused on the AMD-managed client + rotation and cross-links #2104 as the end state that removes the BYO step; its stale "no client secret" claim is corrected to match the connector code (the secret is required even for Desktop-app PKCE clients).

## Test plan

- [ ] `connectors/google.mdx` renders: Step 2 (enable APIs, 403/#2116 warning, 1–2 min propagation), Step 3 (Google Auth Platform → Branding/Audience, External-only for personal Gmail, test user, 7-day expiry), Step 4 (Clients tab, `console.cloud.google.com/auth/clients`), Step 6 (email-agent grant with full scope URLs), and the two new Common-issues entries.
- [ ] Grant command scopes match the code — `installed:email` agent id ([`connector_routes.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/email/gaia_agent_email/connector_routes.py)) and the four `https://www.googleapis.com/auth/…` scopes ([`scopes.py`](https://github.com/amd/gaia/blob/main/hub/agents/python/email/gaia_agent_email/scopes.py)).
- [ ] Internal links resolve: `/connectors`, `/connectors/google`, `/guides/email#setup`, `/security/connections`, in-page anchors, and the runbook's relative `../connectors/google.mdx`.
- [ ] No new page added → `docs/docs.json` unchanged (both edited pages already in nav; the runbook is referenced via GitHub blob links).

Part of #2014
Closes #2120
