### PR TITLE
fix(webui): reachable Agent Hub + installed-agent discovery and per-session picker

### DIFF
--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -11,6 +11,7 @@ import { FileBrowser } from './components/FileBrowser';
 import { MemoryDashboard } from './components/MemoryDashboard';
 import { ScheduleManager } from './components/ScheduleManager';
 import { SettingsPage } from './components/SettingsPage';
+import { AgentHubView } from './components/AgentHubView';
 import { MobileAccessModal } from './components/MobileAccessModal';
 import { ConnectionBanner } from './components/ConnectionBanner';
 import { UpdateIndicator } from './components/UpdateIndicator';
@@ -75,6 +76,8 @@ function App() {
         setShowMemoryDashboard,
         showSchedules,
         setShowSchedules,
+        showHub,
+        setShowHub,
         sidebarOpen,
         toggleSidebar,
         setSidebarOpen,
@@ -82,6 +85,7 @@ function App() {
         setSystemStatus,
         setBackendConnected,
         setAgents,
+        setAgentsError,
         setRunningSessions,
     } = useChatStore();
     const showNotificationPanel = useNotificationStore((s) => s.showPanel);
@@ -101,8 +105,16 @@ function App() {
                 lastAgentFingerprintRef.current = fp;
                 setAgents(agents);
             }
-        } catch { /* ignore -- agents list is non-critical */ }
-    }, [setAgents]);
+            setAgentsError(null);
+        } catch (err) {
+            // Fail loudly: agent discovery powering the Hub/picker must never be
+            // a silent dead button (#2118). The error surfaces in the Hub view;
+            // the poll keeps retrying so a transient blip self-heals.
+            const msg = err instanceof Error ? err.message : 'agent discovery failed';
+            log.api.warn('[App] agent list load failed', err);
+            setAgentsError(msg);
+        }
+    }, [setAgents, setAgentsError]);
 
     useEffect(() => {
         loadAgents();
@@ -452,6 +464,19 @@ function App() {
         await handleNewTask();
     }, [handleNewTask, setPendingPrompt]);
 
+    // Launch a task with an explicitly-chosen agent (from the Agent Hub). Pins
+    // the agent for the new session and leaves the Hub view. The chosen agent
+    // becomes the session's persisted agent_type via handleNewTask (#2179).
+    const handleStartAgentTask = useCallback(async (agentId: string, prompt?: string) => {
+        useChatStore.getState().setActiveAgentId(agentId);
+        setShowHub(false);
+        if (prompt) {
+            await handleNewTaskWithPrompt(prompt);
+        } else {
+            await handleNewTask();
+        }
+    }, [handleNewTask, handleNewTaskWithPrompt, setShowHub]);
+
     // Launch the Gaia Builder Agent in a new session.
     // Uses a dedicated agent_type so the session always gets the builder,
     // regardless of the user's currently selected agent.
@@ -607,7 +632,7 @@ function App() {
 
             <Sidebar
                 onNewTask={handleNewTask}
-                onHome={() => { setCurrentSession(null); setShowSettings(false); setShowMemoryDashboard(false); setShowSchedules(false); window.history.replaceState(null, '', window.location.pathname); }}
+                onHome={() => { setCurrentSession(null); setShowSettings(false); setShowMemoryDashboard(false); setShowSchedules(false); setShowHub(true); window.history.replaceState(null, '', window.location.pathname); }}
                 tunnelActive={tunnelActive}
                 tunnelLoading={tunnelLoading}
                 onMobileToggle={handleMobileToggle}
@@ -620,6 +645,12 @@ function App() {
                     <MemoryDashboard />
                 ) : showSchedules ? (
                     <ScheduleManager />
+                ) : showHub ? (
+                    <AgentHubView
+                        onStartChat={handleStartAgentTask}
+                        onCreateAgent={handleNewBuilderTask}
+                        onRetryAgents={loadAgents}
+                    />
                 ) : (
                     <>
                         {/* Connection / LLM status banner */}

--- a/src/gaia/apps/webui/src/components/AgentHubView.tsx
+++ b/src/gaia/apps/webui/src/components/AgentHubView.tsx
@@ -1,0 +1,61 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { ArrowLeft, AlertTriangle, RotateCcw } from 'lucide-react';
+import { useChatStore } from '../stores/chatStore';
+import { AgentHubGrid } from './AgentHubGrid';
+import './SettingsPage.css';
+import './AgentHub.css';
+
+interface AgentHubViewProps {
+    /** Launch a new task with the chosen agent (optionally pre-filled prompt). */
+    onStartChat: (agentId: string, prompt?: string) => void;
+    onCreateAgent?: () => void;
+    /** Re-fetch the agent list after a loud discovery failure. */
+    onRetryAgents: () => void;
+}
+
+/**
+ * Full-screen Agent Hub — the reachable home for discovery, install, and
+ * launching an agent (#2118). Unlike the WelcomeScreen grid, it renders even
+ * when no agents are registered (a consumer install with no wheels): the
+ * Available tab still lets the user install one, and a discovery failure shows
+ * a loud, actionable error instead of an empty screen.
+ */
+export function AgentHubView({ onStartChat, onCreateAgent, onRetryAgents }: AgentHubViewProps) {
+    const { agents, activeAgentId, setActiveAgentId, setShowHub, agentsError } = useChatStore();
+
+    return (
+        <div className="settings-page">
+            <div className="settings-page-header">
+                <button
+                    className="btn-icon settings-back-btn"
+                    onClick={() => setShowHub(false)}
+                    aria-label="Back"
+                >
+                    <ArrowLeft size={18} />
+                </button>
+                <h3>Agent Hub</h3>
+            </div>
+
+            <div className="settings-page-body">
+                {agentsError && (
+                    <div className="agent-hub-banner agent-hub-banner-error" role="alert">
+                        <AlertTriangle size={14} />
+                        <span>Couldn’t load installed agents: {agentsError}</span>
+                        <button className="agent-hub-retry" onClick={onRetryAgents}>
+                            <RotateCcw size={13} /> Retry
+                        </button>
+                    </div>
+                )}
+                <AgentHubGrid
+                    agents={agents}
+                    activeAgentId={activeAgentId}
+                    onSelect={setActiveAgentId}
+                    onStartChat={onStartChat}
+                    onCreateAgent={onCreateAgent}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/ChatView.tsx
+++ b/src/gaia/apps/webui/src/components/ChatView.tsx
@@ -1186,12 +1186,16 @@ export function ChatView({ sessionId, onCreateAgent, onAgentChange }: ChatViewPr
             },
         };
 
+        // Dispatch to the agent pinned to THIS session (its persisted
+        // agent_type), not the globally-active one — otherwise two sessions
+        // pinned to different agents would both route to whichever was last
+        // selected in the store (#2179).
         const controller = attach
             ? api.attachToRun(sessionId, streamCallbacks)
-            : api.sendMessageStream(sessionId, messageText, streamCallbacks, undefined, undefined, activeAgentId);
+            : api.sendMessageStream(sessionId, messageText, streamCallbacks, undefined, undefined, displayedAgentId);
 
         abortRef.current = controller;
-    }, [input, attachments, isStreaming, sessionId, session, addMessage, setMessages, setStreaming, flushStreamBuffer, clearStreamContent, updateSessionInList, addAgentStep, updateLastAgentStep, appendThinkingContent, updateLastToolStep, clearAgentSteps, appendCard, clearCards, activeAgentId, addNotification, isStale]);
+    }, [input, attachments, isStreaming, sessionId, session, addMessage, setMessages, setStreaming, flushStreamBuffer, clearStreamContent, updateSessionInList, addAgentStep, updateLastAgentStep, appendThinkingContent, updateLastToolStep, clearAgentSteps, appendCard, clearCards, displayedAgentId, addNotification, isStale]);
 
     // Keep ref in sync so event listeners always call the latest sendMessage
     sendMessageRef.current = sendMessage;

--- a/src/gaia/apps/webui/src/components/Sidebar.tsx
+++ b/src/gaia/apps/webui/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import { Plus, Search, Settings, Sun, Moon, Trash2, PanelLeftClose, PanelLeftOpen, Smartphone, Brain, EyeOff, Clock, Loader2 } from 'lucide-react';
+import { Plus, Search, Settings, Sun, Moon, Trash2, PanelLeftClose, PanelLeftOpen, Smartphone, Brain, EyeOff, Clock, Loader2, LayoutGrid } from 'lucide-react';
 import { useChatStore } from '../stores/chatStore';
 import * as api from '../services/api';
 import { log } from '../utils/logger';
@@ -113,7 +113,7 @@ function SessionItem({ session: s, isActive, isRunning, isPendingDelete, isDelet
 export function Sidebar({ onNewTask, onHome, tunnelActive, tunnelLoading, onMobileToggle }: SidebarProps) {
     const {
         sessions, currentSessionId, setCurrentSession, removeSession, addSession,
-        setMessages, theme, toggleTheme, setShowSettings, setShowMemoryDashboard, setShowSchedules,
+        setMessages, theme, toggleTheme, setShowSettings, setShowMemoryDashboard, setShowSchedules, setShowHub,
         sidebarOpen, setSidebarOpen, setLoadingMessages,
         sidebarCollapsed, toggleSidebarCollapsed,
         sidebarWidth, setSidebarWidth,
@@ -461,6 +461,9 @@ export function Sidebar({ onNewTask, onHome, tunnelActive, tunnelLoading, onMobi
                             <Smartphone size={17} />
                         </button>
                     )}
+                    <button className="btn-icon" onClick={() => setShowHub(true)} title="Agent Hub" aria-label="Open Agent Hub">
+                        <LayoutGrid size={17} />
+                    </button>
                     <button className="btn-icon" onClick={() => setShowMemoryDashboard(true)} title="Memory Dashboard" aria-label="Memory Dashboard">
                         <Brain size={17} />
                     </button>

--- a/src/gaia/apps/webui/src/components/__tests__/AgentHubView.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/AgentHubView.test.tsx
@@ -1,0 +1,37 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentHubView } from '../AgentHubView';
+import { useChatStore } from '../../stores/chatStore';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+const mockedApi = vi.mocked(api);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.listCatalog.mockResolvedValue({ agents: [], total: 0, offline: false });
+    useChatStore.setState({ agents: [], activeAgentId: 'chat', agentsError: null });
+});
+
+describe('AgentHubView (#2118)', () => {
+    it('renders the hub even with no registered agents (consumer install)', () => {
+        render(<AgentHubView onStartChat={vi.fn()} onCreateAgent={vi.fn()} onRetryAgents={vi.fn()} />);
+        // Reachable header + the Available tab (install path) is present.
+        expect(screen.getByRole('heading', { name: 'Agent Hub' })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: /Available/i })).toBeInTheDocument();
+    });
+
+    it('surfaces a loud, actionable error when agent discovery fails', () => {
+        useChatStore.setState({ agentsError: 'Server not reachable' });
+        const onRetry = vi.fn();
+        render(<AgentHubView onStartChat={vi.fn()} onCreateAgent={vi.fn()} onRetryAgents={onRetry} />);
+        const alert = screen.getByRole('alert');
+        expect(alert).toHaveTextContent('Server not reachable');
+        screen.getByRole('button', { name: /Retry/i }).click();
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/gaia/apps/webui/src/components/__tests__/AgentHubView.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/AgentHubView.test.tsx
@@ -13,7 +13,7 @@ const mockedApi = vi.mocked(api);
 
 beforeEach(() => {
     vi.clearAllMocks();
-    mockedApi.listCatalog.mockResolvedValue({ agents: [], total: 0, offline: false });
+    mockedApi.listCatalog.mockResolvedValue({ agents: [], offline: false });
     useChatStore.setState({ agents: [], activeAgentId: 'chat', agentsError: null });
 });
 

--- a/src/gaia/apps/webui/src/components/__tests__/ChatView.dispatch.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ChatView.dispatch.test.tsx
@@ -1,0 +1,85 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatView } from '../ChatView';
+import { useChatStore } from '../../stores/chatStore';
+import type { AgentInfo, Session } from '../../types';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api');
+
+const mockedApi = vi.mocked(api);
+
+const SESSION: Session = {
+    id: 'session-email',
+    title: 'New Task',
+    created_at: '2026-06-10T00:00:00Z',
+    updated_at: '2026-06-10T00:00:00Z',
+    model: 'gemma',
+    system_prompt: null,
+    message_count: 0,
+    document_ids: [],
+    // Session is pinned to email, even though the globally-active agent is chat.
+    agent_type: 'email',
+};
+
+const CHAT_AGENT: AgentInfo = {
+    id: 'chat', name: 'Chat', description: '', source: 'builtin',
+    conversation_starters: [], models: [],
+};
+const EMAIL_AGENT: AgentInfo = {
+    id: 'email', name: 'Email', description: '', source: 'installed',
+    conversation_starters: [], models: [],
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.getMessages.mockResolvedValue({ messages: [], total: 0 });
+    mockedApi.getActiveRuns.mockResolvedValue({ session_ids: [] });
+    mockedApi.listDocuments.mockResolvedValue({
+        documents: [], total: 0, total_size_bytes: 0, total_chunks: 0,
+    });
+    mockedApi.sendMessageStream.mockImplementation(() => new AbortController());
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: vi.fn(),
+    });
+
+    useChatStore.setState({
+        agents: [CHAT_AGENT, EMAIL_AGENT],
+        activeAgentId: 'chat', // global selection differs from the session's
+        sessions: [SESSION],
+        currentSessionId: SESSION.id,
+        messages: [],
+        documents: [],
+        isStreaming: false,
+        streamingContent: '',
+        agentSteps: [],
+        isLoadingMessages: false,
+        pendingPrompt: null,
+        systemStatus: null,
+    });
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe('ChatView per-session dispatch (#2179)', () => {
+    it('dispatches to the session-pinned agent, not the globally-active one', async () => {
+        render(<ChatView sessionId={SESSION.id} />);
+
+        await act(async () => {
+            fireEvent.change(screen.getByLabelText('Message input'), {
+                target: { value: 'triage my inbox' },
+            });
+            fireEvent.click(screen.getByLabelText('Send message'));
+        });
+
+        expect(mockedApi.sendMessageStream).toHaveBeenCalledTimes(1);
+        // 6th positional arg is the agent_type dispatch target.
+        const agentTypeArg = mockedApi.sendMessageStream.mock.calls[0][5];
+        expect(agentTypeArg).toBe('email');
+    });
+});

--- a/src/gaia/apps/webui/src/stores/chatStore.ts
+++ b/src/gaia/apps/webui/src/stores/chatStore.ts
@@ -12,6 +12,10 @@ interface ChatState {
     activeAgentId: string;
     setAgents: (agents: AgentInfo[]) => void;
     setActiveAgentId: (id: string) => void;
+    /** Loud, user-facing error when agent discovery (GET /api/agents) fails.
+     *  Surfaced in the Hub view so a broken discovery is never a dead button. */
+    agentsError: string | null;
+    setAgentsError: (error: string | null) => void;
 
     // Device selection (CPU / GPU / NPU)
     activeDevice: string;
@@ -97,6 +101,7 @@ interface ChatState {
     showSettings: boolean;
     showMemoryDashboard: boolean;
     showSchedules: boolean;
+    showHub: boolean;
     sidebarOpen: boolean;
     sidebarCollapsed: boolean;
     sidebarWidth: number;
@@ -109,6 +114,7 @@ interface ChatState {
     setShowSettings: (show: boolean) => void;
     setShowMemoryDashboard: (show: boolean) => void;
     setShowSchedules: (show: boolean) => void;
+    setShowHub: (show: boolean) => void;
     toggleSidebar: () => void;
     setSidebarOpen: (open: boolean) => void;
     toggleSidebarCollapsed: () => void;
@@ -130,6 +136,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         try { localStorage.setItem('gaia-active-agent-id', id); } catch { /* noop */ }
         set({ activeAgentId: id });
     },
+    agentsError: null,
+    setAgentsError: (error) => set({ agentsError: error }),
 
     // Device selection
     activeDevice: (() => {
@@ -292,6 +300,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     showSettings: false,
     showMemoryDashboard: false,
     showSchedules: false,
+    showHub: false,
     toggleTheme: () =>
         set((state) => {
             const next = state.theme === 'dark' ? 'light' : 'dark';
@@ -313,11 +322,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
     setShowDocLibrary: (show) => set({ showDocLibrary: show }),
     setShowFileBrowser: (show) => set({ showFileBrowser: show }),
     setShowSettings: (show) =>
-        set(show ? { showSettings: true, showMemoryDashboard: false, showSchedules: false } : { showSettings: false }),
+        set(show ? { showSettings: true, showMemoryDashboard: false, showSchedules: false, showHub: false } : { showSettings: false }),
     setShowMemoryDashboard: (show) =>
-        set(show ? { showMemoryDashboard: true, showSettings: false, showSchedules: false } : { showMemoryDashboard: false }),
+        set(show ? { showMemoryDashboard: true, showSettings: false, showSchedules: false, showHub: false } : { showMemoryDashboard: false }),
     setShowSchedules: (show) =>
-        set(show ? { showSchedules: true, showSettings: false, showMemoryDashboard: false } : { showSchedules: false }),
+        set(show ? { showSchedules: true, showSettings: false, showMemoryDashboard: false, showHub: false } : { showSchedules: false }),
+    setShowHub: (show) =>
+        set(show ? { showHub: true, showSettings: false, showMemoryDashboard: false, showSchedules: false } : { showHub: false }),
     toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
     setSidebarOpen: (open) => set({ sidebarOpen: open }),
     toggleSidebarCollapsed: () =>

--- a/src/gaia/hub/catalog.py
+++ b/src/gaia/hub/catalog.py
@@ -266,6 +266,26 @@ def load_index(
     )
 
 
+def cached_index_agents(cache_path: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Return the ``agents`` list from the on-disk catalog cache, or ``[]``.
+
+    Offline-only: never touches the network. Used to enrich locally-installed
+    agents (that aren't in the live registry) with the name/description/icon the
+    hub last published, so the agent picker renders a real card even when the
+    hub is unreachable. A missing or malformed cache yields ``[]`` — the caller
+    falls back to a minimal entry rather than failing.
+    """
+    cache_path = Path(cache_path) if cache_path else default_cache_path()
+    cached = _read_disk_cache(cache_path)
+    if cached is None:
+        return []
+    try:
+        return _validate_index(cached)
+    except CatalogError as exc:
+        logger.warning("catalog: cached index is malformed (%s); ignoring", exc)
+        return []
+
+
 def fetch_manifest(
     agent_id: str,
     *,

--- a/src/gaia/ui/routers/agents.py
+++ b/src/gaia/ui/routers/agents.py
@@ -127,15 +127,74 @@ def _reg_to_info(reg) -> AgentInfo:
     )
 
 
+def _installed_sidecar_agents(registry) -> list[AgentInfo]:
+    """Hub-installed sidecar agents that the daemon supervises out-of-process.
+
+    On a consumer machine with no pip-installed agent wheels the in-process
+    registry is empty, so a freshly-installed *binary* agent (e.g. email) would
+    never appear in the picker even though it is installed and healthy (#2118).
+    Bridge the gap here — the router is the one layer allowed to see both
+    ``gaia.daemon`` (which agents can be supervised) and ``gaia.hub`` (which are
+    installed); ``gaia.hub`` and ``gaia.daemon`` never import ``gaia.ui``.
+
+    Only agents that are BOTH daemon-supervisable AND have an install sentinel
+    are surfaced, and only when the registry doesn't already carry them (a
+    wheel/entry-point install wins — it has richer metadata). Metadata is
+    enriched, offline, from the last-cached hub catalog; absent that we fall
+    back to the daemon spec's display name so the picker still renders a real
+    card instead of a dead entry.
+    """
+    from gaia.daemon.sidecars.spec import builtin_specs
+    from gaia.hub import catalog as catalog_mod
+    from gaia.hub import installer
+
+    installed = installer.list_installed()
+    if not installed:
+        return []
+
+    # id -> cached catalog entry (name/description/icon/category), offline-only.
+    cached = {e["id"]: e for e in catalog_mod.cached_index_agents()}
+
+    agents: list[AgentInfo] = []
+    for agent_id, spec in builtin_specs().items():
+        if agent_id not in installed:
+            continue
+        if registry.get(agent_id) is not None:
+            # A registered (wheel/native) agent already covers this id.
+            continue
+        meta = cached.get(agent_id, {})
+        sentinel = installed[agent_id]
+        agents.append(
+            AgentInfo(
+                id=agent_id,
+                name=meta.get("name") or spec.display_name,
+                description=meta.get("description", ""),
+                source="installed",
+                conversation_starters=[],
+                models=list(meta.get("models", [])),
+                namespaced_agent_id=f"installed:{agent_id}",
+                category=meta.get("category", "general"),
+                tags=list(meta.get("tags", [])),
+                icon=meta.get("icon", ""),
+                tools_count=meta.get("tools_count", 0),
+                language=meta.get("language") or sentinel.language,
+            )
+        )
+    return agents
+
+
 @router.get("/api/agents", response_model=AgentListResponse)
 async def list_agents(request: Request):
-    """List all registered agents visible to the UI (excludes hidden system agents)."""
+    """List all agents the UI can launch (excludes hidden system agents).
+
+    Unions the in-process registry with hub-installed *sidecar* agents so a
+    consumer install with no agent wheels still shows its installed binary
+    agents in the picker (#2118). Registry entries win on id collisions.
+    """
     registry = _registry(request)
-    registrations = [r for r in registry.list() if not r.hidden]
-    return AgentListResponse(
-        agents=[_reg_to_info(r) for r in registrations],
-        total=len(registrations),
-    )
+    infos = [_reg_to_info(r) for r in registry.list() if not r.hidden]
+    infos.extend(_installed_sidecar_agents(registry))
+    return AgentListResponse(agents=infos, total=len(infos))
 
 
 @router.get(
@@ -173,12 +232,17 @@ async def list_disk_agents(request: Request):
 
 @router.get("/api/agents/{agent_id:path}", response_model=AgentInfo)
 async def get_agent(agent_id: str, request: Request):
-    """Get details for a specific agent."""
+    """Get details for a specific agent (registry or hub-installed sidecar)."""
     registry = _registry(request)
     reg = registry.get(agent_id)
-    if reg is None:
-        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
-    return _reg_to_info(reg)
+    if reg is not None:
+        return _reg_to_info(reg)
+    # Fall back to hub-installed sidecar agents (email etc.) so the picker's
+    # detail view resolves them on consumer installs without agent wheels.
+    for info in _installed_sidecar_agents(registry):
+        if info.id == agent_id:
+            return info
+    raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
 
 
 @router.post(

--- a/tests/unit/chat/ui/test_agents_router.py
+++ b/tests/unit/chat/ui/test_agents_router.py
@@ -126,6 +126,98 @@ class TestAgentWithMemoryRequirement:
         assert chat["min_memory_gb"] is None
 
 
+class TestInstalledSidecarAgentsMerge:
+    """A hub-installed *binary* sidecar agent must appear in the picker even
+    when the in-process registry is empty (consumer install, no wheels) — #2118.
+    """
+
+    @staticmethod
+    def _email_sentinel():
+        from gaia.hub.installer import InstalledAgent
+
+        return {
+            "email": InstalledAgent(
+                id="email",
+                version="0.5.0",
+                language="python",
+                installed_at="2026-01-01T00:00:00Z",
+                artifact_kind="binary",
+            )
+        }
+
+    def _client_with_empty_registry(self):
+        app = create_app(db_path=":memory:")
+        app.state.agent_registry = make_mock_registry()  # cold: no agents
+        return TestClient(app)
+
+    def test_installed_email_appears_with_empty_registry(self):
+        client = self._client_with_empty_registry()
+        with patch(
+            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+        ), patch(
+            "gaia.hub.catalog.cached_index_agents",
+            return_value=[
+                {
+                    "id": "email",
+                    "name": "Email Triage",
+                    "description": "Triage Gmail locally",
+                    "category": "productivity",
+                    "icon": "mail",
+                }
+            ],
+        ):
+            data = client.get("/api/agents").json()
+
+        ids = [a["id"] for a in data["agents"]]
+        assert ids == ["email"]
+        email = data["agents"][0]
+        assert email["name"] == "Email Triage"
+        assert email["description"] == "Triage Gmail locally"
+        assert email["source"] == "installed"
+        assert email["icon"] == "mail"
+
+    def test_falls_back_to_spec_name_without_catalog_cache(self):
+        """No cached catalog → still a real card using the daemon spec name."""
+        client = self._client_with_empty_registry()
+        with patch(
+            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+        ), patch("gaia.hub.catalog.cached_index_agents", return_value=[]):
+            data = client.get("/api/agents").json()
+
+        assert [a["id"] for a in data["agents"]] == ["email"]
+        assert data["agents"][0]["name"] == "Email"  # spec.display_name
+
+    def test_registry_entry_wins_over_sidecar(self):
+        """A registered (wheel) email is not duplicated by the sidecar merge."""
+        app = create_app(db_path=":memory:")
+        app.state.agent_registry = make_mock_registry(("email", "Email (wheel)"))
+        client = TestClient(app)
+        with patch(
+            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+        ), patch("gaia.hub.catalog.cached_index_agents", return_value=[]):
+            data = client.get("/api/agents").json()
+
+        emails = [a for a in data["agents"] if a["id"] == "email"]
+        assert len(emails) == 1
+        assert emails[0]["name"] == "Email (wheel)"
+
+    def test_uninstalled_sidecar_agent_absent(self):
+        """No install sentinel → the agent is NOT phantom-listed."""
+        client = self._client_with_empty_registry()
+        with patch("gaia.hub.installer.list_installed", return_value={}):
+            data = client.get("/api/agents").json()
+        assert data["agents"] == []
+
+    def test_get_installed_sidecar_agent_by_id(self):
+        client = self._client_with_empty_registry()
+        with patch(
+            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+        ), patch("gaia.hub.catalog.cached_index_agents", return_value=[]):
+            resp = client.get("/api/agents/email")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "email"
+
+
 class TestGetAgent:
     def test_known_agent_returns_200(self, client):
         resp = client.get("/api/agents/chat")

--- a/tests/unit/chat/ui/test_agents_router.py
+++ b/tests/unit/chat/ui/test_agents_router.py
@@ -152,19 +152,22 @@ class TestInstalledSidecarAgentsMerge:
 
     def test_installed_email_appears_with_empty_registry(self):
         client = self._client_with_empty_registry()
-        with patch(
-            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
-        ), patch(
-            "gaia.hub.catalog.cached_index_agents",
-            return_value=[
-                {
-                    "id": "email",
-                    "name": "Email Triage",
-                    "description": "Triage Gmail locally",
-                    "category": "productivity",
-                    "icon": "mail",
-                }
-            ],
+        with (
+            patch(
+                "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+            ),
+            patch(
+                "gaia.hub.catalog.cached_index_agents",
+                return_value=[
+                    {
+                        "id": "email",
+                        "name": "Email Triage",
+                        "description": "Triage Gmail locally",
+                        "category": "productivity",
+                        "icon": "mail",
+                    }
+                ],
+            ),
         ):
             data = client.get("/api/agents").json()
 
@@ -179,9 +182,12 @@ class TestInstalledSidecarAgentsMerge:
     def test_falls_back_to_spec_name_without_catalog_cache(self):
         """No cached catalog → still a real card using the daemon spec name."""
         client = self._client_with_empty_registry()
-        with patch(
-            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
-        ), patch("gaia.hub.catalog.cached_index_agents", return_value=[]):
+        with (
+            patch(
+                "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+            ),
+            patch("gaia.hub.catalog.cached_index_agents", return_value=[]),
+        ):
             data = client.get("/api/agents").json()
 
         assert [a["id"] for a in data["agents"]] == ["email"]
@@ -192,9 +198,12 @@ class TestInstalledSidecarAgentsMerge:
         app = create_app(db_path=":memory:")
         app.state.agent_registry = make_mock_registry(("email", "Email (wheel)"))
         client = TestClient(app)
-        with patch(
-            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
-        ), patch("gaia.hub.catalog.cached_index_agents", return_value=[]):
+        with (
+            patch(
+                "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+            ),
+            patch("gaia.hub.catalog.cached_index_agents", return_value=[]),
+        ):
             data = client.get("/api/agents").json()
 
         emails = [a for a in data["agents"] if a["id"] == "email"]
@@ -210,9 +219,12 @@ class TestInstalledSidecarAgentsMerge:
 
     def test_get_installed_sidecar_agent_by_id(self):
         client = self._client_with_empty_registry()
-        with patch(
-            "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
-        ), patch("gaia.hub.catalog.cached_index_agents", return_value=[]):
+        with (
+            patch(
+                "gaia.hub.installer.list_installed", return_value=self._email_sentinel()
+            ),
+            patch("gaia.hub.catalog.cached_index_agents", return_value=[]),
+        ):
             resp = client.get("/api/agents/email")
         assert resp.status_code == 200
         assert resp.json()["id"] == "email"


### PR DESCRIPTION
## Why this matters

Before: on a consumer install (no pip-installed agent wheels), Agent UI discovery was broken end-to-end — clicking the GAIA logo ("Go to Agent Hub") just cleared the session and dropped you on a blank Welcome screen (the hub grid was gated behind having ≥1 agent), and `GET /api/agents` returned only in-process registry agents, so a freshly-installed, healthy binary agent (email) never appeared. There was no way to pick which agent runs a task — every new task silently became chat, and starting an email task in-app was impossible.

After: the Agent Hub is a dedicated, always-reachable view (logo **and** a new sidebar button, ≤1 click) that renders even with zero registered agents; hub-installed sidecar agents (email) show up in the picker; and each session carries an explicit agent identity that drives dispatch — so two sessions pinned to different agents route to their own agents instead of both following the last global selection.

No silent fallbacks: agent-discovery failures now surface a loud, actionable error with a Retry in the Hub instead of an empty list (replaced a pre-existing swallow in the poll path).

This keeps the per-session `agent_type` field clean and additive — the data model the sidebar-by-agent work (#2106) will consume.

Closes #2118. Closes #2179. Part of #2014 (Agent UI v2 — V2-18).

## Test plan

- [x] `python -m pytest tests/unit/chat/ui/test_agents_router.py` (28) — installed email surfaces from a **cold empty registry**; catalog-cache metadata used, spec-name fallback when absent; registry wins on id collision; uninstalled agents stay absent; get-by-id resolves the sidecar agent
- [x] `python -m pytest tests/unit/test_agent_hub_api.py tests/unit/test_hub_catalog.py` (13) — catalog + hub API green with the new offline `cached_index_agents` accessor
- [x] webui Vitest — `npm run test` in `src/gaia/apps/webui` (185 pass, incl. new `ChatView.dispatch` per-session routing + `AgentHubView` reachable/loud-error tests)
- [x] `npm run build` (tsc clean) · `flake8` clean on changed files · Black/isort report no changes
- [x] Manual (Playwright, backend + built dist): logo/sidebar opens the **Agent Hub** in one click with the full grid incl. Email Triage; **Start Chat → Email Triage** creates a session pinned to email; the footer per-session picker shows the pinned agent and lists all agents. Screenshots captured on the build machine (`/tmp/gaia-pr-screenshots/`): `agent-hub-view.png`, `per-session-agent-picker.png`.

_No eval run: the change touches agent listing, a UI view, and which persisted `agent_type` the request carries (the backend already resolved `request.agent_type or session.agent_type`) — no system prompt, tool schema, model, or parsing path is affected._
