### PR TITLE
feat(cli): gaia email attaches to the daemon — thin client (V2-8)

### DIFF
--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -5011,12 +5011,17 @@ def handle_jira_command(args):
 
 def handle_email_command(args):
     """
-    Handle the ``gaia email`` command.
+    Handle the ``gaia email`` command — a thin client over the GAIA daemon (V2-8).
 
-    Wires the Email Triage Agent (#962) to a CLI session. AC3-critical:
-    this handler does NOT pass ``--use-claude`` / ``--use-chatgpt`` to
-    the agent (the agent's config has no such field). The local-LLM-only
-    path is the only path.
+    The query path (``-q`` / ``-i``) no longer runs the email agent in-process:
+    it ensures/attaches to the always-on daemon, ensures the ``email`` sidecar,
+    and streams ``POST /v1/email/query`` through the daemon relay, presenting ONLY
+    the daemon client token — the CLI never learns the sidecar's port or bearer
+    (design §0.0 "one contract, many front-doors", #2152). Local-LLM only (AC3):
+    no ``--use-claude`` / ``--use-chatgpt`` — the sidecar rejects any non-local
+    provider.
+
+    ``--spec`` stays a fixed-function local operation (no daemon, no Lemonade).
 
     Args:
         args: Parsed command line arguments for the email command
@@ -5024,7 +5029,7 @@ def handle_email_command(args):
     log = get_logger(__name__)
 
     # --spec: generate the HTML endpoint spec and open it in a browser.
-    # No LLM, no Lemonade — short-circuit before any server check.
+    # No LLM, no Lemonade, no daemon — short-circuit before any server check.
     if getattr(args, "spec", False):
         try:
             from gaia_agent_email.spec_html import write_and_open_spec
@@ -5039,9 +5044,10 @@ def handle_email_command(args):
         print(dest)
         sys.exit(0)
 
-    # Initialize Lemonade — local LLM only. The email agent's config will
-    # also reject any non-local base_url at construction time, but the
-    # CLI manager check gives a friendlier "start Lemonade first" message.
+    # Initialize Lemonade — local LLM only. The daemon spawns the sidecar, but the
+    # sidecar's inference runs on Lemonade; this upfront check gives a friendlier
+    # "start Lemonade first" message than a mid-stream error event (AC: Lemonade
+    # down → loud actionable error).
     if not getattr(args, "no_lemonade_check", False):
         success, _ = initialize_lemonade_for_agent(
             agent="email",
@@ -5052,36 +5058,80 @@ def handle_email_command(args):
         if not success:
             sys.exit(1)
 
-    try:
-        from gaia_agent_email.cli import main as email_main
+    verbose = bool(getattr(args, "verbose", False) or getattr(args, "debug", False))
+    query = getattr(args, "query", None)
+    interactive = getattr(args, "interactive", False)
 
-        # Normalize args the agent CLI expects.
-        if not hasattr(args, "verbose"):
-            args.verbose = False
-        if not hasattr(args, "debug"):
-            args.debug = False
-        if not hasattr(args, "model"):
-            args.model = None
-        if not hasattr(args, "query"):
-            args.query = None
-        if not hasattr(args, "interactive"):
-            args.interactive = False
-
-        result = asyncio.run(email_main(args))
-        sys.exit(result)
-
-    except ImportError as e:
-        log.error(f"Failed to import Email agent: {e}")
-        print("❌ Error: Email agent components are not available")
+    if not query and not interactive:
+        # No query and not interactive — print a helpful usage hint (parity with
+        # the retired in-process CLI).
         print(
-            "Install the email agent with `pip install gaia-agent-email` "
-            '(or `pip install "amd-gaia[agents]"` for all agents).'
+            "Usage: gaia email -q '<your question>' OR gaia email -i\n"
+            "Examples:\n"
+            "  gaia email -q 'Triage my inbox'\n"
+            "  gaia email -q 'Summarize my unread emails from this week'\n"
+            "  gaia email -i\n"
         )
+        sys.exit(0)
+
+    from gaia.daemon.agent_query import ConsoleRenderer, run_query
+    from gaia.daemon.errors import DaemonError
+
+    model = getattr(args, "model", None)
+
+    try:
+        if interactive:
+            sys.exit(_email_interactive(model=model, verbose=verbose))
+        renderer = ConsoleRenderer(verbose=verbose)
+        outcome = run_query(
+            "email", query, model=model, renderer=renderer, verbose=verbose
+        )
+        sys.exit(outcome.exit_code)
+    except DaemonError as e:
+        # Daemon unreachable / relay refusal / sidecar dead → loud, actionable,
+        # no silent in-process fallback (CLAUDE.md fail-loudly rule).
+        log.error("email thin client failed: %s", e)
+        print(f"❌ {e}", file=sys.stderr)
         sys.exit(1)
-    except Exception as e:
-        log.error(f"Error running Email agent: {e}")
-        print(f"❌ Error: {e}")
-        sys.exit(1)
+
+
+def _email_interactive(*, model, verbose: bool) -> int:
+    """REPL over the daemon relay — reads queries from stdin until EOF / ``/quit``.
+
+    Maintains the transcript locally and pushes it as ``context`` on each turn
+    (the host owns the transcript; the stateless sidecar is fed the relevant
+    slice per request, spec §2.4).
+    """
+    from gaia.daemon.agent_query import ConsoleRenderer, run_query
+
+    print("Email Triage Agent — interactive. Enter a query, or '/quit' to exit.\n")
+    transcript: list = []
+    while True:
+        try:
+            query = input("email> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+        if not query:
+            continue
+        if query in ("/quit", "/exit", "/q"):
+            return 0
+        renderer = ConsoleRenderer(verbose=verbose)
+        outcome = run_query(
+            "email",
+            query,
+            context=list(transcript),
+            model=model,
+            renderer=renderer,
+            verbose=verbose,
+        )
+        # Only extend the transcript on a successful turn — a failed run must not
+        # poison the context of the next one.
+        if outcome.terminal_type == "final":
+            transcript.append({"role": "user", "content": query})
+            transcript.append(
+                {"role": "assistant", "content": outcome.final_answer or ""}
+            )
 
 
 def handle_docker_command(args):

--- a/src/gaia/daemon/agent_query.py
+++ b/src/gaia/daemon/agent_query.py
@@ -1,0 +1,345 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Thin-client driver: run an agent's ``/query`` loop through the daemon relay
+and render the canonical SSE event stream to the console (V2-8, #2152).
+
+This is the CLI's data plane. ``gaia email "<q>"`` (and, later, ``gaia api`` /
+other front-doors) ensure the daemon + sidecar, then stream
+``POST /v1/<agent>/query`` through the daemon relay (``ANY /v1/<agent>/*``,
+#2150), presenting ONLY the daemon client token — the sidecar's port and bearer
+never leave the daemon. The seven canonical event types (spec #2015/#2016) —
+
+    status | token | tool_call | tool_result | needs_confirmation | final | error
+
+— are parsed off the SSE wire and rendered here; the stream ends with exactly one
+``final`` or ``error``.
+
+No silent fallbacks (CLAUDE.md): a daemon that is unreachable, a relay that
+refuses the query, or a stream that ends without a terminal event all surface as
+a loud, actionable :class:`~gaia.daemon.errors.DaemonError` or a rendered
+terminal ``error`` — never a quiet in-process fallback that masks a broken
+daemon.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from gaia.daemon import client, paths
+from gaia.daemon.constants import AUTH_SCHEME
+from gaia.daemon.errors import DaemonError
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+#: Canonical event types that terminate a ``/query`` stream (spec §3 — mirrors
+#: the relay's own ``TERMINAL_TYPES``).
+TERMINAL_TYPES = frozenset({"final", "error"})
+
+#: Connect fast (a dead daemon should fail quickly); read generously — a single
+#: upstream chunk spans a whole agent-loop step (matches the relay's READ_TIMEOUT).
+_CONNECT_TIMEOUT = 10.0
+_READ_TIMEOUT = 300.0
+#: Cancel POST must never wait out the read timeout.
+_CANCEL_TIMEOUT = 10.0
+
+
+@dataclass
+class QueryOutcome:
+    """The result of one relayed ``/query`` run."""
+
+    exit_code: int
+    terminal_type: Optional[str]  # "final" | "error" | None (no terminal seen)
+    final_answer: Optional[str] = None
+    error_detail: Optional[str] = None
+
+
+class ConsoleRenderer:
+    """Render canonical SSE events to the console.
+
+    The agent's answer (streamed ``token`` deltas and the terminal ``final``)
+    goes to **stdout** so ``gaia email -q`` stays pipe-friendly — its stdout is
+    the answer, matching the retired in-process path. Progress (``status`` /
+    ``tool_call`` / ``tool_result`` / ``needs_confirmation``) and errors go to
+    **stderr** so they never pollute a captured answer. ``--verbose`` widens the
+    progress detail (tool arguments, result payloads).
+    """
+
+    def __init__(self, *, verbose: bool = False, out=None, err=None) -> None:
+        self._verbose = verbose
+        self._out = out if out is not None else sys.stdout
+        self._err = err if err is not None else sys.stderr
+        # Track whether any answer token has been streamed so the terminal
+        # ``final`` does not reprint the full answer on top of the live tokens.
+        self._answer_streamed = False
+        self.final_answer: Optional[str] = None
+        self.error_detail: Optional[str] = None
+
+    # -- dispatch ----------------------------------------------------------
+
+    def render(self, event: Dict[str, Any]) -> None:
+        etype = event.get("type")
+        handler = getattr(self, f"_on_{etype}", None) if etype else None
+        if handler is None:
+            self._on_unknown(event)
+            return
+        handler(event)
+
+    # -- per-type renderers ------------------------------------------------
+
+    def _on_status(self, event: Dict[str, Any]) -> None:
+        message = str(event.get("message", "")).strip()
+        if message:
+            print(f"  … {message}", file=self._err, flush=True)
+
+    def _on_token(self, event: Dict[str, Any]) -> None:
+        delta = event.get("delta", "")
+        if not delta:
+            return
+        self._answer_streamed = True
+        print(delta, end="", file=self._out, flush=True)
+
+    def _on_tool_call(self, event: Dict[str, Any]) -> None:
+        tool = event.get("tool", "unknown")
+        if self._verbose:
+            args = event.get("args") or {}
+            print(f"  🔧 {tool}({_compact(args)})", file=self._err, flush=True)
+        else:
+            print(f"  🔧 {tool}", file=self._err, flush=True)
+
+    def _on_tool_result(self, event: Dict[str, Any]) -> None:
+        tool = event.get("tool", "unknown")
+        if self._verbose:
+            data = event.get("data")
+            print(f"  ✓ {tool} → {_compact(data)}", file=self._err, flush=True)
+        else:
+            print(f"  ✓ {tool}", file=self._err, flush=True)
+
+    def _on_needs_confirmation(self, event: Dict[str, Any]) -> None:
+        action = event.get("action", "action")
+        summary = str(event.get("summary", "")).strip()
+        line = f"  ⚠️  confirmation needed: {action}"
+        if summary:
+            line += f" — {summary}"
+        print(line, file=self._err, flush=True)
+
+    def _on_final(self, event: Dict[str, Any]) -> None:
+        answer = str(event.get("answer", "") or "")
+        self.final_answer = answer
+        if self._answer_streamed:
+            # Tokens already printed the answer live — just end the line cleanly.
+            if answer:
+                print("", file=self._out, flush=True)
+        elif answer:
+            print(answer, file=self._out, flush=True)
+        if self._verbose:
+            usage = event.get("usage")
+            if usage:
+                print(f"  ℹ️  {_compact(usage)}", file=self._err, flush=True)
+
+    def _on_error(self, event: Dict[str, Any]) -> None:
+        detail = str(event.get("detail", "") or "unknown agent error")
+        self.error_detail = detail
+        if self._answer_streamed:
+            print("", file=self._out, flush=True)
+        source = event.get("source")
+        suffix = f" (source: {source})" if source else ""
+        print(f"❌ {detail}{suffix}", file=self._err, flush=True)
+
+    def _on_unknown(self, event: Dict[str, Any]) -> None:
+        # An unknown canonical type must be visible, never silently dropped
+        # (contract §7, receiving-end rule).
+        print(
+            f"  [unknown event: {_compact(event)}]",
+            file=self._err,
+            flush=True,
+        )
+
+    def on_interrupt(self) -> None:
+        """Rendered when the user Ctrl-C's mid-run."""
+        if self._answer_streamed:
+            print("", file=self._out, flush=True)
+        print("⏹  cancelled.", file=self._err, flush=True)
+
+
+def _compact(value: Any, limit: int = 200) -> str:
+    """Compact one-line repr of a value for verbose/progress lines."""
+    try:
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        text = str(value)
+    return text if len(text) <= limit else text[:limit] + "…"
+
+
+def _iter_sse_events(response):
+    """Yield parsed JSON events from an SSE ``response`` (requests, stream=True).
+
+    Minimal SSE framing: accumulate ``data:`` field lines until a blank line, then
+    parse the joined payload as JSON. Comment lines (``:`` heartbeats) are
+    ignored. A malformed ``data:`` payload is logged loudly but does not abort the
+    stream — the terminal-event contract is enforced by the caller.
+    """
+    data_lines: List[str] = []
+
+    def _flush():
+        if not data_lines:
+            return None
+        payload = "\n".join(data_lines)
+        data_lines.clear()
+        try:
+            return json.loads(payload)
+        except (ValueError, UnicodeDecodeError):
+            logger.warning(
+                "agent_query: unparseable SSE data payload (%.120r) — skipped",
+                payload,
+            )
+            return None
+
+    for raw in response.iter_lines(decode_unicode=True):
+        # requests yields None for keep-alive newlines on some transports.
+        if raw is None:
+            continue
+        if raw == "":
+            event = _flush()
+            if event is not None:
+                yield event
+            continue
+        if raw.startswith(":"):  # SSE comment / heartbeat
+            continue
+        field, _, value = raw.partition(":")
+        if field == "data":
+            data_lines.append(value[1:] if value.startswith(" ") else value)
+    # Flush a trailing frame with no terminating blank line (EOF mid-frame).
+    event = _flush()
+    if event is not None:
+        yield event
+
+
+def _best_effort_cancel(inst, agent_id: str, run_id: str) -> None:
+    """Ask the relay to cancel the run (best-effort — the sidecar may be dead)."""
+    import requests
+
+    url = f"{inst.base_url}/v1/{agent_id}/query/{run_id}/cancel"
+    try:
+        requests.post(
+            url,
+            headers={"Authorization": f"{AUTH_SCHEME} {inst.token}"},
+            timeout=_CANCEL_TIMEOUT,
+        )
+    except requests.exceptions.RequestException as e:
+        logger.warning(
+            "agent_query: best-effort cancel for '%s' run_id=%s failed: %s",
+            agent_id,
+            run_id,
+            e,
+        )
+
+
+def _consume(response, renderer: ConsoleRenderer) -> Optional[str]:
+    """Render each event; return the terminal type seen (``final``/``error``) or
+    ``None`` if the stream ended without one."""
+    terminal_type: Optional[str] = None
+    for event in _iter_sse_events(response):
+        renderer.render(event)
+        if event.get("type") in TERMINAL_TYPES:
+            terminal_type = event.get("type")
+            break
+    return terminal_type
+
+
+def run_query(
+    agent_id: str,
+    query: str,
+    *,
+    context: Optional[List[Dict[str, str]]] = None,
+    model: Optional[str] = None,
+    max_steps: Optional[int] = None,
+    renderer: Optional[ConsoleRenderer] = None,
+    verbose: bool = False,
+) -> QueryOutcome:
+    """Ensure the daemon + *agent_id* sidecar, stream ``POST /v1/<agent>/query``
+    through the relay, and render the canonical SSE events.
+
+    The CLI presents ONLY the daemon client token; it never learns the sidecar's
+    port or bearer. Returns a :class:`QueryOutcome` whose ``exit_code`` is 0 on a
+    terminal ``final``, 1 on a terminal ``error`` (or a stream that ends without
+    one), and 130 on Ctrl-C. Raises :class:`DaemonError` if the daemon/relay
+    cannot be reached at all — a broken daemon is loud, not masked.
+    """
+    import requests
+
+    renderer = renderer or ConsoleRenderer(verbose=verbose)
+
+    # Ensure the daemon is up and the sidecar is running (loud on failure).
+    inst = client.ensure_agent(agent_id)
+
+    run_id = str(uuid.uuid4())
+    payload: Dict[str, Any] = {
+        "query": query,
+        "run_id": run_id,
+        "context": context or [],
+    }
+    if model:
+        payload["model"] = model
+    if max_steps is not None:
+        payload["max_steps"] = max_steps
+
+    url = f"{inst.base_url}/v1/{agent_id}/query"
+    headers = {
+        "Authorization": f"{AUTH_SCHEME} {inst.token}",
+        "Accept": "text/event-stream",
+    }
+
+    try:
+        with requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            stream=True,
+            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+        ) as response:
+            if response.status_code != 200:
+                raise DaemonError(
+                    f"the daemon relay refused the '{agent_id}' query "
+                    f"(HTTP {response.status_code}): {client._error_detail(response)} "
+                    f"Check `gaia daemon status` and the daemon log at "
+                    f"{paths.log_path()}."
+                )
+            terminal_type = _consume(response, renderer)
+    except KeyboardInterrupt:
+        # Closing the stream already triggers the relay's cancel propagation;
+        # send an explicit cancel too so the sidecar stops between tool steps.
+        _best_effort_cancel(inst, agent_id, run_id)
+        renderer.on_interrupt()
+        return QueryOutcome(exit_code=130, terminal_type=None)
+    except requests.exceptions.RequestException as e:
+        raise DaemonError(
+            f"could not stream the '{agent_id}' query from the daemon at "
+            f"{inst.base_url}: {e}. Check `gaia daemon status` and the daemon "
+            f"log at {paths.log_path()}."
+        ) from e
+
+    if terminal_type is None:
+        # The contract mandates exactly one terminal event — a stream that ends
+        # without one is a failure, surfaced loudly rather than as a clean exit.
+        detail = (
+            f"the '{agent_id}' query stream ended without a terminal "
+            "final/error event — the sidecar may have crashed mid-run. "
+            f"Check `gaia daemon status` and the daemon log at {paths.log_path()}."
+        )
+        renderer.render({"type": "error", "detail": detail, "source": "cli"})
+        return QueryOutcome(exit_code=1, terminal_type=None, error_detail=detail)
+
+    return QueryOutcome(
+        exit_code=0 if terminal_type == "final" else 1,
+        terminal_type=terminal_type,
+        final_answer=renderer.final_answer,
+        error_detail=renderer.error_detail,
+    )
+
+
+__all__ = ["run_query", "QueryOutcome", "ConsoleRenderer", "TERMINAL_TYPES"]

--- a/src/gaia/daemon/client.py
+++ b/src/gaia/daemon/client.py
@@ -38,6 +38,16 @@ logger = get_logger(__name__)
 
 _START_TIMEOUT = 30.0
 
+# The daemon MINOR that introduced the /daemon/v1/agents control plane + the
+# /v1/<agent>/* relay (#2142 / #2150). A pre-#2142 daemon passes the MAJOR gate
+# but would 404 every agents/relay route — fail loudly instead. A stale daemon
+# surviving an app auto-update is the EXPECTED path, not an edge case.
+_REQUIRED_AGENTS_MINOR = 1
+
+# Ensure: connect fast; read generously — a first-run ensure may lazily fetch the
+# sidecar binary before answering (mirrors gaia.ui.email_sidecar.daemon_client).
+_ENSURE_TIMEOUT = (5.0, 900.0)
+
 
 def _major(version: str) -> int:
     try:
@@ -146,6 +156,81 @@ def _spawn_and_wait(timeout: float) -> DaemonInstance:
         f"the daemon did not become healthy within {timeout}s. It may be stuck "
         f"binding a port or importing. Inspect the daemon log at {paths.log_path()}."
     )
+
+
+def _check_agents_floor(inst: DaemonInstance) -> None:
+    """Fail loudly if the running daemon predates the agents/relay control plane."""
+    parts = str(inst.api_version).split(".")
+    try:
+        minor = int(parts[1]) if len(parts) > 1 else 0
+    except ValueError:
+        minor = 0
+    if minor < _REQUIRED_AGENTS_MINOR:
+        raise DaemonVersionError(
+            f"the running daemon (host API v{inst.api_version}) predates the "
+            "sidecar control plane + relay (needs v1.1+) — it would 404 every "
+            "agents route. Run `gaia daemon restart`, then retry."
+        )
+
+
+def _error_detail(response) -> str:
+    """The actionable ``detail`` from a daemon error response (or raw status)."""
+    try:
+        body = response.json()
+    except ValueError:
+        return f"HTTP {response.status_code}"
+    if isinstance(body, dict) and body.get("detail"):
+        return str(body["detail"])
+    return f"HTTP {response.status_code}"
+
+
+def ensure_agent(
+    agent_id: str,
+    *,
+    mode: Optional[str] = None,
+    timeout=_ENSURE_TIMEOUT,
+) -> DaemonInstance:
+    """Start-or-attach the daemon and ensure *agent_id*'s sidecar is running.
+
+    Returns the :class:`DaemonInstance` — ``base_url`` + the DAEMON client token —
+    which a thin client drives the sidecar through, exclusively via the daemon
+    relay (``ANY /v1/<agent>/*``). The sidecar's own port/bearer in the ensure
+    response are deliberately DISCARDED here so a thin client never holds sidecar
+    credentials (design §0.0 "one contract, many front-doors"): it presents only
+    the daemon client token, and the daemon swaps it for the sidecar bearer
+    server-side.
+
+    Blocking (daemon start + sidecar spawn + possible first-run binary fetch) —
+    call it off any event loop. Every failure raises :class:`DaemonError` with an
+    actionable remedy; there is no silent in-process fallback.
+    """
+    import requests
+
+    inst = start_or_attach()
+    _check_agents_floor(inst)
+    url = f"{inst.base_url}{API_PREFIX}/agents/{agent_id}/ensure"
+    payload = {} if mode is None else {"mode": mode}
+    try:
+        r = requests.post(
+            url,
+            headers={"Authorization": f"{AUTH_SCHEME} {inst.token}"},
+            json=payload,
+            timeout=timeout,
+        )
+    except requests.exceptions.RequestException as e:
+        raise DaemonError(
+            f"could not reach the daemon at {inst.base_url} to ensure the "
+            f"'{agent_id}' sidecar: {e}. Check `gaia daemon status` and the "
+            f"daemon log at {paths.log_path()}."
+        ) from e
+    if r.status_code != 200:
+        raise DaemonError(
+            f"the daemon refused to ensure the '{agent_id}' sidecar: "
+            f"{_error_detail(r)}"
+        )
+    # Deliberately DO NOT read/return the response body — it carries the sidecar
+    # bearer token, which a thin client must never learn or hold.
+    return inst
 
 
 def request_shutdown(inst: DaemonInstance, timeout: float = 5.0) -> bool:

--- a/tests/integration/test_email_thin_client.py
+++ b/tests/integration/test_email_thin_client.py
@@ -1,0 +1,326 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Integration test: ``gaia email`` is a thin client over the daemon (V2-8, #2152).
+
+Exercises the ACTUAL CLI command a user runs (``python -m gaia.cli email -q ...``,
+per CLAUDE.md testing philosophy) against a FAKE daemon that stands in for the
+real one: it answers ``/daemon/v1/status``, ``/daemon/v1/agents/email/ensure``,
+and streams the canonical SSE contract on ``/v1/email/query``.
+
+The fake daemon runs in the pytest process (a threaded HTTP server) and records
+every inbound request, so the test can prove the thin-client custody invariant:
+
+  * ``gaia email`` ensures + streams through the daemon relay,
+  * presenting ONLY the daemon client token — it never learns or presents the
+    sidecar bearer that ``ensure`` returns.
+
+State is isolated under a tmp ``GAIA_DAEMON_HOME`` so the run never touches (or
+spawns) the user's real daemon: instance.json is written pointing at THIS process
+(pid alive + token-authed status probe succeeds → ``start_or_attach`` attaches
+instead of spawning).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from gaia.daemon import instance
+from gaia.daemon.constants import DAEMON_API_VERSION, SERVICE_ID
+from gaia.daemon.instance import DaemonInstance
+
+_REPO_SRC = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "src"
+)
+
+# Distinct tokens: the DAEMON client token the CLI is allowed to present, and the
+# SIDECAR bearer the ensure response leaks — the CLI must NEVER present the latter.
+_DAEMON_TOKEN = "daemon-client-token-abc123"
+_SIDECAR_TOKEN = "sidecar-bearer-SECRET-must-not-leak"
+
+_FINAL_ANSWER = "Triaged 5 emails: 2 urgent, 3 newsletters."
+
+
+class _Recorder:
+    """Thread-safe capture of the requests the fake daemon received."""
+
+    def __init__(self) -> None:
+        self.requests: list = []
+        self._lock = threading.Lock()
+
+    def add(self, method: str, path: str, auth: str, body: bytes) -> None:
+        with self._lock:
+            self.requests.append(
+                {"method": method, "path": path, "auth": auth, "body": body}
+            )
+
+    def find(self, path_contains: str):
+        with self._lock:
+            return [r for r in self.requests if path_contains in r["path"]]
+
+
+def _make_handler(recorder: _Recorder, ensure_status: int, sse_frames: list):
+    """Build a BaseHTTPRequestHandler class bound to this test's fixtures."""
+
+    class Handler(BaseHTTPRequestHandler):
+        # HTTP/1.0 (the default): the server closes the connection at the end of
+        # each response, so the SSE client reads the body until EOF without us
+        # having to chunk it.
+        protocol_version = "HTTP/1.0"
+
+        def log_message(self, *_args):  # silence per-request stderr noise
+            pass
+
+        def _auth(self) -> str:
+            return self.headers.get("Authorization", "")
+
+        def _read_body(self) -> bytes:
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            return self.rfile.read(length) if length else b""
+
+        def _json(self, status: int, payload: dict) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            body = self._read_body()
+            recorder.add("GET", self.path, self._auth(), body)
+            if self.path.startswith("/daemon/v1/status"):
+                self._json(
+                    200,
+                    {
+                        "service": SERVICE_ID,
+                        "api_version": DAEMON_API_VERSION,
+                        "pid": os.getpid(),
+                        "port": self.server.server_address[1],
+                        "host": "127.0.0.1",
+                        "started_at": 0.0,
+                        "uptime_seconds": 1.0,
+                    },
+                )
+                return
+            self._json(404, {"detail": f"no route {self.path}"})
+
+        def do_POST(self):
+            body = self._read_body()
+            recorder.add("POST", self.path, self._auth(), body)
+
+            if self.path.endswith("/agents/email/ensure"):
+                if ensure_status != 200:
+                    self._json(
+                        ensure_status,
+                        {"detail": "the email sidecar failed its health check."},
+                    )
+                    return
+                # The ensure body carries the sidecar bearer — the CLI must
+                # discard it and never present it on the relay call below.
+                self._json(
+                    200,
+                    {
+                        "agent_id": "email",
+                        "state": "running",
+                        "mode": "user",
+                        "pid": 4242,
+                        "port": 59999,
+                        "base_url": "http://127.0.0.1:59999",
+                        "api_version": "1",
+                        "agent_version": "1.0.0",
+                        "started_at": 0.0,
+                        "token": _SIDECAR_TOKEN,
+                    },
+                )
+                return
+
+            if self.path.endswith("/v1/email/query"):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.end_headers()
+                for frame in sse_frames:
+                    self.wfile.write(f"data: {json.dumps(frame)}\n\n".encode("utf-8"))
+                    self.wfile.flush()
+                return
+
+            if self.path.endswith("/cancel"):
+                self._json(200, {"run_id": "x", "cancelled": True, "status": "ok"})
+                return
+
+            self._json(404, {"detail": f"no route {self.path}"})
+
+    return Handler
+
+
+@pytest.fixture()
+def fake_daemon(tmp_path, monkeypatch):
+    """Start a fake daemon in-process and register it in a tmp GAIA_DAEMON_HOME.
+
+    Yields (recorder, configure) where ``configure`` lets a test set the ensure
+    status and the SSE frames BEFORE it runs the CLI.
+    """
+    home = tmp_path / "host"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("GAIA_DAEMON_HOME", str(home))
+
+    recorder = _Recorder()
+    # Mutable config the closure reads at request time.
+    cfg = {
+        "ensure_status": 200,
+        "sse_frames": [
+            {"type": "status", "message": "Processing..."},
+            {"type": "tool_call", "tool": "triage_inbox", "args": {}},
+            {"type": "tool_result", "tool": "triage_inbox", "data": {"count": 5}},
+            {"type": "token", "delta": _FINAL_ANSWER},
+            {"type": "final", "answer": _FINAL_ANSWER},
+        ],
+    }
+
+    # Bind an ephemeral loopback port; build the handler bound to live cfg.
+    def handler_factory(*args, **kwargs):
+        return _make_handler(recorder, cfg["ensure_status"], cfg["sse_frames"])(
+            *args, **kwargs
+        )
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler_factory)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    # Register instance.json pointing at THIS process (pid alive) + the fake port.
+    instance.write_instance(
+        DaemonInstance(
+            pid=os.getpid(),
+            port=port,
+            token=_DAEMON_TOKEN,
+            host="127.0.0.1",
+            api_version=DAEMON_API_VERSION,
+            service=SERVICE_ID,
+            started_at=0.0,
+        )
+    )
+
+    def configure(*, ensure_status=None, sse_frames=None):
+        if ensure_status is not None:
+            cfg["ensure_status"] = ensure_status
+        if sse_frames is not None:
+            cfg["sse_frames"] = sse_frames
+
+    try:
+        yield recorder, configure
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _child_env(home_env) -> dict:
+    env = os.environ.copy()
+    env["GAIA_DAEMON_HOME"] = home_env
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = _REPO_SRC + (os.pathsep + existing if existing else "")
+    # Force UTF-8 I/O so the CLI's emoji/ellipsis output round-trips on Windows
+    # (the default console codec is cp1252, which cannot encode ❌ / … / 🔧).
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env
+
+
+def _run_email(*cli_args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "gaia.cli", "email", "--no-lemonade-check", *cli_args],
+        env=_child_env(os.environ["GAIA_DAEMON_HOME"]),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+
+
+def test_email_streams_through_daemon_relay(fake_daemon):
+    """Golden path: ``gaia email -q`` ensures + streams the answer via the relay."""
+    recorder, _ = fake_daemon
+
+    r = _run_email("-q", "Triage my inbox")
+
+    assert r.returncode == 0, f"stderr={r.stderr}\nstdout={r.stdout}"
+    # The agent's answer lands on stdout (pipe-friendly, parity with the old path).
+    assert _FINAL_ANSWER in r.stdout
+
+    # It went through the daemon: an ensure AND a relayed /v1/email/query happened.
+    assert recorder.find("/agents/email/ensure"), "ensure was never called"
+    query_reqs = recorder.find("/v1/email/query")
+    # The plain query, not the cancel sub-path.
+    query_only = [q for q in query_reqs if q["path"].endswith("/v1/email/query")]
+    assert query_only, "the relayed /v1/email/query was never called"
+
+
+def test_thin_client_presents_only_the_daemon_token(fake_daemon):
+    """Custody invariant: the CLI presents the DAEMON token, never the sidecar bearer."""
+    recorder, _ = fake_daemon
+
+    r = _run_email("-q", "Triage my inbox")
+    assert r.returncode == 0, r.stderr
+
+    ensure = recorder.find("/agents/email/ensure")[0]
+    query = [
+        q
+        for q in recorder.find("/v1/email/query")
+        if q["path"].endswith("/v1/email/query")
+    ][0]
+
+    # Both the ensure and the relayed query authenticate with the DAEMON token.
+    assert ensure["auth"] == f"Bearer {_DAEMON_TOKEN}"
+    assert query["auth"] == f"Bearer {_DAEMON_TOKEN}"
+
+    # The sidecar bearer that `ensure` leaked must appear in NO outgoing request —
+    # the thin client never learns or presents it.
+    for req in recorder.requests:
+        assert _SIDECAR_TOKEN not in req["auth"]
+        assert _SIDECAR_TOKEN not in (req["body"] or b"").decode("utf-8", "replace")
+
+    # The relayed query carries a host-minted run_id + the pushed (empty) context.
+    payload = json.loads(query["body"])
+    assert payload["query"] == "Triage my inbox"
+    assert isinstance(payload["run_id"], str) and payload["run_id"]
+    assert payload["context"] == []
+
+
+def test_ensure_failure_is_loud_not_a_fallback(fake_daemon):
+    """Lemonade/sidecar failure at ensure → loud actionable error, no silent fallback."""
+    recorder, configure = fake_daemon
+    configure(ensure_status=502)
+
+    r = _run_email("-q", "Triage my inbox")
+
+    assert r.returncode == 1
+    # Actionable: names what failed and points at the sidecar.
+    assert "sidecar" in r.stderr.lower()
+    # It did NOT fall back to an in-process run: no /query was attempted.
+    assert not [
+        q
+        for q in recorder.find("/v1/email/query")
+        if q["path"].endswith("/v1/email/query")
+    ]
+
+
+def test_stream_without_terminal_event_fails_loud(fake_daemon):
+    """A stream that ends without a final/error is a failure, surfaced loudly."""
+    _, configure = fake_daemon
+    configure(
+        sse_frames=[
+            {"type": "status", "message": "Processing..."},
+            {"type": "token", "delta": "partial..."},
+            # No terminal final/error — a crashed sidecar mid-run.
+        ]
+    )
+
+    r = _run_email("-q", "Triage my inbox")
+
+    assert r.returncode == 1
+    assert "terminal" in r.stderr.lower()

--- a/tests/unit/test_agent_query.py
+++ b/tests/unit/test_agent_query.py
@@ -1,0 +1,174 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the CLI thin-client driver (``gaia.daemon.agent_query``) and the
+``client.ensure_agent`` helper (V2-8, #2152).
+
+These are Lemonade/daemon-free: the SSE parser and console renderer are pure, and
+``ensure_agent`` is exercised with a stubbed ``requests`` + ``start_or_attach`` so
+the token-discard custody invariant is asserted without a live daemon.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from gaia.daemon.agent_query import ConsoleRenderer, _iter_sse_events
+
+
+class _FakeResponse:
+    """Minimal stand-in for a streamed ``requests`` response."""
+
+    def __init__(self, text: str):
+        self._text = text
+
+    def iter_lines(self, decode_unicode=True):
+        # Mirror requests.iter_lines: split on newlines, no trailing empty.
+        for line in self._text.split("\n"):
+            yield line
+
+
+def test_iter_sse_events_parses_canonical_frames():
+    stream = (
+        'data: {"type": "status", "message": "Processing..."}\n'
+        "\n"
+        'data: {"type": "token", "delta": "Hello "}\n'
+        "\n"
+        ": heartbeat\n"  # SSE comment line — ignored
+        "\n"
+        'data: {"type": "final", "answer": "Hello world"}\n'
+        "\n"
+    )
+    events = list(_iter_sse_events(_FakeResponse(stream)))
+    assert [e["type"] for e in events] == ["status", "token", "final"]
+    assert events[-1]["answer"] == "Hello world"
+
+
+def test_iter_sse_events_skips_unparseable_payload(caplog):
+    stream = "data: not-json\n\n" 'data: {"type": "final", "answer": "ok"}\n\n'
+    events = list(_iter_sse_events(_FakeResponse(stream)))
+    # The bad frame is dropped (logged), the good one survives.
+    assert [e["type"] for e in events] == ["final"]
+
+
+def test_iter_sse_events_flushes_trailing_frame_without_blank_line():
+    stream = 'data: {"type": "final", "answer": "eof"}'  # no terminating blank line
+    events = list(_iter_sse_events(_FakeResponse(stream)))
+    assert events == [{"type": "final", "answer": "eof"}]
+
+
+def test_renderer_answer_on_stdout_progress_on_stderr():
+    out, err = io.StringIO(), io.StringIO()
+    r = ConsoleRenderer(out=out, err=err)
+    r.render({"type": "status", "message": "working"})
+    r.render({"type": "tool_call", "tool": "triage_inbox", "args": {}})
+    r.render({"type": "tool_result", "tool": "triage_inbox", "data": {}})
+    r.render({"type": "final", "answer": "Done."})
+
+    # The answer is the ONLY thing on stdout (pipe-friendly parity).
+    assert out.getvalue().strip() == "Done."
+    # Progress lands on stderr.
+    assert "working" in err.getvalue()
+    assert "triage_inbox" in err.getvalue()
+
+
+def test_renderer_streamed_tokens_are_not_reprinted_by_final():
+    out, err = io.StringIO(), io.StringIO()
+    r = ConsoleRenderer(out=out, err=err)
+    r.render({"type": "token", "delta": "Hello "})
+    r.render({"type": "token", "delta": "world"})
+    r.render({"type": "final", "answer": "Hello world"})
+    # Tokens printed live; the final only adds a trailing newline, not a reprint.
+    assert out.getvalue() == "Hello world\n"
+
+
+def test_renderer_error_goes_to_stderr_and_is_captured():
+    out, err = io.StringIO(), io.StringIO()
+    r = ConsoleRenderer(out=out, err=err)
+    r.render({"type": "error", "detail": "boom", "source": "daemon_relay"})
+    assert r.error_detail == "boom"
+    assert "boom" in err.getvalue()
+    assert "daemon_relay" in err.getvalue()
+    assert out.getvalue() == ""
+
+
+def test_renderer_unknown_event_is_visible():
+    out, err = io.StringIO(), io.StringIO()
+    r = ConsoleRenderer(out=out, err=err)
+    r.render({"type": "mystery", "foo": 1})
+    assert "unknown event" in err.getvalue()
+
+
+def test_ensure_agent_discards_sidecar_token(monkeypatch):
+    """ensure_agent returns the daemon instance and NEVER surfaces the sidecar
+    bearer the ensure response carries."""
+    from gaia.daemon import client
+    from gaia.daemon.instance import DaemonInstance
+
+    inst = DaemonInstance(
+        pid=1234, port=5555, token="DAEMON-TOKEN", host="127.0.0.1", api_version="1.1"
+    )
+    monkeypatch.setattr(client, "start_or_attach", lambda *a, **k: inst)
+
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"agent_id": "email", "token": "SIDECAR-SECRET", "pid": 99}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return _Resp()
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    got = client.ensure_agent("email")
+
+    # Returns the daemon instance (base_url + daemon token), not the sidecar body.
+    assert got is inst
+    # Ensure was authed with the daemon token.
+    assert captured["headers"]["Authorization"] == "Bearer DAEMON-TOKEN"
+    assert captured["url"].endswith("/daemon/v1/agents/email/ensure")
+
+
+def test_ensure_agent_raises_loud_on_non_200(monkeypatch):
+    from gaia.daemon import client
+    from gaia.daemon.errors import DaemonError
+    from gaia.daemon.instance import DaemonInstance
+
+    inst = DaemonInstance(pid=1, port=2, token="T", host="127.0.0.1", api_version="1.1")
+    monkeypatch.setattr(client, "start_or_attach", lambda *a, **k: inst)
+
+    class _Resp:
+        status_code = 502
+
+        def json(self):
+            return {"detail": "sidecar failed to start"}
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: _Resp())
+
+    with pytest.raises(DaemonError) as exc:
+        client.ensure_agent("email")
+    assert "sidecar failed to start" in str(exc.value)
+
+
+def test_ensure_agent_rejects_prehistoric_daemon(monkeypatch):
+    """A daemon predating the agents/relay control plane fails loud (v1.1 floor)."""
+    from gaia.daemon import client
+    from gaia.daemon.errors import DaemonVersionError
+    from gaia.daemon.instance import DaemonInstance
+
+    old = DaemonInstance(pid=1, port=2, token="T", host="127.0.0.1", api_version="1.0")
+    monkeypatch.setattr(client, "start_or_attach", lambda *a, **k: old)
+
+    with pytest.raises(DaemonVersionError):
+        client.ensure_agent("email")


### PR DESCRIPTION
**Before:** `gaia email` ran the email agent **in-process**, holding the sidecar's port and bearer directly — CLI runs bypassed daemon custody entirely (no shared sidecar with the UI, no always-on process owning the run). **After:** `gaia email "<q>"` auto-starts/attaches to the daemon, ensures the `email` sidecar, and streams `POST /v1/email/query` through the daemon relay (#2150), presenting **only** the daemon client token. The CLI never learns the sidecar's port or bearer — one contract, many front-doors (§0.0). Behavior/UX is equivalent (same triage/chat, answer on stdout) but routed through the thin-host path, and it works with the web UI closed.

Fail-loud throughout (CLAUDE.md): daemon unreachable, relay refusal, or a stream that ends without a terminal `final`/`error` all surface an actionable error — there is **no** silent in-process fallback masking a broken daemon. `--spec` stays a fixed-function local operation (no daemon, no Lemonade).

Part of #2014. Closes #2152.

### Test plan
- [x] `python -m pytest tests/unit/test_agent_query.py` — SSE parser, console renderer, `ensure_agent` token-discard/version-floor invariants (10 tests)
- [x] `python -m pytest tests/integration/test_email_thin_client.py` — real `gaia email -q` subprocess against a fake daemon: streams the answer via the relay; presents **only** the daemon token (the sidecar bearer from `ensure` appears in no outgoing request); ensure-failure and no-terminal-event both fail loud with exit 1 (4 tests)
- [x] `python -m pytest tests/unit/test_daemon.py tests/unit/test_email_sidecar_daemon_client.py` — no regressions (36 passed overall)
- [x] `black --check` / `isort --check` / `flake8` (repo config) / `pylint --errors-only` clean on changed files
- [ ] Manual golden-path transcript on a real machine with Lemonade + Google connector: stream → `gaia daemon status` showing a shared sidecar pid with the UI → Ctrl-C cancel between tool steps → `kill -9` the sidecar mid-query renders a terminal error (no hang) → `gaia daemon stop`. *(Not runnable in this environment — no Lemonade/Gmail; left unchecked.)*

> Client-side only: the email agent's `/v1/email/query` contract surface is unchanged, so no agent README/SPEC/SKILL/CHANGELOG updates are bundled.