### PR TITLE
feat(connectors): grant the mailbox to the email agent in the same connect flow

### DIFF
--- a/src/gaia/apps/webui/src/components/ConnectorsSection.css
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.css
@@ -229,6 +229,42 @@
     line-height: 1.4;
 }
 
+/* #2117 — per-agent grant selection shown before connecting an OAuth
+   mailbox. Connecting grants the checked agents in the same flow. */
+.oauth-grant-onconnect {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin: 8px 0 4px 0;
+    padding: 10px 12px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
+}
+
+.oauth-grant-onconnect-label {
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 500;
+    margin: 0;
+}
+
+.oauth-grant-onconnect-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-primary);
+    cursor: pointer;
+}
+
+.oauth-grant-onconnect-help {
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.4;
+    margin: 2px 0 0 0;
+}
+
 .connector-product-link {
     display: inline-flex;
     align-items: center;

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -242,6 +242,32 @@ function OAuthConfigureBody({
     const [err, setErr] = useState<string | null>(null);
     const [setupValues, setSetupValues] = useState<Record<string, string>>({});
 
+    // #2117 — agents that declare this connector as a requirement. Connecting
+    // grants the selected agents in the same flow (default-on), so a mailbox
+    // connected here is usable immediately instead of hitting a "no grant"
+    // dead end that only a CLI command could fix.
+    const { agents } = useChatStore();
+    const grantableAgents = agents.filter(
+        (a) =>
+            a.namespaced_agent_id &&
+            a.required_connections?.some((rc) => rc.connector_id === connector.id),
+    );
+    const grantableKey = grantableAgents
+        .map((a) => a.namespaced_agent_id)
+        .join(',');
+    const [grantSel, setGrantSel] = useState<Set<string>>(() => new Set());
+    // Default every declaring agent ON once the agent list resolves.
+    useEffect(() => {
+        setGrantSel(new Set(grantableAgents.map((a) => a.namespaced_agent_id!)));
+    }, [grantableKey]); // eslint-disable-line react-hooks/exhaustive-deps
+    const toggleGrant = (nsid: string) =>
+        setGrantSel((prev) => {
+            const next = new Set(prev);
+            next.has(nsid) ? next.delete(nsid) : next.add(nsid);
+            return next;
+        });
+    const selectedGrantAgents = () => [...grantSel];
+
     // Refresh the tile when the user returns to the window after completing OAuth.
     useEffect(() => {
         const handleFocus = () => { onChanged(); };
@@ -272,6 +298,7 @@ function OAuthConfigureBody({
                 connector.available_scopes?.length
                     ? connector.available_scopes
                     : connector.default_scopes,
+                selectedGrantAgents(),
             );
             openAuthUrl(r.authorization_url);
             // onChanged is called via the 'focus' listener when the user returns.
@@ -316,6 +343,7 @@ function OAuthConfigureBody({
             const result = await api.configureConnector(connector.id, {
                 ...setupValues,
                 scopes,
+                grant_agents: selectedGrantAgents(),
             });
             const url =
                 typeof result.authorization_url === 'string'
@@ -377,6 +405,29 @@ function OAuthConfigureBody({
                             )}
                         </label>
                     ))}
+                </div>
+            )}
+            {!connector.configured && grantableAgents.length > 0 && (
+                <div className="oauth-grant-onconnect">
+                    <p className="oauth-grant-onconnect-label">
+                        Grant access to these agents when you connect:
+                    </p>
+                    {grantableAgents.map((a) => (
+                        <label
+                            key={a.namespaced_agent_id}
+                            className="oauth-grant-onconnect-item"
+                        >
+                            <input
+                                type="checkbox"
+                                checked={grantSel.has(a.namespaced_agent_id!)}
+                                onChange={() => toggleGrant(a.namespaced_agent_id!)}
+                            />
+                            <span>{a.name}</span>
+                        </label>
+                    ))}
+                    <p className="oauth-grant-onconnect-help">
+                        You can change these any time under Per-agent grants below.
+                    </p>
                 </div>
             )}
             {err && (

--- a/src/gaia/apps/webui/src/components/__tests__/EmailConnectCta.test.ts
+++ b/src/gaia/apps/webui/src/components/__tests__/EmailConnectCta.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, it, expect } from 'vitest';
-import { detectProvider, isAuthRequiredMessage } from '../email/EmailConnectCta';
+import {
+    detectProvider,
+    emailAgentGrantIds,
+    isAuthRequiredMessage,
+} from '../email/EmailConnectCta';
 
 /**
  * Tests for isAuthRequiredMessage — the CTA detection function that decides
@@ -129,5 +133,65 @@ describe('detectProvider', () => {
 
     it('returns both for an ambiguous message without provider names', () => {
         expect(detectProvider('AGENT_NOT_GRANTED: this agent is not granted.')).toBe('both');
+    });
+});
+
+/**
+ * #2117 consent-scoping: the email connect CTA must grant ONLY the email agent,
+ * never co-installed agents that also declare the connector — granting a sibling
+ * agent its mailbox scopes here would bypass the per-agent consent surface.
+ */
+describe('emailAgentGrantIds', () => {
+    const email = {
+        id: 'email',
+        namespaced_agent_id: 'installed:email',
+        required_connections: [
+            { connector_id: 'google' },
+            { connector_id: 'microsoft' },
+        ],
+    };
+    const connectorsDemo = {
+        id: 'connectors-demo',
+        namespaced_agent_id: 'installed:connectors-demo',
+        required_connections: [{ connector_id: 'google' }],
+    };
+
+    it('grants only the email agent, not co-installed agents that declare the connector', () => {
+        expect(emailAgentGrantIds([email, connectorsDemo], 'google')).toEqual([
+            'installed:email',
+        ]);
+    });
+
+    it('does not grant a co-installed agent even when the email agent is absent', () => {
+        // No silent fall-through to a sibling agent — returns empty, not the demo.
+        expect(emailAgentGrantIds([connectorsDemo], 'google')).toEqual([]);
+    });
+
+    it('returns the email agent for microsoft too', () => {
+        expect(emailAgentGrantIds([email, connectorsDemo], 'microsoft')).toEqual([
+            'installed:email',
+        ]);
+    });
+
+    it('returns empty when the email agent does not declare the connector', () => {
+        const emailNoGoogle = {
+            id: 'email',
+            namespaced_agent_id: 'installed:email',
+            required_connections: [{ connector_id: 'microsoft' }],
+        };
+        expect(emailAgentGrantIds([emailNoGoogle], 'google')).toEqual([]);
+    });
+
+    it('is robust to a builtin: namespace prefix', () => {
+        const builtinEmail = {
+            id: 'email',
+            namespaced_agent_id: 'builtin:email',
+            required_connections: [{ connector_id: 'google' }],
+        };
+        expect(emailAgentGrantIds([builtinEmail], 'google')).toEqual(['builtin:email']);
+    });
+
+    it('returns empty for an empty agent list', () => {
+        expect(emailAgentGrantIds([], 'google')).toEqual([]);
     });
 });

--- a/src/gaia/apps/webui/src/components/email/EmailConnectCta.tsx
+++ b/src/gaia/apps/webui/src/components/email/EmailConnectCta.tsx
@@ -24,6 +24,7 @@
 import { useCallback, useState } from 'react';
 import { AlertCircle, ExternalLink, Loader2 } from 'lucide-react';
 import * as api from '../../services/api';
+import { useChatStore } from '../../stores/chatStore';
 import './EmailConnectCta.css';
 
 // ── Detection ────────────────────────────────────────────────────────────────
@@ -99,11 +100,14 @@ function openAuthUrl(url: string): void {
 function ProviderButton({
     connectorId,
     label,
+    grantAgents,
     done,
     onDone,
 }: {
     connectorId: string;
     label: string;
+    /** Namespaced agent ids to grant this connector when OAuth completes (#2117). */
+    grantAgents: string[];
     done: boolean;
     onDone: () => void;
 }) {
@@ -119,7 +123,9 @@ function ProviderButton({
                 connector.available_scopes && connector.available_scopes.length > 0
                     ? connector.available_scopes
                     : connector.default_scopes;
-            const r = await api.authorizeConnector(connectorId, scopes);
+            // Grant the connecting agent(s) in the same flow — this CTA is
+            // email-initiated, so triage works right after consent with no CLI.
+            const r = await api.authorizeConnector(connectorId, scopes, grantAgents);
             openAuthUrl(r.authorization_url);
             onDone();
         } catch (e) {
@@ -127,7 +133,7 @@ function ProviderButton({
         } finally {
             setBusy(false);
         }
-    }, [connectorId, onDone]);
+    }, [connectorId, grantAgents, onDone]);
 
     return (
         <div className="email-connect-cta__provider-slot">
@@ -171,6 +177,23 @@ export function EmailConnectCta({
     const [googleDone, setGoogleDone] = useState(false);
     const [microsoftDone, setMicrosoftDone] = useState(false);
 
+    // #2117 — resolve the namespaced ids of agents that declare each mailbox
+    // connector so connecting grants them in the same flow. This CTA is
+    // email-initiated, so the email agent is granted the moment consent
+    // completes — no follow-up CLI grant, no "no grant for google" dead end.
+    const { agents } = useChatStore();
+    const grantAgentsFor = useCallback(
+        (cid: string): string[] =>
+            agents
+                .filter(
+                    (a) =>
+                        a.namespaced_agent_id &&
+                        a.required_connections?.some((rc) => rc.connector_id === cid),
+                )
+                .map((a) => a.namespaced_agent_id!),
+        [agents],
+    );
+
     // Resolve which provider(s) to surface. Honor an explicit google/microsoft
     // override; any other value (or none) falls back to content detection so we
     // never render zero connect buttons (no silent dead-end).
@@ -203,6 +226,7 @@ export function EmailConnectCta({
                     <ProviderButton
                         connectorId="google"
                         label="Google"
+                        grantAgents={grantAgentsFor('google')}
                         done={googleDone}
                         onDone={() => setGoogleDone(true)}
                     />
@@ -211,6 +235,7 @@ export function EmailConnectCta({
                     <ProviderButton
                         connectorId="microsoft"
                         label="Microsoft"
+                        grantAgents={grantAgentsFor('microsoft')}
                         done={microsoftDone}
                         onDone={() => setMicrosoftDone(true)}
                     />

--- a/src/gaia/apps/webui/src/components/email/EmailConnectCta.tsx
+++ b/src/gaia/apps/webui/src/components/email/EmailConnectCta.tsx
@@ -27,6 +27,45 @@ import * as api from '../../services/api';
 import { useChatStore } from '../../stores/chatStore';
 import './EmailConnectCta.css';
 
+// The base agent id this CTA belongs to. The connect CTA lives in the email
+// chat, so it may only grant the email agent — never co-installed agents that
+// happen to declare the same mailbox connector.
+const EMAIL_AGENT_ID = 'email';
+
+/**
+ * #2117 — resolve the grant target for the email connect CTA.
+ *
+ * Returns the namespaced id of the EMAIL agent (and only it) when that agent
+ * declares ``connectorId``. Co-installed agents that also declare the connector
+ * (e.g. ``installed:connectors-demo`` for Google) are deliberately excluded:
+ * granting them here would hand them the mailbox scopes with no consent surface,
+ * bypassing the per-agent grant model. Those agents are granted explicitly from
+ * Settings → Connectors instead.
+ *
+ * Filtering by base ``id`` keeps this robust to the namespace prefix
+ * (``installed:`` vs ``builtin:``). Returns ``[]`` if the email agent isn't
+ * present or doesn't declare the connector — a connect-only flow, never an
+ * over-grant.
+ */
+export function emailAgentGrantIds(
+    agents: Array<{
+        id?: string;
+        namespaced_agent_id?: string;
+        required_connections?: Array<{ connector_id: string }>;
+    }>,
+    connectorId: string,
+): string[] {
+    return agents
+        .filter(
+            (a) =>
+                a.id === EMAIL_AGENT_ID &&
+                !!a.namespaced_agent_id &&
+                (a.required_connections?.some((rc) => rc.connector_id === connectorId) ??
+                    false),
+        )
+        .map((a) => a.namespaced_agent_id!);
+}
+
 // ── Detection ────────────────────────────────────────────────────────────────
 
 /** Match the canonical prefixes the connectors framework emits. The
@@ -177,20 +216,14 @@ export function EmailConnectCta({
     const [googleDone, setGoogleDone] = useState(false);
     const [microsoftDone, setMicrosoftDone] = useState(false);
 
-    // #2117 — resolve the namespaced ids of agents that declare each mailbox
-    // connector so connecting grants them in the same flow. This CTA is
-    // email-initiated, so the email agent is granted the moment consent
-    // completes — no follow-up CLI grant, no "no grant for google" dead end.
+    // #2117 — this CTA is email-initiated, so connecting grants ONLY the email
+    // agent the moment consent completes (no follow-up CLI grant, no "no grant
+    // for google" dead end). Co-installed agents that declare the same connector
+    // are NOT granted here — that would bypass their per-agent consent; the user
+    // grants them explicitly from Settings → Connectors.
     const { agents } = useChatStore();
     const grantAgentsFor = useCallback(
-        (cid: string): string[] =>
-            agents
-                .filter(
-                    (a) =>
-                        a.namespaced_agent_id &&
-                        a.required_connections?.some((rc) => rc.connector_id === cid),
-                )
-                .map((a) => a.namespaced_agent_id!),
+        (cid: string): string[] => emailAgentGrantIds(agents, cid),
         [agents],
     );
 

--- a/src/gaia/apps/webui/src/services/__tests__/api.test.ts
+++ b/src/gaia/apps/webui/src/services/__tests__/api.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { listConnectors, disconnectConnector } from '../api';
+import { listConnectors, disconnectConnector, authorizeConnector } from '../api';
 
 /**
  * Regression tests for `apiFetch`'s non-JSON handling (issue #983).
@@ -72,5 +72,43 @@ describe('apiFetch non-JSON handling', () => {
             new Response('', { status: 200 }),
         );
         await expect(disconnectConnector('google')).resolves.toBeUndefined();
+    });
+});
+
+/**
+ * #2117 — authorizeConnector forwards `grant_agents` so connecting a mailbox
+ * grants it to the email agent in the same flow.
+ */
+describe('authorizeConnector grant_agents', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    function lastBody(): Record<string, unknown> {
+        const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+        return JSON.parse((call[1] as RequestInit).body as string);
+    }
+
+    it('sends the grant_agents list in the request body', async () => {
+        (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+            jsonResponse({ flow_id: 'f1', authorization_url: 'https://auth' }),
+        );
+        await authorizeConnector('google', ['openid'], ['installed:email']);
+        expect(lastBody()).toEqual({
+            scopes: ['openid'],
+            grant_agents: ['installed:email'],
+        });
+    });
+
+    it('defaults grant_agents to an empty array when omitted', async () => {
+        (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+            jsonResponse({ flow_id: 'f1', authorization_url: 'https://auth' }),
+        );
+        await authorizeConnector('google', ['openid']);
+        expect(lastBody()).toEqual({ scopes: ['openid'], grant_agents: [] });
     });
 });

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -212,8 +212,17 @@ export async function getConnector(connectorId: string): Promise<ConnectorRow> {
 export async function authorizeConnector(
     connectorId: string,
     scopes: string[],
+    grantAgents: string[] = [],
 ): Promise<{ flow_id: string; authorization_url: string }> {
-    return apiFetch('POST', `/connectors/${connectorId}/authorize`, { scopes }, UI_HEADER);
+    // `grantAgents` (#2117) — namespaced agent ids to grant this connector the
+    // moment OAuth completes, so connecting a mailbox grants it to the email
+    // agent in the same flow. The backend resolves each agent's required scopes.
+    return apiFetch(
+        'POST',
+        `/connectors/${connectorId}/authorize`,
+        { scopes, grant_agents: grantAgents },
+        UI_HEADER,
+    );
 }
 
 export async function configureConnector(

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -37,8 +37,8 @@ import logging
 import secrets
 import uuid
 import webbrowser
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 import httpx
 from aiohttp import web
@@ -96,6 +96,10 @@ class _PendingFlow:
     redirect_uri: str
     runner: web.AppRunner
     future: "asyncio.Future[Dict[str, Any]]"
+    # Per-agent grants to commit atomically with a successful token exchange
+    # (#2117). Maps a namespaced agent id → the scopes to grant for this
+    # connector. Empty means "connect only" — the legacy behaviour.
+    grant_agents: Dict[str, list[str]] = field(default_factory=dict)
 
 
 # v1 single-flow constraint per the plan: only one flow can be pending at
@@ -136,6 +140,7 @@ def _decode_email_from_id_token(id_token: str) -> Optional[str]:
 async def start_authorization(
     provider_id: str,
     scopes: Iterable[str],
+    grant_agents: Optional[Mapping[str, Iterable[str]]] = None,
 ) -> Dict[str, Any]:
     """
     Begin the OAuth flow for ``provider_id`` with the requested scopes.
@@ -147,6 +152,15 @@ async def start_authorization(
 
     The caller is expected to await ``complete_authorization(flow_id)``
     to wait for the redirect.
+
+    ``grant_agents`` (#2117) maps a namespaced agent id → the scopes to
+    grant that agent for ``provider_id`` once the token exchange succeeds.
+    This makes the grant part of the same connect flow: connecting a
+    mailbox from the email surface hands the email agent access without a
+    separate CLI step. The grants are committed in
+    ``_exchange_code_for_tokens`` — a grant that cannot be written fails
+    the whole flow loudly rather than leaving a connected-but-ungranted
+    dead end.
     """
     if _pending:
         # User re-clicking Connect signals the previous flow is dead.
@@ -209,6 +223,10 @@ async def start_authorization(
         redirect_uri=redirect_uri,
         runner=runner,
         future=future,
+        grant_agents={
+            agent_id: list(agent_scopes)
+            for agent_id, agent_scopes in (grant_agents or {}).items()
+        },
     )
 
     # Fire-and-forget the browser launch — A8: do not block the event
@@ -229,8 +247,9 @@ async def start_authorization(
     asyncio.ensure_future(_open_browser())
 
     logger.info(
-        "flow: started scopes=%d flow_id=%s",
+        "flow: started scopes=%d grant_agents=%d flow_id=%s",
         len(scopes_list),
+        len(_pending[flow_id].grant_agents),
         flow_id,
     )
     return {"flow_id": flow_id, "authorization_url": authorization_url}
@@ -328,6 +347,53 @@ async def _handle_callback(request: web.Request, flow_id: str) -> web.Response:
     return web.Response(text=_SUCCESS_HTML, content_type="text/html")
 
 
+async def _commit_grants(flow: _PendingFlow) -> None:
+    """Write the per-agent grants requested at ``start_authorization`` time.
+
+    Called only after the connection is persisted. Each grant is written
+    through the same ledger the CLI/SDK/Settings panel use, so it is
+    immediately visible and revocable there. Emits ``connector.grant.changed``
+    per agent so subscribed UIs refresh the grants panel without a reload.
+
+    Fails loudly: a grant that cannot be written raises ``ConnectorsError``,
+    which propagates to ``_handle_callback`` and surfaces on the flow future.
+    Connecting-without-granting is the bug this flow exists to prevent, so a
+    grant failure must not be swallowed.
+    """
+    if not flow.grant_agents:
+        return
+
+    # Local import mirrors the lazy-keyring contract in connectors/__init__.py
+    # and keeps flow.py's module-load dependency graph unchanged.
+    from gaia.connectors.grants import grant_agent
+
+    for agent_id, agent_scopes in flow.grant_agents.items():
+        try:
+            grant_agent(flow.provider_id, agent_id, list(agent_scopes))
+        except Exception as e:
+            raise ConnectorsError(
+                f"Connected {flow.provider_id!r} but failed to grant it to "
+                f"agent {agent_id!r}: {e}. The connection was saved; grant the "
+                f"agent manually from Settings → Connectors, or via "
+                f"`gaia connectors grants grant {flow.provider_id} {agent_id} "
+                f"--scopes {' '.join(agent_scopes)}`."
+            ) from e
+        await emit(
+            "connector.grant.changed",
+            {
+                "connector_id": flow.provider_id,
+                "agent_id": agent_id,
+                "scopes": list(agent_scopes),
+            },
+        )
+        logger.info(
+            "flow: granted connector_id=%s agent_id=%s scopes=%d on connect",
+            flow.provider_id,
+            agent_id,
+            len(agent_scopes),
+        )
+
+
 async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, Any]:
     """Run the token-exchange step and persist the connection."""
     provider = get_provider(flow.provider_id)
@@ -367,6 +433,14 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
     # No separate state-cache write needed — the keyring blob written
     # above is the source of truth for "configured / account / scopes",
     # and the router reads it via ``store.peek_connection`` for the UI.
+
+    # #2117 — commit the per-agent grants requested at connect time, in the
+    # same flow as the connection. This is what closes the consumer-breaking
+    # dead end: a mailbox connected from the email surface now hands the
+    # email agent access without a follow-up CLI grant. Fail loudly — a
+    # connection that persisted but whose grant could not be written is the
+    # exact silent half-success the connect flow must not produce.
+    await _commit_grants(flow)
 
     # Google's token endpoint does not return a ``connected_at`` field
     # (RFC 6749 has no such concept) — record the local wall-clock at

--- a/src/gaia/connectors/oauth_pkce.py
+++ b/src/gaia/connectors/oauth_pkce.py
@@ -161,8 +161,17 @@ class OAuthPkceHandler:
         # Fail loudly here with an actionable message instead.
         _validate_provider_secret(provider_id)
 
+        # Per-agent grants to commit on OAuth success (#2117). The UI router
+        # resolves the {agent_id: scopes} map from the granted agents'
+        # REQUIRED_CONNECTORS before calling configure, so the first-run
+        # "Save & Connect" path grants the mailbox in the same flow as the
+        # plain "Connect" path.
+        grant_agents = config.get("grant_agents") or None
+
         # Start a new PKCE flow; caller will open the URL.
-        return await start_authorization(provider_id, scopes=scopes)
+        return await start_authorization(
+            provider_id, scopes=scopes, grant_agents=grant_agents
+        )
 
     async def disconnect(
         self,

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -141,6 +141,12 @@ def _require_mcp_server(connector_id: str) -> None:
 
 class AuthorizeRequest(BaseModel):
     scopes: List[str] = Field(default_factory=list)
+    # #2117 — namespaced agent ids to grant this connector once OAuth
+    # completes, so connecting a mailbox grants it to the email agent in the
+    # same flow. The router resolves each agent's required scopes from its
+    # REQUIRED_CONNECTORS declaration (single source of truth) before handing
+    # the map to the flow.
+    grant_agents: List[str] = Field(default_factory=list)
 
 
 class GrantRequest(BaseModel):
@@ -288,6 +294,52 @@ def _raise_http_for(exc: ConnectorsError) -> HTTPException:
 # ─────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────
+
+
+def _resolve_grant_scopes(
+    request: Request, connector_id: str, agent_ids: List[str]
+) -> Dict[str, List[str]]:
+    """Resolve ``[namespaced_agent_id]`` → ``{agent_id: required_scopes}`` (#2117).
+
+    Each agent's scopes come from its ``REQUIRED_CONNECTORS`` declaration for
+    ``connector_id`` — the same single source of truth the forwarded-connection
+    route uses. Fails loudly (no silent skips): an unknown agent → 404; an
+    agent that declares no requirement for this connector → 400. Both would
+    otherwise produce a connect that silently grants nothing — the exact
+    dead-end this flow removes.
+    """
+    if not agent_ids:
+        return {}
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None:
+        raise HTTPException(status_code=503, detail="Agent registry not initialized")
+
+    by_nsid = {reg.namespaced_agent_id: reg for reg in registry.list()}
+    unknown = [nsid for nsid in agent_ids if nsid not in by_nsid]
+    if unknown:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "unknown_agent", "agent_ids": unknown},
+        )
+
+    resolved: Dict[str, List[str]] = {}
+    for nsid in agent_ids:
+        reg = by_nsid[nsid]
+        scopes: set[str] = set()
+        for cr in reg.required_connections:
+            if cr.connector_id == connector_id:
+                scopes.update(cr.scopes)
+        if not scopes:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "agent_declares_no_scopes",
+                    "agent_id": nsid,
+                    "connector_id": connector_id,
+                },
+            )
+        resolved[nsid] = sorted(scopes)
+    return resolved
 
 
 def _connector_summary(connector_id: str) -> Dict[str, Any]:
@@ -619,11 +671,23 @@ async def get_connector(connector_id: str) -> Dict[str, Any]:
 
 @router.post("/{connector_id}/configure", dependencies=[Depends(_require_ui_header)])
 async def configure_connector(
-    connector_id: str, body: ConfigureRequest
+    request: Request, connector_id: str, body: ConfigureRequest
 ) -> Dict[str, Any]:
-    """Configure a connector — stores credentials and (for MCP servers) writes mcp_servers.json."""
+    """Configure a connector — stores credentials and (for MCP servers) writes mcp_servers.json.
+
+    For the first-run OAuth "Save & Connect" path, ``config.grant_agents`` (a
+    list of namespaced agent ids) is resolved to a ``{agent_id: scopes}`` map so
+    the mailbox is granted to those agents when the flow completes (#2117) — the
+    same behaviour as the plain ``authorize`` path.
+    """
+    config = dict(body.config)
+    raw_grant_agents = config.get("grant_agents")
+    if raw_grant_agents:
+        config["grant_agents"] = _resolve_grant_scopes(
+            request, connector_id, list(raw_grant_agents)
+        )
     try:
-        result = await configure(connector_id, body.config)
+        result = await configure(connector_id, config)
     except KeyError:
         raise HTTPException(
             status_code=404, detail=f"Unknown connector: {connector_id!r}"
@@ -741,10 +805,22 @@ async def disable_connector(connector_id: str) -> Dict[str, Any]:
 
 
 @router.post("/{connector_id}/authorize", dependencies=[Depends(_require_ui_header)])
-async def authorize(connector_id: str, body: AuthorizeRequest) -> Dict[str, Any]:
-    """Start an OAuth PKCE flow. Returns {flow_id, authorization_url}."""
+async def authorize(
+    request: Request, connector_id: str, body: AuthorizeRequest
+) -> Dict[str, Any]:
+    """Start an OAuth PKCE flow. Returns {flow_id, authorization_url}.
+
+    When ``grant_agents`` is present, the named agents are granted this
+    connector (with their declared REQUIRED_CONNECTORS scopes) the moment the
+    OAuth exchange succeeds — connecting a mailbox grants it to the email agent
+    in the same flow (#2117). Scope resolution happens up front so an unknown
+    or non-declaring agent fails the request before any browser step.
+    """
+    grant_map = _resolve_grant_scopes(request, connector_id, body.grant_agents)
     try:
-        return await connections.start_authorization(connector_id, scopes=body.scopes)
+        return await connections.start_authorization(
+            connector_id, scopes=body.scopes, grant_agents=grant_map or None
+        )
     except ConnectorsError as e:
         raise _raise_http_for(e) from e
 

--- a/tests/unit/connectors/test_flow.py
+++ b/tests/unit/connectors/test_flow.py
@@ -276,6 +276,85 @@ class TestBrowserOpenNonBlocking:
         await cancel_flow(results[0]["flow_id"])
 
 
+class TestGrantOnConnect:
+    """#2117 — grants requested at ``start_authorization`` time are committed
+    to the ledger the moment the token exchange succeeds, so connecting a
+    mailbox grants it to the email agent in the same flow (no CLI step)."""
+
+    _EMAIL_SCOPES = [
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+    ]
+
+    @respx.mock
+    async def test_grant_committed_on_success(self, google_provider):
+        from gaia.connectors.grants import list_agent_grants
+
+        _mock_token_endpoint()
+        info = await start_authorization(
+            "google",
+            scopes=self._EMAIL_SCOPES,
+            grant_agents={"installed:email": self._EMAIL_SCOPES},
+        )
+        params = parse_qs(urlparse(info["authorization_url"]).query)
+        redirect_uri = params["redirect_uri"][0]
+        state = params["state"][0]
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.get(f"{redirect_uri}?code=ok&state={state}")
+        assert resp.status_code == 200
+        await asyncio.wait_for(complete_authorization(info["flow_id"]), timeout=2.0)
+
+        grants = list_agent_grants("google")
+        assert grants.get("installed:email") == self._EMAIL_SCOPES
+
+    @respx.mock
+    async def test_no_grant_agents_leaves_ledger_empty(self, google_provider):
+        from gaia.connectors.grants import list_agent_grants
+
+        _mock_token_endpoint()
+        info = await start_authorization("google", scopes=["openid"])
+        params = parse_qs(urlparse(info["authorization_url"]).query)
+        redirect_uri = params["redirect_uri"][0]
+        state = params["state"][0]
+
+        async with httpx.AsyncClient() as c:
+            await c.get(f"{redirect_uri}?code=ok&state={state}")
+        await asyncio.wait_for(complete_authorization(info["flow_id"]), timeout=2.0)
+
+        assert list_agent_grants("google") == {}
+
+    @respx.mock
+    async def test_grant_failure_fails_flow_loudly(self, google_provider, monkeypatch):
+        """A grant that cannot be written must fail the whole flow — connecting
+        without granting is the exact silent half-success this flow prevents."""
+        from gaia.connectors.errors import ConnectorsError
+
+        _mock_token_endpoint()
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("gaia.connectors.grants.grant_agent", _boom)
+
+        info = await start_authorization(
+            "google",
+            scopes=self._EMAIL_SCOPES,
+            grant_agents={"installed:email": self._EMAIL_SCOPES},
+        )
+        params = parse_qs(urlparse(info["authorization_url"]).query)
+        redirect_uri = params["redirect_uri"][0]
+        state = params["state"][0]
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.get(f"{redirect_uri}?code=ok&state={state}")
+        # The callback surfaces the failure page, not the success page.
+        assert resp.status_code == 502
+
+        with pytest.raises(ConnectorsError, match="failed to grant"):
+            await asyncio.wait_for(complete_authorization(info["flow_id"]), timeout=2.0)
+
+
 class TestDecodeEmailFromIdToken:
     """Unit tests for _decode_email_from_id_token — the multi-provider claim
     fallback added in the provider-aware forward-connection fix."""

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -293,6 +293,132 @@ class TestConfigureEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# POST /api/connectors/{connector_id}/authorize — grant-on-connect (#2117)
+# ---------------------------------------------------------------------------
+
+
+def _fake_registry(nsid: str, connector_id: str, scopes: list[str]):
+    """Minimal AgentRegistry stand-in for the router's scope resolution."""
+    from dataclasses import dataclass, field
+    from typing import List
+
+    from gaia.connectors.providers.base import ConnectorRequirement
+
+    @dataclass
+    class FakeReg:
+        namespaced_agent_id: str
+        required_connections: List[ConnectorRequirement] = field(default_factory=list)
+
+    @dataclass
+    class FakeRegistry:
+        _regs: List[FakeReg]
+
+        def list(self):
+            return self._regs
+
+    cr = ConnectorRequirement(connector_id=connector_id, scopes=scopes)
+    return FakeRegistry(_regs=[FakeReg(namespaced_agent_id=nsid, required_connections=[cr])])
+
+
+class TestAuthorizeGrantAgents:
+    _SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+
+    def test_authorize_resolves_and_passes_grant_agents(
+        self, ui_api_client, monkeypatch
+    ):
+        mock_start = AsyncMock(
+            return_value={"flow_id": "f1", "authorization_url": "https://auth"}
+        )
+        monkeypatch.setattr("gaia.connectors.start_authorization", mock_start)
+        ui_api_client.app.state.agent_registry = _fake_registry(
+            "installed:email", "google", self._SCOPES
+        )
+
+        resp = ui_api_client.post(
+            "/api/connectors/google/authorize",
+            json={"scopes": ["openid"], "grant_agents": ["installed:email"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200, resp.text
+        # The resolved {agent_id: scopes} map is threaded into the flow.
+        _, kwargs = mock_start.call_args
+        assert kwargs["grant_agents"] == {"installed:email": self._SCOPES}
+
+    def test_authorize_without_grant_agents_passes_none(
+        self, ui_api_client, monkeypatch
+    ):
+        mock_start = AsyncMock(
+            return_value={"flow_id": "f1", "authorization_url": "https://auth"}
+        )
+        monkeypatch.setattr("gaia.connectors.start_authorization", mock_start)
+
+        resp = ui_api_client.post(
+            "/api/connectors/google/authorize",
+            json={"scopes": ["openid"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_start.call_args
+        assert kwargs["grant_agents"] is None
+
+    def test_authorize_unknown_agent_is_404(self, ui_api_client, monkeypatch):
+        monkeypatch.setattr("gaia.connectors.start_authorization", AsyncMock())
+        ui_api_client.app.state.agent_registry = _fake_registry(
+            "installed:email", "google", self._SCOPES
+        )
+        resp = ui_api_client.post(
+            "/api/connectors/google/authorize",
+            json={"scopes": ["openid"], "grant_agents": ["installed:ghost"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 404
+
+    def test_authorize_agent_declares_no_scopes_is_400(
+        self, ui_api_client, monkeypatch
+    ):
+        monkeypatch.setattr("gaia.connectors.start_authorization", AsyncMock())
+        # The agent declares microsoft, not google — no scopes for this connector.
+        ui_api_client.app.state.agent_registry = _fake_registry(
+            "installed:email", "microsoft", self._SCOPES
+        )
+        resp = ui_api_client.post(
+            "/api/connectors/google/authorize",
+            json={"scopes": ["openid"], "grant_agents": ["installed:email"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 400
+
+    def test_configure_resolves_grant_agents_into_config(
+        self, ui_api_client, monkeypatch
+    ):
+        captured = {}
+
+        async def fake_configure(connector_id, config):
+            captured["config"] = config
+            return {"configured": True, "flow_id": "f1"}
+
+        monkeypatch.setattr(
+            "gaia.ui.routers.connectors.configure", fake_configure
+        )
+        ui_api_client.app.state.agent_registry = _fake_registry(
+            "installed:email", "google", self._SCOPES
+        )
+        resp = ui_api_client.post(
+            "/api/connectors/google/configure",
+            json={
+                "config": {
+                    "scopes": ["openid"],
+                    "grant_agents": ["installed:email"],
+                }
+            },
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200, resp.text
+        # The list of ids is resolved to the {id: scopes} map the flow expects.
+        assert captured["config"]["grant_agents"] == {"installed:email": self._SCOPES}
+
+
+# ---------------------------------------------------------------------------
 # POST /api/connectors/{connector_id}/test
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -317,7 +317,9 @@ def _fake_registry(nsid: str, connector_id: str, scopes: list[str]):
             return self._regs
 
     cr = ConnectorRequirement(connector_id=connector_id, scopes=scopes)
-    return FakeRegistry(_regs=[FakeReg(namespaced_agent_id=nsid, required_connections=[cr])])
+    return FakeRegistry(
+        _regs=[FakeReg(namespaced_agent_id=nsid, required_connections=[cr])]
+    )
 
 
 class TestAuthorizeGrantAgents:
@@ -397,9 +399,7 @@ class TestAuthorizeGrantAgents:
             captured["config"] = config
             return {"configured": True, "flow_id": "f1"}
 
-        monkeypatch.setattr(
-            "gaia.ui.routers.connectors.configure", fake_configure
-        )
+        monkeypatch.setattr("gaia.ui.routers.connectors.configure", fake_configure)
         ui_api_client.app.state.agent_registry = _fake_registry(
             "installed:email", "google", self._SCOPES
         )


### PR DESCRIPTION
## Why this matters

Before: completing OAuth for a mailbox in Settings → Connectors created the connection but granted it to **no agent**, so the very first email triage dead-ended on `Agent 'installed:email' has no grant for google`. The only recovery was a CLI command (`gaia connectors grants grant …`) that consumers never discover — every user hit this wall right after the consent screen.

After: connecting a mailbox grants it to the email agent in the **same flow**. The Settings connect panel shows a default-on checkbox of every agent that declares the connector; the email chat's inline connect CTA grants the email agent because it knows it's email. The grant is committed the moment the OAuth exchange succeeds and stays visible/revocable under Per-agent grants. Fresh connect → triage works with zero CLI.

The grant model stays the single source of truth — grants are written through the existing ledger, not bypassed. If a grant can't be written, the whole flow fails loudly with an actionable message rather than leaving a connected-but-ungranted dead end (the exact silent half-success this closes).

## How it works

`start_authorization` now accepts a `{agent_id: scopes}` map and commits those grants right after the token exchange persists the connection. The UI router resolves each agent's scopes from its `REQUIRED_CONNECTORS` declaration (same source the forwarded-connection route uses) before handing the map to the flow — an unknown agent 404s, an agent that declares no scopes for the connector 400s, so nothing silently grants nothing.

## Test plan

- [x] `python -m pytest tests/unit/connectors/` → 548 passed, 10 skipped
- [x] New backend tests: grant committed on OAuth success, no-grant-agents leaves ledger empty, **grant failure fails the flow loudly** (`tests/unit/connectors/test_flow.py::TestGrantOnConnect`)
- [x] New router tests: authorize/configure resolve `grant_agents` → scope map; unknown agent → 404; agent-declares-no-scopes → 400 (`test_router_connectors.py::TestAuthorizeGrantAgents`)
- [x] webui Vitest → 184 passed (incl. new `authorizeConnector grant_agents` cases)
- [x] `npm run build` (tsc + vite) clean
- [x] `python util/lint.py` — Black + isort clean (Pylint/Flake8/mypy skipped: no network for `uvx`; Flake8 run locally on changed files → clean)
- [x] Manual walkthrough against a live UI server (screenshot attached in review) — Settings → Connectors → Google renders:

  > **Grant access to these agents when you connect:**
  > ☑ Connectors Demo
  > ☑ Email Triage
  > _You can change these any time under Per-agent grants below._

  Both boxes default-on; the CONNECT button carries the checked agents into the flow.

Part of #2014
Closes #2117
