### PR TITLE
feat(electron): in-app install, R2 auto-update feed, gaia:// deep links

### DIFF
--- a/src/gaia/apps/webui/electron-builder.yml
+++ b/src/gaia/apps/webui/electron-builder.yml
@@ -81,13 +81,23 @@ asarUnpack: []
 # Replaces the postPackage hook from forge.config.cjs.
 afterPack: ../../../../installer/scripts/after-pack.cjs
 
-# Auto-update provider — Phase F wires up the actual electron-updater logic;
-# for now this just declares where electron-updater should look.
+# Auto-update provider — R2-primary generic feed (#1724).
+#
+# The forward-update channel is a generic provider pointing at the R2 channel
+# base URL, with a mutable `latest*.yml` pointer (channel: latest) that the Hub
+# Worker re-points each release while versioned artifacts stay immutable
+# (A6/A7). The base URL is build-time configurable via GAIA_UPDATE_FEED_URL so
+# the R2 bucket/CDN host isn't hard-coded here.
+#
+# NOTE (#1719): the R2 publish feed + Worker channel pointer are milestone-52
+# work and not live yet. At RUNTIME, services/auto-updater.cjs re-resolves the
+# feed (env/config) and calls setFeedURL itself — so this baked value is a
+# fallback only, and an unconfigured app enters a loud "no channel" state
+# rather than checking a dead feed.
 publish:
-  provider: github
-  owner: amd
-  repo: gaia
-  vPrefixedTagName: true
+  provider: generic
+  url: ${env.GAIA_UPDATE_FEED_URL}
+  channel: latest
 
 # Code signing — env-driven, off by default for unsigned local builds.
 # Phase H integrates SignPath for Windows and Apple Developer ID for macOS.

--- a/src/gaia/apps/webui/electron-builder.yml
+++ b/src/gaia/apps/webui/electron-builder.yml
@@ -84,19 +84,23 @@ afterPack: ../../../../installer/scripts/after-pack.cjs
 # Auto-update provider — R2-primary generic feed (#1724).
 #
 # The forward-update channel is a generic provider pointing at the R2 channel
-# base URL, with a mutable `latest*.yml` pointer (channel: latest) that the Hub
-# Worker re-points each release while versioned artifacts stay immutable
-# (A6/A7). The base URL is build-time configurable via GAIA_UPDATE_FEED_URL so
-# the R2 bucket/CDN host isn't hard-coded here.
+# base URL (fronted by the hub.amd-gaia.ai Worker), with a mutable `latest*.yml`
+# pointer (channel: latest) that the Worker re-points each release while
+# versioned artifacts stay immutable (A6/A7).
 #
-# NOTE (#1719): the R2 publish feed + Worker channel pointer are milestone-52
-# work and not live yet. At RUNTIME, services/auto-updater.cjs re-resolves the
-# feed (env/config) and calls setFeedURL itself — so this baked value is a
-# fallback only, and an unconfigured app enters a loud "no channel" state
-# rather than checking a dead feed.
+# This baked `url` is INERT at runtime: services/auto-updater.cjs always
+# re-resolves the feed (GAIA_UPDATE_FEED_URL env → feedUrl in
+# ~/.gaia/update-config.json) and calls setFeedURL itself; with nothing
+# configured it enters a loud "no channel" state instead of checking this feed.
+# The value exists only because electron-builder requires a non-empty,
+# expandable `url` to emit app-update.yml at build time.
+#
+# NOTE (#1719): the R2 publish feed + Worker `latest*.yml` channel pointer are
+# milestone-52 work and not live yet; the exact channel path under
+# hub.amd-gaia.ai is finalized there.
 publish:
   provider: generic
-  url: ${env.GAIA_UPDATE_FEED_URL}
+  url: https://hub.amd-gaia.ai/updates
   channel: latest
 
 # Code signing — env-driven, off by default for unsigned local builds.

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -63,6 +63,7 @@ const backendInstaller = require("./services/backend-installer.cjs");
 const installerProgressDialog = require("./services/backend-installer-progress-dialog.cjs");
 const autoUpdater = require("./services/auto-updater.cjs");
 const agentSeeder = require("./services/agent-seeder.cjs");
+const { parseDeepLink, extractDeepLinkFromArgv } = require("./services/deep-link.cjs");
 
 // ── F7: Ozone hint (issue #782) ─────────────────────────────────────────────
 // Electron-recommended switch for distro-agnostic Linux behaviour: picks
@@ -586,7 +587,12 @@ function initializeServices() {
   console.log("[main] Initializing services...");
 
   // T2: Agent Process Manager (manages OS agent subprocesses)
-  agentProcessManager = new AgentProcessManager(mainWindow);
+  // getBackendPort lets its install/uninstall handlers proxy to the live
+  // Python backend's install runtime (issue #1721) on whatever random port
+  // port-manager picked this session.
+  agentProcessManager = new AgentProcessManager(mainWindow, {
+    getBackendPort: () => backendPort,
+  });
 
   // T1: Tray Manager (system tray icon + context menu)
   trayManager = new TrayManager(mainWindow, { backendPort });
@@ -723,6 +729,132 @@ async function bootstrapBackend() {
   return false;
 }
 
+// ── gaia:// deep-link install bridge (issue #1725) ──────────────────────────
+//
+// The website's "Open in GAIA" button opens a `gaia://hub/install/<id>` URL.
+// The OS routes it to this app (registered as the gaia:// protocol client);
+// we parse it and hand the agent id to the install runtime (issue #1721).
+//
+// Sources of the URL differ per OS:
+//   • macOS      — the `open-url` app event (registered before whenReady).
+//   • Win/Linux  — a command-line argument, either at cold start (process.argv)
+//                  or on a second launch (the `second-instance` event argv).
+// A malformed/unsupported link surfaces a loud error dialog — never a silent
+// no-op (deep-link.cjs throws with an actionable message).
+
+/** Holds a deep link that arrived before services were ready. */
+let pendingDeepLinkUrl = null;
+
+/**
+ * Register this app as the handler for the gaia:// scheme. In dev (`electron .`)
+ * the launcher is Electron itself, so the app path must be threaded through
+ * explicitly; packaged builds register their own executable.
+ */
+function registerProtocolHandler() {
+  try {
+    let registered;
+    if (process.defaultApp && process.argv.length >= 2) {
+      // Dev: `electron . <args>` — point the scheme at this script.
+      registered = app.setAsDefaultProtocolClient("gaia", process.execPath, [
+        path.resolve(process.argv[1]),
+      ]);
+    } else {
+      registered = app.setAsDefaultProtocolClient("gaia");
+    }
+    if (registered) {
+      console.log("[main] Registered as gaia:// protocol client");
+    } else {
+      console.warn(
+        "[main] Could not register gaia:// protocol client — deep-link installs may not route to this app"
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[main] setAsDefaultProtocolClient failed: ${err && err.message ? err.message : err}`
+    );
+  }
+}
+
+/**
+ * Entry point for any inbound deep link. Queues the URL if services aren't up
+ * yet, otherwise dispatches immediately. Parse failures are surfaced loudly.
+ */
+function handleDeepLink(rawUrl) {
+  let command;
+  try {
+    command = parseDeepLink(rawUrl);
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    console.error(`[main] Rejected deep link: ${message}`);
+    try {
+      dialog.showErrorBox("Invalid GAIA link", message);
+    } catch {
+      /* dialog may be unavailable pre-ready — the log line above still fires */
+    }
+    return;
+  }
+
+  // If services aren't wired yet (cold start still bootstrapping), stash it.
+  if (!agentProcessManager) {
+    console.log("[main] Deep link received before services ready — queuing");
+    pendingDeepLinkUrl = rawUrl;
+    return;
+  }
+
+  void dispatchDeepLink(command);
+}
+
+/** Act on a parsed deep-link command. */
+async function dispatchDeepLink(command) {
+  // Surface the window so the user sees install progress.
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    if (!mainWindow.isVisible()) mainWindow.show();
+    mainWindow.focus();
+  }
+
+  if (command.action === "install") {
+    console.log(`[main] Deep-link install request: ${command.agentId}`);
+    try {
+      await agentProcessManager.installAgent(command.agentId);
+    } catch (err) {
+      const message = err && err.message ? err.message : String(err);
+      console.error(
+        `[main] Deep-link install of "${command.agentId}" failed: ${message}`
+      );
+      try {
+        dialog.showErrorBox(
+          `Could not install "${command.agentId}"`,
+          message
+        );
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+}
+
+/** Drain a queued deep link, plus any gaia:// URL present in the cold-start argv. */
+function processStartupDeepLinks() {
+  if (pendingDeepLinkUrl) {
+    const url = pendingDeepLinkUrl;
+    pendingDeepLinkUrl = null;
+    handleDeepLink(url);
+    return;
+  }
+  const fromArgv = extractDeepLinkFromArgv(process.argv);
+  if (fromArgv) handleDeepLink(fromArgv);
+}
+
+// macOS delivers deep links via this event; it can fire before whenReady, so
+// register it at module load and let handleDeepLink queue as needed.
+app.on("open-url", (event, url) => {
+  event.preventDefault();
+  handleDeepLink(url);
+});
+
+registerProtocolHandler();
+
 // ── App Lifecycle ──────────────────────────────────────────────────────────
 
 // Note: electron-squirrel-startup was removed in Phase C of the
@@ -760,7 +892,7 @@ if (!gotTheSingleInstanceLock) {
   process.exit(0);
 }
 
-app.on("second-instance", (_event, _argv, _cwd) => {
+app.on("second-instance", (_event, argv, _cwd) => {
   // A second launch happened while we were running. Surface our window
   // (the user almost certainly wanted to see it). mainWindow may be null
   // if we're still in the bootstrap phase — in that case the first
@@ -771,6 +903,11 @@ app.on("second-instance", (_event, _argv, _cwd) => {
     if (!mainWindow.isVisible()) mainWindow.show();
     mainWindow.focus();
   }
+
+  // Win/Linux: a `gaia://…` deep link from the second launch arrives as an argv
+  // entry. Route it into the already-running first instance (issue #1725).
+  const deepLink = extractDeepLinkFromArgv(argv);
+  if (deepLink) handleDeepLink(deepLink);
 });
 
 app.whenReady().then(async () => {
@@ -836,6 +973,10 @@ app.whenReady().then(async () => {
 
   // Setup Windows Jump List (T11)
   setupJumpList();
+
+  // Act on any gaia:// deep link that arrived during bootstrap or via the
+  // cold-start command line (issue #1725). Services are now wired.
+  processStartupDeepLinks();
 
   // Show loading state
   await loadApp();

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -63,7 +63,11 @@ const backendInstaller = require("./services/backend-installer.cjs");
 const installerProgressDialog = require("./services/backend-installer-progress-dialog.cjs");
 const autoUpdater = require("./services/auto-updater.cjs");
 const agentSeeder = require("./services/agent-seeder.cjs");
-const { parseDeepLink, extractDeepLinkFromArgv } = require("./services/deep-link.cjs");
+const {
+  parseDeepLink,
+  extractDeepLinkFromArgv,
+  dispatchDeepLink,
+} = require("./services/deep-link.cjs");
 
 // ── F7: Ozone hint (issue #782) ─────────────────────────────────────────────
 // Electron-recommended switch for distro-agnostic Linux behaviour: picks
@@ -801,35 +805,60 @@ function handleDeepLink(rawUrl) {
     return;
   }
 
-  void dispatchDeepLink(command);
+  void runDeepLink(command);
 }
 
-/** Act on a parsed deep-link command. */
-async function dispatchDeepLink(command) {
-  // Surface the window so the user sees install progress.
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    if (!mainWindow.isVisible()) mainWindow.show();
-    mainWindow.focus();
-  }
+/**
+ * Explicit per-agent confirmation for a web-triggered install. This is the
+ * security gate: the user must confirm the SPECIFIC agent before any download
+ * happens (issue #2196 review). Defaults to the safe (Cancel) option.
+ * @returns {Promise<boolean>}
+ */
+async function confirmDeepLinkInstall(command) {
+  const choice = await dialog.showMessageBox(
+    mainWindow && !mainWindow.isDestroyed() ? mainWindow : null,
+    {
+      type: "question",
+      buttons: ["Install", "Cancel"],
+      defaultId: 1, // Enter selects the safe option
+      cancelId: 1,
+      title: "Install agent from the web?",
+      message: `Install the "${command.agentId}" agent?`,
+      detail:
+        `A website asked GAIA to install "${command.agentId}". ` +
+        "Only continue if you trust this source — installing downloads and " +
+        "runs third-party code on your machine.",
+      noLink: true,
+    }
+  );
+  return !!choice && choice.response === 0;
+}
 
-  if (command.action === "install") {
-    console.log(`[main] Deep-link install request: ${command.agentId}`);
+/** Wire the injected deep-link dispatcher to this process's runtime effects. */
+async function runDeepLink(command) {
+  console.log(`[main] Deep-link install request: ${command.agentId}`);
+  try {
+    await dispatchDeepLink(command, {
+      confirm: confirmDeepLinkInstall,
+      installAgent: (agentId) => agentProcessManager.installAgent(agentId),
+      focusWindow: () => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          if (mainWindow.isMinimized()) mainWindow.restore();
+          if (!mainWindow.isVisible()) mainWindow.show();
+          mainWindow.focus();
+        }
+      },
+      logger: { log: console.log.bind(console), error: console.error.bind(console) },
+    });
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    console.error(
+      `[main] Deep-link install of "${command.agentId}" failed: ${message}`
+    );
     try {
-      await agentProcessManager.installAgent(command.agentId);
-    } catch (err) {
-      const message = err && err.message ? err.message : String(err);
-      console.error(
-        `[main] Deep-link install of "${command.agentId}" failed: ${message}`
-      );
-      try {
-        dialog.showErrorBox(
-          `Could not install "${command.agentId}"`,
-          message
-        );
-      } catch {
-        /* best-effort */
-      }
+      dialog.showErrorBox(`Could not install "${command.agentId}"`, message);
+    } catch {
+      /* best-effort */
     }
   }
 }

--- a/src/gaia/apps/webui/preload.cjs
+++ b/src/gaia/apps/webui/preload.cjs
@@ -35,7 +35,9 @@ contextBridge.exposeInMainWorld("gaiaAPI", {
     sendRpc: (id, method, params) =>
       ipcRenderer.invoke("agent:send-rpc", id, method, params),
     getManifest: () => ipcRenderer.invoke("agent:get-manifest"),
-    install: (id) => ipcRenderer.invoke("agent:install", id),
+    // install(id, opts?) — opts: { trustNative?, version? }. Proxies to the
+    // backend install runtime; progress arrives via onInstallProgress (#1721).
+    install: (id, opts) => ipcRenderer.invoke("agent:install", id, opts),
     uninstall: (id) => ipcRenderer.invoke("agent:uninstall", id),
 
     // Event streams (return unsubscribe functions)
@@ -43,6 +45,7 @@ contextBridge.exposeInMainWorld("gaiaAPI", {
     onStderr: (cb) => onEvent("agent:stderr", cb),
     onStatusChange: (cb) => onEvent("agent:status-change", cb),
     onCrashed: (cb) => onEvent("agent:crashed", cb),
+    onInstallProgress: (cb) => onEvent("agent:install-progress", cb),
   },
 
   // ── Tray configuration (T1) ───────────────────────────────────────────

--- a/src/gaia/apps/webui/services/agent-process-manager.cjs
+++ b/src/gaia/apps/webui/services/agent-process-manager.cjs
@@ -59,17 +59,41 @@ const STDERR_BUFFER_MAX = 10000;
 /** Max bytes kept in stdout buffer per agent (protects against malformed output without newlines) */
 const STDOUT_BUFFER_MAX = 1024 * 1024; // 1 MB
 
+/** Poll interval while waiting on the backend install-status endpoint (ms) */
+const INSTALL_POLL_INTERVAL = 750;
+
+/**
+ * Hard ceiling on a single install poll loop (ms). A `uv pip install` of a
+ * large wheel over a slow link can legitimately take minutes; we cap at 15 to
+ * turn a wedged backend into a loud timeout instead of an infinite spinner.
+ */
+const INSTALL_TIMEOUT = 15 * 60 * 1000;
+
+/** Header the UI backend requires on state-changing hub routes (see hub.py). */
+const UI_HEADER = { "X-Gaia-UI": "1" };
+
 // ── AgentProcessManager ──────────────────────────────────────────────────
 
 class AgentProcessManager extends EventEmitter {
   /**
    * @param {Electron.BrowserWindow} mainWindow — for sending IPC events to renderer
+   * @param {{ getBackendPort?: () => (number | null) }} [options]
+   *   getBackendPort resolves the live Python-backend port. The install/uninstall
+   *   handlers proxy to that backend's `/api/agents/*` routes (the real install
+   *   runtime), so without a resolver those handlers fail loudly rather than
+   *   duplicating download/verify/uv logic in the main process (issue #1721).
    */
-  constructor(mainWindow) {
+  constructor(mainWindow, options = {}) {
     super();
 
     /** @type {Electron.BrowserWindow} */
     this.mainWindow = mainWindow;
+
+    /** @type {(() => (number | null)) | null} */
+    this._getBackendPort =
+      typeof options.getBackendPort === "function"
+        ? options.getBackendPort
+        : null;
 
     /**
      * Running processes keyed by agentId.
@@ -249,6 +273,219 @@ class AgentProcessManager extends EventEmitter {
   async restartAgent(agentId) {
     await this.stopAgent(agentId);
     return this.startAgent(agentId);
+  }
+
+  // ── Public API: Install / Uninstall (issue #1721) ────────────────────
+  //
+  // The install RUNTIME lives in the Python backend (src/gaia/hub/installer.py,
+  // exposed by src/gaia/ui/routers/hub.py): R2 download, SHA-256 verify,
+  // `uv pip install` into ~/.gaia/agents/<id>/, hot-register, backup/rollback,
+  // and the native-trust gate. Rather than reimplement that in the main
+  // process, these handlers proxy to those routes so there is exactly one
+  // tested install path. Progress streams to the renderer over the existing
+  // `agent:install-progress` channel.
+
+  /**
+   * Resolve the live backend base URL, or throw an actionable error.
+   * @returns {string}
+   */
+  _backendBaseUrl() {
+    const port = this._getBackendPort ? this._getBackendPort() : null;
+    if (!port) {
+      throw new Error(
+        "GAIA backend is not running — cannot install or uninstall agents. " +
+          "The Python backend exposes the install runtime at /api/agents/install; " +
+          "wait for it to finish starting, or restart GAIA if this persists."
+      );
+    }
+    // 127.0.0.1 (not localhost) matches the backend's _require_localhost allowlist
+    // and avoids a DNS/IPv6 hop on Windows.
+    return `http://127.0.0.1:${port}`;
+  }
+
+  /**
+   * Install a published agent via the backend runtime, streaming progress.
+   *
+   * @param {string} agentId
+   * @param {{ trustNative?: boolean, version?: string | null }} [opts]
+   * @returns {Promise<{ id: string, status: string, version: string | null }>}
+   */
+  async installAgent(agentId, opts = {}) {
+    if (typeof agentId !== "string" || !agentId.trim()) {
+      throw new Error("installAgent requires a non-empty agent id");
+    }
+    const base = this._backendBaseUrl();
+    const trustNative = opts.trustNative === true;
+    const version =
+      typeof opts.version === "string" && opts.version ? opts.version : null;
+
+    this._emitInstallProgress(agentId, {
+      status: "queued",
+      phase: "queued",
+      percent: 0,
+    });
+
+    // ── Kick off the background install (202) ──
+    let resp;
+    try {
+      resp = await fetch(`${base}/api/agents/install`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...UI_HEADER },
+        body: JSON.stringify({ id: agentId, trust_native: trustNative, version }),
+      });
+    } catch (err) {
+      throw new Error(
+        `Could not reach the GAIA backend to install "${agentId}": ${err.message}`
+      );
+    }
+
+    if (!resp.ok) {
+      const detail = await this._readErrorDetail(resp);
+      if (resp.status === 409) {
+        throw new Error(`An install for "${agentId}" is already in progress.`);
+      }
+      if (resp.status === 403) {
+        // Native agents require explicit trust — surface the backend's reason.
+        throw new Error(
+          `Install of "${agentId}" was refused: ${detail} ` +
+            `(pass trustNative once the user accepts the trust prompt).`
+        );
+      }
+      throw new Error(
+        `Install request for "${agentId}" failed (HTTP ${resp.status}): ${detail}`
+      );
+    }
+
+    // ── Poll install-status until terminal ──
+    const deadline = Date.now() + INSTALL_TIMEOUT;
+    let lastState = null;
+    while (Date.now() < deadline) {
+      await this._sleep(INSTALL_POLL_INTERVAL);
+
+      let statusResp;
+      try {
+        statusResp = await fetch(
+          `${base}/api/agents/${encodeURIComponent(agentId)}/install-status`,
+          { headers: { ...UI_HEADER } }
+        );
+      } catch (err) {
+        throw new Error(
+          `Lost contact with the GAIA backend while installing "${agentId}": ${err.message}`
+        );
+      }
+
+      // A brief 404 window is possible between the 202 and the worker seeding
+      // progress; keep polling until the deadline rather than failing early.
+      if (statusResp.status === 404) continue;
+      if (!statusResp.ok) {
+        const detail = await this._readErrorDetail(statusResp);
+        throw new Error(
+          `Install-status poll for "${agentId}" failed (HTTP ${statusResp.status}): ${detail}`
+        );
+      }
+
+      lastState = await statusResp.json();
+      this._emitInstallProgress(agentId, {
+        status: lastState.status,
+        phase: lastState.phase,
+        percent: lastState.percent,
+        version: lastState.version,
+        error: lastState.error,
+      });
+
+      if (lastState.status === "completed") {
+        // Hot-register already happened backend-side; refresh our manifest so
+        // getAgentStatus / startAgent see the new binary paths.
+        this.reloadManifest();
+        return {
+          id: agentId,
+          status: "completed",
+          version: lastState.version || null,
+        };
+      }
+      if (lastState.status === "failed") {
+        throw new Error(
+          `Install of "${agentId}" failed: ${lastState.error || "unknown error"}`
+        );
+      }
+    }
+
+    throw new Error(
+      `Install of "${agentId}" timed out after ${Math.round(
+        INSTALL_TIMEOUT / 1000
+      )}s (last phase: ${lastState ? lastState.phase : "unknown"}).`
+    );
+  }
+
+  /**
+   * Uninstall a hub-installed agent: stop any running sidecar, then delegate
+   * removal + de-registration to the backend runtime.
+   *
+   * @param {string} agentId
+   * @returns {Promise<{ id: string, status: string }>}
+   */
+  async uninstallAgent(agentId) {
+    if (typeof agentId !== "string" || !agentId.trim()) {
+      throw new Error("uninstallAgent requires a non-empty agent id");
+    }
+    const base = this._backendBaseUrl();
+
+    // Stop a running sidecar first so its dir/executable isn't held open.
+    if (this.processes[agentId]) {
+      await this.stopAgent(agentId);
+    }
+
+    let resp;
+    try {
+      resp = await fetch(`${base}/api/agents/${encodeURIComponent(agentId)}`, {
+        method: "DELETE",
+        headers: { ...UI_HEADER },
+      });
+    } catch (err) {
+      throw new Error(
+        `Could not reach the GAIA backend to uninstall "${agentId}": ${err.message}`
+      );
+    }
+
+    if (!resp.ok) {
+      const detail = await this._readErrorDetail(resp);
+      if (resp.status === 404) {
+        throw new Error(`"${agentId}" is not installed.`);
+      }
+      if (resp.status === 400) {
+        // e.g. refusing to remove a builtin — surface the backend's reason.
+        throw new Error(`Cannot uninstall "${agentId}": ${detail}`);
+      }
+      throw new Error(
+        `Uninstall of "${agentId}" failed (HTTP ${resp.status}): ${detail}`
+      );
+    }
+
+    this.reloadManifest();
+    return { id: agentId, status: "uninstalled" };
+  }
+
+  /** Read a FastAPI-style `{detail}` error body without throwing. */
+  async _readErrorDetail(resp) {
+    try {
+      const body = await resp.json();
+      if (body && typeof body.detail === "string") return body.detail;
+      return JSON.stringify(body);
+    } catch {
+      return resp.statusText || `HTTP ${resp.status}`;
+    }
+  }
+
+  _emitInstallProgress(agentId, progress) {
+    this._sendToRenderer("agent:install-progress", {
+      agentId,
+      ...progress,
+      timestamp: Date.now(),
+    });
+  }
+
+  _sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   // ── Public API: Monitoring ───────────────────────────────────────────
@@ -803,14 +1040,12 @@ class AgentProcessManager extends EventEmitter {
       return this.getManifest();
     });
 
-    ipcMain.handle("agent:install", async (_event, agentId) => {
-      // TODO: T7 — agent installer integration
-      throw new Error("Agent installation not yet implemented");
+    ipcMain.handle("agent:install", async (_event, agentId, opts) => {
+      return this.installAgent(agentId, opts || {});
     });
 
     ipcMain.handle("agent:uninstall", async (_event, agentId) => {
-      // TODO: T7 — agent uninstaller integration
-      throw new Error("Agent uninstallation not yet implemented");
+      return this.uninstallAgent(agentId);
     });
   }
 }

--- a/src/gaia/apps/webui/services/auto-updater.cjs
+++ b/src/gaia/apps/webui/services/auto-updater.cjs
@@ -4,9 +4,19 @@
 /**
  * auto-updater.cjs — GAIA Agent UI auto-update service.
  *
- * Wraps `electron-updater` for the GitHub Releases auto-update flow.
+ * Wraps `electron-updater` against a CONFIGURABLE generic feed (R2-primary —
+ * issue #1724). The forward-update channel URL is resolved at runtime from
+ * `GAIA_UPDATE_FEED_URL` or `feedUrl` in ~/.gaia/update-config.json, and the
+ * app fetches the mutable `latest*.yml` channel pointer from it. When no feed
+ * is configured the updater enters a loud `no-channel` state (no silent
+ * no-op). The actual R2 publish feed + mutable channel pointer is milestone-52
+ * work (#1719); until it lands, point the env var at any generic feed (a local
+ * mock works) to exercise the path.
+ *
  * Implements §4 Layer 3 + §7 Phase F of docs/plans/desktop-installer.mdx.
- * Issue #1336: adds in-app rollback to a specific previous release.
+ * Issue #1336: in-app rollback to a specific previous release still lists and
+ * installs from GitHub Releases (that path is independent of the forward feed
+ * and migrates to R2 with #1719).
  *
  * Behavior:
  *   - First check 10 seconds after `init()` is called (typically from
@@ -51,6 +61,12 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // Subsequent checks every 4h
 const LOG_PATH = path.join(os.homedir(), ".gaia", "electron-updater.log");
 const UPDATE_CONFIG_PATH = path.join(os.homedir(), ".gaia", "update-config.json");
 
+// Mutable channel pointer name. electron-updater's generic provider fetches
+// `${feedUrl}/${DEFAULT_CHANNEL}.yml` (+ per-platform variants). The Hub Worker
+// re-points this file each release while versioned artifacts stay immutable —
+// that split is the A6/A7 resolution (#1724).
+const DEFAULT_CHANNEL = "latest";
+
 // per_page=100 is the GitHub API max for a single page; we fetch broadly so
 // draft/prerelease/platform filtering still yields a full page of installable
 // releases before the display cap below. >100 releases would need pagination
@@ -72,6 +88,8 @@ const STATES = Object.freeze({
   DOWNLOADED: "downloaded",
   ERROR: "error",
   DISABLED: "disabled",
+  // No forward-update feed configured — loud, actionable, never a silent no-op.
+  NO_CHANNEL: "no-channel",
 });
 
 // ── Module state ─────────────────────────────────────────────────────────────
@@ -93,6 +111,8 @@ let scheduledTimeout = null;
 let initialCheckTimeout = null;
 let ipcHandlersRegistered = false;
 let initialized = false;
+// The resolved forward-update feed URL (generic/R2), or null when unconfigured.
+let forwardFeedUrl = null;
 
 // Lazy-loaded Electron references (populated inside init()).
 let electronApi = null; // { dialog, ipcMain, app }
@@ -147,11 +167,84 @@ function _loadPin() {
  */
 function _savePin(pinnedVersion) {
   fs.mkdirSync(path.dirname(UPDATE_CONFIG_PATH), { recursive: true });
+  // Merge into any existing config so we don't clobber a persisted feedUrl.
+  let existing = {};
+  try {
+    if (fs.existsSync(UPDATE_CONFIG_PATH)) {
+      existing = JSON.parse(fs.readFileSync(UPDATE_CONFIG_PATH, "utf8")) || {};
+    }
+  } catch {
+    existing = {};
+  }
   fs.writeFileSync(
     UPDATE_CONFIG_PATH,
-    JSON.stringify({ pinnedVersion }, null, 2),
+    JSON.stringify({ ...existing, pinnedVersion }, null, 2),
     "utf8"
   );
+}
+
+// ── Forward-update feed resolution (issue #1724) ────────────────────────────────
+
+/**
+ * Resolve the generic forward-update feed URL, or null if none is configured.
+ * Precedence: GAIA_UPDATE_FEED_URL env > feedUrl in update-config.json.
+ */
+function _resolveFeedUrl() {
+  const envUrl = process.env.GAIA_UPDATE_FEED_URL;
+  if (typeof envUrl === "string" && envUrl.trim()) return envUrl.trim();
+  try {
+    if (fs.existsSync(UPDATE_CONFIG_PATH)) {
+      const cfg = JSON.parse(fs.readFileSync(UPDATE_CONFIG_PATH, "utf8"));
+      if (cfg && typeof cfg.feedUrl === "string" && cfg.feedUrl.trim()) {
+        return cfg.feedUrl.trim();
+      }
+    }
+  } catch (err) {
+    log("warn", "Failed to read feedUrl from update-config.json:", err && err.message);
+  }
+  return null;
+}
+
+/**
+ * Point electron-updater at the configured generic (R2) feed + mutable channel.
+ * When nothing is configured, enter the loud NO_CHANNEL state and set no feed —
+ * an unconfigured updater must never silently pretend it's up to date.
+ *
+ * @returns {boolean} true when a feed was applied, false when NO_CHANNEL.
+ */
+function _applyForwardFeed() {
+  if (!autoUpdaterRef) return false;
+  const url = _resolveFeedUrl();
+  if (!url) {
+    forwardFeedUrl = null;
+    setState({
+      status: STATES.NO_CHANNEL,
+      error:
+        "No update channel configured — set GAIA_UPDATE_FEED_URL (or feedUrl " +
+        "in ~/.gaia/update-config.json) to your R2 channel base URL. " +
+        "Auto-update is paused until a feed is configured.",
+    });
+    log("warn", "No update feed configured — auto-update paused (NO_CHANNEL)");
+    return false;
+  }
+  try {
+    autoUpdaterRef.setFeedURL({
+      provider: "generic",
+      url,
+      channel: DEFAULT_CHANNEL,
+    });
+    forwardFeedUrl = url;
+    log("info", `Update feed set (generic): ${url} [channel=${DEFAULT_CHANNEL}]`);
+    return true;
+  } catch (err) {
+    forwardFeedUrl = null;
+    setState({
+      status: STATES.ERROR,
+      error: `Failed to set update feed URL: ${(err && err.message) || String(err)}`,
+    });
+    log("error", "Failed to set feed URL:", err && err.message);
+    return false;
+  }
 }
 
 // ── State management ─────────────────────────────────────────────────────────
@@ -359,8 +452,10 @@ async function installVersion(tag) {
 /**
  * Clear the version pin and resume normal auto-updates.
  *
- * Restores the GitHub provider feed, sets autoDownload=true, and clears
- * allowDowngrade so the next check is the normal forward-only flow.
+ * Restores the configured forward (R2 generic) feed, sets autoDownload=true,
+ * and clears allowDowngrade so the next check is the normal forward-only flow.
+ * If no feed is configured, resume lands in the loud NO_CHANNEL state rather
+ * than silently reverting to a stale rollback feed.
  */
 function clearPin() {
   // A failed clear is non-fatal — worst case the stale pin re-pauses updates
@@ -375,17 +470,9 @@ function clearPin() {
   if (autoUpdaterRef) {
     autoUpdaterRef.autoDownload = true;
     autoUpdaterRef.allowDowngrade = false;
-    // Restore the GitHub provider (overrides any generic/tagged feed set by
-    // installVersion). Owner/repo must match electron-builder.yml publish block.
-    try {
-      autoUpdaterRef.setFeedURL({
-        provider: "github",
-        owner: "amd",
-        repo: "gaia",
-      });
-    } catch (err) {
-      log("warn", "Failed to restore GitHub feed on resume:", err && err.message);
-    }
+    // Restore the forward channel (overrides any generic/tagged rollback feed
+    // set by installVersion). Loud NO_CHANNEL if unconfigured.
+    _applyForwardFeed();
   }
 
   log("info", "Version pin cleared — auto-updates resumed");
@@ -402,6 +489,12 @@ async function checkForUpdates() {
   if (!autoUpdaterRef) {
     log("warn", "checkForUpdates called before init — ignoring");
     return;
+  }
+  // No forward feed and not pinned → surface the loud NO_CHANNEL state instead
+  // of asking electron-updater to check a feed that doesn't exist. Re-resolve
+  // first so a feed written to config after init() is picked up here.
+  if (!forwardFeedUrl && !state.pinnedVersion) {
+    if (!_applyForwardFeed()) return;
   }
   if (checkInProgress) {
     log("info", "Skipping check — another check is already in progress");
@@ -691,6 +784,25 @@ function init(mainWindow) {
     log("warn", "Failed to register IPC handlers:", err && err.message);
   }
 
+  // Point the updater at the configured R2 generic feed (#1724). When a pin is
+  // active, installVersion() owns the feed (rollback path), so skip. With no
+  // pin and no feed, _applyForwardFeed enters the loud NO_CHANNEL state and we
+  // don't schedule checks against a nonexistent feed.
+  let feedReady = true;
+  if (!savedPin) {
+    feedReady = _applyForwardFeed();
+  }
+
+  initialized = true;
+
+  if (!feedReady && !savedPin) {
+    log(
+      "info",
+      "Auto-updater initialized without a channel — checks paused until a feed is configured"
+    );
+    return;
+  }
+
   // First check after CHECK_DELAY_MS, then every CHECK_INTERVAL_MS.
   initialCheckTimeout = setTimeout(async () => {
     try {
@@ -701,7 +813,6 @@ function init(mainWindow) {
     scheduleNextCheck();
   }, CHECK_DELAY_MS);
 
-  initialized = true;
   log(
     "info",
     `Auto-updater initialized; first check in ${CHECK_DELAY_MS}ms`

--- a/src/gaia/apps/webui/services/deep-link.cjs
+++ b/src/gaia/apps/webui/services/deep-link.cjs
@@ -1,0 +1,101 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * deep-link.cjs — parse `gaia://` deep links (issue #1725).
+ *
+ * The website's "Open in GAIA" button hands the running app a
+ * `gaia://hub/install/<id>` URL. This module is the pure, Electron-free
+ * parser so it can be unit-tested without a running app; main.cjs owns the
+ * OS protocol registration and dispatch to the install runtime.
+ *
+ * Design: parse errors are THROWN with an actionable message (no silent
+ * fallback). main.cjs surfaces the message to the user instead of dropping a
+ * malformed link on the floor.
+ */
+
+"use strict";
+
+const SCHEME = "gaia:";
+
+// Agent ids as published on the hub: start alphanumeric, then letters, digits,
+// dot, dash, underscore. Bounded length keeps a hostile link from ballooning.
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+
+/**
+ * Parse a `gaia://` deep link into a structured command.
+ *
+ * Supported form:
+ *   gaia://hub/install/<id>  → { action: "install", agentId }
+ *
+ * @param {string} rawUrl
+ * @returns {{ action: "install", agentId: string }}
+ * @throws {Error} with an actionable message on anything malformed/unsupported
+ */
+function parseDeepLink(rawUrl) {
+  if (typeof rawUrl !== "string" || !rawUrl.trim()) {
+    throw new Error(
+      'Not a GAIA deep link — expected a "gaia://…" URL but got ' +
+        (rawUrl === "" ? "an empty string" : JSON.stringify(rawUrl)) +
+        "."
+    );
+  }
+
+  const trimmed = rawUrl.trim();
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Malformed GAIA deep link "${trimmed}" — not a valid URL.`);
+  }
+
+  if (parsed.protocol !== SCHEME) {
+    throw new Error(
+      `Unsupported URL scheme "${parsed.protocol}" — GAIA deep links must start with "gaia://".`
+    );
+  }
+
+  const host = parsed.hostname;
+  const segments = parsed.pathname.split("/").filter(Boolean);
+
+  if (host === "hub" && segments[0] === "install") {
+    const agentId = segments[1] ? decodeURIComponent(segments[1]) : "";
+    if (!agentId) {
+      throw new Error(
+        `GAIA install link "${trimmed}" is missing an agent id — expected gaia://hub/install/<id>.`
+      );
+    }
+    if (!AGENT_ID_RE.test(agentId)) {
+      throw new Error(
+        `GAIA install link has an invalid agent id "${agentId}" — ids may contain letters, digits, dot, dash and underscore.`
+      );
+    }
+    if (segments.length > 2) {
+      throw new Error(
+        `GAIA install link "${trimmed}" has unexpected extra path segments — expected gaia://hub/install/<id>.`
+      );
+    }
+    return { action: "install", agentId };
+  }
+
+  throw new Error(
+    `Unrecognized GAIA deep link "${trimmed}" — only gaia://hub/install/<id> is supported.`
+  );
+}
+
+/**
+ * Find the first `gaia://` argument in an argv array (Windows/Linux hand the
+ * deep link to the app as a command-line argument). Returns null if absent.
+ *
+ * @param {string[]} argv
+ * @returns {string | null}
+ */
+function extractDeepLinkFromArgv(argv) {
+  if (!Array.isArray(argv)) return null;
+  for (const arg of argv) {
+    if (typeof arg === "string" && arg.startsWith("gaia://")) return arg;
+  }
+  return null;
+}
+
+module.exports = { parseDeepLink, extractDeepLinkFromArgv };

--- a/src/gaia/apps/webui/services/deep-link.cjs
+++ b/src/gaia/apps/webui/services/deep-link.cjs
@@ -98,4 +98,52 @@ function extractDeepLinkFromArgv(argv) {
   return null;
 }
 
-module.exports = { parseDeepLink, extractDeepLinkFromArgv };
+/**
+ * Act on a parsed deep-link command, with every Electron/runtime effect
+ * injected so the security-critical control flow is unit-testable.
+ *
+ * SECURITY (issue #2196 review): a `gaia://hub/install/<id>` link comes from an
+ * untrusted web page, so the install MUST be gated behind an explicit per-agent
+ * confirmation — the same trust bar the in-app install enforces (#2201). A bare
+ * OS "Open GAIA?" prompt is NOT consent to download and run a specific agent.
+ * If `confirm` does not return true, no install is attempted.
+ *
+ * @param {{ action: string, agentId: string }} command
+ * @param {{
+ *   confirm: (command: {action: string, agentId: string}) => Promise<boolean>,
+ *   installAgent: (agentId: string) => Promise<any>,
+ *   focusWindow?: () => void,
+ *   logger?: { log?: (...a: any[]) => void, error?: (...a: any[]) => void },
+ * }} deps
+ * @returns {Promise<{ installed: boolean, reason?: string }>}
+ */
+async function dispatchDeepLink(command, deps) {
+  const { confirm, installAgent, focusWindow, logger } = deps || {};
+  const log = (logger && logger.log) || (() => {});
+
+  if (!command || command.action !== "install") {
+    throw new Error(
+      `Unsupported deep-link action "${command && command.action}".`
+    );
+  }
+  if (typeof confirm !== "function" || typeof installAgent !== "function") {
+    throw new Error(
+      "dispatchDeepLink requires confirm() and installAgent() dependencies"
+    );
+  }
+
+  // Surface the app first so the confirmation dialog is clearly GAIA's.
+  if (typeof focusWindow === "function") focusWindow();
+
+  const approved = await confirm(command);
+  if (approved !== true) {
+    log(`[deep-link] User declined install of "${command.agentId}"`);
+    return { installed: false, reason: "declined" };
+  }
+
+  log(`[deep-link] Confirmed — installing "${command.agentId}"`);
+  await installAgent(command.agentId);
+  return { installed: true };
+}
+
+module.exports = { parseDeepLink, extractDeepLinkFromArgv, dispatchDeepLink };

--- a/tests/electron/auto-updater-feed.test.cjs
+++ b/tests/electron/auto-updater-feed.test.cjs
@@ -1,0 +1,164 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for the R2-primary configurable forward-update feed (issue #1724).
+ *
+ * Covers:
+ *   - init() applies a generic feed (+ mutable "latest" channel) from
+ *     GAIA_UPDATE_FEED_URL and from feedUrl in update-config.json
+ *   - init() with no feed enters the loud NO_CHANNEL state (no silent no-op)
+ *   - checkForUpdates() surfaces NO_CHANNEL rather than checking a dead feed
+ *   - checkForUpdates() picks up a feed configured after init()
+ *
+ * electron-updater is mapped via moduleNameMapper → mocks/electron-updater.js.
+ */
+
+"use strict";
+
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+
+const electronMock = require("electron");
+const { autoUpdater: mockAutoUpdaterInstance } = require("electron-updater");
+
+let tmpHome;
+let loadedModules = [];
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "gaia-feed-test-"));
+  jest.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  jest.clearAllMocks();
+  mockAutoUpdaterInstance.removeAllListeners();
+  mockAutoUpdaterInstance.autoDownload = true;
+  mockAutoUpdaterInstance.allowDowngrade = false;
+  mockAutoUpdaterInstance._feedURL = null;
+  delete process.env.GAIA_DISABLE_UPDATE;
+  delete process.env.GAIA_UPDATE_PRERELEASE;
+  delete process.env.GAIA_UPDATE_FEED_URL;
+});
+
+afterEach(() => {
+  for (const m of loadedModules) {
+    try {
+      m.destroy();
+    } catch {}
+  }
+  loadedModules = [];
+  try {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  } catch {}
+});
+
+function loadModule() {
+  let m;
+  jest.isolateModules(() => {
+    m = require("../../src/gaia/apps/webui/services/auto-updater.cjs");
+  });
+  loadedModules.push(m);
+  return m;
+}
+
+function makeMockWindow() {
+  const win = new electronMock.BrowserWindow();
+  win.isDestroyed = jest.fn(() => false);
+  return win;
+}
+
+describe("forward feed resolution", () => {
+  test("init() applies a generic feed + 'latest' channel from GAIA_UPDATE_FEED_URL", () => {
+    process.env.GAIA_UPDATE_FEED_URL = "https://updates.example.com/gaia";
+    const mod = loadModule();
+    mod.init(makeMockWindow());
+
+    expect(mockAutoUpdaterInstance._feedURL).toEqual({
+      provider: "generic",
+      url: "https://updates.example.com/gaia",
+      channel: "latest",
+    });
+    // A configured feed is NOT the NO_CHANNEL state.
+    expect(mod.getState().status).not.toBe(mod.STATES.NO_CHANNEL);
+  });
+
+  test("init() reads feedUrl from ~/.gaia/update-config.json when env is unset", () => {
+    const gaiaDir = path.join(tmpHome, ".gaia");
+    fs.mkdirSync(gaiaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(gaiaDir, "update-config.json"),
+      JSON.stringify({ feedUrl: "https://cdn.example.com/channel" })
+    );
+
+    const mod = loadModule();
+    mod.init(makeMockWindow());
+
+    expect(mockAutoUpdaterInstance._feedURL.provider).toBe("generic");
+    expect(mockAutoUpdaterInstance._feedURL.url).toBe(
+      "https://cdn.example.com/channel"
+    );
+  });
+
+  test("env takes precedence over the config file", () => {
+    const gaiaDir = path.join(tmpHome, ".gaia");
+    fs.mkdirSync(gaiaDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(gaiaDir, "update-config.json"),
+      JSON.stringify({ feedUrl: "https://cdn.example.com/from-config" })
+    );
+    process.env.GAIA_UPDATE_FEED_URL = "https://updates.example.com/from-env";
+
+    const mod = loadModule();
+    mod.init(makeMockWindow());
+
+    expect(mockAutoUpdaterInstance._feedURL.url).toBe(
+      "https://updates.example.com/from-env"
+    );
+  });
+
+  test("init() with no feed enters the loud NO_CHANNEL state and sets no feed", () => {
+    const mod = loadModule();
+    mod.init(makeMockWindow());
+
+    const state = mod.getState();
+    expect(state.status).toBe(mod.STATES.NO_CHANNEL);
+    expect(typeof state.error).toBe("string");
+    expect(state.error).toMatch(/no update channel configured/i);
+    // Must NOT have silently set a feed.
+    expect(mockAutoUpdaterInstance._feedURL).toBeNull();
+  });
+
+  test("checkForUpdates() surfaces NO_CHANNEL instead of checking a dead feed", async () => {
+    const mod = loadModule();
+    mod.init(makeMockWindow());
+
+    const checkSpy = jest
+      .spyOn(mockAutoUpdaterInstance, "checkForUpdates")
+      .mockResolvedValue(null);
+
+    await mod.checkForUpdates();
+
+    expect(mod.getState().status).toBe(mod.STATES.NO_CHANNEL);
+    expect(checkSpy).not.toHaveBeenCalled();
+  });
+
+  test("checkForUpdates() picks up a feed configured after init()", async () => {
+    const mod = loadModule();
+    mod.init(makeMockWindow());
+    expect(mod.getState().status).toBe(mod.STATES.NO_CHANNEL);
+
+    // Configure a feed after init, then check again.
+    process.env.GAIA_UPDATE_FEED_URL = "https://updates.example.com/gaia";
+    const checkSpy = jest
+      .spyOn(mockAutoUpdaterInstance, "checkForUpdates")
+      .mockResolvedValue(null);
+
+    await mod.checkForUpdates();
+
+    expect(mockAutoUpdaterInstance._feedURL).toEqual({
+      provider: "generic",
+      url: "https://updates.example.com/gaia",
+      channel: "latest",
+    });
+    expect(checkSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/electron/auto-updater.test.cjs
+++ b/tests/electron/auto-updater.test.cjs
@@ -44,6 +44,7 @@ beforeEach(() => {
   mockAutoUpdaterInstance._feedURL = null;
   delete process.env.GAIA_DISABLE_UPDATE;
   delete process.env.GAIA_UPDATE_PRERELEASE;
+  delete process.env.GAIA_UPDATE_FEED_URL;
 });
 
 afterEach(() => {
@@ -334,6 +335,9 @@ describe("installVersion()", () => {
   });
 
   test("throws a busy error when a check is already in progress", async () => {
+    // A configured feed so checkForUpdates() proceeds far enough to flip the
+    // in-progress guard (an unconfigured updater short-circuits to NO_CHANNEL).
+    process.env.GAIA_UPDATE_FEED_URL = "https://updates.example.com/gaia";
     const mod = loadModule();
     const win = makeMockWindow();
     mod.init(win);
@@ -392,7 +396,10 @@ describe("pin gating", () => {
 // ── Tests: clearPin ────────────────────────────────────────────────────────────
 
 describe("clearPin()", () => {
-  test("sets autoDownload=true, allowDowngrade=false, restores github feed, clears pin file", () => {
+  test("sets autoDownload=true, allowDowngrade=false, restores the R2 forward feed, clears pin file", () => {
+    // A configured R2 forward feed is what resume restores to (#1724).
+    process.env.GAIA_UPDATE_FEED_URL = "https://updates.example.com/gaia";
+
     // Write a pin
     const gaiaDirPath = path.join(tmpHome, ".gaia");
     fs.mkdirSync(gaiaDirPath, { recursive: true });
@@ -412,11 +419,15 @@ describe("clearPin()", () => {
 
     expect(mockAutoUpdaterInstance.autoDownload).toBe(true);
     expect(mockAutoUpdaterInstance.allowDowngrade).toBe(false);
-    // Feed should be restored to github
+    // Feed should be restored to the generic R2 forward channel.
     expect(mockAutoUpdaterInstance._feedURL).not.toBeNull();
-    expect(mockAutoUpdaterInstance._feedURL.provider).toBe("github");
+    expect(mockAutoUpdaterInstance._feedURL.provider).toBe("generic");
+    expect(mockAutoUpdaterInstance._feedURL.url).toBe(
+      "https://updates.example.com/gaia"
+    );
+    expect(mockAutoUpdaterInstance._feedURL.channel).toBe("latest");
 
-    // Pin file should be cleared
+    // Pin file should be cleared (feedUrl, if any, preserved).
     const configPath = path.join(gaiaDirPath, "update-config.json");
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
     expect(config.pinnedVersion).toBeNull();

--- a/tests/electron/deep-link.test.cjs
+++ b/tests/electron/deep-link.test.cjs
@@ -1,0 +1,102 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for the gaia:// deep-link parser (issue #1725).
+ *
+ * deep-link.cjs is pure (no Electron), so these run without a running app.
+ */
+
+"use strict";
+
+const {
+  parseDeepLink,
+  extractDeepLinkFromArgv,
+} = require("../../src/gaia/apps/webui/services/deep-link.cjs");
+
+describe("parseDeepLink()", () => {
+  test("parses a well-formed install link", () => {
+    expect(parseDeepLink("gaia://hub/install/summarize")).toEqual({
+      action: "install",
+      agentId: "summarize",
+    });
+  });
+
+  test("accepts ids with dots, dashes and underscores", () => {
+    expect(parseDeepLink("gaia://hub/install/my-agent_v2.1").agentId).toBe(
+      "my-agent_v2.1"
+    );
+  });
+
+  test("decodes a percent-encoded id", () => {
+    expect(parseDeepLink("gaia://hub/install/my%2Dagent").agentId).toBe(
+      "my-agent"
+    );
+  });
+
+  test("rejects a non-gaia scheme", () => {
+    expect(() => parseDeepLink("https://hub/install/x")).toThrow(
+      /must start with "gaia:\/\/"/
+    );
+  });
+
+  test("rejects an empty / non-string input", () => {
+    expect(() => parseDeepLink("")).toThrow(/Not a GAIA deep link/);
+    expect(() => parseDeepLink(null)).toThrow(/Not a GAIA deep link/);
+    expect(() => parseDeepLink(undefined)).toThrow(/Not a GAIA deep link/);
+  });
+
+  test("rejects an install link with no id", () => {
+    expect(() => parseDeepLink("gaia://hub/install/")).toThrow(
+      /missing an agent id/
+    );
+    expect(() => parseDeepLink("gaia://hub/install")).toThrow(
+      /missing an agent id/
+    );
+  });
+
+  test("rejects an id with illegal characters", () => {
+    // URL normalization collapses the "../" (popping "install"), so this is
+    // rejected as unrecognized rather than reaching id validation — either way
+    // it is loudly refused, never silently installing "etc".
+    expect(() => parseDeepLink("gaia://hub/install/../etc")).toThrow();
+    expect(() => parseDeepLink("gaia://hub/install/a b")).toThrow(
+      /invalid agent id/
+    );
+  });
+
+  test("rejects extra path segments", () => {
+    expect(() => parseDeepLink("gaia://hub/install/foo/bar")).toThrow(
+      /extra path segments/
+    );
+  });
+
+  test("rejects an unrecognized host/action", () => {
+    expect(() => parseDeepLink("gaia://hub/uninstall/foo")).toThrow(
+      /only gaia:\/\/hub\/install/
+    );
+    expect(() => parseDeepLink("gaia://settings/open")).toThrow(
+      /only gaia:\/\/hub\/install/
+    );
+  });
+});
+
+describe("extractDeepLinkFromArgv()", () => {
+  test("finds a gaia:// arg among other argv entries", () => {
+    const argv = [
+      "/path/to/electron",
+      "main.cjs",
+      "gaia://hub/install/summarize",
+    ];
+    expect(extractDeepLinkFromArgv(argv)).toBe("gaia://hub/install/summarize");
+  });
+
+  test("returns null when no gaia:// arg is present", () => {
+    expect(extractDeepLinkFromArgv(["electron", "main.cjs"])).toBeNull();
+  });
+
+  test("returns null for a non-array input", () => {
+    expect(extractDeepLinkFromArgv(undefined)).toBeNull();
+    expect(extractDeepLinkFromArgv(null)).toBeNull();
+  });
+});

--- a/tests/electron/deep-link.test.cjs
+++ b/tests/electron/deep-link.test.cjs
@@ -12,6 +12,7 @@
 const {
   parseDeepLink,
   extractDeepLinkFromArgv,
+  dispatchDeepLink,
 } = require("../../src/gaia/apps/webui/services/deep-link.cjs");
 
 describe("parseDeepLink()", () => {
@@ -98,5 +99,88 @@ describe("extractDeepLinkFromArgv()", () => {
   test("returns null for a non-array input", () => {
     expect(extractDeepLinkFromArgv(undefined)).toBeNull();
     expect(extractDeepLinkFromArgv(null)).toBeNull();
+  });
+});
+
+describe("dispatchDeepLink() — install confirmation gate (security)", () => {
+  const command = { action: "install", agentId: "summarize" };
+
+  test("installs only AFTER the user confirms the specific agent", async () => {
+    const confirm = jest.fn().mockResolvedValue(true);
+    const installAgent = jest.fn().mockResolvedValue({ status: "completed" });
+    const focusWindow = jest.fn();
+
+    const result = await dispatchDeepLink(command, {
+      confirm,
+      installAgent,
+      focusWindow,
+    });
+
+    // Confirmation happened before install, and for THIS agent.
+    expect(confirm).toHaveBeenCalledWith(command);
+    expect(installAgent).toHaveBeenCalledWith("summarize");
+    expect(confirm.mock.invocationCallOrder[0]).toBeLessThan(
+      installAgent.mock.invocationCallOrder[0]
+    );
+    expect(result).toEqual({ installed: true });
+  });
+
+  test("does NOT install when the user declines — the core security guarantee", async () => {
+    const confirm = jest.fn().mockResolvedValue(false);
+    const installAgent = jest.fn();
+
+    const result = await dispatchDeepLink(command, { confirm, installAgent });
+
+    expect(installAgent).not.toHaveBeenCalled();
+    expect(result).toEqual({ installed: false, reason: "declined" });
+  });
+
+  test("treats a non-true confirm result as a decline (no install)", async () => {
+    const installAgent = jest.fn();
+    // A dialog that resolves undefined/null (e.g. dismissed) must not install.
+    await dispatchDeepLink(command, {
+      confirm: jest.fn().mockResolvedValue(undefined),
+      installAgent,
+    });
+    expect(installAgent).not.toHaveBeenCalled();
+  });
+
+  test("focuses the window before prompting", async () => {
+    const calls = [];
+    const focusWindow = jest.fn(() => calls.push("focus"));
+    const confirm = jest.fn(() => {
+      calls.push("confirm");
+      return Promise.resolve(false);
+    });
+
+    await dispatchDeepLink(command, {
+      confirm,
+      installAgent: jest.fn(),
+      focusWindow,
+    });
+
+    expect(calls).toEqual(["focus", "confirm"]);
+  });
+
+  test("propagates an install failure so the caller can surface it", async () => {
+    const confirm = jest.fn().mockResolvedValue(true);
+    const installAgent = jest
+      .fn()
+      .mockRejectedValue(new Error("checksum mismatch"));
+
+    await expect(
+      dispatchDeepLink(command, { confirm, installAgent })
+    ).rejects.toThrow(/checksum mismatch/);
+  });
+
+  test("rejects an unsupported action without installing", async () => {
+    const installAgent = jest.fn();
+    await expect(
+      dispatchDeepLink(
+        { action: "uninstall", agentId: "x" },
+        { confirm: jest.fn().mockResolvedValue(true), installAgent }
+      )
+    ).rejects.toThrow(/Unsupported deep-link action/);
+    expect(installAgent).not.toHaveBeenCalled();
   });
 });

--- a/tests/electron/test_agent_process_manager.js
+++ b/tests/electron/test_agent_process_manager.js
@@ -1475,20 +1475,123 @@ describe("AgentProcessManager", () => {
       expect(result).toEqual(SAMPLE_MANIFEST);
     });
 
-    it("should register agent:install handler that throws not-implemented", async () => {
-      createManager();
+    it("should redirect agent:install to the backend install runtime and resolve on completion", async () => {
+      ipcMain._handlers.clear();
+      const mainWindow = new BrowserWindow();
+      const manager = new AgentProcessManager(mainWindow, {
+        getBackendPort: () => 4321,
+      });
+      _activeManagers.push(manager);
+
+      const calls = [];
+      global.fetch = jest.fn(async (url, opts) => {
+        calls.push({ url, opts });
+        if (url.endsWith("/api/agents/install")) {
+          return {
+            ok: true,
+            status: 202,
+            json: async () => ({ id: "test-agent", status: "queued" }),
+          };
+        }
+        if (url.includes("/install-status")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              id: "test-agent",
+              status: "completed",
+              phase: "done",
+              percent: 100,
+              version: "1.2.3",
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`unexpected url ${url}`);
+      });
+
+      const result = await ipcMain.simulateInvoke("agent:install", "test-agent");
+      expect(result).toMatchObject({ id: "test-agent", status: "completed" });
+
+      // POST hits the real backend route with the required UI header + body shape.
+      const post = calls.find((c) => c.url.endsWith("/api/agents/install"));
+      expect(post.url).toBe("http://127.0.0.1:4321/api/agents/install");
+      expect(post.opts.method).toBe("POST");
+      expect(post.opts.headers["X-Gaia-UI"]).toBe("1");
+      expect(JSON.parse(post.opts.body)).toEqual({
+        id: "test-agent",
+        trust_native: false,
+        version: null,
+      });
+
+      delete global.fetch;
+    });
+
+    it("should surface a failed backend install as a thrown error", async () => {
+      ipcMain._handlers.clear();
+      const manager = new AgentProcessManager(new BrowserWindow(), {
+        getBackendPort: () => 4321,
+      });
+      _activeManagers.push(manager);
+
+      global.fetch = jest.fn(async (url) => {
+        if (url.endsWith("/api/agents/install")) {
+          return { ok: true, status: 202, json: async () => ({ status: "queued" }) };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            status: "failed",
+            phase: "failed",
+            percent: 0,
+            error: "checksum mismatch",
+          }),
+        };
+      });
+
+      await expect(
+        ipcMain.simulateInvoke("agent:install", "bad-agent")
+      ).rejects.toThrow(/checksum mismatch/);
+
+      delete global.fetch;
+    });
+
+    it("should fail loudly on install when no backend port is available", async () => {
+      ipcMain._handlers.clear();
+      const manager = new AgentProcessManager(new BrowserWindow());
+      _activeManagers.push(manager);
 
       await expect(
         ipcMain.simulateInvoke("agent:install", "test-agent")
-      ).rejects.toThrow("Agent installation not yet implemented");
+      ).rejects.toThrow(/backend is not running/i);
     });
 
-    it("should register agent:uninstall handler that throws not-implemented", async () => {
-      createManager();
+    it("should redirect agent:uninstall to the backend DELETE route", async () => {
+      ipcMain._handlers.clear();
+      const manager = new AgentProcessManager(new BrowserWindow(), {
+        getBackendPort: () => 4321,
+      });
+      _activeManagers.push(manager);
 
-      await expect(
-        ipcMain.simulateInvoke("agent:uninstall", "test-agent")
-      ).rejects.toThrow("Agent uninstallation not yet implemented");
+      const calls = [];
+      global.fetch = jest.fn(async (url, opts) => {
+        calls.push({ url, opts });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: "test-agent", status: "uninstalled" }),
+        };
+      });
+
+      const result = await ipcMain.simulateInvoke("agent:uninstall", "test-agent");
+      expect(result).toMatchObject({ id: "test-agent", status: "uninstalled" });
+
+      expect(calls[0].url).toBe("http://127.0.0.1:4321/api/agents/test-agent");
+      expect(calls[0].opts.method).toBe("DELETE");
+      expect(calls[0].opts.headers["X-Gaia-UI"]).toBe("1");
+
+      delete global.fetch;
     });
   });
 


### PR DESCRIPTION
## Why this matters

The Agent UI shell had three broken/missing install-and-update surfaces, all in the Electron main/preload layer:

- **Before:** clicking install on a published agent hit a dead `agent:install` IPC stub that threw *"not yet implemented"* — the UI could never actually import an agent. **After:** the IPC handlers proxy to the real backend install runtime (`POST /api/agents/install` → poll `install-status` → `DELETE` for uninstall), streaming progress to the renderer. One tested install path, no duplicated download/verify/`uv` logic in the main process. *(Closes #1721)*
- **Before:** auto-update was hard-wired to GitHub Releases. **After:** the forward channel is a configurable generic **R2** feed with a mutable `latest` channel pointer; the URL resolves from `GAIA_UPDATE_FEED_URL` / `update-config.json`, and an unconfigured app enters a **loud "no channel configured"** state instead of silently checking a dead feed. *(Closes #1724)*
- **Before:** the website's "Open in GAIA" button had nowhere to land. **After:** the app registers the `gaia://` protocol and handles `gaia://hub/install/<id>` (macOS `open-url`, Win/Linux argv + `second-instance`), dispatching the agent id to the install runtime; malformed links raise an actionable dialog. *(Closes #1725)*

No silent fallbacks: a missing backend port, missing update feed, or malformed deep link each surface a loud, actionable error.

Part of #2014.

### Dependency note (#1724)
The actual R2 publish feed + Worker `latest*.yml` channel pointer are milestone-52 work (**#1719**) and not live yet. This PR ships the app-side integration + config so it works against **any** configurable feed URL (a local/mock feed exercises the full path); `electron-builder.yml` switches `provider: github → generic`. Rollback (#1336) still lists/installs from GitHub Releases — independent of the forward feed, migrates with #1719.

## Test plan

- [x] `cd tests/electron && npm install && npx jest` — full suite green (659 passed, 1 skipped, 20 suites)
- [x] New: `tests/electron/deep-link.test.cjs` — `gaia://` parse: valid, bad scheme, missing/invalid id, extra segments, argv extraction
- [x] New: `tests/electron/auto-updater-feed.test.cjs` — feed from env + config file, env precedence, loud `NO_CHANNEL` when unset, `checkForUpdates` picks up a later-configured feed
- [x] Updated: `tests/electron/test_agent_process_manager.js` — install/uninstall IPC redirect (POST/DELETE shape + `X-Gaia-UI` header), failed-install surfaces, loud no-backend error
- [x] Updated: `tests/electron/auto-updater.test.cjs` — `clearPin` restores the R2 forward feed
- [x] `cd src/gaia/apps/webui && npm run build` — TypeScript + Vite build compiles
- [ ] Manual: `GAIA_UPDATE_FEED_URL=<mock> ` end-to-end update against a local feed (blocked on a real R2 feed / #1719 for the production path)