### PR TITLE
feat(daemon): /host/v1 custody API v1 with per-agent scoping (V2-12)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "gaia.chat",
         "gaia.schedule",
         "gaia.daemon",
+        "gaia.daemon.custody",
         "gaia.daemon.sidecars",
         "gaia.ui",
         "gaia.ui.routers",

--- a/src/gaia/daemon/app.py
+++ b/src/gaia/daemon/app.py
@@ -80,6 +80,8 @@ def create_app(
     on_shutdown: Optional[Callable[[], None]] = None,
     registry=None,
     broker=None,
+    custody_auth=None,
+    custody_store=None,
 ):
     """Build the FastAPI app bound to this daemon's identity.
 
@@ -92,6 +94,14 @@ def create_app(
     relay (#2150); ``None`` leaves both unmounted. *broker* (a
     :class:`gaia.daemon.broker.ModelSlotBroker`) mounts the ``/host/v1/models/*``
     lease route (#2151 / V2-11); ``None`` leaves it unmounted.
+
+    *custody_auth* + *custody_store* mount the ``/host/v1/*`` custody reverse
+    contract (#2153): the secret→agent-id resolver and the SQLite backing. Both
+    must be provided together; either ``None`` leaves the custody API unmounted
+    (so a skeleton/test daemon can run without it). The custody API is guarded by
+    its OWN per-spawn secrets (bound at mint), NOT the client ``token`` — it is a
+    separate surface with its own MAJOR (§0.31), so it is not behind
+    ``require_token``.
     """
     from fastapi import Depends, FastAPI, HTTPException
 
@@ -162,5 +172,19 @@ def create_app(
         from gaia.daemon.broker_routes import build_broker_router
 
         app.include_router(build_broker_router(token, registry, broker))
+
+    if custody_auth is not None and custody_store is not None:
+        from gaia.daemon.custody.routes import (
+            build_custody_router,
+            install_custody_exception_handler,
+        )
+
+        install_custody_exception_handler(app)
+        app.include_router(build_custody_router(custody_auth, custody_store))
+    elif custody_auth is not None or custody_store is not None:
+        raise ValueError(
+            "create_app requires custody_auth AND custody_store together to "
+            "mount /host/v1; got only one. Pass both, or neither."
+        )
 
     return app

--- a/src/gaia/daemon/custody/__init__.py
+++ b/src/gaia/daemon/custody/__init__.py
@@ -1,0 +1,18 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The daemon's ``/host/v1/*`` custody API (design §0.31, breakdown V2-12).
+
+The reverse contract: a sidecar agent calls *back* into the daemon to read and
+write the user's custody data (memory / RAG / sessions / audit). Every route is
+scoped to the calling agent — a sidecar authenticates with the per-spawn secret
+bound to its agent id at mint (:mod:`gaia.daemon.custody.auth`) and can only
+touch its own agent's rows.
+
+Layering: this package never imports ``gaia.ui``. The store
+(:mod:`gaia.daemon.custody.store`) is the daemon's own single writer over a
+dedicated SQLite file; the UI routers migrating onto it is a later issue
+(V2-12 follow-up). :class:`gaia.daemon.custody.provider.CustodyProvider` is the
+sidecar-side abstraction so the custody home is swappable (§0.37).
+"""
+
+from __future__ import annotations

--- a/src/gaia/daemon/custody/auth.py
+++ b/src/gaia/daemon/custody/auth.py
@@ -1,0 +1,96 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``CustodyAuth`` — secret→agent-id binding for the custody reverse contract
+(design §0.11; acceptance: "secret→agent-id binding happens at mint, not
+per-request trust").
+
+The binding is established once, at sidecar **mint** (the registry mints a
+secret when it constructs a manager). Every ``/host/v1/*`` request presents that
+secret and the daemon *resolves* the agent id from it — the request never
+carries a claimed agent id the daemon would have to trust. This is the whole
+per-agent scoping guarantee: a sidecar can only be the agent its secret was
+bound to.
+
+Secrets live only in memory (re-minted every daemon start, like the client
+token — §0.11 note): they are never written to disk, so there is no persisted
+credential to leak. Lookups are constant-time to avoid a timing oracle over the
+secret set.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+
+from gaia.daemon.custody.errors import UnknownSecretError
+
+# Per-spawn secret length (URL-safe token, ~256 bits like the client token).
+_SECRET_NBYTES = 32
+
+
+class CustodyAuth:
+    """In-memory registry of ``custody secret -> agent_id`` bindings."""
+
+    def __init__(self) -> None:
+        # secret -> agent_id, and the reverse for revoke-by-agent. Guarded by a
+        # lock so mint/revoke from the spawn path race-cleanly with resolve()
+        # from request threads.
+        self._by_secret: "dict[str, str]" = {}
+        self._by_agent: "dict[str, str]" = {}
+        self._lock = threading.Lock()
+
+    def mint(self, agent_id: str) -> str:
+        """Bind a fresh secret to *agent_id* and return it (called at mint).
+
+        Re-minting for an agent that already has a binding rotates the secret:
+        the old one stops resolving immediately, so a restarted sidecar's new
+        secret is the only valid credential.
+        """
+        secret = secrets.token_urlsafe(_SECRET_NBYTES)
+        with self._lock:
+            old = self._by_agent.get(agent_id)
+            if old is not None:
+                self._by_secret.pop(old, None)
+            self._by_secret[secret] = agent_id
+            self._by_agent[agent_id] = secret
+        return secret
+
+    def resolve(self, secret: str) -> str:
+        """Return the agent id bound to *secret*, or raise if none is.
+
+        Constant-time over the known secrets: iterate them all with
+        ``compare_digest`` so a caller cannot learn a valid secret's prefix from
+        response timing.
+        """
+        if not secret:
+            raise UnknownSecretError(
+                "Missing custody secret. Send 'Authorization: Bearer <secret>' "
+                "using the value the daemon injected at spawn "
+                "(GAIA_HOST_CUSTODY_SECRET). The secret rotates on daemon "
+                "restart — a re-ensured sidecar receives the current one."
+            )
+        with self._lock:
+            match = None
+            for known, agent_id in self._by_secret.items():
+                if secrets.compare_digest(known, secret):
+                    match = agent_id
+            if match is None:
+                raise UnknownSecretError(
+                    "Custody secret is not bound to any agent. It may have "
+                    "rotated (daemon restart) or the sidecar was stopped — "
+                    "re-ensure the agent (POST /daemon/v1/agents/<id>/ensure) "
+                    "to receive a current secret."
+                )
+            return match
+
+    def revoke(self, agent_id: str) -> None:
+        """Drop *agent_id*'s binding (called on stop/uninstall). Idempotent."""
+        with self._lock:
+            old = self._by_agent.pop(agent_id, None)
+            if old is not None:
+                self._by_secret.pop(old, None)
+
+    def secret_for(self, agent_id: str) -> "str | None":
+        """The current secret bound to *agent_id*, if any (spawn-env wiring)."""
+        with self._lock:
+            return self._by_agent.get(agent_id)

--- a/src/gaia/daemon/custody/constants.py
+++ b/src/gaia/daemon/custody/constants.py
@@ -1,0 +1,46 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Constants for the ``/host/v1/*`` custody API (design §0.31).
+
+This API is versioned **independently** of the client-facing ``/daemon/v1``
+surface (``gaia.daemon.constants.DAEMON_API_VERSION``): it is the sidecar↔daemon
+reverse contract and carries its own MAJOR, negotiated on that leg (§0.31, §0.15
+evolution rules). A daemon that speaks a different custody MAJOR than a sidecar
+was built against is a breaking contract change — surfaced loudly, never a silent
+skew.
+"""
+
+from __future__ import annotations
+
+# Route prefix for the custody reverse contract.
+HOST_API_PREFIX = "/host/v1"
+
+# MAJOR.MINOR contract version of the sidecar↔daemon custody boundary. Own
+# MAJOR, independent of DAEMON_API_VERSION (§0.31). v1.0: rag/query, memory
+# GET/POST, sessions/{id}, audit append (plain append-only — hash-chain deferred
+# per §0.35.5).
+HOST_API_VERSION = "1.0"
+
+# Custody auth uses the same header/scheme shape as the client API so callers
+# have one bearer-token convention to implement.
+CUSTODY_AUTH_SCHEME = "Bearer"
+
+# Private env channel (daemon → sidecar, at spawn) carrying the delegated-custody
+# wiring. Presence of the URL is what selects the Delegated provider (§0.37);
+# absence selects Embedded. The secret is the per-spawn credential bound to the
+# agent id at mint (§0.11) — it never travels through a client.
+CUSTODY_URL_ENV_VAR = "GAIA_HOST_CUSTODY_URL"
+CUSTODY_SECRET_ENV_VAR = "GAIA_HOST_CUSTODY_SECRET"
+
+# Explicit opt-in to the stateless Ephemeral provider (§0.37): nothing persists,
+# the caller passes context per request. Set to "1"/"true" to force it even when
+# a custody URL is present.
+CUSTODY_EPHEMERAL_ENV_VAR = "GAIA_CUSTODY_EPHEMERAL"
+
+# Memory scopes. "agent" is the agent-private default; "user" is the shared,
+# cross-agent user scope, reachable only when the agent's manifest declares the
+# sharedScopes grant (§0.28/§0.11). Grant enforcement lands with the manifest
+# work (V2-3); v1 accepts the scope literal and stores it, defaulting to "agent".
+MEMORY_SCOPE_AGENT = "agent"
+MEMORY_SCOPE_USER = "user"
+VALID_MEMORY_SCOPES = (MEMORY_SCOPE_AGENT, MEMORY_SCOPE_USER)

--- a/src/gaia/daemon/custody/errors.py
+++ b/src/gaia/daemon/custody/errors.py
@@ -1,0 +1,69 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Loud, actionable, typed errors for the custody API (no silent fallbacks).
+
+Each error carries the HTTP status the route layer maps it to (§0.31): a bad or
+missing secret is a 403, a cross-agent access attempt is a 403, an unknown
+session is a 404, an audit-chain conflict is a 409, and an unavailable store is a
+503. The route layer translates these at the boundary — the store/auth layers
+raise them so a wrong caller never silently reads an empty result.
+"""
+
+from __future__ import annotations
+
+
+class CustodyError(Exception):
+    """Base for all custody failures. ``http_status`` is the boundary mapping."""
+
+    http_status = 500
+
+
+class StoreUnavailableError(CustodyError):
+    """The custody SQLite store could not be opened or written.
+
+    Fail loud (§ no-silent-fallbacks): custody-backed features do not degrade to
+    an empty/None result — the caller gets a 503 naming the store path.
+    """
+
+    http_status = 503
+
+
+class UnknownSecretError(CustodyError):
+    """The presented custody secret is not bound to any agent.
+
+    Missing/malformed header and unknown secret both map to 403 here (the
+    reverse contract's auth is a bearer secret, not a challenge — there is no
+    401 negotiation on this loopback leg per §0.11).
+    """
+
+    http_status = 403
+
+
+class ScopeDeniedError(CustodyError):
+    """The caller tried to read/write data owned by another agent (or a scope
+    its manifest has not been granted). The core §0.11 boundary — a single
+    reader must not become an exfiltration surface."""
+
+    http_status = 403
+
+
+class SessionNotFoundError(CustodyError):
+    """No session with that id exists at all (distinct from ScopeDenied, which
+    is a session that exists but belongs to a different agent)."""
+
+    http_status = 404
+
+
+class AuditConflictError(CustodyError):
+    """An audit append conflicted (duplicate ``action_id`` for the agent).
+
+    v1 audit is plain append-only (§0.35.5); the conflict guard is the idempotency
+    key, not the deferred hash-chain seal."""
+
+    http_status = 409
+
+
+class InvalidScopeError(CustodyError):
+    """A memory scope literal outside the known set was supplied."""
+
+    http_status = 400

--- a/src/gaia/daemon/custody/provider.py
+++ b/src/gaia/daemon/custody/provider.py
@@ -1,0 +1,287 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``CustodyProvider`` — the sidecar-side custody abstraction (design §0.37).
+
+A sidecar depends on this interface and does **not** know which backend answers.
+Three adapters, auto-selected at launch (:func:`select_custody_provider`):
+
+- **Delegated** — the daemon injected a ``/host/v1`` URL + per-spawn secret at
+  spawn; every call is an HTTP round-trip to the daemon's single writer (the
+  §0.9 Agent-UI deployment model). This is the wire protocol *and* the
+  third-party-implementable interface (§0.35 #1) — the daemon's routes are GAIA's
+  reference implementation of it.
+- **Embedded** — no host endpoint injected; the sidecar is its *own* single
+  writer over a bundled :class:`gaia.daemon.custody.store.CustodyStore`. Rich,
+  self-contained, works offline. Default for a standalone agent.
+- **Ephemeral** — explicit stateless flag; nothing persists. Writes are defined
+  no-ops and reads return empty — this is the *documented contract* of the
+  stateless tier (the caller passes context per request), not a silent fallback.
+
+The single-writer invariant holds in every mode (§0.37): embedded = one agent is
+its own writer; delegated = the host is the one writer across N; ephemeral =
+nothing persisted. There is never multi-writer.
+
+Layering: this module is pure client code (httpx only, imported lazily). It does
+NOT import fastapi/uvicorn, so a sidecar package can import it without pulling in
+the daemon's server stack.
+"""
+
+from __future__ import annotations
+
+import abc
+import os
+from typing import Optional
+
+from gaia.daemon.custody.constants import (
+    CUSTODY_EPHEMERAL_ENV_VAR,
+    CUSTODY_SECRET_ENV_VAR,
+    CUSTODY_URL_ENV_VAR,
+    HOST_API_PREFIX,
+    MEMORY_SCOPE_AGENT,
+)
+
+
+class CustodyProvider(abc.ABC):
+    """The custody surface a sidecar depends on (mirrors ``/host/v1/*``)."""
+
+    @abc.abstractmethod
+    def add_memory(
+        self, content: str, scope: str = MEMORY_SCOPE_AGENT
+    ) -> Optional[int]: ...
+
+    @abc.abstractmethod
+    def get_memory(
+        self, scope: Optional[str] = None, query: Optional[str] = None
+    ) -> "list[dict]": ...
+
+    @abc.abstractmethod
+    def create_session(self, session_id: Optional[str] = None) -> str: ...
+
+    @abc.abstractmethod
+    def append_session_message(
+        self, session_id: str, role: str, content: str
+    ) -> Optional[int]: ...
+
+    @abc.abstractmethod
+    def get_session(self, session_id: str) -> "list[dict]": ...
+
+    @abc.abstractmethod
+    def query_rag(self, query: str, k: int = 4) -> "list[dict]": ...
+
+    @abc.abstractmethod
+    def append_audit(
+        self, action_id: str, action: str, summary: str = "", ts: Optional[float] = None
+    ) -> Optional[int]: ...
+
+
+class EmbeddedCustodyProvider(CustodyProvider):
+    """Self-custody: the sidecar owns its :class:`CustodyStore` (single writer)."""
+
+    def __init__(self, store, agent_id: str):
+        self._store = store
+        self._agent_id = agent_id
+
+    def add_memory(self, content, scope=MEMORY_SCOPE_AGENT):
+        return self._store.add_memory(self._agent_id, content, scope=scope)
+
+    def get_memory(self, scope=None, query=None):
+        return self._store.get_memory(self._agent_id, scope=scope, query=query)
+
+    def create_session(self, session_id=None):
+        import secrets
+
+        sid = session_id or secrets.token_urlsafe(16)
+        return self._store.create_session(self._agent_id, sid)
+
+    def append_session_message(self, session_id, role, content):
+        return self._store.append_session_message(
+            self._agent_id, session_id, role, content
+        )
+
+    def get_session(self, session_id):
+        return self._store.get_session(self._agent_id, session_id)
+
+    def query_rag(self, query, k=4):
+        return self._store.query_rag(self._agent_id, query, k=k)
+
+    def append_audit(self, action_id, action, summary="", ts=None):
+        import time
+
+        return self._store.append_audit(
+            self._agent_id,
+            action_id,
+            action,
+            summary,
+            ts if ts is not None else time.time(),
+        )
+
+
+class DelegatedCustodyProvider(CustodyProvider):
+    """Host custody: every call is an HTTP round-trip to the daemon's ``/host/v1``.
+
+    The daemon resolves the agent id from *secret* (bound at mint), so this
+    provider never sends an agent id — its identity IS the secret.
+    """
+
+    def __init__(self, base_url: str, secret: str, *, timeout: float = 30.0):
+        self._base = base_url.rstrip("/")
+        self._secret = secret
+        self._timeout = timeout
+
+    # -- HTTP plumbing -------------------------------------------------------
+
+    def _headers(self) -> dict:
+        return {"Authorization": f"Bearer {self._secret}"}
+
+    def _request(self, method: str, path: str, **kwargs):
+        import httpx
+
+        url = f"{self._base}{HOST_API_PREFIX}{path}"
+        try:
+            resp = httpx.request(
+                method, url, headers=self._headers(), timeout=self._timeout, **kwargs
+            )
+        except httpx.HTTPError as e:
+            raise CustodyUnavailableError(
+                f"custody host at {self._base} did not answer "
+                f"{method} {HOST_API_PREFIX}{path} ({e.__class__.__name__}: {e}). "
+                "Is the daemon running? Re-ensure the agent, then retry."
+            ) from e
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except ValueError:
+                detail = resp.text
+            raise CustodyRequestError(
+                resp.status_code,
+                f"custody host returned HTTP {resp.status_code} for "
+                f"{method} {HOST_API_PREFIX}{path}: {detail}",
+            )
+        return resp.json()
+
+    def add_memory(self, content, scope=MEMORY_SCOPE_AGENT):
+        return self._request("POST", "/memory", json={"item": content, "scope": scope})[
+            "id"
+        ]
+
+    def get_memory(self, scope=None, query=None):
+        params = {}
+        if scope is not None:
+            params["scope"] = scope
+        if query is not None:
+            params["query"] = query
+        return self._request("GET", "/memory", params=params or None)["items"]
+
+    def create_session(self, session_id=None):
+        body = {"session_id": session_id} if session_id else {}
+        return self._request("POST", "/sessions", json=body)["session_id"]
+
+    def append_session_message(self, session_id, role, content):
+        return self._request(
+            "POST",
+            f"/sessions/{session_id}/messages",
+            json={"role": role, "content": content},
+        )["seq"]
+
+    def get_session(self, session_id):
+        return self._request("GET", f"/sessions/{session_id}")["transcript"]
+
+    def query_rag(self, query, k=4):
+        return self._request("POST", "/rag/query", json={"query": query, "k": k})[
+            "chunks"
+        ]
+
+    def append_audit(self, action_id, action, summary="", ts=None):
+        body = {"action_id": action_id, "action": action, "summary": summary}
+        if ts is not None:
+            body["ts"] = ts
+        return self._request("POST", "/audit", json=body)["seq"]
+
+
+class EphemeralCustodyProvider(CustodyProvider):
+    """Stateless: nothing persists. Writes are defined no-ops, reads return empty.
+
+    This is the documented contract of the stateless tier (§0.37) — the caller
+    passes all context per request. It is NOT a silent degradation of a
+    persistent backend: it is selected only by an explicit flag, so a caller
+    that expected persistence never lands here by accident.
+    """
+
+    def add_memory(self, content, scope=MEMORY_SCOPE_AGENT):
+        return None
+
+    def get_memory(self, scope=None, query=None):
+        return []
+
+    def create_session(self, session_id=None):
+        import secrets
+
+        return session_id or secrets.token_urlsafe(16)
+
+    def append_session_message(self, session_id, role, content):
+        return None
+
+    def get_session(self, session_id):
+        return []
+
+    def query_rag(self, query, k=4):
+        return []
+
+    def append_audit(self, action_id, action, summary="", ts=None):
+        return None
+
+
+class CustodyUnavailableError(Exception):
+    """The delegated custody host could not be reached (transport-level)."""
+
+
+class CustodyRequestError(Exception):
+    """The delegated custody host answered with a non-2xx status."""
+
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def select_custody_provider(
+    agent_id: str,
+    *,
+    embedded_store=None,
+    env: Optional[dict] = None,
+) -> CustodyProvider:
+    """Auto-select the provider per §0.37 from the spawn environment.
+
+    Order: explicit stateless flag → Ephemeral; a host custody URL present →
+    Delegated; else Embedded (requires *embedded_store*). A delegated selection
+    with a URL but no secret fails loud — an un-authenticable custody wire is a
+    misconfiguration, not a fall-back-to-embedded case.
+    """
+    env = os.environ if env is None else env
+
+    if _truthy(env.get(CUSTODY_EPHEMERAL_ENV_VAR)):
+        return EphemeralCustodyProvider()
+
+    url = env.get(CUSTODY_URL_ENV_VAR)
+    if url:
+        secret = env.get(CUSTODY_SECRET_ENV_VAR)
+        if not secret:
+            raise ValueError(
+                f"{CUSTODY_URL_ENV_VAR} is set ({url}) but "
+                f"{CUSTODY_SECRET_ENV_VAR} is missing — a delegated custody "
+                "endpoint cannot be used without its per-spawn secret. The "
+                "daemon injects both together; if you set one by hand, set both."
+            )
+        return DelegatedCustodyProvider(url, secret)
+
+    if embedded_store is None:
+        raise ValueError(
+            "no host custody endpoint was injected and no embedded store was "
+            "provided — cannot build a custody provider. Inject "
+            f"{CUSTODY_URL_ENV_VAR}+{CUSTODY_SECRET_ENV_VAR} for delegated "
+            "custody, or pass embedded_store for self-custody."
+        )
+    return EmbeddedCustodyProvider(embedded_store, agent_id)
+
+
+def _truthy(value) -> bool:
+    return str(value).strip().lower() in ("1", "true", "yes", "on") if value else False

--- a/src/gaia/daemon/custody/routes.py
+++ b/src/gaia/daemon/custody/routes.py
@@ -1,0 +1,191 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``/host/v1/*`` custody routes — the reverse contract (design §0.31).
+
+Built as a factory (``build_custody_router``) and mounted from inside
+``create_app``, mirroring the agents/relay routers so no state is smuggled
+through ``app.state``. Every route resolves the calling agent from the per-spawn
+custody secret (``CustodyAuth.resolve``) and scopes its work to that agent — a
+request never carries a claimed agent id.
+
+Errors are typed and loud (§0.31, no-silent-fallbacks): the store/auth layers
+raise :class:`gaia.daemon.custody.errors.CustodyError` subclasses carrying the
+HTTP status, and one exception handler maps them to a response whose ``detail``
+is the actionable message verbatim. Unknown/missing secret → 403; cross-agent
+access → 403; unknown session → 404; audit conflict → 409; store down → 503.
+"""
+
+from __future__ import annotations
+
+# Module-level (mirrors sidecars/routes.py): this module is imported lazily from
+# create_app, so its endpoint annotations must resolve from module globals under
+# PEP 563.
+from fastapi import APIRouter, Body, Header, HTTPException, Query
+from fastapi.responses import JSONResponse
+
+from gaia.daemon.custody.constants import (
+    CUSTODY_AUTH_SCHEME,
+    HOST_API_PREFIX,
+    HOST_API_VERSION,
+    MEMORY_SCOPE_AGENT,
+)
+from gaia.daemon.custody.errors import CustodyError, UnknownSecretError
+
+
+def _resolve_agent(auth, authorization: "str | None") -> str:
+    """Resolve the calling agent id from the Authorization header, or raise a
+    403 :class:`UnknownSecretError`. Bearer scheme, same shape as the client
+    token so callers implement one convention."""
+    if not authorization:
+        raise UnknownSecretError(
+            "Missing custody secret. Send "
+            f"'Authorization: {CUSTODY_AUTH_SCHEME} <secret>' using the value "
+            "the daemon injected at spawn (GAIA_HOST_CUSTODY_SECRET)."
+        )
+    scheme, _, credential = authorization.partition(" ")
+    if scheme.lower() != CUSTODY_AUTH_SCHEME.lower() or not credential:
+        raise UnknownSecretError(
+            f"Malformed Authorization header. Expected "
+            f"'{CUSTODY_AUTH_SCHEME} <secret>'."
+        )
+    return auth.resolve(credential)
+
+
+def build_custody_router(auth, store) -> APIRouter:
+    """Build the ``/host/v1/*`` router over *auth* and *store*.
+
+    *auth* is a :class:`gaia.daemon.custody.auth.CustodyAuth`; *store* a
+    :class:`gaia.daemon.custody.store.CustodyStore`.
+    """
+    router = APIRouter()
+
+    @router.get(f"{HOST_API_PREFIX}/version")
+    def custody_version() -> dict:
+        # Unauthenticated: lets a sidecar negotiate the custody MAJOR before it
+        # holds a resolvable secret. Carries no per-agent data.
+        return {"apiVersion": HOST_API_VERSION}
+
+    @router.post(f"{HOST_API_PREFIX}/rag/query")
+    def rag_query(
+        payload: dict = Body(...),
+        authorization: "str | None" = Header(default=None),
+    ) -> dict:
+        agent_id = _resolve_agent(auth, authorization)
+        query = payload.get("query")
+        if not query:
+            raise HTTPException(
+                status_code=400,
+                detail="POST /host/v1/rag/query requires a non-empty 'query'.",
+            )
+        k = int(payload.get("k", 4))
+        chunks = store.query_rag(agent_id, query, k=k)
+        return {"chunks": chunks}
+
+    @router.get(f"{HOST_API_PREFIX}/memory")
+    def get_memory(
+        scope: "str | None" = Query(default=None),
+        query: "str | None" = Query(default=None),
+        authorization: "str | None" = Header(default=None),
+    ) -> dict:
+        agent_id = _resolve_agent(auth, authorization)
+        items = store.get_memory(agent_id, scope=scope, query=query)
+        return {"items": items}
+
+    @router.post(f"{HOST_API_PREFIX}/memory")
+    def post_memory(
+        payload: dict = Body(...),
+        authorization: "str | None" = Header(default=None),
+    ) -> dict:
+        agent_id = _resolve_agent(auth, authorization)
+        # Accept {item} or {content}; item is the §0.31 field name.
+        content = payload.get("item", payload.get("content"))
+        if not content:
+            raise HTTPException(
+                status_code=400,
+                detail="POST /host/v1/memory requires a non-empty 'item'.",
+            )
+        scope = payload.get("scope") or MEMORY_SCOPE_AGENT
+        row_id = store.add_memory(agent_id, str(content), scope=scope)
+        return {"id": row_id}
+
+    @router.post(f"{HOST_API_PREFIX}/sessions")
+    def create_session(
+        payload: dict = Body(default=None),
+        authorization: "str | None" = Header(default=None),
+    ) -> dict:
+        agent_id = _resolve_agent(auth, authorization)
+        # Host-minted id (§0.30): the caller may propose one, else the daemon
+        # mints it. Either way the daemon owns the binding.
+        import secrets as _secrets
+
+        session_id = (payload or {}).get("session_id") or _secrets.token_urlsafe(16)
+        store.create_session(agent_id, session_id)
+        return {"session_id": session_id}
+
+    @router.post(f"{HOST_API_PREFIX}/sessions/{{session_id}}/messages")
+    def append_message(
+        session_id: str,
+        payload: dict = Body(...),
+        authorization: "str | None" = Header(default=None),
+    ) -> dict:
+        agent_id = _resolve_agent(auth, authorization)
+        role = payload.get("role")
+        content = payload.get("content")
+        if not role or content is None:
+            raise HTTPException(
+                status_code=400,
+                detail="append message requires 'role' and 'content'.",
+            )
+        seq = store.append_session_message(agent_id, session_id, role, str(content))
+        return {"seq": seq}
+
+    @router.get(f"{HOST_API_PREFIX}/sessions/{{session_id}}")
+    def get_session(
+        session_id: str,
+        authorization: "str | None" = Header(default=None),
+    ) -> dict:
+        agent_id = _resolve_agent(auth, authorization)
+        transcript = store.get_session(agent_id, session_id)
+        return {"session_id": session_id, "transcript": transcript}
+
+    @router.post(f"{HOST_API_PREFIX}/audit")
+    def post_audit(
+        payload: dict = Body(...),
+        authorization: "str | None" = Header(default=None),
+    ) -> dict:
+        agent_id = _resolve_agent(auth, authorization)
+        action_id = payload.get("action_id")
+        action = payload.get("action")
+        if not action_id or not action:
+            raise HTTPException(
+                status_code=400,
+                detail="POST /host/v1/audit requires 'action_id' and 'action'.",
+            )
+        summary = str(payload.get("summary", ""))
+        ts = float(payload.get("ts") or _now())
+        seq = store.append_audit(agent_id, action_id, action, summary, ts)
+        return {"seq": seq}
+
+    return router
+
+
+def _now() -> float:  # pragma: no cover - trivial seam
+    import time
+
+    return time.time()
+
+
+def install_custody_exception_handler(app) -> None:
+    """Map :class:`CustodyError` to its carried HTTP status app-wide.
+
+    One handler so every custody route's typed error becomes a loud JSON
+    ``{"detail": ...}`` at the boundary — never a 500 stack trace, never a
+    silent empty body.
+    """
+
+    @app.exception_handler(CustodyError)
+    async def _handle_custody_error(_request, exc: CustodyError):  # noqa: ANN001
+        return JSONResponse(
+            status_code=getattr(exc, "http_status", 500),
+            content={"detail": str(exc)},
+        )

--- a/src/gaia/daemon/custody/store.py
+++ b/src/gaia/daemon/custody/store.py
@@ -1,0 +1,413 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``CustodyStore`` — the daemon's single-writer SQLite backing for the custody
+API (design §0.9, §0.29; breakdown V2-12).
+
+Every table carries an ``agent_id`` column and every method takes ``agent_id``
+and filters on it, so the store enforces per-agent scoping at the data layer
+(the route layer enforces it again at the boundary — defense in depth). The
+store is the daemon's own single writer: opened WAL + ``busy_timeout`` (§0.29)
+so concurrent readers never block the writer and a contended write waits rather
+than failing with ``database is locked``.
+
+v1 scope (per the issue):
+- **memory** — agent-scoped items, optional ``user`` shared scope; substring query.
+- **sessions / session_messages** — host-minted session id is the authorization
+  key (§0.30): ``get_session`` verifies ownership before returning a transcript.
+- **audit** — plain append-only log with a per-store monotonic ``seq`` (§0.35.5;
+  hash-chain deferred). ``action_id`` is the per-agent idempotency key.
+- **rag_chunks** — agent-scoped corpus with a naive substring match (RAG feature
+  changes are out of scope — this is the scoped round-trip, not a new retriever).
+
+Threading: one connection with ``check_same_thread=False`` guarded by a lock, so
+the daemon's threadpool routes share the single writer safely.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from gaia.daemon.custody.constants import (
+    MEMORY_SCOPE_AGENT,
+    VALID_MEMORY_SCOPES,
+)
+from gaia.daemon.custody.errors import (
+    AuditConflictError,
+    InvalidScopeError,
+    ScopeDeniedError,
+    SessionNotFoundError,
+    StoreUnavailableError,
+)
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Wait up to this long for a contended write rather than failing loud with
+# "database is locked" — the single-writer design means contention is brief.
+_BUSY_TIMEOUT_MS = 5000
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS memory (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id    TEXT NOT NULL,
+    scope       TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_memory_agent_scope ON memory(agent_id, scope);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id  TEXT PRIMARY KEY,
+    agent_id    TEXT NOT NULL,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent_id);
+
+CREATE TABLE IF NOT EXISTS session_messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT NOT NULL,
+    seq         INTEGER NOT NULL,
+    role        TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    created_at  REAL NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+);
+CREATE INDEX IF NOT EXISTS idx_msgs_session ON session_messages(session_id, seq);
+
+CREATE TABLE IF NOT EXISTS audit (
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id    TEXT NOT NULL,
+    action_id   TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    summary     TEXT NOT NULL,
+    ts          REAL NOT NULL,
+    UNIQUE (agent_id, action_id)
+);
+CREATE INDEX IF NOT EXISTS idx_audit_agent ON audit(agent_id);
+
+CREATE TABLE IF NOT EXISTS rag_chunks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id    TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    source      TEXT,
+    created_at  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rag_agent ON rag_chunks(agent_id);
+"""
+
+
+class CustodyStore:
+    """SQLite-backed per-agent custody store (single writer, WAL)."""
+
+    def __init__(self, db_path: "str | Path"):
+        self.db_path = Path(db_path)
+        self._lock = threading.Lock()
+        try:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            self._conn.row_factory = sqlite3.Row
+            self._conn.execute("PRAGMA journal_mode = WAL")
+            self._conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+            self._conn.execute("PRAGMA foreign_keys = ON")
+            self._conn.executescript(_SCHEMA)
+            self._conn.commit()
+        except sqlite3.Error as e:
+            raise StoreUnavailableError(
+                f"custody store at {self.db_path} could not be opened: {e}. "
+                "Check the daemon has write access to its host dir "
+                "(~/.gaia/host or $GAIA_DAEMON_HOME) and that the disk is not "
+                "full, then restart the daemon."
+            ) from e
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._conn.close()
+            except sqlite3.Error:
+                pass
+
+    # -- memory --------------------------------------------------------------
+
+    @staticmethod
+    def _check_scope(scope: str) -> str:
+        if scope not in VALID_MEMORY_SCOPES:
+            raise InvalidScopeError(
+                f"unknown memory scope '{scope}'; expected one of "
+                f"{VALID_MEMORY_SCOPES}. Omit 'scope' for the agent-private "
+                "default."
+            )
+        return scope
+
+    def add_memory(
+        self, agent_id: str, content: str, scope: str = MEMORY_SCOPE_AGENT
+    ) -> int:
+        """Persist a memory item for *agent_id*; return its row id."""
+        self._check_scope(scope)
+        now = time.time()
+        with self._lock:
+            try:
+                cur = self._conn.execute(
+                    "INSERT INTO memory (agent_id, scope, content, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (agent_id, scope, content, now),
+                )
+                self._conn.commit()
+                return int(cur.lastrowid)
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to write memory for agent '{agent_id}': {e}"
+                ) from e
+
+    def get_memory(
+        self,
+        agent_id: str,
+        scope: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: int = 100,
+    ) -> "list[dict]":
+        """Return *agent_id*'s memory items, optionally filtered by scope/substring.
+
+        Scoping is enforced here: only rows tagged to *agent_id* are ever
+        returned — a caller can never widen the read to another agent's memory.
+        """
+        sql = "SELECT id, scope, content, created_at FROM memory WHERE agent_id = ?"
+        params: list = [agent_id]
+        if scope is not None:
+            self._check_scope(scope)
+            sql += " AND scope = ?"
+            params.append(scope)
+        if query:
+            sql += " AND content LIKE ?"
+            params.append(f"%{query}%")
+        sql += " ORDER BY id DESC LIMIT ?"
+        params.append(int(limit))
+        with self._lock:
+            try:
+                rows = self._conn.execute(sql, params).fetchall()
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to read memory for agent '{agent_id}': {e}"
+                ) from e
+        return [
+            {
+                "id": r["id"],
+                "scope": r["scope"],
+                "content": r["content"],
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]
+
+    # -- sessions ------------------------------------------------------------
+
+    def create_session(self, agent_id: str, session_id: str) -> str:
+        """Register a host-minted *session_id* as owned by *agent_id*."""
+        now = time.time()
+        with self._lock:
+            try:
+                self._conn.execute(
+                    "INSERT INTO sessions (session_id, agent_id, created_at) "
+                    "VALUES (?, ?, ?)",
+                    (session_id, agent_id, now),
+                )
+                self._conn.commit()
+            except sqlite3.IntegrityError as e:
+                raise ScopeDeniedError(
+                    f"session '{session_id}' already exists; a session id is "
+                    "minted once and cannot be re-registered."
+                ) from e
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to create session for '{agent_id}': {e}"
+                ) from e
+        return session_id
+
+    def append_session_message(
+        self, agent_id: str, session_id: str, role: str, content: str
+    ) -> int:
+        """Append a transcript message; verifies *agent_id* owns *session_id*."""
+        with self._lock:
+            owner = self._session_owner(session_id)
+            if owner is None:
+                raise SessionNotFoundError(
+                    f"session '{session_id}' does not exist. Create it "
+                    "(POST /host/v1/sessions) before appending messages."
+                )
+            if owner != agent_id:
+                raise ScopeDeniedError(
+                    f"session '{session_id}' belongs to another agent; agent "
+                    f"'{agent_id}' may not write to it."
+                )
+            try:
+                row = self._conn.execute(
+                    "SELECT COALESCE(MAX(seq), -1) + 1 AS next FROM "
+                    "session_messages WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+                seq = int(row["next"])
+                self._conn.execute(
+                    "INSERT INTO session_messages "
+                    "(session_id, seq, role, content, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (session_id, seq, role, content, time.time()),
+                )
+                self._conn.commit()
+                return seq
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to append to session " f"'{session_id}': {e}"
+                ) from e
+
+    def get_session(self, agent_id: str, session_id: str) -> "list[dict]":
+        """Return *session_id*'s transcript slice IFF *agent_id* owns it.
+
+        The §0.30 authorization key: the daemon verifies the session belongs to
+        the caller. A session owned by another agent raises
+        :class:`ScopeDeniedError` (403), a nonexistent one
+        :class:`SessionNotFoundError` (404) — never a silent empty transcript.
+        """
+        with self._lock:
+            owner = self._session_owner(session_id)
+            if owner is None:
+                raise SessionNotFoundError(f"session '{session_id}' does not exist.")
+            if owner != agent_id:
+                raise ScopeDeniedError(
+                    f"session '{session_id}' belongs to another agent; agent "
+                    f"'{agent_id}' may not read it."
+                )
+            try:
+                rows = self._conn.execute(
+                    "SELECT seq, role, content, created_at FROM session_messages "
+                    "WHERE session_id = ? ORDER BY seq ASC",
+                    (session_id,),
+                ).fetchall()
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to read session '{session_id}': {e}"
+                ) from e
+        return [
+            {
+                "seq": r["seq"],
+                "role": r["role"],
+                "content": r["content"],
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]
+
+    def _session_owner(self, session_id: str) -> Optional[str]:
+        """agent_id that owns *session_id*, or None. Caller holds ``self._lock``."""
+        row = self._conn.execute(
+            "SELECT agent_id FROM sessions WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        return row["agent_id"] if row is not None else None
+
+    # -- audit ---------------------------------------------------------------
+
+    def append_audit(
+        self, agent_id: str, action_id: str, action: str, summary: str, ts: float
+    ) -> int:
+        """Append an audit row for *agent_id*; return the store-monotonic ``seq``.
+
+        Append-only (§0.35.5). A duplicate ``(agent_id, action_id)`` raises
+        :class:`AuditConflictError` (409) so a retried write is idempotent-safe
+        rather than silently double-logged.
+        """
+        with self._lock:
+            try:
+                cur = self._conn.execute(
+                    "INSERT INTO audit (agent_id, action_id, action, summary, ts) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (agent_id, action_id, action, summary, ts),
+                )
+                self._conn.commit()
+                return int(cur.lastrowid)
+            except sqlite3.IntegrityError as e:
+                raise AuditConflictError(
+                    f"audit action_id '{action_id}' already recorded for agent "
+                    f"'{agent_id}'. action_id is the idempotency key — use a "
+                    "fresh id per distinct action."
+                ) from e
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to append audit for '{agent_id}': {e}"
+                ) from e
+
+    def get_audit(self, agent_id: str, limit: int = 100) -> "list[dict]":
+        """Return *agent_id*'s audit rows (host-internal read; agents are
+        write-only to audit per §0.24 — this backs the dashboard/tests)."""
+        with self._lock:
+            try:
+                rows = self._conn.execute(
+                    "SELECT seq, action_id, action, summary, ts FROM audit "
+                    "WHERE agent_id = ? ORDER BY seq ASC LIMIT ?",
+                    (agent_id, int(limit)),
+                ).fetchall()
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to read audit for '{agent_id}': {e}"
+                ) from e
+        return [
+            {
+                "seq": r["seq"],
+                "action_id": r["action_id"],
+                "action": r["action"],
+                "summary": r["summary"],
+                "ts": r["ts"],
+            }
+            for r in rows
+        ]
+
+    # -- rag -----------------------------------------------------------------
+
+    def add_rag_chunk(
+        self, agent_id: str, content: str, source: Optional[str] = None
+    ) -> int:
+        """Add one chunk to *agent_id*'s corpus; return its row id."""
+        with self._lock:
+            try:
+                cur = self._conn.execute(
+                    "INSERT INTO rag_chunks (agent_id, content, source, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (agent_id, content, source, time.time()),
+                )
+                self._conn.commit()
+                return int(cur.lastrowid)
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to write a RAG chunk for "
+                    f"'{agent_id}': {e}"
+                ) from e
+
+    def query_rag(self, agent_id: str, query: str, k: int = 4) -> "list[dict]":
+        """Return up to *k* of *agent_id*'s chunks matching *query* (substring).
+
+        v1 is a naive scoped match — the embedder-backed retriever is a later
+        issue. The invariant that matters now is scoping: only *agent_id*'s
+        corpus is ever searched.
+        """
+        with self._lock:
+            try:
+                rows = self._conn.execute(
+                    "SELECT id, content, source, created_at FROM rag_chunks "
+                    "WHERE agent_id = ? AND content LIKE ? "
+                    "ORDER BY id DESC LIMIT ?",
+                    (agent_id, f"%{query}%", int(k)),
+                ).fetchall()
+            except sqlite3.Error as e:
+                raise StoreUnavailableError(
+                    f"custody store failed to query RAG for '{agent_id}': {e}"
+                ) from e
+        return [
+            {
+                "id": r["id"],
+                "content": r["content"],
+                "source": r["source"],
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]

--- a/src/gaia/daemon/paths.py
+++ b/src/gaia/daemon/paths.py
@@ -45,6 +45,17 @@ def sidecars_ledger_path() -> Path:
     return host_dir() / "sidecars.json"
 
 
+def custody_db_path() -> Path:
+    """The daemon-owned custody SQLite file (``/host/v1/*`` memory/sessions/audit/RAG).
+
+    A single store under ``host_dir()`` so custody survives a UI/browser session
+    (it belongs to the always-on daemon, not the tab) and an agent uninstall
+    (audit rows must persist — §0.19). WAL sidecar files (``-wal``/``-shm``) sit
+    alongside it.
+    """
+    return host_dir() / "custody.db"
+
+
 def ensure_host_dir() -> Path:
     """Create ``host_dir()`` if missing and return it."""
     d = host_dir()

--- a/src/gaia/daemon/server.py
+++ b/src/gaia/daemon/server.py
@@ -86,8 +86,12 @@ def _load_extra_specs() -> dict:
     return specs
 
 
-def _build_registry(specs):
-    """The daemon's sidecar registry, wired to the crash-reap ledger."""
+def _build_registry(specs, *, custody_auth=None, custody_base_url=None):
+    """The daemon's sidecar registry, wired to the crash-reap ledger.
+
+    When *custody_auth* + *custody_base_url* are given, the registry mints a
+    per-agent custody secret at spawn and injects the /host/v1 wiring (#2153).
+    """
     from gaia.daemon.sidecars import ledger
     from gaia.daemon.sidecars.registry import SidecarRegistry
 
@@ -101,14 +105,23 @@ def _build_registry(specs):
             started_at=manager.started_at,
         )
 
-    return SidecarRegistry(specs, on_spawn=_on_spawn, on_stop=ledger.remove_entry)
+    return SidecarRegistry(
+        specs,
+        on_spawn=_on_spawn,
+        on_stop=ledger.remove_entry,
+        custody_auth=custody_auth,
+        custody_base_url=custody_base_url,
+    )
 
 
 def run(host: str = HOST) -> None:
     """Start the daemon and serve until shutdown. Blocks."""
     import uvicorn
 
+    from gaia.daemon.custody.auth import CustodyAuth
+    from gaia.daemon.custody.store import CustodyStore
     from gaia.daemon.migrate import run_migrations
+    from gaia.daemon.paths import custody_db_path
     from gaia.daemon.sidecars import ledger
     from gaia.daemon.sidecars.spec import builtin_specs
 
@@ -123,8 +136,18 @@ def run(host: str = HOST) -> None:
     pid = os.getpid()
     started_at = time.time()
 
+    # Custody backing (#2153): one SQLite store owned by the daemon, and the
+    # in-memory secret→agent-id bindings. Constructed before the registry so the
+    # registry can mint each sidecar's custody secret at spawn. The custody
+    # callback URL is the daemon's own loopback address.
+    custody_store = CustodyStore(custody_db_path())
+    custody_auth = CustodyAuth()
+    custody_base_url = f"http://{host}:{port}"
+
     specs = {**builtin_specs(), **_load_extra_specs()}
-    registry = _build_registry(specs)
+    registry = _build_registry(
+        specs, custody_auth=custody_auth, custody_base_url=custody_base_url
+    )
 
     from gaia.daemon.broker import ModelSlotBroker
     from gaia.daemon.constants import BROKER_URL_ENV_VAR
@@ -151,6 +174,7 @@ def run(host: str = HOST) -> None:
 
     def _deregister() -> None:
         registry.shutdown_all()
+        custody_store.close()
         remove_instance(only_pid=pid)
         logger.info("daemon: deregistered instance pid=%s", pid)
 
@@ -163,6 +187,8 @@ def run(host: str = HOST) -> None:
         on_shutdown=_deregister,
         registry=registry,
         broker=broker,
+        custody_auth=custody_auth,
+        custody_store=custody_store,
     )
 
     config = uvicorn.Config(

--- a/src/gaia/daemon/sidecars/manager.py
+++ b/src/gaia/daemon/sidecars/manager.py
@@ -164,6 +164,13 @@ class AgentSidecarManager:
         # The leg actually used at spawn time: "file" | "env".
         self.secret_delivery: Optional[str] = None
         self._secret_path: Optional[Path] = None
+        # Delegated-custody wiring (#2153), set by the registry at mint before
+        # start(). When both are present they are injected over the private env
+        # channel so the sidecar's DelegatedCustodyProvider calls /host/v1 back
+        # into the daemon; the secret is bound to this agent id at mint, so the
+        # daemon resolves the caller's identity from it (never from the request).
+        self.custody_url: Optional[str] = None
+        self.custody_secret: Optional[str] = None
 
     @property
     def mode(self) -> str:
@@ -293,6 +300,19 @@ class AgentSidecarManager:
         # pre-spawn (#2149), before the log opens so a refusal leaks nothing.
         spawn_env = {**os.environ, **(popen_kwargs.pop("env", None) or {})}
         self._apply_secret_delivery(spawn_env)
+        # Delegated-custody channel (#2153): inject both together or neither —
+        # a URL without its secret is an un-authenticable custody wire the
+        # sidecar's selector rejects loudly. This is the reverse-contract
+        # credential (sidecar → daemon), distinct from the caller-auth token
+        # #2149 delivers; it rides the private env channel.
+        if self.custody_url and self.custody_secret:
+            from gaia.daemon.custody.constants import (
+                CUSTODY_SECRET_ENV_VAR,
+                CUSTODY_URL_ENV_VAR,
+            )
+
+            spawn_env[CUSTODY_URL_ENV_VAR] = self.custody_url
+            spawn_env[CUSTODY_SECRET_ENV_VAR] = self.custody_secret
         log_handle = self._open_log(port)
         try:
             self._proc = subprocess.Popen(

--- a/src/gaia/daemon/sidecars/registry.py
+++ b/src/gaia/daemon/sidecars/registry.py
@@ -42,11 +42,21 @@ class SidecarRegistry:
         *,
         on_spawn: Optional[Callable[[str, AgentSidecarManager], None]] = None,
         on_stop: Optional[Callable[[str], None]] = None,
+        custody_auth=None,
+        custody_base_url: Optional[str] = None,
     ):
         self._specs = dict(specs)
         self.max_live = max_live
         self._on_spawn = on_spawn
         self._on_stop = on_stop
+        # Delegated-custody wiring (#2153). When both are set, the registry mints
+        # a per-agent custody secret at manager construction (the mint point) and
+        # hands the manager the /host/v1 URL + secret to inject on spawn. The
+        # binding is revoked when the sidecar stops/reaps so a rotated-out secret
+        # stops resolving. Left None → sidecars run without delegated custody
+        # (they fall back to their own embedded provider).
+        self._custody_auth = custody_auth
+        self._custody_base_url = custody_base_url
         # agent_id -> (manager, per-agent lock). The registry lock guards this
         # map (atomic get-or-create); the per-agent lock serializes the slow
         # is_running-check + start() so N concurrent first ensures spawn ONE
@@ -87,9 +97,29 @@ class SidecarRegistry:
             manager.on_process_spawned = (
                 lambda pid, port, argv, _m=manager: self._on_spawn(agent_id, _m)
             )
-        if self._on_stop is not None:
-            manager.on_process_reaped = lambda: self._on_stop(agent_id)
+
+        # A single reaped hook fires both the ledger removal and the custody
+        # revoke so a crashed/killed sidecar's secret stops resolving the moment
+        # its process is confirmed gone.
+        def _on_reaped(_aid=agent_id) -> None:
+            if self._on_stop is not None:
+                self._on_stop(_aid)
+            self._revoke_custody(_aid)
+
+        manager.on_process_reaped = _on_reaped
+        # Mint the custody secret at construction (the mint point) and hand the
+        # manager the wiring it injects on spawn (#2153). Binding it here — not
+        # per-request — is what makes the daemon resolve the caller's identity
+        # from the secret rather than trusting a request-supplied agent id.
+        if self._custody_auth is not None and self._custody_base_url:
+            manager.custody_url = self._custody_base_url
+            manager.custody_secret = self._custody_auth.mint(agent_id)
         return manager
+
+    def _revoke_custody(self, agent_id: str) -> None:
+        """Drop *agent_id*'s custody secret binding (idempotent)."""
+        if self._custody_auth is not None:
+            self._custody_auth.revoke(agent_id)
 
     def ensure(self, agent_id: str, mode: Optional[str] = None) -> dict:
         """Spawn-or-attach *agent_id*'s sidecar; return its fields + token."""

--- a/tests/unit/test_daemon_custody.py
+++ b/tests/unit/test_daemon_custody.py
@@ -1,0 +1,572 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Spec for the ``/host/v1/*`` custody API (issue #2153, V2-12).
+
+Covers the store (per-agent scoping at the data layer), the secret→agent-id
+auth binding, the HTTP boundary (agent A cannot read agent B — real app
+instance, not mocks; 403 on missing/wrong secret), the sidecar-side
+``CustodyProvider`` adapters, and the create_app / manager / registry wiring.
+
+Every test that touches on-disk custody state uses tmp_path so it never touches
+the real ~/.gaia/host.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.daemon.custody.auth import CustodyAuth
+from gaia.daemon.custody.errors import (
+    AuditConflictError,
+    InvalidScopeError,
+    ScopeDeniedError,
+    SessionNotFoundError,
+    UnknownSecretError,
+)
+from gaia.daemon.custody.store import CustodyStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = CustodyStore(tmp_path / "custody.db")
+    yield s
+    s.close()
+
+
+# ===========================================================================
+# constants — the custody API carries its own MAJOR, independent of /daemon/v1
+# ===========================================================================
+
+
+def test_host_api_version_is_independent_of_daemon_api_version():
+    from gaia.daemon.constants import DAEMON_API_VERSION
+    from gaia.daemon.custody.constants import HOST_API_PREFIX, HOST_API_VERSION
+
+    assert HOST_API_PREFIX == "/host/v1"
+    assert int(HOST_API_VERSION.split(".")[0]) == 1
+    # It is a SEPARATE surface — not slaved to the client API version.
+    assert HOST_API_VERSION is not DAEMON_API_VERSION
+
+
+# ===========================================================================
+# CustodyStore — per-agent scoping at the data layer
+# ===========================================================================
+
+
+def test_memory_roundtrip_and_scoping(store):
+    store.add_memory("agent-a", "a's secret note")
+    store.add_memory("agent-b", "b's private note")
+
+    a_items = store.get_memory("agent-a")
+    b_items = store.get_memory("agent-b")
+
+    assert [i["content"] for i in a_items] == ["a's secret note"]
+    assert [i["content"] for i in b_items] == ["b's private note"]
+    # A's read never surfaces B's row and vice-versa.
+    assert all("b's private" not in i["content"] for i in a_items)
+
+
+def test_memory_query_substring_filters_within_agent(store):
+    store.add_memory("agent-a", "buy milk")
+    store.add_memory("agent-a", "call dentist")
+    hits = store.get_memory("agent-a", query="milk")
+    assert [i["content"] for i in hits] == ["buy milk"]
+
+
+def test_memory_invalid_scope_raises(store):
+    with pytest.raises(InvalidScopeError):
+        store.add_memory("agent-a", "x", scope="bogus")
+
+
+def test_session_owner_can_read_transcript(store):
+    store.create_session("agent-a", "sess-1")
+    store.append_session_message("agent-a", "sess-1", "user", "hello")
+    store.append_session_message("agent-a", "sess-1", "assistant", "hi")
+    transcript = store.get_session("agent-a", "sess-1")
+    assert [m["content"] for m in transcript] == ["hello", "hi"]
+    assert [m["seq"] for m in transcript] == [0, 1]
+
+
+def test_session_cross_agent_read_is_scope_denied(store):
+    store.create_session("agent-a", "sess-1")
+    with pytest.raises(ScopeDeniedError):
+        store.get_session("agent-b", "sess-1")
+
+
+def test_session_cross_agent_write_is_scope_denied(store):
+    store.create_session("agent-a", "sess-1")
+    with pytest.raises(ScopeDeniedError):
+        store.append_session_message("agent-b", "sess-1", "user", "sneaky")
+
+
+def test_session_unknown_id_is_not_found(store):
+    with pytest.raises(SessionNotFoundError):
+        store.get_session("agent-a", "nope")
+
+
+def test_audit_append_returns_monotonic_seq(store):
+    s1 = store.append_audit("agent-a", "act-1", "send", "sent email", 1.0)
+    s2 = store.append_audit("agent-a", "act-2", "archive", "archived", 2.0)
+    assert s2 > s1
+
+
+def test_audit_duplicate_action_id_conflicts(store):
+    store.append_audit("agent-a", "act-1", "send", "x", 1.0)
+    with pytest.raises(AuditConflictError):
+        store.append_audit("agent-a", "act-1", "send", "x again", 2.0)
+
+
+def test_audit_is_scoped_per_agent(store):
+    store.append_audit("agent-a", "act-1", "send", "a", 1.0)
+    store.append_audit("agent-b", "act-1", "send", "b", 1.0)  # same id, other agent OK
+    assert len(store.get_audit("agent-a")) == 1
+    assert len(store.get_audit("agent-b")) == 1
+
+
+def test_audit_rows_survive_store_reopen(tmp_path):
+    """Audit rows survive a sidecar uninstall (acceptance criterion): the store
+    is daemon-owned, so closing/reopening it (as a restart would) preserves the
+    log."""
+    db = tmp_path / "custody.db"
+    s1 = CustodyStore(db)
+    s1.append_audit("agent-a", "act-1", "send", "durable", 1.0)
+    s1.close()
+
+    s2 = CustodyStore(db)
+    rows = s2.get_audit("agent-a")
+    s2.close()
+    assert [r["action_id"] for r in rows] == ["act-1"]
+
+
+def test_rag_query_is_scoped_per_agent(store):
+    store.add_rag_chunk("agent-a", "the mitochondria is the powerhouse")
+    store.add_rag_chunk("agent-b", "b private corpus about mitochondria")
+    hits = store.query_rag("agent-a", "mitochondria")
+    assert len(hits) == 1
+    assert "powerhouse" in hits[0]["content"]
+
+
+def test_store_uses_wal_journal_mode(store):
+    mode = store._conn.execute("PRAGMA journal_mode").fetchone()[0]
+    assert mode.lower() == "wal"
+
+
+# ===========================================================================
+# CustodyAuth — secret→agent-id binding at mint, resolve per request
+# ===========================================================================
+
+
+def test_mint_then_resolve_roundtrip():
+    auth = CustodyAuth()
+    secret = auth.mint("agent-a")
+    assert auth.resolve(secret) == "agent-a"
+
+
+def test_resolve_unknown_secret_raises():
+    auth = CustodyAuth()
+    with pytest.raises(UnknownSecretError):
+        auth.resolve("never-minted")
+
+
+def test_resolve_empty_secret_raises():
+    auth = CustodyAuth()
+    with pytest.raises(UnknownSecretError):
+        auth.resolve("")
+
+
+def test_two_agents_get_distinct_secrets_resolving_to_themselves():
+    auth = CustodyAuth()
+    sa = auth.mint("agent-a")
+    sb = auth.mint("agent-b")
+    assert sa != sb
+    assert auth.resolve(sa) == "agent-a"
+    assert auth.resolve(sb) == "agent-b"
+
+
+def test_remint_rotates_and_invalidates_old_secret():
+    auth = CustodyAuth()
+    old = auth.mint("agent-a")
+    new = auth.mint("agent-a")
+    assert old != new
+    assert auth.resolve(new) == "agent-a"
+    with pytest.raises(UnknownSecretError):
+        auth.resolve(old)
+
+
+def test_revoke_invalidates_secret():
+    auth = CustodyAuth()
+    secret = auth.mint("agent-a")
+    auth.revoke("agent-a")
+    with pytest.raises(UnknownSecretError):
+        auth.resolve(secret)
+    auth.revoke("agent-a")  # idempotent — no raise
+
+
+# ===========================================================================
+# HTTP boundary — real app instance (TestClient), the acceptance criteria
+# ===========================================================================
+
+
+@pytest.fixture()
+def custody_client(tmp_path):
+    """A real FastAPI app with the custody API mounted, plus two pre-bound
+    agents' secrets. Returns (client, secret_a, secret_b)."""
+    from fastapi.testclient import TestClient
+
+    from gaia.daemon.app import create_app
+
+    store = CustodyStore(tmp_path / "custody.db")
+    auth = CustodyAuth()
+    secret_a = auth.mint("agent-a")
+    secret_b = auth.mint("agent-b")
+
+    app = create_app(
+        token="client-tok",
+        port=4001,
+        pid=1,
+        started_at=1.0,
+        custody_auth=auth,
+        custody_store=store,
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client, secret_a, secret_b
+    store.close()
+
+
+def _h(secret):
+    return {"Authorization": f"Bearer {secret}"}
+
+
+def test_http_missing_secret_is_403(custody_client):
+    client, _, _ = custody_client
+    r = client.get("/host/v1/memory")
+    assert r.status_code == 403
+    assert "secret" in r.json()["detail"].lower()
+
+
+def test_http_wrong_secret_is_403(custody_client):
+    client, _, _ = custody_client
+    r = client.get("/host/v1/memory", headers=_h("bogus-secret"))
+    assert r.status_code == 403
+
+
+def test_http_malformed_auth_header_is_403(custody_client):
+    client, secret_a, _ = custody_client
+    r = client.get("/host/v1/memory", headers={"Authorization": secret_a})  # no scheme
+    assert r.status_code == 403
+
+
+def test_http_memory_scoped_to_caller(custody_client):
+    client, secret_a, secret_b = custody_client
+    client.post("/host/v1/memory", headers=_h(secret_a), json={"item": "a note"})
+    client.post("/host/v1/memory", headers=_h(secret_b), json={"item": "b note"})
+
+    a_items = client.get("/host/v1/memory", headers=_h(secret_a)).json()["items"]
+    b_items = client.get("/host/v1/memory", headers=_h(secret_b)).json()["items"]
+    assert [i["content"] for i in a_items] == ["a note"]
+    assert [i["content"] for i in b_items] == ["b note"]
+
+
+def test_http_agent_a_cannot_read_agent_b_session_403(custody_client):
+    """The headline acceptance criterion: A cannot read B's session → 403."""
+    client, secret_a, secret_b = custody_client
+    sid = client.post("/host/v1/sessions", headers=_h(secret_b), json={}).json()[
+        "session_id"
+    ]
+    client.post(
+        f"/host/v1/sessions/{sid}/messages",
+        headers=_h(secret_b),
+        json={"role": "user", "content": "b's private message"},
+    )
+    # Owner reads fine.
+    owner = client.get(f"/host/v1/sessions/{sid}", headers=_h(secret_b))
+    assert owner.status_code == 200
+    assert owner.json()["transcript"][0]["content"] == "b's private message"
+    # A cannot.
+    intruder = client.get(f"/host/v1/sessions/{sid}", headers=_h(secret_a))
+    assert intruder.status_code == 403
+
+
+def test_http_unknown_session_is_404(custody_client):
+    client, secret_a, _ = custody_client
+    r = client.get("/host/v1/sessions/does-not-exist", headers=_h(secret_a))
+    assert r.status_code == 404
+
+
+def test_http_audit_scoped_and_conflict_409(custody_client):
+    client, secret_a, _ = custody_client
+    r1 = client.post(
+        "/host/v1/audit",
+        headers=_h(secret_a),
+        json={"action_id": "a1", "action": "send", "summary": "s", "ts": 1.0},
+    )
+    assert r1.status_code == 200
+    r2 = client.post(
+        "/host/v1/audit",
+        headers=_h(secret_a),
+        json={"action_id": "a1", "action": "send", "ts": 2.0},
+    )
+    assert r2.status_code == 409
+
+
+def test_http_rag_query_scoped(custody_client):
+    client, secret_a, secret_b = custody_client
+    # Seed via the store directly is not exposed over HTTP (no ingest route in
+    # v1), so assert the empty-but-scoped contract: a query returns a list.
+    r = client.post("/host/v1/rag/query", headers=_h(secret_a), json={"query": "x"})
+    assert r.status_code == 200
+    assert r.json()["chunks"] == []
+
+
+def test_http_version_route_is_unauthenticated(custody_client):
+    client, _, _ = custody_client
+    r = client.get("/host/v1/version")
+    assert r.status_code == 200
+    assert int(r.json()["apiVersion"].split(".")[0]) == 1
+
+
+def test_create_app_requires_both_custody_args_or_neither(tmp_path):
+    from gaia.daemon.app import create_app
+
+    with pytest.raises(ValueError):
+        create_app(
+            token="t",
+            port=4001,
+            pid=1,
+            started_at=1.0,
+            custody_auth=CustodyAuth(),  # store missing
+        )
+
+
+def test_create_app_without_custody_does_not_mount_host_routes():
+    from fastapi.testclient import TestClient
+
+    from gaia.daemon.app import create_app
+
+    app = create_app(token="t", port=4001, pid=1, started_at=1.0)
+    client = TestClient(app, raise_server_exceptions=False)
+    assert client.get("/host/v1/version").status_code == 404
+
+
+# ===========================================================================
+# CustodyProvider — sidecar-side adapters (§0.37)
+# ===========================================================================
+
+
+def test_embedded_provider_roundtrip(store):
+    from gaia.daemon.custody.provider import EmbeddedCustodyProvider
+
+    p = EmbeddedCustodyProvider(store, "agent-a")
+    mid = p.add_memory("remember this")
+    assert isinstance(mid, int)
+    assert [i["content"] for i in p.get_memory()] == ["remember this"]
+
+    sid = p.create_session()
+    p.append_session_message(sid, "user", "hi")
+    assert [m["content"] for m in p.get_session(sid)] == ["hi"]
+
+    p.append_audit("act-1", "send", "sent")
+    assert store.get_audit("agent-a")[0]["action_id"] == "act-1"
+
+
+def test_embedded_provider_is_isolated_per_agent(store):
+    from gaia.daemon.custody.provider import EmbeddedCustodyProvider
+
+    a = EmbeddedCustodyProvider(store, "agent-a")
+    b = EmbeddedCustodyProvider(store, "agent-b")
+    a.add_memory("a only")
+    assert a.get_memory()
+    assert b.get_memory() == []
+
+
+def test_ephemeral_provider_persists_nothing():
+    from gaia.daemon.custody.provider import EphemeralCustodyProvider
+
+    p = EphemeralCustodyProvider()
+    assert p.add_memory("ignored") is None
+    assert p.get_memory() == []
+    sid = p.create_session()
+    assert p.append_session_message(sid, "user", "x") is None
+    assert p.get_session(sid) == []
+    assert p.query_rag("x") == []
+    assert p.append_audit("a", "b") is None
+
+
+def test_delegated_provider_roundtrip_against_real_app(custody_client, monkeypatch):
+    """The delegated adapter drives the real /host/v1 routes end-to-end — the
+    embedded and delegated adapters must behave identically (§0.37 conformance).
+
+    Route httpx.request through the TestClient so no socket server is needed.
+    """
+    import httpx
+
+    from gaia.daemon.custody import provider as provider_mod
+
+    client, secret_a, secret_b = custody_client
+
+    def _via_testclient(method, url, headers=None, timeout=None, **kwargs):
+        path = url.split("http://custody", 1)[1]
+        return client.request(method, path, headers=headers, **kwargs)
+
+    monkeypatch.setattr(httpx, "request", _via_testclient)
+
+    pa = provider_mod.DelegatedCustodyProvider("http://custody", secret_a)
+    pb = provider_mod.DelegatedCustodyProvider("http://custody", secret_b)
+
+    pa.add_memory("a note")
+    pb.add_memory("b note")
+    assert [i["content"] for i in pa.get_memory()] == ["a note"]
+    assert [i["content"] for i in pb.get_memory()] == ["b note"]
+
+    sid = pa.create_session()
+    pa.append_session_message(sid, "user", "hello")
+    assert [m["content"] for m in pa.get_session(sid)] == ["hello"]
+
+    # Cross-agent read raises a loud request error (403), never a silent empty.
+    with pytest.raises(provider_mod.CustodyRequestError) as exc:
+        pb.get_session(sid)
+    assert exc.value.status_code == 403
+
+
+def test_select_provider_prefers_ephemeral_flag():
+    from gaia.daemon.custody.provider import (
+        EphemeralCustodyProvider,
+        select_custody_provider,
+    )
+
+    env = {"GAIA_CUSTODY_EPHEMERAL": "1", "GAIA_HOST_CUSTODY_URL": "http://x"}
+    p = select_custody_provider("agent-a", env=env)
+    assert isinstance(p, EphemeralCustodyProvider)
+
+
+def test_select_provider_delegated_when_url_present():
+    from gaia.daemon.custody.provider import (
+        DelegatedCustodyProvider,
+        select_custody_provider,
+    )
+
+    env = {
+        "GAIA_HOST_CUSTODY_URL": "http://127.0.0.1:5000",
+        "GAIA_HOST_CUSTODY_SECRET": "s",
+    }
+    p = select_custody_provider("agent-a", env=env)
+    assert isinstance(p, DelegatedCustodyProvider)
+
+
+def test_select_provider_url_without_secret_fails_loud():
+    from gaia.daemon.custody.provider import select_custody_provider
+
+    env = {"GAIA_HOST_CUSTODY_URL": "http://127.0.0.1:5000"}
+    with pytest.raises(ValueError):
+        select_custody_provider("agent-a", env=env)
+
+
+def test_select_provider_embedded_default(store):
+    from gaia.daemon.custody.provider import (
+        EmbeddedCustodyProvider,
+        select_custody_provider,
+    )
+
+    p = select_custody_provider("agent-a", embedded_store=store, env={})
+    assert isinstance(p, EmbeddedCustodyProvider)
+
+
+def test_select_provider_no_url_no_store_fails_loud():
+    from gaia.daemon.custody.provider import select_custody_provider
+
+    with pytest.raises(ValueError):
+        select_custody_provider("agent-a", env={})
+
+
+# ===========================================================================
+# Registry / manager wiring — secret bound at mint, injected on spawn
+# ===========================================================================
+
+
+def test_registry_mints_custody_secret_at_manager_construction():
+    from gaia.daemon.sidecars.registry import SidecarRegistry
+    from gaia.daemon.sidecars.spec import AgentSidecarSpec
+
+    spec = AgentSidecarSpec(
+        agent_id="toy-a",
+        service_id="gaia-agent-toy-a",
+        display_name="Toy A",
+        expected_api_major="1",
+        token_env_var="GAIA_TOY_A_SIDECAR_TOKEN",
+        mode_env_var="GAIA_TOY_A_AGENT_MODE",
+        cache_dir_name="toy-a",
+    )
+    auth = CustodyAuth()
+
+    captured = {}
+
+    class _FakeManager:
+        def __init__(self, spec, mode=None, **kwargs):
+            self.spec = spec
+            self.custody_url = None
+            self.custody_secret = None
+            self.on_process_spawned = None
+            self.on_process_reaped = None
+
+    reg = SidecarRegistry(
+        {"toy-a": spec},
+        custody_auth=auth,
+        custody_base_url="http://127.0.0.1:4321",
+    )
+    reg._manager_factory = _FakeManager
+    manager = reg._new_manager("toy-a", spec, None)
+    captured["url"] = manager.custody_url
+    captured["secret"] = manager.custody_secret
+
+    assert captured["url"] == "http://127.0.0.1:4321"
+    assert captured["secret"]
+    # The minted secret resolves back to this agent id.
+    assert auth.resolve(captured["secret"]) == "toy-a"
+
+
+def test_manager_injects_custody_env_on_spawn(tmp_path, monkeypatch):
+    from gaia.daemon.custody.constants import (
+        CUSTODY_SECRET_ENV_VAR,
+        CUSTODY_URL_ENV_VAR,
+    )
+    from gaia.daemon.sidecars import manager as mgr_mod
+    from gaia.daemon.sidecars.spec import AgentSidecarSpec
+
+    src = tmp_path / "toy-src"
+    (src / "packaging").mkdir(parents=True, exist_ok=True)
+    spec = AgentSidecarSpec(
+        agent_id="toy-a",
+        service_id="gaia-agent-toy-a",
+        display_name="Toy A",
+        expected_api_major="1",
+        token_env_var="GAIA_TOY_A_SIDECAR_TOKEN",
+        mode_env_var="GAIA_TOY_A_AGENT_MODE",
+        cache_dir_name="toy-a",
+        dev_src_dir=src,
+    )
+    monkeypatch.setenv(spec.mode_env_var, "dev")
+
+    captured_env = {}
+
+    class _Proc:
+        pid = 4242
+        returncode = None
+
+        def poll(self):
+            return None
+
+    def _fake_popen(argv, env=None, **kw):
+        captured_env.update(env or {})
+        return _Proc()
+
+    monkeypatch.setattr(mgr_mod.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(mgr_mod.atexit, "register", lambda fn: None)
+
+    m = mgr_mod.AgentSidecarManager(spec, cache_dir=tmp_path, log_dir=tmp_path / "logs")
+    m.custody_url = "http://127.0.0.1:4321"
+    m.custody_secret = "the-custody-secret"
+    argv, popen_kwargs = m.build_spawn_command(port=55123)
+    m._spawn_process(argv, popen_kwargs, 55123)
+
+    assert captured_env[CUSTODY_URL_ENV_VAR] == "http://127.0.0.1:4321"
+    assert captured_env[CUSTODY_SECRET_ENV_VAR] == "the-custody-secret"


### PR DESCRIPTION
**Before:** the daemon had no host-owned custody surface. Sidecars owned their own state in-process, and design §0.31's reverse contract (`/host/v1/*`) didn't exist — so any future multi-agent deployment was a single-reader exfiltration surface with no per-agent isolation (§0.11 🔒).

**After:** the daemon exposes `/host/v1/*` v1 — memory, sessions, RAG, audit — backed by a daemon-owned SQLite store (WAL + `busy_timeout`, §0.29). Every response is **scoped to the calling agent**: a sidecar authenticates with a per-spawn secret **bound to its agent id at mint** (not per-request trust), so the daemon resolves identity from the secret and can never be told which agent it is. Agent A cannot read agent B's memory or sessions (403); a missing/wrong secret is 403; errors are typed and loud (403/404/409/503), never a silent empty result.

This is the **foundational** custody item — #2154/#2155/#2156 build on the contract below.

## Test plan
- [x] `python -m pytest tests/unit/test_daemon_custody.py` — 42 passed (store scoping, auth mint/resolve/rotate/revoke, HTTP boundary on a real app instance, provider round-trips, registry/manager mint wiring)
- [x] Boundary test at the real HTTP layer: A-vs-B session read → 403; missing/malformed/wrong secret → 403 (`test_http_agent_a_cannot_read_agent_b_session_403`, `test_http_*_secret_is_403`)
- [x] Audit rows survive a store close/reopen (proxy for sidecar uninstall) — `test_audit_rows_survive_store_reopen`
- [x] Delegated vs Embedded provider parity driven through the real routes — `test_delegated_provider_roundtrip_against_real_app`
- [x] `python util/lint.py` black/isort/flake8 clean on all changed files
- [x] Full daemon suite green except 6 **pre-existing** Windows-only failures (`os.killpg` absent on Windows), confirmed failing on `main` without this change

## The `/host/v1` custody contract (for #2154/#2155/#2156 to align)

**Namespace & versioning.** Prefix `/host/v1`. Own MAJOR in `HOST_API_VERSION` (`gaia/daemon/custody/constants.py`), **independent** of the client-facing `/daemon/v1` (`DAEMON_API_VERSION`). Mounts cleanly alongside the model-slot broker's `POST /host/v1/models/lease` (#2151) — no route collision.

**Auth (the core guarantee).** Bearer secret, `Authorization: Bearer <secret>`. The secret is minted by `CustodyAuth.mint(agent_id)` **at sidecar mint** (the registry, when it constructs a manager) and injected over the private spawn env (`GAIA_HOST_CUSTODY_URL` + `GAIA_HOST_CUSTODY_SECRET`). Routes call `CustodyAuth.resolve(secret) -> agent_id`; the request never carries a claimed id. Secrets are in-memory only (re-minted each daemon start), rotate on re-ensure, and are revoked on stop/reap.

**Routes (v1):**

| Route | Request | Response | Scope |
|---|---|---|---|
| `GET /host/v1/version` | — | `{apiVersion}` | unauthenticated (negotiation) |
| `POST /host/v1/rag/query` | `{query, k}` | `{chunks[]}` | caller's corpus only |
| `GET /host/v1/memory` | `?scope=&query=` | `{items[]}` | caller's memory only |
| `POST /host/v1/memory` | `{item, scope?}` | `{id}` | writes as caller |
| `POST /host/v1/sessions` | `{session_id?}` | `{session_id}` | host-minted, owned by caller |
| `POST /host/v1/sessions/{id}/messages` | `{role, content}` | `{seq}` | 403 unless caller owns id |
| `GET /host/v1/sessions/{id}` | — | `{session_id, transcript[]}` | 403 unless caller owns id; 404 if unknown |
| `POST /host/v1/audit` | `{action_id, action, summary?, ts?}` | `{seq}` | append-only; `action_id` = idempotency key |

**Error contract (typed, loud — no silent fallbacks):** `403` missing/malformed/unknown secret or cross-agent access; `404` unknown session; `409` duplicate audit `action_id`; `503` store unavailable; `400` bad scope / missing required field. All map from `CustodyError` subclasses via one app-wide handler.

**Sidecar-side abstraction (§0.37).** `CustodyProvider` ABC + three adapters in `gaia/daemon/custody/provider.py`: **Embedded** (self-custody over a local store), **Delegated** (HTTP to `/host/v1`), **Ephemeral** (stateless). `select_custody_provider(...)` auto-selects: explicit stateless flag → Ephemeral; custody URL present → Delegated; else Embedded. Single-writer invariant holds in every mode.

**Deliberately deferred (out of scope, per the issue):** hash-chained audit (§0.35.5 — v1 is plain append-only), the embedder-backed RAG retriever (v1 is a naive scoped substring match), the one-time data migration (V2-13), and refactoring the fat UI routers into thin `/host/v1` clients (follow-up). `sharedScopes` grant enforcement lands with the manifest work (V2-3); v1 accepts and stores the scope literal.

Part of #2014. Closes #2153.