### PR TITLE
feat(api): relay /v1/<agent>/query through the daemon (V2-17)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,9 @@ setup(
             "fastapi>=0.115.0",
             "uvicorn>=0.32.0",
             "python-multipart>=0.0.9",
+            # Async client for the /v1/<agent>/query daemon relay (#2178): the
+            # API server streams SSE from the daemon unbuffered via httpx.
+            "httpx>=0.27.0",
             # [api] auto-mounts the gaia-agent-email REST router (openai_server.py),
             # whose import chain reaches gaia.connectors.store -> `import keyring`
             # at module load AND at request time (connected_mailbox_providers).

--- a/src/gaia/api/agent_proxy.py
+++ b/src/gaia/api/agent_proxy.py
@@ -56,13 +56,11 @@ CONNECT_TIMEOUT = 10.0
 #: daemon, so it matches the daemon relay's own long per-request budget.
 READ_TIMEOUT = 300.0
 
-#: Methods the proxy accepts — the full surface the daemon relay serves.
-RELAY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
-
 #: First-segment ids owned by the OpenAI-compatible surface — never relayed as
-#: agents. Defense-in-depth: these routes are declared first and win on match
-#: order, but an unknown subpath under them (``/v1/chat/foo``) must not silently
-#: become an "agent chat" relay.
+#: agents. The proxy only claims the ``/v1/<agent>/query`` surface (so it can't
+#: shadow the OpenAI routes' 404/405 semantics), but ``/v1/chat/query`` and
+#: ``/v1/models/query`` would still match the pattern; this blocks them so a
+#: reserved id can never masquerade as an agent.
 _RESERVED_AGENT_IDS = frozenset({"chat", "models"})
 
 # Hop-by-hop headers never forwarded in either direction (RFC 9110 §7.6.1).
@@ -218,14 +216,28 @@ async def _acquire_daemon():
 
 
 def build_agent_proxy_router() -> APIRouter:
-    """API-key-guarded router relaying ``ANY /v1/{agent_id}/*`` to the daemon's
-    streaming relay (#2150). The daemon does the sidecar-bearer swap, so this
-    proxy holds only the daemon client token."""
+    """API-key-guarded router relaying the ``/v1/<agent>/query`` surface to the
+    daemon's streaming relay (#2150). The daemon does the sidecar-bearer swap, so
+    this proxy holds only the daemon client token.
+
+    Scoped to ``POST /v1/{agent}/query`` and ``POST
+    /v1/{agent}/query/{run_id}/cancel`` on purpose: a generic ``/v1/{agent}/*``
+    catch-all would swallow the OpenAI surface's own 404/405 (e.g. ``GET
+    /v1/chat/completions`` or ``GET /v1/nonexistent``) behind this router's
+    API-key dependency. Narrow routes leave those to FastAPI's default routing.
+    """
     require_api_key = build_require_api_key()
     router = APIRouter(dependencies=[Depends(require_api_key)])
 
-    @router.api_route("/v1/{agent_id}/{path:path}", methods=RELAY_METHODS)
-    async def proxy(agent_id: str, path: str, request: Request):
+    @router.post("/v1/{agent_id}/query")
+    async def proxy_query(agent_id: str, request: Request):
+        return await _relay(agent_id, "query", request)
+
+    @router.post("/v1/{agent_id}/query/{run_id}/cancel")
+    async def proxy_query_cancel(agent_id: str, run_id: str, request: Request):
+        return await _relay(agent_id, f"query/{run_id}/cancel", request)
+
+    async def _relay(agent_id: str, path: str, request: Request):
         if agent_id in _RESERVED_AGENT_IDS:
             raise HTTPException(
                 status_code=404,

--- a/src/gaia/api/agent_proxy.py
+++ b/src/gaia/api/agent_proxy.py
@@ -1,0 +1,345 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Thin data-plane proxy exposing ``/v1/<agent>/query`` on ``gaia api`` (#2178 /
+V2-17).
+
+The API server is a thin client of the always-on GAIA daemon: it forwards
+``ANY /v1/<agent>/*`` to the daemon's streaming relay (#2150 / V2-7) carrying
+only the DAEMON client token. The daemon swaps that for the per-agent sidecar
+bearer server-side, so the API server never learns sidecar coordinates nor holds
+a sidecar bearer — the whole point of the thin-host model.
+
+SSE bodies stream UNBUFFERED (``httpx.AsyncClient(stream=True)`` chunks →
+``StreamingResponse``): each daemon chunk is forwarded the moment it arrives.
+The daemon owns the crash/cancel synthetic-terminal contract (§0.13) — this proxy
+forwards those frames verbatim and only authors its OWN synthetic terminal
+``error`` when the DAEMON connection itself drops mid-stream (a failure the
+daemon relay cannot report, being the thing that died). A client disconnect
+closes the upstream connection, which the daemon relay sees as ITS client
+disconnect and propagates as an upstream cancel to the sidecar.
+
+Auth: the ``/v1/<agent>/*`` surface exposes the agentic loop, and ``gaia api``
+may bind beyond loopback, so it is gated by an API key (``GAIA_API_KEY``) —
+stricter than the daemon's loopback trust (§0.33). ``/v1/chat/completions`` and
+``/v1/models`` are untouched. No silent fallback: an unset key, a missing/invalid
+key, an unreachable daemon, and a dead sidecar each raise a loud, actionable HTTP
+error (the daemon's own 404/503/502 envelope is preserved for the last two).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+from typing import Optional
+
+# Module-level import (matches gaia.daemon.relay): the endpoint annotation
+# ``request: Request`` below must resolve from module globals under PEP 563.
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse
+
+from gaia.daemon.errors import DaemonError
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+#: Environment variable holding the API key that gates the agent query surface.
+API_KEY_ENV = "GAIA_API_KEY"
+#: Auth scheme for the API key (mirrors the daemon's Bearer contract).
+AUTH_SCHEME = "Bearer"
+
+#: Connect timeout — a dead daemon should fail fast on TCP connect.
+CONNECT_TIMEOUT = 10.0
+#: Read timeout between chunks — spans a whole agent-loop step relayed by the
+#: daemon, so it matches the daemon relay's own long per-request budget.
+READ_TIMEOUT = 300.0
+
+#: Methods the proxy accepts — the full surface the daemon relay serves.
+RELAY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+
+#: First-segment ids owned by the OpenAI-compatible surface — never relayed as
+#: agents. Defense-in-depth: these routes are declared first and win on match
+#: order, but an unknown subpath under them (``/v1/chat/foo``) must not silently
+#: become an "agent chat" relay.
+_RESERVED_AGENT_IDS = frozenset({"chat", "models"})
+
+# Hop-by-hop headers never forwarded in either direction (RFC 9110 §7.6.1).
+_HOP_BY_HOP = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+# Request headers the proxy owns: host (rewritten by httpx), authorization (the
+# API key is swapped for the daemon client token), content-length (recomputed),
+# accept-encoding (forced to identity so relayed SSE bytes stay uncompressed).
+_REQUEST_DROP = _HOP_BY_HOP | {
+    "host",
+    "authorization",
+    "content-length",
+    "accept-encoding",
+}
+# Response headers the proxy owns: length/encoding are recomputed for the
+# (decoded) body; date/server would duplicate uvicorn's own.
+_RESPONSE_DROP = _HOP_BY_HOP | {"content-length", "content-encoding", "date", "server"}
+
+# Strong refs to fire-and-forget cleanup tasks spawned from a cancelled response
+# generator (asyncio only weak-refs pending tasks).
+_background_tasks: "set[asyncio.Task]" = set()
+
+
+def _spawn_background(coro) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # Loop already gone (server teardown): cleanup cannot run, so the
+        # upstream response/client leak until GC — name it instead of hiding it.
+        logger.warning(
+            "gaia api proxy: no running loop for background cleanup task; "
+            "upstream connection will be reclaimed by GC"
+        )
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+def daemon_stream_dropped_detail(agent_id: str) -> str:
+    """Actionable detail for the proxy's synthetic terminal error frame — used
+    only when the DAEMON connection drops mid-stream (the daemon relay cannot
+    author its own §0.13 terminal because it is the thing that died)."""
+    return (
+        f"the GAIA daemon connection dropped mid-stream while relaying agent "
+        f"'{agent_id}' — the daemon may have exited. Check `gaia daemon status` "
+        "and `gaia daemon logs`, then retry."
+    )
+
+
+def _synthetic_error_frame(detail: str) -> bytes:
+    """One canonical terminal ``error`` SSE frame, proxy-authored.
+
+    Same shape as the daemon relay's frame (the frozen contract's ``error``
+    event) with a distinct ``source`` marker so a downstream consumer can tell a
+    proxy-synthesized terminal (daemon died) from a daemon-synthesized one
+    (sidecar died) from a sidecar-authored one.
+    """
+    return (
+        b"data: "
+        + json.dumps({"type": "error", "detail": detail, "source": "gaia_api"}).encode(
+            "utf-8"
+        )
+        + b"\n\n"
+    )
+
+
+def build_require_api_key():
+    """FastAPI dependency enforcing the ``GAIA_API_KEY`` on the agent surface.
+
+    No silent fallback: an unset key disables the surface with a loud 503 naming
+    the remedy (rather than allowing unauthenticated access to the agentic loop);
+    a missing/malformed/invalid key is a 401 naming what to send.
+    """
+
+    def require_api_key(authorization: Optional[str] = Header(default=None)) -> None:
+        expected = os.environ.get(API_KEY_ENV)
+        if not expected:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "The agent query surface (POST /v1/<agent>/query) is disabled: "
+                    f"no API key is configured. Set {API_KEY_ENV} in the API "
+                    "server's environment (e.g. "
+                    f"`export {API_KEY_ENV}=$(openssl rand -hex 32)`), restart "
+                    "`gaia api`, and send it as "
+                    f"'Authorization: {AUTH_SCHEME} <key>'."
+                ),
+            )
+        if not authorization:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    f"Missing API key. Send 'Authorization: {AUTH_SCHEME} <key>' "
+                    f"matching {API_KEY_ENV} on the API server."
+                ),
+                headers={"WWW-Authenticate": AUTH_SCHEME},
+            )
+        scheme, _, credential = authorization.partition(" ")
+        if scheme.lower() != AUTH_SCHEME.lower() or not credential:
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    f"Malformed Authorization header. Expected "
+                    f"'{AUTH_SCHEME} <key>'."
+                ),
+                headers={"WWW-Authenticate": AUTH_SCHEME},
+            )
+        if not secrets.compare_digest(credential, expected):
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    f"Invalid API key. It must match {API_KEY_ENV} on the API "
+                    "server."
+                ),
+                headers={"WWW-Authenticate": AUTH_SCHEME},
+            )
+
+    return require_api_key
+
+
+async def _acquire_daemon():
+    """``start_or_attach`` off the event loop; loud HTTPException on failure.
+
+    ``start_or_attach`` does blocking ``requests`` I/O (probe + possible detached
+    spawn), so it runs in a threadpool. A daemon that cannot be reached or
+    started is a loud 503 — never a silent in-process fallback (#2178)."""
+    from gaia.daemon.client import start_or_attach
+
+    loop = asyncio.get_event_loop()
+    try:
+        return await loop.run_in_executor(None, start_or_attach)
+    except DaemonError as e:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "the GAIA daemon is unavailable, so the agent query surface "
+                f"cannot relay: {e} Check `gaia daemon status` and "
+                "`gaia daemon logs`, then retry."
+            ),
+        ) from e
+
+
+def build_agent_proxy_router() -> APIRouter:
+    """API-key-guarded router relaying ``ANY /v1/{agent_id}/*`` to the daemon's
+    streaming relay (#2150). The daemon does the sidecar-bearer swap, so this
+    proxy holds only the daemon client token."""
+    require_api_key = build_require_api_key()
+    router = APIRouter(dependencies=[Depends(require_api_key)])
+
+    @router.api_route("/v1/{agent_id}/{path:path}", methods=RELAY_METHODS)
+    async def proxy(agent_id: str, path: str, request: Request):
+        if agent_id in _RESERVED_AGENT_IDS:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"'/v1/{agent_id}/{path}' is not an agent route. The "
+                    "OpenAI-compatible surface is POST /v1/chat/completions and "
+                    "GET /v1/models; agent routes are /v1/<agent>/query."
+                ),
+            )
+
+        inst = await _acquire_daemon()
+        body = await request.body()
+        upstream_headers = {
+            k: v for k, v in request.headers.items() if k.lower() not in _REQUEST_DROP
+        }
+        upstream_headers["Authorization"] = f"{AUTH_SCHEME} {inst.token}"
+        upstream_headers["Accept-Encoding"] = "identity"
+        url = f"{inst.base_url}/v1/{agent_id}/{path}"
+
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(READ_TIMEOUT, connect=CONNECT_TIMEOUT)
+        )
+        try:
+            upstream = await client.send(
+                client.build_request(
+                    request.method,
+                    url,
+                    content=body,
+                    headers=upstream_headers,
+                    params=request.url.query or None,
+                ),
+                stream=True,
+            )
+        except httpx.HTTPError as e:
+            await client.aclose()
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"the GAIA daemon at {inst.base_url} did not answer the relay "
+                    f"for agent '{agent_id}' ({e.__class__.__name__}: {e}). It "
+                    "may have exited — check `gaia daemon status` and "
+                    "`gaia daemon logs`, then retry."
+                ),
+            ) from e
+
+        content_type = upstream.headers.get("content-type", "")
+        response_headers = {
+            k: v for k, v in upstream.headers.items() if k.lower() not in _RESPONSE_DROP
+        }
+
+        if not content_type.lower().startswith("text/event-stream"):
+            # Fixed-function / non-streaming daemon response (including the
+            # daemon's own loud 404/503/502 envelopes): buffered passthrough,
+            # verbatim status + headers + body.
+            try:
+                payload = await upstream.aread()
+            except httpx.HTTPError as e:
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        f"the GAIA daemon dropped the connection mid-response on "
+                        f"/v1/{agent_id}/{path} ({e.__class__.__name__}: {e}). "
+                        "Check `gaia daemon status` and retry."
+                    ),
+                ) from e
+            finally:
+                await upstream.aclose()
+                await client.aclose()
+            return Response(
+                content=payload,
+                status_code=upstream.status_code,
+                headers=response_headers,
+            )
+
+        async def _close() -> None:
+            await upstream.aclose()
+            await client.aclose()
+
+        async def _relay_sse():
+            disconnected = False
+            try:
+                try:
+                    async for chunk in upstream.aiter_bytes():
+                        yield chunk
+                except (GeneratorExit, asyncio.CancelledError):
+                    # Client went away mid-stream. Closing the upstream
+                    # connection makes the daemon relay see ITS client
+                    # disconnect and propagate cancel to the sidecar. This
+                    # generator is being torn down and can no longer await
+                    # safely, so cleanup moves to a detached task.
+                    disconnected = True
+                    _spawn_background(_close())
+                    raise
+                except httpx.HTTPError as exc:
+                    # The daemon connection broke mid-stream — the daemon relay
+                    # (now unreachable) cannot author its §0.13 terminal, so we
+                    # emit our own so the consumer never hangs on a truncated
+                    # stream.
+                    logger.warning(
+                        "gaia api proxy: relay to daemon for agent '%s' broke "
+                        "mid-stream (%s: %s) — emitting synthetic terminal error",
+                        agent_id,
+                        exc.__class__.__name__,
+                        exc,
+                    )
+                    yield _synthetic_error_frame(daemon_stream_dropped_detail(agent_id))
+            finally:
+                if not disconnected:
+                    await _close()
+
+        return StreamingResponse(
+            _relay_sse(),
+            status_code=upstream.status_code,
+            headers=response_headers,
+        )
+
+    return router

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -164,7 +164,14 @@ async def log_raw_requests(request: Request, call_next):
 
         # DON'T read body for streaming endpoints - it breaks ASGI message flow
         # Per FastAPI docs: "Never read the request body in middleware for streaming responses"
-        if request.url.path == "/v1/chat/completions" and request.method == "POST":
+        # Covers /v1/chat/completions AND the agent /query relay (#2178), whose
+        # POST bodies feed a StreamingResponse.
+        _p = request.url.path
+        _is_streaming_post = request.method == "POST" and (
+            _p == "/v1/chat/completions"
+            or (_p.startswith("/v1/") and _p.endswith("/query"))
+        )
+        if _is_streaming_post:
             logger.debug(
                 "Body: [Skipped for streaming endpoint - prevents ASGI message flow disruption]"
             )
@@ -616,3 +623,14 @@ async def health_check():
         ```
     """
     return {"status": "ok", "service": "gaia-api"}
+
+
+# Agent /query surface (#2178 / V2-17): POST /v1/<agent>/query streams the
+# agentic loop through the always-on daemon relay (#2150). Mounted LAST so the
+# OpenAI-compatible routes (/v1/chat/completions, /v1/models) declared above win
+# on match order; the catch-all only claims /v1/<agent>/<path> pairs. The API
+# server stays a thin client — it forwards only the daemon client token, never a
+# sidecar bearer. Gated by GAIA_API_KEY (§0.33), independent of the email wheel.
+from .agent_proxy import build_agent_proxy_router  # noqa: E402
+
+app.include_router(build_agent_proxy_router())

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -28,6 +28,7 @@ from fastapi.responses import StreamingResponse
 
 from gaia.agents.base.api_agent import ApiAgent
 
+from .agent_proxy import build_agent_proxy_router
 from .agent_registry import registry
 from .schemas import (
     ChatCompletionChoice,
@@ -626,11 +627,10 @@ async def health_check():
 
 
 # Agent /query surface (#2178 / V2-17): POST /v1/<agent>/query streams the
-# agentic loop through the always-on daemon relay (#2150). Mounted LAST so the
-# OpenAI-compatible routes (/v1/chat/completions, /v1/models) declared above win
-# on match order; the catch-all only claims /v1/<agent>/<path> pairs. The API
-# server stays a thin client — it forwards only the daemon client token, never a
-# sidecar bearer. Gated by GAIA_API_KEY (§0.33), independent of the email wheel.
-from .agent_proxy import build_agent_proxy_router  # noqa: E402
-
+# agentic loop through the always-on daemon relay (#2150). Mounted after the
+# OpenAI-compatible routes are declared; the router only claims the narrow
+# /v1/<agent>/query surface, so it never shadows /v1/chat/completions or
+# /v1/models (nor their 404/405). The API server stays a thin client — it
+# forwards only the daemon client token, never a sidecar bearer. Gated by
+# GAIA_API_KEY (§0.33), independent of the email wheel.
 app.include_router(build_agent_proxy_router())

--- a/tests/unit/test_api_agent_proxy.py
+++ b/tests/unit/test_api_agent_proxy.py
@@ -12,8 +12,8 @@ Part 1 (helpers): the API-key dependency + synthetic-frame shape (pure unit).
 
 Part 2 (routes): TestClient over the real ``gaia.api.openai_server:app`` — the
 API-key 503/401 contract and the daemon-down loud 503, with ``start_or_attach``
-monkeypatched (no upstream involved). Also asserts ``/v1/chat/completions`` and
-``/v1/models`` are NOT shadowed by the catch-all relay.
+monkeypatched (no upstream involved). Also asserts the scoped ``/query`` relay
+does NOT shadow ``/v1/chat/completions`` / ``/v1/models`` or their 404/405.
 
 Part 3 (integration): a REAL uvicorn fake *daemon* (mimicking the #2150 relay
 surface) + the REAL ``gaia api`` app on ephemeral ports (never 4001). The fake
@@ -174,10 +174,10 @@ def test_daemon_down_maps_to_loud_503(api_client, with_api_key, monkeypatch):
 
 
 @needs_fastapi
-def test_reserved_chat_subpath_not_relayed_as_agent(api_client, with_api_key):
-    """A stray /v1/chat/<x> must not become an "agent chat" relay."""
+def test_reserved_chat_query_not_relayed_as_agent(api_client, with_api_key):
+    """A stray /v1/chat/query must not become an "agent chat" relay."""
     r = api_client.post(
-        "/v1/chat/bogus",
+        "/v1/chat/query",
         json={"query": "hi"},
         headers={"Authorization": f"Bearer {_API_KEY}"},
     )
@@ -188,8 +188,7 @@ def test_reserved_chat_subpath_not_relayed_as_agent(api_client, with_api_key):
 @needs_fastapi
 def test_openai_routes_not_shadowed_by_relay(api_client, with_api_key):
     """/v1/models and /v1/chat/completions keep their own handlers even with the
-    catch-all relay mounted and an API key set."""
-    # /v1/models has a single path segment → cannot match /v1/{agent}/{path}.
+    query relay mounted and an API key set."""
     r = api_client.get("/v1/models")
     assert r.status_code == 200
     assert r.json()["object"] == "list"
@@ -204,6 +203,25 @@ def test_openai_routes_not_shadowed_by_relay(api_client, with_api_key):
     )
     assert r.status_code == 404
     assert "not found" in r.json()["detail"].lower()
+
+
+@needs_fastapi
+@pytest.mark.parametrize("has_key", [False, True])
+def test_query_relay_does_not_shadow_openai_404_405(api_client, monkeypatch, has_key):
+    """The scoped /query relay must NOT swallow the OpenAI surface's own 404/405
+    (regression for the generic-catch-all shadowing that reached CI: GET
+    /v1/chat/completions returned the relay's 503 instead of FastAPI's 405).
+    Holds whether or not the API key is configured — these paths never reach the
+    relay's API-key dependency."""
+    if has_key:
+        monkeypatch.setenv(API_KEY_ENV, _API_KEY)
+    else:
+        monkeypatch.delenv(API_KEY_ENV, raising=False)
+    # Wrong method on a real OpenAI route → 405, not the relay's 503.
+    assert api_client.get("/v1/chat/completions").status_code == 405
+    assert api_client.post("/v1/models", json={}).status_code == 405
+    # Unknown single-segment path → FastAPI 404, not the relay's 503.
+    assert api_client.get("/v1/nonexistent").status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_api_agent_proxy.py
+++ b/tests/unit/test_api_agent_proxy.py
@@ -1,0 +1,474 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Deterministic suite for the ``gaia api`` agent /query proxy
+(``gaia.api.agent_proxy``, issue #2178 / V2-17).
+
+The proxy makes ``gaia api`` a thin client of the always-on daemon relay
+(#2150): it forwards ``/v1/<agent>/query`` to the daemon carrying only the
+DAEMON client token, gated by ``GAIA_API_KEY``. It never learns sidecar
+coordinates nor holds a sidecar bearer.
+
+Part 1 (helpers): the API-key dependency + synthetic-frame shape (pure unit).
+
+Part 2 (routes): TestClient over the real ``gaia.api.openai_server:app`` — the
+API-key 503/401 contract and the daemon-down loud 503, with ``start_or_attach``
+monkeypatched (no upstream involved). Also asserts ``/v1/chat/completions`` and
+``/v1/models`` are NOT shadowed by the catch-all relay.
+
+Part 3 (integration): a REAL uvicorn fake *daemon* (mimicking the #2150 relay
+surface) + the REAL ``gaia api`` app on ephemeral ports (never 4001). The fake
+daemon's stream is gated on explicit events, never wall-clock timing, so the
+load-bearing assertions are deterministic:
+
+  (a) no buffering — the first SSE event reaches the REST client while the fake
+      daemon's stream body is provably still open,
+  (b) cancel-on-disconnect — closing the REST client connection mid-stream tears
+      down the proxy→daemon connection (the daemon then owns sidecar cancel),
+  (c) the daemon-authored synthetic terminal ``error`` (source ``daemon_relay``,
+      §0.13) is forwarded VERBATIM,
+  (d) a daemon connection that drops mid-stream yields the proxy's OWN synthetic
+      terminal ``error`` (source ``gaia_api``) — the consumer never hangs,
+  (e) the DAEMON client token — never the API key — crosses to the daemon.
+"""
+
+# NO `from __future__ import annotations`: the fake daemon's FastAPI endpoints
+# annotate `request: Request` with Request imported inside build_app(); a
+# stringified annotation could not resolve it (PEP 563).
+
+import importlib.util
+import json
+import os
+import threading
+import time
+
+import pytest
+
+from gaia.api.agent_proxy import (
+    API_KEY_ENV,
+    _synthetic_error_frame,
+    daemon_stream_dropped_detail,
+)
+
+_HAS_FASTAPI = importlib.util.find_spec("fastapi") is not None
+_HAS_UVICORN = importlib.util.find_spec("uvicorn") is not None
+_HAS_HTTPX = importlib.util.find_spec("httpx") is not None
+_HAS_REQUESTS = importlib.util.find_spec("requests") is not None
+
+needs_fastapi = pytest.mark.skipif(
+    not (_HAS_FASTAPI and _HAS_HTTPX),
+    reason="fastapi + httpx must be importable for proxy route tests",
+)
+needs_live_servers = pytest.mark.skipif(
+    not (_HAS_FASTAPI and _HAS_HTTPX and _HAS_UVICORN and _HAS_REQUESTS),
+    reason=(
+        "fastapi, httpx, uvicorn, and requests must all be importable for the "
+        "real-server proxy integration tests"
+    ),
+)
+
+_API_KEY = "test-api-key-abc123"
+_DAEMON_TOKEN = "daemon-client-tok"
+
+
+def _frame(event: dict) -> bytes:
+    return b"data: " + json.dumps(event).encode() + b"\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — helpers (pure unit, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_error_frame_shape():
+    raw = _synthetic_error_frame("it broke")
+    assert raw.startswith(b"data: ") and raw.endswith(b"\n\n")
+    event = json.loads(raw[len(b"data: ") : -2])
+    assert event == {"type": "error", "detail": "it broke", "source": "gaia_api"}
+
+
+def test_daemon_stream_dropped_detail_is_actionable():
+    detail = daemon_stream_dropped_detail("email")
+    assert "email" in detail
+    assert "daemon status" in detail  # names where to look
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — route-level auth + daemon-down (TestClient, no upstream)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def api_client():
+    if not (_HAS_FASTAPI and _HAS_HTTPX):
+        pytest.skip("fastapi/httpx not importable")
+    from fastapi.testclient import TestClient
+
+    from gaia.api.openai_server import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture()
+def no_api_key(monkeypatch):
+    monkeypatch.delenv(API_KEY_ENV, raising=False)
+
+
+@pytest.fixture()
+def with_api_key(monkeypatch):
+    monkeypatch.setenv(API_KEY_ENV, _API_KEY)
+
+
+@needs_fastapi
+def test_query_disabled_without_api_key_configured(api_client, no_api_key):
+    r = api_client.post("/v1/toy/query", json={"query": "hi"})
+    assert r.status_code == 503
+    detail = r.json()["detail"]
+    assert API_KEY_ENV in detail  # names the remedy
+
+
+@needs_fastapi
+def test_query_missing_api_key_header_is_401(api_client, with_api_key):
+    r = api_client.post("/v1/toy/query", json={"query": "hi"})
+    assert r.status_code == 401
+    assert API_KEY_ENV in r.json()["detail"]
+
+
+@needs_fastapi
+def test_query_wrong_api_key_is_401(api_client, with_api_key):
+    r = api_client.post(
+        "/v1/toy/query",
+        json={"query": "hi"},
+        headers={"Authorization": "Bearer wrong-key"},
+    )
+    assert r.status_code == 401
+
+
+@needs_fastapi
+def test_query_malformed_auth_header_is_401(api_client, with_api_key):
+    r = api_client.post(
+        "/v1/toy/query",
+        json={"query": "hi"},
+        headers={"Authorization": _API_KEY},  # no "Bearer " scheme
+    )
+    assert r.status_code == 401
+
+
+@needs_fastapi
+def test_daemon_down_maps_to_loud_503(api_client, with_api_key, monkeypatch):
+    """Acceptance: daemon down → loud actionable error, no silent fallback."""
+    from gaia.daemon.errors import DaemonStartError
+
+    def _boom():
+        raise DaemonStartError("the daemon did not become healthy within 30s.")
+
+    monkeypatch.setattr("gaia.daemon.client.start_or_attach", _boom)
+    r = api_client.post(
+        "/v1/toy/query",
+        json={"query": "hi"},
+        headers={"Authorization": f"Bearer {_API_KEY}"},
+    )
+    assert r.status_code == 503
+    detail = r.json()["detail"]
+    assert "daemon" in detail.lower()
+    assert "gaia daemon status" in detail  # names where to look
+
+
+@needs_fastapi
+def test_reserved_chat_subpath_not_relayed_as_agent(api_client, with_api_key):
+    """A stray /v1/chat/<x> must not become an "agent chat" relay."""
+    r = api_client.post(
+        "/v1/chat/bogus",
+        json={"query": "hi"},
+        headers={"Authorization": f"Bearer {_API_KEY}"},
+    )
+    assert r.status_code == 404
+    assert "not an agent route" in r.json()["detail"]
+
+
+@needs_fastapi
+def test_openai_routes_not_shadowed_by_relay(api_client, with_api_key):
+    """/v1/models and /v1/chat/completions keep their own handlers even with the
+    catch-all relay mounted and an API key set."""
+    # /v1/models has a single path segment → cannot match /v1/{agent}/{path}.
+    r = api_client.get("/v1/models")
+    assert r.status_code == 200
+    assert r.json()["object"] == "list"
+    # /v1/chat/completions is declared before the relay → its handler wins; an
+    # unknown model is the OpenAI handler's own 404, not the relay's.
+    r = api_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "does-not-exist",
+            "messages": [{"role": "user", "content": "x"}],
+        },
+    )
+    assert r.status_code == 404
+    assert "not found" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — real-server integration: fake daemon + gaia api proxy over TCP
+# ---------------------------------------------------------------------------
+
+
+class _FakeDaemon:
+    """Scripted stand-in for the #2150 daemon relay surface.
+
+    ``/v1/toy/query`` streams SSE gated on explicit events (never sleeps for
+    effect): one ``status`` event, then — mode ``hold`` — waits for ``release``
+    before the terminal ``final``; mode ``daemon_crash`` — one ``status`` then
+    the stream generator RAISES, so uvicorn aborts the response mid-stream (the
+    proxy's httpx read then errors → the proxy authors its own terminal);
+    mode ``relay_synthetic`` — one ``status`` then the daemon-authored §0.13
+    terminal error (source ``daemon_relay``), which the proxy must forward
+    verbatim. ``stream_body_done`` is set only when the generator has fully
+    exited, which makes the no-buffering assertion deterministic.
+    """
+
+    def __init__(self):
+        self.release = threading.Event()
+        self.stream_body_done = threading.Event()
+        self.mode = "hold"
+        self.seen_auth = []  # Authorization header values the daemon received
+
+    def build_app(self):
+        import asyncio
+
+        from fastapi import FastAPI, Request
+        from fastapi.responses import StreamingResponse
+
+        app = FastAPI()
+        daemon = self
+
+        @app.api_route(
+            "/v1/{agent_id}/{path:path}",
+            methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+        )
+        async def relay(agent_id: str, path: str, request: Request):
+            daemon.seen_auth.append(request.headers.get("authorization"))
+
+            async def _events():
+                try:
+                    yield _frame({"type": "status", "message": "starting"})
+                    if daemon.mode == "daemon_crash":
+                        # Abort the response mid-stream: the client's httpx read
+                        # sees a truncated body → transport error.
+                        raise RuntimeError("simulated daemon crash mid-stream")
+                    if daemon.mode == "relay_synthetic":
+                        # The daemon relay's own §0.13 terminal (sidecar died).
+                        yield _frame(
+                            {
+                                "type": "error",
+                                "detail": "sidecar crashed",
+                                "source": "daemon_relay",
+                            }
+                        )
+                        return
+                    while not daemon.release.is_set():
+                        await asyncio.sleep(0.02)
+                    yield _frame({"type": "final", "answer": "done"})
+                finally:
+                    daemon.stream_body_done.set()
+
+            return StreamingResponse(_events(), media_type="text/event-stream")
+
+        return app
+
+
+def _serve(app):
+    """Run *app* under uvicorn on an ephemeral port (never 4001) in a
+    background thread. Returns (server, thread, port)."""
+    import uvicorn
+
+    from gaia.daemon.sidecars.manager import find_free_port
+
+    port = find_free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10.0
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.02)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=5)
+        raise RuntimeError("test uvicorn server never started")
+    return server, thread, port
+
+
+@pytest.fixture()
+def live_proxy(monkeypatch):
+    """A live fake daemon + the real gaia api app whose start_or_attach points
+    at it. GAIA_API_KEY is set so the surface is enabled."""
+    if not (_HAS_FASTAPI and _HAS_HTTPX and _HAS_UVICORN and _HAS_REQUESTS):
+        pytest.skip("fastapi/httpx/uvicorn/requests not importable")
+
+    from gaia.api.openai_server import app as api_app
+    from gaia.daemon.instance import DaemonInstance
+
+    monkeypatch.setenv(API_KEY_ENV, _API_KEY)
+
+    daemon = _FakeDaemon()
+    d_server, d_thread, d_port = _serve(daemon.build_app())
+
+    def _fake_start_or_attach(*_a, **_k):
+        return DaemonInstance(
+            pid=os.getpid(), port=d_port, token=_DAEMON_TOKEN, host="127.0.0.1"
+        )
+
+    # Patched where agent_proxy imports it (lazily, from gaia.daemon.client).
+    monkeypatch.setattr("gaia.daemon.client.start_or_attach", _fake_start_or_attach)
+
+    api_server, api_thread, api_port = _serve(api_app)
+
+    yield daemon, f"http://127.0.0.1:{api_port}"
+
+    daemon.release.set()  # unblock any still-held stream
+    api_server.should_exit = True
+    d_server.should_exit = True
+    api_thread.join(timeout=10)
+    d_thread.join(timeout=10)
+
+
+def _iter_data_events(resp):
+    for raw_line in resp.iter_lines():
+        if not raw_line:
+            continue
+        line = raw_line.decode() if isinstance(raw_line, bytes) else raw_line
+        if not line.startswith("data:"):
+            continue
+        yield json.loads(line[len("data:") :].strip())
+
+
+def _wait_for(predicate, timeout=5.0, message="condition never became true"):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError(message)
+
+
+def _auth():
+    return {"Authorization": f"Bearer {_API_KEY}"}
+
+
+@needs_live_servers
+def test_sse_relayed_unbuffered_first_event_before_upstream_completes(live_proxy):
+    import requests
+
+    daemon, api_url = live_proxy
+    with requests.post(
+        f"{api_url}/v1/toy/query",
+        json={"query": "q", "run_id": "run-nobuf"},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    ) as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        events = _iter_data_events(resp)
+        first = next(events)
+        assert first["type"] == "status"
+        # THE no-buffering assertion: the first event reached the REST client
+        # while the fake daemon's stream body is provably still open (it only
+        # completes after `release`, which has not been set).
+        assert not daemon.stream_body_done.is_set()
+
+        daemon.release.set()
+        rest = list(events)
+    assert [e["type"] for e in rest] == ["final"]
+
+
+@needs_live_servers
+def test_daemon_client_token_crosses_never_the_api_key(live_proxy):
+    import requests
+
+    daemon, api_url = live_proxy
+    daemon.mode = "relay_synthetic"  # terminates fast, no release needed
+    with requests.post(
+        f"{api_url}/v1/toy/query",
+        json={"query": "q"},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    ) as resp:
+        list(_iter_data_events(resp))
+
+    # The daemon saw the DAEMON client token; the API key never crossed.
+    assert daemon.seen_auth[-1] == f"Bearer {_DAEMON_TOKEN}"
+    assert daemon.seen_auth[-1] != f"Bearer {_API_KEY}"
+
+
+@needs_live_servers
+def test_client_disconnect_tears_down_upstream(live_proxy):
+    import requests
+
+    daemon, api_url = live_proxy
+    resp = requests.post(
+        f"{api_url}/v1/toy/query",
+        json={"query": "q", "run_id": "run-cancel"},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    )
+    events = _iter_data_events(resp)
+    assert next(events)["type"] == "status"
+    resp.close()  # REST client walks away mid-stream
+
+    # Closing the REST connection must tear down the proxy→daemon connection,
+    # ending the fake daemon's held stream body (the daemon then owns the
+    # sidecar cancel, tested in test_daemon_relay.py). Deterministic: release
+    # is NOT set, so a completed `final` cannot be the cause.
+    assert not daemon.release.is_set()
+    _wait_for(
+        daemon.stream_body_done.is_set,
+        message="proxy never tore down the upstream connection on client disconnect",
+    )
+
+
+@needs_live_servers
+def test_daemon_authored_synthetic_error_forwarded_verbatim(live_proxy):
+    import requests
+
+    daemon, api_url = live_proxy
+    daemon.mode = "relay_synthetic"
+    with requests.post(
+        f"{api_url}/v1/toy/query",
+        json={"query": "q", "run_id": "run-relaysyn"},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    ) as resp:
+        assert resp.status_code == 200
+        events = list(_iter_data_events(resp))
+
+    assert [e["type"] for e in events] == ["status", "error"]
+    # The daemon-authored §0.13 frame passes through UNTOUCHED — the proxy did
+    # not re-stamp its source.
+    assert events[-1]["source"] == "daemon_relay"
+    assert events[-1]["detail"] == "sidecar crashed"
+
+
+@needs_live_servers
+def test_daemon_crash_mid_stream_yields_proxy_synthetic_terminal_error(live_proxy):
+    import requests
+
+    daemon, api_url = live_proxy
+    daemon.mode = "daemon_crash"
+    with requests.post(
+        f"{api_url}/v1/toy/query",
+        json={"query": "q", "run_id": "run-dcrash"},
+        headers=_auth(),
+        stream=True,
+        timeout=(5, 15),
+    ) as resp:
+        assert resp.status_code == 200
+        events = list(_iter_data_events(resp))  # stream must end CLEANLY
+
+    assert [e["type"] for e in events] == ["status", "error"]
+    synthetic = events[-1]
+    # The daemon died, so the PROXY authored the terminal — distinct source.
+    assert synthetic["source"] == "gaia_api"
+    assert synthetic["detail"] == daemon_stream_dropped_detail("toy")


### PR DESCRIPTION
## Why this matters

Before, `gaia api` gave programmatic consumers only OpenAI-style chat — the agentic `/query` loop was unreachable over the API server, and the only way to expose an agent would have been to mount it in-process and hold its sidecar credentials. After, `POST /v1/<agent>/query` streams the full agent loop end-to-end (SSE) behind the API server's API key, relaying through the always-on daemon (#2150). The API server stays a **thin client**: it carries only the daemon client token and never learns sidecar coordinates or holds a sidecar bearer — the daemon does the token→bearer swap server-side.

No silent fallback: an unset/invalid API key, an unreachable daemon, and a dead sidecar each surface a loud, actionable HTTP error. Bodies stream unbuffered; a client disconnect propagates cancel through the relay to the sidecar; a daemon that dies mid-stream yields a synthetic terminal `error` frame so the consumer never hangs. `/v1/chat/completions` and `/v1/models` are untouched. The in-process email mount is intentionally left in place — its removal is tracked separately in #2176.

## Test plan

- [x] `python -m pytest tests/unit/test_api_agent_proxy.py` — 14 pass (auth 503/401 contract, daemon-down 503, reserved-id 404, OpenAI routes not shadowed, plus real-server integration: no-buffering, cancel-on-disconnect, daemon-authored terminal forwarded verbatim, proxy-authored terminal on daemon crash, daemon client token crosses — never the API key)
- [x] `python -m pytest tests/test_api.py tests/unit/test_daemon_relay.py` — 36 passed, 89 skipped (Lemonade-gated), no regressions
- [x] `flake8` (repo flags) clean; `black --check` clean on changed files
- [x] `curl -N` through `gaia api` shows **incremental** SSE arrival (real proxy + a fake daemon dripping events 1s apart over TCP):

```
[18:26:23.077] data: {"type": "status", "message": "starting"}
[18:26:26.612] data: {"type": "progress", "step": 1}
[18:26:30.095] data: {"type": "progress", "step": 2}
[18:26:33.389] data: {"type": "final", "answer": "done"}
```
`status` arrives ~11s before `final` — if buffered, all four would land together at the end.
- [x] `grep -rn gaia_agent_email src/gaia/api/` — the sole match is the pre-existing in-process email mount (removal tracked in #2176); the proxy adds no new email import.

Part of #2014
Closes #2178