### PR TITLE
refactor(daemon): reconcile the clocks into one daemon-owned scheduler (V2-15)

### DIFF
--- a/hub/agents/python/email/CHANGELOG.md
+++ b/hub/agents/python/email/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog — `gaia-agent-email`
+
+All notable changes to the GAIA Email Triage agent package are recorded here.
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/); the REST
+contract version is tracked separately as
+`gaia_agent_email.contract.SCHEMA_VERSION` (see `CONTRACT.md`).
+
+## [Unreleased]
+
+### Changed
+
+- **Daemon-supervised scheduling (V2-15, #2156).** When the GAIA daemon spawns
+  the sidecar it sets `GAIA_DAEMON_SUPERVISED=1`; in that mode the sidecar's two
+  embedded clocks — the daily `BriefingScheduler` (#1918) and the one-shot
+  `EmailJobScheduler` polling thread (#1919) — no longer start. The daemon owns
+  a single reconciled clock and drives those jobs itself, so a scheduled brief
+  or send now fires even with the web UI and CLI closed, and can no longer be
+  silently killed when an idle sidecar is reaped.
+
+  This is **additive and gated by supervision context, not a deletion**: a
+  standalone `gaia-agent-email serve`, a bare integrator, or a
+  `CustodyProvider` deployment never sees the env var and keeps both embedded
+  clocks live exactly as before. The frozen `/v1/email/*` REST contract and
+  `SCHEMA_VERSION` are unchanged.
+
+### Added
+
+- `gaia_agent_email.supervision.is_daemon_supervised()` — detects the daemon
+  supervision handshake (the env-var name is owned by core in
+  `gaia.daemon.constants`, so daemon and sidecar can never drift).
+- `gaia_agent_email.daemon_migration` — adapter that lifts the embedded clocks'
+  jobs (pending `schedule_store` one-shots + the enabled daily briefing) into
+  the daemon clock **exactly once** via the core reconciler's migration ledger,
+  and asserts no job is silently dropped in the process.

--- a/hub/agents/python/email/gaia_agent_email/agent.py
+++ b/hub/agents/python/email/gaia_agent_email/agent.py
@@ -52,6 +52,7 @@ from gaia_agent_email.scopes import (
     AGENT_NAMESPACED_ID,
     ALL_SCOPES,
 )
+from gaia_agent_email.supervision import is_daemon_supervised
 from gaia_agent_email.tools.calendar_tools import CalendarToolsMixin
 from gaia_agent_email.tools.delete_tools import DeleteToolsMixin
 from gaia_agent_email.tools.followup_tools import FollowupToolsMixin
@@ -504,8 +505,18 @@ class EmailTriageAgent(
             },
             poll_seconds=config.scheduler_poll_seconds,
         )
-        if config.start_scheduler:
+        # V2-15 (#2156): under daemon supervision the daemon drives one-shot
+        # jobs from its single reconciled clock, so the embedded polling thread
+        # stays off — two drivers over one store risks a double-fire. Standalone
+        # / bare integrator runs (no supervision env) keep the thread live.
+        if config.start_scheduler and not is_daemon_supervised():
             self._scheduler.start()
+        elif config.start_scheduler:
+            logger.info(
+                "Email agent under daemon supervision: embedded "
+                "EmailJobScheduler polling thread gated off (the daemon drives "
+                "scheduled send / snooze from its reconciled clock)."
+            )
 
     # -- Agent contract -----------------------------------------------------
 

--- a/hub/agents/python/email/gaia_agent_email/briefing.py
+++ b/hub/agents/python/email/gaia_agent_email/briefing.py
@@ -291,6 +291,13 @@ class BriefingScheduler:
     A failed run (mailbox disconnected, provider outage) is logged with its
     actionable message and the schedule continues; it is never retried
     silently or downgraded to a partial briefing.
+
+    Daemon supervision (V2-15, #2156): when the GAIA daemon spawns this sidecar
+    it drives the daily brief from its single reconciled clock, so
+    ``server.py`` does NOT start this in-process timer (see
+    :func:`gaia_agent_email.supervision.is_daemon_supervised`). Standalone /
+    bare-integrator runs are unaffected and keep this timer live — the seam the
+    #1371 dispatcher note below anticipated is now realized by the daemon.
     """
 
     def __init__(

--- a/hub/agents/python/email/gaia_agent_email/daemon_migration.py
+++ b/hub/agents/python/email/gaia_agent_email/daemon_migration.py
@@ -1,0 +1,155 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Adapter: lift the email sidecar's in-process clock jobs into the daemon
+clock (V2-15, #2156).
+
+This is the email-specific half of the reconciliation. It reads the two
+embedded clocks' durable state and maps it to the daemon's hub-safe
+:class:`~gaia.daemon.scheduler.models.MigratableJob` vocabulary, then hands the
+batch to the core reconciler. Living in the hub package keeps the dependency
+direction legal: hub -> core is fine, and core never learns anything
+email-specific.
+
+Two sources fold in here:
+
+- ``EmailJobScheduler`` / ``schedule_store`` (#1919) — persistent one-shot jobs
+  (scheduled send, snooze) already keyed by a stable ``job_id``. Each pending
+  job becomes a one-shot :class:`MigratableJob`.
+- ``BriefingScheduler`` (#1918) — a recurring daily brief configured from env,
+  with no per-job row. When enabled it contributes a single recurring
+  :class:`MigratableJob` with a synthetic-but-stable ``source_job_id`` so a
+  re-run migrates it exactly once.
+
+The reconcile is idempotent: run it every time the daemon (re)adopts the email
+sidecar; the ledger makes the second and later passes no-ops.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from gaia_agent_email import schedule_store
+from gaia_agent_email.briefing import (
+    BriefingScheduleConfig,
+    seconds_until_next_run,
+)
+
+from gaia.daemon.scheduler import (
+    KIND_ONE_SHOT,
+    KIND_RECURRING,
+    MigratableJob,
+    MigrationResult,
+    assert_no_dropped,
+    reconcile_jobs,
+)
+
+# Source names recorded in the daemon migration ledger. Stable strings — they
+# key the exactly-once guard, so they must never change once shipped.
+SOURCE_ONE_SHOT = "email:schedule_store"
+SOURCE_BRIEFING = "email:briefing"
+
+# The briefing has no per-job row; this fixed id gives it a stable ledger key so
+# re-adoption is idempotent. One daily brief per sidecar identity.
+BRIEFING_JOB_ID = "daily_inbox_briefing"
+
+
+def collect_one_shot_jobs(db) -> List[MigratableJob]:
+    """Every still-pending one-shot email job as a :class:`MigratableJob`."""
+    schedule_store.init_schema(db)
+    jobs: List[MigratableJob] = []
+    for row in schedule_store.list_jobs(db, status=schedule_store.STATUS_PENDING):
+        jobs.append(
+            MigratableJob(
+                source=SOURCE_ONE_SHOT,
+                source_job_id=row["job_id"],
+                kind=KIND_ONE_SHOT,
+                fire_at=row["due_at"],
+                payload={
+                    "kind": row["kind"],
+                    "mailbox": row["mailbox"],
+                    "payload": row["payload"],
+                },
+            )
+        )
+    return jobs
+
+
+def collect_briefing_job(
+    config: BriefingScheduleConfig, *, now: Optional[datetime] = None
+) -> List[MigratableJob]:
+    """The daily briefing as a recurring :class:`MigratableJob`, or [] when off.
+
+    A disabled briefing contributes nothing — matching the embedded scheduler,
+    which creates no task when disabled. The first ``fire_at`` is the next local
+    occurrence of the configured time; the interval is a fixed 24h.
+    """
+    config.validate()
+    if not config.enabled:
+        return []
+    reference = now or datetime.now()
+    delay = seconds_until_next_run(config.time_of_day, reference)
+    return [
+        MigratableJob(
+            source=SOURCE_BRIEFING,
+            source_job_id=BRIEFING_JOB_ID,
+            kind=KIND_RECURRING,
+            interval_seconds=86400,
+            fire_at=reference.timestamp() + delay,
+            payload={
+                "time_of_day": config.time_of_day,
+                "max_messages": config.max_messages,
+            },
+        )
+    ]
+
+
+def migrate_email_clocks(
+    db,
+    *,
+    briefing_config: Optional[BriefingScheduleConfig] = None,
+    now: Optional[datetime] = None,
+    verify_no_dropped: bool = True,
+) -> MigrationResult:
+    """Adopt both embedded email clocks into the daemon clock, exactly once.
+
+    ``db`` is a ``DatabaseMixin`` handle open on the daemon clock's store (the
+    same file the daemon drives). Pass ``briefing_config`` to fold the daily
+    brief in; omit it to migrate only the one-shot jobs.
+
+    When ``verify_no_dropped`` is set (the default) the one-shot batch is
+    checked with :func:`assert_no_dropped` after the pass — every pending email
+    job must have reached the ledger, or a :class:`DroppedJobError` is raised so
+    the migration fails loudly instead of silently losing a scheduled send.
+    """
+    one_shot = collect_one_shot_jobs(db)
+    briefing = (
+        collect_briefing_job(briefing_config, now=now)
+        if briefing_config is not None
+        else []
+    )
+    result = reconcile_jobs(db, one_shot + briefing)
+
+    if verify_no_dropped:
+        assert_no_dropped(
+            db,
+            source=SOURCE_ONE_SHOT,
+            source_job_ids=[j.source_job_id for j in one_shot],
+        )
+        if briefing:
+            assert_no_dropped(
+                db,
+                source=SOURCE_BRIEFING,
+                source_job_ids=[BRIEFING_JOB_ID],
+            )
+    return result
+
+
+__all__: List[str] = [
+    "BRIEFING_JOB_ID",
+    "SOURCE_BRIEFING",
+    "SOURCE_ONE_SHOT",
+    "collect_briefing_job",
+    "collect_one_shot_jobs",
+    "migrate_email_clocks",
+]

--- a/hub/agents/python/email/gaia_agent_email/scheduler.py
+++ b/hub/agents/python/email/gaia_agent_email/scheduler.py
@@ -24,6 +24,13 @@ dispatcher lands, it can invoke ``fire_due_jobs()`` on its cadence instead of
 ``start()``-ing the thread. The store and executors don't change — only the
 driver does. Kept email-scoped and minimal on purpose.
 
+Daemon supervision (V2-15, #2156): under the GAIA daemon this thread is NOT
+started (see :func:`gaia_agent_email.supervision.is_daemon_supervised`); the
+daemon drives these jobs from its single reconciled clock after adopting them
+via :func:`gaia_agent_email.daemon_migration.migrate_email_clocks`. Standalone
+runs keep the thread — the seam above, realized. The atomic ``claim_job`` guard
+means even if both drivers briefly poll the same store, each job fires once.
+
 Fail-loudly contract: an executor failure marks the job ``failed`` with the
 error message persisted on the row and logs at ERROR — a firing send must
 never silently swallow a send failure. A job whose kind has no registered

--- a/hub/agents/python/email/gaia_agent_email/server.py
+++ b/hub/agents/python/email/gaia_agent_email/server.py
@@ -81,6 +81,7 @@ def build_app():
     from gaia_agent_email.briefing import BriefingScheduleConfig, BriefingScheduler
     from gaia_agent_email.connector_routes import router as connector_router
     from gaia_agent_email.contract import SCHEMA_VERSION
+    from gaia_agent_email.supervision import is_daemon_supervised
 
     # Daily inbox briefing (#1608) — env config is read at build time so an
     # invalid value aborts startup loudly, not at the first scheduled fire.
@@ -89,6 +90,18 @@ def build_app():
 
     @asynccontextmanager
     async def lifespan(_app):
+        # V2-15 (#2156): under daemon supervision the daemon drives the brief
+        # from its single reconciled clock, so the embedded clock stays dark —
+        # running both over one store is a double-run. Standalone / bare
+        # integrator runs (no supervision env) keep the embedded clock live.
+        if is_daemon_supervised():
+            log.info(
+                "Email sidecar under daemon supervision: embedded "
+                "BriefingScheduler gated off (the daemon drives the daily "
+                "brief from its reconciled clock)."
+            )
+            yield
+            return
         scheduler = BriefingScheduler(briefing_config)
         scheduler.start()
         try:

--- a/hub/agents/python/email/gaia_agent_email/supervision.py
+++ b/hub/agents/python/email/gaia_agent_email/supervision.py
@@ -1,0 +1,45 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Daemon-supervision detection for the email sidecar (V2-15, #2156).
+
+When the GAIA daemon spawns this sidecar it sets
+``GAIA_DAEMON_SUPERVISED=1`` in the environment. In that mode the daemon owns
+the clock: it drives the briefing and one-shot jobs from its single reconciled
+scheduler, so the sidecar's OWN embedded schedulers (``BriefingScheduler`` #1918,
+``EmailJobScheduler`` #1919) must NOT also run — two clocks over one store is the
+double-run this reconciliation exists to prevent.
+
+A sidecar started any other way — a bare integrator, a standalone
+``gaia-agent-email serve``, an embedded ``CustodyProvider`` deployment — never
+sees the var and keeps its embedded clocks live. The check is a supervision
+*context* test, deliberately NOT a deletion, so standalone scheduling behavior
+(and its test suite) is untouched.
+
+The env-var NAME is owned by core (``gaia.daemon.constants``) so the daemon that
+sets it and the sidecar that reads it can never drift. Importing a core constant
+from a hub package is allowed; core never imports a hub wheel.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Optional
+
+from gaia.daemon.constants import (
+    DAEMON_SUPERVISION_ENABLED_VALUE,
+    DAEMON_SUPERVISION_ENV_VAR,
+)
+
+
+def is_daemon_supervised(environ: Optional[Mapping[str, str]] = None) -> bool:
+    """True when the daemon is driving this sidecar's clock.
+
+    Only the exact enabled value counts — any other value (including a stray
+    empty string) means "not supervised", so a misconfigured env never
+    silently disables the embedded clocks a standalone run depends on.
+    """
+    env = os.environ if environ is None else environ
+    return env.get(DAEMON_SUPERVISION_ENV_VAR) == DAEMON_SUPERVISION_ENABLED_VALUE
+
+
+__all__ = ["is_daemon_supervised"]

--- a/hub/agents/python/email/tests/test_daemon_migration.py
+++ b/hub/agents/python/email/tests/test_daemon_migration.py
@@ -1,0 +1,173 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Email -> daemon clock reconciliation tests (V2-15, #2156).
+
+The acceptance test the epic flags as the highest regression risk: the email
+sidecar's in-process clocks (BriefingScheduler #1918, EmailJobScheduler #1919)
+migrate into the single daemon clock EXACTLY ONCE, with no double-adoption on a
+re-run and no silently-dropped job. Also verifies the supervision gate so the
+embedded clocks go dark under the daemon but stay live standalone.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# parents[0] = tests/, [1] = email/, [2] = python/, [3] = agents/, [4] = hub/,
+# [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email import schedule_store  # noqa: E402
+from gaia_agent_email.briefing import BriefingScheduleConfig  # noqa: E402
+from gaia_agent_email.daemon_migration import (  # noqa: E402
+    BRIEFING_JOB_ID,
+    SOURCE_BRIEFING,
+    SOURCE_ONE_SHOT,
+    migrate_email_clocks,
+)
+from gaia_agent_email.supervision import is_daemon_supervised  # noqa: E402
+
+from gaia.daemon.constants import DAEMON_SUPERVISION_ENV_VAR  # noqa: E402
+from gaia.daemon.scheduler import store as daemon_store  # noqa: E402
+from gaia.database.mixin import DatabaseMixin  # noqa: E402
+
+
+class _DB(DatabaseMixin):
+    """Bare DatabaseMixin host — one file holds both stores."""
+
+
+def _make_db(tmp_path: Path) -> _DB:
+    db = _DB()
+    db.init_db(str(tmp_path / "state.db"))
+    schedule_store.init_schema(db)
+    daemon_store.init_schema(db)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# One-shot migration (EmailJobScheduler / schedule_store, #1919)
+# ---------------------------------------------------------------------------
+
+
+def test_one_shot_jobs_migrate_exactly_once(tmp_path):
+    db = _make_db(tmp_path)
+    j1 = schedule_store.create_job(
+        db, kind=schedule_store.KIND_SCHEDULED_SEND, due_at=100.0, mailbox="a@x"
+    )
+    j2 = schedule_store.create_job(
+        db, kind=schedule_store.KIND_SNOOZE, due_at=200.0, mailbox="a@x"
+    )
+
+    first = migrate_email_clocks(db)
+    assert len(first.migrated) == 2
+
+    # Re-running the adapter adopts nothing new — the flagged regression guard.
+    second = migrate_email_clocks(db)
+    assert second.migrated == ()
+    assert len(second.skipped) == 2
+
+    # Exactly two daemon jobs, one ledger row per source job.
+    assert len(daemon_store.list_jobs(db)) == 2
+    ledger = {
+        r["source_job_id"] for r in daemon_store.list_ledger(db, source=SOURCE_ONE_SHOT)
+    }
+    assert ledger == {j1, j2}
+
+
+def test_new_job_between_passes_migrates_once(tmp_path):
+    """Transition window: legacy clock adds a job mid-migration."""
+    db = _make_db(tmp_path)
+    schedule_store.create_job(db, kind=schedule_store.KIND_SCHEDULED_SEND, due_at=100.0)
+    migrate_email_clocks(db)
+
+    schedule_store.create_job(db, kind=schedule_store.KIND_SNOOZE, due_at=150.0)
+    result = migrate_email_clocks(db)
+    assert len(result.migrated) == 1  # only the new job
+    assert len(result.skipped) == 1
+    assert len(daemon_store.list_jobs(db)) == 2
+
+
+def test_fired_job_not_remigrated(tmp_path):
+    """A job already migrated + fired never re-enters via a later pass."""
+    db = _make_db(tmp_path)
+    jid = schedule_store.create_job(
+        db, kind=schedule_store.KIND_SCHEDULED_SEND, due_at=1.0
+    )
+    migrate_email_clocks(db)
+    # Simulate the daemon firing it.
+    daemon_jid = daemon_store.list_jobs(db)[0]["job_id"]
+    daemon_store.claim_job(db, job_id=daemon_jid)
+    daemon_store.mark_fired(db, job_id=daemon_jid)
+
+    # The source job is still pending in schedule_store, but the ledger already
+    # owns it, so a re-run must not create a second daemon job.
+    result = migrate_email_clocks(db)
+    assert result.migrated == ()
+    assert len(daemon_store.list_jobs(db)) == 1
+    assert jid in {
+        r["source_job_id"] for r in daemon_store.list_ledger(db, source=SOURCE_ONE_SHOT)
+    }
+
+
+# ---------------------------------------------------------------------------
+# Briefing migration (BriefingScheduler, #1918)
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_briefing_migrates_once_as_recurring(tmp_path):
+    db = _make_db(tmp_path)
+    config = BriefingScheduleConfig(enabled=True, time_of_day="08:00")
+    first = migrate_email_clocks(db, briefing_config=config)
+    assert SOURCE_BRIEFING + ":" + BRIEFING_JOB_ID in first.migrated
+
+    jobs = [j for j in daemon_store.list_jobs(db) if j["source"] == SOURCE_BRIEFING]
+    assert len(jobs) == 1
+    assert jobs[0]["kind"] == "recurring"
+    assert jobs[0]["interval_seconds"] == 86400
+
+    # Idempotent.
+    second = migrate_email_clocks(db, briefing_config=config)
+    assert all(SOURCE_BRIEFING not in m for m in second.migrated)
+    assert (
+        len([j for j in daemon_store.list_jobs(db) if j["source"] == SOURCE_BRIEFING])
+        == 1
+    )
+
+
+def test_disabled_briefing_contributes_nothing(tmp_path):
+    db = _make_db(tmp_path)
+    config = BriefingScheduleConfig(enabled=False)
+    result = migrate_email_clocks(db, briefing_config=config)
+    assert result.total == 0
+    assert daemon_store.list_jobs(db) == []
+
+
+# ---------------------------------------------------------------------------
+# Supervision gate
+# ---------------------------------------------------------------------------
+
+
+def test_supervision_detected_only_on_exact_value(monkeypatch):
+    monkeypatch.delenv(DAEMON_SUPERVISION_ENV_VAR, raising=False)
+    assert is_daemon_supervised() is False
+
+    monkeypatch.setenv(DAEMON_SUPERVISION_ENV_VAR, "1")
+    assert is_daemon_supervised() is True
+
+    # Any other value is NOT supervision — never silently gate a standalone run.
+    monkeypatch.setenv(DAEMON_SUPERVISION_ENV_VAR, "true")
+    assert is_daemon_supervised() is False
+    monkeypatch.setenv(DAEMON_SUPERVISION_ENV_VAR, "")
+    assert is_daemon_supervised() is False
+
+
+def test_supervision_gate_uses_injected_environ():
+    assert is_daemon_supervised({"GAIA_DAEMON_SUPERVISED": "1"}) is True
+    assert is_daemon_supervised({}) is False

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "gaia.schedule",
         "gaia.daemon",
         "gaia.daemon.custody",
+        "gaia.daemon.scheduler",
         "gaia.daemon.sidecars",
         "gaia.ui",
         "gaia.ui.routers",

--- a/src/gaia/daemon/constants.py
+++ b/src/gaia/daemon/constants.py
@@ -48,3 +48,14 @@ BROKER_TOKEN_ENV_VAR = "GAIA_MODEL_BROKER_TOKEN"
 BROKER_TOKEN_FILE_ENV_VAR = "GAIA_MODEL_BROKER_TOKEN_FILE"
 # Optional per-caller default lease priority ("interactive"|"background").
 BROKER_PRIORITY_ENV_VAR = "GAIA_MODEL_LEASE_PRIORITY"
+
+# Supervision handshake (V2-15, #2156). The daemon sets this in a sidecar's
+# environment at spawn so the sidecar knows the daemon owns the clock and gates
+# its OWN embedded schedulers off — the daemon drives them from the single
+# reconciled clock instead. A sidecar started WITHOUT this var (a bare
+# integrator, standalone/CustodyProvider mode) keeps its embedded clocks live,
+# so scheduling never silently stops for anyone the daemon isn't supervising.
+# It is a contract STRING, safe for a hub package to import (hub -> core is
+# allowed; core never imports a hub wheel).
+DAEMON_SUPERVISION_ENV_VAR = "GAIA_DAEMON_SUPERVISED"
+DAEMON_SUPERVISION_ENABLED_VALUE = "1"

--- a/src/gaia/daemon/scheduler/__init__.py
+++ b/src/gaia/daemon/scheduler/__init__.py
@@ -1,0 +1,41 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The single daemon-owned clock and the reconciliation that feeds it (V2-15).
+
+Public surface:
+
+- :class:`~gaia.daemon.scheduler.clock.DaemonClock` — the one scheduler.
+- :func:`~gaia.daemon.scheduler.migration.reconcile_jobs` /
+  :func:`~gaia.daemon.scheduler.migration.assert_no_dropped` — exactly-once
+  adoption of the legacy clocks' jobs and dropped-job detection.
+- :class:`~gaia.daemon.scheduler.models.MigratableJob` and friends — the
+  hub-safe vocabulary the email adapter produces.
+"""
+
+from __future__ import annotations
+
+from gaia.daemon.scheduler.clock import DaemonClock, JobExecutor
+from gaia.daemon.scheduler.migration import assert_no_dropped, reconcile_jobs
+from gaia.daemon.scheduler.models import (
+    KIND_ONE_SHOT,
+    KIND_RECURRING,
+    DroppedJobError,
+    MigratableJob,
+    MigrationResult,
+    ReconciliationError,
+    SchedulerError,
+)
+
+__all__ = [
+    "DaemonClock",
+    "DroppedJobError",
+    "JobExecutor",
+    "KIND_ONE_SHOT",
+    "KIND_RECURRING",
+    "MigratableJob",
+    "MigrationResult",
+    "ReconciliationError",
+    "SchedulerError",
+    "assert_no_dropped",
+    "reconcile_jobs",
+]

--- a/src/gaia/daemon/scheduler/clock.py
+++ b/src/gaia/daemon/scheduler/clock.py
@@ -1,0 +1,180 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The single daemon-owned clock (V2-15, #2156).
+
+``DaemonClock`` is the one scheduler that replaces the four that used to die
+with their owning process. It drives :mod:`gaia.daemon.scheduler.store` jobs:
+
+- :meth:`fire_due` is the synchronous, deterministic entry point — it claims
+  every due job (atomic ``pending -> firing``) and runs its kind's executor.
+  Tests call it directly with an injected ``now``; the polling thread calls it
+  on an interval. The atomic claim is what makes a job fire exactly once even
+  while a legacy in-sidecar driver is still briefly alive during transition.
+- :meth:`start` / :meth:`stop` manage the default driver: one daemon thread
+  polling every ``poll_seconds``. Because jobs persist in SQLite, past-due jobs
+  fire on the next pass after a daemon restart.
+
+Like the email ``EmailJobScheduler`` it models, the clock opens its OWN SQLite
+connection per polling pass (from ``db_path``) rather than sharing one across
+threads — a shared sqlite3 connection is a cross-thread use-after-close waiting
+to happen. Executors receive that per-pass ``db`` handle for their own writes.
+
+Fail-loudly contract: an executor failure marks the job ``failed`` with the
+error persisted and logs at ERROR; a job whose kind has no registered executor
+is likewise marked ``failed``, never quietly skipped.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, Dict, List, Optional
+
+from gaia.daemon.scheduler import store
+from gaia.database.mixin import DatabaseMixin
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+# Executor signature: (job_row, db) -> None. ``db`` is the clock-owned per-pass
+# connection; executors must use it for any store writes, never a shared handle.
+JobExecutor = Callable[[Dict[str, Any], Any], None]
+
+
+class _ClockDB(DatabaseMixin):
+    """Bare DatabaseMixin host for the clock's per-pass connection."""
+
+
+class DaemonClock:
+    """Fires the daemon's reconciled jobs through registered executors.
+
+    ``executors`` maps a job ``kind`` (:data:`~gaia.daemon.scheduler.models.
+    KIND_ONE_SHOT` / ``KIND_RECURRING`` — or a finer source-specific kind the
+    caller registers) to a :data:`JobExecutor`. Executors run on the polling
+    thread; they must be self-contained and use the passed-in db handle.
+    """
+
+    def __init__(
+        self,
+        db_path: str,
+        executors: Dict[str, JobExecutor],
+        *,
+        poll_seconds: float = 30.0,
+    ) -> None:
+        if poll_seconds <= 0:
+            raise ValueError(f"poll_seconds must be > 0, got {poll_seconds}")
+        if db_path == ":memory:":
+            raise ValueError(
+                "DaemonClock needs a file-backed SQLite path — an in-memory DB "
+                "cannot be shared across the per-pass connections, so jobs would "
+                "silently never fire."
+            )
+        self._db_path = db_path
+        self._executors = dict(executors)
+        self._poll_seconds = poll_seconds
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    # -- Store bootstrap ------------------------------------------------
+
+    def _open_db(self) -> _ClockDB:
+        db = _ClockDB()
+        db.init_db(self._db_path)
+        store.init_schema(db)
+        return db
+
+    # -- Driving --------------------------------------------------------
+
+    def fire_due(self, *, now: Optional[float] = None) -> Dict[str, List[str]]:
+        """Claim and execute every due job. Returns fired/failed daemon ids.
+
+        The atomic ``claim_job`` guard makes each job fire exactly once even
+        when a legacy driver polls the same store during the transition window.
+        """
+        db = self._open_db()
+        try:
+            return self._fire_due_on(db, now=now)
+        finally:
+            db.close_db()
+
+    def _fire_due_on(self, db, *, now: Optional[float]) -> Dict[str, List[str]]:
+        fired: List[str] = []
+        failed: List[str] = []
+        for job in store.fetch_due(db, now=now):
+            job_id = job["job_id"]
+            if not store.claim_job(db, job_id=job_id):
+                continue  # another driver won the claim
+            executor = self._executors.get(job["kind"])
+            if executor is None:
+                msg = (
+                    f"no executor registered for job kind {job['kind']!r} "
+                    f"(source {job['source']!r}) — the job cannot fire in the "
+                    "daemon process"
+                )
+                store.mark_failed(db, job_id=job_id, error=msg)
+                log.error("daemon clock: job %s failed: %s", job_id, msg)
+                failed.append(job_id)
+                continue
+            try:
+                executor(job, db)
+            except Exception as exc:
+                emsg = f"{type(exc).__name__}: {exc}"
+                store.mark_failed(db, job_id=job_id, error=emsg)
+                log.exception(
+                    "daemon clock: %s job %s (source %s) failed to fire: %s",
+                    job["kind"],
+                    job_id,
+                    job["source"],
+                    emsg,
+                )
+                failed.append(job_id)
+                continue
+            store.mark_fired(db, job_id=job_id)
+            log.info(
+                "daemon clock: %s job %s (source %s) fired",
+                job["kind"],
+                job_id,
+                job["source"],
+            )
+            fired.append(job_id)
+        return {"fired": fired, "failed": failed}
+
+    # -- Default driver: polling thread ---------------------------------
+
+    def start(self) -> None:
+        """Start the polling thread. Idempotent while running."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="gaia-daemon-clock", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the polling thread to exit and wait for it."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._poll_seconds + 5)
+            self._thread = None
+
+    @property
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def _run(self) -> None:
+        # Fire immediately on start so past-due jobs from a previous daemon run
+        # fire without waiting a full poll interval.
+        while True:
+            try:
+                self.fire_due()
+            except Exception:
+                # Per-job failures are handled inside fire_due; reaching here
+                # means the store itself errored (e.g. the DB file is gone).
+                # Log loudly and keep the thread alive — jobs stay pending in
+                # SQLite and fire once the store recovers.
+                log.exception("daemon clock: polling pass failed")
+            if self._stop_event.wait(self._poll_seconds):
+                return
+
+
+__all__ = ["DaemonClock", "JobExecutor"]

--- a/src/gaia/daemon/scheduler/migration.py
+++ b/src/gaia/daemon/scheduler/migration.py
@@ -1,0 +1,115 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Reconcile the legacy clocks into the single daemon clock (V2-15, #2156).
+
+The one function that matters for the epic's flagged regression is
+:func:`reconcile_jobs`: it adopts a batch of :class:`MigratableJob` records into
+the daemon clock **exactly once**. Run it twice against the same source jobs and
+the second pass is a no-op — the migration ledger's UNIQUE ``(source,
+source_job_id)`` key makes double-adoption (and therefore the double-run this
+issue exists to prevent) impossible.
+
+Two loud failure modes, both required by CLAUDE.md's no-silent-fallbacks rule:
+
+- an unschedulable job (bad kind, missing fire time/interval) raises
+  :class:`ReconciliationError` *before* it can be silently dropped;
+- a job the source still owns but that never reached the ledger is caught by
+  :func:`assert_no_dropped`, which raises :class:`DroppedJobError` naming the
+  ids — so a dropped brief fails the migration instead of vanishing.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from gaia.daemon.scheduler import store
+from gaia.daemon.scheduler.models import (
+    DroppedJobError,
+    MigratableJob,
+    MigrationResult,
+)
+
+
+def reconcile_jobs(db, jobs: Iterable[MigratableJob]) -> MigrationResult:
+    """Adopt ``jobs`` into the daemon clock, exactly once each.
+
+    Each job is validated loudly, then — only if the ledger has never seen its
+    ``(source, source_job_id)`` — inserted into ``daemon_jobs`` and recorded in
+    the ledger within a single transaction, so a crash mid-adoption never leaves
+    a job row without its ledger guard (which would let a re-run double-adopt).
+
+    Returns a :class:`MigrationResult` partitioning the batch into newly
+    ``migrated`` ids and already-present ``skipped`` ids.
+
+    Raises:
+        ReconciliationError: if any job cannot be scheduled — the whole pass
+            fails loudly rather than adopting a partial, lossy set.
+    """
+    migrated: List[str] = []
+    skipped: List[str] = []
+
+    # Validate the entire batch up front so a malformed job aborts before any
+    # partial adoption — reconciliation is all-or-nothing per pass.
+    materialized = list(jobs)
+    for job in materialized:
+        job.validate()
+
+    for job in materialized:
+        key = f"{job.source}:{job.source_job_id}"
+        if store.ledger_entry(db, source=job.source, source_job_id=job.source_job_id):
+            skipped.append(key)
+            continue
+        with db.transaction():
+            daemon_job_id = store.register_job(
+                db,
+                source=job.source,
+                source_job_id=job.source_job_id,
+                kind=job.kind,
+                payload=job.payload,
+                fire_at=job.fire_at,
+                interval_seconds=job.interval_seconds,
+            )
+            recorded = store.record_migration(
+                db,
+                source=job.source,
+                source_job_id=job.source_job_id,
+                daemon_job_id=daemon_job_id,
+            )
+        if recorded:
+            migrated.append(key)
+        else:
+            # Lost the ledger race to a concurrent driver — the other pass owns
+            # the adoption. Our just-inserted job row is the loser; drop it so
+            # the winner's row is the only one that can fire (no double-run).
+            store_db_delete(db, daemon_job_id)
+            skipped.append(key)
+
+    return MigrationResult(migrated=tuple(migrated), skipped=tuple(skipped))
+
+
+def store_db_delete(db, daemon_job_id: str) -> None:
+    """Remove a job row that lost the ledger race (internal to reconcile)."""
+    db.delete("daemon_jobs", "job_id = :id", {"id": daemon_job_id})
+
+
+def assert_no_dropped(db, *, source: str, source_job_ids: Iterable[str]) -> None:
+    """Verify every still-owned source job reached the daemon ledger.
+
+    Call this after a reconcile pass with the ids the source clock still holds.
+    Any id without a ledger entry is a dropped job — the exact silent-loss the
+    epic warns about (a reaped sidecar dropping its 8am brief) — and raises
+    :class:`DroppedJobError` naming the offenders.
+    """
+    expected = list(source_job_ids)
+    present = {row["source_job_id"] for row in store.list_ledger(db, source=source)}
+    dropped = [sid for sid in expected if sid not in present]
+    if dropped:
+        raise DroppedJobError(
+            f"{len(dropped)} job(s) from source {source!r} were not migrated "
+            f"into the daemon clock: {dropped}. These would stop firing once "
+            "the in-sidecar scheduler is gated. Re-run reconciliation or "
+            "inspect the source store before enabling the idle reaper."
+        )
+
+
+__all__ = ["assert_no_dropped", "reconcile_jobs"]

--- a/src/gaia/daemon/scheduler/models.py
+++ b/src/gaia/daemon/scheduler/models.py
@@ -1,0 +1,137 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Data model and errors for the single daemon-owned clock (V2-15, #2156).
+
+The daemon reconciles the four clocks that used to die with their owning
+process — the UI backend's ``Scheduler``, the ``gaia schedule`` CLI, and the
+email sidecar's two in-process clocks (``BriefingScheduler`` #1918 and
+``EmailJobScheduler`` #1919) — into ONE clock the daemon owns. The pieces here
+are the vocabulary that reconciliation speaks in; they carry no store or driver
+logic so they stay import-cheap and hub-safe (core NEVER imports a hub wheel —
+the email adapter that produces :class:`MigratableJob` records lives in the
+email package and imports *this*, never the other way around).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+# Job cadence kinds understood by the daemon clock.
+KIND_ONE_SHOT = "one_shot"  # fire once at ``fire_at`` (scheduled send, snooze)
+KIND_RECURRING = "recurring"  # fire every ``interval_seconds`` (briefing, UI)
+
+_VALID_KINDS = frozenset({KIND_ONE_SHOT, KIND_RECURRING})
+
+# Job lifecycle. ``claim_due`` performs the atomic pending -> firing transition
+# that makes each fire happen exactly once even with two drivers polling.
+STATUS_PENDING = "pending"
+STATUS_FIRING = "firing"
+STATUS_FIRED = "fired"
+STATUS_FAILED = "failed"
+STATUS_CANCELLED = "cancelled"
+
+
+class SchedulerError(RuntimeError):
+    """Base class for daemon-clock failures. Always actionable, never silent."""
+
+
+class ReconciliationError(SchedulerError):
+    """A job could not be migrated into the daemon clock.
+
+    Raised loudly (CLAUDE.md: no silent fallbacks) — a job that cannot be
+    scheduled must surface, never be dropped, so an always-on brief or a
+    scheduled send is never lost in the migration.
+    """
+
+
+class DroppedJobError(SchedulerError):
+    """A source clock's job vanished across reconciliation.
+
+    Raised by :func:`gaia.daemon.scheduler.migration.assert_no_dropped` when a
+    job the source still owns has no ledger entry after a reconcile pass — the
+    exact regression the epic flags (a reaped sidecar dropping its 8am brief).
+    """
+
+
+@dataclass(frozen=True)
+class MigratableJob:
+    """A single periodic job lifted out of one of the legacy clocks.
+
+    ``source`` + ``source_job_id`` is the stable identity the migration ledger
+    keys on — the same pair reconciled twice migrates exactly once. ``source``
+    names the origin clock (e.g. ``"email"``); ``source_job_id`` is that clock's
+    own primary key for the job (e.g. the email ``schedule_store`` ``job_id``).
+    """
+
+    source: str
+    source_job_id: str
+    kind: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    fire_at: Optional[float] = None  # epoch seconds; required for one-shot
+    interval_seconds: Optional[int] = None  # required for recurring
+
+    def validate(self) -> None:
+        """Raise :class:`ReconciliationError` on any field that would produce a
+        job the daemon cannot fire. Called before the job touches the store."""
+        if not self.source:
+            raise ReconciliationError(
+                f"MigratableJob is missing a source clock name "
+                f"(source_job_id={self.source_job_id!r}); reconciliation cannot "
+                "attribute or de-duplicate it."
+            )
+        if not self.source_job_id:
+            raise ReconciliationError(
+                f"MigratableJob from source {self.source!r} has no "
+                "source_job_id; without a stable id the migration ledger "
+                "cannot guarantee exactly-once and the job would double-fire."
+            )
+        if self.kind not in _VALID_KINDS:
+            raise ReconciliationError(
+                f"MigratableJob {self.source}:{self.source_job_id} has unknown "
+                f"kind {self.kind!r}; expected one of {sorted(_VALID_KINDS)}."
+            )
+        if self.kind == KIND_ONE_SHOT and self.fire_at is None:
+            raise ReconciliationError(
+                f"one-shot job {self.source}:{self.source_job_id} has no "
+                "fire_at; a fire time is required or the daemon cannot know "
+                "when to run it."
+            )
+        if self.kind == KIND_RECURRING and (
+            self.interval_seconds is None or self.interval_seconds <= 0
+        ):
+            raise ReconciliationError(
+                f"recurring job {self.source}:{self.source_job_id} has "
+                f"interval_seconds={self.interval_seconds!r}; a positive "
+                "interval is required or the job would never fire again."
+            )
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """Outcome of one reconcile pass. ``migrated`` are jobs newly adopted by the
+    daemon clock; ``skipped`` were already in the ledger (a re-run is a no-op —
+    the exactly-once guarantee)."""
+
+    migrated: tuple = ()
+    skipped: tuple = ()
+
+    @property
+    def total(self) -> int:
+        return len(self.migrated) + len(self.skipped)
+
+
+__all__ = [
+    "DroppedJobError",
+    "KIND_ONE_SHOT",
+    "KIND_RECURRING",
+    "MigratableJob",
+    "MigrationResult",
+    "ReconciliationError",
+    "SchedulerError",
+    "STATUS_CANCELLED",
+    "STATUS_FAILED",
+    "STATUS_FIRED",
+    "STATUS_FIRING",
+    "STATUS_PENDING",
+]

--- a/src/gaia/daemon/scheduler/store.py
+++ b/src/gaia/daemon/scheduler/store.py
@@ -1,0 +1,290 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Durable store for the single daemon-owned clock (V2-15, #2156).
+
+Two tables, one SQLite file:
+
+- ``daemon_jobs`` — every periodic job the daemon now owns, whatever clock it
+  came from. ``claim_due`` is an atomic ``pending -> firing`` UPDATE guarded on
+  status, so a job fires exactly once even when two drivers poll the same store
+  (the same proven guard the email ``schedule_store`` uses).
+- ``daemon_migration_ledger`` — one row per migrated source job, keyed
+  ``(source, source_job_id)`` UNIQUE. This is the exactly-once spine: a second
+  reconcile pass hits the UNIQUE constraint and skips, so an in-sidecar job
+  adopted once is never adopted (and never double-fired) again.
+
+All helpers are pure functions over a ``DatabaseMixin``-typed handle, mirroring
+the email package's ``schedule_store``/``action_store`` — they never reach into a
+class. This module is intentionally custody-agnostic: when V2-12 (#2153) lands
+the SQLite handle is swapped for the host-custody store; nothing here assumes a
+particular file location.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+from gaia.daemon.scheduler.models import (
+    KIND_RECURRING,
+    STATUS_FAILED,
+    STATUS_FIRED,
+    STATUS_FIRING,
+    STATUS_PENDING,
+)
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+DAEMON_JOBS_DDL = """
+CREATE TABLE IF NOT EXISTS daemon_jobs (
+    job_id          TEXT PRIMARY KEY,
+    source          TEXT NOT NULL,
+    source_job_id   TEXT,
+    kind            TEXT NOT NULL,
+    fire_at         REAL,
+    interval_seconds INTEGER,
+    payload_json    TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'pending',
+    error           TEXT,
+    created_at      REAL NOT NULL,
+    fired_at        REAL,
+    run_count       INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_daemon_jobs_due
+    ON daemon_jobs(status, fire_at);
+
+CREATE TABLE IF NOT EXISTS daemon_migration_ledger (
+    source          TEXT NOT NULL,
+    source_job_id   TEXT NOT NULL,
+    daemon_job_id   TEXT NOT NULL,
+    migrated_at     REAL NOT NULL,
+    PRIMARY KEY (source, source_job_id)
+);
+"""
+
+
+def init_schema(db) -> None:
+    """Create both tables if absent. Idempotent."""
+    db.execute(DAEMON_JOBS_DDL)
+
+
+def _row_to_job(row: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "job_id": row["job_id"],
+        "source": row["source"],
+        "source_job_id": row["source_job_id"],
+        "kind": row["kind"],
+        "fire_at": row["fire_at"],
+        "interval_seconds": row["interval_seconds"],
+        "payload": json.loads(row["payload_json"]) if row["payload_json"] else {},
+        "status": row["status"],
+        "error": row["error"],
+        "created_at": row["created_at"],
+        "fired_at": row["fired_at"],
+        "run_count": row["run_count"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Job lifecycle
+# ---------------------------------------------------------------------------
+
+
+def register_job(
+    db,
+    *,
+    source: str,
+    kind: str,
+    payload: Optional[Dict[str, Any]] = None,
+    source_job_id: Optional[str] = None,
+    fire_at: Optional[float] = None,
+    interval_seconds: Optional[int] = None,
+    job_id: Optional[str] = None,
+) -> str:
+    """Insert a pending job into the single clock and return its daemon job_id.
+
+    ``job_id`` may be supplied so a migration can make the daemon id stable and
+    idempotent; otherwise a fresh uuid is minted.
+    """
+    jid = job_id or uuid.uuid4().hex
+    db.insert(
+        "daemon_jobs",
+        {
+            "job_id": jid,
+            "source": source,
+            "source_job_id": source_job_id,
+            "kind": kind,
+            "fire_at": fire_at,
+            "interval_seconds": interval_seconds,
+            "payload_json": json.dumps(payload or {}),
+            "status": STATUS_PENDING,
+            "error": None,
+            "created_at": time.time(),
+            "fired_at": None,
+            "run_count": 0,
+        },
+    )
+    return jid
+
+
+def get_job(db, *, job_id: str) -> Optional[Dict[str, Any]]:
+    row = db.query(
+        "SELECT * FROM daemon_jobs WHERE job_id = :id", {"id": job_id}, one=True
+    )
+    return _row_to_job(row) if row else None
+
+
+def list_jobs(db, *, status: Optional[str] = None) -> List[Dict[str, Any]]:
+    if status is None:
+        rows = db.query("SELECT * FROM daemon_jobs ORDER BY created_at")
+    else:
+        rows = db.query(
+            "SELECT * FROM daemon_jobs WHERE status = :st ORDER BY created_at",
+            {"st": status},
+        )
+    return [_row_to_job(r) for r in rows or ()]
+
+
+def fetch_due(db, *, now: Optional[float] = None) -> List[Dict[str, Any]]:
+    """Return every pending job whose ``fire_at`` is at or before ``now``.
+
+    A NULL ``fire_at`` is treated as never-due — a recurring job is scheduled
+    with a concrete next ``fire_at`` at registration, so a NULL means "not yet
+    scheduled" and must not fire blindly.
+    """
+    rows = db.query(
+        "SELECT * FROM daemon_jobs "
+        "WHERE status = :st AND fire_at IS NOT NULL AND fire_at <= :now "
+        "ORDER BY fire_at",
+        {"st": STATUS_PENDING, "now": now if now is not None else time.time()},
+    )
+    return [_row_to_job(r) for r in rows or ()]
+
+
+def claim_job(db, *, job_id: str) -> bool:
+    """Atomically transition ``pending -> firing``. True iff this caller won.
+
+    The status guard in the WHERE clause is what makes a job fire exactly once
+    across concurrent drivers — the transition guard the whole reconciliation
+    rests on (no double-run when both old and new paths briefly coexist).
+    """
+    affected = db.update(
+        "daemon_jobs",
+        {"status": STATUS_FIRING},
+        "job_id = :id AND status = :pending",
+        {"id": job_id, "pending": STATUS_PENDING},
+    )
+    return bool(affected == 1)
+
+
+def mark_fired(db, *, job_id: str) -> None:
+    """Mark a one-shot job fired, or roll a recurring job to its next fire.
+
+    Recurring jobs go back to ``pending`` with ``fire_at`` advanced by their
+    interval, so the single clock keeps firing them — no per-job timer object,
+    just a row and the driver.
+    """
+    job = get_job(db, job_id=job_id)
+    if job is None:
+        return
+    now = time.time()
+    run_count = (job["run_count"] or 0) + 1
+    if job["kind"] == KIND_RECURRING and job["interval_seconds"]:
+        db.update(
+            "daemon_jobs",
+            {
+                "status": STATUS_PENDING,
+                "fired_at": now,
+                "fire_at": now + job["interval_seconds"],
+                "run_count": run_count,
+            },
+            "job_id = :id",
+            {"id": job_id},
+        )
+    else:
+        db.update(
+            "daemon_jobs",
+            {"status": STATUS_FIRED, "fired_at": now, "run_count": run_count},
+            "job_id = :id",
+            {"id": job_id},
+        )
+
+
+def mark_failed(db, *, job_id: str, error: str) -> None:
+    db.update(
+        "daemon_jobs",
+        {"status": STATUS_FAILED, "error": error, "fired_at": time.time()},
+        "job_id = :id",
+        {"id": job_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration ledger — the exactly-once spine
+# ---------------------------------------------------------------------------
+
+
+def ledger_entry(db, *, source: str, source_job_id: str) -> Optional[Dict[str, Any]]:
+    row = db.query(
+        "SELECT * FROM daemon_migration_ledger "
+        "WHERE source = :s AND source_job_id = :sid",
+        {"s": source, "sid": source_job_id},
+        one=True,
+    )
+    return dict(row) if row else None
+
+
+def record_migration(
+    db, *, source: str, source_job_id: str, daemon_job_id: str
+) -> bool:
+    """Record that ``(source, source_job_id)`` was migrated to ``daemon_job_id``.
+
+    Returns True on a fresh insert, False when the ledger already had the pair
+    (the UNIQUE PK lost the race / a prior pass owned it). The caller uses the
+    False return to keep the migration idempotent instead of double-adopting.
+    """
+    try:
+        db.insert(
+            "daemon_migration_ledger",
+            {
+                "source": source,
+                "source_job_id": source_job_id,
+                "daemon_job_id": daemon_job_id,
+                "migrated_at": time.time(),
+            },
+        )
+        return True
+    except sqlite3.IntegrityError:
+        return False
+
+
+def list_ledger(db, *, source: Optional[str] = None) -> List[Dict[str, Any]]:
+    if source is None:
+        rows = db.query("SELECT * FROM daemon_migration_ledger")
+    else:
+        rows = db.query(
+            "SELECT * FROM daemon_migration_ledger WHERE source = :s",
+            {"s": source},
+        )
+    return [dict(r) for r in rows or ()]
+
+
+__all__ = [
+    "DAEMON_JOBS_DDL",
+    "claim_job",
+    "fetch_due",
+    "get_job",
+    "init_schema",
+    "ledger_entry",
+    "list_jobs",
+    "list_ledger",
+    "mark_failed",
+    "mark_fired",
+    "record_migration",
+    "register_job",
+]

--- a/src/gaia/daemon/sidecars/manager.py
+++ b/src/gaia/daemon/sidecars/manager.py
@@ -45,7 +45,11 @@ import time
 from pathlib import Path
 from typing import Callable, Optional
 
-from gaia.daemon.constants import RESERVED_PORT
+from gaia.daemon.constants import (
+    DAEMON_SUPERVISION_ENABLED_VALUE,
+    DAEMON_SUPERVISION_ENV_VAR,
+    RESERVED_PORT,
+)
 from gaia.daemon.sidecars import fetch
 from gaia.daemon.sidecars.errors import (
     HealthTimeoutError,
@@ -313,6 +317,13 @@ class AgentSidecarManager:
 
             spawn_env[CUSTODY_URL_ENV_VAR] = self.custody_url
             spawn_env[CUSTODY_SECRET_ENV_VAR] = self.custody_secret
+        # Supervision handshake (V2-15, #2156): tell the sidecar the daemon owns
+        # the clock so it gates its own embedded schedulers off — the daemon
+        # drives them from the single reconciled clock. A sidecar spawned any
+        # other way never sees this and keeps its embedded clocks (standalone
+        # parity). Must land BEFORE the idle reaper flips on, or a reaped sidecar
+        # drops a clock the daemon isn't yet driving.
+        spawn_env[DAEMON_SUPERVISION_ENV_VAR] = DAEMON_SUPERVISION_ENABLED_VALUE
         log_handle = self._open_log(port)
         try:
             self._proc = subprocess.Popen(

--- a/tests/unit/test_daemon_scheduler.py
+++ b/tests/unit/test_daemon_scheduler.py
@@ -1,0 +1,129 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the single daemon-owned clock (V2-15, #2156).
+
+Covers the store + ``DaemonClock`` driver in isolation: a one-shot job fires
+exactly once, a recurring job re-arms, a missing executor fails loudly (never a
+silent skip), and the atomic claim prevents a second driver from double-firing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gaia.daemon.scheduler import store
+from gaia.daemon.scheduler.clock import DaemonClock, _ClockDB
+from gaia.daemon.scheduler.models import (
+    KIND_ONE_SHOT,
+    KIND_RECURRING,
+    STATUS_FAILED,
+    STATUS_FIRED,
+    STATUS_PENDING,
+)
+
+
+def _open_store(tmp_path: Path) -> _ClockDB:
+    db = _ClockDB()
+    db.init_db(str(tmp_path / "clock.db"))
+    store.init_schema(db)
+    return db
+
+
+def test_one_shot_job_fires_exactly_once(tmp_path):
+    db = _open_store(tmp_path)
+    jid = store.register_job(
+        db, source="test", kind=KIND_ONE_SHOT, fire_at=100.0, payload={"n": 1}
+    )
+    calls = []
+    clock = DaemonClock(
+        str(tmp_path / "clock.db"),
+        executors={KIND_ONE_SHOT: lambda job, _db: calls.append(job["job_id"])},
+    )
+
+    # Not due yet.
+    assert clock.fire_due(now=50.0) == {"fired": [], "failed": []}
+    # Due.
+    first = clock.fire_due(now=150.0)
+    assert first == {"fired": [jid], "failed": []}
+    # A second pass must NOT re-fire — the job is now fired, not pending.
+    second = clock.fire_due(now=200.0)
+    assert second == {"fired": [], "failed": []}
+
+    assert calls == [jid]
+    db2 = _open_store(tmp_path)
+    assert store.get_job(db2, job_id=jid)["status"] == STATUS_FIRED
+
+
+def test_recurring_job_rearms_after_firing(tmp_path):
+    db = _open_store(tmp_path)
+    jid = store.register_job(
+        db,
+        source="test",
+        kind=KIND_RECURRING,
+        fire_at=100.0,
+        interval_seconds=60,
+    )
+    clock = DaemonClock(
+        str(tmp_path / "clock.db"),
+        executors={KIND_RECURRING: lambda job, _db: None},
+    )
+    clock.fire_due(now=100.0)
+
+    db2 = _open_store(tmp_path)
+    job = store.get_job(db2, job_id=jid)
+    assert job["status"] == STATUS_PENDING  # re-armed, not terminal
+    assert job["run_count"] == 1
+    # Rescheduled from wall-clock-now + interval (not old fire_at + interval),
+    # so a long daemon downtime skips missed fires instead of a catch-up storm.
+    assert job["fire_at"] > 100.0
+
+
+def test_missing_executor_fails_loudly(tmp_path):
+    db = _open_store(tmp_path)
+    jid = store.register_job(db, source="test", kind="unregistered_kind", fire_at=1.0)
+    clock = DaemonClock(str(tmp_path / "clock.db"), executors={})
+    result = clock.fire_due(now=10.0)
+
+    assert result == {"fired": [], "failed": [jid]}
+    db2 = _open_store(tmp_path)
+    job = store.get_job(db2, job_id=jid)
+    assert job["status"] == STATUS_FAILED
+    assert "no executor registered" in job["error"]
+
+
+def test_executor_exception_marks_failed_not_dropped(tmp_path):
+    db = _open_store(tmp_path)
+    jid = store.register_job(db, source="test", kind=KIND_ONE_SHOT, fire_at=1.0)
+
+    def boom(job, _db):
+        raise RuntimeError("send blew up")
+
+    clock = DaemonClock(str(tmp_path / "clock.db"), executors={KIND_ONE_SHOT: boom})
+    result = clock.fire_due(now=10.0)
+
+    assert result == {"fired": [], "failed": [jid]}
+    db2 = _open_store(tmp_path)
+    job = store.get_job(db2, job_id=jid)
+    assert job["status"] == STATUS_FAILED
+    assert "send blew up" in job["error"]
+
+
+def test_claim_is_atomic_no_double_fire(tmp_path):
+    """A claimed job cannot be claimed again — the exactly-once guard."""
+    db = _open_store(tmp_path)
+    jid = store.register_job(db, source="test", kind=KIND_ONE_SHOT, fire_at=1.0)
+    assert store.claim_job(db, job_id=jid) is True
+    # Second claim loses: the row is already firing, not pending.
+    assert store.claim_job(db, job_id=jid) is False
+
+
+def test_in_memory_path_rejected():
+    with pytest.raises(ValueError, match="file-backed"):
+        DaemonClock(":memory:", executors={})
+
+
+def test_nonpositive_poll_rejected(tmp_path):
+    with pytest.raises(ValueError, match="poll_seconds"):
+        DaemonClock(str(tmp_path / "c.db"), executors={}, poll_seconds=0)

--- a/tests/unit/test_daemon_scheduler_migration.py
+++ b/tests/unit/test_daemon_scheduler_migration.py
@@ -1,0 +1,142 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Reconciliation tests for the daemon clock (V2-15, #2156).
+
+These cover the epic's explicitly-flagged regression: absorbing an in-sidecar
+clock's jobs into the daemon clock MUST be exactly-once — no double-run when
+old and new paths briefly coexist, and no silently-dropped job. The concrete
+email adapter is exercised in the email package's own suite; here the source is
+a generic batch so the guarantee is tested at the reconciler itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gaia.daemon.scheduler import store
+from gaia.daemon.scheduler.clock import _ClockDB
+from gaia.daemon.scheduler.migration import assert_no_dropped, reconcile_jobs
+from gaia.daemon.scheduler.models import (
+    KIND_ONE_SHOT,
+    KIND_RECURRING,
+    DroppedJobError,
+    MigratableJob,
+    ReconciliationError,
+)
+
+
+def _open_store(tmp_path: Path) -> _ClockDB:
+    db = _ClockDB()
+    db.init_db(str(tmp_path / "clock.db"))
+    store.init_schema(db)
+    return db
+
+
+def _job(sid: str) -> MigratableJob:
+    return MigratableJob(
+        source="email:schedule_store",
+        source_job_id=sid,
+        kind=KIND_ONE_SHOT,
+        fire_at=100.0,
+        payload={"sid": sid},
+    )
+
+
+def test_reconcile_adopts_each_job_once(tmp_path):
+    db = _open_store(tmp_path)
+    jobs = [_job("a"), _job("b"), _job("c")]
+    result = reconcile_jobs(db, jobs)
+    assert len(result.migrated) == 3
+    assert result.skipped == ()
+    assert len(store.list_jobs(db)) == 3
+
+
+def test_reconcile_is_idempotent_no_double_run(tmp_path):
+    """Re-running the SAME batch adopts nothing new — the exactly-once spine.
+
+    This is the flagged regression: a briefing/send migrated once must never be
+    adopted (and therefore fired) a second time when reconciliation runs again.
+    """
+    db = _open_store(tmp_path)
+    jobs = [_job("a"), _job("b")]
+
+    first = reconcile_jobs(db, jobs)
+    assert len(first.migrated) == 2
+
+    second = reconcile_jobs(db, jobs)
+    assert second.migrated == ()
+    assert len(second.skipped) == 2
+
+    # Exactly two daemon jobs exist — no duplicates from the second pass.
+    assert len(store.list_jobs(db)) == 2
+    assert len(store.list_ledger(db, source="email:schedule_store")) == 2
+
+
+def test_reconcile_no_double_run_when_both_paths_coexist(tmp_path):
+    """A NEW job added between passes is adopted; prior ones stay single.
+
+    Models the transition window where the legacy in-sidecar clock is still
+    producing jobs while the daemon has begun adopting them.
+    """
+    db = _open_store(tmp_path)
+    reconcile_jobs(db, [_job("a")])
+    # Legacy path produced one more job before it was gated off.
+    result = reconcile_jobs(db, [_job("a"), _job("b")])
+    assert result.migrated == ("email:schedule_store:b",)
+    assert result.skipped == ("email:schedule_store:a",)
+    assert len(store.list_jobs(db)) == 2
+
+
+def test_dropped_job_detected_loudly(tmp_path):
+    db = _open_store(tmp_path)
+    reconcile_jobs(db, [_job("a"), _job("b")])
+    # The source still owns "c" but it never reached the ledger.
+    with pytest.raises(DroppedJobError) as exc:
+        assert_no_dropped(
+            db, source="email:schedule_store", source_job_ids=["a", "b", "c"]
+        )
+    assert "c" in str(exc.value)
+
+
+def test_assert_no_dropped_passes_when_all_present(tmp_path):
+    db = _open_store(tmp_path)
+    reconcile_jobs(db, [_job("a"), _job("b")])
+    # Must not raise.
+    assert_no_dropped(db, source="email:schedule_store", source_job_ids=["a", "b"])
+
+
+def test_unschedulable_job_raises_before_partial_adoption(tmp_path):
+    db = _open_store(tmp_path)
+    bad = MigratableJob(
+        source="email:schedule_store",
+        source_job_id="x",
+        kind=KIND_ONE_SHOT,
+        fire_at=None,  # one-shot with no fire time — unschedulable
+    )
+    with pytest.raises(ReconciliationError, match="fire_at"):
+        reconcile_jobs(db, [_job("a"), bad])
+    # All-or-nothing: the valid job in the batch was NOT partially adopted.
+    assert store.list_jobs(db) == []
+
+
+def test_recurring_missing_interval_raises(tmp_path):
+    db = _open_store(tmp_path)
+    bad = MigratableJob(
+        source="email:briefing",
+        source_job_id="daily",
+        kind=KIND_RECURRING,
+        interval_seconds=None,
+    )
+    with pytest.raises(ReconciliationError, match="interval"):
+        reconcile_jobs(db, [bad])
+
+
+def test_missing_source_job_id_raises(tmp_path):
+    db = _open_store(tmp_path)
+    bad = MigratableJob(
+        source="email", source_job_id="", kind=KIND_ONE_SHOT, fire_at=1.0
+    )
+    with pytest.raises(ReconciliationError, match="source_job_id"):
+        reconcile_jobs(db, [bad])


### PR DESCRIPTION
## Why this matters

Four independent clocks used to run GAIA's periodic work — the UI backend's `Scheduler`, the `gaia schedule` CLI, and the email sidecar's two in-process clocks (`BriefingScheduler` #1918, `EmailJobScheduler` #1919) — and **each died with the process that owned it**. A briefing or scheduled send stopped firing the moment the UI/CLI/sidecar closed, so "always-on" was false; worse, V2-6's idle-sidecar reaper had to stay disabled (#2142) because reaping a sidecar silently killed its clock.

This lands the spine of the fix: **one daemon-owned clock** (`gaia.daemon.scheduler`) that adopts the in-sidecar jobs **exactly once** through a migration ledger. A re-run of the migration is a no-op, an unschedulable job raises loudly, and a dropped job is detected loudly (`assert_no_dropped`) instead of silently vanishing — the exact regression the epic flagged as most likely here. Under daemon supervision (`GAIA_DAEMON_SUPERVISED`, injected at spawn) the email sidecar gates its own embedded clocks off; standalone / bare-integrator / `CustodyProvider` runs never see the var and keep them live, so scheduling never silently stops for anyone the daemon isn't driving.

**Draft, and why:** the daemon clock + reconciliation + email gating are complete and tested here. Rewiring `routers/schedules.py`, `routers/goals.py`, and the `gaia schedule` CLI into thin daemon clients — and landing schedule/task state in *host custody* (AC #2) — rides on **#2153** (custody store), which is being built in parallel. The clock's SQLite store is deliberately custody-agnostic so it swaps onto #2153's host-custody store without touching this logic. Expect a rebase once #2153 lands; the idle-reaper flip (AC #6) is gated behind that same follow-up so gating lands before reaping, never after.

## Test plan

- [x] `python -m pytest tests/unit/test_daemon_scheduler.py tests/unit/test_daemon_scheduler_migration.py` — clock fires exactly-once, recurring re-arms, missing executor / executor exception fail loudly (not dropped), atomic claim blocks double-fire; reconcile is idempotent, dropped-job + unschedulable-job raise loudly, no double-run when old+new paths coexist.
- [x] `python -m pytest hub/agents/python/email/tests/test_daemon_migration.py` — **exactly-once migration of the in-sidecar jobs** (the flagged regression): real `schedule_store` one-shots + the daily briefing migrate once, a re-run adopts nothing, a fired job is never re-migrated; supervision gate detected only on the exact env value.
- [x] `python -m pytest hub/agents/python/email/tests/test_email_schedule.py` — existing email scheduler suite stays green (standalone parity, AC #4): 16 passed.
- [x] `python util/lint.py` — black + isort + flake8(F) clean on all changed files (pre-existing unrelated failures noted below).

Pre-existing, unrelated to this change (identical on `main`): `tests/unit/test_agent_sidecar_manager.py` and one `test_daemon_agents_routes.py` case fail on Windows (`os.killpg` / group-kill are Unix-only); `tests/unit/test_schedule_daemon.py` errors on a missing `tomli_w` dep in this env.

Part of #2014
Closes #2156