### PR TITLE
feat(daemon): one-time versioned migration of ~/.gaia state (V2-13)

### DIFF
--- a/src/gaia/daemon/__init__.py
+++ b/src/gaia/daemon/__init__.py
@@ -26,6 +26,7 @@ from gaia.daemon.errors import (
     DaemonLockError,
     DaemonStartError,
     DaemonVersionError,
+    MigrationError,
 )
 from gaia.daemon.instance import (
     DaemonInstance,
@@ -47,6 +48,7 @@ __all__ = [
     "DaemonLockError",
     "DaemonStartError",
     "DaemonVersionError",
+    "MigrationError",
     "DaemonInstance",
     "is_live",
     "probe",

--- a/src/gaia/daemon/errors.py
+++ b/src/gaia/daemon/errors.py
@@ -31,3 +31,12 @@ class DaemonVersionError(DaemonError):
     Restart the daemon so the new client can attach — never silently talk a stale
     contract.
     """
+
+
+class MigrationError(DaemonError):
+    """A one-time state migration could not complete (see ``daemon.migrate``).
+
+    Raised on a corrupt schema stamp, an unknown-newer on-disk version, or a step
+    that failed mid-flight. The daemon does not start on this error — better a
+    loud refusal the user can act on than a silent proceed over ambiguous state.
+    """

--- a/src/gaia/daemon/migrate.py
+++ b/src/gaia/daemon/migrate.py
@@ -24,9 +24,15 @@ Invariants (CLAUDE.md — critical for a migration):
 
 * **Non-destructive.** Legacy stores are *copied*, never moved or deleted, so the
   original data is always recoverable even if the daemon is later rolled back.
-* **Atomic.** Each store is copied via temp-file-then-rename
-  (:func:`gaia.daemon.paths.atomic_copy_file`), so a crash mid-copy never leaves a
-  half-written database in custody.
+* **WAL-aware.** The legacy stores run in WAL mode, so committed-but-not-yet-
+  checkpointed transactions live in the ``-wal`` sidecar, not the main ``.db``.
+  A raw byte copy of the main file would silently drop them — losing the newest
+  sessions/memory of a user whose old process crashed or is still writing. The
+  copy therefore goes through ``sqlite3``'s online-backup API
+  (:func:`_atomic_sqlite_snapshot`), which reads through the engine and captures
+  a transaction-consistent snapshot including the WAL.
+* **Atomic.** Each snapshot is written to a temp file then ``os.replace``-d into
+  place, so a crash mid-copy never leaves a half-written database in custody.
 * **Fail loud.** Any step that cannot complete raises :class:`MigrationError`
   (originals intact, version left un-stamped so the next start retries) — never a
   partial success that swallows the error.
@@ -40,6 +46,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import time
 from pathlib import Path
 from typing import Callable, List
@@ -166,6 +173,59 @@ def _stamp_schema_version(version: int, applied: List[str]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# WAL-aware, atomic SQLite copy
+# ---------------------------------------------------------------------------
+
+
+def _atomic_sqlite_snapshot(src: Path, dst: Path, mode: int = 0o600) -> None:
+    """Copy the SQLite database *src* to *dst* as a consistent, WAL-aware snapshot.
+
+    The legacy stores run in WAL mode (``PRAGMA journal_mode = WAL``), so a
+    committed transaction that has not yet been checkpointed lives in the ``-wal``
+    sidecar file, not the main ``.db``. A raw byte copy of the main file would
+    silently omit it — losing the newest sessions/memory of any user whose old
+    process is still running or crashed before a checkpoint. ``sqlite3``'s
+    online-backup API reads *through* the engine, so the snapshot is
+    transaction-consistent and includes the WAL, even against a live writer.
+
+    The source is opened for reading only — ``backup`` never writes to it, so the
+    migration stays non-destructive. (A literal read-only handle,
+    ``file:...?mode=ro``, cannot be used: SQLite cannot open a WAL database
+    read-only once its writer has exited, because it may not create the ``-shm``
+    wal-index — which is exactly the common upgrade case.) The snapshot is written
+    to a temp file and atomically ``os.replace``-d over *dst*, so a crash
+    mid-backup never leaves a half-written database in custody.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.parent / f".{dst.name}.{os.getpid()}.tmp"
+    if tmp.exists():
+        tmp.unlink()
+    # A generous busy_timeout so a brief lock held by a live legacy writer is
+    # waited out rather than surfaced as a spurious "database is locked" failure.
+    src_conn = sqlite3.connect(str(src), timeout=30.0)
+    try:
+        src_conn.execute("PRAGMA busy_timeout=30000")
+        dst_conn = sqlite3.connect(str(tmp))
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    except BaseException:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    finally:
+        src_conn.close()
+    os.replace(str(tmp), str(dst))
+    try:
+        os.chmod(str(dst), mode)
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Migration steps — each keyed by the version it PRODUCES
 # ---------------------------------------------------------------------------
 
@@ -190,15 +250,15 @@ def _migrate_v0_to_v1() -> List[str]:
             logger.info("migrate: no legacy %s at %s; skipping", name, src)
             continue
         try:
-            paths.atomic_copy_file(src, dst)
-        except OSError as e:
+            _atomic_sqlite_snapshot(src, dst)
+        except (OSError, sqlite3.Error) as e:
             raise MigrationError(
                 f"failed to migrate legacy {name} from {src} to {dst}: {e}. The "
                 f"original at {src} is untouched; free up disk space / fix "
                 "permissions on the custody directory and restart the daemon to "
                 "retry. No data was lost."
             ) from e
-        logger.info("migrate: copied legacy %s %s -> %s", name, src, dst)
+        logger.info("migrate: snapshotted legacy %s %s -> %s", name, src, dst)
         applied.append(f"{name}:{src.name}")
 
     return applied

--- a/src/gaia/daemon/migrate.py
+++ b/src/gaia/daemon/migrate.py
@@ -1,0 +1,274 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""One-time, versioned migration of pre-v2 ``~/.gaia`` state into host custody
+(design §0.10 step 0; breakdown item V2-13).
+
+Before Agent UI v2 the single Agent-UI process owned everything in-process and
+wrote its stores flat under ``~/.gaia`` — sessions at ``~/.gaia/chat/gaia_chat.db``
+and memory at ``~/.gaia/memory.db`` — with no agent tag and no on-disk schema
+version. Under v2 the always-on daemon is the custody owner (§0.9): stores live
+under ``~/.gaia/host/custody/`` and every row is scoped to an agent. Without a
+migration, an upgrader either loses past chats or leaks memory cross-agent.
+
+This module supplies that migration and the schema-version stamp that gates it:
+
+* :func:`run_migrations` runs at every daemon start (wired in ``server.run``).
+* The on-disk schema version is read from ``host/custody/schema.json``. Absent =
+  version 0 = a pre-v2 install that has never been migrated.
+* Older-than-current → ordered migration steps run, then the version is stamped.
+* Current → no-op (this is what makes a second run idempotent).
+* Newer-than-current → **loud refusal** (a downgraded binary must not touch state
+  written by a newer one), never a silent proceed.
+
+Invariants (CLAUDE.md — critical for a migration):
+
+* **Non-destructive.** Legacy stores are *copied*, never moved or deleted, so the
+  original data is always recoverable even if the daemon is later rolled back.
+* **Atomic.** Each store is copied via temp-file-then-rename
+  (:func:`gaia.daemon.paths.atomic_copy_file`), so a crash mid-copy never leaves a
+  half-written database in custody.
+* **Fail loud.** Any step that cannot complete raises :class:`MigrationError`
+  (originals intact, version left un-stamped so the next start retries) — never a
+  partial success that swallows the error.
+
+The custody target paths below are what a pre-#2153 daemon writes; #2153 (the
+``/host/v1`` custody API, V2-12) reads from the same layout. They are centralized
+here so a rebase onto #2153's final scoping repoints one place, not the logic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Callable, List
+
+from gaia.daemon import paths
+from gaia.daemon.errors import MigrationError
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Current on-disk custody schema version. Bump when a new migration step is added
+# and register the step in ``_MIGRATIONS`` keyed by the version it produces.
+SCHEMA_VERSION = 1
+
+# Pre-v2 state predates per-agent scoping, so it all belongs to one agent: the
+# host chat agent that owned the single Agent-UI process. #2153 may repoint this.
+DEFAULT_HOST_AGENT_ID = "chat"
+
+# Legacy ``~/.gaia`` root override. Mirrors ``gaia.config.GAIA_CONFIG_DIR`` but is
+# resolved on every call (not import-time) so tests can monkeypatch the env and so
+# a subprocess with a different env resolves its own root — the same discipline
+# ``paths.host_dir`` uses for ``GAIA_DAEMON_HOME``.
+_ENV_LEGACY_HOME = "GAIA_CONFIG_DIR"
+
+
+class MigrationState:
+    """String constants for the ``status`` field of :func:`run_migrations`."""
+
+    CURRENT = "current"  # on-disk == SCHEMA_VERSION; nothing to do
+    MIGRATED = "migrated"  # ran one or more steps and stamped the new version
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (centralized so a #2153 rebase repoints here, not the logic)
+# ---------------------------------------------------------------------------
+
+
+def legacy_gaia_dir() -> Path:
+    """The pre-v2 ``~/.gaia`` root holding the flat legacy stores."""
+    override = os.environ.get(_ENV_LEGACY_HOME)
+    if override:
+        return Path(override)
+    return Path.home() / ".gaia"
+
+
+def custody_dir() -> Path:
+    """The v2 custody root: ``host/custody/`` (under ``paths.host_dir()``)."""
+    return paths.host_dir() / "custody"
+
+
+def schema_stamp_path() -> Path:
+    """The on-disk schema-version stamp (also the migration journal)."""
+    return custody_dir() / "schema.json"
+
+
+def legacy_sessions_db() -> Path:
+    """Pre-v2 Agent-UI sessions DB (``~/.gaia/chat/gaia_chat.db``)."""
+    return legacy_gaia_dir() / "chat" / "gaia_chat.db"
+
+
+def legacy_memory_db() -> Path:
+    """Pre-v2 agent memory DB (``~/.gaia/memory.db``)."""
+    return legacy_gaia_dir() / "memory.db"
+
+
+def custody_sessions_db() -> Path:
+    """Sessions in custody, tagged to the default host agent (host index)."""
+    return custody_dir() / "agents" / DEFAULT_HOST_AGENT_ID / "sessions.db"
+
+
+def custody_memory_db() -> Path:
+    """Memory in custody, user-scope (single owner across the host's agents)."""
+    return custody_dir() / "memory" / "user" / "memory.db"
+
+
+# ---------------------------------------------------------------------------
+# Schema-version stamp
+# ---------------------------------------------------------------------------
+
+
+def read_schema_version() -> int:
+    """Return the on-disk schema version, or ``0`` if never stamped (pre-v2).
+
+    A present-but-corrupt stamp is a :class:`MigrationError`, not a silent reset —
+    treating an unreadable stamp as "version 0" would re-run migrations over
+    already-migrated state.
+    """
+    path = schema_stamp_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return 0
+    except OSError as e:
+        raise MigrationError(
+            f"cannot read the custody schema stamp at {path}: {e}. Fix the file "
+            "permissions (it must be readable by the daemon user) and restart, or "
+            "inspect it via `gaia daemon logs`."
+        ) from e
+    try:
+        version = int(json.loads(raw)["schema_version"])
+    except (ValueError, KeyError, TypeError) as e:
+        raise MigrationError(
+            f"the custody schema stamp at {path} is present but malformed ({e}); "
+            "refusing to guess the on-disk version. Restore it from a backup or "
+            "remove it only if you are certain the custody store is empty, then "
+            "restart the daemon."
+        ) from e
+    if version < 0:
+        raise MigrationError(
+            f"the custody schema stamp at {path} records a negative version "
+            f"({version}); refusing to proceed over corrupt state."
+        )
+    return version
+
+
+def _stamp_schema_version(version: int, applied: List[str]) -> None:
+    """Atomically write the schema stamp / journal at *version*."""
+    payload = {
+        "schema_version": version,
+        "stamped_at": time.time(),
+        "applied": applied,
+    }
+    paths.atomic_write_json(schema_stamp_path(), payload)
+
+
+# ---------------------------------------------------------------------------
+# Migration steps — each keyed by the version it PRODUCES
+# ---------------------------------------------------------------------------
+
+
+def _migrate_v0_to_v1() -> List[str]:
+    """Relocate flat pre-v2 stores into the v2 custody layout.
+
+    Sessions → the host index tagged with the default agent; memory → user-scope.
+    Each store is copied atomically and only if the legacy file exists (a fresh
+    install has neither — the cold-state path — and simply gets stamped at v1).
+    Re-copying is safe: the source is preserved, so a retry after a partial
+    failure overwrites any half-migrated target with the authoritative original.
+    """
+    applied: List[str] = []
+
+    relocations = (
+        ("sessions", legacy_sessions_db(), custody_sessions_db()),
+        ("memory", legacy_memory_db(), custody_memory_db()),
+    )
+    for name, src, dst in relocations:
+        if not src.exists():
+            logger.info("migrate: no legacy %s at %s; skipping", name, src)
+            continue
+        try:
+            paths.atomic_copy_file(src, dst)
+        except OSError as e:
+            raise MigrationError(
+                f"failed to migrate legacy {name} from {src} to {dst}: {e}. The "
+                f"original at {src} is untouched; free up disk space / fix "
+                "permissions on the custody directory and restart the daemon to "
+                "retry. No data was lost."
+            ) from e
+        logger.info("migrate: copied legacy %s %s -> %s", name, src, dst)
+        applied.append(f"{name}:{src.name}")
+
+    return applied
+
+
+# Ordered registry: index i upgrades version i -> i+1. Extend, don't rewrite.
+_MIGRATIONS: List[Callable[[], List[str]]] = [
+    _migrate_v0_to_v1,
+]
+
+# The registry must always be able to reach SCHEMA_VERSION from 0 — a mismatch is
+# a programming error (a bumped SCHEMA_VERSION without a registered step), caught
+# here at import rather than as a confusing runtime gap. A raise (not assert) so
+# it survives ``python -O``.
+if len(_MIGRATIONS) != SCHEMA_VERSION:
+    raise RuntimeError(
+        "migration registry out of sync with SCHEMA_VERSION: "
+        f"{len(_MIGRATIONS)} steps for version {SCHEMA_VERSION}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run_migrations() -> dict:
+    """Bring ``~/.gaia`` custody state to :data:`SCHEMA_VERSION`. Idempotent.
+
+    Called on every daemon start. Returns a small summary dict
+    (``status``/``from_version``/``to_version``/``applied``). Raises
+    :class:`MigrationError` on a corrupt stamp, an unknown-newer version, or a
+    step that fails — the daemon must not serve over ambiguous state.
+    """
+    current = read_schema_version()
+
+    if current == SCHEMA_VERSION:
+        return {
+            "status": MigrationState.CURRENT,
+            "from_version": current,
+            "to_version": SCHEMA_VERSION,
+            "applied": [],
+        }
+
+    if current > SCHEMA_VERSION:
+        raise MigrationError(
+            f"the on-disk custody schema is version {current} but this GAIA build "
+            f"only understands up to version {SCHEMA_VERSION}. This state was "
+            "written by a NEWER GAIA; refusing to run to avoid corrupting it. "
+            "Upgrade GAIA to a build that supports this schema, or point it at a "
+            "different custody home."
+        )
+
+    paths.ensure_host_dir()
+    custody_dir().mkdir(parents=True, exist_ok=True)
+
+    applied: List[str] = []
+    version = current
+    # Run each pending step in order, stamping after EACH so a failure part-way
+    # through a multi-version upgrade leaves a consistent, resumable checkpoint.
+    for step in _MIGRATIONS[current:SCHEMA_VERSION]:
+        step_applied = step()  # MigrationError propagates: version stays un-bumped
+        version += 1
+        applied.extend(step_applied)
+        _stamp_schema_version(version, applied)
+        logger.info("migrate: stamped custody schema version %s", version)
+
+    return {
+        "status": MigrationState.MIGRATED,
+        "from_version": current,
+        "to_version": version,
+        "applied": applied,
+    }

--- a/src/gaia/daemon/paths.py
+++ b/src/gaia/daemon/paths.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from pathlib import Path
+from typing import Union
 
 _ENV_HOME = "GAIA_DAEMON_HOME"
 
@@ -84,5 +86,42 @@ def atomic_write_json(path: Path, payload, mode: int = 0o600) -> None:
     # where the source mode is not carried across the rename.
     try:
         os.chmod(str(path), mode)
+    except OSError:
+        pass
+
+
+def atomic_copy_file(
+    src: Union[str, Path], dst: Union[str, Path], mode: int = 0o600
+) -> None:
+    """Atomically copy *src* to *dst* — same temp-then-rename discipline as
+    :func:`atomic_write_json`, but for arbitrary (binary) files.
+
+    Used by the one-time state migration to relocate SQLite stores: the copy is
+    written to a uniquely-named temp file in *dst*'s directory, fsynced, then
+    ``os.replace``-d over the target, so a crash mid-copy never leaves a
+    half-written (and therefore corrupt) database at *dst*. *src* is never
+    modified — the migration is non-destructive by construction.
+    """
+    src = Path(src)
+    dst = Path(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.parent / f".{dst.name}.{os.getpid()}.tmp"
+    if tmp.exists():
+        tmp.unlink()
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC, mode)
+    try:
+        with open(src, "rb") as fsrc, os.fdopen(fd, "wb") as fdst:
+            shutil.copyfileobj(fsrc, fdst)
+            fdst.flush()
+            os.fsync(fdst.fileno())
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    os.replace(str(tmp), str(dst))
+    try:
+        os.chmod(str(dst), mode)
     except OSError:
         pass

--- a/src/gaia/daemon/paths.py
+++ b/src/gaia/daemon/paths.py
@@ -12,9 +12,7 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 from pathlib import Path
-from typing import Union
 
 _ENV_HOME = "GAIA_DAEMON_HOME"
 
@@ -86,42 +84,5 @@ def atomic_write_json(path: Path, payload, mode: int = 0o600) -> None:
     # where the source mode is not carried across the rename.
     try:
         os.chmod(str(path), mode)
-    except OSError:
-        pass
-
-
-def atomic_copy_file(
-    src: Union[str, Path], dst: Union[str, Path], mode: int = 0o600
-) -> None:
-    """Atomically copy *src* to *dst* — same temp-then-rename discipline as
-    :func:`atomic_write_json`, but for arbitrary (binary) files.
-
-    Used by the one-time state migration to relocate SQLite stores: the copy is
-    written to a uniquely-named temp file in *dst*'s directory, fsynced, then
-    ``os.replace``-d over the target, so a crash mid-copy never leaves a
-    half-written (and therefore corrupt) database at *dst*. *src* is never
-    modified — the migration is non-destructive by construction.
-    """
-    src = Path(src)
-    dst = Path(dst)
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dst.parent / f".{dst.name}.{os.getpid()}.tmp"
-    if tmp.exists():
-        tmp.unlink()
-    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC, mode)
-    try:
-        with open(src, "rb") as fsrc, os.fdopen(fd, "wb") as fdst:
-            shutil.copyfileobj(fsrc, fdst)
-            fdst.flush()
-            os.fsync(fdst.fileno())
-    except Exception:
-        try:
-            tmp.unlink()
-        except OSError:
-            pass
-        raise
-    os.replace(str(tmp), str(dst))
-    try:
-        os.chmod(str(dst), mode)
     except OSError:
         pass

--- a/src/gaia/daemon/server.py
+++ b/src/gaia/daemon/server.py
@@ -108,8 +108,15 @@ def run(host: str = HOST) -> None:
     """Start the daemon and serve until shutdown. Blocks."""
     import uvicorn
 
+    from gaia.daemon.migrate import run_migrations
     from gaia.daemon.sidecars import ledger
     from gaia.daemon.sidecars.spec import builtin_specs
+
+    # One-time versioned state migration (§0.10 step 0). Runs before the port is
+    # bound so a corrupt/unknown-newer custody schema refuses loudly (MigrationError
+    # propagates and the daemon exits) rather than serving over ambiguous state.
+    result = run_migrations()
+    logger.info("daemon: custody schema %s", result)
 
     port = _find_free_port(host)
     token = secrets.token_urlsafe(32)

--- a/tests/unit/test_daemon_migrate.py
+++ b/tests/unit/test_daemon_migrate.py
@@ -24,7 +24,7 @@ import sqlite3
 
 import pytest
 
-from gaia.daemon import migrate, paths
+from gaia.daemon import migrate
 from gaia.daemon.errors import MigrationError
 
 
@@ -187,6 +187,47 @@ def test_second_run_ignores_new_legacy_writes(homes):
 
 
 # ---------------------------------------------------------------------------
+# WAL safety: committed-but-uncheckpointed rows must survive the migration
+# ---------------------------------------------------------------------------
+
+
+def test_uncheckpointed_wal_row_is_migrated(homes):
+    """Regression for the raw-byte-copy data-loss bug: a row committed to the WAL
+    but not yet checkpointed lives in the ``-wal`` sidecar, which a raw copy of the
+    main ``.db`` misses. The engine-level snapshot must capture it — here with the
+    writer STILL OPEN (the worst case: a live legacy process)."""
+    legacy, _ = homes
+    db = migrate.legacy_memory_db()
+    db.parent.mkdir(parents=True, exist_ok=True)
+
+    writer = sqlite3.connect(str(db))
+    try:
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("CREATE TABLE k(id INTEGER PRIMARY KEY, v TEXT)")
+        writer.execute("INSERT INTO k(v) VALUES('checkpointed')")
+        writer.commit()
+        # Fold the first row into the main file, then commit a SECOND row that
+        # stays in the -wal (no checkpoint) — exactly what a raw copy would drop.
+        writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        writer.execute("INSERT INTO k(v) VALUES('in-wal-only')")
+        writer.commit()
+        assert (db.parent / f"{db.name}-wal").exists()  # sanity: WAL is populated
+
+        result = migrate.run_migrations()
+        assert result["status"] == migrate.MigrationState.MIGRATED
+    finally:
+        writer.close()
+
+    conn = sqlite3.connect(str(migrate.custody_memory_db()))
+    try:
+        values = {row[0] for row in conn.execute("SELECT v FROM k").fetchall()}
+    finally:
+        conn.close()
+    # Both rows survive — the uncheckpointed one is NOT lost.
+    assert values == {"checkpointed", "in-wal-only"}
+
+
+# ---------------------------------------------------------------------------
 # Unknown-newer version → loud refusal
 # ---------------------------------------------------------------------------
 
@@ -216,7 +257,7 @@ def test_failed_step_preserves_originals_and_does_not_stamp(homes, monkeypatch):
     def boom(src, dst, mode=0o600):
         raise OSError("disk full")
 
-    monkeypatch.setattr(paths, "atomic_copy_file", boom)
+    monkeypatch.setattr(migrate, "_atomic_sqlite_snapshot", boom)
 
     with pytest.raises(MigrationError) as ei:
         migrate.run_migrations()
@@ -234,7 +275,7 @@ def test_retry_after_failure_completes(homes, monkeypatch):
     _seed_legacy_memory(legacy)
 
     calls = {"n": 0}
-    real_copy = paths.atomic_copy_file
+    real_copy = migrate._atomic_sqlite_snapshot
 
     def flaky(src, dst, mode=0o600):
         calls["n"] += 1
@@ -242,13 +283,13 @@ def test_retry_after_failure_completes(homes, monkeypatch):
             raise OSError("transient")
         return real_copy(src, dst, mode)
 
-    monkeypatch.setattr(paths, "atomic_copy_file", flaky)
+    monkeypatch.setattr(migrate, "_atomic_sqlite_snapshot", flaky)
     with pytest.raises(MigrationError):
         migrate.run_migrations()
     assert migrate.read_schema_version() == 0
 
     # Retry (fault cleared) completes and stamps.
-    monkeypatch.setattr(paths, "atomic_copy_file", real_copy)
+    monkeypatch.setattr(migrate, "_atomic_sqlite_snapshot", real_copy)
     result = migrate.run_migrations()
     assert result["status"] == migrate.MigrationState.MIGRATED
     assert migrate.read_schema_version() == migrate.SCHEMA_VERSION

--- a/tests/unit/test_daemon_migrate.py
+++ b/tests/unit/test_daemon_migrate.py
@@ -1,0 +1,256 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the one-time versioned ``~/.gaia`` state migration (issue #2155).
+
+Covers the acceptance criteria from V2-13:
+
+* warm-state: a populated pre-v2 fixture migrates into the custody layout;
+* idempotent: a second run is a no-op (the version stamp gates re-runs);
+* cold-state: a fresh profile with nothing to migrate still stamps and succeeds
+  (per the CLAUDE.md hidden-state rule);
+* mid-migration failure leaves the originals intact, the version un-stamped, and
+  is recoverable on retry — and fails loud;
+* schema version stamped and checked; an unknown-newer version → loud refusal.
+
+Fixtures are *real* SQLite databases built by the actual pre-v2 store classes
+(``MemoryStore`` / ``ChatDatabase``), so the migration is exercised against the
+same on-disk schema an upgrader really has — not a hand-rolled stand-in.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from gaia.daemon import migrate, paths
+from gaia.daemon.errors import MigrationError
+
+
+@pytest.fixture()
+def homes(tmp_path, monkeypatch):
+    """Isolate BOTH the legacy ``~/.gaia`` root and the v2 host dir under tmp.
+
+    Legacy state (``GAIA_CONFIG_DIR``) and custody (``GAIA_DAEMON_HOME``) live in
+    separate tmp subdirs so a test never touches the developer's real state.
+    """
+    legacy = tmp_path / "gaia"
+    host = tmp_path / "gaia" / "host"
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(legacy))
+    monkeypatch.setenv("GAIA_DAEMON_HOME", str(host))
+    return legacy, host
+
+
+def _seed_legacy_sessions(legacy_dir):
+    """Create a real pre-v2 sessions DB at ``~/.gaia/chat/gaia_chat.db``."""
+    from gaia.ui.database import ChatDatabase
+
+    db_path = legacy_dir / "chat" / "gaia_chat.db"
+    db = ChatDatabase(db_path=str(db_path))
+    try:
+        session = db.create_session(title="pre-v2 chat")
+        session_id = session["id"]
+        db.add_message(session_id, role="user", content="hello from before v2")
+    finally:
+        db.close()
+    return db_path, session_id
+
+
+def _seed_legacy_memory(legacy_dir):
+    """Create a real pre-v2 memory DB at ``~/.gaia/memory.db``."""
+    from gaia.agents.base.memory_store import MemoryStore
+
+    db_path = legacy_dir / "memory.db"
+    store = MemoryStore(db_path=db_path)
+    try:
+        store.store(category="preference", content="user prefers dark mode")
+    finally:
+        store.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Schema-version stamp
+# ---------------------------------------------------------------------------
+
+
+def test_read_schema_version_absent_is_zero(homes):
+    assert migrate.read_schema_version() == 0
+
+
+def test_read_schema_version_after_migrate(homes):
+    migrate.run_migrations()
+    assert migrate.read_schema_version() == migrate.SCHEMA_VERSION
+
+
+def test_read_schema_version_corrupt_raises_loud(homes):
+    stamp = migrate.schema_stamp_path()
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text("{ not valid json", encoding="utf-8")
+    with pytest.raises(MigrationError) as ei:
+        migrate.read_schema_version()
+    assert str(stamp) in str(ei.value)
+
+
+def test_read_schema_version_missing_key_raises_loud(homes):
+    stamp = migrate.schema_stamp_path()
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text(json.dumps({"unrelated": 1}), encoding="utf-8")
+    with pytest.raises(MigrationError):
+        migrate.read_schema_version()
+
+
+# ---------------------------------------------------------------------------
+# Cold state (nothing to migrate)
+# ---------------------------------------------------------------------------
+
+
+def test_cold_state_stamps_and_reports(homes):
+    result = migrate.run_migrations()
+    assert result["status"] == migrate.MigrationState.MIGRATED
+    assert result["from_version"] == 0
+    assert result["to_version"] == migrate.SCHEMA_VERSION
+    assert result["applied"] == []  # no legacy stores existed
+    assert migrate.read_schema_version() == migrate.SCHEMA_VERSION
+    # No custody stores were fabricated out of nothing.
+    assert not migrate.custody_sessions_db().exists()
+    assert not migrate.custody_memory_db().exists()
+
+
+# ---------------------------------------------------------------------------
+# Warm state (populated fixture)
+# ---------------------------------------------------------------------------
+
+
+def test_warm_state_migrates_sessions_and_memory(homes):
+    legacy, _ = homes
+    sessions_src, session_id = _seed_legacy_sessions(legacy)
+    memory_src = _seed_legacy_memory(legacy)
+
+    result = migrate.run_migrations()
+
+    assert result["status"] == migrate.MigrationState.MIGRATED
+    assert result["to_version"] == migrate.SCHEMA_VERSION
+    assert len(result["applied"]) == 2
+
+    # Custody copies exist under the v2 layout...
+    assert migrate.custody_sessions_db().exists()
+    assert migrate.custody_memory_db().exists()
+
+    # ...and the originals are preserved (non-destructive).
+    assert sessions_src.exists()
+    assert memory_src.exists()
+
+    # The migrated sessions DB carries the real pre-v2 row.
+    conn = sqlite3.connect(str(migrate.custody_sessions_db()))
+    try:
+        row = conn.execute(
+            "SELECT title FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None and row[0] == "pre-v2 chat"
+
+
+def test_second_run_is_noop(homes):
+    legacy, _ = homes
+    _seed_legacy_sessions(legacy)
+    _seed_legacy_memory(legacy)
+
+    first = migrate.run_migrations()
+    assert first["status"] == migrate.MigrationState.MIGRATED
+
+    sessions_dst = migrate.custody_sessions_db()
+    mtime_before = sessions_dst.stat().st_mtime_ns
+
+    second = migrate.run_migrations()
+    assert second["status"] == migrate.MigrationState.CURRENT
+    assert second["applied"] == []
+    # The second run did not rewrite the already-migrated store.
+    assert sessions_dst.stat().st_mtime_ns == mtime_before
+
+
+def test_second_run_ignores_new_legacy_writes(homes):
+    """Once stamped, the migration never re-touches legacy state — even if the old
+    location is written again — so it can't clobber post-migration custody data."""
+    legacy, _ = homes
+    _seed_legacy_sessions(legacy)
+    migrate.run_migrations()
+
+    # Simulate a stray later write to the OLD location; the stamped migration
+    # must ignore it (idempotent by version, not by content diffing).
+    migrate.legacy_memory_db().write_bytes(b"stray-post-migration-bytes")
+    result = migrate.run_migrations()
+    assert result["status"] == migrate.MigrationState.CURRENT
+    assert not migrate.custody_memory_db().exists()
+
+
+# ---------------------------------------------------------------------------
+# Unknown-newer version → loud refusal
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_newer_version_refuses_loud(homes):
+    stamp = migrate.schema_stamp_path()
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text(
+        json.dumps({"schema_version": migrate.SCHEMA_VERSION + 5}), encoding="utf-8"
+    )
+    with pytest.raises(MigrationError) as ei:
+        migrate.run_migrations()
+    msg = str(ei.value)
+    assert "NEWER" in msg or "newer" in msg
+
+
+# ---------------------------------------------------------------------------
+# Mid-migration failure: originals intact, version un-stamped, recoverable
+# ---------------------------------------------------------------------------
+
+
+def test_failed_step_preserves_originals_and_does_not_stamp(homes, monkeypatch):
+    legacy, _ = homes
+    sessions_src, _ = _seed_legacy_sessions(legacy)
+    memory_src = _seed_legacy_memory(legacy)
+
+    def boom(src, dst, mode=0o600):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(paths, "atomic_copy_file", boom)
+
+    with pytest.raises(MigrationError) as ei:
+        migrate.run_migrations()
+    assert "No data was lost" in str(ei.value)
+
+    # Originals untouched; version NOT stamped (so the next start retries).
+    assert sessions_src.exists()
+    assert memory_src.exists()
+    assert migrate.read_schema_version() == 0
+
+
+def test_retry_after_failure_completes(homes, monkeypatch):
+    legacy, _ = homes
+    _seed_legacy_sessions(legacy)
+    _seed_legacy_memory(legacy)
+
+    calls = {"n": 0}
+    real_copy = paths.atomic_copy_file
+
+    def flaky(src, dst, mode=0o600):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("transient")
+        return real_copy(src, dst, mode)
+
+    monkeypatch.setattr(paths, "atomic_copy_file", flaky)
+    with pytest.raises(MigrationError):
+        migrate.run_migrations()
+    assert migrate.read_schema_version() == 0
+
+    # Retry (fault cleared) completes and stamps.
+    monkeypatch.setattr(paths, "atomic_copy_file", real_copy)
+    result = migrate.run_migrations()
+    assert result["status"] == migrate.MigrationState.MIGRATED
+    assert migrate.read_schema_version() == migrate.SCHEMA_VERSION
+    assert migrate.custody_sessions_db().exists()
+    assert migrate.custody_memory_db().exists()


### PR DESCRIPTION
Before: an upgrader's existing `~/.gaia` state (sessions at `~/.gaia/chat/gaia_chat.db`, memory at `~/.gaia/memory.db`) sits in the flat pre-v2 layout — no agent tag, no on-disk schema version — which is incompatible with the v2 daemon custody model. Without a migration, upgrading either loses past chats or leaks memory cross-agent (design §0.10 step 0). After: the first daemon start stamps an on-disk custody schema version and moves the state safely into the v2 custody layout — sessions into the host index under the default agent tag, memory into user-scope — once, idempotently, and without ever losing data.

The migration runs in `server.run()` before the port binds, so ambiguous state stops the daemon instead of being served over. It is **non-destructive** (originals are copied, never moved), **atomic** (temp-then-rename per store via the new `paths.atomic_copy_file`), **idempotent** (the version stamp gates re-runs — a second start is a no-op), and **fails loud** (a corrupt stamp, an unknown-newer version, or a failed copy raises `MigrationError` with the originals intact and the version left un-stamped so the next start retries). Custody target paths are centralized in `migrate.py` so the rebase onto the #2153 custody API (V2-12, built in parallel) repoints one place, not the migration logic.

Part of #2014 · Closes #2155

## Test plan
- [x] `pytest tests/unit/test_daemon_migrate.py` — 11 passing (warm-state migrate, idempotent second run, cold-state, unknown-newer loud refusal, corrupt stamp loud, mid-migration failure leaves originals intact + un-stamped + recoverable on retry, schema-version read)
- [x] `pytest tests/unit/test_daemon.py` — 5 passing (no regression in the daemon skeleton)
- [x] Fixtures are **real** SQLite DBs built by the actual pre-v2 store classes (`ChatDatabase` / `MemoryStore`), so the migration is exercised against the same on-disk schema an upgrader really has
- [x] `black --check` / `isort` clean on all changed files

### Reviewer notes
- **Depends on #2153 (V2-12, in parallel).** The custody target layout under `host/custody/` is this PR's best read of the scoping #2153 defines; expect a rebase to repoint the path helpers in `migrate.py`. The versioning/idempotency/atomicity/loud-failure logic is independent of the exact paths.
- **Copy, not move:** originals are preserved as a rollback safety net — the most data-loss-proof reading of the "never destructive" constraint. Once stamped, stray later writes to the old location are ignored (idempotent by version, not content).
- No user-facing docs surface added: the daemon is internal v2 infrastructure with no CLI/SDK surface yet; the migration runs automatically with no user interaction.
- One pre-existing, unrelated failure in `test_daemon_agents_routes.py` (a Windows `ledger.py` group-kill "known gap") fails on `main` too — not touched by this PR.