### PR TITLE
test(eval): sidecar eval harness + distributed-seams suite (V2-19)

### DIFF
--- a/.github/workflows/test_distributed_seams.yml
+++ b/.github/workflows/test_distributed_seams.yml
@@ -1,0 +1,102 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Distributed-seams suite (V2-19 / #2180): the consolidated, deterministic
+# contract guard for the daemon<->sidecar boundaries the Agent UI v2 introduces
+# (relay vocabulary/crash coherence, the daemon->sidecar auth leg). Seams still
+# in flight (broker #2151, custody #2153, secret-file #2149, migration #2155)
+# self-skip with a named reason and flip to real assertions the moment their
+# source lands — no edit to this job needed.
+#
+# Runs on Ubuntu: every assertion here is deterministic (no Lemonade, no
+# hardware). The on-hardware golden path (UI -> daemon -> sidecar -> Lemonade)
+# lives in tests/integration/eval/test_sidecar_eval.py and runs on the
+# self-hosted strix-halo runner (see Agent Behavior E2E), not here.
+
+name: Distributed Seams
+
+on:
+  workflow_call:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/gaia/daemon/**'
+      - 'src/gaia/eval/sidecar_harness.py'
+      - 'hub/agents/python/email/gaia_agent_email/sse_translation.py'
+      - 'hub/agents/python/email/gaia_agent_email/query_routes.py'
+      - 'hub/agents/python/email/eval_baselines/**'
+      - 'tests/integration/test_distributed_seams.py'
+      - 'tests/unit/test_sidecar_harness.py'
+      - '.github/workflows/test_distributed_seams.yml'
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/gaia/daemon/**'
+      - 'src/gaia/eval/sidecar_harness.py'
+      - 'hub/agents/python/email/gaia_agent_email/sse_translation.py'
+      - 'hub/agents/python/email/gaia_agent_email/query_routes.py'
+      - 'hub/agents/python/email/eval_baselines/**'
+      - 'tests/integration/test_distributed_seams.py'
+      - 'tests/unit/test_sidecar_harness.py'
+      - '.github/workflows/test_distributed_seams.yml'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  distributed-seams:
+    name: Distributed Seams (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.12']
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install dependencies
+        run: |
+          # Core [api] carries fastapi/httpx (relay + harness); the email hub
+          # package makes gaia_agent_email.sse_translation importable so the
+          # cross-seam VOCABULARY coherence assertions run for real (not skipped).
+          uv pip install --system pytest pytest-asyncio pytest-mock pytest-timeout \
+                                  pyfakefs keyring httpx respx
+          uv pip install --system -e ".[api]" -e hub/agents/python/email
+
+      - name: Run harness core unit tests
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+        run: |
+          echo "=== Sidecar eval harness core (pure, no Lemonade) ==="
+          python -m pytest tests/unit/test_sidecar_harness.py -v --tb=short
+
+      - name: Run distributed-seams suite
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+        run: |
+          echo "=== Distributed-seams contract suite (V2-19 / #2180) ==="
+          echo "Covered now: relay vocabulary + synthetic-error coherence, auth leg 2."
+          echo "Skipped-pending-merge: broker #2151, custody #2153, secret-file #2149, migration #2155."
+          echo ""
+          # -rs prints the skip reasons so the covered-vs-pending split is visible
+          # in the job log. Target the file directly (all its tests carry the
+          # distributed_seams marker) so the job never scans the whole tree.
+          python -m pytest tests/integration/test_distributed_seams.py \
+            -m distributed_seams -v -rs --tb=short

--- a/hub/agents/python/email/eval_baselines/query_sequences/send_needs_confirmation.json
+++ b/hub/agents/python/email/eval_baselines/query_sequences/send_needs_confirmation.json
@@ -1,0 +1,7 @@
+{
+  "scenario_id": "send_needs_confirmation",
+  "required_subsequence": ["status", "needs_confirmation", "final"],
+  "terminal": "final",
+  "forbidden": [],
+  "_comment": "A destructive/external step (e.g. send_now) must surface a needs_confirmation event and then, under the stateless D1 stub, end in a final refusal that points at the fixed-function route — never silently perform the action. Pins the §0.2 needs_confirmation seam (issue #2180 / V2-19)."
+}

--- a/hub/agents/python/email/eval_baselines/query_sequences/triage_inbox.json
+++ b/hub/agents/python/email/eval_baselines/query_sequences/triage_inbox.json
@@ -1,0 +1,7 @@
+{
+  "scenario_id": "triage_inbox",
+  "required_subsequence": ["status", "tool_call", "tool_result", "final"],
+  "terminal": "final",
+  "forbidden": ["error"],
+  "_comment": "Golden path for POST /v1/email/query (V2-2 #2016). Pins the frozen §0.2 vocabulary and its ordering, NOT an exact event count (LLM-non-deterministic). A triage run must: reach a status line, call a tool, return its result, and end in exactly one final with no error. Baselines live in the agent package so a drift shows in the email package's own review, next to the /query route it guards (issue #2180 / V2-19)."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ markers = [
     "integration: marks tests as integration tests (require external services like Lemonade server)",
     "gmail_live: marks tests that hit the live Gmail API (requires GAIA_GMAIL_LIVE_ACCOUNT env var; never in CI)",
     "real_model: marks tests that require a real Lemonade model server and real model inference (self-hosted runner only; see #1297)",
+    "distributed_seams: marks the consolidated daemon<->sidecar seam contract suite (V2-19 / #2180); deterministic, runs in normal CI, skips seams not yet merged",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/gaia/eval/sidecar_harness.py
+++ b/src/gaia/eval/sidecar_harness.py
@@ -440,14 +440,41 @@ class SerialEvalLock:
             holder = self._holder_pid()
             if holder is not None and not self._pid_alive(holder):
                 # Stale lock: the previous eval process died without releasing.
+                # Reclaim it verify-at-unlink so two contenders that BOTH saw the
+                # same dead pid can't both steal it (which would run two evals in
+                # parallel against the single Lemonade slot). os.rename is atomic:
+                # only one contender can move THIS file into its own reclaim
+                # token; the loser's rename fails and it loops back to contention.
                 logger.warning(
                     "sidecar eval: reclaiming stale serial lock at %s "
                     "(holder pid %s is gone)",
                     self.path,
                     holder,
                 )
+                token = self.path.with_name(f"{self.path.name}.reclaim.{os.getpid()}")
                 try:
-                    self.path.unlink()
+                    os.rename(self.path, token)
+                except OSError:
+                    # Another contender reclaimed or a live holder recreated the
+                    # lock between our read and rename — re-contend.
+                    continue
+                # We exclusively hold the renamed file. Confirm it still carries
+                # the SAME dead pid; if it changed, a live holder recreated it
+                # first — put it back rather than steal it, then re-contend.
+                try:
+                    token_pid = int(
+                        token.read_text(encoding="utf-8").strip().split()[0]
+                    )
+                except (OSError, ValueError, IndexError):
+                    token_pid = None
+                if token_pid != holder:
+                    try:
+                        os.rename(token, self.path)
+                    except OSError:
+                        pass
+                    continue
+                try:
+                    token.unlink()
                 except FileNotFoundError:
                     pass
                 continue

--- a/src/gaia/eval/sidecar_harness.py
+++ b/src/gaia/eval/sidecar_harness.py
@@ -1,0 +1,631 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Sidecar eval harness — drive an agent's ``/query`` loop THROUGH the sidecar /
+daemon path (not in-process) and assert the canonical SSE event *sequence*
+(V2-19, issue #2180).
+
+Why a separate harness
+----------------------
+``behavior_harness.py`` drives the in-process Agent UI server and asserts tool
+side-effects. It cannot see the v2 distributed seam at all: the sidecar's
+``POST /v1/<agent>/query`` loop (V2-2 / #2016) and the frozen seven-event wire
+contract (§0.2) that every front-door — the daemon relay, ``gaia email``,
+``gaia api`` — relays. This harness exercises exactly that surface over REST, so
+a drift in the §0.2 vocabulary or the loop→SSE translation is caught before a
+third-party agent amplifies it.
+
+What it asserts
+---------------
+Not a single final string, but the event **sequence** (§0.17):
+
+1. every emitted event is one of the seven canonical §0.2 types;
+2. the required ordered milestones appear in order (e.g. a triage run reaches
+   ``status`` → ``tool_call`` → ``tool_result`` → ``final``);
+3. exactly one terminal event (``final`` / ``error``), and it is last;
+4. no forbidden type appears (e.g. a golden run must not end in ``error``).
+
+Assertion 2 uses an ordered-**subsequence** match, not an exact list, because
+the count of ``status`` / ``token`` / repeated ``tool_call`` events is
+LLM-non-deterministic — pinning the exact list would make the baseline flap on
+every model nudge. The *shape* (the §0.2 names and their order) is what the seam
+guarantees, and what stays stable.
+
+Serial by construction (CLAUDE.md)
+----------------------------------
+The eval rule — never two model-loading eval runs at once against the
+single-tenant Lemonade slot — is ENFORCED here, not merely inherited:
+:class:`SerialEvalLock` is a cross-process file lock the live harness takes for
+the duration of a run. A second run blocks up to a timeout, then fails LOUD
+naming the holder — it never silently proceeds in parallel (which is exactly the
+race-evict CLAUDE.md documents).
+
+No silent fallbacks
+-------------------
+A missing/unreachable daemon or sidecar raises :class:`SidecarUnavailable` with
+an actionable message (what failed, what to do, where to look). The *test*
+decides whether that is a skip or a failure — the harness never turns an absent
+backend into a green pass.
+
+Pure-vs-live split (mirrors ``behavior_harness``)
+-------------------------------------------------
+All classification logic (SSE parse, sequence match, baseline load, the lock)
+lives in module-level helpers so unit tests cover it WITHOUT a running server or
+Lemonade. :class:`SidecarEvalHarness` is the thin live driver.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# The frozen §0.2 canonical event vocabulary (#2015). Kept here as the harness's
+# own copy on purpose: the harness must fail if the sidecar drifts from THIS
+# set, so it cannot import the set it is checking. The distributed-seams suite
+# asserts this copy stays equal to the relay's and the translator's copies.
+# ---------------------------------------------------------------------------
+
+CANONICAL_EVENT_TYPES: "frozenset[str]" = frozenset(
+    {
+        "status",
+        "token",
+        "tool_call",
+        "tool_result",
+        "needs_confirmation",
+        "final",
+        "error",
+    }
+)
+
+#: The two event types that terminate a ``/query`` stream (exactly one ends it).
+TERMINAL_TYPES: "frozenset[str]" = frozenset({"final", "error"})
+
+#: Where the live harness takes its cross-process serial lock. Overridable via
+#: ``GAIA_EVAL_LOCK_PATH`` so an isolated test run never contends with a real one.
+DEFAULT_LOCK_PATH = Path.home() / ".gaia" / "eval" / ".sidecar-eval.lock"
+
+
+# ---------------------------------------------------------------------------
+# Errors — loud, actionable (CLAUDE.md "No Silent Fallbacks")
+# ---------------------------------------------------------------------------
+
+
+class SidecarUnavailable(RuntimeError):
+    """The sidecar/daemon under test could not be reached or driven.
+
+    Names what failed, what to do, and where to look — so a caller (or a test's
+    skip reason) is actionable, never a bare "connection refused".
+    """
+
+
+class SerialEvalTimeout(RuntimeError):
+    """Another eval run held the serial lock past the timeout.
+
+    Raised instead of silently running in parallel (which race-evicts the shared
+    Lemonade model slot — the exact failure CLAUDE.md forbids)."""
+
+
+# ---------------------------------------------------------------------------
+# SSE parsing (pure)
+# ---------------------------------------------------------------------------
+
+
+def parse_sse(text: str) -> List[Dict[str, Any]]:
+    """Parse an SSE body into an ordered list of ``data:`` event dicts.
+
+    Tolerant of the CRLF/LF and comment (``:``-prefixed keep-alive) framing a
+    real server emits. A ``data:`` line whose payload is not JSON is surfaced as
+    a synthetic ``{"type": "__unparseable__", "raw": ...}`` marker rather than
+    dropped — a malformed frame is a seam bug the harness must be able to see,
+    not hide.
+    """
+    events: List[Dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:") :].strip()
+        if not payload:
+            continue
+        try:
+            event = json.loads(payload)
+        except (ValueError, UnicodeDecodeError):
+            events.append({"type": "__unparseable__", "raw": payload})
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+        else:
+            events.append({"type": "__non_object__", "raw": event})
+    return events
+
+
+def event_types(events: Sequence[Dict[str, Any]]) -> List[str]:
+    """The ordered list of ``type`` values from parsed events."""
+    return [str(e.get("type", "")) for e in events]
+
+
+def _is_ordered_subsequence(needle: Sequence[str], haystack: Sequence[str]) -> bool:
+    """True if every element of *needle* appears in *haystack* in the same order
+    (not necessarily contiguous)."""
+    it = iter(haystack)
+    return all(any(n == h for h in it) for n in needle)
+
+
+# ---------------------------------------------------------------------------
+# Baseline + verdict (pure)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SequenceBaseline:
+    """The committed expected shape of one ``/query`` run's event sequence.
+
+    Attributes:
+        scenario_id: Stable id — also the baseline file stem.
+        required_subsequence: Canonical event types that MUST appear, in this
+            order (non-contiguous). The stable §0.2-shape pin.
+        terminal: The single terminal type the run must end with (``final`` for
+            a golden path, ``error`` for a negative one).
+        forbidden: Types that must NOT appear at all (e.g. ``error`` on a golden
+            path). ``final``/``error`` are never listed here — ``terminal`` owns
+            the terminal check.
+    """
+
+    scenario_id: str
+    required_subsequence: Tuple[str, ...]
+    terminal: str = "final"
+    forbidden: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        unknown = set(self.required_subsequence) - CANONICAL_EVENT_TYPES
+        if unknown:
+            raise ValueError(
+                f"baseline {self.scenario_id!r} references non-canonical event "
+                f"types {sorted(unknown)}; allowed: {sorted(CANONICAL_EVENT_TYPES)}"
+            )
+        if self.terminal not in TERMINAL_TYPES:
+            raise ValueError(
+                f"baseline {self.scenario_id!r} terminal must be one of "
+                f"{sorted(TERMINAL_TYPES)}, got {self.terminal!r}"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "required_subsequence": list(self.required_subsequence),
+            "terminal": self.terminal,
+            "forbidden": list(self.forbidden),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SequenceBaseline":
+        try:
+            return cls(
+                scenario_id=data["scenario_id"],
+                required_subsequence=tuple(data["required_subsequence"]),
+                terminal=data.get("terminal", "final"),
+                forbidden=tuple(data.get("forbidden", ())),
+            )
+        except KeyError as e:
+            raise ValueError(
+                f"malformed sequence baseline (missing key {e}): {data!r}"
+            ) from e
+
+
+@dataclass
+class SequenceVerdict:
+    """The result of matching one observed event sequence against a baseline."""
+
+    passed: bool
+    scenario_id: str
+    observed_types: List[str]
+    reasons: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "scenario_id": self.scenario_id,
+            "observed_types": self.observed_types,
+            "reasons": self.reasons,
+        }
+
+
+def match_sequence(
+    events: Sequence[Dict[str, Any]], baseline: SequenceBaseline
+) -> SequenceVerdict:
+    """Match an observed event sequence against *baseline*, collecting EVERY
+    violation (never short-circuit — a full report beats a first-failure)."""
+    types = event_types(events)
+    reasons: List[str] = []
+
+    # 1. Vocabulary: every event is a canonical §0.2 type.
+    non_canonical = [t for t in types if t not in CANONICAL_EVENT_TYPES]
+    if non_canonical:
+        reasons.append(
+            f"non-canonical event type(s) emitted: {sorted(set(non_canonical))}; "
+            f"allowed §0.2 set: {sorted(CANONICAL_EVENT_TYPES)}"
+        )
+
+    # 2. Required milestones appear in order.
+    if not _is_ordered_subsequence(baseline.required_subsequence, types):
+        reasons.append(
+            f"required ordered milestones {list(baseline.required_subsequence)} "
+            f"not found in observed sequence {types}"
+        )
+
+    # 3. Exactly one terminal, and it is last.
+    terminal_count = sum(1 for t in types if t in TERMINAL_TYPES)
+    if terminal_count != 1:
+        reasons.append(
+            f"expected exactly one terminal event ({sorted(TERMINAL_TYPES)}), "
+            f"found {terminal_count} in {types}"
+        )
+    elif types[-1] not in TERMINAL_TYPES:
+        reasons.append(f"terminal event is not last; sequence ends with {types[-1]!r}")
+    elif types[-1] != baseline.terminal:
+        reasons.append(
+            f"terminal event is {types[-1]!r}, baseline expected "
+            f"{baseline.terminal!r}"
+        )
+
+    # 4. No forbidden type appears.
+    hit_forbidden = sorted(set(baseline.forbidden) & set(types))
+    if hit_forbidden:
+        reasons.append(f"forbidden event type(s) present: {hit_forbidden}")
+
+    return SequenceVerdict(
+        passed=not reasons,
+        scenario_id=baseline.scenario_id,
+        observed_types=types,
+        reasons=reasons,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Baseline loading (baselines live in the agent package — issue requirement)
+# ---------------------------------------------------------------------------
+
+
+def baselines_dir_for(agent_package_root: Path) -> Path:
+    """The committed-baseline directory inside an agent package.
+
+    ``<package_root>/eval_baselines/query_sequences/`` — one JSON file per
+    scenario, so a baseline diff shows in the agent package's own review, next
+    to the ``/query`` route it pins.
+    """
+    return Path(agent_package_root) / "eval_baselines" / "query_sequences"
+
+
+def load_baseline(path: Path) -> SequenceBaseline:
+    """Load one committed sequence baseline from *path*."""
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError as e:
+        raise SidecarUnavailable(
+            f"sequence baseline not found at {path}. Baselines live in the agent "
+            "package under eval_baselines/query_sequences/; regenerate with the "
+            "harness or restore the committed file."
+        ) from e
+    return SequenceBaseline.from_dict(data)
+
+
+def load_baselines(directory: Path) -> Dict[str, SequenceBaseline]:
+    """Load every ``*.json`` sequence baseline in *directory*, keyed by id."""
+    directory = Path(directory)
+    if not directory.is_dir():
+        raise SidecarUnavailable(
+            f"baseline directory {directory} does not exist. Expected committed "
+            "sequence baselines under eval_baselines/query_sequences/ in the "
+            "agent package."
+        )
+    out: Dict[str, SequenceBaseline] = {}
+    for f in sorted(directory.glob("*.json")):
+        baseline = load_baseline(f)
+        out[baseline.scenario_id] = baseline
+    if not out:
+        raise SidecarUnavailable(f"no *.json sequence baselines found in {directory}.")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Scenario
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class QuerySequenceScenario:
+    """One ``/query`` eval scenario driven through the sidecar path.
+
+    Attributes:
+        agent_id: The relay/sidecar agent id (e.g. ``"email"``) — selects the
+            ``/v1/<agent_id>/query`` route.
+        query: The natural-language request driving the agent loop.
+        baseline: The committed expected event-sequence shape.
+        context: Optional pushed transcript slice (spec §2.4).
+        model: Optional model-id override for the run.
+        max_steps: Optional agent-loop step ceiling.
+    """
+
+    agent_id: str
+    query: str
+    baseline: SequenceBaseline
+    context: List[Dict[str, str]] = field(default_factory=list)
+    model: Optional[str] = None
+    max_steps: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Serial lock (cross-process) — enforces the CLAUDE.md serial-eval rule
+# ---------------------------------------------------------------------------
+
+
+class SerialEvalLock:
+    """A cross-process advisory lock guaranteeing ONE model-loading eval at a
+    time, matching CLAUDE.md's "run evals SERIALLY, never in parallel".
+
+    Implemented as an atomic ``O_CREAT | O_EXCL`` lock file carrying the holder
+    pid. A stale lock (holder pid no longer alive) is reclaimed loudly. On
+    contention past *timeout* it raises :class:`SerialEvalTimeout` naming the
+    holder — it never silently proceeds in parallel.
+
+    Usable as a context manager::
+
+        with SerialEvalLock():
+            harness.run_scenario(...)
+    """
+
+    def __init__(
+        self,
+        path: Optional[Path] = None,
+        *,
+        timeout: float = 900.0,
+        poll: float = 0.5,
+    ) -> None:
+        self.path = Path(
+            path or os.environ.get("GAIA_EVAL_LOCK_PATH") or DEFAULT_LOCK_PATH
+        )
+        self.timeout = timeout
+        self.poll = poll
+        self._acquired = False
+
+    def _holder_pid(self) -> Optional[int]:
+        try:
+            raw = self.path.read_text(encoding="utf-8").strip()
+        except (OSError, ValueError):
+            return None
+        try:
+            return int(raw.split()[0])
+        except (ValueError, IndexError):
+            return None
+
+    @staticmethod
+    def _pid_alive(pid: int) -> bool:
+        try:
+            import psutil
+
+            return psutil.pid_exists(pid)
+        except Exception:
+            # psutil should always be present (a core dep); if it truly is not,
+            # treat the holder as alive — refusing to run is the safe, loud
+            # choice, never silently stealing the lock.
+            return True
+
+    def _try_create(self) -> bool:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            return False
+        try:
+            os.write(fd, f"{os.getpid()} {time.time()}\n".encode("utf-8"))
+        finally:
+            os.close(fd)
+        return True
+
+    def acquire(self) -> "SerialEvalLock":
+        deadline = time.monotonic() + self.timeout
+        while True:
+            if self._try_create():
+                self._acquired = True
+                return self
+            holder = self._holder_pid()
+            if holder is not None and not self._pid_alive(holder):
+                # Stale lock: the previous eval process died without releasing.
+                logger.warning(
+                    "sidecar eval: reclaiming stale serial lock at %s "
+                    "(holder pid %s is gone)",
+                    self.path,
+                    holder,
+                )
+                try:
+                    self.path.unlink()
+                except FileNotFoundError:
+                    pass
+                continue
+            if time.monotonic() >= deadline:
+                raise SerialEvalTimeout(
+                    f"another eval run holds the serial lock at {self.path} "
+                    f"(holder pid {holder}) and did not release within "
+                    f"{self.timeout:.0f}s. Evals MUST run serially against the "
+                    "single-tenant Lemonade slot (CLAUDE.md); wait for it to "
+                    "finish or, if it is truly dead, remove the lock file."
+                )
+            time.sleep(self.poll)
+
+    def release(self) -> None:
+        if not self._acquired:
+            return
+        # Only remove a lock this process owns — never steal another holder's.
+        if self._holder_pid() == os.getpid():
+            try:
+                self.path.unlink()
+            except FileNotFoundError:
+                pass
+        self._acquired = False
+
+    def __enter__(self) -> "SerialEvalLock":
+        return self.acquire()
+
+    def __exit__(self, *exc) -> None:
+        self.release()
+
+
+# ---------------------------------------------------------------------------
+# Live harness (requires a running daemon/sidecar + Lemonade)
+# ---------------------------------------------------------------------------
+
+
+class SidecarEvalHarness:
+    """Drive ``POST /v1/<agent>/query`` over REST and match the event sequence.
+
+    *base_url* is the front-door the run goes through:
+
+    - the DAEMON relay (``http://127.0.0.1:<daemon-port>``) — the true v2 path
+      (client token in ``auth_token``), or
+    - a sidecar directly (``http://127.0.0.1:<sidecar-port>``) — the sidecar
+      bearer in ``auth_token``.
+
+    Either way the wire is identical (that is the point of the contract), so the
+    same harness drives both. Every run takes :class:`SerialEvalLock` unless
+    ``serialize=False`` (only for a caller that already holds it).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        auth_token: Optional[str] = None,
+        timeout: float = 300.0,
+        serialize: bool = True,
+        lock_path: Optional[Path] = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth_token = auth_token
+        self._timeout = timeout
+        self._serialize = serialize
+        self._lock_path = lock_path
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "text/event-stream", "Content-Type": "application/json"}
+        if self._auth_token:
+            headers["Authorization"] = f"Bearer {self._auth_token}"
+        return headers
+
+    def _query_url(self, agent_id: str) -> str:
+        return f"{self._base_url}/v1/{agent_id}/query"
+
+    def run_scenario(
+        self, scenario: QuerySequenceScenario, *, run_id: Optional[str] = None
+    ) -> Tuple[SequenceVerdict, List[Dict[str, Any]]]:
+        """Run *scenario* once and return ``(verdict, events)``.
+
+        Raises :class:`SidecarUnavailable` (loud, actionable) if the front-door
+        cannot be reached or answers non-2xx — never returns a passing verdict
+        for an absent backend. Serialized against other eval runs by default.
+        """
+        if self._serialize:
+            with SerialEvalLock(self._lock_path):
+                return self._run_locked(scenario, run_id)
+        return self._run_locked(scenario, run_id)
+
+    def _run_locked(
+        self, scenario: QuerySequenceScenario, run_id: Optional[str]
+    ) -> Tuple[SequenceVerdict, List[Dict[str, Any]]]:
+        import requests  # local import — only needed when the harness actually runs
+
+        rid = run_id or str(uuid.uuid4())
+        body: Dict[str, Any] = {
+            "query": scenario.query,
+            "run_id": rid,
+            "context": scenario.context,
+        }
+        if scenario.model is not None:
+            body["model"] = scenario.model
+        if scenario.max_steps is not None:
+            body["max_steps"] = scenario.max_steps
+
+        url = self._query_url(scenario.agent_id)
+        try:
+            resp = requests.post(
+                url,
+                json=body,
+                headers=self._headers(),
+                stream=True,
+                timeout=(10, self._timeout),
+            )
+        except requests.RequestException as e:
+            raise SidecarUnavailable(
+                f"could not reach the /query front-door at {url} "
+                f"({e.__class__.__name__}: {e}). Is the daemon running "
+                "(`gaia daemon status`) and the sidecar ensured? Check "
+                "~/.gaia/host/ and the sidecar logs under ~/.gaia/agents/."
+            ) from e
+
+        if resp.status_code != 200:
+            detail = self._safe_body(resp)
+            resp.close()
+            raise SidecarUnavailable(
+                f"/query at {url} returned HTTP {resp.status_code}: {detail}. "
+                "A 401 means the auth token is wrong; 404/503 means the agent is "
+                "not registered/running (ensure it first); 502 means the sidecar "
+                "died after registration."
+            )
+
+        text_parts: List[str] = []
+        try:
+            for chunk in resp.iter_content(chunk_size=None):
+                if chunk:
+                    text_parts.append(
+                        chunk.decode("utf-8", "replace")
+                        if isinstance(chunk, bytes)
+                        else chunk
+                    )
+        finally:
+            resp.close()
+
+        events = parse_sse("".join(text_parts))
+        verdict = match_sequence(events, scenario.baseline)
+        logger.info(
+            "sidecar eval %s: %s (%d events: %s)",
+            scenario.baseline.scenario_id,
+            "PASS" if verdict.passed else "FAIL",
+            len(events),
+            verdict.observed_types,
+        )
+        return verdict, events
+
+    @staticmethod
+    def _safe_body(resp) -> str:
+        try:
+            return resp.text[:500]
+        except Exception:  # noqa: BLE001 - diagnostics only, never mask the outer error
+            return "<unreadable body>"
+
+
+__all__ = [
+    "CANONICAL_EVENT_TYPES",
+    "TERMINAL_TYPES",
+    "DEFAULT_LOCK_PATH",
+    "SidecarUnavailable",
+    "SerialEvalTimeout",
+    "parse_sse",
+    "event_types",
+    "SequenceBaseline",
+    "SequenceVerdict",
+    "match_sequence",
+    "baselines_dir_for",
+    "load_baseline",
+    "load_baselines",
+    "QuerySequenceScenario",
+    "SerialEvalLock",
+    "SidecarEvalHarness",
+]

--- a/tests/integration/eval/test_sidecar_eval.py
+++ b/tests/integration/eval/test_sidecar_eval.py
@@ -134,10 +134,20 @@ def live_daemon_with_email(require_live_optin, tmp_path_factory):
 
     # Ensure the email sidecar (dev mode from source unless the operator set a
     # different mode). Blocking — run it directly; the fixture is module-scoped.
+    from gaia.daemon.sidecars.errors import (
+        BinaryNotFoundError,
+        PlatformError,
+        SidecarSpawnError,
+    )
+
     mode = os.environ.get("GAIA_EMAIL_AGENT_MODE", "dev")
     try:
         registry.ensure("email", mode=mode)
-    except Exception as exc:  # loud skip: name what failed and how to fix it
+    except (BinaryNotFoundError, SidecarSpawnError, PlatformError) as exc:
+        # Skip ONLY on an unconfigured environment (missing binary / dev deps /
+        # unsupported platform). A real startup regression — health timeout,
+        # version mismatch, integrity failure, HTTP error — is NOT one of these
+        # and MUST propagate as a failure, not hide behind a green skip.
         registry.shutdown_all()
         server.should_exit = True
         thread.join(timeout=10)

--- a/tests/integration/eval/test_sidecar_eval.py
+++ b/tests/integration/eval/test_sidecar_eval.py
@@ -1,0 +1,194 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Live golden-path eval — drive the email agent's ``/query`` loop THROUGH the
+daemon → sidecar → Lemonade path and assert the canonical event sequence
+(V2-19 AC2 / issue #2180).
+
+This is the on-hardware acceptance path the design's §0.17 calls for: a thin
+client (the :class:`SidecarEvalHarness`, standing in for the CLI / UI front-door)
+posts to the DAEMON's streaming relay; the daemon spawns/attaches the real email
+sidecar and relays its agent loop; the sidecar runs local Lemonade inference. The
+committed baseline (``hub/agents/python/email/eval_baselines/query_sequences/``)
+pins the §0.2 event *shape*, not a brittle final string.
+
+It is deliberately gated and NOT part of normal CI (it needs a real model + a
+configured mailbox — the same posture as the ``gmail_live`` tests):
+
+- ``@pytest.mark.real_model`` — self-hosted strix-halo only (see #1297).
+- ``require_real_model`` — loud skip if Lemonade is unreachable.
+- ``GAIA_SIDECAR_EVAL_LIVE=1`` — explicit opt-in, because a triage run needs a
+  connected mailbox; absent that, the test skips with a named reason rather than
+  silently passing or failing as if it were a code bug.
+
+Serial by construction: the harness takes the cross-process
+:class:`SerialEvalLock`, so this run can never race a concurrent ``gaia eval``
+for the single Lemonade slot (CLAUDE.md).
+
+Run locally on hardware::
+
+    GAIA_SIDECAR_EVAL_LIVE=1 GAIA_EMAIL_AGENT_MODE=dev \\
+    LEMONADE_BASE_URL=http://localhost:13305/api/v1 \\
+    python -m pytest tests/integration/eval/test_sidecar_eval.py -m real_model -v
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.real_model
+
+
+# ---------------------------------------------------------------------------
+# Gates
+# ---------------------------------------------------------------------------
+
+
+def _lemonade_reachable() -> bool:
+    import requests
+
+    base_url = os.environ.get("LEMONADE_BASE_URL", "http://localhost:13305/api/v1")
+    health_url = base_url.removesuffix("/api/v1").rstrip("/") + "/api/v1/health"
+    try:
+        return requests.get(health_url, timeout=5).status_code == 200
+    except requests.RequestException:
+        return False
+
+
+@pytest.fixture(scope="module")
+def require_live_optin():
+    """Skip unless the operator explicitly opted into the live golden path.
+
+    The triage query drives the real mailbox tools; without a connected mailbox
+    the run cannot produce a golden sequence. Rather than silently pass (or fail
+    as if the code were broken), the test skips with an actionable reason unless
+    ``GAIA_SIDECAR_EVAL_LIVE=1`` is set on a machine that is actually set up.
+    """
+    if os.environ.get("GAIA_SIDECAR_EVAL_LIVE") != "1":
+        pytest.skip(
+            "sidecar live golden path is opt-in: set GAIA_SIDECAR_EVAL_LIVE=1 on "
+            "a machine with a running daemon-capable env + a connected mailbox "
+            "(see the module docstring). Not run in normal CI."
+        )
+    if not _lemonade_reachable():
+        pytest.skip(
+            "Lemonade server not reachable — set LEMONADE_BASE_URL and start it "
+            "before running the sidecar live golden path."
+        )
+
+
+def _serve(app):
+    """Run *app* under uvicorn on an ephemeral port in a background thread."""
+    import uvicorn
+
+    from gaia.daemon.sidecars.manager import find_free_port
+
+    port = find_free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 15.0
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=5)
+        raise RuntimeError("daemon uvicorn server never started")
+    return server, thread, f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture(scope="module")
+def live_daemon_with_email(require_live_optin, tmp_path_factory):
+    """A real in-process daemon supervising the REAL email sidecar (dev mode).
+
+    Yields ``(daemon_url, client_token)``. Ensuring the sidecar can fail if dev
+    deps are missing — that is surfaced as a loud skip (named reason), never a
+    silent pass.
+    """
+    from gaia.daemon.app import create_app
+    from gaia.daemon.sidecars.registry import SidecarRegistry
+    from gaia.daemon.sidecars.spec import builtin_specs
+
+    client_token = "sidecar-eval-client-token"
+    registry = SidecarRegistry(builtin_specs())
+
+    # Isolate the serial lock to this run's tmp dir so it never contends with a
+    # developer's real eval lock.
+    os.environ["GAIA_EVAL_LOCK_PATH"] = str(
+        tmp_path_factory.mktemp("eval_lock") / ".sidecar-eval.lock"
+    )
+
+    daemon_app = create_app(
+        token=client_token,
+        port=55555,
+        pid=os.getpid(),
+        started_at=time.time(),
+        registry=registry,
+    )
+    server, thread, daemon_url = _serve(daemon_app)
+
+    # Ensure the email sidecar (dev mode from source unless the operator set a
+    # different mode). Blocking — run it directly; the fixture is module-scoped.
+    mode = os.environ.get("GAIA_EMAIL_AGENT_MODE", "dev")
+    try:
+        registry.ensure("email", mode=mode)
+    except Exception as exc:  # loud skip: name what failed and how to fix it
+        registry.shutdown_all()
+        server.should_exit = True
+        thread.join(timeout=10)
+        pytest.skip(
+            f"could not ensure the email sidecar in {mode!r} mode ({exc}). "
+            "Install the email package's dev deps (uvicorn + the agent wheel) or "
+            "set GAIA_EMAIL_AGENT_MODE=user with an installed binary."
+        )
+
+    yield daemon_url, client_token
+
+    registry.shutdown_all()
+    server.should_exit = True
+    thread.join(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# The golden path
+# ---------------------------------------------------------------------------
+
+
+def _email_baseline(scenario_id: str):
+    from gaia.eval.sidecar_harness import baselines_dir_for, load_baseline
+
+    pkg_root = (
+        Path(__file__).resolve().parents[3] / "hub" / "agents" / "python" / "email"
+    )
+    return load_baseline(baselines_dir_for(pkg_root) / f"{scenario_id}.json")
+
+
+def test_email_triage_golden_sequence_through_daemon_relay(live_daemon_with_email):
+    """UI/CLI → daemon → sidecar → Lemonade: a triage run streams the committed
+    canonical §0.2 sequence, verified against the agent-package baseline."""
+    from gaia.eval.sidecar_harness import QuerySequenceScenario, SidecarEvalHarness
+
+    daemon_url, client_token = live_daemon_with_email
+    baseline = _email_baseline("triage_inbox")
+
+    harness = SidecarEvalHarness(daemon_url, auth_token=client_token)
+    scenario = QuerySequenceScenario(
+        agent_id="email",
+        query="What needs my attention in my inbox today?",
+        baseline=baseline,
+    )
+
+    verdict, events = harness.run_scenario(scenario)
+
+    assert verdict.passed, (
+        f"golden triage sequence did not match baseline {baseline.scenario_id!r}: "
+        f"{verdict.reasons}; observed types={verdict.observed_types}"
+    )
+    # Sanity: the run really streamed multiple canonical events, not a single
+    # buffered blob.
+    assert len(events) >= len(baseline.required_subsequence)

--- a/tests/integration/test_distributed_seams.py
+++ b/tests/integration/test_distributed_seams.py
@@ -1,0 +1,433 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Distributed-seams suite — the consolidated contract guard for the daemon↔
+sidecar boundaries v2 introduces (V2-19, issue #2180).
+
+Design §0.17: ``/query`` is the most LLM-affecting surface v2 adds, and the
+relay / broker / auth / custody seams each have deterministic failure modes unit
+tests must pin *before* third-party agents amplify them. Individual issues ship
+their own tests (the relay's live suite is ``tests/unit/test_daemon_relay.py``;
+``/query`` is ``hub/agents/python/email/tests/test_query_route.py``); THIS suite
+is the cross-seam layer nothing else owns:
+
+- **cross-seam vocabulary coherence** — the frozen §0.2 seven-event set must be
+  IDENTICAL across the three places that independently define it (the harness,
+  the relay, the sidecar's translator). This is the seam most likely to drift as
+  front-doors multiply, and no single-seam test can catch a mismatch *between*
+  seams.
+- **synthetic-error ↔ canonical-error coherence** — a relay-authored crash
+  terminal (V2-7) must be indistinguishable-in-kind from a sidecar-authored one
+  to a downstream front-door (the CLI, ``gaia api``): it must parse as a valid
+  canonical ``error`` event.
+- **auth leg (Leg 2, LANDED #1980)** — the per-agent sidecar bearer is delivered
+  over a PRIVATE ENV channel, never on argv (where ``ps`` would leak it).
+
+Seams still in flight are marked with an explicit, loud skip reason keyed on
+whether the source module/route actually exists yet — so this suite goes green
+today and each ``pytest.skip`` flips to a real assertion the moment its issue
+merges, without editing the skip logic:
+
+- **secret-file delivery** (V2-3 / #2149) — fd/0600-file delivery of the launch
+  secret (today it is a plain env var; the stronger delivery is not merged).
+- **model-slot broker** (V2-11 / #2151) — load serialization + ``/host/v1/
+  models/lease``.
+- **custody per-agent scoping** (V2-12 / #2153) — ``/host/v1/*`` with A-cannot-
+  read-B scoping.
+- **migration idempotency** (V2-13 / #2155) — one-time ``~/.gaia`` data
+  migration that is a no-op on second run.
+
+Run just this suite (the CI job of AC1)::
+
+    python -m pytest -m distributed_seams
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+
+import pytest
+
+pytestmark = pytest.mark.distributed_seams
+
+
+# ---------------------------------------------------------------------------
+# Seam-presence probes — a skip reason is keyed on the ACTUAL merge state, so
+# the skip auto-flips to a real run when the source lands (no edit needed).
+# ---------------------------------------------------------------------------
+
+
+def _module_exists(dotted: str) -> bool:
+    try:
+        return importlib.util.find_spec(dotted) is not None
+    except (ImportError, ValueError, ModuleNotFoundError):
+        return False
+
+
+def _first_existing_module(*candidates: str) -> "str | None":
+    for name in candidates:
+        if _module_exists(name):
+            return name
+    return None
+
+
+def _module_has_symbol(dotted: str, symbol: str) -> bool:
+    try:
+        import importlib
+
+        return hasattr(importlib.import_module(dotted), symbol)
+    except Exception:
+        return False
+
+
+# V2-11 broker (#2151): net-new daemon module. None of these exist yet.
+_BROKER_MODULE = _first_existing_module(
+    "gaia.daemon.broker",
+    "gaia.daemon.model_broker",
+    "gaia.llm.model_broker",
+)
+
+# V2-13 migration (#2155): net-new daemon module.
+_MIGRATION_MODULE = _first_existing_module(
+    "gaia.daemon.migration",
+    "gaia.daemon.migrate",
+    "gaia.daemon.data_migration",
+)
+
+
+def _daemon_has_route(prefix: str) -> bool:
+    """True if the daemon app mounts any route under *prefix* (e.g. ``/host/v1``).
+
+    Builds the app with a stub registry and inspects its route table — no server,
+    no network. Returns False loudly-safe if the app can't be built at all.
+    """
+    try:
+        import time
+
+        from gaia.daemon.app import create_app
+    except Exception:
+        return False
+
+    class _StubRegistry:
+        def list_agents(self):
+            return []
+
+        def connection(self, agent_id):  # pragma: no cover - unused here
+            raise AssertionError
+
+    try:
+        app = create_app(
+            token="probe",
+            port=0,
+            pid=1,
+            started_at=time.time(),
+            registry=_StubRegistry(),
+        )
+    except Exception:
+        return False
+    return any(getattr(r, "path", "").startswith(prefix) for r in app.routes)
+
+
+# V2-12 custody (#2153): /host/v1/* on the daemon. Only a doc comment today.
+_CUSTODY_MOUNTED = _daemon_has_route("/host/v1")
+
+# V2-3 secret-file delivery (#2149): the launch-secret fd/file channel. Today the
+# manager delivers the bearer via a plain env var (spec.token_env_var); the
+# stronger fd/0600-file delivery is not merged.
+_SECRET_FILE_DELIVERY = _module_exists("gaia.daemon.sidecars.secret_delivery") or any(
+    _module_has_symbol("gaia.daemon.sidecars.manager", sym)
+    for sym in ("LAUNCH_SECRET_ENV_VAR", "deliver_secret_via_fd", "_secret_fd")
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Cross-seam vocabulary coherence (ALWAYS runs — the core V2-19 guard)
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_types_identical_across_relay_translator_harness():
+    """The two terminal types must agree everywhere a stream is terminated —
+    else a front-door and the sidecar disagree on what "done" looks like."""
+    from gaia.daemon.relay import TERMINAL_TYPES as relay_terminal
+    from gaia.eval.sidecar_harness import TERMINAL_TYPES as harness_terminal
+
+    assert relay_terminal == harness_terminal == frozenset({"final", "error"})
+
+    # The sidecar's translator ships in the email package; import it when present.
+    if _module_exists("gaia_agent_email.sse_translation"):
+        from gaia_agent_email.sse_translation import TERMINAL_TYPES as sidecar_terminal
+
+        assert sidecar_terminal == relay_terminal
+
+
+def test_canonical_seven_event_set_matches_translator_outputs():
+    """Every canonical type the harness validates against must be a type the
+    sidecar translator can actually PRODUCE — otherwise the harness would pass
+    runs that emit a type the wire contract forbids, or reject a legal one."""
+    from gaia.eval.sidecar_harness import CANONICAL_EVENT_TYPES
+
+    if not _module_exists("gaia_agent_email.sse_translation"):
+        pytest.skip("email package (gaia_agent_email) not importable in this env")
+
+    from gaia_agent_email import sse_translation
+
+    # The translator's producible types: the terminal set + every type its
+    # per-event maps can emit. We assert the harness's set is exactly the frozen
+    # seven and that the translator never emits something outside it.
+    assert CANONICAL_EVENT_TYPES == frozenset(
+        {
+            "status",
+            "token",
+            "tool_call",
+            "tool_result",
+            "needs_confirmation",
+            "final",
+            "error",
+        }
+    )
+    # Drive the translator across its whole source vocabulary and assert every
+    # emitted type is canonical (a source-vocab leak would fail here).
+    translator = sse_translation.CanonicalTranslator("run-coherence")
+    source_events = [
+        {"type": "status", "message": "s"},
+        {"type": "step", "step": 1, "total": 3},
+        {"type": "thinking", "content": "hmm"},
+        {"type": "plan", "steps": ["a", "b"]},
+        {"type": "tool_start", "tool": "triage_inbox"},
+        {"type": "tool_args", "args": {"x": 1}},
+        {"type": "tool_result", "result_data": {"ok": True}},
+        {"type": "tool_end"},
+        {"type": "chunk", "content": "tok"},
+        {"type": "permission_request", "tool": "send_now", "args": {}},
+        {"type": "user_input_request", "message": "which?"},
+        {"type": "tool_confirm_denied", "message": "denied"},
+        {"type": "policy_alert", "reason": "nope"},
+        {"type": "agent_created"},
+        {"type": "answer", "content": "done"},
+    ]
+    emitted = []
+    for ev in source_events:
+        emitted.extend(translator.translate(ev))
+    emitted.extend(translator.flush())
+    produced_types = {e["type"] for e in emitted}
+    # Every type the translator produced is one the harness will accept — the
+    # sending and receiving ends of the seam agree on the vocabulary.
+    assert produced_types <= CANONICAL_EVENT_TYPES, (
+        f"translator produced non-canonical types: "
+        f"{sorted(produced_types - CANONICAL_EVENT_TYPES)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Synthetic-error ↔ canonical-error coherence (relay V2-7 #2150, LANDED)
+# ---------------------------------------------------------------------------
+
+
+def test_relay_synthetic_crash_error_parses_as_canonical_error():
+    """A relay-authored crash terminal must parse via the harness's own SSE
+    reader as a valid canonical ``error`` event — so the CLI / gaia api front-
+    doors cannot tell a relay-synthesized terminal from a sidecar-authored one
+    (beyond the additive ``source`` marker)."""
+    from gaia.daemon.relay import (
+        _synthetic_error_frame,
+        stream_ended_unexpectedly_detail,
+    )
+    from gaia.eval.sidecar_harness import CANONICAL_EVENT_TYPES, parse_sse
+
+    detail = stream_ended_unexpectedly_detail("email")
+    frame = _synthetic_error_frame(detail, terminate_partial=False)
+    events = parse_sse(frame.decode("utf-8"))
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["type"] == "error"
+    assert event["type"] in CANONICAL_EVENT_TYPES
+    assert event["detail"] == detail
+    # The additive marker lets a front-door attribute the terminal to the relay.
+    assert event["source"] == "daemon_relay"
+
+
+def test_relay_synthetic_error_detail_is_actionable():
+    """No silent fallbacks: the crash terminal names what to check and where."""
+    from gaia.daemon.relay import stream_ended_unexpectedly_detail
+
+    detail = stream_ended_unexpectedly_detail("email")
+    assert "email" in detail
+    assert "ensure" in detail  # the remedy
+    assert "logs" in detail  # where to look
+
+
+# ---------------------------------------------------------------------------
+# 3. Auth leg 2 (daemon→sidecar bearer, LANDED #1980): private env, never argv
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _module_exists("gaia.daemon.sidecars.manager"),
+    reason="daemon sidecar manager not importable in this env",
+)
+def test_sidecar_bearer_delivered_via_private_env_never_on_argv(monkeypatch):
+    """The manager hands the sidecar its per-session bearer over the private env
+    channel (spec.token_env_var), NOT on the command line — argv is world-
+    readable via ``ps`` / Task Manager, so a token there would leak."""
+    from gaia.daemon.sidecars.manager import AgentSidecarManager
+    from gaia.daemon.sidecars.spec import AgentSidecarSpec
+
+    spec = AgentSidecarSpec(
+        agent_id="toy",
+        service_id="gaia-agent-toy",
+        display_name="Toy Agent",
+        expected_api_major="1",
+        token_env_var="GAIA_TOY_SIDECAR_TOKEN",
+        mode_env_var="GAIA_TOY_AGENT_MODE",
+        cache_dir_name="toy",
+    )
+    manager = AgentSidecarManager(spec, mode="user")
+
+    captured = {}
+
+    class _FakeProc:
+        pid = 4321
+
+    def _fake_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["env"] = dict(kwargs.get("env") or {})
+        return _FakeProc()
+
+    # Inspect the spawn without launching a real process: stub Popen + the log.
+    import gaia.daemon.sidecars.manager as mgr_mod
+
+    monkeypatch.setattr(mgr_mod.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(manager, "_open_log", lambda port: None)
+    monkeypatch.setattr(manager, "_close_log", lambda: None)
+    # The real _spawn_process registers atexit shutdown of the (fake) proc;
+    # neutralize it so process teardown doesn't poll the stub.
+    monkeypatch.setattr(mgr_mod.atexit, "register", lambda *a, **k: None)
+
+    manager._spawn_process(["sidecar-bin", "--port", "12345"], {}, 12345)
+
+    token = manager.auth_token
+    # Delivered via the private env channel...
+    assert captured["env"].get("GAIA_TOY_SIDECAR_TOKEN") == token
+    # ...and NEVER on argv (a ps/Task-Manager leak).
+    assert all(
+        token not in str(arg) for arg in captured["argv"]
+    ), "the sidecar bearer token must never appear in argv"
+
+
+# ---------------------------------------------------------------------------
+# 4. Secret-file delivery (V2-3 / #2149) — SKIP-pending-merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _SECRET_FILE_DELIVERY,
+    reason=(
+        "V2-3 (#2149) fd/0600-file launch-secret delivery not merged yet — today "
+        "the manager delivers the bearer via a plain env var (covered by the "
+        "auth-leg test above). This test asserts the STRONGER delivery (secret "
+        "never in /proc/<pid>/environ) once the seam lands."
+    ),
+)
+def test_launch_secret_not_in_process_environ():  # pragma: no cover - pending merge
+    # When V2-3 lands: assert the launch secret is delivered by inherited fd or a
+    # 0600 file and never appears in the spawned process's environ block.
+    raise AssertionError(
+        "secret-file delivery landed — implement the /proc/<pid>/environ "
+        "absence assertion (V2-3 / #2149)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Model-slot broker serialization (V2-11 / #2151) — SKIP-pending-merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    _BROKER_MODULE is None,
+    reason=(
+        "V2-11 (#2151) model-slot broker not merged yet — no daemon broker "
+        "module exists. This test asserts two agents requesting different models "
+        "serialize (no race-evict) and foreground jumps the queue once it lands."
+    ),
+)
+def test_broker_serializes_concurrent_model_loads():  # pragma: no cover - pending merge
+    # When V2-11 lands: two concurrent lease requests for different models must
+    # serialize through the broker (never race-evict the single Lemonade slot),
+    # and an interactive lease must jump ahead of a background one.
+    raise AssertionError(
+        f"broker module {_BROKER_MODULE!r} present — implement the serialization "
+        "+ interactive-priority assertions (V2-11 / #2151)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Custody per-agent scoping (V2-12 / #2153) — SKIP-pending-merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _CUSTODY_MOUNTED,
+    reason=(
+        "V2-12 (#2153) /host/v1/* custody API not merged yet — the daemon mounts "
+        "no /host/v1 routes (only a doc comment references them). This test "
+        "asserts agent A cannot read agent B's memory/sessions once it lands."
+    ),
+)
+def test_custody_scopes_reads_to_the_calling_agent():  # pragma: no cover - pending merge
+    # When V2-12 lands: a secret bound to agent A must get 403 (not B's data)
+    # when reading /host/v1/memory scoped to agent B.
+    raise AssertionError(
+        "/host/v1 custody routes mounted — implement the A-cannot-read-B scoping "
+        "assertions (V2-12 / #2153)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Migration idempotency (V2-13 / #2155) — SKIP-pending-merge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    _MIGRATION_MODULE is None,
+    reason=(
+        "V2-13 (#2155) one-time ~/.gaia data migration not merged yet — no "
+        "migration module exists. This test asserts running the migration twice "
+        "from a real pre-v2 fixture leaves the second run a no-op once it lands."
+    ),
+)
+def test_migration_is_idempotent():  # pragma: no cover - pending merge
+    # When V2-13 lands: run the migration twice against a pre-v2 ~/.gaia fixture;
+    # the second run must be a no-op (cold-state test per CLAUDE.md).
+    raise AssertionError(
+        f"migration module {_MIGRATION_MODULE!r} present — implement the "
+        "run-twice-is-a-no-op assertion (V2-13 / #2155)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coverage manifest — one place to SEE what this suite guards vs. defers. Keeps
+# the "covered vs skipped-pending-merge" split honest and greppable.
+# ---------------------------------------------------------------------------
+
+
+def test_seam_coverage_manifest_reflects_reality():
+    """Assert the documented coverage split matches the live probe results, so
+    the PR's "covered vs skipped" table can never silently drift from the code."""
+    covered = {
+        "relay_vocabulary_coherence": True,  # always
+        "relay_synthetic_error_coherence": True,  # always
+        "auth_leg2_bearer_via_env": _module_exists("gaia.daemon.sidecars.manager"),
+    }
+    pending = {
+        "secret_file_delivery_v2_3": not _SECRET_FILE_DELIVERY,
+        "model_broker_v2_11": _BROKER_MODULE is None,
+        "custody_scoping_v2_12": not _CUSTODY_MOUNTED,
+        "migration_idempotency_v2_13": _MIGRATION_MODULE is None,
+    }
+    # The core cross-seam guards are unconditionally covered.
+    assert covered["relay_vocabulary_coherence"]
+    assert covered["relay_synthetic_error_coherence"]
+    # Everything not-yet-merged is honestly marked pending (this is the state at
+    # authoring time; each flips to False — i.e. covered — when its issue merges).
+    assert isinstance(json.dumps(pending), str)  # serializable manifest

--- a/tests/integration/test_distributed_seams.py
+++ b/tests/integration/test_distributed_seams.py
@@ -412,8 +412,11 @@ def test_migration_is_idempotent():  # pragma: no cover - pending merge
 
 
 def test_seam_coverage_manifest_reflects_reality():
-    """Assert the documented coverage split matches the live probe results, so
-    the PR's "covered vs skipped" table can never silently drift from the code."""
+    """Pin the covered-vs-pending split to the CURRENT tree so it can never
+    silently drift: the LIVE seam probes must equal the explicit expected map
+    below. When a pending seam merges its probe flips, this assertion FAILS, and
+    whoever merged it must flip the manifest here and light up the real test —
+    exactly the forcing function a hardcoded ``True`` cannot provide."""
     covered = {
         "relay_vocabulary_coherence": True,  # always
         "relay_synthetic_error_coherence": True,  # always
@@ -425,9 +428,22 @@ def test_seam_coverage_manifest_reflects_reality():
         "custody_scoping_v2_12": not _CUSTODY_MOUNTED,
         "migration_idempotency_v2_13": _MIGRATION_MODULE is None,
     }
-    # The core cross-seam guards are unconditionally covered.
-    assert covered["relay_vocabulary_coherence"]
-    assert covered["relay_synthetic_error_coherence"]
-    # Everything not-yet-merged is honestly marked pending (this is the state at
-    # authoring time; each flips to False — i.e. covered — when its issue merges).
-    assert isinstance(json.dumps(pending), str)  # serializable manifest
+
+    # Expected as of this tree: Leg-2 auth has LANDED (the sidecar manager is
+    # importable); the four V2 seams below are NOT merged, so each is still
+    # pending. Any drift is a real event — a seam merged (flip it to covered and
+    # implement its test) or the auth manager module moved (fix its probe). Do
+    # NOT soften these to make the test pass.
+    assert covered == {
+        "relay_vocabulary_coherence": True,
+        "relay_synthetic_error_coherence": True,
+        "auth_leg2_bearer_via_env": True,
+    }
+    assert pending == {
+        "secret_file_delivery_v2_3": True,
+        "model_broker_v2_11": True,
+        "custody_scoping_v2_12": True,
+        "migration_idempotency_v2_13": True,
+    }
+    # The manifest stays JSON-serializable so front-doors / CI can emit it.
+    assert isinstance(json.dumps({"covered": covered, "pending": pending}), str)

--- a/tests/unit/test_sidecar_harness.py
+++ b/tests/unit/test_sidecar_harness.py
@@ -334,6 +334,41 @@ def test_serial_lock_reclaims_stale_lock_of_dead_holder(tmp_path, monkeypatch):
         assert int(lock_path.read_text().split()[0]) == os.getpid()
 
 
+def test_serial_lock_reclaim_race_loser_does_not_double_acquire(tmp_path, monkeypatch):
+    """Two contenders both see the SAME dead holder pid. The one that LOSES the
+    atomic reclaim rename must NOT go on to acquire — otherwise both would run
+    evals in parallel, the exact Lemonade race-evict the lock exists to prevent."""
+    import gaia.eval.sidecar_harness as mod
+
+    lock_path = tmp_path / "eval.lock"
+    dead_pid = 999_999_999
+    lock_path.write_text(f"{dead_pid} 1.0\n")
+
+    live_winner = os.getpid()
+    # The stale holder looks dead; the winner (any other pid) looks alive.
+    monkeypatch.setattr(
+        mod.SerialEvalLock,
+        "_pid_alive",
+        staticmethod(lambda pid: pid != dead_pid),
+    )
+
+    def _racing_rename(src, dst):
+        # Simulate a second contender winning the reclaim first: it has already
+        # replaced the stale lock with its OWN live lock, so our rename of the
+        # (now-superseded) path fails and we must re-contend — never acquire.
+        Path(src).write_text(f"{live_winner} 2.0\n")
+        raise FileNotFoundError(src)
+
+    monkeypatch.setattr(mod.os, "rename", _racing_rename)
+
+    loser = SerialEvalLock(lock_path, timeout=0.3, poll=0.05)
+    with pytest.raises(SerialEvalTimeout, match="serial lock"):
+        loser.acquire()
+    assert loser._acquired is False
+    # The winner's live lock is intact — the loser never stole or removed it.
+    assert int(lock_path.read_text().split()[0]) == live_winner
+
+
 def test_serial_lock_env_override(tmp_path, monkeypatch):
     target = tmp_path / "from-env.lock"
     monkeypatch.setenv("GAIA_EVAL_LOCK_PATH", str(target))

--- a/tests/unit/test_sidecar_harness.py
+++ b/tests/unit/test_sidecar_harness.py
@@ -1,0 +1,356 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the sidecar eval harness core (``gaia.eval.sidecar_harness``,
+V2-19 / issue #2180).
+
+These cover the PURE classification logic — SSE parsing, sequence matching,
+baseline load/validation, and the cross-process serial lock — with NO running
+server and NO Lemonade, mirroring the pure-vs-live split in
+``behavior_harness``. The live golden path lives in
+``tests/integration/eval/test_sidecar_eval.py`` (real_model).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from gaia.eval.sidecar_harness import (
+    CANONICAL_EVENT_TYPES,
+    TERMINAL_TYPES,
+    QuerySequenceScenario,
+    SequenceBaseline,
+    SerialEvalLock,
+    SerialEvalTimeout,
+    SidecarEvalHarness,
+    SidecarUnavailable,
+    baselines_dir_for,
+    event_types,
+    load_baseline,
+    load_baselines,
+    match_sequence,
+    parse_sse,
+)
+
+# The email package's committed baselines — used to prove the loader reads the
+# real files the /query route is pinned against.
+_EMAIL_PKG_ROOT = (
+    Path(__file__).resolve().parents[2] / "hub" / "agents" / "python" / "email"
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_vocabulary_is_the_frozen_seven():
+    assert CANONICAL_EVENT_TYPES == frozenset(
+        {
+            "status",
+            "token",
+            "tool_call",
+            "tool_result",
+            "needs_confirmation",
+            "final",
+            "error",
+        }
+    )
+
+
+def test_terminal_types_are_final_and_error():
+    assert TERMINAL_TYPES == frozenset({"final", "error"})
+
+
+# ---------------------------------------------------------------------------
+# parse_sse
+# ---------------------------------------------------------------------------
+
+
+def _sse(*events) -> str:
+    return "".join(f"data: {json.dumps(e)}\n\n" for e in events)
+
+
+def test_parse_sse_extracts_events_in_order():
+    body = _sse(
+        {"type": "status", "message": "go"},
+        {"type": "tool_call", "tool": "triage_inbox", "args": {}},
+        {"type": "final", "answer": "done"},
+    )
+    events = parse_sse(body)
+    assert event_types(events) == ["status", "tool_call", "final"]
+    assert events[1]["tool"] == "triage_inbox"
+
+
+def test_parse_sse_ignores_comments_and_blank_lines_and_crlf():
+    body = (
+        ": keep-alive\r\n\r\n"
+        'data: {"type": "status", "message": "x"}\r\n\r\n'
+        "\r\n"
+        'data: {"type": "final", "answer": "y"}\r\n\r\n'
+    )
+    assert event_types(parse_sse(body)) == ["status", "final"]
+
+
+def test_parse_sse_surfaces_unparseable_frame_not_drops_it():
+    body = "data: {not json}\n\n" + _sse({"type": "final", "answer": "z"})
+    events = parse_sse(body)
+    # A malformed frame is a seam bug the harness must be able to see.
+    assert events[0]["type"] == "__unparseable__"
+    assert events[-1]["type"] == "final"
+
+
+# ---------------------------------------------------------------------------
+# SequenceBaseline validation
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_rejects_non_canonical_required_type():
+    with pytest.raises(ValueError, match="non-canonical"):
+        SequenceBaseline(
+            scenario_id="bad",
+            required_subsequence=("status", "chunk"),  # chunk is source-vocab, not §0.2
+        )
+
+
+def test_baseline_rejects_non_terminal_terminal():
+    with pytest.raises(ValueError, match="terminal"):
+        SequenceBaseline(
+            scenario_id="bad",
+            required_subsequence=("status",),
+            terminal="status",
+        )
+
+
+def test_baseline_round_trips_through_dict():
+    b = SequenceBaseline(
+        scenario_id="t",
+        required_subsequence=("status", "tool_call", "final"),
+        terminal="final",
+        forbidden=("error",),
+    )
+    assert SequenceBaseline.from_dict(b.to_dict()) == b
+
+
+def test_baseline_from_dict_missing_key_is_loud():
+    with pytest.raises(ValueError, match="malformed"):
+        SequenceBaseline.from_dict({"scenario_id": "x"})
+
+
+# ---------------------------------------------------------------------------
+# match_sequence
+# ---------------------------------------------------------------------------
+
+
+_GOLDEN = SequenceBaseline(
+    scenario_id="golden",
+    required_subsequence=("status", "tool_call", "tool_result", "final"),
+    terminal="final",
+    forbidden=("error",),
+)
+
+
+def test_match_passes_on_exact_golden_shape():
+    events = [
+        {"type": "status"},
+        {"type": "tool_call"},
+        {"type": "tool_result"},
+        {"type": "final"},
+    ]
+    verdict = match_sequence(events, _GOLDEN)
+    assert verdict.passed
+    assert verdict.reasons == []
+
+
+def test_match_tolerates_extra_variable_count_events_between_milestones():
+    # Extra status/token events (LLM-non-deterministic) must not fail the match.
+    events = [
+        {"type": "status"},
+        {"type": "status"},
+        {"type": "token"},
+        {"type": "tool_call"},
+        {"type": "tool_result"},
+        {"type": "token"},
+        {"type": "final"},
+    ]
+    assert match_sequence(events, _GOLDEN).passed
+
+
+def test_match_fails_when_milestone_missing():
+    events = [{"type": "status"}, {"type": "final"}]  # no tool_call/tool_result
+    verdict = match_sequence(events, _GOLDEN)
+    assert not verdict.passed
+    assert any("milestones" in r for r in verdict.reasons)
+
+
+def test_match_fails_on_non_canonical_type():
+    events = [
+        {"type": "status"},
+        {"type": "tool_call"},
+        {"type": "tool_result"},
+        {"type": "chunk"},  # source-vocab leak — must be caught
+        {"type": "final"},
+    ]
+    verdict = match_sequence(events, _GOLDEN)
+    assert not verdict.passed
+    assert any("non-canonical" in r for r in verdict.reasons)
+
+
+def test_match_fails_when_terminal_not_last():
+    events = [
+        {"type": "status"},
+        {"type": "tool_call"},
+        {"type": "tool_result"},
+        {"type": "final"},
+        {"type": "status"},  # something after the terminal
+    ]
+    verdict = match_sequence(events, _GOLDEN)
+    assert not verdict.passed
+    assert any("not last" in r for r in verdict.reasons)
+
+
+def test_match_fails_on_two_terminals():
+    events = [
+        {"type": "status"},
+        {"type": "tool_call"},
+        {"type": "tool_result"},
+        {"type": "final"},
+        {"type": "final"},
+    ]
+    verdict = match_sequence(events, _GOLDEN)
+    assert not verdict.passed
+    assert any("exactly one terminal" in r for r in verdict.reasons)
+
+
+def test_match_fails_when_forbidden_error_present():
+    events = [
+        {"type": "status"},
+        {"type": "tool_call"},
+        {"type": "tool_result"},
+        {"type": "error"},
+    ]
+    verdict = match_sequence(events, _GOLDEN)
+    assert not verdict.passed
+    # Both the wrong terminal AND the forbidden hit are reported (no short-circuit).
+    assert any("forbidden" in r for r in verdict.reasons)
+
+
+def test_match_collects_all_violations_not_just_first():
+    events = [
+        {"type": "chunk"},
+        {"type": "chunk"},
+    ]  # non-canonical, no milestones, no terminal
+    verdict = match_sequence(events, _GOLDEN)
+    assert not verdict.passed
+    assert len(verdict.reasons) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Committed baseline loading (the real email-package files)
+# ---------------------------------------------------------------------------
+
+
+def test_baselines_dir_for_points_at_agent_package_convention():
+    d = baselines_dir_for(_EMAIL_PKG_ROOT)
+    assert d.name == "query_sequences"
+    assert d.parent.name == "eval_baselines"
+
+
+@pytest.mark.skipif(
+    not baselines_dir_for(_EMAIL_PKG_ROOT).is_dir(),
+    reason="email package baselines not present in this checkout",
+)
+def test_committed_email_baselines_load_and_validate():
+    baselines = load_baselines(baselines_dir_for(_EMAIL_PKG_ROOT))
+    # The golden triage path is the primary committed baseline.
+    assert "triage_inbox" in baselines
+    triage = baselines["triage_inbox"]
+    assert triage.terminal == "final"
+    assert "tool_call" in triage.required_subsequence
+    # Every committed baseline references only canonical §0.2 types (enforced by
+    # SequenceBaseline.__post_init__, so a bad commit fails to load here).
+    for b in baselines.values():
+        assert set(b.required_subsequence) <= CANONICAL_EVENT_TYPES
+
+
+def test_load_baseline_missing_file_is_loud():
+    with pytest.raises(SidecarUnavailable, match="baseline not found"):
+        load_baseline(Path("does-not-exist.json"))
+
+
+def test_load_baselines_missing_dir_is_loud(tmp_path):
+    with pytest.raises(SidecarUnavailable, match="does not exist"):
+        load_baselines(tmp_path / "nope")
+
+
+def test_load_baselines_empty_dir_is_loud(tmp_path):
+    (tmp_path / "query_sequences").mkdir()
+    with pytest.raises(SidecarUnavailable, match="no .*baselines"):
+        load_baselines(tmp_path / "query_sequences")
+
+
+# ---------------------------------------------------------------------------
+# SerialEvalLock — the CLAUDE.md serial-eval guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_serial_lock_acquire_and_release(tmp_path):
+    lock_path = tmp_path / "eval.lock"
+    lock = SerialEvalLock(lock_path)
+    with lock:
+        assert lock_path.exists()
+        assert int(lock_path.read_text().split()[0]) == os.getpid()
+    assert not lock_path.exists()  # released on exit
+
+
+def test_serial_lock_second_holder_times_out_loud(tmp_path):
+    lock_path = tmp_path / "eval.lock"
+    held = SerialEvalLock(lock_path).acquire()
+    try:
+        # A second acquirer must NOT proceed in parallel — it fails loud.
+        contender = SerialEvalLock(lock_path, timeout=0.2, poll=0.05)
+        with pytest.raises(SerialEvalTimeout, match="serial lock"):
+            contender.acquire()
+    finally:
+        held.release()
+
+
+def test_serial_lock_reclaims_stale_lock_of_dead_holder(tmp_path, monkeypatch):
+    lock_path = tmp_path / "eval.lock"
+    # Simulate a previous eval process that died without releasing.
+    lock_path.write_text("999999999 123.0\n")
+
+    import gaia.eval.sidecar_harness as mod
+
+    monkeypatch.setattr(
+        mod.SerialEvalLock, "_pid_alive", staticmethod(lambda pid: False)
+    )
+    lock = SerialEvalLock(lock_path, timeout=1.0, poll=0.05)
+    with lock:
+        # Reclaimed: the lock now carries OUR pid.
+        assert int(lock_path.read_text().split()[0]) == os.getpid()
+
+
+def test_serial_lock_env_override(tmp_path, monkeypatch):
+    target = tmp_path / "from-env.lock"
+    monkeypatch.setenv("GAIA_EVAL_LOCK_PATH", str(target))
+    lock = SerialEvalLock()
+    assert lock.path == target
+
+
+# ---------------------------------------------------------------------------
+# Live harness — loud failure when the backend is absent (never a silent pass)
+# ---------------------------------------------------------------------------
+
+
+def test_harness_unreachable_backend_raises_actionable(tmp_path, monkeypatch):
+    # Point the serial lock somewhere isolated so this never touches a real run.
+    monkeypatch.setenv("GAIA_EVAL_LOCK_PATH", str(tmp_path / "eval.lock"))
+    # A port nothing listens on → requests.ConnectionError → SidecarUnavailable.
+    harness = SidecarEvalHarness("http://127.0.0.1:9", auth_token="tok")
+    scenario = QuerySequenceScenario(agent_id="email", query="hi", baseline=_GOLDEN)
+    with pytest.raises(SidecarUnavailable, match="could not reach"):
+        harness.run_scenario(scenario)


### PR DESCRIPTION
## Why this matters

Before this, nothing exercised the email agent through the v2 **sidecar/daemon** path — every eval ran the loop in-process — and no test guarded the daemon↔sidecar contracts *as a set*. The frozen §0.2 event vocabulary, the relay's crash/cancel terminal, and the auth leg were each pinned only by their own issue's tests, so a drift *between* seams (e.g. a front-door and the sidecar disagreeing on what "done" looks like) could slip through green.

After: an **eval harness** drives `POST /v1/<agent>/query` over REST and asserts the canonical event **sequence** (not a brittle final string) against baselines committed in the agent package — serial by construction per the CLAUDE.md eval rule. Plus a single **distributed-seams suite** that guards the contracts across seams and self-skips the ones not yet merged, with each skip keyed on the source's real presence so it flips to a live assertion the moment its issue lands.

The harness (`src/gaia/eval/sidecar_harness.py`) keeps its pure core (SSE parse, ordered-subsequence match tolerant of LLM-variable event counts, a cross-process `SerialEvalLock`) split from a thin live driver, mirroring `behavior_harness`. A missing/unreachable backend raises loudly — never a silent green pass.

### Seams: covered vs. skipped-pending-merge

| Seam | Issue | State |
|------|-------|-------|
| Relay ↔ translator ↔ harness vocabulary coherence | V2-7 #2150 | ✅ covered |
| Relay synthetic crash terminal parses as canonical `error` | V2-7 #2150 | ✅ covered |
| Daemon→sidecar bearer via private env, never argv | #1980 | ✅ covered |
| Secret-file (fd/0600) launch-secret delivery | V2-3 #2149 | ⏭️ skip-pending |
| Model-slot broker serialization | V2-11 #2151 | ⏭️ skip-pending |
| Custody `/host/v1/*` per-agent scoping | V2-12 #2153 | ⏭️ skip-pending |
| Migration idempotency | V2-13 #2155 | ⏭️ skip-pending |

The on-hardware golden path (UI → daemon → sidecar → Lemonade) is an opt-in `real_model` test (`tests/integration/eval/test_sidecar_eval.py`); a new Ubuntu CI job (`test_distributed_seams.yml`) runs the deterministic suite on every touching PR.

## Test plan

- [x] `python -m pytest tests/unit/test_sidecar_harness.py` — 27 passed (pure core: SSE parse, sequence match, serial lock, baseline load; no Lemonade)
- [x] `python -m pytest tests/integration/test_distributed_seams.py -m distributed_seams -rs` — 6 passed, 4 skipped (skips print their pending-merge reason)
- [x] `python -m pytest tests/integration/eval/test_sidecar_eval.py` — 1 skipped (loud opt-in reason; runs on hardware with `GAIA_SIDECAR_EVAL_LIVE=1`)
- [x] `python util/lint.py --all --fix` — black/isort/flake8 clean on the new files
- [ ] On strix-halo: `GAIA_SIDECAR_EVAL_LIVE=1 python -m pytest tests/integration/eval/test_sidecar_eval.py -m real_model` (golden path through the real sidecar)

Part of #2014
Closes #2180