### PR TITLE
feat(agent-ui): first-run onboarding wizard — hardware pre-flight, in-app model download, connect-on-install

### DIFF
--- a/src/gaia/apps/webui/src/App.tsx
+++ b/src/gaia/apps/webui/src/App.tsx
@@ -16,6 +16,7 @@ import { ConnectionBanner } from './components/ConnectionBanner';
 import { UpdateIndicator } from './components/UpdateIndicator';
 import { PermissionPrompt } from './components/PermissionPrompt';
 import { NotificationCenter } from './components/NotificationCenter';
+import { OnboardingWizard } from './components/onboarding/OnboardingWizard';
 import { useChatStore } from './stores/chatStore';
 import { useNotificationStore } from './stores/notificationStore';
 import * as api from './services/api';
@@ -109,6 +110,23 @@ function App() {
         const interval = setInterval(loadAgents, 30_000);
         return () => clearInterval(interval);
     }, [loadAgents]);
+
+    // ── First-run onboarding (#1726/#1727) ───────────────────────────
+    // Show the wizard until the ``initialized`` marker exists. Checked once on
+    // mount via a dedicated endpoint so the gate doesn't depend on the heavier
+    // system-status poll or its lemonade-fail debounce.
+    const [showOnboarding, setShowOnboarding] = useState(false);
+    useEffect(() => {
+        let cancelled = false;
+        api.getOnboardingStatus()
+            .then((s) => { if (!cancelled) setShowOnboarding(!s.initialized); })
+            .catch((err) => {
+                // Can't tell — default to NOT blocking an existing user behind a
+                // wizard on a transient error; they can re-run `gaia init`.
+                log.system.warn('Onboarding status check failed', err);
+            });
+        return () => { cancelled = true; };
+    }, []);
 
     // Mobile gateway state
     const [showMobileAccess, setShowMobileAccess] = useState(false);
@@ -674,6 +692,11 @@ function App() {
             {/* Session creation error toast */}
             {createError && (
                 <div className="toast" role="alert">{createError}</div>
+            )}
+
+            {/* First-run onboarding wizard — overlays the app until setup completes */}
+            {showOnboarding && (
+                <OnboardingWizard onComplete={() => { setShowOnboarding(false); checkSystemStatus(); }} />
             )}
         </div>
     );

--- a/src/gaia/apps/webui/src/components/onboarding/ConnectorStep.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/ConnectorStep.tsx
@@ -1,0 +1,165 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { CheckCircle2, Link2, Loader2, XCircle } from 'lucide-react';
+import * as api from '../../services/api';
+import { log } from '../../utils/logger';
+import type { ConnectorRow } from '../../types';
+
+interface ConnectorStepProps {
+    /**
+     * Connector id to offer on first run. Defaults to Google — the connector
+     * the email agent declares as required (``REQUIRED_CONNECTORS``). Optional
+     * step: the wizard never guards it.
+     */
+    connectorId?: string;
+}
+
+const POLL_MS = 2000;
+
+/**
+ * Step 4 — offer to connect an app before first run (#1727, "connector-on-
+ * install"). Reuses the existing OAuth flow (``authorizeConnector`` +
+ * ``getConnector`` polling); it does NOT reimplement grant logic — that lives
+ * in the connectors framework (see #2117/#2118). If the richer connect→grant
+ * flow lands on main, this step can call into it directly; the plain authorize
+ * path here is the interface available today.
+ */
+export function ConnectorStep({ connectorId = 'google' }: ConnectorStepProps) {
+    const [connector, setConnector] = useState<ConnectorRow | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [connecting, setConnecting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    const stopPolling = useCallback(() => {
+        if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        api.listConnectors()
+            .then(({ connectors }) => {
+                if (cancelled) return;
+                setConnector(connectors.find((c) => c.id === connectorId) ?? null);
+            })
+            .catch((err) => {
+                log.system.warn('Onboarding: failed to list connectors', err);
+                if (!cancelled) setError('Could not load connectors.');
+            })
+            .finally(() => { if (!cancelled) setLoading(false); });
+        return () => { cancelled = true; stopPolling(); };
+    }, [connectorId, stopPolling]);
+
+    const openExternal = (url: string) => {
+        const anyWindow = window as unknown as { gaia?: { openExternal?: (url: string) => void } };
+        if (anyWindow.gaia?.openExternal) anyWindow.gaia.openExternal(url);
+        else window.open(url, '_blank', 'noopener');
+    };
+
+    const pollUntilConfigured = useCallback(() => {
+        stopPolling();
+        pollRef.current = setInterval(async () => {
+            try {
+                const row = await api.getConnector(connectorId);
+                setConnector(row);
+                if (row.configured) {
+                    setConnecting(false);
+                    stopPolling();
+                }
+            } catch (err) {
+                log.system.warn('Onboarding: connector poll failed', err);
+            }
+        }, POLL_MS);
+    }, [connectorId, stopPolling]);
+
+    const connect = useCallback(async () => {
+        if (!connector) return;
+        setConnecting(true);
+        setError(null);
+        try {
+            const scopes = connector.default_scopes?.length ? connector.default_scopes : connector.available_scopes;
+            const { authorization_url } = await api.authorizeConnector(connectorId, scopes ?? []);
+            openExternal(authorization_url);
+            pollUntilConfigured();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Failed to start the connection.';
+            log.system.error('Onboarding: connect failed', err);
+            setError(message);
+            setConnecting(false);
+        }
+    }, [connector, connectorId, pollUntilConfigured]);
+
+    if (loading) {
+        return (
+            <div className="onboarding-body" data-testid="onboarding-connector-loading">
+                <h2>Connect an app</h2>
+                <p className="lede" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <Loader2 size={16} className="onboarding-spin" /> Loading…
+                </p>
+            </div>
+        );
+    }
+
+    // No such connector available (not configured on this build) — nothing to
+    // offer, so the step is a no-op the user simply continues past.
+    if (!connector) {
+        return (
+            <div className="onboarding-body" data-testid="onboarding-connector-none">
+                <h2>Connect an app</h2>
+                <p className="lede">
+                    No apps to connect right now. You can add connectors any time from
+                    Settings → Connectors.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="onboarding-body" data-testid="onboarding-connector">
+            <h2>Connect an app <span style={{ color: 'var(--text-muted)', fontWeight: 400, fontSize: '0.9rem' }}>(optional)</span></h2>
+            <p className="lede">
+                Some agents (like Email triage) work with your accounts. Connect now, or skip
+                and do it later from Settings.
+            </p>
+
+            <div className="connector-choice">
+                <span className="cc-icon"><Link2 size={20} /></span>
+                <div className="cc-body">
+                    <div className="cc-title">{connector.display_name}</div>
+                    <div className="cc-desc">{connector.description}</div>
+                </div>
+                {connector.configured ? (
+                    <span className="cc-connected" data-testid="connector-connected">
+                        <CheckCircle2 size={15} /> Connected
+                    </span>
+                ) : (
+                    <button
+                        className="onboarding-btn primary"
+                        onClick={connect}
+                        disabled={connecting || !connector.configurable}
+                        data-testid="connector-connect"
+                    >
+                        {connecting ? <Loader2 size={15} className="onboarding-spin" /> : <Link2 size={15} />}
+                        {connecting ? 'Waiting…' : 'Connect'}
+                    </button>
+                )}
+            </div>
+
+            {!connector.configurable && connector.config_error && (
+                <div className="onboarding-banner warn">
+                    <XCircle size={18} />
+                    <div>{connector.config_error}</div>
+                </div>
+            )}
+
+            {error && (
+                <div className="onboarding-banner error" role="alert" data-testid="connector-error">
+                    <XCircle size={18} />
+                    <div>{error}</div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/onboarding/DoneStep.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/DoneStep.tsx
@@ -1,0 +1,19 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { PartyPopper } from 'lucide-react';
+
+/** Step 5 — setup complete confirmation. */
+export function DoneStep() {
+    return (
+        <div className="onboarding-body" data-testid="onboarding-done">
+            <h1 style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <PartyPopper size={24} /> You're all set
+            </h1>
+            <p className="lede">
+                GAIA is ready. Ask a question, drop in a document, or explore the agents in
+                the sidebar. Everything runs locally on your machine.
+            </p>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/onboarding/ModelDownloadStep.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/ModelDownloadStep.tsx
@@ -1,0 +1,162 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { CheckCircle2, Download, Loader2, XCircle, RefreshCw } from 'lucide-react';
+import * as api from '../../services/api';
+import { log } from '../../utils/logger';
+import type { DownloadProgress } from '../../types';
+
+interface ModelDownloadStepProps {
+    modelName: string;
+    /** Guard the Next button until the model is downloaded (or loaded). */
+    onGuardChange: (blocked: boolean) => void;
+}
+
+const POLL_MS = 2000;
+
+function gb(bytes: number): string {
+    return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+}
+
+/**
+ * Step 3 — in-app model download with visible progress + retry (#1726).
+ *
+ * Drives the existing ``POST /api/system/download-model`` endpoint and reads
+ * its SSE-fed progress from ``GET /api/system/status.download_progress`` — the
+ * same channel the main app uses, no new backend surface. A failed download is
+ * surfaced loudly with the backend's message and a Retry (force re-pull);
+ * nothing silently advances past a missing model.
+ */
+export function ModelDownloadStep({ modelName, onGuardChange }: ModelDownloadStepProps) {
+    const [progress, setProgress] = useState<DownloadProgress | null>(null);
+    const [downloaded, setDownloaded] = useState(false);
+    const [starting, setStarting] = useState(false);
+    const [startError, setStartError] = useState<string | null>(null);
+    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    const stopPolling = useCallback(() => {
+        if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    }, []);
+
+    const poll = useCallback(async () => {
+        try {
+            const status = await api.getSystemStatus();
+            setProgress(status.download_progress);
+            const isReady =
+                status.download_progress?.state === 'complete' ||
+                status.model_downloaded === true ||
+                (!!status.model_loaded &&
+                    status.model_loaded.toLowerCase() === modelName.toLowerCase());
+            if (isReady) {
+                setDownloaded(true);
+                onGuardChange(false);
+                stopPolling();
+            }
+        } catch (err) {
+            log.system.warn('Model download poll failed', err);
+        }
+    }, [modelName, onGuardChange, stopPolling]);
+
+    // On mount: guard until we know the model exists, then poll once to detect
+    // an already-downloaded model (repeat runs of the wizard shouldn't re-pull).
+    useEffect(() => {
+        onGuardChange(true);
+        poll();
+        return stopPolling;
+    }, [onGuardChange, poll, stopPolling]);
+
+    const startDownload = useCallback(async (force: boolean) => {
+        setStarting(true);
+        setStartError(null);
+        onGuardChange(true);
+        try {
+            await api.downloadModel(modelName, force);
+            log.system.info(`Onboarding download started: ${modelName} (force=${force})`);
+            stopPolling();
+            pollRef.current = setInterval(poll, POLL_MS);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Failed to start download.';
+            log.system.error('Onboarding download failed to start', err);
+            setStartError(message);
+        } finally {
+            setStarting(false);
+        }
+    }, [modelName, onGuardChange, poll, stopPolling]);
+
+    if (downloaded) {
+        return (
+            <div className="onboarding-body" data-testid="onboarding-download-done">
+                <h2>Model ready</h2>
+                <div className="onboarding-banner warn" style={{ background: 'transparent', border: 'none' }}>
+                    <CheckCircle2 size={18} className="pf-icon ok" />
+                    <div><span className="download-model-name">{modelName}</span> is downloaded and ready to use.</div>
+                </div>
+            </div>
+        );
+    }
+
+    const errored = progress?.state === 'error' || !!startError;
+    const errorMessage = startError || progress?.message || 'Download failed.';
+    const active = progress?.state === 'downloading' || progress?.state === 'starting';
+
+    return (
+        <div className="onboarding-body" data-testid="onboarding-download">
+            <h2>Download your AI model</h2>
+            <p className="lede">
+                GAIA needs a local model to run. This is a one-time download of{' '}
+                <span className="download-model-name">{modelName}</span>.
+            </p>
+
+            {errored && (
+                <div className="onboarding-banner error" role="alert" data-testid="download-error">
+                    <XCircle size={18} />
+                    <div>
+                        {errorMessage}
+                        <div style={{ marginTop: 6 }}>Check your connection and disk space, then retry.</div>
+                    </div>
+                </div>
+            )}
+
+            {active && progress && (
+                <div data-testid="download-progress">
+                    <div className="download-model-name">{progress.file || modelName}</div>
+                    <div className="download-bar">
+                        <div className="fill" style={{ width: `${progress.percent}%` }} />
+                    </div>
+                    <div className="download-meta">
+                        <span>{progress.percent}%</span>
+                        <span>
+                            {progress.total_bytes > 0
+                                ? `${gb(progress.downloaded_bytes)} / ${gb(progress.total_bytes)}`
+                                : 'Starting…'}
+                        </span>
+                    </div>
+                </div>
+            )}
+
+            {!active && !errored && (
+                <button
+                    className="onboarding-btn primary"
+                    onClick={() => startDownload(false)}
+                    disabled={starting}
+                    data-testid="download-start"
+                >
+                    {starting ? <Loader2 size={15} className="onboarding-spin" /> : <Download size={15} />}
+                    {starting ? 'Starting…' : 'Download model'}
+                </button>
+            )}
+
+            {errored && (
+                <button
+                    className="onboarding-btn primary"
+                    onClick={() => startDownload(true)}
+                    disabled={starting}
+                    data-testid="download-retry"
+                >
+                    <RefreshCw size={15} /> Retry download
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/onboarding/ModelDownloadStep.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/ModelDownloadStep.tsx
@@ -39,7 +39,8 @@ export function ModelDownloadStep({ modelName, onGuardChange }: ModelDownloadSte
         if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
     }, []);
 
-    const poll = useCallback(async () => {
+    // Returns true while a download is still in flight (so callers can keep polling).
+    const poll = useCallback(async (): Promise<boolean> => {
         try {
             const status = await api.getSystemStatus();
             setProgress(status.download_progress);
@@ -52,19 +53,33 @@ export function ModelDownloadStep({ modelName, onGuardChange }: ModelDownloadSte
                 setDownloaded(true);
                 onGuardChange(false);
                 stopPolling();
+                return false;
             }
+            const state = status.download_progress?.state;
+            return state === 'downloading' || state === 'starting';
         } catch (err) {
             log.system.warn('Model download poll failed', err);
+            return false;
         }
     }, [modelName, onGuardChange, stopPolling]);
 
+    // Start the polling loop, guarded so we never stack two intervals.
+    const beginPolling = useCallback(() => {
+        if (pollRef.current) return;
+        pollRef.current = setInterval(poll, POLL_MS);
+    }, [poll]);
+
     // On mount: guard until we know the model exists, then poll once to detect
-    // an already-downloaded model (repeat runs of the wizard shouldn't re-pull).
+    // an already-downloaded model. If a download is already in flight (the wizard
+    // remounted mid-pull — refresh or Back nav), resume the loop so progress keeps
+    // advancing instead of freezing on the first frame.
     useEffect(() => {
         onGuardChange(true);
-        poll();
+        poll().then((active) => {
+            if (active) beginPolling();
+        });
         return stopPolling;
-    }, [onGuardChange, poll, stopPolling]);
+    }, [onGuardChange, poll, beginPolling, stopPolling]);
 
     const startDownload = useCallback(async (force: boolean) => {
         setStarting(true);
@@ -73,8 +88,7 @@ export function ModelDownloadStep({ modelName, onGuardChange }: ModelDownloadSte
         try {
             await api.downloadModel(modelName, force);
             log.system.info(`Onboarding download started: ${modelName} (force=${force})`);
-            stopPolling();
-            pollRef.current = setInterval(poll, POLL_MS);
+            beginPolling();
         } catch (err) {
             const message = err instanceof Error ? err.message : 'Failed to start download.';
             log.system.error('Onboarding download failed to start', err);
@@ -82,7 +96,7 @@ export function ModelDownloadStep({ modelName, onGuardChange }: ModelDownloadSte
         } finally {
             setStarting(false);
         }
-    }, [modelName, onGuardChange, poll, stopPolling]);
+    }, [modelName, onGuardChange, beginPolling]);
 
     if (downloaded) {
         return (

--- a/src/gaia/apps/webui/src/components/onboarding/OnboardingWizard.css
+++ b/src/gaia/apps/webui/src/components/onboarding/OnboardingWizard.css
@@ -1,0 +1,309 @@
+/* Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved. */
+/* SPDX-License-Identifier: MIT */
+
+/* First-run onboarding wizard (#1726, #1727). Full-screen overlay that sits
+   above the app shell until first-run setup completes. */
+
+.onboarding-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-primary);
+    padding: 24px;
+    overflow-y: auto;
+}
+
+.onboarding-card {
+    width: 100%;
+    max-width: 640px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 48px);
+}
+
+.onboarding-progress {
+    display: flex;
+    gap: 8px;
+    padding: 20px 28px 0;
+}
+
+.onboarding-progress .dot {
+    flex: 1;
+    height: 4px;
+    border-radius: var(--radius-full);
+    background: var(--border);
+    transition: background var(--duration-fast) var(--ease);
+}
+
+.onboarding-progress .dot.active {
+    background: var(--accent);
+}
+
+.onboarding-progress .dot.done {
+    background: var(--accent-dark, var(--accent));
+}
+
+.onboarding-body {
+    padding: 24px 28px;
+    overflow-y: auto;
+}
+
+.onboarding-body h1 {
+    font-size: 1.5rem;
+    margin: 0 0 8px;
+    color: var(--text-primary);
+}
+
+.onboarding-body h2 {
+    font-size: 1.25rem;
+    margin: 0 0 6px;
+    color: var(--text-primary);
+}
+
+.onboarding-body p.lede {
+    color: var(--text-secondary);
+    margin: 0 0 18px;
+    line-height: 1.5;
+}
+
+.onboarding-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 28px;
+    border-top: 1px solid var(--border);
+}
+
+.onboarding-footer .spacer {
+    flex: 1;
+}
+
+.onboarding-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: var(--radius-md);
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background var(--duration-fast) var(--ease), opacity var(--duration-fast) var(--ease);
+}
+
+.onboarding-btn.primary {
+    background: var(--accent);
+    color: #fff;
+}
+
+.onboarding-btn.primary:hover:not(:disabled) {
+    background: var(--accent-dark, var(--accent));
+}
+
+.onboarding-btn.secondary {
+    background: transparent;
+    color: var(--text-secondary);
+    border-color: var(--border);
+}
+
+.onboarding-btn.secondary:hover:not(:disabled) {
+    background: var(--bg-hover);
+}
+
+.onboarding-btn.link {
+    background: transparent;
+    color: var(--text-muted);
+    border: none;
+    padding: 10px 6px;
+    font-weight: 500;
+}
+
+.onboarding-btn.link:hover:not(:disabled) {
+    color: var(--text-secondary);
+    text-decoration: underline;
+}
+
+.onboarding-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Welcome step */
+.onboarding-steps-list {
+    list-style: none;
+    margin: 0 0 8px;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.onboarding-steps-list li {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--text-secondary);
+}
+
+.onboarding-steps-list .num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: var(--radius-full);
+    background: var(--bg-tertiary);
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 0.85rem;
+    flex-shrink: 0;
+}
+
+/* Pre-flight rows */
+.preflight-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 4px 0 16px;
+}
+
+.preflight-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-radius: var(--radius-md);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+}
+
+.preflight-row .pf-icon {
+    flex-shrink: 0;
+    display: inline-flex;
+}
+
+.preflight-row .pf-icon.ok { color: var(--terminal-green, #4ade80); }
+.preflight-row .pf-icon.warn { color: var(--accent-yellow, #eab308); }
+.preflight-row .pf-icon.bad { color: var(--danger, #ef4444); }
+
+.preflight-row .pf-label {
+    flex: 1;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.preflight-row .pf-value {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    font-family: var(--font-mono);
+}
+
+.onboarding-banner {
+    display: flex;
+    gap: 10px;
+    padding: 12px 14px;
+    border-radius: var(--radius-md);
+    margin: 8px 0;
+    font-size: 0.88rem;
+    line-height: 1.45;
+}
+
+.onboarding-banner.error {
+    background: color-mix(in srgb, var(--danger) 12%, transparent);
+    border: 1px solid var(--danger);
+    color: var(--text-primary);
+}
+
+.onboarding-banner.warn {
+    background: color-mix(in srgb, var(--accent-yellow, #eab308) 12%, transparent);
+    border: 1px solid var(--accent-yellow, #eab308);
+    color: var(--text-primary);
+}
+
+.onboarding-banner ul {
+    margin: 4px 0 0;
+    padding-left: 18px;
+}
+
+.onboarding-tier {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+    background: var(--bg-tertiary);
+    color: var(--accent);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: capitalize;
+    margin-bottom: 12px;
+}
+
+/* Download progress */
+.download-model-name {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+}
+
+.download-bar {
+    height: 10px;
+    border-radius: var(--radius-full);
+    background: var(--bg-tertiary);
+    overflow: hidden;
+    margin: 6px 0;
+}
+
+.download-bar .fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: var(--radius-full);
+    transition: width var(--duration) var(--ease);
+}
+
+.download-meta {
+    display: flex;
+    justify-content: space-between;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    font-family: var(--font-mono);
+}
+
+.download-spinner {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 8px 0;
+}
+
+/* Connector step */
+.connector-choice {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    border-radius: var(--radius-md);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    margin: 8px 0 16px;
+}
+
+.connector-choice .cc-body { flex: 1; }
+.connector-choice .cc-title { color: var(--text-primary); font-weight: 600; }
+.connector-choice .cc-desc { color: var(--text-muted); font-size: 0.82rem; }
+.connector-choice .cc-connected { color: var(--terminal-green, #4ade80); font-size: 0.85rem; font-weight: 600; }
+
+.onboarding-spin {
+    animation: onboarding-spin 1s linear infinite;
+}
+
+@keyframes onboarding-spin {
+    to { transform: rotate(360deg); }
+}

--- a/src/gaia/apps/webui/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,149 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useState } from 'react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { useOnboarding, ONBOARDING_STEPS } from './useOnboarding';
+import { WelcomeStep } from './WelcomeStep';
+import { PreflightStep } from './PreflightStep';
+import { ModelDownloadStep } from './ModelDownloadStep';
+import { ConnectorStep } from './ConnectorStep';
+import { DoneStep } from './DoneStep';
+import * as api from '../../services/api';
+import { log } from '../../utils/logger';
+import { DEFAULT_MODEL_NAME } from '../../utils/constants';
+import type { PreflightReport } from '../../types';
+import './OnboardingWizard.css';
+
+interface OnboardingWizardProps {
+    /** Called once the ``initialized`` marker is written (wizard should unmount). */
+    onComplete: () => void;
+}
+
+/**
+ * First-run onboarding wizard (#1726, #1727): hardware pre-flight → in-app
+ * model download → optional connector → done. Writes the ``initialized`` marker
+ * on finish/skip so it never re-triggers.
+ */
+export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
+    const nav = useOnboarding();
+    const [report, setReport] = useState<PreflightReport | null>(null);
+    const [finishing, setFinishing] = useState(false);
+    const [finishError, setFinishError] = useState<string | null>(null);
+
+    const recommendedModel = report?.recommended_model || DEFAULT_MODEL_NAME;
+
+    const finish = useCallback(async (skipped: boolean) => {
+        setFinishing(true);
+        setFinishError(null);
+        try {
+            await api.completeOnboarding(skipped);
+            log.system.info(`Onboarding complete (skipped=${skipped})`);
+            onComplete();
+        } catch (err) {
+            // No silent fallback — if we can't persist the marker, say so and
+            // let the user retry rather than dropping them into a half-set-up
+            // app that re-shows the wizard next launch.
+            const message = err instanceof Error ? err.message : 'Failed to finish setup.';
+            log.system.error('Onboarding: failed to write completion marker', err);
+            setFinishError(message);
+            setFinishing(false);
+        }
+    }, [onComplete]);
+
+    const renderStep = () => {
+        switch (nav.step) {
+            case 'welcome':
+                return <WelcomeStep />;
+            case 'preflight':
+                return <PreflightStep onGuardChange={nav.setGuard} onReport={setReport} />;
+            case 'download':
+                return <ModelDownloadStep modelName={recommendedModel} onGuardChange={nav.setGuard} />;
+            case 'connector':
+                return <ConnectorStep />;
+            case 'done':
+                return <DoneStep />;
+        }
+    };
+
+    // Footer actions differ per step; keep the logic here so steps stay purely
+    // presentational and the guard rules live in one place.
+    const renderFooter = () => {
+        if (nav.step === 'welcome') {
+            return (
+                <>
+                    <button className="onboarding-btn link" onClick={() => finish(true)} disabled={finishing}>
+                        Skip — I know what I'm doing
+                    </button>
+                    <div className="spacer" />
+                    <button className="onboarding-btn primary" onClick={nav.next}>
+                        Get started <ArrowRight size={15} />
+                    </button>
+                </>
+            );
+        }
+
+        if (nav.step === 'done') {
+            return (
+                <>
+                    <div className="spacer" />
+                    <button className="onboarding-btn primary" onClick={() => finish(false)} disabled={finishing}>
+                        {finishing ? 'Finishing…' : 'Start using GAIA'}
+                    </button>
+                </>
+            );
+        }
+
+        // Middle steps: Back + Next, with an optional "later" escape on the
+        // optional/guarded steps so a guard never traps the user.
+        const showSkipLater = nav.step === 'download' || nav.step === 'connector';
+        return (
+            <>
+                <button className="onboarding-btn secondary" onClick={nav.back} disabled={nav.isFirst}>
+                    <ArrowLeft size={15} /> Back
+                </button>
+                {showSkipLater && (
+                    <button className="onboarding-btn link" onClick={nav.skip} data-testid="onboarding-skip-later">
+                        Set up later
+                    </button>
+                )}
+                <div className="spacer" />
+                <button
+                    className="onboarding-btn primary"
+                    onClick={nav.next}
+                    disabled={nav.guarded}
+                    data-testid="onboarding-next"
+                >
+                    Continue <ArrowRight size={15} />
+                </button>
+            </>
+        );
+    };
+
+    return (
+        <div className="onboarding-overlay" role="dialog" aria-modal="true" aria-label="GAIA first-run setup">
+            <div className="onboarding-card">
+                <div className="onboarding-progress" aria-hidden="true">
+                    {ONBOARDING_STEPS.map((s, i) => (
+                        <span
+                            key={s}
+                            className={`dot ${i === nav.index ? 'active' : ''} ${i < nav.index ? 'done' : ''}`}
+                        />
+                    ))}
+                </div>
+
+                {renderStep()}
+
+                {finishError && (
+                    <div className="onboarding-banner error" role="alert" style={{ margin: '0 28px' }}>
+                        {finishError}
+                    </div>
+                )}
+
+                <div className="onboarding-footer">
+                    {renderFooter()}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/onboarding/PreflightStep.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/PreflightStep.tsx
@@ -1,0 +1,176 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useEffect, useState } from 'react';
+import { CheckCircle2, AlertTriangle, XCircle, Loader2, RefreshCw } from 'lucide-react';
+import * as api from '../../services/api';
+import { log } from '../../utils/logger';
+import type { PreflightReport } from '../../types';
+
+interface PreflightStepProps {
+    /**
+     * Called whenever the scan resolves so the wizard can guard the Next
+     * button: a hard blocker (``compatible === false``) blocks advancing;
+     * anything else clears the guard. While the scan is in flight the step is
+     * guarded too — we never let the user past an unknown hardware state.
+     */
+    onGuardChange: (blocked: boolean) => void;
+    onReport?: (report: PreflightReport) => void;
+}
+
+type ScanState =
+    | { kind: 'loading' }
+    | { kind: 'error'; message: string }
+    | { kind: 'ready'; report: PreflightReport };
+
+function fmtGb(v: number | null): string {
+    return v === null ? '—' : `${v} GB`;
+}
+
+/** Step 2 — hardware pre-flight scan with gating on hard blockers (#1727). */
+export function PreflightStep({ onGuardChange, onReport }: PreflightStepProps) {
+    const [state, setState] = useState<ScanState>({ kind: 'loading' });
+
+    const scan = useCallback(async () => {
+        setState({ kind: 'loading' });
+        onGuardChange(true); // block advancing until we know the result
+        try {
+            const report = await api.getOnboardingPreflight();
+            setState({ kind: 'ready', report });
+            onReport?.(report);
+            // Only a hard blocker keeps the guard on. Warnings are advisory.
+            onGuardChange(!report.compatible);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Hardware scan failed.';
+            log.system.error('Preflight scan failed', err);
+            setState({ kind: 'error', message });
+            onGuardChange(true); // can't verify — don't let the user past silently
+        }
+    }, [onGuardChange, onReport]);
+
+    useEffect(() => {
+        scan();
+    }, [scan]);
+
+    if (state.kind === 'loading') {
+        return (
+            <div className="onboarding-body" data-testid="onboarding-preflight-loading">
+                <h2>Checking your hardware…</h2>
+                <p className="lede" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <Loader2 size={16} className="onboarding-spin" /> Scanning RAM, disk, and accelerators.
+                </p>
+            </div>
+        );
+    }
+
+    if (state.kind === 'error') {
+        return (
+            <div className="onboarding-body" data-testid="onboarding-preflight-error">
+                <h2>Couldn't scan your hardware</h2>
+                <div className="onboarding-banner error" role="alert">
+                    <XCircle size={18} />
+                    <div>
+                        {state.message}
+                        <div style={{ marginTop: 6 }}>
+                            Make sure the GAIA backend is running, then retry.
+                        </div>
+                    </div>
+                </div>
+                <button className="onboarding-btn secondary" onClick={scan}>
+                    <RefreshCw size={15} /> Retry scan
+                </button>
+            </div>
+        );
+    }
+
+    const { report } = state;
+    const ramOk = report.ram_gb === null || report.ram_gb >= report.required_memory_gb;
+    const diskOk = report.disk_free_gb === null || report.disk_free_gb >= report.required_disk_gb;
+
+    return (
+        <div className="onboarding-body" data-testid="onboarding-preflight">
+            <h2>Hardware check</h2>
+            <span className="onboarding-tier">Tier: {report.tier}</span>
+
+            <div className="preflight-rows">
+                <PfRow
+                    ok={ramOk}
+                    label="Memory (RAM)"
+                    value={fmtGb(report.ram_gb)}
+                />
+                <PfRow
+                    ok={diskOk}
+                    hardFail={!diskOk}
+                    label="Free disk space"
+                    value={fmtGb(report.disk_free_gb)}
+                />
+                <PfRow
+                    ok={report.npu_detected === true}
+                    unknown={report.npu_detected === null}
+                    label="Ryzen AI NPU"
+                    value={
+                        report.npu_detected === true
+                            ? 'Detected'
+                            : report.npu_detected === false
+                                ? 'Not found'
+                                : 'Unknown'
+                    }
+                />
+                {report.gpu_name && (
+                    <PfRow ok label="GPU" value={report.gpu_name} />
+                )}
+            </div>
+
+            {!report.compatible && report.blockers.length > 0 && (
+                <div className="onboarding-banner error" role="alert" data-testid="preflight-blockers">
+                    <XCircle size={18} />
+                    <div>
+                        <strong>This machine can't run the setup yet:</strong>
+                        <ul>
+                            {report.blockers.map((b, i) => <li key={i}>{b}</li>)}
+                        </ul>
+                    </div>
+                </div>
+            )}
+
+            {report.warnings.length > 0 && (
+                <div className="onboarding-banner warn" data-testid="preflight-warnings">
+                    <AlertTriangle size={18} />
+                    <div>
+                        <ul>
+                            {report.warnings.map((w, i) => <li key={i}>{w}</li>)}
+                        </ul>
+                    </div>
+                </div>
+            )}
+
+            <button className="onboarding-btn secondary" onClick={scan}>
+                <RefreshCw size={15} /> Re-scan
+            </button>
+        </div>
+    );
+}
+
+function PfRow({ ok, hardFail, unknown, label, value }: {
+    ok: boolean;
+    hardFail?: boolean;
+    unknown?: boolean;
+    label: string;
+    value: string;
+}) {
+    const icon = unknown ? (
+        <AlertTriangle size={17} />
+    ) : ok ? (
+        <CheckCircle2 size={17} />
+    ) : (
+        hardFail ? <XCircle size={17} /> : <AlertTriangle size={17} />
+    );
+    const cls = unknown ? 'warn' : ok ? 'ok' : hardFail ? 'bad' : 'warn';
+    return (
+        <div className="preflight-row">
+            <span className={`pf-icon ${cls}`}>{icon}</span>
+            <span className="pf-label">{label}</span>
+            <span className="pf-value">{value}</span>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/onboarding/WelcomeStep.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/WelcomeStep.tsx
@@ -1,0 +1,34 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { ShieldCheck, Cpu, Download, MessageSquare } from 'lucide-react';
+
+/** Step 1 — welcome + expectations. Purely presentational. */
+export function WelcomeStep() {
+    return (
+        <div className="onboarding-body" data-testid="onboarding-welcome">
+            <h1>Welcome to GAIA</h1>
+            <p className="lede">
+                Your private AI assistant that runs 100% locally on AMD hardware —
+                no data ever leaves your device. Let's get you set up.
+            </p>
+            <ul className="onboarding-steps-list">
+                <li>
+                    <span className="num"><Cpu size={15} /></span>
+                    Check your hardware
+                </li>
+                <li>
+                    <span className="num"><Download size={15} /></span>
+                    Download an AI model
+                </li>
+                <li>
+                    <span className="num"><MessageSquare size={15} /></span>
+                    Connect an app (optional) and start chatting
+                </li>
+            </ul>
+            <p className="lede" style={{ marginTop: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
+                <ShieldCheck size={16} /> Everything stays on this machine.
+            </p>
+        </div>
+    );
+}

--- a/src/gaia/apps/webui/src/components/onboarding/__tests__/ModelDownloadStep.test.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/__tests__/ModelDownloadStep.test.tsx
@@ -1,0 +1,127 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ModelDownloadStep } from '../ModelDownloadStep';
+import type { DownloadProgress, SystemStatus } from '../../../types';
+
+vi.mock('../../../services/api', () => ({
+    getSystemStatus: vi.fn(),
+    downloadModel: vi.fn(),
+}));
+
+import * as api from '../../../services/api';
+
+const MODEL = 'Gemma-4-E4B-it-GGUF';
+const POLL_MS = 2000;
+
+function status(over: Partial<SystemStatus>): SystemStatus {
+    return {
+        lemonade_running: true,
+        model_loaded: null,
+        embedding_model_loaded: false,
+        disk_space_gb: 500,
+        memory_available_gb: 32,
+        initialized: false,
+        version: '0.0.0-test',
+        lemonade_version: null,
+        model_size_gb: null,
+        model_device: null,
+        model_context_size: null,
+        model_labels: null,
+        gpu_name: null,
+        gpu_vram_gb: null,
+        tokens_per_second: null,
+        time_to_first_token: null,
+        processor_name: null,
+        device_supported: true,
+        context_size_sufficient: true,
+        model_downloaded: null,
+        default_model_name: MODEL,
+        default_model_size_gb: 6,
+        lemonade_url: null,
+        expected_model_loaded: false,
+        download_progress: null,
+        ...over,
+    };
+}
+
+function downloading(percent: number): DownloadProgress {
+    return {
+        state: 'downloading',
+        model_name: MODEL,
+        percent,
+        file: 'model.gguf',
+        file_index: 0,
+        total_files: 1,
+        downloaded_bytes: percent * 1e7,
+        total_bytes: 1e9,
+        message: null,
+    };
+}
+
+// Flush the mount poll's promise chain (getSystemStatus -> setState -> .then).
+async function flushMicrotasks() {
+    await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+});
+
+describe('ModelDownloadStep', () => {
+    // Regression (#2204): a wizard that remounts mid-download (refresh / Back nav)
+    // must resume polling instead of freezing on the first progress frame.
+    it('resumes polling on remount when a download is already in flight', async () => {
+        let calls = 0;
+        vi.mocked(api.getSystemStatus).mockImplementation(async () => {
+            calls += 1;
+            if (calls >= 3) return status({ download_progress: { ...downloading(100), state: 'complete' } });
+            return status({ download_progress: downloading(calls * 20) });
+        });
+        const onGuardChange = vi.fn();
+
+        // Fresh mount — no Download click.
+        render(<ModelDownloadStep modelName={MODEL} onGuardChange={onGuardChange} />);
+
+        // Mount poll sees an in-progress download and renders the bar.
+        await flushMicrotasks();
+        expect(api.getSystemStatus).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId('download-progress')).toBeInTheDocument();
+
+        // The interval keeps polling (the frozen bug never got here).
+        await act(async () => { await vi.advanceTimersByTimeAsync(POLL_MS); });
+        expect(api.getSystemStatus).toHaveBeenCalledTimes(2);
+
+        // Once the backend reports complete, the step reflects completion and unblocks Next.
+        await act(async () => { await vi.advanceTimersByTimeAsync(POLL_MS); });
+        expect(api.getSystemStatus).toHaveBeenCalledTimes(3);
+        expect(screen.getByTestId('onboarding-download-done')).toBeInTheDocument();
+        expect(onGuardChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it('does not start polling on mount when no download is active', async () => {
+        vi.mocked(api.getSystemStatus).mockResolvedValue(status({ download_progress: null }));
+
+        render(<ModelDownloadStep modelName={MODEL} onGuardChange={vi.fn()} />);
+
+        await flushMicrotasks();
+        expect(api.getSystemStatus).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId('download-start')).toBeInTheDocument();
+
+        // No interval was armed — advancing time triggers no further polls.
+        await act(async () => { await vi.advanceTimersByTimeAsync(POLL_MS * 3); });
+        expect(api.getSystemStatus).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/gaia/apps/webui/src/components/onboarding/__tests__/OnboardingWizard.test.tsx
+++ b/src/gaia/apps/webui/src/components/onboarding/__tests__/OnboardingWizard.test.tsx
@@ -1,0 +1,103 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { OnboardingWizard } from '../OnboardingWizard';
+import type { PreflightReport } from '../../../types';
+
+// Mock the API surface the wizard + steps touch.
+vi.mock('../../../services/api', () => ({
+    getOnboardingPreflight: vi.fn(),
+    getSystemStatus: vi.fn(),
+    downloadModel: vi.fn(),
+    listConnectors: vi.fn(),
+    getConnector: vi.fn(),
+    authorizeConnector: vi.fn(),
+    completeOnboarding: vi.fn(),
+}));
+
+import * as api from '../../../services/api';
+
+const okReport: PreflightReport = {
+    os: 'win-x64',
+    detected_platform: 'win-x64',
+    ram_gb: 32,
+    disk_free_gb: 500,
+    npu_detected: true,
+    gpu_name: 'Radeon 780M',
+    gpu_vram_gb: 16,
+    lemonade_running: true,
+    tier: 'full',
+    recommended_profile: 'chat',
+    recommended_model: 'Gemma-4-E4B-it-GGUF',
+    required_disk_gb: 6,
+    required_memory_gb: 8,
+    compatible: true,
+    blockers: [],
+    warnings: [],
+};
+
+const blockedReport: PreflightReport = {
+    ...okReport,
+    tier: 'insufficient',
+    disk_free_gb: 0.5,
+    compatible: false,
+    blockers: ['Not enough disk space: install needs ~6.0 GB but only 0.5 GB is free.'],
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getSystemStatus).mockResolvedValue({ download_progress: null } as never);
+});
+
+describe('OnboardingWizard', () => {
+    it('renders the welcome step first', () => {
+        render(<OnboardingWizard onComplete={vi.fn()} />);
+        expect(screen.getByTestId('onboarding-welcome')).toBeInTheDocument();
+    });
+
+    it('skip on welcome writes the marker (skipped) and completes', async () => {
+        vi.mocked(api.completeOnboarding).mockResolvedValue({ initialized: true, skipped: true, completed_at: null });
+        const onComplete = vi.fn();
+        render(<OnboardingWizard onComplete={onComplete} />);
+
+        fireEvent.click(screen.getByText(/Skip — I know what I'm doing/));
+
+        await waitFor(() => expect(api.completeOnboarding).toHaveBeenCalledWith(true));
+        expect(onComplete).toHaveBeenCalled();
+    });
+
+    it('runs the pre-flight scan when advancing from welcome', async () => {
+        vi.mocked(api.getOnboardingPreflight).mockResolvedValue(okReport);
+        render(<OnboardingWizard onComplete={vi.fn()} />);
+
+        fireEvent.click(screen.getByText(/Get started/));
+
+        await screen.findByTestId('onboarding-preflight');
+        expect(api.getOnboardingPreflight).toHaveBeenCalled();
+        // Compatible report ⇒ Continue is enabled.
+        await waitFor(() => expect(screen.getByTestId('onboarding-next')).not.toBeDisabled());
+    });
+
+    it('gates Continue when the machine fails the hardware check', async () => {
+        vi.mocked(api.getOnboardingPreflight).mockResolvedValue(blockedReport);
+        render(<OnboardingWizard onComplete={vi.fn()} />);
+
+        fireEvent.click(screen.getByText(/Get started/));
+
+        await screen.findByTestId('preflight-blockers');
+        expect(screen.getByTestId('onboarding-next')).toBeDisabled();
+    });
+
+    it('advances into the download step once hardware passes', async () => {
+        vi.mocked(api.getOnboardingPreflight).mockResolvedValue(okReport);
+        render(<OnboardingWizard onComplete={vi.fn()} />);
+
+        fireEvent.click(screen.getByText(/Get started/));
+        await waitFor(() => expect(screen.getByTestId('onboarding-next')).not.toBeDisabled());
+        fireEvent.click(screen.getByTestId('onboarding-next'));
+
+        await screen.findByTestId('onboarding-download');
+    });
+});

--- a/src/gaia/apps/webui/src/components/onboarding/__tests__/useOnboarding.test.ts
+++ b/src/gaia/apps/webui/src/components/onboarding/__tests__/useOnboarding.test.ts
@@ -1,0 +1,86 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useOnboarding, ONBOARDING_STEPS } from '../useOnboarding';
+
+describe('useOnboarding state machine', () => {
+    it('starts on welcome', () => {
+        const { result } = renderHook(() => useOnboarding());
+        expect(result.current.step).toBe('welcome');
+        expect(result.current.index).toBe(0);
+        expect(result.current.isFirst).toBe(true);
+        expect(result.current.isLast).toBe(false);
+        expect(result.current.total).toBe(ONBOARDING_STEPS.length);
+    });
+
+    it('advances forward through every step', () => {
+        const { result } = renderHook(() => useOnboarding());
+        for (let i = 1; i < ONBOARDING_STEPS.length; i++) {
+            act(() => { result.current.next(); });
+            expect(result.current.step).toBe(ONBOARDING_STEPS[i]);
+        }
+        expect(result.current.isLast).toBe(true);
+    });
+
+    it('does not advance past the last step', () => {
+        const { result } = renderHook(() => useOnboarding('done'));
+        act(() => {
+            const moved = result.current.next();
+            expect(moved).toBe(false);
+        });
+        expect(result.current.step).toBe('done');
+    });
+
+    it('goes back and clamps at the first step', () => {
+        const { result } = renderHook(() => useOnboarding('preflight'));
+        act(() => { result.current.back(); });
+        expect(result.current.step).toBe('welcome');
+        act(() => {
+            const moved = result.current.back();
+            expect(moved).toBe(false);
+        });
+        expect(result.current.step).toBe('welcome');
+    });
+
+    it('blocks next() while the current step is guarded', () => {
+        const { result } = renderHook(() => useOnboarding('preflight'));
+        act(() => { result.current.setGuard(true); });
+        expect(result.current.guarded).toBe(true);
+        act(() => {
+            const moved = result.current.next();
+            expect(moved).toBe(false);
+        });
+        expect(result.current.step).toBe('preflight');
+
+        act(() => { result.current.setGuard(false); });
+        act(() => { result.current.next(); });
+        expect(result.current.step).toBe('download');
+    });
+
+    it('skip() bypasses a guard (optional-step escape)', () => {
+        const { result } = renderHook(() => useOnboarding('download'));
+        act(() => { result.current.setGuard(true); });
+        act(() => { result.current.skip(); });
+        expect(result.current.step).toBe('connector');
+    });
+
+    it('guard is scoped per step — moving back to a clean step is not guarded', () => {
+        const { result } = renderHook(() => useOnboarding('preflight'));
+        act(() => { result.current.setGuard(true); });
+        // skip past the guarded step, then walk back to it
+        act(() => { result.current.skip(); }); // -> download
+        expect(result.current.guarded).toBe(false); // download has no guard
+        act(() => { result.current.back(); }); // -> preflight
+        expect(result.current.guarded).toBe(true); // its guard persists
+    });
+
+    it('goTo jumps to an explicit step ignoring guards', () => {
+        const { result } = renderHook(() => useOnboarding('welcome'));
+        act(() => { result.current.goTo('connector'); });
+        expect(result.current.step).toBe('connector');
+        act(() => { result.current.goTo('preflight'); });
+        expect(result.current.step).toBe('preflight');
+    });
+});

--- a/src/gaia/apps/webui/src/components/onboarding/useOnboarding.ts
+++ b/src/gaia/apps/webui/src/components/onboarding/useOnboarding.ts
@@ -1,0 +1,127 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * First-run onboarding wizard state machine (#1726, #1727).
+ *
+ * Pure navigation logic: the ordered steps, the current position, and the
+ * guard that stops a step being left before its work is done (a hardware
+ * blocker on pre-flight, an unfinished model download). Data fetching lives in
+ * the step components; this hook only decides *where* we are and *whether we
+ * may move*. Keeping it side-effect-free makes the gating trivially testable.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+
+/** Ordered wizard steps. ``done`` is the terminal confirmation screen. */
+export const ONBOARDING_STEPS = [
+    'welcome',
+    'preflight',
+    'download',
+    'connector',
+    'done',
+] as const;
+
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+
+export interface UseOnboarding {
+    /** The step currently shown. */
+    step: OnboardingStep;
+    /** Zero-based index of the current step. */
+    index: number;
+    /** Total number of steps. */
+    total: number;
+    isFirst: boolean;
+    isLast: boolean;
+    /**
+     * Whether leaving the current step forward is currently blocked. A guarded
+     * step disables the primary "Next" action; ``skip()`` bypasses it (the
+     * explicit power-user / optional-step escape) so a guard never traps the
+     * user, it only stops a *silent* advance past unfinished work.
+     */
+    guarded: boolean;
+    /** Mark the current step as guarded (true) or clear the guard (false). */
+    setGuard: (blocked: boolean) => void;
+    /**
+     * Advance to the next step. Returns ``false`` (a no-op) when the current
+     * step is guarded — the caller should keep the Next button disabled in
+     * that case rather than relying on this return.
+     */
+    next: () => boolean;
+    /** Go back one step (clears any guard on the step we land on). */
+    back: () => boolean;
+    /** Jump to an explicit step, ignoring guards (used by "Re-scan" etc.). */
+    goTo: (step: OnboardingStep) => void;
+    /** Advance past an optional/guarded step deliberately (records nothing). */
+    skip: () => void;
+}
+
+export function useOnboarding(initial: OnboardingStep = 'welcome'): UseOnboarding {
+    const [index, setIndex] = useState<number>(() =>
+        Math.max(0, ONBOARDING_STEPS.indexOf(initial)),
+    );
+    // Guard is keyed by step so navigating back and forth doesn't leak a guard
+    // set on a different step.
+    const [guards, setGuards] = useState<Partial<Record<OnboardingStep, boolean>>>({});
+
+    const step = ONBOARDING_STEPS[index];
+    const guarded = !!guards[step];
+
+    const setGuard = useCallback(
+        (blocked: boolean) => {
+            setGuards((prev) => (prev[step] === blocked ? prev : { ...prev, [step]: blocked }));
+        },
+        [step],
+    );
+
+    const next = useCallback((): boolean => {
+        if (guards[step]) return false;
+        let moved = false;
+        setIndex((i) => {
+            if (i < ONBOARDING_STEPS.length - 1) {
+                moved = true;
+                return i + 1;
+            }
+            return i;
+        });
+        return moved;
+    }, [guards, step]);
+
+    const skip = useCallback(() => {
+        setIndex((i) => Math.min(i + 1, ONBOARDING_STEPS.length - 1));
+    }, []);
+
+    const back = useCallback((): boolean => {
+        let moved = false;
+        setIndex((i) => {
+            if (i > 0) {
+                moved = true;
+                return i - 1;
+            }
+            return i;
+        });
+        return moved;
+    }, []);
+
+    const goTo = useCallback((target: OnboardingStep) => {
+        const i = ONBOARDING_STEPS.indexOf(target);
+        if (i >= 0) setIndex(i);
+    }, []);
+
+    return useMemo(
+        () => ({
+            step,
+            index,
+            total: ONBOARDING_STEPS.length,
+            isFirst: index === 0,
+            isLast: index === ONBOARDING_STEPS.length - 1,
+            guarded,
+            setGuard,
+            next,
+            back,
+            goTo,
+            skip,
+        }),
+        [step, index, guarded, setGuard, next, back, goTo, skip],
+    );
+}

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -3,7 +3,7 @@
 
 /** API client for GAIA Agent UI backend. */
 
-import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, Schedule, ScheduleResult, ParsedSchedule, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPServerStatus, AgentMCPServerStatus, AgentInfo, DiskAgentInfo, AgentCatalogResponse, InstallStatus } from '../types';
+import type { Session, Message, Document, SystemStatus, Settings, StreamEvent, TunnelStatus, Schedule, ScheduleResult, ParsedSchedule, BrowseResponse, IndexFolderResponse, MCPServerInfo, MCPServerStatus, AgentMCPServerStatus, AgentInfo, DiskAgentInfo, AgentCatalogResponse, InstallStatus, PreflightReport, OnboardingStatusResponse } from '../types';
 import { getApiBase } from '../utils/apiBase';
 import { log } from '../utils/logger';
 
@@ -121,6 +121,23 @@ export async function loadModel(modelName: string, ctxSize?: number): Promise<{ 
 
 export async function downloadModel(modelName: string, force = false): Promise<{ status: string; model: string }> {
     return apiFetch('POST', '/system/download-model', { model_name: modelName, force });
+}
+
+// -- Onboarding (first-run wizard, #1726/#1727) --------------------------------
+
+export async function getOnboardingPreflight(): Promise<PreflightReport> {
+    return apiFetch<PreflightReport>('GET', '/onboarding/preflight');
+}
+
+export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
+    return apiFetch<OnboardingStatusResponse>('GET', '/onboarding/status');
+}
+
+export async function completeOnboarding(skipped: boolean): Promise<OnboardingStatusResponse> {
+    return apiFetch<OnboardingStatusResponse>('POST', '/onboarding/complete', {
+        skipped,
+        completed_at: new Date().toISOString(),
+    });
 }
 
 // -- Agents --------------------------------------------------------------------

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -451,6 +451,38 @@ export interface SystemStatus {
     detected_devices?: string[];
 }
 
+/**
+ * First-run hardware pre-flight report from GET /api/onboarding/preflight
+ * (#1726, #1727). ``compatible`` is false only when there is a hard blocker
+ * (e.g. not enough disk for the model download).
+ */
+export interface PreflightReport {
+    os: string | null;
+    detected_platform: string | null;
+    ram_gb: number | null;
+    disk_free_gb: number | null;
+    /** true/false when probed; null when hardware couldn't be verified. */
+    npu_detected: boolean | null;
+    gpu_name: string | null;
+    gpu_vram_gb: number | null;
+    lemonade_running: boolean;
+    tier: 'full' | 'standard' | 'light' | 'insufficient' | 'unknown' | string;
+    recommended_profile: string;
+    recommended_model: string;
+    required_disk_gb: number;
+    required_memory_gb: number;
+    compatible: boolean;
+    blockers: string[];
+    warnings: string[];
+}
+
+/** First-run completion state from GET /api/onboarding/status. */
+export interface OnboardingStatusResponse {
+    initialized: boolean;
+    skipped: boolean;
+    completed_at: string | null;
+}
+
 // ── File Browser Types ───────────────────────────────────────────────────
 
 /** A single file or folder entry returned by the browse endpoint. */

--- a/src/gaia/hub/compatibility.py
+++ b/src/gaia/hub/compatibility.py
@@ -61,6 +61,9 @@ class CompatibilityReport:
     detected_platform: Optional[str] = None
     total_memory_gb: Optional[float] = None
     free_disk_gb: Optional[float] = None
+    # ``None`` means the caller supplied no hardware scan for that device.
+    detected_npu: Optional[bool] = None
+    detected_gpu_vram_gb: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -73,6 +76,8 @@ class CompatibilityReport:
             "detected_platform": self.detected_platform,
             "total_memory_gb": self.total_memory_gb,
             "free_disk_gb": self.free_disk_gb,
+            "detected_npu": self.detected_npu,
+            "detected_gpu_vram_gb": self.detected_gpu_vram_gb,
         }
 
 
@@ -176,6 +181,8 @@ def check_compatibility(
     *,
     download_size_bytes: int = 0,
     install_dir: Optional[Path] = None,
+    detected_npu: Optional[bool] = None,
+    detected_gpu_vram_gb: Optional[float] = None,
 ) -> CompatibilityReport:
     """Check whether the current machine satisfies *requirements*.
 
@@ -187,6 +194,14 @@ def check_compatibility(
             declares no explicit ``min_disk_gb``.
         install_dir: Where the agent will be installed; the disk check probes
             this volume. Defaults to ``~/.gaia/agents``.
+        detected_npu: Whether an NPU was actually detected by the caller's
+            hardware scan (e.g. the Agent UI's ``/api/system/status`` probe).
+            ``True``/``False`` turn an ``npu`` requirement into a real
+            pass/warning; ``None`` (the default) keeps the conservative
+            "cannot verify" warning for callers that have no scan.
+        detected_gpu_vram_gb: GPU VRAM (GB) reported by the caller's scan, used
+            the same way for a ``gpu_vram_gb`` requirement. ``None`` keeps the
+            "cannot verify" warning.
 
     Returns:
         A :class:`CompatibilityReport`. ``compatible`` is ``True`` only when no
@@ -258,17 +273,38 @@ def check_compatibility(
                 f"but only {free_disk:.1f} GB is free on {install_dir}."
             )
 
-    # --- NPU / GPU (best-effort, advisory) ---
+    # --- NPU / GPU (advisory) ---
+    # When the caller passes a real hardware scan (detected_npu /
+    # detected_gpu_vram_gb), turn the requirement into a concrete pass or
+    # warning instead of the blanket "cannot verify". Absent a scan we fall
+    # back to the conservative message — never silently passing (#1727).
     if reqs.npu:
-        warnings.append(
-            "This agent requests an NPU. GAIA cannot verify NPU availability "
-            "here; ensure your Ryzen AI NPU driver is installed."
-        )
+        if detected_npu is True:
+            pass  # requirement met — no warning
+        elif detected_npu is False:
+            warnings.append(
+                "This agent requests an NPU, but none was detected on this "
+                "machine. It will fall back to GPU/CPU inference, which is "
+                "slower. Ensure your Ryzen AI NPU driver is installed."
+            )
+        else:
+            warnings.append(
+                "This agent requests an NPU. GAIA cannot verify NPU availability "
+                "here; ensure your Ryzen AI NPU driver is installed."
+            )
     if reqs.gpu_vram_gb:
-        warnings.append(
-            f"This agent recommends {reqs.gpu_vram_gb:g} GB of GPU VRAM. GAIA "
-            "cannot verify GPU VRAM here."
-        )
+        if detected_gpu_vram_gb is None:
+            warnings.append(
+                f"This agent recommends {reqs.gpu_vram_gb:g} GB of GPU VRAM. GAIA "
+                "cannot verify GPU VRAM here."
+            )
+        elif detected_gpu_vram_gb < reqs.gpu_vram_gb:
+            warnings.append(
+                f"This agent recommends {reqs.gpu_vram_gb:g} GB of GPU VRAM; this "
+                f"machine has {detected_gpu_vram_gb:g} GB. It may run slowly or "
+                "fail to load its model."
+            )
+        # else: detected VRAM meets/exceeds the recommendation — no warning.
 
     return CompatibilityReport(
         compatible=len(blockers) == 0,
@@ -280,4 +316,6 @@ def check_compatibility(
         detected_platform=detected,
         total_memory_gb=round(total_mem, 2) if total_mem is not None else None,
         free_disk_gb=round(free_disk, 2) if free_disk is not None else None,
+        detected_npu=detected_npu,
+        detected_gpu_vram_gb=detected_gpu_vram_gb,
     )

--- a/src/gaia/ui/routers/onboarding.py
+++ b/src/gaia/ui/routers/onboarding.py
@@ -1,0 +1,265 @@
+# Copyright(C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""First-run onboarding endpoints for the GAIA Agent UI (#1726, #1727).
+
+Two concerns live here:
+
+* **Hardware pre-flight** (``GET /api/onboarding/preflight``) — scans RAM, disk,
+  NPU, and GPU VRAM, classifies a hardware *tier*, recommends a first-run
+  profile/model, and runs the shared :func:`gaia.hub.compatibility.check_compatibility`
+  so the wizard shows the *same* blockers/warnings the hub install path would.
+  Detected NPU/GPU are fed into the checker so a no-NPU machine gets a real
+  warning instead of "couldn't verify" (#1727).
+
+* **First-run state** (``GET /api/onboarding/status`` / ``POST
+  /api/onboarding/complete``) — reads and writes the ``~/.gaia/chat/initialized``
+  marker the rest of GAIA already consults (``system_status.initialized``,
+  ``agent_loop`` startup gate), so completing the wizard once suppresses it for
+  good and a CLI ``gaia init`` and the UI wizard agree on "is this set up".
+
+No silent fallbacks: a shortage of disk is a hard blocker with the exact GB
+figures; anything we cannot probe becomes a named warning, never a silent pass.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from gaia.hub.compatibility import check_compatibility
+from gaia.hub.manifest import Requirements
+from gaia.llm.lemonade_client import lemonade_auth_headers, resolve_lemonade_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["onboarding"])
+
+# The light, multimodal default every first-run profile pulls (see
+# ``INIT_PROFILES`` in ``gaia.installer.init_command``). Kept in sync with
+# ``gaia.ui.routers.system._DEFAULT_MODEL_NAME``.
+_RECOMMENDED_MODEL = "Gemma-4-E4B-it-GGUF"
+# Disk the recommended first-run download needs (model + embedder + headroom).
+# Deliberately conservative so we block *before* a half-finished pull fills the
+# disk rather than after.
+_RECOMMENDED_DISK_GB = 6.0
+# RAM below which the recommended model is likely to swap/fail to load.
+_RECOMMENDED_MEMORY_GB = 8.0
+
+_INIT_MARKER = Path.home() / ".gaia" / "chat" / "initialized"
+
+
+def _get_lemonade_base_url() -> str:
+    return os.environ.get("LEMONADE_BASE_URL", "http://localhost:13305/api/v1")
+
+
+async def _probe_lemonade_devices() -> Dict[str, Any]:
+    """Best-effort NPU/GPU probe via Lemonade's ``/system-info``.
+
+    Returns ``{"lemonade_running": bool, "npu_detected": Optional[bool],
+    "gpu_name": Optional[str], "gpu_vram_gb": Optional[float]}``. A ``None`` for
+    a device means we could not determine it (Lemonade down, or it did not
+    report that device) — the caller turns that into a "couldn't verify"
+    warning rather than assuming the hardware is present.
+    """
+    result: Dict[str, Any] = {
+        "lemonade_running": False,
+        "npu_detected": None,
+        "gpu_name": None,
+        "gpu_vram_gb": None,
+    }
+    try:
+        import httpx  # pylint: disable=import-outside-toplevel
+
+        base_url = _get_lemonade_base_url()
+        auth = lemonade_auth_headers(resolve_lemonade_api_key())
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(f"{base_url}/system-info", headers=auth)
+            if resp.status_code != 200:
+                return result
+            result["lemonade_running"] = True
+            devices = resp.json().get("devices", {})
+            # Once Lemonade reports its device table we *do* know whether an NPU
+            # is present — so absence becomes a definite False, not None.
+            npu_seen = False
+            for key, dev in devices.items():
+                if not isinstance(dev, dict):
+                    continue
+                if "gpu" in key.lower():
+                    result["gpu_name"] = dev.get("name") or result["gpu_name"]
+                    vram = dev.get("vram_gb")
+                    if vram is not None:
+                        result["gpu_vram_gb"] = float(vram)
+                if "npu" in key.lower():
+                    npu_seen = True
+                    if dev.get("available"):
+                        result["npu_detected"] = True
+            if result["npu_detected"] is None and npu_seen:
+                result["npu_detected"] = False
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.debug("onboarding: lemonade device probe failed: %s", exc)
+    return result
+
+
+def _classify_tier(ram_gb: Optional[float], npu: Optional[bool]) -> str:
+    """Coarse hardware tier used only to phrase the recommendation."""
+    if ram_gb is None:
+        return "unknown"
+    if ram_gb >= 32 and npu:
+        return "full"
+    if ram_gb >= 16:
+        return "standard"
+    if ram_gb >= _RECOMMENDED_MEMORY_GB:
+        return "light"
+    return "insufficient"
+
+
+class PreflightReport(BaseModel):
+    """Result of the first-run hardware scan."""
+
+    os: Optional[str] = None
+    detected_platform: Optional[str] = None
+    ram_gb: Optional[float] = None
+    disk_free_gb: Optional[float] = None
+    npu_detected: Optional[bool] = None
+    gpu_name: Optional[str] = None
+    gpu_vram_gb: Optional[float] = None
+    lemonade_running: bool = False
+    tier: str = "unknown"
+    recommended_profile: str = "chat"
+    recommended_model: str = _RECOMMENDED_MODEL
+    required_disk_gb: float = _RECOMMENDED_DISK_GB
+    required_memory_gb: float = _RECOMMENDED_MEMORY_GB
+    # ``compatible`` is False only when there is a hard blocker (e.g. no disk).
+    compatible: bool = True
+    blockers: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+
+
+class OnboardingStatus(BaseModel):
+    initialized: bool = False
+    skipped: bool = False
+    completed_at: Optional[str] = None
+
+
+class CompleteOnboardingRequest(BaseModel):
+    # ``skipped`` records that the user bailed out of the wizard (power-user
+    # path) vs. ran it to completion — surfaced back via ``/status`` so the app
+    # can tell the two apart without re-deriving it.
+    skipped: bool = False
+    # ISO-8601 timestamp; the frontend stamps it (the backend has no clock
+    # dependency to keep this testable and cache-stable).
+    completed_at: Optional[str] = None
+
+
+@router.get("/api/onboarding/preflight", response_model=PreflightReport)
+async def onboarding_preflight() -> PreflightReport:
+    """Scan hardware and report whether this machine can run the first-run model.
+
+    Reuses :func:`check_compatibility` so the blockers/warnings match the hub
+    install path exactly, then layers a tier + model recommendation on top.
+    """
+    devices = await _probe_lemonade_devices()
+
+    npu_detected = devices["npu_detected"]
+    gpu_vram = devices["gpu_vram_gb"]
+
+    # Synthesize the recommended first-run download's requirements and run the
+    # shared checker. NPU is recommended (advisory) — a no-NPU box still runs on
+    # GPU/CPU, so we surface it as a warning rather than blocking first run.
+    # The report carries the detected RAM/disk, so we surface those values from
+    # the *same* scan that produced the blockers/warnings — one detection, no
+    # drift between what we display and what we gate on.
+    reqs = Requirements(
+        min_memory_gb=_RECOMMENDED_MEMORY_GB,
+        min_disk_gb=_RECOMMENDED_DISK_GB,
+        npu=True,
+        platforms=[],  # cross-platform; don't block on the platform triple here
+    )
+    report = check_compatibility(
+        reqs,
+        install_dir=Path.home() / ".gaia",
+        detected_npu=npu_detected,
+        detected_gpu_vram_gb=gpu_vram,
+    )
+
+    ram_gb = report.total_memory_gb
+
+    return PreflightReport(
+        os=report.detected_platform,
+        detected_platform=report.detected_platform,
+        ram_gb=round(ram_gb, 1) if ram_gb is not None else None,
+        disk_free_gb=report.free_disk_gb,
+        npu_detected=npu_detected,
+        gpu_name=devices["gpu_name"],
+        gpu_vram_gb=gpu_vram,
+        lemonade_running=devices["lemonade_running"],
+        tier=_classify_tier(ram_gb, npu_detected),
+        recommended_profile="chat",
+        recommended_model=_RECOMMENDED_MODEL,
+        required_disk_gb=_RECOMMENDED_DISK_GB,
+        required_memory_gb=_RECOMMENDED_MEMORY_GB,
+        compatible=report.compatible,
+        blockers=list(report.blockers),
+        warnings=list(report.warnings),
+    )
+
+
+@router.get("/api/onboarding/status", response_model=OnboardingStatus)
+async def onboarding_status() -> OnboardingStatus:
+    """Report whether first-run setup has already completed."""
+    if not _INIT_MARKER.exists():
+        return OnboardingStatus(initialized=False)
+    skipped = False
+    completed_at: Optional[str] = None
+    try:
+        raw = _INIT_MARKER.read_text(encoding="utf-8").strip()
+        if raw:
+            data = json.loads(raw)
+            skipped = bool(data.get("skipped", False))
+            completed_at = data.get("completed_at")
+    except (OSError, json.JSONDecodeError):
+        # A legacy empty/plain marker still counts as initialized — it just
+        # carries no skip/timestamp metadata.
+        pass
+    return OnboardingStatus(
+        initialized=True, skipped=skipped, completed_at=completed_at
+    )
+
+
+@router.post("/api/onboarding/complete", response_model=OnboardingStatus)
+async def onboarding_complete(body: CompleteOnboardingRequest) -> OnboardingStatus:
+    """Write the ``initialized`` marker so the wizard never re-triggers.
+
+    The marker doubles as the same first-run gate the CLI ``gaia init`` and the
+    agent-loop startup check read, so UI and CLI stay in lock-step.
+    """
+    payload = {
+        "skipped": body.skipped,
+        "completed_at": body.completed_at,
+        "source": "agent-ui-onboarding",
+    }
+    try:
+        _INIT_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _INIT_MARKER.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError as exc:
+        # Fail loudly — a swallowed write here would re-show the wizard forever.
+        from fastapi import HTTPException  # local import: rare error path
+
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"Could not write onboarding marker at {_INIT_MARKER}: {exc}. "
+                "Check that your home directory is writable, then retry."
+            ),
+        ) from exc
+    logger.info("Onboarding marked complete (skipped=%s)", body.skipped)
+    return OnboardingStatus(
+        initialized=True, skipped=body.skipped, completed_at=body.completed_at
+    )

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -59,6 +59,7 @@ from .routers import goals as goals_router_mod
 from .routers import hub as hub_router_mod
 from .routers import mcp as mcp_router_mod
 from .routers import memory as memory_router_mod
+from .routers import onboarding as onboarding_router_mod
 from .routers import schedules as schedules_router_mod
 from .routers import sessions as sessions_router_mod
 from .routers import system as system_router_mod
@@ -576,6 +577,7 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
 
     # ── Include Routers ──────────────────────────────────────────────────
     app.include_router(system_router_mod.router)
+    app.include_router(onboarding_router_mod.router)
     # Hub routes (catalog/install/...) MUST precede the agents router: that
     # router has a greedy GET /api/agents/{agent_id:path} that would otherwise
     # capture /api/agents/catalog and /api/agents/{id}/install-status.

--- a/tests/unit/test_hub_compatibility.py
+++ b/tests/unit/test_hub_compatibility.py
@@ -84,6 +84,53 @@ def test_report_to_dict_round_trips(monkeypatch):
     assert set(
         ["compatible", "platform_ok", "memory_ok", "disk_ok", "warnings", "blockers"]
     ).issubset(d)
+    # Detected NPU/GPU fields are always present (default None).
+    assert "detected_npu" in d
+    assert "detected_gpu_vram_gb" in d
+
+
+# ---------------------------------------------------------------------------
+# Detected NPU / GPU wiring (#1727): a real hardware scan turns the advisory
+# NPU/GPU checks into concrete pass/warning states instead of blanket
+# "cannot verify" — but never a silent pass.
+# ---------------------------------------------------------------------------
+
+
+def test_detected_npu_present_suppresses_warning(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility({"platforms": [], "npu": True}, detected_npu=True)
+    assert report.compatible is True
+    assert not any("NPU" in w for w in report.warnings)
+    assert report.detected_npu is True
+
+
+def test_detected_npu_absent_is_named_warning(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility({"platforms": [], "npu": True}, detected_npu=False)
+    assert report.compatible is True  # advisory, not a hard blocker
+    assert any("none was detected" in w for w in report.warnings)
+
+
+def test_unprobed_npu_keeps_cannot_verify_warning(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility({"platforms": [], "npu": True})
+    assert any("cannot verify NPU" in w for w in report.warnings)
+
+
+def test_detected_gpu_vram_below_requirement_warns(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility(
+        {"platforms": [], "gpu_vram_gb": 16}, detected_gpu_vram_gb=8.0
+    )
+    assert any("16 GB of GPU VRAM" in w and "8" in w for w in report.warnings)
+
+
+def test_detected_gpu_vram_meets_requirement_no_warning(monkeypatch):
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+    report = check_compatibility(
+        {"platforms": [], "gpu_vram_gb": 8}, detected_gpu_vram_gb=16.0
+    )
+    assert not any("VRAM" in w for w in report.warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_onboarding_router.py
+++ b/tests/unit/test_onboarding_router.py
@@ -1,0 +1,163 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the first-run onboarding router (gaia.ui.routers.onboarding)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gaia.hub import compatibility
+from gaia.ui.routers import onboarding as onboarding_mod
+from gaia.ui.server import create_app
+
+
+@pytest.fixture
+def marker(tmp_path, monkeypatch):
+    """Redirect the init marker to a temp file so tests never touch ~/.gaia."""
+    path = tmp_path / ".gaia" / "chat" / "initialized"
+    monkeypatch.setattr(onboarding_mod, "_INIT_MARKER", path)
+    return path
+
+
+@pytest.fixture
+def client(marker):  # noqa: ARG001 - marker fixture applies the monkeypatch
+    app = create_app(db_path=":memory:")
+    return TestClient(app)
+
+
+def _stub_devices(**overrides):
+    base = {
+        "lemonade_running": True,
+        "npu_detected": True,
+        "gpu_name": "Radeon 780M",
+        "gpu_vram_gb": 16.0,
+    }
+    base.update(overrides)
+
+    async def _probe():
+        return base
+
+    return _probe
+
+
+# ── preflight ────────────────────────────────────────────────────────────
+
+
+def test_preflight_full_tier_compatible(client, monkeypatch):
+    monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _stub_devices())
+    monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 32.0)
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+
+    resp = client.get("/api/onboarding/preflight")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["compatible"] is True
+    assert body["blockers"] == []
+    assert body["tier"] == "full"
+    assert body["npu_detected"] is True
+    assert body["recommended_model"] == "Gemma-4-E4B-it-GGUF"
+    # NPU present ⇒ no NPU warning.
+    assert not any("NPU" in w for w in body["warnings"])
+
+
+def test_preflight_no_npu_emits_warning(client, monkeypatch):
+    monkeypatch.setattr(
+        onboarding_mod, "_probe_lemonade_devices", _stub_devices(npu_detected=False)
+    )
+    monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 16.0)
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+
+    body = client.get("/api/onboarding/preflight").json()
+    assert body["compatible"] is True  # advisory, still runnable
+    assert body["tier"] == "standard"
+    assert any("none was detected" in w for w in body["warnings"])
+
+
+def test_preflight_low_disk_is_blocker(client, monkeypatch):
+    monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _stub_devices())
+    monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 32.0)
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 0.5)
+
+    body = client.get("/api/onboarding/preflight").json()
+    assert body["compatible"] is False
+    assert any("disk" in b.lower() for b in body["blockers"])
+
+
+def test_preflight_insufficient_ram_warns(client, monkeypatch):
+    monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _stub_devices())
+    monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 4.0)
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+
+    body = client.get("/api/onboarding/preflight").json()
+    assert body["tier"] == "insufficient"
+    assert any("RAM" in w for w in body["warnings"])
+    # Low RAM is advisory, not a hard block.
+    assert body["compatible"] is True
+
+
+def test_preflight_lemonade_down_leaves_npu_unknown(client, monkeypatch):
+    async def _probe():
+        return {
+            "lemonade_running": False,
+            "npu_detected": None,
+            "gpu_name": None,
+            "gpu_vram_gb": None,
+        }
+
+    monkeypatch.setattr(onboarding_mod, "_probe_lemonade_devices", _probe)
+    monkeypatch.setattr(compatibility, "detect_total_memory_gb", lambda: 16.0)
+    monkeypatch.setattr(compatibility, "detect_free_disk_gb", lambda _p: 500.0)
+
+    body = client.get("/api/onboarding/preflight").json()
+    assert body["npu_detected"] is None
+    assert body["lemonade_running"] is False
+    # Unprobed NPU falls back to the conservative "cannot verify" message.
+    assert any("cannot verify NPU" in w for w in body["warnings"])
+
+
+# ── status / complete ──────────────────────────────────────────────────────
+
+
+def test_status_uninitialized(client, marker):
+    assert not marker.exists()
+    body = client.get("/api/onboarding/status").json()
+    assert body["initialized"] is False
+    assert body["skipped"] is False
+
+
+def test_complete_then_status(client, marker):
+    resp = client.post(
+        "/api/onboarding/complete",
+        json={"skipped": False, "completed_at": "2026-07-17T00:00:00Z"},
+    )
+    assert resp.status_code == 200
+    assert marker.exists()
+
+    body = client.get("/api/onboarding/status").json()
+    assert body["initialized"] is True
+    assert body["skipped"] is False
+    assert body["completed_at"] == "2026-07-17T00:00:00Z"
+
+
+def test_complete_skipped_records_skip(client, marker):
+    client.post("/api/onboarding/complete", json={"skipped": True})
+    body = client.get("/api/onboarding/status").json()
+    assert body["initialized"] is True
+    assert body["skipped"] is True
+
+
+def test_legacy_empty_marker_counts_as_initialized(client, marker):
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("", encoding="utf-8")
+    body = client.get("/api/onboarding/status").json()
+    assert body["initialized"] is True
+    assert body["skipped"] is False
+
+
+def test_detected_npu_flows_into_shared_checker():
+    """Regression guard: the router feeds detected NPU into check_compatibility."""
+    from gaia.hub.manifest import Requirements
+
+    report = compatibility.check_compatibility(
+        Requirements(npu=True), detected_npu=False
+    )
+    assert any("none was detected" in w for w in report.warnings)


### PR DESCRIPTION
## Why this matters

Before: a first-time user had no guided path — models and connectors could only be set up from the terminal (`gaia init`), a machine that couldn't meet an agent's requirements only found out at runtime, and a failed model download was swallowed silently. After: opening the Agent UI on a fresh machine launches an in-app wizard that scans the hardware and gates on real capability (RAM/disk/NPU/GPU), downloads the recommended model with visible progress and retry, and offers to connect an app (e.g. Google for Email triage) before first run. A non-technical user reaches a working chat without touching a terminal.

Bundles the two first-run issues since they share one flow: **#1726** (onboarding wizard + in-app model download) and **#1727** (hardware pre-flight gating + connector-on-install).

Every failure state is loud and actionable — a hardware blocker disables *Continue* and names the shortfall, a failed download shows the backend's message with a Retry, and a missing OAuth credential shows exactly which env vars to set. Nothing silently skips to leave a half-set-up app.

## What's in it

- **Hardware pre-flight (#1727):** detected NPU / GPU VRAM now feed `hub.compatibility.check_compatibility`, so a no-NPU machine gets a real warning instead of a blanket "cannot verify" (values default to `None` to preserve the conservative fallback). New `GET /api/onboarding/preflight` runs the *same* shared checker the hub install path uses, so blockers match.
- **Onboarding state:** `/api/onboarding/status` + `/complete` over the existing `~/.gaia/chat/initialized` marker the CLI and agent-loop already read — UI and CLI stay in lock-step, and completing once suppresses the wizard for good.
- **In-app model download (#1726):** reuses `POST /api/system/download-model` and its status-fed SSE progress — no new download backend. Visible progress bar + Retry on failure.
- **Connect-on-install (#1727):** reuses the existing connector authorize flow; does **not** rebuild grant logic (that lives in the connectors framework, #2117/#2118) — coded against today's `authorize`/`getConnector` interface.
- **Wizard UI:** new `components/onboarding/` (welcome → pre-flight → download → optional connector → done), driven by a pure, unit-tested `useOnboarding` state machine. Isolated to new files; App.tsx edits are minimal (mount + first-run check).

## Test plan

- [x] Backend unit tests — `python -m pytest tests/unit/test_onboarding_router.py tests/unit/test_hub_compatibility.py` (36 passed): pre-flight tiers/blockers/warnings, NPU present/absent/unknown, GPU VRAM below/meets requirement, status/complete marker round-trip.
- [x] Frontend unit tests — `npm run test` in `src/gaia/apps/webui` (195 passed, incl. 13 new): `useOnboarding` state machine (advance/back/guard/skip/goTo) + wizard flow (welcome skip, scan, blocker gating, advance).
- [x] Type-check + build — `npm run build` (tsc + vite) clean.
- [x] Lint — black / isort / flake8 / pylint clean on changed files.
- [x] **Manual first-run walkthrough** (Playwright, real backend on a fresh `~/.gaia`): welcome → hardware check (Tier: Full, RAM/disk/NPU all green, Continue enabled) → model download (Continue correctly *gated* until the model is ready; explicit "Set up later" escape) → Google connector (optional; loud "OAuth credentials not configured" with the exact env vars) → "You're all set". Screenshots captured for each step.

To verify locally:
```bash
# Terminal 1 — backend
python -m gaia.ui.server --port 4200 --host 127.0.0.1
# Terminal 2 — build + open (fresh machine: no ~/.gaia/chat/initialized)
cd src/gaia/apps/webui && npm ci && npm run build
# open http://127.0.0.1:4200 — the wizard overlays until setup completes
```

Part of #2014
Closes #1726
Closes #1727