### PR TITLE
refactor(api): remove the last in-process email mount; relay via daemon (#2176)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,15 +129,12 @@ setup(
             "fastapi>=0.115.0",
             "uvicorn>=0.32.0",
             "python-multipart>=0.0.9",
-            # Async client for the /v1/<agent>/query daemon relay (#2178): the
-            # API server streams SSE from the daemon unbuffered via httpx.
+            # Async client for the /v1/<agent>/* daemon relay (#2178): the API
+            # server streams SSE from the daemon unbuffered via httpx. This is
+            # the sole path to agent surfaces now — no agent is mounted
+            # in-process (#2176), so [api] carries no per-agent deps (keyring is
+            # already a core install_requires dep for `gaia connectors`, #1621).
             "httpx>=0.27.0",
-            # [api] auto-mounts the gaia-agent-email REST router (openai_server.py),
-            # whose import chain reaches gaia.connectors.store -> `import keyring`
-            # at module load AND at request time (connected_mailbox_providers).
-            # Declare it so `amd-gaia[api]` + gaia-agent-email starts & serves triage
-            # with zero manual installs. Same pin as [ui]/[dev]. See #1617.
-            "keyring>=24.0.0,<26.0.0",
         ],
         "ui": [
             "fastapi>=0.115.0",

--- a/src/gaia/api/agent_proxy.py
+++ b/src/gaia/api/agent_proxy.py
@@ -39,6 +39,7 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
+from starlette.convertors import Convertor, register_url_convertor
 
 from gaia.daemon.errors import DaemonError
 from gaia.logger import get_logger
@@ -56,12 +57,53 @@ CONNECT_TIMEOUT = 10.0
 #: daemon, so it matches the daemon relay's own long per-request budget.
 READ_TIMEOUT = 300.0
 
+#: HTTP methods the fixed-function relay accepts. OPTIONS/HEAD are intentionally
+#: left to the CORS middleware / FastAPI defaults.
+RELAY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+
 #: First-segment ids owned by the OpenAI-compatible surface — never relayed as
-#: agents. The proxy only claims the ``/v1/<agent>/query`` surface (so it can't
-#: shadow the OpenAI routes' 404/405 semantics), but ``/v1/chat/query`` and
-#: ``/v1/models/query`` would still match the pattern; this blocks them so a
-#: reserved id can never masquerade as an agent.
+#: agents. The ``/v1/<agent>/query`` routes use the default ``{agent_id}``
+#: convertor and reject these ids in-handler (a stray ``/v1/chat/query`` →
+#: 404). The fixed-function catch-all instead uses the ``relayagent`` convertor
+#: below, whose regex refuses these ids at *routing* time so it never shadows
+#: the OpenAI routes' native 404/405 (e.g. ``GET /v1/chat/completions`` → 405).
 _RESERVED_AGENT_IDS = frozenset({"chat", "models"})
+
+
+class _RelayAgentConvertor(Convertor):
+    """Path convertor for the fixed-function relay's ``{agent_id}`` segment.
+
+    Matches any single segment EXCEPT the reserved OpenAI ids (``chat`` /
+    ``models``). A plain ``{agent_id}`` would match ``GET /v1/chat/completions``
+    and steal FastAPI's native 405; refusing reserved ids at match time leaves
+    those paths to the OpenAI routes' own 404/405 semantics.
+    """
+
+    regex = "(?!chat/)(?!models/)[^/]+"
+
+    def convert(self, value: str) -> str:
+        return value
+
+    def to_string(self, value: str) -> str:
+        return value
+
+
+class _RelaySubpathConvertor(Convertor):
+    """Path convertor for the relay's trailing sub-path — like ``:path`` but
+    NON-empty, so ``/v1/<agent>`` and ``/v1/nonexistent`` (no sub-path) fall
+    through to FastAPI's 404 instead of being relayed as an agent root."""
+
+    regex = ".+"
+
+    def convert(self, value: str) -> str:
+        return value
+
+    def to_string(self, value: str) -> str:
+        return value
+
+
+register_url_convertor("relayagent", _RelayAgentConvertor())
+register_url_convertor("relaysubpath", _RelaySubpathConvertor())
 
 # Hop-by-hop headers never forwarded in either direction (RFC 9110 §7.6.1).
 _HOP_BY_HOP = frozenset(
@@ -216,15 +258,24 @@ async def _acquire_daemon():
 
 
 def build_agent_proxy_router() -> APIRouter:
-    """API-key-guarded router relaying the ``/v1/<agent>/query`` surface to the
-    daemon's streaming relay (#2150). The daemon does the sidecar-bearer swap, so
-    this proxy holds only the daemon client token.
+    """API-key-guarded router relaying the ``/v1/<agent>/*`` surface to the
+    daemon's relay (#2150). The daemon does the sidecar-bearer swap, so this
+    proxy holds only the daemon client token.
 
-    Scoped to ``POST /v1/{agent}/query`` and ``POST
-    /v1/{agent}/query/{run_id}/cancel`` on purpose: a generic ``/v1/{agent}/*``
-    catch-all would swallow the OpenAI surface's own 404/405 (e.g. ``GET
-    /v1/chat/completions`` or ``GET /v1/nonexistent``) behind this router's
-    API-key dependency. Narrow routes leave those to FastAPI's default routing.
+    Two kinds of route, both API-key gated:
+
+    * ``POST /v1/{agent}/query`` and ``.../query/{run_id}/cancel`` — the
+      streaming agent loop (SSE, relayed unbuffered).
+    * ``{METHOD} /v1/{agent}/{subpath}`` — the fixed-function agent surface
+      (e.g. the email agent's ``/v1/email/{triage,draft,send,health,…}``),
+      buffered passthrough. Without this, those routes 404 on ``gaia api`` even
+      though the sidecar serves them (#2176).
+
+    The fixed-function catch-all uses the ``relayagent`` convertor so it refuses
+    the reserved OpenAI ids at routing time (never shadowing ``GET
+    /v1/chat/completions``'s 405) and the ``relaysubpath`` convertor so a bare
+    ``/v1/<agent>`` / ``/v1/nonexistent`` still yields FastAPI's 404. The
+    ``/query`` routes are declared first so they win for that exact path.
     """
     require_api_key = build_require_api_key()
     router = APIRouter(dependencies=[Depends(require_api_key)])
@@ -236,6 +287,12 @@ def build_agent_proxy_router() -> APIRouter:
     @router.post("/v1/{agent_id}/query/{run_id}/cancel")
     async def proxy_query_cancel(agent_id: str, run_id: str, request: Request):
         return await _relay(agent_id, f"query/{run_id}/cancel", request)
+
+    @router.api_route(
+        "/v1/{agent_id:relayagent}/{path:relaysubpath}", methods=RELAY_METHODS
+    )
+    async def proxy_fixed(agent_id: str, path: str, request: Request):
+        return await _relay(agent_id, path, request)
 
     async def _relay(agent_id: str, path: str, request: Request):
         if agent_id in _RESERVED_AGENT_IDS:

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -14,7 +14,6 @@ Endpoints:
 """
 
 import asyncio
-import importlib.util
 import json
 import logging
 import os
@@ -126,26 +125,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Email Triage Agent REST surface (#1229): POST /v1/email/{triage,draft,send}.
-# Ships with the standalone ``gaia-agent-email`` wheel (#1102); mount it only
-# when that wheel is installed so the core API server still starts without it.
-# Gate on the wheel's presence via find_spec (no import side effect), then
-# import the router OUTSIDE the gate so a genuine broken import inside an
-# installed wheel fails loudly rather than being swallowed as "not installed"
-# (no-silent-fallback rule).
-if importlib.util.find_spec("gaia_agent_email") is None:
-    logger.info(
-        "Email REST routes unavailable: install the email agent "
-        "(`pip install gaia-agent-email`) to enable POST /v1/email/*."
-    )
-else:
-    from gaia_agent_email.agent_routes import router as email_agent_router
-    from gaia_agent_email.api_routes import router as email_router
-
-    app.include_router(email_router)
-    # Stateful conversational surface (/v1/email/agent/*): session-scoped agent
-    # with memory + tool-confirmation, for hosts driving the full agent over HTTP.
-    app.include_router(email_agent_router)
+# The email agent's REST surface (POST /v1/email/*) is no longer mounted
+# in-process (#2176). It was the last in-process agent mount after the v2
+# thin-host migration (#1896); the API server now reaches every agent —
+# email included — the same way the UI does: as a thin client of the
+# always-on daemon, via the /v1/<agent>/* relay mounted below (#2178 / V2-17).
+# So `gaia api` exposes /v1/email/{triage,draft,send,...} by relaying to the
+# out-of-process email sidecar, never by importing that wheel in-process.
 
 
 # Raw request logging middleware (debug mode only)

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -612,11 +612,12 @@ async def health_check():
     return {"status": "ok", "service": "gaia-api"}
 
 
-# Agent /query surface (#2178 / V2-17): POST /v1/<agent>/query streams the
-# agentic loop through the always-on daemon relay (#2150). Mounted after the
-# OpenAI-compatible routes are declared; the router only claims the narrow
-# /v1/<agent>/query surface, so it never shadows /v1/chat/completions or
-# /v1/models (nor their 404/405). The API server stays a thin client — it
-# forwards only the daemon client token, never a sidecar bearer. Gated by
-# GAIA_API_KEY (§0.33), independent of the email wheel.
+# Agent /v1/<agent>/* surface (#2178 / V2-17, #2176): the /query loop streams
+# through the always-on daemon relay (#2150); the fixed-function agent routes
+# (e.g. the email agent's /v1/email/{triage,draft,send,…}) relay buffered.
+# Mounted after the OpenAI-compatible routes are declared; the router refuses the
+# reserved chat/models ids at routing time, so it never shadows
+# /v1/chat/completions or /v1/models (nor their 404/405). The API server stays a
+# thin client — it forwards only the daemon client token, never a sidecar
+# bearer. Gated by GAIA_API_KEY (§0.33), independent of the email wheel.
 app.include_router(build_agent_proxy_router())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1261,11 +1261,26 @@ class TestErrorResponseFormat:
 # =============================================================================
 #
 # These exercise the /v1/email/* endpoints exposed by the gaia-agent-email
-# wheel (gaia_agent_email.api_routes), mounted conditionally by openai_server.
+# wheel (gaia_agent_email.api_routes). The email agent is no longer mounted
+# in-process on the core API server (#2176) — `gaia api` reaches it via the
+# daemon relay. So these contract tests run against the wheel's OWN app (the
+# same standalone app the OpenAPI exporter builds), decoupled from `gaia api`.
 # The triage endpoint accepts / returns the FROZEN #1262 contract
 # (gaia_agent_email.contract). The send endpoint enforces the confirmation
 # gate (#1264) at the API boundary: a send without a valid confirmation token
 # is rejected with a 4xx — never silently auto-confirmed.
+
+
+def _email_test_app():
+    """Standalone FastAPI app mounting only the email wheel's REST router.
+
+    Post-#2176 the core API server holds no email routes, so these tests build
+    the email surface directly from the wheel — the exact app its OpenAPI
+    exporter and freeze/sidecar servers mount.
+    """
+    from gaia_agent_email.export_openapi import build_app
+
+    return build_app()
 
 
 def _single_email_payload(
@@ -1373,7 +1388,7 @@ class TestEmailTriageEndpoint:
         task_store.init_schema(task_db)
         monkeypatch.setattr(email_routes, "resolve_action_db", lambda: task_db)
 
-        self.client = TestClient(app)
+        self.client = TestClient(_email_test_app())
 
     def test_single_email_in_structured_out(self):
         """A single email in returns a contract-valid structured result."""
@@ -1499,7 +1514,7 @@ class TestEmailSendConfirmationGate:
         monkeypatch.setattr(
             email_routes, "resolve_send_backend", lambda: self.fake_backend
         )
-        self.client = TestClient(app)
+        self.client = TestClient(_email_test_app())
 
     def test_send_without_confirmation_token_is_4xx(self):
         """No confirmation token → server-side rejection in the 4xx range."""
@@ -1685,7 +1700,7 @@ class TestEmailSendOffLoop:
 
         monkeypatch.setattr(email_routes, "resolve_send_backend", _LoopAssertingBackend)
 
-        client = TestClient(app)
+        client = TestClient(_email_test_app())
         # Get a valid token first
         draft_resp = client.post(
             "/v1/email/draft",
@@ -1744,7 +1759,7 @@ class TestEmailSendOutlook502Fix:
                 return {"id": "", "sent": True, "to": to, "subject": subject}
 
         monkeypatch.setattr(email_routes, "resolve_send_backend", _OutlookLikeBackend)
-        client = TestClient(app)
+        client = TestClient(_email_test_app())
         draft = client.post(
             "/v1/email/draft",
             json={
@@ -1787,7 +1802,7 @@ class TestEmailSendOutlook502Fix:
                 return {"id": ""}  # No 'sent' key — unknown failure
 
         monkeypatch.setattr(email_routes, "resolve_send_backend", _SilentNoOpBackend)
-        client = TestClient(app)
+        client = TestClient(_email_test_app())
         draft = client.post(
             "/v1/email/draft",
             json={

--- a/tests/unit/agents/email/test_draft_token_provider_binding.py
+++ b/tests/unit/agents/email/test_draft_token_provider_binding.py
@@ -27,9 +27,14 @@ pytest.importorskip("gaia_agent_email")
 import gaia_agent_email.api_routes as email_routes
 from fastapi.testclient import TestClient
 
-# The FastAPI app the email router is mounted on.
+# The email agent is no longer mounted in-process on the core API server
+# (#2176); build its standalone REST app directly — the same app the OpenAPI
+# exporter and the sidecar mount, so these binding tests exercise the real
+# email surface, not the (removed) `gaia api` mount.
 try:
-    from gaia.api.openai_server import app
+    from gaia_agent_email.export_openapi import build_app as _build_email_app
+
+    app = _build_email_app()
 except ImportError:
     app = None
 

--- a/tests/unit/test_api_agent_proxy.py
+++ b/tests/unit/test_api_agent_proxy.py
@@ -186,6 +186,52 @@ def test_reserved_chat_query_not_relayed_as_agent(api_client, with_api_key):
 
 
 @needs_fastapi
+def test_fixed_function_route_claimed_by_relay_not_404(api_client, no_api_key):
+    """Regression for #2176: a fixed-function agent route (e.g. the email
+    agent's POST /v1/email/triage) must be CLAIMED by the relay on ``gaia api``,
+    not answered with FastAPI's 404. With no API key configured it hits the
+    relay's own 503 (surface disabled) — proving the route reaches the relay
+    (before the fix it 404'd because the relay only claimed /query)."""
+    r = api_client.post("/v1/email/triage", json={"payload": {}})
+    assert r.status_code == 503
+    assert API_KEY_ENV in r.json()["detail"]  # names the remedy
+
+
+@needs_fastapi
+def test_fixed_function_route_daemon_down_is_loud_503(
+    api_client, with_api_key, monkeypatch
+):
+    """A fixed-function route with the daemon down fails loud (503), never a
+    silent in-process fallback (#2176)."""
+    from gaia.daemon.errors import DaemonStartError
+
+    def _boom():
+        raise DaemonStartError("the daemon did not become healthy within 30s.")
+
+    monkeypatch.setattr("gaia.daemon.client.start_or_attach", _boom)
+    r = api_client.post(
+        "/v1/email/triage",
+        json={"payload": {}},
+        headers={"Authorization": f"Bearer {_API_KEY}"},
+    )
+    assert r.status_code == 503
+    assert "gaia daemon status" in r.json()["detail"]  # names where to look
+
+
+@needs_fastapi
+def test_fixed_function_reserved_id_not_relayed(api_client, with_api_key):
+    """The fixed-function catch-all must not relay the reserved OpenAI ids: a
+    two-segment /v1/chat/<x> is not an agent route (never reaches the daemon)."""
+    r = api_client.post(
+        "/v1/chat/completions/extra",
+        json={},
+        headers={"Authorization": f"Bearer {_API_KEY}"},
+    )
+    # 'chat' is refused by the relayagent convertor, so nothing matches → 404.
+    assert r.status_code == 404
+
+
+@needs_fastapi
 def test_openai_routes_not_shadowed_by_relay(api_client, with_api_key):
     """/v1/models and /v1/chat/completions keep their own handlers even with the
     query relay mounted and an API key set."""
@@ -253,7 +299,7 @@ class _FakeDaemon:
         import asyncio
 
         from fastapi import FastAPI, Request
-        from fastapi.responses import StreamingResponse
+        from fastapi.responses import JSONResponse, StreamingResponse
 
         app = FastAPI()
         daemon = self
@@ -264,6 +310,14 @@ class _FakeDaemon:
         )
         async def relay(agent_id: str, path: str, request: Request):
             daemon.seen_auth.append(request.headers.get("authorization"))
+
+            # Fixed-function (non-/query) routes answer buffered JSON, mimicking
+            # the daemon relaying a sidecar's e.g. /v1/email/triage response.
+            if path != "query" and not path.endswith("/cancel"):
+                return JSONResponse(
+                    {"agent": agent_id, "path": path, "relayed": True},
+                    status_code=200,
+                )
 
             async def _events():
                 try:
@@ -397,6 +451,34 @@ def test_sse_relayed_unbuffered_first_event_before_upstream_completes(live_proxy
         daemon.release.set()
         rest = list(events)
     assert [e["type"] for e in rest] == ["final"]
+
+
+@needs_live_servers
+def test_fixed_function_relayed_buffered_through_core_server(live_proxy):
+    """End-to-end regression for #2176: a fixed-function agent route relays
+    through the REAL ``gaia api`` server (buffered passthrough) to the daemon —
+    status, body, and the DAEMON token all cross. This is the coverage that
+    exercises the email fixed-function surface via the core server, not only the
+    wheel's own app."""
+    import requests
+
+    daemon, api_url = live_proxy
+    r = requests.post(
+        f"{api_url}/v1/email/triage",
+        json={"payload": {"kind": "single"}},
+        headers=_auth(),
+        timeout=(5, 15),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"agent": "email", "path": "triage", "relayed": True}
+    # A GET fixed-function route relays too (email health/version/init are GET).
+    rg = requests.get(f"{api_url}/v1/email/health", headers=_auth(), timeout=(5, 15))
+    assert rg.status_code == 200
+    assert rg.json()["path"] == "health"
+    # The daemon saw the DAEMON client token, never the API key.
+    assert daemon.seen_auth[-1] == f"Bearer {_DAEMON_TOKEN}"
+    assert f"Bearer {_API_KEY}" not in daemon.seen_auth
 
 
 @needs_live_servers

--- a/tests/unit/test_api_extras.py
+++ b/tests/unit/test_api_extras.py
@@ -1,19 +1,25 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""Regression test for issue #1617.
+"""Packaging + wiring guards for the [api] server (issues #1617, #2176).
 
-The [api] server (gaia.api.openai_server) auto-mounts the gaia-agent-email
-REST router when that wheel is importable. Its import chain reaches
-``import keyring`` at module load time (openai_server -> email_router ->
-gaia.connectors.api -> gaia.connectors.store) AND at request time via
-``connected_mailbox_providers()``. Because ``keyring`` was only declared in
-the ``[ui]`` and ``[dev]`` extras — not in ``[api]`` — a deployment of
-``pip install 'amd-gaia[api]' gaia-agent-email`` would crash on startup with
-``ModuleNotFoundError: No module named 'keyring'``.
+History: [api] used to auto-mount the gaia-agent-email REST router in-process
+(openai_server.py), whose import chain reached ``import keyring``, so #1617
+declared keyring in [api]. That in-process mount was the last one after the v2
+thin-host migration and has now been removed (#2176): the API server reaches
+every agent — email included — only through the daemon relay (/v1/<agent>/*).
 
-This is a packaging assertion, not a runtime import test, so it works in the
-CI unit-tests venv that does not actually install ``[api]``. Same framing as
+So this file now asserts the thin-host arrangement instead:
+
+* the API server no longer imports gaia_agent_email in-process (#2176);
+* keyring is still guaranteed for ``pip install 'amd-gaia[api]'`` because it is
+  a *core* install_requires dep (``gaia connectors`` needs it, #1621) — it does
+  not need to be re-declared per-agent in [api];
+* gaia-agent-email still depends on ``amd-gaia[api]`` so its sidecar gets the
+  REST-server deps (fastapi/uvicorn) automatically.
+
+These are static packaging/source assertions (no runtime import), so they work
+in the CI unit-tests venv that does not actually install [api]. Same framing as
 test_ui_extras.py's #845 docstring.
 """
 
@@ -22,55 +28,90 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-SETUP_PY = Path(__file__).resolve().parents[2] / "setup.py"
-EMAIL_PYPROJECT = (
-    Path(__file__).resolve().parents[2]
-    / "hub"
-    / "agents"
-    / "python"
-    / "email"
-    / "pyproject.toml"
-)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_PY = REPO_ROOT / "setup.py"
+OPENAI_SERVER = REPO_ROOT / "src" / "gaia" / "api" / "openai_server.py"
+EMAIL_PYPROJECT = REPO_ROOT / "hub" / "agents" / "python" / "email" / "pyproject.toml"
 
 
-def _parse_api_extra() -> list[str]:
-    """Extract the list of requirement strings from setup.py[api].
+def _parse_extra(name: str) -> list[str]:
+    """Extract the requirement strings from a named extras_require block.
 
     Walks the file line by line so brackets that appear inside ``# comments``
     don't confuse a naive non-greedy regex match.
     """
-    lines = SETUP_PY.read_text().splitlines()
+    lines = SETUP_PY.read_text(encoding="utf-8").splitlines()
     in_block = False
     body: list[str] = []
     for raw in lines:
         stripped = raw.strip()
         if not in_block:
-            if re.match(r'"api"\s*:\s*\[', stripped):
+            if re.match(rf'"{re.escape(name)}"\s*:\s*\[', stripped):
                 in_block = True
             continue
         if stripped.startswith("]"):
             break
-        # Skip comment-only lines so brackets in comments don't matter.
         if stripped.startswith("#"):
             continue
         body.append(raw)
-    assert in_block, 'Could not find "api" extra in setup.py extras_require'
+    assert in_block, f'Could not find "{name}" extra in setup.py extras_require'
     return re.findall(r'"([^"]+)"', "\n".join(body))
 
 
-def test_api_extra_declares_keyring() -> None:
-    """setup.py[api] must declare keyring — see #1617.
+def _parse_install_requires() -> list[str]:
+    """Extract the core install_requires list from setup.py."""
+    lines = SETUP_PY.read_text(encoding="utf-8").splitlines()
+    in_block = False
+    body: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if not in_block:
+            if re.match(r"install_requires\s*=\s*\[", stripped):
+                in_block = True
+            continue
+        if stripped.startswith("]"):
+            break
+        if stripped.startswith("#"):
+            continue
+        body.append(raw)
+    assert in_block, "Could not find install_requires in setup.py"
+    return re.findall(r'"([^"]+)"', "\n".join(body))
 
-    The import chain openai_server -> email_router -> gaia.connectors.api ->
-    gaia.connectors.store reaches ``import keyring`` at module load AND at
-    request time via ``connected_mailbox_providers()``.
+
+def test_api_server_does_not_mount_email_in_process() -> None:
+    """The API server must not import/mount the email agent in-process (#2176).
+
+    After the thin-host migration the only path to any agent surface is the
+    daemon relay; a re-introduced ``import gaia_agent_email`` here would resurrect
+    the last in-process mount and force the API server to hold sidecar deps again.
     """
-    api_reqs = _parse_api_extra()
-    matches = [r for r in api_reqs if r.lower().startswith("keyring")]
-    assert matches, (
-        "setup.py[api] is missing 'keyring' (needed by "
-        "openai_server -> email_router -> gaia.connectors.api -> store -> `import keyring`).\n"
-        f"Current [api] extra: {api_reqs}"
+    src = OPENAI_SERVER.read_text(encoding="utf-8")
+    offending = re.findall(r"^\s*(?:import|from)\s+gaia_agent_email\b", src, re.M)
+    assert not offending, (
+        "openai_server.py must not import gaia_agent_email — the in-process "
+        "email mount was removed in #2176; agents are reached via the daemon "
+        f"relay (/v1/<agent>/*). Found: {offending}"
+    )
+
+
+def test_keyring_guaranteed_for_api_installs_via_core() -> None:
+    """``pip install 'amd-gaia[api]'`` still gets keyring — from core, not [api].
+
+    keyring moved to core install_requires with ``gaia connectors`` (#1621), so
+    [api] no longer needs to re-declare it (#2176). This asserts the guarantee is
+    still in place at its correct home and that [api] doesn't redundantly repeat
+    it now that the email mount (its only [api]-level consumer) is gone.
+    """
+    core = _parse_install_requires()
+    assert any(
+        r.lower().startswith("keyring") for r in core
+    ), f"core install_requires must declare keyring (#1621); got {core}"
+
+    api_reqs = _parse_extra("api")
+    assert not any(r.lower().startswith("keyring") for r in api_reqs), (
+        "setup.py[api] should not re-declare keyring — it is a core "
+        "install_requires dep (#1621) and the in-process email mount that "
+        f"needed it in [api] was removed (#2176). Current [api] extra: {api_reqs}"
     )
 
 
@@ -78,13 +119,14 @@ def test_email_wheel_requires_amd_gaia_api_extra() -> None:
     """gaia-agent-email must depend on ``amd-gaia[api]`` — see #1617.
 
     A bare ``amd-gaia`` dependency let a consuming app's
-    ``pip install gaia-agent-email`` resolve core WITHOUT the [api] extra, so
-    the REST-server deps (fastapi/uvicorn) and keyring were absent and
-    ``gaia api`` crashed. Requesting the [api] extra pulls them automatically.
+    ``pip install gaia-agent-email`` resolve core WITHOUT the [api] extra, so the
+    REST-server deps (fastapi/uvicorn) the email sidecar serves from were absent.
+    Requesting the [api] extra pulls them automatically (keyring rides along via
+    core install_requires, #1621).
     """
-    deps = re.findall(r'"(amd-gaia[^"]*)"', EMAIL_PYPROJECT.read_text())
+    deps = re.findall(r'"(amd-gaia[^"]*)"', EMAIL_PYPROJECT.read_text(encoding="utf-8"))
     assert deps, f"no amd-gaia dependency found in {EMAIL_PYPROJECT}"
     assert any("[api]" in d for d in deps), (
-        "gaia-agent-email must depend on amd-gaia[api] so consumers get the "
-        f"REST-server deps + keyring automatically (got {deps})."
+        "gaia-agent-email must depend on amd-gaia[api] so the sidecar gets the "
+        f"REST-server deps automatically (got {deps})."
     )


### PR DESCRIPTION
## Why this matters

Before, `gaia api` was the last surface still importing and mounting the email agent **in-process** — the final in-process agent mount left after the v2 thin-host migration (#1896), so the OpenAI API server had to carry the email wheel's dependencies and could hold sidecar credentials. After, `gaia api` reaches the email agent exactly the way the UI does: as a **thin client** of the always-on daemon, via the `/v1/<agent>/*` relay (#2178 / #2198). The API server never imports `gaia_agent_email`, never holds its deps, and never learns sidecar coordinates.

Crucially, this relays the **full** email surface, not just the agent loop. The relay merged in #2198 was scoped to `POST /v1/<agent>/query`; on its own, removing the mount would have silently **404'd** the email agent's fixed-function routes (`/v1/email/{triage,draft,send,health,…}`) on `gaia api` even though the sidecar serves them. This PR extends the relay with a fixed-function catch-all (`{METHOD} /v1/<agent>/<subpath>`, buffered passthrough) so every route the sidecar serves is reachable through `gaia api` — with the same daemon-token swap and loud daemon-down / dead-sidecar errors as `/query`.

The catch-all can't regress #2198's OpenAI guards: a `relayagent` path convertor refuses the reserved `chat`/`models` ids at routing time (so `GET /v1/chat/completions` still yields FastAPI's native **405**, never a relay response), and a `relaysubpath` convertor requires a non-empty sub-path (so `/v1/nonexistent` still yields **404**). The `/query` routes stay declared first and win for that path.

This also drops the now-redundant `keyring` pin from the `[api]` extra: it was added (#1617) *solely* for the in-process mount's connectors import chain, and `keyring` is already a core `install_requires` dep (`gaia connectors`, #1621) — so `amd-gaia[api]` and the email wheel still get it transitively. `[api]` is now purely the thin REST-server stack.

Closes #2176.

## Test plan

- [x] `python -m pytest tests/unit/test_api_agent_proxy.py` — 20 pass, incl. the new fixed-function coverage **through the core `gaia api` server**: route claimed by the relay (503 when disabled, not 404), loud 503 on daemon-down, reserved id refused, and an end-to-end buffered relay carrying the daemon token; #2198's 404/405 shadow guards stay green
- [x] `python -m pytest tests/unit/test_daemon_relay.py` — 36 pass (relay path unaffected)
- [x] `python -m pytest tests/unit/test_api_extras.py` — mount-removal guard + keyring-via-core + email-wheel-requires-`[api]`
- [x] `python -m pytest "tests/test_api.py::TestEmailTriageEndpoint" "…SendConfirmationGate" "…SendOffLoop" "…SendOutlook502Fix" tests/unit/agents/email/test_draft_token_provider_binding.py` — email contract coverage preserved against the wheel's own app (the agent logic runs in the sidecar; the core server just relays bytes, covered above)
- [x] `flake8` (repo flags) + `black --check` clean on changed files
- [x] `grep -rn gaia_agent_email src/gaia/api/` → no matches (in-process mount fully removed)