### PR TITLE
spec(factory): define the dogfooding loop — Claudia as live validation runtime

### DIFF
--- a/docs/plans/agent-factory.md
+++ b/docs/plans/agent-factory.md
@@ -219,6 +219,7 @@ is mostly net-new automation; **Back (ship)** cites the pipeline that *already e
 | 16 | **Publish** | cut-from-main + token gates; POST `/publish` to Hub Worker; npm publish; **redeploy catalog site** | `publish_to_r2.py` · Hub Worker · website deploy (*exists*) | governance gates |
 | 17 | **Post-publish edge verify** 🚦 | fetch **every published object via the real fetch CLI** at the CDN edge (#1655 "user's real state") — *per-object verify works; the zip-verify leg is disabled with the zip (§6)* | fetch-verify steps (*exists; zip leg off*) | real download OK |
 | 18 | **Maintain (continuous)** 🚦 | on an SDK delta that regresses the agent's eval, re-run the affected stages 1–17 for the delta (5b only when the capability surface changed, §5.5) | net-new trigger + the above | eval stays ≥ bar |
+| 19 | **Dogfood (continuous)** 🚦 | deployed agents run always-on under a live orchestrator (Claudia); every decision emits a structured trace (amd/gaia#2214); acceptance outcomes feed memory/adaptation (#2215) and become eval scenarios; an acceptance-rate regression is a maintenance trigger equal in rank to an SDK delta (§8.6) | decision-trace log + trace→scenario distiller (net-new, milestone 56) | acceptance ≥ per-agent bar |
 
 Stages 9–17 already run in CI (`release_agent_email.yml`, `build_agents.yml`,
 `publish_agents.yml`, `email_scorecard_refresh.yml`) — **the factory generalizes them
@@ -470,6 +471,54 @@ the npm tarball + R2 binaries, not one zip.
                           ┌──────── Agent Hub (§0.5) — the conveyor ─────────┐──────────────┘
                           └──────────────────────────────────────────────────┘
 ```
+
+## 8.6 The dogfooding loop — Claudia as the live validation runtime
+
+The lifecycle above ends where most SDLCs end: a verified artifact at the edge. But an
+*autonomous, always-on* agent is not validated by its release gate — it is validated by
+**weeks of real workload**. The factory's development loop therefore does not terminate
+at publish; it closes through a live orchestrator:
+
+```
+  publish (16–17) ──► daemon installs + runs agent 24/7 (local NPU, Lemonade)
+                                     │
+                        Claudia (orchestrator + testbed; the maintainer drives it
+                        8–10 h/day) spawns/observes agents via the ops-core contract:
+                        lifecycle API (#2210) · wire envelope (#2211) · resumable
+                        approvals (#2212) · run registry (#2213)
+                                     │
+                        every decision → structured trace (#2214):
+                        saw → proposed → approved/dismissed/modified → did → outcome
+                                     │
+              ┌──────────────────────┼───────────────────────────┐
+              ▼                      ▼                           ▼
+   traces → eval scenarios   acceptance outcomes →      acceptance-rate regression
+   (stage 5/7 corpus grows   memory/adaptation (#2215):  = maintenance trigger,
+   from REAL usage, not      per-user customization,     rank-equal to an SDK delta
+   only synthesis)           graduated trust promotion       (stage 18 → re-run 7)
+```
+
+Three properties make this loop the factory's strongest gate rather than an afterthought:
+
+1. **The eval corpus compounds from reality.** §5.5's synthetic generation seeds the
+   *first* release; every release after that inherits scenarios distilled from traces of
+   real accepted/rejected decisions. The held-out oracle discipline (5b) still applies —
+   trace-derived scenarios enter the *training* side unless the human curator promotes
+   them.
+2. **Acceptance is a scorecard metric.** A deployed agent's rolling acceptance rate
+   (approvals ÷ proposals, from #2214 traces) is reported next to the eval aggregate in
+   `SCORECARD.md`. An agent that scores 90 in the sandbox but 40% acceptance in
+   dogfooding is failing — and the factory knows it without waiting for a bug report.
+3. **Adaptation is shipped state, not retraining.** Per-user memory (#2215) adapts
+   thresholds/priorities/phrasing locally and reversibly; only high-confidence stable
+   patterns are candidates for the distillation flywheel (#666–668) at the *next*
+   factory pass. Learning never mutates the shipped artifact silently.
+
+Scope for the enabling contract and the first agent cohort: milestone 56
+("Local Ops Agents: Claudia-Validated Autonomy", amd/gaia#2210–#2233). Division of
+labor is deliberate: Claude Code remains the coding agent; factory-built gaia agents own
+ambient ops (inbox, task hygiene, workspace management, fleet observation) — continuous,
+low-intensity, privacy-sensitive work that must be cheap enough to never turn off.
 
 ## 9. Component inventory — exists vs net-new
 

--- a/docs/plans/agent-factory.md
+++ b/docs/plans/agent-factory.md
@@ -219,7 +219,7 @@ is mostly net-new automation; **Back (ship)** cites the pipeline that *already e
 | 16 | **Publish** | cut-from-main + token gates; POST `/publish` to Hub Worker; npm publish; **redeploy catalog site** | `publish_to_r2.py` · Hub Worker · website deploy (*exists*) | governance gates |
 | 17 | **Post-publish edge verify** 🚦 | fetch **every published object via the real fetch CLI** at the CDN edge (#1655 "user's real state") — *per-object verify works; the zip-verify leg is disabled with the zip (§6)* | fetch-verify steps (*exists; zip leg off*) | real download OK |
 | 18 | **Maintain (continuous)** 🚦 | on an SDK delta that regresses the agent's eval, re-run the affected stages 1–17 for the delta (5b only when the capability surface changed, §5.5) | net-new trigger + the above | eval stays ≥ bar |
-| 19 | **Dogfood (continuous)** 🚦 | deployed agents run always-on under a live orchestrator (Claudia); every decision emits a structured trace (amd/gaia#2214); acceptance outcomes feed memory/adaptation (#2215) and become eval scenarios; an acceptance-rate regression is a maintenance trigger equal in rank to an SDK delta (§8.6) | decision-trace log + trace→scenario distiller (net-new, milestone 56) | acceptance ≥ per-agent bar |
+| 19 | **Dogfood (continuous, advisory)** | deployed agents run always-on under a live orchestrator (Claudia); every decision emits a structured trace (amd/gaia#2214, local-only); acceptance outcomes feed memory/adaptation (#2215) and are candidate eval scenarios; a locally-observed acceptance regression *prompts* a maintenance run (§8.6) — it cannot be a CI-enforced 🚦 until the §12.9 telemetry decision lands, because the factory has no lawful sight of per-machine traces | decision-trace log + trace→scenario distiller (net-new, milestone 56) | advisory — local signal only; hard gate blocked on §12.9 |
 
 Stages 9–17 already run in CI (`release_agent_email.yml`, `build_agents.yml`,
 `publish_agents.yml`, `email_scorecard_refresh.yml`) — **the factory generalizes them
@@ -504,11 +504,19 @@ Three properties make this loop the factory's strongest gate rather than an afte
    *first* release; every release after that inherits scenarios distilled from traces of
    real accepted/rejected decisions. The held-out oracle discipline (5b) still applies —
    trace-derived scenarios enter the *training* side unless the human curator promotes
-   them.
-2. **Acceptance is a scorecard metric.** A deployed agent's rolling acceptance rate
-   (approvals ÷ proposals, from #2214 traces) is reported next to the eval aggregate in
-   `SCORECARD.md`. An agent that scores 90 in the sandbox but 40% acceptance in
-   dogfooding is failing — and the factory knows it without waiting for a bug report.
+   them. Caveat, stated plainly: in the current dogfooding setup the trace producer (the
+   maintainer driving Claudia 8–10 h/day) and the spec author are the same person — §5's
+   curator ≠ spec-author discipline therefore requires that oracle promotion of
+   trace-derived scenarios be done by a second person (or deferred until one exists).
+2. **Acceptance is a first-class metric — locally.** A deployed agent's rolling
+   acceptance rate (approvals ÷ proposals, from #2214 traces) is computed and displayed
+   **on the user's machine only** (local dashboard / `gaia agent status`), never in the
+   *published* `SCORECARD.md` — the shipped scorecard is a reproducible offline artifact
+   (fixed corpus, committed recipe, `schema_version: 1`) and embedding per-machine field
+   data in it would breach the zero-telemetry property (#890) and overload "acceptance",
+   which already names the offline within-one-bucket accuracy metric. An agent that
+   scores 90 in the sandbox but 40% local acceptance is failing — the *user* (and any
+   opt-in channel §12.9 may later define) knows it without waiting for a bug report.
 3. **Adaptation is shipped state, not retraining.** Per-user memory (#2215) adapts
    thresholds/priorities/phrasing locally and reversibly; only high-confidence stable
    patterns are candidates for the distillation flywheel (#666–668) at the *next*
@@ -685,7 +693,7 @@ and exposes eight gaps, each with a disposition:
 |---|---|---|---|
 | 1 | **No skill lane.** The factory's only unit is the heavyweight packaged agent; skills appear once, as a recipe *input* (§1.5). GAIA's own sibling plans (skill-format #691, marketplace #647) make skills a first-class portable unit | The ~50KB markdown skill is the unit that spreads (52K skills vs our 18 agents). Full freeze-matrix treatment for a 2KB procedure is absurd; shipping it ungated is ClawHavoc | **Open decision §12.7** — a proportionate second lane (eval + scan + provenance, no freeze/OIDC) or an explicit scope hand-off |
 | 2 | **No community-producer path.** The factory assumes first-party recipes, oracles, publish tokens; runtime trust tiers (§0.24) imply third-party submissions the factory never defines a pipeline for | Both ecosystems' scale came from external authors; ClawHavoc says a scan-only community lane is not acceptable | **Open decision §12.8** — tier-differentiated pipeline (Verified = full factory; Community = defined, gated subset) |
-| 3 | **No field→factory feedback.** Stage 18 triggers on SDK deltas + CI evals only; a field regression invisible to the oracle never triggers. Skills synthesized on-device (skill-synthesis #887) have no path through the gates | Hermes learns but cannot verify; the factory verifies but does not learn. **Validation of learned skills is the thing neither competitor has** — synthesis → eval gate → signed Hub skill would be a real moat | **Open decision §12.9** (telemetry channel) + the M3/M4 intake note below |
+| 3 | **No field→factory feedback** (*partially addressed by stage 19/§8.6: local traces now surface field regressions to the user and prompt maintenance runs — but the factory/CI still cannot see them; the automated half remains blocked on §12.9*). Stage 18 triggers on SDK deltas + CI evals only; a field regression invisible to the oracle never triggers automatically. Skills synthesized on-device (skill-synthesis #887) have no path through the gates | Hermes learns but cannot verify; the factory verifies but does not learn. **Validation of learned skills is the thing neither competitor has** — synthesis → eval gate → signed Hub skill would be a real moat | **Open decision §12.9** (telemetry channel) + the M3/M4 intake note below |
 | 4 | **No adversarial/security bucket in the eval gate.** Stage 13 measures capability; §5.5's phishing bucket is coverage, not a floor. Signing proves *who published*, never *what the text does to the model* | Every major incident in both ecosystems was content-borne: ClickFix instructions the agent itself relays, natural-language malice VirusTotal admits it misses, skill descriptions injected verbatim into prompts | **Inline, non-optional** — injection-resistance floor added to §5; static content-scan of recipe-pulled skills/MCP configs at stages 5–6 |
 | 5 | **No malicious-package recovery.** §6.5 is roll-forward for *quality* escapes; a compromised publisher's installs keep running — and the runtime's anti-rollback + TOFU pinning *entrenches* the compromise | ClawHavoc-class response needs registry yank + client-side deny-list, not a higher semver | **Inline, non-optional** — yank/deny-list promoted from "scope if needed" to **M1** (§6.5, §10), as signing's other half |
 | 6 | **No cycle-time budget.** Throughput is priced only via the serial-eval ceiling (M4) | OpenClaw ships multiple times a week; a skill publishes in seconds. If recipe→published takes days, the ecosystem forms elsewhere regardless of quality | Name a target latency per lane when the recipe schema lands (M0); identify amortizable gate costs (cached freezes, incremental eval) |
@@ -736,7 +744,7 @@ review for agent-authored capability.
    factory never defines)? Who curates a community agent's oracle, given curator ≠ spec
    author? *Rec:* Verified = full factory; Community = content-scan + injection floor +
    sandbox smoke-test minimum, and the tier label on the Hub says exactly which gates ran.
-9. **Field telemetry → stage 18/5b (§11.6 gap 3)** — a privacy-preserving, opt-in signal
+9. **Field telemetry → stage 18/5b (§11.6 gap 3; now also the blocker for stage 19's gate — §8.6 dogfooding runs advisory/local-only until this decision lands)** — a privacy-preserving, opt-in signal
    (install success, tool-call error classes; `gaia diagnostics` is the seed) so field
    regressions the oracle can't see still trigger the maintenance loop, and real failures
    feed oracle curation. *Rec:* design it with the local-first constraint as a feature —


### PR DESCRIPTION
## Summary
Extends the Agent Factory spec with the missing post-publish half of the development loop: factory-built agents are validated by continuous real-workload dogfooding under a live orchestrator (Claudia), not just by the release gate.

- **Stage 19 'Dogfood (continuous)'** added to the lifecycle table: decision traces, acceptance-rate bar, regression as a maintenance trigger rank-equal to an SDK delta
- **New §8.6** defines the full circle: publish → daemon runs agent 24/7 on local NPU → Claudia spawns/observes via the ops-core contract (#2210–#2213) → structured decision traces (#2214) → three feedback arms: traces→eval scenarios (compounding real-usage corpus, oracle discipline preserved), acceptance→memory/per-user adaptation (#2215), regression→stage-18 maintenance
- Anchors **milestone 56** (Local Ops Agents: Claudia-Validated Autonomy, #2210–#2233) and the division of labor: Claude Code codes, gaia agents run ambient ops

Spec-only change; no code touched.

## Context
Milestone 56 was scoped from a cross-machine usage audit (580 orchestrator tasks / 239 sessions): the ops-agent catalog, the six enabling ops-core features, and this loop definition come from evidence of what is currently hand-built daily (babysitter crons, hand-run triage sessions, manual fleet hygiene).