### PR TITLE
fix(security): stop leaking stack traces at API boundaries + least-privilege workflow permissions

### DIFF
--- a/.github/workflows/test_eval_rag.yml
+++ b/.github/workflows/test_eval_rag.yml
@@ -12,6 +12,11 @@ name: Eval RAG Quality
 on:
   workflow_dispatch:
 
+# Both jobs only check out code and run the eval — no writes to the repo,
+# issues, or checks are needed.
+permissions:
+  contents: read
+
 concurrency:
   group: lemonade-eval
   cancel-in-progress: false

--- a/hub/agents/python/emr/gaia_agent_emr/dashboard/server.py
+++ b/hub/agents/python/emr/gaia_agent_emr/dashboard/server.py
@@ -1513,8 +1513,13 @@ def create_app(
                     )
                     steps[-1]["status"] = "complete"
                 except Exception as e:
+                    # Full detail stays server-side; steps are returned to the
+                    # client (CodeQL py/stack-trace-exposure).
+                    logger.error(
+                        f"Failed to load {model_type} model {model_name}: {e}"
+                    )
                     steps[-1]["status"] = "warning"
-                    steps[-1]["error"] = str(e)[:50]
+                    steps[-1]["error"] = "Model load failed — check server logs."
 
                 step_num += 1
 

--- a/src/gaia/ui/routers/memory.py
+++ b/src/gaia/ui/routers/memory.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import threading
+import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +25,17 @@ from ..dependencies import get_db
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["memory"])
+
+
+def _log_server_error(context: str, exc: Exception) -> str:
+    """Log full exception detail server-side and return a short correlation id.
+
+    Responses carry only a generic message plus the id so exception
+    internals never reach the client (CodeQL py/stack-trace-exposure).
+    """
+    correlation_id = uuid.uuid4().hex[:8]
+    logger.error("[memory router] %s (id=%s)", context, correlation_id, exc_info=exc)
+    return correlation_id
 
 
 def _require_ui_header(request: Request) -> None:
@@ -1216,14 +1228,28 @@ def stream_discovery():
                     else:
                         yield _sse({"type": "log", "message": "  Nothing found"})
                 except Exception as e:
+                    cid = _log_server_error(
+                        f"discovery scanner '{source_key}' failed", e
+                    )
                     yield _sse(
-                        {"type": "error", "source": source_key, "message": str(e)}
+                        {
+                            "type": "error",
+                            "source": source_key,
+                            "message": f"Scanner failed — see server logs (id={cid}).",
+                        }
                     )
 
             yield _sse({"type": "done", "total": total})
 
         except Exception as exc:
-            yield _sse({"type": "error", "source": "discovery", "message": str(exc)})
+            cid = _log_server_error("discovery stream failed", exc)
+            yield _sse(
+                {
+                    "type": "error",
+                    "source": "discovery",
+                    "message": f"Discovery failed — see server logs (id={cid}).",
+                }
+            )
             yield _sse({"type": "done", "total": 0})
 
     return StreamingResponse(
@@ -1274,10 +1300,14 @@ def stream_inference(include_browser: bool = Query(False)):
                             }
                         )
                 except Exception as e:
+                    cid = _log_server_error("browser history scan failed", e)
                     yield _sse(
                         {
                             "type": "log",
-                            "message": f"  Browser history unavailable: {e}",
+                            "message": (
+                                "  Browser history unavailable — "
+                                f"see server logs (id={cid})"
+                            ),
                         }
                     )
 
@@ -1413,10 +1443,14 @@ def stream_inference(include_browser: bool = Query(False)):
                 ):
                     raw_response = "".join(raw_response)
             except Exception as e:
+                cid = _log_server_error("inference LLM call failed", e)
                 yield _sse(
                     {
                         "type": "error",
-                        "message": f"LLM call failed: {e}. Is Lemonade Server running?",
+                        "message": (
+                            "LLM call failed. Is Lemonade Server running? "
+                            f"See server logs (id={cid})."
+                        ),
                     }
                 )
                 yield _sse({"type": "done", "total": 0})
@@ -1440,8 +1474,15 @@ def stream_inference(include_browser: bool = Query(False)):
                     and i["content"].strip()
                 ]
             except Exception as e:
+                cid = _log_server_error("failed to parse LLM inference response", e)
                 yield _sse(
-                    {"type": "error", "message": f"Failed to parse LLM response: {e}"}
+                    {
+                        "type": "error",
+                        "message": (
+                            "Failed to parse LLM response — "
+                            f"see server logs (id={cid})."
+                        ),
+                    }
                 )
                 yield _sse({"type": "done", "total": 0})
                 return
@@ -1460,8 +1501,13 @@ def stream_inference(include_browser: bool = Query(False)):
             yield _sse({"type": "done", "total": len(insights)})
 
         except Exception as exc:
-            logger.error("[memory router] stream-inference failed: %s", exc)
-            yield _sse({"type": "error", "message": str(exc)})
+            cid = _log_server_error("stream-inference failed", exc)
+            yield _sse(
+                {
+                    "type": "error",
+                    "message": f"Inference failed — see server logs (id={cid}).",
+                }
+            )
             yield _sse({"type": "done", "total": 0})
 
     return StreamingResponse(
@@ -1637,10 +1683,10 @@ def update_memory_settings(
                 result["system_context_refresh"] = refresh_result
                 return result
             except Exception as exc:
-                logger.warning(
-                    "[memory router] system discovery after consent failed: %s", exc
-                )
+                cid = _log_server_error("system discovery after consent failed", exc)
                 result = _get_memory_settings_dict(db)
-                result["system_context_error"] = str(exc)
+                result["system_context_error"] = (
+                    f"System discovery failed — see server logs (id={cid})."
+                )
                 return result
     return _get_memory_settings_dict(db)


### PR DESCRIPTION
Any browser client of the Agent UI memory dashboard or the EMR dashboard could see raw exception text — internal file paths, exception classes, and error internals — whenever a scan, inference, or model load failed. Responses now return a generic message with a short correlation id, and the full exception (with traceback) is logged server-side, so debugging stays possible without exposing internals. `test_eval_rag.yml` also drops the default token grants in favor of an explicit `contents: read`.

Closes 8 of the 9 open medium-severity CodeQL alerts in these two rule classes; the 9th is dismissed as a verified false positive.

| Alert | Rule | Location | Resolution |
|---|---|---|---|
| #249 | py/stack-trace-exposure | `src/gaia/ui/routers/memory.py` stream-discovery SSE | Generic message + correlation id; full detail logged server-side |
| #250 | py/stack-trace-exposure | `src/gaia/ui/routers/memory.py` stream-inference SSE | Same |
| #346 | py/stack-trace-exposure | `src/gaia/ui/routers/memory.py` settings `system_context_error` | Same |
| #347–#349 | py/stack-trace-exposure | EMR dashboard `/api/init` (3 sinks) | Removed `str(e)` from the returned `steps` payload; logged instead |
| #323, #324 | actions/missing-workflow-permissions | `.github/workflows/test_eval_rag.yml` | Top-level `permissions: contents: read` (both jobs only checkout + run the eval) |
| #327 | py/stack-trace-exposure | EMR dashboard `/api/chat` | **Dismissed (false positive)** — response already routed through `_sanitize_response_text`, which strips tracebacks, `File` lines, exception class names, and paths; CodeQL can't model the regex barrier |

## Test plan

- [x] `python util/lint.py --all` passes
- [x] `tests/unit/test_memory_router.py` — 768 passed (1 pre-existing, unrelated failure also fails on clean main: expects faiss missing, but it's installed locally)
- [x] EMR package tests — 67 passed
- [x] Workflow YAML parses; both jobs verified read-only (checkout + eval run, no writes to repo/issues/checks)
- [ ] CodeQL on this PR reports no new alerts and closes the fixed ones after merge