### PR TITLE
fix(security): rate-limit exposed routes, harden JS ReDoS/XSS/cleartext-logging

### DIFF
--- a/docs/server.js
+++ b/docs/server.js
@@ -25,6 +25,11 @@ const url = require('url');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Deployed behind a single reverse-proxy hop; trust it so req.ip is the real
+// client address — express-rate-limit keys on req.ip and rejects
+// X-Forwarded-For from an untrusted proxy (ERR_ERL_UNEXPECTED_X_FORWARDED_FOR).
+app.set('trust proxy', 1);
+
 // Configuration
 const AUTH_ENABLED = process.env.DOCS_AUTH_ENABLED === 'true';
 const ACCESS_CODE = process.env.DOCS_ACCESS_CODE || '';
@@ -271,35 +276,19 @@ const loginLimiter = rateLimit({
   legacyHeaders: false,
 });
 
-// General per-IP rate limiter for all auth endpoints (not just /login).
-// Defined here so it can be applied to every auth route below, closing the
-// "missing rate-limiting" CodeQL alert on /auth/logout and
-// /auth/login-error which would otherwise accept unlimited requests.
-const rateLimitStore = new Map();
-const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
-const RATE_LIMIT_MAX = 100; // max requests per window per IP
-
-function rateLimiter(req, res, next) {
-  const ip = req.ip || req.connection.remoteAddress;
-  const now = Date.now();
-  const record = rateLimitStore.get(ip) || { count: 0, resetAt: now + RATE_LIMIT_WINDOW };
-
-  if (now > record.resetAt) {
-    record.count = 0;
-    record.resetAt = now + RATE_LIMIT_WINDOW;
-  }
-
-  record.count++;
-  rateLimitStore.set(ip, record);
-
-  if (record.count > RATE_LIMIT_MAX) {
-    return res.status(429).send('Too Many Requests');
-  }
-  next();
-}
+// General per-IP rate limiter for every route (auth endpoints and the
+// authorization middleware on proxied requests). Uses express-rate-limit —
+// same 100 req/min/IP budget the previous hand-rolled limiter enforced.
+const generalLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 100, // max requests per window per IP
+  message: 'Too Many Requests',
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 // Login handler
-app.post('/auth/login', loginLimiter, rateLimiter, (req, res) => {
+app.post('/auth/login', loginLimiter, generalLimiter, (req, res) => {
   const { code, nonce } = req.body;
 
   if (code === ACCESS_CODE) {
@@ -344,7 +333,7 @@ app.post('/auth/login', loginLimiter, rateLimiter, (req, res) => {
 });
 
 // Login error handler (uses nonce to retrieve redirect URL)
-app.get('/auth/login-error', rateLimiter, (req, res) => {
+app.get('/auth/login-error', generalLimiter, (req, res) => {
   // Retrieve redirect URL from server-side storage and re-store for the form
   const originalRedirect = consumeRedirect(req.query.nonce);
   const newNonce = storeRedirect(originalRedirect);
@@ -353,13 +342,13 @@ app.get('/auth/login-error', rateLimiter, (req, res) => {
 });
 
 // Logout handler
-app.get('/auth/logout', rateLimiter, (req, res) => {
+app.get('/auth/logout', generalLimiter, (req, res) => {
   res.clearCookie(COOKIE_NAME);
   res.redirect('/');
 });
 
 // Apply rate limiter before auth middleware for every other route
-app.use(rateLimiter);
+app.use(generalLimiter);
 
 // Apply auth middleware
 app.use(authMiddleware);

--- a/src/gaia/apps/_shared/dev-server.js
+++ b/src/gaia/apps/_shared/dev-server.js
@@ -128,8 +128,9 @@ class DevServer {
     // The MCP server sends 'access-control-allow-origin: *' header, allowing direct browser connections
     // No proxy endpoints needed - apps should connect directly to MCP URL from environment variables
 
-    // Start the server
-    this.server = this.app.listen(this.port, () => {
+    // Start the server. Loopback-only bind: this is a local development
+    // server and must never be reachable from other machines.
+    this.server = this.app.listen(this.port, '127.0.0.1', () => {
       console.log(`✅ ${this.appConfig.displayName} dev server running at:`);
       console.log(`   http://localhost:${this.port}`);
       console.log(`   Press Ctrl+C to stop`);

--- a/src/gaia/apps/jira/webui/public/js/modules/chat-ui.js
+++ b/src/gaia/apps/jira/webui/public/js/modules/chat-ui.js
@@ -30,16 +30,17 @@ export class ChatUI {
         // For user/assistant messages we hand the sanitizer a live target
         // DOM node — it parses, strips dangerous elements/attrs, and
         // appends the sanitized children. We never route the sanitized
-        // HTML back through ``innerHTML = str``, which closes the final
-        // CodeQL xss-through-dom sink on line 70.
+        // HTML back through ``innerHTML = str``.
+        //
+        // Non-string payloads render as JSON via textContent — there is no
+        // caller-supplied-DOM-node branch, so nothing caller-controlled is
+        // ever appended to the document unsanitized.
         if (typeof content === 'string') {
             if (type === 'error' || type === 'system') {
                 contentEl.textContent = content;
             } else {
                 this.sanitizeInto(contentEl, this.formatMessage(content));
             }
-        } else if (content instanceof HTMLElement) {
-            contentEl.appendChild(content);
         } else {
             contentEl.textContent = JSON.stringify(content, null, 2);
         }

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -645,7 +645,8 @@ function _extraCaCertificates() {
   try {
     return [fs.readFileSync(file, "utf8")];
   } catch (err) {
-    log(`Could not read NODE_EXTRA_CA_CERTS (${file}): ${err.message}`);
+    // err.message already names the offending path — don't re-log the env value.
+    log(`Could not read NODE_EXTRA_CA_CERTS: ${err.message}`);
     return [];
   }
 }
@@ -725,7 +726,10 @@ function _probeViaProxy(target, proxy, ca, finish, setSock) {
   try {
     proxyUrl = new URL(proxy);
   } catch {
-    finish({ ok: false, kind: "connectivity", message: `${target.href}: invalid proxy URL "${proxy}"` });
+    // HTTPS_PROXY/HTTP_PROXY may embed credentials (http://user:pass@host) —
+    // strip the userinfo before the value reaches the install log.
+    const redacted = proxy.replace(/^(\w+:\/\/)[^@/]*@/, "$1***@");
+    finish({ ok: false, kind: "connectivity", message: `${target.href}: invalid proxy URL "${redacted}"` });
     return;
   }
   const headers = {};

--- a/src/gaia/apps/webui/src/components/MessageBubble.tsx
+++ b/src/gaia/apps/webui/src/components/MessageBubble.tsx
@@ -547,9 +547,12 @@ function CodeBlock({ lang, code }: { lang: string; code: string }) {
 // ── File Path Linkification ──────────────────────────────────────────────
 
 /** Regex to detect Windows file paths like C:\Users\... or C:/Users/... */
-const WIN_PATH_RE = /[A-Z]:[\\\/](?:[^\s*?"<>|,;)}\]]+[\\\/])*[^\s*?"<>|,;)}\]]*\.\w{1,5}/gi;
+// Path separators are excluded from the segment class so each `(segment sep)`
+// repetition has exactly one parse — the ambiguity CodeQL flagged as
+// exponential-backtracking ReDoS (js/redos) on adversarial non-matching input.
+const WIN_PATH_RE = /[A-Z]:[\\/](?:[^\s*?"<>|,;)}\]\\/]+[\\/])*[^\s*?"<>|,;)}\]\\/]*\.\w{1,5}/gi;
 /** Regex to detect Windows directory paths like C:\Users\...\folder\ */
-const WIN_DIR_RE = /[A-Z]:[\\\/](?:[^\s*?"<>|,;)}\]]+[\\\/])+/gi;
+const WIN_DIR_RE = /[A-Z]:[\\/](?:[^\s*?"<>|,;)}\]\\/]+[\\/])+/gi;
 
 function FilePathLink({ path }: { path: string }) {
     const handleClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
Closes the five open JavaScript/web CodeQL alerts. Before: a chat message containing a crafted Windows-path-like string could freeze the Agent UI for minutes (exponential regex backtracking), proxy credentials from `HTTPS_PROXY` could land verbatim in the install log, and the docs proxy's auth endpoints relied on a hand-rolled rate limiter that keyed every client to the load-balancer IP. After: all five alerts are resolved with linear-time matching, credential redaction, and real per-client rate limiting.

| Alert | Rule | Resolution |
|---|---|---|
| #177 (high) | `js/redos` | `MessageBubble.tsx` path-linkify regexes rewritten so `(segment sep)*` has one parse — measured ~700ms at 26 adversarial chars before (doubling per char), 5ms at 500k chars after, identical matches on real paths |
| #338 (high) | `js/clear-text-logging` | `backend-installer.cjs` redacts `user:pass@` from proxy URLs before they reach the install log; `NODE_EXTRA_CA_CERTS` failure no longer re-logs the env value |
| #55 (high) | `js/missing-rate-limiting` | `docs/server.js` auth routes + proxy now use `express-rate-limit` (same 100 req/min/IP budget as the previous hand-rolled limiter, which CodeQL can't recognize) with `trust proxy = 1` so limiting keys on the real client IP behind the deploy proxy |
| #1 (high) | `js/missing-rate-limiting` | `dev-server.js` (dev-only tool) now binds `127.0.0.1` explicitly; in-memory limiter retained — alert dismissed as not network-exposed |
| #16 (medium) | `js/xss-through-exception` | jira `chat-ui.js`: removed the dead caller-supplied-`HTMLElement` branch — the last unsanitized `appendChild` sink reachable from exception-derived content; errors already render via `textContent` |

## Test plan

- [x] Regex parity + timing harness: new patterns match identically on real Windows paths; adversarial input linear (5ms @ 500k chars) vs exponential before (704ms @ 26 chars)
- [x] `cd src/gaia/apps/webui && npm run build` — clean; full `vitest run` 247/247 pass
- [x] `tests/electron`: `jest backend-installer-network backend-installer-lock` — 20/20 pass
- [x] Live smoke of docs proxy: `/health` ok, `RateLimit-Limit: 100` header present, 429 after exceeding budget, no `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` with an `X-Forwarded-For` request
- [ ] CodeQL check on this PR should report alerts #177/#55/#16 fixed (#1 and #338 are dismissed with justification — see alert comments)