### PR TITLE
fix(security): tighten API CORS — no wildcard origin with credentials

### DIFF
--- a/docs/sdk/infrastructure/api-server.mdx
+++ b/docs/sdk/infrastructure/api-server.mdx
@@ -39,6 +39,24 @@ different port (e.g. `gaia api start --port 8081`) if you need both alive at
 the same time.
 </Note>
 
+### CORS
+
+Browser (cross-origin) access is limited to `localhost` / `127.0.0.1` origins
+by default. Non-browser clients (the OpenAI SDK, curl, VSCode) are unaffected —
+CORS only gates requests made from web pages.
+
+To let a web app on another origin call the API, list its origin in
+`GAIA_API_CORS_ORIGINS` (comma-separated):
+
+```bash
+GAIA_API_CORS_ORIGINS="https://myapp.example.com" gaia api start
+```
+
+Setting the variable to `*` opens the API to all origins but disables
+credentialed requests — wildcard origins combined with credentials are
+forbidden by the Fetch spec and would let any website the user visits call
+the local API.
+
 ---
 
 ## 7.2 Custom API Agent

--- a/src/gaia/api/openai_server.py
+++ b/src/gaia/api/openai_server.py
@@ -116,14 +116,45 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# CORS middleware - allow all origins for development
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# Browser origins allowed by default: localhost/127.0.0.1 on any port.
+_LOCAL_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+
+
+def _cors_config() -> dict:
+    """Build the CORS policy: localhost-only by default.
+
+    ``GAIA_API_CORS_ORIGINS`` (comma-separated) adds extra allowed origins,
+    e.g. ``https://myapp.example.com``. A literal ``*`` opts into open CORS
+    for all origins, which the Fetch spec forbids combining with credentials
+    — so the wildcard also disables credentialed requests. Wildcard origins
+    WITH credentials are never configured: Starlette would reflect any
+    request Origin, letting any website the user visits call this local,
+    unauthenticated API with credentials.
+    """
+    raw = os.environ.get("GAIA_API_CORS_ORIGINS", "")
+    origins = [o.strip() for o in raw.split(",") if o.strip()]
+    if "*" in origins:
+        logger.warning(
+            "GAIA_API_CORS_ORIGINS='*': allowing all origins WITHOUT "
+            "credentials. To allow credentialed cross-origin calls, list "
+            "explicit origins instead of '*'."
+        )
+        return {
+            "allow_origins": ["*"],
+            "allow_credentials": False,
+            "allow_methods": ["*"],
+            "allow_headers": ["*"],
+        }
+    return {
+        "allow_origins": origins,
+        "allow_origin_regex": _LOCAL_ORIGIN_REGEX,
+        "allow_credentials": True,
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }
+
+
+app.add_middleware(CORSMiddleware, **_cors_config())
 
 # The email agent's REST surface (POST /v1/email/*) is no longer mounted
 # in-process (#2176). It was the last in-process agent mount after the v2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -448,6 +448,85 @@ class TestApiUnitValidation:
         assert "detail" in error_data
 
 
+class TestApiCorsPolicy:
+    """CORS must never allow wildcard origins together with credentials."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        if not API_AVAILABLE:
+            pytest.skip(f"API dependencies not available: {IMPORT_ERROR}")
+        self.client = TestClient(app)
+
+    def _cors_kwargs(self):
+        from fastapi.middleware.cors import CORSMiddleware
+
+        return next(m.kwargs for m in app.user_middleware if m.cls is CORSMiddleware)
+
+    def test_no_wildcard_origin_with_credentials(self):
+        """The installed middleware must not combine '*' origins with credentials."""
+        kwargs = self._cors_kwargs()
+        if "*" in kwargs.get("allow_origins", []):
+            assert kwargs.get("allow_credentials") is not True
+
+    def test_default_origins_are_localhost_only(self):
+        kwargs = self._cors_kwargs()
+        assert "*" not in kwargs.get("allow_origins", [])
+        assert kwargs.get("allow_origin_regex")
+
+    def test_non_local_origin_is_not_allowed(self):
+        """A random website must not receive CORS approval."""
+        response = self.client.options(
+            "/v1/models",
+            headers={
+                "Origin": "https://evil.example",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.headers.get("access-control-allow-origin") is None
+
+    def test_localhost_origin_is_allowed(self):
+        """Local browser clients (any port) keep working."""
+        for origin in ("http://localhost:3000", "http://127.0.0.1:4200"):
+            response = self.client.options(
+                "/v1/models",
+                headers={
+                    "Origin": origin,
+                    "Access-Control-Request-Method": "GET",
+                },
+            )
+            assert response.status_code == 200
+            assert response.headers.get("access-control-allow-origin") == origin
+
+    def test_env_var_adds_explicit_origin(self, monkeypatch):
+        from gaia.api.openai_server import _cors_config
+
+        monkeypatch.setenv(
+            "GAIA_API_CORS_ORIGINS", "https://myapp.example.com, https://other.example"
+        )
+        cfg = _cors_config()
+        assert cfg["allow_origins"] == [
+            "https://myapp.example.com",
+            "https://other.example",
+        ]
+        assert cfg["allow_credentials"] is True
+
+    def test_blank_env_var_does_not_become_wildcard(self, monkeypatch):
+        from gaia.api.openai_server import _cors_config
+
+        monkeypatch.setenv("GAIA_API_CORS_ORIGINS", "")
+        cfg = _cors_config()
+        assert cfg["allow_origins"] == []
+        assert cfg["allow_origin_regex"]
+
+    def test_explicit_wildcard_disables_credentials(self, monkeypatch):
+        from gaia.api.openai_server import _cors_config
+
+        monkeypatch.setenv("GAIA_API_CORS_ORIGINS", "*")
+        cfg = _cors_config()
+        assert cfg["allow_origins"] == ["*"]
+        assert cfg["allow_credentials"] is False
+
+
 # =============================================================================
 # INTEGRATION TESTS (Require running API server and/or Lemonade)
 # =============================================================================


### PR DESCRIPTION
Weekly-audit security finding (epic #2010, dedup key `security:src/gaia/api/:cors_wildcard_credentials`).

Before: the OpenAI-compatible API server (`gaia api`) shipped `allow_origins=["*"]` with `allow_credentials=True`. Starlette handles that combination by reflecting the request Origin, so any website the user visits could make credentialed cross-origin calls to the local, unauthenticated API — effectively open CORS with credentials. After: browser access is limited to `localhost`/`127.0.0.1` origins (any port) by default; extra origins are opt-in via `GAIA_API_CORS_ORIGINS`, and a blank/missing value stays localhost-only rather than widening to a wildcard. An explicit `*` is honored but forces credentials off (the Fetch spec forbids the combination) and logs a warning.

No legitimate client loses access: the Agent UI talks to its own server (`gaia.ui.server`, which already has an explicit allowlist), and non-browser clients (OpenAI SDK, curl, VSCode) never send CORS preflights. Local browser clients on any port keep working.

Note: `src/gaia/agents/base/server.py` has the same wildcard+credentials pattern in the per-agent `serve_api()`; it's a different audit scope (`src/gaia/agents/`), left for its own finding.

## Test plan

- [x] `pytest tests/test_api.py` — 50 passed (incl. new `TestApiCorsPolicy`: wildcard+credentials never combined, `https://evil.example` gets no CORS approval, localhost origins still allowed, env-var parsing, blank env ≠ wildcard)
- [x] `python util/lint.py --all` — pass