### PR TITLE
fix(security): parameterize SQL, redact sensitive logs, harden ReDoS regexes

### DIFF
--- a/hub/agents/python/emr/gaia_agent_emr/agent.py
+++ b/hub/agents/python/emr/gaia_agent_emr/agent.py
@@ -626,9 +626,10 @@ class MedicalIntakeAgent(Agent, DatabaseMixin, FileWatcherMixin):
                 )
 
                 status = "NEW" if is_new_patient else "RETURNING"
+                # Keep PII (patient name) out of the plain-text success log;
+                # the details panel below displays identity fields on-screen.
                 self.console.print_success(
-                    f"[{status}] Patient record: {patient_data.get('first_name')} "
-                    f"{patient_data.get('last_name')} (ID: {patient_id})"
+                    f"[{status}] Patient record saved (ID: {patient_id})"
                 )
 
                 # Display extracted patient details

--- a/src/gaia/agents/base/memory_store.py
+++ b/src/gaia/agents/base/memory_store.py
@@ -2073,18 +2073,23 @@ class MemoryStore:
 
         Returns: {"items": [...], "total": N, "offset": N, "limit": N}
         """
-        # Whitelist sort columns
+        # Whitelist sort columns — map caller input to our own literal column
+        # names so no external string is ever interpolated into the SQL.
         allowed_sort = {
-            "updated_at",
-            "created_at",
-            "confidence",
-            "category",
-            "context",
-            "content",
-            "use_count",
+            "updated_at": "updated_at",
+            "created_at": "created_at",
+            "confidence": "confidence",
+            "category": "category",
+            "context": "context",
+            "content": "content",
+            "use_count": "use_count",
         }
-        if sort_by not in allowed_sort:
-            sort_by = "updated_at"
+        sort_col = allowed_sort.get(sort_by)
+        if sort_col is None:
+            raise ValueError(
+                f"Invalid sort_by {sort_by!r}; must be one of: "
+                f"{', '.join(sorted(allowed_sort))}"
+            )
         order_dir = "DESC" if order.lower() == "desc" else "ASC"
 
         conditions: list = []
@@ -2146,7 +2151,7 @@ class MemoryStore:
             data_sql = f"""
                 SELECT {select_cols} FROM knowledge k {fts_join}
                 {where}
-                ORDER BY k.{sort_by} {order_dir}
+                ORDER BY k.{sort_col} {order_dir}
                 LIMIT ? OFFSET ?
             """
             data_params = tuple(params) + (limit, offset)

--- a/src/gaia/ui/scheduler.py
+++ b/src/gaia/ui/scheduler.py
@@ -43,6 +43,10 @@ _DAY_ABBR = {
 }
 _ALL_DAY_NAMES = {**_DAY_FULL, **_DAY_ABBR}
 
+# Upper bound on schedule/interval input length before regex parsing —
+# keeps user-provided strings from driving pathological regex backtracking.
+_MAX_SCHEDULE_INPUT_LEN = 256
+
 
 def parse_interval(interval_str: str) -> int:
     """Parse a human-readable interval string into seconds.
@@ -67,6 +71,11 @@ def parse_interval(interval_str: str) -> int:
     Raises:
         ValueError: If the interval string cannot be parsed.
     """
+    if len(interval_str) > _MAX_SCHEDULE_INPUT_LEN:
+        raise ValueError(
+            f"Interval string is too long ({len(interval_str)} chars, "
+            f"max {_MAX_SCHEDULE_INPUT_LEN}). Use a short form like 'every 6h'."
+        )
     s = interval_str.strip().lower()
 
     # Handle aliases
@@ -93,7 +102,7 @@ def parse_interval(interval_str: str) -> int:
 
     # Try "every Xunit" pattern
     match = re.match(
-        r"every\s+(\d+)\s*(s|sec|seconds?|m|min|minutes?|h|hr|hours?|d|days?|w|wk|weeks?)",
+        r"every\s+(\d{1,9})\s*(s|sec|seconds?|m|min|minutes?|h|hr|hours?|d|days?|w|wk|weeks?)",
         s,
     )
     if match:
@@ -111,7 +120,7 @@ def parse_interval(interval_str: str) -> int:
             return value * 604800
 
     # Try bare "Xh", "Xm", etc.
-    match = re.match(r"(\d+)\s*(s|m|h|d|w)", s)
+    match = re.match(r"(\d{1,9})\s*(s|m|h|d|w)", s)
     if match:
         value = int(match.group(1))
         unit = match.group(2)
@@ -315,6 +324,14 @@ def parse_schedule_input(text: str) -> ScheduleConfig:
         interval_seconds will be 0 and description will indicate the error.
     """
     config = ScheduleConfig(raw_input=text)
+
+    if len(text) > _MAX_SCHEDULE_INPUT_LEN:
+        config.description = (
+            f"Could not parse schedule: input too long ({len(text)} chars, "
+            f"max {_MAX_SCHEDULE_INPUT_LEN})"
+        )
+        return config
+
     s = text.strip().lower()
 
     if not s:
@@ -323,7 +340,8 @@ def parse_schedule_input(text: str) -> ScheduleConfig:
 
     # ── 1. Extract time-of-day: "at HH:MM", "at Ham/pm", "at noon" ──
     time_match = re.search(
-        r"\bat\s+(noon|midnight|\d{1,2}(?::\d{2})?\s*(?:am|pm)?|\d{1,2}:\d{2})\b", s
+        r"\bat\s+(noon|midnight|\d{1,2}(?::\d{2})?(?:\s*(?:am|pm))?|\d{1,2}:\d{2})\b",
+        s,
     )
     if time_match:
         parsed_time = _parse_time(time_match.group(1))
@@ -333,9 +351,11 @@ def parse_schedule_input(text: str) -> ScheduleConfig:
         s = s[: time_match.start()] + s[time_match.end() :]
 
     # ── 2. Extract window: "from Ham/pm to Ham/pm" ──
+    # NOTE: "(?:\s*(?:am|pm))?" (not "\s*(?:am|pm)?") — an unconditional \s*
+    # next to the following \s+ makes whitespace runs ambiguous → ReDoS.
     window_match = re.search(
-        r"\bfrom\s+(noon|midnight|\d{1,2}(?::\d{2})?\s*(?:am|pm)?)\s+"
-        r"to\s+(noon|midnight|\d{1,2}(?::\d{2})?\s*(?:am|pm)?)\b",
+        r"\bfrom\s+(noon|midnight|\d{1,2}(?::\d{2})?(?:\s*(?:am|pm))?)\s+"
+        r"to\s+(noon|midnight|\d{1,2}(?::\d{2})?(?:\s*(?:am|pm))?)\b",
         s,
     )
     if window_match:
@@ -439,7 +459,7 @@ def parse_schedule_input(text: str) -> ScheduleConfig:
         config.interval_seconds = 604800
     else:
         # Try bare "Xh", "Xm" patterns
-        bare_match = re.match(r"(\d+)\s*(s|m|h|d|w)", s)
+        bare_match = re.match(r"(\d{1,9})\s*(s|m|h|d|w)", s)
         if bare_match:
             value = int(bare_match.group(1))
             unit = bare_match.group(2)

--- a/tests/unit/test_memory_store.py
+++ b/tests/unit/test_memory_store.py
@@ -3614,22 +3614,14 @@ class TestGetAllKnowledgeSortByValidation:
         result = store.get_all_knowledge(sort_by="updated_at")
         assert result["total"] >= 1
 
-    def test_invalid_sort_by_raises_or_falls_back(self, store):
-        # An invalid sort_by value should either raise ValueError or silently
-        # fall back to the default — it must NOT execute an unvalidated column name.
-        try:
-            result = store.get_all_knowledge(sort_by="'; DROP TABLE knowledge; --")
-            # If it doesn't raise, verify the table is intact
-            assert result["total"] >= 1, "Table should survive an invalid sort_by"
-        except (ValueError, Exception):
-            # Raising is also acceptable
-            pass
+    def test_invalid_sort_by_raises(self, store):
+        # An invalid sort_by must raise ValueError — never reach the SQL.
+        with pytest.raises(ValueError, match="Invalid sort_by"):
+            store.get_all_knowledge(sort_by="'; DROP TABLE knowledge; --")
 
     def test_sql_injection_in_sort_by_does_not_drop_table(self, store):
-        try:
+        with pytest.raises(ValueError, match="Invalid sort_by"):
             store.get_all_knowledge(sort_by="id; DROP TABLE knowledge; --")
-        except Exception:
-            pass
         # Table must still exist and be queryable
         result = store.get_all_knowledge()
         assert result["total"] >= 1

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -22,6 +22,7 @@ from gaia.ui.scheduler import (
     ScheduledTask,
     Scheduler,
     parse_interval,
+    parse_schedule_input,
 )
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -459,6 +460,45 @@ class TestParseIntervalExtended:
         """'every minute' (no number, not a day name) should raise ValueError."""
         with pytest.raises(ValueError, match="Cannot parse interval"):
             parse_interval("every minute")
+
+
+# ── ReDoS hardening tests (input bounds + unambiguous regexes) ──────────────
+
+
+class TestScheduleInputBounds:
+    """Hostile/oversized schedule strings must be rejected up front, and the
+    window regex must stay linear on whitespace-heavy input."""
+
+    def test_parse_interval_rejects_oversized_input(self):
+        with pytest.raises(ValueError, match="too long"):
+            parse_interval("every " + "0" * 10_000 + "m")
+
+    def test_parse_interval_rejects_absurd_digit_runs(self):
+        # Bounded quantifier: >9-digit values no longer parse.
+        with pytest.raises(ValueError, match="Cannot parse interval"):
+            parse_interval("1234567890s")
+
+    def test_parse_schedule_input_rejects_oversized_input(self):
+        config = parse_schedule_input("from 9" + "\t" * 10_000 + "to 5")
+        assert config.interval_seconds == 0
+        assert "too long" in config.description
+
+    def test_window_parsing_still_works(self):
+        config = parse_schedule_input("every hour from 8am to 6pm")
+        assert config.interval_seconds == 3600
+        assert config.start_hour == 8
+        assert config.end_hour == 18
+
+    def test_window_with_minutes_and_spaces(self):
+        config = parse_schedule_input("every 30m from 9:30 am to 5 pm")
+        assert config.interval_seconds == 1800
+        assert config.start_hour == 9
+        assert config.end_hour == 17
+
+    def test_time_of_day_parsing_still_works(self):
+        config = parse_schedule_input("daily at 9 pm")
+        assert config.interval_seconds == 86400
+        assert config.time_of_day == "21:00"
 
 
 # ── ScheduleConfig fail-loudly tests ─────────────────────────────────────────


### PR DESCRIPTION
Closes five open high-severity Python CodeQL alerts. Before: a memory-browser sort parameter was interpolated into SQL after only a silent-fallback check, the EMR agent wrote patient names into its plain-text success log, and three schedule-parsing regexes could be driven into pathological backtracking by hostile input from the schedules API. After: invalid sort columns fail loudly and never touch the SQL, the success log carries only the patient ID (identity fields still display in the details panel right after), and schedule parsing is length-bounded with linear-time patterns.

**Alerts addressed (all fixed, none dismissed):**

| Alert | Rule | Resolution |
|---|---|---|
| #351 | `py/sql-injection` | `get_all_knowledge` maps `sort_by` through a literal column allowlist; unknown values raise `ValueError` instead of silently falling back |
| #350 | `py/clear-text-logging-sensitive-data` | EMR success line redacts the patient name (source of the flagged flow into `print_success`); on-screen details panel unchanged |
| #214 | `py/polynomial-redos` | Bounded digit quantifier (`\d{1,9}`) + 256-char input cap in `parse_interval` |
| #215 | `py/polynomial-redos` | Removed ambiguous `\s*(?:am|pm)?` + `\s+` whitespace overlap in the from/to window regex; input cap in `parse_schedule_input` |
| #216 | `py/polynomial-redos` | Bounded digit quantifier + input cap on the bare `Xh`/`Xm` pattern |

**Test plan**
- [x] `pytest tests/unit/test_scheduler.py tests/unit/test_memory_store.py` — 374 passed (includes new tests: SQLi `sort_by` raises, oversized/hostile schedule inputs rejected, all natural-language schedule formats still parse)
- [x] `pytest tests/unit/test_memory_router.py tests/unit/test_scheduler_api.py tests/unit/test_daemon_scheduler.py tests/unit/test_schedule_daemon.py` — one failure reproduces identically on pristine origin/main (pre-existing, unrelated)
- [x] EMR agent tests — 23 passed
- [x] `python util/lint.py --all` — exit 0
- [x] Hostile-input timing check: 10k-char digit/tab payloads now rejected in <1 ms