### PR TITLE
fix(security): bind MCP bridge to loopback, not all interfaces

### DIFF
--- a/src/gaia/mcp/mcp_bridge.py
+++ b/src/gaia/mcp/mcp_bridge.py
@@ -733,18 +733,34 @@ class MCPHTTPHandler(BaseHTTPRequestHandler):
             super().log_message(format, *args)
 
 
+def resolve_bind_host(host):
+    """Map the requested host to the address the socket actually binds.
+
+    The bridge is unauthenticated, so "localhost" must never widen beyond
+    loopback. On non-Windows it resolves to 127.0.0.1 (Python may otherwise
+    bind ::1, which curl can't reach by default). Binding all interfaces
+    requires the caller to pass a wildcard address explicitly, and is loudly
+    logged because it exposes the bridge to the whole network.
+    """
+    if host == "localhost" and sys.platform != "win32":
+        return "127.0.0.1"
+    if host in ("0.0.0.0", "::"):  # nosec B104 - explicit caller opt-in only
+        logger.warning(
+            "MCP bridge binding to ALL network interfaces (%s). The bridge is "
+            "UNAUTHENTICATED - anyone on the network can invoke its tools. "
+            "Use --host localhost unless network exposure is intentional.",
+            host,
+        )
+    return host
+
+
 def start_server(host="localhost", port=8765, base_url=None, verbose=False):
     """Start the HTTP MCP server."""
     # Fix Windows Unicode
     if sys.platform == "win32":
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
-    # Fix Linux IPv6 issue: When host is "localhost", Python's socket might bind
-    # to ::1 (IPv6) which curl can't connect to by default. Use 0.0.0.0 on Linux
-    # to bind to all IPv4 interfaces. Keep localhost on Windows where it works.
-    bind_host = host
-    if host == "localhost" and sys.platform != "win32":
-        bind_host = "0.0.0.0"
+    bind_host = resolve_bind_host(host)
 
     logger.info(f"Creating MCP bridge for {host}:{port}")
 

--- a/tests/unit/test_mcp_bridge_bind.py
+++ b/tests/unit/test_mcp_bridge_bind.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Bind-host resolution for the MCP bridge.
+
+The bridge is unauthenticated, so a request for "localhost" must never
+silently widen to a wildcard bind. Binding all interfaces is explicit
+opt-in only, and must be loudly logged.
+"""
+
+import sys
+
+import pytest
+
+from gaia.mcp.mcp_bridge import resolve_bind_host
+
+
+class TestResolveBindHost:
+    def test_localhost_resolves_to_ipv4_loopback_on_non_windows(self, monkeypatch):
+        """localhost must bind the IPv4 loopback, never the wildcard address."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert resolve_bind_host("localhost") == "127.0.0.1"
+
+    def test_localhost_resolves_to_ipv4_loopback_on_macos(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert resolve_bind_host("localhost") == "127.0.0.1"
+
+    def test_localhost_kept_on_windows(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert resolve_bind_host("localhost") == "localhost"
+
+    def test_localhost_never_resolves_to_wildcard(self, monkeypatch):
+        """Regression guard: the old code rebound localhost to 0.0.0.0."""
+        for platform in ("linux", "darwin", "win32"):
+            monkeypatch.setattr(sys, "platform", platform)
+            assert resolve_bind_host("localhost") != "0.0.0.0"
+
+    def test_explicit_loopback_passes_through(self):
+        assert resolve_bind_host("127.0.0.1") == "127.0.0.1"
+
+    @pytest.mark.parametrize("wildcard", ["0.0.0.0", "::"])
+    def test_explicit_wildcard_is_honored_but_warns(self, wildcard, caplog):
+        """Binding all interfaces is allowed only as explicit opt-in, with a loud warning."""
+        with caplog.at_level("WARNING", logger="gaia.mcp.mcp_bridge"):
+            assert resolve_bind_host(wildcard) == wildcard
+        assert any(
+            "unauthenticated" in record.getMessage().lower()
+            for record in caplog.records
+        ), "expected a warning that the unauthenticated bridge is network-exposed"
+
+    def test_specific_host_passes_through_without_warning(self, caplog):
+        with caplog.at_level("WARNING", logger="gaia.mcp.mcp_bridge"):
+            assert resolve_bind_host("192.168.1.50") == "192.168.1.50"
+        assert not caplog.records


### PR DESCRIPTION
Fixes a HIGH-severity finding from the weekly security audit (epic #2010, `security:src/gaia/mcp/:mcp_bridge_bind_host`).

**Before:** asking the MCP bridge for `localhost` on Linux/macOS silently rebound it to `0.0.0.0`, exposing the **unauthenticated** bridge on every network interface — anyone on the LAN could invoke its tools. The rewrite existed to dodge Python binding `localhost` to IPv6 `::1` (unreachable by default curl), but a wildcard bind was a massive over-correction.

**After:** `localhost` resolves to the IPv4 loopback `127.0.0.1`, which solves the same IPv6 issue while staying loopback-only. Binding all interfaces still works, but only as explicit caller opt-in (`--host 0.0.0.0`), and it now logs a loud warning that the unauthenticated bridge is network-exposed. All callers and CLI defaults already pass `localhost`, so the default is safe end-to-end.

## Test plan

- [x] New unit tests (`tests/unit/test_mcp_bridge_bind.py`): `localhost` → `127.0.0.1` on Linux/macOS, kept on Windows, never a wildcard; explicit wildcard is honored but warns; specific hosts pass through untouched
- [x] Live check: `gaia mcp start` on a scratch port — socket listens on `127.0.0.1:<port>` (was `*:<port>`), `/health` answers via both `http://localhost` and `http://127.0.0.1`
- [x] `python util/lint.py --all` passes; MCP unit/validation suites pass (169 passed, 4 skipped)