### PR TITLE
fix(cli): implement/gate stubbed api-status, eval flags, schedule --skill

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1272,7 +1272,10 @@ curl http://localhost:8080/health
     gaia api status
     ```
 
-    Shows whether the API server is running and displays connection information.
+    Queries the server's `/health` endpoint and reports whether the GAIA API
+    server is running, plus its endpoints. Exits non-zero when the server is
+    not running or the port is held by a different process. Use `--host` /
+    `--port` to check a non-default address.
   </Tab>
 
   <Tab title="Stop">
@@ -1954,7 +1957,7 @@ gaia schedule {add,list,show,remove,pause,resume,run,daemon} [OPTIONS]
 | `--name` | string | _required_ | Unique schedule name |
 | `--cron` | string | _required_ | Cron expression, e.g. `"0 7 * * 1-5"` |
 | `--prompt` | string | - | One-shot prompt to run on each fire (mutually exclusive with `--skill`) |
-| `--skill` | string | - | Skill to run (mutually exclusive with `--prompt`) — see note below |
+| `--skill` | string | - | Skill to run — not supported yet, rejected at add time; see note below |
 | `--sink` | string | stdout | Where output goes: `stdout` \| `file:<path>` \| `notification` \| `telegram` |
 | `--to` | string | - | Recipient for the `telegram` sink (Telegram user/chat id) |
 
@@ -2010,7 +2013,7 @@ gaia schedule add \
 ```
 
 <Note>
-`--skill` is not yet implemented — running a skill-backed schedule raises an error pending the skill format ([#888](https://github.com/amd/gaia/issues/888)). Use `--prompt` for now.
+`--skill` is not yet implemented — `gaia schedule add --skill` is rejected with an error at add time pending the skill format ([#888](https://github.com/amd/gaia/issues/888)). Use `--prompt` for now.
 </Note>
 
 ---

--- a/src/gaia/api/app.py
+++ b/src/gaia/api/app.py
@@ -122,15 +122,56 @@ def start_server(
         )
 
 
-def check_status() -> None:
+def check_status(host: str = "localhost", port: int = 8080) -> None:
     """
-    Check if API server is running.
+    Check whether the GAIA API server is running by querying its /health endpoint.
 
-    This will be implemented in a future version.
-    For now, it just prints a message.
+    Verifies the responder is actually the GAIA API server (not just any
+    process on the port). Exits 1 when the server is unreachable, unresponsive,
+    or the port is held by something else.
+
+    Args:
+        host: Host the server is expected on (default: localhost)
+        port: Port the server is expected on (default: 8080)
     """
-    print("Status check not yet implemented")
-    print("Try: curl http://localhost:8080/health")
+    import requests
+
+    url = f"http://{host}:{port}/health"
+    try:
+        response = requests.get(url, timeout=5)
+    except requests.exceptions.Timeout:
+        print(f"❌ API server at http://{host}:{port} did not respond within 5s")
+        print("Restart it with: gaia api stop && gaia api start")
+        sys.exit(1)
+    except requests.exceptions.RequestException:
+        print(f"❌ API server is not running at http://{host}:{port}")
+        print("Start it with: gaia api start")
+        sys.exit(1)
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+
+    if (
+        response.status_code == 200
+        and isinstance(payload, dict)
+        and payload.get("service") == "gaia-api"
+    ):
+        print(f"✅ GAIA API server is running at http://{host}:{port}")
+        print(f"   Health: {payload.get('status', 'unknown')}")
+        print("\nAvailable endpoints:")
+        print(f"  • POST http://{host}:{port}/v1/chat/completions")
+        print(f"  • GET  http://{host}:{port}/v1/models")
+        print(f"  • GET  http://{host}:{port}/health")
+        return
+
+    print(
+        f"❌ Port {port} on {host} is in use, but the responder is not the "
+        f"GAIA API server (GET /health returned HTTP {response.status_code})"
+    )
+    print("Free the port, or start GAIA on another one: gaia api start --port <PORT>")
+    sys.exit(1)
 
 
 def stop_server(port: int = 8080) -> None:
@@ -272,7 +313,13 @@ def main() -> None:
     )
 
     # Status command
-    subparsers.add_parser("status", help="Check server status")
+    status_parser = subparsers.add_parser("status", help="Check server status")
+    status_parser.add_argument(
+        "--host", default="localhost", help="Host to check (default: localhost)"
+    )
+    status_parser.add_argument(
+        "--port", type=int, default=8080, help="Port to check (default: 8080)"
+    )
 
     # Stop command
     stop_parser = subparsers.add_parser("stop", help="Stop server")
@@ -293,7 +340,7 @@ def main() -> None:
             getattr(args, "step_through", False),
         )
     elif args.command == "status":
-        check_status()
+        check_status(args.host, args.port)
     elif args.command == "stop":
         stop_server(getattr(args, "port", 8080))
     else:

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1973,7 +1973,9 @@ def build_parser():
     s_add_what = s_add.add_mutually_exclusive_group(required=True)
     s_add_what.add_argument("--prompt", help="One-shot prompt to run on each fire")
     s_add_what.add_argument(
-        "--skill", help="Skill to run (pending skill-format support, #888)"
+        "--skill",
+        help="Skill to run — not supported yet (blocked on #888); "
+        "rejected at add time. Use --prompt instead.",
     )
     s_add.add_argument(
         "--sink",
@@ -2421,37 +2423,6 @@ Examples:
         default=1,
         metavar="N",
         help="Run each scenario N times for reliability measurement (default: 1)",
-    )
-    # NOTE: --reset-between-scenarios / --lemonade-model / --lemonade-ctx-size
-    # are NOT YET IMPLEMENTED. They are accepted by the parser so a future
-    # commit can wire them into AgentEvalRunner without changing the user-
-    # facing surface, but passing a non-None value today raises
-    # NotImplementedError (see the eval-agent handler). Driver scripts that
-    # want clean-state reliability runs should restart Lemonade/Agent UI
-    # externally between iterations until this lands.
-    agent_eval_parser.add_argument(
-        "--reset-between-scenarios",
-        choices=["fast", "full"],
-        default=None,
-        metavar="MODE",
-        help="[NOT YET IMPLEMENTED] Will reset services between scenarios "
-        "for clean-state reliability testing. Passing this flag today "
-        "raises NotImplementedError; restart Lemonade / Agent UI from a "
-        "driver script in the meantime.",
-    )
-    agent_eval_parser.add_argument(
-        "--lemonade-model",
-        metavar="MODEL",
-        help="[NOT YET IMPLEMENTED] Will pair with --reset-between-scenarios "
-        "to reload a specific Lemonade model between scenarios. Today the "
-        "Lemonade model is whatever the running server has loaded.",
-    )
-    agent_eval_parser.add_argument(
-        "--lemonade-ctx-size",
-        type=int,
-        metavar="SIZE",
-        help="[NOT YET IMPLEMENTED] Will pair with --lemonade-model to "
-        "reload the model at this ctx size between scenarios.",
     )
     agent_eval_parser.add_argument(
         "--corpus-dir",
@@ -3113,6 +3084,20 @@ def _handle_schedule(args):
     store = TomlScheduleStore()
 
     if action == "add":
+        # --skill schedules would register fine but raise on every fire
+        # (skill-format resolution is blocked on #888) — reject up front.
+        if getattr(args, "skill", None):
+            print(
+                f"❌ Cannot add schedule {args.name!r}: --skill is not supported yet "
+                "(skill-format resolution is blocked on #888), so a skill-backed "
+                "schedule would never produce output.\n"
+                "Use --prompt instead, e.g.:\n"
+                f'  gaia schedule add --name {args.name} --cron "{args.cron}" '
+                '--prompt "<text>"\n'
+                "Track progress: https://github.com/amd/gaia/issues/888",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         sink_args = {}
         if getattr(args, "to", None):
             sink_args["to"] = args.to
@@ -4308,25 +4293,6 @@ Let me know your answer!
                     sys.exit(1)
                 # compare handled; no further action
 
-            # --reset-between-scenarios / --lemonade-model / --lemonade-ctx-size
-            # are accepted by the parser but not yet wired into
-            # AgentEvalRunner. Fail loudly rather than silently no-op.
-            reset = getattr(args, "reset_between_scenarios", None)
-            lemonade_model = getattr(args, "lemonade_model", None)
-            lemonade_ctx = getattr(args, "lemonade_ctx_size", None)
-            if (
-                reset is not None
-                or lemonade_model is not None
-                or lemonade_ctx is not None
-            ):
-                raise NotImplementedError(
-                    "--reset-between-scenarios / --lemonade-model / "
-                    "--lemonade-ctx-size are reserved for a future commit "
-                    "and are not yet wired into AgentEvalRunner. Restart "
-                    "Lemonade and the Agent UI from your driver script "
-                    "between iterations to get the same effect."
-                )
-
             iterations = getattr(args, "iterations", 1)
             fix_mode = getattr(args, "fix", False)
 
@@ -5268,22 +5234,11 @@ def handle_api_command(args):
             sys.exit(1)
 
     elif args.subcommand == "status":
-        # Check if server is running
-        import socket
+        # /health check that verifies the responder is actually the GAIA API
+        # server — a bare socket probe can't tell it from any process on the port.
+        from gaia.api.app import check_status
 
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            result = sock.connect_ex((args.host, args.port))
-            sock.close()
-
-            if result == 0:
-                print(f"✅ API server is running at http://{args.host}:{args.port}")
-            else:
-                print(f"❌ API server is not running at http://{args.host}:{args.port}")
-                sys.exit(1)
-        except Exception as e:
-            print(f"❌ Error checking server status: {e}")
-            sys.exit(1)
+        check_status(args.host, args.port)
 
     elif args.subcommand == "stop":
         print(f"🛑 Stopping API server on port {args.port}...")

--- a/tests/unit/cli/test_stub_surface_gates.py
+++ b/tests/unit/cli/test_stub_surface_gates.py
@@ -1,0 +1,157 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Weekly-audit fixes for documented-but-stubbed CLI surfaces.
+
+Covers #2004 (`gaia api status` real /health check), #2009 (dead
+``--reset-between-scenarios`` / ``--lemonade-model`` / ``--lemonade-ctx-size``
+eval flags removed from the parser), and the #2103 schedule finding
+(``gaia schedule add --skill`` rejected loudly at add time instead of
+registering a schedule that raises on every fire).
+"""
+
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from gaia.api.app import check_status
+from gaia.cli import _handle_schedule, build_parser, handle_api_command
+
+# ---------------------------------------------------------------------------
+# #2004 — gaia api status
+# ---------------------------------------------------------------------------
+
+
+def _health_response(status_code=200, payload=None, json_error=False):
+    resp = SimpleNamespace(status_code=status_code)
+    if json_error:
+        resp.json = lambda: (_ for _ in ()).throw(ValueError("not json"))
+    else:
+        resp.json = lambda: payload
+    return resp
+
+
+class TestApiStatus:
+    def test_running_server_reports_success(self, mocker, capsys):
+        mocker.patch(
+            "requests.get",
+            return_value=_health_response(
+                payload={"status": "ok", "service": "gaia-api"}
+            ),
+        )
+        check_status("localhost", 8080)
+        out = capsys.readouterr().out
+        assert "✅ GAIA API server is running at http://localhost:8080" in out
+        assert "/v1/chat/completions" in out
+
+    def test_queries_health_endpoint(self, mocker):
+        get = mocker.patch(
+            "requests.get",
+            return_value=_health_response(
+                payload={"status": "ok", "service": "gaia-api"}
+            ),
+        )
+        check_status("myhost", 9999)
+        get.assert_called_once_with("http://myhost:9999/health", timeout=5)
+
+    def test_unreachable_server_exits_nonzero(self, mocker, capsys):
+        mocker.patch(
+            "requests.get", side_effect=requests.exceptions.ConnectionError("refused")
+        )
+        with pytest.raises(SystemExit) as exc:
+            check_status("localhost", 8080)
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "not running" in out
+        assert "gaia api start" in out
+
+    def test_timeout_exits_nonzero(self, mocker, capsys):
+        mocker.patch(
+            "requests.get", side_effect=requests.exceptions.Timeout("timed out")
+        )
+        with pytest.raises(SystemExit) as exc:
+            check_status("localhost", 8080)
+        assert exc.value.code == 1
+        assert "did not respond" in capsys.readouterr().out
+
+    def test_foreign_service_on_port_exits_nonzero(self, mocker, capsys):
+        mocker.patch(
+            "requests.get",
+            return_value=_health_response(payload={"status": "ok", "service": "other"}),
+        )
+        with pytest.raises(SystemExit) as exc:
+            check_status("localhost", 8080)
+        assert exc.value.code == 1
+        assert "not the GAIA API server" in capsys.readouterr().out
+
+    def test_non_json_responder_exits_nonzero(self, mocker, capsys):
+        mocker.patch("requests.get", return_value=_health_response(json_error=True))
+        with pytest.raises(SystemExit) as exc:
+            check_status("localhost", 8080)
+        assert exc.value.code == 1
+        assert "not the GAIA API server" in capsys.readouterr().out
+
+    def test_cli_dispatch_passes_host_and_port(self, mocker):
+        checker = mocker.patch("gaia.api.app.check_status")
+        handle_api_command(Namespace(subcommand="status", host="127.0.0.1", port=8123))
+        checker.assert_called_once_with("127.0.0.1", 8123)
+
+
+# ---------------------------------------------------------------------------
+# #2009 — reserved eval flags removed from the parser
+# ---------------------------------------------------------------------------
+
+
+class TestEvalReservedFlagsRemoved:
+    @pytest.mark.parametrize(
+        "flag_args",
+        [
+            ["--reset-between-scenarios", "fast"],
+            ["--lemonade-model", "some-model"],
+            ["--lemonade-ctx-size", "4096"],
+        ],
+    )
+    def test_parser_rejects_removed_flags(self, flag_args, capsys):
+        parser = build_parser()
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args(["eval", "agent"] + flag_args)
+        assert exc.value.code == 2
+        assert "unrecognized arguments" in capsys.readouterr().err
+
+    def test_eval_agent_still_parses(self):
+        args = build_parser().parse_args(["eval", "agent"])
+        assert not hasattr(args, "reset_between_scenarios")
+        assert not hasattr(args, "lemonade_model")
+        assert not hasattr(args, "lemonade_ctx_size")
+
+
+# ---------------------------------------------------------------------------
+# #2103 — gaia schedule add --skill rejected at add time
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleAddSkillRejected:
+    def _parse_add(self, *extra):
+        return build_parser().parse_args(
+            ["schedule", "add", "--name", "s", "--cron", "* * * * *", *extra]
+        )
+
+    def test_skill_add_exits_nonzero_with_actionable_error(self, mocker, capsys):
+        store_add = mocker.patch("gaia.schedule.store.TomlScheduleStore.add")
+        args = self._parse_add("--skill", "my-skill")
+        with pytest.raises(SystemExit) as exc:
+            _handle_schedule(args)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "--skill is not supported yet" in err
+        assert "--prompt" in err
+        assert "888" in err
+        store_add.assert_not_called()
+
+    def test_prompt_add_still_works(self, mocker, capsys):
+        store_add = mocker.patch("gaia.schedule.store.TomlScheduleStore.add")
+        args = self._parse_add("--prompt", "hello")
+        _handle_schedule(args)
+        store_add.assert_called_once()
+        assert "✅ Added schedule 's'" in capsys.readouterr().out


### PR DESCRIPTION
Three CLI surfaces promised things that didn't work: `gaia api status` printed "not yet implemented" from its standalone entry and only did a blind port probe from the main CLI; `gaia eval agent -h` advertised three Lemonade-state flags that raised `NotImplementedError` on any use; and `gaia schedule add --skill` reported success for a schedule that then raised on every single fire, silently producing nothing. Now: status genuinely queries `/health` (and can tell the GAIA API from a stranger squatting on the port, with non-zero exit for scripting), the dead eval flags are gone from the parser, and skill-backed schedules are rejected up front with a pointer to `--prompt` and #888.

Fixes #2004. Fixes #2009. Addresses the schedule finding from #2103 (does not implement #888).

## Test plan

- [ ] `pytest tests/unit/cli/test_stub_surface_gates.py` — 13 new tests covering all three fixes (health-check outcomes incl. foreign-responder, parser rejection of removed flags, add-time `--skill` rejection with no store write)
- [ ] `pytest tests/unit/test_schedule_*.py tests/unit/test_cli_eval_benchmark_compare.py tests/unit/test_api_extras.py tests/unit/cli/` — surrounding suites green
- [ ] Manual: `gaia api status` with no server → ❌ + exit 1; against a live `/health` responder → ✅ + exit 0; against a non-GAIA HTTP server on the port → ❌ "not the GAIA API server" + exit 1
- [ ] Manual: `gaia schedule add --name x --cron "* * * * *" --skill sk` → exit 1 with actionable error, nothing registered; `--prompt` path unchanged
- [ ] `python util/lint.py --all` passes