### PR TITLE
fix(observability): real system-metrics polling + real rollbackAction

### DIFF
--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -63,6 +63,7 @@ const backendInstaller = require("./services/backend-installer.cjs");
 const installerProgressDialog = require("./services/backend-installer-progress-dialog.cjs");
 const autoUpdater = require("./services/auto-updater.cjs");
 const agentSeeder = require("./services/agent-seeder.cjs");
+const systemMetrics = require("./services/system-metrics.cjs");
 const {
   parseDeepLink,
   extractDeepLinkFromArgv,
@@ -608,6 +609,9 @@ function initializeServices() {
     agentProcessManager,
     trayManager
   );
+
+  // #2007: System metrics for the observability dashboard
+  systemMetrics.registerIpcHandlers();
 
   console.log("[main] Services initialized");
 }

--- a/src/gaia/apps/webui/preload.cjs
+++ b/src/gaia/apps/webui/preload.cjs
@@ -13,6 +13,7 @@
  *   notification:*   — Desktop notifications & permission prompts (T5)
  *   install:*        — First-run backend install progress (Phase A)
  *   gaia:update:*    — Auto-update status & manual check (Phase F)
+ *   system:*         — System metrics for the observability dashboard (#2007)
  */
 
 const { contextBridge, ipcRenderer } = require("electron");
@@ -62,6 +63,11 @@ contextBridge.exposeInMainWorld("gaiaAPI", {
     respondPermission: (id, action, remember) =>
       ipcRenderer.invoke("notification:respond", id, action, remember),
     onNotification: (cb) => onEvent("notification:new", cb),
+  },
+
+  // ── System metrics for the observability dashboard (#2007) ────────────
+  system: {
+    getMetrics: () => ipcRenderer.invoke("system:get-metrics"),
   },
 });
 

--- a/src/gaia/apps/webui/services/system-metrics.cjs
+++ b/src/gaia/apps/webui/services/system-metrics.cjs
@@ -1,0 +1,154 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * GAIA Agent UI — System metrics collection (issue #2007)
+ *
+ * Collects real host metrics (CPU, memory, disk, network, per-process
+ * usage) for the observability dashboard and exposes them to the
+ * renderer over the `system:get-metrics` IPC channel. The shape matches
+ * the renderer's `SystemMetrics` type (src/types/agent.ts).
+ *
+ * GPU/NPU utilization is intentionally omitted (left `undefined`): there
+ * is no dependency-free cross-platform source for it, and the renderer
+ * type marks those fields optional — `undefined` renders as
+ * "unavailable", never as a fake zero.
+ *
+ * Errors propagate: a failing source rejects the IPC invoke so the
+ * renderer can surface it. No silent nulls.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const { app, ipcMain } = require("electron");
+
+const SYSTEM_GET_METRICS_CHANNEL = "system:get-metrics";
+
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+/** Minimum sampling window for the very first CPU reading (ms). */
+const FIRST_CPU_SAMPLE_MS = 120;
+
+// Previous aggregate CPU times — CPU% is a delta between two samples.
+let prevCpuTimes = null;
+
+function readCpuTimes() {
+  let idle = 0;
+  let total = 0;
+  for (const cpu of os.cpus()) {
+    for (const [kind, ms] of Object.entries(cpu.times)) {
+      total += ms;
+      if (kind === "idle") idle += ms;
+    }
+  }
+  return { idle, total };
+}
+
+function cpuPercentBetween(prev, curr) {
+  const totalDelta = curr.total - prev.total;
+  const idleDelta = curr.idle - prev.idle;
+  if (totalDelta <= 0) return 0;
+  const pct = (1 - idleDelta / totalDelta) * 100;
+  return Math.min(100, Math.max(0, pct));
+}
+
+async function sampleCpuPercent() {
+  if (prevCpuTimes === null) {
+    // First call: take a short two-point sample so the reading is real,
+    // not a since-boot average.
+    prevCpuTimes = readCpuTimes();
+    await new Promise((r) => setTimeout(r, FIRST_CPU_SAMPLE_MS));
+  }
+  const curr = readCpuTimes();
+  const pct = cpuPercentBetween(prevCpuTimes, curr);
+  prevCpuTimes = curr;
+  return pct;
+}
+
+async function readDiskUsage(diskPath) {
+  let stat;
+  try {
+    stat = await fs.promises.statfs(diskPath);
+  } catch (err) {
+    throw new Error(
+      `Failed to read disk usage for ${diskPath}: ${err.message}. ` +
+        "The observability dashboard needs a readable filesystem path — " +
+        "check that the path exists and is accessible."
+    );
+  }
+  const totalBytes = stat.blocks * stat.bsize;
+  const freeBytes = stat.bfree * stat.bsize;
+  return {
+    diskUsedGB: (totalBytes - freeBytes) / BYTES_PER_GB,
+    diskTotalGB: totalBytes / BYTES_PER_GB,
+  };
+}
+
+function readProcesses(now) {
+  // Electron's own process tree (main, renderer, GPU, utility) — the
+  // processes this app can meaningfully report on without a system-wide
+  // process scanner dependency.
+  return app.getAppMetrics().map((p) => ({
+    pid: p.pid,
+    name: p.name || p.serviceName || p.type,
+    cpuPercent: p.cpu.percentCPUUsage,
+    memoryMB: p.memory.workingSetSize / 1024, // workingSetSize is in KB
+    uptime: p.creationTime ? Math.max(0, (now - p.creationTime) / 1000) : 0,
+  }));
+}
+
+function readNetworkUp() {
+  return Object.values(os.networkInterfaces()).some((addrs) =>
+    (addrs || []).some((a) => !a.internal)
+  );
+}
+
+/**
+ * Collect a full SystemMetrics snapshot from the real host.
+ *
+ * @param {object} [options]
+ * @param {string} [options.diskPath] Filesystem path to report disk usage
+ *   for (defaults to the user's home directory).
+ * @returns {Promise<object>} SystemMetrics-shaped snapshot.
+ */
+async function collectSystemMetrics(options = {}) {
+  const diskPath = options.diskPath || os.homedir();
+
+  const [cpuPercent, disk] = await Promise.all([
+    sampleCpuPercent(),
+    readDiskUsage(diskPath),
+  ]);
+
+  const totalMem = os.totalmem();
+  const freeMem = os.freemem();
+  const now = Date.now();
+
+  return {
+    cpuPercent,
+    memoryUsedGB: (totalMem - freeMem) / BYTES_PER_GB,
+    memoryTotalGB: totalMem / BYTES_PER_GB,
+    diskUsedGB: disk.diskUsedGB,
+    diskTotalGB: disk.diskTotalGB,
+    networkUp: readNetworkUp(),
+    processes: readProcesses(now),
+    timestamp: now,
+  };
+}
+
+/**
+ * Register the `system:get-metrics` IPC handler. Collection errors reject
+ * the renderer's invoke() so the store can surface them.
+ */
+function registerIpcHandlers() {
+  ipcMain.handle(SYSTEM_GET_METRICS_CHANNEL, async () => {
+    return collectSystemMetrics();
+  });
+}
+
+module.exports = {
+  collectSystemMetrics,
+  registerIpcHandlers,
+  SYSTEM_GET_METRICS_CHANNEL,
+};

--- a/src/gaia/apps/webui/src/stores/__tests__/auditStore.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/auditStore.test.ts
@@ -1,0 +1,118 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * auditStore rollback — issue #2008.
+ *
+ * rollbackAction must actually perform the rollback (dispatch an
+ * `agent/rollback` JSON-RPC to the agent that executed the action) and
+ * only mark the entry rolled back after that succeeds. Failures must
+ * raise actionable errors and leave the entry unmarked — a "successful"
+ * rollback that reversed nothing is an audit-integrity violation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useAuditStore } from '../auditStore';
+import type { AuditEntry } from '../../types/agent';
+
+const makeEntry = (overrides: Partial<AuditEntry> = {}): AuditEntry => ({
+    id: 'a1',
+    timestamp: 1750000000000,
+    agentId: 'email-agent',
+    agentName: 'Email Agent',
+    tool: 'gmail_archive',
+    tier: 'confirm',
+    args: { threadId: 't-42' },
+    success: true,
+    resultSummary: 'archived thread t-42',
+    reversible: true,
+    ...overrides,
+});
+
+function getEntry(id: string): AuditEntry | undefined {
+    return useAuditStore.getState().entries.find((e) => e.id === id);
+}
+
+describe('auditStore rollbackAction (issue #2008)', () => {
+    beforeEach(() => {
+        useAuditStore.setState({ entries: [], rollbackTarget: null });
+    });
+
+    afterEach(() => {
+        delete (window as { gaiaAPI?: unknown }).gaiaAPI;
+        vi.restoreAllMocks();
+    });
+
+    it('performs the rollback RPC before marking the entry rolled back', async () => {
+        const sendRpc = vi.fn().mockResolvedValue({ ok: true });
+        (window as { gaiaAPI?: unknown }).gaiaAPI = { agent: { sendRpc } };
+        useAuditStore.getState().addEntry(makeEntry());
+
+        await useAuditStore.getState().rollbackAction('a1');
+
+        expect(sendRpc).toHaveBeenCalledWith('email-agent', 'agent/rollback', {
+            audit_id: 'a1',
+            tool: 'gmail_archive',
+            args: { threadId: 't-42' },
+        });
+        expect(getEntry('a1')?.rolledBack).toBe(true);
+        expect(useAuditStore.getState().rollbackTarget).toBeNull();
+    });
+
+    it('does NOT mark the entry rolled back when the rollback RPC fails', async () => {
+        const sendRpc = vi
+            .fn()
+            .mockRejectedValue(new Error('Agent "email-agent" is not running'));
+        (window as { gaiaAPI?: unknown }).gaiaAPI = { agent: { sendRpc } };
+        useAuditStore.getState().addEntry(makeEntry());
+
+        await expect(
+            useAuditStore.getState().rollbackAction('a1')
+        ).rejects.toThrow(/email-agent.*not running/);
+
+        expect(getEntry('a1')?.rolledBack).toBeFalsy();
+        expect(useAuditStore.getState().rollbackTarget).toBeNull();
+    });
+
+    it('raises an actionable error for irreversible actions and does not call the agent', async () => {
+        const sendRpc = vi.fn();
+        (window as { gaiaAPI?: unknown }).gaiaAPI = { agent: { sendRpc } };
+        useAuditStore.getState().addEntry(makeEntry({ reversible: false }));
+
+        await expect(
+            useAuditStore.getState().rollbackAction('a1')
+        ).rejects.toThrow(/not reversible/);
+
+        expect(sendRpc).not.toHaveBeenCalled();
+        expect(getEntry('a1')?.rolledBack).toBeFalsy();
+    });
+
+    it('rejects a second rollback of an already-rolled-back entry', async () => {
+        const sendRpc = vi.fn();
+        (window as { gaiaAPI?: unknown }).gaiaAPI = { agent: { sendRpc } };
+        useAuditStore.getState().addEntry(makeEntry({ rolledBack: true }));
+
+        await expect(
+            useAuditStore.getState().rollbackAction('a1')
+        ).rejects.toThrow(/already.*rolled back/i);
+
+        expect(sendRpc).not.toHaveBeenCalled();
+    });
+
+    it('rejects unknown entry ids', async () => {
+        await expect(
+            useAuditStore.getState().rollbackAction('nope')
+        ).rejects.toThrow(/not found/);
+    });
+
+    it('fails loudly when the Electron API is unavailable instead of faking success', async () => {
+        // No window.gaiaAPI — browser mode has no rollback executor.
+        useAuditStore.getState().addEntry(makeEntry());
+
+        await expect(
+            useAuditStore.getState().rollbackAction('a1')
+        ).rejects.toThrow(/desktop app/);
+
+        expect(getEntry('a1')?.rolledBack).toBeFalsy();
+    });
+});

--- a/src/gaia/apps/webui/src/stores/__tests__/systemStore.test.ts
+++ b/src/gaia/apps/webui/src/stores/__tests__/systemStore.test.ts
@@ -1,0 +1,120 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * systemStore polling — issue #2007.
+ *
+ * The store must surface REAL metrics from the Electron IPC bridge
+ * (window.gaiaAPI.system.getMetrics) and fail loudly — never silently
+ * poll a source that returns nothing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useSystemStore } from '../systemStore';
+import type { SystemMetrics } from '../../types/agent';
+
+const sampleMetrics = (overrides: Partial<SystemMetrics> = {}): SystemMetrics => ({
+    cpuPercent: 37.5,
+    memoryUsedGB: 12.4,
+    memoryTotalGB: 32,
+    diskUsedGB: 210.7,
+    diskTotalGB: 512,
+    networkUp: true,
+    processes: [
+        { pid: 1234, name: 'browser', cpuPercent: 2.1, memoryMB: 384.2, uptime: 3600 },
+    ],
+    timestamp: 1750000000000,
+    ...overrides,
+});
+
+function resetStore() {
+    useSystemStore.getState().stopPolling();
+    useSystemStore.setState({
+        metrics: null,
+        metricsHistory: [],
+        isPolling: false,
+        lastError: null,
+    });
+}
+
+describe('systemStore polling (issue #2007)', () => {
+    beforeEach(() => {
+        resetStore();
+    });
+
+    afterEach(() => {
+        useSystemStore.getState().stopPolling();
+        delete (window as { gaiaAPI?: unknown }).gaiaAPI;
+        vi.restoreAllMocks();
+    });
+
+    it('populates real metrics from the IPC bridge on startPolling', async () => {
+        const metrics = sampleMetrics();
+        const getMetrics = vi.fn().mockResolvedValue(metrics);
+        (window as { gaiaAPI?: unknown }).gaiaAPI = { system: { getMetrics } };
+
+        useSystemStore.getState().startPolling();
+
+        await vi.waitFor(() => {
+            expect(useSystemStore.getState().metrics).not.toBeNull();
+        });
+
+        const state = useSystemStore.getState();
+        expect(getMetrics).toHaveBeenCalled();
+        expect(state.metrics).toEqual(metrics);
+        expect(state.metrics?.cpuPercent).toBe(37.5);
+        expect(state.metricsHistory).toHaveLength(1);
+        expect(state.lastError).toBeNull();
+        expect(state.isPolling).toBe(true);
+    });
+
+    it('fails loudly and stops polling when the IPC call rejects', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const getMetrics = vi
+            .fn()
+            .mockRejectedValue(new Error('statfs failed for /home: EIO'));
+        (window as { gaiaAPI?: unknown }).gaiaAPI = { system: { getMetrics } };
+
+        useSystemStore.getState().startPolling();
+
+        await vi.waitFor(() => {
+            expect(useSystemStore.getState().lastError).not.toBeNull();
+        });
+
+        const state = useSystemStore.getState();
+        expect(state.lastError).toContain('statfs failed for /home: EIO');
+        expect(state.metrics).toBeNull();
+        expect(state.isPolling).toBe(false);
+        expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('fails loudly when the Electron API is not available (no silent null)', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        // No window.gaiaAPI at all — browser mode.
+
+        useSystemStore.getState().startPolling();
+
+        await vi.waitFor(() => {
+            expect(useSystemStore.getState().lastError).not.toBeNull();
+        });
+
+        const state = useSystemStore.getState();
+        // Actionable: names what is missing and where metrics come from.
+        expect(state.lastError).toMatch(/gaiaAPI\.system/);
+        expect(state.isPolling).toBe(false);
+        expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('clears lastError once a later poll succeeds', async () => {
+        const getMetrics = vi.fn().mockResolvedValue(sampleMetrics());
+        (window as { gaiaAPI?: unknown }).gaiaAPI = { system: { getMetrics } };
+        useSystemStore.setState({ lastError: 'previous failure' });
+
+        useSystemStore.getState().startPolling();
+
+        await vi.waitFor(() => {
+            expect(useSystemStore.getState().metrics).not.toBeNull();
+        });
+        expect(useSystemStore.getState().lastError).toBeNull();
+    });
+});

--- a/src/gaia/apps/webui/src/stores/auditStore.ts
+++ b/src/gaia/apps/webui/src/stores/auditStore.ts
@@ -45,6 +45,12 @@ interface AuditState {
   clearFilters: () => void;
 
   // ── Rollback Actions ────────────────────────────────────────────────
+  /**
+   * Undo the recorded action by dispatching `agent/rollback` to the agent
+   * that executed it, then mark the entry rolled back. Throws (and leaves
+   * the entry unmarked) when the entry is missing, irreversible, already
+   * rolled back, or the agent rejects/cannot be reached.
+   */
   rollbackAction: (id: string) => Promise<void>;
   setRollbackTarget: (id: string | null) => void;
 
@@ -125,23 +131,50 @@ export const useAuditStore = create<AuditState>((set, get) => ({
   rollbackAction: async (id) => {
     const { entries } = get();
     const entry = entries.find((e) => e.id === id);
-    if (!entry || !entry.reversible || entry.rolledBack) {
-      console.warn(`[auditStore] Cannot rollback entry ${id}`);
-      return;
+    if (!entry) {
+      throw new Error(`Audit entry ${id} not found — it may have been cleared.`);
+    }
+    if (!entry.reversible) {
+      throw new Error(
+        `Action "${entry.tool}" (audit entry ${id}) is not reversible — ` +
+          'the agent recorded it as irreversible, so there is nothing to undo.'
+      );
+    }
+    if (entry.rolledBack) {
+      throw new Error(`Audit entry ${id} has already been rolled back.`);
+    }
+
+    const sendRpc = window.gaiaAPI?.agent?.sendRpc;
+    if (!sendRpc) {
+      throw new Error(
+        'Rollback unavailable: window.gaiaAPI.agent is not exposed. ' +
+          'Rollback dispatches an agent/rollback RPC to the agent that ran ' +
+          'the action, which requires the GAIA desktop app (Electron).'
+      );
     }
 
     set({ rollbackTarget: id });
     try {
-      // TODO: Implement IPC call to rollback via main process
-      // For now, mark as rolled back locally
-      console.log(`[auditStore] rollbackAction(${id}): marking as rolled back`);
+      // The agent that executed the tool is the only party that can undo
+      // it — it must implement the `agent/rollback` JSON-RPC method and
+      // reject when it cannot revert the action.
+      await sendRpc(entry.agentId, 'agent/rollback', {
+        audit_id: entry.id,
+        tool: entry.tool,
+        args: entry.args,
+      });
+      // Only mark rolled back AFTER the agent confirmed the undo.
       set((state) => ({
         entries: state.entries.map((e) =>
           e.id === id ? { ...e, rolledBack: true } : e
         ),
       }));
     } catch (err) {
-      console.error(`[auditStore] Failed to rollback entry ${id}:`, err);
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Rollback of "${entry.tool}" (audit entry ${id}) failed — the entry ` +
+          `was NOT marked rolled back: ${message}`
+      );
     } finally {
       set({ rollbackTarget: null });
     }

--- a/src/gaia/apps/webui/src/stores/systemStore.ts
+++ b/src/gaia/apps/webui/src/stores/systemStore.ts
@@ -33,6 +33,8 @@ interface SystemState {
   isPolling: boolean;
   /** Polling interval in milliseconds. */
   pollInterval: number;
+  /** Last polling error (null when metrics are flowing). */
+  lastError: string | null;
 
   // ── Internal ──────────────────────────────────────────────────────────
   /** Timer ID for the polling interval (null when not polling). */
@@ -57,15 +59,20 @@ interface SystemState {
 // ── Polling Fetch Helper ─────────────────────────────────────────────────
 
 /**
- * Fetch system metrics from the Electron main process.
- * Returns null if the Electron API is not available.
+ * Fetch system metrics from the Electron main process over the
+ * `system:get-metrics` IPC channel (services/system-metrics.cjs).
+ * Throws when no metrics source is available — never returns null.
  */
-async function fetchSystemMetrics(): Promise<SystemMetrics | null> {
-  // TODO: Implement IPC call to main process for system metrics.
-  // For now this is a placeholder — the main process will expose a
-  // system:getMetrics IPC handler in a future ticket.
-  console.log('[systemStore] fetchSystemMetrics: not yet implemented (needs IPC)');
-  return null;
+async function fetchSystemMetrics(): Promise<SystemMetrics> {
+  const getMetrics = window.gaiaAPI?.system?.getMetrics;
+  if (!getMetrics) {
+    throw new Error(
+      'System metrics source unavailable: window.gaiaAPI.system is not exposed. ' +
+        'The observability dashboard requires the GAIA desktop app (Electron) — ' +
+        'browser mode has no system metrics IPC bridge.'
+    );
+  }
+  return getMetrics();
 }
 
 // ── Store Implementation ─────────────────────────────────────────────────
@@ -77,6 +84,7 @@ export const useSystemStore = create<SystemState>((set, get) => ({
   showDashboard: false,
   isPolling: false,
   pollInterval: DEFAULT_POLL_INTERVAL,
+  lastError: null,
   _timerId: null,
 
   // ── Metrics Actions ───────────────────────────────────────────────────
@@ -105,9 +113,17 @@ export const useSystemStore = create<SystemState>((set, get) => ({
     if (isPolling && _timerId !== null) return; // Already polling
 
     const tick = async () => {
-      const result = await fetchSystemMetrics();
-      if (result) {
+      try {
+        const result = await fetchSystemMetrics();
         get().updateMetrics(result);
+        if (get().lastError !== null) set({ lastError: null });
+      } catch (err) {
+        // Fail loudly: record the error and stop polling — the failure is
+        // structural (no IPC bridge / broken source), not transient.
+        const message = err instanceof Error ? err.message : String(err);
+        console.error('[systemStore] metrics poll failed — stopping polling:', message);
+        get().stopPolling();
+        set({ lastError: message });
       }
     };
 

--- a/src/gaia/apps/webui/src/types/agent.ts
+++ b/src/gaia/apps/webui/src/types/agent.ts
@@ -269,6 +269,9 @@ export interface GaiaElectronAPI {
     respondPermission: (id: string, action: 'allow' | 'deny', remember: boolean) => Promise<void>;
     onNotification: (cb: (data: GaiaNotification) => void) => void;
   };
+  system: {
+    getMetrics: () => Promise<SystemMetrics>;
+  };
 }
 
 // Augment Window to include gaiaAPI when running in Electron

--- a/tests/electron/mocks/electron.js
+++ b/tests/electron/mocks/electron.js
@@ -144,6 +144,28 @@ class MockApp extends EventEmitter {
     return this._isReady;
   }
 
+  getAppMetrics() {
+    // Mirrors Electron's app.getAppMetrics() shape (memory sizes in KB).
+    return [
+      {
+        pid: process.pid,
+        type: 'Browser',
+        name: 'Browser',
+        creationTime: Date.now() - 5000,
+        cpu: { percentCPUUsage: 1.5, idleWakeupsPerSecond: 0 },
+        memory: { workingSetSize: 204800, peakWorkingSetSize: 262144 },
+      },
+      {
+        pid: process.pid + 1,
+        type: 'Tab',
+        name: 'GAIA Agent UI',
+        creationTime: Date.now() - 4000,
+        cpu: { percentCPUUsage: 0.4, idleWakeupsPerSecond: 0 },
+        memory: { workingSetSize: 102400, peakWorkingSetSize: 131072 },
+      },
+    ];
+  }
+
   focus() {
     this.emit('browser-window-focus');
   }

--- a/tests/electron/system-metrics.test.cjs
+++ b/tests/electron/system-metrics.test.cjs
@@ -1,0 +1,95 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Real system-metrics collection for the observability dashboard — issue #2007.
+ *
+ * collectSystemMetrics() must return REAL host data (CPU, memory, disk,
+ * network, processes) in the SystemMetrics shape the renderer store expects,
+ * and must throw — not return null — when a source is unavailable.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const { app, ipcMain } = require("electron"); // mocked via moduleNameMapper
+const {
+  collectSystemMetrics,
+  registerIpcHandlers,
+  SYSTEM_GET_METRICS_CHANNEL,
+} = require("../../src/gaia/apps/webui/services/system-metrics.cjs");
+
+const PRELOAD_PATH = path.resolve(
+  __dirname,
+  "../../src/gaia/apps/webui/preload.cjs"
+);
+
+describe("collectSystemMetrics returns real host data", () => {
+  test("resolves a fully-populated SystemMetrics snapshot", async () => {
+    const before = Date.now();
+    const metrics = await collectSystemMetrics();
+
+    // CPU
+    expect(typeof metrics.cpuPercent).toBe("number");
+    expect(metrics.cpuPercent).toBeGreaterThanOrEqual(0);
+    expect(metrics.cpuPercent).toBeLessThanOrEqual(100);
+
+    // Memory — a real host always has non-zero totals and usage.
+    expect(metrics.memoryTotalGB).toBeGreaterThan(0);
+    expect(metrics.memoryUsedGB).toBeGreaterThan(0);
+    expect(metrics.memoryUsedGB).toBeLessThanOrEqual(metrics.memoryTotalGB);
+
+    // Disk — statfs on the home dir must yield real capacity.
+    expect(metrics.diskTotalGB).toBeGreaterThan(0);
+    expect(metrics.diskUsedGB).toBeGreaterThanOrEqual(0);
+    expect(metrics.diskUsedGB).toBeLessThanOrEqual(metrics.diskTotalGB);
+
+    // Network + timestamp
+    expect(typeof metrics.networkUp).toBe("boolean");
+    expect(metrics.timestamp).toBeGreaterThanOrEqual(before);
+
+    // Processes come from Electron's app.getAppMetrics()
+    expect(Array.isArray(metrics.processes)).toBe(true);
+    expect(metrics.processes.length).toBeGreaterThan(0);
+    for (const p of metrics.processes) {
+      expect(typeof p.pid).toBe("number");
+      expect(typeof p.name).toBe("string");
+      expect(p.name).not.toBe("");
+      expect(typeof p.cpuPercent).toBe("number");
+      expect(p.memoryMB).toBeGreaterThan(0);
+      expect(p.uptime).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("consecutive calls both return real values (cpu delta path)", async () => {
+    const first = await collectSystemMetrics();
+    const second = await collectSystemMetrics();
+    expect(first.cpuPercent).toBeGreaterThanOrEqual(0);
+    expect(second.cpuPercent).toBeGreaterThanOrEqual(0);
+    expect(second.timestamp).toBeGreaterThanOrEqual(first.timestamp);
+  });
+
+  test("throws an actionable error when the disk source is unavailable — no silent null", async () => {
+    await expect(
+      collectSystemMetrics({ diskPath: "/nonexistent-gaia-metrics-path" })
+    ).rejects.toThrow(/\/nonexistent-gaia-metrics-path/);
+  });
+});
+
+describe("IPC wiring for system:get-metrics", () => {
+  test("registerIpcHandlers exposes the channel and it returns metrics", async () => {
+    registerIpcHandlers();
+    const metrics = await ipcMain.simulateInvoke(SYSTEM_GET_METRICS_CHANNEL);
+    expect(metrics.memoryTotalGB).toBeGreaterThan(0);
+    ipcMain.removeHandler(SYSTEM_GET_METRICS_CHANNEL);
+  });
+
+  test("preload.cjs invokes the same channel the service registers", () => {
+    const preloadSrc = fs.readFileSync(PRELOAD_PATH, "utf8");
+    expect(preloadSrc).toContain(
+      `ipcRenderer.invoke("${SYSTEM_GET_METRICS_CHANNEL}")`
+    );
+  });
+});


### PR DESCRIPTION
Two weekly-audit findings made the observability layer wired-but-broken: the system dashboard's store polled a placeholder that always returned null (so it could structurally never display data), and `rollbackAction` marked audit entries rolled back without reversing anything — an audit-integrity hole where the user sees a "successful" rollback that undid nothing. Both now do the real work: a main-process service collects live host metrics (CPU/mem/disk/network/process tree) over a new `system:get-metrics` IPC channel, and rollback dispatches an `agent/rollback` JSON-RPC to the agent that executed the action, marking the entry only after the agent confirms. Every unavailable-source or failed-undo path now raises an actionable error instead of silently returning null or faking success.

GPU/NPU utilization stays `undefined` (optional in the `SystemMetrics` type — rendered as "unavailable"): there is no dependency-free cross-platform source, and a fake zero would be a silent fallback.

Fixes #2007
Fixes #2008

## Test plan

- [x] `npx vitest run src/stores/__tests__/systemStore.test.ts src/stores/__tests__/auditStore.test.ts` — TDD'd both fixes: metrics store populates real non-null data from the IPC bridge, records `lastError` + stops polling on failure; rollback only marks after RPC success, rejects (unmarked) on RPC failure / irreversible / already-rolled-back / browser mode
- [x] `cd tests/electron && npx jest system-metrics.test.cjs` — collector returns real host CPU/mem/disk/process values, throws on an unreadable disk path, and the preload channel matches the registered handler
- [x] Full suites green: webui vitest 257/257, electron jest 671/671, `npm run build`, `python util/lint.py --all`
- [x] Real-runtime proof: ran the collector inside actual Electron (`npx electron`) — returned live host data (CPU 56.8%, mem 23.8/24 GB, disk 328/460 GB, real process tree)