### PR TITLE
test(audit): risk-bearing coverage — jira, trust-gate, flag-precedence, #1655 boundaries

### DIFF
--- a/hub/agents/python/code/tests/test_external_tools.py
+++ b/hub/agents/python/code/tests/test_external_tools.py
@@ -8,12 +8,23 @@ This test suite validates:
 - Context7Service: Documentation search functionality
 - PerplexityService: Web search functionality
 - ExternalToolsMixin: Tool registration and integration
+
+Beyond the happy-path return values, these tests assert the OUTGOING
+subprocess.run() call: the npx argv, the env, and the JSON-RPC request
+piped to stdin (method, tool name, argument keys). A typo'd tool name
+(e.g. "get-library-doc") or argument key (e.g. "context7CompatibleLibrary")
+would still return whatever canned stdout a naive mock provides, so
+asserting only the parsed result — as the previous version of this file
+did — lets that typo pass CI while every real call to the npx service
+fails (#1993).
 """
 
 import json
 import os
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 # Add parent directory to path
@@ -30,13 +41,112 @@ from gaia.mcp.external_services import (
     get_perplexity_service,
 )
 
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+
+def _rpc_result_response(result):
+    """Build a MagicMock CompletedProcess wrapping a canned JSON-RPC result."""
+    return MagicMock(
+        returncode=0,
+        stdout=json.dumps({"jsonrpc": "2.0", "id": 1, "result": result}),
+        stderr="",
+    )
+
+
+def _rpc_responder(by_method=None, by_tool=None):
+    """Build a subprocess.run side_effect that routes on the JSON-RPC
+    request piped to stdin, rather than returning one fixed response for
+    every call regardless of what was asked for.
+
+    Requests are routed by "method" (e.g. "tools/list") or, for
+    "tools/call", by the tool name in params["name"] (e.g.
+    "get-library-docs"). A request that doesn't match the routing table
+    gets a nonzero-returncode response — surfaced by the production code
+    as an {"error": ...} result — instead of silently matching whatever
+    canned response happens to be configured, so a typo'd tool/method name
+    fails the test's result assertions instead of passing unnoticed.
+
+    Every call is recorded on the returned callable's `.calls` list as
+    {"command": argv, "env": env, "request": parsed JSON-RPC request} so
+    tests can assert the exact outgoing payload.
+    """
+    by_method = by_method or {}
+    by_tool = by_tool or {}
+    calls = []
+
+    def _run(command, *, input, capture_output, text, env, timeout, check):
+        request = json.loads(input)
+        calls.append({"command": command, "env": env, "request": request})
+        method = request.get("method")
+        if method == "tools/call":
+            tool_name = request.get("params", {}).get("name")
+            if tool_name in by_tool:
+                return _rpc_result_response(by_tool[tool_name])
+            return MagicMock(
+                returncode=1,
+                stdout="",
+                stderr=f"unrouted tools/call for tool_name={tool_name!r}",
+            )
+        if method in by_method:
+            return _rpc_result_response(by_method[method])
+        return MagicMock(
+            returncode=1, stdout="", stderr=f"unrouted JSON-RPC method={method!r}"
+        )
+
+    _run.calls = calls
+    return _run
+
+
+class _Context7IsolationMixin:
+    """Context7Service.check_availability() caches its result on the class
+    (across every instance, for the life of the process) and its cache /
+    rate-limiter persist to real files under ~/.gaia/cache/context7. Left
+    alone, one test's cached "unavailable" result or exhausted rate-limit
+    state leaks into every test that runs after it in the same process —
+    this is what made test_search_documentation_success and
+    test_search_documentation_no_library fail when the full suite ran
+    (passing in isolation, failing after an earlier test poisoned the
+    class-level cache). Reset the cache and redirect persistence to a
+    temp dir so each test is hermetic.
+    """
+
+    def setUp(self):
+        super().setUp()
+        Context7Service._availability_checked = False
+        Context7Service._is_available = False
+
+        import gaia.mcp.external_services as external_services_module
+
+        self._singleton_patcher = patch.object(
+            external_services_module, "_context7_service", None
+        )
+        self._singleton_patcher.start()
+
+        self._tmp_home = tempfile.TemporaryDirectory()
+        self._home_patcher = patch(
+            "gaia.mcp.context7_cache.Path.home",
+            return_value=Path(self._tmp_home.name),
+        )
+        self._home_patcher.start()
+
+    def tearDown(self):
+        self._home_patcher.stop()
+        self._tmp_home.cleanup()
+        self._singleton_patcher.stop()
+        Context7Service._availability_checked = False
+        Context7Service._is_available = False
+        super().tearDown()
+
 
 class TestExternalMCPService(unittest.TestCase):
     """Test the base ExternalMCPService class."""
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_call_tool_success(self, mock_run):
-        """Test successful tool call."""
+        """Test successful tool call — and that the outgoing subprocess call
+        carries the right argv, env, and JSON-RPC tools/call payload."""
         # Mock successful subprocess response
         mock_run.return_value = MagicMock(
             returncode=0,
@@ -50,12 +160,27 @@ class TestExternalMCPService(unittest.TestCase):
             stderr="",
         )
 
-        service = ExternalMCPService(command=["test", "command"])
+        service = ExternalMCPService(command=["test", "command"], env={"FOO": "bar"})
         result = service.call_tool("test_tool", {"arg": "value"})
 
         self.assertIn("content", result)
         self.assertEqual(result["content"][0]["text"], "Test result")
         mock_run.assert_called_once()
+
+        # The #1993 regression this guards against: a bare
+        # assert_called_once() only proves subprocess.run was invoked, not
+        # that the argv, env, or JSON-RPC payload it received were correct.
+        call_args, call_kwargs = mock_run.call_args
+        self.assertEqual(call_args[0], ["test", "command"])
+        self.assertEqual(call_kwargs["env"]["FOO"], "bar")
+        self.assertTrue(call_kwargs["text"])
+        self.assertEqual(call_kwargs["timeout"], service.timeout)
+
+        request = json.loads(call_kwargs["input"])
+        self.assertEqual(request["method"], "tools/call")
+        self.assertEqual(
+            request["params"], {"name": "test_tool", "arguments": {"arg": "value"}}
+        )
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_call_tool_error(self, mock_run):
@@ -97,28 +222,48 @@ class TestExternalMCPService(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("Invalid JSON", result["error"])
 
+    @patch("gaia.mcp.external_services.subprocess.run")
+    def test_list_tools_sends_tools_list_request(self, mock_run):
+        """list_tools() must send a "tools/list" JSON-RPC request — not
+        "tools/call" — with empty params."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "echo"}]}}
+            ),
+            stderr="",
+        )
 
-class TestContext7Service(unittest.TestCase):
+        service = ExternalMCPService(command=["test", "command"])
+        tools = service.list_tools()
+
+        self.assertEqual(tools, [{"name": "echo"}])
+        _, call_kwargs = mock_run.call_args
+        request = json.loads(call_kwargs["input"])
+        self.assertEqual(request["method"], "tools/list")
+        self.assertEqual(request["params"], {})
+
+
+class TestContext7Service(_Context7IsolationMixin, unittest.TestCase):
     """Test Context7Service functionality."""
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_search_documentation_success(self, mock_run):
-        """Test successful documentation search."""
-        # Mock successful Context7 response
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {
-                        "content": [
-                            {"type": "text", "text": "Documentation for useState hook"}
-                        ]
-                    },
-                }
-            ),
-            stderr="",
+        """Test successful documentation search — and that the
+        get-library-docs tools/call payload carries the right argument
+        keys, not just that some content came back."""
+        mock_run.side_effect = _rpc_responder(
+            by_method={"tools/list": {"tools": [{"name": "get-library-docs"}]}},
+            by_tool={
+                "resolve-library-id": {
+                    "content": [{"type": "text", "text": "No matches found."}]
+                },
+                "get-library-docs": {
+                    "content": [
+                        {"type": "text", "text": "Documentation for useState hook"}
+                    ]
+                },
+            },
         )
 
         service = Context7Service()
@@ -127,19 +272,78 @@ class TestContext7Service(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("useState hook", result["documentation"])
 
+        # argv is the real npx invocation, not a stand-in command.
+        first_call = mock_run.side_effect.calls[0]
+        self.assertEqual(first_call["command"], ["npx", "-y", "@upstash/context7-mcp"])
+
+        docs_call = next(
+            c
+            for c in mock_run.side_effect.calls
+            if c["request"]["params"].get("name") == "get-library-docs"
+        )
+        self.assertEqual(docs_call["request"]["method"], "tools/call")
+        # The canned resolve-library-id response has no parseable library
+        # ID, so resolution fails and no context7CompatibleLibraryID key
+        # is sent — see test_search_documentation_forwards_resolved_library_id
+        # below for the case where resolution succeeds.
+        self.assertEqual(
+            docs_call["request"]["params"]["arguments"], {"topic": "useState hook"}
+        )
+
+    @patch("gaia.mcp.external_services.subprocess.run")
+    def test_search_documentation_forwards_resolved_library_id(self, mock_run):
+        """When resolve-library-id resolves a library, get-library-docs
+        must receive it as context7CompatibleLibraryID — the exact
+        argument key #1993 flagged as unverified."""
+        mock_run.side_effect = _rpc_responder(
+            by_method={"tools/list": {"tools": [{"name": "get-library-docs"}]}},
+            by_tool={
+                "resolve-library-id": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "- Title: React\n"
+                                "- Context7-compatible library ID: /facebook/react\n"
+                                "- Code Snippets: 500\n"
+                            ),
+                        }
+                    ]
+                },
+                "get-library-docs": {
+                    "content": [{"type": "text", "text": "React docs"}]
+                },
+            },
+        )
+
+        service = Context7Service()
+        result = service.search_documentation("useState hook", library="react")
+
+        self.assertTrue(result["success"])
+
+        docs_call = next(
+            c
+            for c in mock_run.side_effect.calls
+            if c["request"]["params"].get("name") == "get-library-docs"
+        )
+        self.assertEqual(
+            docs_call["request"]["params"]["arguments"],
+            {
+                "topic": "useState hook",
+                "context7CompatibleLibraryID": "/facebook/react",
+            },
+        )
+
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_search_documentation_no_library(self, mock_run):
         """Test documentation search without library specified."""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {"content": [{"type": "text", "text": "Generic docs"}]},
+        mock_run.side_effect = _rpc_responder(
+            by_method={"tools/list": {"tools": [{"name": "get-library-docs"}]}},
+            by_tool={
+                "get-library-docs": {
+                    "content": [{"type": "text", "text": "Generic docs"}]
                 }
-            ),
-            stderr="",
+            },
         )
 
         service = Context7Service()
@@ -147,6 +351,19 @@ class TestContext7Service(unittest.TestCase):
 
         self.assertTrue(result["success"])
         self.assertIn("documentation", result)
+
+        # No library was passed, so no resolve-library-id call should have
+        # happened and get-library-docs should carry only "topic".
+        tool_names = [
+            c["request"]["params"].get("name")
+            for c in mock_run.side_effect.calls
+            if c["request"]["method"] == "tools/call"
+        ]
+        self.assertEqual(tool_names, ["get-library-docs"])
+        docs_call = mock_run.side_effect.calls[-1]
+        self.assertEqual(
+            docs_call["request"]["params"]["arguments"], {"topic": "async patterns"}
+        )
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_search_documentation_error(self, mock_run):
@@ -161,19 +378,16 @@ class TestContext7Service(unittest.TestCase):
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_resolve_library_id(self, mock_run):
-        """Test library ID resolution."""
-        # Mock actual Context7 response format
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": """Available Libraries:
+        """Test library ID resolution — and that resolve-library-id is
+        called with the "libraryName" argument key the real npx package
+        expects."""
+        mock_run.side_effect = _rpc_responder(
+            by_tool={
+                "resolve-library-id": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": """Available Libraries:
 
 Each result includes:
 - Library ID: Context7-compatible identifier (format: /org/project)
@@ -186,12 +400,10 @@ Each result includes:
 - Description: A JavaScript library for building user interfaces
 - Code Snippets: 500
 - Source Reputation: High""",
-                            }
-                        ]
-                    },
+                        }
+                    ]
                 }
-            ),
-            stderr="",
+            }
         )
 
         service = Context7Service()
@@ -199,31 +411,50 @@ Each result includes:
 
         self.assertEqual(result, "/facebook/react")
 
+        self.assertEqual(len(mock_run.side_effect.calls), 1)
+        call = mock_run.side_effect.calls[0]
+        self.assertEqual(call["command"], ["npx", "-y", "@upstash/context7-mcp"])
+        self.assertEqual(call["request"]["method"], "tools/call")
+        self.assertEqual(
+            call["request"]["params"],
+            {"name": "resolve-library-id", "arguments": {"libraryName": "react"}},
+        )
+
+    @patch("gaia.mcp.external_services.subprocess.run")
+    def test_context7_service_passes_api_key_via_env(self, mock_run):
+        """The CONTEXT7_API_KEY constructor arg must reach the npx
+        subprocess's environment — not just be stored on the instance."""
+        mock_run.side_effect = _rpc_responder(
+            by_method={"tools/list": {"tools": [{"name": "get-library-docs"}]}}
+        )
+
+        service = Context7Service(api_key="ctx-key-123")
+        service.list_tools()
+
+        self.assertEqual(len(mock_run.side_effect.calls), 1)
+        call = mock_run.side_effect.calls[0]
+        self.assertEqual(call["command"], ["npx", "-y", "@upstash/context7-mcp"])
+        self.assertEqual(call["env"]["CONTEXT7_API_KEY"], "ctx-key-123")
+
 
 class TestPerplexityService(unittest.TestCase):
     """Test PerplexityService functionality."""
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_search_web_success(self, mock_run):
-        """Test successful web search."""
-        # Mock successful Perplexity response
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": "Python best practices include...",
-                            }
-                        ]
-                    },
+        """Test successful web search — and that perplexity_ask is called
+        with the right argv, env, and "messages" argument shape."""
+        mock_run.side_effect = _rpc_responder(
+            by_tool={
+                "perplexity_ask": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Python best practices include...",
+                        }
+                    ]
                 }
-            ),
-            stderr="",
+            }
         )
 
         service = PerplexityService(api_key="test_key")
@@ -231,6 +462,21 @@ class TestPerplexityService(unittest.TestCase):
 
         self.assertTrue(result["success"])
         self.assertIn("best practices", result["answer"])
+
+        self.assertEqual(len(mock_run.side_effect.calls), 1)
+        call = mock_run.side_effect.calls[0]
+        self.assertEqual(call["command"], ["npx", "-y", "server-perplexity-ask"])
+        self.assertEqual(call["env"]["PERPLEXITY_API_KEY"], "test_key")
+        self.assertEqual(call["request"]["method"], "tools/call")
+        self.assertEqual(
+            call["request"]["params"],
+            {
+                "name": "perplexity_ask",
+                "arguments": {
+                    "messages": [{"role": "user", "content": "Python best practices"}]
+                },
+            },
+        )
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_search_web_no_api_key(self, mock_run):
@@ -254,17 +500,19 @@ class TestPerplexityService(unittest.TestCase):
         self.assertIn("error", result)
 
 
-class TestExternalToolsMixin(unittest.TestCase):
+class TestExternalToolsMixin(_Context7IsolationMixin, unittest.TestCase):
     """Test ExternalToolsMixin integration with Code Agent."""
 
     def setUp(self):
         """Set up test fixtures."""
+        super().setUp()
         self.agent = CodeAgent(silent_mode=True, max_steps=5)
         self.agent._register_tools()
 
     def tearDown(self):
         """Clean up test fixtures."""
         _TOOL_REGISTRY.clear()
+        super().tearDown()
 
     def test_external_tools_registered(self):
         """Test that external tools are registered."""
@@ -290,18 +538,18 @@ class TestExternalToolsMixin(unittest.TestCase):
 
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_search_documentation_tool_execution(self, mock_run):
-        """Test search_documentation tool execution."""
-        # Mock successful response
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {"content": [{"type": "text", "text": "Test docs"}]},
-                }
-            ),
-            stderr="",
+        """Test search_documentation tool execution — through the full
+        tool-registry path, asserting the get-library-docs call shape."""
+        mock_run.side_effect = _rpc_responder(
+            by_method={"tools/list": {"tools": [{"name": "get-library-docs"}]}},
+            by_tool={
+                "resolve-library-id": {
+                    "content": [{"type": "text", "text": "No matches."}]
+                },
+                "get-library-docs": {
+                    "content": [{"type": "text", "text": "Test docs"}]
+                },
+            },
         )
 
         tool_func = _TOOL_REGISTRY["search_documentation"]["function"]
@@ -310,20 +558,25 @@ class TestExternalToolsMixin(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("documentation", result)
 
+        docs_call = next(
+            c
+            for c in mock_run.side_effect.calls
+            if c["request"]["params"].get("name") == "get-library-docs"
+        )
+        self.assertEqual(
+            docs_call["request"]["params"]["arguments"]["topic"], "test query"
+        )
+
     @patch("gaia.mcp.external_services.subprocess.run")
     def test_search_web_tool_execution(self, mock_run):
-        """Test search_web tool execution."""
-        # Mock successful response
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "result": {"content": [{"type": "text", "text": "Test answer"}]},
+        """Test search_web tool execution — through the full tool-registry
+        path, asserting the perplexity_ask call shape."""
+        mock_run.side_effect = _rpc_responder(
+            by_tool={
+                "perplexity_ask": {
+                    "content": [{"type": "text", "text": "Test answer"}]
                 }
-            ),
-            stderr="",
+            }
         )
 
         tool_func = _TOOL_REGISTRY["search_web"]["function"]
@@ -332,8 +585,16 @@ class TestExternalToolsMixin(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("answer", result)
 
+        self.assertEqual(len(mock_run.side_effect.calls), 1)
+        call = mock_run.side_effect.calls[0]
+        self.assertEqual(call["command"], ["npx", "-y", "server-perplexity-ask"])
+        self.assertEqual(
+            call["request"]["params"]["arguments"],
+            {"messages": [{"role": "user", "content": "test query"}]},
+        )
 
-class TestServiceSingletons(unittest.TestCase):
+
+class TestServiceSingletons(_Context7IsolationMixin, unittest.TestCase):
     """Test singleton service instances."""
 
     def test_context7_singleton(self):

--- a/hub/agents/python/connectors-demo/tests/test_connectors_demo.py
+++ b/hub/agents/python/connectors-demo/tests/test_connectors_demo.py
@@ -14,6 +14,7 @@ correctly and that the registry sees it as a built-in.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from unittest.mock import patch
 
 import httpx
@@ -135,10 +136,35 @@ class TestFormatConnectorError:
 # ---------------------------------------------------------------------------
 
 
-def _stub_gmail_response(messages):
-    """Build the two-step Gmail API response shape the impl expects."""
+class _CapturingGet:
+    """Fake httpx.get that records every call's headers/params instead of
+    discarding them, so tests can assert on the OUTGOING request shape —
+    not just the parsed response.
 
-    def _fake_get(url, headers=None, params=None, timeout=None):
+    A fake that accepts headers/params and ignores them proves the code
+    path executed, but not that a dropped Authorization header or a
+    limit-that-never-reached-maxResults would be caught: the canned
+    response comes back regardless, and the test still passes (#1999).
+    """
+
+    def __init__(self, response_for_url):
+        """response_for_url: a fixed httpx.Response, OR a callable
+        url -> httpx.Response for multi-step call chains (e.g. Gmail)."""
+        self._response_for_url = response_for_url
+        self.calls = []
+
+    def __call__(self, url, headers=None, params=None, timeout=None):
+        self.calls.append({"url": url, "headers": headers, "params": params})
+        if callable(self._response_for_url):
+            return self._response_for_url(url)
+        return self._response_for_url
+
+
+def _stub_gmail_response(messages):
+    """Build the two-step Gmail API response shape the impl expects, while
+    recording every call's headers/params for assertions."""
+
+    def _response_for_url(url):
         if url.endswith("/messages"):
             return httpx.Response(
                 200, json={"messages": [{"id": m["id"]} for m in messages]}
@@ -158,7 +184,7 @@ def _stub_gmail_response(messages):
             },
         )
 
-    return _fake_get
+    return _CapturingGet(_response_for_url)
 
 
 class TestGmailRecentSubjects:
@@ -167,18 +193,45 @@ class TestGmailRecentSubjects:
             {"id": "1", "from": "alice@example.com", "subject": "Lunch?"},
             {"id": "2", "from": "bob@example.com", "subject": "Re: PR review"},
         ]
+        fake_get = _stub_gmail_response(fake_messages)
         with (
             patch(
                 "gaia_agent_connectors_demo.agent._gmail_token",
                 return_value="tok-xyz",
             ),
-            patch("httpx.get", side_effect=_stub_gmail_response(fake_messages)),
+            patch("httpx.get", side_effect=fake_get),
         ):
             result = _gmail_recent_subjects_impl(limit=5)
         assert result["ok"] is True
         assert result["count"] == 2
         assert result["messages"][0]["subject"] == "Lunch?"
         assert result["messages"][1]["from"] == "bob@example.com"
+
+        # The #1999 regression this guards against: a dropped bearer token
+        # or a limit that never reaches maxResults would still return this
+        # canned data — assert the OUTGOING request, not just the parsed
+        # result.
+        list_call = fake_get.calls[0]
+        assert list_call["headers"] == {"Authorization": "Bearer tok-xyz"}
+        assert list_call["params"] == {"maxResults": 5}
+
+    def test_limit_flows_into_max_results_param(self):
+        # A different limit than the happy-path test's default of 5 —
+        # proves maxResults tracks the caller's limit rather than being a
+        # hardcoded value that happens to match.
+        fake_get = _stub_gmail_response(
+            [{"id": "1", "from": "a@example.com", "subject": "Hi"}]
+        )
+        with (
+            patch(
+                "gaia_agent_connectors_demo.agent._gmail_token",
+                return_value="tok",
+            ),
+            patch("httpx.get", side_effect=fake_get),
+        ):
+            _gmail_recent_subjects_impl(limit=2)
+
+        assert fake_get.calls[0]["params"] == {"maxResults": 2}
 
     def test_grant_failure_returns_actionable_error(self):
         with patch(
@@ -237,12 +290,13 @@ class TestCalendarToday:
                 ]
             },
         )
+        fake_get = _CapturingGet(fake_response)
         with (
             patch(
                 "gaia_agent_connectors_demo.agent._calendar_token",
                 return_value="tok",
             ),
-            patch("httpx.get", return_value=fake_response),
+            patch("httpx.get", side_effect=fake_get),
         ):
             result = _calendar_today_impl()
         assert result["ok"] is True
@@ -251,6 +305,21 @@ class TestCalendarToday:
         # All-day events have a 'date' field rather than 'dateTime' —
         # the impl must accept both shapes.
         assert result["events"][1]["start"] == "2026-05-01"
+
+        # #1999: assert the outgoing bearer header and the intent-carrying
+        # timeMin/timeMax window params, not just the parsed result.
+        call = fake_get.calls[0]
+        assert call["headers"] == {"Authorization": "Bearer tok"}
+        params = call["params"]
+        assert params["singleEvents"] == "true"
+        assert params["orderBy"] == "startTime"
+        # timeMin/timeMax must be RFC3339 timestamps bracketing today, with
+        # timeMin < timeMax — a swapped or malformed window would silently
+        # return the wrong day's events against the real API.
+        time_min = datetime.fromisoformat(params["timeMin"])
+        time_max = datetime.fromisoformat(params["timeMax"])
+        assert time_min < time_max
+        assert time_min.date() == time_max.date() == datetime.now().date()
 
 
 # ---------------------------------------------------------------------------
@@ -274,16 +343,37 @@ class TestDriveRecentFiles:
                 ]
             },
         )
+        fake_get = _CapturingGet(fake_response)
         with (
             patch(
                 "gaia_agent_connectors_demo.agent._drive_token",
                 return_value="tok",
             ),
-            patch("httpx.get", return_value=fake_response),
+            patch("httpx.get", side_effect=fake_get),
         ):
             result = _drive_recent_files_impl(limit=5)
         assert result["ok"] is True
         assert result["files"][0]["name"] == "Q3 Plan.gdoc"
+
+        # #1999: assert the outgoing bearer header and that limit flows
+        # into pageSize, not just the parsed result.
+        call = fake_get.calls[0]
+        assert call["headers"] == {"Authorization": "Bearer tok"}
+        assert call["params"]["pageSize"] == 5
+        assert call["params"]["orderBy"] == "modifiedTime desc"
+
+    def test_limit_flows_into_page_size_param(self):
+        fake_get = _CapturingGet(httpx.Response(200, json={"files": []}))
+        with (
+            patch(
+                "gaia_agent_connectors_demo.agent._drive_token",
+                return_value="tok",
+            ),
+            patch("httpx.get", side_effect=fake_get),
+        ):
+            _drive_recent_files_impl(limit=3)
+
+        assert fake_get.calls[0]["params"]["pageSize"] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -305,16 +395,43 @@ class TestGithubMyRepos:
                 }
             ],
         )
+        fake_get = _CapturingGet(fake_response)
         with (
             patch(
                 "gaia_agent_connectors_demo.agent._github_pat",
                 return_value="ghp_x",
             ),
-            patch("httpx.get", return_value=fake_response),
+            patch("httpx.get", side_effect=fake_get),
         ):
             result = _github_my_repos_impl(limit=10)
         assert result["ok"] is True
         assert result["repos"][0]["full_name"] == "octocat/Hello-World"
+
+        # #1999: assert the bearer token, the GitHub-specific Accept +
+        # API-version headers, and that limit flows into per_page — not
+        # just the parsed result. A dropped Accept header or a stale
+        # X-GitHub-Api-Version would 401/406 against the real API while
+        # this canned response still comes back.
+        call = fake_get.calls[0]
+        assert call["headers"] == {
+            "Authorization": "Bearer ghp_x",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        assert call["params"] == {"per_page": 10, "sort": "updated"}
+
+    def test_limit_flows_into_per_page_param(self):
+        fake_get = _CapturingGet(httpx.Response(200, json=[]))
+        with (
+            patch(
+                "gaia_agent_connectors_demo.agent._github_pat",
+                return_value="ghp_x",
+            ),
+            patch("httpx.get", side_effect=fake_get),
+        ):
+            _github_my_repos_impl(limit=25)
+
+        assert fake_get.calls[0]["params"]["per_page"] == 25
 
     def test_pat_missing_returns_connector_error(self):
         with patch(

--- a/hub/agents/python/jira/tests/test_jira_agent.py
+++ b/hub/agents/python/jira/tests/test_jira_agent.py
@@ -1,0 +1,782 @@
+#!/usr/bin/env python
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for JiraAgent (issue #1991).
+
+Covers the HTTP tool implementations at the mocked Atlassian boundary:
+- ``_get_jira_credentials`` URL normalization and caching
+- ``_discover_jira_config`` endpoint fan-out and response parsing
+- ``_execute_jira_search_async`` request shape and result mapping
+- ``_execute_jira_create_async`` payload building, project auto-discovery,
+  and the Atlassian 400 error-rewriting branch
+- ``_execute_jira_update_async`` field-diff payload building
+- System-prompt JQL guidance (config-driven vs. fallback)
+
+Per the #1655 rule, every mocked HTTP interaction asserts the OUTGOING
+request shape (method, URL path, auth header, params, JSON payload) —
+never merely that a mock was called. The JQL template helper is covered
+separately in tests/unit/agents/test_jql_templates.py and not duplicated
+here.
+
+No network, no Atlassian, no LLM — the aiohttp boundary is replaced with
+a recording fake session.
+"""
+
+import asyncio
+import base64
+import os
+import sys
+from types import SimpleNamespace
+
+import aiohttp
+import pytest
+
+# Add package directory to path (hub-package test convention)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gaia_agent_jira import agent as agent_module  # noqa: E402
+from gaia_agent_jira.agent import JiraAgent  # noqa: E402
+
+from gaia.agents.base.tools import _TOOL_REGISTRY  # noqa: E402
+
+SITE = "https://example.atlassian.net"
+EMAIL = "user@example.com"
+TOKEN = "api-token-123"
+EXPECTED_AUTH = "Basic " + base64.b64encode(f"{EMAIL}:{TOKEN}".encode()).decode()
+
+SEARCH_URL = f"{SITE}/rest/api/3/search/jql"
+ISSUE_URL = f"{SITE}/rest/api/3/issue"
+PROJECT_URL = f"{SITE}/rest/api/3/project"
+DEFAULT_SEARCH_FIELDS = "key,summary,status,priority,issuetype,assignee"
+
+
+# ---------------------------------------------------------------------------
+# Fake aiohttp boundary
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Async-context-manager response double for aiohttp."""
+
+    def __init__(self, status=200, json_data=None, json_exc=None):
+        self.status = status
+        self._json_data = json_data
+        self._json_exc = json_exc
+
+    async def json(self):
+        if self._json_exc is not None:
+            raise self._json_exc
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            # real_url is required by ClientResponseError.__str__
+            request_info = SimpleNamespace(real_url="https://fake.test/")
+            raise aiohttp.ClientResponseError(
+                request_info=request_info,
+                history=(),
+                status=self.status,
+                message=f"HTTP {self.status}",
+            )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    """Records every outgoing request; serves responses from a route table.
+
+    Routes are keyed by ``(METHOD, full_url)``. An un-routed request is a
+    test failure — the agent must never make a call the test didn't expect.
+    """
+
+    def __init__(self, routes=None):
+        self.routes = routes or {}
+        self.requests = []
+
+    def _handle(self, method, url, **kwargs):
+        self.requests.append(
+            SimpleNamespace(
+                method=method,
+                url=url,
+                headers=kwargs.get("headers"),
+                params=kwargs.get("params"),
+                json=kwargs.get("json"),
+            )
+        )
+        key = (method, url)
+        if key not in self.routes:
+            raise AssertionError(f"unexpected request: {method} {url}")
+        return self.routes[key]
+
+    def get(self, url, **kwargs):
+        return self._handle("GET", url, **kwargs)
+
+    def post(self, url, **kwargs):
+        return self._handle("POST", url, **kwargs)
+
+    def put(self, url, **kwargs):
+        return self._handle("PUT", url, **kwargs)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def jira_env(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_SITE_URL", SITE)
+    monkeypatch.setenv("ATLASSIAN_API_KEY", TOKEN)
+    monkeypatch.setenv("ATLASSIAN_USER_EMAIL", EMAIL)
+
+
+@pytest.fixture
+def make_agent():
+    """Build a JiraAgent without a Lemonade server; clean up the tool registry."""
+    _TOOL_REGISTRY.clear()
+
+    def _make(**kwargs):
+        kwargs.setdefault("silent_mode", True)
+        kwargs.setdefault("skip_lemonade", True)
+        return JiraAgent(**kwargs)
+
+    yield _make
+    _TOOL_REGISTRY.clear()
+
+
+@pytest.fixture
+def agent(jira_env, make_agent):
+    return make_agent()
+
+
+@pytest.fixture
+def http(monkeypatch):
+    """Replace the aiohttp module used by the agent with a recording fake."""
+
+    def _install(routes=None):
+        session = FakeSession(routes)
+        monkeypatch.setattr(
+            agent_module,
+            "aiohttp",
+            SimpleNamespace(ClientSession=lambda: session),
+        )
+        return session
+
+    return _install
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def assert_auth_headers(request):
+    assert request.headers["Authorization"] == EXPECTED_AUTH
+    assert request.headers["Content-Type"] == "application/json"
+    assert request.headers["Accept"] == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# _get_jira_credentials — URL normalization
+# ---------------------------------------------------------------------------
+
+
+class TestGetJiraCredentials:
+    def test_missing_env_raises_actionable_error(self, monkeypatch, make_agent):
+        for var in (
+            "ATLASSIAN_SITE_URL",
+            "ATLASSIAN_API_KEY",
+            "ATLASSIAN_USER_EMAIL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        agent = make_agent()
+        with pytest.raises(ValueError) as excinfo:
+            agent._get_jira_credentials()
+        msg = str(excinfo.value)
+        assert "ATLASSIAN_SITE_URL" in msg
+        assert "ATLASSIAN_API_KEY" in msg
+        assert "ATLASSIAN_USER_EMAIL" in msg
+
+    def test_partial_env_raises(self, monkeypatch, make_agent):
+        monkeypatch.setenv("ATLASSIAN_SITE_URL", SITE)
+        monkeypatch.setenv("ATLASSIAN_API_KEY", TOKEN)
+        monkeypatch.delenv("ATLASSIAN_USER_EMAIL", raising=False)
+        with pytest.raises(ValueError):
+            make_agent()._get_jira_credentials()
+
+    def test_trailing_slash_stripped(self, monkeypatch, jira_env, make_agent):
+        monkeypatch.setenv("ATLASSIAN_SITE_URL", f"{SITE}/")
+        site_url, api_key, user_email = make_agent()._get_jira_credentials()
+        assert site_url == SITE
+        assert api_key == TOKEN
+        assert user_email == EMAIL
+
+    def test_bare_host_gets_https_prefix(self, monkeypatch, jira_env, make_agent):
+        monkeypatch.setenv("ATLASSIAN_SITE_URL", "example.atlassian.net")
+        site_url, _, _ = make_agent()._get_jira_credentials()
+        assert site_url == "https://example.atlassian.net"
+
+    def test_explicit_http_scheme_preserved(self, monkeypatch, jira_env, make_agent):
+        monkeypatch.setenv("ATLASSIAN_SITE_URL", "http://jira.internal:8080/")
+        site_url, _, _ = make_agent()._get_jira_credentials()
+        assert site_url == "http://jira.internal:8080"
+
+    def test_credentials_cached_after_first_read(
+        self, monkeypatch, jira_env, make_agent
+    ):
+        agent = make_agent()
+        first = agent._get_jira_credentials()
+        monkeypatch.setenv("ATLASSIAN_SITE_URL", "https://other.atlassian.net")
+        assert agent._get_jira_credentials() == first
+
+
+# ---------------------------------------------------------------------------
+# _discover_jira_config
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverJiraConfig:
+    def test_discovery_request_shape_and_parsing(self, agent, http):
+        session = http(
+            {
+                ("GET", PROJECT_URL): FakeResponse(
+                    json_data=[
+                        {"key": "ENG", "name": "Engineering", "id": "10000"},
+                        {"key": "OPS", "name": "Operations", "id": "10001"},
+                    ]
+                ),
+                ("GET", f"{SITE}/rest/api/3/issuetype"): FakeResponse(
+                    json_data=[
+                        {"name": "Task"},
+                        {"name": "Sub-task", "subtask": True},
+                        {"name": "Bug", "subtask": False},
+                    ]
+                ),
+                ("GET", f"{SITE}/rest/api/3/status"): FakeResponse(
+                    json_data=[{"name": "To Do"}, {"name": "Done"}]
+                ),
+                ("GET", f"{SITE}/rest/api/3/priority"): FakeResponse(
+                    json_data=[{"name": "High"}, {"name": "Low"}]
+                ),
+            }
+        )
+
+        config = run(agent._discover_jira_config())
+
+        # Outgoing request shape: all four discovery endpoints, GET, authed
+        assert [(r.method, r.url) for r in session.requests] == [
+            ("GET", PROJECT_URL),
+            ("GET", f"{SITE}/rest/api/3/issuetype"),
+            ("GET", f"{SITE}/rest/api/3/status"),
+            ("GET", f"{SITE}/rest/api/3/priority"),
+        ]
+        for request in session.requests:
+            assert_auth_headers(request)
+
+        # Parsing: only key/name kept, subtask types filtered out
+        assert config["projects"] == [
+            {"key": "ENG", "name": "Engineering"},
+            {"key": "OPS", "name": "Operations"},
+        ]
+        assert config["issue_types"] == ["Task", "Bug"]
+        assert config["statuses"] == ["To Do", "Done"]
+        assert config["priorities"] == ["High", "Low"]
+        assert agent._jira_config == config
+
+    def test_non_200_endpoint_leaves_section_empty(self, agent, http):
+        http(
+            {
+                ("GET", PROJECT_URL): FakeResponse(
+                    json_data=[{"key": "ENG", "name": "Engineering"}]
+                ),
+                ("GET", f"{SITE}/rest/api/3/issuetype"): FakeResponse(status=500),
+                ("GET", f"{SITE}/rest/api/3/status"): FakeResponse(
+                    json_data=[{"name": "Done"}]
+                ),
+                ("GET", f"{SITE}/rest/api/3/priority"): FakeResponse(status=403),
+            }
+        )
+
+        config = run(agent._discover_jira_config())
+
+        assert config["projects"] == [{"key": "ENG", "name": "Engineering"}]
+        assert config["issue_types"] == []
+        assert config["statuses"] == ["Done"]
+        assert config["priorities"] == []
+
+    def test_cached_config_short_circuits_http(self, jira_env, make_agent, monkeypatch):
+        cached = {
+            "projects": [{"key": "ENG", "name": "Engineering"}],
+            "issue_types": ["Bug"],
+            "statuses": ["Done"],
+            "priorities": ["High"],
+        }
+        agent = make_agent(jira_config=cached)
+
+        def _fail():
+            raise AssertionError("HTTP session must not be created for cached config")
+
+        monkeypatch.setattr(
+            agent_module, "aiohttp", SimpleNamespace(ClientSession=_fail)
+        )
+        assert run(agent._discover_jira_config()) == cached
+
+    def test_initialize_returns_empty_config_on_failure(self, monkeypatch, make_agent):
+        for var in (
+            "ATLASSIAN_SITE_URL",
+            "ATLASSIAN_API_KEY",
+            "ATLASSIAN_USER_EMAIL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        agent = make_agent()
+        config = agent.initialize()
+        assert config == {
+            "projects": [],
+            "issue_types": [],
+            "statuses": [],
+            "priorities": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# _execute_jira_search_async
+# ---------------------------------------------------------------------------
+
+
+class TestJiraSearch:
+    def test_search_request_shape_defaults(self, agent, http):
+        session = http(
+            {("GET", SEARCH_URL): FakeResponse(json_data={"issues": [], "total": 0})}
+        )
+        jql = "assignee = currentUser()"
+
+        run(agent._execute_jira_search_async(jql))
+
+        assert len(session.requests) == 1
+        request = session.requests[0]
+        assert request.method == "GET"
+        assert request.url == SEARCH_URL
+        assert_auth_headers(request)
+        # No maxResults when not requested; default field list always sent
+        assert request.params == {"jql": jql, "fields": DEFAULT_SEARCH_FIELDS}
+
+    def test_search_request_shape_with_max_results_and_fields(self, agent, http):
+        session = http(
+            {("GET", SEARCH_URL): FakeResponse(json_data={"issues": [], "total": 0})}
+        )
+
+        run(
+            agent._execute_jira_search_async(
+                "project = ENG", max_results=25, fields="key,summary"
+            )
+        )
+
+        assert session.requests[0].params == {
+            "jql": "project = ENG",
+            "maxResults": 25,
+            "fields": "key,summary",
+        }
+
+    def test_search_result_parsing(self, agent, http):
+        http(
+            {
+                ("GET", SEARCH_URL): FakeResponse(
+                    json_data={
+                        "total": 7,
+                        "issues": [
+                            {
+                                "key": "ENG-1",
+                                "fields": {
+                                    "summary": "Fix login",
+                                    "status": {"name": "In Progress"},
+                                    "priority": {"name": "High"},
+                                    "issuetype": {"name": "Bug"},
+                                    "assignee": {"displayName": "Ada Lovelace"},
+                                },
+                            },
+                            {
+                                "key": "ENG-2",
+                                "fields": {
+                                    "summary": "Bare issue",
+                                    "status": None,
+                                    "priority": None,
+                                    "issuetype": None,
+                                    "assignee": None,
+                                },
+                            },
+                        ],
+                    }
+                )
+            }
+        )
+
+        result = run(agent._execute_jira_search_async("project = ENG"))
+
+        assert result["total"] == 7
+        assert result["jql"] == "project = ENG"
+        assert result["issues"][0] == {
+            "key": "ENG-1",
+            "summary": "Fix login",
+            "status": "In Progress",
+            "priority": "High",
+            "type": "Bug",
+            "assignee": "Ada Lovelace",
+        }
+        # Null nested fields must map to None / "Unassigned", not crash
+        assert result["issues"][1] == {
+            "key": "ENG-2",
+            "summary": "Bare issue",
+            "status": None,
+            "priority": None,
+            "type": None,
+            "assignee": "Unassigned",
+        }
+
+    def test_search_total_falls_back_to_issue_count(self, agent, http):
+        http(
+            {
+                ("GET", SEARCH_URL): FakeResponse(
+                    json_data={
+                        "issues": [{"key": "ENG-1", "fields": {"summary": "One"}}]
+                    }
+                )
+            }
+        )
+        result = run(agent._execute_jira_search_async("project = ENG"))
+        assert result["total"] == 1
+
+    def test_search_http_error_raises(self, agent, http):
+        http({("GET", SEARCH_URL): FakeResponse(status=401)})
+        with pytest.raises(aiohttp.ClientResponseError):
+            run(agent._execute_jira_search_async("project = ENG"))
+
+    def test_sync_wrapper_converts_failure_to_error_dict(self, agent, http):
+        http({("GET", SEARCH_URL): FakeResponse(status=401)})
+        result = agent._execute_jira_search("project = ENG")
+        assert result["status"] == "error"
+        assert result["error"].startswith("Async execution failed")
+
+
+# ---------------------------------------------------------------------------
+# _execute_jira_create_async
+# ---------------------------------------------------------------------------
+
+
+class TestJiraCreate:
+    def test_create_request_shape_with_explicit_project(self, agent, http):
+        session = http(
+            {
+                ("POST", ISSUE_URL): FakeResponse(
+                    json_data={"key": "ENG-42", "id": "10042"}
+                )
+            }
+        )
+
+        result = run(
+            agent._execute_jira_create_async(
+                summary="Fix login",
+                description="",
+                issue_type="Bug",
+                priority=None,
+                project="ENG",
+            )
+        )
+
+        # Exactly one call — no project auto-discovery when project is given
+        assert len(session.requests) == 1
+        request = session.requests[0]
+        assert request.method == "POST"
+        assert request.url == ISSUE_URL
+        assert_auth_headers(request)
+        assert request.json == {
+            "fields": {
+                "project": {"key": "ENG"},
+                "summary": "Fix login",
+                "description": "Created via GAIA",  # empty description defaulted
+                "issuetype": {"name": "Bug"},
+            }
+        }
+
+        assert result == {
+            "status": "success",
+            "created": True,
+            "key": "ENG-42",
+            "id": "10042",
+            "url": f"{SITE}/browse/ENG-42",
+            "metadata": {
+                "project": "ENG",
+                "issue_type": "Bug",
+                "priority": None,
+                "summary": "Fix login",
+            },
+        }
+
+    def test_create_payload_includes_priority_and_description(self, agent, http):
+        session = http(
+            {("POST", ISSUE_URL): FakeResponse(json_data={"key": "ENG-1", "id": "1"})}
+        )
+
+        run(
+            agent._execute_jira_create_async(
+                summary="Add SSO",
+                description="Support SAML login",
+                issue_type="Story",
+                priority="High",
+                project="ENG",
+            )
+        )
+
+        assert session.requests[0].json == {
+            "fields": {
+                "project": {"key": "ENG"},
+                "summary": "Add SSO",
+                "description": "Support SAML login",
+                "issuetype": {"name": "Story"},
+                "priority": {"name": "High"},
+            }
+        }
+
+    def test_create_auto_discovers_first_project(self, agent, http):
+        session = http(
+            {
+                ("GET", PROJECT_URL): FakeResponse(
+                    json_data=[
+                        {"key": "OPS", "name": "Operations"},
+                        {"key": "ENG", "name": "Engineering"},
+                    ]
+                ),
+                ("POST", ISSUE_URL): FakeResponse(
+                    json_data={"key": "OPS-7", "id": "7"}
+                ),
+            }
+        )
+
+        result = run(
+            agent._execute_jira_create_async(summary="New task", project=None)
+        )
+
+        assert [(r.method, r.url) for r in session.requests] == [
+            ("GET", PROJECT_URL),
+            ("POST", ISSUE_URL),
+        ]
+        assert_auth_headers(session.requests[0])
+        assert session.requests[1].json["fields"]["project"] == {"key": "OPS"}
+        assert result["key"] == "OPS-7"
+        assert result["metadata"]["project"] == "OPS"
+
+    def test_create_no_projects_available_errors_without_post(self, agent, http):
+        session = http({("GET", PROJECT_URL): FakeResponse(json_data=[])})
+
+        result = run(agent._execute_jira_create_async(summary="Orphan"))
+
+        assert result == {"status": "error", "error": "No projects available"}
+        assert [(r.method, r.url) for r in session.requests] == [("GET", PROJECT_URL)]
+
+    def test_create_400_rewrites_atlassian_error_messages(self, agent, http):
+        http(
+            {
+                ("POST", ISSUE_URL): FakeResponse(
+                    status=400,
+                    json_data={
+                        "errorMessages": [
+                            "Specify a valid project ID",
+                            "Field 'issuetype' is invalid",
+                        ]
+                    },
+                )
+            }
+        )
+
+        result = run(
+            agent._execute_jira_create_async(
+                summary="Bad", issue_type="Wibble", project="ENG"
+            )
+        )
+
+        assert result["status"] == "error"
+        assert (
+            "Bad Request: Specify a valid project ID; Field 'issuetype' is invalid"
+            in result["error"]
+        )
+        # Rewritten error must include recovery guidance for the LLM
+        assert "jira_search" in result["error"]
+
+    def test_create_400_without_error_messages_names_issue_type(self, agent, http):
+        http(
+            {
+                ("POST", ISSUE_URL): FakeResponse(
+                    status=400, json_data={"errorMessages": []}
+                )
+            }
+        )
+
+        result = run(
+            agent._execute_jira_create_async(
+                summary="Bad", issue_type="Wibble", project="ENG"
+            )
+        )
+
+        assert result["status"] == "error"
+        assert "Invalid issue type 'Wibble'" in result["error"]
+
+    def test_create_400_with_unparseable_body_uses_fallback_error(self, agent, http):
+        http(
+            {
+                ("POST", ISSUE_URL): FakeResponse(
+                    status=400, json_exc=ValueError("not json")
+                )
+            }
+        )
+
+        result = run(
+            agent._execute_jira_create_async(
+                summary="Bad", issue_type="Wibble", project="ENG"
+            )
+        )
+
+        assert result["status"] == "error"
+        assert "'Wibble' may not be valid" in result["error"]
+
+    def test_create_non_400_http_error_raises(self, agent, http):
+        http({("POST", ISSUE_URL): FakeResponse(status=500)})
+        with pytest.raises(aiohttp.ClientResponseError):
+            run(agent._execute_jira_create_async(summary="Boom", project="ENG"))
+
+
+# ---------------------------------------------------------------------------
+# _execute_jira_update_async — field-diff payload building
+# ---------------------------------------------------------------------------
+
+
+class TestJiraUpdate:
+    def test_update_without_issue_key_errors_without_http(self, agent, http):
+        session = http()
+        result = run(agent._execute_jira_update_async(issue_key=""))
+        assert result == {"status": "error", "error": "Issue key is required"}
+        assert session.requests == []
+
+    def test_update_without_fields_errors_without_http(self, agent, http):
+        session = http()
+        result = run(agent._execute_jira_update_async(issue_key="ENG-7"))
+        assert result == {"status": "error", "error": "No fields to update"}
+        assert session.requests == []
+
+    def test_update_payload_contains_only_provided_fields(self, agent, http):
+        session = http(
+            {("PUT", f"{ISSUE_URL}/ENG-7"): FakeResponse(json_data={})}
+        )
+
+        result = run(
+            agent._execute_jira_update_async(
+                issue_key="ENG-7", summary="New title", priority="High"
+            )
+        )
+
+        assert len(session.requests) == 1
+        request = session.requests[0]
+        assert request.method == "PUT"
+        assert request.url == f"{ISSUE_URL}/ENG-7"
+        assert_auth_headers(request)
+        # Field diff: only the provided fields, priority wrapped as {"name": ...}
+        assert request.json == {
+            "fields": {"summary": "New title", "priority": {"name": "High"}}
+        }
+
+        assert result["status"] == "success"
+        assert result["updated"] is True
+        assert result["key"] == "ENG-7"
+        assert result["url"] == f"{SITE}/browse/ENG-7"
+        assert result["metadata"]["updated_fields"] == ["summary", "priority"]
+
+    def test_update_payload_with_all_fields(self, agent, http):
+        session = http(
+            {("PUT", f"{ISSUE_URL}/OPS-3"): FakeResponse(json_data={})}
+        )
+
+        run(
+            agent._execute_jira_update_async(
+                issue_key="OPS-3",
+                summary="S",
+                description="D",
+                priority="Low",
+                status="Done",
+            )
+        )
+
+        assert session.requests[0].json == {
+            "fields": {
+                "summary": "S",
+                "description": "D",
+                "priority": {"name": "Low"},
+                "status": {"name": "Done"},
+            }
+        }
+
+    def test_update_http_error_raises(self, agent, http):
+        http({("PUT", f"{ISSUE_URL}/ENG-404"): FakeResponse(status=404)})
+        with pytest.raises(aiohttp.ClientResponseError):
+            run(agent._execute_jira_update_async(issue_key="ENG-404", summary="X"))
+
+    def test_sync_wrapper_converts_failure_to_error_dict(self, agent, http):
+        http({("PUT", f"{ISSUE_URL}/ENG-404"): FakeResponse(status=404)})
+        result = agent._execute_jira_update("ENG-404", "X", None, None, None)
+        assert result["status"] == "error"
+        assert result["error"].startswith("Async execution failed")
+
+
+# ---------------------------------------------------------------------------
+# JQL guidance in the system prompt + registered tool surface
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptAndTools:
+    def test_prompt_includes_discovered_configuration(self, make_agent):
+        agent = make_agent(
+            jira_config={
+                "projects": [
+                    {"key": "ENG", "name": "Engineering"},
+                    {"key": "OPS", "name": "Operations"},
+                ],
+                "issue_types": ["Bug", "Story"],
+                "statuses": ["To Do", "In Review"],
+                "priorities": ["Highest", "Lowest"],
+            }
+        )
+        prompt = agent._get_system_prompt()
+
+        assert "Available projects are ENG, OPS" in prompt
+        assert "Available issue types are Bug, Story" in prompt
+        assert "Available priorities are Highest, Lowest" in prompt
+        assert "Available statuses are To Do, In Review" in prompt
+        # Discovered config replaces the hardcoded fallback guidance
+        assert 'issuetype = "Idea"' not in prompt
+
+    def test_prompt_falls_back_to_defaults_without_config(self, make_agent):
+        prompt = make_agent()._get_system_prompt()
+        assert 'issuetype = "Idea"' in prompt
+        assert 'status = "Parking lot"' in prompt
+
+    def test_registered_tools_and_search_default_jql(self, agent):
+        assert set(_TOOL_REGISTRY) >= {"jira_search", "jira_create", "jira_update"}
+
+        import inspect
+
+        search_sig = inspect.signature(_TOOL_REGISTRY["jira_search"]["function"])
+        assert (
+            search_sig.parameters["jql"].default
+            == "created >= -30d ORDER BY updated DESC"
+        )
+
+        create_sig = inspect.signature(_TOOL_REGISTRY["jira_create"]["function"])
+        assert create_sig.parameters["issue_type"].default == "Task"
+        assert _TOOL_REGISTRY["jira_create"]["parameters"]["summary"]["required"]
+        assert _TOOL_REGISTRY["jira_update"]["parameters"]["issue_key"]["required"]

--- a/tests/unit/test_cli_agent_import.py
+++ b/tests/unit/test_cli_agent_import.py
@@ -1,0 +1,219 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the `gaia agent import` trust gate (issue #1996).
+
+``handle_agent_import`` (src/gaia/cli.py) is the confirmation boundary before
+installing third-party Python code from a bundle into ``~/.gaia/agents/``. It
+must:
+
+  * refuse non-interactively (stdin not a TTY) unless ``--yes`` is given
+  * ask a ``[y/N]`` prompt interactively, proceeding only on 'y'/'yes'
+  * let ``--yes`` skip the prompt entirely
+  * refuse a bundle whose ``bundle.json`` exceeds the 1 MB manifest cap,
+    before ever touching the installer
+
+Every case mocks ``gaia.installer.export_import.import_agent_bundle`` and
+asserts whether it was invoked — the underlying import logic is covered
+elsewhere; this file only covers the trust-gate wiring in the CLI handler.
+"""
+
+import json
+import sys
+import zipfile
+from argparse import Namespace
+
+import pytest
+
+from gaia import cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ImportResult:
+    """Stand-in for ``gaia.installer.export_import.ImportResult``."""
+
+    def __init__(self, imported=None, overwritten=None, errors=None):
+        self.imported = imported or []
+        self.overwritten = overwritten or []
+        self.errors = errors or []
+
+
+def _make_bundle(tmp_path, *, agent_ids=None, oversized=False, name="bundle.zip"):
+    """Build a minimal .zip bundle with a bundle.json manifest entry."""
+    path = tmp_path / name
+    with zipfile.ZipFile(path, "w") as zf:
+        if oversized:
+            # Content doesn't need to be valid JSON — the size check runs
+            # before the bundle.json bytes are ever parsed.
+            zf.writestr("bundle.json", "x" * (1024 * 1024 + 1))
+        else:
+            manifest = {"agent_ids": agent_ids if agent_ids is not None else ["demo"]}
+            zf.writestr("bundle.json", json.dumps(manifest))
+    return path
+
+
+def _import_args(path, yes=False):
+    return Namespace(path=str(path), yes=yes)
+
+
+def _patch_import_agent_bundle(monkeypatch, calls, result=None):
+    def _fake(bundle_path):
+        calls.append(bundle_path)
+        return result if result is not None else _ImportResult(imported=["demo"])
+
+    monkeypatch.setattr("gaia.installer.export_import.import_agent_bundle", _fake)
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive refusal without --yes
+# ---------------------------------------------------------------------------
+
+
+def test_non_interactive_without_yes_refuses(tmp_path, monkeypatch):
+    bundle = _make_bundle(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.handle_agent_import(_import_args(bundle, yes=False))
+
+    assert excinfo.value.code == 1
+    assert calls == []  # the installer must never run
+
+
+def test_non_interactive_without_yes_never_calls_input(tmp_path, monkeypatch):
+    """A non-TTY refusal must not even attempt to read a prompt answer."""
+    bundle = _make_bundle(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("input() was called")),
+    )
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    with pytest.raises(SystemExit):
+        cli.handle_agent_import(_import_args(bundle, yes=False))
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Interactive [y/N] prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("answer", ["y", "Y", "yes", "YES"])
+def test_interactive_yes_answer_proceeds(tmp_path, monkeypatch, answer):
+    bundle = _make_bundle(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: answer)
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    cli.handle_agent_import(_import_args(bundle, yes=False))
+
+    assert calls == [bundle]
+
+
+@pytest.mark.parametrize("answer", ["n", "N", "no", "", "  ", "maybe"])
+def test_interactive_non_yes_answer_refuses(tmp_path, monkeypatch, answer):
+    bundle = _make_bundle(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: answer)
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.handle_agent_import(_import_args(bundle, yes=False))
+
+    assert excinfo.value.code == 0  # a declined prompt is not an error exit
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# --yes bypasses the prompt entirely
+# ---------------------------------------------------------------------------
+
+
+def test_yes_flag_bypasses_prompt(tmp_path, monkeypatch):
+    bundle = _make_bundle(tmp_path)
+
+    def _boom(*a, **k):
+        raise AssertionError("input() must not be called when --yes is given")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    # isatty is irrelevant once --yes is set; don't even patch it.
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    cli.handle_agent_import(_import_args(bundle, yes=True))
+
+    assert calls == [bundle]
+
+
+def test_yes_flag_works_non_interactively_too(tmp_path, monkeypatch):
+    bundle = _make_bundle(tmp_path)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    cli.handle_agent_import(_import_args(bundle, yes=True))
+
+    assert calls == [bundle]
+
+
+# ---------------------------------------------------------------------------
+# 1 MB bundle.json cap
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_bundle_json_refused_before_install(tmp_path, monkeypatch):
+    bundle = _make_bundle(tmp_path, oversized=True)
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    # --yes so the trust-gate prompt can't be the thing that refuses.
+    with pytest.raises(SystemExit) as excinfo:
+        cli.handle_agent_import(_import_args(bundle, yes=True))
+
+    assert excinfo.value.code == 1
+    assert calls == []  # size cap must reject before the installer ever runs
+
+
+def test_bundle_just_under_cap_is_accepted(tmp_path, monkeypatch):
+    """Sanity check the cap is 1 MB, not an off-by-one that rejects valid bundles."""
+    path = tmp_path / "bundle.zip"
+    manifest = json.dumps({"agent_ids": ["demo"], "pad": "x" * (900 * 1024)})
+    assert len(manifest.encode("utf-8")) < 1024 * 1024
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("bundle.json", manifest)
+
+    calls = []
+    _patch_import_agent_bundle(monkeypatch, calls)
+
+    cli.handle_agent_import(_import_args(path, yes=True))
+
+    assert calls == [path]
+
+
+# ---------------------------------------------------------------------------
+# Result handling — errors from the installer still exit non-zero
+# ---------------------------------------------------------------------------
+
+
+def test_installer_errors_exit_1(tmp_path, monkeypatch):
+    bundle = _make_bundle(tmp_path)
+    calls = []
+    _patch_import_agent_bundle(
+        monkeypatch, calls, result=_ImportResult(errors=["demo: boom"])
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.handle_agent_import(_import_args(bundle, yes=True))
+
+    assert excinfo.value.code == 1
+    assert calls == [bundle]  # the installer did run; it just reported an error

--- a/tests/unit/test_cli_knowledge_command.py
+++ b/tests/unit/test_cli_knowledge_command.py
@@ -1,0 +1,198 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for the `gaia knowledge` CLI handler wiring (issue #2000).
+
+Covers ``handle_knowledge_command`` (src/gaia/cli.py):
+
+  * ``BudgetConfig`` is constructed with ``block = not args.no_block`` —
+    inverting this would silently disable the Tavily spend cap
+  * ``TavilyBudgetExceeded`` and ``TavilyConfigError`` raised by the client
+    map to ``sys.exit(1)``
+
+``tests/unit/test_tavily_wrapper.py`` covers the Tavily client itself; this
+file only exercises the CLI handler's wiring, so ``BudgetConfig`` and
+``TavilyClient`` are replaced with lightweight fakes.
+"""
+
+from argparse import Namespace
+
+import pytest
+
+import gaia.web.tavily as tavily_module
+from gaia import cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _knowledge_args(action="usage", *, budget=None, no_block=False, **extra):
+    base = dict(
+        knowledge_action=action,
+        budget=budget,
+        no_block=no_block,
+        query="test query",
+        depth="basic",
+        max_results=5,
+        urls=["https://example.com"],
+    )
+    base.update(extra)
+    return Namespace(**base)
+
+
+class _RecordingBudgetConfig:
+    """Stands in for ``gaia.web.tavily.BudgetConfig``; records its kwargs."""
+
+    #: populated per-instantiation by the test via monkeypatch closure
+    last_kwargs = None
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+        self.cap = kwargs.get("cap")
+        self.block = kwargs.get("block")
+
+
+class _FakeTavilyClient:
+    """Stands in for ``gaia.web.tavily.TavilyClient``."""
+
+    #: set per-test to control what search()/extract() do
+    on_search = None
+    on_extract = None
+
+    def __init__(self, *, budget=None, **kwargs):  # noqa: ARG002 - signature match
+        self.budget = budget
+        self.closed = False
+
+    def search(self, *a, **k):
+        if self.on_search is not None:
+            return self.on_search(*a, **k)
+        return {"source": "tavily", "results": []}
+
+    def extract(self, *a, **k):
+        if self.on_extract is not None:
+            return self.on_extract(*a, **k)
+        return {}
+
+    def usage(self):
+        return {"cap": None, "total_credits": 0}
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _patch_tavily(monkeypatch):
+    """Replace BudgetConfig / TavilyClient with fakes for every test here.
+
+    The real exception classes (``TavilyBudgetExceeded``, ``TavilyConfigError``)
+    are left untouched — the CLI handler imports and catches those directly,
+    so raising the real classes from a fake client exercises the real except
+    clauses.
+    """
+    _RecordingBudgetConfig.last_kwargs = None
+    _FakeTavilyClient.on_search = None
+    _FakeTavilyClient.on_extract = None
+    monkeypatch.setattr(tavily_module, "BudgetConfig", _RecordingBudgetConfig)
+    monkeypatch.setattr(tavily_module, "TavilyClient", _FakeTavilyClient)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# BudgetConfig(block=not args.no_block) wiring
+# ---------------------------------------------------------------------------
+
+
+def test_budget_blocks_by_default_when_no_block_is_false():
+    cli.handle_knowledge_command(_knowledge_args("usage", no_block=False))
+
+    assert _RecordingBudgetConfig.last_kwargs["block"] is True
+
+
+def test_no_block_flag_disables_blocking():
+    cli.handle_knowledge_command(_knowledge_args("usage", no_block=True))
+
+    assert _RecordingBudgetConfig.last_kwargs["block"] is False
+
+
+def test_budget_cap_is_forwarded():
+    cli.handle_knowledge_command(_knowledge_args("usage", budget=42, no_block=False))
+
+    assert _RecordingBudgetConfig.last_kwargs["cap"] == 42
+    assert _RecordingBudgetConfig.last_kwargs["block"] is True
+
+
+# ---------------------------------------------------------------------------
+# TavilyBudgetExceeded / TavilyConfigError -> exit code 1
+# ---------------------------------------------------------------------------
+
+
+def test_budget_exceeded_during_search_exits_1(capsys):
+    from gaia.web.tavily import TavilyBudgetExceeded
+
+    def _raise_budget(*a, **k):
+        raise TavilyBudgetExceeded("credit cap of 10 reached")
+
+    _FakeTavilyClient.on_search = _raise_budget
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.handle_knowledge_command(_knowledge_args("search"))
+
+    assert excinfo.value.code == 1
+    assert "credit cap of 10 reached" in capsys.readouterr().out
+
+
+def test_config_error_during_search_exits_1(capsys):
+    from gaia.web.tavily import TavilyConfigError
+
+    def _raise_config(*a, **k):
+        raise TavilyConfigError("tavily-python SDK is not installed")
+
+    _FakeTavilyClient.on_search = _raise_config
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.handle_knowledge_command(_knowledge_args("search"))
+
+    assert excinfo.value.code == 1
+    assert "tavily-python SDK is not installed" in capsys.readouterr().out
+
+
+def test_budget_exceeded_during_extract_exits_1():
+    from gaia.web.tavily import TavilyBudgetExceeded
+
+    def _raise_budget(*a, **k):
+        raise TavilyBudgetExceeded("credit cap reached")
+
+    _FakeTavilyClient.on_extract = _raise_budget
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.handle_knowledge_command(_knowledge_args("extract"))
+
+    assert excinfo.value.code == 1
+
+
+def test_client_is_closed_even_when_budget_exceeded(monkeypatch):
+    from gaia.web.tavily import TavilyBudgetExceeded
+
+    created = []
+    real_init = _FakeTavilyClient.__init__
+
+    def _tracking_init(self, *a, **k):
+        real_init(self, *a, **k)
+        created.append(self)
+
+    monkeypatch.setattr(_FakeTavilyClient, "__init__", _tracking_init)
+
+    def _raise_budget(*a, **k):
+        raise TavilyBudgetExceeded("cap reached")
+
+    _FakeTavilyClient.on_search = _raise_budget
+
+    with pytest.raises(SystemExit):
+        cli.handle_knowledge_command(_knowledge_args("search"))
+
+    assert created[0].closed is True
+
+
+def test_successful_search_does_not_exit():
+    # A clean run must not raise SystemExit at all.
+    cli.handle_knowledge_command(_knowledge_args("search"))

--- a/tests/unit/test_memory_bootstrap_precedence.py
+++ b/tests/unit/test_memory_bootstrap_precedence.py
@@ -1,0 +1,245 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for `_handle_memory_bootstrap`'s 7-way flag precedence (#2001).
+
+``_handle_memory_bootstrap`` (src/gaia/cli.py) is an ``elif`` ladder dispatching
+one of seven operations from six independent boolean flags:
+
+    reset_system > system > reset > chat_only > discover > infer > (default)
+
+Two of those operations are destructive (``_bootstrap_reset_system`` clears
+system-context entries; ``_bootstrap_reset`` clears discovery memories). This
+file asserts, per flag combination, exactly which underlying
+``_bootstrap_*`` function runs — and, critically, that the destructive ones
+never run for a read-only flag or combination that doesn't request them.
+
+Every ``_bootstrap_*`` function is mocked; no real ``MemoryStore`` is touched.
+The filename keeps the ``test_memory_`` prefix so
+``tests/unit/conftest.py`` clears ``GAIA_MEMORY_DISABLED`` for it, matching
+the convention in ``test_memory_bootstrap.py``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gaia import cli
+
+_ALL_FLAGS = ("reset_system", "system", "reset", "chat_only", "discover", "infer")
+
+_BOOTSTRAP_FNS = (
+    "_bootstrap_reset_system",
+    "_bootstrap_system",
+    "_bootstrap_reset",
+    "_bootstrap_chat",
+    "_bootstrap_discover",
+    "_bootstrap_infer",
+)
+
+#: The two destructive operations — must never fire for a read-only request.
+_DESTRUCTIVE_FNS = ("_bootstrap_reset_system", "_bootstrap_reset")
+
+
+def _args(**overrides):
+    base = {flag: False for flag in _ALL_FLAGS}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _ChatResult:
+    def __init__(self, cancelled=False):
+        self.cancelled = cancelled
+
+
+@pytest.fixture
+def tracked_calls(monkeypatch):
+    """Mock every ``_bootstrap_*`` function on the ``cli`` module.
+
+    Returns the list of call records in invocation order. ``_bootstrap_chat``
+    returns a non-cancelled result by default so the default (no-flags) path
+    falls through to ``_bootstrap_discover`` as the real code does.
+    """
+    calls = []
+
+    def _recorder(name, return_value=None):
+        def _fn(*args, **kwargs):
+            calls.append((name, args, kwargs))
+            return return_value
+
+        return _fn
+
+    for name in _BOOTSTRAP_FNS:
+        return_value = (
+            _ChatResult(cancelled=False) if name == "_bootstrap_chat" else None
+        )
+        monkeypatch.setattr(cli, name, _recorder(name, return_value))
+
+    return calls
+
+
+def _names(calls):
+    return [name for name, _args, _kwargs in calls]
+
+
+# ---------------------------------------------------------------------------
+# Single-flag dispatch — each flag alone runs exactly its own operation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flag,expected_fn",
+    [
+        ("reset_system", "_bootstrap_reset_system"),
+        ("system", "_bootstrap_system"),
+        ("reset", "_bootstrap_reset"),
+        ("chat_only", "_bootstrap_chat"),
+        ("discover", "_bootstrap_discover"),
+        ("infer", "_bootstrap_infer"),
+    ],
+)
+def test_single_flag_runs_only_its_own_operation(tracked_calls, flag, expected_fn):
+    cli._handle_memory_bootstrap(_args(**{flag: True}))
+
+    assert _names(tracked_calls) == [expected_fn]
+
+
+def test_no_flags_runs_the_default_chat_then_discover_sequence(tracked_calls):
+    cli._handle_memory_bootstrap(_args())
+
+    assert _names(tracked_calls) == ["_bootstrap_chat", "_bootstrap_discover"]
+
+
+def test_default_skips_discover_when_chat_is_cancelled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "_bootstrap_chat",
+        lambda: calls.append("_bootstrap_chat") or _ChatResult(cancelled=True),
+    )
+    monkeypatch.setattr(
+        cli, "_bootstrap_discover", lambda: calls.append("_bootstrap_discover")
+    )
+
+    cli._handle_memory_bootstrap(_args())
+
+    assert calls == ["_bootstrap_chat"]
+
+
+# ---------------------------------------------------------------------------
+# Precedence — the ladder's declared order wins when multiple flags are set
+# ---------------------------------------------------------------------------
+
+#: (kwargs set True, expected sole operation) — each row also sets every flag
+#: *after* the winner in ladder order, to prove later flags are ignored.
+_PRECEDENCE_CASES = [
+    pytest.param(
+        dict(
+            reset_system=True,
+            system=True,
+            reset=True,
+            chat_only=True,
+            discover=True,
+            infer=True,
+        ),
+        "_bootstrap_reset_system",
+        id="reset_system-beats-everything",
+    ),
+    pytest.param(
+        dict(system=True, reset=True, chat_only=True, discover=True, infer=True),
+        "_bootstrap_system",
+        id="system-beats-reset-and-read-only-flags",
+    ),
+    pytest.param(
+        dict(reset=True, chat_only=True, discover=True, infer=True),
+        "_bootstrap_reset",
+        id="reset-beats-read-only-flags",
+    ),
+    pytest.param(
+        dict(chat_only=True, discover=True, infer=True),
+        "_bootstrap_chat",
+        id="chat_only-beats-discover-and-infer",
+    ),
+    pytest.param(
+        dict(discover=True, infer=True),
+        "_bootstrap_discover",
+        id="discover-beats-infer",
+    ),
+]
+
+
+@pytest.mark.parametrize("flags,expected_fn", _PRECEDENCE_CASES)
+def test_precedence_ladder_runs_only_the_winner(tracked_calls, flags, expected_fn):
+    cli._handle_memory_bootstrap(_args(**flags))
+
+    assert _names(tracked_calls) == [expected_fn]
+
+
+@pytest.mark.parametrize("flags,expected_fn", _PRECEDENCE_CASES)
+def test_precedence_ladder_never_runs_a_destructive_op_for_a_non_destructive_winner(
+    tracked_calls, flags, expected_fn
+):
+    """Belt-and-suspenders: when a read-only/less-destructive flag should win,
+    neither destructive operation may have fired — regardless of what else
+    changes about the dispatch in the future.
+    """
+    cli._handle_memory_bootstrap(_args(**flags))
+
+    if expected_fn not in _DESTRUCTIVE_FNS:
+        assert not (set(_names(tracked_calls)) & set(_DESTRUCTIVE_FNS))
+
+
+@pytest.mark.parametrize(
+    "flag", ["chat_only", "discover", "infer"], ids=lambda f: f"only-{f}"
+)
+def test_read_only_flags_never_trigger_a_destructive_reset(tracked_calls, flag):
+    cli._handle_memory_bootstrap(_args(**{flag: True}))
+
+    assert not (set(_names(tracked_calls)) & set(_DESTRUCTIVE_FNS))
+
+
+def test_default_no_flags_never_triggers_a_destructive_reset(tracked_calls):
+    cli._handle_memory_bootstrap(_args())
+
+    assert not (set(_names(tracked_calls)) & set(_DESTRUCTIVE_FNS))
+
+
+# ---------------------------------------------------------------------------
+# system is always called with force=True
+# ---------------------------------------------------------------------------
+
+
+def test_system_flag_forces_a_full_rescan(tracked_calls):
+    cli._handle_memory_bootstrap(_args(system=True))
+
+    name, args, kwargs = tracked_calls[0]
+    assert name == "_bootstrap_system"
+    assert kwargs == {"force": True}
+
+
+# ---------------------------------------------------------------------------
+# Fail-loudly: a RuntimeError from any operation exits 1, not silently
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flag,fn_name",
+    [
+        ("reset_system", "_bootstrap_reset_system"),
+        ("reset", "_bootstrap_reset"),
+        ("discover", "_bootstrap_discover"),
+    ],
+)
+def test_runtime_error_from_the_dispatched_op_exits_1(
+    monkeypatch, capsys, flag, fn_name
+):
+    monkeypatch.setattr(
+        cli,
+        fn_name,
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("store is locked")),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli._handle_memory_bootstrap(_args(**{flag: True}))
+
+    assert excinfo.value.code == 1
+    assert "store is locked" in capsys.readouterr().out


### PR DESCRIPTION
Closes #1991, #1993, #1996, #1999, #2000, #2001.

Six risk-bearing gaps from the weekly audit now have tests: the JiraAgent (1184 lines, previously zero tests anywhere), the `gaia agent import` trust gate that stands between users and third-party agent code, the `gaia memory bootstrap` ladder that decides whether a destructive wipe runs, the Tavily spend-cap wiring, and two suites that mocked external boundaries without ever checking what we send them (#1655 pattern). Before this, a dropped auth header, an inverted `--yes` check, or a reordered reset branch would have shipped green; now each fails a specific test. Tests only — no production code changed, and no bugs were found while writing them (all six handlers behave as their issues describe).

All boundary tests assert the **outgoing** call shape, not just invocation: Jira REST method/path/Basic-auth/params/payload (incl. the Atlassian 400 error-rewriting branch and update field-diff), external-tool npx argv + env + JSON-RPC stdin (`tools/call`, tool names, `context7CompatibleLibraryID` propagation), and connectors-demo bearer/Accept/`X-GitHub-Api-Version` headers plus `limit` → `maxResults`/`per_page`/`timeMin`/`timeMax`.

**CI-wiring note:** hub package tests run via per-package workflows (`test_code_agent.yml`, `test_chat_agent.yml`, …); nothing auto-discovers `hub/agents/python/jira/tests/`, so the new Jira suite won't run in CI until a `test_jira_agent.yml` exists (needs only `pip install -e . -e hub/agents/python/jira && pytest hub/agents/python/jira/tests/` — no server or credentials). Left out of this PR to keep it tests-only; happy to follow up.

## Test plan

- [ ] `python -m pytest hub/agents/python/jira/tests/ hub/agents/python/code/tests/test_external_tools.py hub/agents/python/connectors-demo/tests/test_connectors_demo.py tests/unit/test_cli_agent_import.py tests/unit/test_cli_knowledge_command.py tests/unit/test_memory_bootstrap_precedence.py -q` → 128 passed
- [ ] `python util/lint.py --all` → all blocking checks pass (mypy/bandit warnings pre-existing repo-wide)
- [ ] Diff touches test files only