### PR TITLE
fix(ci): weekly audit cross-links the prior parent instead of auto-closing it

### DIFF
--- a/.claude/skills/weekly-audit-patterns/SKILL.md
+++ b/.claude/skills/weekly-audit-patterns/SKILL.md
@@ -84,12 +84,23 @@ skips a finding whose key is in EITHER set:
   `audit-wontfix` and it never comes back. Without this, wontfix findings resurface every
   deep run forever.
 
-## Parent triage issues roll over
+## Parent triage issues accumulate — the workflow NEVER closes one
 
-Each run files a NEW parent (`Weekly audit — <mode> — <run_id>`) and then **closes the
-previous open parent** with a "Superseded by #N" comment — otherwise ~52 stale parents pile
-up per year. Only the parent rolls over; child issues stay open (they're the actionable
-units). The parent opens with a one-line tally (new/low/suppressed counts) for trend.
+Each run files a NEW parent (`Weekly audit — <mode> — <run_id>`) and **cross-links the
+most recently created open parent** with a comment ("Follow-up audit run filed as #N —
+stays OPEN until its findings are addressed") — it does **not** close it. An earlier
+version auto-closed the previous parent as "superseded," which silently hid an epic's
+still-open child findings the moment the next run fired (#2010: 18 unaddressed children
+went dark). Only a **human maintainer** may close a parent, and only after its findings
+are addressed. Child issues stay open regardless (they're the actionable units) — that
+was already true and is unchanged.
+
+Since parents are never auto-closed, there can be several open `Weekly audit —` issues at
+once; synthesis always cross-links the highest-numbered (most recent) one, never assumes
+there's "at most one." The tradeoff is deliberate: parents pile up until a maintainer
+closes them, trading tracker tidiness for guaranteeing unaddressed findings stay visible.
+The parent opens with a one-line tally (new/low/suppressed counts) for trend. On a
+zero-new-findings run, synthesis posts nothing and does not touch any prior parent.
 
 ## Security findings stay private
 

--- a/.github/workflows/claude-weekly-audit.yml
+++ b/.github/workflows/claude-weekly-audit.yml
@@ -404,8 +404,10 @@ jobs:
             4. Build the **suppressed-forever** key set (accepted debt):
                `gh issue list --repo ${{ github.repository }} --label weekly-audit --label audit-wontfix --state all --json body --limit 200`
                Collect their `audit-key` KEYs too. These are permanently dismissed.
-            5. Find the **previous parent** to supersede: the currently-open issue whose title
-               starts `Weekly audit —` (there should be at most one). Note its number.
+            5. Find the **previous parent** to cross-link: parents are never auto-closed, so
+               there may now be SEVERAL currently-open issues whose title starts
+               `Weekly audit —`. Pick the MOST RECENTLY CREATED one (highest issue number).
+               Note its number. Do NOT close it.
 
             ## Dedup + verify (the single biggest quality risk)
             Reduce the raw findings to the NEW, real set, in this order:
@@ -418,8 +420,8 @@ jobs:
             3. **Evidence gate:** drop any 🔴/🟠 finding whose `evidence` is missing or does not
                actually substantiate its `title`. If evidence looks thin, spot-check by reading the
                cited `path`/`symbol` yourself before filing — a false issue erodes the whole audit.
-            If, after all of the above, there are ZERO new findings, post NOTHING, still run the
-            "supersede" step below to close the stale parent, and exit cleanly.
+            If, after all of the above, there are ZERO new findings, post NOTHING and exit
+            cleanly — do not file a parent issue, and never close or comment on a prior parent.
 
             ## File per-finding CHILD issues — 🔴 high / 🟠 medium ONLY (non-security)
             Open a child issue only for NEW, verified, non-security findings whose severity is
@@ -474,15 +476,20 @@ jobs:
             with the run-log link: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
             NEVER put a security `file:line`, exploit, or payload in this issue.
 
-            ## Supersede the previous parent (tracker hygiene — always run this)
-            After filing the new parent (or, on a zero-new-findings run, instead of filing one),
-            close the previous parent you found in First-actions step 5 so triage issues don't
-            pile up: `gh issue close <prev-parent-#> --repo ${{ github.repository }} --comment "Superseded by #<new-parent-# or 'this week — no new findings'>."`
-            Child issues stay OPEN — they are the actionable units; only the parent rolls over.
+            ## Cross-link the previous parent (NEVER close it)
+            After filing the new parent, comment on the previous parent you found in
+            First-actions step 5 so readers can follow the chain — but leave it OPEN:
+            `gh issue comment <prev-parent-#> --repo ${{ github.repository }} --body "Follow-up audit run filed as #<new-parent-#>. This issue stays OPEN until its findings are addressed — only a maintainer should close it."`
+            Child issues stay OPEN too — they are the actionable units. Parents now
+            accumulate across runs by design, so unaddressed findings stay visible: only a
+            human maintainer closes a parent, and only after its findings are addressed.
+            Never call `gh issue close` on a parent from this workflow.
 
             ## Rules
             - No Claude attribution anywhere (no "Generated with", no Co-Authored-By).
             - Do not open any PR and do not apply the `bug` label — humans gate every code change.
+            - Never close a parent triage issue — only a human maintainer closes one, after its
+              findings are addressed.
             - Lead with the finding; keep each line to one sentence (CLAUDE.md issue style).
           claude_args: |
             --max-turns 32


### PR DESCRIPTION
The synthesis job in the weekly audit workflow closed the previous parent triage issue as "superseded" on every run — that auto-closed epic #2010 while its 18 child findings were still open and unaddressed, hiding real, unfinished work behind a green checkmark. After this change, a run still files a new parent each time, but the previous parent is only cross-linked with a comment and left open; only a human maintainer can close a parent, and only after its findings are addressed.

Refs #2010.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-weekly-audit.yml'))"` — workflow YAML parses cleanly
- [ ] Next scheduled/dispatched run of `claude-weekly-audit.yml` files a new parent, comments on (does not close) the most recent prior open parent, and child issues are unaffected