### PR TITLE
fix(ui): stop silently accepting unimplemented agent_mode 'autonomous'

### DIFF
--- a/docs/spec/autonomous-agent-mode.md
+++ b/docs/spec/autonomous-agent-mode.md
@@ -4,6 +4,13 @@
 **Status:** Draft v4 — aligned with OpenClaw Strategy
 **Date:** 2026-04-01
 
+> **Implementation status (2026-07):** `manual` and `goal_driven` are shipped
+> and `goal_driven` is the default. `autonomous` mode is **not implemented** —
+> its defining observation cycle (§6.7) has not shipped, so the settings API
+> rejects `agent_mode="autonomous"` rather than silently running it as
+> `goal_driven`. Tracked in
+> [#2005](https://github.com/amd/gaia/issues/2005).
+
 ---
 
 ## 1. Overview
@@ -35,7 +42,9 @@ The agent's behavior is controlled by a single `agent_mode` setting:
 | `goal_driven` | Executes user-approved goals in the background | Automation |
 | `autonomous` | Observes environment, infers and executes its own goals | Agent |
 
-Default: `autonomous`. Users can downgrade at any time from Settings.
+Design default: `autonomous`; users can downgrade at any time from Settings.
+(Until the observation cycle ships, the shipped default is `goal_driven` and
+`autonomous` is not selectable — see the implementation-status note above.)
 
 **What makes this genuinely autonomous (not just reactive):**
 - In `autonomous` mode the agent runs an *observation cycle* on idle ticks

--- a/src/gaia/ui/agent_loop.py
+++ b/src/gaia/ui/agent_loop.py
@@ -51,6 +51,38 @@ _OBSERVE_MODEL = os.environ.get("GAIA_AUTO_OBSERVE_MODEL", "Qwen3-4B-GGUF")
 # Timeout (seconds) for a single autonomous tick execution
 _TICK_TIMEOUT = int(os.environ.get("GAIA_AGENT_TICK_TIMEOUT", "300"))
 
+# Default agent mode. "autonomous" (observe → infer goals → execute, spec
+# docs/spec/autonomous-agent-mode.md §6.7) is not implemented yet (#2005), so
+# the honest default is "goal_driven" — which is exactly what the loop does.
+DEFAULT_AGENT_MODE = "goal_driven"
+
+# Warn once per process when a legacy-stored "autonomous" mode is normalized.
+_warned_legacy_autonomous = False
+
+
+def resolve_agent_mode(db) -> str:
+    """Return the effective agent mode: "manual" or "goal_driven".
+
+    "autonomous" mode's observation cycle is unimplemented (#2005), so a
+    legacy-stored "autonomous" value is normalized to "goal_driven" — the
+    behavior it always had — with a loud warning instead of a silent no-op
+    label. New writes of "autonomous" are rejected at the settings API.
+    """
+    global _warned_legacy_autonomous
+    mode = db.get_setting("agent_mode") or DEFAULT_AGENT_MODE
+    if mode == "autonomous":
+        if not _warned_legacy_autonomous:
+            logger.warning(
+                "agent_mode 'autonomous' is stored in settings but its "
+                "observation cycle is not implemented (see "
+                "https://github.com/amd/gaia/issues/2005); running as "
+                "'goal_driven', which is what 'autonomous' has always "
+                "effectively done."
+            )
+            _warned_legacy_autonomous = True
+        return "goal_driven"
+    return mode
+
 
 # ── Data classes ─────────────────────────────────────────────────────────────
 
@@ -230,7 +262,7 @@ class AgentLoop:
             return LoopDirective("idle")
 
         # ── Agent mode gate ───────────────────────────────────────────────
-        agent_mode = self._db.get_setting("agent_mode") or "autonomous"
+        agent_mode = resolve_agent_mode(self._db)
         if agent_mode == "manual":
             return LoopDirective("paused", reason="agent_mode=manual")
 
@@ -257,12 +289,11 @@ class AgentLoop:
             return LoopDirective("idle")
 
         # ── Goal check ───────────────────────────────────────────────────
+        # goal_driven only executes existing approved goals. The planned
+        # "autonomous" mode would run an observation cycle here instead of
+        # idling (docs/spec/autonomous-agent-mode.md §6.7, #2005).
         goals = self._get_actionable_goals()
         if not goals:
-            if agent_mode == "goal_driven":
-                return LoopDirective("idle")
-            # autonomous mode: TODO — run observation cycle (Phase 2)
-            # For now, also idle when there are no goals
             return LoopDirective("idle")
 
         # ── Execute tick ─────────────────────────────────────────────────

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -137,7 +137,9 @@ class SettingsResponse(BaseModel):
     context_size: Optional[int] = (
         None  # Persisted ctx_size override; None = use default
     )
-    agent_mode: str = "autonomous"  # "manual" | "goal_driven" | "autonomous"
+    # "manual" | "goal_driven". "autonomous" is unshipped (#2005) and rejected
+    # on write; legacy-stored values are reported as "goal_driven".
+    agent_mode: str = "goal_driven"
     # Beta dynamic tool loader (#1798). Effective value: env override
     # (GAIA_DYNAMIC_TOOLS) wins when set, else the persisted setting.
     dynamic_tools: bool = False
@@ -170,9 +172,9 @@ class SettingsUpdateRequest(BaseModel):
         None,
         description=(
             "Agent operating mode. One of: 'manual' (request/response only), "
-            "'goal_driven' (execute approved goals), "
-            "'autonomous' (observe, infer, and execute own goals). "
-            "Default: 'autonomous'."
+            "'goal_driven' (execute approved goals). Default: 'goal_driven'. "
+            "'autonomous' (observe, infer, and execute own goals) is not "
+            "implemented yet and is rejected (#2005)."
         ),
     )
     dynamic_tools: Optional[bool] = Field(

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -23,6 +23,7 @@ from gaia.llm.lemonade_client import (
     resolve_lemonade_api_key,
 )
 
+from ..agent_loop import resolve_agent_mode
 from ..database import ChatDatabase
 from ..dependencies import get_db, get_dispatch_queue
 from ..models import (
@@ -36,7 +37,9 @@ from ..models import (
     TaskResponse,
 )
 
-_VALID_AGENT_MODES = {"manual", "goal_driven", "autonomous"}
+# "autonomous" is intentionally absent: its observation cycle is unimplemented
+# (#2005) and accepting it would silently behave as "goal_driven".
+_VALID_AGENT_MODES = {"manual", "goal_driven"}
 
 logger = logging.getLogger(__name__)
 
@@ -850,7 +853,7 @@ async def get_settings(db: ChatDatabase = Depends(get_db)):
     custom_model = db.get_setting("custom_model")
     context_size_str = db.get_setting("context_size")
     context_size = int(context_size_str) if context_size_str else None
-    agent_mode = db.get_setting("agent_mode") or "autonomous"
+    agent_mode = resolve_agent_mode(db)
     dynamic_tools, dynamic_tools_locked = _resolve_dynamic_tools_setting(db)
     logger.debug(
         "Settings loaded: custom_model=%s, context_size=%s, agent_mode=%s, "
@@ -888,8 +891,10 @@ async def update_settings(
     Setting ``context_size`` to null resets to the default (32768 tokens).
     Non-null values must be >= 32768.
 
-    Setting ``agent_mode`` controls autonomous behaviour:
-    'manual' | 'goal_driven' | 'autonomous' (default).
+    Setting ``agent_mode`` controls background behaviour:
+    'manual' | 'goal_driven' (default). 'autonomous' is rejected until its
+    observation cycle ships (#2005) — it would silently behave as
+    'goal_driven'.
     """
     if request.custom_model is not None:
         value = request.custom_model.strip() if request.custom_model else None
@@ -918,6 +923,17 @@ async def update_settings(
 
     if "agent_mode" in request.model_fields_set and request.agent_mode is not None:
         mode = request.agent_mode.strip()
+        if mode == "autonomous":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "agent_mode 'autonomous' is not implemented yet: its "
+                    "observation cycle (docs/spec/autonomous-agent-mode.md "
+                    "§6.7) has not shipped, so it would behave identically "
+                    "to 'goal_driven'. Use 'goal_driven' instead. Tracked in "
+                    "https://github.com/amd/gaia/issues/2005."
+                ),
+            )
         if mode not in _VALID_AGENT_MODES:
             raise HTTPException(
                 status_code=400,
@@ -938,7 +954,7 @@ async def update_settings(
     custom_model = db.get_setting("custom_model")
     context_size_str = db.get_setting("context_size")
     context_size = int(context_size_str) if context_size_str else None
-    agent_mode = db.get_setting("agent_mode") or "autonomous"
+    agent_mode = resolve_agent_mode(db)
     dynamic_tools, dynamic_tools_locked = _resolve_dynamic_tools_setting(db)
     model_status = await _check_model_status(custom_model) if custom_model else None
     return SettingsResponse(

--- a/tests/unit/chat/ui/test_agent_loop.py
+++ b/tests/unit/chat/ui/test_agent_loop.py
@@ -1,0 +1,114 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""AgentLoop agent-mode gate tests (#2005).
+
+The 'autonomous' mode's observation cycle is unimplemented, so the loop must
+not pretend it exists: the default is 'goal_driven', legacy-stored
+'autonomous' values normalize to 'goal_driven' with a loud warning, and the
+loop's behavior for a legacy 'autonomous' value is bit-identical to
+'goal_driven' (idle when no goals — no phantom observation cycle).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import gaia.ui.agent_loop as agent_loop_mod
+from gaia.ui.agent_loop import AgentLoop, resolve_agent_mode
+
+
+class FakeDB:
+    """Minimal stand-in for ChatDatabase settings/session reads."""
+
+    def __init__(self, settings=None, sessions=None):
+        self._settings = settings or {}
+        self._sessions = sessions if sessions is not None else [{"id": "s1"}]
+
+    def get_setting(self, key, default=None):
+        return self._settings.get(key, default)
+
+    def list_sessions(self, limit=20):
+        return self._sessions
+
+    def get_session(self, session_id):
+        for s in self._sessions:
+            if s["id"] == session_id:
+                return s
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_flag():
+    agent_loop_mod._warned_legacy_autonomous = False
+    yield
+    agent_loop_mod._warned_legacy_autonomous = False
+
+
+class TestResolveAgentMode:
+    def test_default_is_goal_driven(self):
+        assert resolve_agent_mode(FakeDB()) == "goal_driven"
+
+    def test_manual_and_goal_driven_pass_through(self):
+        assert resolve_agent_mode(FakeDB({"agent_mode": "manual"})) == "manual"
+        assert (
+            resolve_agent_mode(FakeDB({"agent_mode": "goal_driven"})) == "goal_driven"
+        )
+
+    def test_legacy_autonomous_normalizes_with_warning(self, caplog):
+        with caplog.at_level("WARNING", logger="gaia.ui.agent_loop"):
+            mode = resolve_agent_mode(FakeDB({"agent_mode": "autonomous"}))
+        assert mode == "goal_driven"
+        assert any("2005" in r.message for r in caplog.records)
+        assert any("not implemented" in r.message for r in caplog.records)
+
+    def test_legacy_autonomous_warns_only_once(self, caplog):
+        db = FakeDB({"agent_mode": "autonomous"})
+        with caplog.at_level("WARNING", logger="gaia.ui.agent_loop"):
+            resolve_agent_mode(db)
+            resolve_agent_mode(db)
+        warnings = [r for r in caplog.records if "2005" in r.message]
+        assert len(warnings) == 1
+
+
+class TestRunStepModeGate:
+    """_run_step must treat legacy 'autonomous' exactly as 'goal_driven'."""
+
+    def _make_loop(self, db):
+        loop = AgentLoop()
+        loop._db = db
+        loop._app_state = type("S", (), {"tunnel": None})()
+        return loop
+
+    async def _run(self, mode, tmp_path):
+        settings = {"agent_mode": mode} if mode else {}
+        loop = self._make_loop(FakeDB(settings))
+        initialized = tmp_path / ".gaia" / "chat" / "initialized"
+        initialized.parent.mkdir(parents=True, exist_ok=True)
+        initialized.touch()
+        with patch("gaia.ui.agent_loop.Path.home", return_value=tmp_path):
+            with patch.object(AgentLoop, "_get_actionable_goals", return_value=[]):
+                trigger = agent_loop_mod.AgentTrigger("idle_tick", None)
+                return await loop._run_step(trigger)
+
+    async def test_manual_pauses(self, tmp_path):
+        directive = await self._run("manual", tmp_path)
+        assert directive.directive == "paused"
+
+    async def test_goal_driven_idles_without_goals(self, tmp_path):
+        directive = await self._run("goal_driven", tmp_path)
+        assert directive.directive == "idle"
+
+    async def test_legacy_autonomous_identical_to_goal_driven(self, tmp_path):
+        """No phantom observation cycle: legacy 'autonomous' == 'goal_driven'."""
+        auto = await self._run("autonomous", tmp_path)
+        goal = await self._run("goal_driven", tmp_path)
+        assert (auto.directive, auto.wake_in_seconds, auto.reason) == (
+            goal.directive,
+            goal.wake_in_seconds,
+            goal.reason,
+        )
+
+    async def test_unset_mode_defaults_to_goal_driven(self, tmp_path):
+        directive = await self._run(None, tmp_path)
+        assert directive.directive == "idle"

--- a/tests/unit/chat/ui/test_server.py
+++ b/tests/unit/chat/ui/test_server.py
@@ -813,6 +813,42 @@ class TestDynamicToolsSetting:
         assert unlocked["dynamic_tools_locked"] is False
 
 
+class TestAgentModeSetting:
+    """/api/settings agent_mode honesty (#2005): 'autonomous' is unshipped —
+    reject it on write, default to 'goal_driven', normalize legacy values."""
+
+    def test_default_is_goal_driven(self, client):
+        assert client.get("/api/settings").json()["agent_mode"] == "goal_driven"
+
+    def test_put_goal_driven_and_manual_round_trip(self, client):
+        for mode in ("manual", "goal_driven"):
+            put = client.put("/api/settings", json={"agent_mode": mode})
+            assert put.status_code == 200
+            assert put.json()["agent_mode"] == mode
+            assert client.get("/api/settings").json()["agent_mode"] == mode
+
+    def test_put_autonomous_rejected_with_actionable_error(self, client, db):
+        resp = client.put("/api/settings", json={"agent_mode": "autonomous"})
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "not implemented" in detail
+        assert "goal_driven" in detail
+        assert "2005" in detail
+        # Nothing was persisted
+        assert db.get_setting("agent_mode") is None
+
+    def test_put_unknown_mode_rejected(self, client):
+        resp = client.put("/api/settings", json={"agent_mode": "bogus"})
+        assert resp.status_code == 400
+        assert "goal_driven" in resp.json()["detail"]
+
+    def test_legacy_stored_autonomous_reported_as_goal_driven(self, client, db):
+        """A DB written before #2005 may hold 'autonomous'; GET must report the
+        effective mode, not the no-op label."""
+        db.set_setting("agent_mode", "autonomous")
+        assert client.get("/api/settings").json()["agent_mode"] == "goal_driven"
+
+
 class TestSessionEndpoints:
     """Tests for /api/sessions/* endpoints."""
 


### PR DESCRIPTION
Fixes #2005 (also covers the duplicate medium finding flagged in #2103).

## Why this matters

Before: the documented default `agent_mode="autonomous"` was a no-op label — the loop's tick handler has no observation cycle, so it behaved byte-identically to `goal_driven` while the spec and API docs promised "observe, infer, and execute own goals". After: the default is honestly `goal_driven`, selecting `autonomous` fails loudly with a 400 that says exactly why and what to use instead, and legacy DBs that already stored `autonomous` keep working (normalized to `goal_driven` with a once-per-process warning). Zero behavior change for any existing user — only the labels stop lying.

**Scoped fix, not the full feature.** The real observation cycle (spec §6.7) is a large open-ended build: six sensors (email/git/error-log/conversation/memory/system-state), a lightweight-model inference step, confidence-gated auto-approval against FAISS permission grants. That needs design decisions (sensor plumbing through connectors, auto-approval safety semantics, observe-model provisioning), so this PR makes the mode selection honest rather than shipping a half-baked cycle. The spec doc now carries an implementation-status note.

## Follow-up needed for the full `autonomous` mode
- Implement the §6.7 observation cycle behind the goal-check in `AgentLoop._run_step` (sensors → lightweight-model inference → `GoalStore` entries with `source="agent_inferred"`)
- Decide auto-approval semantics (confidence ≥ 0.8 + `safe_to_auto_execute` vs. FAISS permission grants)
- Re-admit `"autonomous"` to `_VALID_AGENT_MODES`, flip the default back, and drop the legacy normalization in `resolve_agent_mode()`

## Test plan
- [x] `pytest tests/unit/chat/ui/test_server.py tests/unit/chat/ui/test_agent_loop.py tests/unit/test_goal_store.py` — 182 passed
- [x] New API tests: default is `goal_driven`; PUT `autonomous` → 400 with actionable detail (nothing persisted); PUT `manual`/`goal_driven` round-trip; legacy stored `autonomous` reported as `goal_driven` on GET
- [x] New loop tests: `_run_step` with legacy `autonomous` returns a directive identical to `goal_driven` (proves no phantom observation cycle); `manual` pauses; normalization warns exactly once
- [x] `python util/lint.py --all` green