### PR TITLE
ci(hub): wire nine hub package test suites into CI; fix .cjs docs-link guard gap

### DIFF
--- a/.github/workflows/test_hub_agents.yml
+++ b/.github/workflows/test_hub_agents.yml
@@ -1,0 +1,98 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Runs the test suites that ship inside hub agent packages which have no
+# dedicated test_*_agent.yml workflow (#1992). Packages with their own
+# workflow (analyst, browser, chat, code, docqa, email, routing, mcp-server)
+# are intentionally NOT in this matrix.
+#
+# LLM-integration tests inside these suites (summarize's `lemonade`-marked
+# tests, blender's `integration`-marked tests) skip cleanly on hosted
+# runners — the remaining tests run for real, and every suite is at least
+# imported and collected so bit-rot fails loudly.
+
+name: Hub Agent Package Tests
+
+on:
+  workflow_call:
+  push:
+    branches: [ main ]
+    paths:
+      - 'hub/agents/python/blender/**'
+      - 'hub/agents/python/doc-search/**'
+      - 'hub/agents/python/docker/**'
+      - 'hub/agents/python/emr/**'
+      - 'hub/agents/python/fileio/**'
+      - 'hub/agents/python/hello-world/**'
+      - 'hub/agents/python/sd/**'
+      - 'hub/agents/python/summarize/**'
+      - 'hub/agents/python/word-count/**'
+      - 'src/gaia/agents/base/**'
+      - 'src/gaia/agents/tools/**'
+      - 'setup.py'
+      - '.github/workflows/test_hub_agents.yml'
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'hub/agents/python/blender/**'
+      - 'hub/agents/python/doc-search/**'
+      - 'hub/agents/python/docker/**'
+      - 'hub/agents/python/emr/**'
+      - 'hub/agents/python/fileio/**'
+      - 'hub/agents/python/hello-world/**'
+      - 'hub/agents/python/sd/**'
+      - 'hub/agents/python/summarize/**'
+      - 'hub/agents/python/word-count/**'
+      - 'src/gaia/agents/base/**'
+      - 'src/gaia/agents/tools/**'
+      - 'setup.py'
+      - '.github/workflows/test_hub_agents.yml'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-hub-package:
+    name: Test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - blender
+          - doc-search
+          - docker
+          - emr
+          - fileio
+          - hello-world
+          - sd
+          - summarize
+          - word-count
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system -e .[dev]
+          uv pip install --system -e hub/agents/python/${{ matrix.package }}
+
+      - name: Run ${{ matrix.package }} package tests
+        run: |
+          python -m pytest hub/agents/python/${{ matrix.package }}/tests/ -v --tb=short

--- a/hub/agents/python/blender/tests/conftest.py
+++ b/hub/agents/python/blender/tests/conftest.py
@@ -17,19 +17,8 @@ def is_port_in_use(port, host="localhost"):
         return s.connect_ex((host, port)) == 0
 
 
-@pytest.fixture(scope="session", autouse=True)
-def check_mcp_server():
-    """Check if the MCP server is running before running integration tests."""
-    # Port that MCP server uses
-    mcp_port = 9876
-
-    if not is_port_in_use(mcp_port):
-        pytest.skip(
-            f"MCP server not running on port {mcp_port}. Skipping integration tests."
-        )
-
-    logger.info("MCP server is running, proceeding with integration tests")
-    return True
+# Port that the Blender MCP server uses
+MCP_PORT = 9876
 
 
 @pytest.fixture(scope="session")
@@ -47,12 +36,22 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip integration tests if --skip-integration flag is provided."""
+    """Skip integration tests when requested or when the MCP server is down.
+
+    Mocked unit tests always run; only ``integration``-marked tests need the
+    live Blender MCP server (test_mcp_client.py self-skips via its fixture).
+    """
     if config.getoption("--skip-integration"):
         skip_integration = pytest.mark.skip(reason="--skip-integration option provided")
-        for item in items:
-            if "integration" in item.keywords:
-                item.add_marker(skip_integration)
+    elif not is_port_in_use(MCP_PORT):
+        skip_integration = pytest.mark.skip(
+            reason=f"MCP server not running on port {MCP_PORT}"
+        )
+    else:
+        return
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)
 
 
 def pytest_addoption(parser):

--- a/hub/agents/python/blender/tests/test_agent.py
+++ b/hub/agents/python/blender/tests/test_agent.py
@@ -138,6 +138,14 @@ MOCKED_RESPONSES = {
     """,
 }
 
+# Skip: these tests pre-date the BlenderAgent/base-Agent refactor — the
+# ``agent.llm`` mock seam is no longer the LLM boundary (they'd hit a live
+# Lemonade server) and patched internals (_get_domain_patterns,
+# _create_fallback_response) were removed. Rewrite tracked in #1992.
+_STALE_REFACTOR_SKIP = pytest.mark.skip(
+    reason="stale: pre-dates BlenderAgent refactor; needs rewrite (#1992)"
+)
+
 # ----- Fixtures -----
 
 
@@ -247,7 +255,6 @@ def agent(mock_llm_client, mock_mcp_client, mock_console):
     """Create a Blender agent with mock clients for testing."""
     agent = BlenderAgent(
         mcp=mock_mcp_client,
-        max_retries=3,
         debug_prompts=False,
         max_steps=10,
     )
@@ -286,6 +293,7 @@ class TestJSONValidation:
         assert parsed["plan"][0]["tool"] == "clear_scene"
         assert parsed["tool"] == "clear_scene"
 
+    @_STALE_REFACTOR_SKIP
     def test_json_extraction_from_invalid_response(self, agent):
         """Test extraction of JSON from invalid response with markdown and text."""
         parsed = agent._parse_llm_response(INVALID_JSON_RESPONSE)
@@ -296,6 +304,7 @@ class TestJSONValidation:
         assert parsed["tool"] == "create_object"
         assert "tool_args" in parsed
 
+    @_STALE_REFACTOR_SKIP
     def test_json_correction_for_single_quotes(self, agent):
         """Test correction of JSON with single quotes instead of double quotes."""
         # Configure the mock to return a corrected response
@@ -309,6 +318,7 @@ class TestJSONValidation:
         assert "tool" in parsed
         assert "tool_args" in parsed
 
+    @_STALE_REFACTOR_SKIP
     def test_natural_language_fallback(self, agent):
         """Test fallback mechanism for natural language responses."""
         # Mock domain pattern detection with a specific return value
@@ -336,6 +346,7 @@ class TestJSONValidation:
                 assert parsed["tool"] == "create_object"
                 assert parsed["tool_args"]["type"] == "CUBE"
 
+    @_STALE_REFACTOR_SKIP
     def test_retry_mechanism(self, agent):
         """Test the retry mechanism for invalid JSON responses."""
         # Configure mock to return valid JSON on second try
@@ -354,6 +365,7 @@ class TestJSONValidation:
             assert "goal" in parsed
             assert "tool" in parsed
 
+    @_STALE_REFACTOR_SKIP
     def test_graduated_retry_escalation(self, agent):
         """Test that retry prompts escalate in strictness."""
         # Configure to return valid JSON on second try
@@ -373,6 +385,7 @@ class TestJSONValidation:
                 # Check that the correction prompt was called
                 mock_create_prompt.assert_called_once()
 
+    @_STALE_REFACTOR_SKIP
     def test_blender_domain_patterns(self, agent):
         """Test Blender-specific domain patterns for natural language responses."""
         # Get the domain patterns
@@ -390,6 +403,7 @@ class TestJSONValidation:
         assert match is not None
         assert match.group(1) == "cube"
 
+    @_STALE_REFACTOR_SKIP
     def test_fallback_response(self, agent):
         """Test the fallback response mechanism."""
         fallback = agent._create_fallback_response(
@@ -432,6 +446,7 @@ class TestAgentIntegration:
     @pytest.mark.parametrize(
         "example", [EXAMPLE_TASKS[0]]
     )  # Test just the first example for speed
+    @_STALE_REFACTOR_SKIP
     def test_example_tasks(self, agent, example):
         """Test processing example tasks with the agent."""
         # Configure a simple success response based on the example
@@ -463,6 +478,7 @@ class TestAgentIntegration:
         assert parsed["tool"] == "set_material_color"
         assert parsed["tool_args"]["color"] == [0, 0, 1, 1]
 
+    @_STALE_REFACTOR_SKIP
     def test_natural_language_intent_detection(self, agent):
         """Test detection of intentions from natural language."""
         # Create a specific return value for the fallback
@@ -495,6 +511,7 @@ class TestAgentIntegration:
                     assert parsed["goal"] == "Create a complex scene"
                     assert parsed["tool"] == "create_object"
 
+    @_STALE_REFACTOR_SKIP
     def test_retry_mechanism_integration(self, agent):
         """Test the complete retry mechanism with JSON correction."""
         # Configure specific responses for the test

--- a/hub/agents/python/emr/pyproject.toml
+++ b/hub/agents/python/emr/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "AMD" }]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["amd-gaia>=0.20.0"]
+dependencies = ["amd-gaia[api]>=0.20.0"]
 
 [project.scripts]
 gaia-emr = "gaia_agent_emr.cli:main"

--- a/hub/agents/python/summarize/pyproject.toml
+++ b/hub/agents/python/summarize/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "AMD" }]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["amd-gaia>=0.20.0"]
+dependencies = ["amd-gaia[rag]>=0.20.0"]
 
 [project.entry-points."gaia.agent"]
 summarize = "gaia_agent_summarize:build_registration"

--- a/hub/agents/python/summarize/tests/conftest.py
+++ b/hub/agents/python/summarize/tests/conftest.py
@@ -1,0 +1,39 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Shared fixtures for the summarizer test suite.
+
+Most of these tests drive real LLM inference through the CLI and need a
+running Lemonade server; they are marked ``lemonade`` and skip cleanly when
+the server is unreachable (mirrors the ``require_lemonade`` convention in
+the repo-root tests/conftest.py) so the LLM-free tests still run in CI.
+"""
+
+import pytest
+import requests
+
+LEMONADE_HEALTH_URL = "http://localhost:13305/api/v1/health"
+
+
+def _lemonade_available() -> bool:
+    try:
+        return requests.get(LEMONADE_HEALTH_URL, timeout=5).status_code == 200
+    except requests.RequestException:
+        return False
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "lemonade: test needs a running Lemonade server (real LLM inference)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if _lemonade_available():
+        return
+    skip = pytest.mark.skip(
+        reason=f"Lemonade server not reachable at {LEMONADE_HEALTH_URL}"
+    )
+    for item in items:
+        if "lemonade" in item.keywords:
+            item.add_marker(skip)

--- a/hub/agents/python/summarize/tests/test_summarizer.py
+++ b/hub/agents/python/summarize/tests/test_summarizer.py
@@ -252,21 +252,24 @@ class TestSummarizer:
 
         print(f"Successfully created synthetic OCR PDF (text as images): {output_path}")
 
+    # Test data lives at the repo root (data/), not in the hub package — the
+    # suite predates the move to hub/agents/python/summarize (#1992).
     @pytest.fixture
     def data_txt_path(self) -> Path:
-        """Path to data/txt directory"""
-        return Path(__file__).parent.parent / "data" / "txt"
+        """Path to the repo-root data/txt directory"""
+        return Path(__file__).resolve().parents[5] / "data" / "txt"
 
     @pytest.fixture
     def data_pdf_path(self) -> Path:
-        """Path to data/pdf directory"""
-        return Path(__file__).parent.parent / "data" / "pdf"
+        """Path to the repo-root data/pdf directory"""
+        return Path(__file__).resolve().parents[5] / "data" / "pdf"
 
     @pytest.fixture
     def test_model(self) -> str:
         """Get test model from environment or use default"""
         return os.environ.get("GAIA_TEST_MODEL", SummarizerAgent.DEFAULT_MODEL)
 
+    @pytest.mark.lemonade
     def test_summarize_transcript(self, data_txt_path, test_model) -> None:
         """Integration test: summarize a real meeting transcript via CLI"""
         # Create temporary output file
@@ -395,6 +398,7 @@ class TestSummarizer:
             if output_path.exists():
                 output_path.unlink()
 
+    @pytest.mark.lemonade
     def test_summarize_email(self, data_txt_path, test_model) -> None:
         """Integration test: summarize a real email via CLI"""
         # Add delay to prevent server overload from previous test
@@ -519,6 +523,7 @@ class TestSummarizer:
             if output_path.exists():
                 output_path.unlink()
 
+    @pytest.mark.lemonade
     def test_multiple_styles(self, data_txt_path, test_model) -> None:
         """Integration test: verify multiple summary styles work correctly via CLI"""
         # Add delay to prevent server overload from previous tests
@@ -651,6 +656,7 @@ class TestSummarizer:
             if output_path.exists():
                 output_path.unlink()
 
+    @pytest.mark.lemonade
     def test_summarize_directory(self, test_model) -> None:
         """Unit-style test for SummarizerAgent.summarize_directory on a temp dir."""
         # Build a temporary directory with a few small files
@@ -721,6 +727,7 @@ class TestSummarizer:
         # Error message should list allowed styles
         assert "Unsupported style" in str(exc.value)
 
+    @pytest.mark.lemonade
     def test_summarize_synthetic_pdf_ocr(self, data_pdf_path, test_model) -> None:
         """Test OCR extraction on a synthetically generated PDF"""
         if not HAS_REPORTLAB:
@@ -741,6 +748,7 @@ class TestSummarizer:
         )
         print(f"Synthetic PDF retained at: {synthetic_pdf_path}")
 
+    @pytest.mark.lemonade
     def test_summarize_pdf_ocr(self, data_pdf_path, test_model) -> None:
         self._run_pdf_cli_test(
             data_pdf_path,

--- a/src/gaia/apps/webui/bin/gaia-ui.cjs
+++ b/src/gaia/apps/webui/bin/gaia-ui.cjs
@@ -81,7 +81,7 @@ Logs: ~/.gaia/electron-install.log
 Update:   npm install -g @amd-gaia/agent-ui@latest
 Uninstall: npm uninstall -g @amd-gaia/agent-ui && rm -rf ~/.gaia
 
-Documentation: https://amd-gaia.ai/guides/agent-ui
+Documentation: https://amd-gaia.ai/docs/guides/agent-ui
 `);
 }
 

--- a/src/gaia/apps/webui/services/backend-installer-progress-dialog.cjs
+++ b/src/gaia/apps/webui/services/backend-installer-progress-dialog.cjs
@@ -399,7 +399,7 @@ async function showFailureDialog(parentWindow, errorInfo = {}) {
         return "retry";
       case 2: {
         try {
-          await shell.openExternal("https://amd-gaia.ai/quickstart#cli-install");
+          await shell.openExternal("https://amd-gaia.ai/docs/quickstart#cli-install");
         } catch {
           // ignore
         }

--- a/src/gaia/apps/webui/services/backend-installer.cjs
+++ b/src/gaia/apps/webui/services/backend-installer.cjs
@@ -1530,11 +1530,11 @@ async function installBackend(opts = {}) {
           ? "GAIA retried with the OS certificate store and it still failed. "
           : "") +
         "Ask IT to install the proxy's root CA in your system's trusted certificate store, then relaunch GAIA. " +
-        "See https://amd-gaia.ai/quickstart#cli-install";
+        "See https://amd-gaia.ai/docs/quickstart#cli-install";
     } else {
       suggestion = `Try installing manually:\n  uv pip install ${pipPackage} --python ${
         IS_WINDOWS ? `${GAIA_VENV_DISPLAY}/Scripts/python.exe` : `${GAIA_VENV_DISPLAY}/bin/python`
-      }\nThen restart GAIA. See https://amd-gaia.ai/quickstart#cli-install`;
+      }\nThen restart GAIA. See https://amd-gaia.ai/docs/quickstart#cli-install`;
     }
     throw new InstallError(
       `Failed to install ${pipPackage} (pip exit ${installResult.code}).`,
@@ -1551,7 +1551,7 @@ async function installBackend(opts = {}) {
       `GAIA binary not found at ${GAIA_VENV_DISPLAY} after install.`,
       {
         stage: STAGES.INSTALL_PACKAGE,
-        suggestion: "The package was installed but the gaia executable is missing. Try reinstalling from https://amd-gaia.ai/quickstart",
+        suggestion: "The package was installed but the gaia executable is missing. Try reinstalling from https://amd-gaia.ai/docs/quickstart",
       }
     );
   }
@@ -1788,7 +1788,7 @@ async function ensureBackend(opts = {}) {
         "GAIA backend not found after installation.",
         {
           stage: STAGES.VERIFY,
-          suggestion: "Check the log file and try reinstalling. See https://amd-gaia.ai/quickstart",
+          suggestion: "Check the log file and try reinstalling. See https://amd-gaia.ai/docs/quickstart",
         }
       );
       setState(STATES.FAILED, {

--- a/tests/unit/test_amd_gaia_urls.py
+++ b/tests/unit/test_amd_gaia_urls.py
@@ -21,7 +21,7 @@ _ALLOWLIST = {
     "https://amd-gaia.ai/install.ps1",
     "https://amd-gaia.ai/install.sh",
 }
-_SCAN_EXTENSIONS = {".py", ".tsx", ".ts", ".js", ".json", ".md"}
+_SCAN_EXTENSIONS = {".py", ".tsx", ".ts", ".js", ".cjs", ".mjs", ".json", ".md"}
 _SKIP_PATH_PARTS = {"node_modules", "dist", ".turbo"}
 
 


### PR DESCRIPTION
Closes #1992. Closes the docs finding from #2103.

Nine hub packages (emr 1722 test lines, blender 1138, summarize 894, sd, docker, doc-search, fileio, hello-world, word-count) shipped test suites that no workflow ever ran — a broken change published green. They now run on every PR via a `test_hub_agents.yml` matrix, and actually running them surfaced (and this PR fixes) real rot. Separately, Agent-UI `.cjs` files linked users to bare `amd-gaia.ai` paths that 404 — shown exactly when an install had just failed — because the #1058 URL guard never scanned `.cjs`; the guard now covers `.cjs`/`.mjs` and the six broken links point at working `/docs/` URLs (verified live).

**What running the un-run suites surfaced:**
- **blender**: conftest skipped the *entire* suite whenever the Blender MCP port was closed — masking 10 mocked tests that no longer match the refactored agent API (removed `max_retries` kwarg; the `agent.llm` mock seam is no longer the LLM boundary, so they'd silently hit a live Lemonade; `_get_domain_patterns`/`_create_fallback_response` were removed). The port gate now only skips `integration`-marked tests; the 10 stale tests are explicitly skipped pending a rewrite (not trivially fixable — they need re-mocking against the current agent loop); 6 parsing tests run again.
- **summarize**: data fixtures pointed at a `data/` dir inside the hub package that never existed after the move from `src/gaia/apps/summarize` — every file-based test failed on any machine. Fixtures now point at the repo-root `data/`, and the LLM-inference tests are marked `lemonade` (skip cleanly when no server is reachable, mirroring `require_lemonade`). Verified green against a live Lemonade locally, except `test_summarize_synthetic_pdf_ocr`, which additionally requires the optional Qwen3-VL model for image-only-PDF OCR — it skips in hosted CI and fails with an actionable error on boxes without that model.
- The other seven suites pass as-is (verified locally: emr 67, blender 6+skips, sd 8, docker 5, doc-search 3, fileio 5, hello-world 4, word-count 5).

**Test plan**
- [ ] `test_hub_agents.yml` matrix (9 jobs) goes green on this PR (workflow triggers on its own path)
- [ ] `python -m pytest tests/unit/test_amd_gaia_urls.py` passes (fails on main once `.cjs` is scanned)
- [ ] Spot-check: https://amd-gaia.ai/docs/quickstart#cli-install and https://amd-gaia.ai/docs/guides/agent-ui resolve

**Update:** the first CI run of the matrix immediately caught two real packaging bugs — `gaia-agent-summarize` and `gaia-agent-emr` under-declared their runtime deps (missing `rag`/`api` extras), so a fresh install of either wheel crashed at runtime. Fixed in this PR.
