### PR TITLE
test(audit): coverage for schedule CLI, perf-vis, VLM extraction, PDF gen/export; fix silent table-row loss

### DIFF
--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -71,8 +71,12 @@ jobs:
           # exercises the perf-vis plotting functions headlessly (Agg backend).
           # It stays out of the runtime extras on purpose — gaia.perf_analysis
           # imports it lazily and errors loudly when it is missing.
+          # pymupdf (fitz) is required by tests/unit/test_structured_vlm_extraction.py:
+          # the PDF branch of StructuredExtractor.extract() does `import fitz`, and
+          # mocker.patch("fitz.open") can only resolve that target if the module
+          # exists. It ships in the [ui]/[rag] extras, which this job does not install.
           uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx matplotlib
+                                  pyfakefs keyring httpx respx matplotlib pymupdf
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity
@@ -188,7 +192,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system pytest pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx matplotlib
+                                  pyfakefs keyring httpx respx matplotlib pymupdf
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -67,8 +67,12 @@ jobs:
           # keyring + httpx + respx are required by tests/unit/connections/
           # (issue #915). The in-memory keyring backend in tests/conftest.py
           # avoids the SecretService daemon prerequisite on Linux runners.
+          # matplotlib is required by tests/unit/test_perf_analysis.py, which
+          # exercises the perf-vis plotting functions headlessly (Agg backend).
+          # It stays out of the runtime extras on purpose — gaia.perf_analysis
+          # imports it lazily and errors loudly when it is missing.
           uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx
+                                  pyfakefs keyring httpx respx matplotlib
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity
@@ -184,7 +188,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system pytest pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx
+                                  pyfakefs keyring httpx respx matplotlib
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity

--- a/hub/agents/python/emr/gaia_agent_emr/agent.py
+++ b/hub/agents/python/emr/gaia_agent_emr/agent.py
@@ -1100,6 +1100,25 @@ class MedicalIntakeAgent(Agent, DatabaseMixin, FileWatcherMixin):
             logger.warning("No valid JSON found in extraction")
             return None
 
+        # A VLM sometimes wraps the single patient object in an array.
+        if isinstance(result, list):
+            if len(result) == 1 and isinstance(result[0], dict):
+                result = result[0]
+            else:
+                logger.error(
+                    f"Extraction returned a JSON array of {len(result)} item(s); "
+                    "expected one patient object. Re-scan the form, or adjust the "
+                    "extraction prompt to emit a single JSON object per form."
+                )
+                return None
+
+        if not isinstance(result, dict):
+            logger.error(
+                f"Extraction returned a JSON {type(result).__name__}; expected an "
+                "object of patient fields. Check the VLM output for this form."
+            )
+            return None
+
         # Normalize phone fields: prefer mobile_phone if phone is not set
         # This handles forms where VLM extracts to mobile_phone instead of phone
         if not result.get("phone"):

--- a/hub/agents/python/emr/tests/test_emr_agent.py
+++ b/hub/agents/python/emr/tests/test_emr_agent.py
@@ -180,6 +180,96 @@ class TestPatientDataParsing(unittest.TestCase):
             finally:
                 agent.stop()
 
+    def test_parse_single_object_wrapped_in_array(self):
+        """A VLM that wraps the patient object in an array is unwrapped, not crashed."""
+        with temp_directory() as tmp_dir:
+            from gaia_agent_emr import MedicalIntakeAgent
+
+            agent = MedicalIntakeAgent(
+                watch_dir=str(tmp_dir / "intake"),
+                db_path=str(tmp_dir / "patients.db"),
+                skip_lemonade=True,
+                silent_mode=True,
+                auto_start_watching=False,
+            )
+
+            try:
+                wrapped = json.dumps([{"first_name": "Ada", "last_name": "Lovelace"}])
+
+                result = agent._parse_extraction(wrapped)
+
+                self.assertIsNotNone(result)
+                self.assertIsInstance(result, dict)
+                self.assertEqual(result["first_name"], "Ada")
+                self.assertEqual(result["last_name"], "Lovelace")
+            finally:
+                agent.stop()
+
+    def test_parse_multi_element_array_returns_none(self):
+        """A multi-row array is ambiguous for a single patient — reject it loudly."""
+        with temp_directory() as tmp_dir:
+            from gaia_agent_emr import MedicalIntakeAgent
+
+            agent = MedicalIntakeAgent(
+                watch_dir=str(tmp_dir / "intake"),
+                db_path=str(tmp_dir / "patients.db"),
+                skip_lemonade=True,
+                silent_mode=True,
+                auto_start_watching=False,
+            )
+
+            try:
+                multi = json.dumps(
+                    [{"first_name": "Ada"}, {"first_name": "Grace"}],
+                )
+
+                result = agent._parse_extraction(multi)
+
+                self.assertIsNone(result)
+            finally:
+                agent.stop()
+
+    def test_parse_array_in_surrounding_text_does_not_crash(self):
+        """Top-level array embedded in prose hits the same guard, no AttributeError."""
+        with temp_directory() as tmp_dir:
+            from gaia_agent_emr import MedicalIntakeAgent
+
+            agent = MedicalIntakeAgent(
+                watch_dir=str(tmp_dir / "intake"),
+                db_path=str(tmp_dir / "patients.db"),
+                skip_lemonade=True,
+                silent_mode=True,
+                auto_start_watching=False,
+            )
+
+            try:
+                text = 'Here you go: [{"first_name": "Ada", "phone": ""}] done'
+
+                result = agent._parse_extraction(text)
+
+                self.assertIsNotNone(result)
+                self.assertEqual(result["first_name"], "Ada")
+            finally:
+                agent.stop()
+
+    def test_parse_scalar_json_returns_none(self):
+        """A bare JSON scalar is not a patient object — reject instead of crashing."""
+        with temp_directory() as tmp_dir:
+            from gaia_agent_emr import MedicalIntakeAgent
+
+            agent = MedicalIntakeAgent(
+                watch_dir=str(tmp_dir / "intake"),
+                db_path=str(tmp_dir / "patients.db"),
+                skip_lemonade=True,
+                silent_mode=True,
+                auto_start_watching=False,
+            )
+
+            try:
+                self.assertIsNone(agent._parse_extraction("42"))
+            finally:
+                agent.stop()
+
     def test_parse_json_with_nested_objects_in_text(self):
         """Test parsing nested JSON embedded in text."""
         with temp_directory() as tmp_dir:

--- a/src/gaia/utils/parsing.py
+++ b/src/gaia/utils/parsing.py
@@ -16,19 +16,58 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 logger = logging.getLogger(__name__)
 
 
-def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
+def _extract_balanced_json(
+    text: str, start: int, open_ch: str, close_ch: str
+) -> Optional[Union[Dict[str, Any], List[Any]]]:
+    """Parse the balanced JSON value opening at ``text[start]``.
+
+    Counts only the outer bracket type (inner brackets of the same type are
+    themselves balanced), ignoring brackets inside JSON string values and
+    handling escaped characters within them.
     """
-    Extract a JSON object from text that may contain surrounding content.
+    depth = 0
+    in_string = False
+    escaped = False
+    for i, char in enumerate(text[start:], start):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == open_ch:
+            depth += 1
+        elif char == close_ch:
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(  # type: ignore[no-any-return]
+                        text[start : i + 1]
+                    )
+                except json.JSONDecodeError as e:
+                    logger.debug(f"JSON decode error: {e}")
+                    return None
+    logger.debug(f"Failed to find matching {close_ch!r} in text: {text[:200]}...")
+    return None
+
+
+def extract_json_from_text(text: str) -> Optional[Union[Dict[str, Any], List[Any]]]:
+    """
+    Extract a JSON object or array from text that may contain surrounding content.
 
     LLMs often return JSON embedded in explanatory text. This function
-    handles nested JSON objects correctly using balanced brace counting,
+    handles nested JSON correctly using balanced bracket counting,
     unlike simple regex approaches.
 
     Args:
-        text: Text potentially containing a JSON object.
+        text: Text potentially containing a JSON object or array.
 
     Returns:
-        Parsed JSON as a dict, or None if no valid JSON found.
+        Parsed JSON as a dict or list, or None if no valid JSON found.
 
     Example:
         from gaia.utils import extract_json_from_text
@@ -50,45 +89,22 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
     except json.JSONDecodeError:
         pass
 
-    # Look for JSON object in response (handles nested braces properly)
-    try:
-        # Find first {
-        start = text.find("{")
-        if start == -1:
-            logger.debug("No JSON object found in text")
-            return None
-
-        # Count braces to find matching close, ignoring braces inside JSON
-        # string values (and handling escaped characters within them) so a "}"
-        # in a string does not terminate the object prematurely.
-        brace_count = 0
-        in_string = False
-        escaped = False
-        for i, char in enumerate(text[start:], start):
-            if in_string:
-                if escaped:
-                    escaped = False
-                elif char == "\\":
-                    escaped = True
-                elif char == '"':
-                    in_string = False
-                continue
-            if char == '"':
-                in_string = True
-            elif char == "{":
-                brace_count += 1
-            elif char == "}":
-                brace_count -= 1
-                if brace_count == 0:
-                    json_str = text[start : i + 1]
-                    return json.loads(json_str)  # type: ignore[no-any-return]
-
-        logger.debug(f"Failed to find matching brace in text: {text[:200]}...")
+    # Look for a JSON object or array in the response, trying whichever
+    # opens first (a top-level array's first "{" is an inner row object —
+    # scanning only "{" would silently drop every row after the first).
+    candidates = sorted(
+        (text.find(open_ch), open_ch, close_ch)
+        for open_ch, close_ch in (("{", "}"), ("[", "]"))
+        if text.find(open_ch) != -1
+    )
+    if not candidates:
+        logger.debug("No JSON object or array found in text")
         return None
-
-    except json.JSONDecodeError as e:
-        logger.debug(f"JSON decode error: {e}")
-        return None
+    for start, open_ch, close_ch in candidates:
+        parsed = _extract_balanced_json(text, start, open_ch, close_ch)
+        if parsed is not None:
+            return parsed
+    return None
 
 
 def pdf_page_to_image(

--- a/tests/unit/cli/test_cli_schedule.py
+++ b/tests/unit/cli/test_cli_schedule.py
@@ -1,0 +1,360 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for `gaia schedule` CLI dispatch (_handle_schedule, issue #1995).
+
+Exercises the real argparse parser (build_parser().parse_args(argv)) end to
+end, then mocks only the schedule-store / schedule-package boundary
+(``gaia.schedule.store.TomlScheduleStore``, ``gaia.schedule.daemon``,
+``gaia.schedule.runner``) and asserts the *actual* constructed ``Schedule``
+object / store-call arguments produced from parsed CLI args — not just that
+a mock was called (see issue #1655).
+"""
+
+from __future__ import annotations
+
+import datetime as datetime_module
+
+import pytest
+
+from gaia.cli import _handle_schedule, build_parser
+from gaia.schedule.store import Schedule
+
+# ---- Shared fixtures ----
+
+
+@pytest.fixture(scope="module")
+def parser():
+    """Module-scoped real argparse parser, built once (mirrors test_cli_smoke.py)."""
+    return build_parser()
+
+
+def _parse(parser_, argv):
+    return parser_.parse_args(["schedule", *argv])
+
+
+@pytest.fixture
+def mock_store(mocker):
+    """Patch the store class at its source so _handle_schedule's local
+    `from gaia.schedule.store import TomlScheduleStore` picks up the mock."""
+    store_cls = mocker.patch("gaia.schedule.store.TomlScheduleStore")
+    return store_cls.return_value
+
+
+@pytest.fixture
+def mock_next_fire_time(mocker):
+    return mocker.patch(
+        "gaia.schedule.daemon.next_fire_time", return_value="2026-07-18T07:00:00+00:00"
+    )
+
+
+@pytest.fixture
+def mock_run_daemon(mocker):
+    return mocker.patch("gaia.schedule.daemon.run_daemon")
+
+
+@pytest.fixture
+def mock_fire(mocker):
+    return mocker.patch("gaia.schedule.runner.fire", return_value="ok")
+
+
+# ---- add ----
+
+
+def test_add_prompt_constructs_schedule_from_parsed_args(parser, mock_store, capsys):
+    args = _parse(
+        parser,
+        [
+            "add",
+            "--name",
+            "daily-standup",
+            "--cron",
+            "0 7 * * 1-5",
+            "--prompt",
+            "summarize my day",
+            "--sink",
+            "telegram",
+            "--to",
+            "12345",
+        ],
+    )
+
+    _handle_schedule(args)
+
+    mock_store.add.assert_called_once()
+    (constructed,) = mock_store.add.call_args.args
+    assert isinstance(constructed, Schedule)
+    assert constructed.name == "daily-standup"
+    assert constructed.cron == "0 7 * * 1-5"
+    assert constructed.prompt == "summarize my day"
+    assert constructed.skill is None
+    assert constructed.sink == "telegram"
+    assert constructed.sink_args == {"to": "12345"}
+
+    out = capsys.readouterr().out
+    assert "daily-standup" in out
+    assert "0 7 * * 1-5" in out
+
+
+def test_add_skill_variant_leaves_prompt_unset(parser, mock_store):
+    args = _parse(
+        parser,
+        [
+            "add",
+            "--name",
+            "morning-brief",
+            "--cron",
+            "0 8 * * *",
+            "--skill",
+            "brainstorming",
+        ],
+    )
+
+    _handle_schedule(args)
+
+    (constructed,) = mock_store.add.call_args.args
+    assert constructed.skill == "brainstorming"
+    assert constructed.prompt is None
+    # default sink, no --to supplied
+    assert constructed.sink == "stdout"
+    assert constructed.sink_args == {}
+
+
+def test_add_default_sink_without_to_has_empty_sink_args(parser, mock_store):
+    """sink_args must only carry `to` when --to was actually passed (#1995 munging risk)."""
+    args = _parse(
+        parser,
+        ["add", "--name", "n", "--cron", "* * * * *", "--prompt", "hi"],
+    )
+
+    _handle_schedule(args)
+
+    (constructed,) = mock_store.add.call_args.args
+    assert constructed.sink == "stdout"
+    assert constructed.sink_args == {}
+    assert "to" not in constructed.sink_args
+
+
+def test_add_requires_name_and_cron(parser):
+    with pytest.raises(SystemExit) as excinfo:
+        _parse(parser, ["add", "--prompt", "hi"])
+    assert excinfo.value.code == 2
+
+
+def test_add_requires_exactly_one_of_skill_or_prompt(parser):
+    with pytest.raises(SystemExit) as excinfo:
+        _parse(
+            parser,
+            ["add", "--name", "n", "--cron", "* * * * *"],
+        )
+    assert excinfo.value.code == 2
+
+
+def test_add_rejects_both_skill_and_prompt(parser):
+    with pytest.raises(SystemExit) as excinfo:
+        _parse(
+            parser,
+            [
+                "add",
+                "--name",
+                "n",
+                "--cron",
+                "* * * * *",
+                "--prompt",
+                "hi",
+                "--skill",
+                "brainstorming",
+            ],
+        )
+    assert excinfo.value.code == 2
+
+
+# ---- list ----
+
+
+def test_list_prints_enabled_schedule_with_next_fire(
+    parser, mock_store, mock_next_fire_time, capsys
+):
+    mock_store.load.return_value = {
+        "daily-standup": Schedule(
+            name="daily-standup",
+            cron="0 7 * * 1-5",
+            prompt="summarize my day",
+            sink="telegram",
+            enabled=True,
+        ),
+    }
+
+    args = _parse(parser, ["list"])
+    _handle_schedule(args)
+
+    mock_next_fire_time.assert_called_once_with("0 7 * * 1-5")
+    out = capsys.readouterr().out
+    assert "daily-standup" in out
+    assert "[enabled]" in out
+    assert "cron='0 7 * * 1-5'" in out
+    assert "sink=telegram" in out
+    assert "next=2026-07-18T07:00:00+00:00" in out
+
+
+def test_list_paused_schedule_skips_next_fire_lookup(
+    parser, mock_store, mock_next_fire_time, capsys
+):
+    mock_store.load.return_value = {
+        "paused-job": Schedule(
+            name="paused-job",
+            cron="0 9 * * *",
+            prompt="hi",
+            enabled=False,
+        ),
+    }
+
+    args = _parse(parser, ["list"])
+    _handle_schedule(args)
+
+    mock_next_fire_time.assert_not_called()
+    out = capsys.readouterr().out
+    assert "[paused]" in out
+    assert "next=" not in out
+
+
+def test_list_empty_prints_hint(parser, mock_store, capsys):
+    mock_store.load.return_value = {}
+
+    args = _parse(parser, ["list"])
+    _handle_schedule(args)
+
+    out = capsys.readouterr().out
+    assert "No schedules registered" in out
+    assert "gaia schedule add" in out
+
+
+# ---- show ----
+
+
+def test_show_prints_prompt_target(parser, mock_store, mock_next_fire_time, capsys):
+    mock_store.get.return_value = Schedule(
+        name="daily-standup",
+        cron="0 7 * * 1-5",
+        prompt="summarize my day",
+        sink="stdout",
+        enabled=True,
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+
+    args = _parse(parser, ["show", "daily-standup"])
+    _handle_schedule(args)
+
+    mock_store.get.assert_called_once_with("daily-standup")
+    mock_next_fire_time.assert_called_once_with("0 7 * * 1-5")
+    out = capsys.readouterr().out
+    assert "name:       daily-standup" in out
+    assert "target:     prompt=summarize my day" in out
+    assert "next_fire:  2026-07-18T07:00:00+00:00" in out
+
+
+def test_show_prints_skill_target(parser, mock_store, mock_next_fire_time, capsys):
+    mock_store.get.return_value = Schedule(
+        name="morning-brief",
+        cron="0 8 * * *",
+        skill="brainstorming",
+        enabled=True,
+    )
+
+    args = _parse(parser, ["show", "morning-brief"])
+    _handle_schedule(args)
+
+    out = capsys.readouterr().out
+    assert "target:     skill=brainstorming" in out
+
+
+# ---- remove ----
+
+
+def test_remove_dispatches_name_from_parsed_args(parser, mock_store, capsys):
+    args = _parse(parser, ["remove", "daily-standup"])
+    _handle_schedule(args)
+
+    mock_store.remove.assert_called_once_with("daily-standup")
+    out = capsys.readouterr().out
+    assert "Removed schedule 'daily-standup'" in out
+
+
+# ---- pause / resume ----
+
+
+def test_pause_disables_named_schedule(parser, mock_store, capsys):
+    args = _parse(parser, ["pause", "daily-standup"])
+    _handle_schedule(args)
+
+    mock_store.set_enabled.assert_called_once_with("daily-standup", False)
+    out = capsys.readouterr().out
+    assert "Paused schedule 'daily-standup'" in out
+
+
+def test_resume_enables_named_schedule(parser, mock_store, capsys):
+    args = _parse(parser, ["resume", "daily-standup"])
+    _handle_schedule(args)
+
+    mock_store.set_enabled.assert_called_once_with("daily-standup", True)
+    out = capsys.readouterr().out
+    assert "Resumed schedule 'daily-standup'" in out
+
+
+# ---- run ----
+
+
+class _FixedDatetime(datetime_module.datetime):
+    """Deterministic stand-in so `mark_run`'s last_run timestamp is assertable."""
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 7, 18, 6, 30, 0, tzinfo=tz)
+
+
+def test_run_fires_schedule_and_marks_run_with_next_fire_time(
+    parser, mock_store, mock_next_fire_time, mock_fire, monkeypatch
+):
+    schedule = Schedule(
+        name="daily-standup",
+        cron="0 7 * * 1-5",
+        prompt="summarize my day",
+        enabled=True,
+    )
+    mock_store.get.return_value = schedule
+    monkeypatch.setattr(datetime_module, "datetime", _FixedDatetime)
+
+    args = _parse(parser, ["run", "daily-standup"])
+    _handle_schedule(args)
+
+    mock_store.get.assert_called_once_with("daily-standup")
+    mock_fire.assert_called_once_with(schedule)
+    mock_next_fire_time.assert_called_once_with("0 7 * * 1-5")
+    mock_store.mark_run.assert_called_once_with(
+        "daily-standup",
+        "2026-07-18T06:30:00+00:00",
+        next_run="2026-07-18T07:00:00+00:00",
+    )
+
+
+# ---- daemon ----
+
+
+def test_daemon_dispatches_with_no_extra_args(parser, mock_store, mock_run_daemon):
+    args = _parse(parser, ["daemon"])
+    _handle_schedule(args)
+
+    mock_run_daemon.assert_called_once_with()
+
+
+# ---- no subcommand ----
+
+
+def test_no_subcommand_prints_usage_hint_to_stderr(parser, mock_store, capsys):
+    args = _parse(parser, [])
+    assert args.schedule_action is None
+
+    _handle_schedule(args)
+
+    err = capsys.readouterr().err
+    assert "No schedule action specified" in err
+    assert "add|list|show|remove|pause|resume|run|daemon" in err

--- a/tests/unit/cli/test_cli_schedule.py
+++ b/tests/unit/cli/test_cli_schedule.py
@@ -95,7 +95,8 @@ def test_add_prompt_constructs_schedule_from_parsed_args(parser, mock_store, cap
     assert "0 7 * * 1-5" in out
 
 
-def test_add_skill_variant_leaves_prompt_unset(parser, mock_store):
+def test_add_skill_variant_is_rejected_until_888(parser, mock_store, capsys):
+    """A --skill schedule would register but never fire, so `add` rejects it (#888)."""
     args = _parse(
         parser,
         [
@@ -109,14 +110,17 @@ def test_add_skill_variant_leaves_prompt_unset(parser, mock_store):
         ],
     )
 
-    _handle_schedule(args)
+    with pytest.raises(SystemExit) as excinfo:
+        _handle_schedule(args)
 
-    (constructed,) = mock_store.add.call_args.args
-    assert constructed.skill == "brainstorming"
-    assert constructed.prompt is None
-    # default sink, no --to supplied
-    assert constructed.sink == "stdout"
-    assert constructed.sink_args == {}
+    assert excinfo.value.code == 1
+    # Nothing may be persisted — a stored skill schedule is the silent-failure case.
+    mock_store.add.assert_not_called()
+
+    err = capsys.readouterr().err
+    assert "--skill is not supported yet" in err
+    assert "--prompt" in err  # names the workaround
+    assert "888" in err  # points at the tracking issue
 
 
 def test_add_default_sink_without_to_has_empty_sink_args(parser, mock_store):

--- a/tests/unit/eval/test_pdf_document_generator.py
+++ b/tests/unit/eval/test_pdf_document_generator.py
@@ -1,0 +1,285 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``gaia.eval.pdf_document_generator.PDFDocumentGenerator``.
+
+Mocks the Claude boundary (``ClaudeClient``) so no ``ANTHROPIC_API_KEY`` or
+network access is required. Generated PDFs are validated by actually opening
+them with ``pypdf`` — a generation bug here would quietly invalidate every
+downstream eval that consumes these synthetic fixtures.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("reportlab")
+pypdf = pytest.importorskip("pypdf")
+
+from gaia.eval.pdf_document_generator import PDFDocumentGenerator  # noqa: E402
+
+
+def _usage_response(content, input_tokens=100, output_tokens=200):
+    return {
+        "content": content,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+        "cost": {
+            "input_cost": round(input_tokens / 1_000_000 * 3.0, 6),
+            "output_cost": round(output_tokens / 1_000_000 * 15.0, 6),
+            "total_cost": round(
+                input_tokens / 1_000_000 * 3.0 + output_tokens / 1_000_000 * 15.0, 6
+            ),
+        },
+    }
+
+
+@pytest.fixture
+def mock_claude_client(mocker):
+    """Patch ClaudeClient so PDFDocumentGenerator never touches the network."""
+    mock_cls = mocker.patch("gaia.eval.pdf_document_generator.ClaudeClient")
+    instance = mock_cls.return_value
+    instance.model = "test-claude-model"
+    return instance
+
+
+@pytest.fixture
+def generator(mock_claude_client):
+    return PDFDocumentGenerator()
+
+
+def _open_pdf(path):
+    """Open and sanity-check a generated PDF, returning the pypdf reader."""
+    assert path.exists()
+    reader = pypdf.PdfReader(str(path))
+    assert len(reader.pages) >= 1
+    return reader
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_raises_valueerror_when_claude_client_fails(mocker):
+    mocker.patch(
+        "gaia.eval.pdf_document_generator.ClaudeClient",
+        side_effect=Exception("ANTHROPIC_API_KEY not found"),
+    )
+
+    with pytest.raises(ValueError, match="Could not initialize Claude client"):
+        PDFDocumentGenerator()
+
+
+def test_init_success_sets_up_document_templates(generator):
+    assert "technical_spec" in generator.document_templates
+    assert "financial_report" in generator.document_templates
+    assert len(generator.document_templates) == 8
+
+
+# ---------------------------------------------------------------------------
+# _estimate_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_tokens_is_roughly_four_chars_per_token(generator):
+    assert generator._estimate_tokens("a" * 400) == 100
+    assert generator._estimate_tokens("") == 0
+
+
+# ---------------------------------------------------------------------------
+# generate_document
+# ---------------------------------------------------------------------------
+
+
+def test_generate_document_unknown_doc_type_raises(generator):
+    with pytest.raises(ValueError, match="Unknown document type"):
+        generator.generate_document("not_a_real_type")
+
+
+def test_generate_document_returns_content_and_metadata(generator, mock_claude_client):
+    long_content = "Technical Spec\n\n" + ("Realistic section content. " * 100)
+    mock_claude_client.get_completion_with_usage.return_value = _usage_response(
+        long_content
+    )
+
+    content, metadata = generator.generate_document("technical_spec", target_tokens=500)
+
+    assert content == long_content
+    assert metadata["doc_type"] == "technical_spec"
+    assert metadata["target_tokens"] == 500
+    assert metadata["claude_model"] == "test-claude-model"
+    assert metadata["claude_usage"]["total_tokens"] == 300
+    assert metadata["claude_cost"]["total_cost"] > 0
+    assert (
+        metadata["sections"]
+        == generator.document_templates["technical_spec"]["sections"]
+    )
+    # Content was long enough (>= 80% of target) — no extension call made.
+    mock_claude_client.get_completion_with_usage.assert_called_once()
+
+
+def test_generate_document_extends_when_too_short(generator, mock_claude_client):
+    short_content = "Too short."  # ~2 tokens, far below 80% of any real target
+    extension_content = "Additional generated content. " * 50
+
+    mock_claude_client.get_completion_with_usage.side_effect = [
+        _usage_response(short_content, input_tokens=50, output_tokens=10),
+        _usage_response(extension_content, input_tokens=60, output_tokens=400),
+    ]
+
+    content, metadata = generator.generate_document("white_paper", target_tokens=500)
+
+    assert content.startswith(short_content)
+    assert extension_content in content
+    assert mock_claude_client.get_completion_with_usage.call_count == 2
+    # Usage/cost from both calls accumulated.
+    assert metadata["claude_usage"]["input_tokens"] == 110
+    assert metadata["claude_usage"]["output_tokens"] == 410
+
+
+def test_generate_document_propagates_claude_failure(generator, mock_claude_client):
+    mock_claude_client.get_completion_with_usage.side_effect = Exception("api down")
+
+    with pytest.raises(RuntimeError, match="Failed to generate document"):
+        generator.generate_document("research_report", target_tokens=500)
+
+
+def test_extend_content_skips_call_when_already_at_target(
+    generator, mock_claude_client
+):
+    content, usage, cost = generator._extend_content_with_claude(
+        base_content="x" * 4000,  # 1000 tokens, already >= target
+        target_tokens=500,
+        doc_type="technical_spec",
+        current_usage={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        current_cost={"input_cost": 0.0, "output_cost": 0.0, "total_cost": 0.0},
+    )
+
+    assert content == "x" * 4000
+    mock_claude_client.get_completion_with_usage.assert_not_called()
+
+
+def test_extend_content_returns_original_on_failure(generator, mock_claude_client):
+    mock_claude_client.get_completion_with_usage.side_effect = Exception("boom")
+    base_usage = {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+    base_cost = {"input_cost": 0.1, "output_cost": 0.2, "total_cost": 0.3}
+
+    content, usage, cost = generator._extend_content_with_claude(
+        base_content="short",
+        target_tokens=500,
+        doc_type="technical_spec",
+        current_usage=base_usage,
+        current_cost=base_cost,
+    )
+
+    assert content == "short"
+    assert usage == base_usage
+    assert cost == base_cost
+
+
+# ---------------------------------------------------------------------------
+# _create_pdf_from_content — direct PDF generation + validity checks
+# ---------------------------------------------------------------------------
+
+
+def test_create_pdf_from_content_produces_valid_pdf_with_headings(generator, tmp_path):
+    content = (
+        "OVERVIEW:\n"
+        "This document describes the system.\n"
+        "\n"
+        "# Markdown Heading\n"
+        "Body text under the markdown heading.\n"
+        "\n"
+        "ALL CAPS HEADING\n"
+        "Final paragraph of body content.\n"
+    )
+    output_path = tmp_path / "doc.pdf"
+
+    generator._create_pdf_from_content(content, output_path, "Test Document")
+
+    reader = _open_pdf(output_path)
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    assert "Test Document" in text
+    assert "This document describes the system." in text
+    assert "Body text under the markdown heading." in text
+
+
+def test_create_pdf_from_content_empty_content_still_produces_valid_pdf(
+    generator, tmp_path
+):
+    output_path = tmp_path / "empty.pdf"
+
+    generator._create_pdf_from_content("", output_path, "Empty Document")
+
+    reader = _open_pdf(output_path)
+    text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    assert "Empty Document" in text
+
+
+# ---------------------------------------------------------------------------
+# generate_document_set — end-to-end into tmp_path
+# ---------------------------------------------------------------------------
+
+
+def test_generate_document_set_writes_pdfs_and_manifest(
+    generator, mock_claude_client, tmp_path
+):
+    generator.document_templates = {
+        "technical_spec": generator.document_templates["technical_spec"]
+    }
+    long_content = "Section content. " * 100
+    mock_claude_client.get_completion_with_usage.return_value = _usage_response(
+        long_content
+    )
+
+    result = generator.generate_document_set(
+        tmp_path, target_tokens=500, count_per_type=1
+    )
+
+    pdfs_dir = tmp_path / "pdfs"
+    pdf_path = pdfs_dir / "technical_spec.pdf"
+    txt_path = pdfs_dir / "technical_spec.txt"
+    manifest_path = pdfs_dir / "pdf_metadata.json"
+
+    _open_pdf(pdf_path)
+    assert txt_path.read_text(encoding="utf-8") == long_content
+    assert result["output_directory"] == str(pdfs_dir)
+    assert result["generated_files"] == [str(pdf_path)]
+    assert result["metadata_file"] == str(manifest_path)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["generation_info"]["total_files"] == 1
+    assert manifest["generation_info"]["document_types"] == ["technical_spec"]
+    assert manifest["generation_info"]["total_claude_usage"]["total_tokens"] == 300
+    assert len(manifest["documents"]) == 1
+    doc_meta = manifest["documents"][0]
+    assert doc_meta["pdf_filename"] == "technical_spec.pdf"
+    assert doc_meta["txt_filename"] == "technical_spec.txt"
+    assert doc_meta["file_size_bytes"] == len(long_content.encode("utf-8"))
+
+
+def test_generate_document_set_multiple_per_type_uses_indexed_filenames(
+    generator, mock_claude_client, tmp_path
+):
+    generator.document_templates = {
+        "technical_spec": generator.document_templates["technical_spec"]
+    }
+    long_content = "Section content. " * 100
+    mock_claude_client.get_completion_with_usage.return_value = _usage_response(
+        long_content
+    )
+
+    result = generator.generate_document_set(
+        tmp_path, target_tokens=500, count_per_type=2
+    )
+
+    pdfs_dir = tmp_path / "pdfs"
+    assert (pdfs_dir / "technical_spec_1.pdf").exists()
+    assert (pdfs_dir / "technical_spec_2.pdf").exists()
+    assert len(result["generated_files"]) == 2
+    for pdf_file in result["generated_files"]:
+        _open_pdf(Path(pdf_file))

--- a/tests/unit/test_file_watcher.py
+++ b/tests/unit/test_file_watcher.py
@@ -188,6 +188,25 @@ class TestJsonExtraction:
         result = extract_json_from_text(text)
         assert result == {"q": 'say "hi" }', "n": 2}
 
+    def test_extract_array_with_surrounding_text(self):
+        """A top-level array in chatter must come back whole, not as its
+        first row object (which silently dropped every other row)."""
+        text = (
+            "Sure! Here's the table:\n"
+            '[{"a": 1}, {"a": 2}]\n'
+            "Let me know if you need anything else."
+        )
+        assert extract_json_from_text(text) == [{"a": 1}, {"a": 2}]
+
+    def test_extract_plain_array(self):
+        """A bare JSON array parses via the whole-text path."""
+        assert extract_json_from_text('[1, 2, "three"]') == [1, 2, "three"]
+
+    def test_extract_object_after_prose_bracket(self):
+        """A stray '[' in prose before the object must not mask the object."""
+        text = 'See [note 1] then {"ok": true} thanks'
+        assert extract_json_from_text(text) == {"ok": True}
+
 
 class TestFieldChangeDetection:
     """Tests for field change detection."""

--- a/tests/unit/test_pdf_formatter.py
+++ b/tests/unit/test_pdf_formatter.py
@@ -1,0 +1,244 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``gaia.apps.summarize.pdf_formatter.PDFFormatter``.
+
+Exercises every formatting branch (single vs. multi-style summaries,
+performance tables, original-content sections, empty/edge inputs) and
+validates output by actually opening the generated PDFs with ``pypdf`` — the
+covered ``SummarizerApp`` tests never invoke this renderer directly (#2003),
+so a crash or garbled export here would otherwise ship unnoticed.
+"""
+
+import pytest
+
+pytest.importorskip("reportlab")
+pypdf = pytest.importorskip("pypdf")
+
+import gaia.apps.summarize.pdf_formatter as pdf_formatter_module  # noqa: E402
+from gaia.apps.summarize.pdf_formatter import PDFFormatter  # noqa: E402
+
+
+@pytest.fixture
+def formatter():
+    return PDFFormatter()
+
+
+def _pdf_text(path):
+    assert path.exists()
+    reader = pypdf.PdfReader(str(path))
+    assert len(reader.pages) >= 1
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_raises_import_error_without_reportlab(monkeypatch):
+    monkeypatch.setattr(pdf_formatter_module, "HAS_REPORTLAB", False)
+
+    with pytest.raises(ImportError, match="reportlab"):
+        PDFFormatter()
+
+
+def test_init_success_registers_custom_styles(formatter):
+    for style_name in ("CustomTitle", "SectionHeader", "Metadata"):
+        assert style_name in formatter.styles
+
+
+# ---------------------------------------------------------------------------
+# format_summary_as_pdf — single-style summary
+# ---------------------------------------------------------------------------
+
+
+def test_format_single_summary_with_text_items_and_participants(formatter, tmp_path):
+    result = {
+        "metadata": {
+            "input_file": "/tmp/meeting_notes.txt",
+            "input_type": "meeting",
+            "timestamp": "2026-01-01T00:00:00",
+            "model": "test-model",
+            "processing_time_ms": 1234,
+        },
+        "summary": {
+            "text": "Line one.\nLine two.",
+            "items": ["Action item A", "Action item B"],
+            "participants": ["Alice", "Bob"],
+        },
+    }
+    output_path = tmp_path / "single.pdf"
+
+    formatter.format_summary_as_pdf(result, output_path)
+
+    text = _pdf_text(output_path)
+    assert "meeting_notes.txt" in text
+    assert "Action item A" in text
+    assert "Alice" in text
+
+
+def test_format_single_summary_missing_metadata_uses_defaults(formatter, tmp_path):
+    result = {"summary": {"text": "Just a summary."}}
+    output_path = tmp_path / "no_metadata.pdf"
+
+    formatter.format_summary_as_pdf(result, output_path)
+
+    text = _pdf_text(output_path)
+    assert "Unknown" in text
+    assert "Just a summary." in text
+
+
+# ---------------------------------------------------------------------------
+# format_summary_as_pdf — multi-style summaries
+# ---------------------------------------------------------------------------
+
+
+def test_format_multiple_summaries_dict_content_all_fields(formatter, tmp_path):
+    result = {
+        "metadata": {"input_file": "email.txt", "input_type": "email"},
+        "summaries": {
+            "brief": {"text": "Short version."},
+            "detailed": {
+                "items": ["point one", "point two"],
+                "participants": [
+                    {"name": "Carol", "role": "Engineer"},
+                    "Plain Name",
+                ],
+                "sender": "carol@example.com",
+                "recipients": ["dave@example.com", "erin@example.com"],
+            },
+        },
+    }
+    output_path = tmp_path / "multi.pdf"
+
+    formatter.format_summary_as_pdf(result, output_path)
+
+    text = _pdf_text(output_path)
+    assert "Short version." in text
+    assert "point one" in text
+    assert "Carol" in text
+    assert "Engineer" in text
+    assert "Plain Name" in text
+    assert "carol@example.com" in text
+    assert "dave@example.com" in text
+
+
+def test_format_multiple_summaries_string_content(formatter, tmp_path):
+    result = {
+        "summaries": {"quick": "Just a plain string summary."},
+    }
+    output_path = tmp_path / "string_summary.pdf"
+
+    formatter.format_summary_as_pdf(result, output_path)
+
+    text = _pdf_text(output_path)
+    assert "Just a plain string summary." in text
+
+
+# ---------------------------------------------------------------------------
+# format_summary_as_pdf — performance section
+# ---------------------------------------------------------------------------
+
+
+def test_format_with_performance_metrics(formatter, tmp_path):
+    result = {
+        "summary": {"text": "Body."},
+        "performance": {
+            "total_tokens": 500,
+            "prompt_tokens": 300,
+            "completion_tokens": 200,
+            "time_to_first_token_ms": 42,
+            "tokens_per_second": 12.5,
+            "processing_time_ms": 800,
+        },
+        "metadata": {"model": "test-model", "use_local_llm": True},
+    }
+    output_path = tmp_path / "performance.pdf"
+
+    formatter.format_summary_as_pdf(result, output_path)
+
+    text = _pdf_text(output_path)
+    assert "Performance Metrics" in text
+    assert "test-model" in text
+    assert "500" in text
+
+
+def test_format_with_aggregate_performance_fallback(formatter, tmp_path):
+    result = {
+        "summary": {"text": "Body."},
+        "aggregate_performance": {
+            "model_info": {"model": "aggregate-model", "local_llm": False},
+            "total_tokens": 999,
+        },
+    }
+    output_path = tmp_path / "aggregate_performance.pdf"
+
+    formatter.format_summary_as_pdf(result, output_path)
+
+    text = _pdf_text(output_path)
+    assert "aggregate-model" in text
+    assert "999" in text
+
+
+# ---------------------------------------------------------------------------
+# format_summary_as_pdf — original content section
+# ---------------------------------------------------------------------------
+
+
+def test_format_with_original_content_splits_paragraphs(formatter, tmp_path):
+    result = {
+        "summary": {"text": "Summary text."},
+        "original_content": "Para one.\n\nPara two.\n\n\n\nPara three.",
+    }
+    output_path = tmp_path / "original_content.pdf"
+
+    formatter.format_summary_as_pdf(result, output_path)
+
+    text = _pdf_text(output_path)
+    assert "Original Content" in text
+    assert "Para one." in text
+    assert "Para three." in text
+
+
+# ---------------------------------------------------------------------------
+# format_summary_as_pdf — empty / edge inputs
+# ---------------------------------------------------------------------------
+
+
+def test_format_empty_result_does_not_crash(formatter, tmp_path):
+    output_path = tmp_path / "empty.pdf"
+
+    formatter.format_summary_as_pdf({}, output_path)
+
+    text = _pdf_text(output_path)
+    assert "Unknown" in text
+
+
+def test_format_summary_with_empty_items_and_participants(formatter, tmp_path):
+    result = {"summary": {"items": [], "participants": []}}
+    output_path = tmp_path / "empty_lists.pdf"
+
+    # Should not raise even though items/participants are present but empty.
+    formatter.format_summary_as_pdf(result, output_path)
+    assert output_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# _add_text_with_newlines
+# ---------------------------------------------------------------------------
+
+
+def test_add_text_with_newlines_converts_to_br(formatter):
+    story = []
+    formatter._add_text_with_newlines(story, "line1\nline2")
+
+    assert len(story) == 1
+    assert story[0].text == "line1<br/>line2"
+
+
+@pytest.mark.parametrize("empty_value", [None, ""])
+def test_add_text_with_newlines_skips_falsy_text(formatter, empty_value):
+    story = []
+    formatter._add_text_with_newlines(story, empty_value)
+
+    assert story == []

--- a/tests/unit/test_perf_analysis.py
+++ b/tests/unit/test_perf_analysis.py
@@ -1,0 +1,374 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for gaia.perf_analysis (regex log parsing + aggregation, issue #1998).
+
+Covers ``extract_metrics`` against realistic llama-server / Lemonade telemetry
+log lines (built from the module's own regexes), the malformed/empty-log
+paths, the prefill/decode aggregation in ``run_perf_visualization``, and the
+plotting functions exercised headlessly via the Agg backend (no display, no
+`plt.show()` blocking).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+
+from gaia.perf_analysis import (  # noqa: E402
+    METRIC_CONFIGS,
+    Metric,
+    build_plot,
+    build_prefill_decode_pies,
+    extract_metrics,
+    main,
+    parse_cli,
+    run_perf_visualization,
+)
+
+# ---- extract_metrics: realistic matching lines ----
+
+
+def _lines(text: str) -> list[str]:
+    return text.splitlines()
+
+
+def test_extract_metrics_single_request_all_fields_on_separate_lines():
+    log = """\
+slot update_slots: id  0 | task 0 | new prompt, n_ctx_slot = 4096, n_keep = 0
+slot update_slots: id  0 | task 0 | n_prompt_tokens = 128
+Input tokens: 128
+Output tokens: 256
+TTFT (s): 0.357
+TPS: 53.21
+"""
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.PROMPT_TOKENS] == [128.0]
+    assert metrics[Metric.INPUT_TOKENS] == [128.0]
+    assert metrics[Metric.OUTPUT_TOKENS] == [256.0]
+    assert metrics[Metric.TTFT] == [0.357]
+    assert metrics[Metric.TPS] == [53.21]
+
+
+def test_extract_metrics_marker_and_token_count_on_same_line():
+    """llama-server actually logs both on one line: `new prompt, ..., n_prompt_tokens = N`."""
+    log = (
+        "slot update_slots: id  0 | task 12 | new prompt, n_ctx_slot = 4096, "
+        "n_keep = 0, n_prompt_tokens = 64"
+    )
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.PROMPT_TOKENS] == [64.0]
+
+
+def test_extract_metrics_case_insensitive_labels():
+    log = """\
+input tokens: 10
+OUTPUT TOKENS: 20
+ttft (S): 0.1
+tps: 99.5
+"""
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.INPUT_TOKENS] == [10.0]
+    assert metrics[Metric.OUTPUT_TOKENS] == [20.0]
+    assert metrics[Metric.TTFT] == [0.1]
+    assert metrics[Metric.TPS] == [99.5]
+
+
+def test_extract_metrics_multiple_requests_appends_in_order():
+    log = """\
+slot update_slots: new prompt, n_prompt_tokens = 128
+Input tokens: 128
+Output tokens: 256
+TTFT (s): 0.357
+TPS: 53.21
+slot update_slots: new prompt, n_prompt_tokens = 512
+Input tokens: 512
+Output tokens: 64
+TTFT (s): 1.204
+TPS: 41.09
+"""
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.PROMPT_TOKENS] == [128.0, 512.0]
+    assert metrics[Metric.INPUT_TOKENS] == [128.0, 512.0]
+    assert metrics[Metric.OUTPUT_TOKENS] == [256.0, 64.0]
+    assert metrics[Metric.TTFT] == [0.357, 1.204]
+    assert metrics[Metric.TPS] == [53.21, 41.09]
+
+
+# ---- extract_metrics: empty / malformed input ----
+
+
+def test_extract_metrics_empty_log_returns_empty_lists_for_every_metric():
+    metrics = extract_metrics([])
+
+    assert set(metrics.keys()) == set(Metric)
+    assert all(values == [] for values in metrics.values())
+
+
+def test_extract_metrics_malformed_lines_are_skipped_without_crashing():
+    log = """\
+Input tokens missing colon 128
+TTFT (s) 0.5 missing colon
+random unrelated log noise
+n_prompt_tokens = 99 with no marker line before it
+"""
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.INPUT_TOKENS] == []
+    assert metrics[Metric.TTFT] == []
+    # n_prompt_tokens only counts when a "new prompt" marker preceded it.
+    assert metrics[Metric.PROMPT_TOKENS] == []
+
+
+def test_extract_metrics_non_numeric_token_count_does_not_resolve_await():
+    """A malformed count after the marker must not silently produce a bogus value,
+    and the awaiting flag should persist until a real digit match arrives."""
+    log = """\
+new prompt marker line
+n_prompt_tokens = not-a-number
+n_prompt_tokens = 77
+"""
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.PROMPT_TOKENS] == [77.0]
+
+
+def test_extract_metrics_repeated_marker_before_resolution_is_ignored():
+    """Guard: a second 'new prompt' while still awaiting a token count must not
+    reset/duplicate — only the eventual n_prompt_tokens match counts once."""
+    log = """\
+new prompt (first)
+new prompt (second, still awaiting)
+n_prompt_tokens = 77
+"""
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.PROMPT_TOKENS] == [77.0]
+
+
+def test_extract_metrics_multi_metric_single_line():
+    """All patterns use independent `.search()` calls (no elif), so a single
+    line carrying several fields must populate all of them."""
+    log = "Input tokens: 5 Output tokens: 6 TTFT (s): 0.2 TPS: 30"
+    metrics = extract_metrics(_lines(log))
+
+    assert metrics[Metric.INPUT_TOKENS] == [5.0]
+    assert metrics[Metric.OUTPUT_TOKENS] == [6.0]
+    assert metrics[Metric.TTFT] == [0.2]
+    assert metrics[Metric.TPS] == [30.0]
+
+
+# ---- run_perf_visualization: aggregation + headless plotting ----
+
+
+def _write_log(path: Path, requests: list[dict]) -> None:
+    lines = []
+    for req in requests:
+        lines.append(
+            f"slot update_slots: new prompt, n_prompt_tokens = {req['prompt']}"
+        )
+        lines.append(f"Input tokens: {req['input']}")
+        lines.append(f"Output tokens: {req['output']}")
+        lines.append(f"TTFT (s): {req['ttft']}")
+        lines.append(f"TPS: {req['tps']}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_run_perf_visualization_end_to_end_creates_plots_and_aggregates(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.chdir(tmp_path)
+    log_path = tmp_path / "server.log"
+    _write_log(
+        log_path,
+        [
+            {"prompt": 128, "input": 128, "output": 200, "ttft": 0.5, "tps": 50.0},
+            {"prompt": 64, "input": 64, "output": 100, "ttft": 0.25, "tps": 40.0},
+        ],
+    )
+
+    rc = run_perf_visualization([log_path], show=False)
+
+    assert rc == 0
+    for metric_config in METRIC_CONFIGS.values():
+        assert (tmp_path / metric_config.filename).exists()
+    assert (tmp_path / "prefill_decode_split.png").exists()
+
+    out = capsys.readouterr().out
+    assert "Saved" in out
+    assert (
+        "5 entries" not in out
+    )  # sanity: not accidentally summing all metrics together
+    assert "2 entries from 1 log(s)" in out
+
+
+def test_run_perf_visualization_missing_file_errors_without_crash(tmp_path, capsys):
+    missing = tmp_path / "does-not-exist.log"
+
+    rc = run_perf_visualization([missing], show=False)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "log file not found" in err
+
+
+def test_run_perf_visualization_log_missing_a_metric_errors(
+    tmp_path, monkeypatch, capsys
+):
+    """A log with prompt/input/output tokens but no TTFT/TPS lines must fail loudly,
+    not silently plot a partial/empty series."""
+    monkeypatch.chdir(tmp_path)
+    log_path = tmp_path / "partial.log"
+    log_path.write_text(
+        "slot update_slots: new prompt, n_prompt_tokens = 10\n"
+        "Input tokens: 10\n"
+        "Output tokens: 20\n",
+        encoding="utf-8",
+    )
+
+    rc = run_perf_visualization([log_path], show=False)
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "were found in the log" in err
+
+
+def test_run_perf_visualization_computes_prefill_decode_split(tmp_path, monkeypatch):
+    """Aggregation: prefill = sum(TTFT); decode = sum(output_tokens / tps) for tps > 0."""
+    monkeypatch.chdir(tmp_path)
+    log_path = tmp_path / "server.log"
+    _write_log(
+        log_path,
+        [
+            {"prompt": 10, "input": 10, "output": 100, "ttft": 1.0, "tps": 50.0},
+            {"prompt": 10, "input": 10, "output": 50, "ttft": 0.5, "tps": 25.0},
+        ],
+    )
+
+    captured_calls = []
+    real_build_pies = build_prefill_decode_pies
+
+    def _spy(prefill_decode_times, output_path, show):
+        captured_calls.append(prefill_decode_times)
+        return real_build_pies(prefill_decode_times, output_path, show)
+
+    import gaia.perf_analysis as perf_analysis_mod
+
+    orig = perf_analysis_mod.build_prefill_decode_pies
+    perf_analysis_mod.build_prefill_decode_pies = _spy
+    try:
+        rc = run_perf_visualization([log_path], show=False)
+    finally:
+        perf_analysis_mod.build_prefill_decode_pies = orig
+
+    assert rc == 0
+    assert len(captured_calls) == 1
+    log_name, prefill_total, decode_total = captured_calls[0][0]
+    assert log_name == "server.log"
+    assert prefill_total == pytest.approx(1.5)  # 1.0 + 0.5
+    assert decode_total == pytest.approx(100 / 50.0 + 50 / 25.0)  # 2.0 + 2.0 = 4.0
+
+
+# ---- plotting functions: headless (Agg), no display ----
+
+
+def test_build_plot_saves_png_without_display(tmp_path):
+    output_path = tmp_path / "prompt_token_counts.png"
+    build_plot(
+        series=[("run-a.log", [1.0, 2.0, 3.0]), ("run-b.log", [4.0, 5.0])],
+        metric_config=METRIC_CONFIGS[Metric.PROMPT_TOKENS],
+        output_path=output_path,
+        show=False,
+    )
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+
+
+def test_build_plot_show_true_does_not_hang_on_agg_backend(tmp_path):
+    """Agg is non-interactive, so show=True must return immediately, not block."""
+    output_path = tmp_path / "tps.png"
+    build_plot(
+        series=[("run-a.log", [10.0])],
+        metric_config=METRIC_CONFIGS[Metric.TPS],
+        output_path=output_path,
+        show=True,
+    )
+
+    assert output_path.exists()
+
+
+def test_build_prefill_decode_pies_saves_png(tmp_path):
+    output_path = tmp_path / "prefill_decode_split.png"
+    build_prefill_decode_pies(
+        prefill_decode_times=[("run-a.log", 1.5, 4.0), ("run-b.log", 0.2, 1.1)],
+        output_path=output_path,
+        show=False,
+    )
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+
+
+def test_build_prefill_decode_pies_empty_input_prints_message_and_skips(
+    tmp_path, capsys
+):
+    output_path = tmp_path / "prefill_decode_split.png"
+    build_prefill_decode_pies(
+        prefill_decode_times=[], output_path=output_path, show=False
+    )
+
+    assert not output_path.exists()
+    err = capsys.readouterr().err
+    assert "No timing data available" in err
+
+
+def test_build_prefill_decode_pies_zero_total_time_slot_is_skipped(tmp_path):
+    """A (0, 0) prefill/decode pair must not raise (division by total_time would)."""
+    output_path = tmp_path / "prefill_decode_split.png"
+    build_prefill_decode_pies(
+        prefill_decode_times=[("empty.log", 0.0, 0.0), ("real.log", 1.0, 2.0)],
+        output_path=output_path,
+        show=False,
+    )
+
+    assert output_path.exists()
+
+
+# ---- CLI dispatch: parse_cli / main() ----
+
+
+def test_parse_cli_parses_log_paths_and_show_flag():
+    args = parse_cli(["a.log", "b.log", "--show"])
+
+    assert args.log_paths == [Path("a.log"), Path("b.log")]
+    assert args.show is True
+
+
+def test_parse_cli_show_defaults_false():
+    args = parse_cli(["a.log"])
+
+    assert args.show is False
+
+
+def test_parse_cli_requires_at_least_one_log_path():
+    with pytest.raises(SystemExit) as excinfo:
+        parse_cli([])
+    assert excinfo.value.code == 2
+
+
+def test_main_forwards_parsed_log_paths_and_show_to_run_perf_visualization(mocker):
+    mock_run = mocker.patch("gaia.perf_analysis.run_perf_visualization", return_value=0)
+
+    rc = main(["x.log", "y.log", "--show"])
+
+    assert rc == 0
+    mock_run.assert_called_once_with([Path("x.log"), Path("y.log")], show=True)

--- a/tests/unit/test_structured_vlm_extraction.py
+++ b/tests/unit/test_structured_vlm_extraction.py
@@ -1,0 +1,436 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit tests for ``gaia.vlm.structured_extraction.StructuredVLMExtractor``.
+
+Covers the VLM-output parsers (table/key-value/schema/chart extraction), the
+pure helpers (``_parse_page_range``, ``_parse_time_to_hours``), and the
+top-level ``extract()`` orchestration — with the VLM/LLM boundary
+(``VLMClient.extract_from_image``) mocked so no real Lemonade server is
+required. Malformed-input branches are exercised explicitly since silent
+misparsing here would corrupt every downstream consumer (e.g. the EMR flow).
+"""
+
+import pytest
+
+from gaia.vlm.structured_extraction import StructuredVLMExtractor
+
+
+@pytest.fixture
+def extractor(mocker):
+    """A StructuredVLMExtractor with VLMClient replaced by a mock.
+
+    Patches the VLM boundary at construction time so no real LemonadeClient
+    is ever created; each test configures ``extractor.vlm.extract_from_image``
+    directly.
+    """
+    mocker.patch("gaia.vlm.structured_extraction.VLMClient")
+    return StructuredVLMExtractor()
+
+
+# ---------------------------------------------------------------------------
+# extract_table
+# ---------------------------------------------------------------------------
+
+
+def test_extract_table_parses_json_array(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        '[{"name": "John", "age": "30"}, {"name": "Jane", "age": "25"}]'
+    )
+
+    rows = extractor.extract_table(b"fake-image")
+
+    assert rows == [
+        {"name": "John", "age": "30"},
+        {"name": "Jane", "age": "25"},
+    ]
+
+
+def test_extract_table_strips_surrounding_chatter(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        "Sure! Here's the extracted table:\n"
+        '[{"col1": "value1", "col2": "value2"}]\n'
+        "Let me know if you need anything else."
+    )
+
+    rows = extractor.extract_table(b"fake-image", table_description="a receipt")
+
+    assert rows == [{"col1": "value1", "col2": "value2"}]
+
+
+def test_extract_table_empty_array_returns_empty_list(extractor):
+    extractor.vlm.extract_from_image.return_value = "[]"
+
+    assert extractor.extract_table(b"fake-image") == []
+
+
+def test_extract_table_non_list_json_falls_back_to_empty(extractor):
+    # VLM misbehaves and returns an object instead of an array.
+    extractor.vlm.extract_from_image.return_value = '{"col1": "value1"}'
+
+    assert extractor.extract_table(b"fake-image") == []
+
+
+def test_extract_table_unparsable_text_falls_back_to_empty(extractor):
+    extractor.vlm.extract_from_image.return_value = "I could not find a table."
+
+    assert extractor.extract_table(b"fake-image") == []
+
+
+# ---------------------------------------------------------------------------
+# extract_key_values
+# ---------------------------------------------------------------------------
+
+
+def test_extract_key_values_parses_json_object(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        '{"invoice_number": "INV-12345", "total": 150.00, "date": "2024-01-15"}'
+    )
+
+    data = extractor.extract_key_values(
+        b"fake-image", keys=["invoice_number", "total", "date"]
+    )
+
+    assert data == {
+        "invoice_number": "INV-12345",
+        "total": 150.00,
+        "date": "2024-01-15",
+    }
+
+
+def test_extract_key_values_with_descriptions_builds_prompt(extractor):
+    extractor.vlm.extract_from_image.return_value = '{"name": "John"}'
+
+    extractor.extract_key_values(
+        b"fake-image",
+        keys=["name"],
+        descriptions={"name": "the patient's full name"},
+    )
+
+    _, kwargs = extractor.vlm.extract_from_image.call_args
+    assert "the patient's full name" in kwargs["prompt"]
+
+
+def test_extract_key_values_malformed_output_defaults_keys_to_none(extractor):
+    extractor.vlm.extract_from_image.return_value = "not valid json at all"
+
+    data = extractor.extract_key_values(b"fake-image", keys=["a", "b", "c"])
+
+    assert data == {"a": None, "b": None, "c": None}
+
+
+def test_extract_key_values_non_dict_json_defaults_to_none(extractor):
+    # VLM returns an array instead of the requested object.
+    extractor.vlm.extract_from_image.return_value = '["a", "b"]'
+
+    data = extractor.extract_key_values(b"fake-image", keys=["a", "b"])
+
+    assert data == {"a": None, "b": None}
+
+
+# ---------------------------------------------------------------------------
+# extract_structured
+# ---------------------------------------------------------------------------
+
+
+def test_extract_structured_parses_schema_result(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        '{"patient_name": "Jane Smith", "total_cost": 1250.00}'
+    )
+    schema = {
+        "fields": {
+            "patient_name": {"type": "string", "description": "patient full name"},
+            "total_cost": {
+                "type": "number",
+                "description": "total billing amount",
+                "required": True,
+            },
+        }
+    }
+
+    data = extractor.extract_structured(b"fake-image", schema)
+
+    assert data == {"patient_name": "Jane Smith", "total_cost": 1250.00}
+
+
+def test_extract_structured_empty_schema_still_calls_vlm(extractor):
+    extractor.vlm.extract_from_image.return_value = "{}"
+
+    data = extractor.extract_structured(b"fake-image", schema={})
+
+    assert data == {}
+    extractor.vlm.extract_from_image.assert_called_once()
+
+
+def test_extract_structured_malformed_output_returns_empty_dict(extractor):
+    extractor.vlm.extract_from_image.return_value = "garbage response"
+
+    assert extractor.extract_structured(b"fake-image", schema={"fields": {}}) == {}
+
+
+# ---------------------------------------------------------------------------
+# _parse_time_to_hours
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "time_str, expected",
+    [
+        ("14:46:38", 14 + 46 / 60.0 + 38 / 3600.0),
+        ("01:00", 1.0),
+        ("1", 1.0),  # "1" has no ":" so falls through to float("1") below
+        ("5", 5.0),
+        ("00:00:00", 0.0),
+    ],
+)
+def test_parse_time_to_hours_valid_inputs(extractor, time_str, expected):
+    assert extractor._parse_time_to_hours(time_str) == pytest.approx(expected)
+
+
+def test_parse_time_to_hours_malformed_returns_zero(extractor):
+    assert extractor._parse_time_to_hours("not-a-time") == 0.0
+
+
+def test_parse_time_to_hours_empty_string_returns_zero(extractor):
+    assert extractor._parse_time_to_hours("") == 0.0
+
+
+def test_parse_time_to_hours_trailing_colon_returns_zero(extractor):
+    # "14:" splits into ["14", ""] — int("") raises ValueError, caught -> 0.0
+    assert extractor._parse_time_to_hours("14:") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _parse_page_range
+# ---------------------------------------------------------------------------
+
+
+def test_parse_page_range_all(extractor):
+    assert extractor._parse_page_range("all", 5) == [1, 2, 3, 4, 5]
+
+
+def test_parse_page_range_all_case_insensitive(extractor):
+    assert extractor._parse_page_range("ALL", 3) == [1, 2, 3]
+
+
+def test_parse_page_range_dash_range(extractor):
+    assert extractor._parse_page_range("2-4", 10) == [2, 3, 4]
+
+
+def test_parse_page_range_dash_range_with_whitespace(extractor):
+    assert extractor._parse_page_range(" 2 - 4 ", 10) == [2, 3, 4]
+
+
+def test_parse_page_range_single_page(extractor):
+    assert extractor._parse_page_range("3", 10) == [3]
+
+
+def test_parse_page_range_malformed_raises_value_error(extractor):
+    with pytest.raises(ValueError):
+        extractor._parse_page_range("not-a-page", 10)
+
+
+# ---------------------------------------------------------------------------
+# extract_chart_data
+# ---------------------------------------------------------------------------
+
+
+def test_extract_chart_data_time_hms_decimal_converts_hours(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        '{"Active": "14:46:38", "Idle": "00:01:20"}'
+    )
+
+    data = extractor.extract_chart_data(
+        b"fake-image", categories=["Active", "Idle"], value_format="time_hms_decimal"
+    )
+
+    assert data["Active"] == pytest.approx(14 + 46 / 60.0 + 38 / 3600.0)
+    assert data["Idle"] == pytest.approx(0 + 1 / 60.0 + 20 / 3600.0)
+
+
+def test_extract_chart_data_time_hms_decimal_accepts_numeric_values(extractor):
+    # VLM occasionally returns numbers directly instead of HH:MM:SS strings.
+    extractor.vlm.extract_from_image.return_value = '{"Active": 5, "Idle": 2.5}'
+
+    data = extractor.extract_chart_data(
+        b"fake-image", categories=["Active", "Idle"], value_format="time_hms_decimal"
+    )
+
+    assert data == {"Active": 5.0, "Idle": 2.5}
+
+
+def test_extract_chart_data_time_hms_decimal_unexpected_type_defaults_zero(extractor):
+    extractor.vlm.extract_from_image.return_value = '{"Active": null, "Idle": [1, 2]}'
+
+    data = extractor.extract_chart_data(
+        b"fake-image", categories=["Active", "Idle"], value_format="time_hms_decimal"
+    )
+
+    assert data == {"Active": 0.0, "Idle": 0.0}
+
+
+def test_extract_chart_data_time_hms_returns_strings_as_is(extractor):
+    extractor.vlm.extract_from_image.return_value = '{"Active": "14:46:38"}'
+
+    data = extractor.extract_chart_data(
+        b"fake-image", categories=["Active"], value_format="time_hms"
+    )
+
+    assert data == {"Active": "14:46:38"}
+
+
+def test_extract_chart_data_number_format(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        '{"Q1": 150000, "Q2": 175000, "Q3": 200000, "Q4": 225000}'
+    )
+
+    data = extractor.extract_chart_data(
+        b"fake-image",
+        categories=["Q1", "Q2", "Q3", "Q4"],
+        value_format="number",
+    )
+
+    assert data == {"Q1": 150000, "Q2": 175000, "Q3": 200000, "Q4": 225000}
+
+
+def test_extract_chart_data_percentage_format(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        '{"Product A": 45.5, "Product B": 32.0, "Product C": 22.5}'
+    )
+
+    data = extractor.extract_chart_data(
+        b"fake-image",
+        categories=["Product A", "Product B", "Product C"],
+        value_format="percentage",
+    )
+
+    assert data == {"Product A": 45.5, "Product B": 32.0, "Product C": 22.5}
+
+
+def test_extract_chart_data_auto_format_passthrough(extractor):
+    extractor.vlm.extract_from_image.return_value = '{"A": "yes", "B": 3}'
+
+    data = extractor.extract_chart_data(
+        b"fake-image", categories=["A", "B"], value_format="auto"
+    )
+
+    assert data == {"A": "yes", "B": 3}
+
+
+def test_extract_chart_data_malformed_defaults_to_zero_for_non_time_format(extractor):
+    extractor.vlm.extract_from_image.return_value = "not json"
+
+    data = extractor.extract_chart_data(
+        b"fake-image", categories=["Q1", "Q2"], value_format="number"
+    )
+
+    assert data == {"Q1": 0.0, "Q2": 0.0}
+
+
+def test_extract_chart_data_malformed_defaults_to_zero_time_string_for_time_hms(
+    extractor,
+):
+    extractor.vlm.extract_from_image.return_value = "not json"
+
+    data = extractor.extract_chart_data(
+        b"fake-image", categories=["Active", "Idle"], value_format="time_hms"
+    )
+
+    assert data == {"Active": "00:00:00", "Idle": "00:00:00"}
+
+
+# ---------------------------------------------------------------------------
+# extract_timeline (thin wrapper over extract_chart_data)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_timeline_delegates_to_chart_data_with_decimal_hours(extractor):
+    extractor.vlm.extract_from_image.return_value = (
+        '{"Active": "01:30:00", "Offline": "00:45:00"}'
+    )
+
+    data = extractor.extract_timeline(b"fake-image", status_types=["Active", "Offline"])
+
+    assert data == {"Active": 1.5, "Offline": 0.75}
+
+
+# ---------------------------------------------------------------------------
+# extract() — top-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_extract_raises_file_not_found(extractor, tmp_path):
+    with pytest.raises(FileNotFoundError):
+        extractor.extract(str(tmp_path / "does-not-exist.png"))
+
+
+def test_extract_non_pdf_image_with_fields(extractor, tmp_path):
+    image_path = tmp_path / "page.png"
+    image_path.write_bytes(b"fake-png-bytes")
+
+    extractor.vlm.extract_from_image.return_value = '{"name": "John"}'
+
+    result = extractor.extract(str(image_path), extract_fields=["name"])
+
+    assert result["metadata"]["source"] == "page.png"
+    assert result["metadata"]["total_pages"] == 1
+    assert result["metadata"]["pages_processed"] == 1
+    assert result["pages"][0]["page"] == 1
+    assert result["pages"][0]["fields"] == {"name": "John"}
+    assert "raw_text" in result["pages"][0]
+    assert "aggregated_data" not in result
+
+
+def test_extract_non_pdf_image_with_schema(extractor, tmp_path):
+    image_path = tmp_path / "page.png"
+    image_path.write_bytes(b"fake-png-bytes")
+
+    extractor.vlm.extract_from_image.return_value = '{"total_cost": 42.0}'
+
+    result = extractor.extract(
+        str(image_path), schema={"fields": {"total_cost": {"type": "number"}}}
+    )
+
+    assert result["pages"][0]["fields"] == {"total_cost": 42.0}
+
+
+def test_extract_skips_page_with_no_image_bytes(extractor, tmp_path):
+    image_path = tmp_path / "empty.png"
+    image_path.write_bytes(b"")  # doc_path.read_bytes() -> b"" -> falsy -> skipped
+
+    result = extractor.extract(str(image_path))
+
+    assert result["metadata"]["pages_processed"] == 0
+    assert result["pages"] == []
+
+
+def test_extract_pdf_multipage_aggregates_timeline(extractor, tmp_path, mocker):
+    pdf_path = tmp_path / "report.pdf"
+    pdf_path.write_bytes(b"%PDF-fake")
+
+    fake_doc = mocker.MagicMock()
+    fake_doc.__len__.return_value = 2
+    mocker.patch("fitz.open", return_value=fake_doc)
+    mocker.patch("gaia.utils.pdf_page_to_image", return_value=b"rendered-page-bytes")
+
+    extractor.vlm.extract_from_image.return_value = (
+        '{"Active": "02:00:00", "Idle": "01:30:00"}'
+    )
+
+    progress_calls = []
+    result = extractor.extract(
+        str(pdf_path),
+        extract_timelines=True,
+        timeline_status_types=["Active", "Idle"],
+        on_progress=lambda current, total: progress_calls.append((current, total)),
+    )
+
+    assert result["metadata"]["total_pages"] == 2
+    assert result["metadata"]["pages_processed"] == 2
+    assert result["pages"][0]["timeline"] == {"Active": 2.0, "Idle": 1.5}
+    assert result["pages"][1]["timeline"] == {"Active": 2.0, "Idle": 1.5}
+    assert result["aggregated_data"]["timeline_totals"] == {
+        "Active": 4.0,
+        "Idle": 3.0,
+    }
+    assert progress_calls == [(1, 2), (2, 2)]
+    fake_doc.close.assert_called_once()


### PR DESCRIPTION
Closes #1995, #1997, #1998, #2002, #2003 (weekly-audit zero-coverage findings).

Five modules where a parsing or formatting bug would ship silently — the `gaia schedule` CLI dispatch, the perf-log parser behind `gaia perf-vis`, the VLM structured-extraction parsers, the synthetic-PDF eval corpus generator, and the summarizer PDF export — now have 102 unit tests. Writing them immediately caught a real production bug: when a VLM wrapped a table's JSON array in any chatter ("Sure! Here's the table: [...]"), `extract_json_from_text` parsed only the first row object and `extract_table` silently returned `[]` — every row dropped, exactly the corruption #1997 warned about. Fixed in `gaia.utils.parsing` (now extracts top-level arrays too, with regression tests; all existing callers type-check the result, and the EMR suite still passes).

Tests assert the outgoing call shape at mocked boundaries (#1655 rule) — e.g. the schedule tests drive the real argparse parser and assert the constructed `Schedule`/store arguments, and the PDF tests validate output by reopening the files with pypdf. No LLM or Lemonade server needed anywhere.

**Test plan**
- [ ] `python -m pytest tests/unit/cli/test_cli_schedule.py tests/unit/test_perf_analysis.py tests/unit/test_structured_vlm_extraction.py tests/unit/eval/test_pdf_document_generator.py tests/unit/test_pdf_formatter.py tests/unit/test_file_watcher.py` → 162 passed
- [ ] `test_extract_table_strips_surrounding_chatter` fails without the parsing fix (reverts red)
- [ ] `python util/lint.py --all` passes