### PR TITLE
fix(packaging): stop the amd-gaia[agents] extra from downgrading the core wheel

### DIFF
--- a/.github/workflows/publish_agents.yml
+++ b/.github/workflows/publish_agents.yml
@@ -3,12 +3,18 @@
 #
 # Publish the AMD production *Python* agent wheels (gaia-agent-<id>) to PyPI.
 # Issue #1179 (Agent Hub dual distribution): R2 is the canonical source for the
-# Hub UI; PyPI is the canonical source for `pip install gaia-agent-<id>` and the
-# `amd-gaia[agents]` meta-extra. The C++ agent binaries are handled separately
-# by build_agents.yml.
+# Hub UI; PyPI is the canonical source for `pip install gaia-agent-<id>`. The
+# C++ agent binaries are handled separately by build_agents.yml.
+#
+# NOTE (#2240): there is deliberately no `amd-gaia[agents]` meta-extra. While
+# these wheels aren't live on PyPI (publishing is paused below), declaring
+# them as an extras_require entry made the extra unsatisfiable at the
+# current amd-gaia release, which made pip/uv silently backtrack-downgrade
+# to an older release that didn't declare it. The agent list instead lives
+# as a plain constant, setup.py's AGENT_WHEEL_PACKAGES.
 #
 # Flow:
-#   discover (read setup.py[agents] -> matrix)
+#   discover (read setup.py's AGENT_WHEEL_PACKAGES -> matrix)
 #     -> build  (tag only: build each wheel + twine check, upload artifact)
 #       -> approve (tag only: single manual gate, "publish" environment)
 #         -> publish (tag only: gh-action-pypi-publish per agent, skip-existing)
@@ -54,9 +60,9 @@ permissions:
 
 jobs:
 
-  # ── Discover: derive the agent matrix from setup.py[agents] ──────────
-  # Single source of truth — adding an agent to the meta-extra auto-includes
-  # it here. No hand-maintained second list to drift.
+  # ── Discover: derive the agent matrix from setup.py's AGENT_WHEEL_PACKAGES ──
+  # Single source of truth — adding an agent to that list auto-includes it
+  # here. No hand-maintained second list to drift.
   discover:
     name: Discover Agent Packages
     runs-on: ubuntu-latest

--- a/.github/workflows/test_chat_agent.yml
+++ b/.github/workflows/test_chat_agent.yml
@@ -84,6 +84,21 @@ jobs:
           echo ""
           python -m pytest hub/agents/python/chat/tests/ -v --tb=short
 
+      - name: Run Framework Registry Discovery Tests
+        env:
+          GAIA_MEMORY_DISABLED: "1"
+        run: |
+          echo "================================================================"
+          echo "           FRAMEWORK REGISTRY DISCOVERY TESTS"
+          echo "================================================================"
+          # tests/unit/agents/test_registry.py::TestBuiltinRegistration has
+          # chat-specific cases that importorskip("gaia_agent_chat") -- this
+          # is the only CI job that installs that wheel, so it's the only
+          # place these actually run instead of silently skipping (#2240).
+          echo "Verifying AgentRegistry actually resolves the installed gaia-agent-chat wheel..."
+          echo ""
+          python -m pytest tests/unit/agents/test_registry.py -v --tb=short
+
       - name: Run Chat Agent Unit Tests
         env:
           # Skip memory init — Lemonade isn't available in this CI job; the

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -539,6 +539,16 @@ pip install gaia-agent-summarize          # one agent
 pip install "amd-gaia[agents]"            # every AMD production agent
 ```
 
+<Note>
+PyPI publishing for `gaia-agent-*` wheels is currently paused (tracked by
+[#2240](https://github.com/amd/gaia/issues/2240)), so the commands above don't
+resolve yet. Until publishing lands, install an agent straight from this repo:
+
+```bash From source (works today)
+uv pip install "gaia-agent-summarize @ git+https://github.com/amd/gaia.git#subdirectory=hub/agents/python/summarize"
+```
+</Note>
+
 The **Hub (R2)** path is the Agent UI's discover/install panel, which downloads
 the wheel from R2 into `~/.gaia/agents/<id>/` (`POST /api/agents/install`, backed
 by `gaia.hub.installer`). Use it when browsing the Hub UI; use `pip install` for

--- a/hub/agents/python/chat/README.md
+++ b/hub/agents/python/chat/README.md
@@ -8,8 +8,9 @@ framework wheel.
 ## Install
 
 ```bash
-pip install gaia-agent-chat              # from PyPI (once published)
+pip install gaia-agent-chat              # from PyPI (once published — see #2240)
 pip install -e hub/agents/python/chat    # editable, for development
+uv pip install "gaia-agent-chat @ git+https://github.com/amd/gaia.git#subdirectory=hub/agents/python/chat"  # works today without a repo checkout
 ```
 
 Installing registers the `chat`, `doc`, and `file` agents via the `gaia.agent`

--- a/hub/agents/python/routing/README.md
+++ b/hub/agents/python/routing/README.md
@@ -14,13 +14,15 @@ importable so the API server can resolve it.
 ## Install
 
 ```bash
-pip install gaia-agent-routing              # from PyPI (once published)
+pip install gaia-agent-routing              # from PyPI (once published — see #2240)
 pip install -e hub/agents/python/routing    # editable, for development
+uv pip install "gaia-agent-routing @ git+https://github.com/amd/gaia.git#subdirectory=hub/agents/python/routing"  # works today without a repo checkout
 ```
 
 The API server's `gaia-code` model routes through `RoutingAgent`, which in turn
-needs the `gaia-agent-code` wheel installed. Install both (or
-`pip install amd-gaia[agents]`) to use `gaia api` for code generation.
+needs the `gaia-agent-code` wheel installed. Install both the same way (swap
+`routing` for `code` in the subdirectory) to use `gaia api` for code
+generation.
 
 ## Develop / test
 

--- a/hub/agents/python/routing/gaia_agent_routing/agent.py
+++ b/hub/agents/python/routing/gaia_agent_routing/agent.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from gaia.agents.base.agent import Agent
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.llm import create_client
 from gaia.logger import get_logger
 
@@ -490,11 +491,13 @@ Conversation:
         registry.discover()
         if registry.get("code") is None:
             raise RuntimeError(
-                "CodeAgent is not installed. RoutingAgent routes coding tasks "
-                "to the 'gaia-agent-code' package, which is not present. "
-                "Install it with 'uv pip install gaia-agent-code' (or "
-                "'uv pip install \"amd-gaia[agents]\"'), then retry. See "
-                "docs/spec/agent-hub-restructure.mdx."
+                agent_not_installed_message(
+                    "CodeAgent is not installed. RoutingAgent routes coding "
+                    "tasks to the 'gaia-agent-code' package, which is not "
+                    "present",
+                    "gaia-agent-code",
+                    next_step=("Then retry. See docs/spec/agent-hub-restructure.mdx."),
+                )
             )
 
         # Build agent kwargs, including output_handler if provided

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,37 @@ with open("src/gaia/version.py", encoding="utf-8") as fp:
 
 tkml_version = "5.0.4"
 
+# Standalone AMD production agent wheels (issues #1102, #1179). Each ships as
+# a separate 'gaia-agent-<id>' PyPI package depending on this framework
+# wheel. Deliberately NOT an extras_require entry: this list is read
+# statically by util/list_agent_packages.py (single source of truth for
+# .github/workflows/publish_agents.yml's build/publish matrix and
+# tests/unit/test_agent_pypi_publish.py) without ever being handed to pip's
+# resolver. An extras_require entry naming these packages made 'pip install
+# "amd-gaia[agents]"' unsatisfiable while the wheels are unpublished
+# (publish_agents.yml's publish job is paused), which made the resolver
+# silently downgrade amd-gaia itself to the newest release that didn't
+# declare the extra (#2240) -- see setup.py history / PR fixing #2240 for
+# the incident. Do not move this back into extras_require until the wheels
+# are live on PyPI.
+AGENT_WHEEL_PACKAGES = [
+    "gaia-agent-summarize",
+    "gaia-agent-sd",
+    "gaia-agent-fileio",
+    "gaia-agent-docker",
+    "gaia-agent-jira",
+    "gaia-agent-blender",
+    "gaia-agent-emr",
+    "gaia-agent-code",
+    "gaia-agent-connectors-demo",
+    "gaia-agent-analyst",
+    "gaia-agent-browser",
+    "gaia-agent-docqa",
+    "gaia-agent-routing",
+    "gaia-agent-email",
+    "gaia-agent-chat",
+]
+
 setup(
     name="amd-gaia",
     version=gaia_version,
@@ -270,42 +301,12 @@ setup(
             "build>=1.0.0",
             "twine>=5.0.0",
         ],
-        # Standalone AMD production agents (issues #1102, #1179). Each agent
-        # ships as a separate 'gaia-agent-<id>' wheel that depends on this
-        # framework wheel; 'amd-gaia[agents]' installs all migrated agents at
-        # once. Add an entry here when each agent's wheel is first published.
-        "agent-summarize": ["gaia-agent-summarize"],
-        "agent-sd": ["gaia-agent-sd"],
-        "agent-fileio": ["gaia-agent-fileio"],
-        "agent-docker": ["gaia-agent-docker"],
-        "agent-jira": ["gaia-agent-jira"],
-        "agent-blender": ["gaia-agent-blender"],
-        "agent-emr": ["gaia-agent-emr"],
-        "agent-code": ["gaia-agent-code"],
-        "agent-connectors-demo": ["gaia-agent-connectors-demo"],
-        "agent-analyst": ["gaia-agent-analyst"],
-        "agent-browser": ["gaia-agent-browser"],
-        "agent-docqa": ["gaia-agent-docqa"],
-        "agent-routing": ["gaia-agent-routing"],
-        "agent-email": ["gaia-agent-email"],
-        "agent-chat": ["gaia-agent-chat"],
-        "agents": [
-            "gaia-agent-summarize",
-            "gaia-agent-sd",
-            "gaia-agent-fileio",
-            "gaia-agent-docker",
-            "gaia-agent-jira",
-            "gaia-agent-blender",
-            "gaia-agent-emr",
-            "gaia-agent-code",
-            "gaia-agent-connectors-demo",
-            "gaia-agent-analyst",
-            "gaia-agent-browser",
-            "gaia-agent-docqa",
-            "gaia-agent-routing",
-            "gaia-agent-email",
-            "gaia-agent-chat",
-        ],
+        # NOTE: no 'agent-<id>' / 'agents' extras here -- see
+        # AGENT_WHEEL_PACKAGES above for why (#2240) and where that list
+        # actually lives now. Install an agent from source until the wheels
+        # are published:
+        #   uv pip install "gaia-agent-<id> @ git+https://github.com/amd/gaia.git#subdirectory=hub/agents/python/<id>"
+        # (see gaia.agents.install_hints.source_install_command).
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/src/gaia/agents/install_hints.py
+++ b/src/gaia/agents/install_hints.py
@@ -1,0 +1,76 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Shared "agent wheel not installed" messaging.
+
+The ``gaia-agent-*`` wheels (chat, email, code, sd, docker, ...) are built
+and packaged (``hub/agents/python/<id>/``) but publishing them to PyPI is
+still paused (see ``.github/workflows/publish_agents.yml``, tracked by
+#1179 / #1513). Until that lands, ``pip install gaia-agent-<id>`` and
+``pip install "amd-gaia[agents]"`` both fail on a clean environment (#2240)
+-- so every call site that used to recommend them needs to point at the one
+install path that actually resolves today: pip installing straight from the
+package's subdirectory in this repo.
+"""
+
+# hub/agents/python/<subdir> for each wheel this module has a hint for. Keep
+# in sync with the directories under hub/agents/python/ (ls hub/agents/python/).
+_AGENT_SOURCE_SUBDIRS = {
+    "gaia-agent-analyst": "analyst",
+    "gaia-agent-blender": "blender",
+    "gaia-agent-browser": "browser",
+    "gaia-agent-chat": "chat",
+    "gaia-agent-code": "code",
+    "gaia-agent-connectors-demo": "connectors-demo",
+    "gaia-agent-docker": "docker",
+    "gaia-agent-docqa": "docqa",
+    "gaia-agent-email": "email",
+    "gaia-agent-emr": "emr",
+    "gaia-agent-fileio": "fileio",
+    "gaia-agent-jira": "jira",
+    "gaia-agent-routing": "routing",
+    "gaia-agent-sd": "sd",
+    "gaia-agent-summarize": "summarize",
+}
+
+_REPO_URL = "https://github.com/amd/gaia.git"
+
+
+def source_install_command(wheel: str) -> str:
+    """Return the pip command that installs ``wheel`` straight from source.
+
+    Raises ``KeyError`` if ``wheel`` isn't a known ``gaia-agent-*`` package --
+    that's a bug at the call site (a typo'd wheel name), not a runtime
+    condition to swallow.
+    """
+    subdir = _AGENT_SOURCE_SUBDIRS[wheel]
+    return (
+        f'uv pip install "{wheel} @ git+{_REPO_URL}#subdirectory='
+        f'hub/agents/python/{subdir}"'
+    )
+
+
+def agent_not_installed_message(
+    subject: str, wheel: str, *, next_step: str = ""
+) -> str:
+    """Build the standard "agent not installed" error text for ``wheel``.
+
+    ``subject`` is the complete first sentence, without a trailing period,
+    e.g. ``"The chat agent is not installed"`` or ``"The drafting eval needs
+    the email agent"``. ``next_step`` is an optional trailing instruction,
+    e.g. ``"Then re-run `gaia chat`."``.
+
+    The ``gaia-agent-*`` wheels aren't on PyPI yet (#2240), so this
+    deliberately does NOT recommend ``pip install gaia-agent-<id>`` or
+    ``pip install "amd-gaia[agents]"`` -- both fail on a clean environment.
+    It points at the verified working install instead: pip installing
+    straight from this repo's subdirectory.
+    """
+    command = source_install_command(wheel)
+    message = (
+        f"{subject}. The `{wheel}` package isn't published yet "
+        f"(see https://github.com/amd/gaia/issues/2240); install it from "
+        f"source instead:\n`{command}`"
+    )
+    if next_step:
+        message = f"{message} {next_step}"
+    return message

--- a/src/gaia/api/agent_registry.py
+++ b/src/gaia/api/agent_registry.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List
 
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.api_agent import ApiAgent
+from gaia.agents.install_hints import source_install_command
 from gaia.api.sse_handler import SSEOutputHandler
 
 logger = logging.getLogger(__name__)
@@ -164,9 +165,10 @@ class AgentRegistry:
                 # an install hint rather than degrading silently.
                 hint = (
                     " The 'gaia-code' model routes through RoutingAgent, which "
-                    "ships as the 'gaia-agent-routing' wheel. Install it with "
-                    "'pip install gaia-agent-routing gaia-agent-code' (or "
-                    "'pip install amd-gaia[agents]'). See "
+                    "ships as the 'gaia-agent-routing' wheel. Neither it nor "
+                    "'gaia-agent-code' is published yet (#2240); install both "
+                    f"from source: '{source_install_command('gaia-agent-routing')}' "
+                    f"and '{source_install_command('gaia-agent-code')}'. See "
                     "docs/spec/agent-hub-restructure.mdx."
                 )
             raise ValueError(f"Agent {model_id} not available: {e}.{hint}") from e

--- a/src/gaia/apps/docker/app.py
+++ b/src/gaia/apps/docker/app.py
@@ -15,6 +15,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from gaia.agents.install_hints import agent_not_installed_message
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,9 +30,11 @@ def _load_docker_agent():
         from gaia_agent_docker.agent import DEFAULT_MODEL, DockerAgent
     except ImportError as e:
         raise ImportError(
-            "The docker agent is not installed. Install it with "
-            '`uv pip install gaia-agent-docker` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents). See https://amd-gaia.ai/docs/guides/docker."
+            agent_not_installed_message(
+                "The docker agent is not installed",
+                "gaia-agent-docker",
+                next_step="See https://amd-gaia.ai/docs/guides/docker.",
+            )
         ) from e
     return DockerAgent, DEFAULT_MODEL
 

--- a/src/gaia/apps/jira/app.py
+++ b/src/gaia/apps/jira/app.py
@@ -15,6 +15,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from gaia.agents.install_hints import agent_not_installed_message
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,9 +30,11 @@ def _load_jira_agent_class():
         from gaia_agent_jira.agent import JiraAgent
     except ImportError as e:
         raise ImportError(
-            "The jira agent is not installed. Install it with "
-            '`uv pip install gaia-agent-jira` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents). See https://amd-gaia.ai/docs/guides/jira."
+            agent_not_installed_message(
+                "The jira agent is not installed",
+                "gaia-agent-jira",
+                next_step="See https://amd-gaia.ai/docs/guides/jira.",
+            )
         ) from e
     return JiraAgent
 

--- a/src/gaia/apps/summarize/app.py
+++ b/src/gaia/apps/summarize/app.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME
 from gaia.logger import get_logger
 
@@ -25,9 +26,11 @@ def _load_summarizer_agent_class():
         from gaia_agent_summarize.agent import SummarizerAgent
     except ImportError as e:
         raise ImportError(
-            "The summarize agent is not installed. Install it with "
-            '`uv pip install gaia-agent-summarize` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents). See https://amd-gaia.ai/docs/guides/summarize."
+            agent_not_installed_message(
+                "The summarize agent is not installed",
+                "gaia-agent-summarize",
+                next_step="See https://amd-gaia.ai/docs/guides/summarize.",
+            )
         ) from e
     return SummarizerAgent
 

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from gaia.agents.base.console import AgentConsole
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.llm import create_client
 from gaia.llm.lemonade_client import (
     DEFAULT_HOST,
@@ -602,9 +603,11 @@ async def async_main(action, **kwargs):
             from gaia_agent_chat.app import interactive_mode
         except ImportError as e:
             raise RuntimeError(
-                "The chat agent is not installed. Install it with "
-                '`pip install gaia-agent-chat` (or `pip install "amd-gaia[agents]"` '
-                "for all agents), then re-run `gaia chat`."
+                agent_not_installed_message(
+                    "The chat agent is not installed",
+                    "gaia-agent-chat",
+                    next_step="Then re-run `gaia chat`.",
+                )
             ) from e
 
         try:
@@ -818,9 +821,11 @@ async def async_main(action, **kwargs):
         registry.discover()
         if registry.get(agent_id) is None:
             raise RuntimeError(
-                f"The '{action}' agent is not installed. Install it with "
-                f'`uv pip install {wheel}` (or `uv pip install "amd-gaia[agents]"` '
-                f"for all agents), then re-run `gaia {action}`."
+                agent_not_installed_message(
+                    f"The '{action}' agent is not installed",
+                    wheel,
+                    next_step=f"Then re-run `gaia {action}`.",
+                )
             )
         agent = registry.create_agent(agent_id, **agent_config_kwargs)
 
@@ -1003,9 +1008,11 @@ def _launch_interactive_cli(log=None):
             from gaia_agent_chat.app import interactive_mode
         except ImportError as e:
             raise RuntimeError(
-                "The chat agent is not installed. Install it with "
-                '`pip install gaia-agent-chat` (or `pip install "amd-gaia[agents]"` '
-                "for all agents), then re-run `gaia chat`."
+                agent_not_installed_message(
+                    "The chat agent is not installed",
+                    "gaia-agent-chat",
+                    next_step="Then re-run `gaia chat`.",
+                )
             ) from e
 
         config = ChatAgentConfig(
@@ -5035,9 +5042,11 @@ def handle_email_command(args):
             from gaia_agent_email.spec_html import write_and_open_spec
         except ImportError as e:
             raise RuntimeError(
-                "The email agent is not installed. Install it with "
-                '`pip install gaia-agent-email` (or `pip install "amd-gaia[agents]"` '
-                "for all agents), then re-run `gaia email --spec`."
+                agent_not_installed_message(
+                    "The email agent is not installed",
+                    "gaia-agent-email",
+                    next_step="Then re-run `gaia email --spec`.",
+                )
             ) from e
 
         dest = write_and_open_spec(getattr(args, "output", None))
@@ -5331,9 +5340,11 @@ def handle_sd_command(args):
         from gaia_agent_sd import SDAgent, SDAgentConfig
     except ImportError as e:
         raise ImportError(
-            "The sd agent is not installed. Install it with "
-            '`uv pip install gaia-agent-sd` (or `uv pip install "amd-gaia[agents]"` for '
-            "all AMD agents). See https://amd-gaia.ai/docs/guides/sd."
+            agent_not_installed_message(
+                "The sd agent is not installed",
+                "gaia-agent-sd",
+                next_step="See https://amd-gaia.ai/docs/guides/sd.",
+            )
         ) from e
 
     # Ensure Lemonade is ready with proper context size for SD agent

--- a/src/gaia/eval/action_item_quality.py
+++ b/src/gaia/eval/action_item_quality.py
@@ -45,6 +45,7 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.eval.fixture_paths import resolve_repo_fixture
 from gaia.eval.quality_metrics import Confusion
 
@@ -814,10 +815,11 @@ def generate_extractions(
             from gaia_agent_email.config import EmailAgentConfig
         except ImportError as exc:
             raise RuntimeError(
-                "The action-item extraction eval needs the email agent. Install "
-                "it with `pip install gaia-agent-email` (or `pip install "
-                '"amd-gaia[agents]"`). '
-                f"Original import error: {exc}"
+                agent_not_installed_message(
+                    "The action-item extraction eval needs the email agent",
+                    "gaia-agent-email",
+                    next_step=f"Original import error: {exc}",
+                )
             ) from exc
 
         def agent_factory(backend: Any, db_path: str) -> Any:

--- a/src/gaia/eval/benchmark.py
+++ b/src/gaia/eval/benchmark.py
@@ -31,6 +31,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.eval import performance, quality_metrics
 from gaia.eval.fixture_paths import resolve_repo_fixture
 from gaia.llm.lemonade_client import _model_ids_match
@@ -834,10 +835,11 @@ def run_benchmark(
                     )
                 except ImportError as exc:
                     raise RuntimeError(
-                        "The email throughput benchmark needs the email agent. "
-                        "Install it with `pip install gaia-agent-email` (or "
-                        '`pip install "amd-gaia[agents]"`). '
-                        f"Original import error: {exc}"
+                        agent_not_installed_message(
+                            "The email throughput benchmark needs the email agent",
+                            "gaia-agent-email",
+                            next_step=f"Original import error: {exc}",
+                        )
                     ) from exc
 
                 try:

--- a/src/gaia/eval/briefing_quality.py
+++ b/src/gaia/eval/briefing_quality.py
@@ -45,6 +45,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.eval.fixture_paths import resolve_repo_fixture
 
 # ---------------------------------------------------------------------------
@@ -746,10 +747,11 @@ def generate_briefings(
             from gaia_agent_email.briefing import run_briefing_job
         except ImportError as exc:
             raise RuntimeError(
-                "The briefing eval needs the email agent. Install it with "
-                "`pip install gaia-agent-email` (or `pip install "
-                '"amd-gaia[agents]"`). '
-                f"Original import error: {exc}"
+                agent_not_installed_message(
+                    "The briefing eval needs the email agent",
+                    "gaia-agent-email",
+                    next_step=f"Original import error: {exc}",
+                )
             ) from exc
 
         def briefing_fn(backend: Any, max_msgs: int) -> Mapping[str, Any]:

--- a/src/gaia/eval/draft_quality.py
+++ b/src/gaia/eval/draft_quality.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.eval.fixture_paths import resolve_repo_fixture
 
 # ---------------------------------------------------------------------------
@@ -652,10 +653,11 @@ def generate_drafts(
             from gaia_agent_email.config import EmailAgentConfig
         except ImportError as exc:
             raise RuntimeError(
-                "The drafting eval needs the email agent. Install it with "
-                "`pip install gaia-agent-email` (or `pip install "
-                '"amd-gaia[agents]"`). '
-                f"Original import error: {exc}"
+                agent_not_installed_message(
+                    "The drafting eval needs the email agent",
+                    "gaia-agent-email",
+                    next_step=f"Original import error: {exc}",
+                )
             ) from exc
 
         def agent_factory(backend: Any, db_path: str) -> Any:

--- a/src/gaia/eval/followup_quality.py
+++ b/src/gaia/eval/followup_quality.py
@@ -52,6 +52,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.eval.fixture_paths import resolve_repo_fixture
 from gaia.eval.quality_metrics import Confusion
 
@@ -554,10 +555,11 @@ def _default_detector(
         from gaia_agent_email.tools.followup_tools import check_followups_impl
     except ImportError as exc:
         raise RuntimeError(
-            "The follow-up detection eval needs the email agent. Install it with "
-            "`pip install gaia-agent-email` (or `pip install "
-            '"amd-gaia[agents]"`). '
-            f"Original import error: {exc}"
+            agent_not_installed_message(
+                "The follow-up detection eval needs the email agent",
+                "gaia-agent-email",
+                next_step=f"Original import error: {exc}",
+            )
         ) from exc
     return check_followups_impl(backend, window_days=window_days, now_ms=now_ms)
 

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -12,6 +12,7 @@ Main entry point for `gaia init` command that:
 5. Verifies setup is working
 """
 
+import importlib.util
 import logging
 import os
 import subprocess
@@ -30,6 +31,7 @@ except ImportError:
     RICH_AVAILABLE = False
 
 from gaia.agents.base.console import AgentConsole
+from gaia.agents.install_hints import source_install_command
 from gaia.installer.lemonade_installer import LemonadeInfo, LemonadeInstaller
 from gaia.llm.lemonade_launcher import build_start_command, resolve_lemonade
 from gaia.version import LEMONADE_VERSION
@@ -1893,8 +1895,24 @@ class InitCommand:
             self._print_error(f"Verification failed: {e}")
             return False
 
+    @staticmethod
+    def _chat_agent_available() -> bool:
+        """Whether the standalone gaia-agent-chat wheel is importable.
+
+        ``gaia chat`` resolves through that wheel (#1102), which no init
+        profile installs (it isn't a pip extra -- #2240). Printing `gaia
+        chat` as a ready next step when it isn't installed is a false
+        promise, so completion messaging checks first.
+        """
+        return importlib.util.find_spec("gaia_agent_chat") is not None
+
     def _print_completion(self):
         """Print completion message with next steps."""
+        chat_agent_available = self._chat_agent_available()
+        chat_install_note = (
+            "Chat agent not installed yet -- run: "
+            f"{source_install_command('gaia-agent-chat')}"
+        )
         if RICH_AVAILABLE and self.console:
             self.console.print()
             self.console.print(
@@ -1929,6 +1947,8 @@ class InitCommand:
                 self.console.print(
                     "    [cyan]gaia chat --ui[/cyan]                       Launch the Agent UI (browser-based)"
                 )
+                if not chat_agent_available:
+                    self.console.print(f"    [yellow]{chat_install_note}[/yellow]")
             elif self.profile == "npu":
                 self.console.print(
                     "    [cyan]gaia chat --device npu[/cyan]             Chat using Ryzen AI NPU"
@@ -1939,6 +1959,8 @@ class InitCommand:
                 self.console.print(
                     "    [dim]Note: NPU inference is active. Use --device gpu to switch back.[/dim]"
                 )
+                if not chat_agent_available:
+                    self.console.print(f"    [yellow]{chat_install_note}[/yellow]")
             elif self.profile == "vlm":
                 self.console.print(
                     "    [cyan]gaia cache status[/cyan]      Verify VLM model is available"
@@ -1971,6 +1993,8 @@ class InitCommand:
                 self.console.print(
                     "    [cyan]gaia talk[/cyan]              Voice interaction"
                 )
+                if not chat_agent_available:
+                    self.console.print(f"    [yellow]{chat_install_note}[/yellow]")
             self.console.print()
         else:
             self._print("")
@@ -2002,6 +2026,8 @@ class InitCommand:
                 self._print(
                     "    gaia chat --ui                       # Launch the Agent UI (browser-based)"
                 )
+                if not chat_agent_available:
+                    self._print(f"    {chat_install_note}")
             elif self.profile == "npu":
                 self._print(
                     "    gaia chat --device npu             # Chat using Ryzen AI NPU"
@@ -2013,6 +2039,8 @@ class InitCommand:
                 self._print(
                     "  Note: NPU inference is active. Use --device gpu to switch back."
                 )
+                if not chat_agent_available:
+                    self._print(f"    {chat_install_note}")
             elif self.profile == "vlm":
                 self._print(
                     "    gaia cache status      # Verify VLM model is available"
@@ -2037,6 +2065,8 @@ class InitCommand:
                 )
                 self._print("    gaia llm 'Hello'       # Quick LLM query")
                 self._print("    gaia talk              # Voice interaction")
+                if not chat_agent_available:
+                    self._print(f"    {chat_install_note}")
             self._print("")
 
 

--- a/src/gaia/mcp/servers/docker_mcp.py
+++ b/src/gaia/mcp/servers/docker_mcp.py
@@ -6,6 +6,7 @@ Docker MCP Server Launcher
 Starts an MCP server for the Docker agent
 """
 
+from gaia.agents.install_hints import agent_not_installed_message
 from gaia.mcp.agent_mcp_server import MCP_DEFAULT_HOST, MCP_DEFAULT_PORT, AgentMCPServer
 
 
@@ -30,9 +31,9 @@ def start_docker_mcp(
         from gaia_agent_docker.agent import DockerAgent
     except ImportError as e:
         raise ImportError(
-            "The docker agent is not installed. Install it with "
-            '`uv pip install gaia-agent-docker` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents)."
+            agent_not_installed_message(
+                "The docker agent is not installed", "gaia-agent-docker"
+            )
         ) from e
 
     # Prepare agent parameters

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -25,6 +25,8 @@ from typing import Optional
 
 from fastapi import HTTPException
 
+from gaia.agents.install_hints import agent_not_installed_message
+
 from .database import PLACEHOLDER_TITLES, SESSION_DEFAULT_MODEL, ChatDatabase
 from .models import ChatRequest
 from .sse_handler import (
@@ -1403,9 +1405,11 @@ async def _get_chat_response(
                 from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
             except ImportError as e:
                 raise RuntimeError(
-                    "The chat agent is not installed. Run "
-                    "`pip install gaia-agent-chat` (or `pip install "
-                    '"amd-gaia[agents]"`), then restart the server.'
+                    agent_not_installed_message(
+                        "The chat agent is not installed",
+                        "gaia-agent-chat",
+                        next_step="Then restart the server.",
+                    )
                 ) from e
 
             logger.info(
@@ -1846,9 +1850,11 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
                         )
                     except ImportError as e:
                         raise RuntimeError(
-                            "The chat agent is not installed. Run "
-                            "`pip install gaia-agent-chat` (or `pip install "
-                            '"amd-gaia[agents]"`), then restart the server.'
+                            agent_not_installed_message(
+                                "The chat agent is not installed",
+                                "gaia-agent-chat",
+                                next_step="Then restart the server.",
+                            )
                         ) from e
 
                     logger.info(

--- a/src/gaia/ui/agent_loop.py
+++ b/src/gaia/ui/agent_loop.py
@@ -32,6 +32,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from gaia.agents.install_hints import agent_not_installed_message
+
 logger = logging.getLogger(__name__)
 
 # ── Configuration constants ─────────────────────────────────────────────────
@@ -334,9 +336,11 @@ class AgentLoop:
                     from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
                 except ImportError as e:
                     raise RuntimeError(
-                        "The chat agent is not installed. Run "
-                        "`pip install gaia-agent-chat` (or `pip install "
-                        '"amd-gaia[agents]"`), then restart the server.'
+                        agent_not_installed_message(
+                            "The chat agent is not installed",
+                            "gaia-agent-chat",
+                            next_step="Then restart the server.",
+                        )
                     ) from e
 
                 import gaia.ui._chat_helpers as _helpers

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -33,6 +33,8 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from gaia.agents.install_hints import agent_not_installed_message
+
 # ── Backward-compatible re-exports ──────────────────────────────────────────
 # Tests use @patch("gaia.ui.server._get_chat_response") etc., so we must
 # expose these names at module level.  The canonical implementations live
@@ -378,10 +380,11 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
                     from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
                 except ImportError as e:
                     raise RuntimeError(
-                        "The chat agent is not installed. Install it with "
-                        "`pip install gaia-agent-chat` (or `pip install "
-                        '"amd-gaia[agents]"` for all agents) to run scheduled '
-                        "chat tasks."
+                        agent_not_installed_message(
+                            "The chat agent is not installed",
+                            "gaia-agent-chat",
+                            next_step="Then re-run the scheduled chat task.",
+                        )
                     ) from e
 
                 # Beta dynamic tool loader (#1798). Inert here: scheduled runs

--- a/tests/unit/agents/test_install_hints.py
+++ b/tests/unit/agents/test_install_hints.py
@@ -1,0 +1,83 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Guards for gaia.agents.install_hints (#2240).
+
+Every "agent X is not installed" message in the codebase used to recommend
+`pip install gaia-agent-<id>` and `pip install "amd-gaia[agents]"` -- both
+fail on a clean environment because the gaia-agent-* wheels aren't published
+to PyPI yet. These tests pin the replacement contract: the generated message
+must never recommend either broken command, and the source-install command it
+does recommend must reference a directory that actually exists on disk.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from gaia.agents.install_hints import (
+    _AGENT_SOURCE_SUBDIRS,
+    agent_not_installed_message,
+    source_install_command,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PYTHON_AGENTS_DIR = REPO_ROOT / "hub" / "agents" / "python"
+
+
+class TestSourceInstallCommand:
+    def test_known_wheel_produces_git_subdirectory_install(self):
+        cmd = source_install_command("gaia-agent-chat")
+        assert cmd == (
+            'uv pip install "gaia-agent-chat @ '
+            "git+https://github.com/amd/gaia.git#subdirectory="
+            'hub/agents/python/chat"'
+        )
+
+    def test_unknown_wheel_raises(self):
+        with pytest.raises(KeyError):
+            source_install_command("gaia-agent-does-not-exist")
+
+    @pytest.mark.parametrize("wheel", sorted(_AGENT_SOURCE_SUBDIRS))
+    def test_every_registered_subdir_exists_on_disk(self, wheel):
+        """Guards against the map drifting from hub/agents/python/ (#2240)."""
+        subdir = _AGENT_SOURCE_SUBDIRS[wheel]
+        assert (PYTHON_AGENTS_DIR / subdir).is_dir(), (
+            f"{wheel} maps to hub/agents/python/{subdir}, which doesn't "
+            "exist -- update _AGENT_SOURCE_SUBDIRS in install_hints.py."
+        )
+
+
+class TestAgentNotInstalledMessage:
+    def test_never_recommends_the_broken_pip_commands(self):
+        """Regression guard: neither broken install path appears (#2240)."""
+        message = agent_not_installed_message(
+            "The chat agent is not installed", "gaia-agent-chat"
+        )
+        assert "pip install gaia-agent-chat`" not in message
+        assert "amd-gaia[agents]" not in message
+
+    def test_includes_working_source_install_command(self):
+        message = agent_not_installed_message(
+            "The chat agent is not installed", "gaia-agent-chat"
+        )
+        assert source_install_command("gaia-agent-chat") in message
+
+    def test_references_tracking_issue(self):
+        message = agent_not_installed_message(
+            "The chat agent is not installed", "gaia-agent-chat"
+        )
+        assert "github.com/amd/gaia/issues/2240" in message
+
+    def test_next_step_is_appended(self):
+        message = agent_not_installed_message(
+            "The chat agent is not installed",
+            "gaia-agent-chat",
+            next_step="Then re-run `gaia chat`.",
+        )
+        assert message.endswith("Then re-run `gaia chat`.")
+
+    def test_no_next_step_has_no_trailing_space(self):
+        message = agent_not_installed_message(
+            "The chat agent is not installed", "gaia-agent-chat"
+        )
+        assert not message.endswith(" ")

--- a/tests/unit/test_agent_pypi_publish.py
+++ b/tests/unit/test_agent_pypi_publish.py
@@ -5,12 +5,16 @@
 These tests do *not* touch the network or PyPI. They assert the static
 invariants that make dual distribution (R2 + PyPI) correct and drift-proof:
 
-* the production-agent list (``setup.py[agents]``) maps cleanly to packages
-  under ``hub/agents/python/<id>/`` (via ``util/list_agent_packages.py``);
+* the production-agent list (``setup.py``'s ``AGENT_WHEEL_PACKAGES``) maps
+  cleanly to packages under ``hub/agents/python/<id>/`` (via
+  ``util/list_agent_packages.py``);
 * every such wheel declares the ``gaia-agent-<id>`` name and an ``amd-gaia``
   framework dependency (issue #1179 scope item 3);
 * the publish workflow derives its matrix from that same list, so a new agent
-  added to the extra is published automatically with no second list to sync.
+  added to ``AGENT_WHEEL_PACKAGES`` is published automatically with no second
+  list to sync. That list is a plain module-level constant rather than an
+  ``extras_require`` entry -- see #2240 and the module docstring on
+  ``util/list_agent_packages.py`` for why.
 
 The live dual-publish logic is covered by ``test_hub_publisher.py``; the CLI
 wiring by ``test_cli_agent.py``.
@@ -143,10 +147,10 @@ def test_helper_matrix_format_matches_packages(packages):
 
 
 def test_helper_rejects_missing_package(tmp_path):
-    """A dist in the extra with no on-disk package fails loudly (no silent skip)."""
+    """A dist in the list with no on-disk package fails loudly (no silent skip)."""
     fake_setup = tmp_path / "setup.py"
     fake_setup.write_text(
-        'setup(\n    extras_require={"agents": ["gaia-agent-doesnotexist"]},\n)\n',
+        'AGENT_WHEEL_PACKAGES = ["gaia-agent-doesnotexist"]\nsetup()\n',
         encoding="utf-8",
     )
     with pytest.raises(lap.AgentListError, match="no package at"):
@@ -157,7 +161,7 @@ def test_helper_rejects_bad_naming(tmp_path):
     """A dist not following gaia-agent-<id> fails loudly."""
     fake_setup = tmp_path / "setup.py"
     fake_setup.write_text(
-        'setup(\n    extras_require={"agents": ["totally-wrong-name"]},\n)\n',
+        'AGENT_WHEEL_PACKAGES = ["totally-wrong-name"]\nsetup()\n',
         encoding="utf-8",
     )
     with pytest.raises(lap.AgentListError, match="naming convention"):

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -231,3 +231,55 @@ class TestBaseDependencies:
                 "not in setup.py install_requires (only extras). A plain "
                 "`pip install amd-gaia` would ship a broken gaia-mcp entry point."
             )
+
+
+def _parse_extras_require_block():
+    """Extract the raw text inside extras_require={...} from setup.py."""
+    content = SETUP_PY.read_text()
+    match = re.search(
+        r"extras_require\s*=\s*\{(.*?)\n    \},\n    classifiers=", content, re.DOTALL
+    )
+    assert match, "Could not find extras_require={} in setup.py"
+    return match.group(1)
+
+
+class TestAgentWheelExtras:
+    """Regression guard for #2240.
+
+    The gaia-agent-* wheels (chat, email, code, ...) aren't published to
+    PyPI yet (publish_agents.yml's publish job is gated off). An 'agents'
+    extra -- or any 'agent-<id>' extra -- naming one of those packages
+    makes that *whole* amd-gaia release unsatisfiable, so pip/uv silently
+    backtrack past it to the newest older release that doesn't declare the
+    extra. That's what turned `pip install "amd-gaia[agents]"` into a
+    silent downgrade from 0.22.0 to 0.20.0. Don't re-add these extras until
+    the wheels are actually live on PyPI.
+    """
+
+    def test_no_agents_extra_declared(self):
+        extras_keys = re.findall(
+            r'"([a-zA-Z0-9_-]+)"\s*:', _parse_extras_require_block()
+        )
+        broken = {k for k in extras_keys if k == "agents" or k.startswith("agent-")}
+        assert not broken, (
+            f"setup.py declares extras {sorted(broken)} -- this is exactly "
+            "the shape that caused #2240's silent amd-gaia downgrade. Don't "
+            "re-add until the gaia-agent-* wheels are live on PyPI."
+        )
+
+    def test_no_extras_reference_unpublished_agent_wheels(self):
+        # Drop comment lines first -- e.g. the "install from source" hint
+        # left in place of the removed extras legitimately mentions
+        # gaia-agent-* as a string, not as a live dependency spec.
+        code_lines = (
+            line
+            for line in _parse_extras_require_block().splitlines()
+            if not line.strip().startswith("#")
+        )
+        extras_block = "\n".join(code_lines)
+        assert "gaia-agent-" not in extras_block, (
+            "An extras_require value references a gaia-agent-* wheel; those "
+            "aren't published to PyPI yet (#2240), so any extra naming one "
+            "makes amd-gaia unsatisfiable at that version and pip/uv "
+            "silently backtrack-downgrade to an older release instead."
+        )

--- a/util/list_agent_packages.py
+++ b/util/list_agent_packages.py
@@ -2,23 +2,34 @@
 # SPDX-License-Identifier: MIT
 """List the AMD production agent packages that ship as ``gaia-agent-<id>`` wheels.
 
-Single source of truth = the ``agents`` entry of ``extras_require`` in
-``setup.py`` (the same list behind ``pip install "amd-gaia[agents]"``). This
-script reads that list *statically* (``ast``, never executing ``setup.py``),
-maps each ``gaia-agent-<id>`` distribution name to its package directory under
-``hub/agents/python/<id>/``, and verifies the directory exists.
+Single source of truth = the ``AGENT_WHEEL_PACKAGES`` list in ``setup.py``.
+This script reads that list *statically* (``ast``, never executing
+``setup.py``), maps each ``gaia-agent-<id>`` distribution name to its package
+directory under ``hub/agents/python/<id>/``, and verifies the directory
+exists.
+
+``AGENT_WHEEL_PACKAGES`` deliberately lives as a plain module-level constant,
+not an ``extras_require`` entry (issue #2240): while the ``gaia-agent-*``
+wheels aren't published to PyPI, declaring them as an extra made
+``pip install "amd-gaia[agents]"`` unsatisfiable at the current release,
+which made pip/uv silently backtrack-downgrade to an older amd-gaia that
+didn't declare the extra. Keeping the list out of the package's own metadata
+avoids handing pip's resolver something it can't satisfy, while keeping a
+single place both this tool and end users (``gaia.agents.install_hints``)
+read from.
 
 Consumers:
 
 * ``.github/workflows/publish_agents.yml`` calls ``--format matrix`` to generate
-  the build/publish matrix, so adding an agent to ``setup.py[agents]`` is all it
-  takes to start publishing its wheel — no second list to keep in sync.
+  the build/publish matrix, so adding an agent to ``setup.py``'s
+  ``AGENT_WHEEL_PACKAGES`` is all it takes to start publishing its wheel — no
+  second list to keep in sync.
 * ``tests/unit/test_agent_pypi_publish.py`` calls :func:`list_agent_packages`
   to assert the published set, the on-disk packages, and their ``amd-gaia``
   dependency all agree.
 
-Per ``CLAUDE.md`` (No Silent Fallbacks): a distribution listed in the extra with
-no matching ``hub/agents/python/<id>/`` directory, or a malformed ``setup.py``,
+Per ``CLAUDE.md`` (No Silent Fallbacks): a distribution listed with no
+matching ``hub/agents/python/<id>/`` directory, or a malformed ``setup.py``,
 raises rather than silently dropping the agent from the publish set.
 """
 
@@ -57,8 +68,11 @@ class AgentPackage:
         return self.path.relative_to(REPO_ROOT).as_posix()
 
 
+AGENT_WHEEL_PACKAGES_NAME = "AGENT_WHEEL_PACKAGES"
+
+
 def _read_agents_extra(setup_py: Path) -> List[str]:
-    """Return the string list under ``extras_require["agents"]`` in *setup_py*.
+    """Return the string list assigned to ``AGENT_WHEEL_PACKAGES`` in *setup_py*.
 
     Parses statically with :mod:`ast` — ``setup.py`` is never imported or run.
     """
@@ -70,36 +84,31 @@ def _read_agents_extra(setup_py: Path) -> List[str]:
     tree = ast.parse(setup_py.read_text(encoding="utf-8"), filename=str(setup_py))
 
     for node in ast.walk(tree):
-        if not (isinstance(node, ast.keyword) and node.arg == "extras_require"):
+        if not isinstance(node, ast.Assign):
             continue
-        if not isinstance(node.value, ast.Dict):
+        if not any(
+            isinstance(target, ast.Name) and target.id == AGENT_WHEEL_PACKAGES_NAME
+            for target in node.targets
+        ):
+            continue
+        try:
+            dists = ast.literal_eval(node.value)
+        except ValueError as exc:
             raise AgentListError(
-                "setup.py: extras_require is not a dict literal — cannot derive "
-                "the production-agent list statically."
+                f"setup.py: {AGENT_WHEEL_PACKAGES_NAME} is not a literal list "
+                f"of strings: {exc}."
+            ) from exc
+        if not isinstance(dists, list) or not all(isinstance(d, str) for d in dists):
+            raise AgentListError(
+                f"setup.py: {AGENT_WHEEL_PACKAGES_NAME} must be a list of "
+                "distribution-name strings."
             )
-        for key, value in zip(node.value.keys, node.value.values):
-            if isinstance(key, ast.Constant) and key.value == "agents":
-                try:
-                    dists = ast.literal_eval(value)
-                except ValueError as exc:
-                    raise AgentListError(
-                        f"setup.py: extras_require['agents'] is not a literal "
-                        f"list of strings: {exc}."
-                    ) from exc
-                if not isinstance(dists, list) or not all(
-                    isinstance(d, str) for d in dists
-                ):
-                    raise AgentListError(
-                        "setup.py: extras_require['agents'] must be a list of "
-                        "distribution-name strings."
-                    )
-                return dists
-        raise AgentListError(
-            "setup.py: extras_require has no 'agents' key. Add it (the meta "
-            "extra behind 'pip install \"amd-gaia[agents]\"')."
-        )
+        return dists
     raise AgentListError(
-        "setup.py: no extras_require keyword found in the setup() call."
+        f"setup.py: no top-level {AGENT_WHEEL_PACKAGES_NAME} assignment found. "
+        "Add it (the list of gaia-agent-<id> wheels this repo publishes) -- "
+        "see util/list_agent_packages.py's module docstring for why it isn't "
+        "an extras_require entry (#2240)."
     )
 
 


### PR DESCRIPTION
## Summary

After `gaia init --profile npu`, running `gaia chat --device npu` failed with an install hint that couldn't work: `pip install "amd-gaia[agents]"` doesn't install the chat agent — it silently **downgrades amd-gaia from 0.22.0 to 0.20.0**. The `agents` extra named 15 `gaia-agent-*` wheels that aren't published to PyPI yet, and a declared-but-unsatisfiable extra makes the *whole* release unresolvable, so pip/uv backtrack to the newest older release that doesn't declare the extra at all. Every "agent not installed" error in the codebase pointed at this same broken pair of commands.

This PR removes the broken extras and repoints every one of those messages — plus the `gaia init` completion banner, which was recommending `gaia chat` as a ready next step right after installing nothing that could run it — at the install path that actually resolves today: pulling the agent straight from this repo's `hub/agents/python/<id>/` subdirectory. The registry's discovery mechanism itself was already correct (verified against an isolated venv with `gaia-agent-chat` actually installed); the bug was entirely in the packaging metadata and the guidance text.

Publishing the `gaia-agent-*` wheels to PyPI is a separate, deliberately-paused decision (`.github/workflows/publish_agents.yml`, tracked by #1179/#1513) — out of scope here.

## Test plan
- [x] `python util/lint.py --all` — clean (pre-existing mypy/bandit warnings only)
- [x] `tests/unit/test_packaging.py::TestAgentWheelExtras` — new regression guard; fails against the old `setup.py`, passes against the fix
- [x] `tests/unit/agents/test_install_hints.py` — new; asserts no message recommends the broken commands and every source-install path exists on disk
- [x] `tests/unit/test_agent_pypi_publish.py`, `tests/unit/test_publish_agents_to_hub.py` — publish-matrix discovery still resolves via the new `AGENT_WHEEL_PACKAGES` list
- [x] `tests/unit/agents/test_registry.py` (48 tests) — run against an isolated venv with `gaia-agent-chat` actually installed; registry correctly discovers `chat`/`doc`/`file`. Wired into `test_chat_agent.yml` so this stops silently skipping in CI.
- [x] `tests/unit/` full suite — 6458 passed, 151 skipped, 8 pre-existing failures unrelated to this change (confirmed identical via `git stash`)
- [x] Manual repro: `gaia chat` now prints the working `uv pip install "gaia-agent-chat @ git+...#subdirectory=hub/agents/python/chat"` command instead of the broken one