### PR TITLE
docs(connectors): correct the client_id_hash claim in the OAuth runbook

### DIFF
--- a/docs/runbooks/google-oauth-client.md
+++ b/docs/runbooks/google-oauth-client.md
@@ -163,7 +163,8 @@ Trouble: "Connect button does nothing in AgentUI."
 - The keyring backend allowlist (`PlaintextKeyring`/`EncryptedKeyring`
   refused) prevents silent fallback to plaintext file storage on Linux
   without SecretService.
-- The `client_id_hash` is sha256 of the client id, NOT the client id
-  itself; it can be logged at INFO without leaking the client id.
+- The `client_id_hash` is a CRC32 fingerprint of the client id
+  (`gaia.connectors.providers.google`), NOT the client id itself; it is
+  for log correlation and the rotation tripwire only, not security.
 - The OAuth `state` parameter is a per-flow random nonce compared via
   `hmac.compare_digest`; mismatched callbacks return 400.


### PR DESCRIPTION
## Why this matters

The runbook's security-boundaries section tells operators `client_id_hash` is a sha256 of the client id and therefore safe to log without leaking it — but the provider actually computes a CRC32 fingerprint (`zlib.crc32`, explicitly non-cryptographic, for log correlation and the rotation tripwire only). The doc now matches the code instead of overstating the guarantee.

This is the surviving remainder of the #2119/#2120 branch — everything else on it was superseded by #2189, #2193, and #2195 landing on main first.

## Test plan

- [x] Doc-only change; verified against `src/gaia/connectors/providers/google.py` (`client_id_hash = format(zlib.crc32(...), "08x")`)