### PR TITLE
feat(ui): always-available OAuth client field in Settings (#2104 interim)

### DIFF
--- a/docs/connectors/google.mdx
+++ b/docs/connectors/google.mdx
@@ -151,6 +151,14 @@ This is the credential GAIA uses.
 4. Paste the **Client ID** and **Client Secret** from Step 4.
 5. Click **Save & Connect**.
 
+Already past first-time setup (client came from env vars, or you need to
+rotate it)? Expand the tile's collapsible **OAuth client** section — it
+shows which client GAIA currently resolves (saved / environment / none)
+and accepts a replacement Client ID + Secret at any time. **Save client**
+persists to the OS keyring without starting a sign-in; saved credentials
+take precedence over `GAIA_GOOGLE_CLIENT_ID` / `GAIA_GOOGLE_CLIENT_SECRET`,
+exactly like `gaia connectors configure google`.
+
 GAIA will:
 
 1. Store the credentials in your OS keyring (macOS Keychain on Mac,

--- a/docs/connectors/google.mdx
+++ b/docs/connectors/google.mdx
@@ -188,10 +188,14 @@ completes.
 
 ## Step 6 — Grant scopes to specific agents
 
-Connecting Google doesn't automatically give every agent access to
-your inbox. **Each agent must be granted the specific scopes it needs** —
-connecting alone is not enough. You can do this in the UI (open the Google
-tile → **Per-agent grants**) or the CLI.
+Each agent must be granted the specific scopes it needs — a connection
+alone is not enough. In the Agent UI this happens **during connect**: the
+Google tile's connect panel shows **"Grant access to these agents when
+you connect"** with a default-on checkbox per installed agent that
+declares Google access, and checked agents receive their declared scopes
+the moment the OAuth flow completes. Uncheck an agent to withhold its
+grant, and adjust or revoke any grant later under the tile's
+**Per-agent grants** section. On the CLI you grant explicitly:
 
 **Chat agent — read-only Gmail:**
 

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -75,10 +75,17 @@ GAIA will:
 
 The tile flips to **Connected as you@outlook.com** once the flow completes.
 
-## Step 4 — Grant scopes to specific agents
+## Step 4 — Per-agent grants
 
-Connecting Microsoft doesn't automatically give every agent access to your
-mailbox. Each agent must be granted the specific Graph scopes it needs:
+The connect panel shows **"Grant access to these agents when you
+connect"** — a default-on checkbox for every installed agent that
+declares Microsoft access. Checked agents are granted their declared
+Graph scopes automatically the moment the OAuth flow completes, so a
+fresh connect needs no follow-up command. Uncheck an agent before
+connecting to withhold its grant.
+
+You can adjust or revoke grants at any time from the same tile's
+**Per-agent grants** section, or via the CLI:
 
 ```bash
 # Grant an agent read-only Outlook mail access

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -55,6 +55,14 @@ You do **not** need to create a client secret for the standard flow.
    Secret** field blank.
 5. Click **Save & Connect**.
 
+Already past first-time setup (client came from env vars, or you need to
+rotate it)? Expand the tile's collapsible **OAuth client** section — it
+shows which client GAIA currently resolves (saved / environment / none)
+and accepts a replacement at any time. **Save client** persists to the OS
+keyring without starting a sign-in; saved credentials take precedence over
+`GAIA_MICROSOFT_CLIENT_ID`, exactly like
+`gaia connectors configure microsoft`.
+
 GAIA will:
 
 1. Store the Client ID in your OS keyring (macOS Keychain on Mac,

--- a/docs/sdk/infrastructure/connectors.mdx
+++ b/docs/sdk/infrastructure/connectors.mdx
@@ -207,6 +207,13 @@ gaia connectors grants grant google builtin:chat \
 gaia connectors grants list google
 gaia connectors grants revoke google builtin:chat
 
+# NOTE: the Agent UI grants on connect (#2117): POST
+# /api/connectors/{id}/authorize accepts grant_agents (namespaced agent
+# ids); the router resolves each agent's REQUIRED_CONNECTORS scopes and
+# the OAuth callback commits the grants the moment the token exchange
+# succeeds. Explicit CLI grants remain the path for scripts and headless
+# setups.
+
 # Per-agent activations — gate which agents see this MCP server's tools.
 # Activations apply to mcp_server connectors only; OAuth connectors are
 # rejected with exit 3 (use per-scope grants above instead).

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.css
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.css
@@ -721,3 +721,38 @@
     border-top: 1px solid var(--border-light);
     margin-top: 4px;
 }
+
+/* OAuth client editor (#2104) — collapsible bring-your-own-client section */
+.oauth-client-editor {
+    margin: 6px 0 8px;
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-sm);
+}
+
+.oauth-client-editor__toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 6px 8px;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+}
+
+.oauth-client-editor__status {
+    margin-left: auto;
+    color: var(--text-muted);
+    font-size: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 60%;
+}
+
+.oauth-client-editor .oauth-setup-form {
+    padding: 0 8px 8px;
+}

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -430,6 +430,9 @@ function OAuthConfigureBody({
                     </p>
                 </div>
             )}
+            {!showSetupForm && (
+                <OAuthClientEditor connector={connector} onChanged={onChanged} />
+            )}
             {err && (
                 <div className="configure-error">
                     <AlertCircle size={12} /> {err}
@@ -487,6 +490,147 @@ function OAuthConfigureBody({
                     </a>
                 )}
             </div>
+        </div>
+    );
+}
+
+// ── OAuthClientEditor ────────────────────────────────────────────────────────
+
+/**
+ * Collapsible "OAuth client" editor (#2104 interim).
+ *
+ * The first-time setup form only renders while the provider is
+ * unconfigurable; every other state (client from env, stale keyring
+ * credentials, rotating a client, already connected) previously had no
+ * UI at all — a user holding a client ID dead-ended in Settings. This
+ * section is always available for OAuth connectors: it shows which
+ * client the provider resolves (keyring / env / none) and saves a new
+ * client ID + optional secret through the same keyring slot the CLI
+ * `gaia connectors configure` path writes, so precedence (stored → env)
+ * is unchanged. Saving never starts an OAuth flow (``save_only``).
+ */
+function OAuthClientEditor({
+    connector,
+    onChanged,
+}: {
+    connector: ConnectorRow;
+    onChanged: () => void;
+}) {
+    const [open, setOpen] = useState(false);
+    const [values, setValues] = useState<Record<string, string>>({});
+    const [busy, setBusy] = useState(false);
+    const [saved, setSaved] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+
+    const fields = connector.oauth_setup_fields ?? [];
+    if (fields.length === 0) return null;
+
+    const client = connector.oauth_client;
+    const statusLine =
+        client?.source === 'keyring'
+            ? `Saved client: ${client.client_id}`
+            : client?.source === 'env'
+              ? `From environment: ${client.client_id}`
+              : 'No OAuth client configured';
+
+    const handleSave = async () => {
+        const clientId = values['client_id']?.trim();
+        if (!clientId) {
+            setErr('Client ID is required.');
+            return;
+        }
+        setBusy(true);
+        setErr(null);
+        setSaved(false);
+        try {
+            await api.configureConnector(connector.id, {
+                ...Object.fromEntries(
+                    Object.entries(values).map(([k, v]) => [k, v.trim()]),
+                ),
+                save_only: true,
+            });
+            setSaved(true);
+            setValues({});
+            onChanged();
+            setTimeout(() => setSaved(false), 2200);
+        } catch (e) {
+            setErr(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="oauth-client-editor">
+            <button
+                type="button"
+                className="oauth-client-editor__toggle"
+                onClick={() => setOpen((v) => !v)}
+                aria-expanded={open}
+            >
+                {open ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                <span>OAuth client</span>
+                <span className="oauth-client-editor__status">{statusLine}</span>
+            </button>
+            {open && (
+                <div className="oauth-setup-form">
+                    <p className="connector-desc">
+                        Bring your own OAuth client — saved encrypted in your OS
+                        keyring (same store as{' '}
+                        <code>gaia connectors configure</code>) and reused for
+                        future connections. Environment variables are only used
+                        when no saved client exists.
+                    </p>
+                    {fields.map((field) => (
+                        <label key={field.key} className="oauth-setup-field">
+                            <span className="oauth-setup-label">{field.label}</span>
+                            <input
+                                type={field.kind === 'secret' ? 'password' : 'text'}
+                                className="oauth-setup-input"
+                                placeholder={
+                                    field.kind === 'secret' &&
+                                    client?.source === 'keyring' &&
+                                    client.has_secret
+                                        ? '••••••••'
+                                        : field.placeholder
+                                }
+                                value={values[field.key] ?? ''}
+                                onChange={(e) =>
+                                    setValues((prev) => ({
+                                        ...prev,
+                                        [field.key]: e.target.value,
+                                    }))
+                                }
+                                autoComplete="off"
+                                spellCheck={false}
+                            />
+                            {field.help_md && (
+                                <span className="oauth-setup-help">{field.help_md}</span>
+                            )}
+                        </label>
+                    ))}
+                    {err && (
+                        <div className="configure-error">
+                            <AlertCircle size={12} /> {err}
+                        </div>
+                    )}
+                    <div className="configure-actions">
+                        <button
+                            className={`btn-model-save${saved ? ' saved' : ''}`}
+                            disabled={busy || !values['client_id']?.trim()}
+                            onClick={() => void handleSave()}
+                        >
+                            {busy ? (
+                                <Loader2 size={12} className="spin" />
+                            ) : saved ? (
+                                <><CheckCircle2 size={12} /> Saved</>
+                            ) : (
+                                'Save client'
+                            )}
+                        </button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -287,6 +287,19 @@ export interface ConnectorRow {
      * provider credentials.
      */
     oauth_setup_fields: ConnectorConfigField[];
+    /**
+     * Which OAuth *client* (app credentials) the provider resolves (#2104).
+     * ``source`` is ``'keyring'`` for credentials saved via Settings /
+     * `gaia connectors configure`, ``'env'`` for GAIA_*_CLIENT_ID, or
+     * ``null`` when no client is configured. The client secret value is
+     * never included — only whether one is stored. ``null``/absent for
+     * ``mcp_server`` connectors.
+     */
+    oauth_client?: {
+        source: 'keyring' | 'env' | null;
+        client_id: string | null;
+        has_secret: boolean;
+    } | null;
 }
 
 /**

--- a/src/gaia/connectors/oauth_pkce.py
+++ b/src/gaia/connectors/oauth_pkce.py
@@ -115,14 +115,18 @@ class OAuthPkceHandler:
         """
         Persist OAuth-client credentials (if supplied), then start a PKCE flow.
 
-        Three call shapes:
+        Four call shapes:
           1. ``{client_id, client_secret}`` — first-run path from the
              AgentUI "Save & Connect" form. We persist the app
              credentials in the keyring, evict the cached provider
              instance, then start a fresh PKCE flow.
-          2. ``{flow_id, code}`` — completion path for callers that
+          2. ``{client_id, client_secret, save_only: true}`` — persist
+             the OAuth client credentials WITHOUT starting a flow
+             (#2104). Same persistence as ``gaia connectors configure``;
+             the user connects separately.
+          3. ``{flow_id, code}`` — completion path for callers that
              drove the browser step themselves.
-          3. ``{}`` (or just ``scopes``) — start a new PKCE flow using
+          4. ``{}`` (or just ``scopes``) — start a new PKCE flow using
              whatever provider credentials are already on disk
              (keyring / env vars).
 
@@ -147,6 +151,16 @@ class OAuthPkceHandler:
                 client_secret=client_secret,
             )
             _provider_registry.pop(provider_id, None)
+
+        if config.get("save_only"):
+            if not client_id:
+                raise ConfigurationError(
+                    f"configure({spec.id!r}): save_only requires a non-empty "
+                    "client_id. Enter the OAuth client ID from your provider "
+                    "console, or use `gaia connectors configure "
+                    f"{provider_id}`."
+                )
+            return {"status": "saved", "connector_id": spec.id}
 
         scopes = config.get("scopes") or list(spec.default_scopes)
 

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -77,7 +77,7 @@ from gaia.connectors.mcp_server import (
     is_mcp_server_configured,
 )
 from gaia.connectors.registry import REGISTRY
-from gaia.connectors.store import peek_connection
+from gaia.connectors.store import peek_connection, peek_provider_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -370,6 +370,7 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
     scopes: list = []
     configurable = True
     config_error: Optional[str] = None
+    oauth_client: Optional[Dict[str, Any]] = None
 
     # TODO: when a 3rd connector type lands, push this if/elif into a
     # Handler.summary(spec) method so this becomes a single polymorphic
@@ -406,6 +407,27 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
             configured = True
             account_id = blob.get("account_email")
             scopes = list(blob.get("scopes", []))
+
+        # OAuth *client* status (#2104): which client the provider would
+        # resolve, so Settings can render/rotate it. client_id is not a
+        # secret (it ships inside desktop apps); the secret itself is
+        # NEVER included — only whether one is stored.
+        _env_prefix = f"GAIA_{provider_ref.upper()}"
+        stored_creds = peek_provider_credentials(provider_ref) or {}
+        if stored_creds.get("client_id"):
+            oauth_client = {
+                "source": "keyring",
+                "client_id": stored_creds["client_id"],
+                "has_secret": bool(stored_creds.get("client_secret")),
+            }
+        elif os.environ.get(f"{_env_prefix}_CLIENT_ID"):
+            oauth_client = {
+                "source": "env",
+                "client_id": os.environ[f"{_env_prefix}_CLIENT_ID"],
+                "has_secret": bool(os.environ.get(f"{_env_prefix}_CLIENT_SECRET")),
+            }
+        else:
+            oauth_client = {"source": None, "client_id": None, "has_secret": False}
 
     # ``enabled`` is meaningful only for ``mcp_server`` connectors. We
     # default to ``True`` for both not-configured connectors AND OAuth so
@@ -451,6 +473,7 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
         "configured": configured,
         "configurable": configurable,
         "config_error": config_error,
+        "oauth_client": oauth_client,
         "account_id": account_id,
         "scopes": scopes,
         "enabled": enabled,

--- a/tests/unit/connectors/test_oauth_client_field.py
+++ b/tests/unit/connectors/test_oauth_client_field.py
@@ -1,0 +1,143 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Settings OAuth-client field — #2104 interim deliverable.
+
+The Settings tile previously only offered a client-credentials form in the
+never-configured state; every other state (client from env, connected
+account with a lost client, rotation) dead-ended with no field. These
+tests cover the two backend pieces the always-available editor rides on:
+
+- ``POST /{id}/configure`` with ``save_only`` persists the OAuth client to
+  the same keyring slot the ``gaia connectors configure`` CLI writes —
+  WITHOUT starting an OAuth flow — and never echoes the secret.
+- The connector summary's ``oauth_client`` block reports which client the
+  provider resolves (keyring / env / none) and never includes the secret
+  value, only whether one is stored.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+UI_HEADER = {"x-gaia-ui": "1"}
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(monkeypatch):
+    """Fresh REGISTRY with one OAuth and one MCP spec (mirrors
+    test_router_connectors.py) so tests don't depend on the shipped catalog."""
+    from gaia.connectors.registry import ConnectorRegistry
+    from gaia.connectors.spec import ConnectorSpec
+
+    fresh = ConnectorRegistry()
+    fresh.register(
+        ConnectorSpec(
+            id="google",
+            display_name="Google",
+            icon="G",
+            category="productivity",
+            tier=1,
+            type="oauth_pkce",
+            description="Google OAuth",
+            default_scopes=("openid",),
+            oauth_provider_ref="google",
+        )
+    )
+    fresh.register(
+        ConnectorSpec(
+            id="mcp-test",
+            display_name="MCP Test",
+            icon="M",
+            category="dev-tools",
+            tier=1,
+            type="mcp_server",
+            description="Stub MCP server",
+            mcp_command="true",
+            mcp_args=(),
+        )
+    )
+    monkeypatch.setattr("gaia.ui.routers.connectors.REGISTRY", fresh)
+    monkeypatch.setattr("gaia.connectors.handler.REGISTRY", fresh)
+    monkeypatch.setattr("gaia.connectors.registry.REGISTRY", fresh)
+    yield fresh
+
+
+class TestConfigureSaveOnly:
+    def test_save_only_persists_client_without_flow(self, ui_api_client, monkeypatch):
+        async def _explode(*_a, **_k):  # pragma: no cover — must not run
+            raise AssertionError("save_only must not start an OAuth flow")
+
+        monkeypatch.setattr("gaia.connectors.oauth_pkce.start_authorization", _explode)
+        resp = ui_api_client.post(
+            "/api/connectors/google/configure",
+            json={
+                "config": {
+                    "client_id": "abc.apps.example",
+                    "client_secret": "SECRET-VALUE",
+                    "save_only": True,
+                }
+            },
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "saved"
+        assert "SECRET-VALUE" not in resp.text
+
+        from gaia.connectors.store import peek_provider_credentials
+
+        creds = peek_provider_credentials("google")
+        assert creds == {
+            "client_id": "abc.apps.example",
+            "client_secret": "SECRET-VALUE",
+        }
+
+    def test_save_only_without_client_id_fails_loudly(self, ui_api_client):
+        resp = ui_api_client.post(
+            "/api/connectors/google/configure",
+            json={"config": {"save_only": True}},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 503
+        assert "client_id" in resp.json()["detail"]
+
+
+class TestSummaryOAuthClient:
+    def test_keyring_source(self, ui_api_client, monkeypatch):
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_ID", raising=False)
+        from gaia.connectors.store import save_provider_credentials
+
+        save_provider_credentials(
+            "google", client_id="stored.apps.example", client_secret="SECRET-VALUE"
+        )
+        resp = ui_api_client.get("/api/connectors/google")
+        assert resp.status_code == 200
+        client = resp.json()["oauth_client"]
+        assert client == {
+            "source": "keyring",
+            "client_id": "stored.apps.example",
+            "has_secret": True,
+        }
+        assert "SECRET-VALUE" not in resp.text
+
+    def test_env_source(self, ui_api_client, monkeypatch):
+        monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "env.apps.example")
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_SECRET", raising=False)
+        resp = ui_api_client.get("/api/connectors/google")
+        client = resp.json()["oauth_client"]
+        assert client == {
+            "source": "env",
+            "client_id": "env.apps.example",
+            "has_secret": False,
+        }
+
+    def test_no_client_configured(self, ui_api_client, monkeypatch):
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GAIA_GOOGLE_CLIENT_SECRET", raising=False)
+        resp = ui_api_client.get("/api/connectors/google")
+        client = resp.json()["oauth_client"]
+        assert client == {"source": None, "client_id": None, "has_secret": False}
+
+    def test_mcp_connector_has_no_oauth_client(self, ui_api_client):
+        resp = ui_api_client.get("/api/connectors/mcp-test")
+        assert resp.json()["oauth_client"] is None


### PR DESCRIPTION
## Why this matters

A user holding their own OAuth client ID could still dead-end in Settings: the credentials form only rendered in the never-configured state, so anyone whose client came from env vars, whose keyring lost the client, or who needed to rotate credentials had no UI field at all and was pushed to the CLI. Every OAuth tile now carries a collapsible **OAuth client** section that shows which client the provider resolves (saved / environment / none) and accepts a replacement client ID + optional secret at any time — writing through the same keyring slot as `gaia connectors configure`, so precedence (stored → env) is unchanged. No first-party client IDs ship here; that stays gated on the #2104 sign-off.

Also folds in the doc updates #2195 (grant-on-connect, #2117) shipped without — the Google/Microsoft guides still described per-agent grants as an always-manual step.

## How it works

- `POST /{id}/configure` gains a `save_only` shape: persist the client without starting a sign-in flow (missing client_id fails loudly).
- The connector summary gains an `oauth_client` block (`source`, `client_id`, `has_secret`) — the secret value is never returned or logged.

## Test plan

- [x] `python -m pytest tests/unit/connectors/` → 554 passed, 7 skipped (new: `test_oauth_client_field.py` — save_only persists to keyring **without** starting a flow, missing client_id 503s, summary reports keyring/env/none source, secret never echoed)
- [x] webui `npm run build` (tsc + vite) clean; Vitest → 247 passed
- [x] `python util/lint.py` — Black + isort clean
- [x] Live UI server: Google tile in the connected-but-clientless state (reproduced locally — previously zero UI) now renders the OAuth client editor

Interim deliverable of #2104