### PR TITLE
fix(install): stop recommending agent-install commands that cannot work

### DIFF
--- a/.github/workflows/publish_agents.yml
+++ b/.github/workflows/publish_agents.yml
@@ -3,12 +3,17 @@
 #
 # Publish the AMD production *Python* agent wheels (gaia-agent-<id>) to PyPI.
 # Issue #1179 (Agent Hub dual distribution): R2 is the canonical source for the
-# Hub UI; PyPI is the canonical source for `pip install gaia-agent-<id>` and the
-# `amd-gaia[agents]` meta-extra. The C++ agent binaries are handled separately
-# by build_agents.yml.
+# Hub UI; PyPI is the canonical source for `pip install gaia-agent-<id>` once
+# publishing is enabled. The C++ agent binaries are handled separately by
+# build_agents.yml.
+#
+# The `amd-gaia[agents]` meta-extra that used to accompany this was removed in
+# #2240 — naming unpublished packages made it unsatisfiable, which silently
+# downgraded users' installs. Until these wheels actually publish, agents are
+# installed from the repo (see gaia.install_hints).
 #
 # Flow:
-#   discover (read setup.py[agents] -> matrix)
+#   discover (read setup.py AGENT_PACKAGES -> matrix)
 #     -> build  (tag only: build each wheel + twine check, upload artifact)
 #       -> approve (tag only: single manual gate, "publish" environment)
 #         -> publish (tag only: gh-action-pypi-publish per agent, skip-existing)

--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -85,7 +85,9 @@ pick one of the entry points below.
     against one host.
 
     ```bash
-    pip install gaia-agent-email        # installs the email REST routes
+    # The email agent is not on PyPI yet (#1179/#1513) — install it from the
+    # repo, pinned to the GAIA version you are running (`gaia --version`).
+    pip install "git+https://github.com/amd/gaia.git@v0.23.0#subdirectory=hub/agents/python/email"
     python -m gaia.ui.server --port 4200 --host 127.0.0.1
     ```
 

--- a/docs/guides/hub-publishing.mdx
+++ b/docs/guides/hub-publishing.mdx
@@ -13,7 +13,8 @@ serves a catalog file, `index.json`.
 
 Publishing your agent to the Hub does two things:
 
-1. Anyone can install it with `uv pip install gaia-agent-<id>` (or from the Agent UI's Hub panel).
+1. Anyone can install it from the Agent UI's Hub panel — and, once your wheel is
+   live on PyPI, with `uv pip install gaia-agent-<id>`.
 2. It **auto-creates the agent's page** on the Hub website
    (`amd-gaia.ai/hub`). The website is generated entirely
    from the Hub's catalog, so **publishing _is_ the website update** — there's no
@@ -296,9 +297,9 @@ be tampered with, stores it so it can **never be overwritten**, attaches your
 # Confirm your agent is in the catalog:
 curl -s https://hub.amd-gaia.ai/index.json | grep my-agent
 
-# Install it the way a user would (PyPI path):
+# Install it the way a user would — browse the Agent UI's Hub panel, or,
+# once your wheel is live on PyPI, take the pip path:
 uv pip install gaia-agent-my-agent
-# …or browse and install it from the Agent UI's Hub panel.
 ```
 
 Your page appears at `https://amd-gaia.ai/hub/my-agent` the next time the website

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -528,28 +528,37 @@ gaia agent publish --skip-r2
 ```
 </CodeGroup>
 
-##### Installing a published agent
+##### Installing an agent
 
-The two publish targets back two install paths, and both register the agent the
-same way — via the `gaia.agent` entry point, so the registry discovers it
-automatically:
+Agents register themselves via the `gaia.agent` entry point, so the registry
+discovers them automatically however they were installed.
 
-```bash From PyPI (pip)
-pip install gaia-agent-summarize          # one agent
-pip install "amd-gaia[agents]"            # every AMD production agent
+<Note>
+  The AMD production agents are **not published to PyPI yet** (tracked by
+  issues #1179 / #1513). Install them from the repo, pinned to the GAIA version
+  you are running so the agent matches its core:
+
+```bash
+pip install "git+https://github.com/amd/gaia.git@v0.23.0#subdirectory=hub/agents/python/summarize"
 ```
+
+  Replace `v0.23.0` with your installed version (`gaia --version`) and
+  `summarize` with the agent you want. `gaia chat` and friends print this exact
+  command when the agent they need is missing.
+</Note>
 
 The **Hub (R2)** path is the Agent UI's discover/install panel, which downloads
 the wheel from R2 into `~/.gaia/agents/<id>/` (`POST /api/agents/install`, backed
-by `gaia.hub.installer`). Use it when browsing the Hub UI; use `pip install` for
-scripted or headless setups.
+by `gaia.hub.installer`). Use it when browsing the Hub UI; use the git install
+above for scripted or headless setups.
 
 ##### Automated PyPI publishing (CI)
 
 `.github/workflows/publish_agents.yml` builds every production agent wheel and
 publishes it to PyPI on a version tag (`v*`). Its matrix is derived from the
-`agents` extra in `setup.py` (via `util/list_agent_packages.py`), so adding an
-agent there is all it takes to start publishing it. The workflow uploads with
+`AGENT_PACKAGES` constant in `setup.py` (via `util/list_agent_packages.py`), so
+adding an agent there is all it takes to start publishing it. (The publish job
+itself is currently gated off — see #1179 / #1513.) The workflow uploads with
 [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish)
 using the `PYPI_API_TOKEN` secret and `skip-existing: true`, so an unchanged
 agent version is a no-op rather than an error — PyPI enforces version

--- a/docs/spec/agent-hub-restructure.mdx
+++ b/docs/spec/agent-hub-restructure.mdx
@@ -62,7 +62,7 @@ src/gaia/agents/                 src/gaia/agents/        ← framework only
 ## Key Decisions
 
 1. **Framework-only core wheel.** `pip install amd-gaia` provides `Agent`, `@tool`, `MCPAgent`, `AgentConsole`, registry, LLM clients, RAG, MCP. No production agents.
-2. **Agents are separate wheels.** `gaia-agent-chat`, `gaia-agent-jira`, `gaia-agent-code`, etc. — installable via `gaia agent install <id>`, `pip install gaia-agent-{id}`, or `amd-gaia[agents]` for all of them. One wheel per **codebase**, not per registry ID: the `chat` package ships multiple prompt profiles (`doc`, `file`, `data`, `web`) and model presets (lite variants) selectable via config — they are not separate wheels (see [#1162](https://github.com/amd/gaia/issues/1162)).
+2. **Agents are separate wheels.** `gaia-agent-chat`, `gaia-agent-jira`, `gaia-agent-code`, etc. — installable via `gaia agent install <id>` or, once published, `pip install gaia-agent-{id}`. Until then, install from the repo pinned to your core version (`gaia.install_hints` emits the exact command; the `amd-gaia[agents]` meta-extra this spec originally proposed was removed in [#2240](https://github.com/amd/gaia/issues/2240) because naming unpublished packages made it unsatisfiable and silently downgraded installs). One wheel per **codebase**, not per registry ID: the `chat` package ships multiple prompt profiles (`doc`, `file`, `data`, `web`) and model presets (lite variants) selectable via config — they are not separate wheels (see [#1162](https://github.com/amd/gaia/issues/1162)).
 3. **Shared tool mixins promoted to framework.** RAG, FileIO, Shell, CodeIndex mixins move into `src/gaia/agents/tools/` so agents don't depend on each other for tools.
 4. **Entry-point discovery.** Agents register via the `gaia.agent` entry point group. The registry discovers installed agent wheels at startup — no hardcoded agent list.
 5. **Framework-provided generic server.** `src/gaia/agents/base/server.py` wraps any Agent into an OpenAI-compatible REST API + MCP stdio server. Agents don't implement server logic.
@@ -144,7 +144,7 @@ Start with `summarize` — simplest, fewest dependencies. Proves the pattern end
 Migrate the other 15 agents. Rewrite internal imports (`gaia.agents.{name}` → `gaia_agent_{name}`). Framework imports stay. Cross-agent deps become package deps.
 </Step>
 <Step title="Strip the core wheel">
-Remove agent packages from `setup.py`. Remove `gaia-emr`/`gaia-code` console scripts. Add `amd-gaia[agents]` and per-agent extras.
+Remove agent packages from `setup.py`. Remove `gaia-emr`/`gaia-code` console scripts. (The `amd-gaia[agents]` and per-agent extras added here were later removed — see [#2240](https://github.com/amd/gaia/issues/2240).)
 </Step>
 <Step title="Update the registry">
 `_register_builtin_agents()` keeps only `builder`. Add `_discover_installed_agents()` using the `gaia.agent` entry point group.
@@ -214,7 +214,7 @@ The exploration found these agent-to-agent couplings that must be resolved:
 | Risk | Mitigation |
 |------|-----------|
 | 252 import references across the codebase break | Promote mixins first (Step 1), then migrate one agent at a time |
-| `pip install amd-gaia` no longer ships agents (breaking change) | `amd-gaia[agents]` extras preserves the "everything" install; document migration |
+| `pip install amd-gaia` no longer ships agents (breaking change) | Originally an `amd-gaia[agents]` extra; removed in [#2240](https://github.com/amd/gaia/issues/2240) (unsatisfiable → silent downgrade). Agents install from the repo until the wheels publish |
 | Editable dev workflow friction | `pip install -e hub/agents/python/{id}/` registers via entry points |
 | Registry can't find agents | Entry-point discovery + `~/.gaia/agents/` scan; fail loudly if an agent's `min_gaia_version` is unmet |
 

--- a/hub/agents/python/routing/README.md
+++ b/hub/agents/python/routing/README.md
@@ -19,8 +19,8 @@ pip install -e hub/agents/python/routing    # editable, for development
 ```
 
 The API server's `gaia-code` model routes through `RoutingAgent`, which in turn
-needs the `gaia-agent-code` wheel installed. Install both (or
-`pip install amd-gaia[agents]`) to use `gaia api` for code generation.
+needs the code agent installed. Install both to use `gaia api` for code
+generation — `gaia api` prints the exact commands if either is missing.
 
 ## Develop / test
 

--- a/hub/agents/python/routing/gaia_agent_routing/agent.py
+++ b/hub/agents/python/routing/gaia_agent_routing/agent.py
@@ -489,12 +489,15 @@ Conversation:
         registry = AgentRegistry()
         registry.discover()
         if registry.get("code") is None:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                "CodeAgent is not installed. RoutingAgent routes coding tasks "
-                "to the 'gaia-agent-code' package, which is not present. "
-                "Install it with 'uv pip install gaia-agent-code' (or "
-                "'uv pip install \"amd-gaia[agents]\"'), then retry. See "
-                "docs/spec/agent-hub-restructure.mdx."
+                agent_not_installed_message(
+                    "code",
+                    package="code agent (RoutingAgent routes coding tasks to it)",
+                    retry_command="the same query",
+                )
+                + " See docs/spec/agent-hub-restructure.mdx."
             )
 
         # Build agent kwargs, including output_handler if provided

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,34 @@ with open("src/gaia/version.py", encoding="utf-8") as fp:
 
 tkml_version = "5.0.4"
 
+# Agent distributions built by publish_agents.yml's `discover` job (issues
+# #1102, #1179). Deliberately NOT an extras_require entry — see #2240: an
+# `amd-gaia[agents]` extra naming these gaia-agent-* packages before any of
+# them were published on PyPI made pip/uv treat the extra as unsatisfiable.
+# An unsatisfiable extra doesn't fail cleanly: the resolver backtracks past
+# every version that declares it and silently lands on 0.20.0 (the last
+# version without the extra), *downgrading* a working install. Re-add these
+# as extras only once the wheels are actually published (tracked by #1179 /
+# #1513); until then this list is read statically by
+# util/list_agent_packages.py, never imported.
+AGENT_PACKAGES = [
+    "gaia-agent-summarize",
+    "gaia-agent-sd",
+    "gaia-agent-fileio",
+    "gaia-agent-docker",
+    "gaia-agent-jira",
+    "gaia-agent-blender",
+    "gaia-agent-emr",
+    "gaia-agent-code",
+    "gaia-agent-connectors-demo",
+    "gaia-agent-analyst",
+    "gaia-agent-browser",
+    "gaia-agent-docqa",
+    "gaia-agent-routing",
+    "gaia-agent-email",
+    "gaia-agent-chat",
+]
+
 setup(
     name="amd-gaia",
     version=gaia_version,
@@ -270,42 +298,13 @@ setup(
             "build>=1.0.0",
             "twine>=5.0.0",
         ],
-        # Standalone AMD production agents (issues #1102, #1179). Each agent
-        # ships as a separate 'gaia-agent-<id>' wheel that depends on this
-        # framework wheel; 'amd-gaia[agents]' installs all migrated agents at
-        # once. Add an entry here when each agent's wheel is first published.
-        "agent-summarize": ["gaia-agent-summarize"],
-        "agent-sd": ["gaia-agent-sd"],
-        "agent-fileio": ["gaia-agent-fileio"],
-        "agent-docker": ["gaia-agent-docker"],
-        "agent-jira": ["gaia-agent-jira"],
-        "agent-blender": ["gaia-agent-blender"],
-        "agent-emr": ["gaia-agent-emr"],
-        "agent-code": ["gaia-agent-code"],
-        "agent-connectors-demo": ["gaia-agent-connectors-demo"],
-        "agent-analyst": ["gaia-agent-analyst"],
-        "agent-browser": ["gaia-agent-browser"],
-        "agent-docqa": ["gaia-agent-docqa"],
-        "agent-routing": ["gaia-agent-routing"],
-        "agent-email": ["gaia-agent-email"],
-        "agent-chat": ["gaia-agent-chat"],
-        "agents": [
-            "gaia-agent-summarize",
-            "gaia-agent-sd",
-            "gaia-agent-fileio",
-            "gaia-agent-docker",
-            "gaia-agent-jira",
-            "gaia-agent-blender",
-            "gaia-agent-emr",
-            "gaia-agent-code",
-            "gaia-agent-connectors-demo",
-            "gaia-agent-analyst",
-            "gaia-agent-browser",
-            "gaia-agent-docqa",
-            "gaia-agent-routing",
-            "gaia-agent-email",
-            "gaia-agent-chat",
-        ],
+        # NOTE: the `agents` / `agent-<id>` extras were removed (#2240). They
+        # named gaia-agent-* packages that are not published, which made the
+        # extra unsatisfiable — pip/uv then backtrack to 0.20.0 (the last
+        # version without the extra) and silently DOWNGRADE a working
+        # install. The publish inventory now lives in the module-level
+        # AGENT_PACKAGES constant above. Re-add these only when the wheels
+        # are actually published; publishing is tracked by #1179 / #1513.
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/src/gaia/api/agent_registry.py
+++ b/src/gaia/api/agent_registry.py
@@ -159,15 +159,17 @@ class AgentRegistry:
             logger.error(f"Failed to load agent {model_id}: {e}")
             hint = ""
             if model_id == "gaia-code":
-                # gaia-code routes through the standalone gaia-agent-routing wheel
-                # (#1102), which in turn needs gaia-agent-code. Fail loudly with
-                # an install hint rather than degrading silently.
+                # gaia-code routes through RoutingAgent, which in turn needs the
+                # code agent. Both ship outside the core wheel (#1102). Fail
+                # loudly with an install hint rather than degrading silently.
+                from gaia.install_hints import agent_install_command
+
                 hint = (
                     " The 'gaia-code' model routes through RoutingAgent, which "
-                    "ships as the 'gaia-agent-routing' wheel. Install it with "
-                    "'pip install gaia-agent-routing gaia-agent-code' (or "
-                    "'pip install amd-gaia[agents]'). See "
-                    "docs/spec/agent-hub-restructure.mdx."
+                    "ships separately along with the code agent. Install both "
+                    f"with:\n  {agent_install_command('routing')}\n"
+                    f"  {agent_install_command('code')}\n"
+                    "See docs/spec/agent-hub-restructure.mdx."
                 )
             raise ValueError(f"Agent {model_id} not available: {e}.{hint}") from e
 

--- a/src/gaia/apps/docker/app.py
+++ b/src/gaia/apps/docker/app.py
@@ -27,10 +27,15 @@ def _load_docker_agent():
     try:
         from gaia_agent_docker.agent import DEFAULT_MODEL, DockerAgent
     except ImportError as e:
+        from gaia.install_hints import agent_not_installed_message
+
         raise ImportError(
-            "The docker agent is not installed. Install it with "
-            '`uv pip install gaia-agent-docker` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents). See https://amd-gaia.ai/docs/guides/docker."
+            agent_not_installed_message(
+                "docker",
+                package="docker agent",
+                retry_command="gaia docker",
+            )
+            + " See https://amd-gaia.ai/docs/guides/docker."
         ) from e
     return DockerAgent, DEFAULT_MODEL
 

--- a/src/gaia/apps/jira/app.py
+++ b/src/gaia/apps/jira/app.py
@@ -27,10 +27,15 @@ def _load_jira_agent_class():
     try:
         from gaia_agent_jira.agent import JiraAgent
     except ImportError as e:
+        from gaia.install_hints import agent_not_installed_message
+
         raise ImportError(
-            "The jira agent is not installed. Install it with "
-            '`uv pip install gaia-agent-jira` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents). See https://amd-gaia.ai/docs/guides/jira."
+            agent_not_installed_message(
+                "jira",
+                package="jira agent",
+                retry_command="gaia jira",
+            )
+            + " See https://amd-gaia.ai/docs/guides/jira."
         ) from e
     return JiraAgent
 

--- a/src/gaia/apps/summarize/app.py
+++ b/src/gaia/apps/summarize/app.py
@@ -24,10 +24,15 @@ def _load_summarizer_agent_class():
     try:
         from gaia_agent_summarize.agent import SummarizerAgent
     except ImportError as e:
+        from gaia.install_hints import agent_not_installed_message
+
         raise ImportError(
-            "The summarize agent is not installed. Install it with "
-            '`uv pip install gaia-agent-summarize` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents). See https://amd-gaia.ai/docs/guides/summarize."
+            agent_not_installed_message(
+                "summarize",
+                package="summarize agent",
+                retry_command="gaia summarize",
+            )
+            + " See https://amd-gaia.ai/docs/guides/summarize."
         ) from e
     return SummarizerAgent
 

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -601,10 +601,15 @@ async def async_main(action, **kwargs):
             from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
             from gaia_agent_chat.app import interactive_mode
         except ImportError as e:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                "The chat agent is not installed. Install it with "
-                '`pip install gaia-agent-chat` (or `pip install "amd-gaia[agents]"` '
-                "for all agents), then re-run `gaia chat`."
+                agent_not_installed_message(
+                    "chat",
+                    package="chat agent",
+                    retry_command="gaia chat",
+                    also_see="gaia chat --ui",
+                )
             ) from e
 
         try:
@@ -796,7 +801,7 @@ async def async_main(action, **kwargs):
         from gaia.agents.registry import AgentRegistry
 
         agent_id = "web" if action == "browse" else "data"
-        wheel = "gaia-agent-browser" if action == "browse" else "gaia-agent-analyst"
+        hub_dir = "browser" if action == "browse" else "analyst"
         agent_config_kwargs = dict(
             use_claude=kwargs.get("use_claude", False),
             use_chatgpt=kwargs.get("use_chatgpt", False),
@@ -817,10 +822,14 @@ async def async_main(action, **kwargs):
         registry = AgentRegistry()
         registry.discover()
         if registry.get(agent_id) is None:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                f"The '{action}' agent is not installed. Install it with "
-                f'`uv pip install {wheel}` (or `uv pip install "amd-gaia[agents]"` '
-                f"for all agents), then re-run `gaia {action}`."
+                agent_not_installed_message(
+                    hub_dir,
+                    package=f"'{action}' agent",
+                    retry_command=f"gaia {action}",
+                )
             )
         agent = registry.create_agent(agent_id, **agent_config_kwargs)
 
@@ -1002,10 +1011,15 @@ def _launch_interactive_cli(log=None):
             from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
             from gaia_agent_chat.app import interactive_mode
         except ImportError as e:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                "The chat agent is not installed. Install it with "
-                '`pip install gaia-agent-chat` (or `pip install "amd-gaia[agents]"` '
-                "for all agents), then re-run `gaia chat`."
+                agent_not_installed_message(
+                    "chat",
+                    package="chat agent",
+                    retry_command="gaia chat",
+                    also_see="gaia chat --ui",
+                )
             ) from e
 
         config = ChatAgentConfig(
@@ -5034,10 +5048,14 @@ def handle_email_command(args):
         try:
             from gaia_agent_email.spec_html import write_and_open_spec
         except ImportError as e:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                "The email agent is not installed. Install it with "
-                '`pip install gaia-agent-email` (or `pip install "amd-gaia[agents]"` '
-                "for all agents), then re-run `gaia email --spec`."
+                agent_not_installed_message(
+                    "email",
+                    package="email agent",
+                    retry_command="gaia email --spec",
+                )
             ) from e
 
         dest = write_and_open_spec(getattr(args, "output", None))
@@ -5330,10 +5348,15 @@ def handle_sd_command(args):
     try:
         from gaia_agent_sd import SDAgent, SDAgentConfig
     except ImportError as e:
+        from gaia.install_hints import agent_not_installed_message
+
         raise ImportError(
-            "The sd agent is not installed. Install it with "
-            '`uv pip install gaia-agent-sd` (or `uv pip install "amd-gaia[agents]"` for '
-            "all AMD agents). See https://amd-gaia.ai/docs/guides/sd."
+            agent_not_installed_message(
+                "sd",
+                package="sd agent",
+                retry_command="gaia sd",
+            )
+            + " See https://amd-gaia.ai/docs/guides/sd."
         ) from e
 
     # Ensure Lemonade is ready with proper context size for SD agent

--- a/src/gaia/eval/action_item_quality.py
+++ b/src/gaia/eval/action_item_quality.py
@@ -813,11 +813,15 @@ def generate_extractions(
             from gaia_agent_email.agent import EmailTriageAgent
             from gaia_agent_email.config import EmailAgentConfig
         except ImportError as exc:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                "The action-item extraction eval needs the email agent. Install "
-                "it with `pip install gaia-agent-email` (or `pip install "
-                '"amd-gaia[agents]"`). '
-                f"Original import error: {exc}"
+                agent_not_installed_message(
+                    "email",
+                    package="email agent (needed by the action-item extraction eval)",
+                    retry_command="gaia eval agent",
+                )
+                + f" Original import error: {exc}"
             ) from exc
 
         def agent_factory(backend: Any, db_path: str) -> Any:

--- a/src/gaia/eval/benchmark.py
+++ b/src/gaia/eval/benchmark.py
@@ -833,11 +833,15 @@ def run_benchmark(
                         CONTEXT_TARGET_TOKENS,
                     )
                 except ImportError as exc:
+                    from gaia.install_hints import agent_not_installed_message
+
                     raise RuntimeError(
-                        "The email throughput benchmark needs the email agent. "
-                        "Install it with `pip install gaia-agent-email` (or "
-                        '`pip install "amd-gaia[agents]"`). '
-                        f"Original import error: {exc}"
+                        agent_not_installed_message(
+                            "email",
+                            package="email agent (needed by the throughput benchmark)",
+                            retry_command="gaia eval benchmark",
+                        )
+                        + f" Original import error: {exc}"
                     ) from exc
 
                 try:

--- a/src/gaia/eval/briefing_quality.py
+++ b/src/gaia/eval/briefing_quality.py
@@ -745,11 +745,15 @@ def generate_briefings(
         try:
             from gaia_agent_email.briefing import run_briefing_job
         except ImportError as exc:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                "The briefing eval needs the email agent. Install it with "
-                "`pip install gaia-agent-email` (or `pip install "
-                '"amd-gaia[agents]"`). '
-                f"Original import error: {exc}"
+                agent_not_installed_message(
+                    "email",
+                    package="email agent (needed by the briefing eval)",
+                    retry_command="gaia eval agent",
+                )
+                + f" Original import error: {exc}"
             ) from exc
 
         def briefing_fn(backend: Any, max_msgs: int) -> Mapping[str, Any]:

--- a/src/gaia/eval/draft_quality.py
+++ b/src/gaia/eval/draft_quality.py
@@ -651,11 +651,15 @@ def generate_drafts(
             from gaia_agent_email.agent import EmailTriageAgent
             from gaia_agent_email.config import EmailAgentConfig
         except ImportError as exc:
+            from gaia.install_hints import agent_not_installed_message
+
             raise RuntimeError(
-                "The drafting eval needs the email agent. Install it with "
-                "`pip install gaia-agent-email` (or `pip install "
-                '"amd-gaia[agents]"`). '
-                f"Original import error: {exc}"
+                agent_not_installed_message(
+                    "email",
+                    package="email agent (needed by the drafting eval)",
+                    retry_command="gaia eval agent",
+                )
+                + f" Original import error: {exc}"
             ) from exc
 
         def agent_factory(backend: Any, db_path: str) -> Any:

--- a/src/gaia/eval/followup_quality.py
+++ b/src/gaia/eval/followup_quality.py
@@ -553,11 +553,15 @@ def _default_detector(
     try:
         from gaia_agent_email.tools.followup_tools import check_followups_impl
     except ImportError as exc:
+        from gaia.install_hints import agent_not_installed_message
+
         raise RuntimeError(
-            "The follow-up detection eval needs the email agent. Install it with "
-            "`pip install gaia-agent-email` (or `pip install "
-            '"amd-gaia[agents]"`). '
-            f"Original import error: {exc}"
+            agent_not_installed_message(
+                "email",
+                package="email agent (needed by the follow-up detection eval)",
+                retry_command="gaia eval agent",
+            )
+            + f" Original import error: {exc}"
         ) from exc
     return check_followups_impl(backend, window_days=window_days, now_ms=now_ms)
 

--- a/src/gaia/install_hints.py
+++ b/src/gaia/install_hints.py
@@ -1,0 +1,88 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""One truthful install hint for agents that ship outside the core wheel.
+
+Agents live in ``hub/agents/python/<id>/`` and are not published to PyPI, so
+a plain ``pip install`` of an agent distribution cannot work. The meta-extra
+that used to be recommended alongside it was worse than not working: being
+unsatisfiable, it made pip/uv backtrack to an old core version that lacked
+the extra and silently *downgrade* the user's install (issue #2240). Both
+phrases were copy-pasted into ~20 error messages; this module replaces them.
+
+What does work today is a git install pinned to the running core's version,
+which this module is the single source of. Keep it dependency-free (stdlib
+only) — it is imported from lightweight consumers such as
+``gaia.mcp.servers.docker_mcp`` and ``gaia.eval.*``.
+
+Publishing real wheels is tracked by #1179 / #1513; when that lands, this is
+the one place to change.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Optional
+
+_REPO = "https://github.com/amd/gaia.git"
+
+
+def agent_install_command(agent_id: str) -> str:
+    """Return the ``pip install`` command that actually installs *agent_id*.
+
+    The git ref is pinned to the installed core's version so the agent a user
+    is told to install always matches the core they are running. An unpinned
+    ``main`` ref would build whatever HEAD happens to be at install time and
+    execute its ``setup.py`` — there is no precedent for that anywhere in
+    this repo, and it is not something to put in a user-facing hint.
+
+    Raises:
+        RuntimeError: If the ``amd-gaia`` distribution has no installed
+            metadata to read a version from, since the alternative would be
+            emitting an unpinned command (CLAUDE.md: no silent fallbacks).
+    """
+    try:
+        core_version = importlib.metadata.version("amd-gaia")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise RuntimeError(
+            "Cannot build an agent install command: the 'amd-gaia' "
+            "distribution has no installed metadata, so there is no version "
+            "to pin the agent to. Install GAIA into this environment "
+            "('pip install -e .' from a checkout, or 'pip install amd-gaia') "
+            "and retry. See issue #2240."
+        ) from exc
+    return (
+        f'pip install "git+{_REPO}@v{core_version}'
+        f'#subdirectory=hub/agents/python/{agent_id}"'
+    )
+
+
+def agent_not_installed_message(
+    agent_id: str,
+    *,
+    package: str,
+    retry_command: str,
+    also_see: Optional[str] = None,
+) -> str:
+    """Return the standard "this agent isn't installed" message.
+
+    Args:
+        agent_id: Hub directory name, e.g. ``chat`` — also the git
+            subdirectory the install command points at.
+        package: Human-readable name for the message, e.g. ``chat agent``.
+        retry_command: What the user should re-run afterwards, e.g.
+            ``gaia chat``.
+        also_see: Optional extra pointer appended as its own sentence, e.g.
+            ``gaia chat --ui``.
+
+    Raises:
+        RuntimeError: Propagated from :func:`agent_install_command` when the
+            core version cannot be determined.
+    """
+    message = (
+        f"The {package} is not installed. Install it with:\n"
+        f"  {agent_install_command(agent_id)}\n"
+        f"Then re-run `{retry_command}`."
+    )
+    if also_see:
+        message += f" Custom and additional agents run in `{also_see}`."
+    return message

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -12,6 +12,7 @@ Main entry point for `gaia init` command that:
 5. Verifies setup is working
 """
 
+import importlib.util
 import logging
 import os
 import subprocess
@@ -1893,6 +1894,24 @@ class InitCommand:
             self._print_error(f"Verification failed: {e}")
             return False
 
+    def _chat_agent_install_step(self) -> Optional[str]:
+        """Return the install command if the chat agent is missing, else None.
+
+        `gaia init` installs models and Lemonade, never the chat agent, so
+        every profile whose banner recommends `gaia chat` can complete and
+        still dead-end on the very next command (#2240). Surface the missing
+        step instead of promising one that fails.
+
+        Uses find_spec rather than importing: importing gaia_agent_chat pulls
+        in the RAG/SD/VLM/MCP mixins, which is slow here and would misreport a
+        broken transitive dependency (faiss, torch) as "chat agent missing".
+        """
+        if importlib.util.find_spec("gaia_agent_chat") is not None:
+            return None
+        from gaia.install_hints import agent_install_command
+
+        return agent_install_command("chat")
+
     def _print_completion(self):
         """Print completion message with next steps."""
         if RICH_AVAILABLE and self.console:
@@ -1917,6 +1936,16 @@ class InitCommand:
                     "    [cyan]gaia sd -i[/cyan]                                        Interactive mode"
                 )
             elif self.profile == "chat":
+                install_step = self._chat_agent_install_step()
+                if install_step:
+                    self.console.print(
+                        "    [yellow]The chat agent is not installed yet — "
+                        "install it first:[/yellow]"
+                    )
+                    self.console.print(
+                        f"    [cyan]{install_step}[/cyan]", soft_wrap=True
+                    )
+                    self.console.print()
                 self.console.print(
                     "    [cyan]gaia chat[/cyan]                            Start interactive chat with RAG"
                 )
@@ -1930,6 +1959,16 @@ class InitCommand:
                     "    [cyan]gaia chat --ui[/cyan]                       Launch the Agent UI (browser-based)"
                 )
             elif self.profile == "npu":
+                install_step = self._chat_agent_install_step()
+                if install_step:
+                    self.console.print(
+                        "    [yellow]The chat agent is not installed yet — "
+                        "install it first:[/yellow]"
+                    )
+                    self.console.print(
+                        f"    [cyan]{install_step}[/cyan]", soft_wrap=True
+                    )
+                    self.console.print()
                 self.console.print(
                     "    [cyan]gaia chat --device npu[/cyan]             Chat using Ryzen AI NPU"
                 )
@@ -1959,6 +1998,16 @@ class InitCommand:
                 self.console.print("    [cyan]gaia init --profile chat[/cyan]")
             else:
                 # Default commands for other profiles
+                install_step = self._chat_agent_install_step()
+                if install_step:
+                    self.console.print(
+                        "    [yellow]The chat agent is not installed yet — "
+                        "install it first:[/yellow]"
+                    )
+                    self.console.print(
+                        f"    [cyan]{install_step}[/cyan]", soft_wrap=True
+                    )
+                    self.console.print()
                 self.console.print(
                     "    [cyan]gaia chat[/cyan]              Start interactive chat"
                 )
@@ -1990,6 +2039,13 @@ class InitCommand:
                     "    gaia sd -i                                        # Interactive mode"
                 )
             elif self.profile == "chat":
+                install_step = self._chat_agent_install_step()
+                if install_step:
+                    self._print(
+                        "    The chat agent is not installed yet — install it first:"
+                    )
+                    self._print(f"    {install_step}")
+                    self._print("")
                 self._print(
                     "    gaia chat                            # Start interactive chat with RAG"
                 )
@@ -2003,6 +2059,13 @@ class InitCommand:
                     "    gaia chat --ui                       # Launch the Agent UI (browser-based)"
                 )
             elif self.profile == "npu":
+                install_step = self._chat_agent_install_step()
+                if install_step:
+                    self._print(
+                        "    The chat agent is not installed yet — install it first:"
+                    )
+                    self._print(f"    {install_step}")
+                    self._print("")
                 self._print(
                     "    gaia chat --device npu             # Chat using Ryzen AI NPU"
                 )
@@ -2031,6 +2094,13 @@ class InitCommand:
                 self._print("    gaia init --profile chat")
             else:
                 # Default commands for other profiles
+                install_step = self._chat_agent_install_step()
+                if install_step:
+                    self._print(
+                        "    The chat agent is not installed yet — install it first:"
+                    )
+                    self._print(f"    {install_step}")
+                    self._print("")
                 self._print("    gaia chat              # Start interactive chat")
                 self._print(
                     "    gaia chat --ui         # Launch the Agent UI (browser-based)"

--- a/src/gaia/mcp/servers/docker_mcp.py
+++ b/src/gaia/mcp/servers/docker_mcp.py
@@ -29,10 +29,14 @@ def start_docker_mcp(
     try:
         from gaia_agent_docker.agent import DockerAgent
     except ImportError as e:
+        from gaia.install_hints import agent_not_installed_message
+
         raise ImportError(
-            "The docker agent is not installed. Install it with "
-            '`uv pip install gaia-agent-docker` (or `uv pip install "amd-gaia[agents]"` '
-            "for all AMD agents)."
+            agent_not_installed_message(
+                "docker",
+                package="docker agent",
+                retry_command="gaia mcp docker",
+            )
         ) from e
 
     # Prepare agent parameters

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -1402,10 +1402,14 @@ async def _get_chat_response(
             try:
                 from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
             except ImportError as e:
+                from gaia.install_hints import agent_not_installed_message
+
                 raise RuntimeError(
-                    "The chat agent is not installed. Run "
-                    "`pip install gaia-agent-chat` (or `pip install "
-                    '"amd-gaia[agents]"`), then restart the server.'
+                    agent_not_installed_message(
+                        "chat",
+                        package="chat agent",
+                        retry_command="gaia chat --ui",
+                    )
                 ) from e
 
             logger.info(
@@ -1845,10 +1849,14 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
                             ChatAgentConfig,
                         )
                     except ImportError as e:
+                        from gaia.install_hints import agent_not_installed_message
+
                         raise RuntimeError(
-                            "The chat agent is not installed. Run "
-                            "`pip install gaia-agent-chat` (or `pip install "
-                            '"amd-gaia[agents]"`), then restart the server.'
+                            agent_not_installed_message(
+                                "chat",
+                                package="chat agent",
+                                retry_command="gaia chat --ui",
+                            )
                         ) from e
 
                     logger.info(

--- a/src/gaia/ui/agent_loop.py
+++ b/src/gaia/ui/agent_loop.py
@@ -333,10 +333,14 @@ class AgentLoop:
                 try:
                     from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
                 except ImportError as e:
+                    from gaia.install_hints import agent_not_installed_message
+
                     raise RuntimeError(
-                        "The chat agent is not installed. Run "
-                        "`pip install gaia-agent-chat` (or `pip install "
-                        '"amd-gaia[agents]"`), then restart the server.'
+                        agent_not_installed_message(
+                            "chat",
+                            package="chat agent",
+                            retry_command="gaia chat --ui",
+                        )
                     ) from e
 
                 import gaia.ui._chat_helpers as _helpers

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -377,11 +377,14 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
                 try:
                     from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig
                 except ImportError as e:
+                    from gaia.install_hints import agent_not_installed_message
+
                     raise RuntimeError(
-                        "The chat agent is not installed. Install it with "
-                        "`pip install gaia-agent-chat` (or `pip install "
-                        '"amd-gaia[agents]"` for all agents) to run scheduled '
-                        "chat tasks."
+                        agent_not_installed_message(
+                            "chat",
+                            package="chat agent (needed to run scheduled chat tasks)",
+                            retry_command="gaia chat --ui",
+                        )
                     ) from e
 
                 # Beta dynamic tool loader (#1798). Inert here: scheduled runs

--- a/tests/unit/installer/test_init_completion_chat_hint.py
+++ b/tests/unit/installer/test_init_completion_chat_hint.py
@@ -1,0 +1,142 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""`gaia init`'s completion banner must not promise `gaia chat` when the chat
+agent isn't installed (#2240).
+
+Today `_print_completion()` prints `gaia chat` / `gaia chat --ui` unconditionally
+in the chat/npu/default-else branches, even on a bare `pip install amd-gaia`
+with no chat agent wheel present — the exact dead end the issue reports.
+
+Detection must use `importlib.util.find_spec("gaia_agent_chat")` (a real
+import would transitively drag in the RAG/SD/VLM/MCP mixins, and a broken
+transitive dependency would misreport as "chat agent not installed" — see
+CLAUDE.md's fail-loudly rule). Every test below patches
+`importlib.util.find_spec` directly (rather than some
+`gaia.installer.init_command`-local re-export) on the assumption the
+implementation calls it as qualified `importlib.util.find_spec(...)`
+(`import importlib.util`, not `from importlib.util import find_spec`) — the
+same qualified-access convention the plan mandates so the patch actually
+takes effect regardless of which module does the check.
+
+The `minimal` profile is explicitly out of scope (#2240) — it already only
+recommends `gaia llm 'Hello'` plus `gaia init --profile chat`, and must not
+grow a find_spec guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.installer.init_command import InitCommand
+
+
+def _printed_strings(mock_console: MagicMock) -> str:
+    """Join only the string args passed to console.print().
+
+    Rich's completion header is a `Panel(...)` object, not a string — its
+    default `str()` embeds a live memory address (`<rich.panel.Panel object
+    at 0x...>`), which differs across otherwise-identical runs and would
+    make any equality comparison over the full printed text flaky. Only the
+    plain-string print() calls (the actual quick-start lines) are relevant
+    to what this test suite asserts.
+    """
+    return "\n".join(
+        c.args[0]
+        for c in mock_console.print.call_args_list
+        if c.args and isinstance(c.args[0], str)
+    )
+
+
+def _rich_output(profile: str, chat_agent_installed: bool) -> str:
+    """Render the rich-console completion banner and return the printed text."""
+    cmd = InitCommand(profile=profile, yes=True)
+    cmd.console = MagicMock()
+    find_spec_result = object() if chat_agent_installed else None
+    with patch("importlib.util.find_spec", return_value=find_spec_result):
+        cmd._print_completion()
+    return _printed_strings(cmd.console)
+
+
+def _plain_output(profile: str, chat_agent_installed: bool, capsys) -> str:
+    """Render the plain-text completion banner (RICH_AVAILABLE forced False)."""
+    cmd = InitCommand(profile=profile, yes=True)
+    find_spec_result = object() if chat_agent_installed else None
+    with (
+        patch("gaia.installer.init_command.RICH_AVAILABLE", False),
+        patch("importlib.util.find_spec", return_value=find_spec_result),
+    ):
+        cmd._print_completion()
+    return capsys.readouterr().out
+
+
+@pytest.mark.parametrize("profile", ["chat", "npu", "all"])
+def test_rich_banner_unchanged_when_chat_agent_present(profile):
+    """The "all" profile exercises the default/else branch — all three recommend gaia chat."""
+    printed = _rich_output(profile, chat_agent_installed=True)
+    assert "gaia chat" in printed
+    assert "not installed" not in printed.lower()
+
+
+@pytest.mark.parametrize("profile", ["chat", "npu", "all"])
+def test_rich_banner_shows_install_hint_before_chat_commands_when_absent(profile):
+    printed = _rich_output(profile, chat_agent_installed=False)
+    assert "not installed" in printed.lower()
+    # The install hint text must appear before the `gaia chat` quick-start
+    # line, not after — a user reading top-to-bottom needs the install step
+    # first.
+    install_pos = printed.lower().find("not installed")
+    chat_cmd_pos = printed.find("gaia chat")
+    assert install_pos != -1 and chat_cmd_pos != -1
+    assert install_pos < chat_cmd_pos
+    # And the hint must be truthful — no broken advice (#2240).
+    assert "amd-gaia[agents]" not in printed
+    assert "pip install gaia-agent-" not in printed
+
+
+@pytest.mark.parametrize("profile", ["chat", "npu", "all"])
+def test_plain_banner_shows_install_hint_before_chat_commands_when_absent(
+    profile, capsys
+):
+    printed = _plain_output(profile, chat_agent_installed=False, capsys=capsys)
+    assert "not installed" in printed.lower()
+    install_pos = printed.lower().find("not installed")
+    chat_cmd_pos = printed.find("gaia chat")
+    assert install_pos != -1 and chat_cmd_pos != -1
+    assert install_pos < chat_cmd_pos
+    assert "amd-gaia[agents]" not in printed
+    assert "pip install gaia-agent-" not in printed
+
+
+@pytest.mark.parametrize("profile", ["chat", "npu", "all"])
+def test_plain_banner_unchanged_when_chat_agent_present(profile, capsys):
+    printed = _plain_output(profile, chat_agent_installed=True, capsys=capsys)
+    assert "gaia chat" in printed
+    assert "not installed" not in printed.lower()
+
+
+def test_minimal_profile_never_calls_find_spec_and_is_unaffected():
+    """Minimal is explicitly out of scope for the chat-agent guard (#2240)."""
+    cmd = InitCommand(profile="minimal", yes=True)
+    cmd.console = MagicMock()
+    with patch("importlib.util.find_spec") as mock_find_spec:
+        cmd._print_completion()
+    mock_find_spec.assert_not_called()
+
+    printed = _printed_strings(cmd.console)
+    assert "gaia llm" in printed
+    assert "gaia init --profile chat" in printed
+    assert "not installed" not in printed.lower()
+
+
+def test_minimal_profile_output_identical_regardless_of_chat_agent_presence():
+    outputs = []
+    for installed in (True, False):
+        cmd = InitCommand(profile="minimal", yes=True)
+        cmd.console = MagicMock()
+        find_spec_result = object() if installed else None
+        with patch("importlib.util.find_spec", return_value=find_spec_result):
+            cmd._print_completion()
+        outputs.append(_printed_strings(cmd.console))
+    assert outputs[0] == outputs[1]

--- a/tests/unit/test_agent_install_call_sites.py
+++ b/tests/unit/test_agent_install_call_sites.py
@@ -1,0 +1,61 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Integration-style locks on a couple of real agent-not-installed call
+sites (#2240). These exercise the actual code paths in ``gaia.cli`` and
+``gaia.api.agent_registry`` — no mocking of the import failure itself is
+needed, because ``gaia_agent_chat`` / ``gaia_agent_routing`` are genuinely
+not installed in the unit-test environment (they ship as separate hub
+wheels), so the real ``ImportError`` fires naturally.
+
+These are a spot-check, not the full backstop — ``test_agent_install_hints.py``
+(Increment 4's repo-wide guard test) is what prevents every other one of the
+~20 call sites from reintroducing the same broken advice.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.cli import async_main
+
+
+async def test_cli_chat_action_not_installed_message_is_truthful():
+    """`gaia chat` with no chat agent installed must not advise a broken
+    install path, and must point at `gaia chat --ui` per #2240."""
+    with pytest.raises(RuntimeError) as excinfo:
+        await async_main("chat", no_lemonade_check=True)
+    message = str(excinfo.value)
+    assert "amd-gaia[agents]" not in message
+    assert "pip install gaia-agent-" not in message
+    assert "uv pip install gaia-agent-" not in message
+    assert "gaia chat --ui" in message
+    # Working install path, pinned to the running core's version.
+    assert "git+https://github.com/amd/gaia.git@v" in message
+    assert "#subdirectory=hub/agents/python/chat" in message
+
+
+def test_api_agent_registry_gaia_code_hint_is_truthful():
+    """AgentRegistry.get_agent("gaia-code") must not advise a broken path
+    when gaia-agent-routing/gaia-agent-code aren't installed (#2240)."""
+    from gaia.api.agent_registry import AgentRegistry
+
+    with pytest.raises(ValueError) as excinfo:
+        AgentRegistry().get_agent("gaia-code")
+    message = str(excinfo.value)
+    assert "amd-gaia[agents]" not in message
+    assert "pip install gaia-agent-" not in message
+    assert "uv pip install gaia-agent-" not in message
+    assert "git+https://github.com/amd/gaia.git@v" in message
+
+
+def test_cli_blender_branch_local_extra_untouched():
+    """The blender install hint is a REAL local extra (setup.py `[blender]`)
+    and must not be swept into the shared agent_not_installed_message()
+    helper or the git-subdirectory install advice (#2240 explicitly
+    excludes it)."""
+    from pathlib import Path
+
+    import gaia.cli as cli_module
+
+    source = Path(cli_module.__file__).read_text(encoding="utf-8")
+    assert 'uv pip install -e ".[blender]"' in source

--- a/tests/unit/test_agent_install_hints.py
+++ b/tests/unit/test_agent_install_hints.py
@@ -1,0 +1,321 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Guard against reintroducing broken agent-install advice (issue #2240).
+
+`amd-gaia[agents]` names an unsatisfiable pip/uv extra (it lists 15
+`gaia-agent-<id>` packages, none of which are published) — an unsatisfiable
+extra doesn't fail cleanly, it makes the resolver backtrack past every
+version that declares it and silently *downgrade* the user's install. A bare
+`pip install gaia-agent-<id>` fails outright for the same reason: nothing is
+published. Both phrases were copy-pasted into ~20 raised error messages
+across `src/gaia/` and `hub/agents/python/`.
+
+Scope, stated explicitly so this test's coverage is unambiguous:
+
+* **In scope:** ``src/gaia/**/*.py`` and ``hub/agents/python/<id>/**/*.py``
+  (this deliberately includes each hub agent's own ``tests/`` subtree and
+  packaging scripts — nothing currently living there matches the patterns
+  below, by design; see the false-positive corpus this test was validated
+  against, in the PR description).
+* **Out of scope, deliberately — NOT covered by this test:** ``docs/**``
+  (fixed by hand in a separate increment), ``hub/agents/python/*/README.md``
+  (already hedge with "once published"), and
+  ``hub/agents/python/*/pyproject.toml`` (real dependency declarations, not
+  user-facing advice). Non-``.py`` files are also naturally skipped by the
+  ``*.py`` glob, but the README/pyproject exclusion is called out explicitly
+  so a reader doesn't assume docs are covered when they are not.
+
+No network calls (no PyPI queries) — this only reads local files with
+``ast``/regex.
+
+Why AST instead of a raw-text regex scan (the ``test_amd_gaia_urls.py``
+style): a naive regex for ``gaia-agent-[a-z0-9_-]+`` over raw file text hits
+many strings that are NOT install advice — console-script usage docstrings,
+argparse ``prog=``, health-check JSON payloads, pyproject-name assertions in
+each hub agent's own tests, a `--copy-metadata` pyinstaller flag, and a
+docstring in ``gaia/hub/publisher.py`` describing the *future* PyPI design.
+None of those are inside a raised exception. Every real offender in the
+current codebase (verified by reading each of the ~20 sites) is a string
+literal passed directly to a raised exception constructor (``raise
+RuntimeError(...)`` / ``ImportError(...)`` / ``ValueError(...)``) — so this
+test walks ``ast.Raise`` nodes specifically, not the whole file's text, for
+the ``gaia-agent-<name>`` pattern. One real site (``agent_registry.py``)
+builds its offending text in a local ``hint = "..."`` variable and
+interpolates it into the raise's f-string rather than writing the literal
+directly in the ``raise(...)`` call — so the scanner also resolves a simple
+one-level "name assigned a string literal earlier in the file, then
+referenced by a bare ``{name}`` in the raised f-string" indirection. This is
+a deliberate, narrow extension beyond pure literal-argument scanning; it is
+exercised directly by
+``test_scan_resolves_a_name_bound_to_a_literal_and_interpolated_into_the_raise``
+below.
+
+The `amd-gaia[agents]` bracket-extra syntax, by contrast, is dead syntax with
+no legitimate use anywhere in shipped source after the fix — so that check is
+intentionally NOT limited to raise() calls; it's a broad whole-file substring
+scan across the same in-scope files.
+
+An allowlist exists for future-proofing: once an agent wheel is actually
+published, its `gaia-agent-<id>` name becomes legitimate install advice and
+should be added to `_PUBLISHED_AGENT_WHEELS` below. It is empty today — all
+15 `gaia-agent-*` names 404 on PyPI as of this writing (issues #1179, #1513
+track publishing).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC_GAIA = REPO_ROOT / "src" / "gaia"
+_HUB_AGENTS_PYTHON = REPO_ROOT / "hub" / "agents" / "python"
+
+_BAD_PACKAGE_RE = re.compile(r"gaia-agent-[a-z0-9_-]+")
+_BRACKET_EXTRA = "amd-gaia[agents]"
+
+# Grows only once a hub agent wheel is actually published to PyPI (#1179,
+# #1513). Empty today.
+_PUBLISHED_AGENT_WHEELS: frozenset[str] = frozenset()
+
+
+def _in_scope_files() -> list[Path]:
+    """Every ``*.py`` under ``src/gaia/`` and each ``hub/agents/python/<id>/``.
+
+    Deliberately excludes docs/**, hub agent READMEs, and pyproject.toml —
+    see the module docstring.
+    """
+    files = list(_SRC_GAIA.rglob("*.py"))
+    if _HUB_AGENTS_PYTHON.is_dir():
+        for agent_dir in sorted(_HUB_AGENTS_PYTHON.iterdir()):
+            if agent_dir.is_dir():
+                files.extend(agent_dir.rglob("*.py"))
+    return sorted(files)
+
+
+def _string_literal_text(node: ast.AST) -> str:
+    """Return the literal string content of a Constant or a JoinedStr's
+    constant segments (FormattedValue expressions are not evaluated — a
+    variable's runtime value can't contain a hardcoded broken package name
+    from a variable alone; see the module docstring for the one exception
+    this scanner does resolve)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            value.value
+            for value in node.values
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        )
+    return ""
+
+
+def _build_name_literal_map(tree: ast.AST) -> dict:
+    """Resolve simple ``name = "literal"`` assignments anywhere in the file.
+
+    Deliberately not scope-aware (module- vs function-local) — this is a
+    lint-style heuristic, not an interpreter. It exists solely to catch the
+    one real call site (``agent_registry.py``) that builds its offending
+    text in a ``hint = "..."`` variable and interpolates it into the raised
+    f-string via a bare ``{hint}``, rather than writing the string directly
+    as a raise() argument.
+    """
+    mapping: dict = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        text = _string_literal_text(node.value)
+        if text:
+            mapping[node.targets[0].id] = text
+    return mapping
+
+
+def _raise_call_text(call: ast.Call, name_map: dict) -> str:
+    """Concatenate all string content passed to a raised exception's Call,
+    including one-level resolution of bare-Name f-string interpolations
+    against `name_map` (see `_build_name_literal_map`)."""
+    chunks = []
+    for arg in call.args:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            chunks.append(arg.value)
+        elif isinstance(arg, ast.JoinedStr):
+            for value in arg.values:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    chunks.append(value.value)
+                elif isinstance(value, ast.FormattedValue) and isinstance(
+                    value.value, ast.Name
+                ):
+                    resolved = name_map.get(value.value.id)
+                    if resolved:
+                        chunks.append(resolved)
+    return "".join(chunks)
+
+
+def _scan_file_for_bad_raises(path: Path) -> list[str]:
+    """Return one `"path:line: reason"` string per offending raise() in *path*."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return []
+
+    name_map = _build_name_literal_map(tree)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+            continue
+        combined = _raise_call_text(node.exc, name_map)
+        if not combined:
+            continue
+        bad_names = sorted(
+            {
+                m
+                for m in _BAD_PACKAGE_RE.findall(combined)
+                if m not in _PUBLISHED_AGENT_WHEELS
+            }
+        )
+        has_bracket_extra = _BRACKET_EXTRA in combined
+        if not bad_names and not has_bracket_extra:
+            continue
+        reasons = list(bad_names)
+        if has_bracket_extra:
+            reasons.append(_BRACKET_EXTRA)
+        offenders.append(f"{path}:{node.lineno}: {', '.join(reasons)}")
+    return offenders
+
+
+def _file_contains_bracket_extra_anywhere(path: Path) -> bool:
+    """Whole-file substring check — NOT limited to raise() calls. There is no
+    legitimate reason for `amd-gaia[agents]` to appear anywhere in shipped
+    source after #2240; unlike the `gaia-agent-<name>` pattern (which
+    legitimately appears in docstrings, health-check payloads, etc.), this
+    dead syntax gets no benefit-of-the-doubt scoping."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return False
+    return _BRACKET_EXTRA in text
+
+
+# ── Whole-repo scans (the actual regression guard) ──────────────────────────
+
+
+def test_no_raise_recommends_installing_an_unpublished_agent_package():
+    offenders: list[str] = []
+    for path in _in_scope_files():
+        offenders.extend(_scan_file_for_bad_raises(path))
+    assert not offenders, (
+        "raise() calls that advise installing an unpublished gaia-agent-* "
+        "package or the broken amd-gaia[agents] extra (issue #2240):\n  "
+        + "\n  ".join(str(o) for o in offenders)
+    )
+
+
+def test_amd_gaia_agents_extra_appears_nowhere_in_shipped_source():
+    offenders = [
+        str(path)
+        for path in _in_scope_files()
+        if _file_contains_bracket_extra_anywhere(path)
+    ]
+    assert not offenders, (
+        "amd-gaia[agents] must not appear anywhere in shipped source "
+        "(issue #2240) — an unsatisfiable pip/uv extra silently downgrades "
+        "installs:\n  " + "\n  ".join(offenders)
+    )
+
+
+# ── Semantic-lock tests: nail down the scanner's own matching rules ─────────
+# (self-contained tmp_path fixtures — these test the scanner's logic, not the
+# repo's current state, so they are expected to PASS even in the red phase.)
+
+
+def test_scan_flags_a_bare_pip_install_of_an_unpublished_package(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def f():\n" '    raise RuntimeError("pip install gaia-agent-foo")\n',
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_raises(
+        f
+    ), "a raise() naming gaia-agent-foo must be flagged"
+
+
+def test_scan_ignores_a_comment_mentioning_the_package_name(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "# comment mentioning gaia-agent-foo\n" "def f():\n" "    return 1\n",
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_raises(f) == []
+
+
+def test_scan_ignores_a_non_raise_assignment_of_the_package_name(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text('SERVICE_NAME = "gaia-agent-foo"\n', encoding="utf-8")
+    assert _scan_file_for_bad_raises(f) == []
+
+
+def test_scan_flags_the_bracket_extra_inside_a_raise(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def f():\n" "    raise ValueError('pip install \"amd-gaia[agents]\"')\n",
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_raises(
+        f
+    ), "a raise() naming amd-gaia[agents] must be flagged"
+
+
+def test_scan_ignores_an_fstring_whose_interpolated_value_is_a_real_variable(tmp_path):
+    """Mirrors cli.py's `wheel` variable case — the literal text around the
+    interpolation contains no gaia-agent- substring, only the runtime value
+    does, which this static scanner correctly can't (and shouldn't) see."""
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def f(wheel):\n" '    raise RuntimeError(f"install {wheel} for all agents")\n',
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_raises(f) == []
+
+
+def test_scan_resolves_a_name_bound_to_a_literal_and_interpolated_into_the_raise(
+    tmp_path,
+):
+    """Mirrors agent_registry.py's `hint` variable: the offending text is
+    assigned to a plain-string local earlier, then interpolated via a bare
+    `{name}` into the raised f-string."""
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def f():\n"
+        '    hint = "install gaia-agent-foo"\n'
+        '    raise ValueError(f"boom.{hint}")\n',
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_raises(f), "the resolved hint variable must be flagged"
+
+
+def test_bracket_extra_anywhere_flags_non_raise_usage(tmp_path):
+    """The broader bracket-extra scan (unlike the raise-scoped one) also
+    catches non-raise occurrences — e.g. a stray docstring or comment."""
+    f = tmp_path / "mod.py"
+    f.write_text('# See pip install "amd-gaia[agents]" for details\n', encoding="utf-8")
+    assert _file_contains_bracket_extra_anywhere(f) is True
+
+
+def test_bracket_extra_anywhere_false_when_absent(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("x = 1\n", encoding="utf-8")
+    assert _file_contains_bracket_extra_anywhere(f) is False
+
+
+def test_published_agent_wheels_allowlist_is_empty_today():
+    """Locks in the plan's stated fact so a silent edit doesn't go unnoticed;
+    bump this (and cite the publish PR) only once a wheel is actually live
+    on PyPI (#1179, #1513)."""
+    assert _PUBLISHED_AGENT_WHEELS == frozenset()

--- a/tests/unit/test_agent_install_hints.py
+++ b/tests/unit/test_agent_install_hints.py
@@ -7,7 +7,7 @@
 extra doesn't fail cleanly, it makes the resolver backtrack past every
 version that declares it and silently *downgrade* the user's install. A bare
 `pip install gaia-agent-<id>` fails outright for the same reason: nothing is
-published. Both phrases were copy-pasted into ~20 raised error messages
+published. Both phrases were copy-pasted into ~20 user-facing messages
 across `src/gaia/` and `hub/agents/python/`.
 
 Scope, stated explicitly so this test's coverage is unambiguous:
@@ -304,9 +304,9 @@ def test_scan_flags_an_fstring_whose_literal_segments_carry_the_bad_advice(tmp_p
     f = tmp_path / "mod.py"
     f.write_text(
         "def f(wheel):\n"
-        '    raise RuntimeError(\n'
+        "    raise RuntimeError(\n"
         '        f"install `uv pip install {wheel}` (or "\n'
-        '        f\'`uv pip install "amd-gaia[agents]"`)\'\n'
+        "        f'`uv pip install \"amd-gaia[agents]\"`)'\n"
         "    )\n",
         encoding="utf-8",
     )

--- a/tests/unit/test_agent_install_hints.py
+++ b/tests/unit/test_agent_install_hints.py
@@ -12,11 +12,11 @@ across `src/gaia/` and `hub/agents/python/`.
 
 Scope, stated explicitly so this test's coverage is unambiguous:
 
-* **In scope:** ``src/gaia/**/*.py`` and ``hub/agents/python/<id>/**/*.py``
-  (this deliberately includes each hub agent's own ``tests/`` subtree and
-  packaging scripts — nothing currently living there matches the patterns
-  below, by design; see the false-positive corpus this test was validated
-  against, in the PR description).
+* **In scope:** ``src/gaia/**/*.py`` and ``hub/agents/python/<id>/**/*.py``,
+  excluding any ``tests/`` subtree. Test files are skipped because they
+  legitimately assert on the very strings this guard forbids — both the
+  historical ones and the new replacement text — so scanning them would
+  make the guard flag its own fixtures.
 * **Out of scope, deliberately — NOT covered by this test:** ``docs/**``
   (fixed by hand in a separate increment), ``hub/agents/python/*/README.md``
   (already hedge with "once published"), and
@@ -28,32 +28,42 @@ Scope, stated explicitly so this test's coverage is unambiguous:
 No network calls (no PyPI queries) — this only reads local files with
 ``ast``/regex.
 
-Why AST instead of a raw-text regex scan (the ``test_amd_gaia_urls.py``
-style): a naive regex for ``gaia-agent-[a-z0-9_-]+`` over raw file text hits
-many strings that are NOT install advice — console-script usage docstrings,
-argparse ``prog=``, health-check JSON payloads, pyproject-name assertions in
-each hub agent's own tests, a `--copy-metadata` pyinstaller flag, and a
-docstring in ``gaia/hub/publisher.py`` describing the *future* PyPI design.
-None of those are inside a raised exception. Every real offender in the
-current codebase (verified by reading each of the ~20 sites) is a string
-literal passed directly to a raised exception constructor (``raise
-RuntimeError(...)`` / ``ImportError(...)`` / ``ValueError(...)``) — so this
-test walks ``ast.Raise`` nodes specifically, not the whole file's text, for
-the ``gaia-agent-<name>`` pattern. One real site (``agent_registry.py``)
-builds its offending text in a local ``hint = "..."`` variable and
-interpolates it into the raise's f-string rather than writing the literal
-directly in the ``raise(...)`` call — so the scanner also resolves a simple
-one-level "name assigned a string literal earlier in the file, then
-referenced by a bare ``{name}`` in the raised f-string" indirection. This is
-a deliberate, narrow extension beyond pure literal-argument scanning; it is
-exercised directly by
-``test_scan_resolves_a_name_bound_to_a_literal_and_interpolated_into_the_raise``
-below.
+**The discriminator, stated plainly:** a string literal is flagged when it
+contains BOTH
 
-The `amd-gaia[agents]` bracket-extra syntax, by contrast, is dead syntax with
-no legitimate use anywhere in shipped source after the fix — so that check is
-intentionally NOT limited to raise() calls; it's a broad whole-file substring
-scan across the same in-scope files.
+1. an install verb — ``pip install`` or ``uv pip install``; and
+2. a package that cannot be installed — ``gaia-agent-<name>`` (nothing is
+   published) or the exact broken extra ``amd-gaia[agents]``.
+
+Both halves are required, and this is a *content* test, not a *context*
+one — it deliberately does NOT care whether the literal sits in a
+``raise``, a ``print``, an f-string, a logger call, or a return value. An
+install hint can hide in any of them: ``gaia init``'s completion banner
+emits guidance through ``self._print(...)``, with existing precedent at
+``src/gaia/installer/init_command.py:1301,1304``
+(``"Run: pip install lemonade-sdk"``). Scoping this guard to ``raise``
+arguments would leave every ``print``-based hint uncovered — including the
+one this issue's own fix adds to that banner.
+
+Requiring the install verb is what makes an allowlist unnecessary. Every
+legitimate ``gaia-agent-<name>`` reference in the tree — console-script
+usage docstrings, argparse ``prog=``, health-check JSON payloads, the
+``--copy-metadata`` pyinstaller flag, pyproject-name assertions, plain
+comments — names the distribution without telling anyone to install it, so
+none contain an install verb and all fall out with nothing to maintain.
+
+Note the second half is ``amd-gaia[agents]`` exactly, NOT a broad
+``amd-gaia[`` prefix. ``amd-gaia[ui]``, ``[api]``, ``[dev]``, ``[publish]``
+and friends are real, working, still-declared extras; ~15 shipped hints
+recommend them correctly. Flagging those would repeat precisely the mistake
+this issue is about — mislabelling a functioning install path as a broken
+one (the same reason ``cli.py``'s ``pip install -e ".[blender]"`` branch is
+deliberately left alone).
+
+The `amd-gaia[agents]` bracket-extra syntax is additionally checked on its
+own, with no install-verb requirement: it is dead syntax with no legitimate
+use anywhere in shipped source after this fix, so that check is a broad
+whole-file substring scan across the same in-scope files.
 
 An allowlist exists for future-proofing: once an agent wheel is actually
 published, its `gaia-agent-<id>` name becomes legitimate install advice and
@@ -72,8 +82,15 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 _SRC_GAIA = REPO_ROOT / "src" / "gaia"
 _HUB_AGENTS_PYTHON = REPO_ROOT / "hub" / "agents" / "python"
 
-_BAD_PACKAGE_RE = re.compile(r"gaia-agent-[a-z0-9_-]+")
 _BRACKET_EXTRA = "amd-gaia[agents]"
+
+# Half 2 of the discriminator: a package that cannot be installed. Note the
+# exact `[agents]` — a bare `amd-gaia[` prefix would flag the working
+# [ui]/[api]/[dev]/[publish] extras (see the module docstring).
+_UNINSTALLABLE_RE = re.compile(r"gaia-agent-[a-z0-9_-]+|amd-gaia\[agents\]")
+
+# Half 1 of the discriminator: an install verb.
+_INSTALL_VERB_RE = re.compile(r"\b(?:uv\s+)?pip\s+install\b")
 
 # Grows only once a hub agent wheel is actually published to PyPI (#1179,
 # #1513). Empty today.
@@ -81,7 +98,8 @@ _PUBLISHED_AGENT_WHEELS: frozenset[str] = frozenset()
 
 
 def _in_scope_files() -> list[Path]:
-    """Every ``*.py`` under ``src/gaia/`` and each ``hub/agents/python/<id>/``.
+    """Every ``*.py`` under ``src/gaia/`` and each ``hub/agents/python/<id>/``,
+    excluding ``tests/`` subtrees.
 
     Deliberately excludes docs/**, hub agent READMEs, and pyproject.toml —
     see the module docstring.
@@ -91,71 +109,39 @@ def _in_scope_files() -> list[Path]:
         for agent_dir in sorted(_HUB_AGENTS_PYTHON.iterdir()):
             if agent_dir.is_dir():
                 files.extend(agent_dir.rglob("*.py"))
-    return sorted(files)
+    return sorted(f for f in files if "tests" not in f.parts)
 
 
-def _string_literal_text(node: ast.AST) -> str:
-    """Return the literal string content of a Constant or a JoinedStr's
-    constant segments (FormattedValue expressions are not evaluated — a
-    variable's runtime value can't contain a hardcoded broken package name
-    from a variable alone; see the module docstring for the one exception
-    this scanner does resolve)."""
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value
-    if isinstance(node, ast.JoinedStr):
-        return "".join(
-            value.value
-            for value in node.values
-            if isinstance(value, ast.Constant) and isinstance(value.value, str)
-        )
-    return ""
+def _iter_string_literals(tree: ast.AST):
+    """Yield ``(lineno, text)`` for every string literal in *tree*.
 
-
-def _build_name_literal_map(tree: ast.AST) -> dict:
-    """Resolve simple ``name = "literal"`` assignments anywhere in the file.
-
-    Deliberately not scope-aware (module- vs function-local) — this is a
-    lint-style heuristic, not an interpreter. It exists solely to catch the
-    one real call site (``agent_registry.py``) that builds its offending
-    text in a ``hint = "..."`` variable and interpolates it into the raised
-    f-string via a bare ``{hint}``, rather than writing the string directly
-    as a raise() argument.
+    Covers plain ``str`` constants (adjacent literals are already merged
+    into one node by the parser, so a hint split across several source
+    lines is seen whole) and f-strings, for which only the constant
+    segments are concatenated — a ``{variable}``'s runtime value is not
+    knowable statically and never supplies the literal ``pip install`` /
+    ``gaia-agent-`` characters this scanner matches on.
     """
-    mapping: dict = {}
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
-            continue
-        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
-            continue
-        text = _string_literal_text(node.value)
-        if text:
-            mapping[node.targets[0].id] = text
-    return mapping
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.lineno, node.value
+        elif isinstance(node, ast.JoinedStr):
+            text = "".join(
+                value.value
+                for value in node.values
+                if isinstance(value, ast.Constant) and isinstance(value.value, str)
+            )
+            if text:
+                yield node.lineno, text
 
 
-def _raise_call_text(call: ast.Call, name_map: dict) -> str:
-    """Concatenate all string content passed to a raised exception's Call,
-    including one-level resolution of bare-Name f-string interpolations
-    against `name_map` (see `_build_name_literal_map`)."""
-    chunks = []
-    for arg in call.args:
-        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-            chunks.append(arg.value)
-        elif isinstance(arg, ast.JoinedStr):
-            for value in arg.values:
-                if isinstance(value, ast.Constant) and isinstance(value.value, str):
-                    chunks.append(value.value)
-                elif isinstance(value, ast.FormattedValue) and isinstance(
-                    value.value, ast.Name
-                ):
-                    resolved = name_map.get(value.value.id)
-                    if resolved:
-                        chunks.append(resolved)
-    return "".join(chunks)
+def _scan_file_for_bad_install_hints(path: Path) -> list[str]:
+    """Return one ``"path:line: reason"`` per offending literal in *path*.
 
-
-def _scan_file_for_bad_raises(path: Path) -> list[str]:
-    """Return one `"path:line: reason"` string per offending raise() in *path*."""
+    A literal offends when it carries an install verb AND names something
+    that cannot be installed — see the module docstring for why both halves
+    are required and why context (raise vs print vs return) is irrelevant.
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except (UnicodeDecodeError, OSError):
@@ -165,28 +151,22 @@ def _scan_file_for_bad_raises(path: Path) -> list[str]:
     except SyntaxError:
         return []
 
-    name_map = _build_name_literal_map(tree)
     offenders: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+    seen: set = set()
+    for lineno, literal in _iter_string_literals(tree):
+        if not _INSTALL_VERB_RE.search(literal):
             continue
-        combined = _raise_call_text(node.exc, name_map)
-        if not combined:
-            continue
-        bad_names = sorted(
+        bad = sorted(
             {
-                m
-                for m in _BAD_PACKAGE_RE.findall(combined)
-                if m not in _PUBLISHED_AGENT_WHEELS
+                match
+                for match in _UNINSTALLABLE_RE.findall(literal)
+                if match not in _PUBLISHED_AGENT_WHEELS
             }
         )
-        has_bracket_extra = _BRACKET_EXTRA in combined
-        if not bad_names and not has_bracket_extra:
+        if not bad or (lineno, tuple(bad)) in seen:
             continue
-        reasons = list(bad_names)
-        if has_bracket_extra:
-            reasons.append(_BRACKET_EXTRA)
-        offenders.append(f"{path}:{node.lineno}: {', '.join(reasons)}")
+        seen.add((lineno, tuple(bad)))
+        offenders.append(f"{path}:{lineno}: {', '.join(bad)}")
     return offenders
 
 
@@ -206,13 +186,13 @@ def _file_contains_bracket_extra_anywhere(path: Path) -> bool:
 # ── Whole-repo scans (the actual regression guard) ──────────────────────────
 
 
-def test_no_raise_recommends_installing_an_unpublished_agent_package():
+def test_no_shipped_string_advises_installing_an_unpublished_package():
     offenders: list[str] = []
     for path in _in_scope_files():
-        offenders.extend(_scan_file_for_bad_raises(path))
+        offenders.extend(_scan_file_for_bad_install_hints(path))
     assert not offenders, (
-        "raise() calls that advise installing an unpublished gaia-agent-* "
-        "package or the broken amd-gaia[agents] extra (issue #2240):\n  "
+        "install hints naming an unpublished gaia-agent-* package or the "
+        "broken amd-gaia[agents] extra (issue #2240):\n  "
         + "\n  ".join(str(o) for o in offenders)
     )
 
@@ -235,15 +215,28 @@ def test_amd_gaia_agents_extra_appears_nowhere_in_shipped_source():
 # repo's current state, so they are expected to PASS even in the red phase.)
 
 
-def test_scan_flags_a_bare_pip_install_of_an_unpublished_package(tmp_path):
+def test_scan_flags_a_pip_install_of_an_unpublished_package(tmp_path):
     f = tmp_path / "mod.py"
     f.write_text(
         "def f():\n" '    raise RuntimeError("pip install gaia-agent-foo")\n',
         encoding="utf-8",
     )
-    assert _scan_file_for_bad_raises(
+    assert _scan_file_for_bad_install_hints(
         f
-    ), "a raise() naming gaia-agent-foo must be flagged"
+    ), "a hint naming gaia-agent-foo must be flagged"
+
+
+def test_scan_flags_a_hint_inside_a_print_not_only_a_raise(tmp_path):
+    """The discriminator is content, not context — `gaia init`'s banner emits
+    guidance via print(), and that path must be covered too (#2240)."""
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def f():\n" '    print("Install it with: pip install gaia-agent-foo")\n',
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_install_hints(
+        f
+    ), "a print()-based hint must be flagged just like a raise()"
 
 
 def test_scan_ignores_a_comment_mentioning_the_package_name(tmp_path):
@@ -252,24 +245,44 @@ def test_scan_ignores_a_comment_mentioning_the_package_name(tmp_path):
         "# comment mentioning gaia-agent-foo\n" "def f():\n" "    return 1\n",
         encoding="utf-8",
     )
-    assert _scan_file_for_bad_raises(f) == []
+    assert _scan_file_for_bad_install_hints(f) == []
 
 
-def test_scan_ignores_a_non_raise_assignment_of_the_package_name(tmp_path):
+def test_scan_ignores_the_package_name_without_an_install_verb(tmp_path):
+    """The install verb is what separates advice from mere reference — this
+    is why no allowlist is needed for prog=/docstrings/health payloads."""
     f = tmp_path / "mod.py"
-    f.write_text('SERVICE_NAME = "gaia-agent-foo"\n', encoding="utf-8")
-    assert _scan_file_for_bad_raises(f) == []
+    f.write_text(
+        'SERVICE_NAME = "gaia-agent-foo"\n'
+        'PROG = "gaia-agent-foo"\n'
+        '"""Smoke tests for the standalone gaia-agent-foo package."""\n',
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_install_hints(f) == []
 
 
-def test_scan_flags_the_bracket_extra_inside_a_raise(tmp_path):
+def test_scan_ignores_an_install_verb_for_a_working_extra(tmp_path):
+    """amd-gaia[ui]/[api]/[dev]/[publish] are real, declared, working extras.
+    Flagging them would mislabel a functioning install path as broken — the
+    same mistake #2240 exists to fix."""
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def f():\n"
+        '    raise RuntimeError("Install it with: uv pip install \\"amd-gaia[ui]\\"")\n',
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_install_hints(f) == []
+
+
+def test_scan_flags_the_broken_agents_extra(tmp_path):
     f = tmp_path / "mod.py"
     f.write_text(
         "def f():\n" "    raise ValueError('pip install \"amd-gaia[agents]\"')\n",
         encoding="utf-8",
     )
-    assert _scan_file_for_bad_raises(
+    assert _scan_file_for_bad_install_hints(
         f
-    ), "a raise() naming amd-gaia[agents] must be flagged"
+    ), "a hint naming amd-gaia[agents] must be flagged"
 
 
 def test_scan_ignores_an_fstring_whose_interpolated_value_is_a_real_variable(tmp_path):
@@ -278,31 +291,51 @@ def test_scan_ignores_an_fstring_whose_interpolated_value_is_a_real_variable(tmp
     does, which this static scanner correctly can't (and shouldn't) see."""
     f = tmp_path / "mod.py"
     f.write_text(
-        "def f(wheel):\n" '    raise RuntimeError(f"install {wheel} for all agents")\n',
+        "def f(wheel):\n"
+        '    raise RuntimeError(f"pip install {wheel} for all agents")\n',
         encoding="utf-8",
     )
-    assert _scan_file_for_bad_raises(f) == []
+    assert _scan_file_for_bad_install_hints(f) == []
 
 
-def test_scan_resolves_a_name_bound_to_a_literal_and_interpolated_into_the_raise(
-    tmp_path,
-):
-    """Mirrors agent_registry.py's `hint` variable: the offending text is
-    assigned to a plain-string local earlier, then interpolated via a bare
-    `{name}` into the raised f-string."""
+def test_scan_flags_an_fstring_whose_literal_segments_carry_the_bad_advice(tmp_path):
+    """Mirrors cli.py:821 — the interpolated `{wheel}` is opaque, but the
+    literal text around it still names the broken extra."""
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "def f(wheel):\n"
+        '    raise RuntimeError(\n'
+        '        f"install `uv pip install {wheel}` (or "\n'
+        '        f\'`uv pip install "amd-gaia[agents]"`)\'\n'
+        "    )\n",
+        encoding="utf-8",
+    )
+    assert _scan_file_for_bad_install_hints(
+        f
+    ), "literal f-string segments naming the broken extra must be flagged"
+
+
+def test_scan_flags_a_hint_split_across_adjacent_source_lines(tmp_path):
+    """The real call sites wrap the hint across several adjacent string
+    literals; the parser merges them, so the verb and the package are seen
+    together even though neither line carries both."""
     f = tmp_path / "mod.py"
     f.write_text(
         "def f():\n"
-        '    hint = "install gaia-agent-foo"\n'
-        '    raise ValueError(f"boom.{hint}")\n',
+        "    raise RuntimeError(\n"
+        '        "The chat agent is not installed. Install it with "\n'
+        '        "`pip install gaia-agent-chat`, then retry."\n'
+        "    )\n",
         encoding="utf-8",
     )
-    assert _scan_file_for_bad_raises(f), "the resolved hint variable must be flagged"
+    assert _scan_file_for_bad_install_hints(
+        f
+    ), "a hint split across adjacent literals must still be flagged"
 
 
-def test_bracket_extra_anywhere_flags_non_raise_usage(tmp_path):
-    """The broader bracket-extra scan (unlike the raise-scoped one) also
-    catches non-raise occurrences — e.g. a stray docstring or comment."""
+def test_bracket_extra_anywhere_flags_non_hint_usage(tmp_path):
+    """The broader bracket-extra scan (unlike the discriminator) needs no
+    install verb — it catches a stray docstring or comment too."""
     f = tmp_path / "mod.py"
     f.write_text('# See pip install "amd-gaia[agents]" for details\n', encoding="utf-8")
     assert _file_contains_bracket_extra_anywhere(f) is True

--- a/tests/unit/test_agent_pypi_publish.py
+++ b/tests/unit/test_agent_pypi_publish.py
@@ -18,6 +18,7 @@ wiring by ``test_cli_agent.py``.
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from pathlib import Path
@@ -143,10 +144,16 @@ def test_helper_matrix_format_matches_packages(packages):
 
 
 def test_helper_rejects_missing_package(tmp_path):
-    """A dist in the extra with no on-disk package fails loudly (no silent skip)."""
+    """A dist in AGENT_PACKAGES with no on-disk package fails loudly (no silent skip).
+
+    Issue #2240: the source of truth moved from `extras_require["agents"]`
+    (an unsatisfiable pip/uv extra that silently downgraded installs) to a
+    plain module-level `AGENT_PACKAGES = [...]` constant. The fixture below
+    reflects that new contract.
+    """
     fake_setup = tmp_path / "setup.py"
     fake_setup.write_text(
-        'setup(\n    extras_require={"agents": ["gaia-agent-doesnotexist"]},\n)\n',
+        'AGENT_PACKAGES = ["gaia-agent-doesnotexist"]\n',
         encoding="utf-8",
     )
     with pytest.raises(lap.AgentListError, match="no package at"):
@@ -154,14 +161,78 @@ def test_helper_rejects_missing_package(tmp_path):
 
 
 def test_helper_rejects_bad_naming(tmp_path):
-    """A dist not following gaia-agent-<id> fails loudly."""
+    """A dist not following gaia-agent-<id> fails loudly (#2240: AGENT_PACKAGES)."""
     fake_setup = tmp_path / "setup.py"
     fake_setup.write_text(
-        'setup(\n    extras_require={"agents": ["totally-wrong-name"]},\n)\n',
+        'AGENT_PACKAGES = ["totally-wrong-name"]\n',
         encoding="utf-8",
     )
     with pytest.raises(lap.AgentListError, match="naming convention"):
         lap.list_agent_packages(setup_py=fake_setup)
+
+
+def test_setup_py_has_no_agents_extra_or_agent_star_extras():
+    """extras_require in the real setup.py must not declare the removed
+    keys (#2240): `agents` (an unsatisfiable pip/uv extra that silently
+    downgrades a working install) and every single-agent `agent-<id>` extra.
+    """
+    setup_py = REPO_ROOT / "setup.py"
+    tree = ast.parse(setup_py.read_text(encoding="utf-8"), filename=str(setup_py))
+
+    extras_require_dict = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.keyword) and node.arg == "extras_require":
+            extras_require_dict = node.value
+            break
+    assert isinstance(
+        extras_require_dict, ast.Dict
+    ), "setup.py: extras_require is not a dict literal"
+
+    keys = {
+        key.value
+        for key in extras_require_dict.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+    assert "agents" not in keys, "setup.py[agents] must be removed (issue #2240)"
+    bad_keys = {k for k in keys if k.startswith("agent-")}
+    assert (
+        not bad_keys
+    ), f"setup.py must not declare per-agent extras: {bad_keys} (#2240)"
+
+
+def test_setup_py_declares_module_level_agent_packages_constant():
+    """#2240: the publish/CI inventory moves to a module-level AGENT_PACKAGES
+    constant, deliberately NOT an extras_require entry (see setup.py's
+    removal comment, which must cite #1179/#1513)."""
+    setup_py = REPO_ROOT / "setup.py"
+    source = setup_py.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(setup_py))
+
+    found = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "AGENT_PACKAGES"
+        ):
+            found = ast.literal_eval(node.value)
+            break
+
+    assert found is not None, (
+        "setup.py must declare a module-level `AGENT_PACKAGES = [...]` "
+        "constant (issue #2240)"
+    )
+    assert isinstance(found, list) and all(isinstance(d, str) for d in found)
+    assert len(found) == 15, f"expected 15 agent packages, got {len(found)}: {found}"
+    assert all(d.startswith("gaia-agent-") for d in found)
+
+    # The removal comment must name the tracking issues so a future reader
+    # knows what re-adds the extra.
+    assert "#1179" in source and "#1513" in source, (
+        "setup.py's AGENT_PACKAGES / removed-extras comment must cite "
+        "issues #1179 and #1513 (publishing tracker)"
+    )
 
 
 # ── --only filter tests (#1598) ──────────────────────────────────────────────

--- a/tests/unit/test_install_hints.py
+++ b/tests/unit/test_install_hints.py
@@ -1,0 +1,198 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Contract tests for the shared agent-not-installed message helper (#2240).
+
+Today ~20 call sites hand-roll their own "agent not installed" text, and two
+of the phrases they use don't work: ``pip install gaia-agent-<id>`` (no such
+package is published) and ``pip install "amd-gaia[agents]"`` (an unsatisfiable
+extra that makes pip/uv silently *downgrade* a working install). This module
+locks in the contract for the replacement: a single helper,
+``gaia.install_hints.agent_not_installed_message``, that only ever emits
+advice that works today.
+
+``gaia.install_hints`` does not exist yet — every test below is expected to
+fail with ``ModuleNotFoundError`` until it is implemented. That is the
+intended red-phase state.
+
+Interface assumed (documented here since no implementation exists to read):
+
+    def agent_not_installed_message(
+        agent_id: str,
+        *,
+        package: str,
+        retry_command: str,
+        also_see: str | None = None,
+    ) -> str
+
+``also_see`` is this test file's assumed mechanism for the chat-specific
+requirement that the message point at ``gaia chat --ui`` as where custom
+agents run today. If the real implementation instead special-cases
+``agent_id == "chat"`` internally (no ``also_see`` kwarg), only
+``test_chat_message_mentions_agent_ui_and_does_not_imply_a_routing_decision``
+needs adjusting — the rest of this file does not depend on that kwarg.
+
+Two tests assume the implementation calls the qualified
+``importlib.metadata.version(...)`` / raises via qualified
+``importlib.metadata.PackageNotFoundError`` (i.e. ``import importlib.metadata``,
+not ``from importlib.metadata import version``) so that patching
+``importlib.metadata.version`` takes effect — mirroring the qualified
+``importlib.util.find_spec(...)`` style mandated for Increment 3. If the real
+helper does a bare ``from ... import version`` instead, these two tests will
+fail because the patch silently has no effect (the real installed amd-gaia
+version leaks through) rather than because of missing pinning logic; switch
+the import style to qualified access to fix it.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import subprocess  # nosec B404 - fixed argv, no shell
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def _import_helper():
+    from gaia.install_hints import agent_not_installed_message
+
+    return agent_not_installed_message
+
+
+def test_message_is_version_pinned_never_a_bare_main_ref():
+    """The git-install command must pin @v{version}, never a bare main ref."""
+    agent_not_installed_message = _import_helper()
+    with patch("importlib.metadata.version", return_value="9.9.9"):
+        msg = agent_not_installed_message(
+            "chat", package="chat agent", retry_command="gaia chat"
+        )
+    assert "@v9.9.9" in msg
+    assert "@main" not in msg
+    assert "#main" not in msg
+    assert "/main#" not in msg
+
+
+def test_message_shape_is_the_git_subdirectory_install():
+    """The exact working install command must appear, subdirectory-scoped."""
+    agent_not_installed_message = _import_helper()
+    with patch("importlib.metadata.version", return_value="9.9.9"):
+        msg = agent_not_installed_message(
+            "chat", package="chat agent", retry_command="gaia chat"
+        )
+    assert (
+        "git+https://github.com/amd/gaia.git@v9.9.9#subdirectory=hub/agents/python/chat"
+        in msg
+    )
+
+
+def test_message_never_mentions_the_broken_bracket_extra():
+    agent_not_installed_message = _import_helper()
+    with patch("importlib.metadata.version", return_value="9.9.9"):
+        msg = agent_not_installed_message(
+            "sd", package="sd agent", retry_command="gaia sd"
+        )
+    assert "amd-gaia[agents]" not in msg
+
+
+def test_message_never_recommends_a_bare_pip_install_of_the_unpublished_wheel():
+    agent_not_installed_message = _import_helper()
+    with patch("importlib.metadata.version", return_value="9.9.9"):
+        msg = agent_not_installed_message(
+            "docker", package="docker agent", retry_command="gaia docker"
+        )
+    assert "pip install gaia-agent-" not in msg
+    assert "uv pip install gaia-agent-" not in msg
+
+
+def test_message_mentions_the_retry_command_verbatim():
+    agent_not_installed_message = _import_helper()
+    with patch("importlib.metadata.version", return_value="9.9.9"):
+        msg = agent_not_installed_message(
+            "jira", package="jira agent", retry_command="gaia jira"
+        )
+    assert "gaia jira" in msg
+
+
+def test_package_not_found_error_fails_loudly_not_silently_unpinned():
+    """A source checkout with no installed amd-gaia metadata must raise, not
+    silently emit an unpinned URL (fail-loudly, CLAUDE.md)."""
+    agent_not_installed_message = _import_helper()
+    with patch(
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError("amd-gaia"),
+    ):
+        with pytest.raises(RuntimeError) as excinfo:
+            agent_not_installed_message(
+                "chat", package="chat agent", retry_command="gaia chat"
+            )
+    message = str(excinfo.value)
+    assert message, "the raised error must carry an actionable message"
+    # No unpinned fallback URL of any kind.
+    assert "git+https://github.com/amd/gaia.git#" not in message
+
+
+def test_chat_message_mentions_agent_ui_and_does_not_imply_a_routing_decision():
+    """The chat message must state the fact plainly, not sound like GAIA chose
+    the built-in agent over a custom one (the reporter's actual misreading)."""
+    agent_not_installed_message = _import_helper()
+    with patch("importlib.metadata.version", return_value="9.9.9"):
+        msg = agent_not_installed_message(
+            "chat",
+            package="chat agent",
+            retry_command="gaia chat",
+            also_see="gaia chat --ui",
+        )
+    lowered = msg.lower()
+    assert "prefers" not in lowered
+    assert "instead of your" not in lowered
+    assert "chose" not in lowered
+    assert "gaia chat --ui" in msg
+
+
+def test_install_hints_module_has_no_heavy_top_level_imports():
+    """gaia.install_hints must be importable without pulling in the agent
+    stack (RAG/SD/VLM/MCP/torch/faiss/fastapi) — it is used from lightweight
+    consumers like gaia.mcp.servers.docker_mcp and gaia.eval.* (#2240).
+
+    This runs in a fresh subprocess so an already-populated sys.modules in
+    the current test process (e.g. from importing other gaia submodules
+    earlier in the run) can't mask a real regression.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys\n"
+            "before = set(sys.modules)\n"
+            "import gaia.install_hints\n"
+            "after = set(sys.modules) - before\n"
+            "print(','.join(sorted(after)))\n",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "importing gaia.install_hints failed:\n" + result.stderr
+    )
+    newly_imported = (
+        set(result.stdout.strip().split(",")) if result.stdout.strip() else set()
+    )
+    heavy_prefixes = (
+        "torch",
+        "faiss",
+        "fastapi",
+        "sentence_transformers",
+        "transformers",
+        "mcp",
+        "uvicorn",
+        "gaia.agents",
+        "gaia.rag",
+        "gaia.sd",
+        "gaia.vlm",
+        "gaia.apps",
+    )
+    offenders = {m for m in newly_imported if m.startswith(heavy_prefixes)}
+    assert (
+        not offenders
+    ), f"gaia.install_hints pulled in heavy modules at import time: {offenders}"

--- a/tests/unit/test_install_hints.py
+++ b/tests/unit/test_install_hints.py
@@ -150,9 +150,20 @@ def test_chat_message_mentions_agent_ui_and_does_not_imply_a_routing_decision():
 
 
 def test_install_hints_module_has_no_heavy_top_level_imports():
-    """gaia.install_hints must be importable without pulling in the agent
-    stack (RAG/SD/VLM/MCP/torch/faiss/fastapi) — it is used from lightweight
-    consumers like gaia.mcp.servers.docker_mcp and gaia.eval.* (#2240).
+    """gaia.install_hints must add no import cost beyond the unavoidable
+    baseline of importing the top-level `gaia` package.
+
+    `src/gaia/__init__.py` already unconditionally imports
+    `gaia.agents.base` (which chains into `gaia.agents.__init__`'s
+    optional `gaia.apps.llm.app` import) — that is pre-existing baseline
+    behavior paid by literally any `import gaia.<anything>` today,
+    independent of this module (verified empirically: a bare `import gaia`
+    alone already populates sys.modules with gaia.agents, gaia.agents.base,
+    and gaia.apps.llm.app). This test therefore captures "before" *after*
+    that unavoidable baseline import, so it measures only the incremental
+    cost `gaia.install_hints` itself adds — which must be zero heavy
+    modules, since it's used from lightweight consumers like
+    gaia.mcp.servers.docker_mcp and gaia.eval.* (#2240).
 
     This runs in a fresh subprocess so an already-populated sys.modules in
     the current test process (e.g. from importing other gaia submodules
@@ -163,6 +174,7 @@ def test_install_hints_module_has_no_heavy_top_level_imports():
             sys.executable,
             "-c",
             "import sys\n"
+            "import gaia\n"  # pay the unavoidable package-init tax first
             "before = set(sys.modules)\n"
             "import gaia.install_hints\n"
             "after = set(sys.modules) - before\n"

--- a/util/list_agent_packages.py
+++ b/util/list_agent_packages.py
@@ -90,8 +90,7 @@ def _read_agent_packages_constant(setup_py: Path) -> List[str]:
             dists = ast.literal_eval(node.value)
         except ValueError as exc:
             raise AgentListError(
-                f"setup.py: AGENT_PACKAGES is not a literal list of strings: "
-                f"{exc}."
+                f"setup.py: AGENT_PACKAGES is not a literal list of strings: {exc}."
             ) from exc
         if not isinstance(dists, list) or not all(isinstance(d, str) for d in dists):
             raise AgentListError(

--- a/util/list_agent_packages.py
+++ b/util/list_agent_packages.py
@@ -2,22 +2,31 @@
 # SPDX-License-Identifier: MIT
 """List the AMD production agent packages that ship as ``gaia-agent-<id>`` wheels.
 
-Single source of truth = the ``agents`` entry of ``extras_require`` in
-``setup.py`` (the same list behind ``pip install "amd-gaia[agents]"``). This
-script reads that list *statically* (``ast``, never executing ``setup.py``),
-maps each ``gaia-agent-<id>`` distribution name to its package directory under
-``hub/agents/python/<id>/``, and verifies the directory exists.
+Single source of truth = the module-level ``AGENT_PACKAGES`` constant in
+``setup.py``. This script reads that list *statically* (``ast``, never
+executing ``setup.py``), maps each ``gaia-agent-<id>`` distribution name to
+its package directory under ``hub/agents/python/<id>/``, and verifies the
+directory exists.
+
+Issue #2240: this used to read ``extras_require["agents"]`` — the list
+backing a real ``pip install "amd-gaia[agents]"`` extra. That extra named
+packages that were never published, which made it unsatisfiable; pip/uv
+handled that by silently backtracking to an old version that lacked the
+extra, *downgrading* a working install. The inventory moved to a plain
+constant so it stops being installable syntax while remaining the single
+source of truth for CI (see setup.py's removal comment for the full story;
+re-adding an extra is tracked by #1179 / #1513).
 
 Consumers:
 
 * ``.github/workflows/publish_agents.yml`` calls ``--format matrix`` to generate
-  the build/publish matrix, so adding an agent to ``setup.py[agents]`` is all it
+  the build/publish matrix, so adding an agent to ``setup.py``'s ``AGENT_PACKAGES`` is all it
   takes to start publishing its wheel — no second list to keep in sync.
 * ``tests/unit/test_agent_pypi_publish.py`` calls :func:`list_agent_packages`
   to assert the published set, the on-disk packages, and their ``amd-gaia``
   dependency all agree.
 
-Per ``CLAUDE.md`` (No Silent Fallbacks): a distribution listed in the extra with
+Per ``CLAUDE.md`` (No Silent Fallbacks): a distribution listed in the constant with
 no matching ``hub/agents/python/<id>/`` directory, or a malformed ``setup.py``,
 raises rather than silently dropping the agent from the publish set.
 """
@@ -57,8 +66,8 @@ class AgentPackage:
         return self.path.relative_to(REPO_ROOT).as_posix()
 
 
-def _read_agents_extra(setup_py: Path) -> List[str]:
-    """Return the string list under ``extras_require["agents"]`` in *setup_py*.
+def _read_agent_packages_constant(setup_py: Path) -> List[str]:
+    """Return the string list assigned to ``AGENT_PACKAGES`` in *setup_py*.
 
     Parses statically with :mod:`ast` — ``setup.py`` is never imported or run.
     """
@@ -70,51 +79,45 @@ def _read_agents_extra(setup_py: Path) -> List[str]:
     tree = ast.parse(setup_py.read_text(encoding="utf-8"), filename=str(setup_py))
 
     for node in ast.walk(tree):
-        if not (isinstance(node, ast.keyword) and node.arg == "extras_require"):
+        if not (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "AGENT_PACKAGES"
+        ):
             continue
-        if not isinstance(node.value, ast.Dict):
+        try:
+            dists = ast.literal_eval(node.value)
+        except ValueError as exc:
             raise AgentListError(
-                "setup.py: extras_require is not a dict literal — cannot derive "
-                "the production-agent list statically."
+                f"setup.py: AGENT_PACKAGES is not a literal list of strings: "
+                f"{exc}."
+            ) from exc
+        if not isinstance(dists, list) or not all(isinstance(d, str) for d in dists):
+            raise AgentListError(
+                "setup.py: AGENT_PACKAGES must be a list of distribution-name "
+                "strings."
             )
-        for key, value in zip(node.value.keys, node.value.values):
-            if isinstance(key, ast.Constant) and key.value == "agents":
-                try:
-                    dists = ast.literal_eval(value)
-                except ValueError as exc:
-                    raise AgentListError(
-                        f"setup.py: extras_require['agents'] is not a literal "
-                        f"list of strings: {exc}."
-                    ) from exc
-                if not isinstance(dists, list) or not all(
-                    isinstance(d, str) for d in dists
-                ):
-                    raise AgentListError(
-                        "setup.py: extras_require['agents'] must be a list of "
-                        "distribution-name strings."
-                    )
-                return dists
-        raise AgentListError(
-            "setup.py: extras_require has no 'agents' key. Add it (the meta "
-            "extra behind 'pip install \"amd-gaia[agents]\"')."
-        )
+        return dists
     raise AgentListError(
-        "setup.py: no extras_require keyword found in the setup() call."
+        "setup.py: no module-level 'AGENT_PACKAGES' assignment found. Add it "
+        "(the static list of production agent wheels; see issue #2240 — it "
+        "is deliberately not a pip extra)."
     )
 
 
 def list_agent_packages(setup_py: Path = SETUP_PY) -> List[AgentPackage]:
-    """Return the production agent packages declared by ``setup.py[agents]``.
+    """Return the production agent packages declared by ``setup.py``'s ``AGENT_PACKAGES``.
 
     Raises:
         AgentListError: For a malformed list, a distribution name that does not
             start with ``gaia-agent-``, or a missing package directory.
     """
     packages: List[AgentPackage] = []
-    for dist in _read_agents_extra(setup_py):
+    for dist in _read_agent_packages_constant(setup_py):
         if not dist.startswith(DIST_PREFIX):
             raise AgentListError(
-                f"distribution {dist!r} in setup.py[agents] does not follow the "
+                f"distribution {dist!r} in setup.py's AGENT_PACKAGES does not follow the "
                 f"'{DIST_PREFIX}<id>' naming convention required by issue #1179."
             )
         agent_id = dist[len(DIST_PREFIX) :]
@@ -122,8 +125,8 @@ def list_agent_packages(setup_py: Path = SETUP_PY) -> List[AgentPackage]:
         if not (path / "pyproject.toml").exists():
             raise AgentListError(
                 f"{dist}: no package at {path}/pyproject.toml. Every entry in "
-                f"setup.py[agents] must have a wheel source under "
-                f"hub/agents/python/<id>/ (or remove it from the extra)."
+                f"setup.py's AGENT_PACKAGES must have a wheel source under "
+                f"hub/agents/python/<id>/ (or remove it from the list)."
             )
         packages.append(AgentPackage(dist_name=dist, agent_id=agent_id, path=path))
     return packages
@@ -142,7 +145,7 @@ def main(argv: List[str] | None = None) -> int:
         "--only",
         metavar="AGENT_ID",
         help="filter output to a single agent by id (e.g. email); fails loudly "
-        "if the id is not found in setup.py[agents]",
+        "if the id is not found in setup.py's AGENT_PACKAGES",
     )
     args = parser.parse_args(argv)
 
@@ -157,7 +160,7 @@ def main(argv: List[str] | None = None) -> int:
         if not filtered:
             valid = ", ".join(p.agent_id for p in packages)
             print(
-                f"error: agent id {args.only!r} not found in setup.py[agents]. "
+                f"error: agent id {args.only!r} not found in setup.py's AGENT_PACKAGES. "
                 f"Valid ids: {valid}",
                 file=sys.stderr,
             )


### PR DESCRIPTION
Closes #2240

A new user ran `gaia init --profile npu`, followed the next step it printed, and hit a wall. `gaia chat` told them to run one of two install commands. **Neither works** — and one of them actively damages a working install:

```
uv pip install "amd-gaia[agents]"   →  amd-gaia 0.22.0 DOWNGRADED to 0.20.0
uv pip install "amd-gaia"           →  0.22.0        (correct)
```

Asking for agents left them on an **older** GAIA than not asking. The `[agents]` extra named 15 `gaia-agent-*` packages that are not published, which makes it unsatisfiable — so the resolver backtracks past every version declaring it and lands on 0.20.0, where a missing extra is merely a warning. `pip` and `uv` behave identically; this was not a uv quirk.

`gaia init` set the trap itself: its completion banner recommends `gaia chat`, while every profile ships `pip_extras` that install no agent. GAIA recommended a command it had not made runnable, then the resulting error recommended two more that could not work.

Now the guidance is true everywhere. The one install command GAIA prints is one that works, pinned to the version of the core actually running:

```
The chat agent is not installed. Install it with:
  pip install "git+https://github.com/amd/gaia.git@v0.22.0#subdirectory=hub/agents/python/chat"
Then re-run `gaia chat`. Custom and additional agents run in `gaia chat --ui`.
```

The same untrue sentence had been copy-pasted into ~55 places across 31 files, so it now comes from one helper instead — the next person cannot get it wrong in a 56th place, and a guard test fails the build if they try.

**This does not publish any wheels.** Publishing stays with #1179 / #1513, and #2085 §2 flags it as needing an explicit decision first.

## Evidence

Verified on a Ryzen AI MAX+ 395 in a **fresh venv with no chat agent** — a new user's actual starting state.

The extra that caused the downgrade is gone, and every legitimate extra survives:
```
extras: ['api','audio','blender','dev','eval','image','lint','litellm','mcp',
         'publish','rag','talk','telegram','ui','youtube']
agents extra present : False
any agent-* extra    : NONE
```

`gaia init`'s chat banner now leads with the install step instead of dead-ending:
```
pip install "git+https://github.com/amd/gaia.git@v0.22.0#subdirectory=hub/agents/python/chat"
gaia chat                            Start interactive chat with RAG
gaia chat --ui                       Launch the Agent UI (browser-based)
```

The replacement command resolves cleanly and touches only the agent:
```
uv pip install --dry-run "git+...@v0.22.0#subdirectory=hub/agents/python/chat"
  → Would install 1 package: gaia-agent-chat
```

## Notes for the reviewer

- **This helps 0.23.0 onward only.** 0.22.0's metadata is already published and immutable, and the wrong message ships *inside* 0.22.0, so today's users still need the workaround documented on the issue.
- The install command is **version-pinned** via `importlib.metadata.version("amd-gaia")`. An unpinned `main` ref would have had users building whatever HEAD happened to be and executing its `setup.py`; there is no precedent for that anywhere in this repo.
- `setup.py`'s agent inventory moved from `extras_require["agents"]` to a plain `AGENT_PACKAGES` constant. This is load-bearing: `publish_agents.yml`'s `discover` job runs `list_agent_packages.py` on **every `v*` tag** and is *not* behind the `if: false` publish guard, so deleting the key without repointing it would have turned every future release tag red.
- `cli.py`'s blender branch is deliberately untouched — it refers to `.[blender]`, a real working extra (0 lines of it in the diff).
- The guard test flags a string containing `pip install` **and** `gaia-agent-`/`amd-gaia[agents]`. Scoping on `pip install` is what removes the need for an allowlist — legitimate references (`prog=`, health-check JSON, `--copy-metadata`) never contain it. It is deliberately narrowed to `amd-gaia[agents]` rather than `amd-gaia[`, since `[ui]`/`[api]`/`[dev]` are real extras that hints correctly recommend.
- Docs examples pin `@v0.23.0`, assuming the next release. If the version lands differently, three examples need a touch-up.

## Test plan

- [x] `python -m pytest tests/unit/` — 6431 passed; 6 failures confirmed pre-existing on the stashed baseline
- [x] `python util/lint.py --all` — 8/8 checks pass
- [x] `python util/list_agent_packages.py --format matrix` — exits 0, returns all 15 agents from `AGENT_PACKAGES`
- [x] `tests/unit/test_agent_pypi_publish.py` — 15/15
- [x] Guard test fails on a reintroduced bad hint; makes no network calls
- [x] Real-world: fresh venv on AMD hardware — extras gone, new error message, init banner guarded (above)
- [ ] Not run: `discover` job against a live `v*` tag (verified locally instead)