### PR TITLE
feat(cli): add `gaia agent run <id>` for custom and built-in agents

### DIFF
--- a/docs/guides/custom-agent.mdx
+++ b/docs/guides/custom-agent.mdx
@@ -10,7 +10,7 @@ icon: "wand-magic-sparkles"
 
 ## Overview
 
-GAIA's agent registry lets you extend the Agent UI with your own custom agents. Each agent lives in its own directory under `~/.gaia/agents/` as a Python module. Once placed there, the agent appears automatically in the **agent selector** dropdown of the Gaia Agent UI.
+GAIA's agent registry lets you extend the Agent UI with your own custom agents. Each agent lives in its own directory under `~/.gaia/agents/` as a Python module. Once placed there, the agent appears automatically in the **agent selector** dropdown of the Gaia Agent UI — and can be launched from the terminal with [`gaia agent run <id>`](#run-your-agent-from-the-cli), no UI required.
 
 Custom agents can have their own:
 - **Personality and instructions** (system prompt)
@@ -189,6 +189,38 @@ is a working reference for both `oauth_pkce` (Google) and `mcp_server`
   Walks through what connectors are, how the OAuth + MCP flows differ,
   per-agent grants, and a step-by-step setup for Google and GitHub.
 </Card>
+
+---
+
+## Run your agent from the CLI
+
+The Agent UI isn't the only way to talk to a custom agent. `gaia agent run <id>`
+launches any agent GAIA can discover — a custom agent under `~/.gaia/agents/`
+or a built-in — the same way `gaia agent status` lists it:
+
+```bash
+# Interactive session
+gaia agent run my-agent
+
+# Single query, non-interactive
+gaia agent run my-agent -q "What can you help me with?"
+
+# List the agent's registered tools and exit
+gaia agent run my-agent --list-tools
+```
+
+`<id>` is the agent's `AGENT_ID` — the same id shown in the `AGENT` column of
+`gaia agent status`. An unknown id fails with the list of ids that *are*
+registered, rather than a bare traceback:
+
+```bash
+$ gaia agent run no-such-agent
+Error: Unknown agent ID: 'no-such-agent'. Registered agents: builder, my-agent
+```
+
+`run` accepts `--model`, `--stream`, `--max-steps`, and `--allowed-paths`,
+mirroring `gaia browse`/`gaia analyze`. See the
+[CLI reference](/reference/cli#agent-command) for the full flag list.
 
 ---
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -488,6 +488,49 @@ gaia agent status            # every discovered agent
 ```
 </CodeGroup>
 
+#### Running: `run`
+
+Launch any registered agent — a custom agent under `~/.gaia/agents/<id>/` or a
+built-in — by id. Shares the same discover/construct path as `gaia browse`/
+`gaia analyze`, so any id `gaia agent status` lists can be run.
+
+```bash
+gaia agent run <id> [--query QUERY] [--debug] [--model NAME] [--stream] \
+    [--max-steps N] [--allowed-paths PATH ...] [--list-tools]
+```
+
+An unknown id fails with the ids that *are* registered, instead of a
+traceback. An agent that fails to construct reports the id and the
+underlying cause.
+
+| Option | Description |
+|--------|-------------|
+| `id` | Agent id to run (positional, required) |
+| `--query`, `-q` | Single query to run non-interactively (default: interactive mode) |
+| `--debug` | Enable debug output |
+| `--model` | Model ID to use (default: auto-selected by the agent) |
+| `--stream` | Enable real-time streaming of LLM responses |
+| `--max-steps` | Maximum conversation steps (default: the agent's own default) |
+| `--allowed-paths` | Allowed directory paths for file operations |
+| `--list-tools` | List the agent's registered tools and exit |
+
+**Examples:**
+
+<CodeGroup>
+```bash Run interactively
+gaia agent run my-agent
+```
+
+```bash Single query
+gaia agent run my-agent -q "What can you help me with?"
+```
+
+```bash Unknown id
+gaia agent run no-such-agent
+# Error: Unknown agent ID: 'no-such-agent'. Registered agents: builder, my-agent
+```
+</CodeGroup>
+
 #### Distribution: `pack`, `publish`, `login`
 
 Build a distributable wheel from a Python agent package, then dual-publish it to the Agent Hub (R2, the source for the Hub UI) **and** PyPI (the source for `pip install`).

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -829,7 +829,7 @@ async def async_main(action, **kwargs):
         # standalone gaia-agent-browser / gaia-agent-analyst wheels (#1102);
         # resolve them through the registry so the framework doesn't hard-import
         # the external packages.
-        from gaia.agents.registry import AgentRegistry
+        from gaia import cli_agent
 
         agent_id = "web" if action == "browse" else "data"
         wheel = "gaia-agent-browser" if action == "browse" else "gaia-agent-analyst"
@@ -850,17 +850,19 @@ async def async_main(action, **kwargs):
             debug=kwargs.get("debug", False),
             allowed_paths=kwargs.get("allowed_paths", None),
         )
-        registry = AgentRegistry()
-        registry.discover()
-        if registry.get(agent_id) is None:
-            raise RuntimeError(
-                agent_not_installed_message(
-                    f"The '{action}' agent is not installed",
-                    wheel,
-                    next_step=f"Then re-run `gaia {action}`.",
-                )
-            )
-        agent = registry.create_agent(agent_id, **agent_config_kwargs)
+        # Shared discover/get/create_agent path with `gaia agent run` (#2242) —
+        # one mechanism, not a parallel copy per caller. The not-found hint is
+        # passed lazily (a callable) so it's only built — and only reads
+        # installed-package metadata — on the actual not-found path.
+        agent = cli_agent.resolve_and_create_agent(
+            agent_id,
+            agent_config_kwargs,
+            not_found_message=lambda: agent_not_installed_message(
+                f"The '{action}' agent is not installed",
+                wheel,
+                next_step=f"Then re-run `gaia {action}`.",
+            ),
+        )
 
         try:
             if kwargs.get("list_tools", False):
@@ -6889,7 +6891,7 @@ def handle_agent_command(args):
         print("❌ Error: No agent action specified")
         print(
             "Available actions: init, version, test, configure, health, status, "
-            "export, import"
+            "run, export, import"
         )
         print("Run 'gaia agent --help' for more information")
         sys.exit(1)

--- a/src/gaia/cli_agent.py
+++ b/src/gaia/cli_agent.py
@@ -32,7 +32,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from gaia.logger import get_logger
 from gaia.version import __version__ as GAIA_VERSION
@@ -247,6 +247,49 @@ def register_subparsers(agent_subparsers) -> None:
         help="Agent id (omit to show every discovered agent)",
     )
 
+    run_p = agent_subparsers.add_parser(
+        "run",
+        help="Run a registered agent (custom or built-in) by id",
+    )
+    run_p.add_argument(
+        "id", help="Agent id to run, e.g. 'jarvis' (custom) or 'chat' (built-in)"
+    )
+    run_p.add_argument(
+        "--query",
+        "-q",
+        type=str,
+        default=None,
+        help="Single query to execute (defaults to interactive mode if not provided)",
+    )
+    run_p.add_argument("--debug", action="store_true", help="Enable debug output")
+    run_p.add_argument(
+        "--model",
+        default=None,
+        help="Model ID to use (default: auto-selected by the agent)",
+    )
+    run_p.add_argument(
+        "--stream",
+        action="store_true",
+        help="Enable real-time streaming of LLM responses",
+    )
+    run_p.add_argument(
+        "--max-steps",
+        type=int,
+        default=None,
+        help="Maximum conversation steps (default: the agent's own default)",
+    )
+    run_p.add_argument(
+        "--allowed-paths",
+        nargs="+",
+        default=None,
+        help="Allowed directory paths for file operations",
+    )
+    run_p.add_argument(
+        "--list-tools",
+        action="store_true",
+        help="List the agent's registered tools and exit",
+    )
+
     login_p = agent_subparsers.add_parser(
         "login",
         help="Store publisher tokens (R2 Hub and/or PyPI) in the OS keyring",
@@ -291,6 +334,7 @@ def handle(args) -> bool:
         "configure": cmd_configure,
         "health": cmd_health,
         "status": cmd_status,
+        "run": cmd_run,
     }
     fn = dispatch.get(action)
     if fn is None:
@@ -1031,6 +1075,100 @@ def _build_registry():
     registry = AgentRegistry()
     registry.discover()
     return registry
+
+
+def resolve_and_create_agent(
+    agent_id: str,
+    agent_config_kwargs: Dict[str, Any],
+    *,
+    not_found_message: Optional[Callable[[], str]] = None,
+) -> Any:
+    """Discover, resolve, and construct *agent_id* through the registry.
+
+    The single discover → get → create_agent path shared by ``gaia browse``/
+    ``gaia analyze`` (``gaia.cli``) and ``gaia agent run`` (this module) — one
+    mechanism, not a parallel copy per caller (#2242).
+
+    Args:
+        agent_id: Registry id to resolve — a built-in id (e.g. ``web``), a
+            hub-installed id, or a custom agent's ``AGENT_ID``.
+        agent_config_kwargs: Forwarded to the resolved registration's factory.
+        not_found_message: Lazily-evaluated message to raise when *agent_id*
+            isn't registered. Evaluated only on the not-found path so a
+            caller-supplied hint (e.g. one that reads installed package
+            metadata to build a pip-install pointer) never runs on the happy
+            path. When omitted, a generic message lists every registered id.
+
+    Raises:
+        RuntimeError: *agent_id* is not registered (either the caller's hint
+            or the generic "unknown id" message), or it is registered but its
+            factory raised while constructing it.
+    """
+    registry = _build_registry()
+
+    if registry.get(agent_id) is None:
+        if not_found_message is not None:
+            raise RuntimeError(not_found_message())
+        available = sorted(reg.id for reg in registry.list())
+        raise RuntimeError(
+            f"Unknown agent ID: '{agent_id}'. Registered agents: "
+            f"{', '.join(available) if available else '(none discovered)'}"
+        )
+
+    try:
+        return registry.create_agent(agent_id, **agent_config_kwargs)
+    except Exception as exc:  # pylint: disable=broad-except
+        raise RuntimeError(
+            f"Agent '{agent_id}' is registered but failed to start: {exc}"
+        ) from exc
+
+
+def cmd_run(args) -> None:
+    """Run any registered agent (custom or built-in) by id.
+
+    Shares the discover/get/construct path used by ``gaia browse``/``gaia
+    analyze`` via :func:`resolve_and_create_agent`, so a user's own
+    ``~/.gaia/agents/<id>/agent.py`` runs through the exact same mechanism as
+    a built-in — there is no second, custom-only construction path (#2242).
+    """
+    agent_config_kwargs = dict(
+        model_id=args.model,
+        # None → global default (default_max_steps / env) in Agent.
+        max_steps=args.max_steps,
+        streaming=args.stream,
+        show_stats=False,
+        silent_mode=not (args.debug or args.list_tools),
+        debug=args.debug,
+        allowed_paths=args.allowed_paths,
+    )
+
+    try:
+        agent = resolve_and_create_agent(args.id, agent_config_kwargs)
+    except RuntimeError as exc:
+        raise AgentWorkflowError(str(exc)) from exc
+
+    try:
+        if args.list_tools:
+            agent.list_tools(verbose=True)
+            return
+
+        if args.query:
+            result = agent.process_query(args.query, trace=False)
+            if result.get("status") != "success":
+                sys.exit(1)
+            return
+
+        print(f"Starting {agent.__class__.__name__}. Type /quit to exit.")
+        while True:
+            user_input = input("\nYou: ").strip()
+            if not user_input:
+                continue
+            if user_input.lower() in {"/quit", "/exit"}:
+                return
+            agent.process_query(user_input, trace=False)
+    finally:
+        if hasattr(agent, "close"):
+            agent.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gaia_agent_run.py
+++ b/tests/unit/test_gaia_agent_run.py
@@ -18,10 +18,49 @@ the ``run`` subcommand does not exist yet.
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _repair_closed_root_logger_streams():
+    """Repair any root-logger ``StreamHandler`` left pointed at a dead stream.
+
+    ``gaia.logger.GaiaLogger`` is a module-level singleton: its console
+    ``StreamHandler`` is created once, at first import, bound to whatever
+    ``sys.stdout`` object was current at that moment. If this test file is
+    run on its own (rather than as part of the full suite, where some
+    earlier-collected module imports ``gaia.logger`` before any test's
+    ``capsys`` fixture activates), that first import can happen *inside*
+    an earlier test's ``capsys``-captured context. ``capsys`` then closes
+    its captured stream when that test ends, leaving the handler holding a
+    stale reference — and the next ``logger.warning()``/``.error()`` call
+    from *any* test crashes ``emit()`` with "I/O operation on closed
+    file", which logging reports by dumping a raw traceback to the
+    now-current ``sys.stderr``. Several tests below assert no raw
+    traceback leaks into `gaia agent run`'s own output, so this file's
+    correctness must not depend on which test (in this file or another)
+    happens to import ``gaia.logger`` first.
+
+    Only handlers whose *current* stream is already closed are touched —
+    pytest's own ``_pytest.logging`` handlers are also plain
+    ``StreamHandler`` instances (bound to a live, open ``CaptureIO``), and
+    reassigning those unconditionally corrupts pytest's own log capture.
+    Checking ``.closed`` first keeps this scoped to the one broken handler.
+    """
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if isinstance(handler, logging.StreamHandler) and not isinstance(
+            handler, logging.FileHandler
+        ):
+            stream = getattr(handler, "stream", None)
+            if stream is not None and getattr(stream, "closed", False):
+                handler.stream = sys.stdout
+    yield
+
 
 # ---------------------------------------------------------------------------
 # Fixture helpers — write a real ~/.gaia/agents/<id>/agent.py to disk so

--- a/tests/unit/test_gaia_agent_run.py
+++ b/tests/unit/test_gaia_agent_run.py
@@ -1,0 +1,340 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Failing (TDD) contract tests for ``gaia agent run <id>`` (#2242).
+
+There is currently no CLI path to launch an arbitrary registered agent (built-in
+or a user's custom agent under ``~/.gaia/agents/<id>/agent.py``) other than the
+two hardcoded verbs ``gaia browse``/``gaia analyze``. These tests fix the
+observable CLI contract for the new ``gaia agent run <id>`` subcommand *before*
+it is implemented, per TDD. They deliberately do not import or assume the name
+of the shared discover/get/create_agent helper the implementation will add —
+only ``gaia.agents.registry.AgentRegistry`` (already public) and the CLI entry
+point (``gaia.cli.main``) are treated as fixed surface.
+
+Every test in this module is expected to FAIL until #2242 is implemented,
+typically with an argparse ``SystemExit(2)`` ("invalid choice: 'run'") since
+the ``run`` subcommand does not exist yet.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — write a real ~/.gaia/agents/<id>/agent.py to disk so
+# gaia.agents.registry.AgentRegistry.discover() picks it up exactly the way a
+# real user's custom agent would be discovered (no mocking of discovery
+# itself).
+# ---------------------------------------------------------------------------
+
+_MARKER_AGENT_TEMPLATE = '''\
+from gaia.agents.base.agent import Agent
+
+
+class {cls}(Agent):
+    """Test-only custom agent for #2242 CLI contract tests."""
+
+    AGENT_ID = "{id}"
+    AGENT_NAME = "{cls}"
+
+    def __init__(self, **kwargs):
+        # Force skip_lemonade so construction never needs a live Lemonade
+        # server, regardless of what the CLI/registry thread through.
+        kwargs["skip_lemonade"] = True
+        kwargs["silent_mode"] = False
+        super().__init__(**kwargs)
+
+    def _register_tools(self):
+        pass
+
+    def process_query(self, query, **kwargs):
+        # No LLM call at all — the response is a canned marker so the test
+        # can prove this exact class's process_query ran with this query,
+        # without needing a live Lemonade server.
+        print("CUSTOM_MARKER_RESPONSE::" + str(query))
+        return dict(status="success", result="custom-response-to::" + str(query))
+'''
+
+_EXPLODING_AGENT_TEMPLATE = '''\
+from gaia.agents.base.agent import Agent
+
+
+class {cls}(Agent):
+    """Test-only custom agent whose constructor always raises (#2242)."""
+
+    AGENT_ID = "{id}"
+    AGENT_NAME = "{cls}"
+
+    def __init__(self, **kwargs):
+        raise RuntimeError(
+            "synthetic-construction-failure: {id} always fails to construct "
+            "(test fixture for #2242)"
+        )
+
+    def _register_tools(self):
+        pass
+'''
+
+
+def _write_custom_agent(
+    home: Path, agent_id: str, class_name: str, template: str
+) -> Path:
+    """Write a ``~/.gaia/agents/<agent_id>/agent.py`` under *home*."""
+    agent_dir = home / ".gaia" / "agents" / agent_id
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.py").write_text(
+        template.format(cls=class_name, id=agent_id), encoding="utf-8"
+    )
+    return agent_dir
+
+
+def _run_cli(argv):
+    """Invoke ``gaia.cli.main()`` with *argv* as ``sys.argv``, restoring after."""
+    from gaia import cli
+
+    original_argv = sys.argv
+    try:
+        sys.argv = argv
+        return cli.main()
+    finally:
+        sys.argv = original_argv
+
+
+# ---------------------------------------------------------------------------
+# 1. Unknown agent id -> actionable error naming both the bad id and a real
+#    registered id, non-zero exit, no raw traceback.
+# ---------------------------------------------------------------------------
+
+
+def test_run_unknown_agent_id_reports_available_ids(monkeypatch, tmp_path, capsys):
+    # Sandbox HOME so AgentRegistry.discover() sees a clean, deterministic set
+    # of agents (no leftover custom agents from the real environment).
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from gaia.agents.registry import AgentRegistry
+
+    registry = AgentRegistry()
+    registry.discover()
+    known_ids = [reg.id for reg in registry.list()]
+    assert known_ids, (
+        "expected at least one real registered agent id (e.g. the 'builder' "
+        "built-in) to assert against — if this fails, the test environment "
+        "itself has no discoverable agents at all"
+    )
+
+    bogus_id = "totally-bogus-agent-id-2242"
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run_cli(["gaia", "agent", "run", bogus_id, "-q", "hello"])
+
+    assert excinfo.value.code not in (0, None), "unknown agent id must exit non-zero"
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert bogus_id in combined, "error must name the unknown id the user typed"
+    assert any(kid in combined for kid in known_ids), (
+        "error must name at least one real registered agent id so the user "
+        "knows what IS available"
+    )
+    assert "Traceback (most recent call last)" not in combined, (
+        "an unknown agent id must produce a clean CLI error, not a raw "
+        "Python traceback"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. A registered custom_python agent resolves and is actually constructed
+#    (not just "no crash" — proven via a class-specific marker in the
+#    --list-tools output, which only prints if the real custom class was
+#    instantiated and its console reached).
+# ---------------------------------------------------------------------------
+
+
+def test_run_resolves_and_constructs_custom_python_agent(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agent_id = "custom-marker-agent-2242"
+    class_name = "CustomMarkerAgent2242"
+    _write_custom_agent(tmp_path, agent_id, class_name, _MARKER_AGENT_TEMPLATE)
+
+    rc = _run_cli(["gaia", "agent", "run", agent_id, "--list-tools"])
+    assert rc in (0, None), "listing tools for a valid custom agent must succeed"
+
+    out = capsys.readouterr().out
+    assert f"Registered Tools for {class_name}" in out, (
+        "the --list-tools output must come from the real custom agent class "
+        "instantiated by the registry, not a stub or a different agent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. A built-in agent id also resolves through the SAME path (not a
+#    custom-only special case). Uses the in-core 'builder' built-in, which
+#    needs no external hub wheel, so it is always available in a bare
+#    framework unit-test environment.
+# ---------------------------------------------------------------------------
+
+
+def test_run_resolves_and_constructs_builtin_agent(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from gaia.llm.lemonade_manager import LemonadeManager
+
+    # BuilderAgent.__init__ -> Agent.__init__ calls LemonadeManager.ensure_ready
+    # unless skip_lemonade=True is threaded through; stub it so construction
+    # doesn't need a live Lemonade server (behavioral boundary, not an
+    # assumption about how `run` wires kwargs).
+    monkeypatch.setattr(LemonadeManager, "ensure_ready", lambda **kwargs: True)
+
+    rc = _run_cli(["gaia", "agent", "run", "builder", "--list-tools"])
+    assert rc in (
+        0,
+        None,
+    ), "listing tools for the built-in 'builder' agent must succeed"
+
+    out = capsys.readouterr().out
+    assert "Registered Tools for BuilderAgent" in out, (
+        "the --list-tools output must come from the real, in-core "
+        "BuilderAgent class — proving 'run' reaches built-in construction, "
+        "not only custom_python agents"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Construction failure -> clean, actionable message naming the agent id
+#    and the underlying cause; non-zero exit; no raw traceback to the user.
+# ---------------------------------------------------------------------------
+
+
+def test_run_agent_construction_failure_is_reported_cleanly(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agent_id = "exploding-agent-2242"
+    class_name = "ExplodingAgent2242"
+    _write_custom_agent(tmp_path, agent_id, class_name, _EXPLODING_AGENT_TEMPLATE)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run_cli(["gaia", "agent", "run", agent_id, "-q", "hello"])
+
+    assert excinfo.value.code not in (
+        0,
+        None,
+    ), "a construction failure must exit non-zero, not silently succeed"
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert agent_id in combined, "the error must name the agent id that failed"
+    assert (
+        "synthetic-construction-failure" in combined
+    ), "the error must surface the underlying cause, not swallow it"
+    assert "Traceback (most recent call last)" not in combined, (
+        "a constructor exception must be converted into a clean CLI error, "
+        "not dumped to the user as a raw Python traceback (raise ... from e "
+        "chaining internally is fine — that's not what this asserts)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. `gaia agent run <id>` and `gaia browse` resolve agents through
+#    equivalent AgentRegistry calls — proving one shared discover/get/
+#    create_agent code path, not a second, independently reimplemented one
+#    living only in cli_agent.py's `run` command.
+#
+# This is a black-box, behavioral coupling test rather than a check on a
+# specific helper function name: the shared helper's name/location is an
+# implementation decision left to whoever implements #2242, not part of this
+# test's contract. If neither browse/analyze nor `run` end up calling
+# AgentRegistry.get()/.create_agent() with the same (agent_id) shape, this is
+# the strongest signal available at this layer that the two paths diverged;
+# full duplicate-inline-code detection (e.g. "browse doesn't have its own
+# second copy of the get()-is-None-check + create_agent() pair") is left to
+# code review, since asserting that reliably requires knowing the
+# implementation's file layout, which this test intentionally does not.
+# ---------------------------------------------------------------------------
+
+
+def test_run_and_browse_share_the_same_registry_resolution_path(
+    monkeypatch, tmp_path, capsys
+):
+    pytest.importorskip("gaia_agent_browser")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from gaia.agents.registry import AgentRegistry
+    from gaia.llm.lemonade_manager import LemonadeManager
+
+    monkeypatch.setattr(LemonadeManager, "ensure_ready", lambda **kwargs: True)
+
+    call_log = []
+    orig_get = AgentRegistry.get
+    orig_create_agent = AgentRegistry.create_agent
+
+    def logging_get(self, agent_id):
+        call_log.append(("get", agent_id))
+        return orig_get(self, agent_id)
+
+    def logging_create_agent(self, agent_id, **kwargs):
+        call_log.append(("create_agent", agent_id))
+        return orig_create_agent(self, agent_id, **kwargs)
+
+    monkeypatch.setattr(AgentRegistry, "get", logging_get)
+    monkeypatch.setattr(AgentRegistry, "create_agent", logging_create_agent)
+
+    _run_cli(["gaia", "browse", "--no-lemonade-check", "--list-tools"])
+    browse_calls = list(call_log)
+    call_log.clear()
+    capsys.readouterr()  # discard browse's stdout before the run invocation
+
+    _run_cli(["gaia", "agent", "run", "web", "--list-tools"])
+    run_calls = list(call_log)
+
+    assert (
+        "get",
+        "web",
+    ) in browse_calls, "gaia browse must resolve id 'web' via AgentRegistry.get()"
+    assert ("create_agent", "web") in browse_calls
+    assert ("get", "web") in run_calls, (
+        "gaia agent run web must resolve the SAME id 'web' via the SAME "
+        "AgentRegistry.get() call, not a separate lookup mechanism"
+    )
+    assert ("create_agent", "web") in run_calls, (
+        "gaia agent run web must construct via the SAME AgentRegistry."
+        "create_agent(), not a duplicated construction path"
+    )
+    # Both entry points went through exactly the same *set* of registry
+    # operations for the same agent id.
+    assert (
+        {c[0] for c in browse_calls}
+        == {c[0] for c in run_calls}
+        == {
+            "get",
+            "create_agent",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. End-to-end integration: a real custom agent, run via
+#    `gaia agent run <id> -q "<query>"`, produces a response.
+# ---------------------------------------------------------------------------
+
+
+def test_run_custom_agent_end_to_end_produces_a_response(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agent_id = "custom-e2e-agent-2242"
+    class_name = "CustomE2EAgent2242"
+    _write_custom_agent(tmp_path, agent_id, class_name, _MARKER_AGENT_TEMPLATE)
+
+    query = "what is the answer to 2242"
+    rc = _run_cli(["gaia", "agent", "run", agent_id, "-q", query])
+    assert rc in (0, None), "a successful query must not exit non-zero"
+
+    out = capsys.readouterr().out
+    assert f"CUSTOM_MARKER_RESPONSE::{query}" in out, (
+        "the real custom agent's process_query must have run with the "
+        "given query and produced a response, end-to-end through "
+        "'gaia agent run <id> -q'"
+    )


### PR DESCRIPTION
Closes #2242

> **Stacked on #2266** (`fix/2240-truthful-agent-install-hints`). Review that first; this PR's diff is only the five files listed below. Retarget to `main` once #2266 merges.

You can create a custom agent, GAIA will list it as installed, and then there is no way to run it. The user who reported this built an agent called `jarvis`, saw it in `gaia agent status`, and asked what the command was — there wasn't one, so nothing they typed could have worked.

`gaia agent run <id>` is the missing verb. `gaia agent` already owns the agent lifecycle (`status`, `health`, `export`, `import`); someone who runs `status`, sees their agent, and types `run <id>` is following the tool's own vocabulary.

This is not new machinery. `gaia browse` / `gaia analyze` already resolved agents through the registry — the only non-generic part was that the id came from the verb rather than from argv. That block is now a single shared helper used by `browse`, `analyze` and `run` alike, so there is one resolution path rather than a parallel copy.

`gaia chat` is deliberately untouched. Running an arbitrary agent through a command named `chat` would conflate the chat experience with agent identity, and custom agents are not necessarily conversational.

## Evidence

Verified on a Ryzen AI MAX+ 395 with a real custom agent authored at `~/.gaia/agents/jarvis/agent.py`, exactly as a user would write one.

**It runs** — the thing that was impossible before:
```
$ gaia agent run jarvis --list-tools
🛠️ Registered Tools for JarvisAgent
📌 greet(name: string)
   Greet someone by name.
exit 0
```

**Failures are actionable and exit non-zero:**
```
$ gaia agent run nosuchagent -q "x"
Error: Unknown agent ID: 'nosuchagent'. Registered agents: builder, jarvis, zoo-agent
exit 1

$ gaia agent run broken -q "x"
Error: Agent 'broken' is registered but failed to start:
       Can't instantiate abstract class B with abstract method _register_tools
exit 1
```

That second case is not hypothetical — see below.

## A real bug this surfaced (not fixed here)

**Every file-based custom agent reports `HEALTH: error` in `gaia agent status`, even when it works perfectly.** Confirmed on hardware: `jarvis` shows `error` and runs correctly.

Root cause is `src/gaia/hub/lifecycle.py`'s `_default_loader()`, used by `health_check()`. It can probe a `builtin` (registry presence) or an installed wheel's `gaia.agent` setuptools entry point — but has **no branch for `source == "custom_python"`**. Those agents are loaded directly from `~/.gaia/agents/<id>/agent.py` and have no entry point by construction, so the loader always raises "exposes no 'gaia.agent' entry point" and every custom agent is reported unhealthy.

This is why `resolve_and_create_agent()` deliberately does **not** consult health state — it determines runnability by attempting construction. Tracked separately; out of scope here.

## Notes for the reviewer

- `--list-tools` is included beyond the flags originally scoped. It mirrors `browse`/`analyze`'s existing flag and lets the test suite prove real agent construction without a live Lemonade server. Flag it if you would rather it came out.
- `tests/unit/test_gaia_agent_run.py` carries an autouse fixture repairing root-logger `StreamHandler`s left pointed at a closed stream. That is a pre-existing cross-test pollution issue between `gaia.logger` and `capsys`; the fixture only repairs already-dead handlers and touches no assertion.
- A custom `agent.py` must define `AGENT_ID`, `AGENT_NAME` **and** implement `_register_tools` — the last one is easy to miss and produces the "failed to start" message above. Documented in `docs/guides/custom-agent.mdx`.

## Test plan

- [x] `tests/unit/test_gaia_agent_run.py` — 6/6, written test-first by an agent blind to the implementation
- [x] Full `python -m pytest tests/unit/` — 6530 passed, 145 skipped; 7 failures identical to a clean pre-change baseline
- [x] `python util/lint.py --all` — passes
- [x] Regression: `browse`/`analyze` still resolve through the shared helper (35 passed, 2 skipped; the skips pass once the hub wheels are installed)
- [x] Real-world on AMD hardware: valid agent runs (exit 0); unknown id and broken agent both exit 1 with actionable messages