### PR TITLE
feat(ci): execution-based weekly doc walkthrough

### DIFF
--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -111,6 +111,22 @@ jobs:
           echo "docs=$docs" >> "$GITHUB_OUTPUT"
           echo "Resolved docs: $docs"
 
+          {
+            echo "## 📋 Doc walkthrough — scope for this run"
+            echo ""
+            if [ -n "$DOC_FILTER" ]; then
+              echo "Filter: \`$DOC_FILTER\`"
+              echo ""
+            fi
+            count=$(echo "$docs" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+            echo "**$count doc(s) in scope:**"
+            echo "$docs" | python3 -c "
+          import json, sys
+          for d in json.load(sys.stdin):
+              print(f\"- \`{d['path']}\`\")
+          "
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # One matrix entry per doc, each acting as a real user/developer walking
   # that guide on real hardware. Serialized (max-parallel: 1) -- same
   # one-model-slot-at-a-time discipline the eval workflows already use
@@ -151,6 +167,11 @@ jobs:
           New-Item -ItemType Directory -Path $runDir | Out-Null
           echo "RUN_DIR=$runDir" >> $env:GITHUB_ENV
           echo "GAIA_HOME=$runDir\gaia_home" >> $env:GITHUB_ENV
+          Write-Host "RUN_DIR=$runDir"
+          Write-Host "GAIA_HOME=$runDir\gaia_home"
+          "### 🚶 ${{ matrix.doc.path }}" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+          "" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+          "- **Start:** $(Get-Date -Format o), clean run dir: ``$runDir``" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
 
       - name: Fresh venv, real-user install (no -e install, no hub packages)
         shell: powershell
@@ -162,16 +183,23 @@ jobs:
           # hub/agents/python/* package alongside it. This is the property
           # that would have caught #2260 -- do not "fix" a resulting
           # ImportError by installing a hub package here; that IS the bug.
+          Write-Host "Creating venv at $env:RUN_DIR\venv ..."
           python -m venv "$env:RUN_DIR\venv"
           & "$env:RUN_DIR\venv\Scripts\python.exe" -m pip install --upgrade pip build
+          Write-Host "Building wheel from the checkout ..."
           & "$env:RUN_DIR\venv\Scripts\python.exe" -m build --wheel --outdir "$env:RUN_DIR\dist" .
           $wheel = Get-ChildItem "$env:RUN_DIR\dist\amd_gaia-*.whl" | Select-Object -First 1
           if (-not $wheel) {
             Write-Host "::error::No wheel built -- 'python -m build' did not produce amd_gaia-*.whl"
+            "- **Environment:** ❌ wheel build failed" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
             exit 1
           }
+          Write-Host "Built: $($wheel.Name)"
+          Write-Host "Installing $($wheel.Name) into the fresh venv (no -e, no hub packages) ..."
           & "$env:RUN_DIR\venv\Scripts\pip.exe" install $wheel.FullName
-          & "$env:RUN_DIR\venv\Scripts\gaia.exe" --version
+          $gaiaVersion = & "$env:RUN_DIR\venv\Scripts\gaia.exe" --version
+          Write-Host "Installed: $gaiaVersion"
+          "- **Environment:** ✅ $($wheel.Name) installed, ``gaia --version`` -> $gaiaVersion" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
 
       - name: Start an isolated Lemonade instance on the dedicated port
         shell: powershell
@@ -189,10 +217,12 @@ jobs:
           } catch {}
           if ($alreadyHealthy) {
             Write-Host "Dedicated-port Lemonade already healthy (leftover from a prior run) -- reusing it."
+            "- **Lemonade:** ✅ reused an already-healthy instance on port $env:WALKTHROUGH_LEMONADE_PORT" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
           } else {
             Write-Host "Dedicated port not yet serving -- starting a fresh instance."
             $proc = Start-Process -FilePath "LemonadeServer.exe" -ArgumentList "serve --port $env:WALKTHROUGH_LEMONADE_PORT" -PassThru
             $proc.Id | Out-File "$env:RUN_DIR\lemonade.pid"
+            Write-Host "Started LemonadeServer.exe pid=$($proc.Id) on port $env:WALKTHROUGH_LEMONADE_PORT, polling for health ..."
             $deadline = (Get-Date).AddSeconds(60)
             $healthy = $false
             do {
@@ -204,8 +234,11 @@ jobs:
             } while ((Get-Date) -lt $deadline)
             if (-not $healthy) {
               Write-Host "::error::Dedicated-port Lemonade did not become healthy within 60s"
+              "- **Lemonade:** ❌ did not become healthy within 60s (pid=$($proc.Id))" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
               exit 1
             }
+            Write-Host "Lemonade healthy on port $env:WALKTHROUGH_LEMONADE_PORT after $((Get-Date) - ($deadline.AddSeconds(-60))) "
+            "- **Lemonade:** ✅ started fresh (pid=$($proc.Id)), healthy on port $env:WALKTHROUGH_LEMONADE_PORT" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
           }
 
       - name: "Executor (Sonnet): walk ${{ matrix.doc.path }}"
@@ -284,6 +317,49 @@ jobs:
             --model ${{ env.WALKTHROUGH_EXECUTOR_MODEL }}
             --allowedTools Read,Grep,Glob,Bash
 
+      # continue-on-error above means a crashed executor still lets cleanup
+      # run -- which is correct -- but it also means the job can look green
+      # in the Actions UI while the executor actually failed. Surface that
+      # explicitly: check the action's own execution_file (same technique
+      # claude-weekly-audit.yml's synthesis job uses), and independently
+      # confirm the transcript the judge depends on actually exists.
+      - name: Report executor status
+        if: always()
+        shell: powershell
+        env:
+          EXEC_FILE: ${{ steps.executor.outputs.execution_file }}
+        run: |
+          # PowerShell-native JSON parsing (ConvertFrom-Json), not jq -- jq's
+          # presence on this self-hosted Windows runner is not a confirmed
+          # dependency (the ubuntu-hosted synthesis job below uses jq safely,
+          # since GH-hosted runners guarantee it; this job cannot assume that).
+          # execution_file is JSONL (one object per line); walk every line and
+          # keep the LAST one that has an is_error key, matching the bash
+          # `jq -s '[.. | objects | select(has("is_error")) | .is_error] | .[-1]'`
+          # claude-weekly-audit.yml uses on ubuntu.
+          $ok = $false
+          $isErr = $null
+          if ($env:EXEC_FILE -and (Test-Path $env:EXEC_FILE)) {
+            foreach ($line in Get-Content $env:EXEC_FILE) {
+              try {
+                $obj = $line | ConvertFrom-Json -ErrorAction Stop
+                if ($obj.PSObject.Properties.Name -contains "is_error") { $isErr = $obj.is_error }
+              } catch {}
+            }
+            if ($isErr -eq $false) { $ok = $true }
+          }
+          $transcriptExists = Test-Path "$env:RUN_DIR\transcript.md"
+          if ($ok -and $transcriptExists) {
+            Write-Host "✅ Executor completed and wrote a transcript."
+            "- **Executor (Sonnet):** ✅ completed, transcript written" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+          } elseif ($ok -and -not $transcriptExists) {
+            Write-Host "::warning::Executor step reported success but no transcript.md was written -- the judge will file a crash finding for this."
+            "- **Executor (Sonnet):** ⚠️ reported success but wrote no transcript" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+          } else {
+            Write-Host "::warning title=Executor did not complete cleanly (${{ matrix.doc.path }})::log: $env:EXEC_FILE"
+            "- **Executor (Sonnet):** ❌ did not complete cleanly" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+          }
+
       - name: "Judge (Opus): verify ${{ matrix.doc.path }} against its transcript"
         id: judge
         if: always()
@@ -349,6 +425,47 @@ jobs:
             --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}
             --allowedTools Read,Grep,Glob,Bash
 
+      # Same rationale as "Report executor status": continue-on-error hides a
+      # judge crash from the job's pass/fail color. Also this is the one place
+      # a human scanning the run can see, per doc, how many findings came out
+      # and at what severity -- without downloading the artifact.
+      - name: Report judge status + findings summary
+        if: always()
+        shell: powershell
+        env:
+          EXEC_FILE: ${{ steps.judge.outputs.execution_file }}
+        run: |
+          # PowerShell-native JSON parsing (ConvertFrom-Json), not jq -- see
+          # the "Report executor status" step above for why.
+          $ok = $false
+          $isErr = $null
+          if ($env:EXEC_FILE -and (Test-Path $env:EXEC_FILE)) {
+            foreach ($line in Get-Content $env:EXEC_FILE) {
+              try {
+                $obj = $line | ConvertFrom-Json -ErrorAction Stop
+                if ($obj.PSObject.Properties.Name -contains "is_error") { $isErr = $obj.is_error }
+              } catch {}
+            }
+            if ($isErr -eq $false) { $ok = $true }
+          }
+          $findingsFile = "findings-walkthrough-${{ matrix.doc.slug }}.json"
+          if ($ok) {
+            Write-Host "✅ Judge completed."
+          } else {
+            Write-Host "::warning title=Judge did not complete cleanly (${{ matrix.doc.path }})::log: $env:EXEC_FILE"
+          }
+          if (Test-Path $findingsFile) {
+            $findingsObj = Get-Content $findingsFile -Raw | ConvertFrom-Json
+            $total = @($findingsObj.findings).Count
+            $bySeverity = @($findingsObj.findings) | Group-Object severity | ForEach-Object { "$($_.Name)=$($_.Count)" }
+            $counts = if ($bySeverity) { $bySeverity -join ", " } else { "none" }
+            Write-Host "Findings for ${{ matrix.doc.path }}: $total total -- $counts"
+            "- **Judge (Opus):** $(if ($ok) { '✅' } else { '❌' }) -- **$total finding(s):** $counts" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+          } else {
+            Write-Host "::warning::No findings file at $findingsFile -- judge did not write output (see executor/judge status above)"
+            "- **Judge (Opus):** $(if ($ok) { '✅ ran' } else { '❌' }) but wrote no findings file" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
+          }
+
       - name: Verify clean end state
         if: always()
         shell: powershell
@@ -360,8 +477,10 @@ jobs:
           Remove-Item -Recurse -Force $env:RUN_DIR -ErrorAction SilentlyContinue
           if (Test-Path $env:RUN_DIR) {
             Write-Host "::warning::Run dir did not clean up: $env:RUN_DIR"
+            "- **Cleanup:** ⚠️ run dir did not clean up" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
           } else {
             Write-Host "Clean: run dir removed."
+            "- **Cleanup:** ✅ run dir removed" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
           }
           # Confirm we never touched the SHARED 13305 instance other workflows
           # use -- this is a read-only health probe, never a cleanup action.
@@ -371,6 +490,7 @@ jobs:
           } catch {
             Write-Host "Shared Lemonade (13305) not reachable right now -- not this workflow's concern; confirming only that we did not kill it if it WAS up."
           }
+          "- **End:** $(Get-Date -Format o)" | Out-File -Append -Encoding utf8 $env:GITHUB_STEP_SUMMARY
 
       - name: Upload findings
         if: always()
@@ -399,6 +519,39 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: walkthrough-findings
+
+      # Raw, deterministic tally -- independent of whether the Claude
+      # synthesis step below succeeds. If that step crashes, this is still on
+      # the record: how many matrix jobs actually reported in, and how many
+      # findings they carried in total, per doc. Grep-able in the job log and
+      # visible in the run's step summary either way.
+      - name: Raw findings tally (pre-synthesis)
+        run: |
+          set -euo pipefail
+          echo "## 📊 Doc walkthrough — raw tally (pre-dedup)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          total_files=0
+          total_findings=0
+          {
+            echo "| Doc | Findings |"
+            echo "|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          for f in walkthrough-findings/findings-walkthrough-*/findings-walkthrough-*.json; do
+            [ -f "$f" ] || continue
+            total_files=$((total_files + 1))
+            count=$(jq '.findings | length' "$f" 2>/dev/null || echo "unreadable")
+            doc_path=$(jq -r '.findings[0].path // "unknown"' "$f" 2>/dev/null || echo "unreadable")
+            echo "$f -> path=$doc_path count=$count"
+            if [ "$count" != "unreadable" ]; then
+              total_findings=$((total_findings + count))
+              echo "| \`$doc_path\` | $count |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| \`$f\` | ⚠️ unreadable JSON |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**$total_files findings file(s) reported in, $total_findings raw finding(s) before dedup/verification.**" >> "$GITHUB_STEP_SUMMARY"
+          echo "Reported in: $total_files files, $total_findings raw findings before dedup"
 
       - name: Ensure labels exist
         env:

--- a/.github/workflows/claude-weekly-doc-walkthrough.yml
+++ b/.github/workflows/claude-weekly-doc-walkthrough.yml
@@ -1,0 +1,520 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Execution-based sibling to claude-weekly-audit.yml (see docs/plans/
+# weekly-doc-walkthrough-audit.md and docs/plans/weekly-claude-audit.md's
+# "Non-goals"). That workflow is deliberately static (read-only, never installs
+# or runs repo code) -- this one exists because that non-goal has a real blind
+# spot: #2260 (gaia chat ImportErrors on a plain PyPI install) and #2261 (seven
+# hub agents silently fall back to an uninstalled 35B model) are both only
+# observable by actually running GAIA from a real user's initial state, never
+# by reading source. This workflow acts as that user: one matrix job per doc
+# guide, each walking the guide's commands for real on the self-hosted
+# Windows/STX runner, in a fresh venv + isolated config + a dedicated-port
+# Lemonade instance -- never the runner's shared, CI-warmed install (see
+# "Execution environment" in the design doc for why that distinction matters).
+#
+# STANDALONE from claude-weekly-audit.yml on purpose: different runner
+# (self-hosted Windows vs. ubuntu-latest), different cost/runtime profile
+# (hours, not minutes -- deliberate; see design doc "Cadence"), different
+# failure modes (a live command can hang). Isolating them means a stuck
+# walkthrough never delays the fast static audit's triage issue. Shares
+# vocabulary with it (severity scale, dedup-key pattern, weekly-audit label,
+# bug-label auto-fix promotion) but files its OWN parent issue.
+#
+# MODEL SPLIT: Sonnet executes (cheap, high tool-call volume, grinding
+# sequential work); Opus (WALKTHROUGH_JUDGE_MODEL) judges (low volume -- one
+# pass per guide -- and never rubber-stamps the executor's own summary, same
+# principle the gaia-testing skill states explicitly). See design doc "Job
+# structure".
+#
+# PORT ISOLATION: runs its own Lemonade Server on a dedicated, non-13305 port
+# so it never collides with the six other workflows issue #2122 documents
+# fighting over the shared runner's Lemonade instance -- sidesteps that
+# contention by construction, not by coordination. NEEDS LIVE-RUNNER
+# VERIFICATION (flagged in the design doc): whether a second Lemonade Server
+# instance can run concurrently on this box and what it does for model-cache
+# visibility. Model-*resolution* checks (the #2261 shape) do not depend on the
+# answer -- they use a targeted Python snippet against AgentRegistry instead
+# of a live model catalog; see the executor prompt below.
+#
+# NOT VALIDATED END-TO-END AT AUTHORING TIME: this workflow was written and
+# reviewed without access to the self-hosted runner. Run it once via
+# workflow_dispatch with doc_filter scoped to a single guide (e.g.
+# "docs/quickstart.mdx") before trusting the full weekly schedule. In
+# particular: the executor/judge prompts do not assume a specific shell
+# (PowerShell vs. bash/git-bash) for claude-code-action's Bash tool on this
+# runner -- they instruct Claude to detect it at runtime, since which one the
+# action actually uses here was not confirmed at authoring time. Confirm this
+# on the first live run and hardcode the syntax if it's always the same.
+
+name: Claude Weekly Doc Walkthrough
+
+on:
+  schedule:
+    # 12:00 UTC every Monday -- offset 6h from claude-weekly-audit.yml's 06:00
+    # UTC run so the two don't compete for runner time or review attention.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+    inputs:
+      doc_filter:
+        description: "Glob to scope this run to one or a few docs (e.g. docs/quickstart.mdx). Empty = all discovered docs."
+        default: ""
+
+permissions:
+  contents: read
+
+# Own group -- deliberately NOT the eval workflows' `lemonade-eval` group.
+# This workflow runs its own Lemonade instance on a dedicated port (see
+# header), so it does not need to serialize against workflows using the
+# shared 13305 instance; it only needs to serialize against ITSELF across
+# scheduled runs.
+concurrency:
+  group: claude-weekly-doc-walkthrough
+  cancel-in-progress: false
+
+env:
+  WALKTHROUGH_EXECUTOR_MODEL: claude-sonnet-4-6
+  WALKTHROUGH_JUDGE_MODEL: claude-opus-4-8
+  # Dedicated port for this workflow's own Lemonade instance -- never touches
+  # the shared 13305 port the other self-hosted-runner workflows use.
+  WALKTHROUGH_LEMONADE_PORT: 13405
+
+jobs:
+  # Cheap, fast, ubuntu-hosted discovery so the expensive Windows matrix below
+  # never spins up for a misconfigured or empty doc set.
+  discover:
+    if: github.repository == 'amd/gaia'
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.discover.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Discover in-scope docs
+        id: discover
+        env:
+          DOC_FILTER: ${{ github.event.inputs.doc_filter }}
+        run: |
+          set -euo pipefail
+          all_docs=$(python3 scripts/audit/discover_walkthrough_docs.py)
+          if [ -n "$DOC_FILTER" ]; then
+            docs=$(ALL_DOCS="$all_docs" DOC_FILTER="$DOC_FILTER" python3 -c "
+          import json, os, fnmatch
+          docs = json.loads(os.environ['ALL_DOCS'])
+          pattern = os.environ['DOC_FILTER']
+          print(json.dumps([d for d in docs if fnmatch.fnmatch(d['path'], pattern)]))
+          ")
+          else
+            docs="$all_docs"
+          fi
+          echo "docs=$docs" >> "$GITHUB_OUTPUT"
+          echo "Resolved docs: $docs"
+
+  # One matrix entry per doc, each acting as a real user/developer walking
+  # that guide on real hardware. Serialized (max-parallel: 1) -- same
+  # one-model-slot-at-a-time discipline the eval workflows already use
+  # (CLAUDE.md "Run agent evals SERIALLY"), and it gives natural checkpointing
+  # for a run that's allowed to take hours: one guide hanging doesn't lose the
+  # findings already captured from guides that finished first.
+  walkthrough:
+    needs: discover
+    if: github.repository == 'amd/gaia' && needs.discover.outputs.docs != '[]'
+    # Expression-wrapped 'stx' (not a bare literal) to match the rest of the repo's
+    # self-hosted-runner workflows and stay actionlint-clean (a literal label isn't
+    # in actionlint's default known-labels list; an expression sidesteps that
+    # static check the same way test_api.yml / test_lemonade_server.yml do).
+    runs-on:
+      - self-hosted
+      - Windows
+      - ${{ 'stx' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        doc: ${{ fromJson(needs.discover.outputs.docs) }}
+    # Ceiling for ONE guide, not the whole matrix -- the workflow overall may
+    # run for hours across many matrix entries, but a single stuck command
+    # must not eat the entire run silently.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify clean start state
+        shell: powershell
+        run: |
+          $runDir = "$env:RUNNER_TEMP\walkthrough-${{ matrix.doc.slug }}"
+          if (Test-Path $runDir) {
+            Write-Host "Stale run dir from a previous failed run -- removing: $runDir"
+            Remove-Item -Recurse -Force $runDir
+          }
+          New-Item -ItemType Directory -Path $runDir | Out-Null
+          echo "RUN_DIR=$runDir" >> $env:GITHUB_ENV
+          echo "GAIA_HOME=$runDir\gaia_home" >> $env:GITHUB_ENV
+
+      - name: Fresh venv, real-user install (no -e install, no hub packages)
+        shell: powershell
+        run: |
+          # Deliberately NOT `.github/actions/setup-venv` -- that composite
+          # action installs `.[dev,...]` from the checkout (an editable dev
+          # install). This step exists to reproduce what a real `pip install
+          # amd-gaia` user gets: a built wheel, installed normally, with no
+          # hub/agents/python/* package alongside it. This is the property
+          # that would have caught #2260 -- do not "fix" a resulting
+          # ImportError by installing a hub package here; that IS the bug.
+          python -m venv "$env:RUN_DIR\venv"
+          & "$env:RUN_DIR\venv\Scripts\python.exe" -m pip install --upgrade pip build
+          & "$env:RUN_DIR\venv\Scripts\python.exe" -m build --wheel --outdir "$env:RUN_DIR\dist" .
+          $wheel = Get-ChildItem "$env:RUN_DIR\dist\amd_gaia-*.whl" | Select-Object -First 1
+          if (-not $wheel) {
+            Write-Host "::error::No wheel built -- 'python -m build' did not produce amd_gaia-*.whl"
+            exit 1
+          }
+          & "$env:RUN_DIR\venv\Scripts\pip.exe" install $wheel.FullName
+          & "$env:RUN_DIR\venv\Scripts\gaia.exe" --version
+
+      - name: Start an isolated Lemonade instance on the dedicated port
+        shell: powershell
+        run: |
+          # Health-check first -- never assume the port is free, never
+          # force-kill whatever might already be on it. This workflow owns
+          # WALKTHROUGH_LEMONADE_PORT exclusively across its own runs; a
+          # leftover process from a prior crashed run of THIS workflow is a
+          # legitimate thing to clean up, but nothing else's.
+          $healthUrl = "http://localhost:$env:WALKTHROUGH_LEMONADE_PORT/api/v1/health"
+          $alreadyHealthy = $false
+          try {
+            $resp = Invoke-WebRequest -Uri $healthUrl -TimeoutSec 3 -ErrorAction Stop
+            if ($resp.StatusCode -eq 200) { $alreadyHealthy = $true }
+          } catch {}
+          if ($alreadyHealthy) {
+            Write-Host "Dedicated-port Lemonade already healthy (leftover from a prior run) -- reusing it."
+          } else {
+            Write-Host "Dedicated port not yet serving -- starting a fresh instance."
+            $proc = Start-Process -FilePath "LemonadeServer.exe" -ArgumentList "serve --port $env:WALKTHROUGH_LEMONADE_PORT" -PassThru
+            $proc.Id | Out-File "$env:RUN_DIR\lemonade.pid"
+            $deadline = (Get-Date).AddSeconds(60)
+            $healthy = $false
+            do {
+              Start-Sleep -Seconds 2
+              try {
+                $resp = Invoke-WebRequest -Uri $healthUrl -TimeoutSec 3 -ErrorAction Stop
+                if ($resp.StatusCode -eq 200) { $healthy = $true; break }
+              } catch {}
+            } while ((Get-Date) -lt $deadline)
+            if (-not $healthy) {
+              Write-Host "::error::Dedicated-port Lemonade did not become healthy within 60s"
+              exit 1
+            }
+          }
+
+      - name: "Executor (Sonnet): walk ${{ matrix.doc.path }}"
+        id: executor
+        continue-on-error: true
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are the EXECUTOR half of GAIA's weekly doc walkthrough. Your only job is
+            to run commands and capture their raw output -- judging correctness is a
+            SEPARATE step that reads your transcript independently. Do not editorialize
+            or decide what's a bug; just execute faithfully and record everything.
+
+            DOC UNDER TEST: ${{ matrix.doc.path }}
+            ENVIRONMENT: two OS-level environment variables are already set for you by an
+            earlier PowerShell step in this job -- `RUN_DIR` (a per-run scratch directory)
+            and `GAIA_HOME` (an isolated GAIA config dir under it). A fresh venv is already
+            built at `<RUN_DIR>\venv` (GAIA installed from a built wheel, no -e install, no
+            hub agent packages preinstalled -- this is deliberate, do not "fix" a missing
+            hub package by installing it). A Lemonade instance is running at
+            http://localhost:${{ env.WALKTHROUGH_LEMONADE_PORT }} -- point any
+            Lemonade-aware command at that port, never the default 13305.
+            **First, confirm which shell your Bash tool actually runs on this Windows
+            runner** (e.g. `echo $SHELL` or check if `$env:RUN_DIR` resolves vs. `$RUN_DIR`)
+            and use that shell's syntax consistently for every command below -- this
+            workflow was authored without live-runner access, so the exact shell your tool
+            uses was not confirmed at authoring time; do not assume PowerShell syntax works
+            if your tool is actually a POSIX shell, or vice versa.
+
+            ## What to do
+            1. Read `${{ matrix.doc.path }}` in full.
+            2. Extract every command a reader is expected to actually run, in the order
+               the doc presents them (code fences, inline `gaia ...` examples).
+            3. Run each command for real, using the `gaia` executable from
+               `<RUN_DIR>\venv\Scripts\` explicitly (not a bare `gaia` that might resolve
+               to something else on the runner). Capture stdout, stderr, exit code, and
+               wall-clock time for each.
+            4. **Stop the guide at its first failing step whose failure blocks later
+               steps** (e.g. `gaia init` failing means don't attempt `gaia chat` after
+               it) -- report the root step, don't manufacture cascading noise from steps
+               whose precondition already failed. Steps that are independently runnable
+               (separate subcommands not depending on the failed one) still get attempted.
+            5. A step needing something this environment cannot provide (Jira/Atlassian
+               credentials, a Google OAuth connector, a Blender install, a microphone, a
+               non-Windows install path) is NOT attempted -- record it explicitly as
+               `"requires <X> -- not verifiable in this environment"` and move to the next
+               independently-runnable step.
+            6. **Model-resolution checks are a special case -- do NOT drive them through
+               a live end-to-end CLI run.** If the doc's guide involves an agent choosing
+               a model when its preferred model isn't installed (this is exactly the
+               #2261 bug shape), the runner's shared Lemonade cache may already have
+               other models downloaded from unrelated CI and would silently defeat the
+               check. Instead write and run a small, throwaway Python snippet using the
+               `python` executable from `<RUN_DIR>\venv\Scripts\` that imports the
+               relevant registry code and calls its model-resolution function with an EXPLICIT
+               `available_models` list matching only what the doc's target `gaia init`
+               profile installs (cross-reference `INIT_PROFILES` in
+               `src/gaia/installer/init_command.py` for the real list) -- then assert the
+               agent does not silently fall through to a different hardcoded model.
+               Capture the snippet's full source and output as evidence.
+            7. **A failing step must reproduce before you treat it as real.** Retry it
+               once. If it passes the second time, note it as a flake (timing, network) in
+               your transcript rather than a confirmed failure -- the judge decides what
+               to do with that note, you do not decide it's a non-issue yourself.
+
+            Write the full raw transcript (every command, its output, exit code, timing,
+            and any retry) to `<RUN_DIR>\transcript.md` (substitute the real value of the
+            `RUN_DIR` env var), structured with one section per step in doc order. This
+            transcript is the ONLY thing the judge step reads -- anything not captured
+            there does not exist for judging purposes.
+          claude_args: |
+            --max-turns 60
+            --model ${{ env.WALKTHROUGH_EXECUTOR_MODEL }}
+            --allowedTools Read,Grep,Glob,Bash
+
+      - name: "Judge (Opus): verify ${{ matrix.doc.path }} against its transcript"
+        id: judge
+        if: always()
+        continue-on-error: true
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are the JUDGE half of GAIA's weekly doc walkthrough. Do not trust the
+            executor's framing -- read its raw transcript and the doc yourself, and reach
+            your own conclusion. This split exists because a single self-judging session
+            is a known false-negative risk (see docs/plans/weekly-doc-walkthrough-audit.md
+            "Job structure").
+
+            DOC UNDER TEST: ${{ matrix.doc.path }}
+            TRANSCRIPT: `<RUN_DIR>\transcript.md`, where `RUN_DIR` is the OS-level env var
+            set by an earlier step in this job (check your Bash tool's shell to read it --
+            `$env:RUN_DIR` in PowerShell, `$RUN_DIR` in a POSIX shell; not confirmed which
+            this runner's tool uses at authoring time). If the file is missing, the
+            executor crashed before writing it -- file ONE 🟠 finding for that, dedup_key
+            `walkthrough:${{ matrix.doc.path }}:executor-crash`, and stop.
+
+            ## What to do
+            1. Read `${{ matrix.doc.path }}` and the transcript file above, in full.
+            2. For each step in the transcript, check: does the actual captured output
+               match what the doc claims will happen? A step marked "not verifiable in
+               this environment" is not a finding by itself -- it's expected coverage,
+               unless the doc presents that exact step as something every reader can run
+               (in which case the doc itself needs a caveat -- that IS a finding).
+            3. **`docs/reference/cli.mdx` gets an extra deterministic pass:** enumerate
+               every flag from the transcript's `gaia -h` / subcommand `-h` output and
+               every flag documented in the doc's tables, and diff them explicitly,
+               flag by flag -- don't rely on a narrative skim for this file, a single
+               dropped row in a long table is easy to miss that way.
+            4. A step the executor noted as "reproduced as a flake" is NOT a finding --
+               skip it. A step that failed and did NOT reproduce cleanly on retry (i.e.
+               failed twice) IS eligible.
+            5. Write findings to `findings-walkthrough-${{ matrix.doc.slug }}.json`
+               (repo root), same shape `claude-weekly-audit.yml` uses:
+               ```json
+               {"findings": [
+                 {
+                   "severity": "🔴" | "🟠" | "🟡",
+                   "path": "${{ matrix.doc.path }}",
+                   "symbol": "the doc heading or step name -- NOT a line number",
+                   "title": "one-line statement of the problem",
+                   "why": "one sentence: the concrete impact / what breaks",
+                   "evidence": "the exact transcript excerpt (command + captured output) proving the claim",
+                   "auto_fixable": true | false,
+                   "dedup_key": "walkthrough:${{ matrix.doc.path }}:<step-heading>"
+                 }
+               ]}
+               ```
+               Write `{"findings": []}` if nothing is wrong. Severity: 🔴 a default-path
+               command in the doc fails outright; 🟠 the doc's claim about behavior is
+               false but the underlying command doesn't crash; 🟡 a cosmetic/minor gap
+               (a missing caveat, a stale example). `auto_fixable` = true only if the fix
+               is small and locatable (~1-3 files, no design call).
+          claude_args: |
+            --max-turns 25
+            --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}
+            --allowedTools Read,Grep,Glob,Bash
+
+      - name: Verify clean end state
+        if: always()
+        shell: powershell
+        run: |
+          if (Test-Path "$env:RUN_DIR\lemonade.pid") {
+            $procId = Get-Content "$env:RUN_DIR\lemonade.pid"
+            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+          }
+          Remove-Item -Recurse -Force $env:RUN_DIR -ErrorAction SilentlyContinue
+          if (Test-Path $env:RUN_DIR) {
+            Write-Host "::warning::Run dir did not clean up: $env:RUN_DIR"
+          } else {
+            Write-Host "Clean: run dir removed."
+          }
+          # Confirm we never touched the SHARED 13305 instance other workflows
+          # use -- this is a read-only health probe, never a cleanup action.
+          try {
+            $resp = Invoke-WebRequest -Uri "http://localhost:13305/api/v1/health" -TimeoutSec 3 -ErrorAction Stop
+            Write-Host "Shared Lemonade (13305) still healthy: $($resp.StatusCode)"
+          } catch {
+            Write-Host "Shared Lemonade (13305) not reachable right now -- not this workflow's concern; confirming only that we did not kill it if it WAS up."
+          }
+
+      - name: Upload findings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: findings-walkthrough-${{ matrix.doc.slug }}
+          path: findings-walkthrough-${{ matrix.doc.slug }}.json
+          if-no-files-found: warn
+
+  # Collect every matrix job's findings, dedupe against open weekly-audit
+  # issues, and file ONE parent triage issue + per-finding child issues.
+  # Same conventions as claude-weekly-audit.yml's synthesis job (label
+  # scheme, dedup-key marker, evidence gate, cross-link-never-close
+  # lifecycle) -- see the weekly-audit-patterns skill.
+  synthesize:
+    needs: [discover, walkthrough]
+    if: github.repository == 'amd/gaia' && !cancelled() && needs.discover.outputs.docs != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download all findings
+        uses: actions/download-artifact@v8
+        with:
+          path: walkthrough-findings
+
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create weekly-audit --color 5319e7 \
+            --description "Proactive weekly Claude audit finding" \
+            2>/dev/null && echo "created weekly-audit label" || echo "weekly-audit label already exists"
+          gh label create audit-wontfix --color cccccc \
+            --description "Accepted debt -- weekly audit will never re-file this finding" \
+            2>/dev/null && echo "created audit-wontfix label" || echo "audit-wontfix label already exists"
+
+      - name: Synthesize and file the triage issue
+        id: claude
+        continue-on-error: true
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are the synthesis step of GAIA's weekly DOC WALKTHROUGH (the
+            execution-based sibling of the static weekly-audit -- see
+            docs/plans/weekly-doc-walkthrough-audit.md). Each matrix job wrote a
+            findings-walkthrough-<slug>.json. Dedupe, rank, and file the output.
+
+            REPO: ${{ github.repository }}
+            RUN LOG: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ## First actions
+            1. Read every `findings-walkthrough-*.json` under `walkthrough-findings/`
+               (each artifact is in its own subdir). Missing/empty files are fine -- a
+               guide may have found nothing, or its job may have crashed.
+            2. Read `CLAUDE.md` -> "Issue Response Guidelines" for tone/format.
+            3. Already-filed keys:
+               `gh issue list --repo ${{ github.repository }} --label weekly-audit --state open --json number,title,body --limit 200`,
+               collect the `<!-- audit-key: KEY -->` marker from each body.
+            4. Suppressed-forever keys:
+               `gh issue list --repo ${{ github.repository }} --label weekly-audit --label audit-wontfix --state all --json body --limit 200`.
+            5. Previous parent to cross-link: the most recently created OPEN issue whose
+               title starts `Doc walkthrough —` (NOT `Weekly audit —` -- that belongs to
+               the static audit, a different lineage; do not cross-link across workflows).
+
+            ## Dedup + verify
+            1. Drop any finding whose `dedup_key` is in either key set from step 3/4 above.
+               Match the exact key string -- never line numbers or prose similarity.
+            2. Evidence gate: drop any 🔴/🟠 finding whose `evidence` doesn't actually
+               substantiate its `title` -- spot-check by reading the cited transcript
+               excerpt/doc section yourself before filing.
+            3. If zero new findings remain after the above, post NOTHING and exit
+               cleanly -- do not file a parent issue, and never touch a prior parent.
+
+            ## File child issues -- 🔴/🟠 ONLY, non-security (this workflow finds no
+            security issues -- that lens belongs to claude-weekly-audit.yml)
+            🟡 (low) findings get NO child issue -- list them in the parent only. For each
+            NEW, verified 🔴/🟠 finding, write the body to a temp file, then
+            `gh issue create --repo ${{ github.repository }} --label weekly-audit --title "<title>" --body-file <file>`
+            WITHOUT the `bug` label. Body format:
+            ```
+            <one-paragraph why-this-matters: what's wrong + the concrete impact>
+
+            **Where:** `path` · `symbol`
+            **Evidence:** <the finding's `evidence` -- the concrete transcript/doc excerpt>
+            **Severity:** 🔴 high / 🟠 medium
+            **Auto-fixable:** yes — apply `bug` to let auto-fix open the PR  |  no — needs a human
+
+            Not acting on this? Close it with the `audit-wontfix` label and the audit will
+            never re-file it. Applying `bug` instead hands it to the existing auto-fix job.
+
+            <!-- audit-key: <the finding's dedup_key> -->
+            ```
+            Capture each child issue number to reference from the parent.
+
+            ## File ONE parent issue
+            Title: `Doc walkthrough — ${{ github.run_id }}`. Label it `weekly-audit`.
+            Group findings by DOC PATH (this workflow has one detection mechanism, not
+            five dimensions like the static audit) -- most-severe-first across the whole
+            run, 🔴 before 🟠 before 🟡, each line prefixed with its severity emoji.
+            🔴/🟠 lines link their child issue (`· #<n>`); 🟡 lines have no child. Start
+            the body with a one-line tally: `New this run: N (🔴 a · 🟠 b) · low
+            (in-parent only): c · suppressed as dup/wontfix: d`.
+
+            ## Cross-link the previous parent -- NEVER close it
+            After filing the new parent, comment on the previous `Doc walkthrough —`
+            parent found in First-actions step 5 (if one exists) so readers can follow the
+            chain, but leave it OPEN:
+            `gh issue comment <prev-parent-#> --repo ${{ github.repository }} --body "Follow-up walkthrough run filed as #<new-parent-#>. This issue stays OPEN until its findings are addressed — only a maintainer should close it."`
+            Never call `gh issue close` on a parent from this workflow.
+
+            ## Rules
+            - No Claude attribution anywhere (no "Generated with", no Co-Authored-By).
+            - Do not open any PR and do not apply the `bug` label -- humans gate every
+              code change.
+            - Lead with the finding; keep each line to one sentence (CLAUDE.md issue style).
+          claude_args: |
+            --max-turns 32
+            --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}
+            --allowedTools Read,Grep,Glob,Bash
+
+      - name: Verify the walkthrough filed output
+        if: always()
+        env:
+          EXEC_FILE: ${{ steps.claude.outputs.execution_file }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Don't trust step outcome (continue-on-error masks it; an install
+          # crash exits before it's set). Check the real artifact the action
+          # writes on completion -- same verification claude-weekly-audit.yml
+          # uses for its own synthesis step.
+          ok=false
+          if [ -n "$EXEC_FILE" ] && [ -f "$EXEC_FILE" ]; then
+            is_err=$(jq -s -r '[.. | objects | select(has("is_error")) | .is_error] | .[-1]' "$EXEC_FILE" 2>/dev/null)
+            [ "$is_err" = "false" ] && ok=true
+          fi
+          if [ "$ok" = "true" ]; then
+            echo "✅ Weekly doc walkthrough synthesis completed (log: $EXEC_FILE)"
+          else
+            echo "::warning title=Weekly doc walkthrough did not complete::The synthesis step crashed or errored before finishing. Re-run: $RUN_URL"
+          fi

--- a/docs/plans/weekly-claude-audit.md
+++ b/docs/plans/weekly-claude-audit.md
@@ -99,4 +99,8 @@ ranks by severity (**🔴 high · 🟠 medium · 🟡 low** — no green; green 
 
 - ❌ Auto-merging anything, or opening PRs directly (promotion via `bug` → `auto-fix`).
 - ❌ Running `gaia eval agent` / Lemonade-dependent checks (this is static analysis).
+  Execution-based verification now lives in the sibling workflow
+  `.github/workflows/claude-weekly-doc-walkthrough.yml` — see
+  `docs/plans/weekly-doc-walkthrough-audit.md`. That workflow exists precisely because
+  this one's static-only scope let #2260 and #2261 both ship undetected.
 - ❌ Replacing per-PR review — it complements `claude.yml`, doesn't duplicate it.

--- a/docs/plans/weekly-doc-walkthrough-audit.md
+++ b/docs/plans/weekly-doc-walkthrough-audit.md
@@ -1,0 +1,224 @@
+# Weekly doc walkthrough — execution-based audit companion
+
+Design record for `.github/workflows/claude-weekly-doc-walkthrough.yml`.
+
+## Why this matters
+
+`claude-weekly-audit.yml` (see `docs/plans/weekly-claude-audit.md`) is deliberately
+**static** — five read-only Claude lenses that read and grep, never install or run repo
+code. That non-goal was intentional, but it has a real blind spot: two bugs shipped that
+are only observable by actually running GAIA from a real user's initial state, never by
+reading source.
+
+- **#2260** — `gaia chat` ImportErrors on a plain `pip install amd-gaia` because the
+  `gaia-agent-chat` wheel it depends on was never published. Every existing CI path
+  (`test_chat_agent.yml`) installs that hub package explicitly before testing, so nothing
+  has ever exercised the environment a real PyPI user actually gets.
+- **#2261** — seven hub agents silently fall back to a hardcoded 35B model when their
+  only preferred model isn't installed, 404ing on any standard `gaia init` profile. The
+  fallback is a three-hop chain (`registry.py` → `_build_create_kwargs` → the agent's
+  own `__init__` default) that doesn't match any of the static audit's literal
+  Fail-Loudly examples, and confirming it requires knowing which models a profile
+  actually installs — external knowledge a static read can't easily reach.
+
+This workflow is the execution-based counterpart: it acts as a real user/developer
+working through GAIA's documentation, on real hardware, and reports where reality
+diverges from the docs — a class of bug static analysis structurally cannot see.
+
+**This supersedes the "no Lemonade-dependent checks" non-goal** in
+`docs/plans/weekly-claude-audit.md` — that non-goal still holds for the *static* audit;
+this sibling workflow is where execution-based verification now lives.
+
+## Relationship to the static audit
+
+A **standalone sibling workflow**, not a 6th dimension of `claude-weekly-audit.yml`:
+
+- Different runner (`[self-hosted, Windows, stx]` vs. the static audit's `ubuntu-latest`).
+- Different cost/runtime profile (hours, not minutes — deliberately; see Cadence).
+- Different failure modes (can queue behind other work on a shared runner; a live command
+  can hang or time out).
+
+Isolating them means a slow or stuck walkthrough never delays or destabilizes the fast
+static lenses' weekly triage issue. The two workflows share vocabulary — severity scale
+(🔴 high · 🟠 medium · 🟡 low, no green), the `weekly-audit` label, the dedup-key pattern,
+`bug` → auto-fix promotion, `audit-wontfix` permanent suppression — but each files its
+**own** parent triage issue (`Doc walkthrough — <run_id>` vs. `Weekly audit — <mode> —
+<run_id>`), because they are different detection mechanisms surfacing potentially
+different root causes.
+
+## Cadence & runtime
+
+Weekly, same day as the static audit but offset (static audit: Monday 06:00 UTC; this
+workflow: Monday 12:00 UTC) so the two don't compete for review attention or runner time
+in the same window. **Deliberately allowed to run for hours** — this is the one weekly
+deep pass, not a per-PR check, and thoroughness is the explicit goal over speed.
+`workflow_dispatch` accepts an optional `doc_filter` glob input so a single guide can be
+re-run in isolation (for validating the workflow itself, or re-checking one finding).
+
+## Scope
+
+Every file under `docs/guides/*.mdx`, plus `docs/quickstart.mdx`, `docs/setup.mdx`, and
+`docs/reference/cli.mdx` — discovered by a **runtime glob**, not a hardcoded list, so a
+new guide is covered automatically (same extensibility principle the static audit uses
+for its dimensions).
+
+For a guide whose flow needs something this runner genuinely cannot provide — Jira/
+Atlassian credentials, a Google OAuth connector, a Blender install, a microphone, a
+non-Windows install path (`install.sh` vs. `install.ps1`) — every CI-feasible step still
+gets walked (install, config validation, flag parsing, documented error messages), and
+the infeasible step is reported explicitly: `"requires <X> — not verifiable in this
+environment"`. It is never silently skipped or silently counted as passing.
+
+**Stretch goal, explicitly not in v1:** browser-driven verification of `agent-ui.mdx` via
+Playwright (`gaia chat --ui`). Flagged here as a known, stated gap rather than a silent
+absence — CLI/install/API-surface guides ship first.
+
+## Execution environment (the crux of the design)
+
+Runner: `[self-hosted, Windows, stx]` — GAIA's existing hardware runner pool (NPU-capable,
+already running `install-lemonade`-managed Lemonade Server for other scheduled workflows).
+
+**Isolation requirements, and how each is met:**
+
+1. **A real user's install, not a dev checkout.** Fresh Python venv per run; GAIA
+   installed via `pip install` against a **built wheel** — never `pip install -e
+   .[dev,...]` and never an explicit hub-agent-package install alongside it. Existing CI
+   (`test_chat_agent.yml`) always installs `hub/agents/python/chat` explicitly before
+   testing ChatAgent, so this environment is genuinely novel — it is what would have
+   caught #2260.
+2. **A real user's config, not accumulated runner state.** `GAIA_HOME` set to a per-run
+   temp directory (GAIA already supports this override — `installer/uninstall_command.py`
+   reads `GAIA_HOME`). A guide's `gaia init` must not see, or leave behind, another run's
+   config or model registry.
+3. **A real user's model set, not this runner's accumulated cache.** This is the one
+   confirmed, non-hypothetical risk in the design: `test_agent_behavior_e2e.yml` already
+   pulls `Qwen3.5-35B-A3B-GGUF` onto this exact runner pool. If a guide's model-resolution
+   behavior were checked by pointing a live CLI at the runner's shared, kitchen-sink
+   Lemonade install, the 35B model being already-cached would silently defeat the exact
+   check meant to catch #2261-shaped bugs — the runner would no longer resemble a fresh
+   `gaia init --profile npu` machine.
+
+   **Resolution:** model-*resolution*-shaped checks (does this agent 404 when its
+   preferred model isn't installed) are verified with a **targeted Python snippet**, not
+   a live end-to-end CLI run — construct `AgentRegistry.resolve_model()` (or the
+   equivalent registry call) with an explicit `available_models` list matching exactly
+   what the profile under test installs, and assert the agent doesn't silently fall
+   through to a different hardcoded model. This sidesteps the shared-cache problem by
+   construction: the check never depends on what happens to be downloaded on this box.
+   Guides that need to verify **inference actually responds** (not "is this model
+   installed") are unaffected by this and can use a live Lemonade instance normally,
+   since the shared cache's contents are irrelevant to that question.
+4. **No collision with the other workflows already fighting over the shared runner.**
+   Issue #2122 (open, unresolved) documents six workflows force-killing port 13305 out
+   from under each other via `cleanup-lemonade.ps1`. Rather than depending on #2122 being
+   fixed first, this workflow **runs its own Lemonade Server instance on a dedicated,
+   non-13305 port**, entirely separate from the shared instance the other workflows use —
+   it sidesteps the contention by construction instead of by coordination. **Needs
+   live-runner verification**, flagged honestly: whether two Lemonade Server instances can
+   run concurrently on one Windows box (different ports), and whether a second instance
+   defaults to a separate model-cache path or shares the global one. If they must share a
+   cache path, that's still fine for the inference-response checks (item 3's snippet
+   approach already covers the resolution-logic checks independent of cache contents).
+5. **Cooperative, never destructive.** Never calls `cleanup-lemonade.ps1` or any
+   force-kill path. Health-checks its own port before use; if occupied by a leftover
+   process from a prior failed run, cleans up only what it started, never another
+   workflow's.
+6. **Clean start, clean end — verified, not assumed.** Before a run: confirm no stray
+   process/venv/temp-dir survives from a previous run. After a run (success or failure):
+   confirm no stray processes remain, the per-run temp dir is gone, and — if it touched
+   anything shared — that shared state is unaffected. Concrete checks (`Get-Process`,
+   directory-exists, a health probe), mirroring `gaia-testing`'s Phase 7 discipline.
+
+## Job structure
+
+One matrix entry per discovered doc file, `max-parallel: 1` — the same one-model-slot-at-
+a-time discipline the eval workflows already use (CLAUDE.md: "Run agent evals SERIALLY").
+This also gives natural checkpointing for an hours-long run: one guide hanging or timing
+out doesn't lose the findings already captured from guides that finished first.
+
+Each matrix entry:
+
+1. **Environment setup** — venv, isolated `GAIA_HOME`, dedicated-port Lemonade instance
+   (per Execution environment above).
+2. **Executor pass — model: Sonnet.** Cheap and well-suited to high tool-call-volume,
+   grinding, sequential work (mirrors the `gaia-testing` skill's own executor/judge model
+   split: strongest model plans+judges, a faster model executes). Walks the guide's
+   commands in the order a copy-pasting user would hit them, capturing raw stdout/stderr/
+   exit code/timing per step. **Stops a guide at its first failing step** — if step 2
+   depends on step 1 and step 1 failed, steps 3+ are not attempted; report the root cause,
+   not five cascading symptoms of it.
+3. **Judge pass — model: Opus** (matches the static audit's `AUDIT_MODEL`). Low volume —
+   one pass per guide — so the cost difference against Sonnet here is small, and this is
+   the piece worth paying for: it reviews the executor's **raw captured transcript**
+   independently against the doc's literal claims. It does not rubber-stamp the executor's
+   own summary — same principle `gaia-testing` states explicitly ("the executor's report
+   is a claim, never trusted on its face"), applied here because a single self-judging
+   session is exactly the kind of false-negative risk that would quietly erode trust in
+   this workflow the way a false positive would.
+4. **Deterministic layer for `cli.mdx` specifically.** In addition to the judge's
+   narrative read, the judge is instructed to explicitly enumerate every flag from
+   `gaia -h` / each subcommand's `-h` output and from the doc's flag tables and diff them
+   line by line — narrative judgment alone is prone to missing a single dropped row in a
+   long table. A follow-up hardening (out of scope for v1) would replace this with a real
+   `argparse`-introspecting script; flagged here rather than silently deferred.
+5. **Reproduce before filing.** A failing step is retried once before being treated as a
+   confirmed finding — a shared, contended runner will have real transient failures
+   (network blip, a slow model load), and one bad run is a flake, not a bug. Matches the
+   static audit's "verify before you report" precision rule.
+6. **Output** — `findings-walkthrough-<doc-slug>.json`, same shape as the static audit's
+   findings (`severity`/`path`/`symbol`/`title`/`why`/`evidence`/`auto_fixable`/
+   `dedup_key`), with `dedup_key` namespaced `walkthrough:<doc-path>:<step-heading>` —
+   a different namespace from the static lenses' `<dimension>:<path>:<symbol>`, so the two
+   mechanisms won't automatically cross-dedupe a shared root cause. Accepted as a known
+   gap for v1: a maintainer fixing either finding closes the underlying bug, which makes
+   the duplicate moot going forward.
+
+## Synthesis
+
+A separate synthesis job (same repo, `issues: write` only there, matching the static
+audit's least-privilege pattern) collects every `findings-walkthrough-*.json`, dedupes
+against already-open `weekly-audit`-labeled issues via the same `<!-- audit-key: KEY -->`
+marker convention, rolls 🟡 (low) findings into the parent issue only (no child issue —
+reuses the static audit's already-learned churn-control rule: its first deep run filed 19
+children, ~13 low-value), files 🔴/🟠 findings as child issues, and posts one parent
+`Doc walkthrough — <run_id>` issue labeled `weekly-audit`. Cross-links (never closes) the
+previous walkthrough parent — the static audit's own postmortem (#2010: an earlier
+auto-close silently hid 18 unaddressed children) is the reason this rule exists; it
+applies identically here.
+
+## Non-goals (v1)
+
+- Browser-driven Agent UI verification (Playwright) — stated stretch goal, not silently
+  dropped.
+- macOS/Linux install-path verification — this runner is Windows-only; reported as
+  unverifiable here, never claimed as covered.
+- Jira / Blender / Google-OAuth-gated flows — reported as unverifiable without those
+  credentials/software present, per-step, not skipped wholesale.
+- A real `argparse`-introspecting deterministic flag-diff tool for `cli.mdx` (v1 uses an
+  instructed-but-still-LLM enumeration/diff as an interim hardening).
+
+## Open questions carried into implementation (stated, not hidden)
+
+Implemented in `.github/workflows/claude-weekly-doc-walkthrough.yml`. Syntactically
+validated with `actionlint` (clean) and `scripts/audit/discover_walkthrough_docs.py`
+(run directly — discovers 28 docs, correctly excludes `agent-ui.mdx`). **Not** validated
+end-to-end against the real runner — that requires items below, plus a live
+`workflow_dispatch`.
+
+1. Whether two Lemonade Server instances can coexist on one Windows box on different
+   ports, and whether the second defaults to an isolated or shared model-cache path —
+   needs verification on the real runner. Implemented as a dedicated-port instance
+   (`WALKTHROUGH_LEMONADE_PORT: 13405`, separate from the shared 13305); the design does
+   not depend on the answer being "isolated" (see Execution environment, item 3).
+2. **New, found during implementation:** which shell `claude-code-action`'s Bash tool
+   actually invokes on this Windows runner (PowerShell vs. bash/git-bash) was not
+   confirmed at authoring time. The executor/judge prompts do not hardcode a syntax —
+   they instruct Claude to detect its own shell and adapt — but this is a workaround for
+   an unknown, not a resolution. Confirm on the first live run and hardcode the correct
+   syntax once known (removes a class of avoidable flakiness).
+3. Exact per-guide job timeout (implemented: 90 minutes) may need tuning once real
+   command timings from a live run are known.
+4. First live `workflow_dispatch` validation run (scoped to one guide via `doc_filter`,
+   e.g. `docs/quickstart.mdx`) is required before enabling the full weekly schedule with
+   confidence — this design was authored and reviewed without runner access, and is not
+   claimed to be validated end-to-end.

--- a/docs/superpowers/plans/2026-07-18-weekly-doc-walkthrough.md
+++ b/docs/superpowers/plans/2026-07-18-weekly-doc-walkthrough.md
@@ -1,0 +1,716 @@
+# Weekly Doc Walkthrough Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `.github/workflows/claude-weekly-doc-walkthrough.yml`, an execution-based
+sibling to the static `claude-weekly-audit.yml`, that acts as a real user/developer
+working through GAIA's documentation on the self-hosted Windows/STX runner and files
+findings where reality diverges from the docs.
+
+**Architecture:** One GH Actions workflow, matrix over discovered doc files
+(`max-parallel: 1`). Each matrix entry: isolated venv + isolated `GAIA_HOME` + a
+dedicated-port Lemonade instance, a Sonnet **executor** step that walks the guide's
+commands and captures raw output, an Opus **judge** step that independently verifies the
+transcript against the doc, writing `findings-walkthrough-<slug>.json`. A synthesis job
+(same conventions as `claude-weekly-audit.yml`: label scheme, dedup-key marker, child
+issues for 🔴/🟠 only) files one `Doc walkthrough — <run_id>` parent issue.
+
+**Tech Stack:** GitHub Actions (YAML), PowerShell (Windows runner steps),
+`anthropics/claude-code-action`, `gaia` CLI, Lemonade Server.
+
+## Global Constraints
+
+- Runner: `[self-hosted, Windows, stx]` for every step that installs/runs GAIA or Lemonade.
+- Never call `cleanup-lemonade.ps1` or force-kill any process this run didn't start.
+- Never install GAIA editable (`-e`) or install any `hub/agents/python/*` package
+  alongside core — the fresh-venv, real-user-install property is load-bearing (#2260).
+- Model-resolution-shaped checks (does an agent 404 on an uninstalled preferred model) use
+  a targeted Python snippet against `AgentRegistry`, never a live CLI run against a
+  model-catalog that might already be warmed by unrelated CI (#2261) — see design doc
+  "Execution environment" item 3.
+- Executor model: Sonnet. Judge model: `claude-opus-4-8` (matches `AUDIT_MODEL` in the
+  static audit — single source of truth, defined once as a workflow-level `env`).
+- Severity scale 🔴/🟠/🟡 (no green), `dedup_key` format
+  `walkthrough:<doc-path>:<step-heading>`, labels `weekly-audit` / `audit-wontfix`,
+  🟡 findings roll into the parent only (no child issue) — same conventions as
+  `claude-weekly-audit.yml` (`weekly-audit-patterns` skill).
+- No Claude attribution anywhere in generated issue text.
+- A finding must reproduce (retry once) before being written to the findings JSON.
+- Every out-of-scope step (missing creds/hardware/platform) is reported explicitly as
+  `"requires <X> — not verifiable in this environment"`, never silently skipped.
+
+---
+
+### Task 1: Design + non-goals docs (already complete)
+
+**Files:**
+- Created: `docs/plans/weekly-doc-walkthrough-audit.md`
+- Modified: `docs/plans/weekly-claude-audit.md` (non-goals bullet now points at the
+  sibling workflow)
+
+- [x] Written and cross-referenced in this session.
+
+### Task 2: Doc discovery + skip helper script
+
+**Files:**
+- Create: `scripts/audit/discover_walkthrough_docs.py`
+- Test: manual run (see Step 3) — this is a standalone CLI helper, not a pytest unit; it
+  has no GAIA runtime dependency (stdlib only) so it can be exercised directly.
+
+**Interfaces:**
+- Produces: a JSON array on stdout, `[{"path": "docs/guides/chat.mdx", "slug": "guides-chat"}, ...]`,
+  consumed by Task 3's `preflight` job as the matrix input (`fromJson`).
+
+- [ ] **Step 1: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Discover docs in scope for the weekly doc walkthrough.
+
+Emits a JSON array of {"path": ..., "slug": ...} for every doc the walkthrough
+should walk. Glob-based (not a hardcoded list) so a new guide is picked up
+automatically -- same extensibility principle as claude-weekly-audit.yml's
+dimension matrix. stdlib only: this runs before any venv exists.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Explicit exclude list for docs that are structurally out of scope for a
+# CLI walkthrough (not "hard to test" -- those still get walked with a
+# per-step "not verifiable" flag; these have no command-line surface at all).
+EXCLUDE = {
+    "docs/guides/agent-ui.mdx",  # stretch goal: needs a browser driver, see design doc
+}
+
+GLOBS = [
+    "docs/guides/*.mdx",
+    "docs/quickstart.mdx",
+    "docs/setup.mdx",
+    "docs/reference/cli.mdx",
+]
+
+
+def slugify(rel_path: str) -> str:
+    stem = re.sub(r"\.mdx?$", "", rel_path)
+    return re.sub(r"[^a-zA-Z0-9]+", "-", stem).strip("-").lower()
+
+
+def discover() -> list[dict]:
+    seen = set()
+    docs = []
+    for pattern in GLOBS:
+        for match in sorted(REPO_ROOT.glob(pattern)):
+            rel = match.relative_to(REPO_ROOT).as_posix()
+            if rel in EXCLUDE or rel in seen:
+                continue
+            seen.add(rel)
+            docs.append({"path": rel, "slug": slugify(rel)})
+    return docs
+
+
+def main() -> int:
+    docs = discover()
+    if not docs:
+        print("no docs discovered -- EXCLUDE list or GLOBS is misconfigured", file=sys.stderr)
+        return 1
+    print(json.dumps(docs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x scripts/audit/discover_walkthrough_docs.py
+```
+
+- [ ] **Step 3: Run it and verify real output**
+
+Run: `python3 scripts/audit/discover_walkthrough_docs.py | python3 -m json.tool | head -20`
+Expected: a JSON array whose entries include `docs/guides/chat.mdx`,
+`docs/quickstart.mdx`, `docs/reference/cli.mdx`, and do NOT include
+`docs/guides/agent-ui.mdx`. Confirm the count is sane (`... | python3 -c
+"import json,sys; print(len(json.load(sys.stdin)))"` — expect roughly the number of files
+`ls docs/guides/*.mdx docs/quickstart.mdx docs/setup.mdx docs/reference/cli.mdx | wc -l`
+reports, minus 1 for the excluded Agent UI guide).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/audit/discover_walkthrough_docs.py
+git commit -m "feat(ci): doc-discovery helper for the weekly doc walkthrough"
+```
+
+### Task 3: The workflow file — preflight, matrix skeleton, environment isolation
+
+**Files:**
+- Create: `.github/workflows/claude-weekly-doc-walkthrough.yml`
+
+**Interfaces:**
+- Consumes: `scripts/audit/discover_walkthrough_docs.py` (Task 2) for the matrix.
+- Produces: per-matrix-entry `findings-walkthrough-<slug>.json` artifacts, consumed by
+  Task 5's synthesis job.
+
+- [ ] **Step 1: Write the header comment + triggers + concurrency + env**
+
+```yaml
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Execution-based sibling to claude-weekly-audit.yml (see docs/plans/
+# weekly-doc-walkthrough-audit.md and docs/plans/weekly-claude-audit.md's
+# "Non-goals"). That workflow is deliberately static (read-only, never installs
+# or runs repo code) -- this one exists because that non-goal has a real blind
+# spot: #2260 (gaia chat ImportErrors on a plain PyPI install) and #2261 (seven
+# hub agents silently fall back to an uninstalled 35B model) are both only
+# observable by actually running GAIA from a real user's initial state, never
+# by reading source. This workflow acts as that user: one matrix job per doc
+# guide, each walking the guide's commands for real on the self-hosted
+# Windows/STX runner, in a fresh venv + isolated config + a dedicated-port
+# Lemonade instance -- never the runner's shared, CI-warmed install (see
+# "Execution environment" in the design doc for why that distinction matters).
+#
+# STANDALONE from claude-weekly-audit.yml on purpose: different runner
+# (self-hosted Windows vs. ubuntu-latest), different cost/runtime profile
+# (hours, not minutes -- deliberate; see design doc "Cadence"), different
+# failure modes (a live command can hang). Isolating them means a stuck
+# walkthrough never delays the fast static audit's triage issue. Shares
+# vocabulary with it (severity scale, dedup-key pattern, weekly-audit label,
+# bug-label auto-fix promotion) but files its OWN parent issue.
+#
+# MODEL SPLIT: Sonnet executes (cheap, high tool-call volume, grinding
+# sequential work); Opus (WALKTHROUGH_JUDGE_MODEL) judges (low volume -- one
+# pass per guide -- and never rubber-stamps the executor's own summary, same
+# principle the gaia-testing skill states explicitly). See design doc "Job
+# structure".
+#
+# PORT ISOLATION: runs its own Lemonade Server on a dedicated, non-13305 port
+# so it never collides with the six other workflows issue #2122 documents
+# fighting over the shared runner's Lemonade instance -- sidesteps that
+# contention by construction, not by coordination. NEEDS LIVE-RUNNER
+# VERIFICATION (flagged in the design doc): whether a second Lemonade Server
+# instance can run concurrently on this box and what it does for model-cache
+# visibility. Model-*resolution* checks (the #2261 shape) do not depend on the
+# answer -- they use a targeted Python snippet against AgentRegistry instead
+# of a live model catalog; see Task 4.
+#
+# NOT VALIDATED END-TO-END AT AUTHORING TIME: this workflow was written and
+# reviewed without access to the self-hosted runner. Run it once via
+# workflow_dispatch with doc_filter scoped to a single guide before trusting
+# the full weekly schedule.
+
+name: Claude Weekly Doc Walkthrough
+
+on:
+  schedule:
+    # 12:00 UTC every Monday -- offset 6h from claude-weekly-audit.yml's 06:00
+    # UTC run so the two don't compete for runner time or review attention.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+    inputs:
+      doc_filter:
+        description: "Glob to scope this run to one or a few docs (e.g. docs/guides/chat.mdx). Empty = all discovered docs."
+        default: ""
+
+permissions:
+  contents: read
+
+# Own group -- deliberately NOT the eval workflows' `lemonade-eval` group.
+# This workflow runs its own Lemonade instance on a dedicated port (see header),
+# so it does not need to serialize against workflows using the shared 13305
+# instance; it only needs to serialize against ITSELF across scheduled runs.
+concurrency:
+  group: claude-weekly-doc-walkthrough
+  cancel-in-progress: false
+
+env:
+  WALKTHROUGH_EXECUTOR_MODEL: claude-sonnet-4-6
+  WALKTHROUGH_JUDGE_MODEL: claude-opus-4-8
+  # Dedicated port for this workflow's own Lemonade instance -- never touches
+  # the shared 13305 port the other self-hosted-runner workflows use.
+  WALKTHROUGH_LEMONADE_PORT: 13405
+
+jobs:
+```
+
+- [ ] **Step 2: Write the `discover` job**
+
+```yaml
+  discover:
+    if: github.repository == 'amd/gaia'
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.discover.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Discover in-scope docs
+        id: discover
+        env:
+          DOC_FILTER: ${{ github.event.inputs.doc_filter }}
+        run: |
+          set -euo pipefail
+          all_docs=$(python3 scripts/audit/discover_walkthrough_docs.py)
+          if [ -n "$DOC_FILTER" ]; then
+            filtered=$(python3 -c "
+          import json, os, fnmatch
+          docs = json.loads(os.environ['ALL_DOCS'])
+          pattern = os.environ['DOC_FILTER']
+          print(json.dumps([d for d in docs if fnmatch.fnmatch(d['path'], pattern)]))
+          " )
+            echo "docs=$filtered" >> "$GITHUB_OUTPUT"
+            echo "Filtered to: $filtered"
+          else
+            echo "docs=$all_docs" >> "$GITHUB_OUTPUT"
+            echo "All in-scope docs: $all_docs"
+          fi
+        env:
+          ALL_DOCS: ${{ steps.discover.outputs.docs }}
+          DOC_FILTER: ${{ github.event.inputs.doc_filter }}
+```
+
+Note the two-pass env reference (the `ALL_DOCS` step output isn't set until the `id:
+discover` step's `run:` block finishes) — restructure as two steps in the actual file if
+`actions/github-script` proves cleaner than shelling out to Python twice; validate with
+`act` or a `workflow_dispatch` dry run before relying on it (this is exactly the kind of
+detail Step 3 of Task 6 exists to catch).
+
+- [ ] **Step 3: Write the `walkthrough` matrix job skeleton (environment isolation only, no executor/judge yet)**
+
+```yaml
+  walkthrough:
+    needs: discover
+    if: github.repository == 'amd/gaia' && needs.discover.outputs.docs != '[]'
+    runs-on: [self-hosted, Windows, stx]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        doc: ${{ fromJson(needs.discover.outputs.docs) }}
+    timeout-minutes: 90  # one guide's ceiling; the workflow overall may run for hours across the matrix
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify clean start state
+        shell: powershell
+        run: |
+          $runDir = "$env:RUNNER_TEMP\walkthrough-${{ matrix.doc.slug }}"
+          if (Test-Path $runDir) {
+            Write-Host "Stale run dir from a previous failed run -- removing: $runDir"
+            Remove-Item -Recurse -Force $runDir
+          }
+          New-Item -ItemType Directory -Path $runDir | Out-Null
+          echo "RUN_DIR=$runDir" >> $env:GITHUB_ENV
+          echo "GAIA_HOME=$runDir\gaia_home" >> $env:GITHUB_ENV
+
+      - name: Fresh venv, real-user install (no -e, no hub packages)
+        shell: powershell
+        run: |
+          python -m venv "$env:RUN_DIR\venv"
+          & "$env:RUN_DIR\venv\Scripts\python.exe" -m pip install --upgrade pip build
+          & "$env:RUN_DIR\venv\Scripts\python.exe" -m build --wheel --outdir "$env:RUN_DIR\dist" .
+          $wheel = Get-ChildItem "$env:RUN_DIR\dist\amd_gaia-*.whl" | Select-Object -First 1
+          & "$env:RUN_DIR\venv\Scripts\pip.exe" install $wheel.FullName
+          & "$env:RUN_DIR\venv\Scripts\gaia.exe" --version
+
+      - name: Start an isolated Lemonade instance on the dedicated port
+        shell: powershell
+        run: |
+          # Health-check first -- never assume the port is free, never force-kill
+          # whatever might already be on it (this workflow owns WALKTHROUGH_LEMONADE_PORT
+          # exclusively across its own runs, but a leftover process from a prior
+          # crashed run of THIS workflow is a legitimate thing to clean up).
+          $healthUrl = "http://localhost:$env:WALKTHROUGH_LEMONADE_PORT/api/v1/health"
+          try {
+            $resp = Invoke-WebRequest -Uri $healthUrl -TimeoutSec 3 -ErrorAction Stop
+            if ($resp.StatusCode -eq 200) {
+              Write-Host "Dedicated-port Lemonade already healthy (leftover from a prior run) -- reusing it."
+              exit 0
+            }
+          } catch {
+            Write-Host "Dedicated port not yet serving -- starting a fresh instance."
+          }
+          Start-Process -FilePath "LemonadeServer.exe" -ArgumentList "serve --port $env:WALKTHROUGH_LEMONADE_PORT" -PassThru |
+            ForEach-Object { $_.Id } | Out-File "$env:RUN_DIR\lemonade.pid"
+          # Poll for health rather than a fixed sleep.
+          $deadline = (Get-Date).AddSeconds(60)
+          do {
+            Start-Sleep -Seconds 2
+            try {
+              $resp = Invoke-WebRequest -Uri $healthUrl -TimeoutSec 3 -ErrorAction Stop
+              if ($resp.StatusCode -eq 200) { break }
+            } catch {}
+          } while ((Get-Date) -lt $deadline)
+```
+
+- [ ] **Step 4: Sanity-check the YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-weekly-doc-walkthrough.yml'))" `
+Expected: no exception. (This only proves syntactic validity, not runner-side
+correctness — Task 6 covers what can and can't be verified before a live run.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/claude-weekly-doc-walkthrough.yml
+git commit -m "feat(ci): scaffold the weekly doc walkthrough workflow"
+```
+
+### Task 4: Executor + judge steps, model-resolution snippet checks
+
+**Files:**
+- Modify: `.github/workflows/claude-weekly-doc-walkthrough.yml` (append to the
+  `walkthrough` job from Task 3)
+
+**Interfaces:**
+- Consumes: `RUN_DIR`, `GAIA_HOME`, `WALKTHROUGH_LEMONADE_PORT` env vars set in Task 3.
+- Produces: `findings-walkthrough-${{ matrix.doc.slug }}.json` (same shape as
+  `claude-weekly-audit.yml`'s findings, `dedup_key` namespaced `walkthrough:...`).
+
+- [ ] **Step 1: Add the executor step**
+
+```yaml
+      - name: "Executor (Sonnet): walk ${{ matrix.doc.path }}"
+        id: executor
+        continue-on-error: true
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are the EXECUTOR half of GAIA's weekly doc walkthrough. Your only job is
+            to run commands and capture their raw output -- judging correctness is a
+            SEPARATE step that reads your transcript independently. Do not editorialize
+            or decide what's a bug; just execute faithfully and record everything.
+
+            DOC UNDER TEST: ${{ matrix.doc.path }}
+            ENVIRONMENT: a fresh venv is already active at $env:RUN_DIR\venv (GAIA
+            installed from a built wheel, no -e install, no hub agent packages
+            preinstalled -- this is deliberate, do not "fix" a missing hub package by
+            installing it). GAIA_HOME is isolated at $env:GAIA_HOME. A Lemonade instance
+            is running at http://localhost:${{ env.WALKTHROUGH_LEMONADE_PORT }} -- point
+            any Lemonade-aware command at that port, never the default 13305.
+
+            ## What to do
+            1. Read `${{ matrix.doc.path }}` in full.
+            2. Extract every command a reader is expected to actually run, in the order
+               the doc presents them (code fences, inline `gaia ...` examples).
+            3. Run each command for real, using `$env:RUN_DIR\venv\Scripts\gaia.exe`
+               explicitly (not a bare `gaia` that might resolve to something else on the
+               runner). Capture stdout, stderr, exit code, and wall-clock time for each.
+            4. **Stop the guide at its first failing step whose failure blocks later
+               steps** (e.g. `gaia init` failing means don't attempt `gaia chat` after
+               it) -- report the root step, don't manufacture cascading noise from steps
+               whose precondition already failed. Steps that are independently runnable
+               (separate subcommands not depending on the failed one) still get attempted.
+            5. A step needing something this environment cannot provide (Jira/Atlassian
+               credentials, a Google OAuth connector, a Blender install, a microphone, a
+               non-Windows install path) is NOT attempted -- record it explicitly as
+               `"requires <X> -- not verifiable in this environment"` and move to the next
+               independently-runnable step.
+            6. **Model-resolution checks are a special case -- do NOT drive them through
+               a live end-to-end CLI run.** If the doc's guide involves an agent choosing
+               a model when its preferred model isn't installed (this is exactly the
+               #2261 bug shape), the runner's shared Lemonade cache may already have
+               other models downloaded from unrelated CI and would silently defeat the
+               check. Instead write and run a small, throwaway Python snippet using
+               `$env:RUN_DIR\venv\Scripts\python.exe` that imports the relevant registry
+               code and calls its model-resolution function with an EXPLICIT
+               `available_models` list matching only what the doc's target `gaia init`
+               profile installs (cross-reference `INIT_PROFILES` in
+               `src/gaia/installer/init_command.py` for the real list) -- then assert the
+               agent does not silently fall through to a different hardcoded model.
+               Capture the snippet's full source and output as evidence.
+            7. **A failing step must reproduce before you treat it as real.** Retry it
+               once. If it passes the second time, note it as a flake (timing, network) in
+               your transcript rather than a confirmed failure -- the judge decides what
+               to do with that note, you do not decide it's a non-issue yourself.
+
+            Write the full raw transcript (every command, its output, exit code, timing,
+            and any retry) to `$env:RUN_DIR\transcript.md`, structured with one section per
+            step in doc order. This transcript is the ONLY thing the judge step reads --
+            anything not captured there does not exist for judging purposes.
+          claude_args: |
+            --max-turns 60
+            --model ${{ env.WALKTHROUGH_EXECUTOR_MODEL }}
+            --allowedTools Read,Grep,Glob,Bash
+```
+
+- [ ] **Step 2: Add the judge step**
+
+```yaml
+      - name: "Judge (Opus): verify ${{ matrix.doc.path }} against its transcript"
+        id: judge
+        if: always()
+        continue-on-error: true
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are the JUDGE half of GAIA's weekly doc walkthrough. Do not trust the
+            executor's framing -- read its raw transcript and the doc yourself, and reach
+            your own conclusion. This split exists because a single self-judging session
+            is a known false-negative risk (see docs/plans/weekly-doc-walkthrough-audit.md
+            "Job structure").
+
+            DOC UNDER TEST: ${{ matrix.doc.path }}
+            TRANSCRIPT: $env:RUN_DIR\transcript.md (if missing, the executor crashed before
+            writing it -- file ONE 🟠 finding for that, dedup_key
+            `walkthrough:${{ matrix.doc.path }}:executor-crash`, and stop)
+
+            ## What to do
+            1. Read `${{ matrix.doc.path }}` and `$env:RUN_DIR\transcript.md` in full.
+            2. For each step in the transcript, check: does the actual captured output
+               match what the doc claims will happen? A step marked "not verifiable in
+               this environment" is not a finding by itself -- it's expected coverage,
+               unless the doc presents that exact step as something every reader can run
+               (in which case the doc itself needs a caveat -- that IS a finding).
+            3. **`docs/reference/cli.mdx` gets an extra deterministic pass:** enumerate
+               every flag from the transcript's `gaia -h` / subcommand `-h` output and
+               every flag documented in the doc's tables, and diff them explicitly,
+               flag by flag -- don't rely on a narrative skim for this file, a single
+               dropped row in a long table is easy to miss that way.
+            4. A step the executor noted as "reproduced as a flake" is NOT a finding --
+               skip it. A step that failed and did NOT reproduce cleanly on retry (i.e.
+               failed twice) IS eligible.
+            5. Write findings to `findings-walkthrough-${{ matrix.doc.slug }}.json`
+               (repo root), same shape `claude-weekly-audit.yml` uses:
+               ```json
+               {"findings": [
+                 {
+                   "severity": "🔴" | "🟠" | "🟡",
+                   "path": "${{ matrix.doc.path }}",
+                   "symbol": "the doc heading or step name -- NOT a line number",
+                   "title": "one-line statement of the problem",
+                   "why": "one sentence: the concrete impact / what breaks",
+                   "evidence": "the exact transcript excerpt (command + captured output) proving the claim",
+                   "auto_fixable": true | false,
+                   "dedup_key": "walkthrough:${{ matrix.doc.path }}:<step-heading>"
+                 }
+               ]}
+               ```
+               Write `{"findings": []}` if nothing is wrong. Severity: 🔴 a default-path
+               command in the doc fails outright; 🟠 the doc's claim about behavior is
+               false but the underlying command doesn't crash; 🟡 a cosmetic/minor gap
+               (a missing caveat, a stale example). `auto_fixable` = true only if the fix
+               is small and locatable (~1-3 files, no design call).
+          claude_args: |
+            --max-turns 25
+            --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}
+            --allowedTools Read,Grep,Glob,Bash
+```
+
+- [ ] **Step 3: Add cleanup + upload steps**
+
+```yaml
+      - name: Verify clean end state
+        if: always()
+        shell: powershell
+        run: |
+          if (Test-Path "$env:RUN_DIR\lemonade.pid") {
+            $pid = Get-Content "$env:RUN_DIR\lemonade.pid"
+            Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue
+          }
+          Remove-Item -Recurse -Force $env:RUN_DIR -ErrorAction SilentlyContinue
+          if (Test-Path $env:RUN_DIR) {
+            Write-Host "::warning::Run dir did not clean up: $env:RUN_DIR"
+          } else {
+            Write-Host "Clean: run dir removed."
+          }
+          # Confirm this run never touched the shared 13305 instance's health.
+          try {
+            $resp = Invoke-WebRequest -Uri "http://localhost:13305/api/v1/health" -TimeoutSec 3 -ErrorAction Stop
+            Write-Host "Shared Lemonade (13305) still healthy: $($resp.StatusCode)"
+          } catch {
+            Write-Host "Shared Lemonade (13305) not reachable or not running -- not this workflow's concern, just confirming we didn't kill it if it WAS up."
+          }
+
+      - name: Upload findings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: findings-walkthrough-${{ matrix.doc.slug }}
+          path: findings-walkthrough-${{ matrix.doc.slug }}.json
+          if-no-files-found: warn
+```
+
+- [ ] **Step 4: Sanity-check the YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-weekly-doc-walkthrough.yml'))"`
+Expected: no exception.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/claude-weekly-doc-walkthrough.yml
+git commit -m "feat(ci): executor/judge steps for the weekly doc walkthrough"
+```
+
+### Task 5: Synthesis job
+
+**Files:**
+- Modify: `.github/workflows/claude-weekly-doc-walkthrough.yml` (append the `synthesize`
+  job)
+
+**Interfaces:**
+- Consumes: `findings-walkthrough-*.json` artifacts from Task 4.
+- Produces: one `Doc walkthrough — <run_id>` GitHub issue, `weekly-audit`-labeled,
+  cross-linking the previous walkthrough parent (never closing it) — same lifecycle rule
+  as `claude-weekly-audit.yml`'s synthesis job.
+
+- [ ] **Step 1: Write the `synthesize` job**, adapting `claude-weekly-audit.yml`'s
+  synthesis prompt (dedup against `weekly-audit`/`audit-wontfix` keys, evidence gate,
+  fixed-order parent body, cross-link not close) with these differences: title prefix
+  `Doc walkthrough —` instead of `Weekly audit —`; no per-dimension sections (this
+  workflow has one detection mechanism, not five) — group findings by doc path instead,
+  most-severe first; no security carve-out (this workflow's prompts never instruct
+  finding of security issues — out of scope, the static audit already owns that lens).
+
+```yaml
+  synthesize:
+    needs: [discover, walkthrough]
+    if: github.repository == 'amd/gaia' && !cancelled() && needs.discover.outputs.docs != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download all findings
+        uses: actions/download-artifact@v8
+        with:
+          path: walkthrough-findings
+
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create weekly-audit --color 5319e7 \
+            --description "Proactive weekly Claude audit finding" \
+            2>/dev/null && echo "created weekly-audit label" || echo "weekly-audit label already exists"
+          gh label create audit-wontfix --color cccccc \
+            --description "Accepted debt -- weekly audit will never re-file this finding" \
+            2>/dev/null && echo "created audit-wontfix label" || echo "audit-wontfix label already exists"
+
+      - name: Synthesize and file the triage issue
+        id: claude
+        continue-on-error: true
+        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1.0.171
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are the synthesis step of GAIA's weekly DOC WALKTHROUGH (the
+            execution-based sibling of the static weekly-audit -- see
+            docs/plans/weekly-doc-walkthrough-audit.md). Each matrix job wrote a
+            findings-walkthrough-<slug>.json. Dedupe, rank, and file the output.
+
+            REPO: ${{ github.repository }}
+            RUN LOG: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ## First actions
+            1. Read every `findings-walkthrough-*.json` under `walkthrough-findings/`.
+               Missing/empty files are fine.
+            2. Read `CLAUDE.md` -> "Issue Response Guidelines" for tone/format.
+            3. Already-filed keys: `gh issue list --repo ${{ github.repository }} --label weekly-audit --state open --json number,title,body --limit 200`,
+               collect `<!-- audit-key: KEY -->` markers.
+            4. Suppressed-forever keys: `gh issue list --repo ${{ github.repository }} --label weekly-audit --label audit-wontfix --state all --json body --limit 200`.
+            5. Previous parent to cross-link: the most recently created OPEN issue whose
+               title starts `Doc walkthrough —` (NOT `Weekly audit —` -- that's the other
+               workflow's parent, a different lineage; do not cross-link across workflows).
+
+            ## Dedup + verify
+            1. Drop any finding whose `dedup_key` is in either key set from step 3/4.
+            2. Evidence gate: drop any 🔴/🟠 finding whose `evidence` doesn't actually
+               substantiate its `title` -- spot-check by reading the transcript excerpt.
+            3. If zero new findings remain, post NOTHING and exit cleanly.
+
+            ## File child issues -- 🔴/🟠 only
+            Same body format and rules as the static weekly audit's synthesis (no `bug`
+            label, `<!-- audit-key: KEY -->` required, "Not acting on this? Close it with
+            `audit-wontfix`" line, Auto-fixable line from the finding's field).
+
+            ## File ONE parent issue
+            Title: `Doc walkthrough — ${{ github.run_id }}`. Label `weekly-audit`.
+            Group findings by DOC PATH (not by dimension -- this workflow has one
+            mechanism), most-severe-first across the whole run, 🔴 before 🟠 before 🟡.
+            Start with a one-line tally: `New this run: N (🔴 a · 🟠 b) · low
+            (in-parent only): c · suppressed as dup/wontfix: d`.
+
+            ## Cross-link the previous parent -- NEVER close it
+            Same rule as the static audit: comment on the previous `Doc walkthrough —`
+            parent found in step 5, leave it OPEN, never call `gh issue close` on a parent.
+
+            ## Rules
+            - No Claude attribution anywhere.
+            - Do not open a PR, do not apply `bug` -- humans gate every code change.
+            - Lead with the finding; one sentence per line (CLAUDE.md issue style).
+          claude_args: |
+            --max-turns 32
+            --model ${{ env.WALKTHROUGH_JUDGE_MODEL }}
+            --allowedTools Read,Grep,Glob,Bash
+```
+
+- [ ] **Step 2: Sanity-check the YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-weekly-doc-walkthrough.yml'))"`
+Expected: no exception.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/claude-weekly-doc-walkthrough.yml
+git commit -m "feat(ci): synthesis job for the weekly doc walkthrough"
+```
+
+### Task 6: Validate what can be validated without runner access, document what can't
+
+**Files:**
+- No new files; verification only.
+
+- [ ] **Step 1: actionlint (if available) or a manual structural read-through**
+
+Run: `actionlint .github/workflows/claude-weekly-doc-walkthrough.yml` if `actionlint` is
+installed; otherwise `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-weekly-doc-walkthrough.yml'))"`
+plus a manual read comparing every `${{ }}` reference against a job/step output actually
+defined earlier in the file (the `discover` job's two-pass env-var reference flagged in
+Task 3 Step 2 is exactly the kind of bug this read-through exists to catch — resolve it
+concretely here, don't leave the note from Task 3 unresolved).
+
+Expected: no syntax errors; every referenced output/secret/env var traces to a real
+definition.
+
+- [ ] **Step 2: Confirm `docs/plans/weekly-doc-walkthrough-audit.md`'s "Open questions"
+  section still accurately lists what remains unverified** (Lemonade dual-instance
+  behavior, per-guide timeout tuning, the required first `workflow_dispatch` validation
+  run) — update it if implementation changed any assumption from the design doc.
+
+- [ ] **Step 3: State plainly, in the PR description, that this has NOT been run against
+  the real runner** — a `workflow_dispatch` with `doc_filter: docs/quickstart.mdx` (or
+  similar single-doc scope) is the required next step before trusting the weekly
+  schedule, and per CLAUDE.md's "Commit Only When Bulletproof," this is disclosed rather
+  than implied to be end-to-end verified.
+
+### Task 7: Open the PR
+
+**Files:** none (process step).
+
+- [ ] **Step 1: Push the branch and open the PR** with a tight, why-first description
+  (CLAUDE.md "PR Descriptions — Tight and Value-Focused"): lead with the #2260/#2261
+  gap this closes, note the standalone-workflow + Sonnet/Opus split + port-isolation
+  design decisions in one short paragraph each only if a reviewer needs them to evaluate
+  the change, and an explicit test-plan checkbox for the required single-doc
+  `workflow_dispatch` validation run (unchecked — it happens after merge, on the real
+  runner, not from this session).

--- a/scripts/audit/discover_walkthrough_docs.py
+++ b/scripts/audit/discover_walkthrough_docs.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Discover docs in scope for the weekly doc walkthrough.
+
+Emits a JSON array of {"path": ..., "slug": ...} for every doc the
+walkthrough should walk. Glob-based (not a hardcoded list) so a new guide is
+picked up automatically -- same extensibility principle as
+claude-weekly-audit.yml's dimension matrix. stdlib only: this runs before any
+venv exists.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Explicit exclude list for docs that are structurally out of scope for a CLI
+# walkthrough (not "hard to test" -- those still get walked with a per-step
+# "not verifiable" flag; these have no command-line surface at all).
+EXCLUDE = {
+    # Needs a browser driver (Playwright) to verify for real -- stretch goal,
+    # see docs/plans/weekly-doc-walkthrough-audit.md "Non-goals (v1)".
+    "docs/guides/agent-ui.mdx",
+}
+
+GLOBS = [
+    "docs/guides/*.mdx",
+    "docs/quickstart.mdx",
+    "docs/setup.mdx",
+    "docs/reference/cli.mdx",
+]
+
+
+def slugify(rel_path: str) -> str:
+    stem = re.sub(r"\.mdx?$", "", rel_path)
+    return re.sub(r"[^a-zA-Z0-9]+", "-", stem).strip("-").lower()
+
+
+def discover() -> list:
+    seen = set()
+    docs = []
+    for pattern in GLOBS:
+        for match in sorted(REPO_ROOT.glob(pattern)):
+            rel = match.relative_to(REPO_ROOT).as_posix()
+            if rel in EXCLUDE or rel in seen:
+                continue
+            seen.add(rel)
+            docs.append({"path": rel, "slug": slugify(rel)})
+    return docs
+
+
+def main() -> int:
+    docs = discover()
+    if not docs:
+        print(
+            "no docs discovered -- EXCLUDE list or GLOBS is misconfigured",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(docs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why this matters

The weekly audit is deliberately static (read-only, never installs or runs repo code) — a non-goal that let #2260 (`gaia chat` ImportErrors on a plain PyPI install) and #2261 (seven hub agents silently fall back to an uninstalled 35B model) both ship undetected, since neither bug is observable without actually running GAIA from a real user's initial state. This adds a standalone sibling workflow that does exactly that: walks every doc guide's commands for real, weekly, on the self-hosted Windows/STX runner, in an environment deliberately isolated from this runner's CI-warmed state (fresh venv with no hub packages preinstalled, a dedicated-port Lemonade instance separate from the shared one other workflows fight over per #2122). An independent Opus pass judges each guide's raw execution transcript against what the doc claims, rather than trusting a single session's self-report.

Design record: `docs/plans/weekly-doc-walkthrough-audit.md` (includes the critique/mitigation pass this went through before implementation). `docs/plans/weekly-claude-audit.md`'s non-goals section is updated to point at this workflow.

**Not yet validated against the real runner** — this was authored and reviewed without self-hosted-runner access. Opening as a draft; see the design doc's "Open questions" (dedicated-Lemonade-instance coexistence, and which shell `claude-code-action`'s Bash tool actually uses on this runner) for what the first live run needs to confirm.

## Test plan

- [x] `actionlint` clean on the new workflow and on `claude-weekly-audit.yml` (no regression)
- [x] `scripts/audit/discover_walkthrough_docs.py` run directly — discovers 28 in-scope docs, correctly excludes `agent-ui.mdx` (stretch goal, not v1)
- [x] `black`/`isort` clean on the new script
- [ ] Live `workflow_dispatch` with `doc_filter: docs/quickstart.mdx` on the real `stx` runner, before enabling the full weekly schedule with confidence