### PR TITLE
docs(models): point consolidated-agent defaults at Gemma-4-E4B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -568,7 +568,7 @@ When adding a new tool mixin, register it in `KNOWN_TOOLS` so other agents can c
 
 ### Default Models
 - `gaia llm` default: `Gemma-4-E4B-it-GGUF` (`DEFAULT_MODEL_NAME` in [`src/gaia/llm/lemonade_client.py`](src/gaia/llm/lemonade_client.py)). ChatAgent and EmailTriageAgent explicitly use it too.
-- Agents that leave `model_id` unset fall back to `Qwen3.5-35B-A3B-GGUF` — the base `Agent.__init__` default (`model_id or "Qwen3.5-35B-A3B-GGUF"`). That covers Analyst, Browser, FileIO, plus Code/Builder/Jira/Docker/Routing/DocumentQA which also hardcode it.
+- Agents that leave `model_id` unset fall back to `Gemma-4-E4B-it-GGUF` — the base `Agent.__init__` default (`model_id or "Gemma-4-E4B-it-GGUF"`). That covers Analyst, Browser, FileIO, plus Code/Builder/Jira/Docker/Routing/DocumentQA/Blender/doc-search/connectors-demo which also hardcode it.
 - Summarizer: `Qwen3-4B-Instruct-2507-GGUF`
 - Vision: `Gemma-4-E4B-it-GGUF` is the default VLM (VLM mixin + EMR agent); `Qwen3-VL-4B-Instruct-GGUF` also supported
 - Image generation (SD): `SDXL-Turbo`

--- a/docs/guides/blender.mdx
+++ b/docs/guides/blender.mdx
@@ -99,7 +99,7 @@ gaia blender [OPTIONS]
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--model` | string | auto-selected by agent | Language model ID for AI processing (not a Blender 3D model). When omitted, the Blender agent picks a model based on your installed profile — typically a Qwen3 variant. Pass e.g. `--model Qwen3.5-35B-A3B-GGUF` to pin the 35B model. |
+| `--model` | string | auto-selected by agent | Language model ID for AI processing (not a Blender 3D model). When omitted, the Blender agent picks a model based on your installed profile — typically `Gemma-4-E4B-it-GGUF`. Pass e.g. `--model Gemma-4-E4B-it-GGUF` to pin it explicitly. |
 | `--example` | int (1-6) | None | Run a specific example, if not specified run interactive mode |
 | `--steps` | int | 5 | Maximum number of steps per query |
 | `--output-dir` | string | "output" | Directory to save output files |

--- a/docs/guides/docker.mdx
+++ b/docs/guides/docker.mdx
@@ -29,14 +29,14 @@ The GAIA Docker Agent provides a natural language interface for containerizing a
    ```
 
 3. **Download Required Model**:
-   The Docker agent uses the `Qwen3.5-35B-A3B-GGUF` model for reliable Dockerfile generation and application analysis.
+   The Docker agent uses the `Gemma-4-E4B-it-GGUF` model for reliable Dockerfile generation and application analysis.
 
    Use the Lemonade server's model manager to download it:
    1. Start Lemonade server with extended context size: `lemonade-server serve --ctx-size 8192`
    2. Open the model manager in your browser (typically http://localhost:13305)
-   3. Search for and download: `Qwen3.5-35B-A3B-GGUF`
+   3. Search for and download: `Gemma-4-E4B-it-GGUF`
 
-   Note: The model is over 17GB and can take a while to download depending on your internet connection. It provides excellent results for Dockerfile generation and application analysis.
+   Note: The model is around 3GB and downloads quickly on most connections. It provides excellent results for Dockerfile generation and application analysis.
    
    **Important**: The Docker agent requires a higher context size (8192) than the default (4096) to handle complex application analysis and Dockerfile generation. For more details on Lemonade Server CLI options, see the [Lemonade Server documentation](https://lemonade-server.ai/docs/guide/cli/#options-for-run).
 
@@ -201,7 +201,7 @@ For more details on the MCP bridge, see [MCP Documentation](/integrations/mcp).
 from gaia.agents.docker.agent import DockerAgent
 
 # Initialize and execute
-agent = DockerAgent(model_id="Qwen3.5-35B-A3B-GGUF", silent_mode=True)
+agent = DockerAgent(model_id="Gemma-4-E4B-it-GGUF", silent_mode=True)
 result = agent.process_query("create a Dockerfile for my Flask app in directory: ./app")
 
 if result['status'] == 'success':
@@ -306,7 +306,7 @@ The `command` is a natural language instruction that tells the agent what Docker
 | `-d`, `--directory` | string | `.` | Directory containing the application to containerize |
 | `-v`, `--verbose` | flag | - | Enable verbose output |
 | `--debug` | flag | - | Enable debug logging |
-| `--model` | string | `Qwen3.5-35B-A3B-GGUF` | LLM model to use |
+| `--model` | string | `Gemma-4-E4B-it-GGUF` | LLM model to use |
 
 ## Troubleshooting
 
@@ -346,10 +346,10 @@ If the agent doesn't generate a Dockerfile:
 
 #### "Model Not Found"
 
-Verify the Qwen3.5-35B model is downloaded:
+Verify the Gemma 4 E4B model is downloaded:
 
 1. Open Lemonade UI: http://localhost:13305
-2. Check Models section for Qwen3.5-35B-A3B-GGUF
+2. Check Models section for Gemma-4-E4B-it-GGUF
 
 #### MCP Integration Issues
 

--- a/docs/guides/jira.mdx
+++ b/docs/guides/jira.mdx
@@ -22,12 +22,12 @@ The GAIA Jira Agent provides a natural language interface to Atlassian Jira. It 
 
 1. **GAIA Installation** — Follow the [Setup](/setup) guide. The base install includes everything the Jira agent needs.
 
-2. **Download the model** — The agent uses `Qwen3.5-35B-A3B-GGUF` for reliable JSON parsing and JQL generation. Download it via the Lemonade model manager:
+2. **Download the model** — The agent uses `Gemma-4-E4B-it-GGUF` for reliable JSON parsing and JQL generation. Download it via the Lemonade model manager:
    1. Start the server: `lemonade-server serve`
    2. Open the model manager (typically http://localhost:13305)
-   3. Search for and download `Qwen3.5-35B-A3B-GGUF`
+   3. Search for and download `Gemma-4-E4B-it-GGUF`
 
-   The model is over 17 GB, so download takes a while and is best run on a Strix Halo (or similar high-memory) device. It is selected automatically when you run Jira commands.
+   The model is around 3 GB, so the download is quick on most connections. It is selected automatically when you run Jira commands.
 
 3. **Set Jira credentials**:
 

--- a/docs/guides/routing.mdx
+++ b/docs/guides/routing.mdx
@@ -171,8 +171,8 @@ What language/framework would you like to use for your backend project?
 The routing agent can be configured via environment variables:
 
 ```bash
-# Model used for routing analysis (default: Qwen3.5-35B-A3B-GGUF)
-export AGENT_ROUTING_MODEL=Qwen3.5-35B-A3B-GGUF
+# Model used for routing analysis (default: Gemma-4-E4B-it-GGUF)
+export AGENT_ROUTING_MODEL=Gemma-4-E4B-it-GGUF
 
 # Lemonade server URL (default: http://localhost:13305/api/v1)
 export LEMONADE_BASE_URL=http://localhost:13305/api/v1
@@ -233,7 +233,7 @@ gaia-code "Create an Express API with SQLite"
 **Issue**: Even with specific frameworks, routing agent asks for clarification.
 
 **Solution**:
-- Check the routing model is loaded: `AGENT_ROUTING_MODEL=Qwen3.5-35B-A3B-GGUF`
+- Check the routing model is loaded: `AGENT_ROUTING_MODEL=Gemma-4-E4B-it-GGUF`
 - Verify Lemonade server has sufficient context size: `--ctx-size 32768`
 - Ensure the coding model is available in Lemonade's model list
 

--- a/docs/reference/api-spec.mdx
+++ b/docs/reference/api-spec.mdx
@@ -199,7 +199,7 @@ Supports both **streaming** (SSE) and **non-streaming** responses.
 
 **Requirements:**
 - Lemonade Server with `--ctx-size 32768`
-- Model: `Qwen3.5-35B-A3B-GGUF`
+- Model: `Gemma-4-E4B-it-GGUF`
 
 **Capabilities:**
 - Code generation (functions, classes, projects)

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -82,7 +82,7 @@ The GAIA API Server exposes GAIA agents as "models" through an OpenAI-compatible
 </CardGroup>
 
 <Note>
-**Required Models:** Download `Qwen3.5-35B-A3B-GGUF` via Lemonade's model manager
+**Required Models:** Download `Gemma-4-E4B-it-GGUF` via Lemonade's model manager
 </Note>
 
 ---

--- a/docs/reference/features.mdx
+++ b/docs/reference/features.mdx
@@ -89,7 +89,7 @@ gaia chat --show-stats
 - `/help` - Show available commands
 - `quit`, `exit`, or `bye` - End the chat session
 
-**Requirements:** Requires lemonade-server to be running. The chat agent defaults to Qwen3.5-35B-A3B-GGUF model for optimal performance.
+**Requirements:** Requires lemonade-server to be running. The chat agent defaults to the Gemma-4-E4B-it-GGUF model for optimal performance.
 
 **Platform Availability**: Windows and Linux
 

--- a/docs/sdk/core/agent-system.mdx
+++ b/docs/sdk/core/agent-system.mdx
@@ -355,7 +355,7 @@ agent = MyAgent(
 
     # === Local LLM Settings ===
     base_url="http://localhost:13305/api/v1",  # Lemonade server URL
-    model_id="Qwen3.5-35B-A3B-GGUF",  # Model to use
+    model_id="Gemma-4-E4B-it-GGUF",  # Model to use
 
     # === Cloud LLM Settings ===
     claude_model="claude-sonnet-4-20250514",  # Claude model version

--- a/docs/spec/docker-agent.mdx
+++ b/docs/spec/docker-agent.mdx
@@ -10,7 +10,7 @@ title: "DockerAgent"
 **Component:** DockerAgent - Intelligent Docker Containerization
 **Module:** `gaia.agents.docker.agent`
 **Inherits:** MCPAgent
-**Model:** Qwen3.5-35B-A3B-GGUF (default)
+**Model:** Gemma-4-E4B-it-GGUF (default)
 </Note>
 
 ---
@@ -68,7 +68,7 @@ class DockerAgent(MCPAgent):
     Intelligent Docker agent for containerization.
     """
 
-    DEFAULT_MODEL = "Qwen3.5-35B-A3B-GGUF"
+    DEFAULT_MODEL = "Gemma-4-E4B-it-GGUF"
     DEFAULT_MAX_STEPS = 10
     DEFAULT_PORT = 8080
 

--- a/docs/spec/jira-agent.mdx
+++ b/docs/spec/jira-agent.mdx
@@ -10,7 +10,7 @@ title: "JiraAgent"
 **Component:** JiraAgent - Natural Language Jira Interface
 **Module:** `gaia.agents.jira.agent`
 **Inherits:** Agent
-**Model:** Qwen3.5-35B-A3B-GGUF (default)
+**Model:** Gemma-4-E4B-it-GGUF (default)
 </Note>
 
 ---
@@ -70,7 +70,7 @@ class JiraAgent(Agent):
         self,
         jira_config: Dict[str, Any] = None,
         max_steps: int = 10,
-        model_id: str = "Qwen3.5-35B-A3B-GGUF",
+        model_id: str = "Gemma-4-E4B-it-GGUF",
         silent_mode: bool = False,
         **kwargs
     ):


### PR DESCRIPTION
Docs currently tell users the Docker, Jira, Routing, Blender and Code agents run on `Qwen3.5-35B-A3B-GGUF`, and walk them through downloading a 17 GB model — on Jira, with a note that it's "best run on a Strix Halo (or similar high-memory) device" — before those agents will work. Under the model consolidation those agents fall back to `Gemma-4-E4B-it-GGUF` at ~3 GB, which drops that prerequisite entirely. This updates the setup steps, `--model` defaults, spec headers and download-size guidance so a user following the guides installs the model the agent actually loads.

## ⚠️ Blocked — do not merge yet

**The code change these docs describe has not landed.** `src/gaia/agents/base/agent.py:516` is still `model_id or "Qwen3.5-35B-A3B-GGUF"`, and 28 non-test files across `src/` and `hub/` still hardcode the 35B model. I could not find a PR or issue for the consolidation.

Also worth a maintainer's eye: #1810 ("correct stale default-model comment (Gemma → Qwen3.5-35B-A3B)", merged 2026-06-22) deliberately moved this the *other* way, and `lemonade_client.py:116` still carries `# Do NOT change this to 35B — it would break CI tests and force large downloads in minimal setups`. So the current Qwen default appears load-bearing and recently reaffirmed, not drift.

Merging this before the code change would make the docs contradict both the runtime and #1810. Draft until the consolidation lands; it should probably go in as part of that PR rather than ahead of it.

## Test plan

- [ ] Confirm the consolidation is actually intended, given #1810
- [ ] Land the `src/`/`hub/` default change first, then rebase this
- [ ] `gaia docker "containerize this app"` — loads Gemma-4-E4B, no 35B download prompt
- [ ] `gaia jira "show my open issues"` — same
- [ ] `AGENT_ROUTING_MODEL` unset → routing uses Gemma-4-E4B
- [ ] Mintlify docs build passes and no navigation entries broke

## Known-remaining (deliberately not in this PR)

- `docs/guides/docker.mdx:35,150` still recommend `--ctx-size 8192` and call it "required". Against Gemma-4-E4B's `min_ctx_size=65536` that reads as wrong, but fixing it means picking a value across ~10 sites (Code and Routing guides say `32768`) — wanted a decision before sweeping it.
- `docs/sdk/sdks/agent-ui.mdx:1247,1388` document the sessions-table default as the 35B model; source is `SESSION_DEFAULT_MODEL = "Gemma-4-E4B-it-GGUF"`. Wrong today, independent of this change.
- `docs/spec/rag-sdk.mdx:43` mirrors `RAGConfig.model`, still Qwen in source. Needs updating only if the consolidation also flips that default.