### PR TITLE
fix(security): require allowed_dir in compute_file_hash

### DIFF
--- a/src/gaia/utils/file_watcher.py
+++ b/src/gaia/utils/file_watcher.py
@@ -14,7 +14,7 @@ Example:
 
     def on_new_file(path: str):
         print(f"New file: {path}")
-        file_hash = compute_file_hash(path)
+        file_hash = compute_file_hash(path, allowed_dir="./data")
         print(f"Hash: {file_hash}")
 
     watcher = FileWatcher(
@@ -80,33 +80,47 @@ def compute_file_hash(
         algorithm: Hash algorithm to use (default: sha256).
                    Supports any algorithm from hashlib.
         chunk_size: Size of chunks to read at a time (default: 64KB).
-        allowed_dir: If provided, validates that the resolved file path
-                     is within this directory (prevents path traversal).
+        allowed_dir: Directory the file must be contained in. Required —
+                     the containment check is not opt-in, so no caller can
+                     hash a path outside the root it meant to scan.
 
     Returns:
-        Hex-encoded hash string, or None if file cannot be read.
+        Hex-encoded hash string, or None if the file cannot be read or
+        lies outside *allowed_dir*.
+
+    Raises:
+        ValueError: If *allowed_dir* is not supplied.
 
     Example:
         from gaia.utils import compute_file_hash
 
         # Check if file was already processed
-        file_hash = compute_file_hash("intake_form.pdf")
+        file_hash = compute_file_hash("intake_form.pdf", allowed_dir=watch_dir)
         if file_hash in processed_hashes:
             print("Already processed")
         else:
             process_file("intake_form.pdf")
             processed_hashes.add(file_hash)
     """
+    # Outside the try: the handler below catches ValueError, which would
+    # otherwise swallow this guard and return None.
+    if allowed_dir is None:
+        raise ValueError(
+            "compute_file_hash() requires allowed_dir: the directory the file "
+            "must be contained in. Pass the already-validated root you are "
+            "scanning (e.g. str(self._watch_dir)). Omitting it leaves the hash "
+            "target unconstrained, which is a path-traversal sink."
+        )
+
     try:
         # Resolve to canonical absolute path
         file_path = os.path.realpath(str(path))
 
-        # Validate path is within allowed directory
-        if allowed_dir is not None:
-            real_base = os.path.realpath(str(allowed_dir))
-            if not file_path.startswith(real_base + os.sep) and file_path != real_base:
-                logger.warning("Path is outside allowed directory")
-                return None
+        # Containment is unconditional — allowed_dir is guaranteed non-None.
+        real_base = os.path.realpath(str(allowed_dir))
+        if not file_path.startswith(real_base + os.sep) and file_path != real_base:
+            logger.warning("Path is outside allowed directory")
+            return None
 
         if not os.path.isfile(file_path):
             return None

--- a/tests/unit/test_file_watcher.py
+++ b/tests/unit/test_file_watcher.py
@@ -29,7 +29,7 @@ class TestFileHashUtilities:
             temp_path = f.name
 
         try:
-            result = compute_file_hash(temp_path)
+            result = compute_file_hash(temp_path, allowed_dir=tempfile.gettempdir())
             assert result is not None
             # SHA-256 produces 64 hex characters
             assert len(result) == 64
@@ -44,8 +44,9 @@ class TestFileHashUtilities:
             temp_path = f.name
 
         try:
-            hash1 = compute_file_hash(temp_path)
-            hash2 = compute_file_hash(temp_path)
+            tmp_root = tempfile.gettempdir()
+            hash1 = compute_file_hash(temp_path, allowed_dir=tmp_root)
+            hash2 = compute_file_hash(temp_path, allowed_dir=tmp_root)
             assert hash1 == hash2
         finally:
             Path(temp_path).unlink()
@@ -61,8 +62,9 @@ class TestFileHashUtilities:
             path2 = f2.name
 
         try:
-            hash1 = compute_file_hash(path1)
-            hash2 = compute_file_hash(path2)
+            tmp_root = tempfile.gettempdir()
+            hash1 = compute_file_hash(path1, allowed_dir=tmp_root)
+            hash2 = compute_file_hash(path2, allowed_dir=tmp_root)
             assert hash1 != hash2
         finally:
             Path(path1).unlink()
@@ -70,7 +72,9 @@ class TestFileHashUtilities:
 
     def test_compute_file_hash_nonexistent_file(self):
         """Test that nonexistent file returns None."""
-        result = compute_file_hash("/nonexistent/path/file.txt")
+        result = compute_file_hash(
+            "/nonexistent/path/file.txt", allowed_dir="/nonexistent/path"
+        )
         assert result is None
 
     def test_compute_file_hash_with_path_object(self):
@@ -80,11 +84,34 @@ class TestFileHashUtilities:
             temp_path = Path(f.name)
 
         try:
-            result = compute_file_hash(temp_path)
+            result = compute_file_hash(temp_path, allowed_dir=tempfile.gettempdir())
             assert result is not None
             assert len(result) == 64
         finally:
             temp_path.unlink()
+
+    def test_compute_file_hash_requires_allowed_dir(self, tmp_path):
+        """Omitting allowed_dir must fail loudly, not hash an arbitrary path.
+
+        The containment check used to be opt-in (``allowed_dir=None`` skipped
+        it entirely), so a caller could hash any file on disk. The guard sits
+        outside the try/except because that handler catches ValueError and
+        would otherwise swallow it into a ``None`` return.
+        """
+        f = tmp_path / "form.pdf"
+        f.write_bytes(b"intake form bytes")
+
+        with pytest.raises(ValueError, match="requires allowed_dir"):
+            compute_file_hash(str(f))
+
+        # Explicitly passing None is the same mistake, not a bypass.
+        with pytest.raises(ValueError, match="requires allowed_dir"):
+            compute_file_hash(str(f), allowed_dir=None)
+
+    def test_compute_file_hash_unguarded_call_cannot_read_etc_passwd(self):
+        """The pre-fix traversal capability must stay closed."""
+        with pytest.raises(ValueError, match="requires allowed_dir"):
+            compute_file_hash("/etc/passwd")
 
     def test_compute_file_hash_allowed_dir_rejects_traversal(self, tmp_path):
         """A path outside allowed_dir must be rejected, including via '../'."""
@@ -143,7 +170,7 @@ class TestFileHashUtilities:
             temp_path = f.name
 
         try:
-            file_hash = compute_file_hash(temp_path)
+            file_hash = compute_file_hash(temp_path, allowed_dir=tempfile.gettempdir())
             bytes_hash = compute_bytes_hash(content)
             assert file_hash == bytes_hash
         finally:
@@ -159,11 +186,12 @@ class TestFileHashUtilities:
             temp_path = f.name
 
         try:
-            result = compute_file_hash(temp_path)
+            tmp_root = tempfile.gettempdir()
+            result = compute_file_hash(temp_path, allowed_dir=tmp_root)
             assert result is not None
             assert len(result) == 64
             # Verify consistency
-            assert result == compute_file_hash(temp_path)
+            assert result == compute_file_hash(temp_path, allowed_dir=tmp_root)
         finally:
             Path(temp_path).unlink()
 

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -1288,3 +1288,62 @@ class TestAgentIdPathSafety:
         junk.mkdir()
         (junk / installer.SENTINEL_NAME).write_text("{}")
         assert list_installed(tmp_path) == {}
+
+    @pytest.mark.parametrize(
+        "sink",
+        [
+            "read_sentinel",
+            "uninstall",
+            "rollback",
+            "read_config",
+            "configure",
+            "health_check",
+        ],
+    )
+    def test_every_path_sink_rejects_traversal_id(self, tmp_path, sink):
+        """Each CodeQL-flagged path sink must reject a traversal id.
+
+        CodeQL reports py/path-injection at the *sinks* in these functions
+        (``rmtree``/``move``/``read_text``/``write_text``) because its
+        dataflow engine does not follow ``_require_safe_agent_id`` through
+        the ``agent_install_dir``/``_backup_dir`` helpers. This test pins
+        the property CodeQL cannot see: no sink is reachable with a
+        traversal-shaped id. If a future refactor bypasses the helper, this
+        fails rather than silently reopening the traversal.
+        """
+        from gaia.hub import lifecycle
+
+        bad_id = "../../../../../../tmp/gaia-traversal-probe"
+        calls = {
+            "read_sentinel": lambda: installer.read_sentinel(bad_id, tmp_path),
+            "uninstall": lambda: uninstall(bad_id, install_root=tmp_path),
+            "rollback": lambda: rollback(bad_id, install_root=tmp_path),
+            "read_config": lambda: lifecycle.read_config(bad_id, tmp_path),
+            "configure": lambda: lifecycle.configure(
+                bad_id, {"model": "x"}, install_root=tmp_path
+            ),
+            "health_check": lambda: lifecycle.health_check(
+                bad_id, install_root=tmp_path
+            ),
+        }
+        with pytest.raises(
+            (InstallError, lifecycle.LifecycleError), match="Invalid agent id"
+        ):
+            calls[sink]()
+
+    def test_traversal_id_never_creates_anything_outside_install_root(self, tmp_path):
+        """The rejected id must leave no trace outside the install root."""
+        from gaia.hub import lifecycle
+
+        install_root = tmp_path / "agents"
+        install_root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "keep.txt").write_text("untouched")
+
+        with pytest.raises(lifecycle.LifecycleError):
+            lifecycle.configure("../outside", {"model": "x"}, install_root=install_root)
+
+        assert (outside / "keep.txt").read_text() == "untouched"
+        assert not (outside / "config.json").exists()
+        assert list(install_root.iterdir()) == []


### PR DESCRIPTION
`compute_file_hash()` only enforced directory containment when a caller happened to pass `allowed_dir` — the check sat behind `if allowed_dir is not None:`, so the default call shape had no containment at all and would hash any file on disk (verified against `/etc/passwd`). Every in-repo caller already passed it, so nothing was exploitable in practice, but an opt-in security guard that defaults to off is exactly the silent-fallback pattern the project bans: one new call site reopens the traversal with no signal. `allowed_dir` is now required and containment runs unconditionally — this is the same class of gap #2252 found in EMR, recurring in a second location.

Two notes for review:

- **The guard deliberately raises outside the `try`.** The handler below it catches `ValueError`, so moving the check inside would swallow it and return `None` — silently restoring the unguarded behaviour. Please don't "simplify" it back in; the test `test_compute_file_hash_requires_allowed_dir` covers this, but it is easy to undo by accident.
- **Why this PR is small relative to the alert count.** These were 2 of 15 open `py/path-injection` alerts. The other 13 are dismissed as false positives with per-site justifications: each flagged sink resolves its path through `agent_install_dir()`/`_backup_dir()`, which call `_require_safe_agent_id()` (`installer.py:133`) and reject anything that is not a single safe path component — a sanitizer CodeQL's dataflow cannot follow through the helper. These 2 are the ones that warranted a real fix.

## Test plan

- [ ] `python -m pytest tests/unit/test_hub_installer.py tests/unit/chat/ui/test_toctou.py tests/unit/test_file_watcher.py -q` — 147 passed
- [ ] `python -m pytest tests/unit/ -q` — 6600 passed (5 failures are pre-existing on a clean tree: 3 `test_cli_smoke` needing `gaia` on PATH, `test_init_command` x3, `test_memory_router` x1)
- [ ] EMR agent tests still pass against the changed signature: `cd hub/agents/python/emr && python -m pytest tests/ -q` — 67 passed
- [ ] `python util/lint.py --all` — all quality checks pass
- [ ] Confirm CodeQL clears alerts 63 and 314 (`src/gaia/utils/file_watcher.py:111,115`) on this PR — this cannot be verified locally
- [ ] Verify a traversal input is rejected rather than silently hashed: `compute_file_hash("/etc/passwd")` raises `ValueError`