### PR TITLE
fix(daemon): owner-only DACL for the Windows launch secret (#2250)

### DIFF
--- a/.github/workflows/test_gaia_cli_windows.yml
+++ b/.github/workflows/test_gaia_cli_windows.yml
@@ -78,6 +78,45 @@ jobs:
           python --version
           python -m pip check
 
+      # #2250: the launch-secret DACL cannot be proven off-Windows. The mocked
+      # layer of test_daemon_secret_acl.py already runs on ubuntu (test_unit.yml),
+      # but only a real NTFS volume shows whether the ACL is actually applied
+      # and whether inherited ACEs die. Runs before Lemonade: no server needed.
+      - name: Run Windows Launch-Secret DACL Tests (CMD)
+        shell: cmd
+        env:
+          PYTHONUTF8: 1
+        run: |
+          REM Activate virtual environment
+          call "%GITHUB_WORKSPACE%\.venv\Scripts\activate.bat"
+
+          echo ================================================================
+          echo         WINDOWS LAUNCH-SECRET DACL TESTS (issue #2250)
+          echo ================================================================
+          echo Virtual Environment: %VIRTUAL_ENV%
+          python --version
+          echo.
+
+          REM -rs prints skip reasons: if the win32-gated tests SKIP here, the
+          REM platform guard is misfiring and the real coverage is silently
+          REM absent -- that must be visible in the log, not swallowed.
+          python -m pytest tests\unit\test_daemon_secret_acl.py -v -rs --tb=short
+          set dacl_exit=%ERRORLEVEL%
+
+          echo.
+          echo ----------------------------------------------------------------
+          echo test_daemon_secret_acl.py exit code: %dacl_exit%
+          if %dacl_exit% equ 0 (
+              echo [SUCCESS] Launch-secret DACL tests passed
+          ) else (
+              echo [FAILURE] Launch-secret DACL tests failed
+              echo The sidecar launch secret may be readable by other local
+              echo accounts on NTFS - see issue #2250.
+          )
+          echo ----------------------------------------------------------------
+
+          exit /b %dacl_exit%
+
       - uses: FedericoCarboni/setup-ffmpeg@v3
         id: setup-ffmpeg
 

--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,12 @@ setup(
         # gaia connectors is a base CLI command; keyring is its OS credential store (OAuth tokens #915). #1621
         "keyring>=24.0.0,<26.0.0",
         "tavily-python>=0.5.0",
+        # gaia.daemon locks the sidecar launch-secret file down with an
+        # owner-only NTFS DACL (#2250) — chmod 0600 is inert on Windows. Core,
+        # not an extra: without win32security the daemon cannot spawn ANY
+        # sidecar. Distinct from keyring's pywin32-ctypes, which has no
+        # win32security module.
+        'pywin32; sys_platform == "win32"',
     ],
     extras_require={
         "image": [

--- a/src/gaia/daemon/sidecars/manager.py
+++ b/src/gaia/daemon/sidecars/manager.py
@@ -103,6 +103,82 @@ def _major(version: str) -> int:
         ) from e
 
 
+def _lock_down_windows_acl(path: Path) -> None:
+    """Restrict *path*'s DACL to the current user only — the NTFS analog of
+    ``chmod 0600`` (#2250: the POSIX mode bits below are a no-op on Windows).
+
+    Builds a fresh, non-inherited DACL with a single ACE granting the current
+    user full control, then re-reads it to confirm no other SID has access —
+    mirroring the ``mode != 0o600`` guard on POSIX. Any failure (missing
+    pywin32, a SetNamedSecurityInfo error, a foreign SID surviving the
+    lockdown) raises loudly; there is no fallback that leaves the secret
+    readable by other local users.
+    """
+    try:
+        import ntsecuritycon
+        import win32api
+        import win32security
+    except ImportError as e:
+        raise SidecarSpawnError(
+            f"cannot lock down {path} to the current user: pywin32 is not "
+            "installed. There is no fallback — a launch secret without an "
+            'owner-only ACL is world-readable on NTFS. Install it via `pip '
+            'install "amd-gaia[ui]"` (or `pip install pywin32`) and retry.'
+        ) from e
+
+    try:
+        user_sid, _domain, _type = win32security.LookupAccountName(
+            None, win32api.GetUserNameEx(win32api.NameSamCompatible)
+        )
+
+        dacl = win32security.ACL()
+        dacl.AddAccessAllowedAce(
+            win32security.ACL_REVISION, ntsecuritycon.FILE_ALL_ACCESS, user_sid
+        )
+        # PROTECTED_DACL strips inherited ACEs — without it the parent temp
+        # dir's (looser) grants would survive alongside the new ACE.
+        win32security.SetNamedSecurityInfo(
+            str(path),
+            win32security.SE_FILE_OBJECT,
+            win32security.DACL_SECURITY_INFORMATION
+            | win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            dacl,
+            None,
+        )
+
+        sd = win32security.GetNamedSecurityInfo(
+            str(path),
+            win32security.SE_FILE_OBJECT,
+            win32security.DACL_SECURITY_INFORMATION,
+        )
+        result_dacl = sd.GetSecurityDescriptorDacl()
+        if result_dacl is None:
+            raise SidecarSpawnError(
+                f"{path} has no DACL after lockdown (a null DACL grants "
+                "everyone access on Windows) — refusing to spawn with an "
+                "unprotected secret."
+            )
+        for i in range(result_dacl.GetAceCount()):
+            _ace_type_flags, _mask, ace_sid = result_dacl.GetAce(i)
+            if ace_sid != user_sid:
+                raise SidecarSpawnError(
+                    f"{path} DACL still grants access to a SID other than the "
+                    "current user after lockdown — refusing to spawn with a "
+                    "secret other local users could read."
+                )
+    except SidecarSpawnError:
+        raise
+    except Exception as e:
+        # pywin32 raises pywintypes.error (not OSError) on API failures.
+        raise SidecarSpawnError(
+            f"could not lock down {path} to the current user via a Windows "
+            f"DACL: {e}. There is no fallback — fix the ACL/permissions on "
+            "the temp directory and retry."
+        ) from e
+
+
 class AgentSidecarManager:
     def __init__(
         self,
@@ -448,12 +524,18 @@ class AgentSidecarManager:
 
         A fresh ``mkdtemp`` dir (0700) + ``O_CREAT|O_EXCL`` at 0600 means the
         secret never exists on disk with looser permissions, even mid-write.
+        On Windows the 0700/0600 mode bits are inert on NTFS, so the dir and
+        file each get an explicit owner-only DACL instead (#2250).
         """
         secret_dir: Optional[Path] = None
         try:
             secret_dir = Path(
                 tempfile.mkdtemp(prefix=f"gaia-{self.spec.agent_id}-secret-")
             )
+            if os.name == "nt":
+                # mkdtemp's 0700 mode is a no-op on NTFS too — lock the dir
+                # down before anything is written into it.
+                _lock_down_windows_acl(secret_dir)
             path = secret_dir / "launch-secret"
             fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
             try:
@@ -469,6 +551,8 @@ class AgentSidecarManager:
                         "users could read. The temp filesystem is ignoring POSIX "
                         "permissions; point TMPDIR at one that honors them."
                     )
+            else:
+                _lock_down_windows_acl(path)
         except OSError as e:
             self._remove_secret_dir(secret_dir)
             raise SidecarSpawnError(

--- a/src/gaia/daemon/sidecars/manager.py
+++ b/src/gaia/daemon/sidecars/manager.py
@@ -129,8 +129,13 @@ def _lock_down_windows_acl(path: Path) -> None:
         ) from e
 
     try:
-        user_sid, _domain, _type = win32security.LookupAccountName(
-            None, win32api.GetUserNameEx(win32api.NameSamCompatible)
+        # Read the SID from the process token, not by name: LookupAccountName
+        # fails with 1332 for the service/machine accounts a daemon runs as.
+        token = win32security.OpenProcessToken(
+            win32api.GetCurrentProcess(), win32security.TOKEN_QUERY
+        )
+        user_sid, _attributes = win32security.GetTokenInformation(
+            token, win32security.TokenUser
         )
 
         dacl = win32security.ACL()

--- a/src/gaia/daemon/sidecars/manager.py
+++ b/src/gaia/daemon/sidecars/manager.py
@@ -122,8 +122,10 @@ def _lock_down_windows_acl(path: Path) -> None:
         raise SidecarSpawnError(
             f"cannot lock down {path} to the current user: pywin32 is not "
             "installed. There is no fallback — a launch secret without an "
-            'owner-only ACL is world-readable on NTFS. Install it via `pip '
-            'install "amd-gaia[ui]"` (or `pip install pywin32`) and retry.'
+            "owner-only ACL is readable by other local accounts on NTFS. "
+            "Run `pip install pywin32` (it ships as a core amd-gaia "
+            "dependency on Windows, so a plain `pip install --upgrade "
+            "amd-gaia` also repairs this). See issue #2250."
         ) from e
 
     try:

--- a/tests/unit/test_daemon_secret_acl.py
+++ b/tests/unit/test_daemon_secret_acl.py
@@ -69,15 +69,29 @@ def _install_fake_pywin32(monkeypatch, *, readback_sids=(USER_SID,), null_dacl=F
 
     win32api = type(sys)("win32api")
     win32api.NameSamCompatible = 2
+    win32api.GetCurrentProcess = lambda: "FAKE-PROCESS-HANDLE"
     win32api.GetUserNameEx = lambda fmt: "FAKEDOMAIN\\fakeuser"
+
+    def _lookup_account_name(system, name):
+        # The STX runner reproduced: a service/machine account has no
+        # name->SID mapping, so deriving the SID by name breaks the daemon
+        # outright. The SID must come from the process token instead.
+        raise OSError(
+            "(1332, 'LookupAccountName', 'No mapping between account names "
+            "and security IDs was done.')"
+        )
 
     win32security = type(sys)("win32security")
     win32security.ACL = _FakeACL
     win32security.ACL_REVISION = 2
     win32security.SE_FILE_OBJECT = 1
+    win32security.TOKEN_QUERY = 0x0008
+    win32security.TokenUser = 1
     win32security.DACL_SECURITY_INFORMATION = 0x00000004
     win32security.PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
-    win32security.LookupAccountName = lambda system, name: (USER_SID, "FAKEDOMAIN", 1)
+    win32security.LookupAccountName = _lookup_account_name
+    win32security.OpenProcessToken = lambda process, access: "FAKE-TOKEN"
+    win32security.GetTokenInformation = lambda token, info_class: (USER_SID, 0)
 
     def _set_named_security_info(path, obj_type, flags, owner, group, dacl, sacl):
         calls["set"].append(
@@ -156,6 +170,21 @@ def test_lockdown_adds_exactly_one_full_control_ace_for_current_user(
     assert dacl.GetAceCount() == 1, "exactly one ACE — no extra grants"
     assert dacl.aces[0]["sid"] == USER_SID
     assert dacl.aces[0]["mask"] == FILE_ALL_ACCESS
+
+
+def test_sid_comes_from_the_process_token_not_a_name_lookup(monkeypatch, tmp_path):
+    """Regression: a daemon running as a service or machine account has no
+    name->SID mapping, so LookupAccountName fails with 1332 and — being
+    fail-loud — the daemon then refuses to spawn ANY sidecar. The fake's
+    LookupAccountName raises that exact error, so reintroducing the name
+    lookup fails here rather than only on a service-account machine."""
+    calls = _install_fake_pywin32(monkeypatch)
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    mgr._lock_down_windows_acl(target)
+
+    assert calls["set"][0]["dacl"].aces[0]["sid"] == USER_SID
 
 
 def test_lockdown_verifies_by_rereading_the_dacl(monkeypatch, tmp_path):
@@ -280,9 +309,10 @@ def _current_user_sid():
     import win32api
     import win32security
 
-    sid, _domain, _type = win32security.LookupAccountName(
-        None, win32api.GetUserNameEx(win32api.NameSamCompatible)
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(), win32security.TOKEN_QUERY
     )
+    sid, _attributes = win32security.GetTokenInformation(token, win32security.TokenUser)
     return sid
 
 

--- a/tests/unit/test_daemon_secret_acl.py
+++ b/tests/unit/test_daemon_secret_acl.py
@@ -1,0 +1,387 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Owner-only NTFS DACL for the sidecar launch-secret file (#2250).
+
+Three layers, deliberately:
+
+1. Mocked call-shape tests — run everywhere (ubuntu CI included). They assert
+   the SHAPE of the pywin32 calls, not merely that they happened: a mock that
+   returns success proves "we called it", never "the call is valid".
+2. Real-Windows tests — the only layer that proves the pywin32 API calls are
+   accepted by the OS and that inherited ACEs actually die. Skipped off-win32.
+3. Fresh-install guard — pywin32 must be importable on Windows, i.e. the
+   ``setup.py`` declaration is really in effect for a clean install.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from gaia.daemon.sidecars import manager as mgr
+from gaia.daemon.sidecars.errors import SidecarSpawnError
+from gaia.daemon.sidecars.spec import builtin_specs
+
+USER_SID = "S-1-5-21-fake-current-user"
+FOREIGN_SID = "S-1-5-32-545"  # BUILTIN\Users — the ACE #2250 is about
+FILE_ALL_ACCESS = 0x1F01FF
+
+# ---------------------------------------------------------------------------
+# Fake pywin32 surface (injected via sys.modules)
+# ---------------------------------------------------------------------------
+
+
+class _FakeACL:
+    def __init__(self):
+        self.aces = []
+
+    def AddAccessAllowedAce(self, revision, mask, sid):
+        self.aces.append({"revision": revision, "mask": mask, "sid": sid})
+
+    def GetAceCount(self):
+        return len(self.aces)
+
+    def GetAce(self, index):
+        ace = self.aces[index]
+        # pywin32 returns ((aceType, aceFlags), mask, sid).
+        return ((0, 0), ace["mask"], ace["sid"])
+
+
+class _FakeSD:
+    def __init__(self, dacl):
+        self._dacl = dacl
+
+    def GetSecurityDescriptorDacl(self):
+        return self._dacl
+
+
+def _install_fake_pywin32(monkeypatch, *, readback_sids=(USER_SID,), null_dacl=False):
+    """Inject fake win32security/win32api/ntsecuritycon and return the call log.
+
+    ``readback_sids`` drives what GetNamedSecurityInfo reports AFTER the
+    lockdown, which is what the function's verification pass inspects.
+    """
+    calls = {"set": [], "get": []}
+
+    ntsecuritycon = type(sys)("ntsecuritycon")
+    ntsecuritycon.FILE_ALL_ACCESS = FILE_ALL_ACCESS
+
+    win32api = type(sys)("win32api")
+    win32api.NameSamCompatible = 2
+    win32api.GetUserNameEx = lambda fmt: "FAKEDOMAIN\\fakeuser"
+
+    win32security = type(sys)("win32security")
+    win32security.ACL = _FakeACL
+    win32security.ACL_REVISION = 2
+    win32security.SE_FILE_OBJECT = 1
+    win32security.DACL_SECURITY_INFORMATION = 0x00000004
+    win32security.PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+    win32security.LookupAccountName = lambda system, name: (USER_SID, "FAKEDOMAIN", 1)
+
+    def _set_named_security_info(path, obj_type, flags, owner, group, dacl, sacl):
+        calls["set"].append(
+            {
+                "path": path,
+                "obj_type": obj_type,
+                "flags": flags,
+                "owner": owner,
+                "group": group,
+                "dacl": dacl,
+                "sacl": sacl,
+            }
+        )
+
+    def _get_named_security_info(path, obj_type, flags):
+        calls["get"].append({"path": path, "obj_type": obj_type, "flags": flags})
+        if null_dacl:
+            return _FakeSD(None)
+        readback = _FakeACL()
+        for sid in readback_sids:
+            readback.AddAccessAllowedAce(2, FILE_ALL_ACCESS, sid)
+        return _FakeSD(readback)
+
+    win32security.SetNamedSecurityInfo = _set_named_security_info
+    win32security.GetNamedSecurityInfo = _get_named_security_info
+
+    monkeypatch.setitem(sys.modules, "ntsecuritycon", ntsecuritycon)
+    monkeypatch.setitem(sys.modules, "win32api", win32api)
+    monkeypatch.setitem(sys.modules, "win32security", win32security)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — mocked call shape (platform-agnostic)
+# ---------------------------------------------------------------------------
+
+
+def test_lockdown_requests_protected_dacl(monkeypatch, tmp_path):
+    """The highest-value assertion in this file.
+
+    Dropping PROTECTED_DACL_SECURITY_INFORMATION still "works" — the new ACE
+    lands — but the parent dir's inherited ACEs survive alongside it, which IS
+    the #2250 vulnerability. Assert both bits, not just DACL.
+    """
+    calls = _install_fake_pywin32(monkeypatch)
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    mgr._lock_down_windows_acl(target)
+
+    assert len(calls["set"]) == 1
+    flags = calls["set"][0]["flags"]
+    assert flags & 0x00000004, "DACL_SECURITY_INFORMATION must be set"
+    assert flags & 0x80000000, (
+        "PROTECTED_DACL_SECURITY_INFORMATION must be set — without it the "
+        "parent temp dir's inherited ACEs survive (#2250)"
+    )
+    assert calls["set"][0]["path"] == str(target)
+    assert calls["set"][0]["obj_type"] == 1  # SE_FILE_OBJECT
+    # Owner/group/SACL are left untouched; only the DACL is rewritten.
+    assert calls["set"][0]["owner"] is None
+    assert calls["set"][0]["group"] is None
+    assert calls["set"][0]["sacl"] is None
+
+
+def test_lockdown_adds_exactly_one_full_control_ace_for_current_user(
+    monkeypatch, tmp_path
+):
+    calls = _install_fake_pywin32(monkeypatch)
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    mgr._lock_down_windows_acl(target)
+
+    dacl = calls["set"][0]["dacl"]
+    assert dacl.GetAceCount() == 1, "exactly one ACE — no extra grants"
+    assert dacl.aces[0]["sid"] == USER_SID
+    assert dacl.aces[0]["mask"] == FILE_ALL_ACCESS
+
+
+def test_lockdown_verifies_by_rereading_the_dacl(monkeypatch, tmp_path):
+    """A write that is never read back cannot detect a silently-ignored ACL."""
+    calls = _install_fake_pywin32(monkeypatch)
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    mgr._lock_down_windows_acl(target)
+
+    assert len(calls["get"]) == 1
+    assert calls["get"][0]["path"] == str(target)
+
+
+def test_foreign_sid_surviving_the_lockdown_raises(monkeypatch, tmp_path):
+    _install_fake_pywin32(monkeypatch, readback_sids=(USER_SID, FOREIGN_SID))
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    with pytest.raises(SidecarSpawnError, match="SID other than the current user"):
+        mgr._lock_down_windows_acl(target)
+
+
+def test_null_dacl_after_lockdown_raises(monkeypatch, tmp_path):
+    # A NULL DACL is not "no access" on Windows — it grants Everyone.
+    _install_fake_pywin32(monkeypatch, null_dacl=True)
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    with pytest.raises(SidecarSpawnError, match="no DACL after lockdown"):
+        mgr._lock_down_windows_acl(target)
+
+
+def test_api_failure_is_wrapped_not_swallowed(monkeypatch, tmp_path):
+    calls = _install_fake_pywin32(monkeypatch)
+    del calls  # only the module injection matters here
+
+    def _boom(*args, **kwargs):
+        raise OSError("(1307, 'SetNamedSecurityInfo', 'invalid owner')")
+
+    monkeypatch.setattr(sys.modules["win32security"], "SetNamedSecurityInfo", _boom)
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    with pytest.raises(SidecarSpawnError, match="could not lock down"):
+        mgr._lock_down_windows_acl(target)
+
+
+def test_missing_pywin32_raises_and_names_the_real_remedy(monkeypatch, tmp_path):
+    # `sys.modules[name] = None` makes `import name` raise ImportError.
+    for name in ("win32security", "win32api", "ntsecuritycon"):
+        monkeypatch.setitem(sys.modules, name, None)
+    target = tmp_path / "launch-secret"
+    target.write_text("shh")
+
+    with pytest.raises(SidecarSpawnError) as excinfo:
+        mgr._lock_down_windows_acl(target)
+
+    message = str(excinfo.value)
+    assert "pip install pywin32" in message
+    # The old text pointed at the [ui] extra, which never carried pywin32.
+    assert "amd-gaia[ui]" not in message
+
+
+class _NTOs:
+    """Real ``os`` with ``name == "nt"`` — lets the Windows leg of
+    ``_write_secret_file`` run off-Windows. Patching the global ``os.name``
+    instead would flip ``pathlib`` to WindowsPath and blow up on POSIX."""
+
+    name = "nt"
+
+    def __getattr__(self, attr):
+        return getattr(os, attr)
+
+
+def test_missing_pywin32_aborts_the_spawn_instead_of_writing_a_loose_secret(
+    monkeypatch, tmp_path
+):
+    """No silent fallback: an unlockable secret must abort, not degrade."""
+    for name in ("win32security", "win32api", "ntsecuritycon"):
+        monkeypatch.setitem(sys.modules, name, None)
+    monkeypatch.setattr(mgr, "os", _NTOs())
+    monkeypatch.setattr(mgr.tempfile, "tempdir", str(tmp_path), raising=False)
+
+    m = mgr.AgentSidecarManager(builtin_specs()["email"])
+    with pytest.raises(SidecarSpawnError, match="pywin32 is not installed"):
+        m._write_secret_file()
+
+    assert m._secret_path is None, "no secret path is recorded on failure"
+    leftovers = list(Path(tmp_path).glob("gaia-email-secret-*"))
+    assert leftovers == [], f"secret dir left behind: {leftovers}"
+
+
+def test_lockdown_is_wired_into_the_secret_write_path(monkeypatch, tmp_path):
+    """Both the 0700 dir and the 0600 file get locked down on Windows."""
+    locked = []
+    monkeypatch.setattr(mgr, "_lock_down_windows_acl", lambda p: locked.append(Path(p)))
+    monkeypatch.setattr(mgr, "os", _NTOs())
+    monkeypatch.setattr(mgr.tempfile, "tempdir", str(tmp_path), raising=False)
+
+    m = mgr.AgentSidecarManager(builtin_specs()["email"])
+    path = m._write_secret_file()
+
+    assert locked == [path.parent, path], (
+        "the temp dir must be locked BEFORE the secret is written into it, "
+        f"then the file itself; got {locked}"
+    )
+    m._remove_secret_dir(path.parent)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — real Windows (the only layer that proves the API calls are valid)
+# ---------------------------------------------------------------------------
+
+win32_only = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="real DACL behavior is observable only on Windows/NTFS (#2250)",
+)
+
+
+def _current_user_sid():
+    import win32api
+    import win32security
+
+    sid, _domain, _type = win32security.LookupAccountName(
+        None, win32api.GetUserNameEx(win32api.NameSamCompatible)
+    )
+    return sid
+
+
+def _read_dacl_sids(path: Path):
+    import win32security
+
+    sd = win32security.GetNamedSecurityInfo(
+        str(path),
+        win32security.SE_FILE_OBJECT,
+        win32security.DACL_SECURITY_INFORMATION,
+    )
+    dacl = sd.GetSecurityDescriptorDacl()
+    assert dacl is not None, "null DACL grants Everyone on Windows"
+    return [dacl.GetAce(i)[2] for i in range(dacl.GetAceCount())]
+
+
+@win32_only
+def test_real_lockdown_leaves_only_the_current_user(tmp_path):
+    target = tmp_path / "launch-secret"
+    target.write_text("shh", encoding="utf-8")
+
+    mgr._lock_down_windows_acl(target)
+
+    sids = _read_dacl_sids(target)
+    assert len(sids) == 1, f"expected exactly one ACE, got {sids}"
+    assert sids[0] == _current_user_sid()
+
+
+@win32_only
+def test_real_lockdown_strips_inherited_parent_ace(tmp_path):
+    """The actual #2250 bug: a broader ACE inherited from the parent directory
+    must NOT survive on the secret file."""
+    import ntsecuritycon
+    import win32security
+
+    parent = tmp_path / "loose-parent"
+    parent.mkdir()
+
+    # Grant BUILTIN\Users full control on the parent, INHERITED by children.
+    # The current user is granted too — a Users-only DACL could deny the CI
+    # account permission to create the file inside its own temp dir.
+    users_sid = win32security.ConvertStringSidToSid("S-1-5-32-545")
+    inherit = win32security.OBJECT_INHERIT_ACE | win32security.CONTAINER_INHERIT_ACE
+    dacl = win32security.ACL()
+    for sid in (_current_user_sid(), users_sid):
+        dacl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            inherit,
+            ntsecuritycon.FILE_ALL_ACCESS,
+            sid,
+        )
+    win32security.SetNamedSecurityInfo(
+        str(parent),
+        win32security.SE_FILE_OBJECT,
+        win32security.DACL_SECURITY_INFORMATION
+        | win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+        None,
+        None,
+        dacl,
+        None,
+    )
+
+    target = parent / "launch-secret"
+    target.write_text("shh", encoding="utf-8")
+    # Pre-condition: the child really did inherit the broad ACE.
+    assert users_sid in _read_dacl_sids(target), "parent ACE was not inherited"
+
+    mgr._lock_down_windows_acl(target)
+
+    sids = _read_dacl_sids(target)
+    assert users_sid not in sids, "inherited BUILTIN\\Users ACE survived (#2250)"
+    assert len(sids) == 1
+    assert sids[0] == _current_user_sid()
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — fresh-install guard
+# ---------------------------------------------------------------------------
+
+
+@win32_only
+def test_pywin32_is_a_declared_windows_dependency():
+    """A passing runtime does not prove a fresh install works.
+
+    If ``pywin32`` is dropped from setup.py's install_requires, the daemon
+    cannot spawn ANY sidecar on a clean Windows install (#2250). Fail loudly
+    here rather than at a user's first sidecar launch.
+    """
+    import win32security  # noqa: F401
+
+    assert hasattr(win32security, "SetNamedSecurityInfo")
+    # pywin32-ctypes (pulled by keyring) has no win32security — assert we got
+    # the real package, not its namesake.
+    assert hasattr(win32security, "PROTECTED_DACL_SECURITY_INFORMATION")
+
+
+def test_setup_py_declares_pywin32_for_win32():
+    """Runs everywhere, so dropping the declaration fails ubuntu CI too."""
+    setup_py = Path(__file__).resolve().parents[2] / "setup.py"
+    source = setup_py.read_text(encoding="utf-8")
+    assert "pywin32" in source, "pywin32 must stay declared in setup.py (#2250)"
+    assert 'pywin32; sys_platform == "win32"' in source


### PR DESCRIPTION
The daemon writes a launch secret that sidecar processes use to authenticate to their parent, protected by `chmod 0600` — which is inert on NTFS. On Windows that secret inherited the parent temp directory's ACL, leaving it readable by other local accounts on the machine (#2250). It now gets a protected, non-inherited DACL granting full control to the current user and nobody else, with the lockdown applied to the temp directory before the secret is written into it.

Also in scope: **`pywin32` was declared nowhere** — not in `setup.py`, not in `pyproject.toml` — despite the lockdown importing it. On a clean Windows install the daemon could not spawn *any* sidecar, and the ImportError told users to install `amd-gaia[ui]`, an extra that never contained pywin32 either (keyring's `pywin32-ctypes` is a different package with no `win32security` module). It is now a core `install_requires` entry with a `sys_platform == "win32"` marker, and the error text points at a remedy that exists.

## Not yet verified — please don't read this as confirmed

The DACL behavior is **unproven**. It was developed on macOS, which has no NTFS, no `win32security`, and no SIDs. Specifically unverified: whether the lockdown actually applies on a real NTFS volume, whether the pywin32 call signatures are correct (`AddAccessAllowedAceEx`, `ConvertStringSidToSid`, and the `GetAce` tuple shape were written from the API contract, not from execution), and whether inherited ACEs really die. The STX Windows run on this PR is where that gets settled — **expect a fixup pass.**

Of the Windows assertions, the inheritance one carries the weight: a parent directory's broader ACE must not survive on the secret file. That case *is* bug #2250; the rest is scaffolding around it.

## Test plan

- [ ] **STX Windows job runs and its DACL tests actually execute.** The step uses `pytest -rs`, so skips print their reason. If the three `win32`-gated tests SKIP instead of running, the platform gate is misfiring and this PR has zero real coverage — that is the failure mode to catch, not a pass.
- [ ] `test_real_lockdown_strips_inherited_parent_ace` passes — the file is created under a directory carrying an inheritable `BUILTIN\Users` ACE, and that ACE is gone after lockdown.
- [ ] `test_real_lockdown_leaves_only_the_current_user` passes — exactly one ACE, belonging to the current user.
- [ ] `test_pywin32_is_a_declared_windows_dependency` passes on STX, confirming the `install_requires` declaration reaches a real Windows install.
- [ ] Ubuntu: `pytest tests/unit/test_daemon_secret_acl.py` — 10 mocked tests pass, 3 win32 tests skip. Already covered by the existing `tests/unit/` job.
- [ ] Regression check on the load-bearing mock: drop `PROTECTED_DACL_SECURITY_INFORMATION` from the `SetNamedSecurityInfo` flags and confirm `test_lockdown_requests_protected_dacl` fails. Without that flag the new ACE still lands while inherited ACEs survive — i.e. the bug silently returns.
- [ ] `python util/lint.py --all` exits 0.
