### PR TITLE
fix(ui): detect GPU from real Lemonade payload shapes

### DIFF
--- a/src/gaia/llm/lemonade_manager.py
+++ b/src/gaia/llm/lemonade_manager.py
@@ -12,7 +12,7 @@ import sys
 import threading
 import time
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 from gaia.llm.lemonade_client import (
     DEFAULT_CONTEXT_SIZE,
@@ -116,6 +116,95 @@ def system_info_has_gpu(devices) -> bool:
                 if k in item and _is_gpu_device_key(str(item[k])):
                     return True
     return False
+
+
+def _iter_gpu_entries(devices) -> Iterator[Dict[str, Any]]:
+    """Yield every per-GPU entry in a ``devices`` payload, shape-agnostic.
+
+    Live Lemonade reports ``amd_gpu``/``nvidia_gpu`` as *lists* of entries
+    while ``metal`` and the legacy ``amd_igpu``/``amd_dgpu`` keys are single
+    dicts; both are flattened here so callers never branch on shape. A
+    top-level *list* payload — where GPU-ness lives in the entry rather than
+    the key — is handled the same way :func:`system_info_has_gpu` handles it,
+    so the two helpers agree on every shape.
+    """
+    if isinstance(devices, dict):
+        for key, value in devices.items():
+            if not _is_gpu_device_key(key):
+                continue
+            for entry in value if isinstance(value, list) else [value]:
+                if isinstance(entry, dict):
+                    yield entry
+    elif isinstance(devices, list):
+        for entry in devices:
+            if not isinstance(entry, dict):
+                continue
+            if any(
+                k in entry and _is_gpu_device_key(str(entry[k]))
+                for k in ("device_type", "type", "id", "name")
+            ):
+                yield entry
+
+
+def _coerce_vram_gb(raw) -> Optional[float]:
+    """Parse a device entry's ``vram_gb``, or ``None`` when it is unusable."""
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        log = get_logger(__name__)
+        log.warning(
+            "Lemonade reported a non-numeric vram_gb (%r); "
+            "reporting VRAM as undetected rather than guessing.",
+            raw,
+        )
+        return None
+
+
+def _gpu_rank(entry: Dict[str, Any]) -> Tuple[int, float, int, int]:
+    """Sort key picking the GPU a user would call "their" GPU (highest wins).
+
+    Ordered: not-integrated, then most VRAM, then carries discrete-card
+    identity, then named. The identity term matters on real Windows payloads,
+    where an APU's iGPU and a discrete card are both listed with neither
+    ``vram_gb`` nor ``integrated`` — only the discrete entry reports a
+    ``family``/``driver_version``, so without it a 7900 XTX owner would be
+    told they have "AMD Radeon(TM) Graphics". It ranks below VRAM so a larger
+    card still wins when both report VRAM.
+    """
+    vram = _coerce_vram_gb(entry.get("vram_gb"))
+    has_discrete_identity = bool(
+        str(entry.get("family") or "").strip() or entry.get("driver_version")
+    )
+    return (
+        0 if entry.get("integrated") else 1,
+        vram if vram is not None else -1.0,
+        1 if has_discrete_identity else 0,
+        1 if str(entry.get("name") or "").strip() else 0,
+    )
+
+
+def gpu_display_info(devices) -> Tuple[Optional[str], Optional[float]]:
+    """``(name, vram_gb)`` for the GPU a UI should name, from ``get_system_info()``.
+
+    Returns ``(None, None)`` when no *available* GPU is reported, so callers can
+    say "not detected" honestly. Never returns a blank string: an entry whose
+    ``name`` is empty (real Lemonade does this for an absent NVIDIA card) yields
+    ``None``, because a blank name renders as success in the UI when it is not.
+
+    Availability and GPU-key matching reuse :func:`_device_is_available` and
+    :func:`_is_gpu_device_key` — the same checks :func:`system_info_has_gpu`
+    uses — so the UI and CLI cannot disagree about what counts as a GPU.
+    When several GPUs are available, :func:`_gpu_rank` picks the one the user
+    would call theirs (the discrete card over an APU's integrated graphics).
+    """
+    available = [e for e in _iter_gpu_entries(devices) if _device_is_available(e)]
+    if not available:
+        return None, None
+    best = max(available, key=_gpu_rank)
+    name = str(best.get("name") or "").strip() or None
+    return name, _coerce_vram_gb(best.get("vram_gb"))
 
 
 def _format_device_error(

--- a/src/gaia/ui/routers/onboarding.py
+++ b/src/gaia/ui/routers/onboarding.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field
 from gaia.hub.compatibility import check_compatibility
 from gaia.hub.manifest import Requirements
 from gaia.llm.lemonade_client import lemonade_auth_headers, resolve_lemonade_api_key
+from gaia.llm.lemonade_manager import gpu_display_info
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,14 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
     "gpu_name": Optional[str], "gpu_vram_gb": Optional[float]}``. A ``None`` for
     a device means we could not determine it (Lemonade down, or it did not
     report that device) — the caller turns that into a "couldn't verify"
-    warning rather than assuming the hardware is present.
+    warning rather than assuming the hardware is present. A ``None`` GPU name
+    likewise means "not detected"; it is never the empty string, which the UI
+    would render as a successfully-detected but nameless GPU.
+
+    GPU shape handling is delegated to :func:`gpu_display_info` so this probe,
+    the ``/api/system/status`` probe, and the CLI all agree on what counts as
+    an available GPU (live Lemonade reports ``amd_gpu`` as a *list*; Apple
+    Silicon reports ``metal``).
     """
     result: Dict[str, Any] = {
         "lemonade_running": False,
@@ -88,14 +96,10 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
             # Once Lemonade reports its device table we *do* know whether an NPU
             # is present — so absence becomes a definite False, not None.
             npu_seen = False
+            result["gpu_name"], result["gpu_vram_gb"] = gpu_display_info(devices)
             for key, dev in devices.items():
                 if not isinstance(dev, dict):
                     continue
-                if "gpu" in key.lower():
-                    result["gpu_name"] = dev.get("name") or result["gpu_name"]
-                    vram = dev.get("vram_gb")
-                    if vram is not None:
-                        result["gpu_vram_gb"] = float(vram)
                 if "npu" in key.lower():
                     npu_seen = True
                     if dev.get("available"):

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -22,6 +22,7 @@ from gaia.llm.lemonade_client import (
     lemonade_auth_headers,
     resolve_lemonade_api_key,
 )
+from gaia.llm.lemonade_manager import gpu_display_info
 
 from ..agent_loop import resolve_agent_mode
 from ..database import ChatDatabase
@@ -618,16 +619,17 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
                         # works on both via cpu/vulkan backends. NPU requires
                         # explicit hardware detection.
                         detected = ["cpu", "gpu"]
+                        status.gpu_name, status.gpu_vram_gb = gpu_display_info(devices)
                         for key, dev in devices.items():
-                            if "gpu" in key.lower() and isinstance(dev, dict):
-                                status.gpu_name = dev.get("name")
-                                status.gpu_vram_gb = dev.get("vram_gb")
                             if "npu" in key.lower() and isinstance(dev, dict):
                                 if dev.get("available"):
                                     detected.append("npu")
                         status.detected_devices = detected
-                except Exception:
-                    pass
+                except Exception as exc:
+                    # Supplementary info — a failure must not fail the whole
+                    # status call, but log it so a payload shape change is
+                    # visible instead of silently blanking the GPU row.
+                    logger.debug("system status: device probe failed: %s", exc)
             else:
                 # Fall back to /models if /health isn't available
                 resp = await client.get(f"{base_url}/models", headers=_auth)

--- a/tests/unit/test_ui_gpu_detection.py
+++ b/tests/unit/test_ui_gpu_detection.py
@@ -1,0 +1,272 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GPU detection in the Agent UI against real captured Lemonade payloads.
+
+The UI's two GPU probes (`/api/system/status` and the onboarding preflight)
+both used `isinstance(dev, dict)` and a `"gpu" in key` substring test. Live
+Lemonade reports `amd_gpu`/`nvidia_gpu` as *lists*, and Apple Silicon reports
+its GPU under `metal` — so on real hardware both probes silently reported a
+blank GPU name and blank VRAM (#2244 fixed the same shape mismatch in the CLI).
+
+These tests stub only the HTTP boundary and feed the *real* captured payloads
+from tests/fixtures/hardware/, so they pin the shapes rather than a mock's idea
+of them.
+"""
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gaia.llm.lemonade_manager import gpu_display_info, system_info_has_gpu
+from gaia.ui.routers import onboarding as onboarding_mod
+from gaia.ui.server import create_app
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "fixtures", "hardware")
+
+
+def load_devices(name: str):
+    with open(os.path.join(FIXTURES_DIR, name), "r", encoding="utf-8") as f:
+        return json.load(f)["devices"]
+
+
+# Real captured payloads -> the GPU the UI should name.
+# amd_dgpu_windows lists the APU's integrated graphics *first* and the discrete
+# RX 7900 XTX second, with neither reporting vram_gb or `integrated` — the
+# discrete card must still win, or a 7900 XTX owner is told they have
+# "AMD Radeon(TM) Graphics".
+REAL_PAYLOADS = [
+    ("lemonade11_amd_dgpu_windows.json", "AMD Radeon RX 7900 XTX", None),
+    ("lemonade11_amd_igpu_linux.json", "110501", 0.5),
+    ("lemonade11_metal_macos.json", "Apple M3 Max", 51.84),
+]
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Routes Lemonade GETs by path suffix; unknown paths 404."""
+
+    def __init__(self, routes):
+        self._routes = routes
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def get(self, url, **_kwargs):
+        for suffix, payload in self._routes.items():
+            if url.endswith(suffix):
+                return _FakeResponse(payload)
+        return _FakeResponse({}, status_code=404)
+
+
+@pytest.fixture
+def stub_lemonade(monkeypatch):
+    """Patch httpx.AsyncClient so the routers' real parsing runs on a fixture."""
+
+    def _apply(routes):
+        import httpx
+
+        monkeypatch.setattr(
+            httpx, "AsyncClient", lambda *a, **k: _FakeAsyncClient(routes)
+        )
+
+    return _apply
+
+
+# ── the shared helper ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("fixture,expected_name,expected_vram", REAL_PAYLOADS)
+def test_gpu_display_info_reads_real_payloads(fixture, expected_name, expected_vram):
+    name, vram = gpu_display_info(load_devices(fixture))
+
+    assert name == expected_name
+    assert vram == expected_vram
+
+
+def test_gpu_display_info_no_gpu_reports_none_not_blank():
+    name, vram = gpu_display_info(load_devices("cpu_only.json"))
+
+    # None means "not detected"; "" would render as success in the UI.
+    assert name is None
+    assert vram is None
+
+
+def test_gpu_display_info_legacy_dict_shape_still_works():
+    """The pre-Lemonade-11 dict-keyed shape must keep working."""
+    name, vram = gpu_display_info(load_devices("dgpu_only.json"))
+
+    assert name == "AMD Radeon RX 7900 XTX"
+    # The legacy fixtures report `memory_mb`, not `vram_gb`. We deliberately
+    # don't read it: it is a synthetic shape real Lemonade 11 no longer emits,
+    # and an undetected VRAM is honest where a unit-guess would not be.
+    assert vram is None
+
+
+def test_gpu_display_info_agrees_with_system_info_has_gpu_on_list_payload():
+    """Both helpers must accept the top-level-list shape, or UI and CLI disagree."""
+    with open(
+        os.path.join(FIXTURES_DIR, "hardware_list.json"), "r", encoding="utf-8"
+    ) as f:
+        devices = json.load(f)["devices"]
+
+    assert system_info_has_gpu(devices) is True
+    assert gpu_display_info(devices) == ("Radeon Vega", None)
+
+
+def test_gpu_display_info_skips_unavailable_gpu():
+    """An entry present but available:false is not a detected GPU."""
+    devices = {
+        "nvidia_gpu": [{"available": False, "error": "no NVIDIA GPU", "name": ""}],
+        "cpu": {"available": True},
+    }
+
+    assert gpu_display_info(devices) == (None, None)
+
+
+def test_gpu_display_info_prefers_larger_vram():
+    devices = {
+        "amd_gpu": [
+            {"available": True, "name": "iGPU", "vram_gb": 0.5, "integrated": True},
+            {"available": True, "name": "dGPU", "vram_gb": 24.0},
+        ]
+    }
+
+    assert gpu_display_info(devices) == ("dGPU", 24.0)
+
+
+def test_gpu_display_info_non_numeric_vram_is_undetected_not_zero(caplog):
+    devices = {"amd_gpu": [{"available": True, "name": "GPU", "vram_gb": "lots"}]}
+
+    name, vram = gpu_display_info(devices)
+
+    assert name == "GPU"
+    assert vram is None  # never a silently-wrong 0.0
+    assert "vram_gb" in caplog.text
+
+
+# ── /api/system/status ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("fixture,expected_name,expected_vram", REAL_PAYLOADS)
+def test_system_status_reports_gpu(
+    fixture, expected_name, expected_vram, stub_lemonade
+):
+    stub_lemonade(
+        {
+            "/health": {"model_loaded": "Gemma-4-E4B-it-GGUF"},
+            "/models": {"data": []},
+            "/system-info": {"devices": load_devices(fixture)},
+        }
+    )
+
+    body = TestClient(create_app(db_path=":memory:")).get("/api/system/status").json()
+
+    assert body["gpu_name"] == expected_name
+    assert body["gpu_vram_gb"] == expected_vram
+
+
+def test_system_status_no_gpu_reports_null(stub_lemonade):
+    stub_lemonade(
+        {
+            "/health": {"model_loaded": "Gemma-4-E4B-it-GGUF"},
+            "/models": {"data": []},
+            "/system-info": {"devices": load_devices("cpu_only.json")},
+        }
+    )
+
+    body = TestClient(create_app(db_path=":memory:")).get("/api/system/status").json()
+
+    assert body["gpu_name"] is None
+    assert body["gpu_vram_gb"] is None
+
+
+def test_system_status_detects_npu_from_real_payload(stub_lemonade):
+    """NPU detection must survive the GPU refactor (linux fixture has an NPU)."""
+    stub_lemonade(
+        {
+            "/health": {"model_loaded": "Gemma-4-E4B-it-GGUF"},
+            "/models": {"data": []},
+            "/system-info": {"devices": load_devices("lemonade11_amd_igpu_linux.json")},
+        }
+    )
+
+    body = TestClient(create_app(db_path=":memory:")).get("/api/system/status").json()
+
+    assert "npu" in body["detected_devices"]
+
+
+def test_system_status_no_npu_on_macos(stub_lemonade):
+    stub_lemonade(
+        {
+            "/health": {"model_loaded": "Gemma-4-E4B-it-GGUF"},
+            "/models": {"data": []},
+            "/system-info": {"devices": load_devices("lemonade11_metal_macos.json")},
+        }
+    )
+
+    body = TestClient(create_app(db_path=":memory:")).get("/api/system/status").json()
+
+    assert "npu" not in body["detected_devices"]
+
+
+# ── onboarding preflight probe ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("fixture,expected_name,expected_vram", REAL_PAYLOADS)
+@pytest.mark.asyncio
+async def test_onboarding_probe_reports_gpu(
+    fixture, expected_name, expected_vram, stub_lemonade
+):
+    stub_lemonade({"/system-info": {"devices": load_devices(fixture)}})
+
+    result = await onboarding_mod._probe_lemonade_devices()
+
+    assert result["lemonade_running"] is True
+    assert result["gpu_name"] == expected_name
+    assert result["gpu_vram_gb"] == expected_vram
+
+
+@pytest.mark.asyncio
+async def test_onboarding_probe_no_gpu_reports_none(stub_lemonade):
+    stub_lemonade({"/system-info": {"devices": load_devices("cpu_only.json")}})
+
+    result = await onboarding_mod._probe_lemonade_devices()
+
+    assert result["gpu_name"] is None
+    assert result["gpu_vram_gb"] is None
+
+
+@pytest.mark.asyncio
+async def test_onboarding_probe_npu_flags_from_real_payloads(stub_lemonade):
+    stub_lemonade(
+        {"/system-info": {"devices": load_devices("lemonade11_amd_igpu_linux.json")}}
+    )
+
+    result = await onboarding_mod._probe_lemonade_devices()
+
+    assert result["npu_detected"] is True
+
+
+@pytest.mark.asyncio
+async def test_onboarding_probe_npu_absent_is_false_not_unknown(stub_lemonade):
+    """Lemonade answered, so a missing NPU is a definite False (not None)."""
+    stub_lemonade(
+        {"/system-info": {"devices": load_devices("lemonade11_metal_macos.json")}}
+    )
+
+    result = await onboarding_mod._probe_lemonade_devices()
+
+    assert result["npu_detected"] is False


### PR DESCRIPTION
> **Stacks on #2244 — merge after it.** This PR targets #2244's branch (`autofix/issue-2241`) because it builds on the `_device_is_available` / `_is_gpu_device_key` helpers that PR introduces. GitHub will retarget it to `main` automatically once #2244 merges.

Before: on real hardware the Agent UI showed no GPU at all — the Settings status panel and the first-run onboarding preflight both hid the GPU row, so a machine with an RX 7900 XTX or an Apple M3 Max looked identical to a CPU-only box. #2244 fixed this same shape mismatch for the CLI but left the two UI probes untouched, so the two surfaces disagreed about the same hardware. After: both UI probes read the real payload shapes and report the actual GPU and its VRAM, and they share one availability check with the CLI rather than re-implementing it. A machine with genuinely no GPU now reports "not detected" honestly instead of a blank that reads as success.

Two details worth a reviewer's eye. On the captured Windows payload Lemonade lists an APU's integrated graphics *first* and the discrete RX 7900 XTX second, with neither entry reporting `vram_gb` or `integrated` — picking naively would tell a 7900 XTX owner they have "AMD Radeon(TM) Graphics", so selection ranks the discrete card's `family`/`driver_version` identity. And `system.py`'s `detected_devices = ["cpu", "gpu"]` hardcode is deliberately left alone: it carries its own documented rationale (llamacpp runs on GPU via vulkan regardless of what the device table reports), and changing which agent device configs the UI offers is a behaviour change beyond this fix.

## Test plan

- [x] `pytest tests/unit/test_ui_gpu_detection.py` — 21 new tests, all green
- [x] Red-phase proof: reverting only the two routers makes 6 tests fail with `assert None == 'AMD Radeon RX 7900 XTX'` (and the Linux/macOS equivalents) — the tests catch the actual bug, not just the new helper
- [x] `pytest tests/unit/test_system_info_has_gpu.py tests/unit/test_cli_device_resolution.py tests/unit/test_onboarding_router.py tests/unit/test_ui_extras.py` — #2244's own tests and the existing UI tests still pass (51 total)
- [x] `pytest tests/unit/ -q` — 6485 passed; the 8 failures are pre-existing and reproduce identically on `autofix/issue-2241` with these changes stashed (CLI-binary-on-PATH, init_command, memory_router, file_write_guardrails — none GPU-related)
- [x] `python util/lint.py --all` — `ALL QUALITY CHECKS PASSED` (2 pre-existing non-blocking warnings)
- [x] Both helpers cross-checked against all 9 hardware fixtures: `system_info_has_gpu` and `gpu_display_info` now agree on every shape, including the top-level-list payload where they previously diverged

Tests feed the **real captured payloads** in `tests/fixtures/hardware/lemonade11_*.json` through the routers with only the HTTP boundary stubbed, so they pin Lemonade's actual shapes rather than a mock's idea of them.