### PR TITLE
feat(daemon): broker-wire the remaining direct model-load surfaces

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2157,6 +2157,26 @@ Requires the daemon extras (`fastapi`/`uvicorn`/`psutil`) — install with
 `pip install "amd-gaia[ui]"` (or `[api]`/`[dev]`). Running it on a base install
 fails loudly with that instruction.
 
+#### Model-slot serialization
+
+Lemonade is single-tenant per model slot: a second process loading a different
+model **evicts** the first. The daemon therefore runs a **model-slot broker**
+that hands out one lease at a time, so model loads queue instead of racing.
+
+When a daemon is running, `gaia` commands and the Agent UI backend attach to it
+automatically and take a lease around each model load — you may see a brief
+`⏳ switching model…` while another process finishes. Interactive chat turns
+take priority over background work (embedder warm-ups, autonomous briefs).
+
+With **no daemon running, nothing changes**: there are no sidecars, nothing else
+holds the slot, and loads proceed directly. Attaching never starts a daemon.
+
+If the daemon is running but unreachable, a model load **fails loudly** rather
+than doing a direct load that would evict another process's model — check
+`gaia daemon status`. A daemon left running at an incompatible version is
+reported as a warning and loads proceed unbrokered; `gaia daemon restart`
+restores serialization.
+
 ```bash
 gaia daemon start      # start the daemon, or attach if one is already running
 gaia daemon status     # pid, port, uptime + the supervised sidecar list

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -3219,6 +3219,18 @@ def main():
     if hasattr(args, "logging_level"):
         log_manager.set_level("gaia", getattr(logging, args.logging_level))
 
+    # ── Model-slot broker (#2248) ────────────────────────────────────────
+    # A CLI run is host-side and not daemon-spawned, so it inherits no broker
+    # URL and its model loads would bypass the broker, race-evicting models a
+    # running sidecar just loaded. Opting in costs nothing here: it only sets a
+    # flag, and the daemon is probed lazily at the first actual model load — so
+    # commands that never load a model never probe. Discovery attaches to a LIVE
+    # daemon only and never starts one, leaving standalone `gaia llm` on a
+    # daemon-less machine exactly as it was (nothing else holds the slot).
+    from gaia.daemon.broker_client import enable_broker_discovery
+
+    enable_broker_discovery()
+
     # Apply the persistent default_model (issue #98) for model-bearing commands.
     # Precedence: explicit --model flag > config default_model > built-in default.
     # An explicit `chat --device` requests a device-specific model, so it keeps

--- a/src/gaia/daemon/broker_client.py
+++ b/src/gaia/daemon/broker_client.py
@@ -9,9 +9,11 @@ instead of racing the single slot. This module is the thin HTTP client for the
 manager that acquires a lease, yields, and releases it.
 
 **Env-gated, and no silent fallback (CLAUDE.md).** Broker routing is active only
-when ``GAIA_MODEL_BROKER_URL`` is set — the daemon sets it for the processes it
-spawns and host-side components discover it via ``start_or_attach``. When it is
-unset the caller is running standalone (e.g. ``gaia llm`` with no daemon): there
+when ``GAIA_MODEL_BROKER_URL`` is set. The daemon sets it for the processes it
+spawns; host-side processes it did NOT spawn (the UI backend, a CLI run) opt in
+via :func:`enable_broker_discovery` and then attach to a live daemon lazily at
+their first load (:func:`attach_broker_env`). When it is unset the caller is
+running standalone (e.g. ``gaia llm`` with no daemon): there
 is no slot contention to arbitrate, so :func:`model_lease` is a no-op — that is
 the *absence* of a broker, not a fallback around a failed one. But when the URL
 IS set and the broker cannot be reached, :func:`model_lease` raises loudly rather
@@ -21,6 +23,7 @@ than doing a direct load that would race-evict another process's model.
 from __future__ import annotations
 
 import os
+import threading
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional
@@ -44,16 +47,135 @@ class BrokerUnavailableError(Exception):
     Fail-loud, per CLAUDE.md: raising this beats a silent direct load that would
     race the model slot. The message names what failed, what to do, and where to
     look.
+
+    ``status_code`` is the broker's HTTP status when the failure came from a
+    response, and ``None`` when it came from the transport (connection refused,
+    timeout). Callers use it to tell "wrong/stale credential" apart from "this
+    daemon has no broker at all" — those need opposite responses.
     """
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 def broker_configured() -> bool:
     """True when this process should route model loads through the broker."""
-    return bool(os.environ.get(BROKER_URL_ENV_VAR, "").strip())
+    return bool(os.environ.get(BROKER_URL_ENV_VAR, "").strip()) or _attached is not None
+
+
+_discovery_enabled = False
+
+# Address + credential discovered by :func:`attach_broker_env`, as (url, token).
+#
+# Deliberately NOT written into ``os.environ``. The daemon client token is not
+# broker-scoped — it also guards ``/daemon/v1/shutdown`` and the sidecar control
+# plane (``app.py``) — so exporting it would hand full daemon authority to every
+# child process this one spawns and leave it inspectable in the process
+# environment. That is exactly the posture the ``BROKER_TOKEN_FILE`` leg below
+# exists to avoid. Keeping it in-process also means a child re-discovers the
+# daemon on its own terms rather than inheriting a URL it has no credential for.
+_attached: Optional[tuple] = None
+
+
+def enable_broker_discovery() -> None:
+    """Declare this process a host-side broker participant (#2248).
+
+    Call once from a process *entry point* (the UI backend's lifespan, the CLI's
+    ``main``). It only sets a flag — no probing here — so it is free to call
+    unconditionally.
+
+    Discovery is opt-in rather than implicit because importing
+    :class:`~gaia.llm.lemonade_client.LemonadeClient` must not, by itself, make
+    an arbitrary script or test silently join whatever daemon happens to be
+    running on the machine. Entry points know they are a real host process;
+    library code does not.
+    """
+    global _discovery_enabled  # pylint: disable=global-statement
+    _discovery_enabled = True
+
+
+def discovery_enabled() -> bool:
+    """True when this process opted into host-side broker discovery."""
+    return _discovery_enabled
+
+
+def attach_broker_env() -> bool:
+    """Point this process at a running daemon's broker. Returns True if attached.
+
+    The daemon exports :data:`BROKER_URL_ENV_VAR` into its *own* environment, so
+    only the processes it spawns (sidecars) inherit it. A host-side process that
+    the daemon did NOT spawn — the UI backend, a CLI run — starts with no broker
+    configured even when a daemon is live, and would load models directly,
+    race-evicting whatever a sidecar just loaded (#2248).
+
+    This closes that gap by *discovering* the live daemon and adopting its
+    address plus client token (the credential ``/host/v1`` resolves to the
+    ``"host"`` caller label).
+
+    Returning False when no daemon is running is **not** a fallback: with no
+    daemon there are no sidecars, nothing else holds the single Lemonade slot,
+    and there is no arbiter to route through. A broker that IS configured but
+    unreachable still raises loudly from :func:`model_lease`.
+    """
+    global _attached  # pylint: disable=global-statement
+
+    if broker_configured():
+        return True
+    # Deferred: keeps the daemon client (and its httpx/probe path) off the
+    # import path of standalone callers that never attach.
+    from gaia.daemon.client import attach
+    from gaia.daemon.errors import DaemonVersionError
+
+    try:
+        inst = attach()
+    except DaemonVersionError as e:
+        # A MAJOR-skewed daemon left running is an expected state after an app
+        # update (see gaia.daemon.client), and it must not take down commands
+        # that merely load a model — `gaia llm` has no business hard-failing on
+        # it. Loud warning + unbrokered rather than a hard stop, since the
+        # alternative bricks the CLI until the user finds `gaia daemon restart`.
+        logger.warning(
+            "broker client: a version-skewed daemon is running (%s). Model "
+            "loads in this process run UNBROKERED and may race a sidecar's "
+            "model. Run `gaia daemon restart` to restore serialization.",
+            e,
+        )
+        return False
+    if inst is None:
+        logger.debug(
+            "broker client: no live daemon to attach to; model loads run "
+            "unbrokered (standalone — nothing else holds the model slot)"
+        )
+        return False
+    _attached = (inst.base_url, inst.token)
+    logger.info(
+        "broker client: attached to daemon broker at %s — model loads in this "
+        "process now serialize against sidecar loads",
+        inst.base_url,
+    )
+    return True
+
+
+def _detach() -> None:
+    """Forget a discovered daemon so the next load re-discovers it.
+
+    Called when a lease attempt fails against an auto-attached daemon: a
+    ``gaia daemon restart`` rotates both the port and the token, and a
+    long-lived host process (the UI backend) holding the stale pair would
+    otherwise fail EVERY subsequent load until it was itself restarted.
+    """
+    global _attached  # pylint: disable=global-statement
+    _attached = None
 
 
 def _broker_base() -> str:
-    return os.environ[BROKER_URL_ENV_VAR].rstrip("/")
+    # Env first: a daemon-spawned process is told where its broker is, and that
+    # assignment outranks anything this process discovered on its own.
+    url = os.environ.get(BROKER_URL_ENV_VAR, "").strip()
+    if not url and _attached is not None:
+        url = _attached[0]
+    return url.rstrip("/")
 
 
 def _credential() -> str:
@@ -74,6 +196,10 @@ def _credential() -> str:
         if token:
             return token
     token = os.environ.get(BROKER_TOKEN_ENV_VAR, "").strip()
+    if not token and _attached is not None:
+        # Discovered in-process by attach_broker_env (never exported to env —
+        # see the _attached docstring for why).
+        token = _attached[1]
     if not token:
         raise BrokerUnavailableError(
             f"{BROKER_URL_ENV_VAR} is set (broker routing is active) but neither "
@@ -127,7 +253,8 @@ def acquire_lease(
         detail = _safe_detail(r)
         raise BrokerUnavailableError(
             f"model-slot broker refused the lease for '{model}' "
-            f"(HTTP {r.status_code}): {detail}. Check `gaia daemon logs`."
+            f"(HTTP {r.status_code}): {detail}. Check `gaia daemon logs`.",
+            status_code=r.status_code,
         )
     return r.json()
 
@@ -172,6 +299,79 @@ def _safe_detail(response) -> str:
     return (response.text or "")[:500]
 
 
+# Set when the attached daemon answers the lease route with 404 — it is an
+# older build with no broker mounted. Sticky for the process so we neither
+# re-probe nor re-warn on every load.
+_broker_unsupported = False
+
+# Statuses that mean "the credential/address I hold is stale", i.e. worth one
+# re-discovery. A 404 (no broker on this daemon) or a 5xx (broker is there and
+# broken) are NOT stale-attach signals and must not trigger a pointless retry.
+_STALE_ATTACH_STATUSES = (401, 403)
+
+
+def _acquire_with_reattach(model: str, priority: Optional[str]) -> Optional[dict]:
+    """Acquire a lease, re-discovering the daemon once if a stale one is cached.
+
+    Returns ``None`` when the attached daemon has no broker to lease from — see
+    the 404 branch below.
+
+    ``gaia daemon restart`` rotates the daemon's port AND token. A long-lived
+    host process (the UI backend) that auto-attached before the restart holds a
+    dead address, and every later load would fail permanently — the daemon's own
+    401 text tells the caller to "re-attach", which is precisely what this does.
+
+    Only retried for daemons this process DISCOVERED, and only for failures that
+    actually indicate a stale attach. A URL handed down by the daemon that
+    spawned us is authoritative: if that one is unreachable the failure is real
+    and propagates untouched.
+    """
+    global _broker_unsupported  # pylint: disable=global-statement
+
+    try:
+        return acquire_lease(model, priority=priority)
+    except BrokerUnavailableError as e:
+        if e.status_code == 404:
+            # The daemon is running but exposes no lease route: a build older
+            # than the broker (#2151). There is no arbiter to route through —
+            # and such a daemon is not managing sidecars that lease either — so
+            # loads proceed unbrokered. That is the *absence* of a broker, the
+            # same as no daemon at all, not a fallback around a failed one. Warn
+            # once (not per load) because serialization is genuinely off.
+            _broker_unsupported = True
+            logger.warning(
+                "broker client: the running daemon at %s has no model-slot "
+                "broker (HTTP 404 on the lease route) — it predates #2151. "
+                "Model loads in this process run UNBROKERED. Run "
+                "`gaia daemon restart` on a current build to restore "
+                "serialization.",
+                _broker_base(),
+            )
+            return None
+        stale = e.status_code is None or e.status_code in _STALE_ATTACH_STATUSES
+        if _attached is None or not _discovery_enabled or not stale:
+            raise
+        logger.info(
+            "broker client: lease attempt failed against the discovered daemon "
+            "at %s (%s); it likely restarted and rotated its port/token. "
+            "Re-discovering once.",
+            _attached[0],
+            f"HTTP {e.status_code}" if e.status_code else "unreachable",
+        )
+        _detach()
+        if not attach_broker_env():
+            raise
+        return acquire_lease(model, priority=priority)
+
+
+_held = threading.local()
+
+
+def holding_lease() -> bool:
+    """True when this thread already owns the model slot (see :func:`model_lease`)."""
+    return getattr(_held, "depth", 0) > 0
+
+
 @contextmanager
 def model_lease(
     model: str,
@@ -185,14 +385,55 @@ def model_lease(
     yields ``None``. Otherwise it acquires a lease (blocking until the slot is
     free), yields the lease dict, and releases on exit — even on exception.
 
+    **Re-entrant per thread.** The broker grants exactly one lease at a time, so
+    a nested acquire on a thread that already holds the slot would block forever
+    waiting for itself. Nesting is normal now that the lease lives at the
+    ``load_model`` chokepoint (#2248): a caller wrapping a multi-step
+    unload→load sequence in an outer lease reaches an inner one on the load. The
+    outermost ``with`` owns the lease; inner ones yield ``None`` and are no-ops.
+
     ``on_wait`` is called with a human-readable reason when the grant response
     indicates the request had to queue, so the caller can surface a
     ``switching model…`` status.
     """
-    if not broker_configured():
+    # Discover lazily, at the moment of the load, rather than once at process
+    # start: a daemon can come up *after* a long-lived host process (the UI
+    # backend) did, and a start-time-only check would leave every later load in
+    # that process permanently unbrokered. Gated on the process having opted in
+    # (see :func:`enable_broker_discovery`), and once attached the address is
+    # cached so this short-circuits and never probes again.
+    if _broker_unsupported:
         yield None
         return
-    lease = acquire_lease(model, priority=priority)
+    if not broker_configured():
+        if not (_discovery_enabled and attach_broker_env()):
+            yield None
+            return
+    if holding_lease():
+        held_model = getattr(_held, "model", None)
+        if held_model is not None and held_model != model:
+            # The outer holder leased a DIFFERENT model. Folding silently would
+            # let this load happen under a lease the broker booked against
+            # another model, desyncing its slot bookkeeping — loud, because the
+            # quiet version is a race the broker thinks it prevented.
+            raise BrokerUnavailableError(
+                f"nested model-slot lease for '{model}' on a thread already "
+                f"holding the slot for '{held_model}'. A nested load must "
+                "target the same model as the enclosing lease; leasing a "
+                "second model would corrupt the broker's slot accounting. "
+                "Move the inner load outside the enclosing lease."
+            )
+        logger.debug(
+            "broker client: already holding the model slot on this thread; "
+            "nested lease for '%s' is a no-op",
+            model,
+        )
+        yield None
+        return
+    lease = _acquire_with_reattach(model, priority)
+    if lease is None:  # daemon has no broker — proceed unbrokered (warned above)
+        yield None
+        return
     if lease.get("waited") and on_wait is not None:
         reason = (
             "switching model…"
@@ -200,7 +441,11 @@ def model_lease(
             else "waiting for the model slot…"
         )
         on_wait(reason)
+    _held.depth = 1
+    _held.model = model
     try:
         yield lease
     finally:
+        _held.depth = 0
+        _held.model = None
         release_lease(lease["lease_id"])

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -3209,8 +3209,50 @@ class LemonadeClient:
         prompt: bool = True,
         load_retries: int = DEFAULT_MODEL_LOAD_RETRIES,
     ) -> Dict[str, Any]:
+        """Load a model on the server, holding a broker model-slot lease.
+
+        This is the single chokepoint where a load actually reaches Lemonade, so
+        it is where the lease belongs (#2248). Every direct caller — the UI
+        backend's startup preload, the per-request pre-flight, the RAG and
+        code-index embedder warm-ups, the VLM client — serializes against sidecar
+        loads without each having to remember to wrap itself.
+
+        The lease is re-entrant per thread: callers that must make a multi-step
+        sequence atomic (``unload`` → ``load``) take an outer lease themselves,
+        and the one taken here folds into it. See
+        :func:`gaia.daemon.broker_client.model_lease`. A no-op when no broker is
+        configured.
+
+        See :meth:`_load_model_leased` for the full parameter documentation.
         """
-        Load a model on the server.
+        with self._model_slot_lease(model_name):
+            return self._load_model_leased(
+                model_name,
+                timeout=timeout,
+                auto_download=auto_download,
+                _download_timeout=_download_timeout,
+                llamacpp_args=llamacpp_args,
+                ctx_size=ctx_size,
+                save_options=save_options,
+                prompt=prompt,
+                load_retries=load_retries,
+            )
+
+    def _load_model_leased(
+        self,
+        model_name: str,
+        timeout: int = DEFAULT_MODEL_LOAD_TIMEOUT,
+        auto_download: bool = False,
+        _download_timeout: int = 7200,  # Reserved for future use
+        llamacpp_args: Optional[str] = None,
+        ctx_size: Optional[int] = None,
+        save_options: bool = False,
+        prompt: bool = True,
+        load_retries: int = DEFAULT_MODEL_LOAD_RETRIES,
+    ) -> Dict[str, Any]:
+        """
+        Load a model on the server. Body of :meth:`load_model`, run while holding
+        the broker's model-slot lease.
 
         If auto_download is enabled and the model is not available:
         1. Prompts user for confirmation (with size and ETA) - unless prompt=False

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -502,18 +502,27 @@ class RAGSDK:
                         f"(or run `gaia init --profile rag`)."
                     )
 
-            # Scoped unload of the embedder ONLY — a global /unload would evict
-            # the co-resident chat model and trigger a ~100s cold reload (#1544).
-            # ignore_if_not_loaded: on a cold start the embedder slot is empty
-            # and Lemonade 404s "Model not loaded" — a benign no-op here, since
-            # we reload it on the next line anyway.
-            self.llm_client.unload_model(
-                self.config.embedding_model, ignore_if_not_loaded=True
-            )
-            self.llm_client.load_model(
-                self.config.embedding_model,
-                llamacpp_args="--ubatch-size 2048",
-            )
+            # Serialize the whole unload→load swap through the broker (#2248).
+            # Not an eviction guard — per #1544 the embedder is co-resident in
+            # its own slot, so a chat load will not evict it. It is a guard on
+            # the *load* itself: concurrent loads contend for GPU memory and
+            # backend startup, which is what the broker arbitrates. Background
+            # priority so a warm-up never makes an interactive turn wait.
+            from gaia.daemon.broker_client import model_lease
+
+            with model_lease(self.config.embedding_model, priority="background"):
+                # Scoped unload of the embedder ONLY — a global /unload would evict
+                # the co-resident chat model and trigger a ~100s cold reload (#1544).
+                # ignore_if_not_loaded: on a cold start the embedder slot is empty
+                # and Lemonade 404s "Model not loaded" — a benign no-op here, since
+                # we reload it on the next line anyway.
+                self.llm_client.unload_model(
+                    self.config.embedding_model, ignore_if_not_loaded=True
+                )
+                self.llm_client.load_model(
+                    self.config.embedding_model,
+                    llamacpp_args="--ubatch-size 2048",
+                )
 
             self.embedder = self.llm_client
             self.use_lemonade_embeddings = True

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -26,6 +26,7 @@ from typing import Optional
 from fastapi import HTTPException
 
 from gaia.agents.install_hints import agent_not_installed_message
+from gaia.daemon.broker_client import BrokerUnavailableError
 
 from .database import PLACEHOLDER_TITLES, SESSION_DEFAULT_MODEL, ChatDatabase
 from .models import ChatRequest
@@ -1230,9 +1231,21 @@ def _maybe_load_expected_model(model_id: str, sse_handler=None) -> None:
                 {"type": "status", "status": "info", "message": "Loading LLM model..."}
             )
 
+        from gaia.daemon.broker_client import model_lease
         from gaia.llm.lemonade_client import LemonadeClient
 
-        with model_load_lock:
+        # Interactive priority: this pre-flight is on the user's turn, so it
+        # must jump ahead of queued background loads (embedder warm-ups,
+        # autonomous briefs). The lease spans the re-check and the unload→load
+        # pair so no other process can take the slot mid-swap (#2248).
+        #
+        # Lease BEFORE model_load_lock, and in that order everywhere (see
+        # server.py's startup preload). Taking the in-process lock first would
+        # let a background holder sit on it for the whole cross-process wait,
+        # and this interactive request would then queue behind it on the lock —
+        # where the broker's priority ordering has no say, silently defeating
+        # the priority it just asked for.
+        with model_lease(model_id, priority="interactive"), model_load_lock:
             # Re-check after acquiring the lock: another thread may have
             # already loaded the expected model with sufficient context.
             resident_chat_models = []
@@ -1273,6 +1286,22 @@ def _maybe_load_expected_model(model_id: str, sse_handler=None) -> None:
                 ctx_size=DEFAULT_CONTEXT_SIZE,
                 prompt=False,
                 timeout=_PREFLIGHT_LOAD_TIMEOUT_S,
+            )
+    except BrokerUnavailableError as exc:
+        # Do NOT report this as "check that Lemonade is running" — Lemonade is
+        # fine, the daemon that arbitrates the model slot is not, and pointing
+        # the user at the wrong subsystem costs them the debugging session.
+        logger.error("Pre-flight model load could not lease the model slot: %s", exc)
+        if sse_handler is not None:
+            sse_handler._emit(
+                {
+                    "type": "status",
+                    "status": "warning",
+                    "message": (
+                        "Could not reserve the model slot from the GAIA daemon. "
+                        "Check `gaia daemon status`."
+                    ),
+                }
             )
     except Exception as exc:
         logger.warning("Pre-flight model check failed: %s", exc)

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -219,6 +219,17 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
         queue = DispatchQueue(max_workers=4)
         app.state.dispatch_queue = queue
 
+        # ── Model-slot broker (#2248) ───────────────────────────────────
+        # The daemon exports the broker URL into its own environment, so only
+        # the sidecars it spawns inherit it. This backend is host-side and not
+        # daemon-spawned, so it must discover the daemon itself — otherwise its
+        # model loads bypass the broker and race-evict sidecar models. Attaching
+        # happens lazily at the first load, so a daemon that starts after this
+        # backend is still picked up.
+        from gaia.daemon.broker_client import enable_broker_discovery
+
+        enable_broker_discovery()
+
         # ── Agent Registry ──────────────────────────────────────────────
         from gaia.agents.registry import AgentRegistry
         from gaia.ui._chat_helpers import set_agent_registry
@@ -309,9 +320,20 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
                 if any(m.get("type") in ("llm", "vlm") for m in all_models):
                     return  # Already loaded — nothing to do
 
+            from gaia.daemon.broker_client import model_lease
             from gaia.llm.lemonade_client import LemonadeClient
+            from gaia.ui.routers.system import _DEFAULT_MODEL_NAME
 
-            with model_load_lock:
+            model_id = db.get_setting("custom_model") or _DEFAULT_MODEL_NAME
+
+            # model_load_lock guards other threads in THIS process; the broker
+            # lease guards other processes sharing Lemonade's single slot
+            # (#2248). Both are needed, and the lease spans the re-check so a
+            # sidecar cannot load between our "nothing resident" verdict and our
+            # load. Lease first, then the lock — same order as the chat
+            # pre-flight, so this background preload can never hold the lock
+            # across a cross-process wait and starve an interactive turn.
+            with model_lease(model_id, priority="background"), model_load_lock:
                 # Double-check after acquiring the lock: another thread may have
                 # loaded the model while we were waiting.
                 try:
@@ -323,9 +345,6 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
                 except Exception:
                     pass  # proceed with load attempt
 
-                from gaia.ui.routers.system import _DEFAULT_MODEL_NAME
-
-                model_id = db.get_setting("custom_model") or _DEFAULT_MODEL_NAME
                 LemonadeClient(verbose=False).load_model(
                     model_id, ctx_size=DEFAULT_CONTEXT_SIZE, prompt=False
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,38 @@ def _ensure_email_corpus():
     ensure_corpus()
 
 
+@pytest.fixture(autouse=True)
+def _reset_model_broker_state():
+    """Isolate the model-slot broker's process-global state between tests (#2248).
+
+    ``broker_client`` deliberately keeps process-global state: an entry point
+    calls ``enable_broker_discovery()`` once and it stays on for the life of the
+    process, and a discovered daemon's address is cached so later loads do not
+    re-probe. Correct in production — but in a test session it leaks: any test
+    that runs ``cli.main()`` flips discovery on for every test that follows, and
+    those then attach to whatever daemon happens to be running on the developer's
+    machine. That makes unrelated specs pass in CI and fail on a dev box.
+
+    Resetting per test keeps the suite hermetic and machine-independent.
+    """
+    try:
+        from gaia.daemon import broker_client
+    except ImportError:
+        yield
+        return
+
+    def _reset():
+        broker_client._discovery_enabled = False
+        broker_client._attached = None
+        broker_client._broker_unsupported = False
+        broker_client._held.depth = 0
+        broker_client._held.model = None
+
+    _reset()
+    yield
+    _reset()
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--hybrid",

--- a/tests/unit/test_broker_wiring.py
+++ b/tests/unit/test_broker_wiring.py
@@ -1,0 +1,835 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Unit spec for broker-wiring the direct model-load surfaces (#2248).
+
+V2-11 (#2151) put a lease around ``_ensure_model_loaded`` only, so the surfaces
+that call ``load_model`` directly — the UI backend's startup preload and
+per-request pre-flight, the RAG embedder warm-up, CLI runs — still raced the
+single Lemonade model slot. This spec pins the three things that fix:
+
+1. **The chokepoint.** ``LemonadeClient.load_model`` itself takes the lease, so
+   every direct caller is covered without having to remember to wrap itself.
+2. **Re-entrancy.** Callers that wrap a multi-step ``unload``→``load`` sequence
+   in an outer lease must not self-deadlock on the inner one — the broker grants
+   exactly one lease at a time.
+3. **Host-side discovery.** Only daemon-*spawned* processes inherit the broker
+   URL, so host-side processes must attach to a live daemon themselves or the
+   lease code never activates.
+
+Serialization is proven against a REAL :class:`ModelSlotBroker` (its true
+queueing/priority logic) with only the HTTP hop faked — a mock that merely
+records "a lease was requested" would prove invocation, not mutual exclusion
+(CLAUDE.md: assert the call is valid, not just that it happened).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import List, Optional, Tuple
+
+import pytest
+
+from gaia.daemon import broker_client
+from gaia.daemon.broker import ModelSlotBroker
+from gaia.daemon.constants import (
+    BROKER_TOKEN_ENV_VAR,
+    BROKER_URL_ENV_VAR,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_broker_env(monkeypatch):
+    """Every test starts AND ends with no broker configured and no lease held.
+
+    Two hygiene points, both learned the hard way:
+
+    - Explicit ``os.environ`` cleanup rather than ``monkeypatch.delenv``:
+      :func:`attach_broker_env` sets the vars directly, and monkeypatch records
+      no undo for a variable that was absent when it was asked to delete it — so
+      the address one test attaches to would leak into every later test in the
+      session and make unrelated model-load specs dial a dead broker.
+    - ``attach`` is stubbed to "no daemon" and discovery is reset to opt-OUT.
+      Discovery is process-global, so a test that enables it would otherwise
+      leak into later tests, which would then find whatever daemon happens to be
+      running on the developer's machine — green in CI, red on a dev box.
+    """
+    import os
+
+    def _clear():
+        for var in (BROKER_URL_ENV_VAR, BROKER_TOKEN_ENV_VAR):
+            os.environ.pop(var, None)
+
+    _clear()
+    broker_client._held.depth = 0
+    broker_client._held.model = None
+    monkeypatch.setattr(broker_client, "_discovery_enabled", False)
+    monkeypatch.setattr(broker_client, "_attached", None)
+    monkeypatch.setattr(broker_client, "_broker_unsupported", False)
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: None)
+    yield
+    _clear()
+    broker_client._held.depth = 0
+    broker_client._held.model = None
+
+
+class _LocalBroker:
+    """Routes ``broker_client``'s lease calls into a real in-process broker.
+
+    Substitutes only the HTTP hop; the queueing, priority ordering and
+    one-lease-at-a-time invariant under test are the broker's own.
+    """
+
+    def __init__(self, monkeypatch, *, url: str = "http://127.0.0.1:0"):
+        self.broker = ModelSlotBroker()
+        self.acquired: List[Tuple[str, str]] = []  # (model, priority)
+        self.released: List[str] = []
+        self._leases = {}
+        monkeypatch.setenv(BROKER_URL_ENV_VAR, url)
+        monkeypatch.setenv(BROKER_TOKEN_ENV_VAR, "test-token")
+        monkeypatch.setattr(broker_client, "acquire_lease", self._acquire)
+        monkeypatch.setattr(broker_client, "release_lease", self._release)
+
+    def _acquire(self, model, *, priority=None, timeout=None, request_timeout=310.0):
+        prio = priority or "background"
+        self.acquired.append((model, prio))
+        lease = self.broker.acquire(model, priority=prio, holder="host")
+        self._leases[lease.lease_id] = lease
+        return {
+            "lease_id": lease.lease_id,
+            "model": lease.model,
+            "waited": False,
+            "switching": False,
+        }
+
+    def _release(self, lease_id, *, request_timeout=10.0):
+        self.released.append(lease_id)
+        self.broker.release(lease_id)
+
+
+# ── Re-entrancy ──────────────────────────────────────────────────────────────
+
+
+def test_nested_model_lease_does_not_self_deadlock(monkeypatch):
+    """An outer lease + an inner one on the same thread must acquire ONCE.
+
+    The broker hands out one lease at a time, so a genuine second acquire here
+    would block forever waiting for the lease this very thread holds. This is
+    the load-bearing guarantee for the unload→load callers.
+    """
+    local = _LocalBroker(monkeypatch)
+
+    with broker_client.model_lease("m1", priority="background") as outer:
+        assert outer is not None
+        assert broker_client.holding_lease()
+        with broker_client.model_lease("m1") as inner:
+            assert inner is None, "nested lease must be a pass-through no-op"
+
+    assert len(local.acquired) == 1
+    assert len(local.released) == 1
+    assert not broker_client.holding_lease()
+
+
+def test_lease_released_and_depth_cleared_on_exception(monkeypatch):
+    """An exception inside the block must not leak the lease or the depth flag."""
+    local = _LocalBroker(monkeypatch)
+
+    with pytest.raises(RuntimeError):
+        with broker_client.model_lease("m1"):
+            raise RuntimeError("boom")
+
+    assert len(local.released) == 1
+    assert not broker_client.holding_lease()
+    # The slot is genuinely free again — a fresh acquire returns immediately.
+    with broker_client.model_lease("m2") as lease:
+        assert lease is not None
+
+
+def test_reentrancy_is_per_thread(monkeypatch):
+    """Holding the slot on one thread must NOT let another thread skip the queue."""
+    local = _LocalBroker(monkeypatch)
+    other_saw_lease: List[Optional[dict]] = []
+    released = threading.Event()
+
+    with broker_client.model_lease("m1"):
+
+        def _other():
+            # Not a no-op: this thread holds nothing, so it must really queue.
+            with broker_client.model_lease("m2") as lease:
+                other_saw_lease.append(lease)
+            released.set()
+
+        t = threading.Thread(target=_other, daemon=True)
+        t.start()
+        # It must still be blocked while we hold the slot.
+        assert not released.wait(timeout=0.3), "second thread bypassed the lease"
+
+    t.join(timeout=5)
+    assert released.is_set()
+    assert other_saw_lease and other_saw_lease[0] is not None
+    assert len(local.acquired) == 2
+
+
+# ── The load_model chokepoint ────────────────────────────────────────────────
+
+
+class _FakeClient:
+    """LemonadeClient with the HTTP load body replaced, lease path intact."""
+
+    def __init__(self, on_load=None):
+        from gaia.llm.lemonade_client import LemonadeClient
+
+        self.cls = LemonadeClient
+        self._on_load = on_load
+        self.loads: List[str] = []
+
+    def build(self, monkeypatch):
+        client = object.__new__(self.cls)
+        client.model_lease_priority = "background"
+        import logging
+
+        client.log = logging.getLogger("test.lemonade")
+
+        def _leased(model_name, **kwargs):
+            self.loads.append(model_name)
+            if self._on_load is not None:
+                self._on_load(model_name)
+            return {"status": "loaded", "model": model_name}
+
+        monkeypatch.setattr(client, "_load_model_leased", _leased)
+        return client
+
+
+def test_load_model_takes_a_lease(monkeypatch):
+    """A DIRECT load_model call — the #2248 bypass — must hold a lease."""
+    local = _LocalBroker(monkeypatch)
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    client.load_model("Gemma-4-E4B-it-GGUF", ctx_size=8192, prompt=False)
+
+    assert fake.loads == ["Gemma-4-E4B-it-GGUF"]
+    assert local.acquired == [("Gemma-4-E4B-it-GGUF", "background")]
+    assert len(local.released) == 1
+
+
+def test_load_model_holds_the_lease_across_the_load(monkeypatch):
+    """The lease must span the load, not merely bracket it."""
+    local = _LocalBroker(monkeypatch)
+    held_during_load: List[bool] = []
+    fake = _FakeClient(
+        on_load=lambda m: held_during_load.append(broker_client.holding_lease())
+    )
+    client = fake.build(monkeypatch)
+
+    client.load_model("m1")
+
+    assert held_during_load == [True]
+
+
+def test_load_model_is_a_noop_without_a_broker(monkeypatch):
+    """Standalone (no daemon, no broker URL) must be completely unaffected.
+
+    This is the absence of a broker, not a fallback around a failed one: with no
+    daemon there are no sidecars and nothing else holds the slot.
+    """
+    calls: List[str] = []
+    monkeypatch.setattr(
+        broker_client,
+        "acquire_lease",
+        lambda *a, **k: calls.append("acquire") or {},
+    )
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    client.load_model("m1")
+
+    assert fake.loads == ["m1"], "the load must still happen"
+    assert calls == [], "no broker configured → no lease traffic"
+
+
+def test_load_model_fails_loudly_when_broker_unreachable(monkeypatch):
+    """Broker configured but dead → raise, never a direct race-evicting load.
+
+    The unreachable broker is simulated at ``acquire_lease`` rather than by
+    dialling a closed port: ``requests`` honours ``HTTP_PROXY``/``ALL_PROXY``, so
+    a real connect would route through a dev box's proxy and hang on the 310s
+    request timeout instead of failing fast.
+    """
+    monkeypatch.setenv(BROKER_URL_ENV_VAR, "http://127.0.0.1:1")
+    monkeypatch.setenv(BROKER_TOKEN_ENV_VAR, "test-token")
+
+    def _dead(*a, **k):
+        raise broker_client.BrokerUnavailableError("daemon is down")
+
+    monkeypatch.setattr(broker_client, "acquire_lease", _dead)
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    with pytest.raises(broker_client.BrokerUnavailableError):
+        client.load_model("m1")
+
+    assert fake.loads == [], "must NOT fall back to a direct load"
+
+
+def test_load_model_forwards_every_kwarg_through_the_lease(monkeypatch):
+    """The lease wrapper must not drop load parameters.
+
+    ``load_model`` re-lists its kwargs into ``_load_model_leased`` by hand.
+    Silently dropping ``ctx_size`` there would reintroduce the #1030 class of
+    bug — a model loaded at the wrong context window — with every other test
+    still green.
+    """
+    _LocalBroker(monkeypatch)
+    seen = {}
+
+    from gaia.llm.lemonade_client import LemonadeClient
+
+    client = object.__new__(LemonadeClient)
+    client.model_lease_priority = "background"
+    import logging
+
+    client.log = logging.getLogger("test.lemonade")
+    monkeypatch.setattr(
+        client,
+        "_load_model_leased",
+        lambda model_name, **kwargs: seen.update({"model": model_name}, **kwargs),
+    )
+
+    client.load_model(
+        "m1",
+        timeout=123,
+        auto_download=True,
+        llamacpp_args="--ubatch-size 2048",
+        ctx_size=65536,
+        save_options=True,
+        prompt=False,
+        load_retries=7,
+    )
+
+    assert seen["model"] == "m1"
+    assert seen["timeout"] == 123
+    assert seen["auto_download"] is True
+    assert seen["llamacpp_args"] == "--ubatch-size 2048"
+    assert seen["ctx_size"] == 65536
+    assert seen["save_options"] is True
+    assert seen["prompt"] is False
+    assert seen["load_retries"] == 7
+
+
+def test_nested_lease_for_a_different_model_is_loud(monkeypatch):
+    """Folding a different model into an outer lease must raise, not pass.
+
+    The broker booked the slot against the outer model; quietly loading a
+    different one under that lease desyncs its accounting — a race the broker
+    would report as prevented.
+    """
+    _LocalBroker(monkeypatch)
+
+    with broker_client.model_lease("model-a"):
+        with pytest.raises(broker_client.BrokerUnavailableError, match="model-a"):
+            with broker_client.model_lease("model-b"):
+                pass
+
+
+def test_outer_lease_plus_load_model_acquires_once(monkeypatch):
+    """The unload→load pattern used by RAG / the UI pre-flight.
+
+    The caller takes an outer lease to make the pair atomic; load_model's own
+    lease folds into it. Exactly one acquire — a second would deadlock.
+    """
+    local = _LocalBroker(monkeypatch)
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    with broker_client.model_lease("embed", priority="background"):
+        client.load_model("embed", llamacpp_args="--ubatch-size 2048")
+
+    assert local.acquired == [("embed", "background")]
+    assert fake.loads == ["embed"]
+
+
+# ── Serialization: the property the broker exists to provide ────────────────
+
+
+def test_concurrent_direct_loads_serialize(monkeypatch):
+    """Two threads doing DIRECT load_model calls must never overlap.
+
+    This is the #2248 regression in miniature: pre-fix both threads would enter
+    the load body concurrently and race-evict each other's model.
+    """
+    local = _LocalBroker(monkeypatch)
+    concurrent = []
+    active = {"n": 0}
+    guard = threading.Lock()
+
+    def _on_load(_model):
+        with guard:
+            active["n"] += 1
+            concurrent.append(active["n"])
+        time.sleep(0.05)  # widen the window a racing thread would slip into
+        with guard:
+            active["n"] -= 1
+
+    fake = _FakeClient(on_load=_on_load)
+    errors: List[BaseException] = []
+
+    def _worker(model):
+        try:
+            client = fake.build(monkeypatch)
+            client.load_model(model)
+        except BaseException as e:  # surfaced below; never swallowed
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=_worker, args=(f"model-{i}",), daemon=True)
+        for i in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    assert not errors, f"worker(s) failed: {errors}"
+    assert len(fake.loads) == 4, "every load must still complete"
+    assert max(concurrent) == 1, f"loads overlapped: peak concurrency {max(concurrent)}"
+    assert len(local.acquired) == 4 and len(local.released) == 4
+
+
+# ── The wired call sites ─────────────────────────────────────────────────────
+
+
+def test_rag_embedder_warmup_holds_one_lease_across_unload_and_load(monkeypatch):
+    """The RAG warm-up's unload→load pair must be atomic under ONE lease.
+
+    ``load_model``'s own lease covers the load but NOT the gap between the
+    unload and it. Without the outer lease another process can take the slot in
+    that window; without re-entrancy the inner acquire would deadlock. This
+    pins both, and fails if the outer lease at rag/sdk.py is removed.
+    """
+    local = _LocalBroker(monkeypatch)
+    held_during: List[Tuple[str, bool]] = []
+
+    class _Client:
+        def unload_model(self, model, ignore_if_not_loaded=False):
+            held_during.append(("unload", broker_client.holding_lease()))
+
+        def load_model(self, model, **kwargs):
+            held_during.append(("load", broker_client.holding_lease()))
+
+    from gaia.rag.sdk import RAGSDK
+
+    sdk = object.__new__(RAGSDK)
+    sdk.embedder = None
+    sdk.log = __import__("logging").getLogger("test.rag")
+    sdk.llm_client = _Client()
+
+    class _Config:
+        embedding_model = "nomic-embed-text-v1-GGUF"  # not a "user." model
+
+    sdk.config = _Config()
+
+    sdk._load_embedder()
+
+    assert held_during == [("unload", True), ("load", True)]
+    # ONE lease for the whole swap — not one per operation.
+    assert len(local.acquired) == 1
+    assert local.acquired[0][1] == "background", "a warm-up must not be interactive"
+
+
+def test_host_entry_points_opt_into_broker_discovery():
+    """The CLI and the UI backend must declare themselves broker participants.
+
+    Discovery is opt-in, so deleting the single ``enable_broker_discovery()``
+    call from either entry point silently restores #2248 with every behavioural
+    test still green. This pins the wiring itself.
+    """
+    import ast
+    import inspect
+
+    import gaia.cli
+    import gaia.ui.server
+
+    for module, func_name in ((gaia.cli, "main"), (gaia.ui.server, "create_app")):
+        source = inspect.getsource(module)
+        tree = ast.parse(source)
+        target = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == func_name
+        )
+        called = {
+            node.func.id
+            for node in ast.walk(target)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "enable_broker_discovery" in called, (
+            f"{module.__name__}.{func_name} no longer opts into broker "
+            "discovery — its model loads would silently bypass the broker"
+        )
+
+
+# ── End-to-end over real HTTP ────────────────────────────────────────────────
+
+
+def test_host_side_lease_works_against_a_real_daemon_over_http(monkeypatch):
+    """Drive a REAL daemon over HTTP: does the host credential actually work?
+
+    Every other test here fakes the HTTP hop, which proves the client *asks* for
+    a lease but never that the daemon would *accept* the request — the exact gap
+    CLAUDE.md calls out (#1655). This stands up the real ``/host/v1`` route on an
+    ephemeral port and checks both halves of the contract: the discovered daemon
+    client token authenticates as the ``"host"`` caller, and four concurrent
+    loads genuinely serialize end to end.
+    """
+    uvicorn = pytest.importorskip("uvicorn")
+
+    import socket
+
+    from gaia.daemon.app import create_app
+    from gaia.daemon.broker import ModelSlotBroker
+
+    token = "e2e-daemon-client-token"
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    app = create_app(
+        token=token,
+        port=port,
+        pid=os.getpid(),
+        started_at=time.time(),
+        broker=ModelSlotBroker(),
+    )
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    try:
+        deadline = time.time() + 15
+        while not server.started and time.time() < deadline:
+            time.sleep(0.05)
+        assert server.started, "test daemon did not come up"
+
+        class _Inst:
+            base_url = f"http://127.0.0.1:{port}"
+            token = "e2e-daemon-client-token"
+
+        monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: _Inst())
+        monkeypatch.setattr(broker_client, "_discovery_enabled", True)
+
+        granted: List[str] = []
+        active = {"n": 0}
+        peak = {"v": 0}
+        guard = threading.Lock()
+        errors: List[BaseException] = []
+
+        def _worker(i):
+            try:
+                with broker_client.model_lease(f"model-{i}") as lease:
+                    assert lease is not None, "expected a real lease from the daemon"
+                    with guard:
+                        active["n"] += 1
+                        peak["v"] = max(peak["v"], active["n"])
+                    time.sleep(0.1)
+                    with guard:
+                        active["n"] -= 1
+                    granted.append(lease["lease_id"])
+            except BaseException as e:  # surfaced below; never swallowed
+                errors.append(e)
+
+        workers = [
+            threading.Thread(target=_worker, args=(i,), daemon=True) for i in range(4)
+        ]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=60)
+
+        assert not errors, f"worker(s) failed: {errors}"
+        assert len(granted) == 4, "the daemon must grant every lease"
+        assert len(set(granted)) == 4, "each grant must be a distinct lease"
+        assert peak["v"] == 1, f"loads overlapped: peak concurrency {peak['v']}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=15)
+
+
+# ── Host-side discovery ──────────────────────────────────────────────────────
+
+
+class _FakeInstance:
+    base_url = "http://127.0.0.1:54321"
+    token = "daemon-client-token"
+
+
+def test_attach_broker_env_adopts_a_live_daemon(monkeypatch):
+    """Host-side processes aren't daemon-spawned, so they must discover it."""
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: _FakeInstance())
+
+    assert broker_client.attach_broker_env() is True
+    assert broker_client.broker_configured()
+    assert broker_client._broker_base() == _FakeInstance.base_url
+    # The daemon client token is what /host/v1 resolves to the "host" caller.
+    assert broker_client._credential() == _FakeInstance.token
+
+
+def test_model_lease_attaches_lazily_to_a_late_daemon(monkeypatch):
+    """A daemon that starts AFTER this process must still capture its loads.
+
+    The UI backend outlives many daemon lifecycles. Discovering only at process
+    start would leave every subsequent load in a long-lived host process
+    permanently unbrokered — the #2248 bug reintroduced through the back door.
+    """
+    live = {"yes": False}
+    monkeypatch.setattr(broker_client, "_discovery_enabled", True)
+    monkeypatch.setattr(
+        "gaia.daemon.client.attach",
+        lambda *a, **k: _FakeInstance() if live["yes"] else None,
+    )
+    acquired: List[str] = []
+    monkeypatch.setattr(
+        broker_client,
+        "acquire_lease",
+        lambda model, **k: acquired.append(model) or {"lease_id": "L1"},
+    )
+    monkeypatch.setattr(broker_client, "release_lease", lambda *a, **k: None)
+
+    # No daemon yet — unbrokered, and nothing cached that would block attaching.
+    with broker_client.model_lease("m1") as lease:
+        assert lease is None
+    assert acquired == []
+
+    # Daemon comes up; the very next load must route through it.
+    live["yes"] = True
+    with broker_client.model_lease("m2") as lease:
+        assert lease is not None
+    assert acquired == ["m2"]
+
+
+def test_library_use_never_probes_for_a_daemon(monkeypatch):
+    """Without an explicit opt-in, a load must not go looking for a daemon.
+
+    Importing LemonadeClient must not make an arbitrary script — or a unit test
+    on a developer box that happens to run a daemon — silently join that
+    daemon's broker. Entry points opt in; library code does not.
+    """
+
+    def _boom(*a, **k):
+        raise AssertionError("library code must not probe for a daemon")
+
+    monkeypatch.setattr("gaia.daemon.client.attach", _boom)
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    client.load_model("m1")
+
+    assert fake.loads == ["m1"]
+
+
+def test_enable_broker_discovery_does_not_probe(monkeypatch):
+    """Opting in only sets a flag — the probe is deferred to the first load.
+
+    This is what makes it safe for ``gaia <anything>`` to opt in unconditionally
+    without adding daemon-probe latency to commands that never load a model.
+    """
+
+    def _boom(*a, **k):
+        raise AssertionError("enable_broker_discovery must not probe")
+
+    monkeypatch.setattr("gaia.daemon.client.attach", _boom)
+    monkeypatch.setattr(broker_client, "_discovery_enabled", False)
+
+    broker_client.enable_broker_discovery()
+
+    assert broker_client.discovery_enabled()
+    assert not broker_client.broker_configured()
+
+
+def test_reattaches_after_a_daemon_restart_rotates_its_token(monkeypatch):
+    """A restarted daemon must not permanently brick a long-lived host process.
+
+    `gaia daemon restart` rotates both port and token. The UI backend outlives
+    that, so without re-discovery every subsequent load would 401 forever — the
+    daemon's own 401 text tells the caller to re-attach.
+    """
+
+    class _New:
+        base_url = "http://127.0.0.1:60000"
+        token = "rotated-token"
+
+    monkeypatch.setattr(broker_client, "_discovery_enabled", True)
+    monkeypatch.setattr(broker_client, "_attached", ("http://127.0.0.1:54321", "stale"))
+
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: _New())
+    attempts = []
+
+    def _acquire(model, **kwargs):
+        attempts.append(broker_client._attached)
+        if len(attempts) == 1:
+            raise broker_client.BrokerUnavailableError("HTTP 401: token rotated")
+        return {"lease_id": "L-new"}
+
+    monkeypatch.setattr(broker_client, "acquire_lease", _acquire)
+    monkeypatch.setattr(broker_client, "release_lease", lambda *a, **k: None)
+
+    with broker_client.model_lease("m1") as lease:
+        assert lease == {"lease_id": "L-new"}
+
+    assert len(attempts) == 2, "should retry once after re-discovering"
+    assert broker_client._attached == (_New.base_url, _New.token)
+
+
+def test_daemon_without_a_broker_route_does_not_brick_model_loading(monkeypatch):
+    """A daemon predating the broker (404) must not fail every model load.
+
+    Found by driving a real daemon: an older build has no lease route, and
+    treating its 404 as a hard failure would break model loading outright for
+    anyone who hadn't restarted their daemon. No lease route means no arbiter —
+    the absence of a broker, like no daemon at all — so loads proceed, warned.
+    Sticky, so it warns and re-probes once rather than on every load.
+    """
+    monkeypatch.setattr(broker_client, "_discovery_enabled", True)
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: _FakeInstance())
+    calls = []
+
+    def _not_found(model, **kwargs):
+        calls.append(model)
+        raise broker_client.BrokerUnavailableError("Not Found", status_code=404)
+
+    monkeypatch.setattr(broker_client, "acquire_lease", _not_found)
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    client.load_model("m1")
+    client.load_model("m2")
+
+    assert fake.loads == ["m1", "m2"], "loads must still happen"
+    assert calls == ["m1"], "must not re-probe a daemon known to have no broker"
+    assert broker_client._broker_unsupported
+
+
+def test_a_404_does_not_trigger_a_pointless_reattach(monkeypatch):
+    """Only stale-credential failures justify re-discovery.
+
+    Retrying a 404 re-probes the daemon and logs a misleading "it likely
+    rotated its token" — noise that sends the reader after the wrong cause.
+    """
+    monkeypatch.setattr(broker_client, "_discovery_enabled", True)
+    monkeypatch.setattr(broker_client, "_attached", ("http://127.0.0.1:1", "tok"))
+    attaches = []
+    monkeypatch.setattr(
+        "gaia.daemon.client.attach",
+        lambda *a, **k: attaches.append(1) or _FakeInstance(),
+    )
+    monkeypatch.setattr(
+        broker_client,
+        "acquire_lease",
+        lambda model, **k: (_ for _ in ()).throw(
+            broker_client.BrokerUnavailableError("Not Found", status_code=404)
+        ),
+    )
+
+    with broker_client.model_lease("m1") as lease:
+        assert lease is None
+
+    assert attaches == [], "a 404 must not trigger re-discovery"
+
+
+def test_server_error_propagates_instead_of_reattaching(monkeypatch):
+    """A broker that IS there and broken (5xx) must fail loudly, not retry."""
+    monkeypatch.setattr(broker_client, "_discovery_enabled", True)
+    monkeypatch.setattr(broker_client, "_attached", ("http://127.0.0.1:1", "tok"))
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: _FakeInstance())
+    monkeypatch.setattr(
+        broker_client,
+        "acquire_lease",
+        lambda model, **k: (_ for _ in ()).throw(
+            broker_client.BrokerUnavailableError("boom", status_code=500)
+        ),
+    )
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    with pytest.raises(broker_client.BrokerUnavailableError):
+        client.load_model("m1")
+
+    assert fake.loads == [], "must not fall back to a direct load"
+
+
+def test_version_skewed_daemon_does_not_break_model_loading(monkeypatch):
+    """A stale-MAJOR daemon must not hard-fail commands that merely load a model.
+
+    `gaia llm` has no business dying because a skewed daemon was left running;
+    the load proceeds unbrokered and the skew is reported loudly instead.
+    """
+    from gaia.daemon.errors import DaemonVersionError
+
+    def _skewed(*a, **k):
+        raise DaemonVersionError("daemon speaks v1, client speaks v2")
+
+    monkeypatch.setattr(broker_client, "_discovery_enabled", True)
+    monkeypatch.setattr("gaia.daemon.client.attach", _skewed)
+    fake = _FakeClient()
+    client = fake.build(monkeypatch)
+
+    client.load_model("m1")
+
+    assert fake.loads == ["m1"]
+
+
+def test_daemon_token_is_never_exported_to_the_environment(monkeypatch):
+    """The discovered credential must stay in-process.
+
+    The daemon client token is not broker-scoped — it also guards daemon
+    shutdown and the sidecar control plane. Exporting it would hand that
+    authority to every child process and leave it inspectable in the process
+    environment.
+    """
+    import os
+
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: _FakeInstance())
+
+    assert broker_client.attach_broker_env() is True
+    assert broker_client.broker_configured()
+    assert BROKER_TOKEN_ENV_VAR not in os.environ
+    assert BROKER_URL_ENV_VAR not in os.environ
+    # ...but it IS usable for signing a lease request.
+    assert broker_client._credential() == _FakeInstance.token
+
+
+def test_attach_broker_env_without_a_daemon_leaves_env_clean(monkeypatch):
+    """No daemon → no sidecars → nothing to serialize against. Stay unbrokered."""
+    import os
+
+    monkeypatch.setattr("gaia.daemon.client.attach", lambda *a, **k: None)
+
+    assert broker_client.attach_broker_env() is False
+    assert not broker_client.broker_configured()
+    assert BROKER_URL_ENV_VAR not in os.environ
+    assert BROKER_TOKEN_ENV_VAR not in os.environ
+
+
+def test_attach_broker_env_preserves_an_inherited_config(monkeypatch):
+    """A daemon-spawned process already has its credential — don't clobber it.
+
+    Sidecars get a launch-token file/env from the manager; overwriting it with
+    the daemon client token would change the caller identity the broker derives.
+    """
+    monkeypatch.setenv(BROKER_URL_ENV_VAR, "http://127.0.0.1:9999")
+    monkeypatch.setenv(BROKER_TOKEN_ENV_VAR, "sidecar-launch-token")
+
+    def _boom(*a, **k):
+        raise AssertionError("must not probe when already configured")
+
+    monkeypatch.setattr("gaia.daemon.client.attach", _boom)
+
+    import os
+
+    assert broker_client.attach_broker_env() is True
+    assert os.environ[BROKER_URL_ENV_VAR] == "http://127.0.0.1:9999"
+    assert os.environ[BROKER_TOKEN_ENV_VAR] == "sidecar-launch-token"


### PR DESCRIPTION
Before this, GAIA could still evict its own models out from under itself. Lemonade is single-tenant per model slot — a second process loading a different model evicts the first — and the V2-11 broker (#2151) only serialized loads made through `_ensure_model_loaded`. The UI backend's startup preload, the per-request chat pre-flight, and the RAG embedder warm-up all called `load_model()` directly and raced the slot anyway. Worse, the broker was effectively dormant outside the daemon: it advertises itself only through its own process environment, which only daemon-spawned sidecars inherit, so a `gaia` command or the UI backend never had it configured and the lease code never ran at all. Now every host model load goes through the broker, queues behind whatever holds the slot, and interactive chat turns take priority over background warm-ups.

With no daemon running nothing changes: there are no sidecars, nothing else holds the slot, and loads proceed directly as before.

### Threads

- **The lease moved to the chokepoint.** `LemonadeClient.load_model()` now takes it, rather than each of the ~8 direct callers having to remember to. That covers the UI, RAG, code-index, VLM and installer paths in one place instead of leaving the next new caller to reintroduce the bug.
- **Host-side discovery, opt-in and lazy.** Entry points (`cli.main`, the UI lifespan) declare themselves broker participants; the daemon is probed at the *first actual load*, so a daemon that starts after a long-lived UI backend is still picked up, and commands that never load a model never probe. Library code never probes — importing `LemonadeClient` must not make an arbitrary script silently join whatever daemon is running.
- **Re-entrant leases.** The broker grants one lease at a time, so callers that need an `unload`→`load` pair to be atomic (RAG, the chat pre-flight) take an outer lease and the inner one folds in. Without this, the chokepoint would self-deadlock. A nested lease naming a *different* model raises rather than silently corrupting the broker's slot accounting.
- **Recovers from a daemon restart.** `gaia daemon restart` rotates the port and token; a long-lived backend holding the stale pair re-discovers once instead of failing every subsequent load forever.
- **The daemon token stays in-process.** Discovery does not export it to `os.environ` — it is not broker-scoped (it also guards daemon shutdown and the sidecar control plane), so exporting it would hand that authority to every child process and leave it inspectable.

### Notes for the reviewer

- **`gaia eval` / `gaia llm` needed no lease code** — they already load via `_ensure_model_loaded`. They were bypassing the broker only because no CLI process ever discovered the daemon; the discovery opt-in is what actually wires them up.
- **A version-skewed daemon warns and runs unbrokered** rather than hard-failing. `attach()` raises on MAJOR skew, and letting that propagate would make `gaia llm` die because an old daemon was left running.
- **Known follow-up (not introduced blindly):** `load_model(auto_download=True)` now downloads *inside* the lease, and the broker's TTL is 900s. A first-run multi-GB pull on a slow link can exceed it and be reclaimed mid-download. Pre-existing for the `_ensure_model_loaded` path; this widens it to the installer path. Reclaim is logged loudly, so it is detectable rather than silent. Fixing it properly means leasing after the download/prompt, or heartbeating the lease — larger than this wiring change and worth its own issue.

### Test plan

- [ ] `python -m pytest tests/unit/test_broker_wiring.py -q` — 22 tests covering the chokepoint, re-entrancy, discovery, rotation recovery and version skew.
- [ ] Serialization is proven against a **real** `ModelSlotBroker` with only the HTTP hop faked: `test_concurrent_direct_loads_serialize` asserts peak concurrency `== 1` across 4 threads doing direct `load_model` calls. Reverting the chokepoint makes it report peak concurrency 4.
- [ ] Mutation-checked: removing the RAG outer lease, the re-attach retry, or the version-skew handling each fails a specific test.
- [ ] `python -m pytest tests/unit/ -q` — green (one pre-existing unrelated failure in `test_init_command.py`, also failing on `main`).
- [ ] `python util/lint.py --all` — Black / isort / flake8 / pylint clean.
- [ ] Tests are hermetic: the fixture stubs daemon discovery, so a developer box running a daemon can't change the result.

Closes #2248
