### PR TITLE
fix(cli): add --layout hub to gaia agent init for the agent-first hub tree

### DIFF
--- a/.claude/skills/gaia-build-agent/SKILL.md
+++ b/.claude/skills/gaia-build-agent/SKILL.md
@@ -26,10 +26,15 @@ the publish skill).
 
 ## Steps
 
-1. **Scaffold.** `gaia agent init my-agent` generates a starter package. For a
-   publishable hub package, scaffold into the hub tree —
-   so the package lands at `hub/agents/<id>/python/` — and mirror an existing one
-   (e.g. `analyst`, `browser`).
+1. **Scaffold.** `gaia agent init my-agent` generates a starter package at
+   `./my-agent/`. For a publishable hub package in this repo, add `--layout hub`
+   so it lands at `hub/agents/<id>/python/`:
+
+   ```bash
+   gaia agent init my-agent -o hub/agents/ --layout hub
+   ```
+
+   Then mirror an existing package (e.g. `analyst`, `browser`) for structure.
 
 2. **Write the `Agent` subclass.** Inherit from `Agent` (or a closer base like the
    chat/docqa agents). Set the model with `model_id` — omit it only if the

--- a/docs/guides/custom-agent.mdx
+++ b/docs/guides/custom-agent.mdx
@@ -408,9 +408,10 @@ agent and publish it through the curated PR route:
 
 <Steps>
   <Step title="Package it">
-    `gaia agent init <id>` scaffolds a publishable package under
-    `hub/agents/<id>/python/` — a `gaia-agent.yaml` manifest, your agent code, a
-    README, and `pyproject.toml`. Move your `agent.py` logic in and fill the manifest.
+    `gaia agent init <id> -o hub/agents/ --layout hub` scaffolds a publishable
+    package under `hub/agents/<id>/python/` — a `gaia-agent.yaml` manifest, your
+    agent code, a README, and `pyproject.toml`. Move your `agent.py` logic in and
+    fill the manifest.
   </Step>
   <Step title="Validate it">
     `gaia agent test --lint` checks the manifest and that the agent loads. Add tests

--- a/docs/guides/hub-publishing.mdx
+++ b/docs/guides/hub-publishing.mdx
@@ -95,8 +95,17 @@ cd my-agent
 
 This creates a folder with the four parts above already wired together. Flags:
 `--language python|cpp` (default `python`), `--output <dir>` / `-o` to choose where
-it's created (default: current folder), and `--force` to overwrite an existing
-folder.
+it's created (default: current folder), `--layout flat|hub` (default `flat`), and
+`--force` to overwrite an existing folder.
+
+If you're contributing the agent to the `amd/gaia` repo rather than shipping it
+standalone, scaffold straight into the hub tree with `--layout hub`, which nests
+the code under a language directory the way every hub package is arranged:
+
+```bash
+gaia agent init my-agent -o hub/agents/ --layout hub
+cd hub/agents/my-agent/python
+```
 
 <Note>
 **Prefer to learn from a working example?** The repo ships tiny, heavily

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -396,7 +396,7 @@ Author, version, validate, and share GAIA agents.
 Scaffold a new agent package, bump its version, and run the quality gates that publishing requires. The scaffold mirrors the canonical hub package layout (`hub/agents/summarize/python/`).
 
 ```bash
-gaia agent init <name> [--language python|cpp] [--output DIR] [--force]
+gaia agent init <name> [--language python|cpp] [--output DIR] [--layout flat|hub] [--force]
 gaia agent version <patch|minor|major> [--path DIR]
 gaia agent test [--lint | --live] [--path DIR] [--timeout SECONDS]
 ```
@@ -411,7 +411,10 @@ gaia agent test [--lint | --live] [--path DIR] [--timeout SECONDS]
 | `name` | string | Agent id/name — lowercase, hyphens allowed (positional, required) |
 | `--language` | choice | `python` (default) or `cpp` |
 | `--output, -o` | string | Parent directory to create the package in (default: current dir) |
+| `--layout` | choice | `flat` (default) creates `<output>/<id>/`; `hub` creates `<output>/<id>/<language>/` to match the hub tree |
 | `--force` | flag | Overwrite an existing package directory |
+
+Use `--layout hub` when authoring a package for this repo's `hub/agents/` tree, which nests the implementation under a language directory (`hub/agents/<id>/python/`). Standalone packages outside the repo want the default `flat` layout.
 
 **`version`** bumps the SemVer in `gaia-agent.yaml` and keeps `pyproject.toml` / `__init__.py` in sync.
 
@@ -430,6 +433,12 @@ The publish workflow requires `--lint` to pass; `--live` is recommended but not 
 ```bash Scaffold and validate
 gaia agent init my-agent
 cd my-agent
+gaia agent test --lint
+```
+
+```bash Scaffold into the hub tree
+gaia agent init my-agent -o hub/agents/ --layout hub
+cd hub/agents/my-agent/python
 gaia agent test --lint
 ```
 

--- a/hub/README.md
+++ b/hub/README.md
@@ -31,10 +31,11 @@ guided reading order.
 ## Creating a new agent
 
 ```bash
-gaia agent init my-agent --language python
+gaia agent init my-agent --language python -o agents/ --layout hub
 ```
 
-…or copy one of the examples above. See
+That lands the package at `agents/my-agent/python/`, matching the layout of every
+agent in this tree. …or copy one of the examples above. See
 [docs/plans/agent-hub-ui.mdx](../docs/plans/agent-hub-ui.mdx) for the full Agent
 Hub platform plan and
 [docs/spec/agent-hub-restructure.mdx](../docs/spec/agent-hub-restructure.mdx)

--- a/hub/agents/README.md
+++ b/hub/agents/README.md
@@ -50,9 +50,10 @@ The GAIA registry discovers installed agents automatically through the
 ## Build your own
 
 ```bash
-gaia agent init my-agent --language python
+gaia agent init my-agent --language python -o . --layout hub
 ```
 
+That lands the package at `my-agent/python/`, matching every other agent here.
 …or copy `hello-world/python/`, rename the package + class, and edit the prompt. See
 [docs/guides/custom-agent.mdx](../../docs/guides/custom-agent.mdx) and the
 [Agent Hub restructure spec](../../docs/spec/agent-hub-restructure.mdx).

--- a/src/gaia/cli_agent.py
+++ b/src/gaia/cli_agent.py
@@ -93,6 +93,16 @@ def register_subparsers(agent_subparsers) -> None:
         help="Parent directory to create the package in (default: current dir)",
     )
     init_p.add_argument(
+        "--layout",
+        choices=["flat", "hub"],
+        default="flat",
+        help=(
+            "Package layout: 'flat' creates <output>/<id>/ (default, for "
+            "standalone packages); 'hub' creates <output>/<id>/<language>/ to "
+            "match the hub tree (e.g. -o hub/agents/ --layout hub)"
+        ),
+    )
+    init_p.add_argument(
         "--force",
         action="store_true",
         help="Overwrite an existing package directory if it exists",
@@ -338,6 +348,8 @@ def cmd_init(args) -> None:
     names = _Names(args.name)
     parent = Path(args.output).expanduser().resolve()
     pkg_dir = parent / names.id
+    if args.layout == "hub":
+        pkg_dir = pkg_dir / args.language
 
     if pkg_dir.exists():
         if not args.force:
@@ -345,7 +357,7 @@ def cmd_init(args) -> None:
                 f"directory already exists: {pkg_dir}. Re-run with --force to "
                 f"overwrite, or choose a different name/--output."
             )
-    parent.mkdir(parents=True, exist_ok=True)
+    pkg_dir.parent.mkdir(parents=True, exist_ok=True)
 
     if args.language == "python":
         _scaffold_python(pkg_dir, names)

--- a/tests/unit/test_cli_agent.py
+++ b/tests/unit/test_cli_agent.py
@@ -20,13 +20,14 @@ from gaia.hub import manifest as hub_manifest
 # ---------------------------------------------------------------------------
 
 
-def _init_args(name, output, language="python", force=False):
+def _init_args(name, output, language="python", force=False, layout="flat"):
     return Namespace(
         agent_action="init",
         name=name,
         language=language,
         output=str(output),
         force=force,
+        layout=layout,
     )
 
 
@@ -121,6 +122,29 @@ def test_init_force_overwrites(tmp_path):
     cli_agent.cmd_init(_init_args("demo-agent", tmp_path))
     # Should not raise with force=True.
     cli_agent.cmd_init(_init_args("demo-agent", tmp_path, force=True))
+
+
+def test_init_flat_layout_is_the_default(tmp_path):
+    cli_agent.cmd_init(_init_args("demo-agent", tmp_path))
+    assert (tmp_path / "demo-agent" / "gaia-agent.yaml").exists()
+    assert not (tmp_path / "demo-agent" / "python").exists()
+
+
+def test_init_hub_layout_nests_language_under_id(tmp_path):
+    cli_agent.cmd_init(_init_args("demo-agent", tmp_path, layout="hub"))
+    pkg = tmp_path / "demo-agent" / "python"
+    assert (pkg / "gaia-agent.yaml").exists()
+    assert (pkg / "pyproject.toml").exists()
+    assert (pkg / "gaia_agent_demo_agent" / "agent.py").exists()
+    # The id must stay the agent's own id, not the language leaf.
+    assert hub_manifest.parse(pkg).id == "demo-agent"
+
+
+def test_init_hub_layout_cpp_uses_cpp_leaf(tmp_path):
+    cli_agent.cmd_init(
+        _init_args("native-demo", tmp_path, language="cpp", layout="hub")
+    )
+    assert (tmp_path / "native-demo" / "cpp" / "CMakeLists.txt").exists()
 
 
 def test_init_cpp_scaffold(tmp_path):


### PR DESCRIPTION
Follow-up to #2060, which moved hub packages to `hub/agents/<id>/<lang>/`.

Anyone scaffolding a new agent for this repo got a package in the wrong place, with no supported way to fix it. `gaia agent init` was never taught the new layout: `--output` always appends the agent id as the leaf, so no invocation produced `<parent>/<id>/python` while keeping the id correct — `gaia agent init python -o hub/agents/<id>/` created the right directory but set the agent id to the literal string `"python"`. The `gaia-build-agent` skill was worse off: #2060 stripped its scaffold command entirely and left a dangling em-dash sentence naming the destination but no command to get there, so an AI agent following it could not place files at all. Now `--layout hub` nests the language directory under the id in one command, the default `flat` layout is untouched for standalone packages scaffolded outside the repo, and every guidance surface carries a real copy-pasteable command.

Chose the CLI fix over documenting a `mkdir && init && mv` workaround because after #2060 the scaffold otherwise emits a layout that is wrong everywhere in this repo — a functional gap, not a docs nit. A bot review flagged this three times (2026-07-14, 07-18, 07-19) and it merged unfixed.

## Test plan

- [ ] `pytest tests/unit/test_cli_agent.py -q` — 40 pass, including new coverage that the flat default is unchanged and that hub layout yields `<parent>/<id>/<lang>/` with the id intact (not `"python"`).
- [ ] Flat default unchanged: `gaia agent init my-agent -o /tmp/flat` → `/tmp/flat/my-agent/`.
- [ ] Hub layout: `gaia agent init my-agent -o /tmp/hub/agents --layout hub` → `/tmp/hub/agents/my-agent/python/`, with `id: my-agent` in `gaia-agent.yaml`.
- [ ] The hub-layout scaffold passes its own gate: `gaia agent test --lint --path /tmp/hub/agents/my-agent/python`.
- [ ] `python util/lint.py --all` clean.
- [ ] `git grep -rn "hub/agents/python\|hub/agents/npm" -- . ':!docs/releases/'` returns nothing; historical release notes left untouched.