### PR TITLE
fix(ci): make the weekly eval and runner heartbeat monitor actually run

### DIFF
--- a/.github/workflows/monitor_selfhosted_runners.yml
+++ b/.github/workflows/monitor_selfhosted_runners.yml
@@ -10,55 +10,46 @@ on:
 
 
 permissions:
-  actions: read  # Required to read artifacts
+  actions: read    # Read heartbeat artifacts
+  contents: read   # Checkout, to read the runner matrix from runner_heartbeat.yml
 
 jobs:
   check:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Get list of runners
         id: runners
         run: |
-          # Try to get repo-level runners first
-          curl -s \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/actions/runners \
-            > repo_runners.json
-          
-          # Also get org-level runners
-          curl -s \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/orgs/${{ github.repository_owner }}/actions/runners \
-            > org_runners.json
-          
-          # Combine and deduplicate runner names
-          repo_names=$(jq -r '.runners[]?.name // empty' repo_runners.json 2>/dev/null || echo "")
-          org_names=$(jq -r '.runners[]?.name // empty' org_runners.json 2>/dev/null || echo "")
-          
-          # Fallback to known runner list if API fails
-          known_runners="sjlab-stx-1, sjlab-stx-3"
-          
-          if [ -n "$repo_names" ] || [ -n "$org_names" ]; then
-            all_names=$(echo -e "$repo_names\n$org_names" | sort -u | tr '\n' ',' | sed 's/,$//') 
-            echo "names=$all_names" >> $GITHUB_OUTPUT
-            echo "Using API discovered runners: $all_names"
-          else
-            echo "names=$known_runners" >> $GITHUB_OUTPUT
-            echo "Using fallback runner list: $known_runners"
+          set -euo pipefail
+          # Read the runner list from runner_heartbeat.yml's matrix — the single
+          # committed source. Deliberately NOT the runners API: it needs
+          # `administration: read` (this token only has `actions: read`, so it
+          # always 403'd and silently fell through to a hardcoded list), and it
+          # returns runners that never publish a heartbeat, which this check
+          # would then report as permanently missing.
+          names=$(awk '/^ *runner: *$/{f=1;next} f&&/^ *- /{gsub(/^ *- */,"");print;next} f{exit}' \
+            .github/workflows/runner_heartbeat.yml | paste -sd, -)
+
+          if [ -z "$names" ]; then
+            echo "ERROR: no runners parsed from .github/workflows/runner_heartbeat.yml." >&2
+            echo "The heartbeat matrix is the source of truth for this check; if its" >&2
+            echo "format changed, update the parser above." >&2
+            exit 1
           fi
 
-      - name: Get artifacts
-        id: artifacts
-        run: |
-          curl -s \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/actions/artifacts \
-            > artifacts.json
+          echo "names=$names" >> "$GITHUB_OUTPUT"
+          echo "Monitoring runners (from the heartbeat matrix): $names"
 
       - name: Check each runner heartbeat
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -uo pipefail
           missing=""
           now=$(date -u +%s)
 
@@ -66,24 +57,34 @@ jobs:
             [ -z "$r" ] && continue
             echo "Checking $r"
 
-            ts=$(jq -r --arg r "$r" '[.artifacts[] | select(.name=="heartbeat-"+$r)] | sort_by(.updated_at) | last | .updated_at // empty' artifacts.json)
+            # Query by artifact NAME. The unfiltered /actions/artifacts listing
+            # is capped at 30 results out of ~31k artifacts in this repo, so a
+            # weekly heartbeat is never on page 1 — that made this check report
+            # "no heartbeat" for healthy runners and page the team on nothing.
+            if ! gh api "/repos/${{ github.repository }}/actions/artifacts?name=heartbeat-$r&per_page=100" > hb.json; then
+              echo "ERROR: artifact lookup failed for $r — cannot determine runner health." >&2
+              exit 1
+            fi
 
-            if [ -z "$ts" ] || [ "$ts" == "null" ]; then
-              echo "No heartbeat found for $r"
+            # Ignore expired artifacts: the blob is gone, so it proves nothing.
+            ts=$(jq -r '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .created_at // empty' hb.json)
+
+            if [ -z "$ts" ]; then
+              echo "  no live heartbeat artifact for $r"
               missing="$missing $r"
               continue
             fi
 
-            hb=$(date -d "$ts" +%s)
-            diff=$((now - hb))
+            age=$(( now - $(date -d "$ts" +%s) ))
+            echo "  last heartbeat: $ts (${age}s ago)"
 
-            if [ $diff -gt 691200 ]; then   # 8 days (weekly + 1 day buffer)
-              echo "Heartbeat stale for $r (last seen: $ts)"
+            if [ "$age" -gt 691200 ]; then   # 8 days (weekly + 1 day buffer)
+              echo "  STALE — older than 8 days"
               missing="$missing $r"
             fi
           done
 
-          echo "missing=$missing" >> $GITHUB_OUTPUT
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
 
       - name: Fail if any runner missing
         if: steps.check.outputs.missing != ''
@@ -91,8 +92,11 @@ jobs:
           echo "Missing or stale runners: ${{ steps.check.outputs.missing }}"
           exit 1
 
+      # Only page on an actual runner outage. An infra error (artifact lookup
+      # failed, matrix unparseable) still fails the run loudly, but must not
+      # send a "runners are offline" card naming nothing.
       - name: Send Teams alert via Power Automate
-        if: failure()
+        if: failure() && steps.check.outputs.missing != ''
         run: |
           echo "Sending Teams alert via Power Automate..."
           response=$(curl -s -w "%{http_code}" -X POST \

--- a/.github/workflows/runner_heartbeat.yml
+++ b/.github/workflows/runner_heartbeat.yml
@@ -16,12 +16,26 @@ jobs:
   heartbeat:
     strategy:
       matrix:
-        runner: 
+        # SINGLE SOURCE for which runners are monitored — monitor_selfhosted_runners.yml
+        # parses this list, so adding a runner here is all that is needed to
+        # start alerting on it. Only list runners that are actually registered:
+        # an unregistered name is never picked up and its job sits queued until
+        # GitHub cancels it at the 24h limit, which marks the whole run
+        # `cancelled` and buries the healthy runners' results.
+        #
+        # sjlab-stx-2 removed: last successful heartbeat 2026-03-22, offline from
+        # 2026-03-30 onward, so it made every run `cancelled` for ~4 months. Its
+        # removal here is a bookkeeping fix, NOT a decision that the box is gone —
+        # re-add the line if it is brought back.
+        runner:
           - sjlab-stx-1
-          - sjlab-stx-2
           - sjlab-stx-3
       fail-fast: false  # Continue even if one runner fails
     runs-on: [self-hosted, "${{ matrix.runner }}"]
+    # Fail fast if a runner is offline. Without this the job waits the full 24h
+    # queue timeout, so an outage surfaces a day late and reports `cancelled`
+    # (ambiguous) instead of a clean failure.
+    timeout-minutes: 10
     steps:
       - name: Create heartbeat file (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -152,7 +152,9 @@ jobs:
     # steps + LemonadeServer.exe) — landing on Linux dies instantly with
     # 'powershell: command not found'. fromJSON(...) yields a label ARRAY so the
     # runner must have Windows AND the stx/stx-test label.
-    runs-on: ${{ fromJSON(contains(github.event.pull_request.labels.*.name, 'stx-test') && '["self-hosted","Windows","stx-test"]' || '["self-hosted","Windows","stx"]') }}
+    # The event_name guard keeps the pull_request dereference off schedule /
+    # workflow_dispatch / workflow_call runs, where that context is absent.
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'stx-test') && '["self-hosted","Windows","stx-test"]' || '["self-hosted","Windows","stx"]') }}
     timeout-minutes: 90
     steps:
       - name: Checkout

--- a/.github/workflows/weekly_eval.yml
+++ b/.github/workflows/weekly_eval.yml
@@ -7,9 +7,10 @@
 # logs is escalated into the tracker once a week instead of scrolling past.
 #
 # This calls the SAME reusable workflow the nightly and the release gates use
-# (test_email_agent_eval.yml), so there is one eval definition, not a fork. The
-# shared `lemonade-eval` concurrency group keeps it strictly serial with the
-# nightly/refresh/release runs on the single Lemonade slot.
+# (test_email_agent_eval.yml), so there is one eval definition, not a fork. That
+# callee owns the `lemonade-eval` concurrency group, which is what keeps every
+# eval serial on the single Lemonade slot — this caller MUST NOT also claim it
+# (see the concurrency block below).
 #
 # "Failure" here is a real signal, never a silent skip: the action-item eval
 # REQUIRES the Claude judge (no fuzzy fallback), so a missing/broken judge, a
@@ -19,14 +20,21 @@
 name: Weekly Eval
 
 on:
-  # Sundays 08:17 UTC — off the nightly's 07:00 slot; the concurrency group
-  # serializes them if they ever overlap.
+  # Sundays 08:17 UTC — off the nightly's 07:00 slot; the callee's concurrency
+  # group serializes them if they ever overlap.
   schedule:
     - cron: '17 8 * * 0'
   workflow_dispatch:
 
 concurrency:
-  group: lemonade-eval
+  # MUST NOT be `lemonade-eval`. A called reusable workflow's concurrency is
+  # evaluated in the caller's context, so if this caller held the same group the
+  # callee could never acquire it — it would die before a job record was ever
+  # created, and `needs.email-eval.result` would report 'failure' for an eval
+  # that never ran (the phantom-job bug: every Weekly Eval run 2026-07-09..19
+  # ended in <60s with only the notify job, filing issue #2026 on a no-op).
+  # Serialization on the Lemonade slot belongs to the callee, which owns it.
+  group: weekly-eval
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
Three CI safety nets have been reporting on work they never did.

The **Weekly Eval** has never once run an eval. Its caller claimed the same `lemonade-eval` concurrency group as the reusable workflow it calls, and a called workflow's concurrency is evaluated in the caller's context — so the callee could never acquire a group its own caller was holding. It died before a job record existed, `needs.email-eval.result` reported `failure` for an eval that never ran, and that has been filing comments on rolling issue #2026 since 2026-07-12. Every run since the workflow landed ended in under 60 seconds with only the notify job. The **runner monitor** was paging the team on healthy runners: it read `/actions/artifacts` unpaginated — 30 results out of ~31k in this repo — so the weekly heartbeat was never on page 1 and every runner looked dead. And the **heartbeat workflow** has reported `cancelled` every week for ~4 months because it matrixes over `sjlab-stx-2`, offline since 2026-03-22, whose job sits queued until GitHub cancels it at the 24h limit and buries the healthy runners' results. After this, all three either do their job or fail loudly.

**Release integrity is not affected** — I checked before assuming the worst. `publish.yml` and `release_agent_email.yml` use different concurrency groups, so their eval gates really ran (85 and 87 minutes, on hardware, on 2026-07-14 and 07-16), and both gate on an explicit success result. No release shipped on a vacuous gate.

## Test plan

- [x] **Headline fix proven by dispatch.** Same workflow, before and after:
  - before (`main`, run 29666811629) → `jobs=1 | Open an issue if the weekly eval failed` — the eval never existed
  - after (this branch, run 29668655924) → `jobs=1 | Weekly email eval suite / Email Triage Eval (synthetic corpus, report mode)` — the real eval job, queued onto the runner
  Cancelled once the job record appeared rather than burning 90 min of `sjlab-stx-3` and judge tokens. Confirmed the cancel filed no comment on #2026 (last comment still 00:22:08Z).
- [x] New monitor logic executed against the live GitHub API: both runners resolve, heartbeat 6.98 days old, under the 8-day bar, `missing=''` → green. Correct, since both runners are healthy.
- [x] Negative test: `sjlab-stx-2` and a fake runner name are both correctly reported missing, so the alert path still fires.
- [x] `?name=` artifact filter verified live — returns 27 correctly-named artifacts with the right latest timestamp.
- [x] `date -d` on the artifact timestamp format confirmed working from the monitor's own passing 2026-07-13 run log.
- [x] `actionlint`: monitor 3 findings → 0; heartbeat 3 → 2; no new findings anywhere.

## Note for the reviewer

`sjlab-stx-2` was a working runner until 2026-03-22, not a typo. Removing it here is bookkeeping so the workflow stops reporting `cancelled` — **please confirm whether it is decommissioned or a 4-month outage nobody noticed**, since the monitor has been blind this whole time and could not have told you.