### PR TITLE
fix(ci): repair the startup-failing GAIA CLI aggregate workflow

### DIFF
--- a/.github/workflows/test_gaia_cli.yml
+++ b/.github/workflows/test_gaia_cli.yml
@@ -115,20 +115,6 @@ jobs:
     uses: ./.github/workflows/test_email_agent.yml
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
 
-  # Test DocQA Agent (standalone hub wheel, #1102)
-  test-docqa-agent:
-    name: DocQA Agent Tests
-    needs: lint
-    uses: ./.github/workflows/test_docqa_agent.yml
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
-
-  # Test Routing Agent (standalone hub wheel, #1102)
-  test-routing-agent:
-    name: Routing Agent Tests
-    needs: lint
-    uses: ./.github/workflows/test_routing_agent.yml
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'ready_for_ci')
-
   # Test Security features
   test-security:
     name: Security Tests

--- a/.github/workflows/test_gaia_cli.yml
+++ b/.github/workflows/test_gaia_cli.yml
@@ -17,9 +17,13 @@ on:
 permissions:
   contents: read
 
-# Group concurrent runs but don't cancel - child workflows have their own concurrency
+# Group concurrent runs but don't cancel - child workflows have their own concurrency.
+# The -aggregate suffix keeps this distinct from called workflows' groups: inside a
+# reusable workflow github.workflow is the CALLER's name, so a bare
+# "${{ github.workflow }}-${{ github.ref }}" collides with lint.yml's group whenever
+# github.head_ref is empty (push / dispatch / merge_group) and the lint job never starts.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-aggregate-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
`GAIA CLI Tests (All Platforms)` has posted a red ❌ on every push, PR, and merge-queue entry since 2026-07-07 — a 0-second failure with zero job records. The file declared `test-docqa-agent` and `test-routing-agent` twice, and GitHub rejects duplicate job keys while building the run graph; because a workflow that fails to *parse* produces a failed run on every event regardless of its declared triggers, this fired even though the workflow only has `workflow_call`/`workflow_dispatch`. Fixing the parse then exposed a second defect underneath it: inside a reusable workflow `github.workflow` resolves to the *caller's* name, so this workflow's concurrency group and `lint.yml`'s collapsed to the same string whenever `github.head_ref` is empty — the parent held the group, the called `lint` job could never acquire it, and every job with `needs: lint` skipped. Both are fixed, so the aggregate suite builds its graph and actually executes again.

Worth stating plainly for anyone assessing risk: **test coverage was never lost.** The 14 called workflows (`lint`, `test_unit`, `test_code_agent`, `test_security`, …) trigger independently on push/pull_request and have been running and passing throughout — verified on today's runs. The damage was a permanently-red bogus check drowning real signal, plus an aggregate entry point that could not be run on demand.

## Test plan

- [x] `actionlint .github/workflows/test_gaia_cli.yml` — clean
- [x] Strict YAML parse rejecting duplicate keys: old file → `DUPLICATE KEY: test-docqa-agent`; new file → parses, 15 unique jobs, `test-summary` needs all resolve
- [x] Real dispatched run before the concurrency fix ([29668746202](https://github.com/amd/gaia/actions/runs/29668746202)) — 14 job records instead of 0, proving the run graph builds
- [x] Real dispatched run after it ([29668863253](https://github.com/amd/gaia/actions/runs/29668863253)) — `Code Quality (Linting) / Run Code Quality Checks` expands and executes; previously it produced no job record at all
- [ ] Reviewer: confirm the red `GAIA CLI Tests (All Platforms)` check stops appearing on new PRs once this lands