### PR TITLE
fix(hub): harden agent-archive extraction against path traversal

### DIFF
--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -14,6 +14,11 @@ Safety properties (CLAUDE.md — fail loudly, no silent fallbacks):
 
 * **Checksum verified** before anything is written to the install dir — a
   mismatch raises :class:`ChecksumError` and nothing is installed.
+* **Archive members validated** — every entry in a C++ agent archive is checked
+  to resolve inside the install dir (and links / non-regular entries refused)
+  before extraction, so a self-consistent malicious archive cannot escape via
+  ``../`` traversal (CWE-22) even when ``GAIA_HUB_URL`` points at an untrusted
+  origin.
 * **Disk + platform checked** up front via
   :func:`gaia.hub.compatibility.check_compatibility`; a hard blocker raises
   before any download.
@@ -419,10 +424,34 @@ def _install_python_artifact(
     return site_packages
 
 
+def _assert_member_within(install_dir: Path, member_name: str) -> None:
+    """Refuse an archive member whose path escapes *install_dir* (CWE-22).
+
+    ``_sanitize_artifact_filename`` only checks the *archive's* own filename, not
+    the paths of members inside it. ``tarfile`` follows ``..`` in member names and
+    would write outside the install dir, so every member is validated here before
+    anything is extracted (a self-consistent malicious archive whose checksum
+    matches the manifest still cannot escape the agent's install dir).
+    """
+    base = install_dir.resolve()
+    dest = (base / member_name).resolve()
+    if dest != base and not dest.is_relative_to(base):
+        raise InstallError(
+            f"Archive member {member_name!r} would extract outside the agent "
+            f"install directory. Refusing to install; report this hub artifact "
+            f"as malicious (path traversal, CWE-22)."
+        )
+
+
 def _install_cpp_artifact(
     artifact_bytes: bytes, filename: str, install_dir: Path
 ) -> Path:
-    """Extract a C++ agent archive into ``install_dir``."""
+    """Extract a C++ agent archive into ``install_dir``.
+
+    Every archive member is validated against ``install_dir`` before extraction
+    and links / non-regular entries are refused, so a malicious archive cannot
+    write outside the agent's install dir via ``../`` traversal or a symlink.
+    """
     install_dir.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="gaia-hub-") as tmp:
         archive_path = Path(tmp) / filename
@@ -430,10 +459,37 @@ def _install_cpp_artifact(
         lower = filename.lower()
         if lower.endswith(".zip"):
             with zipfile.ZipFile(archive_path) as zf:
-                zf.extractall(install_dir)
+                infos = zf.infolist()
+                for info in infos:
+                    if stat.S_ISLNK(info.external_attr >> 16):
+                        raise InstallError(
+                            f"Archive member {info.filename!r} is a symlink; "
+                            f"symlinks are not allowed in hub artifacts."
+                        )
+                    _assert_member_within(install_dir, info.filename)
+                # Members validated above — extract one at a time so this stays
+                # clear of ZipFile.extractall (S202).
+                for info in infos:
+                    zf.extract(info, install_dir)
         elif lower.endswith((".tar.gz", ".tgz", ".tar")):
             with tarfile.open(archive_path) as tf:
-                tf.extractall(install_dir)  # noqa: S202 - hub artifacts are trusted
+                members = tf.getmembers()
+                for member in members:
+                    if member.issym() or member.islnk():
+                        raise InstallError(
+                            f"Archive member {member.name!r} is a link; links "
+                            f"are not allowed in hub artifacts (path traversal)."
+                        )
+                    if not (member.isfile() or member.isdir()):
+                        raise InstallError(
+                            f"Archive member {member.name!r} is not a regular "
+                            f"file or directory; refusing to install."
+                        )
+                    _assert_member_within(install_dir, member.name)
+                # Members validated above (no traversal, no links) — extract one
+                # at a time so this stays clear of tarfile.extractall (S202).
+                for member in members:
+                    tf.extract(member, install_dir)
         else:
             raise InstallError(
                 f"Unsupported C++ artifact format '{filename}'. Expected a .zip "

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -828,6 +828,100 @@ def test_install_cpp_with_artifacts_list_uses_singular_zip(tmp_path):
     assert sentinel.artifact_kind == "cpp"
 
 
+# --- T4d: malicious cpp archives cannot escape the install dir (CWE-22) -------
+
+
+def _cpp_install_from_archive(tmp_path, filename, archive_bytes):
+    """Run install() for a cpp agent serving *archive_bytes* under *filename*."""
+    sha = hashlib.sha256(archive_bytes).hexdigest()
+    path = f"agents/native/1.0.0/{filename}"
+    manifest = {
+        "id": "native",
+        "language": "cpp",
+        "latest_version": "1.0.0",
+        "requirements": {"platforms": []},
+        "versions": {
+            "1.0.0": {
+                "version": "1.0.0",
+                "artifact": {
+                    "filename": filename,
+                    "path": path,
+                    "size_bytes": len(archive_bytes),
+                    "sha256": sha,
+                    "content_type": "application/octet-stream",
+                },
+            }
+        },
+    }
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: native\n"
+        if url == f"{BASE}/{path}":
+            return archive_bytes
+        raise AssertionError(url)
+
+    return install(
+        "native",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=fetcher,
+        install_root=tmp_path,
+        trust_native=True,
+    )
+
+
+def test_install_cpp_tar_member_path_traversal_blocked(tmp_path):
+    """A self-consistent tar with a ``../../`` member must not write outside.
+
+    Regression for the Hub Installer tar-slip (CWE-22): the archive filename
+    passes ``_sanitize_artifact_filename`` but a member escapes install_dir.
+    """
+    import io
+    import tarfile as _tarfile
+
+    buf = io.BytesIO()
+    with _tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        good = _tarfile.TarInfo("agent.so")
+        good_data = b"binary"
+        good.size = len(good_data)
+        tf.addfile(good, io.BytesIO(good_data))
+        evil = _tarfile.TarInfo("../../mcp_servers.json")
+        evil_data = b"TAR_SLIP_CONFIRMED"
+        evil.size = len(evil_data)
+        tf.addfile(evil, io.BytesIO(evil_data))
+    archive = buf.getvalue()
+
+    with pytest.raises(InstallError, match="outside the agent install directory"):
+        _cpp_install_from_archive(
+            tmp_path, "evil_agent-1.0.0-linux-x86_64.tar.gz", archive
+        )
+
+    # The escaped file must NOT have been written two levels up, and nothing
+    # from the malicious archive should survive in the install dir either.
+    assert not (tmp_path.parent / "mcp_servers.json").exists()
+    assert not (tmp_path / "mcp_servers.json").exists()
+    assert not (tmp_path / "native" / "agent.so").exists()
+
+
+def test_install_cpp_tar_symlink_member_rejected(tmp_path):
+    """A tar symlink member is refused (link target could escape install_dir)."""
+    import io
+    import tarfile as _tarfile
+
+    buf = io.BytesIO()
+    with _tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        link = _tarfile.TarInfo("evil-link")
+        link.type = _tarfile.SYMTYPE
+        link.linkname = "../../../../etc/passwd"
+        tf.addfile(link)
+    archive = buf.getvalue()
+
+    with pytest.raises(InstallError, match="link"):
+        _cpp_install_from_archive(tmp_path, "native-1.0.0.tar.gz", archive)
+    assert not (tmp_path / "native" / "evil-link").exists()
+
+
 # --- T5: binaries-only manifest, no artifact for platform_key --------------
 
 


### PR DESCRIPTION
## Why this matters

Installing a native (C++) agent from the hub extracted the downloaded archive without checking where each member wanted to land — only the archive's own filename was sanitized. A malformed or malicious archive could therefore write files **outside** the agent's `~/.gaia/agents/<id>/` install directory. After this change the installer validates every archive member against the install directory (and rejects symlink / non-regular entries) before extracting anything, so extraction can no longer escape the intended directory. Checksum verification alone did not protect against this — a self-consistent archive passes the checksum yet still escaped.

This closes a path-traversal weakness in the install path and removes the `# noqa: S202` "trusted artifacts" suppression, which no longer holds once the hub origin is caller-configurable (`--hub-url` / `GAIA_HUB_URL`).

## Test plan

- [x] `python -m pytest tests/unit/test_hub_installer.py` — 50 pass, incl. 2 new regression tests (a `../` traversal member and a symlink member are both refused; nothing is written outside the install dir)
- [x] `python -m bandit src/gaia/hub/installer.py -ll` — 0 High (previously flagged the extraction call)
- [x] `black` / `isort` clean