### PR TITLE
fix(security): enforce --allowed-paths sandbox on file read tools

### DIFF
--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -800,6 +800,14 @@ class FileSearchToolsMixin:
             Searches actual file contents on disk, not RAG indexed documents.
             """
             try:
+                # Enforce the --allowed-paths sandbox before the existence probe
+                # so out-of-sandbox paths can't be used as a directory-existence
+                # oracle (mirrors read_file / get_file_info). Grepping file
+                # contents outside the sandbox leaks the same data as read_file.
+                denied = self._read_access_error(directory)
+                if denied:
+                    return denied
+
                 directory = Path(directory).resolve()
 
                 if not directory.exists():
@@ -807,12 +815,6 @@ class FileSearchToolsMixin:
                         "status": "error",
                         "error": f"Directory not found: {directory}",
                     }
-
-                # Enforce the --allowed-paths sandbox: grepping file contents
-                # outside the sandbox leaks the same data as read_file.
-                denied = self._read_access_error(str(directory))
-                if denied:
-                    return denied
 
                 # Text file extensions to search
                 text_extensions = {

--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -1664,7 +1664,7 @@ class FileSearchToolsMixin:
                 # content preview, so it must honor the same read boundary.
                 denied = self._read_access_error(str(fp))
                 if denied:
-                    denied["operation"] = "get_file_info"
+                    denied.update({"has_errors": True, "operation": "get_file_info"})
                     return denied
 
                 if not fp.exists():
@@ -1902,7 +1902,9 @@ class FileSearchToolsMixin:
                 # indexed documents inside the sandbox still resolve).
                 denied = self._read_access_error(str(fp))
                 if denied:
-                    denied["operation"] = "analyze_data_file"
+                    denied.update(
+                        {"has_errors": True, "operation": "analyze_data_file"}
+                    )
                     return denied
 
                 # Read the file (use resolved fp path in case of fallback)

--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -55,6 +55,32 @@ class FileSearchToolsMixin:
             )
         return file_list
 
+    def _get_path_validator(self):
+        """Return the host agent's PathValidator, or None if it has none."""
+        return getattr(self, "path_validator", None) or getattr(
+            self, "_path_validator", None
+        )
+
+    def _read_access_error(self, path: str):
+        """Enforce the ``--allowed-paths`` sandbox on read operations.
+
+        Reads must honor the same allowlist boundary as ``write_file`` /
+        ``edit_file`` — otherwise the documented security sandbox only
+        restricts writes while any file readable by the process leaks
+        through the read tools (CWE-862). ``FileIOToolsMixin`` already
+        gates its reads this way; this mirrors it.
+
+        Returns an error dict when ``path`` is outside the sandbox, or
+        ``None`` when the read is permitted (or no validator is attached).
+        """
+        validator = self._get_path_validator()
+        if validator is not None and not validator.is_path_allowed(path):
+            return {
+                "status": "error",
+                "error": f"Access denied: '{path}' is not in allowed paths",
+            }
+        return None
+
     def register_file_search_tools(self) -> None:
         """Register shared file search tools."""
         from gaia.agents.base.tools import tool
@@ -558,6 +584,13 @@ class FileSearchToolsMixin:
                 Dictionary with file content and type-specific metadata
             """
             try:
+                # Enforce the --allowed-paths sandbox on reads. Checked before
+                # the existence probe so paths outside the sandbox can't be used
+                # as a file-existence oracle.
+                denied = self._read_access_error(file_path)
+                if denied:
+                    return denied
+
                 if not os.path.exists(file_path):
                     # Check if parent directory exists to give a more helpful error
                     parent_dir = os.path.dirname(file_path)
@@ -774,6 +807,12 @@ class FileSearchToolsMixin:
                         "status": "error",
                         "error": f"Directory not found: {directory}",
                     }
+
+                # Enforce the --allowed-paths sandbox: grepping file contents
+                # outside the sandbox leaks the same data as read_file.
+                denied = self._read_access_error(str(directory))
+                if denied:
+                    return denied
 
                 # Text file extensions to search
                 text_extensions = {
@@ -1621,6 +1660,13 @@ class FileSearchToolsMixin:
             try:
                 fp = Path(file_path)
 
+                # Enforce the --allowed-paths sandbox: get_file_info returns a
+                # content preview, so it must honor the same read boundary.
+                denied = self._read_access_error(str(fp))
+                if denied:
+                    denied["operation"] = "get_file_info"
+                    return denied
+
                 if not fp.exists():
                     return {
                         "status": "error",
@@ -1850,6 +1896,14 @@ class FileSearchToolsMixin:
                         "has_errors": True,
                         "operation": "analyze_data_file",
                     }
+
+                # Enforce the --allowed-paths sandbox on the resolved path
+                # (checked after the indexed-file fallback so legitimately
+                # indexed documents inside the sandbox still resolve).
+                denied = self._read_access_error(str(fp))
+                if denied:
+                    denied["operation"] = "analyze_data_file"
+                    return denied
 
                 # Read the file (use resolved fp path in case of fallback)
                 rows, all_columns, read_error = _read_tabular_file(str(fp))

--- a/tests/unit/test_file_tools.py
+++ b/tests/unit/test_file_tools.py
@@ -900,6 +900,19 @@ class TestReadToolsSandbox:
         assert self._denied(result)
         assert "abc123" not in str(result)
 
+    def test_search_file_content_denies_before_existence_probe(
+        self, sandboxed_read_tools
+    ):
+        """A nonexistent out-of-sandbox dir returns access-denied, not a
+        'Directory not found' existence oracle."""
+        tools, _, secret_dir = sandboxed_read_tools
+        missing = str(secret_dir / "does_not_exist")
+
+        result = tools["search_file_content"]("x", directory=missing)
+
+        assert self._denied(result)
+        assert "not found" not in result.get("error", "").lower()
+
     def test_get_file_info_outside_sandbox_denied(self, sandboxed_read_tools):
         tools, _, secret_dir = sandboxed_read_tools
         secret = secret_dir / "notes.txt"

--- a/tests/unit/test_file_tools.py
+++ b/tests/unit/test_file_tools.py
@@ -825,3 +825,101 @@ class TestReadFileBinaryGuard:
         assert result.get("status") != "error" or "index_document" not in result.get(
             "error", ""
         )
+
+
+# ===========================================================================
+# 10. Read tools honor the --allowed-paths sandbox (CWE-862 regression)
+# ===========================================================================
+
+
+@pytest.fixture
+def sandboxed_read_tools(tmp_path):
+    """Register the read tools on a mixin whose PathValidator sandboxes to safe/.
+
+    Returns (tools_by_name, safe_dir, secret_dir). ``secret_dir`` is outside
+    the allowlist; reads targeting it must be denied. Runs non-interactively
+    (pytest has no TTY), so out-of-sandbox paths auto-deny deterministically.
+    """
+    from gaia.security import PathValidator
+
+    safe_dir = tmp_path / "safe"
+    safe_dir.mkdir()
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+
+    inst = _StubMixin()
+    inst.path_validator = PathValidator(allowed_paths=[str(safe_dir)])
+    inst.register_file_search_tools()
+
+    names = ("read_file", "search_file_content", "get_file_info", "analyze_data_file")
+    tools = {name: _TOOL_REGISTRY[name]["function"] for name in names}
+    return tools, safe_dir, secret_dir
+
+
+class TestReadToolsSandbox:
+    """read tools must enforce the same allowlist that write_file enforces."""
+
+    def _denied(self, result) -> bool:
+        return result.get("status") == "error" and "not in allowed paths" in result.get(
+            "error", ""
+        )
+
+    def test_read_file_inside_sandbox_succeeds(self, sandboxed_read_tools):
+        tools, safe_dir, _ = sandboxed_read_tools
+        ok = safe_dir / "ok.txt"
+        ok.write_text("safe content", encoding="utf-8")
+
+        result = tools["read_file"](str(ok))
+
+        assert result["status"] == "success"
+        assert result["content"] == "safe content"
+
+    def test_read_file_outside_sandbox_denied(self, sandboxed_read_tools):
+        tools, _, secret_dir = sandboxed_read_tools
+        secret = secret_dir / "credentials.txt"
+        secret.write_text("API_KEY=ghp_SECRETTOKEN_12345", encoding="utf-8")
+
+        result = tools["read_file"](str(secret))
+
+        assert self._denied(result)
+        # The secret content must never reach the caller/LLM.
+        assert "ghp_SECRETTOKEN_12345" not in str(result)
+
+    def test_search_file_content_outside_sandbox_denied(self, sandboxed_read_tools):
+        tools, _, secret_dir = sandboxed_read_tools
+        (secret_dir / "creds.env").write_text("TOKEN=abc123", encoding="utf-8")
+
+        result = tools["search_file_content"]("TOKEN", directory=str(secret_dir))
+
+        assert self._denied(result)
+        assert "abc123" not in str(result)
+
+    def test_get_file_info_outside_sandbox_denied(self, sandboxed_read_tools):
+        tools, _, secret_dir = sandboxed_read_tools
+        secret = secret_dir / "notes.txt"
+        secret.write_text("line1\nline2\n", encoding="utf-8")
+
+        result = tools["get_file_info"](str(secret))
+
+        assert self._denied(result)
+        assert "line1" not in str(result)
+
+    def test_analyze_data_file_outside_sandbox_denied(self, sandboxed_read_tools):
+        tools, _, secret_dir = sandboxed_read_tools
+        secret = secret_dir / "data.csv"
+        secret.write_text("name,salary\nalice,999999\n", encoding="utf-8")
+
+        result = tools["analyze_data_file"](str(secret))
+
+        assert self._denied(result)
+        assert "999999" not in str(result)
+
+    def test_read_file_no_validator_still_reads(self, read_file_fn, tmp_path):
+        """A mixin host with no PathValidator keeps working (backward compat)."""
+        f = tmp_path / "plain.txt"
+        f.write_text("no validator here", encoding="utf-8")
+
+        result = read_file_fn(str(f))
+
+        assert result["status"] == "success"
+        assert result["content"] == "no validator here"

--- a/tests/unit/test_file_tools.py
+++ b/tests/unit/test_file_tools.py
@@ -833,14 +833,20 @@ class TestReadFileBinaryGuard:
 
 
 @pytest.fixture
-def sandboxed_read_tools(tmp_path):
+def sandboxed_read_tools(tmp_path, monkeypatch):
     """Register the read tools on a mixin whose PathValidator sandboxes to safe/.
 
     Returns (tools_by_name, safe_dir, secret_dir). ``secret_dir`` is outside
-    the allowlist; reads targeting it must be denied. Runs non-interactively
-    (pytest has no TTY), so out-of-sandbox paths auto-deny deterministically.
+    the allowlist; reads targeting it must be denied.
+
+    ``_is_interactive`` is forced False so out-of-sandbox paths auto-deny
+    deterministically — otherwise, under ``pytest -s`` on a real TTY, the
+    validator would call ``input()`` and hang the test.
     """
+    from gaia import security as _security
     from gaia.security import PathValidator
+
+    monkeypatch.setattr(_security, "_is_interactive", lambda: False)
 
     safe_dir = tmp_path / "safe"
     safe_dir.mkdir()


### PR DESCRIPTION
## Why this matters

GAIA documents `--allowed-paths` as a security sandbox for agent file tools, but it only ever restricted **writes**. `read_file` (and three sibling read tools) in `FileSearchToolsMixin` called `open()` directly with no allowlist check, so an agent could read **any file the process owner can access** — credentials, SSH keys, `.env` — regardless of the configured sandbox. `write_file`/`edit_file` correctly blocked the same paths, and the sibling `FileIOToolsMixin` already gates its reads, so reads were always meant to be confined; this one mixin just never applied the check.

This was reported by an external researcher (CWE-862 / missing authorization) with a working PoC against a shipped version. After this change the PoC no longer reproduces: a read outside `allowed_paths` returns `Access denied` and no file content reaches the agent/LLM.

The fix routes every **content-reading** tool in the mixin — `read_file`, `search_file_content`, `get_file_info`, `analyze_data_file` — through a shared `_read_access_error` helper that mirrors the write-side `PathValidator` enforcement. It no-ops when no validator is attached, so hosts without a sandbox are unaffected. Affected agents: ChatAgent, DocumentQAAgent, FileIOAgent.

**Scope note:** pure *enumeration* tools (`search_file`, `search_directory`, `browse_directory`) are intentionally left unchanged — their documented purpose is discovering files anywhere for the user, and gating them to the allowlist would break that UX. They disclose paths/metadata, not file contents; whether discovery should also honor the sandbox is a separate product decision, not this confidentiality fix.

## Test plan

- [x] `pytest tests/unit/test_file_tools.py` — 84 pass, incl. new `TestReadToolsSandbox` (in-sandbox read succeeds; out-of-sandbox `read_file`/`search_file_content`/`get_file_info`/`analyze_data_file` denied with no content leak; no-validator host still reads)
- [x] `pytest tests/unit/test_security_edge_cases.py test_file_write_guardrails.py test_hub_security.py` — 237 pass, 6 skipped
- [x] `black --check` / `isort --check` clean on changed files
- [x] Researcher PoC re-run against patched code → bypass no longer reproduces (read returns "Access denied", write still blocked)