### PR TITLE
docs(skills): fix broken email ground-truth path in porting-agent-to-hub

### DIFF
--- a/.claude/skills/porting-agent-to-hub/SKILL.md
+++ b/.claude/skills/porting-agent-to-hub/SKILL.md
@@ -95,8 +95,10 @@ Two halves, and the expensive one is not the code:
 
 - **The oracle (not automatable):** a labelled, human-curated ground-truth corpus
   plus a deterministic fixture harness so the eval needs no live service and no
-  LLM judge. Email's is `tests/fixtures/email/ground_truth.json` +
-  `FakeGmailBackend`.
+  LLM judge. Email's is the per-task corpus under `tests/fixtures/email/`
+  (`action_items_ground_truth.json`, `briefing_ground_truth.json`,
+  `drafting_ground_truth.json`, `followups_ground_truth.json`,
+  `longthread_ground_truth.json`) + `FakeGmailBackend` (`fake_gmail.py`).
 - **The mechanism:** the adapter, `SCORECARD.md`, the `scorecard_gate.py` wiring
   and a refresh workflow → **use `adding-eval-scorecard`**.
 


### PR DESCRIPTION
The `porting-agent-to-hub` skill (merged in #2338) sent porters to `tests/fixtures/email/ground_truth.json` in its Phase 4 eval guidance — a file that does not exist. Email's ground truth is split per task, so anyone following the skill hit a dead path on the one step the skill calls the "long pole." This corrects it to the real per-task corpus. Found while verifying #2338 was, as flagged, rushed — it directly contradicts that PR's checked-off "all 18 referenced paths resolve" item.

## Test plan
- [x] `ls tests/fixtures/email/*ground_truth.json` → the 5 real per-task files, no `ground_truth.json`
- [x] The 4 files the skill now names all resolve
- [x] Skill still loads via the `Skill` tool

Follow-up to #2338.