### PR TITLE
feat(security): proactive Claude security-audit workflow + CVSS/SARIF tooling

### DIFF
--- a/.github/workflows/claude-security-audit.yml
+++ b/.github/workflows/claude-security-audit.yml
@@ -1,0 +1,265 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Proactive Claude SECURITY audit. A dedicated, security-only companion to
+# claude-weekly-audit.yml (which now owns correctness/docs/tests/features). It
+# exists because the weekly audit's single general "security lens" missed the hub
+# tar-slip (CWE-22): it sampled a huge repo in one pass and trusted a
+# `# noqa: S202 - hub artifacts are trusted` comment as a settled decision.
+#
+# This workflow fixes both failure modes:
+#   1. DETERMINISTIC layer (semgrep) — maintained security rules over the whole
+#      tree, uploaded to code scanning. Catches known sink patterns exhaustively.
+#   2. REASONING layer (Claude) — the taint/authz/suppression analysis static
+#      tools can't do, over an explicit worklist so nothing is sampled away.
+#      Every '# noqa: S*' / '# nosec' is RE-VERIFIED from scratch, never trusted.
+#
+# PRIVACY: findings never go to a public issue. Both layers upload SARIF to the
+# repo's private Security > Code scanning tab; Claude's full detail also goes to
+# the (access-controlled) run log. High-severity findings ping @kovtcharov-amd.
+#
+# SCORING: each Claude finding carries a proposed CVSS 4.0 *vector*; the score is
+# computed deterministically by util/cvss4.py (matches the FIRST v4 calculator) —
+# never an LLM's guessed number. Scores are PROPOSED and need human confirmation.
+#
+# READ-ONLY: Claude jobs run --allowedTools Read,Grep,Glob,Bash — no Edit/Write,
+# never install or execute repo code (same rule as claude.yml review jobs).
+
+name: Claude Security Audit
+
+on:
+  schedule:
+    # 06:00 UTC every Thursday — offset from the Monday weekly audit so the two
+    # proactive Claude runs don't stack on the shared subscription rate limit.
+    - cron: "0 6 * * 4"
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Git ref to audit (for backtesting a known-vuln commit)"
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: claude-security-audit
+  cancel-in-progress: false
+
+env:
+  AUDIT_MODEL: claude-opus-4-8
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Deterministic layer — maintained security rules, native SARIF.
+  # ---------------------------------------------------------------------------
+  semgrep:
+    if: github.repository == 'amd/gaia'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.target_ref || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Run semgrep (security rulesets) -> SARIF
+        run: |
+          python -m pip install --quiet semgrep
+          # continue-on-error semantics: a rule-parse hiccup must not sink the SARIF
+          # upload of everything that did scan.
+          semgrep scan --sarif --output semgrep.sarif \
+            --config p/python --config p/security-audit --config p/secrets \
+            src hub || true
+      - name: Upload semgrep SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+  # ---------------------------------------------------------------------------
+  # Reasoning layer — one read-only Claude job per lens. continue-on-error so one
+  # lens crashing doesn't sink the others.
+  # ---------------------------------------------------------------------------
+  audit:
+    if: github.repository == 'amd/gaia'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        lens: [sink-taint, authz, suppression-review]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.target_ref || github.ref }}
+
+      - name: Build the deterministic worklist
+        run: |
+          set -euo pipefail
+          {
+            echo "# Security worklist for lens: ${{ matrix.lens }}"
+            echo "## Every security suppression (RE-VERIFY each — do NOT trust the comment)"
+            grep -rnE "# *noqa: *S[0-9]|# *nosec" src hub --include=*.py || true
+            echo ""
+            echo "## Archive extraction / deserialization sinks"
+            grep -rnE "extractall|pickle\.load|yaml\.load\(|marshal\.load" src hub --include=*.py || true
+            echo ""
+            echo "## Shell / eval sinks"
+            grep -rnE "shell=True|os\.system|subprocess\.(run|Popen|call)|\beval\(|\bexec\(" src hub --include=*.py || true
+            echo ""
+            echo "## PathValidator / allowlist / trust gates (check for asymmetric enforcement)"
+            grep -rnE "is_path_allowed|validate_write|validate_read|allowed_paths|trust_native|ensure_native_trust" src hub --include=*.py || true
+          } > security-worklist.txt
+          echo "worklist lines: $(wc -l < security-worklist.txt)"
+
+      - name: Run Claude (${{ matrix.lens }} lens)
+        id: claude
+        continue-on-error: true
+        uses: anthropics/claude-code-action@3553f84341b92da26052e28acf1aa898f9511f32  # v1.0.177
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            You are one lens of GAIA's proactive SECURITY audit. YOUR LENS: ${{ matrix.lens }}.
+            Find real, exploitable security weaknesses. Precision beats recall — a false
+            finding erodes trust in the whole audit.
+
+            REPO: ${{ github.repository }}
+            RUN LOG: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ## First actions
+            1. Read `CLAUDE.md` (esp. "No Silent Fallbacks" and the Security Handling Protocol).
+            2. Read `security-worklist.txt` — a deterministic list of suppressions, sinks, and
+               gate call-sites. Investigate every item relevant to your lens; do not sample.
+            3. Investigate with Grep/Glob/Read/Bash (READ-ONLY — never edit, install, or run repo code).
+
+            ## Your lens
+            - **sink-taint**: trace ATTACKER-CONTROLLED input into a dangerous sink (archive
+              extraction, deserialization, subprocess/shell, eval). A sink is only a finding if
+              untrusted data can reach it. The hub tar-slip (CWE-22) is the archetype: a hub
+              archive's member paths reached `tarfile.extractall` with no per-member check.
+            - **authz**: access-control gaps — a sandbox/allowlist/trust gate that one code path
+              enforces and a sibling path skips. The read_file bypass (CWE-284) is the archetype:
+              `write_file` called the PathValidator but `read_file` did not. Look for ASYMMETRIC
+              enforcement (read vs write, one tool vs another) of `is_path_allowed`,
+              `validate_*`, `allowed_paths`, `trust_native`, auth checks.
+            - **suppression-review**: for EACH `# noqa: S<n>` / `# nosec` in the worklist, RE-DERIVE
+              whether the finding it silences is truly safe. TREAT THE COMMENT AS AN UNPROVEN CLAIM,
+              NOT A DECISION — "hub artifacts are trusted" is exactly the assumption that shipped the
+              tar-slip. If the suppressed risk is real, report it.
+
+            ## Published hub agents (`hub/agents/**`) run on integrators' machines — hold to the
+            strictest reading and bump any real finding up one severity.
+
+            ## Score every finding with a CVSS 4.0 VECTOR (the number is computed later)
+            Propose a vector; do NOT invent a number (an LLM CVSS number is untrustworthy — a real
+            triage guessed 7.3 for a vector that scores 8.7). Pick metrics with this GAIA rubric:
+            - **AV** Network only if untrusted data crosses a network boundary to reach the sink
+              (hub artifact, HTTP request); else Local (a local CLI/file input on the same host).
+            - **AT** Present if exploitation needs a precondition outside the attacker's control
+              (victim points at a non-default hub, a specific agent is installed); else None.
+            - **PR** None unless GAIA privilege/auth is required to trigger it.
+            - **UI** Active if the user must click through a warning (a trust gate); Passive if they
+              must merely initiate an install/command; None only if fully automatic.
+            - **Impact** VC for disclosure/reads, VI for writes/tampering, VA for crash/DoS. Set
+              SC/SI/SA (subsequent) only if it escapes into a SEPARATE security scope.
+            Full vector form: `CVSS:4.0/AV:_/AC:_/AT:_/PR:_/UI:_/VC:_/VI:_/VA:_/SC:_/SI:_/SA:_`.
+
+            ## Verify before reporting
+            Open the cited file, confirm the weakness is present AND not already handled (re-raised,
+            validated two lines down, guarded elsewhere). If you cannot quote concrete evidence you
+            have not verified it — omit it.
+
+            ## Output — write `findings-${{ matrix.lens }}.json` at the repo root
+            `{"findings": []}` if nothing. Each finding:
+            ```json
+            {"findings": [{
+              "path": "src/gaia/....py",
+              "line": 382,
+              "symbol": "function_or_class",
+              "cwe": "CWE-22",
+              "title": "one-line problem statement",
+              "why": "one sentence: concrete impact / what an attacker gains",
+              "evidence": "a direct quote or path:line you READ that proves it",
+              "remediation": "the fix in one sentence",
+              "confidence": "high" | "medium" | "low",
+              "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N",
+              "dedup_key": "security:<path>:<symbol>"
+            }]}
+            ```
+            `dedup_key` is `security:<path>:<symbol>` — a stable symbol, NEVER a line number.
+            Also print each finding's full detail to STDOUT prefixed "SECURITY FINDING:" (the run
+            log is access-controlled; this is the private detail channel).
+          claude_args: |
+            --max-turns 30
+            --model ${{ env.AUDIT_MODEL }}
+            --allowedTools Read,Grep,Glob,Bash
+
+      - name: Upload findings
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: findings-${{ matrix.lens }}
+          path: findings-${{ matrix.lens }}.json
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # Score + publish. Converts Claude findings to SARIF (CVSS -> security-severity)
+  # and uploads to the private code-scanning tab. Only job with security-events.
+  # ---------------------------------------------------------------------------
+  synthesize:
+    needs: [audit]
+    if: github.repository == 'amd/gaia' && !cancelled()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install CVSS scorer
+        run: python -m pip install --quiet "cvss>=3.6,<4.0"
+      - name: Download findings
+        uses: actions/download-artifact@v8
+        with:
+          path: audit-findings
+      - name: Convert findings to SARIF
+        run: |
+          set -euo pipefail
+          # Flatten the per-lens artifact subdirs into one glob for the converter.
+          find audit-findings -name 'findings-*.json' -exec cp {} . \; || true
+          if ls findings-*.json >/dev/null 2>&1; then
+            python util/findings_to_sarif.py findings-*.json -o claude-security.sarif
+          else
+            echo "No findings files produced; writing an empty SARIF run."
+            python util/findings_to_sarif.py /dev/null -o claude-security.sarif || \
+              echo '{"$schema":"https://json.schemastore.org/sarif-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"gaia-claude-security-audit","rules":[]}},"results":[]}]}' > claude-security.sarif
+          fi
+      - name: Upload Claude SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: claude-security.sarif
+          category: claude-security
+      - name: Ping maintainer on high-severity findings
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          high=$(python -c "import json,glob; n=0
+          for f in glob.glob('findings-*.json'):
+              for x in json.load(open(f)).get('findings',[]):
+                  v=x.get('cvss_vector','')
+                  n+=1 if ('VI:H' in v or 'VC:H' in v or 'VA:H' in v) else 0
+          print(n)" 2>/dev/null || echo 0)
+          if [ "${high:-0}" -gt 0 ]; then
+            echo "::warning title=Security audit::$high high-impact finding(s) — review the private code-scanning alerts. cc @kovtcharov-amd ($RUN_URL)"
+          fi

--- a/.github/workflows/claude-security-audit.yml
+++ b/.github/workflows/claude-security-audit.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Run Claude (${{ matrix.lens }} lens)
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@3553f84341b92da26052e28acf1aa898f9511f32  # v1.0.177
+        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e  # v1.0.178
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -75,8 +75,10 @@ jobs:
           # the PDF branch of StructuredExtractor.extract() does `import fitz`, and
           # mocker.patch("fitz.open") can only resolve that target if the module
           # exists. It ships in the [ui]/[rag] extras, which this job does not install.
+          # cvss is required by tests/unit/test_cvss4.py and test_findings_to_sarif.py
+          # (the security-audit scorer); it lives in the [dev] extra, not [api].
           uv pip install --system pytest pytest-cov pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx matplotlib pymupdf
+                                  pyfakefs keyring httpx respx matplotlib pymupdf cvss
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity
@@ -192,7 +194,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system pytest pytest-asyncio pytest-mock pytest-timeout \
-                                  pyfakefs keyring httpx respx matplotlib pymupdf
+                                  pyfakefs keyring httpx respx matplotlib pymupdf cvss
           uv pip install --system -e ".[api]"
 
       - name: Validate packaging integrity

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security vulnerability.** Public issues disclose
+the exploit before a fix exists.
+
+Instead, report privately through **[GitHub Security Advisories](https://github.com/amd/gaia/security/advisories/new)**
+("Report a vulnerability"). This creates a private channel with the maintainers and
+carries first-class CVSS and CWE fields. Please include:
+
+- affected version / commit,
+- a description and, if possible, a minimal proof of concept,
+- the impact you observed (what an attacker gains).
+
+For AMD product-security process, findings are tracked by AMD PSIRT; a maintainer
+(@kovtcharov-amd) will route the advisory. We aim to acknowledge within a few
+business days.
+
+## Severity
+
+We score vulnerabilities with **CVSS 4.0** (the [FIRST v4 calculator](https://www.first.org/cvss/calculator/4.0)).
+The base score comes from the reviewed vector; the vector itself (attack vector,
+required precondition, user interaction, impact) is a judgment call confirmed by a
+maintainer before disclosure.
+
+## Automated security review
+
+Two proactive checks guard the tree, in addition to reactive PR review:
+
+- **Suppression gate** (`util/check_security_gates.py`, run by `util/lint.py`):
+  every `# noqa: S<n>` / `# nosec` must be justified in `.security-suppressions.json`,
+  so no security finding is silenced without human review.
+- **Security audit** (`.github/workflows/claude-security-audit.yml`): a scheduled
+  deterministic (semgrep) + reasoning (Claude taint/authz/suppression) sweep whose
+  findings land in the repo's private **Security → Code scanning** tab, scored with
+  CVSS 4.0. It never posts findings to a public issue.
+
+## Scope
+
+In scope: the `gaia` core (`src/gaia/`), the hub agents (`hub/agents/`), the hub
+installer, the API/UI servers, and the MCP surface. Out of scope: issues requiring a
+already-compromised host, and vulnerabilities in third-party dependencies (report
+those upstream; we track them via Dependabot).

--- a/setup.py
+++ b/setup.py
@@ -244,6 +244,10 @@ setup(
             "autoflake",
             "mypy",
             "bandit",
+            # CVSS 4.0 scoring for the security-audit workflow (util/cvss4.py,
+            # util/findings_to_sarif.py). Pinned: its 4.0 scores match the FIRST
+            # v4 calculator, which the audit's scores must agree with.
+            "cvss>=3.6,<4.0",
             "responses",
             "requests",
             # gaia.connectors runtime deps surfaced in [dev] so that

--- a/tests/unit/test_cvss4.py
+++ b/tests/unit/test_cvss4.py
@@ -1,0 +1,53 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for util/cvss4.py.
+
+Anchors the scorer against values confirmed in the FIRST v4 calculator so a
+future cvss-library bump that drifts from FIRST fails loudly here.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "util"))
+
+import cvss4  # noqa: E402
+
+# vector -> (base_score, severity), each verified against
+# https://www.first.org/cvss/calculator/4.0
+ANCHORS = {
+    # The hub tar-slip triage vector — confirmed 6.0 in the calculator.
+    "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N": (6.0, "Medium"),
+    # All-max.
+    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H": (
+        10.0,
+        "Critical",
+    ),
+    # No impact.
+    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N": (0.0, "None"),
+    # Single high-integrity, network, no UI — the vector the AI triage mis-scored
+    # as 7.3; the real value is 8.7 (this is why we don't trust LLM CVSS numbers).
+    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N": (8.7, "High"),
+}
+
+
+@pytest.mark.parametrize("vector,expected", ANCHORS.items())
+def test_score_matches_first_calculator(vector, expected):
+    result = cvss4.score(vector)
+    assert (result["base_score"], result["severity"]) == expected
+
+
+def test_invalid_vector_raises():
+    with pytest.raises(ValueError, match="Invalid CVSS 4.0 vector"):
+        cvss4.score("CVSS:4.0/not-a-vector")
+
+
+def test_cli_outputs_json(capsys):
+    rc = cvss4.main(["CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"base_score": 6.0' in out and '"severity": "Medium"' in out

--- a/tests/unit/test_findings_to_sarif.py
+++ b/tests/unit/test_findings_to_sarif.py
@@ -1,0 +1,97 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for util/findings_to_sarif.py.
+
+Verifies the SARIF shape GitHub code scanning needs: CVSS-derived
+security-severity, stable partialFingerprints, and a valid 2.1.0 skeleton.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "util"))
+
+import findings_to_sarif as f2s  # noqa: E402
+
+TARSLIP_FINDING = {
+    "path": "src/gaia/hub/installer.py",
+    "line": 382,
+    "symbol": "_install_cpp_artifact",
+    "cwe": "CWE-22",
+    "title": "Unvalidated tarfile.extractall enables path traversal",
+    "why": "A crafted archive member escapes the install dir.",
+    "evidence": "installer.py:382 tf.extractall(install_dir) with no member check",
+    "remediation": "Validate every member resolves inside install_dir.",
+    "confidence": "high",
+    "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N",
+    "dedup_key": "security:src/gaia/hub/installer.py:_install_cpp_artifact",
+}
+
+
+def test_sarif_skeleton_is_valid():
+    sarif = f2s.to_sarif([TARSLIP_FINDING])
+    assert sarif["version"] == "2.1.0"
+    run = sarif["runs"][0]
+    assert run["tool"]["driver"]["name"] == "gaia-claude-security-audit"
+    assert len(run["results"]) == 1
+
+
+def test_security_severity_from_cvss():
+    sarif = f2s.to_sarif([TARSLIP_FINDING])
+    rule = sarif["runs"][0]["tool"]["driver"]["rules"][0]
+    # 6.0 -> GitHub maps 4.0-6.9 to medium; the value must be the real CVSS score.
+    assert rule["properties"]["security-severity"] == "6.0"
+
+
+def test_stable_fingerprint_is_dedup_key_not_line():
+    sarif = f2s.to_sarif([TARSLIP_FINDING])
+    result = sarif["runs"][0]["results"][0]
+    fp = result["partialFingerprints"][f2s.FINGERPRINT_KEY]
+    assert fp == TARSLIP_FINDING["dedup_key"]
+    # Same finding on a different line keeps the same fingerprint (won't re-fire).
+    moved = dict(TARSLIP_FINDING, line=999)
+    moved_fp = f2s.to_sarif([moved])["runs"][0]["results"][0]["partialFingerprints"][
+        f2s.FINGERPRINT_KEY
+    ]
+    assert moved_fp == fp
+
+
+def test_location_carries_path_and_line():
+    result = f2s.to_sarif([TARSLIP_FINDING])["runs"][0]["results"][0]
+    loc = result["locations"][0]["physicalLocation"]
+    assert loc["artifactLocation"]["uri"] == "src/gaia/hub/installer.py"
+    assert loc["region"]["startLine"] == 382
+
+
+def test_high_severity_maps_to_error_level():
+    crit = dict(
+        TARSLIP_FINDING,
+        cvss_vector="CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+    )
+    assert f2s.to_sarif([crit])["runs"][0]["results"][0]["level"] == "error"
+
+
+def test_missing_required_field_raises():
+    bad = dict(TARSLIP_FINDING)
+    del bad["cvss_vector"]
+    with pytest.raises(ValueError, match="missing required field"):
+        f2s.to_sarif([bad])
+
+
+def test_load_findings_reads_multiple(tmp_path):
+    (tmp_path / "findings-a.json").write_text(
+        '{"findings": [%s]}' % _json(TARSLIP_FINDING), encoding="utf-8"
+    )
+    (tmp_path / "findings-b.json").write_text('{"findings": []}', encoding="utf-8")
+    loaded = f2s.load_findings([str(tmp_path / "findings-*.json")])
+    assert len(loaded) == 1
+
+
+def _json(obj):
+    import json
+
+    return json.dumps(obj)

--- a/util/cvss4.py
+++ b/util/cvss4.py
@@ -1,0 +1,69 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Score a CVSS 4.0 vector to a base score + severity.
+
+A thin, deterministic wrapper over the ``cvss`` library, whose 4.0 scores match
+the FIRST v4 calculator (https://www.first.org/cvss/calculator/4.0) — verified in
+``tests/unit/test_cvss4.py`` against known anchors. The security-audit workflow
+uses this so a finding's severity comes from arithmetic on a reviewed *vector*,
+never an LLM's guess at a number (the AI triage on a real ticket estimated 7.3 for
+a vector that actually scores 8.7 — see the tests).
+
+Usage:
+    python util/cvss4.py "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
+    -> {"vector": "...", "base_score": 6.0, "severity": "Medium"}
+
+The *vector* is the judgment call (which requires human review); this tool only
+does the math on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict
+
+
+def score(vector: str) -> Dict[str, Any]:
+    """Return ``{vector, base_score, severity}`` for a CVSS 4.0 vector string.
+
+    Raises ValueError (with the offending vector) if it is malformed — a bad
+    vector is a loud error, never a silent 0.0.
+    """
+    try:
+        from cvss import CVSS4
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise ImportError(
+            "The 'cvss' package is required to score CVSS 4.0 vectors. "
+            'Install it with `pip install -e ".[dev]"` (it is in the dev extra).'
+        ) from exc
+
+    try:
+        c = CVSS4(vector)
+    except Exception as exc:  # cvss raises its own CVSSError subclasses
+        raise ValueError(f"Invalid CVSS 4.0 vector {vector!r}: {exc}") from exc
+
+    return {
+        "vector": c.clean_vector(),
+        "base_score": c.base_score,
+        "severity": c.severities()[0],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Score a CVSS 4.0 vector.")
+    parser.add_argument("vector", help="e.g. 'CVSS:4.0/AV:N/AC:L/.../SA:N'")
+    args = parser.parse_args(argv)
+    try:
+        result = score(args.vector)
+    except (ValueError, ImportError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/findings_to_sarif.py
+++ b/util/findings_to_sarif.py
@@ -1,0 +1,198 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Convert Claude security-audit findings into SARIF 2.1.0 for GitHub code scanning.
+
+The security-audit workflow writes findings as JSON; this renders them as SARIF so
+they upload to the repo's **private** Security > Code scanning tab (not a public
+issue), where GitHub deduplicates them and shows a CVSS-derived severity.
+
+Two properties matter for that pipeline:
+
+* ``security-severity`` on each rule — GitHub maps the CVSS base score to the alert
+  severity (>=9.0 critical, 7.0-8.9 high, 4.0-6.9 medium, <4.0 low). The score is
+  computed here from the finding's reviewed CVSS 4.0 vector via ``util/cvss4.py`` —
+  never an LLM's guessed number.
+* ``partialFingerprints`` from the finding's stable ``dedup_key`` (path + symbol,
+  never a line number) — so an alert tracks the same weakness across runs instead
+  of re-firing every time a line moves.
+
+Finding schema (one object per weakness)::
+
+    {"findings": [{
+        "path": "src/gaia/hub/installer.py",
+        "line": 382,                       # optional
+        "symbol": "_install_cpp_artifact", # for the dedup_key / message
+        "cwe": "CWE-22",                   # optional
+        "title": "...", "why": "...", "evidence": "...",
+        "remediation": "...",              # optional
+        "confidence": "high",              # optional
+        "cvss_vector": "CVSS:4.0/AV:N/.../SA:N",
+        "dedup_key": "security:src/gaia/hub/installer.py:_install_cpp_artifact"
+    }]}
+
+Usage:
+    python util/findings_to_sarif.py findings-*.json -o security.sarif
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:
+    from cvss4 import score as cvss_score
+except ImportError:  # pragma: no cover - resolved when run from util/ or tests
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from cvss4 import score as cvss_score
+
+REQUIRED_FIELDS = ("path", "title", "cvss_vector", "dedup_key")
+FINGERPRINT_KEY = "gaiaSecurityAudit/v1"
+TOOL_NAME = "gaia-claude-security-audit"
+TOOL_URI = (
+    "https://github.com/amd/gaia/blob/main/.github/workflows/claude-security-audit.yml"
+)
+
+
+def _level_for(severity: str) -> str:
+    """SARIF level from CVSS qualitative severity."""
+    return {
+        "Critical": "error",
+        "High": "error",
+        "Medium": "warning",
+        "Low": "note",
+        "None": "note",
+    }.get(severity, "warning")
+
+
+def load_findings(paths: List[str]) -> List[Dict[str, Any]]:
+    """Read and concatenate the ``findings`` arrays from one or more JSON files."""
+    findings: List[Dict[str, Any]] = []
+    for pattern in paths:
+        for fname in sorted(glob.glob(pattern)) or [pattern]:
+            p = Path(fname)
+            if not p.exists():
+                continue
+            data = json.loads(p.read_text(encoding="utf-8"))
+            findings.extend(data.get("findings", []))
+    return findings
+
+
+def _validate(finding: Dict[str, Any]) -> None:
+    missing = [f for f in REQUIRED_FIELDS if not finding.get(f)]
+    if missing:
+        raise ValueError(
+            f"Finding {finding.get('dedup_key') or finding.get('title') or finding!r} "
+            f"is missing required field(s): {', '.join(missing)}."
+        )
+
+
+def to_sarif(findings: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Render findings as a SARIF 2.1.0 document (one rule + result per finding)."""
+    rules: List[Dict[str, Any]] = []
+    results: List[Dict[str, Any]] = []
+    seen_rule_ids: set[str] = set()
+
+    for f in findings:
+        _validate(f)
+        scored = cvss_score(f["cvss_vector"])
+        rule_id = f["dedup_key"]
+
+        if rule_id not in seen_rule_ids:
+            seen_rule_ids.add(rule_id)
+            rules.append(
+                {
+                    "id": rule_id,
+                    "name": (f.get("cwe") or "SecurityFinding").replace("-", ""),
+                    "shortDescription": {"text": f["title"]},
+                    "properties": {
+                        # GitHub reads this to set the alert's severity.
+                        "security-severity": str(scored["base_score"]),
+                        "cwe": f.get("cwe", ""),
+                        "tags": ["security"] + ([f["cwe"]] if f.get("cwe") else []),
+                    },
+                }
+            )
+
+        text = f["title"]
+        for label in ("why", "evidence", "remediation"):
+            if f.get(label):
+                text += f"\n\n{label.capitalize()}: {f[label]}"
+        text += (
+            f"\n\nCVSS 4.0: {scored['base_score']} ({scored['severity']}) "
+            f"[{scored['vector']}] — proposed, confirm the vector before disclosure."
+        )
+
+        region: Dict[str, Any] = {}
+        if f.get("line"):
+            region["startLine"] = int(f["line"])
+
+        results.append(
+            {
+                "ruleId": rule_id,
+                "level": _level_for(scored["severity"]),
+                "message": {"text": text},
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": f["path"]},
+                            **({"region": region} if region else {}),
+                        }
+                    }
+                ],
+                "partialFingerprints": {FINGERPRINT_KEY: rule_id},
+                "properties": {
+                    "security-severity": str(scored["base_score"]),
+                    "cvss_vector": scored["vector"],
+                    "confidence": f.get("confidence", ""),
+                },
+            }
+        )
+
+    return {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": TOOL_NAME,
+                        "informationUri": TOOL_URI,
+                        "version": "1.0.0",
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert findings JSON to SARIF.")
+    parser.add_argument("findings", nargs="+", help="findings JSON file(s) or globs")
+    parser.add_argument("-o", "--output", help="write SARIF here (default: stdout)")
+    args = parser.parse_args(argv)
+
+    findings = load_findings(args.findings)
+    try:
+        sarif = to_sarif(findings)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    out = json.dumps(sarif, indent=2)
+    if args.output:
+        Path(args.output).write_text(out, encoding="utf-8")
+        print(f"Wrote {len(sarif['runs'][0]['results'])} result(s) to {args.output}")
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why this matters

The weekly audit's single general "security lens" missed the hub tar-slip (CWE-22, #2342): it sampled a large repo in one pass and read a `# noqa: S202 - hub artifacts are trusted` comment as a settled decision. This adds a **dedicated** security audit that fixes both failure modes and scores findings the way we actually triage them.

- **Deterministic layer** — semgrep security rulesets over the whole tree, native SARIF → private code-scanning tab. Maintained rules, exhaustive on known sinks.
- **Reasoning layer** — Claude over an explicit deterministic worklist (so nothing is sampled away), in three lenses: **sink-taint** (the CWE-22 class), **authz** (the CWE-284 read/write gate-asymmetry class), and **suppression-review** (every `# noqa: S*`/`# nosec` re-verified from scratch — never trusted, which is the exact failure that hid the tar-slip).
- **CVSS 4.0 done right** — `util/cvss4.py` scores a *reviewed vector* via the `cvss` lib (validated against the FIRST v4 calculator, incl. the 6.0 tar-slip vector). Scores are arithmetic on a vector, never an LLM's guessed number — a real triage on the ticket guessed 7.3 for a vector that actually scores 8.7.
- **Private by design** — findings go to the repo's Security → Code scanning tab (CVSS-derived `security-severity`, stable fingerprints), never a public issue. `SECURITY.md` adds a private reporting channel.

## Validation against the two reported vulnerabilities

- The deterministic worklist surfaces **both** locations: the `read_file`/`write_file` + `is_path_allowed`/`validate_write` asymmetry (CWE-284) is handed to the authz lens, and the `extractall` sink (CWE-22) to sink-taint.
- The suppression gate (PR #2343) already backtests catching the tar-slip's `# noqa: S202`.
- The LLM layer is validated post-merge by dispatching this workflow with `target_ref` set to a known-vuln commit (pre-#2342 for CWE-22, pre-#2344 for CWE-284) and confirming alerts appear.

## Test plan

- [x] `pytest tests/unit/test_cvss4.py tests/unit/test_findings_to_sarif.py` — 13 pass (FIRST-anchored CVSS incl. 6.0/8.7, SARIF shape, stable fingerprints)
- [x] `cvss` lib matches the FIRST v4 calculator on 4 anchors
- [x] workflow YAML parses; deterministic worklist confirmed to surface both CWE locations
- [ ] Post-merge: `workflow_dispatch` at a pre-fix ref; confirm code-scanning alerts for both CWEs
- [ ] Precondition: confirm code scanning is enabled + org allows third-party SARIF on `amd/gaia`

## Follow-ups (not in this PR)

- Strip the now-redundant `security` dimension from `claude-weekly-audit.yml` + its skill/plan docs.
- Enable the bandit-HIGH blocking gate after the 18 pre-existing HIGH findings are fixed.