### PR TITLE
chore(audit): drop the security dimension from the weekly audit

### DIFF
--- a/.claude/skills/weekly-audit-patterns/SKILL.md
+++ b/.claude/skills/weekly-audit-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "weekly-audit-patterns"
-description: "The non-obvious invariants of the proactive weekly Claude audit workflow (.github/workflows/claude-weekly-audit.yml): the stable dedup-key scheme that keeps it from re-filing findings every week, the private channel for security findings, the five audit dimensions and which one owns the Fail-Loudly check, and the `bug`-label → auto-fix promotion path. Read before editing that workflow, changing how findings are filed/deduped, or adding an audit dimension."
+description: "The non-obvious invariants of the proactive weekly Claude audit workflow (.github/workflows/claude-weekly-audit.yml): the stable dedup-key scheme that keeps it from re-filing findings every week, the four audit dimensions (security has its own workflow, claude-security-audit.yml) and which one owns the Fail-Loudly check, and the `bug`-label → auto-fix promotion path. Read before editing that workflow, changing how findings are filed/deduped, or adding an audit dimension."
 ---
 
 # Weekly Audit Patterns
@@ -10,9 +10,13 @@ lens — a scheduled deep review (not triggered by a PR) that fans out one read-
 Claude job per dimension and files a ranked triage issue. Everything else in
 `claude.yml` is reactive. These are the invariants a future editor will otherwise break.
 
-## The five dimensions are mutually exclusive
+## The four dimensions are mutually exclusive
 
-`security`, `correctness`, `docs`, `tests`, `features` — a matrix of one Claude job each.
+`correctness`, `docs`, `tests`, `features` — a matrix of one Claude job each. **Security
+is NOT a dimension here** — it moved to its own workflow, `claude-security-audit.yml`
+(deterministic semgrep + a Claude taint/authz/suppression sweep, CVSS-scored, findings to
+the private code-scanning tab). Don't re-add it here; that created two half-owners and the
+single general "security lens" is what missed the hub tar-slip.
 The lenses **overlap unless the prompt keeps them disjoint**, and the first run proved it:
 correctness findings (a rollback that never rolls back, a poller returning null, a mode
 that no-ops) leaked into `features`, and the priciest job's output vanished from the
@@ -50,7 +54,7 @@ missing test** — never rate "module X has no tests" above a feature that's act
 broken. High = security / data loss / default-path break; medium = broken user-facing
 behavior, a false doc, or a missing test guarding auth/a gate/destructive logic; low =
 missing tests on non-risk logic, cosmetic gaps. The synthesis emits a section per
-dimension (fixed order: Security, Correctness, Features, Docs, Tests), grouping each
+dimension (fixed order: Correctness, Features, Docs, Tests), grouping each
 finding under the dimension it **declares** — it never re-buckets.
 
 ## Child issues are 🔴/🟠 only, and tagged auto-fixable
@@ -102,16 +106,13 @@ closes them, trading tracker tidiness for guaranteeing unaddressed findings stay
 The parent opens with a one-line tally (new/low/suppressed counts) for trend. On a
 zero-new-findings run, synthesis posts nothing and does not touch any prior parent.
 
-## Security findings stay private
+## Security is out of scope here — it has its own workflow
 
-A GitHub Actions run has no DM channel and the triage issue is **public**. So the
-security dimension writes full detail (file, symbol, remediation) ONLY to the **job
-run log** (visible to those with Actions read access), and puts a redacted stub in
-`findings-security.json` — coarse directory path, no exploit, title exactly
-`"Security finding (details in run log)"`. The synthesis job renders security as a
-**count + run-log pointer + `@kovtcharov-amd`**, never a `file:line` or payload. This
-matches the CLAUDE.md "Security Handling Protocol" and the `code-reviewer` agent's rule.
-Do not "improve" this by putting detail in the public issue.
+Security moved to `.github/workflows/claude-security-audit.yml` (see its own patterns
+skill). This audit files to a **public** triage issue, which is the wrong channel for a
+vulnerability — so the prompt now tells every lens to hand off any security issue it
+notices rather than file it, and the synthesis emits **no** security section. Do not
+re-add a security dimension here or route a security finding into the public issue.
 
 ## Promotion: `bug` label → existing auto-fix job
 
@@ -129,7 +130,7 @@ route promotions through `bug` unless you deliberately widen the auto-fix `if`.
   `claude-fable-5` for maximum depth at ~2x cost. A measured Fable deep run was ~$45 of
   API-equivalent subscription usage; Opus roughly halves that.
 - **Serialized dimensions**: the matrix runs `max-parallel: 1` so the run is a steady
-  drip, not a 5-job burst — this keeps it under the Max subscription's rolling (5-hour)
+  drip, not a 4-job burst — this keeps it under the Max subscription's rolling (5-hour)
   rate limit. If you re-parallelize, expect a token spike that can trip that limit.
 - **Skip-if-empty**: normal mode exits in `preflight` before any Claude call on a
   no-change week. Deep mode never skips.

--- a/.github/workflows/claude-weekly-audit.yml
+++ b/.github/workflows/claude-weekly-audit.yml
@@ -19,9 +19,12 @@
 #                      Monday of each month; also selectable via workflow_dispatch.
 #   The `auto` dispatch default resolves to deep on day-of-month <= 7, else normal.
 #
+# SECURITY is NOT a dimension here — it has its own dedicated workflow,
+# .github/workflows/claude-security-audit.yml (deterministic semgrep + a Claude
+# taint/authz/suppression sweep, CVSS-scored, findings to the private code-scanning
+# tab). This audit deliberately leaves security to it, to avoid two half-owners.
+#
 # DIMENSIONS (one read-only Claude job each, run in parallel):
-#   security    — injection, unsafe subprocess/eval, secret handling. NEVER posts
-#                 details publicly (see "Security findings" below).
 #   correctness — logic bugs AND the CLAUDE.md "Fail Loudly" rule: `except Exception:
 #                 pass`, try/except that returns a placeholder, silent degradation.
 #                 (This dimension owns the silent-fallback check.)
@@ -32,7 +35,7 @@
 #                 invocation, not call validity (CLAUDE.md "#1655" boundary rule).
 #   features    — half-finished follow-ups, TODO-as-placeholder, gaps a recent feature implies.
 #
-# A synthesis job collects the five structured outputs, dedupes against already-open
+# A synthesis job collects the four structured outputs, dedupes against already-open
 # `weekly-audit` issues via a stable per-finding key, ranks by severity, and files output.
 #
 # MODEL: claude-opus-4-8 (Claude Opus 4.8) — excellent for static review at half the
@@ -45,9 +48,9 @@
 # (CLAUDE_CODE_OAUTH_TOKEN, covered by the monthly claude-auth-canary.yml). Runs on the
 # Claude Max subscription pool, so there is no per-run dollar cost — only shared quota.
 #
-# COST CEILING: 5 dimension jobs (--max-turns 30) + 1 synthesis job (--max-turns 32) =
+# COST CEILING: 4 dimension jobs (--max-turns 30) + 1 synthesis job (--max-turns 32) =
 # a known per-run ceiling. The dimension matrix runs `max-parallel: 1` (serialized) so
-# the run is a steady drip rather than a 5-job burst — this keeps it under the Max
+# the run is a steady drip rather than a 4-job burst — this keeps it under the Max
 # subscription's rolling (5-hour) rate limit, at the cost of a longer wall-clock.
 # skip-if-empty exits before any Claude call on a no-change week. The concurrency group
 # prevents two scheduled runs from overlapping.
@@ -144,12 +147,12 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      # Serialize the dimensions so the run is a steady drip, not a 5-job burst —
+      # Serialize the dimensions so the run is a steady drip, not a 4-job burst —
       # keeps it under the Max subscription's rolling (5-hour) rate limit. Trades
       # wall-clock (~5 sequential Claude jobs) for a smoother token profile.
       max-parallel: 1
       matrix:
-        dimension: [security, correctness, docs, tests, features]
+        dimension: [correctness, docs, tests, features]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -203,12 +206,12 @@ jobs:
                changed files to focus on. In deep mode, review beyond the diff.
             3. Investigate with Grep/Glob/Read/Bash (read-only — do NOT edit, install, or run repo code).
 
-            ## Your lens — the five are mutually exclusive; claim ONLY yours
+            ## Your lens — the four are mutually exclusive; claim ONLY yours
             The lenses overlap unless you respect these boundaries. The decisive question for a
             broken thing is: **is the code wired but misbehaving (correctness), never written
-            (features), or contradicted by its docs (docs)?**
-            - **security**: injection (SQL/command), unsafe subprocess/eval, `pickle`/`yaml.load`
-              without SafeLoader, secrets in code or logs, path traversal, fork-PR surface.
+            (features), or contradicted by its docs (docs)?** SECURITY is out of scope for this
+            audit — it has a dedicated workflow (claude-security-audit.yml); if you spot a security
+            issue, leave it to that workflow rather than filing it here.
             - **correctness**: code that IS wired and runs but silently does the wrong thing or
               nothing — a handler that flips a success flag without doing the work (a rollback
               that never rolls back), a poller that always returns a placeholder/null, a mode
@@ -265,7 +268,6 @@ jobs:
                 a missing, stale, hand-authored, or gate-failing scorecard.
               - **correctness**: the agent's runtime code is bulletproof — NO stubs, NO silent
                 fallbacks, NO half-finished paths, actionable errors at every boundary.
-              - **security**: hold agent code to the strictest reading (it runs on integrators' machines).
 
             ## Severity — calibrate consistently (🔴 high · 🟠 medium · 🟡 low)
             - **🔴 high**: a security issue, data loss, or a break that hits users on the default path.
@@ -317,17 +319,10 @@ jobs:
             and skip anything you are not confident is real. A shorter, fully-substantiated list is
             the goal — never pad.
 
-            ## Security lens — details stay PRIVATE (this overrides the output rule above)
-            If YOUR LENS IS security: a GitHub Actions run has no private DM channel and this
-            job's findings feed a PUBLIC triage issue. So for security findings:
-            - Print the FULL detail (file, symbol, why, remediation) to STDOUT — the job log is
-              visible only to those with Actions read access. Start each with "SECURITY FINDING:".
-            - In `findings-security.json`, write ONLY a redacted stub per finding: a coarse
-              `path` (directory, e.g. `src/gaia/ui/`), NO exploit detail, `title` exactly
-              "Security finding (details in run log)", and a stable `dedup_key`. Never put a
-              `file:line`, exploit steps, or a payload in the JSON.
-            The synthesis job will surface security as a COUNT + a pointer to the run log,
-            tagging @kovtcharov-amd — it never appears with detail in the public issue.
+            ## Security is out of scope — hand it off, do not file it here
+            If you notice a security weakness, do NOT file it in this audit's findings or the
+            public triage issue (that would disclose it). Security has a dedicated private-channel
+            workflow (claude-security-audit.yml). Leave it to that sweep.
           claude_args: |
             --max-turns 30
             --model ${{ env.AUDIT_MODEL }}
@@ -341,7 +336,7 @@ jobs:
           path: findings-${{ matrix.dimension }}.json
           if-no-files-found: warn
 
-  # Collect the five dimension outputs, dedupe against open weekly-audit issues, rank,
+  # Collect the four dimension outputs, dedupe against open weekly-audit issues, rank,
   # and file ONE parent triage issue + per-finding child issues. This is the only job
   # with issues: write.
   synthesize:
@@ -385,8 +380,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
-            You are the synthesis step of GAIA's weekly proactive audit. Five dimension jobs
-            (security, correctness, docs, tests, features) each wrote a findings JSON file.
+            You are the synthesis step of GAIA's weekly proactive audit. Four dimension jobs
+            (correctness, docs, tests, features) each wrote a findings JSON file.
             Dedupe them against already-open findings, rank them, and file the output.
 
             REPO: ${{ github.repository }}
@@ -450,7 +445,7 @@ jobs:
             ## File ONE parent TRIAGE issue
             Title: `Weekly audit — ${{ needs.preflight.outputs.mode }} — ${{ github.run_id }}`.
             Label it `weekly-audit`. **Emit a section for EVERY dimension that has at least one
-            finding, in this fixed order: 🔒 Security, Correctness, Features, Docs, Tests.** Group
+            finding, in this fixed order: Correctness, Features, Docs, Tests.** Group
             each finding under the dimension IT declares in its JSON — NEVER re-bucket a
             correctness finding under features (the `dimension` field is authoritative). Within a
             section, order 🔴 → 🟠 → 🟡 and prefix each line with its severity emoji. 🔴/🟠 lines
@@ -469,12 +464,9 @@ jobs:
             ```
             Start the parent body with a one-line tally so trend is visible at a glance, e.g.
             `New this run: 4 (🔴 1 · 🟠 3) · low (in-parent only): 2 · suppressed as dup/wontfix: 9`.
-            **Security section — count + pointer ONLY.** If there were any security findings,
-            render exactly one line at the top and NOTHING else about them (no file, no symbol,
-            no detail):
-            `## 🔒 Security (<count>) — details in the run log, cc @kovtcharov-amd`
-            with the run-log link: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
-            NEVER put a security `file:line`, exploit, or payload in this issue.
+            Security is not a dimension here (see claude-security-audit.yml) — do not emit a
+            security section, and if any dimension's findings JSON contains a security issue,
+            omit it rather than disclosing it in this public issue.
 
             ## Cross-link the previous parent (NEVER close it)
             After filing the new parent, comment on the previous parent you found in

--- a/docs/plans/weekly-claude-audit.md
+++ b/docs/plans/weekly-claude-audit.md
@@ -22,15 +22,20 @@ review that files **one ranked triage issue** a maintainer skims and promotes.
 
 ## Dimensions (one read-only Claude job each, in parallel)
 
+> **Security is not a dimension here.** It moved to a dedicated workflow,
+> `.github/workflows/claude-security-audit.yml` (deterministic semgrep + a Claude
+> taint/authz/suppression sweep, CVSS-scored, findings to the private code-scanning tab).
+> Filing security into this audit's **public** triage issue was the wrong channel, and a
+> single general "security lens" is what missed the hub tar-slip.
+
 | Dimension | Looks for |
 |-----------|-----------|
-| `security` | injection, unsafe subprocess/eval, unsafe deserialization, secret handling, path traversal, fork-PR surface — **never posts detail publicly** (see below) |
 | `correctness` | code that is **wired but misbehaves** — a handler that flips a success flag without doing the work (a rollback that never rolls back), a poller that always returns null, a mode that no-ops, a flag whose handler raises `NotImplementedError` — plus real logic bugs and every CLAUDE.md "Fail Loudly" violation. **Owns wired-but-broken behavior and the silent-fallback check.** |
 | `docs` | new feature with no `docs/` page or `docs.json` entry; `cli.mdx` drift; `amd-gaia.ai` links missing `/docs/`; hub-agent README/SPEC/SKILL/CHANGELOG drift. A feature **documented as working but stubbed** is a docs finding (doc-vs-code drift), not features. |
 | `tests` | code paths with no test, or assertions that prove invocation not call validity (#1655). In **deep** mode, plain "module X has no coverage" rolls up into ONE aggregate finding; separate findings only for risk-bearing untested logic (auth/gate/precedence/error-mapping/#1655). |
 | `features` | a genuinely **missing or half-shipped** capability where nothing is wired yet (a TODO standing in for unwritten code). If the code is wired but broken, that is `correctness`, not features. |
 
-The five lenses are **mutually exclusive** — the decisive question for a broken thing is
+The four lenses are **mutually exclusive** — the decisive question for a broken thing is
 *is the code wired but misbehaving (correctness), never written (features), or contradicted
 by its docs (docs)?* Without that boundary, correctness findings leak into features and the
 priciest job's output disappears.
@@ -52,22 +57,25 @@ detected by a `release_agent_<id>.yml` workflow, a shipped `SCORECARD.md`, or a 
   `gaia.eval.scorecard_gate` (never hand-authored).
 - **correctness** — runtime code is bulletproof: no stubs, no silent fallbacks, no
   half-finished paths, actionable errors at every boundary.
-- **security** — strictest reading (agent code runs on integrators' machines).
+
+(The security review of published agents runs in `claude-security-audit.yml`.)
 
 > **Fix vs. the original handoff:** the first draft had four dimensions
 > (security/tests/docs/features) and listed the silent-fallback check in the scope
 > narrative but assigned it to **no** dimension — it would have fallen through. This
-> design adds a fifth **`correctness`** dimension and gives it that check explicitly, so
+> design adds a **`correctness`** dimension and gives it that check explicitly, so
 > the workflow covers code *correctness* (bugs) as well as code *debt* (tests, features).
+> (Security was later split out into `claude-security-audit.yml`, leaving the four
+> dimensions above.)
 
 ## Synthesis → one triage issue + child issues
 
-A synthesis job collects the five structured outputs, reduces them to the verified new set,
+A synthesis job collects the four structured outputs, reduces them to the verified new set,
 ranks by severity (**🔴 high · 🟠 medium · 🟡 low** — no green; green reads as "pass"), and files:
 
 - **Parent triage issue** (`weekly-audit`): opens with a one-line tally (new/low/suppressed
   counts) for trend, then a section for **every** dimension with a finding, in fixed order
-  (Security, Correctness, Features, Docs, Tests), each finding grouped under the dimension it
+  (Correctness, Features, Docs, Tests), each finding grouped under the dimension it
   *declares* (never re-bucketed). Each run **supersedes and closes the previous parent** so
   they don't pile up.
 - **Per-finding child issues** for **🔴/🟠 only** — 🟡 (low) findings are listed in the
@@ -87,8 +95,8 @@ ranks by severity (**🔴 high · 🟠 medium · 🟡 low** — no green; green 
   heading, **never a line number** (line numbers move and re-file the finding every week).
   Embedded as `<!-- audit-key: KEY -->` in each child body; synthesis skips any key already
   on an *open* `weekly-audit` issue OR on any `audit-wontfix` issue (accepted debt).
-- **Security stays private**: full detail to the job run log only; a redacted stub in
-  `findings-security.json`; the public issue shows a count + run-log pointer + `@kovtcharov-amd`.
+- **Security is a separate workflow**: `claude-security-audit.yml` owns it; this audit files
+  to a public issue, so it hands security off rather than disclosing it here.
 - **Skip-if-empty**: normal mode exits before any Claude call on a no-change week.
 - **Read-only**: `--allowedTools Read,Grep,Glob,Bash`; never install or run repo code.
 - **Model** `claude-opus-4-8` via the top-level `AUDIT_MODEL` env (one place to change);


### PR DESCRIPTION
## Why this matters

Security now has a dedicated workflow (`claude-security-audit.yml`, PR #2346). Keeping a general "security lens" as one of five sampled dimensions in the weekly audit is exactly what missed the hub tar-slip — and this audit files to a **public** triage issue, which is the wrong channel for a vulnerability. This removes the overlap so there's one clear owner.

Changes: drop `security` from the matrix (now `correctness`/`docs`/`tests`/`features`), tell each lens to hand off any security issue it notices instead of filing it, and remove the public security section from synthesis. The `weekly-audit-patterns` skill and the plan doc are updated to match (four dimensions, security pointer).

No behavior change to the other four dimensions.

## Test plan

- [x] `claude-weekly-audit.yml` parses as valid YAML
- [x] no residual "five dimensions" / `findings-security` / security-section references remain
- [ ] next scheduled/dispatched run files a triage issue with four dimensions and no security section

Depends conceptually on #2346 (the dedicated security workflow) but is independently mergeable.