### PR TITLE
test(daemon): de-flake sidecar stop test on the pid-liveness check

### DIFF
--- a/tests/unit/test_daemon_relay.py
+++ b/tests/unit/test_daemon_relay.py
@@ -274,7 +274,16 @@ def test_connection_running_returns_base_url_and_bearer():
     assert bearer == ensured["token"]
 
 
-def test_connection_stopped_after_running_raises_again():
+def test_connection_stopped_after_running_raises_again(monkeypatch):
+    # The fake manager reports a hardcoded pid but owns no real OS process, so
+    # its shutdown() can't make that pid disappear. registry.stop() verifies the
+    # pid is gone via psutil.pid_exists against the real process table, which
+    # flakes when the fake pid collides with a live process on the runner. Model
+    # the fake sidecar as fully terminated so the check reflects the double's
+    # intent, not the host's process table.
+    monkeypatch.setattr(
+        "gaia.daemon.sidecars.registry.psutil.pid_exists", lambda pid: False
+    )
     reg = _toy_registry()
     reg.ensure("toy")
     reg.stop("toy")


### PR DESCRIPTION
## Why this matters

`test_connection_stopped_after_running_raises_again` fails intermittently on CI (seen on the macOS smoke runner: `StopFailedError: agent 'toy' sidecar pid 4321 survived the tree-kill`). It's a false failure that blocks unrelated PRs and erodes trust in the suite — the production code is fine.

**Root cause:** the test's fake manager reports a hardcoded pid (`4321`) but owns no real OS process, so its `shutdown()` can't make that pid disappear. `registry.stop()` then verifies the pid is gone via `psutil.pid_exists(pid)` against the **real process table**. On most runners pid 4321 is dead → passes; when it collides with a live process on the runner → spurious `StopFailedError`. Test-double fidelity bug, not a product bug: a real manager tree-kills its own real pid, so the liveness check stays meaningful in production.

**Fix:** patch `pid_exists` to `False` for the fake so the check reflects the double's intent (the fake sidecar is terminated) instead of the host's process table. One line + a comment; production behavior untouched.

## Test plan

- [x] `pytest tests/unit/test_daemon_relay.py` — 36 pass
- [x] Verified the mechanism: forcing `pid_exists → True` (simulating pid 4321 alive on the runner) reproduces the `StopFailedError`; the fix's `pid_exists → False` patch neutralizes it while `stop()` still succeeds
- [x] `black`/`isort` clean