### PR TITLE
ci(labeler): add tui/daemon/sidecar auto-label rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -50,6 +50,26 @@ talk:
     - any-glob-to-any-file: ['src/gaia/talk/**/*', 'docs/guides/talk.md', 'docs/sdk/agents/talk.md']
 
 # ---------------------------------------------------------------------------
+# Terminal Agent Hub: Go TUI, daemon supervisor, and the agent sidecar contract
+# (milestone #45). Kept with the src/gaia area rules above the hub-agent block.
+# ---------------------------------------------------------------------------
+
+# Go terminal UI (gaia-tui)
+tui:
+  - changed-files:
+    - any-glob-to-any-file: ['tui/**/*', '.github/workflows/build_tui.yml']
+
+# Daemon supervisor / sidecar control plane
+daemon:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/daemon/**/*']
+
+# Agent sidecar contract / harness
+sidecar:
+  - changed-files:
+    - any-glob-to-any-file: ['src/gaia/daemon/sidecars/**/*', 'hub/agents/*/python/packaging/**/*']
+
+# ---------------------------------------------------------------------------
 # Hub agents (hub/agents/<id>/python, hub/agents/<id>/npm). One label per
 # packaged agent so a PR touching a single agent's sources is labelled for it.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

The terminal-hub / sidecar architecture work (milestone #45) added new code surfaces the auto-labeler didn't know about, so PRs touching the Go TUI, the daemon supervisor, or the agent sidecar contract landed unlabelled and had to be triaged by hand. This teaches `actions/labeler` about those paths and introduces the matching `tui` / `daemon` / `sidecar` repo labels (already created), so future PRs in these areas self-label.

## Test plan

- [x] `labeler.yml` parses as valid YAML and every referenced label exists as a repo label.
- [ ] A PR touching `tui/**` (or `.github/workflows/build_tui.yml`) receives the `tui` label.
- [ ] A PR touching `src/gaia/daemon/**` receives the `daemon` label.
- [ ] A PR touching `src/gaia/daemon/sidecars/**` or `hub/agents/*/python/packaging/**` receives the `sidecar` label.

No change to `auto-label.yml` — it's generic (`actions/labeler@v6`, no per-label config), so the new rules take effect on next PR event.