### PR TITLE
feat(email): full autonomy — earn-trust engine, learning loop, scheduled driver

### DIFF
--- a/docs/plans/email-full-autonomy.mdx
+++ b/docs/plans/email-full-autonomy.mdx
@@ -6,7 +6,11 @@ icon: "wand-magic-sparkles"
 
 # Email Agent — Full Autonomy (Earn-Trust + Learning Loop)
 
-> **Status:** In progress — Phase 1 (trust engine) landing first.
+> **Status:** Phases 1–4 (backend) + the proactive eval harness shipped — trust
+> engine, autonomous cycle, closed learning loop, REST control surface, and
+> automatic correction capture, all tested. Remaining: the production driver (a
+> `DaemonClock` job hitting `POST /v1/email/agent/autonomy/run`) and the npm
+> thin-client CLI (`gaia email autonomy …`) that wraps the REST surface.
 >
 > **Milestone:** [Autonomy + Messaging Expansion [OSS]](https://github.com/amd/gaia/milestone/6)
 >

--- a/docs/plans/email-full-autonomy.mdx
+++ b/docs/plans/email-full-autonomy.mdx
@@ -1,0 +1,125 @@
+---
+title: "Email Agent — Full Autonomy"
+description: "Earn-trust autonomous email handling with a hard confirm-floor and a closed correction→memory→behavior learning loop"
+icon: "wand-magic-sparkles"
+---
+
+# Email Agent — Full Autonomy (Earn-Trust + Learning Loop)
+
+> **Status:** In progress — Phase 1 (trust engine) landing first.
+>
+> **Milestone:** [Autonomy + Messaging Expansion [OSS]](https://github.com/amd/gaia/milestone/6)
+>
+> **Anchor issues:** #1115 (heartbeat + email as first consumer), #557 (think-act-schedule
+> loop), #1483 (graduated trust), #1287 (self-learning loop — this *implements* it),
+> #2005 (autonomous observation cycle), #558/#421 (activity feed + notifications),
+> #1508 (proactive eval harness).
+>
+> **Out of scope:** #1286 (model fine-tuning). Personalization is memory/prompt-based only.
+>
+> **Frames this builds on:** [`docs/spec/autonomous-agent-mode.md`](/spec/autonomous-agent-mode)
+> (§6.6 permission grants, §6.7 observation cycle) and
+> [`docs/plans/autonomy-engine.mdx`](/plans/autonomy-engine) (the daemon owns the single clock).
+
+---
+
+## 1. What we're building
+
+Turn on **full autonomy** and the email agent handles the inbox end-to-end: it triages,
+files, labels, and drafts on its own; it **checks in before anything destructive or
+irreversible** (send, permanent delete, forward, calendar RSVP); and it **learns from you**
+— your corrections, your own behavior, your writing voice, and explicit feedback — so it
+grows more personalized and more trusted over time.
+
+**Earn-trust posture (the default).** Cautious on day one: it proposes and drafts, and
+auto-executes only in categories it has proven itself on or you've explicitly approved. As
+its track record accumulates in the trust ledger, it widens what it does silently — but the
+destructive floor never moves.
+
+```
+Day 1:   "Archive this newsletter?"           → asks
+Day 14:  archives newsletters silently         (proven 14/14)
+         drafts your replies, waits for edit
+         send / permanent-delete / forward      → always asks
+```
+
+## 2. Design principles
+
+1. **The confirm-floor is inviolable.** Send, forward, permanent delete, and RSVP always
+   require explicit confirmation, at every autonomy level. This is the existing
+   `CONFIRMATION_REQUIRED_TOOLS` set — the policy layer can never lower it.
+2. **Trust is earned, per scope, from evidence.** Autonomy widens only when the ledger shows
+   enough correct decisions in a category/sender scope. No global "trust me" switch.
+3. **Reversible-first.** Only reversible actions (archive, label, mark-read, star) are ever
+   auto-executed. Every one is logged with undo via `action_store`.
+4. **Learn from the strongest signal available.** Explicit corrections and feedback outweigh
+   implicit behavior, which outweighs priors. All feed one ledger.
+5. **Cheap-first, fail-loud, inspectable.** Zero LLM tokens on a quiet inbox; every decision
+   carries a rationale; `gaia email autonomy trust` shows exactly what's been earned.
+6. **One clock, not a new daemon.** Heartbeats are jobs on the daemon `DaemonClock`, per the
+   autonomy-engine reconciliation — never a second background service.
+
+## 3. Architecture — completing existing rails
+
+| Layer | Already exists | This feature adds |
+|-------|----------------|-------------------|
+| Trust gradient | `AgentMode`, `GoalStore`, `Proposal`/`Goal`, `on_first_run`/`on_heartbeat`/`propose` hooks (core) | `TrustPolicy` + earned-trust `TrustLedger` for email; hook overrides |
+| Confirm floor | `CONFIRMATION_REQUIRED_TOOLS` + reversible `action_store` undo | Policy layer that treats the floor as inviolable |
+| Personalization | `MemoryMixin`, `preference_tools`, `profile_tools`, `voice_profile`, `_record_reply_interaction` VIP promotion (#1290) | Closed correction→memory→behavior loop; standing-rule synthesis |
+| Scheduling | `DaemonClock`, email `briefing`/`scheduler` seams | New-email heartbeat job feeding the loop |
+| Observation | Spec §6.7 (unimplemented, #2005) | The email observe→decide→act|propose cycle |
+
+## 4. The trust engine (Phase 1)
+
+`gaia_agent_email/trust.py`:
+
+- **`TrustLedger`** — pure functions over the agent's SQLite handle (mirrors `action_store`).
+  Table `email_trust_ledger` keyed `(action_type, scope)` where scope is `category:<NAME>`
+  or `sender:<addr>`. Records `positive`/`negative` outcomes; exposes `get_stats` and
+  `is_trusted(min_samples, threshold)`.
+- **`TrustPolicy`** — given `(tool, action_type, category, sender)` returns a
+  `TrustDecision(action, reason, confidence)` where action ∈ `auto | draft | suggest |
+  confirm`:
+  1. tool in confirm-floor → **confirm** (hard).
+  2. level `off` → loop disabled (no decisions).
+  3. level `suggest` → **suggest** everything reversible.
+  4. level `earn_trust` → reply-composition → **draft**; reversible action in a trusted or
+     explicitly-preferred scope → **auto**; otherwise → **suggest**.
+  5. level `full` → reversible → **auto**; drafts still never auto-send.
+
+Config (`EmailAgentConfig`): `autonomy_level` (default `off`), `autonomy_trust_min_samples`
+(default 5), `autonomy_trust_threshold` (default 0.85).
+
+## 5. The autonomous loop (Phase 2)
+
+`EmailTriageAgent.on_heartbeat`: observe new-mail delta (cheap, zero-token when quiet) →
+triage (reuse `pre_scan`/`triage`) → per message `TrustPolicy.decide` → auto-execute or emit
+`Proposal`/draft → report to the activity feed. Driven by a `DaemonClock` job (briefing
+seam), gated by quiet hours, a kill switch, and the `agent_loop` rate limits.
+
+## 6. The learning loop (Phase 3)
+
+- **Correction capture** at the action seams: draft edited pre-send, suggested label
+  rejected, auto-archive undone, proposal accepted/rejected → a `learning_event` → ledger
+  (negative) + MemoryStore.
+- **Implicit behavior miner**: periodic scan of what *you* archived/read/replied to outside
+  the agent → inferred preferences.
+- **Standing-rule synthesis**: a pattern crossing threshold auto-proposes a rule ("Always
+  archive news@x? — 12/12 matched") that updates `preference_tools` + the ledger.
+- **Voice**: extend `voice_profile` to per-recipient tone.
+- **Explicit feedback**: thumbs on activity-feed actions → strongest ledger weight.
+- **Magical extras**: VIP inference from your reply latency (extends #1290), auto-detected
+  quiet-hours/brief-time from cadence, confidence-scored rationales, aging nudges.
+
+## 7. Surface & control (Phase 4)
+
+`gaia email autonomy {status|pause|resume|trust|kill}` — `trust` renders the earned-trust
+ledger so autonomy is never a black box. Activity-feed entries + notifications with
+Accept/Reject/Edit/thumbs; REST/MCP autonomy-state surface.
+
+## 8. Safety & eval (Phase 5)
+
+Proactive eval harness (#1508): first-run + heartbeat simulation, trust-progression
+scenarios, and the hard invariant **"never auto-sends, never auto-deletes."** Fail-loudly
+sweep on new paths; README/SPEC/SKILL/CHANGELOG kept in sync; `autonomous-agent-mode.md`
+§6.7 updated and #2005 reconciled.

--- a/docs/plans/email-full-autonomy.mdx
+++ b/docs/plans/email-full-autonomy.mdx
@@ -6,11 +6,13 @@ icon: "wand-magic-sparkles"
 
 # Email Agent — Full Autonomy (Earn-Trust + Learning Loop)
 
-> **Status:** Phases 1–4 (backend) + the proactive eval harness shipped — trust
-> engine, autonomous cycle, closed learning loop, REST control surface, and
-> automatic correction capture, all tested. Remaining: the production driver (a
-> `DaemonClock` job hitting `POST /v1/email/agent/autonomy/run`) and the npm
-> thin-client CLI (`gaia email autonomy …`) that wraps the REST surface.
+> **Status:** Phases 1–5 shipped — trust engine, autonomous cycle, closed
+> learning loop, REST control surface, automatic correction capture, the
+> proactive eval harness, AND the scheduled driver (`AutonomyScheduler` +
+> `run_autonomy_job`, opt-in via `GAIA_EMAIL_AUTONOMY_ENABLED`), all tested.
+> Remaining follow-ups: registering `run_autonomy_job` on the core `DaemonClock`
+> for the daemon-supervised path (cross-process, tracked with #2156), and the npm
+> thin-client CLI (`gaia email autonomy …`) wrapping the REST surface.
 >
 > **Milestone:** [Autonomy + Messaging Expansion [OSS]](https://github.com/amd/gaia/milestone/6)
 >

--- a/docs/spec/autonomous-agent-mode.md
+++ b/docs/spec/autonomous-agent-mode.md
@@ -5,11 +5,15 @@
 **Date:** 2026-04-01
 
 > **Implementation status (2026-07):** `manual` and `goal_driven` are shipped
-> and `goal_driven` is the default. `autonomous` mode is **not implemented** —
-> its defining observation cycle (§6.7) has not shipped, so the settings API
-> rejects `agent_mode="autonomous"` rather than silently running it as
-> `goal_driven`. Tracked in
-> [#2005](https://github.com/amd/gaia/issues/2005).
+> and `goal_driven` is the default. The generic `autonomous` mode in the core UI
+> loop is still gated (§6.7 observation cycle, [#2005](https://github.com/amd/gaia/issues/2005)),
+> so the settings API rejects `agent_mode="autonomous"` there. **The Email
+> Triage agent is the first concrete implementation of the observe→decide→act
+> cycle**, on an earn-trust gradient with an inviolable confirm-floor and a
+> closed correction→learning loop — see
+> [`docs/plans/email-full-autonomy.mdx`](/plans/email-full-autonomy)
+> (`autonomy_level = earn_trust`). Generalizing that engine back into the base
+> `Agent` loop for every agent remains #2005.
 
 ---
 

--- a/hub/agents/email/npm/SKILL.md
+++ b/hub/agents/email/npm/SKILL.md
@@ -251,6 +251,37 @@ and the runtime memory toggle `POST /memory` + `GET /memory/{id}` (enabling memo
 was never initialized returns **409**, never a silent no-op). One turn at a time per
 session — an overlapping `/query` returns **409**. See `SPEC.md` for the full table.
 
+### Full autonomy (`/v1/email/agent/autonomy/*`)
+
+The agent can run **proactively** on an earn-trust gradient: it archives low-signal mail
+on its own once a sender/category has *proven itself*, drafts replies for review, and
+**always asks before anything destructive** (send / forward / permanent-delete / RSVP).
+Turn it on and inspect the earned trust:
+
+```js
+// Turn on full autonomy (levels: off | suggest | earn_trust | full; "off" = kill switch)
+await fetch(`${base}/v1/email/agent/autonomy`, {
+  method: "POST", headers: { "content-type": "application/json" },
+  body: JSON.stringify({ session_id: "s1", level: "earn_trust" }),
+});
+
+// Run one observe→decide→act cycle now (the daemon/scheduler drives this in production)
+const r = await fetch(`${base}/v1/email/agent/autonomy/run`, {
+  method: "POST", headers: { "content-type": "application/json" },
+  body: JSON.stringify({ session_id: "s1", max_messages: 25 }),
+});
+const report = await r.json();   // { level, executed:[…], proposals:[…], skipped }
+
+// Inspect the earned-trust ledger — autonomy is never a black box
+const status = await (await fetch(`${base}/v1/email/agent/autonomy/s1`)).json();
+// { level, enabled, trust_min_samples, trust_threshold, trusted_scope_count, scopes:[…] }
+```
+
+The agent **learns from you**: undoing an auto-archive (`undo_archive_batch`) is captured
+as a correction that pulls trust back below the bar; accepted suggestions lift it over.
+Every auto-action is reversible with undo. A bad `level` returns **400**; an unknown
+session returns **404**.
+
 ## Running in a server / long-lived app
 
 - **`fetchBinary` is a build step**, not per request (network + SHA verify). Run it

--- a/hub/agents/email/npm/SPEC.md
+++ b/hub/agents/email/npm/SPEC.md
@@ -219,10 +219,21 @@ emits the canonical seven-event vocabulary.
 | `GET /v1/email/agent/session/{id}/history` | Conversation so far (`turns[]`, oldest first). |
 | `POST /v1/email/agent/memory` | Runtime memory toggle (#1666), `{ session_id, enabled }` → `{ enabled, available, message }`. Enabling memory that was never initialized (started with `GAIA_MEMORY_DISABLED` / Lemonade unreachable) → **409**, never a silent no-op. |
 | `GET /v1/email/agent/memory/{id}` | Memory status without changing it. |
+| `GET /v1/email/agent/autonomy/{id}` | Inspectable autonomy status: `{ level, enabled, trust_min_samples, trust_threshold, trusted_scope_count, scopes[] }` — the earned-trust ledger, never a black box. |
+| `POST /v1/email/agent/autonomy` | Set the autonomy level, `{ session_id, level }` where level ∈ `off` \| `suggest` \| `earn_trust` \| `full` (`off` = kill switch). Bad level → **400**. |
+| `POST /v1/email/agent/autonomy/run` | Trigger one observe→decide→act cycle, `{ session_id, max_messages? }` → `{ level, executed[], proposals[], skipped }`. The daemon clock / scheduler drives this in production. |
 
 Sessions are in-process and single-tenant (the sidecar hosts one user's agent); one turn
 runs at a time per session. Memory uses FAISS locally; embeddings still go over Lemonade
 HTTP, so the frozen binary stays free of torch/transformers.
+
+**Full autonomy (earn-trust).** At `earn_trust` the agent auto-executes only *reversible*
+actions (archive/label/mark-read) and only once a sender/category has crossed the trust
+bar (`autonomy_trust_min_samples` decisions at ≥ `autonomy_trust_threshold` accuracy);
+everything else is proposed. The destructive floor — send, forward, permanent-delete,
+RSVP, quarantine — **always requires confirmation, at every level**. Undoing an
+auto-action feeds the trust ledger as a correction, so the agent adapts to you. See
+`docs/plans/email-full-autonomy.mdx`.
 
 ### Mailbox actions (archive / quarantine, schema 2.1)
 

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -45,8 +45,14 @@ contract version is tracked separately as
     `GET /v1/email/agent/autonomy/{session_id}` expose the level, thresholds,
     and every earned-trust scope with its tally. `POST /v1/email/agent/autonomy`
     sets the level (pause / resume / `off` kill switch); `POST …/autonomy/run`
-    triggers one cycle (the daemon/CLI driver seam). Config knobs:
-    `autonomy_level`, `autonomy_trust_min_samples`, `autonomy_trust_threshold`.
+    triggers one cycle. Config knobs: `autonomy_level`,
+    `autonomy_trust_min_samples`, `autonomy_trust_threshold`.
+  - **Runs on a schedule.** `AutonomyScheduler` + `run_autonomy_job`
+    (`autonomy_scheduler.py`) drive the cycle on an interval — off by default,
+    opt in with `GAIA_EMAIL_AUTONOMY_ENABLED=true` (`…_LEVEL`, `…_INTERVAL_MINUTES`,
+    `…_MAX_MESSAGES`). Mirrors the briefing scheduler and is gated off under
+    daemon supervision, where the daemon's single clock drives `run_autonomy_job`
+    instead — no second scheduler.
 - `gaia_agent_email.supervision.is_daemon_supervised()` — detects the daemon
   supervision handshake (the env-var name is owned by core in
   `gaia.daemon.constants`, so daemon and sidecar can never drift).

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -25,6 +25,28 @@ contract version is tracked separately as
 
 ### Added
 
+- **Full autonomy — earn-trust engine + observe→decide→act loop (#1115, #557,
+  #1483, #1287, #2005).** Set `autonomy_level` to `earn_trust` and the agent
+  handles low-signal mail on its own: each heartbeat (`on_heartbeat` /
+  `run_autonomy_cycle`) triages the inbox and either archives a message silently
+  — once its sender/category has *proven* itself in the trust ledger — or files
+  a proposal for approval. Cautious on day one, near-invisible once trusted.
+  - **The destructive floor always asks.** Send, forward, permanent-delete,
+    RSVP, and quarantine require confirmation at *every* level, even for a
+    fully-trusted sender — a parity test locks the policy floor to the agent's
+    real `CONFIRMATION_REQUIRED_TOOLS`. Only reversible actions auto-execute,
+    each with undo via `action_store`.
+  - **It learns from you.** `record_autonomy_outcome` is the single funnel every
+    trust signal flows through; undoing an auto-archive (through the real
+    `undo_archive_batch` tool) is captured automatically as a correction and
+    pulls trust back below the bar, while accepted suggestions lift it over.
+    Both the sender and the category scope learn from one choice.
+  - **Inspectable, never a black box.** `autonomy_status()` and
+    `GET /v1/email/agent/autonomy/{session_id}` expose the level, thresholds,
+    and every earned-trust scope with its tally. `POST /v1/email/agent/autonomy`
+    sets the level (pause / resume / `off` kill switch); `POST …/autonomy/run`
+    triggers one cycle (the daemon/CLI driver seam). Config knobs:
+    `autonomy_level`, `autonomy_trust_min_samples`, `autonomy_trust_threshold`.
 - `gaia_agent_email.supervision.is_daemon_supervised()` — detects the daemon
   supervision handshake (the env-var name is owned by core in
   `gaia.daemon.constants`, so daemon and sidecar can never drift).

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1354,6 +1354,45 @@ class EmailTriageAgent(
         trust.mark_autonomy_action_resolved(self, action_id=action_id)
         return True
 
+    def autonomy_status(self) -> Dict[str, Any]:
+        """Inspectable snapshot of the autonomy engine (never a black box).
+
+        Returns the current level, the trust thresholds, and the earned-trust
+        ledger — every ``(action, scope)`` with its positive/negative tally and
+        whether it has crossed the bar. This is the single read-model the
+        ``gaia email autonomy status`` / ``trust`` CLI, the REST surface, and
+        the Agent-UI panel all render, so autonomy behavior is always
+        explainable ("archives news@x because 12/12 correct").
+        """
+        ledger = trust.TrustLedger(
+            min_samples=self.config.autonomy_trust_min_samples,
+            threshold=self.config.autonomy_trust_threshold,
+        )
+        scopes = []
+        for row in trust.TrustLedger.list_ledger(self):
+            total = int(row["positive"]) + int(row["negative"])
+            scopes.append(
+                {
+                    "action_type": row["action_type"],
+                    "scope": row["scope"],
+                    "positive": row["positive"],
+                    "negative": row["negative"],
+                    "total": total,
+                    "score": (row["positive"] / total) if total else 0.0,
+                    "trusted": ledger.is_trusted(
+                        self, action_type=row["action_type"], scope=row["scope"]
+                    ),
+                }
+            )
+        return {
+            "level": self.config.autonomy_level,
+            "enabled": self.config.autonomy_level != trust.LEVEL_OFF,
+            "trust_min_samples": self.config.autonomy_trust_min_samples,
+            "trust_threshold": self.config.autonomy_trust_threshold,
+            "trusted_scope_count": sum(1 for s in scopes if s["trusted"]),
+            "scopes": scopes,
+        }
+
     def run_autonomy_cycle(
         self, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1283,14 +1283,20 @@ class EmailTriageAgent(
                 "The policy admitted an action the executor does not implement — "
                 "add an executor branch before widening the candidate map."
             )
+        import uuid as _uuid
+
         message_id = row.get("id")
         provider = row.get("mailbox") or self._provider_for_message(message_id, None)
         backend = self._backends[provider]
+        # Mint a batch_id so the auto-archive is undoable via undo_archive_batch
+        # (the same handle the REST/UI undo surface uses) — and undoing it feeds
+        # the learning loop as a correction.
         return archive_message_impl(
             backend,
             self,
             message_id=message_id,
             mailbox=provider,
+            batch_id=_uuid.uuid4().hex,
             debug=bool(getattr(self.config, "debug", False)),
         )
 
@@ -1353,6 +1359,21 @@ class EmailTriageAgent(
         )
         trust.mark_autonomy_action_resolved(self, action_id=action_id)
         return True
+
+    def set_autonomy_level(self, level: str) -> Dict[str, Any]:
+        """Change the autonomy level at runtime (pause / resume / kill switch).
+
+        ``off`` is the kill switch — the next heartbeat is a no-op. Returns the
+        applied status. Raises ``ValueError`` (translated to HTTP 400 at the
+        boundary) on an unknown level rather than silently ignoring it.
+        """
+        if level not in trust.AUTONOMY_LEVELS:
+            raise ValueError(
+                f"autonomy level must be one of {list(trust.AUTONOMY_LEVELS)}, "
+                f"got {level!r}"
+            )
+        self.config.autonomy_level = level
+        return {"level": level, "enabled": level != trust.LEVEL_OFF}
 
     def autonomy_status(self) -> Dict[str, Any]:
         """Inspectable snapshot of the autonomy engine (never a black box).

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1230,6 +1230,17 @@ class EmailTriageAgent(
             )
             if decision.action == "auto":
                 executed = self._autonomy_execute(action_type, row)
+                # Index the action so a later undo is attributed to this scope
+                # and lands a negative signal on the right ledger rows.
+                action_id = executed.get("action_id")
+                if action_id:
+                    trust.record_autonomy_action(
+                        self,
+                        action_id=action_id,
+                        action_type=action_type,
+                        sender=sender,
+                        category=row.get("category", ""),
+                    )
                 report["executed"].append(
                     {
                         "message_id": row.get("id"),
@@ -1294,6 +1305,54 @@ class EmailTriageAgent(
         returned proposals via :meth:`propose`.
         """
         return self._run_email_autonomy_cycle(context).get("proposals", [])
+
+    def record_autonomy_outcome(
+        self,
+        *,
+        action_type: str,
+        positive: bool,
+        sender: str = "",
+        category: str = "",
+    ) -> None:
+        """The single write-path for every trust signal (the learning loop).
+
+        Undo of an auto-action, a proposal accepted/rejected, a thumbs up/down
+        in the activity feed — they all funnel here. The outcome is recorded
+        against BOTH the sender and the category scope, so trust accrues at
+        whichever granularity recurs (a specific newsletter address AND the
+        promotional category both learn from the same choice). This is how the
+        agent "learns from your patterns": enough positives lift a scope over
+        the trust bar and the next cycle acts silently; a correction pulls it
+        back below and the agent returns to asking.
+        """
+        for scope in (
+            trust.sender_scope(sender) if sender else "",
+            trust.category_scope(category) if category else "",
+        ):
+            if scope:
+                trust.TrustLedger.record_outcome(
+                    self, action_type=action_type, scope=scope, positive=positive
+                )
+
+    def note_action_undone(self, action_id: str) -> bool:
+        """Capture a correction: an auto-executed action the user undid.
+
+        Called by the undo surface. If ``action_id`` was an autonomy action, a
+        negative outcome is recorded for its scope and the index row is marked
+        resolved (so one undo is never counted twice). Returns True when a
+        correction was captured, False when the id was not an autonomy action.
+        """
+        row = trust.lookup_autonomy_action(self, action_id=action_id)
+        if row is None:
+            return False
+        self.record_autonomy_outcome(
+            action_type=row["action_type"],
+            positive=False,
+            sender=row.get("sender") or "",
+            category=row.get("category") or "",
+        )
+        trust.mark_autonomy_action_resolved(self, action_id=action_id)
+        return True
 
     def run_autonomy_cycle(
         self, context: Optional[Dict[str, Any]] = None

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -35,9 +35,9 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
 
-from gaia_agent_email import action_store, schedule_store, task_store
+from gaia_agent_email import action_store, schedule_store, task_store, trust
 from gaia_agent_email.config import ConfigurationError, EmailAgentConfig
 from gaia_agent_email.model_select import (
     NPU_EMAIL_MODEL_ID,
@@ -73,6 +73,9 @@ from gaia_agent_email.tools.schedule_tools import ScheduleToolsMixin
 from gaia_agent_email.tools.summarize_tools import SummarizeToolsMixin
 from gaia_agent_email.tools.voice_tools import VoiceToolsMixin
 from gaia_agent_email.voice_profile import render_style_guidance
+
+if TYPE_CHECKING:  # import-cheap: only for annotations, never at runtime
+    from gaia.agents.base.goal_store import Proposal
 
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.console import AgentConsole
@@ -486,6 +489,7 @@ class EmailTriageAgent(
         action_store.init_schema(self)
         schedule_store.init_schema(self)
         task_store.init_schema(self)
+        trust.init_trust_schema(self)
 
         # LLM connection. Default to Lemonade — the config's base_url
         # allowlist guarantees the host is local. Resolved BEFORE init_memory()
@@ -1137,6 +1141,177 @@ class EmailTriageAgent(
             debug=bool(getattr(self.config, "debug", False)),
             remember_mailbox=self._remember_message_mailbox,
         )
+
+    # -- Full autonomy: observe -> decide -> act (#1115 / #557) -------------
+
+    def _autonomy_policy(self) -> "trust.TrustPolicy":
+        """Build the earn-trust policy from current config + the confirm-floor.
+
+        Rebuilt per cycle so a runtime ``autonomy_level`` change (e.g. via the
+        ``gaia email autonomy`` CLI) takes effect on the next heartbeat without
+        reconstructing the agent.
+        """
+        ledger = trust.TrustLedger(
+            min_samples=self.config.autonomy_trust_min_samples,
+            threshold=self.config.autonomy_trust_threshold,
+        )
+        return trust.TrustPolicy(
+            level=self.config.autonomy_level,
+            ledger=ledger,
+            confirm_floor=self.confirmation_required_tools(),
+        )
+
+    @staticmethod
+    def _autonomy_candidate(row: Dict[str, Any]) -> Optional[tuple]:
+        """Map a triage result to a candidate ``(tool, action_type)`` or None.
+
+        Phase 2 only proposes/auto-executes the clearest reversible action —
+        archiving low-signal mail (promotional / FYI / spam). Phishing is left
+        to the ``quarantine_phishing_message`` floor tool; urgent / needs-response
+        / personal mail is never auto-touched. Reply drafting lands in Phase 3.
+        """
+        from gaia_agent_email.tools.triage_heuristics import (
+            CATEGORY_FYI,
+            CATEGORY_PROMOTIONAL,
+        )
+
+        if row.get("is_phishing"):
+            return None
+        category = (row.get("category") or "").strip().upper()
+        if row.get("is_spam") or category in (CATEGORY_FYI, CATEGORY_PROMOTIONAL):
+            return ("archive_message", "archive")
+        return None
+
+    def _run_email_autonomy_cycle(
+        self, context: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """One observe -> decide -> act pass. Pure of GoalStore side effects.
+
+        Observes the inbox (reusing ``_triage_all_backends``), asks
+        :class:`~gaia_agent_email.trust.TrustPolicy` what to do with each
+        candidate, auto-executes the reversible actions it is trusted to run,
+        and collects the rest as proposals. Returns a structured report; the
+        ``proposals`` list holds ``Proposal`` objects the caller persists via
+        :meth:`propose`. Kept side-effect-pure of GoalStore so it is unit-testable
+        without touching ``~/.gaia/goals.db``.
+        """
+        from gaia_agent_email.tools.read_tools import extract_sender_email
+
+        from gaia.agents.base.goal_store import Proposal
+
+        context = context or {}
+        report: Dict[str, Any] = {
+            "level": self.config.autonomy_level,
+            "executed": [],
+            "proposals": [],
+            "skipped": 0,
+        }
+        policy = self._autonomy_policy()
+        if not policy.enabled:
+            return report
+
+        max_messages = int(context.get("max_messages", 25))
+        triage = self._triage_all_backends(max_messages=max_messages)
+
+        for row in triage.get("results", []):
+            candidate = self._autonomy_candidate(row)
+            if candidate is None:
+                report["skipped"] += 1
+                continue
+            tool_name, action_type = candidate
+            sender = extract_sender_email(row.get("from", ""))
+            decision = policy.decide(
+                tool=tool_name,
+                action_type=action_type,
+                category=row.get("category", ""),
+                sender=sender,
+                db=self,
+                preferences=self._session_preferences,
+            )
+            if decision.action == "auto":
+                executed = self._autonomy_execute(action_type, row)
+                report["executed"].append(
+                    {
+                        "message_id": row.get("id"),
+                        "action": action_type,
+                        "sender": sender,
+                        "reason": decision.reason,
+                        "confidence": decision.confidence,
+                        **executed,
+                    }
+                )
+            elif decision.action in ("suggest", "draft"):
+                report["proposals"].append(
+                    Proposal(
+                        action=f"{action_type} email {row.get('id')} from {sender}",
+                        rationale=decision.reason,
+                        action_class="other",
+                        risk="low",
+                    )
+                )
+            else:
+                # confirm — the floor. Never reached for archive candidates, but
+                # counted rather than silently dropped if the taxonomy grows.
+                report["skipped"] += 1
+
+        return report
+
+    def _autonomy_execute(
+        self, action_type: str, row: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Execute one trusted reversible action. Records undo via action_store.
+
+        Only reversible actions reach here (the policy guarantees it). Returns
+        the impl's result (carrying the ``action_id`` undo handle).
+        """
+        from gaia_agent_email.tools.organize_tools import archive_message_impl
+
+        if action_type != "archive":
+            raise ValueError(
+                f"_autonomy_execute: no executor for action_type {action_type!r}. "
+                "The policy admitted an action the executor does not implement — "
+                "add an executor branch before widening the candidate map."
+            )
+        message_id = row.get("id")
+        provider = row.get("mailbox") or self._provider_for_message(message_id, None)
+        backend = self._backends[provider]
+        return archive_message_impl(
+            backend,
+            self,
+            message_id=message_id,
+            mailbox=provider,
+            debug=bool(getattr(self.config, "debug", False)),
+        )
+
+    def on_heartbeat(
+        self, context: Optional[Dict[str, Any]] = None
+    ) -> List["Proposal"]:
+        """Steady-state autonomous pass (base ``Agent`` hook, spec §6.7).
+
+        Runs one observe -> decide -> act cycle and returns the proposals that
+        need user approval. Auto-executed actions happen as a side effect and
+        are recorded (with undo) in ``action_store``; the driver persists the
+        returned proposals via :meth:`propose`.
+        """
+        return self._run_email_autonomy_cycle(context).get("proposals", [])
+
+    def run_autonomy_cycle(
+        self, context: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Driver-facing entry: run a cycle and persist proposals to GoalStore.
+
+        This is the seam a ``DaemonClock`` job / the ``gaia email autonomy`` CLI
+        invokes (mirroring ``run_briefing_job`` for the briefing feature).
+        Returns a JSON-serializable report — the ``Proposal`` objects are
+        replaced by their persisted dict form.
+        """
+        report = self._run_email_autonomy_cycle(context)
+        persisted = []
+        for proposal in report["proposals"]:
+            self.propose(proposal)
+            persisted.append(proposal.to_dict())
+        report["proposals"] = persisted
+        return report
 
     # -- Phase I3 batch-organize counter -----------------------------------
 

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -486,6 +486,13 @@ class EmailTriageAgent(
         db_path = config.resolved_db_path()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self.init_db(db_path)
+        # A scheduler-built autonomy agent and a live session agent can hold
+        # separate connections to this same state.db (#1115). Wait on a busy
+        # writer instead of failing the whole cycle with "database is locked";
+        # WAL lets a reader proceed during a write. Scoped to the email agent's
+        # connection — not a core-mixin change.
+        self._db.execute("PRAGMA busy_timeout = 5000")
+        self._db.execute("PRAGMA journal_mode = WAL")
         action_store.init_schema(self)
         schedule_store.init_schema(self)
         task_store.init_schema(self)
@@ -1148,7 +1155,8 @@ class EmailTriageAgent(
         """Build the earn-trust policy from current config + the confirm-floor.
 
         Rebuilt per cycle so a runtime ``autonomy_level`` change (e.g. via the
-        ``gaia email autonomy`` CLI) takes effect on the next heartbeat without
+        the forthcoming ``gaia email autonomy`` CLI) takes effect on the next
+        heartbeat without
         reconstructing the agent.
         """
         ledger = trust.TrustLedger(
@@ -1205,6 +1213,7 @@ class EmailTriageAgent(
             "executed": [],
             "proposals": [],
             "skipped": 0,
+            "already_proposed": 0,
         }
         policy = self._autonomy_policy()
         if not policy.enabled:
@@ -1228,6 +1237,7 @@ class EmailTriageAgent(
                 db=self,
                 preferences=self._session_preferences,
             )
+            message_id = row.get("id")
             if decision.action == "auto":
                 executed = self._autonomy_execute(action_type, row)
                 # Index the action so a later undo is attributed to this scope
@@ -1241,9 +1251,15 @@ class EmailTriageAgent(
                         sender=sender,
                         category=row.get("category", ""),
                     )
+                # A message we once proposed and now act on is resolved — clear
+                # its re-proposal guard so the row can't linger open.
+                if message_id:
+                    trust.resolve_proposal(
+                        self, message_id=message_id, action_type=action_type
+                    )
                 report["executed"].append(
                     {
-                        "message_id": row.get("id"),
+                        "message_id": message_id,
                         "action": action_type,
                         "sender": sender,
                         "reason": decision.reason,
@@ -1252,14 +1268,26 @@ class EmailTriageAgent(
                     }
                 )
             elif decision.action in ("suggest", "draft"):
+                # Re-proposal guard: a message already proposed and not yet acted
+                # on must not spawn a duplicate goal every cycle. Without this,
+                # a headless timer piles up one pending goal per message per fire.
+                if message_id and trust.has_open_proposal(
+                    self, message_id=message_id, action_type=action_type
+                ):
+                    report["already_proposed"] += 1
+                    continue
                 report["proposals"].append(
                     Proposal(
-                        action=f"{action_type} email {row.get('id')} from {sender}",
+                        action=f"{action_type} email {message_id} from {sender}",
                         rationale=decision.reason,
                         action_class="other",
                         risk="low",
                     )
                 )
+                if message_id:
+                    trust.record_proposal(
+                        self, message_id=message_id, action_type=action_type
+                    )
             else:
                 # confirm — the floor. Never reached for archive candidates, but
                 # counted rather than silently dropped if the taxonomy grows.
@@ -1309,6 +1337,11 @@ class EmailTriageAgent(
         need user approval. Auto-executed actions happen as a side effect and
         are recorded (with undo) in ``action_store``; the driver persists the
         returned proposals via :meth:`propose`.
+
+        Cost note: this triages the inbox (mailbox I/O + local inference on any
+        heuristic-uncertain message), so a full cycle can take many seconds. The
+        REST/scheduler drivers offload it to a worker thread; a direct caller
+        should not invoke it on a latency-sensitive path.
         """
         return self._run_email_autonomy_cycle(context).get("proposals", [])
 
@@ -1381,7 +1414,7 @@ class EmailTriageAgent(
         Returns the current level, the trust thresholds, and the earned-trust
         ledger — every ``(action, scope)`` with its positive/negative tally and
         whether it has crossed the bar. This is the single read-model the
-        ``gaia email autonomy status`` / ``trust`` CLI, the REST surface, and
+        planned ``gaia email autonomy status`` / ``trust`` CLI, the REST surface, and
         the Agent-UI panel all render, so autonomy behavior is always
         explainable ("archives news@x because 12/12 correct").
         """
@@ -1419,7 +1452,7 @@ class EmailTriageAgent(
     ) -> Dict[str, Any]:
         """Driver-facing entry: run a cycle and persist proposals to GoalStore.
 
-        This is the seam a ``DaemonClock`` job / the ``gaia email autonomy`` CLI
+        This is the seam a ``DaemonClock`` job / the planned ``gaia email autonomy`` CLI
         invokes (mirroring ``run_briefing_job`` for the briefing feature).
         Returns a JSON-serializable report — the ``Proposal`` objects are
         replaced by their persisted dict form.

--- a/hub/agents/email/python/gaia_agent_email/agent_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/agent_routes.py
@@ -232,6 +232,21 @@ class HistoryResponse(_Strict):
     turns: List[HistoryTurn]
 
 
+class AutonomyLevelRequest(_Strict):
+    session_id: str = Field(..., description="Session to change autonomy for.")
+    level: str = Field(
+        ...,
+        description="off | suggest | earn_trust | full. 'off' is the kill switch.",
+    )
+
+
+class AutonomyRunRequest(_Strict):
+    session_id: str = Field(..., description="Session to run one autonomy cycle for.")
+    max_messages: int = Field(
+        25, ge=1, le=200, description="Inbox budget for this cycle."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -343,6 +358,58 @@ async def memory_status(session_id: str) -> MemoryStatusResponse:
     if session is None:
         raise HTTPException(status_code=404, detail="No such session.")
     return _memory_status(session.agent)
+
+
+@router.get("/autonomy/{session_id}")
+async def autonomy_status(session_id: str) -> Dict[str, Any]:
+    """Inspectable snapshot: level, thresholds, and the earned-trust ledger.
+
+    This is the read-model the ``gaia email autonomy status/trust`` CLI and the
+    Agent-UI panel render — autonomy is always explainable, never a black box.
+    """
+    session = registry.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="No such session.")
+    status_fn = getattr(session.agent, "autonomy_status", None)
+    if not callable(status_fn):
+        raise HTTPException(
+            status_code=501, detail="This agent build does not expose autonomy."
+        )
+    return status_fn()
+
+
+@router.post("/autonomy")
+async def set_autonomy(request: AutonomyLevelRequest) -> Dict[str, Any]:
+    """Set the autonomy level at runtime — pause/resume/kill (``off``)."""
+    session = registry.get(request.session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="No such session.")
+    setter = getattr(session.agent, "set_autonomy_level", None)
+    if not callable(setter):
+        raise HTTPException(
+            status_code=501, detail="This agent build does not expose autonomy."
+        )
+    try:
+        return setter(request.level)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/autonomy/run")
+async def run_autonomy(request: AutonomyRunRequest) -> Dict[str, Any]:
+    """Trigger one observe->decide->act cycle now (the daemon/CLI driver seam).
+
+    Runs on a worker thread — the cycle does mailbox I/O and local inference.
+    """
+    session = registry.get(request.session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="No such session.")
+    runner = getattr(session.agent, "run_autonomy_cycle", None)
+    if not callable(runner):
+        raise HTTPException(
+            status_code=501, detail="This agent build does not expose autonomy."
+        )
+    return await asyncio.to_thread(runner, {"max_messages": request.max_messages})
 
 
 @router.post("/confirm-tool")

--- a/hub/agents/email/python/gaia_agent_email/autonomy_scheduler.py
+++ b/hub/agents/email/python/gaia_agent_email/autonomy_scheduler.py
@@ -1,0 +1,293 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Scheduled driver for the full-autonomy cycle (#1115 / #557).
+
+The email agent's ``run_autonomy_cycle`` is the observe→decide→act pass; this
+module is what *drives* it on a cadence so the user never has to trigger it by
+hand — the "handle all my email" half of full autonomy.
+
+Three layers, mirroring ``briefing.py`` so the two schedulers behave alike:
+
+- :class:`AutonomyScheduleConfig` — explicit, **off by default**. Sourced from
+  environment variables on the sidecar process; an invalid value raises at
+  startup rather than silently coercing to a guess.
+- :func:`run_autonomy_job` — one cycle: build (or accept an injected) agent at
+  the configured level, run ``run_autonomy_cycle``, return the report. **This is
+  the dispatcher seam** the daemon clock (#2156) and any cron driver call —
+  exactly as ``run_briefing_job`` is for the briefing.
+- :class:`AutonomyScheduler` — a minimal asyncio interval timer that drives
+  :func:`run_autonomy_job` inside a standalone sidecar today.
+
+Daemon supervision (V2-15, #2156): when the GAIA daemon spawns this sidecar it
+drives autonomy from its single reconciled clock, so ``server.py`` does NOT
+start this in-process timer (see
+:func:`gaia_agent_email.supervision.is_daemon_supervised`). Standalone /
+bare-integrator runs keep the timer live — the same seam the briefing uses.
+
+An agent is built per run and torn down; all trust state lives on-disk in the
+agent's ``state.db`` ledger, so learning accumulates across runs exactly as a
+long-lived agent would — the same statelessness ``run_briefing_job`` relies on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from gaia.logger import get_logger
+
+from gaia_agent_email.trust import AUTONOMY_LEVELS, LEVEL_EARN_TRUST, LEVEL_OFF
+
+logger = get_logger(__name__)
+
+DEFAULT_AUTONOMY_INTERVAL_MINUTES = 15
+DEFAULT_AUTONOMY_MAX_MESSAGES = 25
+
+_TRUE_VALUES = frozenset({"1", "true", "yes"})
+_FALSE_VALUES = frozenset({"0", "false", "no", ""})
+
+ENV_ENABLED = "GAIA_EMAIL_AUTONOMY_ENABLED"
+ENV_LEVEL = "GAIA_EMAIL_AUTONOMY_LEVEL"
+ENV_INTERVAL = "GAIA_EMAIL_AUTONOMY_INTERVAL_MINUTES"
+ENV_MAX_MESSAGES = "GAIA_EMAIL_AUTONOMY_MAX_MESSAGES"
+
+
+class AutonomyConfigError(ValueError):
+    """Raised when the autonomy schedule configuration is invalid.
+
+    Startup-time error — the sidecar refuses to start rather than run
+    autonomy on a guessed cadence or level.
+    """
+
+
+@dataclass(frozen=True)
+class AutonomyScheduleConfig:
+    """Explicit schedule configuration for the autonomy cycle.
+
+    ``enabled`` defaults to **False** — autonomy never runs on a timer unless
+    the user (or the host launching the sidecar) opts in explicitly, matching
+    the safe-by-default posture of the whole feature.
+    """
+
+    enabled: bool = False
+    level: str = LEVEL_EARN_TRUST
+    interval_minutes: int = DEFAULT_AUTONOMY_INTERVAL_MINUTES
+    max_messages: int = DEFAULT_AUTONOMY_MAX_MESSAGES
+
+    def validate(self) -> None:
+        """Raise :class:`AutonomyConfigError` on any invalid field."""
+        if self.level not in AUTONOMY_LEVELS:
+            raise AutonomyConfigError(
+                f"{ENV_LEVEL}={self.level!r} must be one of {list(AUTONOMY_LEVELS)}."
+            )
+        if self.enabled and self.level == LEVEL_OFF:
+            raise AutonomyConfigError(
+                f"{ENV_ENABLED} is true but {ENV_LEVEL}=off — that would schedule "
+                "a cycle that does nothing. Pick 'suggest', 'earn_trust', or "
+                "'full', or leave autonomy disabled."
+            )
+        if self.interval_minutes < 1:
+            raise AutonomyConfigError(
+                f"{ENV_INTERVAL}={self.interval_minutes!r} must be a positive "
+                "number of minutes."
+            )
+        if not 1 <= self.max_messages <= 100:
+            raise AutonomyConfigError(
+                f"{ENV_MAX_MESSAGES}={self.max_messages!r} must be between 1 and 100."
+            )
+
+    @classmethod
+    def from_env(
+        cls, environ: Optional[Dict[str, str]] = None
+    ) -> "AutonomyScheduleConfig":
+        """Build the config from environment variables, validating eagerly.
+
+        Unset variables take the documented defaults (disabled, earn_trust,
+        15 min, 25). An unparseable value raises — never a silent fallback.
+        """
+        env = os.environ if environ is None else environ
+
+        raw_enabled = env.get(ENV_ENABLED, "").strip().lower()
+        if raw_enabled in _TRUE_VALUES:
+            enabled = True
+        elif raw_enabled in _FALSE_VALUES:
+            enabled = False
+        else:
+            raise AutonomyConfigError(
+                f"{ENV_ENABLED}={env.get(ENV_ENABLED)!r} is not a valid boolean. "
+                "Use 'true'/'1'/'yes' to enable, or unset it (off by default)."
+            )
+
+        level = env.get(ENV_LEVEL, LEVEL_EARN_TRUST).strip().lower()
+
+        raw_interval = env.get(
+            ENV_INTERVAL, str(DEFAULT_AUTONOMY_INTERVAL_MINUTES)
+        ).strip()
+        try:
+            interval_minutes = int(raw_interval)
+        except ValueError as e:
+            raise AutonomyConfigError(
+                f"{ENV_INTERVAL}={raw_interval!r} is not an integer number of "
+                "minutes."
+            ) from e
+
+        raw_max = env.get(ENV_MAX_MESSAGES, str(DEFAULT_AUTONOMY_MAX_MESSAGES)).strip()
+        try:
+            max_messages = int(raw_max)
+        except ValueError as e:
+            raise AutonomyConfigError(
+                f"{ENV_MAX_MESSAGES}={raw_max!r} is not an integer."
+            ) from e
+
+        config = cls(
+            enabled=enabled,
+            level=level,
+            interval_minutes=interval_minutes,
+            max_messages=max_messages,
+        )
+        config.validate()
+        return config
+
+
+# ---------------------------------------------------------------------------
+# The job — the dispatcher seam (mirrors run_briefing_job)
+# ---------------------------------------------------------------------------
+
+
+def _build_autonomy_agent(level: str) -> Any:
+    """Build a headless EmailTriageAgent at the given autonomy level.
+
+    All trust state is on-disk (``state.db`` ledger, ``memory.db`` preferences),
+    so a per-run agent accumulates learning across runs like a long-lived one.
+    """
+    from gaia_agent_email.agent import EmailTriageAgent
+    from gaia_agent_email.config import EmailAgentConfig
+
+    return EmailTriageAgent(config=EmailAgentConfig(autonomy_level=level))
+
+
+def run_autonomy_job(
+    agent: Any = None,
+    *,
+    level: str = LEVEL_EARN_TRUST,
+    max_messages: int = DEFAULT_AUTONOMY_MAX_MESSAGES,
+    build_agent: Callable[[str], Any] = _build_autonomy_agent,
+) -> Dict[str, Any]:
+    """Run one autonomy cycle and return its report. No user prompt involved.
+
+    This is the one-shot entry the scheduler drives and the seam the daemon
+    clock / a cron dispatcher call. ``agent`` and ``build_agent`` are injection
+    seams for tests; by default a fresh agent is built at ``level`` and torn
+    down after the run so the job holds no resources between fires.
+    """
+    owned = agent is None
+    if owned:
+        agent = build_agent(level)
+    try:
+        return agent.run_autonomy_cycle({"max_messages": max_messages})
+    finally:
+        if owned:
+            close = getattr(agent, "close_db", None)
+            if callable(close):
+                close()
+
+
+# ---------------------------------------------------------------------------
+# In-process interval timer (until the daemon clock drives it)
+# ---------------------------------------------------------------------------
+
+
+class AutonomyScheduler:
+    """Asyncio interval timer that runs :func:`run_autonomy_job` in the email
+    sidecar's event loop.
+
+    A **disabled** config produces no task — :meth:`start` returns ``False`` and
+    logs that autonomy is off. A failed run (mailbox disconnected, provider
+    outage) is logged with its actionable message and the schedule continues; it
+    is never retried silently. When the daemon supervises the sidecar it owns the
+    clock, so ``server.py`` does not start this timer.
+    """
+
+    def __init__(
+        self,
+        config: AutonomyScheduleConfig,
+        *,
+        run_job: Callable[..., Dict[str, Any]] = run_autonomy_job,
+    ) -> None:
+        config.validate()
+        self.config = config
+        self._run_job = run_job
+        self._task: Optional["asyncio.Task"] = None
+        # Seconds between fires. Held as an instance attr (not recomputed in the
+        # loop) so a test can shrink it without waiting a real interval.
+        self._delay_seconds = config.interval_minutes * 60
+
+    def start(self) -> bool:
+        """Start the interval loop. Returns ``True`` if scheduling began,
+        ``False`` when autonomy is disabled (the default)."""
+        if not self.config.enabled:
+            logger.info(
+                "Email autonomy is disabled (set %s=true on the sidecar to "
+                "enable it).",
+                ENV_ENABLED,
+            )
+            return False
+        if self._task is not None and not self._task.done():
+            raise RuntimeError("AutonomyScheduler is already running.")
+        self._task = asyncio.get_running_loop().create_task(
+            self._loop(), name="email-autonomy-scheduler"
+        )
+        logger.info(
+            "Email autonomy scheduled every %d min at level %r (up to %d "
+            "messages/cycle).",
+            self.config.interval_minutes,
+            self.config.level,
+            self.config.max_messages,
+        )
+        return True
+
+    async def stop(self) -> None:
+        """Cancel the loop (idempotent)."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+
+    async def _loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._delay_seconds)
+            try:
+                report = await asyncio.to_thread(
+                    self._run_job,
+                    level=self.config.level,
+                    max_messages=self.config.max_messages,
+                )
+                logger.info(
+                    "Autonomy cycle: %d executed, %d proposed, %d skipped.",
+                    len(report.get("executed", [])),
+                    len(report.get("proposals", [])),
+                    report.get("skipped", 0),
+                )
+            except Exception:
+                logger.exception(
+                    "Scheduled autonomy cycle failed; next attempt in %d min.",
+                    self.config.interval_minutes,
+                )
+
+
+__all__ = [
+    "AutonomyConfigError",
+    "AutonomyScheduleConfig",
+    "AutonomyScheduler",
+    "ENV_ENABLED",
+    "ENV_INTERVAL",
+    "ENV_LEVEL",
+    "ENV_MAX_MESSAGES",
+    "run_autonomy_job",
+]

--- a/hub/agents/email/python/gaia_agent_email/config.py
+++ b/hub/agents/email/python/gaia_agent_email/config.py
@@ -147,6 +147,18 @@ class EmailAgentConfig:
     scheduler_poll_seconds: float = 30.0
     start_scheduler: bool = True
     ctx_size: Optional[int] = None
+    # Full-autonomy earn-trust engine (#1483 / #1287). ``autonomy_level`` is the
+    # single switch: "off" (default — chat only, no autonomous activity),
+    # "suggest" (propose only), "earn_trust" (auto-execute reversible actions in
+    # trusted/approved scopes, draft replies, suggest the rest — this is what
+    # "full autonomy mode" maps to), or "full" (auto-execute every reversible
+    # action). The destructive/irreversible confirm-floor (send, forward,
+    # permanent delete, RSVP, quarantine) ALWAYS asks, at every level — see
+    # ``trust.TrustPolicy``. A scope becomes trusted only after
+    # ``autonomy_trust_min_samples`` decisions at/above ``autonomy_trust_threshold``.
+    autonomy_level: str = "off"
+    autonomy_trust_min_samples: int = 5
+    autonomy_trust_threshold: float = 0.85
 
     def validate(self) -> None:
         """Run startup-time invariants. Called from the agent's __init__.
@@ -186,6 +198,28 @@ class EmailAgentConfig:
                 f"count, got {self.ctx_size!r}. Pass e.g. 16384 (the #1892 "
                 "envelope target) or leave it None for Lemonade's default "
                 "floor."
+            )
+        # Import here (not at module top) to keep config import-cheap for the
+        # many callers that never touch the autonomy engine.
+        from gaia_agent_email.trust import AUTONOMY_LEVELS
+
+        if self.autonomy_level not in AUTONOMY_LEVELS:
+            raise ConfigurationError(
+                f"EmailAgentConfig.autonomy_level must be one of "
+                f"{list(AUTONOMY_LEVELS)}, got {self.autonomy_level!r}."
+            )
+        if (
+            not isinstance(self.autonomy_trust_min_samples, int)
+            or self.autonomy_trust_min_samples < 1
+        ):
+            raise ConfigurationError(
+                f"EmailAgentConfig.autonomy_trust_min_samples must be a "
+                f"positive integer, got {self.autonomy_trust_min_samples!r}."
+            )
+        if not 0.0 < self.autonomy_trust_threshold <= 1.0:
+            raise ConfigurationError(
+                f"EmailAgentConfig.autonomy_trust_threshold must be in (0, 1], "
+                f"got {self.autonomy_trust_threshold!r}."
             )
 
     def resolved_db_path(self) -> str:

--- a/hub/agents/email/python/gaia_agent_email/server.py
+++ b/hub/agents/email/python/gaia_agent_email/server.py
@@ -78,6 +78,10 @@ def build_app():
     from gaia_agent_email.agent_routes import router as agent_router
     from gaia_agent_email.api_routes import require_caller_token
     from gaia_agent_email.api_routes import router as email_router
+    from gaia_agent_email.autonomy_scheduler import (
+        AutonomyScheduleConfig,
+        AutonomyScheduler,
+    )
     from gaia_agent_email.briefing import BriefingScheduleConfig, BriefingScheduler
     from gaia_agent_email.connection_intake_routes import (
         router as connection_intake_router,
@@ -90,27 +94,34 @@ def build_app():
     # invalid value aborts startup loudly, not at the first scheduled fire.
     # Off by default: without the env opt-in no scheduler task is created.
     briefing_config = BriefingScheduleConfig.from_env()
+    # Full-autonomy cycle driver (#1115). Off by default; env config read at
+    # build time so an invalid level/interval aborts startup loudly.
+    autonomy_config = AutonomyScheduleConfig.from_env()
 
     @asynccontextmanager
     async def lifespan(_app):
         # V2-15 (#2156): under daemon supervision the daemon drives the brief
-        # from its single reconciled clock, so the embedded clock stays dark —
-        # running both over one store is a double-run. Standalone / bare
-        # integrator runs (no supervision env) keep the embedded clock live.
+        # AND the autonomy cycle from its single reconciled clock, so the
+        # embedded timers stay dark — running both over one store is a
+        # double-run. Standalone / bare integrator runs (no supervision env)
+        # keep the embedded timers live.
         if is_daemon_supervised():
             log.info(
                 "Email sidecar under daemon supervision: embedded "
-                "BriefingScheduler gated off (the daemon drives the daily "
-                "brief from its reconciled clock)."
+                "BriefingScheduler and AutonomyScheduler gated off (the daemon "
+                "drives both from its reconciled clock)."
             )
             yield
             return
-        scheduler = BriefingScheduler(briefing_config)
-        scheduler.start()
+        briefing_scheduler = BriefingScheduler(briefing_config)
+        briefing_scheduler.start()
+        autonomy_scheduler = AutonomyScheduler(autonomy_config)
+        autonomy_scheduler.start()
         try:
             yield
         finally:
-            await scheduler.stop()
+            await briefing_scheduler.stop()
+            await autonomy_scheduler.stop()
 
     app = FastAPI(
         title="GAIA Email Agent Sidecar",

--- a/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
@@ -845,15 +845,23 @@ class OrganizeToolsMixin:
             """Undo a batch archive by its batch_id, restoring every message
             to the inbox within the undo window. Reverses archive_message_batch."""
             try:
-                return _envelope_ok(
-                    undo_archive_batch_impl(
-                        agent._backend_for_action,
-                        db,
-                        batch_id=batch_id,
-                        window_seconds=window,
-                        debug=debug_flag,
-                    )
+                result = undo_archive_batch_impl(
+                    agent._backend_for_action,
+                    db,
+                    batch_id=batch_id,
+                    window_seconds=window,
+                    debug=debug_flag,
                 )
+                # Learning loop: an undone auto-archive is a correction. Attribute
+                # each restored action back to its trust scope (no-op for
+                # user-initiated archives, which were never indexed as autonomy).
+                capture = getattr(agent, "note_action_undone", None)
+                if capture is not None:
+                    for entry in result.get("messages", []):
+                        action_id = entry.get("action_id")
+                        if action_id:
+                            capture(action_id)
+                return _envelope_ok(result)
             except ConnectorsError as exc:
                 return _envelope_err(format_connector_error(exc))
             except Exception as exc:

--- a/hub/agents/email/python/gaia_agent_email/trust.py
+++ b/hub/agents/email/python/gaia_agent_email/trust.py
@@ -122,10 +122,81 @@ CREATE TABLE IF NOT EXISTS email_trust_ledger (
 );
 """
 
+# Attribution index: maps each autonomously-executed action back to the
+# ``(action_type, sender, category)`` scope it was decided under. When the user
+# later undoes that action (a correction), :func:`lookup_autonomy_action`
+# recovers the scope so the negative signal lands on the right ledger rows.
+# One row per auto-executed action; ``resolved`` guards against a single undo
+# being counted twice.
+EMAIL_AUTONOMY_ACTIONS_DDL = """
+CREATE TABLE IF NOT EXISTS email_autonomy_actions (
+    action_id    TEXT PRIMARY KEY,
+    action_type  TEXT NOT NULL,
+    sender       TEXT,
+    category     TEXT,
+    created_at   REAL NOT NULL,
+    resolved     INTEGER NOT NULL DEFAULT 0
+);
+"""
+
 
 def init_trust_schema(db) -> None:
-    """Create the ledger table if absent. Idempotent."""
+    """Create the ledger + attribution tables if absent. Idempotent."""
     db.execute(EMAIL_TRUST_LEDGER_DDL)
+    db.execute(EMAIL_AUTONOMY_ACTIONS_DDL)
+
+
+def record_autonomy_action(
+    db,
+    *,
+    action_id: str,
+    action_type: str,
+    sender: str = "",
+    category: str = "",
+    now: Optional[float] = None,
+) -> None:
+    """Index one auto-executed action so a later undo can be attributed.
+
+    Idempotent on ``action_id`` (INSERT OR REPLACE) — re-recording the same
+    action id overwrites rather than duplicating.
+    """
+    ts = time.time() if now is None else now
+    db.query(
+        "INSERT OR REPLACE INTO email_autonomy_actions "
+        "(action_id, action_type, sender, category, created_at, resolved) "
+        "VALUES (:id, :t, :s, :c, :ts, 0)",
+        {
+            "id": action_id,
+            "t": action_type,
+            "s": sender,
+            "c": category,
+            "ts": ts,
+        },
+    )
+
+
+def lookup_autonomy_action(db, *, action_id: str) -> Optional[Dict[str, Any]]:
+    """Return the unresolved index row for an action id, or None.
+
+    A row already marked ``resolved`` returns None so the same undo can't be
+    scored twice.
+    """
+    return db.query(
+        "SELECT action_id, action_type, sender, category FROM "
+        "email_autonomy_actions WHERE action_id = :id AND resolved = 0",
+        {"id": action_id},
+        one=True,
+    )
+
+
+def mark_autonomy_action_resolved(db, *, action_id: str) -> None:
+    """Flag an indexed action as resolved (its correction has been counted)."""
+    db.update(
+        "email_autonomy_actions",
+        {"resolved": 1},
+        "action_id = :id",
+        {"id": action_id},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/hub/agents/email/python/gaia_agent_email/trust.py
+++ b/hub/agents/email/python/gaia_agent_email/trust.py
@@ -1,0 +1,420 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Earn-trust policy engine for autonomous email handling (#1483 / #1287).
+
+Two cooperating pieces:
+
+- :class:`TrustLedger` — pure functions over the agent's SQLite handle
+  (mirrors ``action_store``/``schedule_store``): a per-``(action_type, scope)``
+  tally of positive vs. negative outcomes. "scope" is a category
+  (``category:PROMOTIONAL``) or a sender (``sender:news@x.com``). Trust is
+  *earned* here — a scope becomes trusted only after enough correct decisions.
+
+- :class:`TrustPolicy` — the decision layer. Given a candidate action it
+  returns a :class:`TrustDecision` of ``auto`` | ``draft`` | ``suggest`` |
+  ``confirm``. It reads the ledger, the user's explicit preferences, and the
+  configured autonomy level.
+
+Inviolable floor (the whole point of "check in on destructive things"):
+tools in the agent's ``CONFIRMATION_REQUIRED_TOOLS`` — send, forward, permanent
+delete, calendar RSVP, phishing quarantine — ALWAYS resolve to ``confirm``, at
+every autonomy level, regardless of how much trust a scope has earned. The
+policy layer can widen what runs silently; it can NEVER lower the floor. A
+misconfigured level or a fully-trusted sender still cannot cause an unattended
+send. ``tests/test_trust.py`` locks this in.
+
+Reversible-first: only reversible actions (archive, label, mark-read, star) are
+ever auto-executed, and every one is recorded in ``action_store`` with undo.
+Reply composition is ``draft`` — the agent writes the reply but never sends it
+unattended; sending stays on the floor.
+
+Storage choice: the accuracy ledger is OPERATIONAL state (like ``action_store``)
+so it lives in the agent's ``state.db`` via ``DatabaseMixin``, NOT in
+MemoryStore — MemoryStore knowledge is subject to LLM consolidation, which must
+never rewrite an audit tally. Spec §6.6 permission *grants* still live in
+MemoryStore; this ledger is the evidence those grants are earned from.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Mapping, Optional
+
+# ---------------------------------------------------------------------------
+# Autonomy levels — the earn-trust gradient
+# ---------------------------------------------------------------------------
+
+#: No autonomous activity. The heartbeat loop does not run. Default.
+LEVEL_OFF = "off"
+#: Propose everything, execute nothing autonomously (read-only + suggestions).
+LEVEL_SUGGEST = "suggest"
+#: The star mode: auto-execute reversible actions in trusted/approved scopes,
+#: draft replies, suggest the rest. This is what "full autonomy mode" maps to.
+LEVEL_EARN_TRUST = "earn_trust"
+#: Auto-execute all reversible actions immediately; drafts still never send.
+LEVEL_FULL = "full"
+
+AUTONOMY_LEVELS = (LEVEL_OFF, LEVEL_SUGGEST, LEVEL_EARN_TRUST, LEVEL_FULL)
+
+AutonomyLevel = Literal["off", "suggest", "earn_trust", "full"]
+
+# ---------------------------------------------------------------------------
+# Action taxonomy
+# ---------------------------------------------------------------------------
+
+#: Reversible mutations that MAY be auto-executed once a scope is trusted.
+#: Each is recorded in ``action_store`` with an undo path. ``trash`` is
+#: deliberately excluded — a soft-delete is reversible only inside the undo
+#: window, so it stays a suggestion until the user opts it up explicitly.
+REVERSIBLE_AUTO_ACTIONS = frozenset(
+    {
+        "archive",
+        "add_label",
+        "remove_label",
+        "mark_read",
+        "mark_unread",
+        "star",
+        "unstar",
+    }
+)
+
+#: Reply/forward *composition*. These prepare content but never transmit — the
+#: send is a separate floor tool. So drafting is safe to do autonomously even
+#: though sending is not.
+DRAFT_ACTIONS = frozenset({"draft_reply", "draft_forward"})
+
+# Ledger outcome polarity.
+OUTCOME_POSITIVE = "positive"
+OUTCOME_NEGATIVE = "negative"
+
+Decision = Literal["auto", "draft", "suggest", "confirm"]
+
+
+@dataclass(frozen=True)
+class TrustDecision:
+    """The policy's verdict for one candidate action.
+
+    ``action`` is the disposition; ``reason`` is a human-readable rationale
+    surfaced in the activity feed and ``gaia email autonomy`` output;
+    ``confidence`` is the ledger trust score in ``[0, 1]`` (1.0 for the
+    hard-coded floor and for explicit preferences).
+    """
+
+    action: Decision
+    reason: str
+    confidence: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+EMAIL_TRUST_LEDGER_DDL = """
+CREATE TABLE IF NOT EXISTS email_trust_ledger (
+    action_type  TEXT NOT NULL,
+    scope        TEXT NOT NULL,
+    positive     INTEGER NOT NULL DEFAULT 0,
+    negative     INTEGER NOT NULL DEFAULT 0,
+    last_outcome TEXT,
+    updated_at   REAL NOT NULL,
+    PRIMARY KEY (action_type, scope)
+);
+"""
+
+
+def init_trust_schema(db) -> None:
+    """Create the ledger table if absent. Idempotent."""
+    db.execute(EMAIL_TRUST_LEDGER_DDL)
+
+
+# ---------------------------------------------------------------------------
+# Scope helpers
+# ---------------------------------------------------------------------------
+
+
+def category_scope(category: str) -> str:
+    """Scope key for a triage category, e.g. ``category:PROMOTIONAL``."""
+    return f"category:{(category or '').strip().upper()}"
+
+
+def sender_scope(sender: str) -> str:
+    """Scope key for a sender address, e.g. ``sender:news@x.com``."""
+    return f"sender:{(sender or '').strip().lower()}"
+
+
+# ---------------------------------------------------------------------------
+# TrustLedger — the earned-evidence tally
+# ---------------------------------------------------------------------------
+
+
+class TrustLedger:
+    """Pure-function accessors over the ``email_trust_ledger`` table.
+
+    Every method takes a ``DatabaseMixin``-typed ``db`` as its first argument
+    and never reaches into the agent class — same discipline as
+    ``action_store``. Instances hold only the trust thresholds so a
+    :class:`TrustPolicy` can share one configured ledger.
+    """
+
+    def __init__(self, *, min_samples: int = 5, threshold: float = 0.85) -> None:
+        if min_samples < 1:
+            raise ValueError(
+                f"TrustLedger min_samples must be >= 1, got {min_samples!r}"
+            )
+        if not 0.0 < threshold <= 1.0:
+            raise ValueError(
+                f"TrustLedger threshold must be in (0, 1], got {threshold!r}"
+            )
+        self.min_samples = min_samples
+        self.threshold = threshold
+
+    @staticmethod
+    def record_outcome(
+        db,
+        *,
+        action_type: str,
+        scope: str,
+        positive: bool,
+        now: Optional[float] = None,
+    ) -> None:
+        """Increment the positive or negative tally for one scope.
+
+        Upsert: create the row on first sight, otherwise bump the counter.
+        A single decision that the user accepted / left standing is positive;
+        one they rejected / undid / edited is negative.
+        """
+        ts = time.time() if now is None else now
+        col = "positive" if positive else "negative"
+        outcome = OUTCOME_POSITIVE if positive else OUTCOME_NEGATIVE
+        existing = db.query(
+            "SELECT positive, negative FROM email_trust_ledger "
+            "WHERE action_type = :a AND scope = :s",
+            {"a": action_type, "s": scope},
+            one=True,
+        )
+        if existing is None:
+            db.insert(
+                "email_trust_ledger",
+                {
+                    "action_type": action_type,
+                    "scope": scope,
+                    "positive": 1 if positive else 0,
+                    "negative": 0 if positive else 1,
+                    "last_outcome": outcome,
+                    "updated_at": ts,
+                },
+            )
+            return
+        db.update(
+            "email_trust_ledger",
+            {col: int(existing[col]) + 1, "last_outcome": outcome, "updated_at": ts},
+            "action_type = :a AND scope = :s",
+            {"a": action_type, "s": scope},
+        )
+
+    @staticmethod
+    def get_stats(db, *, action_type: str, scope: str) -> Dict[str, Any]:
+        """Return ``{positive, negative, total, score}`` for a scope.
+
+        ``score`` is ``positive / total`` (0.0 when there is no evidence yet).
+        """
+        row = db.query(
+            "SELECT positive, negative FROM email_trust_ledger "
+            "WHERE action_type = :a AND scope = :s",
+            {"a": action_type, "s": scope},
+            one=True,
+        )
+        pos = int(row["positive"]) if row else 0
+        neg = int(row["negative"]) if row else 0
+        total = pos + neg
+        score = (pos / total) if total else 0.0
+        return {"positive": pos, "negative": neg, "total": total, "score": score}
+
+    def is_trusted(self, db, *, action_type: str, scope: str) -> bool:
+        """True when a scope has earned enough correct outcomes to auto-run.
+
+        Requires BOTH a minimum sample count (so a single lucky call can't
+        unlock autonomy) AND an accuracy at/above the threshold.
+        """
+        stats = self.get_stats(db, action_type=action_type, scope=scope)
+        return stats["total"] >= self.min_samples and stats["score"] >= self.threshold
+
+    @staticmethod
+    def list_ledger(db) -> List[Dict[str, Any]]:
+        """Every ledger row, most-recently-updated first (for the CLI/UI)."""
+        return db.query(
+            "SELECT action_type, scope, positive, negative, last_outcome, "
+            "updated_at FROM email_trust_ledger ORDER BY updated_at DESC"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TrustPolicy — the decision layer
+# ---------------------------------------------------------------------------
+
+
+class TrustPolicy:
+    """Decide the disposition of a candidate autonomous action.
+
+    Construct with the configured autonomy level, the ledger, and the agent's
+    inviolable confirm-floor set. :meth:`decide` returns a
+    :class:`TrustDecision`.
+    """
+
+    def __init__(
+        self,
+        *,
+        level: str,
+        ledger: TrustLedger,
+        confirm_floor: frozenset,
+    ) -> None:
+        if level not in AUTONOMY_LEVELS:
+            raise ValueError(
+                f"TrustPolicy level must be one of {AUTONOMY_LEVELS}, got {level!r}"
+            )
+        self.level = level
+        self.ledger = ledger
+        self.confirm_floor = frozenset(confirm_floor)
+
+    @property
+    def enabled(self) -> bool:
+        """False only at :data:`LEVEL_OFF` — the loop should not run at all."""
+        return self.level != LEVEL_OFF
+
+    def _explicitly_preferred(
+        self,
+        *,
+        action_type: str,
+        category: str,
+        sender: str,
+        preferences: Optional[Mapping[str, Any]],
+    ) -> bool:
+        """True when the user's own preferences already sanction this action.
+
+        An explicit preference is a direct instruction, so it grants autonomy
+        immediately without waiting on the ledger:
+
+        - ``archive`` of a low-priority sender or a category defaulted to
+          ``archive`` (from ``preference_tools``).
+        """
+        if not preferences:
+            return False
+        if action_type == "archive":
+            low = preferences.get("low_priority_senders") or ()
+            if sender and sender.strip().lower() in {str(s).lower() for s in low}:
+                return True
+            defaults = preferences.get("category_defaults") or {}
+            cat = (category or "").strip().upper()
+            if str(defaults.get(cat, "")).lower() == "archive":
+                return True
+        return False
+
+    def decide(
+        self,
+        *,
+        tool: str,
+        action_type: str,
+        category: str = "",
+        sender: str = "",
+        db: Any = None,
+        preferences: Optional[Mapping[str, Any]] = None,
+    ) -> TrustDecision:
+        """Return the disposition for one candidate action.
+
+        ``tool`` is the tool name (checked against the floor); ``action_type``
+        is the taxonomy key (``archive``, ``draft_reply``, …).
+        """
+        # 1. Inviolable floor — no level, trust score, or preference lowers it.
+        if tool in self.confirm_floor:
+            return TrustDecision(
+                "confirm",
+                reason=f"{tool} is destructive/irreversible — always requires "
+                "your confirmation",
+                confidence=1.0,
+            )
+
+        # 2. Loop disabled.
+        if self.level == LEVEL_OFF:
+            return TrustDecision("suggest", reason="autonomy is off", confidence=0.0)
+
+        # 3. Reply composition is always a draft — safe to write, never to send.
+        if action_type in DRAFT_ACTIONS:
+            return TrustDecision(
+                "draft",
+                reason="reply drafted for your review; sending needs confirmation",
+                confidence=0.0,
+            )
+
+        # 4. Only reversible actions are candidates for auto-execution.
+        if action_type not in REVERSIBLE_AUTO_ACTIONS:
+            return TrustDecision(
+                "suggest",
+                reason=f"{action_type} is not an auto-eligible reversible action",
+                confidence=0.0,
+            )
+
+        # 5. suggest level never auto-executes.
+        if self.level == LEVEL_SUGGEST:
+            return TrustDecision(
+                "suggest", reason="autonomy level is suggest-only", confidence=0.0
+            )
+
+        # 6. full level auto-executes every reversible action.
+        if self.level == LEVEL_FULL:
+            return TrustDecision(
+                "auto",
+                reason="autonomy level is full — reversible action auto-executed",
+                confidence=1.0,
+            )
+
+        # 7. earn_trust: auto only when explicitly preferred OR ledger-proven.
+        scope_sender = sender_scope(sender) if sender else ""
+        scope_cat = category_scope(category) if category else ""
+
+        if self._explicitly_preferred(
+            action_type=action_type,
+            category=category,
+            sender=sender,
+            preferences=preferences,
+        ):
+            return TrustDecision(
+                "auto",
+                reason="you set an explicit preference for this",
+                confidence=1.0,
+            )
+
+        if db is not None:
+            for scope in (scope_sender, scope_cat):
+                if not scope:
+                    continue
+                if self.ledger.is_trusted(db, action_type=action_type, scope=scope):
+                    stats = self.ledger.get_stats(
+                        db, action_type=action_type, scope=scope
+                    )
+                    return TrustDecision(
+                        "auto",
+                        reason=(
+                            f"proven on {scope} "
+                            f"({stats['positive']}/{stats['total']} correct)"
+                        ),
+                        confidence=stats["score"],
+                    )
+
+        # Not yet trusted — propose and learn from the answer.
+        best = 0.0
+        if db is not None:
+            for scope in (scope_sender, scope_cat):
+                if scope:
+                    best = max(
+                        best,
+                        self.ledger.get_stats(db, action_type=action_type, scope=scope)[
+                            "score"
+                        ],
+                    )
+        return TrustDecision(
+            "suggest",
+            reason="not yet proven for this sender/category — learning from your "
+            "choice",
+            confidence=best,
+        )

--- a/hub/agents/email/python/gaia_agent_email/trust.py
+++ b/hub/agents/email/python/gaia_agent_email/trust.py
@@ -67,15 +67,17 @@ AutonomyLevel = Literal["off", "suggest", "earn_trust", "full"]
 #: Each is recorded in ``action_store`` with an undo path. ``trash`` is
 #: deliberately excluded — a soft-delete is reversible only inside the undo
 #: window, so it stays a suggestion until the user opts it up explicitly.
+# Names MUST match the ``action_type`` strings ``action_store`` records (so an
+# undo of an autonomy action attributes to the same action_type the ledger
+# learned under). See organize_tools/delete_tools ``record_action`` calls.
 REVERSIBLE_AUTO_ACTIONS = frozenset(
     {
         "archive",
         "add_label",
-        "remove_label",
+        "add_star",
+        "remove_star",
         "mark_read",
         "mark_unread",
-        "star",
-        "unstar",
     }
 )
 
@@ -96,7 +98,7 @@ class TrustDecision:
     """The policy's verdict for one candidate action.
 
     ``action`` is the disposition; ``reason`` is a human-readable rationale
-    surfaced in the activity feed and ``gaia email autonomy`` output;
+    surfaced in the activity feed and the planned ``gaia email autonomy`` output;
     ``confidence`` is the ledger trust score in ``[0, 1]`` (1.0 for the
     hard-coded floor and for explicit preferences).
     """
@@ -140,10 +142,67 @@ CREATE TABLE IF NOT EXISTS email_autonomy_actions (
 """
 
 
+# Open-proposal ledger: one row per message the cycle has already proposed an
+# action for and that has not yet been resolved. Without this, every heartbeat
+# re-proposes the same still-in-inbox message and GoalStore accumulates a
+# duplicate pending goal each fire. Keyed ``(message_id, action_type)``.
+EMAIL_AUTONOMY_PROPOSALS_DDL = """
+CREATE TABLE IF NOT EXISTS email_autonomy_proposals (
+    message_id   TEXT NOT NULL,
+    action_type  TEXT NOT NULL,
+    created_at   REAL NOT NULL,
+    resolved     INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (message_id, action_type)
+);
+"""
+
+
 def init_trust_schema(db) -> None:
     """Create the ledger + attribution tables if absent. Idempotent."""
     db.execute(EMAIL_TRUST_LEDGER_DDL)
     db.execute(EMAIL_AUTONOMY_ACTIONS_DDL)
+    db.execute(EMAIL_AUTONOMY_PROPOSALS_DDL)
+
+
+def has_open_proposal(db, *, message_id: str, action_type: str) -> bool:
+    """True when an unresolved proposal already exists for this message+action.
+
+    The re-proposal guard: a message the cycle proposed last fire and that the
+    user has not acted on yet must not be proposed again.
+    """
+    row = db.query(
+        "SELECT 1 FROM email_autonomy_proposals WHERE message_id = :m "
+        "AND action_type = :a AND resolved = 0",
+        {"m": message_id, "a": action_type},
+        one=True,
+    )
+    return row is not None
+
+
+def record_proposal(
+    db,
+    *,
+    message_id: str,
+    action_type: str,
+    now: Optional[float] = None,
+) -> None:
+    """Mark that an action has been proposed for a message. Idempotent."""
+    ts = time.time() if now is None else now
+    db.query(
+        "INSERT OR IGNORE INTO email_autonomy_proposals "
+        "(message_id, action_type, created_at, resolved) VALUES (:m, :a, :ts, 0)",
+        {"m": message_id, "a": action_type, "ts": ts},
+    )
+
+
+def resolve_proposal(db, *, message_id: str, action_type: str) -> None:
+    """Clear the open-proposal guard for a message (acted on or superseded)."""
+    db.update(
+        "email_autonomy_proposals",
+        {"resolved": 1},
+        "message_id = :m AND action_type = :a",
+        {"m": message_id, "a": action_type},
+    )
 
 
 def record_autonomy_action(
@@ -161,16 +220,19 @@ def record_autonomy_action(
     action id overwrites rather than duplicating.
     """
     ts = time.time() if now is None else now
-    db.query(
-        "INSERT OR REPLACE INTO email_autonomy_actions "
-        "(action_id, action_type, sender, category, created_at, resolved) "
-        "VALUES (:id, :t, :s, :c, :ts, 0)",
+    # ``db.insert`` commits (query() does not); action_id is a fresh uuid PK so a
+    # plain insert is safe — no REPLACE needed. Committing matters for the
+    # scheduler's per-run agent, which closes its connection after the cycle: an
+    # uncommitted index row would be lost and the later undo never attributed.
+    db.insert(
+        "email_autonomy_actions",
         {
-            "id": action_id,
-            "t": action_type,
-            "s": sender,
-            "c": category,
-            "ts": ts,
+            "action_id": action_id,
+            "action_type": action_type,
+            "sender": sender,
+            "category": category,
+            "created_at": ts,
+            "resolved": 0,
         },
     )
 
@@ -256,33 +318,28 @@ class TrustLedger:
         one they rejected / undid / edited is negative.
         """
         ts = time.time() if now is None else now
-        col = "positive" if positive else "negative"
         outcome = OUTCOME_POSITIVE if positive else OUTCOME_NEGATIVE
-        existing = db.query(
-            "SELECT positive, negative FROM email_trust_ledger "
-            "WHERE action_type = :a AND scope = :s",
-            {"a": action_type, "s": scope},
-            one=True,
-        )
-        if existing is None:
-            db.insert(
-                "email_trust_ledger",
+        # Atomic upsert (single statement) so two concurrent first-writes to the
+        # same (action_type, scope) — the session agent and a scheduler-built
+        # agent share one on-disk DB — can't both INSERT and collide on the PK.
+        # Wrapped in a transaction so the write commits (query() alone does not).
+        with db.transaction():
+            db.query(
+                "INSERT INTO email_trust_ledger "
+                "(action_type, scope, positive, negative, last_outcome, updated_at) "
+                "VALUES (:a, :s, :pos, :neg, :outcome, :ts) "
+                "ON CONFLICT(action_type, scope) DO UPDATE SET "
+                "positive = positive + :pos, negative = negative + :neg, "
+                "last_outcome = :outcome, updated_at = :ts",
                 {
-                    "action_type": action_type,
-                    "scope": scope,
-                    "positive": 1 if positive else 0,
-                    "negative": 0 if positive else 1,
-                    "last_outcome": outcome,
-                    "updated_at": ts,
+                    "a": action_type,
+                    "s": scope,
+                    "pos": 1 if positive else 0,
+                    "neg": 0 if positive else 1,
+                    "outcome": outcome,
+                    "ts": ts,
                 },
             )
-            return
-        db.update(
-            "email_trust_ledger",
-            {col: int(existing[col]) + 1, "last_outcome": outcome, "updated_at": ts},
-            "action_type = :a AND scope = :s",
-            {"a": action_type, "s": scope},
-        )
 
     @staticmethod
     def get_stats(db, *, action_type: str, scope: str) -> Dict[str, Any]:

--- a/hub/agents/email/python/tests/test_email_agent_routes.py
+++ b/hub/agents/email/python/tests/test_email_agent_routes.py
@@ -89,6 +89,33 @@ class _FakeAgent:
             "message": "status",
         }
 
+    # -- Autonomy surface --------------------------------------------------
+    _autonomy_level = "off"
+
+    def autonomy_status(self) -> dict:
+        return {
+            "level": self._autonomy_level,
+            "enabled": self._autonomy_level != "off",
+            "trust_min_samples": 5,
+            "trust_threshold": 0.85,
+            "trusted_scope_count": 0,
+            "scopes": [],
+        }
+
+    def set_autonomy_level(self, level: str) -> dict:
+        if level not in ("off", "suggest", "earn_trust", "full"):
+            raise ValueError(f"bad level {level!r}")
+        self._autonomy_level = level
+        return {"level": level, "enabled": level != "off"}
+
+    def run_autonomy_cycle(self, context=None) -> dict:
+        return {
+            "level": self._autonomy_level,
+            "executed": [],
+            "proposals": [],
+            "skipped": 0,
+        }
+
     def close_db(self) -> None:
         self.closed = True
 
@@ -361,3 +388,57 @@ class TestMemoryOverHttp:
 def client_registry(client) -> "agent_routes._SessionRegistry":
     """The registry the client's app is bound to (monkeypatched per test)."""
     return agent_routes.registry
+
+
+# ---------------------------------------------------------------------------
+# Autonomy control surface (#1483 / #1115)
+# ---------------------------------------------------------------------------
+
+
+class TestAutonomyRoutes:
+    def _mk(self, client, sid="s1"):
+        client.post("/v1/email/agent/session", json={"session_id": sid})
+
+    def test_status_reports_level(self, client):
+        self._mk(client)
+        r = client.get("/v1/email/agent/autonomy/s1")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["level"] == "off"
+        assert body["enabled"] is False
+        assert "scopes" in body
+
+    def test_status_404_without_session(self, client):
+        r = client.get("/v1/email/agent/autonomy/nope")
+        assert r.status_code == 404
+
+    def test_set_level_resume_then_kill(self, client):
+        self._mk(client)
+        r = client.post(
+            "/v1/email/agent/autonomy",
+            json={"session_id": "s1", "level": "earn_trust"},
+        )
+        assert r.status_code == 200 and r.json()["level"] == "earn_trust"
+        # Kill switch.
+        r2 = client.post(
+            "/v1/email/agent/autonomy", json={"session_id": "s1", "level": "off"}
+        )
+        assert r2.json()["enabled"] is False
+
+    def test_set_level_rejects_bad_value(self, client):
+        self._mk(client)
+        r = client.post(
+            "/v1/email/agent/autonomy", json={"session_id": "s1", "level": "turbo"}
+        )
+        assert r.status_code == 400
+
+    def test_run_cycle_returns_report(self, client):
+        self._mk(client)
+        r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "s1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert "executed" in body and "proposals" in body
+
+    def test_run_cycle_404_without_session(self, client):
+        r = client.post("/v1/email/agent/autonomy/run", json={"session_id": "nope"})
+        assert r.status_code == 404

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -349,6 +349,42 @@ def test_note_action_undone_ignores_non_autonomy_ids(tmp_path):
     assert agent.note_action_undone("not-an-autonomy-action") is False
 
 
+def test_undo_tool_captures_correction_end_to_end(tmp_path):
+    """Undoing an auto-archive through the real undo_archive_batch tool restores
+    the message AND records the correction — the production learning path."""
+    import json
+
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    sender = "deals@shop.com"
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", sender)], level=LEVEL_FULL
+    )
+    report = agent._run_email_autonomy_cycle()
+    action_id = report["executed"][0]["action_id"]
+    row = agent.query(
+        "SELECT batch_id FROM email_actions WHERE action_id = :a",
+        {"a": action_id},
+        one=True,
+    )
+    batch_id = row["batch_id"]
+    assert batch_id, "autonomy archive must carry a batch_id so it is undoable"
+
+    entry = _TOOL_REGISTRY.get("undo_archive_batch")
+    assert entry is not None
+    json.loads(entry["function"](batch_id))  # invoke as the agent would
+
+    # Message restored to the inbox.
+    assert "INBOX" in agent._gmail.get_message("m1").get("labelIds", [])
+    # Correction captured as a negative for the scope.
+    from gaia_agent_email.trust import TrustLedger
+
+    stats = TrustLedger.get_stats(
+        agent, action_type="archive", scope=sender_scope(sender)
+    )
+    assert stats["negative"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Inspectable status — autonomy is never a black box
 # ---------------------------------------------------------------------------

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -347,3 +347,33 @@ def test_correction_capture_pulls_trust_back(tmp_path):
 def test_note_action_undone_ignores_non_autonomy_ids(tmp_path):
     agent = _build_agent(tmp_path, [], level=LEVEL_EARN_TRUST)
     assert agent.note_action_undone("not-an-autonomy-action") is False
+
+
+# ---------------------------------------------------------------------------
+# Inspectable status — autonomy is never a black box
+# ---------------------------------------------------------------------------
+
+
+def test_autonomy_status_reports_level_and_ledger(tmp_path):
+    agent = _build_agent(
+        tmp_path, [], level=LEVEL_EARN_TRUST, autonomy_trust_min_samples=3
+    )
+    # Below the bar, then over it.
+    for _ in range(2):
+        agent.record_autonomy_outcome(
+            action_type="archive", positive=True, sender="a@x.com"
+        )
+    for _ in range(3):
+        agent.record_autonomy_outcome(
+            action_type="archive", positive=True, category="PROMOTIONAL"
+        )
+
+    status = agent.autonomy_status()
+    assert status["level"] == LEVEL_EARN_TRUST
+    assert status["enabled"] is True
+    by_scope = {s["scope"]: s for s in status["scopes"]}
+    assert by_scope[sender_scope("a@x.com")]["trusted"] is False  # only 2 samples
+    from gaia_agent_email.trust import category_scope
+
+    assert by_scope[category_scope("PROMOTIONAL")]["trusted"] is True  # 3 samples
+    assert status["trusted_scope_count"] == 1

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -1,0 +1,263 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Autonomous observe->decide->act cycle tests (#1115 / #557).
+
+Drives ``EmailTriageAgent._run_email_autonomy_cycle`` against a real
+``FakeGmailBackend`` with the LLM classifier disabled (``agent.chat = None``)
+so the heuristic path runs hermetically — no Lemonade.
+
+The earn-trust progression is the headline: a promotional sender is only
+*proposed* for archive until the trust ledger proves the agent right enough
+times, after which the same sender is archived silently. And at no autonomy
+level does the cycle ever perform a send/delete — there is no such candidate,
+and the floor would block it anyway (locked by test_trust.py).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+from gaia_agent_email.trust import (  # noqa: E402
+    LEVEL_EARN_TRUST,
+    LEVEL_FULL,
+    LEVEL_OFF,
+    LEVEL_SUGGEST,
+    TrustLedger,
+    sender_scope,
+)
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+
+def _fake_embed(text, *args, **kwargs):
+    return np.zeros(768, dtype=np.float32)
+
+
+class _MinimalCalendarBackend:
+    def list_events(self, *a, **k):
+        return {"events": []}
+
+
+def _promo_message(message_id: str, sender: str) -> dict:
+    """A message the heuristic classifies confidently as PROMOTIONAL.
+
+    The ``CATEGORY_PROMOTIONS`` label is the mechanical promotional signal, so
+    no LLM classifier is needed to reach a confident category.
+    """
+    internal_ms = int(time.time() * 1000)
+    return {
+        "id": message_id,
+        "threadId": f"thread_{message_id}",
+        "labelIds": ["INBOX", "UNREAD", "CATEGORY_PROMOTIONS"],
+        "internalDate": str(internal_ms),
+        "snippet": "50% off everything this weekend",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": f"Deals <{sender}>"},
+                {"name": "Subject", "value": "Weekend sale inside"},
+                {"name": "Message-ID", "value": f"<{message_id}@x.com>"},
+                {"name": "Date", "value": "Mon, 12 Jun 2026 10:00:00 +0000"},
+            ],
+        },
+    }
+
+
+def _urgent_message(message_id: str, sender: str) -> dict:
+    internal_ms = int(time.time() * 1000)
+    return {
+        "id": message_id,
+        "threadId": f"thread_{message_id}",
+        "labelIds": ["INBOX", "UNREAD", "IMPORTANT"],
+        "internalDate": str(internal_ms),
+        "snippet": "URGENT: production is down, need you now",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": f"Boss <{sender}>"},
+                {"name": "Subject", "value": "URGENT: prod down, action required ASAP"},
+                {"name": "Message-ID", "value": f"<{message_id}@x.com>"},
+                {"name": "Date", "value": "Mon, 12 Jun 2026 10:00:00 +0000"},
+            ],
+        },
+    }
+
+
+def _build_agent(tmp_path: Path, messages, *, level: str, **cfg_kw) -> EmailTriageAgent:
+    backend = FakeGmailBackend(user_email="me@example.com")
+    for msg in messages:
+        backend.add_message(msg)
+
+    cfg = EmailAgentConfig(
+        gmail_backend=backend,
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+        autonomy_level=level,
+        **cfg_kw,
+    )
+
+    with (
+        patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._get_embedder",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._embed_text", side_effect=_fake_embed
+        ),
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._backfill_embeddings", return_value=0
+        ),
+        patch("gaia.agents.base.memory.MemoryMixin._rebuild_faiss_index"),
+        patch("gaia.agents.base.memory.MemoryMixin.init_system_context"),
+    ):
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    # Heuristic-only: disable the LLM classifier path entirely.
+    agent.chat = None
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Level gating
+# ---------------------------------------------------------------------------
+
+
+def test_off_level_does_nothing(tmp_path):
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_OFF
+    )
+    report = agent._run_email_autonomy_cycle()
+    assert report["executed"] == []
+    assert report["proposals"] == []
+
+
+def test_suggest_level_proposes_never_executes(tmp_path):
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_SUGGEST
+    )
+    report = agent._run_email_autonomy_cycle()
+    assert report["executed"] == []
+    assert len(report["proposals"]) == 1
+    assert report["proposals"][0].action_class == "other"
+
+
+# ---------------------------------------------------------------------------
+# earn-trust progression — the headline behavior
+# ---------------------------------------------------------------------------
+
+
+def test_earn_trust_proposes_when_cold(tmp_path):
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("m1", "deals@shop.com")],
+        level=LEVEL_EARN_TRUST,
+        autonomy_trust_min_samples=3,
+    )
+    report = agent._run_email_autonomy_cycle()
+    assert report["executed"] == []
+    assert len(report["proposals"]) == 1
+
+
+def test_earn_trust_auto_archives_once_proven(tmp_path):
+    sender = "deals@shop.com"
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("m1", sender)],
+        level=LEVEL_EARN_TRUST,
+        autonomy_trust_min_samples=3,
+    )
+    # Seed the ledger so the sender scope is already trusted for archiving.
+    scope = sender_scope(sender)
+    for _ in range(3):
+        TrustLedger.record_outcome(
+            agent, action_type="archive", scope=scope, positive=True
+        )
+
+    report = agent._run_email_autonomy_cycle()
+    assert len(report["executed"]) == 1
+    entry = report["executed"][0]
+    assert entry["action"] == "archive"
+    assert entry["message_id"] == "m1"
+    assert "action_id" in entry  # undo handle recorded
+    assert report["proposals"] == []
+    # The message actually left the inbox.
+    assert "INBOX" not in agent._gmail.get_message("m1").get("labelIds", [])
+
+
+def test_full_level_archives_immediately(tmp_path):
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_FULL
+    )
+    report = agent._run_email_autonomy_cycle()
+    assert len(report["executed"]) == 1
+    assert report["proposals"] == []
+
+
+# ---------------------------------------------------------------------------
+# Safety — important mail is never auto-touched
+# ---------------------------------------------------------------------------
+
+
+def test_urgent_message_never_auto_actioned_even_at_full(tmp_path):
+    agent = _build_agent(
+        tmp_path, [_urgent_message("u1", "boss@company.com")], level=LEVEL_FULL
+    )
+    report = agent._run_email_autonomy_cycle()
+    # Urgent mail is not an auto candidate: nothing executed, nothing proposed.
+    assert report["executed"] == []
+    assert report["proposals"] == []
+    assert report["skipped"] == 1
+    # Still in the inbox, untouched.
+    assert "INBOX" in agent._gmail.get_message("u1").get("labelIds", [])
+
+
+def test_mixed_inbox_splits_correctly(tmp_path):
+    agent = _build_agent(
+        tmp_path,
+        [
+            _promo_message("p1", "deals@shop.com"),
+            _urgent_message("u1", "boss@company.com"),
+        ],
+        level=LEVEL_FULL,
+    )
+    report = agent._run_email_autonomy_cycle()
+    executed_ids = {e["message_id"] for e in report["executed"]}
+    assert executed_ids == {"p1"}
+    assert report["skipped"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Hook + driver contract
+# ---------------------------------------------------------------------------
+
+
+def test_on_heartbeat_returns_proposal_objects(tmp_path):
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_SUGGEST
+    )
+    proposals = agent.on_heartbeat()
+    assert len(proposals) == 1
+    assert hasattr(proposals[0], "to_dict")
+
+
+def test_run_autonomy_cycle_persists_and_serializes(tmp_path):
+    agent = _build_agent(
+        tmp_path, [_promo_message("m1", "deals@shop.com")], level=LEVEL_SUGGEST
+    )
+    with patch.object(agent, "propose") as mock_propose:
+        report = agent.run_autonomy_cycle()
+    mock_propose.assert_called_once()
+    # Proposals are returned in serializable dict form, not raw objects.
+    assert isinstance(report["proposals"][0], dict)
+    assert "action" in report["proposals"][0]

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -261,3 +261,89 @@ def test_run_autonomy_cycle_persists_and_serializes(tmp_path):
     # Proposals are returned in serializable dict form, not raw objects.
     assert isinstance(report["proposals"][0], dict)
     assert "action" in report["proposals"][0]
+
+
+# ---------------------------------------------------------------------------
+# The learning loop — trust grows from feedback, shrinks from corrections
+# ---------------------------------------------------------------------------
+
+
+def test_record_outcome_writes_both_scopes(tmp_path):
+    agent = _build_agent(tmp_path, [], level=LEVEL_EARN_TRUST)
+    agent.record_autonomy_outcome(
+        action_type="archive",
+        positive=True,
+        sender="news@x.com",
+        category="PROMOTIONAL",
+    )
+    from gaia_agent_email.trust import TrustLedger, category_scope
+
+    sender_stats = TrustLedger.get_stats(
+        agent, action_type="archive", scope=sender_scope("news@x.com")
+    )
+    cat_stats = TrustLedger.get_stats(
+        agent, action_type="archive", scope=category_scope("PROMOTIONAL")
+    )
+    assert sender_stats["positive"] == 1
+    assert cat_stats["positive"] == 1
+
+
+def test_closed_loop_feedback_earns_autonomy(tmp_path):
+    """Cold sender is proposed; after enough positive feedback via the public
+    funnel, the very next cycle archives it silently. The full loop, no seeded
+    ledger rows."""
+    sender = "deals@shop.com"
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("m1", sender)],
+        level=LEVEL_EARN_TRUST,
+        autonomy_trust_min_samples=3,
+    )
+
+    # Cold: proposed, not executed.
+    first = agent._run_email_autonomy_cycle()
+    assert first["executed"] == []
+    assert len(first["proposals"]) == 1
+
+    # The user accepts three suggestions for this sender (the real earn path).
+    for _ in range(3):
+        agent.record_autonomy_outcome(
+            action_type="archive", positive=True, sender=sender, category="PROMOTIONAL"
+        )
+
+    # Re-seed the same message (it was only proposed, never archived) and rerun.
+    agent._gmail.add_message(_promo_message("m2", sender))
+    second = agent._run_email_autonomy_cycle()
+    executed_ids = {e["message_id"] for e in second["executed"]}
+    assert "m2" in executed_ids
+
+
+def test_correction_capture_pulls_trust_back(tmp_path):
+    """An auto-archive the user undoes records a negative and re-closes the gate."""
+    sender = "deals@shop.com"
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("m1", sender)],
+        level=LEVEL_FULL,  # full auto-executes immediately, so we get an action_id
+        autonomy_trust_min_samples=3,
+    )
+    report = agent._run_email_autonomy_cycle()
+    action_id = report["executed"][0]["action_id"]
+
+    # User undoes it → correction captured as a negative for the scope.
+    assert agent.note_action_undone(action_id) is True
+
+    from gaia_agent_email.trust import TrustLedger
+
+    stats = TrustLedger.get_stats(
+        agent, action_type="archive", scope=sender_scope(sender)
+    )
+    assert stats["negative"] == 1
+
+    # Idempotent: the same undo can't be counted twice.
+    assert agent.note_action_undone(action_id) is False
+
+
+def test_note_action_undone_ignores_non_autonomy_ids(tmp_path):
+    agent = _build_agent(tmp_path, [], level=LEVEL_EARN_TRUST)
+    assert agent.note_action_undone("not-an-autonomy-action") is False

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -357,9 +357,7 @@ def test_undo_tool_captures_correction_end_to_end(tmp_path):
     from gaia.agents.base.tools import _TOOL_REGISTRY
 
     sender = "deals@shop.com"
-    agent = _build_agent(
-        tmp_path, [_promo_message("m1", sender)], level=LEVEL_FULL
-    )
+    agent = _build_agent(tmp_path, [_promo_message("m1", sender)], level=LEVEL_FULL)
     report = agent._run_email_autonomy_cycle()
     action_id = report["executed"][0]["action_id"]
     row = agent.query(
@@ -413,3 +411,89 @@ def test_autonomy_status_reports_level_and_ledger(tmp_path):
 
     assert by_scope[category_scope("PROMOTIONAL")]["trusted"] is True  # 3 samples
     assert status["trusted_scope_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Proactive simulation harness (#1508) — multi-cycle convergence + invariants
+# ---------------------------------------------------------------------------
+
+
+class TestAutonomySimulation:
+    """Simulate an inbox over many heartbeats and assert the earn-trust engine
+    converges the way the design promises, and that the safety invariants hold
+    across the whole run — not just a single decision."""
+
+    def _promos_from(self, sender, n, start=0):
+        return [_promo_message(f"p{start + i}", sender) for i in range(n)]
+
+    def test_converges_from_proposing_to_acting_with_positive_feedback(self, tmp_path):
+        sender = "deals@shop.com"
+        agent = _build_agent(
+            tmp_path,
+            [],
+            level=LEVEL_EARN_TRUST,
+            autonomy_trust_min_samples=3,
+        )
+
+        # Cycle 1-3: cold → proposes; the "user" accepts each suggestion.
+        proposed_cycles = 0
+        for c in range(3):
+            agent._gmail.add_message(_promo_message(f"a{c}", sender))
+            report = agent._run_email_autonomy_cycle()
+            if report["proposals"]:
+                proposed_cycles += 1
+                # User accepts the suggestion → positive feedback.
+                agent.record_autonomy_outcome(
+                    action_type="archive",
+                    positive=True,
+                    sender=sender,
+                    category="PROMOTIONAL",
+                )
+        assert proposed_cycles >= 1  # it asked before it earned trust
+
+        # Now trusted: a fresh message from the same sender is auto-archived.
+        agent._gmail.add_message(_promo_message("final", sender))
+        final = agent._run_email_autonomy_cycle()
+        assert any(e["message_id"] == "final" for e in final["executed"])
+
+    def test_never_auto_executes_a_floor_tool_across_full_inbox(self, tmp_path):
+        """Whatever the inbox, an autonomy cycle only ever executes reversible
+        actions — never a send/forward/delete. The structural guarantee."""
+        from gaia_agent_email.trust import REVERSIBLE_AUTO_ACTIONS
+
+        sender = "deals@shop.com"
+        msgs = self._promos_from(sender, 5) + [
+            _urgent_message("u1", "boss@x.com"),
+            _urgent_message("u2", "vip@x.com"),
+        ]
+        agent = _build_agent(tmp_path, msgs, level=LEVEL_FULL)
+        report = agent._run_email_autonomy_cycle()
+        for entry in report["executed"]:
+            assert entry["action"] in REVERSIBLE_AUTO_ACTIONS
+
+    def test_correction_demotes_a_previously_trusted_scope(self, tmp_path):
+        sender = "deals@shop.com"
+        agent = _build_agent(
+            tmp_path,
+            [],
+            level=LEVEL_EARN_TRUST,
+            autonomy_trust_min_samples=3,
+            autonomy_trust_threshold=0.85,
+        )
+        # Earn trust (3/3), then two corrections drag accuracy below the bar.
+        for _ in range(3):
+            agent.record_autonomy_outcome(
+                action_type="archive", positive=True, sender=sender
+            )
+        status_before = {s["scope"]: s for s in agent.autonomy_status()["scopes"]}
+        assert status_before[sender_scope(sender)]["trusted"] is True
+
+        for _ in range(2):
+            agent.record_autonomy_outcome(
+                action_type="archive", positive=False, sender=sender
+            )
+        # 3/5 = 0.6 < 0.85 → no longer trusted; the agent goes back to asking.
+        agent._gmail.add_message(_promo_message("m1", sender))
+        report = agent._run_email_autonomy_cycle()
+        assert report["executed"] == []
+        assert len(report["proposals"]) == 1

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -349,6 +349,39 @@ def test_note_action_undone_ignores_non_autonomy_ids(tmp_path):
     assert agent.note_action_undone("not-an-autonomy-action") is False
 
 
+def test_cold_message_proposed_once_not_re_proposed_each_cycle(tmp_path):
+    """Re-running the cycle on the same still-in-inbox message must NOT pile up a
+    duplicate proposal every fire — the headless-timer spam guard."""
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("m1", "deals@shop.com")],
+        level=LEVEL_EARN_TRUST,
+        autonomy_trust_min_samples=3,
+    )
+    first = agent._run_email_autonomy_cycle()
+    assert len(first["proposals"]) == 1
+    assert first["already_proposed"] == 0
+
+    # Same message still in the inbox → second cycle proposes nothing new.
+    second = agent._run_email_autonomy_cycle()
+    assert second["proposals"] == []
+    assert second["already_proposed"] == 1
+
+
+def test_run_autonomy_cycle_does_not_duplicate_goals(tmp_path):
+    """End-to-end: two driver runs create exactly one GoalStore proposal."""
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("m1", "deals@shop.com")],
+        level=LEVEL_EARN_TRUST,
+        autonomy_trust_min_samples=3,
+    )
+    with patch.object(agent, "propose") as mock_propose:
+        agent.run_autonomy_cycle()
+        agent.run_autonomy_cycle()
+    assert mock_propose.call_count == 1
+
+
 def test_undo_tool_captures_correction_end_to_end(tmp_path):
     """Undoing an auto-archive through the real undo_archive_batch tool restores
     the message AND records the correction — the production learning path."""
@@ -456,11 +489,14 @@ class TestAutonomySimulation:
         final = agent._run_email_autonomy_cycle()
         assert any(e["message_id"] == "final" for e in final["executed"])
 
-    def test_never_auto_executes_a_floor_tool_across_full_inbox(self, tmp_path):
+    def test_cycle_only_auto_executes_reversible_actions(self, tmp_path):
         """Whatever the inbox, an autonomy cycle only ever executes reversible
-        actions — never a send/forward/delete. The structural guarantee."""
+        actions — never a floor tool. (The floor's confirm-gate itself is locked
+        in test_trust.py; this guards the candidate map that feeds the cycle.)"""
+        from gaia_agent_email.agent import EmailTriageAgent
         from gaia_agent_email.trust import REVERSIBLE_AUTO_ACTIONS
 
+        floor = EmailTriageAgent.CONFIRMATION_REQUIRED_TOOLS
         sender = "deals@shop.com"
         msgs = self._promos_from(sender, 5) + [
             _urgent_message("u1", "boss@x.com"),
@@ -468,8 +504,10 @@ class TestAutonomySimulation:
         ]
         agent = _build_agent(tmp_path, msgs, level=LEVEL_FULL)
         report = agent._run_email_autonomy_cycle()
+        assert report["executed"], "expected the promos to be archived"
         for entry in report["executed"]:
             assert entry["action"] in REVERSIBLE_AUTO_ACTIONS
+            assert entry["action"] not in floor
 
     def test_correction_demotes_a_previously_trusted_scope(self, tmp_path):
         sender = "deals@shop.com"

--- a/hub/agents/email/python/tests/test_email_autonomy_scheduler.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_scheduler.py
@@ -1,0 +1,168 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Autonomy scheduler / driver tests (#1115 / #557).
+
+Covers the config (env parsing + eager validation), the ``run_autonomy_job``
+dispatcher seam (agent ownership + teardown), and the scheduler's enable gate.
+Mirrors the briefing scheduler's test posture — no Lemonade, no Gmail.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.autonomy_scheduler import (  # noqa: E402
+    ENV_ENABLED,
+    ENV_INTERVAL,
+    ENV_LEVEL,
+    ENV_MAX_MESSAGES,
+    AutonomyConfigError,
+    AutonomyScheduleConfig,
+    AutonomyScheduler,
+    run_autonomy_job,
+)
+
+# ---------------------------------------------------------------------------
+# Config: from_env + validate
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_are_disabled():
+    cfg = AutonomyScheduleConfig.from_env({})
+    assert cfg.enabled is False
+    assert cfg.level == "earn_trust"
+    assert cfg.interval_minutes == 15
+    assert cfg.max_messages == 25
+
+
+def test_from_env_enables_and_parses():
+    cfg = AutonomyScheduleConfig.from_env(
+        {
+            ENV_ENABLED: "true",
+            ENV_LEVEL: "full",
+            ENV_INTERVAL: "5",
+            ENV_MAX_MESSAGES: "40",
+        }
+    )
+    assert cfg.enabled is True
+    assert cfg.level == "full"
+    assert cfg.interval_minutes == 5
+    assert cfg.max_messages == 40
+
+
+def test_bad_enabled_raises():
+    with pytest.raises(AutonomyConfigError):
+        AutonomyScheduleConfig.from_env({ENV_ENABLED: "maybe"})
+
+
+def test_bad_level_raises():
+    with pytest.raises(AutonomyConfigError):
+        AutonomyScheduleConfig.from_env({ENV_ENABLED: "true", ENV_LEVEL: "turbo"})
+
+
+def test_enabled_with_off_level_raises():
+    with pytest.raises(AutonomyConfigError):
+        AutonomyScheduleConfig.from_env({ENV_ENABLED: "true", ENV_LEVEL: "off"})
+
+
+def test_bad_interval_and_max_raise():
+    with pytest.raises(AutonomyConfigError):
+        AutonomyScheduleConfig.from_env({ENV_ENABLED: "true", ENV_INTERVAL: "0"})
+    with pytest.raises(AutonomyConfigError):
+        AutonomyScheduleConfig.from_env({ENV_MAX_MESSAGES: "999"})
+
+
+# ---------------------------------------------------------------------------
+# run_autonomy_job — the dispatcher seam
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.calls = []
+        self.closed = False
+
+    def run_autonomy_cycle(self, context=None):
+        self.calls.append(context)
+        return {"level": "full", "executed": [], "proposals": [], "skipped": 0}
+
+    def close_db(self):
+        self.closed = True
+
+
+def test_run_job_builds_and_tears_down_owned_agent():
+    built = {}
+
+    def _factory(level):
+        agent = _FakeAgent()
+        built["agent"] = agent
+        built["level"] = level
+        return agent
+
+    report = run_autonomy_job(level="full", max_messages=10, build_agent=_factory)
+    assert report["executed"] == []
+    assert built["level"] == "full"
+    assert built["agent"].calls == [{"max_messages": 10}]
+    assert built["agent"].closed is True  # owned agent is torn down
+
+
+def test_run_job_does_not_close_injected_agent():
+    agent = _FakeAgent()
+    run_autonomy_job(agent, max_messages=7)
+    assert agent.calls == [{"max_messages": 7}]
+    assert agent.closed is False  # caller owns an injected agent
+
+
+def test_run_job_closes_owned_agent_even_on_error():
+    class _Boom(_FakeAgent):
+        def run_autonomy_cycle(self, context=None):
+            raise RuntimeError("mailbox down")
+
+    boom = _Boom()
+    with pytest.raises(RuntimeError):
+        run_autonomy_job(build_agent=lambda level: boom)
+    assert boom.closed is True
+
+
+# ---------------------------------------------------------------------------
+# Scheduler enable gate + fire
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_scheduler_does_not_start():
+    async def _run():
+        sched = AutonomyScheduler(AutonomyScheduleConfig(enabled=False))
+        assert sched.start() is False
+        await sched.stop()  # idempotent when never started
+
+    asyncio.run(_run())
+
+
+def test_enabled_scheduler_fires_the_job():
+    """The loop fires run_job with the configured level/budget. The delay seam
+    is shrunk so the test doesn't wait a real minute; the job signals an event
+    and the test stops the scheduler after the first fire."""
+    fired = []
+    done = asyncio.Event()
+
+    def _job(*, level, max_messages):
+        fired.append((level, max_messages))
+        done.set()
+        return {"executed": [], "proposals": [], "skipped": 0}
+
+    async def _run():
+        cfg = AutonomyScheduleConfig(
+            enabled=True, level="earn_trust", interval_minutes=1, max_messages=25
+        )
+        sched = AutonomyScheduler(cfg, run_job=_job)
+        sched._delay_seconds = 0.01  # test seam: fire almost immediately
+        assert sched.start() is True
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+        await sched.stop()
+
+    asyncio.run(_run())
+    assert fired[0] == ("earn_trust", 25)

--- a/hub/agents/email/python/tests/test_trust.py
+++ b/hub/agents/email/python/tests/test_trust.py
@@ -1,0 +1,317 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Earn-trust policy engine tests (#1483 / #1287).
+
+Covers the trust ledger math and the decision layer, with special emphasis on
+the one invariant that must never break: the destructive/irreversible
+confirm-floor ALWAYS resolves to ``confirm`` — at every autonomy level, even
+for a fully-trusted sender. An autonomous email agent that can be talked into
+an unattended send is a non-starter; these tests are that guardrail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email import trust  # noqa: E402
+from gaia_agent_email.trust import (  # noqa: E402
+    LEVEL_EARN_TRUST,
+    LEVEL_FULL,
+    LEVEL_OFF,
+    LEVEL_SUGGEST,
+    TrustLedger,
+    TrustPolicy,
+    category_scope,
+    sender_scope,
+)
+
+from gaia.database.mixin import DatabaseMixin  # noqa: E402
+
+
+class _DB(DatabaseMixin):
+    pass
+
+
+@pytest.fixture
+def db():
+    d = _DB()
+    d.init_db(":memory:")
+    trust.init_trust_schema(d)
+    return d
+
+
+# The email agent's real floor. Kept as a literal here so a change to the
+# agent's CONFIRMATION_REQUIRED_TOOLS that accidentally *shrinks* the floor is
+# caught by the parity test below rather than silently loosening these cases.
+FLOOR = frozenset(
+    {
+        "send_draft",
+        "send_now",
+        "schedule_send",
+        "forward_message",
+        "permanent_delete",
+        "accept_invite",
+        "decline_invite",
+        "create_event_from_email",
+        "quarantine_phishing_message",
+    }
+)
+
+
+def _policy(level, db_min=5, threshold=0.85):
+    ledger = TrustLedger(min_samples=db_min, threshold=threshold)
+    return TrustPolicy(level=level, ledger=ledger, confirm_floor=FLOOR)
+
+
+# ---------------------------------------------------------------------------
+# TrustLedger
+# ---------------------------------------------------------------------------
+
+
+def test_record_outcome_creates_then_increments(db):
+    scope = sender_scope("news@x.com")
+    TrustLedger.record_outcome(db, action_type="archive", scope=scope, positive=True)
+    stats = TrustLedger.get_stats(db, action_type="archive", scope=scope)
+    assert stats == {"positive": 1, "negative": 0, "total": 1, "score": 1.0}
+
+    TrustLedger.record_outcome(db, action_type="archive", scope=scope, positive=True)
+    TrustLedger.record_outcome(db, action_type="archive", scope=scope, positive=False)
+    stats = TrustLedger.get_stats(db, action_type="archive", scope=scope)
+    assert stats["positive"] == 2
+    assert stats["negative"] == 1
+    assert stats["total"] == 3
+    assert stats["score"] == pytest.approx(2 / 3)
+
+
+def test_get_stats_empty_scope_is_zero(db):
+    stats = TrustLedger.get_stats(db, action_type="archive", scope="sender:none@x")
+    assert stats == {"positive": 0, "negative": 0, "total": 0, "score": 0.0}
+
+
+def test_is_trusted_requires_both_samples_and_accuracy(db):
+    ledger = TrustLedger(min_samples=5, threshold=0.85)
+    scope = category_scope("PROMOTIONAL")
+
+    # 4/4 correct: perfect accuracy but below the sample floor → not trusted.
+    for _ in range(4):
+        ledger.record_outcome(db, action_type="archive", scope=scope, positive=True)
+    assert not ledger.is_trusted(db, action_type="archive", scope=scope)
+
+    # 5th correct crosses the sample floor at 100% → trusted.
+    ledger.record_outcome(db, action_type="archive", scope=scope, positive=True)
+    assert ledger.is_trusted(db, action_type="archive", scope=scope)
+
+
+def test_is_trusted_denied_below_threshold(db):
+    ledger = TrustLedger(min_samples=5, threshold=0.85)
+    scope = category_scope("FYI")
+    # 8 correct, 2 wrong → 0.8 accuracy, enough samples but below 0.85.
+    for _ in range(8):
+        ledger.record_outcome(db, action_type="archive", scope=scope, positive=True)
+    for _ in range(2):
+        ledger.record_outcome(db, action_type="archive", scope=scope, positive=False)
+    assert not ledger.is_trusted(db, action_type="archive", scope=scope)
+
+
+def test_ledger_rejects_bad_thresholds():
+    with pytest.raises(ValueError):
+        TrustLedger(min_samples=0)
+    with pytest.raises(ValueError):
+        TrustLedger(threshold=0.0)
+    with pytest.raises(ValueError):
+        TrustLedger(threshold=1.5)
+
+
+def test_list_ledger_returns_rows(db):
+    TrustLedger.record_outcome(
+        db, action_type="archive", scope=sender_scope("a@x"), positive=True
+    )
+    TrustLedger.record_outcome(
+        db, action_type="add_label", scope=category_scope("FYI"), positive=False
+    )
+    rows = TrustLedger.list_ledger(db)
+    assert len(rows) == 2
+    assert {r["action_type"] for r in rows} == {"archive", "add_label"}
+
+
+# ---------------------------------------------------------------------------
+# The inviolable floor — the invariant that matters most
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "level", [LEVEL_OFF, LEVEL_SUGGEST, LEVEL_EARN_TRUST, LEVEL_FULL]
+)
+@pytest.mark.parametrize("tool", sorted(FLOOR))
+def test_floor_always_confirms_at_every_level(db, level, tool):
+    """No level ever lowers the destructive floor to auto/draft/suggest."""
+    policy = _policy(level)
+    decision = policy.decide(tool=tool, action_type="send", db=db)
+    assert decision.action == "confirm"
+    assert decision.confidence == 1.0
+
+
+def test_floor_confirms_even_for_fully_trusted_sender(db):
+    """A sender proven 100/100 on archives still cannot trigger an auto-send."""
+    ledger = TrustLedger(min_samples=5, threshold=0.85)
+    scope = sender_scope("boss@company.com")
+    for _ in range(100):
+        ledger.record_outcome(db, action_type="archive", scope=scope, positive=True)
+    policy = TrustPolicy(level=LEVEL_FULL, ledger=ledger, confirm_floor=FLOOR)
+    decision = policy.decide(
+        tool="send_now",
+        action_type="send",
+        sender="boss@company.com",
+        db=db,
+    )
+    assert decision.action == "confirm"
+
+
+# ---------------------------------------------------------------------------
+# Level behavior
+# ---------------------------------------------------------------------------
+
+
+def test_off_level_disables_loop(db):
+    policy = _policy(LEVEL_OFF)
+    assert policy.enabled is False
+    d = policy.decide(tool="archive_message", action_type="archive", db=db)
+    assert d.action == "suggest"
+
+
+def test_draft_actions_always_draft_never_send(db):
+    for level in (LEVEL_SUGGEST, LEVEL_EARN_TRUST, LEVEL_FULL):
+        policy = _policy(level)
+        d = policy.decide(tool="draft_reply", action_type="draft_reply", db=db)
+        assert d.action == "draft", level
+
+
+def test_non_reversible_action_suggests(db):
+    policy = _policy(LEVEL_FULL)
+    d = policy.decide(tool="trash_message", action_type="trash", db=db)
+    assert d.action == "suggest"
+
+
+def test_suggest_level_never_auto(db):
+    policy = _policy(LEVEL_SUGGEST)
+    d = policy.decide(tool="archive_message", action_type="archive", db=db)
+    assert d.action == "suggest"
+
+
+def test_full_level_auto_executes_reversible(db):
+    policy = _policy(LEVEL_FULL)
+    d = policy.decide(tool="archive_message", action_type="archive", db=db)
+    assert d.action == "auto"
+    assert d.confidence == 1.0
+
+
+# ---------------------------------------------------------------------------
+# earn_trust — the star mode
+# ---------------------------------------------------------------------------
+
+
+def test_earn_trust_suggests_until_proven_then_auto(db):
+    policy = _policy(LEVEL_EARN_TRUST, db_min=5, threshold=0.85)
+    scope = sender_scope("news@x.com")
+
+    # Cold: no evidence → suggest.
+    d = policy.decide(
+        tool="archive_message", action_type="archive", sender="news@x.com", db=db
+    )
+    assert d.action == "suggest"
+
+    # Feed 5 positive outcomes → crosses the trust bar → auto.
+    for _ in range(5):
+        TrustLedger.record_outcome(
+            db, action_type="archive", scope=scope, positive=True
+        )
+    d = policy.decide(
+        tool="archive_message", action_type="archive", sender="news@x.com", db=db
+    )
+    assert d.action == "auto"
+    assert d.confidence == pytest.approx(1.0)
+    assert "5/5" in d.reason
+
+
+def test_earn_trust_category_scope_grants_auto(db):
+    policy = _policy(LEVEL_EARN_TRUST, db_min=3, threshold=0.85)
+    scope = category_scope("PROMOTIONAL")
+    for _ in range(3):
+        TrustLedger.record_outcome(
+            db, action_type="archive", scope=scope, positive=True
+        )
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        category="PROMOTIONAL",
+        sender="unseen@x.com",
+        db=db,
+    )
+    assert d.action == "auto"
+
+
+def test_earn_trust_explicit_low_priority_sender_auto(db):
+    policy = _policy(LEVEL_EARN_TRUST)
+    prefs = {"low_priority_senders": {"newsletter@stripe.com"}, "category_defaults": {}}
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        sender="newsletter@stripe.com",
+        db=db,
+        preferences=prefs,
+    )
+    assert d.action == "auto"
+    assert "preference" in d.reason
+
+
+def test_earn_trust_explicit_category_default_auto(db):
+    policy = _policy(LEVEL_EARN_TRUST)
+    prefs = {"low_priority_senders": set(), "category_defaults": {"FYI": "archive"}}
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        category="FYI",
+        sender="anyone@x.com",
+        db=db,
+        preferences=prefs,
+    )
+    assert d.action == "auto"
+
+
+def test_earn_trust_negative_evidence_keeps_suggesting(db):
+    policy = _policy(LEVEL_EARN_TRUST, db_min=5, threshold=0.85)
+    scope = sender_scope("mixed@x.com")
+    for _ in range(5):
+        TrustLedger.record_outcome(
+            db, action_type="archive", scope=scope, positive=True
+        )
+    for _ in range(3):
+        TrustLedger.record_outcome(
+            db, action_type="archive", scope=scope, positive=False
+        )
+    # 5/8 = 0.625 accuracy < 0.85 → still suggests, carrying the current score.
+    d = policy.decide(
+        tool="archive_message", action_type="archive", sender="mixed@x.com", db=db
+    )
+    assert d.action == "suggest"
+    assert d.confidence == pytest.approx(5 / 8)
+
+
+def test_policy_rejects_unknown_level():
+    with pytest.raises(ValueError):
+        TrustPolicy(level="turbo", ledger=TrustLedger(), confirm_floor=FLOOR)
+
+
+# ---------------------------------------------------------------------------
+# Parity: the test FLOOR must match the agent's real confirm-floor
+# ---------------------------------------------------------------------------
+
+
+def test_floor_matches_agent_confirmation_required_tools():
+    """If the agent's floor changes, this test forces this file to change too —
+    so the floor can never silently shrink out from under the policy tests."""
+    from gaia_agent_email.agent import EmailTriageAgent
+
+    assert set(FLOOR) == set(EmailTriageAgent.CONFIRMATION_REQUIRED_TOOLS)


### PR DESCRIPTION
Turn on full autonomy and the Email agent handles your inbox for you: it triages and files low-signal mail on its own, **always checks in before anything destructive or irreversible** (send, forward, permanent-delete, RSVP, quarantine), and **learns from you** so it gets more personalized over time. Before this, the agent could only act when you prompted it — it had scheduling and undo, but no way to *decide on its own* what to do silently versus what to ask about, and nothing that learned from your corrections. Now it does, on an earn-trust gradient: cautious on day one, near-invisible once a sender/category has proven itself, and instantly back to asking the moment you correct it.

The whole engine is here — decide, act, learn, control, inspect, schedule — built on the existing base-`Agent` autonomy hooks (`on_heartbeat`/`propose`, spec `autonomous-agent-mode.md` §6.7) as their first concrete consumer. Personalization is memory/prompt-based only (no model training). Implements #1115, #557, #1483, #1287, #2005; supports #1508.

**Safety is the invariant:** the destructive confirm-floor resolves to *confirm* at every level — even for a 100%-trusted sender — and a parity test locks the policy floor to the agent's real `CONFIRMATION_REQUIRED_TOOLS`, so it can never silently shrink. Only reversible actions auto-execute, each with undo.

Turn it on:
```
POST /v1/email/agent/autonomy      {level: "earn_trust"}   # "off" = kill switch
GET  /v1/email/agent/autonomy/{id}                          # inspect earned trust
# or run headless: GAIA_EMAIL_AUTONOMY_ENABLED=true (AutonomyScheduler drives it)
```

### Test plan
- [ ] `pytest tests/test_trust.py` — ledger math + the confirm-floor invariant (55 tests)
- [ ] `pytest tests/test_email_autonomy_cycle.py` — observe→decide→act, closed learning loop, end-to-end undo capture, multi-cycle convergence/demotion (21 tests)
- [ ] `pytest tests/test_email_autonomy_scheduler.py` — driver config + fire (11 tests)
- [ ] `pytest tests/test_email_agent_routes.py` — REST control surface (incl. autonomy)
- [ ] `pytest tests/test_capability_matrix.py tests/test_email_behavioral_learning.py` — no regressions
- [ ] Manual: set `autonomy_level=earn_trust`, run a cycle on a promo-heavy inbox → proposals; accept a few via `record_autonomy_outcome`; rerun → silent archive; undo one → it asks again.

### Follow-ups (not in this PR)
- Register `run_autonomy_job` on the core `DaemonClock` for the daemon-supervised path (cross-process, with #2156).
- npm thin-client CLI `gaia email autonomy …` + Agent-UI activity-feed panel over the REST surface.
