### PR TITLE
feat(connectors): support work/school Outlook + zero-setup device-code sign-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,13 @@ util/custom/*
 # exist in that specific MCP integration.
 eval/scenarios/mcp_tool_reliability/
 tests/unit/eval/test_mcp_tool_reliability_scenarios.py
+
+# Internal skill-marketplace installs (slai-marketplace). AMD-internal skills
+# copied into per-tool dirs; never ship them to the public repo. The repo's own
+# committed skills under .claude/skills/* stay tracked — only the
+# marketplace-installed m365-* skill dir is ignored.
+/skills/
+/.cline/
+/.codex/
+/.cursor/
+/.claude/skills/m365-email/

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -8,11 +8,24 @@ description: "Connect GAIA to Outlook mail, calendar, and OneDrive via Microsoft
   **Connector ID:** `microsoft` · **Type:** `oauth_pkce` · **Catalog entry:** [`src/gaia/connectors/catalog/microsoft.py`](https://github.com/amd/gaia/blob/main/src/gaia/connectors/catalog/microsoft.py)
 </Info>
 
-GAIA connects to your **personal** Microsoft account — Outlook.com, Hotmail,
-or Live — using the Microsoft identity platform v2.0 with PKCE. Work and
-school (Microsoft Entra ID) accounts are not supported in this release.
+GAIA connects to your Microsoft account — **personal** (Outlook.com, Hotmail,
+Live) **or work/school** (Microsoft 365 / Entra ID) — using the Microsoft
+identity platform v2.0. The default login tenant is `common`, which accepts
+both account types. To restrict sign-in to one tenant, set
+`GAIA_MICROSOFT_TENANT` (a specific Entra tenant id, or `organizations` /
+`consumers`).
 
-## What you'll need
+There are two ways to sign in:
+
+- **Browser (PKCE)** — the default. Needs an Azure **App registration** you
+  create once (below). Best when you control your own app registration.
+- **Device code** — `gaia connectors connect microsoft --device`. You enter a
+  short code at a Microsoft URL; no loopback redirect. This is the zero-setup
+  path when a pre-registered public **client ID** is supplied via
+  `GAIA_MICROSOFT_CLIENT_ID` (no per-user app registration or redirect URI
+  needed). See [Device-code sign-in](#device-code-sign-in) below.
+
+## What you'll need (browser flow)
 
 Microsoft requires every app — including GAIA running locally — to identify
 itself with an **App registration** that you create once in the Azure portal.
@@ -27,9 +40,10 @@ GAIA stores the Client ID encrypted in your OS keyring.
 
 1. Go to the [Azure portal → App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).
 2. Click **New registration**.
-3. **Name**: `GAIA Personal` (or whatever you like).
-4. **Supported account types**: choose **Personal Microsoft accounts only**.
-   <Tooltip tip="This maps to the 'consumers' tenant GAIA uses. Picking a work/school option would target a tenant GAIA does not authenticate against in this release.">Why this option?</Tooltip>
+3. **Name**: `GAIA` (or whatever you like).
+4. **Supported account types**: choose **Accounts in any organizational
+   directory and personal Microsoft accounts**.
+   <Tooltip tip="This maps to the 'common' tenant GAIA uses by default, so both work/school and personal accounts can sign in. To restrict to one, register for that audience and set GAIA_MICROSOFT_TENANT.">Why this option?</Tooltip>
 5. Click **Register**. The **Overview** page shows the **Application (client)
    ID** — copy it for Step 3.
 
@@ -104,6 +118,39 @@ The scopes a connection can request are listed in the spec at
 | `https://graph.microsoft.com/Calendars.Read` | Read your calendar events |
 | `https://graph.microsoft.com/Calendars.ReadWrite` | Manage your calendar events |
 
+## Device-code sign-in
+
+The device-code flow skips the Azure app registration and the loopback
+redirect entirely — useful for headless machines, or when a public **client
+ID** is already available (e.g. an org-published GAIA app registration).
+
+```bash
+# Supply a pre-registered public client id (personal + work/school audience)
+export GAIA_MICROSOFT_CLIENT_ID=<application-client-id>
+# Optional: pin a single tenant instead of the default 'common'
+# export GAIA_MICROSOFT_TENANT=organizations
+
+gaia connectors connect microsoft --device
+```
+
+GAIA prints a short code and a URL (`https://microsoft.com/devicelogin`). Open
+the URL on any device, enter the code, and approve. GAIA polls until sign-in
+completes, then stores the refresh token in your OS keyring — identical to the
+browser flow from that point on. Grant an agent afterward:
+
+```bash
+gaia connectors grants grant microsoft installed:email \
+  --scopes https://graph.microsoft.com/Mail.ReadWrite \
+           https://graph.microsoft.com/Mail.Send
+```
+
+<Note>
+  The client ID used for device code must be a **public client** registered for
+  the "any account" audience with device-code flow allowed. GAIA does not ship
+  a client ID — supply your own via `GAIA_MICROSOFT_CLIENT_ID`, or use the
+  browser flow with your own app registration.
+</Note>
+
 ## Common issues
 
 ### `AADSTS50011: redirect URI mismatch`
@@ -114,9 +161,12 @@ or you added it under the wrong platform. Re-check Step 2 — it must be a
 
 ### `AADSTS700016` / `unauthorized_client`
 
-The Client ID is wrong, or the app was registered for the wrong account type.
-Confirm you copied the **Application (client) ID** from the Overview page and
-chose **Personal Microsoft accounts only** in Step 1.
+The Client ID is wrong, or the app was registered for an account type that
+doesn't match your sign-in. Confirm you copied the **Application (client) ID**
+from the Overview page and chose **Accounts in any organizational directory
+and personal Microsoft accounts** in Step 1. If you pinned
+`GAIA_MICROSOFT_TENANT`, make sure it matches your account type
+(`organizations` for work/school, `consumers` for personal).
 
 ### `AADSTS65001` / consent required
 

--- a/docs/connectors/microsoft.mdx
+++ b/docs/connectors/microsoft.mdx
@@ -124,6 +124,14 @@ The device-code flow skips the Azure app registration and the loopback
 redirect entirely — useful for headless machines, or when a public **client
 ID** is already available (e.g. an org-published GAIA app registration).
 
+**In the Agent UI:** with a client ID configured (env or the OAuth-client
+form), the Microsoft tile in Settings → Connections shows a **Sign in with a
+code** button next to **Connect**. Click it, then enter the displayed code at
+the Microsoft URL — the tile flips to **Connected** automatically when you
+finish. No browser redirect, no app registration.
+
+**From the CLI:**
+
 ```bash
 # Supply a pre-registered public client id (personal + work/school audience)
 export GAIA_MICROSOFT_CLIENT_ID=<application-client-id>

--- a/docs/guides/email-integration.mdx
+++ b/docs/guides/email-integration.mdx
@@ -298,7 +298,7 @@ offline access and the scopes the agent needs:
 | Provider | OAuth flow | Mail scopes to request |
 |---|---|---|
 | **Gmail** | Web or Desktop-app client (authorization-code) | `https://www.googleapis.com/auth/gmail.modify`, `https://www.googleapis.com/auth/gmail.send` |
-| **Personal Outlook.com** | **Device-code** flow | `https://graph.microsoft.com/Mail.ReadWrite`, `https://graph.microsoft.com/Mail.Send` |
+| **Outlook** (personal Outlook.com **or** work/school Microsoft 365) | Browser (PKCE) or **device-code** flow, `common` tenant | `https://graph.microsoft.com/Mail.ReadWrite`, `https://graph.microsoft.com/Mail.Send` |
 
 Add calendar scopes only if you use the calendar endpoints: Google
 `https://www.googleapis.com/auth/calendar.events` (and/or `calendar.readonly`),
@@ -323,7 +323,7 @@ curl -s -X POST http://127.0.0.1:4200/v1/connections/google \
   }'
 ```
 
-For personal Outlook, `POST /v1/connections/microsoft` with the Graph scopes above.
+For Outlook (personal or work/school), `POST /v1/connections/microsoft` with the Graph scopes above.
 
 **Response** — `201 Created`, metadata only (secrets are never echoed back):
 
@@ -554,10 +554,10 @@ Tools exposed: `triage_email`, `triage_email_batch`, `draft_reply`, `send_email`
 ## Provider coverage
 
 - **Gmail** — full support (triage, search, draft/send, archive, quarantine, calendar).
-- **Personal Outlook.com** — supported via the device-code OAuth flow; phishing
-  quarantine is **Gmail-only** (an Outlook mailbox is refused with **400**, because its
-  label-based undo can't reverse Outlook's folder move).
-- **Enterprise Microsoft Graph** — deferred.
+- **Outlook** — personal (Outlook.com) **and** work/school (Microsoft 365 / Entra
+  ID) mailboxes, via the browser (PKCE) or device-code OAuth flow on the `common`
+  tenant. Phishing quarantine is **Gmail-only** (an Outlook mailbox is refused with
+  **400**, because its label-based undo can't reverse Outlook's folder move).
 
 ## Related
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1500,6 +1500,13 @@ gaia connectors <subcommand> [OPTIONS]
 gaia connectors connect google
 ```
 
+```bash Authorize Microsoft (device code, no app registration)
+# Personal Outlook.com or work/school Microsoft 365 (common tenant).
+# Supply a pre-registered public client id; GAIA prints a code + URL.
+export GAIA_MICROSOFT_CLIENT_ID=<application-client-id>
+gaia connectors connect microsoft --device
+```
+
 ```bash Configure an MCP server token
 gaia connectors configure github --set GITHUB_TOKEN=ghp_xxx
 ```
@@ -1508,6 +1515,11 @@ gaia connectors configure github --set GITHUB_TOKEN=ghp_xxx
 gaia connectors grants grant google builtin:chat --scopes gmail.readonly
 ```
 </CodeGroup>
+
+The `--device` flag on `connect` uses the RFC 8628 device-code flow instead of
+the browser redirect — required for Microsoft zero-setup sign-in (no Azure app
+registration or loopback redirect URI). Pin `GAIA_MICROSOFT_TENANT` to restrict
+sign-in to one tenant (`organizations`, `consumers`, or a specific Entra id).
 
 [→ Connectors Guide](/connectors) · [→ Connectors SDK](/sdk/infrastructure/connectors)
 

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -11,9 +11,11 @@ behind any entry — API shapes, endpoints, and version semantics — see
   against the `consumers` tenant, so a corporate Microsoft 365 account was
   rejected before GAIA ever saw a token. It now uses the `common` tenant by
   default (both account types), overridable with `GAIA_MICROSOFT_TENANT`. A new
-  zero-setup device-code sign-in (`gaia connectors connect microsoft --device`)
-  connects without an Azure app registration or loopback redirect. No email-agent
-  tool changed — the existing Outlook backend just reaches more mailboxes (#1275).
+  zero-setup device-code sign-in connects without an Azure app registration or
+  loopback redirect — from the CLI (`gaia connectors connect microsoft --device`)
+  or the Agent UI (a **Sign in with a code** button on the Microsoft tile). No
+  email-agent tool changed — the existing Outlook backend just reaches more
+  mailboxes (#1275).
 - **In the GAIA daemon deployment, the sidecar no longer holds long-lived OAuth
   secrets.** Previously a sidecar read the mailbox connection straight from the
   machine keyring. Now, under the Agent UI daemon, the daemon (the custody home)

--- a/hub/agents/email/npm/CHANGELOG.md
+++ b/hub/agents/email/npm/CHANGELOG.md
@@ -6,6 +6,14 @@ behind any entry — API shapes, endpoints, and version semantics — see
 
 ## Unreleased
 
+- **Work/school Outlook (Microsoft 365 / Entra ID) mailboxes now work, not just
+  personal Outlook.com.** The Microsoft connector previously signed in only
+  against the `consumers` tenant, so a corporate Microsoft 365 account was
+  rejected before GAIA ever saw a token. It now uses the `common` tenant by
+  default (both account types), overridable with `GAIA_MICROSOFT_TENANT`. A new
+  zero-setup device-code sign-in (`gaia connectors connect microsoft --device`)
+  connects without an Azure app registration or loopback redirect. No email-agent
+  tool changed — the existing Outlook backend just reaches more mailboxes (#1275).
 - **In the GAIA daemon deployment, the sidecar no longer holds long-lived OAuth
   secrets.** Previously a sidecar read the mailbox connection straight from the
   machine keyring. Now, under the Agent UI daemon, the daemon (the custody home)

--- a/hub/agents/email/python/gaia_agent_email/__init__.py
+++ b/hub/agents/email/python/gaia_agent_email/__init__.py
@@ -88,9 +88,10 @@ def build_registration():
             connector_id="microsoft",
             scopes=OUTLOOK_MAIL_SCOPES + OUTLOOK_CALENDAR_SCOPES,
             reason=(
-                "Read and organize your personal Outlook.com mailbox, send "
-                "messages on your behalf, and read/respond to your Outlook "
-                "calendar via Microsoft Graph."
+                "Read and organize your Outlook mailbox — personal "
+                "(Outlook.com) or work/school (Microsoft 365) — send messages "
+                "on your behalf, and read/respond to your Outlook calendar via "
+                "Microsoft Graph."
             ),
         ),
     ]

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -418,9 +418,10 @@ class EmailTriageAgent(
             connector_id="microsoft",
             scopes=OUTLOOK_MAIL_SCOPES + OUTLOOK_CALENDAR_SCOPES,
             reason=(
-                "Read and organize your personal Outlook.com mailbox, send "
-                "messages on your behalf, and read/respond to your Outlook "
-                "calendar via Microsoft Graph."
+                "Read and organize your Outlook mailbox — personal "
+                "(Outlook.com) or work/school (Microsoft 365) — send messages "
+                "on your behalf, and read/respond to your Outlook calendar via "
+                "Microsoft Graph."
             ),
         ),
     ]

--- a/hub/agents/email/python/gaia_agent_email/config.py
+++ b/hub/agents/email/python/gaia_agent_email/config.py
@@ -94,8 +94,8 @@ class EmailAgentConfig:
       ``resolve_mail_backend`` stays connector-agnostic (``None`` → Gmail) for
       the eval seam. Case-insensitive.
     - ``calendar_provider``: which calendar provider the agent operates on —
-      ``"google"`` (the default) or ``"microsoft"`` (personal Outlook.com
-      calendar via MS Graph, #1276). Selects the live backend in
+      ``"google"`` (the default) or ``"microsoft"`` (Outlook calendar —
+      personal or work/school — via MS Graph, #1276). Selects the live backend in
       ``resolve_calendar_backend``. Case-insensitive. When ``None`` (the
       default), tracks ``mail_provider`` so a Microsoft-only user who set
       ``mail_provider="microsoft"`` gets the Outlook calendar too without

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.css
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.css
@@ -756,3 +756,46 @@
 .oauth-client-editor .oauth-setup-form {
     padding: 0 8px 8px;
 }
+
+/* Device-code sign-in block (#1275) — shown after "Sign in with a code". */
+.device-code-block {
+    margin-top: 10px;
+    padding: 12px;
+    border: 1px solid var(--border-color, #333);
+    border-radius: 8px;
+    background: var(--surface-2, rgba(255, 255, 255, 0.03));
+}
+
+.device-code-instructions {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--text-primary);
+}
+
+.device-code-value {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.device-code-value code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 18px;
+    letter-spacing: 2px;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: var(--surface-3, rgba(255, 255, 255, 0.06));
+    color: var(--text-primary);
+    user-select: all;
+}
+
+.device-code-waiting {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: var(--text-muted);
+}

--- a/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectorsSection.tsx
@@ -241,6 +241,10 @@ function OAuthConfigureBody({
     const [busy, setBusy] = useState(false);
     const [err, setErr] = useState<string | null>(null);
     const [setupValues, setSetupValues] = useState<Record<string, string>>({});
+    // Device-code sign-in (#1275): once started, the server polls in the
+    // background and we display the code + URL here until the SSE
+    // oauth_completed/oauth_error event resolves it.
+    const [deviceInfo, setDeviceInfo] = useState<api.DeviceAuthInfo | null>(null);
 
     // #2117 — agents that declare this connector as a requirement. Connecting
     // grants the selected agents in the same flow (default-on), so a mailbox
@@ -308,6 +312,52 @@ function OAuthConfigureBody({
             setBusy(false);
         }
     };
+
+    // Device-code connect: no browser redirect / no Azure app registration.
+    // The server polls in the background; we just show the code + URL and let
+    // the SSE oauth_completed / oauth_error events (below) resolve the state.
+    const handleConnectDevice = async () => {
+        setBusy(true);
+        setErr(null);
+        setDeviceInfo(null);
+        try {
+            const info = await api.authorizeConnectorDevice(
+                connector.id,
+                connector.available_scopes?.length
+                    ? connector.available_scopes
+                    : connector.default_scopes,
+                selectedGrantAgents(),
+            );
+            setDeviceInfo(info);
+        } catch (e) {
+            setErr(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    // Success path: once the backend reports the connection, drop the code UI.
+    useEffect(() => {
+        if (connector.configured) setDeviceInfo(null);
+    }, [connector.configured]);
+
+    // While a device sign-in is pending, react to THIS connector's SSE events
+    // so an expiry / denial surfaces as an error instead of a spinner that
+    // never resolves. Mounted only while the tile is expanded.
+    useConnectorsSSE(
+        useCallback(
+            (event) => {
+                if (event.connectorId !== connector.id) return;
+                if (event.reason === 'oauth_error') {
+                    setErr(String(event.payload.error ?? 'Device sign-in failed.'));
+                    setDeviceInfo(null);
+                } else if (event.reason === 'oauth_completed') {
+                    setDeviceInfo(null);
+                }
+            },
+            [connector.id],
+        ),
+    );
 
     const handleDisconnect = async () => {
         setBusy(true);
@@ -467,17 +517,29 @@ function OAuthConfigureBody({
                         Setup required
                     </span>
                 ) : (
-                    <button
-                        className="btn-primary"
-                        disabled={busy}
-                        onClick={() => void handleConnect()}
-                    >
-                        {busy ? (
-                            <Loader2 size={12} className="spin" />
-                        ) : (
-                            <><ExternalLink size={12} /> Connect</>
+                    <>
+                        <button
+                            className="btn-primary"
+                            disabled={busy || deviceInfo !== null}
+                            onClick={() => void handleConnect()}
+                        >
+                            {busy ? (
+                                <Loader2 size={12} className="spin" />
+                            ) : (
+                                <><ExternalLink size={12} /> Connect</>
+                            )}
+                        </button>
+                        {connector.supports_device_code && (
+                            <button
+                                className="btn-secondary"
+                                disabled={busy || deviceInfo !== null}
+                                onClick={() => void handleConnectDevice()}
+                                title="Enter a short code at a URL — no browser redirect or app registration needed"
+                            >
+                                Sign in with a code
+                            </button>
                         )}
-                    </button>
+                    </>
                 )}
                 {(connector.docs_url || connector.product_url) && (
                     <a
@@ -490,6 +552,48 @@ function OAuthConfigureBody({
                     </a>
                 )}
             </div>
+            {deviceInfo && !connector.configured && (
+                <div className="device-code-block">
+                    <p className="device-code-instructions">
+                        Go to{' '}
+                        <a
+                            href={deviceInfo.verification_uri}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={(e) => {
+                                e.preventDefault();
+                                openAuthUrl(deviceInfo.verification_uri);
+                            }}
+                        >
+                            {deviceInfo.verification_uri}
+                        </a>{' '}
+                        and enter this code:
+                    </p>
+                    <div className="device-code-value">
+                        <code>{deviceInfo.user_code}</code>
+                        <button
+                            type="button"
+                            className="btn-secondary"
+                            onClick={() =>
+                                void navigator.clipboard?.writeText(deviceInfo.user_code)
+                            }
+                            title="Copy code"
+                        >
+                            Copy
+                        </button>
+                    </div>
+                    <p className="device-code-waiting">
+                        <Loader2 size={12} className="spin" /> Waiting for sign-in…
+                    </p>
+                    <button
+                        type="button"
+                        className="btn-secondary"
+                        onClick={() => setDeviceInfo(null)}
+                    >
+                        Cancel
+                    </button>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/gaia/apps/webui/src/services/api.ts
+++ b/src/gaia/apps/webui/src/services/api.ts
@@ -242,6 +242,32 @@ export async function authorizeConnector(
     );
 }
 
+export interface DeviceAuthInfo {
+    user_code: string;
+    verification_uri: string;
+    expires_in: number;
+    interval: number;
+    message: string;
+}
+
+export async function authorizeConnectorDevice(
+    connectorId: string,
+    scopes: string[],
+    grantAgents: string[] = [],
+): Promise<DeviceAuthInfo> {
+    // Device-code sign-in: no browser redirect / no Azure app registration.
+    // The server polls in the background and emits connector.oauth.completed /
+    // connector.oauth.error over SSE (useConnectorsSSE) when the user finishes,
+    // so the caller displays the code and waits for the same events the browser
+    // flow uses. `grantAgents` are committed atomically on success.
+    return apiFetch(
+        'POST',
+        `/connectors/${connectorId}/authorize-device`,
+        { scopes, grant_agents: grantAgents },
+        UI_HEADER,
+    );
+}
+
 export async function configureConnector(
     connectorId: string,
     config: Record<string, unknown>,

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -278,6 +278,13 @@ export interface ConnectorRow {
     default_scopes: string[];
     available_scopes: string[];
     /**
+     * Whether the provider supports the RFC 8628 device-code flow (#1275) —
+     * a short code entered at a URL, no browser redirect and no per-user Azure
+     * app registration. When ``true`` the tile offers a "Sign in with a code"
+     * option alongside the browser Connect button (Microsoft today).
+     */
+    supports_device_code?: boolean;
+    /**
      * First-time setup fields the user fills in to provide OAuth-app
      * client credentials (e.g. Google Cloud Console client_id +
      * client_secret). When ``configurable`` is ``false`` and this list

--- a/src/gaia/connectors/__init__.py
+++ b/src/gaia/connectors/__init__.py
@@ -82,9 +82,11 @@ _API_NAMES: frozenset[str] = frozenset(
         "list_connections",
         "load_activations",
         "load_grants",
+        "poll_device_flow",
         "revoke_agent_grant",
         "revoke_connection",
         "start_authorization",
+        "start_device_flow",
         "tripwire_check",
     }
 )

--- a/src/gaia/connectors/api.py
+++ b/src/gaia/connectors/api.py
@@ -44,7 +44,9 @@ from gaia.connectors.events import emit_change
 from gaia.connectors.flow import (
     cancel_flow,
     complete_authorization,
+    poll_device_flow,
     start_authorization,
+    start_device_flow,
 )
 from gaia.connectors.grants import (
     check_agent_grant,
@@ -687,8 +689,10 @@ __all__ = [
     "list_connections",
     "load_activations",
     "load_grants",
+    "poll_device_flow",
     "revoke_agent_grant",
     "revoke_connection",
     "start_authorization",
+    "start_device_flow",
     "tripwire_check",
 ]

--- a/src/gaia/connectors/catalog/microsoft.py
+++ b/src/gaia/connectors/catalog/microsoft.py
@@ -71,6 +71,10 @@ MICROSOFT_SPEC = ConnectorSpec(
         "https://graph.microsoft.com/Calendars.ReadWrite",
     ),
     oauth_provider_ref="microsoft",
+    # The Microsoft provider implements the RFC 8628 device-code endpoints, so
+    # the UI can offer zero-setup "sign in with a code" alongside the browser
+    # flow (no Azure app registration / loopback redirect needed).
+    supports_device_code=True,
     # First-time setup form. Microsoft public-client PKCE flows take ONLY a
     # Client ID — Microsoft forbids a client_secret for public/native clients.
     # The optional secret field exists solely for the rare confidential

--- a/src/gaia/connectors/catalog/microsoft.py
+++ b/src/gaia/connectors/catalog/microsoft.py
@@ -15,9 +15,10 @@ leads add agent tools that request a Bearer token for these Graph scopes via
 the generic ``oauth_pkce`` handler — no Microsoft-specific OAuth code in the
 agents.
 
-Tenant is ``consumers`` (personal Outlook.com / Hotmail / Live). ``openid`` and
-``offline_access`` are in ``default_scopes`` because the shared OAuth flow
-requires an id_token (account email) and a refresh token respectively.
+Tenant defaults to ``common`` (personal Outlook.com / Hotmail / Live AND
+work/school Entra ID accounts; override with ``GAIA_MICROSOFT_TENANT``).
+``openid`` and ``offline_access`` are in ``default_scopes`` because the shared
+OAuth flow requires an id_token (account email) and a refresh token respectively.
 """
 
 import gaia.connectors.oauth_pkce  # noqa: F401  # pylint: disable=unused-import
@@ -32,14 +33,16 @@ MICROSOFT_SPEC = ConnectorSpec(
     tier=1,
     type="oauth_pkce",
     description=(
-        "Connect GAIA to your personal Microsoft account for Outlook mail, "
-        "calendar, OneDrive, and more via Microsoft Graph."
+        "Connect GAIA to your Microsoft account — personal (Outlook.com / "
+        "Hotmail / Live) or work/school (Microsoft 365 / Entra ID) — for "
+        "Outlook mail, calendar, OneDrive, and more via Microsoft Graph."
     ),
     instructions_md=(
-        "Sign in with your personal Microsoft account (Outlook.com, Hotmail, "
-        "or Live) to allow GAIA to access your Outlook mail and calendar. You "
-        "can revoke access at any time from your "
-        "[Microsoft account privacy page](https://account.live.com/consent/Manage)."
+        "Sign in with your Microsoft account — personal (Outlook.com, Hotmail, "
+        "or Live) or work/school (Microsoft 365) — to allow GAIA to access your "
+        "Outlook mail and calendar. Personal accounts can revoke access from the "
+        "[Microsoft account privacy page](https://account.live.com/consent/Manage); "
+        "work/school accounts from [My Apps](https://myapps.microsoft.com)."
     ),
     product_url="https://www.microsoft.com/microsoft-365",
     docs_url="https://amd-gaia.ai/docs/connectors/microsoft",
@@ -81,10 +84,11 @@ MICROSOFT_SPEC = ConnectorSpec(
             kind="text",
             help_md=(
                 "From the Azure portal → App registrations → your app → "
-                "Overview. Register the app with the "
-                "'Personal Microsoft accounts only' audience and a "
-                "http://localhost redirect URI of type 'Mobile and desktop "
-                "applications'. Looks like a GUID, e.g. "
+                "Overview. Register the app with the 'Accounts in any "
+                "organizational directory and personal Microsoft accounts' "
+                "audience (so both work/school and personal accounts can sign "
+                "in) and a http://localhost redirect URI of type 'Mobile and "
+                "desktop applications'. Looks like a GUID, e.g. "
                 "11112222-bbbb-3333-cccc-4444dddd5555."
             ),
         ),

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -66,7 +66,7 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     p_status.add_argument("connector_id", nargs="?")
     p_status.add_argument("--json", action="store_true", dest="as_json")
 
-    # connect (OAuth PKCE)
+    # connect (OAuth PKCE, or device-code with --device)
     p_conn = sub.add_parser(
         "connect", help="Authorize an OAuth connector (opens browser)"
     )
@@ -75,6 +75,15 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--scopes",
         nargs="+",
         help="OAuth scopes to request (connector-specific)",
+    )
+    p_conn.add_argument(
+        "--device",
+        action="store_true",
+        help=(
+            "Use the device-code flow (enter a short code at a URL) instead of "
+            "the browser redirect. Needed for zero-setup Microsoft sign-in "
+            "(no Azure app registration). Provider must support device code."
+        ),
     )
 
     # configure (generic dispatcher + OAuth-client convenience flags)
@@ -302,6 +311,13 @@ def _handle_list(args: argparse.Namespace) -> int:
 
 
 def _handle_connect(args: argparse.Namespace) -> int:
+    # Importing the catalog registers the built-in specs so an unknown-connector
+    # error is actionable rather than a bare KeyError.
+    import gaia.connectors.catalog  # noqa: F401  # pylint: disable=unused-import
+
+    if getattr(args, "device", False):
+        return _handle_connect_device(args)
+
     from gaia.connectors.api import complete_authorization, start_authorization
 
     async def _run() -> str:
@@ -315,6 +331,42 @@ def _handle_connect(args: argparse.Namespace) -> int:
         return result.get("account_email") or "<unknown>"
 
     email = asyncio.run(_run())
+    sys.stdout.write(f"Connected as {email}\n")
+    return 0
+
+
+def _handle_connect_device(args: argparse.Namespace) -> int:
+    """Device-code connect: print the code + URL, then poll until sign-in."""
+    from gaia.connectors.api import poll_device_flow, start_device_flow
+    from gaia.connectors.errors import ConnectorsError
+
+    async def _run() -> str:
+        info = await start_device_flow(args.connector_id, scopes=args.scopes or [])
+        # Prefer the provider's own message (it already contains the URL + code);
+        # fall back to a constructed instruction line.
+        if info.get("message"):
+            sys.stdout.write(info["message"] + "\n")
+        else:
+            sys.stdout.write(
+                f"To authorize {args.connector_id}, visit "
+                f"{info['verification_uri']} and enter code: {info['user_code']}\n"
+            )
+        sys.stdout.write("Waiting for sign-in...\n")
+        sys.stdout.flush()
+        result = await poll_device_flow(
+            args.connector_id,
+            info["device_code"],
+            scopes=info["scopes"],
+            interval=info["interval"],
+            expires_in=info["expires_in"],
+        )
+        return result.get("account_email") or "<unknown>"
+
+    try:
+        email = asyncio.run(_run())
+    except ConnectorsError as e:
+        sys.stderr.write(f"gaia connectors connect --device: {e}\n")
+        return 1
     sys.stdout.write(f"Connected as {email}\n")
     return 0
 

--- a/src/gaia/connectors/cli.py
+++ b/src/gaia/connectors/cli.py
@@ -338,7 +338,6 @@ def _handle_connect(args: argparse.Namespace) -> int:
 def _handle_connect_device(args: argparse.Namespace) -> int:
     """Device-code connect: print the code + URL, then poll until sign-in."""
     from gaia.connectors.api import poll_device_flow, start_device_flow
-    from gaia.connectors.errors import ConnectorsError
 
     async def _run() -> str:
         info = await start_device_flow(args.connector_id, scopes=args.scopes or [])

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -137,6 +137,43 @@ def _decode_email_from_id_token(id_token: str) -> Optional[str]:
     return email if isinstance(email, str) else None
 
 
+async def _resolve_account_email(
+    provider, id_token: str, access_token: str
+) -> str:
+    """Best-effort account email for display: prefer the id_token claim; if it
+    yields nothing, fall back to the provider's ``userinfo_url`` (e.g. Graph
+    ``/me``). Returns ``"default"`` when neither works — the connection is keyed
+    by DEFAULT_ACCOUNT internally, so this only affects the display label and
+    must never fail the connect. The userinfo call is skipped entirely for
+    providers whose id_token already carries the email (e.g. Google)."""
+    email = _decode_email_from_id_token(id_token or "")
+    if email:
+        return email
+    userinfo_url = getattr(provider, "userinfo_url", None)
+    parse = getattr(provider, "parse_account_email", None)
+    if userinfo_url and access_token and callable(parse):
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    userinfo_url, headers={"Authorization": f"Bearer {access_token}"}
+                )
+            if resp.status_code == 200:
+                return parse(resp.json()) or "default"
+            logger.warning(
+                "flow: userinfo lookup for %s returned %s (label only)",
+                getattr(provider, "provider_id", "?"),
+                resp.status_code,
+            )
+        except Exception as e:  # noqa: BLE001 — label-only, never fail connect
+            logger.warning(
+                "flow: userinfo lookup for %s failed (%s); label falls back to "
+                "'default'",
+                getattr(provider, "provider_id", "?"),
+                e,
+            )
+    return "default"
+
+
 async def start_authorization(
     provider_id: str,
     scopes: Iterable[str],
@@ -420,7 +457,9 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
             "docs/security/connections.mdx."
         )
 
-    account_email = _decode_email_from_id_token(payload.get("id_token", "")) or ""
+    account_email = await _resolve_account_email(
+        provider, payload.get("id_token", ""), payload.get("access_token", "")
+    )
 
     save_connection(
         provider=flow.provider_id,
@@ -469,3 +508,184 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
         {"provider": flow.provider_id, "account_email": state_dict["account_email"]},
     )
     return state_dict
+
+
+# ---------------------------------------------------------------------------
+# Device-code flow (RFC 8628) — #1275
+# ---------------------------------------------------------------------------
+# Zero-setup sign-in for providers that expose a ``device_code_url`` (Microsoft
+# today). No loopback redirect and no per-user app registration: the user opens
+# a short URL, types a code, and approves. The resulting refresh token persists
+# through the SAME ``store.save_connection`` as the loopback flow, so every
+# downstream consumer (tokens.get_or_refresh, the email agent's
+# _get_outlook_token) is identical regardless of how the user connected.
+
+_DEVICE_POLL_DEFAULT_INTERVAL = 5
+
+
+async def start_device_flow(
+    provider_id: str, scopes: Iterable[str]
+) -> Dict[str, Any]:
+    """Request a device + user code from the provider's device-code endpoint.
+
+    Returns ``{provider_id, scopes, device_code, user_code, verification_uri,
+    expires_in, interval, message}``. The caller shows ``user_code`` +
+    ``verification_uri`` (or the provider-supplied ``message``) to the user,
+    then awaits :func:`poll_device_flow` with the returned ``device_code``.
+    """
+    provider = get_provider(provider_id)
+    device_code_url = getattr(provider, "device_code_url", None)
+    if not device_code_url:
+        raise ConnectorsError(
+            f"Provider {provider_id!r} does not support the device-code flow. "
+            "Use start_authorization (browser loopback) instead. See "
+            "docs/security/connections.mdx."
+        )
+    scopes_list = list(scopes) or list(provider.default_scopes)
+    body = provider.device_code_request_body(scopes_list)
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(device_code_url, data=body)
+    if resp.status_code != 200:
+        raise ConnectorsError(
+            f"Device-code request for {provider_id} failed with status "
+            f"{resp.status_code}: {resp.text[:300]}. Check the client id / "
+            "tenant (GAIA_MICROSOFT_CLIENT_ID / GAIA_MICROSOFT_TENANT). See "
+            "docs/security/connections.mdx."
+        )
+    d = resp.json()
+    logger.info(
+        "device-flow: started provider=%s scopes=%d", provider_id, len(scopes_list)
+    )
+    return {
+        "provider_id": provider_id,
+        "scopes": scopes_list,
+        "device_code": d["device_code"],
+        "user_code": d["user_code"],
+        "verification_uri": (
+            d.get("verification_uri") or d.get("verification_url") or ""
+        ),
+        "expires_in": int(d.get("expires_in", 900)),
+        "interval": int(d.get("interval", _DEVICE_POLL_DEFAULT_INTERVAL)),
+        "message": d.get("message", ""),
+    }
+
+
+async def poll_device_flow(
+    provider_id: str,
+    device_code: str,
+    *,
+    scopes: Iterable[str],
+    interval: int = _DEVICE_POLL_DEFAULT_INTERVAL,
+    expires_in: int = 900,
+    grant_agents: Optional[Mapping[str, Iterable[str]]] = None,
+) -> Dict[str, Any]:
+    """Poll the token endpoint until the user approves the device code.
+
+    Honors the RFC 8628 poll cadence: ``authorization_pending`` waits one
+    ``interval``; ``slow_down`` widens it by 5s. Persists the connection on
+    success and commits any ``grant_agents`` (namespaced agent id → scopes) in
+    the same step, so a device-code connect can grant an agent atomically the
+    way the loopback flow does. Raises ``FlowTimeoutError`` /
+    ``ConsentDeniedError`` / ``ConnectorsError`` on the unhappy paths — never a
+    silent empty result.
+    """
+    import time as _time
+
+    provider = get_provider(provider_id)
+    scopes_list = list(scopes) or list(provider.default_scopes)
+    body = provider.device_token_request_body(device_code)
+    poll_interval = max(int(interval), 1)
+    deadline = _time.monotonic() + max(int(expires_in), poll_interval)
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        while True:
+            resp = await client.post(provider.token_url, data=body)
+            if resp.status_code == 200:
+                payload = resp.json()
+                break
+            try:
+                err_payload = resp.json()
+            except Exception:  # noqa: BLE001 — body may be empty/non-JSON
+                err_payload = {}
+            err = err_payload.get("error", "")
+            if err == "authorization_pending":
+                pass
+            elif err == "slow_down":
+                poll_interval += 5
+            elif err == "expired_token":
+                raise FlowTimeoutError(
+                    f"Device-code for {provider_id} expired before sign-in. "
+                    "Run the connect command again."
+                )
+            elif err in ("authorization_declined", "access_denied"):
+                raise ConsentDeniedError(
+                    f"Device-code sign-in for {provider_id} was declined."
+                )
+            else:
+                raise ConnectorsError(
+                    f"Device-code polling for {provider_id} failed: "
+                    f"{err or resp.status_code}: "
+                    f"{err_payload.get('error_description', resp.text[:200])}. "
+                    "See docs/security/connections.mdx."
+                )
+            if _time.monotonic() >= deadline:
+                raise FlowTimeoutError(
+                    f"Device-code for {provider_id} timed out after "
+                    f"{expires_in}s waiting for sign-in. Run connect again."
+                )
+            await asyncio.sleep(poll_interval)
+
+    refresh_token = payload.get("refresh_token")
+    if not refresh_token:
+        raise ConnectorsError(
+            f"Device-code token response for {provider_id} returned no "
+            "refresh_token. The 'offline_access' scope must be requested (it is "
+            "in the Microsoft default_scopes). See docs/security/connections.mdx."
+        )
+    account_email = await _resolve_account_email(
+        provider, payload.get("id_token", ""), payload.get("access_token", "")
+    )
+
+    save_connection(
+        provider=provider_id,
+        account_email=account_email,
+        refresh_token=refresh_token,
+        scopes=scopes_list,
+        client_id_hash=provider.client_id_hash,
+    )
+
+    if grant_agents:
+        from gaia.connectors.grants import grant_agent
+
+        for agent_id, agent_scopes in grant_agents.items():
+            try:
+                grant_agent(provider_id, agent_id, list(agent_scopes))
+            except Exception as e:
+                raise ConnectorsError(
+                    f"Connected {provider_id!r} via device code but failed to "
+                    f"grant it to agent {agent_id!r}: {e}. Grant it manually "
+                    f"with `gaia connectors grants grant {provider_id} "
+                    f"{agent_id} --scopes {' '.join(agent_scopes)}`."
+                ) from e
+
+    await emit(
+        "connector.oauth.completed",
+        {"connector_id": provider_id, "account_email": account_email},
+    )
+    await emit(
+        "connection.connected",
+        {"provider": provider_id, "account_email": account_email},
+    )
+    logger.info(
+        "device-flow: connected provider=%s account=%s scopes=%d",
+        provider_id,
+        account_email,
+        len(scopes_list),
+    )
+    return {
+        "provider": provider_id,
+        "account_email": account_email,
+        "scopes": scopes_list,
+        "connected_at": _time.time(),
+    }

--- a/src/gaia/connectors/flow.py
+++ b/src/gaia/connectors/flow.py
@@ -137,9 +137,7 @@ def _decode_email_from_id_token(id_token: str) -> Optional[str]:
     return email if isinstance(email, str) else None
 
 
-async def _resolve_account_email(
-    provider, id_token: str, access_token: str
-) -> str:
+async def _resolve_account_email(provider, id_token: str, access_token: str) -> str:
     """Best-effort account email for display: prefer the id_token claim; if it
     yields nothing, fall back to the provider's ``userinfo_url`` (e.g. Graph
     ``/me``). Returns ``"default"`` when neither works — the connection is keyed
@@ -523,9 +521,7 @@ async def _exchange_code_for_tokens(flow: _PendingFlow, code: str) -> Dict[str, 
 _DEVICE_POLL_DEFAULT_INTERVAL = 5
 
 
-async def start_device_flow(
-    provider_id: str, scopes: Iterable[str]
-) -> Dict[str, Any]:
+async def start_device_flow(provider_id: str, scopes: Iterable[str]) -> Dict[str, Any]:
     """Request a device + user code from the provider's device-code endpoint.
 
     Returns ``{provider_id, scopes, device_code, user_code, verification_uri,

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -48,7 +48,10 @@ _DEFAULT_TENANT = "common"
 
 def _resolve_tenant() -> str:
     """Return the Microsoft login tenant segment for the endpoint URLs."""
-    return (os.environ.get("GAIA_MICROSOFT_TENANT") or _DEFAULT_TENANT).strip() or _DEFAULT_TENANT
+    return (
+        os.environ.get("GAIA_MICROSOFT_TENANT") or _DEFAULT_TENANT
+    ).strip() or _DEFAULT_TENANT
+
 
 # Plain-language descriptions for the AgentUI consent dialog, mirroring the
 # Google provider's SCOPE_DESCRIPTIONS. The router/CLI render these strings;

--- a/src/gaia/connectors/providers/microsoft.py
+++ b/src/gaia/connectors/providers/microsoft.py
@@ -12,8 +12,10 @@ NO module-level side effects: instantiating the provider reads
 module registers nothing — registration is lazy on first ``get("microsoft")``
 (see ``providers/__init__.py``), matching ``GoogleOAuthProvider``.
 
-Tenant is ``consumers`` — personal Microsoft accounts (Outlook.com / Hotmail /
-Live). Work/school (Entra ID) tenants are out of scope for v1.
+Tenant defaults to ``common`` — accepts BOTH personal Microsoft accounts
+(Outlook.com / Hotmail / Live) AND work/school (Entra ID) accounts. Override
+with ``GAIA_MICROSOFT_TENANT`` to pin a single Entra tenant id (or
+``organizations`` / ``consumers``) for orgs that want to restrict sign-in.
 
 Public-client PKCE: per the Microsoft identity platform docs, public clients
 (native/desktop, single-page apps) MUST NOT send a ``client_secret`` when
@@ -37,8 +39,16 @@ from urllib.parse import urlencode
 
 from gaia.connectors.errors import ConfigurationError
 
-# Personal-account tenant. Pinned in both endpoint URLs.
-_TENANT = "consumers"
+# Default login tenant. ``common`` accepts personal AND work/school accounts.
+# Overridable via GAIA_MICROSOFT_TENANT (a single-tenant Entra id, or
+# ``organizations`` / ``consumers``). Resolved per-instance so an env change
+# takes effect on the next provider instantiation without a module reload.
+_DEFAULT_TENANT = "common"
+
+
+def _resolve_tenant() -> str:
+    """Return the Microsoft login tenant segment for the endpoint URLs."""
+    return (os.environ.get("GAIA_MICROSOFT_TENANT") or _DEFAULT_TENANT).strip() or _DEFAULT_TENANT
 
 # Plain-language descriptions for the AgentUI consent dialog, mirroring the
 # Google provider's SCOPE_DESCRIPTIONS. The router/CLI render these strings;
@@ -62,9 +72,10 @@ SCOPE_DESCRIPTIONS: dict[str, str] = {
 
 class MicrosoftOAuthProvider:
     """
-    Concrete provider for the Microsoft identity platform (``consumers``
-    tenant). Implements the ``OAuthProvider`` Protocol structurally — no
-    inheritance, matching ``GoogleOAuthProvider``.
+    Concrete provider for the Microsoft identity platform (``common``
+    tenant by default — personal + work/school). Implements the
+    ``OAuthProvider`` Protocol structurally — no inheritance, matching
+    ``GoogleOAuthProvider``.
 
     Reads ``GAIA_MICROSOFT_CLIENT_ID`` at instantiation time, NOT at import
     time. ``client_id_hash`` is a non-cryptographic CRC32 fingerprint used
@@ -72,8 +83,6 @@ class MicrosoftOAuthProvider:
     """
 
     provider_id: str = "microsoft"
-    auth_url: str = f"https://login.microsoftonline.com/{_TENANT}/oauth2/v2.0/authorize"
-    token_url: str = f"https://login.microsoftonline.com/{_TENANT}/oauth2/v2.0/token"
     # offline_access => refresh token; openid => id_token (account email).
     # The shared flow depends on both; keep them in the default set so a bare
     # connect (no explicit scopes) still works end-to-end.
@@ -82,8 +91,46 @@ class MicrosoftOAuthProvider:
         "offline_access",
         "https://graph.microsoft.com/User.Read",
     )
+    # Userinfo fallback (#1275): the flow layer calls this when the token
+    # response carries no decodable email in the id_token (common on the
+    # device-code path). Provider-agnostic hook — flow.py GETs ``userinfo_url``
+    # with the access token and hands the JSON to ``parse_account_email``.
+    userinfo_url: str = (
+        "https://graph.microsoft.com/v1.0/me?$select=mail,userPrincipalName"
+    )
 
-    def __init__(self, client_id: str | None = None, client_secret: str | None = None):
+    @staticmethod
+    def parse_account_email(userinfo: dict) -> str | None:
+        """Extract the account email from a Graph ``/me`` response. Personal
+        accounts often null ``mail`` and carry the address in
+        ``userPrincipalName`` instead."""
+        return (userinfo.get("mail") or userinfo.get("userPrincipalName") or "") or None
+
+    def __init__(
+        self,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        tenant: str | None = None,
+    ):
+        # Login tenant resolved per-instance (GAIA_MICROSOFT_TENANT honored).
+        # ``common`` accepts personal AND work/school accounts. The endpoint
+        # URLs are instance attributes (not class constants) so an env change
+        # is picked up on the next instantiation without a module reload.
+        self.tenant: str = tenant or _resolve_tenant()
+        self.auth_url: str = (
+            f"https://login.microsoftonline.com/{self.tenant}/oauth2/v2.0/authorize"
+        )
+        self.token_url: str = (
+            f"https://login.microsoftonline.com/{self.tenant}/oauth2/v2.0/token"
+        )
+        # Device-code endpoint (#1275): enables zero-Azure-app-registration
+        # sign-in — the user enters a short code at a Microsoft URL instead of
+        # a browser redirect. Presence of this attribute is how the generic
+        # device flow detects device-code capable providers (duck-typed, like
+        # authorization_params()).
+        self.device_code_url: str = (
+            f"https://login.microsoftonline.com/{self.tenant}/oauth2/v2.0/devicecode"
+        )
         # Resolution order matches GoogleOAuthProvider (user-friendliness
         # first):
         #   1. Explicit kwargs (tests / library callers).
@@ -110,8 +157,8 @@ class MicrosoftOAuthProvider:
                 "Microsoft OAuth client is not configured. Open Settings → "
                 "Connections → Microsoft in the AgentUI and paste the "
                 "Application (client) ID from your Azure App registration "
-                "(personal-accounts / 'consumers' audience, with a "
-                "http://localhost redirect URI). (Power users may also set the "
+                "('any account' / 'common' audience — personal + work/school — "
+                "with a http://localhost redirect URI). (Power users may also set the "
                 "GAIA_MICROSOFT_CLIENT_ID env var — and, only for a "
                 "confidential web-app registration, GAIA_MICROSOFT_CLIENT_SECRET "
                 "— before launching GAIA.) See "
@@ -183,6 +230,28 @@ class MicrosoftOAuthProvider:
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
             "client_id": self.client_id,
+        }
+        if self.client_secret:
+            body["client_secret"] = self.client_secret
+        return body
+
+    # ---- Device-code flow (#1275) ------------------------------------------
+    # RFC 8628 device authorization grant. Used for the zero-setup sign-in that
+    # does not need a per-user Azure app registration or a loopback redirect
+    # URI — the user just enters a short code at a Microsoft URL. A public
+    # client sends NO secret here either (unless a confidential app is
+    # configured), matching the auth-code bodies above.
+
+    def device_code_request_body(self, scopes: Iterable[str]) -> dict:
+        """POST body for the ``/devicecode`` endpoint (request a user code)."""
+        return {"client_id": self.client_id, "scope": " ".join(scopes)}
+
+    def device_token_request_body(self, device_code: str) -> dict:
+        """POST body for polling ``/token`` with a pending device code."""
+        body: dict = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "client_id": self.client_id,
+            "device_code": device_code,
         }
         if self.client_secret:
             body["client_secret"] = self.client_secret

--- a/src/gaia/connectors/spec.py
+++ b/src/gaia/connectors/spec.py
@@ -101,6 +101,12 @@ class ConnectorSpec:
     # setup fields persist as *provider* credentials reused across many
     # connect/disconnect cycles.
     oauth_setup_fields: tuple[ConfigField, ...] = field(default_factory=tuple)
+    # oauth_pkce only: the provider also supports the RFC 8628 device-code flow
+    # (a short code entered at a URL — no loopback redirect / no per-user app
+    # registration). Surfaced to the UI so it can offer a "sign in with a code"
+    # path alongside the browser button. Default False — the provider must
+    # implement the device-code endpoints (e.g. Microsoft).
+    supports_device_code: bool = False
     # mcp_server only
     mcp_command: str | None = None
     mcp_args: tuple[str, ...] = field(default_factory=tuple)

--- a/src/gaia/connectors/store.py
+++ b/src/gaia/connectors/store.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+import zlib
 from typing import List, Optional
 
 from gaia.connectors._keyring import keyring  # actionable error if missing (#1621)
@@ -140,8 +141,21 @@ def _wrap_keyring_call(operation: str):
 # an oversized value across extra keyring slots (``<username>#<idx>``) and
 # reassemble on read. Small values stay in a single raw slot — backward
 # compatible with every pre-existing entry and the short Google blobs.
+#
+# Torn-write safety: keyring has no atomic multi-slot transaction, and
+# Microsoft rotates the refresh token on every refresh (varying length →
+# varying chunk count), so an overwrite can crash mid-rewrite with slots and
+# manifest out of sync. The manifest therefore carries a CRC32 of the full
+# payload; ``_kr_get`` validates the reassembled value against it and returns
+# ``None`` ("reconnect") on any mismatch — a torn state can never surface as a
+# truncated-but-valid-looking token.
 _CHUNK_CHARS = 1024
 _CHUNK_SENTINEL = "\x00gaia-chunked\x00"  # cannot occur inside a JSON blob
+
+
+def _payload_crc(payload: str) -> str:
+    """Non-cryptographic integrity check for reassembled chunk payloads."""
+    return format(zlib.crc32(payload.encode("utf-8")), "08x")
 
 
 def _chunk_username(username: str, idx: int) -> str:
@@ -198,32 +212,54 @@ def _kr_set(username: str, payload: str) -> None:
     ]
     for idx, chunk in enumerate(chunks):
         _kr_raw_set(_chunk_username(username, idx), chunk)
+    # Publish the manifest (count + CRC of the full payload) BEFORE sweeping
+    # stale high slots, so a reader after this point reassembles against the
+    # new count and the CRC guards any partial state.
+    _kr_raw_set(username, f"{_CHUNK_SENTINEL}{len(chunks)}:{_payload_crc(payload)}")
     # Drop any extra chunk slots left over from a longer previous value.
     stale = len(chunks)
     while _kr_raw_get(_chunk_username(username, stale)) is not None:
         _kr_raw_delete(_chunk_username(username, stale))
         stale += 1
-    _kr_raw_set(username, f"{_CHUNK_SENTINEL}{len(chunks)}")
+
+
+def _parse_manifest(raw: str) -> Optional[tuple[int, Optional[str]]]:
+    """Parse ``<SENTINEL><count>[:<crc>]`` → ``(count, crc)``. ``None`` if the
+    manifest is malformed. ``crc`` is ``None`` for a legacy count-only manifest."""
+    body = raw[len(_CHUNK_SENTINEL) :]
+    count_str, _, crc = body.partition(":")
+    try:
+        return int(count_str), (crc or None)
+    except ValueError:
+        return None
 
 
 def _kr_get(username: str) -> Optional[str]:
-    """Read a (possibly chunked) value stored via :func:`_kr_set`."""
+    """Read a (possibly chunked) value stored via :func:`_kr_set`.
+
+    Any partial/torn state (missing slot, or a CRC mismatch from a crashed
+    mid-rewrite) resolves to ``None`` — never a truncated-but-valid-looking
+    value."""
     raw = _kr_raw_get(username)
     if raw is None or not raw.startswith(_CHUNK_SENTINEL):
         return raw
-    try:
-        count = int(raw[len(_CHUNK_SENTINEL) :])
-    except ValueError:
+    parsed = _parse_manifest(raw)
+    if parsed is None:
         return None
+    count, crc = parsed
     parts: list[str] = []
     for idx in range(count):
         part = _kr_raw_get(_chunk_username(username, idx))
         if part is None:
-            # Torn entry — return None (treated as "not configured") rather
-            # than a truncated token that would fail cryptically downstream.
+            # Missing slot — torn entry; treat as "not configured".
             return None
         parts.append(part)
-    return "".join(parts)
+    value = "".join(parts)
+    if crc is not None and _payload_crc(value) != crc:
+        # Reassembled payload doesn't match the manifest CRC — a crashed
+        # mid-rewrite left slots and manifest out of sync. Fail safe.
+        return None
+    return value
 
 
 def _kr_delete(username: str) -> None:
@@ -231,10 +267,8 @@ def _kr_delete(username: str) -> None:
     raw = _kr_raw_get(username)
     _kr_raw_delete(username)
     if raw is not None and raw.startswith(_CHUNK_SENTINEL):
-        try:
-            count = int(raw[len(_CHUNK_SENTINEL) :])
-        except ValueError:
-            count = 0
+        parsed = _parse_manifest(raw)
+        count = parsed[0] if parsed else 0
         for idx in range(count):
             _kr_raw_delete(_chunk_username(username, idx))
     _kr_clear_chunks(username)

--- a/src/gaia/connectors/store.py
+++ b/src/gaia/connectors/store.py
@@ -128,6 +128,118 @@ def _wrap_keyring_call(operation: str):
     return wrapper
 
 
+# ---------------------------------------------------------------------------
+# Transparent large-blob chunking (#1275 Windows fix)
+# ---------------------------------------------------------------------------
+# Windows Credential Manager caps a single credential blob at 2560 bytes
+# (CRED_MAX_CREDENTIAL_BLOB_SIZE). keyring stores the value as UTF-16, so the
+# practical ceiling is ~1280 chars — and CredWrite fails with a cryptic
+# "The stub received bad data" (error 1783) past it. Google refresh tokens
+# (~100 chars) never came close, so this went unnoticed; Microsoft Graph
+# refresh tokens (~1600 chars) blow straight past it. We transparently split
+# an oversized value across extra keyring slots (``<username>#<idx>``) and
+# reassemble on read. Small values stay in a single raw slot — backward
+# compatible with every pre-existing entry and the short Google blobs.
+_CHUNK_CHARS = 1024
+_CHUNK_SENTINEL = "\x00gaia-chunked\x00"  # cannot occur inside a JSON blob
+
+
+def _chunk_username(username: str, idx: int) -> str:
+    return f"{username}#{idx}"
+
+
+def _kr_raw_set(username: str, value: str) -> None:
+    @_wrap_keyring_call("set_password")
+    def _set():
+        keyring.set_password(SERVICE_NAME, username, value)
+
+    _set()
+
+
+def _kr_raw_get(username: str) -> Optional[str]:
+    @_wrap_keyring_call("get_password")
+    def _get():
+        return keyring.get_password(SERVICE_NAME, username)
+
+    return _get()
+
+
+def _kr_raw_delete(username: str) -> None:
+    try:
+        keyring.delete_password(SERVICE_NAME, username)
+    except keyring.errors.PasswordDeleteError:
+        pass
+    except keyring.errors.KeyringError as e:
+        raise ConnectorsError(
+            f"Keyring delete_password failed: {e}. See "
+            "docs/security/connections.mdx."
+        ) from e
+
+
+def _kr_clear_chunks(username: str) -> None:
+    """Best-effort removal of any leftover chunk slots for ``username``."""
+    idx = 0
+    while _kr_raw_get(_chunk_username(username, idx)) is not None:
+        _kr_raw_delete(_chunk_username(username, idx))
+        idx += 1
+
+
+def _kr_set(username: str, payload: str) -> None:
+    """Store ``payload`` under ``username``, chunking if it exceeds the
+    single-slot ceiling. Chunks are written BEFORE the manifest so a reader
+    never sees a manifest pointing at not-yet-written parts."""
+    if len(payload) <= _CHUNK_CHARS:
+        _kr_raw_set(username, payload)
+        # A prior write may have been chunked; sweep stale chunk slots.
+        _kr_clear_chunks(username)
+        return
+    chunks = [
+        payload[i : i + _CHUNK_CHARS] for i in range(0, len(payload), _CHUNK_CHARS)
+    ]
+    for idx, chunk in enumerate(chunks):
+        _kr_raw_set(_chunk_username(username, idx), chunk)
+    # Drop any extra chunk slots left over from a longer previous value.
+    stale = len(chunks)
+    while _kr_raw_get(_chunk_username(username, stale)) is not None:
+        _kr_raw_delete(_chunk_username(username, stale))
+        stale += 1
+    _kr_raw_set(username, f"{_CHUNK_SENTINEL}{len(chunks)}")
+
+
+def _kr_get(username: str) -> Optional[str]:
+    """Read a (possibly chunked) value stored via :func:`_kr_set`."""
+    raw = _kr_raw_get(username)
+    if raw is None or not raw.startswith(_CHUNK_SENTINEL):
+        return raw
+    try:
+        count = int(raw[len(_CHUNK_SENTINEL) :])
+    except ValueError:
+        return None
+    parts: list[str] = []
+    for idx in range(count):
+        part = _kr_raw_get(_chunk_username(username, idx))
+        if part is None:
+            # Torn entry — return None (treated as "not configured") rather
+            # than a truncated token that would fail cryptically downstream.
+            return None
+        parts.append(part)
+    return "".join(parts)
+
+
+def _kr_delete(username: str) -> None:
+    """Delete a (possibly chunked) value and all its chunk slots. Idempotent."""
+    raw = _kr_raw_get(username)
+    _kr_raw_delete(username)
+    if raw is not None and raw.startswith(_CHUNK_SENTINEL):
+        try:
+            count = int(raw[len(_CHUNK_SENTINEL) :])
+        except ValueError:
+            count = 0
+        for idx in range(count):
+            _kr_raw_delete(_chunk_username(username, idx))
+    _kr_clear_chunks(username)
+
+
 def save_connection(
     *,
     provider: str,
@@ -171,11 +283,7 @@ def save_connection(
     # migration since the username shape already accommodates it.
     username = _connection_username(provider, DEFAULT_ACCOUNT)
 
-    @_wrap_keyring_call("set_password")
-    def _set():
-        keyring.set_password(SERVICE_NAME, username, payload)
-
-    _set()
+    _kr_set(username, payload)
 
 
 def load_connection(
@@ -195,11 +303,7 @@ def load_connection(
     verify_keyring_backend()
     username = _connection_username(provider, account_email)
 
-    @_wrap_keyring_call("get_password")
-    def _get():
-        return keyring.get_password(SERVICE_NAME, username)
-
-    raw = _get()
+    raw = _kr_get(username)
     if raw is None:
         return None
 
@@ -261,11 +365,7 @@ def peek_connection(
     verify_keyring_backend()
     username = _connection_username(provider, account_email)
 
-    @_wrap_keyring_call("get_password")
-    def _get():
-        return keyring.get_password(SERVICE_NAME, username)
-
-    raw = _get()
+    raw = _kr_get(username)
     if raw is None:
         return None
     try:
@@ -282,17 +382,7 @@ def delete_connection(provider: str, *, account_email: str = DEFAULT_ACCOUNT) ->
     """Remove the keyring entry for ``provider`` if present. Idempotent."""
     verify_keyring_backend()
     username = _connection_username(provider, account_email)
-
-    try:
-        keyring.delete_password(SERVICE_NAME, username)
-    except keyring.errors.PasswordDeleteError:
-        # Already gone — fine.
-        pass
-    except keyring.errors.KeyringError as e:
-        raise ConnectorsError(
-            f"Keyring delete_password failed: {e}. See "
-            "docs/security/connections.mdx."
-        ) from e
+    _kr_delete(username)
 
 
 def save_provider_credentials(
@@ -314,12 +404,7 @@ def save_provider_credentials(
         {"client_id": client_id, "client_secret": client_secret}, sort_keys=True
     )
     username = _provider_credentials_username(provider)
-
-    @_wrap_keyring_call("set_password")
-    def _set():
-        keyring.set_password(SERVICE_NAME, username, payload)
-
-    _set()
+    _kr_set(username, payload)
 
 
 def peek_provider_credentials(provider: str) -> Optional[dict]:
@@ -332,11 +417,7 @@ def peek_provider_credentials(provider: str) -> Optional[dict]:
     verify_keyring_backend()
     username = _provider_credentials_username(provider)
 
-    @_wrap_keyring_call("get_password")
-    def _get():
-        return keyring.get_password(SERVICE_NAME, username)
-
-    raw = _get()
+    raw = _kr_get(username)
     if raw is None:
         return None
     try:
@@ -349,15 +430,7 @@ def clear_provider_credentials(provider: str) -> None:
     """Remove the stored OAuth client credentials for *provider*. Idempotent."""
     verify_keyring_backend()
     username = _provider_credentials_username(provider)
-    try:
-        keyring.delete_password(SERVICE_NAME, username)
-    except keyring.errors.PasswordDeleteError:
-        pass
-    except keyring.errors.KeyringError as e:
-        raise ConnectorsError(
-            f"Keyring delete_password failed: {e}. See "
-            "docs/security/connections.mdx."
-        ) from e
+    _kr_delete(username)
 
 
 def list_connections() -> List[str]:
@@ -384,9 +457,9 @@ def list_connections() -> List[str]:
     for provider in known:
         username = _connection_username(provider, DEFAULT_ACCOUNT)
         try:
-            if keyring.get_password(SERVICE_NAME, username) is not None:
+            if _kr_raw_get(username) is not None:
                 found.append(provider)
-        except keyring.errors.KeyringError:
+        except ConnectorsError:
             # Translate-and-skip is OK for an enumeration call: a single
             # failed backend doesn't invalidate the list.
             continue

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -897,11 +897,18 @@ async def authorize_device(
                 "connector.oauth.error",
                 {"connector_id": connector_id, "error": str(e)},
             )
-        except Exception as e:  # noqa: BLE001 — surface, don't crash the loop
+        except Exception:  # noqa: BLE001 — surface, don't crash the loop
+            # Unexpected (non-ConnectorsError) failure: keep the detail in the
+            # server log, emit a generic message so an arbitrary exception
+            # string never reaches the client over SSE.
             logger.exception("device-flow poll failed for %s", connector_id)
             await _emitter.emit(
                 "connector.oauth.error",
-                {"connector_id": connector_id, "error": str(e)},
+                {
+                    "connector_id": connector_id,
+                    "error": "Device-code sign-in failed unexpectedly. "
+                    "Check the server logs and try again.",
+                },
             )
 
     task = asyncio.create_task(_poll_and_emit())

--- a/src/gaia/ui/routers/connectors.py
+++ b/src/gaia/ui/routers/connectors.py
@@ -481,6 +481,9 @@ def _connector_summary(connector_id: str) -> Dict[str, Any]:
         "mcp_env_keys": list(spec.mcp_env_keys),
         "default_scopes": list(spec.default_scopes),
         "available_scopes": list(spec.available_scopes),
+        # Device-code capability (#1275): lets the UI offer "sign in with a
+        # code" (no browser redirect / no Azure app registration).
+        "supports_device_code": spec.supports_device_code,
         # OAuth setup form (e.g. Google client_id/client_secret) — empty
         # tuple for connectors that don't need first-time provider creds.
         "oauth_setup_fields": [
@@ -846,6 +849,72 @@ async def authorize(
         )
     except ConnectorsError as e:
         raise _raise_http_for(e) from e
+
+
+# Keeps background device-poll tasks referenced so they aren't garbage
+# collected mid-flight (asyncio holds only weak refs to bare tasks).
+_device_poll_tasks: set = set()
+
+
+@router.post(
+    "/{connector_id}/authorize-device", dependencies=[Depends(_require_ui_header)]
+)
+async def authorize_device(
+    request: Request, connector_id: str, body: AuthorizeRequest
+) -> Dict[str, Any]:
+    """Start a device-code flow (no browser redirect / no Azure app needed).
+
+    Returns ``{user_code, verification_uri, expires_in, interval, message}`` for
+    the UI to display. Unlike the browser flow there is no loopback callback, so
+    the server kicks off a background poller; on completion ``poll_device_flow``
+    emits ``connector.oauth.completed`` (and ``connection.connected``) over the
+    same SSE stream the UI already watches, and this endpoint emits
+    ``connector.oauth.error`` if it fails. ``grant_agents`` are resolved up front
+    and committed atomically on success, mirroring ``authorize``.
+
+    The ``device_code`` is intentionally NOT returned — it is a bearer-equivalent
+    for polling and the server owns the poll loop.
+    """
+    grant_map = _resolve_grant_scopes(request, connector_id, body.grant_agents)
+    try:
+        info = await connections.start_device_flow(connector_id, scopes=body.scopes)
+    except ConnectorsError as e:
+        raise _raise_http_for(e) from e
+
+    async def _poll_and_emit() -> None:
+        try:
+            # poll_device_flow emits connector.oauth.completed itself on success.
+            await connections.poll_device_flow(
+                connector_id,
+                info["device_code"],
+                scopes=info["scopes"],
+                interval=info["interval"],
+                expires_in=info["expires_in"],
+                grant_agents=grant_map or None,
+            )
+        except ConnectorsError as e:
+            await _emitter.emit(
+                "connector.oauth.error",
+                {"connector_id": connector_id, "error": str(e)},
+            )
+        except Exception as e:  # noqa: BLE001 — surface, don't crash the loop
+            logger.exception("device-flow poll failed for %s", connector_id)
+            await _emitter.emit(
+                "connector.oauth.error",
+                {"connector_id": connector_id, "error": str(e)},
+            )
+
+    task = asyncio.create_task(_poll_and_emit())
+    _device_poll_tasks.add(task)
+    task.add_done_callback(_device_poll_tasks.discard)
+
+    return {
+        "user_code": info["user_code"],
+        "verification_uri": info["verification_uri"],
+        "expires_in": info["expires_in"],
+        "interval": info["interval"],
+        "message": info["message"],
+    }
 
 
 @router.delete(

--- a/tests/unit/connectors/test_device_flow.py
+++ b/tests/unit/connectors/test_device_flow.py
@@ -1,0 +1,257 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Tests for the device-code flow (#1275) — the zero-Azure-app-registration
+sign-in used for Microsoft work/school + personal accounts.
+
+All HTTP is mocked; there are NO live calls. Coverage:
+
+- ``start_device_flow`` returns the user code / verification URI and raises
+  loudly on a non-200 devicecode response or a provider with no device support.
+- ``poll_device_flow`` honors ``authorization_pending`` / ``slow_down``, then
+  persists the connection on success (via the real in-memory keyring) and
+  commits per-agent grants atomically.
+- The unhappy paths (declined, expired, missing refresh_token) each raise a
+  typed error rather than returning a partial / empty result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from gaia.connectors import flow as flow_mod
+from gaia.connectors.errors import (
+    ConnectorsError,
+    ConsentDeniedError,
+    FlowTimeoutError,
+)
+
+MAIL_READ = "https://graph.microsoft.com/Mail.Read"
+
+
+@pytest.fixture(autouse=True)
+def _ms_env(monkeypatch):
+    monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "test-client-id")
+    monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("GAIA_MICROSOFT_TENANT", raising=False)
+    # Reset the provider registry so each test builds a fresh provider.
+    from gaia.connectors import providers
+
+    providers._registry.clear()  # type: ignore[attr-defined]
+    yield
+    providers._registry.clear()  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def _instant_sleep(monkeypatch):
+    async def _no_wait(_seconds):
+        return None
+
+    monkeypatch.setattr(flow_mod.asyncio, "sleep", _no_wait)
+
+
+class _FakeResp:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json body")
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Pops a queued response per ``post`` call; ``get`` pops from a separate
+    queue (used for the userinfo /me fallback). Records the requests made."""
+
+    _queue: list = []
+    _get_queue: list = []
+    calls: list = []
+    get_calls: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, data=None):
+        _FakeAsyncClient.calls.append((url, data))
+        return _FakeAsyncClient._queue.pop(0)
+
+    async def get(self, url, headers=None):
+        _FakeAsyncClient.get_calls.append((url, headers))
+        return _FakeAsyncClient._get_queue.pop(0)
+
+
+def _install_responses(monkeypatch, responses, get_responses=None):
+    _FakeAsyncClient._queue = list(responses)
+    _FakeAsyncClient._get_queue = list(get_responses or [])
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.get_calls = []
+    monkeypatch.setattr(flow_mod.httpx, "AsyncClient", _FakeAsyncClient)
+
+
+def _id_token(claims: dict) -> str:
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"header.{payload}.sig"
+
+
+class TestStartDeviceFlow:
+    def test_returns_user_code_and_uri(self, monkeypatch):
+        _install_responses(
+            monkeypatch,
+            [
+                _FakeResp(
+                    200,
+                    {
+                        "device_code": "DEV",
+                        "user_code": "ABCD-EFGH",
+                        "verification_uri": "https://microsoft.com/devicelogin",
+                        "expires_in": 900,
+                        "interval": 5,
+                        "message": "Go to ... and enter ABCD-EFGH",
+                    },
+                )
+            ],
+        )
+        info = asyncio.run(flow_mod.start_device_flow("microsoft", [MAIL_READ]))
+        assert info["user_code"] == "ABCD-EFGH"
+        assert info["device_code"] == "DEV"
+        assert info["verification_uri"].endswith("devicelogin")
+        # Hit the tenant-scoped devicecode endpoint.
+        assert _FakeAsyncClient.calls[0][0].endswith("/common/oauth2/v2.0/devicecode")
+
+    def test_non_200_raises(self, monkeypatch):
+        _install_responses(monkeypatch, [_FakeResp(400, {"error": "invalid_client"}, "bad")])
+        with pytest.raises(ConnectorsError) as exc:
+            asyncio.run(flow_mod.start_device_flow("microsoft", [MAIL_READ]))
+        assert "Device-code request" in str(exc.value)
+
+    def test_provider_without_device_support_raises(self, monkeypatch):
+        # Google has no device_code_url -> loud, actionable error.
+        monkeypatch.setenv("GAIA_GOOGLE_CLIENT_ID", "g")
+        monkeypatch.setenv("GAIA_GOOGLE_CLIENT_SECRET", "s")
+        with pytest.raises(ConnectorsError) as exc:
+            asyncio.run(flow_mod.start_device_flow("google", []))
+        assert "does not support the device-code flow" in str(exc.value)
+
+
+class TestPollDeviceFlow:
+    def _success_payload(self):
+        return {
+            "access_token": "AT",
+            "refresh_token": "RT-value",
+            "expires_in": 3600,
+            "id_token": _id_token({"preferred_username": "user@example.com"}),
+            "scope": MAIL_READ,
+        }
+
+    def test_pending_then_success_persists_connection(self, monkeypatch):
+        _install_responses(
+            monkeypatch,
+            [
+                _FakeResp(400, {"error": "authorization_pending"}),
+                _FakeResp(400, {"error": "slow_down"}),
+                _FakeResp(200, self._success_payload()),
+            ],
+        )
+        result = asyncio.run(
+            flow_mod.poll_device_flow(
+                "microsoft", "DEV", scopes=[MAIL_READ], interval=1, expires_in=900
+            )
+        )
+        assert result["account_email"] == "user@example.com"
+
+        # Connection persisted through the real (in-memory) keyring store.
+        from gaia.connectors.store import peek_connection
+
+        blob = peek_connection("microsoft")
+        assert blob is not None
+        assert blob["refresh_token"] == "RT-value"
+
+    def test_grant_agents_committed_on_success(self, monkeypatch):
+        _install_responses(monkeypatch, [_FakeResp(200, self._success_payload())])
+        asyncio.run(
+            flow_mod.poll_device_flow(
+                "microsoft",
+                "DEV",
+                scopes=[MAIL_READ],
+                grant_agents={"installed:email": [MAIL_READ]},
+            )
+        )
+        from gaia.connectors.grants import list_agent_grants
+
+        grants = list_agent_grants("microsoft")
+        assert grants.get("installed:email") == [MAIL_READ]
+
+    def test_account_email_falls_back_to_userinfo(self, monkeypatch):
+        # Device-code id_token often carries no decodable email — the flow then
+        # GETs the provider userinfo_url (Graph /me) with the access token.
+        payload = self._success_payload()
+        payload["id_token"] = ""  # no claim to decode
+        _install_responses(
+            monkeypatch,
+            [_FakeResp(200, payload)],
+            get_responses=[
+                _FakeResp(200, {"mail": "user@example.com", "userPrincipalName": "u@example.com"})
+            ],
+        )
+        result = asyncio.run(
+            flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ])
+        )
+        assert result["account_email"] == "user@example.com"
+        # The /me endpoint was queried with the bearer token.
+        assert _FakeAsyncClient.get_calls
+        assert "/me" in _FakeAsyncClient.get_calls[0][0]
+
+    def test_account_email_default_when_userinfo_unavailable(self, monkeypatch):
+        payload = self._success_payload()
+        payload["id_token"] = ""
+        _install_responses(
+            monkeypatch,
+            [_FakeResp(200, payload)],
+            get_responses=[_FakeResp(403, {}, "forbidden")],
+        )
+        result = asyncio.run(
+            flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ])
+        )
+        # Label-only fallback — connection still persists, never fails.
+        assert result["account_email"] == "default"
+
+    def test_declined_raises_consent_denied(self, monkeypatch):
+        _install_responses(
+            monkeypatch, [_FakeResp(400, {"error": "authorization_declined"})]
+        )
+        with pytest.raises(ConsentDeniedError):
+            asyncio.run(
+                flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ])
+            )
+
+    def test_expired_token_raises_timeout(self, monkeypatch):
+        _install_responses(
+            monkeypatch, [_FakeResp(400, {"error": "expired_token"})]
+        )
+        with pytest.raises(FlowTimeoutError):
+            asyncio.run(
+                flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ])
+            )
+
+    def test_missing_refresh_token_raises(self, monkeypatch):
+        payload = self._success_payload()
+        del payload["refresh_token"]
+        _install_responses(monkeypatch, [_FakeResp(200, payload)])
+        with pytest.raises(ConnectorsError) as exc:
+            asyncio.run(
+                flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ])
+            )
+        assert "offline_access" in str(exc.value)

--- a/tests/unit/connectors/test_device_flow.py
+++ b/tests/unit/connectors/test_device_flow.py
@@ -132,7 +132,9 @@ class TestStartDeviceFlow:
         assert _FakeAsyncClient.calls[0][0].endswith("/common/oauth2/v2.0/devicecode")
 
     def test_non_200_raises(self, monkeypatch):
-        _install_responses(monkeypatch, [_FakeResp(400, {"error": "invalid_client"}, "bad")])
+        _install_responses(
+            monkeypatch, [_FakeResp(400, {"error": "invalid_client"}, "bad")]
+        )
         with pytest.raises(ConnectorsError) as exc:
             asyncio.run(flow_mod.start_device_flow("microsoft", [MAIL_READ]))
         assert "Device-code request" in str(exc.value)
@@ -203,7 +205,10 @@ class TestPollDeviceFlow:
             monkeypatch,
             [_FakeResp(200, payload)],
             get_responses=[
-                _FakeResp(200, {"mail": "user@example.com", "userPrincipalName": "u@example.com"})
+                _FakeResp(
+                    200,
+                    {"mail": "user@example.com", "userPrincipalName": "u@example.com"},
+                )
             ],
         )
         result = asyncio.run(
@@ -238,9 +243,7 @@ class TestPollDeviceFlow:
             )
 
     def test_expired_token_raises_timeout(self, monkeypatch):
-        _install_responses(
-            monkeypatch, [_FakeResp(400, {"error": "expired_token"})]
-        )
+        _install_responses(monkeypatch, [_FakeResp(400, {"error": "expired_token"})])
         with pytest.raises(FlowTimeoutError):
             asyncio.run(
                 flow_mod.poll_device_flow("microsoft", "DEV", scopes=[MAIL_READ])

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -265,9 +265,7 @@ class TestDeviceCodeFlow:
     def test_device_token_body_public_client_has_no_secret(self, _ms_env):
         prov = providers.get("microsoft")
         body = prov.device_token_request_body("DEV-CODE-123")
-        assert body["grant_type"] == (
-            "urn:ietf:params:oauth:grant-type:device_code"
-        )
+        assert body["grant_type"] == ("urn:ietf:params:oauth:grant-type:device_code")
         assert body["device_code"] == "DEV-CODE-123"
         assert body["client_id"] == "11112222-bbbb-3333-cccc-4444dddd5555"
         assert "client_secret" not in body
@@ -298,7 +296,9 @@ class TestUserinfoFallback:
     def test_parse_account_email_falls_back_to_upn(self, _ms_env):
         prov = providers.get("microsoft")
         assert (
-            prov.parse_account_email({"mail": None, "userPrincipalName": "b@example.com"})
+            prov.parse_account_email(
+                {"mail": None, "userPrincipalName": "b@example.com"}
+            )
             == "b@example.com"
         )
 

--- a/tests/unit/connectors/test_microsoft_provider.py
+++ b/tests/unit/connectors/test_microsoft_provider.py
@@ -8,8 +8,9 @@ All network/OAuth is mocked; there are NO live calls. Coverage mirrors the
 Google provider tests in ``test_providers.py`` plus the Microsoft-specific
 invariants that the later mail/calendar leads depend on:
 
-- Tenant is ``consumers`` (personal Outlook.com/Hotmail/Live) — pinned in
-  BOTH the authorize and token endpoint URLs.
+- Tenant defaults to ``common`` (personal Outlook.com/Hotmail/Live AND
+  work/school Entra ID) — in BOTH the authorize and token endpoint URLs;
+  overridable via ``GAIA_MICROSOFT_TENANT``.
 - Public/native PKCE client: ``token_request_body`` / ``refresh_request_body``
   carry NO ``client_secret`` unless one is explicitly configured (Microsoft
   forbids secrets for public clients — unlike Google, which requires one).
@@ -31,8 +32,8 @@ from gaia.connectors import providers
 from gaia.connectors.errors import ConfigurationError
 from gaia.connectors.providers.base import OAuthProvider
 
-CONSUMERS_AUTH_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize"
-CONSUMERS_TOKEN_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token"
+COMMON_AUTH_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+COMMON_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
 
 MAIL_READ = "https://graph.microsoft.com/Mail.Read"
 MAIL_SEND = "https://graph.microsoft.com/Mail.Send"
@@ -55,6 +56,9 @@ def _ms_env(monkeypatch):
         "GAIA_MICROSOFT_CLIENT_ID", "11112222-bbbb-3333-cccc-4444dddd5555"
     )
     monkeypatch.delenv("GAIA_MICROSOFT_CLIENT_SECRET", raising=False)
+    # Default tenant must resolve to ``common`` unless a test opts into an
+    # override — clear any ambient value from the developer's shell.
+    monkeypatch.delenv("GAIA_MICROSOFT_TENANT", raising=False)
     return "11112222-bbbb-3333-cccc-4444dddd5555"
 
 
@@ -110,13 +114,32 @@ class TestProtocol:
 
 
 class TestEndpointsAndTenant:
-    def test_endpoints_pin_consumers_tenant(self, _ms_env):
+    def test_endpoints_default_to_common_tenant(self, _ms_env):
         prov = providers.get("microsoft")
-        assert prov.auth_url == CONSUMERS_AUTH_URL
-        assert prov.token_url == CONSUMERS_TOKEN_URL
-        # The personal-account tenant must be in both URLs.
-        assert "/consumers/" in prov.auth_url
-        assert "/consumers/" in prov.token_url
+        assert prov.auth_url == COMMON_AUTH_URL
+        assert prov.token_url == COMMON_TOKEN_URL
+        # ``common`` accepts personal AND work/school accounts; it must be in
+        # both URLs so neither account type is rejected before token exchange.
+        assert "/common/" in prov.auth_url
+        assert "/common/" in prov.token_url
+
+    def test_tenant_override_from_env(self, monkeypatch, _ms_env):
+        # An org can pin a single Entra tenant id (or organizations/consumers)
+        # via GAIA_MICROSOFT_TENANT; both endpoint URLs must reflect it.
+        monkeypatch.setenv("GAIA_MICROSOFT_TENANT", "organizations")
+        providers._registry.clear()  # type: ignore[attr-defined]
+        prov = providers.get("microsoft")
+        assert prov.tenant == "organizations"
+        assert "/organizations/" in prov.auth_url
+        assert "/organizations/" in prov.token_url
+
+    def test_tenant_override_accepts_bare_guid(self, monkeypatch, _ms_env):
+        monkeypatch.setenv(
+            "GAIA_MICROSOFT_TENANT", "aaaabbbb-cccc-dddd-eeee-ffff00001111"
+        )
+        providers._registry.clear()  # type: ignore[attr-defined]
+        prov = providers.get("microsoft")
+        assert "/aaaabbbb-cccc-dddd-eeee-ffff00001111/" in prov.token_url
 
     def test_client_id_hash_is_stable_crc32(self, monkeypatch):
         client_id = "11112222-bbbb-3333-cccc-4444dddd5555"
@@ -217,6 +240,71 @@ class TestAuthorizationParams:
         prov = providers.get("microsoft")
         params = prov.authorization_params()
         assert params.get("response_mode") == "query"
+
+
+class TestDeviceCodeFlow:
+    def test_device_code_url_uses_resolved_tenant(self, _ms_env):
+        prov = providers.get("microsoft")
+        assert prov.device_code_url == (
+            "https://login.microsoftonline.com/common/oauth2/v2.0/devicecode"
+        )
+
+    def test_device_code_url_honors_tenant_override(self, monkeypatch, _ms_env):
+        monkeypatch.setenv("GAIA_MICROSOFT_TENANT", "organizations")
+        providers._registry.clear()  # type: ignore[attr-defined]
+        prov = providers.get("microsoft")
+        assert "/organizations/" in prov.device_code_url
+
+    def test_device_code_request_body_carries_client_id_and_scopes(self, _ms_env):
+        prov = providers.get("microsoft")
+        body = prov.device_code_request_body([MAIL_READ, "offline_access"])
+        assert body["client_id"] == "11112222-bbbb-3333-cccc-4444dddd5555"
+        # Space-delimited scope string per the MS v2.0 spec.
+        assert body["scope"] == f"{MAIL_READ} offline_access"
+
+    def test_device_token_body_public_client_has_no_secret(self, _ms_env):
+        prov = providers.get("microsoft")
+        body = prov.device_token_request_body("DEV-CODE-123")
+        assert body["grant_type"] == (
+            "urn:ietf:params:oauth:grant-type:device_code"
+        )
+        assert body["device_code"] == "DEV-CODE-123"
+        assert body["client_id"] == "11112222-bbbb-3333-cccc-4444dddd5555"
+        assert "client_secret" not in body
+
+    def test_device_token_body_confidential_includes_secret(self, monkeypatch):
+        monkeypatch.delenv("GAIA_MICROSOFT_TENANT", raising=False)
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_ID", "conf-client")
+        monkeypatch.setenv("GAIA_MICROSOFT_CLIENT_SECRET", "super-secret")
+        prov = providers.get("microsoft")
+        body = prov.device_token_request_body("DEV")
+        assert body["client_secret"] == "super-secret"
+
+
+class TestUserinfoFallback:
+    def test_userinfo_url_targets_graph_me(self, _ms_env):
+        prov = providers.get("microsoft")
+        assert prov.userinfo_url.startswith("https://graph.microsoft.com/v1.0/me")
+
+    def test_parse_account_email_prefers_mail(self, _ms_env):
+        prov = providers.get("microsoft")
+        assert (
+            prov.parse_account_email(
+                {"mail": "a@example.com", "userPrincipalName": "b@example.com"}
+            )
+            == "a@example.com"
+        )
+
+    def test_parse_account_email_falls_back_to_upn(self, _ms_env):
+        prov = providers.get("microsoft")
+        assert (
+            prov.parse_account_email({"mail": None, "userPrincipalName": "b@example.com"})
+            == "b@example.com"
+        )
+
+    def test_parse_account_email_none_when_absent(self, _ms_env):
+        prov = providers.get("microsoft")
+        assert prov.parse_account_email({}) is None
 
 
 class TestCatalog:

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -419,6 +419,74 @@ class TestAuthorizeGrantAgents:
 
 
 # ---------------------------------------------------------------------------
+# POST /api/connectors/{connector_id}/authorize-device — device-code (#1275)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizeDeviceEndpoint:
+    _DEVICE_INFO = {
+        "provider_id": "microsoft",
+        "scopes": ["https://graph.microsoft.com/Mail.ReadWrite"],
+        "device_code": "SECRET-DEVICE-CODE",
+        "user_code": "ABCD-EFGH",
+        "verification_uri": "https://microsoft.com/devicelogin",
+        "expires_in": 900,
+        "interval": 5,
+        "message": "Go to https://microsoft.com/devicelogin and enter ABCD-EFGH",
+    }
+
+    def test_returns_display_fields_and_hides_device_code(
+        self, ui_api_client, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "gaia.connectors.start_device_flow",
+            AsyncMock(return_value=dict(self._DEVICE_INFO)),
+        )
+        # Background poll is mocked so no real network/keyring work happens.
+        monkeypatch.setattr(
+            "gaia.connectors.poll_device_flow",
+            AsyncMock(return_value={"account_email": "user@example.com"}),
+        )
+        resp = ui_api_client.post(
+            "/api/connectors/microsoft/authorize-device",
+            json={"scopes": ["https://graph.microsoft.com/Mail.ReadWrite"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["user_code"] == "ABCD-EFGH"
+        assert body["verification_uri"].endswith("devicelogin")
+        assert body["interval"] == 5
+        # The device_code is a bearer-equivalent for polling — never returned.
+        assert "device_code" not in body
+
+    def test_without_header_is_403(self, ui_api_client):
+        resp = ui_api_client.post(
+            "/api/connectors/microsoft/authorize-device",
+            json={"scopes": []},
+        )
+        assert resp.status_code == 403
+
+    def test_unknown_agent_is_404(self, ui_api_client, monkeypatch):
+        monkeypatch.setattr(
+            "gaia.connectors.start_device_flow",
+            AsyncMock(return_value=dict(self._DEVICE_INFO)),
+        )
+        monkeypatch.setattr("gaia.connectors.poll_device_flow", AsyncMock())
+        ui_api_client.app.state.agent_registry = _fake_registry(
+            "installed:email",
+            "microsoft",
+            ["https://graph.microsoft.com/Mail.ReadWrite"],
+        )
+        resp = ui_api_client.post(
+            "/api/connectors/microsoft/authorize-device",
+            json={"scopes": [], "grant_agents": ["installed:ghost"]},
+            headers=UI_HEADER,
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # POST /api/connectors/{connector_id}/test
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/connectors/test_store.py
+++ b/tests/unit/connectors/test_store.py
@@ -184,7 +184,9 @@ class TestLargeBlobChunking:
         base = keyring.get_password(SERVICE_NAME, username)
         assert base.startswith(_CHUNK_SENTINEL)
         # At least the first chunk slot exists.
-        assert keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is not None
+        assert (
+            keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is not None
+        )
 
     def test_delete_removes_all_chunk_slots(self):
         big_token = "R" * (_CHUNK_CHARS * 2)
@@ -212,7 +214,9 @@ class TestLargeBlobChunking:
             scopes=["s1"],
             client_id_hash="h",
         )
-        assert keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is not None
+        assert (
+            keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is not None
+        )
         # Overwrite with a short token — stored raw, chunk slots swept.
         save_connection(
             provider="microsoft",

--- a/tests/unit/connectors/test_store.py
+++ b/tests/unit/connectors/test_store.py
@@ -136,6 +136,27 @@ class TestLargeBlobChunking:
     in-memory keyring has no size cap, so we assert the chunk *mechanics*
     directly rather than relying on a backend to reject the write)."""
 
+    def test_torn_rewrite_fails_safe_to_none(self):
+        # A crashed mid-rewrite (chunk overwritten but manifest still points at
+        # a stale count/CRC) must NOT reassemble into a truncated-but-valid
+        # token — the CRC guard turns it into None ("reconnect").
+        import keyring as _kr
+
+        from gaia.connectors.store import _chunk_username
+
+        save_connection(
+            provider="microsoft",
+            account_email="a@example.com",
+            refresh_token="R" * (_CHUNK_CHARS * 2),  # 2 chunks
+            scopes=["s1"],
+            client_id_hash="h",
+        )
+        username = _connection_username("microsoft", "default")
+        # Simulate a torn rewrite: chunk #0 gets new (longer) data, but the
+        # manifest still describes the old payload.
+        _kr.set_password(SERVICE_NAME, _chunk_username(username, 0), "X" * _CHUNK_CHARS)
+        assert load_connection("microsoft", current_client_id_hash="h") is None
+
     def test_large_refresh_token_round_trips(self):
         big_token = "R" * (_CHUNK_CHARS * 3 + 17)  # forces 4 chunks
         save_connection(

--- a/tests/unit/connectors/test_store.py
+++ b/tests/unit/connectors/test_store.py
@@ -25,7 +25,10 @@ import pytest
 
 from gaia.connectors.errors import AuthRequiredError, ConnectorsError
 from gaia.connectors.store import (
+    _CHUNK_CHARS,
+    _CHUNK_SENTINEL,
     SERVICE_NAME,
+    _chunk_username,
     _connection_username,
     _provider_credentials_username,
     clear_provider_credentials,
@@ -124,6 +127,82 @@ class TestRoundTrip:
         # Only oauth_pkce providers are enumerated — MCP-server connectors have
         # no keyring connection and must not appear.
         assert "mcp-git" not in ids
+
+
+class TestLargeBlobChunking:
+    """#1275: Windows Credential Manager caps a blob at ~2560 bytes. Microsoft
+    refresh tokens (~1600 chars) exceed it, so the store transparently chunks
+    oversized values across extra slots. These tests exercise that path (the
+    in-memory keyring has no size cap, so we assert the chunk *mechanics*
+    directly rather than relying on a backend to reject the write)."""
+
+    def test_large_refresh_token_round_trips(self):
+        big_token = "R" * (_CHUNK_CHARS * 3 + 17)  # forces 4 chunks
+        save_connection(
+            provider="microsoft",
+            account_email="a@example.com",
+            refresh_token=big_token,
+            scopes=["s1"],
+            client_id_hash="h",
+        )
+        blob = load_connection("microsoft", current_client_id_hash="h")
+        assert blob is not None
+        assert blob["refresh_token"] == big_token
+
+    def test_large_blob_writes_sentinel_and_chunk_slots(self):
+        big_token = "R" * (_CHUNK_CHARS * 2)
+        save_connection(
+            provider="microsoft",
+            account_email="a@example.com",
+            refresh_token=big_token,
+            scopes=["s1"],
+            client_id_hash="h",
+        )
+        username = _connection_username("microsoft", "default")
+        # Base slot holds the manifest sentinel, not raw JSON.
+        base = keyring.get_password(SERVICE_NAME, username)
+        assert base.startswith(_CHUNK_SENTINEL)
+        # At least the first chunk slot exists.
+        assert keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is not None
+
+    def test_delete_removes_all_chunk_slots(self):
+        big_token = "R" * (_CHUNK_CHARS * 2)
+        save_connection(
+            provider="microsoft",
+            account_email="a@example.com",
+            refresh_token=big_token,
+            scopes=["s1"],
+            client_id_hash="h",
+        )
+        username = _connection_username("microsoft", "default")
+        delete_connection("microsoft")
+        assert keyring.get_password(SERVICE_NAME, username) is None
+        assert keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is None
+        assert load_connection("microsoft", current_client_id_hash="h") is None
+
+    def test_shrink_from_chunked_to_small_sweeps_stale_chunks(self):
+        # A large value (chunked) overwritten by a small one must not leave
+        # orphaned chunk slots that a later reader could trip over.
+        username = _connection_username("microsoft", "default")
+        save_connection(
+            provider="microsoft",
+            account_email="a@example.com",
+            refresh_token="R" * (_CHUNK_CHARS * 2),
+            scopes=["s1"],
+            client_id_hash="h",
+        )
+        assert keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is not None
+        # Overwrite with a short token — stored raw, chunk slots swept.
+        save_connection(
+            provider="microsoft",
+            account_email="a@example.com",
+            refresh_token="short",
+            scopes=["s1"],
+            client_id_hash="h",
+        )
+        assert keyring.get_password(SERVICE_NAME, _chunk_username(username, 0)) is None
+        blob = load_connection("microsoft", current_client_id_hash="h")
+        assert blob["refresh_token"] == "short"
 
 
 class TestSingleBlobAtomicity:


### PR DESCRIPTION
## Why this matters

Before: GAIA's email agent could only reach **personal** Outlook.com mailboxes — the Microsoft connector was pinned to the `consumers` tenant, so any **work/school (Microsoft 365 / Entra ID)** account was rejected before a token was ever issued. A corporate user simply could not use Outlook with GAIA. On top of that, connecting required each user to register their own Azure app.

After: the connector defaults to the `common` tenant (personal **and** work/school), with a `GAIA_MICROSOFT_TENANT` override, and adds a **zero-setup device-code sign-in** — enter a short code at a URL, no Azure app registration and no loopback redirect. Available from both the CLI (`gaia connectors connect microsoft --device`) and the Agent UI (a **Sign in with a code** button on the Microsoft tile). The existing Outlook backend and email-agent tools are unchanged — they just reach more mailboxes.

This also fixes a latent Windows blocker found while testing from a cold state: the connectors keyring store could not persist Microsoft refresh tokens (~1600 chars) because Windows Credential Manager caps a blob at ~2560 bytes. Oversized values are now transparently chunked across slots (Google's short tokens are unaffected). Without this fix, Outlook on Windows failed at connect time with a cryptic `CredWrite` error.

Validated end-to-end on a real AMD work/school account: device-code connect → per-agent grant → live inbox triage through the email agent (both in-process and via the `gaia email` daemon CLI).

## Test plan

- [ ] `python -m pytest tests/unit/connectors/ -q` — provider tenant/override, device-code flow (start/poll/grant/errors), keyring chunking round-trip, and the `authorize-device` router endpoint all pass.
- [ ] Personal or work/school Outlook, device code:
  - `export GAIA_MICROSOFT_CLIENT_ID=<public-client-id>` (add `GAIA_MICROSOFT_TENANT=organizations` for work/school)
  - `gaia connectors connect microsoft --device` → enter the code → `gaia connectors list` shows **Connected**
- [ ] Agent UI: Settings → Connections → Microsoft → **Sign in with a code** → tile flips to Connected after sign-in.
- [ ] `gaia connectors grants grant microsoft installed:email --scopes https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send` then `gaia email -q "Triage my inbox"` returns a triage of the Outlook mailbox.