### PR TITLE
fix(hub): importable CLI wheel agents + chat distribution via gaia init

### DIFF
--- a/.github/workflows/release_agent_chat.yml
+++ b/.github/workflows/release_agent_chat.yml
@@ -1,0 +1,339 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Tag-triggered release for the `gaia-agent-chat` package (issue #2358).
+#
+# Deliberately LEAN compared to release_agent_email.yml: chat ships as a
+# single pure-Python wheel through the Agent Hub R2 catalog only -- there is
+# no per-OS frozen-binary matrix, no darwin-x64 compat leg, no npm package,
+# no OIDC trusted publishing, and no binaries.lock.json. Distribution model
+# mirrors email's: the Agent Hub Worker (workers/agent-hub/) fronts the
+# gaia-hub R2 bucket; publishing goes through POST /publish (server-side
+# checksummed, rebuilds index.json); `gaia init --profile chat` / `gaia agent
+# install chat` pull the wheel from the live catalog once published.
+#
+#   1. build       — `python -m build` (sdist + wheel) for
+#                     hub/agents/chat/python on one Linux runner, then a
+#                     wheel-smoke: install the JUST-BUILT wheel into a
+#                     throwaway venv and import ChatAgent from it (proves the
+#                     wheel that will be tagged v0.1.0 forever actually works
+#                     BEFORE that tag becomes immutable).
+#   2. gate        — reuses test_chat_agent.yml (already workflow_call-ready)
+#                     as the unit/registration/discovery gate. NOTE: that
+#                     workflow installs chat via an EDITABLE (`-e`) install
+#                     (same-process sys.path), so it does NOT exercise the
+#                     isolated hub-installer directory this release ships --
+#                     it's a valid unit gate, not a wheel-smoke substitute
+#                     (see the `build` job's own wheel-smoke for that). The
+#                     honest release bar per CLAUDE.md is `gaia eval agent
+#                     --agent-type doc` (live backend + judge); chat has no
+#                     committed SCORECARD.md yet (#2312/#2333), so that eval
+#                     is a documented MANUAL pre-publish step, not a CI gate.
+#   3. publish     — behind the `agent-publish` environment's manual approval
+#                     (same environment release_agent_email.yml uses):
+#                     verify pyproject.toml <-> gaia-agent.yaml version lock
+#                     (stamp_version.py --check) + the pushed tag/dispatch
+#                     input matches those files (publish_to_r2.py takes no
+#                     --version -- it trusts gaia-agent.yaml alone), then
+#                     `publish_to_r2.py --artifact ...=wheel --readme ...`,
+#                     then dispatch deploy_website.yml (cosmetic -- the
+#                     installer reads the R2 index.json directly, the
+#                     website's Agent Hub page is a separate rendering of it).
+#
+# dry_run (workflow_dispatch only): default true. A dry run runs build + gate
+# + the version checks + wheel-smoke, and explicitly SKIPS the real POST
+# /publish + deploy_website dispatch. A tag push is NEVER a dry run (that IS
+# the real release trigger). Unlike release_agent_email.yml (whose
+# workflow_dispatch always triggers a real publish -- there's no
+# dry-run-skip precedent to copy there), this input exists specifically so a
+# maintainer can exercise the whole pipeline (including the version gates
+# and wheel-smoke) without cutting an immutable release.
+#
+# Maintainer setup (one-time) -- IDENTICAL environment/secrets/variables to
+# release_agent_email.yml (see that file's header for the full setup notes):
+#   Environment: agent-publish (required reviewers; deployment branches/tags
+#     restricted to `main` AND the `agent-pkg-*` tag pattern).
+#   Secrets:     GAIA_HUB_TOKEN (Agent Hub Bearer publish token, defined as
+#     an ENVIRONMENT secret on agent-publish, NOT a repo secret).
+#   Variables:   GAIA_HUB_BASE_URL (default https://hub.amd-gaia.ai),
+#     GAIA_HUB_PUBLISH_URL (the Worker's workers.dev origin -- large uploads
+#     are blocked on the proxied custom domain's managed WAF; a wheel is
+#     small so this matters less than for email's binaries, but the Worker
+#     endpoint is the same one either way).
+#
+# Tag namespace: `agent-pkg-chat-*` (NOT `v*` -- avoids firing publish.yml /
+# the paused publish_agents.yml). Example:
+#   git tag agent-pkg-chat-v0.1.0 && git push origin --tags
+
+name: Release Agent (chat)
+
+on:
+  push:
+    tags:
+      - 'agent-pkg-chat-*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: build + gate + version checks + wheel-smoke only, skip the real publish'
+        type: boolean
+        default: true
+      version:
+        description: 'Version to release (must match pyproject.toml + gaia-agent.yaml), e.g. 0.1.0. Only required for a REAL (non-dry-run) dispatch.'
+        required: false
+
+concurrency:
+  # Never cancel a half-done release — a partial publish must finish.
+  group: release-agent-chat-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CHAT_DIR: hub/agents/chat/python
+  MANIFEST: hub/agents/chat/python/gaia-agent.yaml
+  README: hub/agents/chat/python/README.md
+  HUB_PREFIX: agents/chat
+
+jobs:
+  # ── Stage 1: build the wheel + prove it actually works ──────────────
+  build:
+    name: Build + wheel-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install build backend
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist + wheel
+        working-directory: ${{ env.CHAT_DIR }}
+        run: python -m build
+
+      - name: Assert a .whl was produced
+        working-directory: ${{ env.CHAT_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          whl="$(find dist -maxdepth 1 -name '*.whl' | head -n1)"
+          if [ -z "${whl}" ]; then
+            echo "::error::no .whl found in dist/ — a build that only produces an sdist would defer PEP517 build code to install time; check the [build-system] section of pyproject.toml."
+            ls -la dist/ || true
+            exit 1
+          fi
+          echo "built: ${whl}"
+
+      - name: Wheel-smoke — install the JUST-BUILT wheel into a throwaway venv
+        working-directory: ${{ env.CHAT_DIR }}
+        shell: bash
+        # Budget for a heavy install: gaia-agent-chat depends on bare
+        # amd-gaia (no [rag] marker — RAG extras come from `gaia init`'s
+        # _install_pip_extras, not the wheel itself, see Increment 4), which
+        # itself pulls the full core dependency tree (~40 pkgs, >100 MB:
+        # transformers, accelerate, etc.). This proves the EXACT bytes that
+        # would be tagged v0.1.0 forever actually import, before that tag
+        # becomes immutable (the version-burn guard).
+        run: |
+          set -euo pipefail
+          whl="$(find dist -maxdepth 1 -name '*.whl' | head -n1)"
+          python -m venv /tmp/wheel-smoke-venv
+          /tmp/wheel-smoke-venv/bin/pip install -q "${whl}"
+          /tmp/wheel-smoke-venv/bin/python -c "from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig; print('wheel-smoke OK:', ChatAgent, ChatAgentConfig)"
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: gaia-agent-chat-wheel
+          path: ${{ env.CHAT_DIR }}/dist/*.whl
+          if-no-files-found: error
+
+  # ── Stage 1b: unit/registration/discovery gate ──────────────────────
+  gate:
+    name: Chat Agent Tests (gate)
+    uses: ./.github/workflows/test_chat_agent.yml
+
+  # ── Stage 2: publish to the Agent Hub (manual approval gate) ────────
+  publish:
+    name: Publish to Agent Hub
+    runs-on: ubuntu-latest
+    needs: [build, gate]
+    # Manual approval gate: the `agent-publish` environment (repo Settings →
+    # Environments) pauses this job until a maintainer approves — the human
+    # backstop for an accidental/tampered release tag. GAIA_HUB_TOKEN lives
+    # as an ENVIRONMENT secret here, so it isn't even readable until
+    # approval. Same environment release_agent_email.yml uses.
+    environment: agent-publish
+    permissions:
+      contents: read
+      actions: write   # gh workflow run deploy_website.yml (redeploy on publish)
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0   # full history so the main-ancestry guard can resolve
+
+      # Publishing is allowed ONLY from main. A tag must point at a commit
+      # on main; a workflow_dispatch must run on main. Blocks an accidental
+      # release from a feature branch.
+      - name: Assert release is cut from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if git merge-base --is-ancestor "$(git rev-parse HEAD)" origin/main; then
+            echo "✓ release commit is on main"
+          else
+            echo "::error::Publishing is only allowed from main. The current ref '${GITHUB_REF_NAME}' ($(git rev-parse --short HEAD)) is not on main — merge to main, then tag or dispatch the release from main."
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Resolve dry-run state
+        id: dry
+        shell: bash
+        # A tag push is NEVER a dry run (that is the real release trigger).
+        # workflow_dispatch defaults to a dry run unless the input is
+        # explicitly set to false.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_DRY_RUN" != "false" ]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "DRY RUN — will skip the real publish + deploy_website dispatch."
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "REAL PUBLISH."
+          fi
+
+      # Single-source version gate: pyproject.toml's version and
+      # gaia-agent.yaml's version must agree before we publish anything.
+      - name: Verify pyproject.toml <-> gaia-agent.yaml version lock
+        shell: bash
+        run: python hub/agents/chat/python/packaging/stamp_version.py --check
+
+      - name: Resolve + validate release version
+        id: ver
+        shell: bash
+        # User-controlled inputs go through env (never inlined into the
+        # script) so a value can't inject shell — GitHub Actions
+        # script-injection hardening.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          DRY_RUN: ${{ steps.dry.outputs.dry_run }}
+          GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}
+        run: |
+          set -euo pipefail
+          PYPROJECT_VER="$(python -c "import re,pathlib; print(re.search(r'(?m)^version\s*=\s*\"([^\"]+)\"', pathlib.Path('${CHAT_DIR}/pyproject.toml').read_text()).group(1))")"
+          MAN_VER="$(python -c "import re,pathlib; print(re.search(r'(?m)^version:[ \t]*(\S+)', pathlib.Path('${MANIFEST}').read_text()).group(1))")"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$DRY_RUN" = "true" ]; then
+              # A dry run needs no user-supplied version — the committed
+              # files (already lock-checked above) are the source of truth.
+              VERSION="${PYPROJECT_VER}"
+            else
+              if [ -z "${INPUT_VERSION:-}" ]; then
+                echo "::error::a REAL (non-dry-run) workflow_dispatch requires the 'version' input."
+                exit 1
+              fi
+              VERSION="${INPUT_VERSION}"
+            fi
+          else
+            TAG="${GITHUB_REF_NAME}"
+            VERSION="${TAG#agent-pkg-chat-}"
+            VERSION="${VERSION#v}"
+          fi
+          echo "release version: ${VERSION} (pyproject.toml=${PYPROJECT_VER}, gaia-agent.yaml=${MAN_VER})"
+          if [ "$VERSION" != "$PYPROJECT_VER" ] || [ "$VERSION" != "$MAN_VER" ]; then
+            echo "::error::version mismatch — tag/input=${VERSION}, pyproject.toml=${PYPROJECT_VER}, gaia-agent.yaml=${MAN_VER}. Align all three before tagging/dispatching."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "base_url=${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}/${HUB_PREFIX}/${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download wheel artifact
+        if: steps.dry.outputs.dry_run == 'false'
+        uses: actions/download-artifact@v8
+        with:
+          name: gaia-agent-chat-wheel
+          path: dist
+
+      - name: Assert hub publish token present
+        if: steps.dry.outputs.dry_run == 'false'
+        shell: bash
+        # Secret goes through env (never inlined into the script text) so a
+        # value with shell metacharacters can't break parsing or defeat log
+        # masking.
+        env:
+          GAIA_HUB_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GAIA_HUB_TOKEN:-}" ]; then
+            echo "::error::missing environment secret GAIA_HUB_TOKEN on the agent-publish environment — the Agent Hub Bearer publish token (must match the Worker's PUBLISH_TOKENS). See workers/agent-hub/README.md."
+            exit 1
+          fi
+
+      - name: Install requests + PyYAML (publish_to_r2.py deps)
+        if: steps.dry.outputs.dry_run == 'false'
+        run: python -m pip install --upgrade requests pyyaml
+
+      - name: Publish the wheel to the Agent Hub (POST /publish)
+        if: steps.dry.outputs.dry_run == 'false'
+        shell: bash
+        env:
+          # The Worker reads the Bearer token from this env var only — never
+          # the command line or disk.
+          AGENT_HUB_PUBLISH_TOKEN: ${{ secrets.GAIA_HUB_TOKEN }}
+          GAIA_HUB_PUBLISH_URL: ${{ vars.GAIA_HUB_PUBLISH_URL }}
+          GAIA_HUB_BASE_URL: ${{ vars.GAIA_HUB_BASE_URL }}
+        run: |
+          set -euo pipefail
+          whl="$(find dist -maxdepth 1 -name '*.whl' | head -n1)"
+          if [ -z "${whl}" ]; then
+            echo "::error::no .whl found in the downloaded artifact."
+            exit 1
+          fi
+          # publish_to_r2.py is a generic, --manifest-driven publisher (no
+          # email-specific hardcoding in its POST/verify path) that only
+          # ships under email's packaging/ today — reused here in place
+          # rather than duplicated, matching Increment 3's file-ownership
+          # scope (only stamp_version.py is a NEW chat-owned file).
+          # --artifact needs the explicit =wheel key: _infer_platform_key
+          # only special-cases 'email-agent-*'/'.zip' filenames — a bare
+          # gaia_agent_chat-*.whl has no inferrable prefix.
+          python hub/agents/email/python/packaging/publish_to_r2.py \
+            --base-url "${GAIA_HUB_PUBLISH_URL:-${GAIA_HUB_BASE_URL:-https://hub.amd-gaia.ai}}" \
+            --manifest "${MANIFEST}" \
+            --artifact "${whl}=wheel" \
+            --readme "${README}" \
+            --summary-out published.json
+          echo "=== publish summary ==="
+          cat published.json
+
+      - name: Redeploy the website to publish the new catalog entry
+        if: steps.dry.outputs.dry_run == 'false'
+        shell: bash
+        # The website builds its Agent Hub pages at deploy time from the
+        # live hub index.json (website/src/data/catalog.ts,
+        # HUB_CATALOG_URL), so a freshly published agent only appears after
+        # the site rebuilds. deploy_website.yml auto-triggers only on
+        # website/** changes — a hub publish touches no such file — so
+        # trigger it explicitly via workflow_dispatch. Least-privilege: uses
+        # this job's GITHUB_TOKEN (actions: write), no extra secret.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run deploy_website.yml --ref main
+          echo "✓ requested website redeploy (deploy_website.yml on main)"

--- a/hub/agents/chat/python/packaging/stamp_version.py
+++ b/hub/agents/chat/python/packaging/stamp_version.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Single-source version stamping for the ``gaia-agent-chat`` package.
+
+Unlike the email agent's ``stamp_version.py`` (``hub/agents/email/python/
+packaging/stamp_version.py``), chat has no ``version.py`` / no npm side / no
+``binaries.lock.json`` / no version-pinned doc links -- it is a single Python
+wheel with exactly two version references that must agree:
+
+  * ``pyproject.toml``  -- the ``[project]`` ``version = "<v>"`` (the real
+    source of truth: this is what ``python -m build`` stamps onto the wheel
+    filename and its dist-info).
+  * ``gaia-agent.yaml``  -- the hub catalog manifest's top-level
+    ``version: <v>`` (what the Agent Hub Worker records at publish time).
+
+Usage::
+
+  python hub/agents/chat/python/packaging/stamp_version.py
+      # read the version from pyproject.toml and stamp gaia-agent.yaml to match
+
+  python hub/agents/chat/python/packaging/stamp_version.py --check
+      # verify gaia-agent.yaml matches pyproject.toml; exit non-zero (with
+      # both values printed) on any mismatch -- the CI / publish-time gate.
+
+Deliberately hardcoded to THIS package's two files (not a generic multi-agent
+tool) -- if a future agent needs the same two-rule check, copy this file into
+its own ``packaging/`` directory rather than parameterizing this one, per the
+email script's own precedent of being intentionally single-package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# packaging/ -> python/ : this package's root.
+CHAT_ROOT = Path(__file__).resolve().parent.parent
+
+PYPROJECT = CHAT_ROOT / "pyproject.toml"
+MANIFEST = CHAT_ROOT / "gaia-agent.yaml"
+
+_PYPROJECT_VERSION_RE = re.compile(r'(?m)^(version\s*=\s*")([^"]+)(")')
+_MANIFEST_VERSION_RE = re.compile(r"(?m)^(version:[ \t]*)(\S+)([ \t]*)$")
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
+
+
+def _read_pyproject_version() -> str:
+    if not PYPROJECT.exists():
+        sys.exit(f"ERROR: source of truth not found: {PYPROJECT}")
+    text = PYPROJECT.read_text(encoding="utf-8")
+    m = _PYPROJECT_VERSION_RE.search(text)
+    if not m:
+        sys.exit(f"ERROR: could not parse [project] version from {PYPROJECT}")
+    version = m.group(2)
+    if not _SEMVER_RE.match(version):
+        sys.exit(f"ERROR: pyproject version '{version}' is not a valid x.y.z version")
+    return version
+
+
+def _read_manifest_version() -> str | None:
+    if not MANIFEST.exists():
+        return None
+    m = _MANIFEST_VERSION_RE.search(MANIFEST.read_text(encoding="utf-8"))
+    return m.group(2) if m else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Stamp/verify gaia-agent.yaml's version against pyproject.toml."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify gaia-agent.yaml matches pyproject.toml; exit non-zero on "
+        "mismatch (CI / publish gate). Does not modify files.",
+    )
+    args = parser.parse_args(argv)
+
+    version = _read_pyproject_version()
+    manifest_version = _read_manifest_version()
+    print(f"pyproject.toml version (source of truth): {version}")
+
+    if args.check:
+        if manifest_version is None:
+            print(f"  FAIL  gaia-agent.yaml: version field not found in {MANIFEST}")
+            return 1
+        if manifest_version != version:
+            print(
+                f"  FAIL  gaia-agent.yaml: version = {manifest_version} -- "
+                f"expected {version}"
+            )
+            print(
+                "\nVersion drift detected. Run "
+                "`python hub/agents/chat/python/packaging/stamp_version.py` "
+                "to sync gaia-agent.yaml to pyproject.toml."
+            )
+            return 1
+        print(f"  OK    gaia-agent.yaml (already {version})")
+        print(f"\nAll present targets match pyproject.toml ({version}).")
+        return 0
+
+    if manifest_version == version:
+        print(f"  OK    gaia-agent.yaml (already {version})")
+        print(f"\nDone. 0 file(s) stamped -- gaia-agent.yaml already {version}.")
+        return 0
+
+    text = MANIFEST.read_text(encoding="utf-8")
+    new_text, count = _MANIFEST_VERSION_RE.subn(
+        lambda m: f"{m.group(1)}{version}{m.group(3)}", text
+    )
+    if count == 0:
+        sys.exit(f"ERROR: could not find a 'version:' field to stamp in {MANIFEST}")
+    MANIFEST.write_text(new_text, encoding="utf-8")
+    old = manifest_version if manifest_version is not None else "(absent)"
+    print(f"  STAMP gaia-agent.yaml: {old} -> {version}")
+    print(f"\nDone. 1 file(s) stamped to v{version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hub/agents/chat/python/pyproject.toml
+++ b/hub/agents/chat/python/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+# >=70.0 for SPDX `license = "..."` string-expression support (PEP 639) below
+# -- the classic `license = { text = "..." }` table form setuptools still
+# accepts is hard-deprecated for removal 2027-02.
+requires = ["setuptools>=70.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,12 +10,19 @@ name = "gaia-agent-chat"
 version = "0.1.0"
 description = "GAIA chat agent — conversation, document Q&A (RAG), and file-system profiles"
 authors = [{ name = "AMD" }]
-license = { text = "MIT" }
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 # Floor: 0.22.0 is the first core release shipping
 # gaia.agents.registry.get_embedding_model_for_device, imported at agent
 # start (#2112). tests/test_chat_dependency_floor.py guards this floor.
+#
+# Intentionally bare `amd-gaia` (no `[rag]` extras marker): a plain
+# `pip install gaia-agent-chat` must not implicitly pull faiss/pymupdf/
+# sentence-transformers just to import ChatAgent. RAG's real dependencies
+# come from `gaia init --profile chat`'s own `_install_pip_extras()` step
+# into the ACTIVE interpreter, not from this wheel's install -- do not "fix"
+# this by adding `[rag]` here (#2358).
 dependencies = ["amd-gaia>=0.22.0"]
 
 [project.entry-points."gaia.agent"]

--- a/src/gaia/agents/install_hints.py
+++ b/src/gaia/agents/install_hints.py
@@ -12,6 +12,8 @@ install path that actually resolves today: pip installing straight from the
 package's subdirectory in this repo.
 """
 
+import sys
+
 # hub/agents/<subdir>/python for each wheel this module has a hint for. Keep
 # in sync with the directories under hub/agents/ (ls hub/agents/).
 _AGENT_SOURCE_SUBDIRS = {
@@ -38,13 +40,21 @@ _REPO_URL = "https://github.com/amd/gaia.git"
 def source_install_command(wheel: str) -> str:
     """Return the pip command that installs ``wheel`` straight from source.
 
+    Uses ``sys.executable -m pip`` rather than a bare ``uv`` binary: a stock
+    ``python -m venv`` has neither the ``uv`` executable on PATH nor the
+    ``uv`` Python module, so hard-coding ``uv pip install`` here would just
+    move the #2240 dead end from ``pip install gaia-agent-<id>`` to this
+    hint's own recommended command. ``python -m pip`` is the one frontend
+    every stock venv provides (the same last-resort fallback
+    ``InitCommand._install_pip_extras`` already uses for this reason).
+
     Raises ``KeyError`` if ``wheel`` isn't a known ``gaia-agent-*`` package --
     that's a bug at the call site (a typo'd wheel name), not a runtime
     condition to swallow.
     """
     subdir = _AGENT_SOURCE_SUBDIRS[wheel]
     return (
-        f'uv pip install "{wheel} @ git+{_REPO_URL}#subdirectory='
+        f'{sys.executable} -m pip install "{wheel} @ git+{_REPO_URL}#subdirectory='
         f'hub/agents/{subdir}/python"'
     )
 

--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -11,6 +11,7 @@ import inspect
 import os
 import platform
 import re
+import sys
 import threading
 import time
 import warnings
@@ -617,6 +618,14 @@ class AgentRegistry:
         else:
             logger.info("registry: No custom agent directory found at %s", agents_dir)
 
+        # 2.5. Prime sys.path with every hub-installed wheel agent's
+        # site-packages BEFORE the entry-point scan below. installer.install()
+        # only mutates sys.path in the process that ran the install
+        # (_hot_register); a fresh process (e.g. the next `gaia chat`
+        # invocation) never sees a wheel agent installed by an earlier `gaia
+        # init` unless something re-adds it here (#2358).
+        self._prime_installed_wheel_agents_path()
+
         # 3. Discover installed Python agents exposed by standalone wheels
         self._discover_installed_agents()
 
@@ -629,6 +638,59 @@ class AgentRegistry:
             len(agent_ids),
             agent_ids,
         )
+
+    def _prime_installed_wheel_agents_path(self) -> None:
+        """Append every hub-installed WHEEL agent's ``site-packages`` to
+        ``sys.path`` so the entry-point scan in ``_discover_installed_agents``
+        can find it, even in a process that never ran the install (#2358).
+
+        Import of ``gaia.hub.installer`` is deliberately function-local:
+        ``installer.py`` does an unconditional module-level ``from
+        gaia.agents.registry import _RESERVED_BUILTIN_IDS``, so a module-level
+        import here would create a circular partial-init error on whichever
+        module happens to import ``gaia.agents.registry`` first.
+
+        Uses ``sys.path.append`` (never ``insert(0)``): entry-point discovery
+        via ``importlib.metadata.entry_points()`` unions dist-info across
+        every ``sys.path`` entry regardless of order, so prepending buys
+        nothing for discovery here — but it WOULD give an isolated per-agent
+        ``site-packages`` process-wide precedence over the active
+        environment's own pinned dependencies (``amd-gaia`` and its NPU/
+        torch/numpy pins), since ``pip install --target`` installs a fresh
+        copy of any dependency the active env doesn't already satisfy.
+        """
+        from gaia.hub import installer as hub_installer
+
+        try:
+            installed = hub_installer.list_installed()
+        except Exception as exc:  # noqa: BLE001 - best-effort discovery step
+            logger.warning(
+                "registry: could not list hub-installed agents for sys.path "
+                "priming: %s",
+                exc,
+            )
+            return
+
+        for agent_id, info in installed.items():
+            if info.artifact_kind != hub_installer.ARTIFACT_KIND_WHEEL:
+                continue
+            if info.path is None:
+                continue
+            site_packages = info.path / hub_installer.SITE_PACKAGES_DIRNAME
+            if not site_packages.is_dir():
+                continue
+            sp = str(site_packages)
+            if sp not in sys.path:
+                sys.path.append(sp)
+                logger.debug(
+                    "registry: primed sys.path with %s's site-packages (%s)",
+                    agent_id,
+                    sp,
+                )
+
+        # Invalidate import-machinery caches (mirrors _hot_register) so the
+        # entry-point scan right after this sees the newly appended paths.
+        importlib.invalidate_caches()
 
     # ------------------------------------------------------------------
     # Built-in agents

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -397,25 +397,47 @@ def _download_and_verify(
 
 
 def _default_run_pip(args: List[str]) -> None:
-    """Run ``uv pip install <args>``; raise InstallError on failure."""
-    cmd = ["uv", "pip", "install", *args]
-    try:
-        proc = subprocess.run(  # noqa: S603 - args are constructed, not shell
-            cmd,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except FileNotFoundError as exc:
-        raise InstallError(
-            "Could not run 'uv' to install the agent's Python package. Install "
-            "uv (https://docs.astral.sh/uv/) or ensure it is on PATH."
-        ) from exc
-    if proc.returncode != 0:
-        raise InstallError(
-            f"'uv pip install' failed (exit {proc.returncode}): "
+    """Install ``args`` via pip, trying frontends in order until one works.
+
+    Mirrors the frontend list in
+    ``gaia.installer.init_command.InitCommand._install_pip_extras``: the
+    standalone ``uv`` binary leads (fastest, honours the active venv), then
+    ``python -m uv``, then ``python -m pip`` -- guaranteed present in any
+    venv, so a machine with no ``uv`` on PATH (the #2358 dead end: a stock
+    ``pip install amd-gaia`` user hitting ``gaia init --profile chat``)
+    still installs the wheel instead of hard-failing. Raises InstallError
+    only if every frontend fails.
+    """
+    frontends = [
+        ["uv", "pip", "install"],
+        [sys.executable, "-m", "uv", "pip", "install"],
+        [sys.executable, "-m", "pip", "install"],
+    ]
+    attempts: List[str] = []
+    for frontend in frontends:
+        cmd = [*frontend, *args]
+        try:
+            proc = subprocess.run(  # noqa: S603 - args are constructed, not shell
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            attempts.append(f"{frontend[0]} (not found on PATH)")
+            continue
+        if proc.returncode == 0:
+            return
+        attempts.append(
+            f"{' '.join(frontend)} (exit {proc.returncode}): "
             f"{proc.stderr.strip() or proc.stdout.strip()}"
         )
+    raise InstallError(
+        "Could not install the agent's Python package -- every pip frontend "
+        "failed:\n" + "\n".join(f"  - {a}" for a in attempts) + "\n"
+        f"Install uv (https://docs.astral.sh/uv/) or ensure "
+        f"'{sys.executable} -m pip' works, then retry."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -39,6 +39,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
 import tarfile
 import tempfile
 import threading
@@ -65,6 +66,20 @@ BACKUP_DIRNAME = ".backup"
 
 # Where Python wheels get installed (``uv pip install --target``).
 SITE_PACKAGES_DIRNAME = "site-packages"
+
+# ``.pth`` file written into the ACTIVE environment's own site-packages
+# (never the isolated per-agent one above) at wheel install time. A `pip
+# install --target` install is only importable via an explicit sys.path
+# mutation in the installing process (see _hot_register) -- a later, unrelated
+# process using the SAME interpreter/venv (e.g. the next `gaia chat`
+# invocation, which imports `gaia_agent_chat` directly rather than through
+# AgentRegistry) would otherwise never see it. Python's `site` module reads
+# every `.pth` file in site-packages at interpreter startup and appends each
+# line to sys.path, so one shared file with one absolute path per installed
+# wheel agent closes that gap with no code change anywhere else (#2358). This
+# is the same mechanism `pip install -e` uses for editable installs -- a
+# pointer file, not core-bundling.
+ACTIVE_ENV_PTH_FILENAME = "gaia-hub-agents.pth"
 
 # ``artifact_kind`` values recorded in the sentinel. A sentinel written before
 # this field existed reads as "wheel" (the only kind installed pre-#2084).
@@ -697,6 +712,127 @@ def _snapshot_backup(agent_id: str, install_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Active-environment .pth priming (#2358)
+#
+# _hot_register (below) makes a freshly-installed wheel importable in the
+# CALLING process only, via an in-memory sys.path mutation. Some callers
+# never construct an AgentRegistry at all -- e.g. `gaia chat`'s CLI handler
+# does a bare `from gaia_agent_chat.agent import ChatAgent` (cli.py) -- so a
+# later, unrelated `gaia` invocation using the SAME interpreter/venv would
+# still fail to import a wheel agent installed by an earlier `gaia init`.
+# Writing one absolute site-packages path per installed wheel agent into a
+# shared `.pth` file in the ACTIVE environment's own site-packages closes
+# that gap generically, with no call-site change required anywhere: Python's
+# `site` module reads every `.pth` file at interpreter startup and appends
+# each line to sys.path before user code runs.
+# ---------------------------------------------------------------------------
+
+
+def _default_active_env_site_packages() -> Path:
+    """The current interpreter's own (active-environment) site-packages dir.
+
+    This is deliberately NOT the isolated per-agent ``site-packages`` under
+    ``install_root/<id>/`` -- it's the ambient environment's own
+    (``sysconfig``'s ``purelib`` scheme path), the one Python's ``site``
+    module scans for ``.pth`` files at interpreter startup.
+    """
+    return Path(sysconfig.get_path("purelib"))
+
+
+def _read_pth_lines(pth_path: Path) -> List[str]:
+    if not pth_path.exists():
+        return []
+    return [
+        line
+        for line in pth_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _write_pth_lines(pth_path: Path, lines: List[str]) -> None:
+    """Write *lines* to *pth_path* atomically (temp file + ``os.replace``),
+    so a crash mid-write never corrupts a ``.pth`` file other packages also
+    rely on. Deletes the file entirely when *lines* is empty."""
+    if not lines:
+        pth_path.unlink(missing_ok=True)
+        return
+    pth_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        dir=str(pth_path.parent), prefix=".gaia-hub-pth-"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+        os.replace(str(tmp_path), str(pth_path))
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _add_wheel_agent_to_active_env_path(
+    site_packages: Path, active_env_site_packages: Optional[Path] = None
+) -> None:
+    """Add *site_packages* to the active environment's ``.pth`` file (idempotent).
+
+    Raises:
+        InstallError: If the ``.pth`` file cannot be written (permissions,
+            missing directory, etc.) -- a wheel agent that isn't importable
+            outside the installing process is a real, actionable failure, not
+            one to silently swallow (CLAUDE.md fail-loudly).
+    """
+    target_dir = active_env_site_packages or _default_active_env_site_packages()
+    pth_path = target_dir / ACTIVE_ENV_PTH_FILENAME
+    line = str(site_packages)
+    try:
+        lines = _read_pth_lines(pth_path)
+        if line in lines:
+            return
+        lines.append(line)
+        _write_pth_lines(pth_path, lines)
+        logger.info(
+            "installer: added %s to %s (wheel agent importable in any new "
+            "process using this environment)",
+            line,
+            pth_path,
+        )
+    except OSError as exc:
+        raise InstallError(
+            f"Could not write {pth_path} to make the newly installed wheel "
+            f"agent at {site_packages} importable outside this process: "
+            f"{exc}. Check write permissions on {target_dir}."
+        ) from exc
+
+
+def _remove_wheel_agent_from_active_env_path(
+    site_packages: Path, active_env_site_packages: Optional[Path] = None
+) -> None:
+    """Remove *site_packages* from the active environment's ``.pth`` file.
+
+    No-op if the file or the line is already absent (uninstall of an agent
+    whose install predates this mechanism, or a repeated uninstall).
+
+    Raises:
+        InstallError: If the ``.pth`` file cannot be rewritten/removed.
+    """
+    target_dir = active_env_site_packages or _default_active_env_site_packages()
+    pth_path = target_dir / ACTIVE_ENV_PTH_FILENAME
+    line = str(site_packages)
+    try:
+        lines = _read_pth_lines(pth_path)
+        if line not in lines:
+            return
+        remaining = [entry for entry in lines if entry != line]
+        _write_pth_lines(pth_path, remaining)
+        logger.info("installer: removed %s from %s", line, pth_path)
+    except OSError as exc:
+        raise InstallError(
+            f"Could not clean up {pth_path} after removing the wheel agent "
+            f"at {site_packages}: {exc}."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
 # Hot-register
 # ---------------------------------------------------------------------------
 
@@ -810,6 +946,7 @@ def install(
     skip_compatibility_check: bool = False,
     trust_native: bool = False,
     platform_key: Optional[str] = None,
+    active_env_site_packages: Optional[Path] = None,
 ) -> InstallResult:
     """Download, verify, and install an agent from the hub.
 
@@ -827,6 +964,11 @@ def install(
         platform_key: Artifact-filename platform key (``win32-x64`` etc.) used
             to select among ``versions[v].artifacts[]``; defaults to the real
             host's key (injectable for tests).
+        active_env_site_packages: Where to write the ``.pth`` entry that makes
+            a wheel install importable by ANY later process using this same
+            interpreter/venv (not just the calling process); defaults to this
+            interpreter's own site-packages (``sysconfig``'s ``purelib``).
+            Injectable so tests don't write into the real active environment.
 
     Raises:
         InstallInProgressError, ChecksumError, DiskSpaceError,
@@ -946,6 +1088,16 @@ def install(
                     artifact_kind=artifact_kind,
                     executable=generic_name,
                 )
+                # Prime the ACTIVE environment (not just this process) so a
+                # later, unrelated `gaia` invocation using the same
+                # interpreter/venv can import this wheel too (#2358) — closes
+                # the gap for call sites that never touch AgentRegistry (e.g.
+                # `gaia chat`'s hardcoded `import gaia_agent_chat`).
+                if artifact_kind == ARTIFACT_KIND_WHEEL:
+                    _add_wheel_agent_to_active_env_path(
+                        install_dir / SITE_PACKAGES_DIRNAME,
+                        active_env_site_packages,
+                    )
             except Exception:
                 # Install failed mid-write — restore the backup if we made one so
                 # the user is left with a working previous version, not a stub.
@@ -1058,8 +1210,14 @@ def uninstall(
     *,
     install_root: Optional[Path] = None,
     registry: Any = None,
+    active_env_site_packages: Optional[Path] = None,
 ) -> None:
     """Remove a hub-installed agent. Refuses builtins.
+
+    Args:
+        active_env_site_packages: Where the ``.pth`` entry added at install
+            time lives; defaults to this interpreter's own site-packages.
+            Injectable so tests don't touch the real active environment.
 
     Raises:
         InstallError: If *agent_id* is a reserved builtin.
@@ -1071,7 +1229,8 @@ def uninstall(
         )
     root = install_root or default_install_root()
     install_dir = agent_install_dir(agent_id, root)
-    if read_sentinel(agent_id, root) is None:
+    installed = read_sentinel(agent_id, root)
+    if installed is None:
         raise NotInstalledError(
             f"'{agent_id}' is not installed (no {SENTINEL_NAME} at {install_dir})."
         )
@@ -1082,6 +1241,10 @@ def uninstall(
             f"Could not remove '{agent_id}': {exc}. It appears to be running — "
             f"close it and retry."
         ) from exc
+    if installed.artifact_kind == ARTIFACT_KIND_WHEEL:
+        _remove_wheel_agent_from_active_env_path(
+            install_dir / SITE_PACKAGES_DIRNAME, active_env_site_packages
+        )
     _discard_backup(agent_id, root)
     if registry is not None:
         _deregister(agent_id, registry)

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -454,11 +454,16 @@ class InitCommand:
                     break
             break
 
+        # The fallback message must resolve in a stock venv with no `uv` on
+        # PATH (same reasoning as gaia.agents.install_hints.
+        # source_install_command, #2358) -- this is the frontend the loop
+        # below always ends up trying last, so it's the one the user's
+        # terminal message must actually work with.
         if editable and location:
-            install_spec = f'uv pip install -e ".[{extras_str}]"'
+            install_spec = f'{sys.executable} -m pip install -e ".[{extras_str}]"'
             install_args = ["install", "-e", f"{location}[{extras_str}]"]
         else:
-            install_spec = f'uv pip install "amd-gaia[{extras_str}]"'
+            install_spec = f'{sys.executable} -m pip install "amd-gaia[{extras_str}]"'
             install_args = ["install", f"amd-gaia[{extras_str}]"]
 
         self._print_success(f"Installing extras: {extras_str}")
@@ -502,6 +507,13 @@ class InitCommand:
 
         profile_config = INIT_PROFILES[self.profile]
         has_pip_extras = bool(profile_config.get("pip_extras"))
+        # Data-driven scope (#2358): "chat" and "npu" both declare
+        # `"agent": "chat"` (they resolve to the same standalone wheel), so
+        # keying off the declared agent -- not a hardcoded profile-name
+        # literal -- naturally covers both without a special case, and never
+        # touches profiles for other hub agents (sd/code/analyst/email/...),
+        # each of which has its own, separately-owned install lifecycle.
+        has_hub_agent_check = profile_config.get("agent") == "chat"
 
         _webui_src = Path(__file__).resolve().parent.parent / "apps" / "webui" / "src"
         _is_dev_install = _webui_src.is_dir()
@@ -515,6 +527,8 @@ class InitCommand:
         if has_backend_install:
             total_steps += 1
         if has_pip_extras:
+            total_steps += 1
+        if has_hub_agent_check:
             total_steps += 1
         if _is_dev_install:
             total_steps += 1
@@ -596,6 +610,25 @@ class InitCommand:
                     step_num, total_steps, "Installing Python dependencies..."
                 )
                 self._install_pip_extras()
+
+            # Ensure the profile's hub agent (chat's standalone wheel) is
+            # installed (#2358). Independent of the pip-extras step above:
+            # the hub install targets the isolated
+            # ~/.gaia/agents/chat/site-packages dir, while [rag] extras
+            # target the ACTIVE interpreter — one must not replace or block
+            # the other. Unlike _install_pip_extras (warn-but-continue), a
+            # genuine failure here is allowed to propagate into this
+            # method's own top-level `except Exception` below, which already
+            # converts it into an actionable non-zero exit — silently
+            # continuing would just recreate the "chat isn't installed"
+            # state this issue exists to close.
+            if has_hub_agent_check:
+                step_num += 1
+                self._print("")
+                self._print_step(
+                    step_num, total_steps, "Checking chat agent installation..."
+                )
+                self._ensure_hub_agent_installed()
 
             # Build Agent UI frontend (dev/source installs only)
             if _is_dev_install:
@@ -1901,6 +1934,15 @@ class InitCommand:
             return False
 
     @staticmethod
+    def _is_hub_agent_available(agent_id: str) -> bool:
+        """Whether the standalone ``gaia-agent-<agent_id>`` wheel is
+        importable in THIS process (by the same naming convention
+        ``install_hints._AGENT_SOURCE_SUBDIRS`` and every ``gaia-agent-*``
+        wheel already use: import name ``gaia_agent_<id>``).
+        """
+        return importlib.util.find_spec(f"gaia_agent_{agent_id}") is not None
+
+    @staticmethod
     def _chat_agent_available() -> bool:
         """Whether the standalone gaia-agent-chat wheel is importable.
 
@@ -1909,7 +1951,89 @@ class InitCommand:
         chat` as a ready next step when it isn't installed is a false
         promise, so completion messaging checks first.
         """
-        return importlib.util.find_spec("gaia_agent_chat") is not None
+        return InitCommand._is_hub_agent_available("chat")
+
+    def _ensure_hub_agent_installed(self) -> None:
+        """Install this profile's hub agent from the Agent Hub catalog if it
+        isn't already available and the live catalog confirms it's published.
+
+        Scoped by ``run()``'s ``has_hub_agent_check`` (profiles whose
+        declared ``"agent"`` is ``"chat"`` -- both ``chat`` and ``npu``).
+
+        Distinguishes two catalog states (#2358):
+
+        * Not yet published (today's state — only ``email`` is live on the
+          Hub): NOT an error. A blind "call install() and fail loud" would
+          turn today's soft success (``init`` completes, prints a
+          source-install hint) into a hard failure for every `gaia init
+          --profile chat` until the publish lands — a real regression this
+          method must not introduce. Silently returns; the existing
+          ``_print_completion()`` hint already tells the user how to
+          source-install it in the meantime.
+        * Published but the install itself genuinely fails: this method
+          does NOT catch that exception — it propagates into ``run()``'s
+          own top-level ``except Exception`` handler, which already turns
+          any unexpected exception into an actionable non-zero exit. Unlike
+          ``_install_pip_extras``, a real hub-install failure must fail
+          loudly, not warn-and-continue (that would just recreate the
+          "agent isn't installed" state this issue exists to close).
+
+        A catalog-fetch failure (network down, no offline cache) is treated
+        the same as "not yet published" — `gaia init` must not hard-fail
+        merely because the Hub catalog service is briefly unreachable.
+        """
+        agent_id = INIT_PROFILES[self.profile]["agent"]
+
+        if self._is_hub_agent_available(agent_id):
+            return
+
+        from gaia.hub import catalog as hub_catalog
+
+        try:
+            catalog_result = hub_catalog.load_index()
+            published = any(
+                agent.get("id") == agent_id for agent in catalog_result.agents
+            )
+        except Exception as exc:  # noqa: BLE001 - catalog reachability, not install
+            log.warning(
+                "Could not check the Agent Hub catalog for '%s': %s -- "
+                "treating as not-yet-published (non-fatal)",
+                agent_id,
+                exc,
+            )
+            published = False
+
+        if not published:
+            log.debug(
+                "'%s' is not yet published to the Agent Hub catalog; "
+                "skipping the hub install for this run.",
+                agent_id,
+            )
+            return
+
+        from gaia.hub import installer as hub_installer
+
+        self._print(f"   Installing '{agent_id}' from the Agent Hub...")
+        result = hub_installer.install(agent_id)
+        self._print_success(f"Installed '{agent_id}' from the Agent Hub")
+
+        # No AgentRegistry exists in this process to hot-register into (we
+        # deliberately don't construct one just for this), so mirror the
+        # sys.path side of _hot_register directly: without this, THIS same
+        # process's own _print_completion() would still (incorrectly) show
+        # the "chat agent not installed yet" hint immediately after a
+        # successful install, since installer.install() only mutates
+        # sys.path when a registry= is passed. isinstance-guarded (rather
+        # than a bare truthiness/attribute check) so a test double standing
+        # in for InstallResult can't accidentally make it past this into a
+        # real sys.path mutation.
+        if isinstance(result.path, Path):
+            site_packages = result.path / hub_installer.SITE_PACKAGES_DIRNAME
+            if site_packages.is_dir():
+                sp = str(site_packages)
+                if sp not in sys.path:
+                    sys.path.append(sp)
+                    importlib.invalidate_caches()
 
     def _print_completion(self):
         """Print completion message with next steps."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,38 @@ def _reset_model_broker_state():
     _reset()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_hub_installer_active_env_pth(tmp_path_factory, monkeypatch):
+    """Redirect ``gaia.hub.installer``'s active-environment ``.pth`` target (#2358).
+
+    ``installer.install()``/``uninstall()`` write/remove an absolute
+    site-packages path in a ``.pth`` file under the ACTIVE interpreter's own
+    site-packages by default (``_default_active_env_site_packages()``) so a
+    hub-installed wheel agent stays importable by a later, unrelated process
+    using the same interpreter/venv -- not just the one that ran the install.
+    Every test in ``test_hub_installer.py`` (and anywhere else that calls
+    ``install()``) builds a wheel-shaped manifest by default, so without this
+    guard EVERY such test would write into the REAL dev/CI venv's
+    site-packages, accumulating stale entries across every test run. This
+    autouse fixture makes that impossible: each test gets its own isolated,
+    throwaway target unless it explicitly overrides ``active_env_site_packages=``
+    for a test that needs to prove the real mechanism (e.g. a dedicated
+    throwaway venv in an integration test).
+    """
+    try:
+        from gaia.hub import installer as hub_installer
+    except ImportError:
+        yield
+        return
+    fake_site_packages = tmp_path_factory.mktemp("hub-installer-active-env")
+    monkeypatch.setattr(
+        hub_installer,
+        "_default_active_env_site_packages",
+        lambda: fake_site_packages,
+    )
+    yield
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--hybrid",

--- a/tests/fixtures/wheel_builder.py
+++ b/tests/fixtures/wheel_builder.py
@@ -1,0 +1,197 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Hand-rolled pure-Python wheel builder for hub-installer tests (#2358).
+
+Builds a minimal, spec-valid ``.whl`` in memory -- no ``build``/``wheel``
+package required -- so tests can run a REAL ``pip install --target`` against
+a real artifact instead of mocking pip. The wheel declares one ``gaia.agent``
+entry point so it is discoverable by ``importlib.metadata.entry_points()``
+once its ``site-packages`` install dir lands on ``sys.path``, exactly what
+``gaia.hub.installer.install()`` does for a Python-agent artifact.
+"""
+
+import base64
+import hashlib
+import zipfile
+from io import BytesIO
+from typing import Dict, Optional, Tuple
+
+
+def _b64_nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _normalize_dist_name(dist_name: str) -> str:
+    """Normalize a distribution name for use in a wheel FILENAME / dist-info
+    dir, per the wheel spec (PEP 427): hyphens are the segment separator in
+    ``{distribution}-{version}-{python tag}-{abi tag}-{platform tag}.whl``,
+    so any hyphen already IN the distribution name must become an
+    underscore, or pip rejects the filename as "wrong number of parts". The
+    human-readable ``Name:`` field in METADATA keeps the original hyphenated
+    form -- only the filename/dist-info-dir segment is normalized.
+    """
+    return dist_name.replace("-", "_")
+
+
+def build_fixture_wheel_bytes(
+    *,
+    dist_name: str,
+    version: str,
+    module_name: str,
+    entry_point_group: str,
+    entry_point_name: str,
+    entry_point_target: str,
+    module_source: str,
+    extra_modules: Optional[Dict[str, str]] = None,
+) -> bytes:
+    """Build a minimal, real, installable wheel and return its raw bytes.
+
+    ``extra_modules`` maps extra relative-path -> source for additional files
+    inside ``module_name`` (e.g. ``{"app.py": "..."}``), for fixtures that
+    need more than one module (e.g. mimicking ``gaia_agent_chat.agent`` +
+    ``gaia_agent_chat.app`` for a hardcoded-import call site).
+    """
+    dist_info = f"{_normalize_dist_name(dist_name)}-{version}.dist-info"
+    files: Dict[str, str] = {
+        f"{module_name}/__init__.py": "",
+        f"{module_name}/agent.py": module_source,
+    }
+    for rel_path, source in (extra_modules or {}).items():
+        files[f"{module_name}/{rel_path}"] = source
+    files.update(
+        {
+            f"{dist_info}/METADATA": (
+                "Metadata-Version: 2.1\n"
+                f"Name: {dist_name}\n"
+                f"Version: {version}\n"
+                "Summary: fixture wheel for gaia hub install tests\n"
+            ),
+            f"{dist_info}/WHEEL": (
+                "Wheel-Version: 1.0\n"
+                "Generator: gaia-test-fixture\n"
+                "Root-Is-Purelib: true\n"
+                "Tag: py3-none-any\n"
+            ),
+            f"{dist_info}/entry_points.txt": (
+                f"[{entry_point_group}]\n{entry_point_name} = {entry_point_target}\n"
+            ),
+        }
+    )
+    buf = BytesIO()
+    record_lines = []
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in files.items():
+            data = content.encode("utf-8")
+            zf.writestr(name, data)
+            digest = hashlib.sha256(data).digest()
+            record_lines.append(f"{name},sha256={_b64_nopad(digest)},{len(data)}")
+        record_lines.append(f"{dist_info}/RECORD,,")
+        zf.writestr(f"{dist_info}/RECORD", "\n".join(record_lines) + "\n")
+    return buf.getvalue()
+
+
+_DEFAULT_AGENT_MODULE_SOURCE = '''\
+"""Fixture agent module -- proves a hub-installed wheel is real & importable."""
+
+from gaia.agents.registry import AgentRegistration
+
+
+def _factory(**kwargs):
+    return object()
+
+
+def build_registration():
+    return AgentRegistration(
+        id={agent_id!r},
+        name="Fixture Test Agent",
+        description="Fixture agent for hub-install cross-process import tests",
+        source="installed",
+        conversation_starters=[],
+        factory=_factory,
+        agent_dir=None,
+        models=[],
+    )
+'''
+
+
+def build_chat_shaped_fixture_wheel(
+    agent_id: str = "fixturetestagent", version: str = "0.1.0"
+) -> bytes:
+    """A wheel shaped like a hub Python-agent package, registering *agent_id*.
+
+    Doesn't need to be the literal ``gaia_agent_chat`` package -- the point is
+    proving the wheel-install -> cross-process-import *mechanism* (#2358),
+    the same mechanism a real ``gaia-agent-chat`` install would exercise.
+    """
+    module_name = f"{agent_id}_pkg"
+    module_source = _DEFAULT_AGENT_MODULE_SOURCE.format(agent_id=agent_id)
+    return build_fixture_wheel_bytes(
+        dist_name=agent_id,
+        version=version,
+        module_name=module_name,
+        entry_point_group="gaia.agent",
+        entry_point_name=agent_id,
+        entry_point_target=f"{module_name}.agent:build_registration",
+        module_source=module_source,
+    )
+
+
+def build_wheel_manifest(
+    agent_id: str,
+    version: str,
+    wheel_bytes: bytes,
+    *,
+    dist_name: Optional[str] = None,
+) -> Tuple[Dict, str]:
+    """Return ``(manifest, artifact_path)`` for :func:`gaia.hub.installer.install`.
+
+    Mirrors the manifest shape used by ``tests/unit/test_hub_installer.py``'s
+    ``_manifest()`` helper (id, language, latest_version, requirements,
+    versions[v].artifact{filename,path,size_bytes,sha256,content_type}).
+
+    ``dist_name`` (defaults to *agent_id*) names the wheel FILE itself --
+    per wheel spec the filename's distribution segment must match the
+    wheel's own ``.dist-info`` dir name, which is independent of the hub
+    *agent_id* (the install-directory name). Pass it explicitly when the
+    wheel's ``dist_name`` (as built by :func:`build_fixture_wheel_bytes`)
+    differs from *agent_id* -- e.g. a fixture installed under the hub id
+    ``chat`` whose wheel is distributed as ``gaia-agent-chat``.
+    """
+    dist_name = dist_name or agent_id
+    sha = hashlib.sha256(wheel_bytes).hexdigest()
+    filename = f"{_normalize_dist_name(dist_name)}-{version}-py3-none-any.whl"
+    path = f"agents/{agent_id}/{version}/{filename}"
+    manifest = {
+        "id": agent_id,
+        "language": "python",
+        "latest_version": version,
+        "requirements": {"platforms": []},
+        "versions": {
+            version: {
+                "version": version,
+                "artifact": {
+                    "filename": filename,
+                    "path": path,
+                    "size_bytes": len(wheel_bytes),
+                    "sha256": sha,
+                    "content_type": "application/octet-stream",
+                },
+            }
+        },
+    }
+    return manifest, path
+
+
+def build_wheel_fetcher(
+    base_url: str, artifact_path: str, wheel_bytes: bytes, agent_id: str
+):
+    """Fetcher callable serving *wheel_bytes* + a stub ``gaia-agent.yaml``."""
+
+    def fetcher(url: str) -> bytes:
+        if url.endswith("/gaia-agent.yaml"):
+            return f"id: {agent_id}\nname: Fixture\n".encode("utf-8")
+        if url == f"{base_url}/{artifact_path}":
+            return wheel_bytes
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    return fetcher

--- a/tests/integration/test_chat_hub_wheel_journey.py
+++ b/tests/integration/test_chat_hub_wheel_journey.py
@@ -1,0 +1,372 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""AC-6 (issue #2358): the clean/core-only `init -> chat` integration test.
+
+Proves the wheel-install -> cross-process-import MECHANISM end-to-end using
+REAL subprocesses, from a `$HOME`-redirected temp dir standing in for "the
+real user's initial state" (a plain `pip install amd-gaia`, no hub-agent
+wheel editable-installed anywhere) -- see CLAUDE.md's "test from the user's
+real initial state" rule and the #1655 postmortem it's named for.
+
+Journey:
+
+1. Install a REAL, self-contained fixture wheel (built by
+   ``tests/fixtures/wheel_builder.py``) via ``gaia.hub.installer.install()``
+   -- real ``run_pip`` subprocess, no mocks -- standing in for what the Hub
+   R2 channel would serve for `chat` once it's published. It does NOT need
+   to be the literal, production ``gaia_agent_chat`` wheel from
+   ``hub/agents/chat/python`` -- but it DOES need to be importable as the
+   literal ``gaia_agent_chat`` module, because `gaia chat`'s CLI handler
+   hardcodes ``from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig``
+   (``src/gaia/cli.py:650``) rather than resolving through
+   ``AgentRegistry`` -- unlike `gaia browse`/`gaia analyze`, which DO go
+   through the registry (``cli.py:832-855``). This is a real, load-bearing
+   finding for whoever implements the fix: making
+   ``AgentRegistry.discover()`` aware of hub installs (the crux fix in
+   ``tests/unit/test_registry_installed_import.py``) is necessary but NOT
+   sufficient to make `gaia chat` work -- something must also make
+   `gaia_agent_chat` importable before that hardcoded import line runs in a
+   fresh process.
+2. Run `gaia init --profile chat --skip-models --yes --remote` as a REAL
+   subprocess, against a tiny local fake HTTP `/health` responder (so the
+   test needs neither a real Lemonade Server nor network access) -- proves
+   `init` completes cleanly in this environment without disturbing the
+   pre-installed fixture.
+3. Run `gaia chat -q "hello"` as a REAL subprocess, same redirected `$HOME`.
+   Asserts it does NOT show the CURRENT (broken) "chat agent is not
+   installed" / ModuleNotFoundError signature. It also asserts the process
+   got all the way to the agent's real logic (our fixture's deliberate stub
+   marker) -- not just "didn't crash on import" -- which is a stronger
+   proof than an absence check alone. Reaching an unrelated, expected
+   downstream failure (no real LLM backend is running) is fine and is NOT
+   the crux bug; only the "not installed" signature is.
+
+This test is expected to be SLOW/heavy (real subprocess pip installs, a real
+`gaia` subprocess) -- marked ``@pytest.mark.integration`` per this repo's
+slow-test convention (see ``tests/integration/*`` and
+``tests/conftest.py``/``pyproject.toml`` markers) so it stays out of the
+default fast unit run.
+
+MUST currently fail: no wiring installs `chat` during `gaia init`, and (more
+fundamentally) nothing makes a hub-installed wheel importable in the fresh
+`gaia chat` subprocess -- see the assertion's failure message for exactly
+which signature shows up today.
+"""
+
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+from gaia.hub import installer as hub_installer
+from tests.fixtures.wheel_builder import (
+    build_fixture_wheel_bytes,
+    build_wheel_fetcher,
+    build_wheel_manifest,
+)
+
+BASE_URL = "https://hub.test"
+AGENT_ID = "chat"
+
+# The crux bug's exact failure signature on unfixed `main` (verified by
+# running `gaia chat -q hello` against a fresh $HOME with nothing installed;
+# see cli.py:650-659 / gaia.agents.install_hints.agent_not_installed_message).
+_CRUX_NOT_INSTALLED_SIGNATURE = "chat agent is not installed"
+
+# Our fixture ChatAgent deliberately raises this from process_query() so the
+# test can positively confirm execution reached real agent logic, not just
+# "didn't raise ImportError".
+_FIXTURE_STUB_MARKER = "GAIA_TEST_FIXTURE_CHAT_STUB_REACHED"
+
+_FIXTURE_AGENT_MODULE_SOURCE = f'''\
+"""Fixture stand-in for gaia_agent_chat.agent (#2358 AC-6 mechanism proof).
+
+Provides just enough of the real gaia_agent_chat.agent surface (ChatAgent,
+ChatAgentConfig) for `gaia chat`'s hardcoded
+`from gaia_agent_chat.agent import ChatAgent, ChatAgentConfig` (cli.py:650)
+to succeed, plus a `build_registration()` entry point for AgentRegistry-based
+discovery. Deliberately NOT a faithful re-implementation -- the point is
+proving the wheel-install -> cross-process-import mechanism, not chat
+functionality.
+"""
+
+from gaia.agents.registry import AgentRegistration
+
+FIXTURE_STUB_MARKER = {_FIXTURE_STUB_MARKER!r}
+
+
+class ChatAgentConfig:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class _DummySession:
+    session_id = "fixture-session"
+
+
+class _DummySessionManager:
+    def create_session(self):
+        return _DummySession()
+
+
+class ChatAgent:
+    def __init__(self, config):
+        self.config = config
+        self.current_session = None
+        self.session_manager = _DummySessionManager()
+
+    def process_query(self, query, trace=False):
+        # Deliberately fails PAST the import/construction gate -- proves the
+        # cross-process import + construction worked, distinct from the
+        # crux "chat agent is not installed" signature.
+        raise RuntimeError(FIXTURE_STUB_MARKER)
+
+    def stop_watching(self):
+        pass
+
+
+def _factory(**kwargs):
+    return ChatAgent(ChatAgentConfig(**kwargs))
+
+
+def build_registration():
+    return AgentRegistration(
+        id={AGENT_ID!r},
+        name="Fixture Chat Agent",
+        description="AC-6 mechanism-proof fixture (#2358)",
+        source="installed",
+        conversation_starters=[],
+        factory=_factory,
+        agent_dir=None,
+        models=[],
+    )
+'''
+
+_FIXTURE_APP_MODULE_SOURCE = """\
+def interactive_mode(agent):
+    raise RuntimeError("fixture stub: interactive_mode not exercised by -q tests")
+"""
+
+
+def _build_chat_fixture_wheel() -> bytes:
+    """A wheel importable as the literal ``gaia_agent_chat`` module."""
+    return build_fixture_wheel_bytes(
+        dist_name="gaia-agent-chat",
+        version="0.1.0",
+        module_name="gaia_agent_chat",
+        entry_point_group="gaia.agent",
+        entry_point_name=AGENT_ID,
+        entry_point_target="gaia_agent_chat.agent:build_registration",
+        module_source=_FIXTURE_AGENT_MODULE_SOURCE,
+        extra_modules={"app.py": _FIXTURE_APP_MODULE_SOURCE},
+    )
+
+
+def _real_pip_run_pip(python_exe):
+    def run_pip(args):
+        subprocess.run(
+            [python_exe, "-m", "pip", "install", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    return run_pip
+
+
+# `gaia init`'s final "Verifying setup..." step (init_command.py:1696,
+# _verify_setup) unconditionally calls `LemonadeManager.ensure_ready()` for
+# the profile's min_context_size, even with --skip-models. ensure_ready()
+# reads `client.get_status()`, which is built entirely from this `/health`
+# payload's `all_models_loaded[].{type,recipe_options.ctx_size}`
+# (lemonade_client.py:3777-3801). Reporting an LLM model already loaded with
+# ctx_size >= the chat profile's min_context_size (32768) makes
+# ensure_ready() take its "already sufficient" fast path and return True
+# WITHOUT ever issuing the real model-load POST -- which this fake server
+# deliberately does not implement (avoids re-implementing Lemonade's load
+# API just to satisfy a health probe).
+_FAKE_HEALTH_BODY = json.dumps(
+    {
+        "status": "ok",
+        "version": "10.9.0",
+        "all_models_loaded": [
+            {
+                "model_name": "Gemma-4-E4B-it-GGUF",
+                "type": "llm",
+                "recipe_options": {"ctx_size": 32768},
+            }
+        ],
+    }
+).encode("utf-8")
+
+
+class _HealthHandler(http.server.BaseHTTPRequestHandler):
+    """Answers exactly the one endpoint `gaia init`'s remote-mode server
+    check needs (`GET {base_url}/health`) -- avoids any dependency on a real
+    Lemonade Server or the network for the `gaia init` step."""
+
+    def do_GET(self):  # noqa: N802 - stdlib method name
+        if self.path == "/api/v1/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(_FAKE_HEALTH_BODY)))
+            self.end_headers()
+            self.wfile.write(_FAKE_HEALTH_BODY)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):  # noqa: A002 - silence stderr spam
+        pass
+
+
+@contextmanager
+def _fake_lemonade_health_server():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _HealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}/api/v1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _gaia_executable() -> str:
+    """Resolve the `gaia` console script next to the active interpreter --
+    the same venv `.venv-wt/bin/python` runs from has `.venv-wt/bin/gaia`,
+    guaranteed present for any editable/real install (unlike relying on
+    inherited shell PATH, which pytest's own invocation may not carry)."""
+    from pathlib import Path
+
+    suffix = ".exe" if sys.platform == "win32" else ""
+    return str(Path(sys.executable).parent / f"gaia{suffix}")
+
+
+def _minimal_path_env() -> str:
+    """A PATH with `node`/`npm` deliberately excluded.
+
+    `gaia init` unconditionally attempts to rebuild the Agent UI frontend in
+    a dev/source checkout (`_is_dev_install`, init_command.py:507) when
+    `apps/webui/dist` doesn't exist yet -- true for a fresh worktree. If
+    node/npm ARE on PATH, `ensure_webui_built` (gaia/ui/build.py) will
+    happily kick off a REAL `npm install && npm run build`, which is slow,
+    unrelated to this test, and not hermetic. Stripping node/npm from PATH
+    makes that gate no-op cleanly (it already handles "node not found" as a
+    graceful non-failure, gaia/ui/build.py:76-80) -- so keep the venv's own
+    bin dir (for `gaia`/`python`) plus basic system dirs, nothing else.
+    """
+    from pathlib import Path
+
+    venv_bin = str(Path(sys.executable).parent)
+    if sys.platform == "win32":
+        return venv_bin
+    return os.pathsep.join([venv_bin, "/usr/bin", "/bin", "/usr/sbin", "/sbin"])
+
+
+@pytest.mark.integration
+def test_clean_core_only_init_then_chat_journey(tmp_path):
+    tmp_home = tmp_path / "home"
+    tmp_home.mkdir()
+    install_root = tmp_home / ".gaia" / "agents"
+
+    # --- 1. Install a REAL fixture wheel, standing in for chat (#2358) ---
+    wheel_bytes = _build_chat_fixture_wheel()
+    manifest, artifact_path = build_wheel_manifest(
+        AGENT_ID, "0.1.0", wheel_bytes, dist_name="gaia-agent-chat"
+    )
+    fetcher = build_wheel_fetcher(BASE_URL, artifact_path, wheel_bytes, AGENT_ID)
+
+    result = hub_installer.install(
+        AGENT_ID,
+        manifest=manifest,
+        base_url=BASE_URL,
+        fetcher=fetcher,
+        run_pip=_real_pip_run_pip(sys.executable),
+        install_root=install_root,
+    )
+    site_packages = install_root / AGENT_ID / "site-packages"
+    assert (site_packages / "gaia_agent_chat" / "agent.py").exists(), (
+        "fixture wheel did not actually install -- test setup is broken, "
+        "not the crux bug"
+    )
+    assert (
+        result.hot_registered is False
+    )  # no registry= passed -- fresh-process proof only
+
+    gaia_exe = _gaia_executable()
+    base_env = {**os.environ, "HOME": str(tmp_home), "PATH": _minimal_path_env()}
+
+    # --- 2. `gaia init --profile chat` as a REAL subprocess ---
+    with _fake_lemonade_health_server() as lemonade_base_url:
+        init_env = {**base_env, "LEMONADE_BASE_URL": lemonade_base_url}
+        init_proc = subprocess.run(
+            [
+                gaia_exe,
+                "init",
+                "--profile",
+                "chat",
+                "--skip-models",
+                "--yes",
+                "--remote",
+            ],
+            env=init_env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    assert init_proc.returncode == 0, (
+        f"`gaia init --profile chat` failed unexpectedly.\n"
+        f"stdout={init_proc.stdout}\nstderr={init_proc.stderr}"
+    )
+    # The pre-installed fixture must still be there -- init must not clobber it.
+    assert (site_packages / "gaia_agent_chat" / "agent.py").exists()
+
+    # --- 3. `gaia chat -q "hello"` as a REAL subprocess ---
+    # `--no-lemonade-check` skips the CLI's own pre-flight
+    # `initialize_lemonade_for_agent()` gate (cli.py:583-596, which would
+    # otherwise hard-exit(1) with "Lemonade server is not running" before
+    # ever reaching the `elif action == "chat":` handler this test cares
+    # about). LEMONADE_BASE_URL still points at a guaranteed-closed port so
+    # the handler's OWN device probe (cli.py:690-731) hits its documented
+    # "connection refused -> soft pass" path deterministically, without
+    # needing a second fake server.
+    chat_env = {**base_env, "LEMONADE_BASE_URL": "http://127.0.0.1:1/api/v1"}
+    chat_proc = subprocess.run(
+        [gaia_exe, "chat", "-q", "hello", "--no-lemonade-check"],
+        env=chat_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined_output = chat_proc.stdout + chat_proc.stderr
+
+    assert _CRUX_NOT_INSTALLED_SIGNATURE not in combined_output, (
+        "`gaia chat -q hello` still shows the #2358 crux bug's exact failure "
+        "signature ('chat agent is not installed') even though a chat-shaped "
+        "wheel WAS installed under ~/.gaia/agents/chat/ -- nothing made the "
+        "hub-installed gaia_agent_chat importable in this fresh subprocess.\n"
+        f"stdout={chat_proc.stdout}\nstderr={chat_proc.stderr}"
+    )
+    assert "ModuleNotFoundError" not in combined_output, (
+        f"`gaia chat -q hello` raised ModuleNotFoundError -- the crux bug is "
+        f"still present.\nstdout={chat_proc.stdout}\nstderr={chat_proc.stderr}"
+    )
+    # Positive proof, not just an absence check: execution must have reached
+    # our fixture ChatAgent's real logic (process_query), which is only
+    # possible if `from gaia_agent_chat.agent import ChatAgent,
+    # ChatAgentConfig` (cli.py:650) actually succeeded in this fresh process.
+    assert _FIXTURE_STUB_MARKER in combined_output, (
+        "`gaia chat -q hello` did not reach the fixture agent's process_query "
+        "-- it neither hit the crux 'not installed' signature nor our stub "
+        "marker, so something else entirely went wrong before proving (or "
+        f"disproving) the crux mechanism.\nstdout={chat_proc.stdout}\n"
+        f"stderr={chat_proc.stderr}"
+    )

--- a/tests/integration/test_chat_hub_wheel_journey.py
+++ b/tests/integration/test_chat_hub_wheel_journey.py
@@ -239,33 +239,79 @@ def _fake_lemonade_health_server():
         thread.join(timeout=5)
 
 
-def _gaia_executable() -> str:
-    """Resolve the `gaia` console script next to the active interpreter --
-    the same venv `.venv-wt/bin/python` runs from has `.venv-wt/bin/gaia`,
-    guaranteed present for any editable/real install (unlike relying on
-    inherited shell PATH, which pytest's own invocation may not carry)."""
-    from pathlib import Path
+def _build_throwaway_venv(venv_dir) -> str:
+    """Build a standalone, disposable venv with core ``amd-gaia`` editable-
+    installed, and return its own ``purelib`` (site-packages) directory.
 
+    This is the "active environment" mechanism 2 (#2358's active-env `.pth`
+    priming) actually needs to prove itself against: the mechanism writes a
+    ``.pth`` file into a specific interpreter's own site-packages so THAT
+    interpreter's later, unrelated invocations (the `gaia chat` subprocess
+    below) pick it up automatically at startup. The pytest process's own
+    venv (`.venv-wt`) is NOT an acceptable stand-in -- writing there would
+    permanently pollute this repo's real dev venv with a `.pth` entry
+    pointing at a `tmp_path` directory that gets deleted the moment this
+    test tears down. A disposable venv gets the isolation for free: it (and
+    its `.pth` file) is deleted along with the rest of `tmp_path`.
+
+    A NESTED venv's ``--system-site-packages`` inherits from the ORIGINAL
+    base Python install, not from `.venv-wt` (verified empirically), so
+    there is no cheap way to "borrow" `.venv-wt`'s already-installed
+    packages -- this does a real (but core-only, no `[dev,rag]` extras)
+    editable install. With a warm local pip cache this takes well under a
+    minute; this test is already marked ``@pytest.mark.integration`` for
+    exactly this kind of cost.
+    """
+    import subprocess as _subprocess
+    from pathlib import Path as _Path
+
+    repo_root = _Path(__file__).resolve().parents[2]
+    _subprocess.run(
+        [sys.executable, "-m", "venv", str(venv_dir)], check=True, timeout=120
+    )
+    bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+    venv_python = str(bin_dir / ("python.exe" if sys.platform == "win32" else "python"))
+    _subprocess.run(
+        [venv_python, "-m", "pip", "install", "-q", "-e", str(repo_root)],
+        check=True,
+        timeout=600,
+    )
+    purelib = _subprocess.run(
+        [venv_python, "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    ).stdout.strip()
+    return purelib
+
+
+def _gaia_executable(venv_dir) -> str:
+    """Resolve the `gaia` console script inside the throwaway venv."""
     suffix = ".exe" if sys.platform == "win32" else ""
-    return str(Path(sys.executable).parent / f"gaia{suffix}")
+    bin_name = "Scripts" if sys.platform == "win32" else "bin"
+    return str(venv_dir / bin_name / f"gaia{suffix}")
 
 
-def _minimal_path_env() -> str:
+def _minimal_path_env(venv_dir) -> str:
     """A PATH with `node`/`npm` deliberately excluded.
 
     `gaia init` unconditionally attempts to rebuild the Agent UI frontend in
     a dev/source checkout (`_is_dev_install`, init_command.py:507) when
-    `apps/webui/dist` doesn't exist yet -- true for a fresh worktree. If
+    `apps/webui/dist` doesn't exist yet -- true for a fresh worktree (the
+    throwaway venv's editable install points at the SAME repo checkout). If
     node/npm ARE on PATH, `ensure_webui_built` (gaia/ui/build.py) will
     happily kick off a REAL `npm install && npm run build`, which is slow,
     unrelated to this test, and not hermetic. Stripping node/npm from PATH
     makes that gate no-op cleanly (it already handles "node not found" as a
-    graceful non-failure, gaia/ui/build.py:76-80) -- so keep the venv's own
-    bin dir (for `gaia`/`python`) plus basic system dirs, nothing else.
+    graceful non-failure, gaia/ui/build.py:76-80) -- so keep the throwaway
+    venv's own bin dir (for `gaia`/`python`) plus basic system dirs, nothing
+    else.
     """
     from pathlib import Path
 
-    venv_bin = str(Path(sys.executable).parent)
+    bin_name = "Scripts" if sys.platform == "win32" else "bin"
+    venv_bin = str(Path(venv_dir) / bin_name)
     if sys.platform == "win32":
         return venv_bin
     return os.pathsep.join([venv_bin, "/usr/bin", "/bin", "/usr/sbin", "/sbin"])
@@ -276,6 +322,14 @@ def test_clean_core_only_init_then_chat_journey(tmp_path):
     tmp_home = tmp_path / "home"
     tmp_home.mkdir()
     install_root = tmp_home / ".gaia" / "agents"
+
+    # A dedicated, disposable venv stands in for "the real user's active
+    # environment" -- see _build_throwaway_venv's docstring for why this
+    # can't be the pytest process's own `.venv-wt`.
+    from pathlib import Path as _Path
+
+    throwaway_venv = tmp_path / "throwaway-venv"
+    throwaway_purelib = _Path(_build_throwaway_venv(throwaway_venv))
 
     # --- 1. Install a REAL fixture wheel, standing in for chat (#2358) ---
     wheel_bytes = _build_chat_fixture_wheel()
@@ -291,6 +345,11 @@ def test_clean_core_only_init_then_chat_journey(tmp_path):
         fetcher=fetcher,
         run_pip=_real_pip_run_pip(sys.executable),
         install_root=install_root,
+        # The throwaway venv's OWN site-packages -- this is the mechanism-2
+        # `.pth` write under test; a fresh `gaia chat` subprocess launched
+        # from that same venv (below) picks it up at interpreter startup
+        # with zero other wiring.
+        active_env_site_packages=throwaway_purelib,
     )
     site_packages = install_root / AGENT_ID / "site-packages"
     assert (site_packages / "gaia_agent_chat" / "agent.py").exists(), (
@@ -301,8 +360,12 @@ def test_clean_core_only_init_then_chat_journey(tmp_path):
         result.hot_registered is False
     )  # no registry= passed -- fresh-process proof only
 
-    gaia_exe = _gaia_executable()
-    base_env = {**os.environ, "HOME": str(tmp_home), "PATH": _minimal_path_env()}
+    gaia_exe = _gaia_executable(throwaway_venv)
+    base_env = {
+        **os.environ,
+        "HOME": str(tmp_home),
+        "PATH": _minimal_path_env(throwaway_venv),
+    }
 
     # --- 2. `gaia init --profile chat` as a REAL subprocess ---
     with _fake_lemonade_health_server() as lemonade_base_url:

--- a/tests/unit/agents/test_install_hints.py
+++ b/tests/unit/agents/test_install_hints.py
@@ -25,12 +25,30 @@ AGENTS_DIR = REPO_ROOT / "hub" / "agents"
 
 
 class TestSourceInstallCommand:
-    def test_known_wheel_produces_git_subdirectory_install(self):
+    def test_known_wheel_does_not_require_a_bare_uv_executable(self):
+        """#2358: a stock `python -m venv` has neither a `uv` binary on PATH
+        nor the `uv` Python module. Hard-coding `uv pip install` in the hint
+        recreates the exact dead end #2240 was supposed to fix -- it just
+        moves the broken command from `pip install gaia-agent-chat` to
+        `uv pip install "... @ git+..."`. The command must be runnable with
+        nothing more than the active interpreter's own pip (`python -m pip`),
+        the same last-resort frontend `InitCommand._install_pip_extras`
+        already falls back to for exactly this reason.
+        """
         cmd = source_install_command("gaia-agent-chat")
-        assert cmd == (
-            'uv pip install "gaia-agent-chat @ '
-            "git+https://github.com/amd/gaia.git#subdirectory="
-            'hub/agents/chat/python"'
+        assert not cmd.startswith("uv "), (
+            f"command requires a bare `uv` executable on PATH, which a stock "
+            f"`python -m venv` does not have: {cmd!r}"
+        )
+        assert "-m pip install" in cmd, (
+            f"command must be runnable via `python -m pip`, which every "
+            f"stock venv provides even with no `uv` on PATH: {cmd!r}"
+        )
+        # The core operation (which wheel, from which subdirectory) must be
+        # unchanged regardless of which frontend invokes pip.
+        assert (
+            "gaia-agent-chat @ git+https://github.com/amd/gaia.git"
+            "#subdirectory=hub/agents/chat/python" in cmd
         )
 
     def test_unknown_wheel_raises(self):

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -1497,6 +1497,10 @@ def test_install_real_wheel_lands_in_site_packages_and_is_importable(tmp_path):
             text=True,
         )
 
+    # This test proves the wheel-artifact install path lands real files
+    # (#2358 item 6) -- it isn't chartered to prove the separate active-env
+    # `.pth` mechanism, so redirect that target to an isolated scratch dir
+    # rather than writing into this real dev venv's site-packages.
     result = install(
         agent_id,
         manifest=manifest,
@@ -1504,6 +1508,7 @@ def test_install_real_wheel_lands_in_site_packages_and_is_importable(tmp_path):
         fetcher=fetcher,
         run_pip=real_run_pip,
         install_root=tmp_path,
+        active_env_site_packages=tmp_path / "_fake_active_env_site_packages",
     )
 
     site_packages = tmp_path / agent_id / "site-packages"

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -1441,3 +1441,89 @@ class TestAgentIdPathSafety:
         assert (outside / "keep.txt").read_text() == "untouched"
         assert not (outside / "config.json").exists()
         assert list(install_root.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Real (non-mocked) wheel install (#2358)
+#
+# Every other test in this file uses the mock-and-record `run_pip=lambda
+# args: pip_calls.append(args)` pattern -- it proves install() *called*
+# something shaped like a pip invocation, never that a real wheel would
+# actually unpack into an importable package. This test runs a REAL `pip
+# install --target` subprocess against a real, hand-built wheel (see
+# tests/fixtures/wheel_builder.py) so it can only pass because the install
+# genuinely happened.
+# ---------------------------------------------------------------------------
+
+
+def test_install_real_wheel_lands_in_site_packages_and_is_importable(tmp_path):
+    """Regression guard for the #1655-shaped "already there" trap: assert the
+    fixture package is NOT importable before the install (cold-state
+    precondition), then prove a REAL pip subprocess made it importable.
+    """
+    import importlib
+    import importlib.util
+    import subprocess
+    import sys
+
+    from tests.fixtures.wheel_builder import (
+        build_chat_shaped_fixture_wheel,
+        build_wheel_fetcher,
+        build_wheel_manifest,
+    )
+
+    agent_id = "realwheeltestagent"
+    module_name = f"{agent_id}_pkg"
+
+    # Cold-state precondition (#1655-shaped trap): if this module were
+    # already importable somehow (a stray leftover install, a name
+    # collision), the "it's importable after install" assertion below would
+    # pass for the wrong reason. Fail loud here instead.
+    assert importlib.util.find_spec(module_name) is None, (
+        f"{module_name} is already importable before the install -- this "
+        "test cannot prove anything about a REAL install; pick a more "
+        "unique fixture module name or clean up the stray install"
+    )
+
+    wheel_bytes = build_chat_shaped_fixture_wheel(agent_id=agent_id)
+    manifest, artifact_path = build_wheel_manifest(agent_id, "0.1.0", wheel_bytes)
+    fetcher = build_wheel_fetcher(BASE, artifact_path, wheel_bytes, agent_id)
+
+    def real_run_pip(args):
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    result = install(
+        agent_id,
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=fetcher,
+        run_pip=real_run_pip,
+        install_root=tmp_path,
+    )
+
+    site_packages = tmp_path / agent_id / "site-packages"
+    assert result.path == tmp_path / agent_id
+    assert (site_packages / module_name / "__init__.py").exists()
+    assert (site_packages / module_name / "agent.py").exists()
+    dist_info = site_packages / f"{agent_id}-0.1.0.dist-info"
+    assert dist_info.is_dir(), "pip did not produce a real dist-info dir"
+
+    sys.path.insert(0, str(site_packages))
+    try:
+        importlib.invalidate_caches()
+        spec = importlib.util.find_spec(module_name)
+        assert spec is not None, (
+            "fixture package did not become importable after adding its "
+            "site-packages to sys.path -- the real pip install did not "
+            "produce a valid package layout"
+        )
+    finally:
+        # Don't leak this fixture's importability into other tests.
+        sys.path.remove(str(site_packages))
+        sys.modules.pop(module_name, None)
+        importlib.invalidate_caches()

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -1532,3 +1532,76 @@ def test_install_real_wheel_lands_in_site_packages_and_is_importable(tmp_path):
         sys.path.remove(str(site_packages))
         sys.modules.pop(module_name, None)
         importlib.invalidate_caches()
+
+
+# ---------------------------------------------------------------------------
+# Default pip runner uv-fallback (#2358 regression)
+#
+# Every test above injects its own `run_pip` (mocked or real), so none of
+# them ever exercise `installer._default_run_pip` -- the runner install()
+# actually falls back to when the caller passes none. That default used to
+# shell out to `uv pip install` only and hard-fail with an "install uv"
+# error when `uv` wasn't on PATH, which is exactly what happened on a real
+# `pip install amd-gaia` machine running `gaia init --profile chat`
+# (#1655-shaped blind spot: a mocked run_pip proves install() *called*
+# something, never that the real default works).
+# ---------------------------------------------------------------------------
+
+
+def test_default_run_pip_falls_back_to_python_pip_when_uv_missing(tmp_path, monkeypatch):
+    """`_default_run_pip` must fall back to `python -m pip install` and
+    actually install the wheel when `uv` is unavailable, not raise.
+    """
+    import sys
+
+    from tests.fixtures.wheel_builder import build_chat_shaped_fixture_wheel
+
+    real_run = installer.subprocess.run
+    uv_calls = []
+    pip_calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[0] == "uv" or (cmd[0] == sys.executable and cmd[1:3] == ["-m", "uv"]):
+            uv_calls.append(cmd)
+            raise FileNotFoundError(f"simulated missing uv: {cmd[0]}")
+        if cmd[0] == sys.executable and cmd[1:3] == ["-m", "pip"]:
+            pip_calls.append(cmd)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    agent_id = "uvfallbacktestagent"
+    module_name = f"{agent_id}_pkg"
+    wheel_bytes = build_chat_shaped_fixture_wheel(agent_id=agent_id)
+    wheel_path = tmp_path / "wheel_src" / f"{agent_id}-0.1.0-py3-none-any.whl"
+    wheel_path.parent.mkdir(parents=True)
+    wheel_path.write_bytes(wheel_bytes)
+
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+
+    installer._default_run_pip(["--target", str(site_packages), str(wheel_path)])
+
+    assert uv_calls, "expected _default_run_pip to try the uv frontends first"
+    assert pip_calls, (
+        "expected _default_run_pip to fall back to `python -m pip install` "
+        "when uv is unavailable -- this is the #2358 regression this test "
+        "guards against"
+    )
+    assert (site_packages / module_name / "__init__.py").exists(), (
+        "the wheel was not actually installed via the python -m pip fallback"
+    )
+
+
+def test_default_run_pip_raises_when_every_frontend_fails(monkeypatch):
+    """If uv AND `python -m pip` both fail, `_default_run_pip` must raise an
+    actionable InstallError naming what was tried -- never silently no-op.
+    """
+
+    def fake_run(cmd, *args, **kwargs):
+        raise FileNotFoundError(f"simulated missing frontend: {cmd[0]}")
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+
+    with pytest.raises(InstallError, match="every pip frontend failed"):
+        installer._default_run_pip(["--target", "/nonexistent", "some-package"])

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -1548,7 +1548,9 @@ def test_install_real_wheel_lands_in_site_packages_and_is_importable(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_default_run_pip_falls_back_to_python_pip_when_uv_missing(tmp_path, monkeypatch):
+def test_default_run_pip_falls_back_to_python_pip_when_uv_missing(
+    tmp_path, monkeypatch
+):
     """`_default_run_pip` must fall back to `python -m pip install` and
     actually install the wheel when `uv` is unavailable, not raise.
     """
@@ -1588,9 +1590,9 @@ def test_default_run_pip_falls_back_to_python_pip_when_uv_missing(tmp_path, monk
         "when uv is unavailable -- this is the #2358 regression this test "
         "guards against"
     )
-    assert (site_packages / module_name / "__init__.py").exists(), (
-        "the wheel was not actually installed via the python -m pip fallback"
-    )
+    assert (
+        site_packages / module_name / "__init__.py"
+    ).exists(), "the wheel was not actually installed via the python -m pip fallback"
 
 
 def test_default_run_pip_raises_when_every_frontend_fails(monkeypatch):

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -1511,5 +1511,291 @@ class TestEnsureServerRunningAutoStartFirst(unittest.TestCase):
         mock_input.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# #2358: `gaia init --profile chat` must install the chat agent from the Hub
+# (via gaia.hub.installer.install) when it isn't already importable, so
+# `gaia chat` works right after `gaia init` on a plain `pip install amd-gaia`.
+#
+# ``gaia.hub.installer.install`` is patched at its OWN module
+# (``gaia.hub.installer.install``), not at an alias imported into
+# ``init_command``, because every other collaborator in this file
+# (``LemonadeClient``, ``resolve_lemonade``, ``build_start_command``) is
+# imported LAZILY inside method bodies in init_command.py and this test suite
+# consistently patches those at their origin module (e.g.
+# ``gaia.llm.lemonade_client.LemonadeClient`` above) rather than at an
+# init_command-local alias -- the hub-install wiring is expected to follow
+# the same lazy-import convention.
+# ---------------------------------------------------------------------------
+
+
+def _fake_catalog_result(agents):
+    """Build a ``gaia.hub.catalog.CatalogResult`` listing *agents* (dicts with
+    at least an ``id`` key), for mocking ``gaia.hub.catalog.load_index``."""
+    from gaia.hub.catalog import CatalogResult
+
+    return CatalogResult(agents=agents, offline=False, source="network")
+
+
+class _HubInstallWiringTestBase(unittest.TestCase):
+    """Shared run()-reaching harness for the #2358 hub-install wiring tests.
+
+    Patches every `InitCommand.run()` step OTHER than the (not-yet-written)
+    hub-install step, so `run()` can be exercised end-to-end deterministically
+    without touching the network, a real Lemonade server, real pip, or the
+    user's real ``~/.gaia/config.json``.
+    """
+
+    def _make_cmd(self, profile, **kwargs):
+        from gaia.installer.init_command import InitCommand
+
+        with patch("gaia.installer.init_command.LemonadeInstaller"):
+            cmd = InitCommand(profile=profile, yes=True, skip_lemonade=True, **kwargs)
+        return cmd
+
+    def _patch_common_steps(self, cmd, order=None):
+        """Patch every step so run() reaches (and passes through) the
+        hub-install step deterministically. Records call order in *order*
+        when provided (list of step-name strings).
+        """
+
+        def _tracked(name, retval=True):
+            def _fn(*_a, **_k):
+                if order is not None:
+                    order.append(name)
+                return retval
+
+            return _fn
+
+        patches = [
+            patch.object(cmd, "_ensure_server_running", side_effect=_tracked("server")),
+            patch.object(
+                cmd, "_download_models", side_effect=_tracked("download_models")
+            ),
+            patch.object(
+                cmd, "_install_pip_extras", side_effect=_tracked("pip_extras")
+            ),
+            patch.object(cmd, "_verify_setup", side_effect=_tracked("verify")),
+            # NPU-only steps; harmless no-ops for profiles that don't declare
+            # required_device/backend (run() only calls them when declared).
+            patch.object(
+                cmd, "_check_device_available", side_effect=_tracked("device_check")
+            ),
+            patch.object(
+                cmd, "_install_backend", side_effect=_tracked("install_backend")
+            ),
+            patch("gaia.ui.build.ensure_webui_built", return_value=True),
+            # Never touch the real user's ~/.gaia/config.json during a test.
+            patch("gaia.config.GaiaConfig"),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+
+class TestHubInstallWiringChatProfile(_HubInstallWiringTestBase):
+    """AC: `gaia init --profile chat` installs chat from the Hub when it
+    isn't already importable, and skips the install when it already is."""
+
+    def test_installs_chat_agent_when_not_available_and_published(self):
+        cmd = self._make_cmd("chat")
+        self._patch_common_steps(cmd)
+        with (
+            patch(
+                "gaia.installer.init_command.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "gaia.hub.catalog.load_index",
+                return_value=_fake_catalog_result(
+                    [{"id": "chat", "latest_version": "0.1.0"}]
+                ),
+            ),
+            patch("gaia.hub.installer.install") as mock_install,
+        ):
+            mock_install.return_value = MagicMock(hot_registered=True)
+            rc = cmd.run()
+
+        self.assertEqual(rc, 0)
+        mock_install.assert_called_once()
+
+    def test_skips_install_when_chat_agent_already_available(self):
+        cmd = self._make_cmd("chat")
+        self._patch_common_steps(cmd)
+        with (
+            patch(
+                "gaia.installer.init_command.importlib.util.find_spec",
+                return_value=MagicMock(),  # a real find_spec() result -> importable
+            ),
+            patch("gaia.hub.installer.install") as mock_install,
+        ):
+            rc = cmd.run()
+
+        self.assertEqual(rc, 0)
+        mock_install.assert_not_called()
+
+    def test_hub_install_runs_after_download_models_and_pip_extras_still_runs(self):
+        """Ordering: the hub-install attempt happens AFTER `_download_models()`
+        (models must exist before the agent that uses them is wired in), and
+        the `[rag]` pip-extras step still runs independently -- the hub
+        install targets `~/.gaia/agents/chat/site-packages` while the extras
+        step targets the ACTIVE interpreter's site-packages; one must not
+        replace or block the other (#2358 plan amendment A9).
+        """
+        cmd = self._make_cmd("chat")
+        order = []
+        self._patch_common_steps(cmd, order)
+
+        def _track_install(*_a, **_k):
+            order.append("hub_install")
+            return MagicMock(hot_registered=True)
+
+        with (
+            patch(
+                "gaia.installer.init_command.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "gaia.hub.catalog.load_index",
+                return_value=_fake_catalog_result([{"id": "chat"}]),
+            ),
+            patch("gaia.hub.installer.install", side_effect=_track_install),
+        ):
+            rc = cmd.run()
+
+        self.assertEqual(rc, 0)
+        self.assertIn("download_models", order)
+        self.assertIn("hub_install", order)
+        self.assertIn("pip_extras", order)
+        self.assertLess(
+            order.index("download_models"),
+            order.index("hub_install"),
+            f"hub install must happen after model downloads; order was {order}",
+        )
+
+
+class TestHubInstallWiringFailsLoudly(_HubInstallWiringTestBase):
+    """AC: unlike `_install_pip_extras` (warn-but-continue), a genuine hub
+    install failure for a PUBLISHED chat agent must hard-fail `init` --
+    silently continuing would recreate the exact "chat isn't installed"
+    state this issue closes. But chat isn't in the live Hub catalog yet
+    (only `email` is, as of #2358) -- so `init --profile chat` must NOT
+    hard-fail merely because chat isn't published yet; it must only fail
+    loud once chat IS published and the install itself genuinely fails.
+    """
+
+    def test_returns_nonzero_when_published_chat_install_genuinely_fails(self):
+        from gaia.hub.installer import InstallError
+
+        cmd = self._make_cmd("chat")
+        self._patch_common_steps(cmd)
+        with (
+            patch(
+                "gaia.installer.init_command.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "gaia.hub.catalog.load_index",
+                return_value=_fake_catalog_result(
+                    [{"id": "chat", "latest_version": "0.1.0"}]
+                ),
+            ),
+            patch(
+                "gaia.hub.installer.install",
+                side_effect=InstallError("simulated genuine hub install failure"),
+            ),
+        ):
+            rc = cmd.run()
+
+        self.assertNotEqual(
+            rc,
+            0,
+            "a genuine hub-install failure for a published agent must fail "
+            "`gaia init` loudly, not warn-and-continue like the pip-extras "
+            "step does",
+        )
+
+    def test_returns_zero_when_chat_not_yet_published_in_catalog(self):
+        """Regression guard: chat isn't in the live catalog yet (only
+        `email` is) -- `init --profile chat` must still exit 0 today, not
+        hard-fail on every user's `gaia init` before chat is ever published.
+        This may currently pass "by accident" (no hub-install call exists at
+        all yet) -- that's fine; it pins the not-yet-published case so a
+        later "install unconditionally" implementation doesn't regress it.
+        """
+        cmd = self._make_cmd("chat")
+        self._patch_common_steps(cmd)
+        with (
+            patch(
+                "gaia.installer.init_command.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "gaia.hub.catalog.load_index",
+                return_value=_fake_catalog_result([]),  # chat not yet published
+            ),
+            patch("gaia.hub.installer.install") as mock_install,
+        ):
+            rc = cmd.run()
+
+        self.assertEqual(rc, 0)
+        mock_install.assert_not_called()
+
+
+class TestHubInstallWiringChatOnlyScope(_HubInstallWiringTestBase):
+    """AC: only profiles whose declared agent is "chat" trigger the hub
+    install. A generic "install the profile's agent" would make
+    `gaia init --profile sd/code/rag/vlm/minimal/all` hard-fail today, since
+    none of those agents are in the hub index (#2358 review finding).
+
+    Scope decision (documented, since the plan text left this ambiguous):
+    ``INIT_PROFILES["npu"]["agent"] == "chat"`` too (both profiles resolve to
+    the same standalone chat wheel), so `npu` is treated as IN-SCOPE for the
+    hub-install wiring -- same as `chat` -- and is deliberately excluded from
+    the "must never call install" list below. See
+    ``TestHubInstallWiringNpuProfile`` for the positive case.
+    """
+
+    NON_CHAT_PROFILES = ("sd", "code", "rag", "vlm", "minimal", "all")
+
+    def test_non_chat_profiles_never_call_hub_install_and_still_exit_zero(self):
+        for profile in self.NON_CHAT_PROFILES:
+            with self.subTest(profile=profile):
+                cmd = self._make_cmd(profile)
+                self._patch_common_steps(cmd)
+                with patch("gaia.hub.installer.install") as mock_install:
+                    rc = cmd.run()
+                self.assertEqual(rc, 0, f"profile={profile}")
+                mock_install.assert_not_called()
+
+
+class TestHubInstallWiringNpuProfile(_HubInstallWiringTestBase):
+    """Positive case for the npu-profile scope decision above: `npu`
+    declares ``"agent": "chat"`` just like `chat` does, so it must ALSO
+    trigger the hub install when chat isn't already available.
+    """
+
+    def test_npu_profile_also_installs_chat_agent_when_not_available(self):
+        cmd = self._make_cmd("npu")
+        self._patch_common_steps(cmd)
+        with (
+            patch(
+                "gaia.installer.init_command.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "gaia.hub.catalog.load_index",
+                return_value=_fake_catalog_result(
+                    [{"id": "chat", "latest_version": "0.1.0"}]
+                ),
+            ),
+            patch("gaia.hub.installer.install") as mock_install,
+        ):
+            mock_install.return_value = MagicMock(hot_registered=True)
+            rc = cmd.run()
+
+        self.assertEqual(rc, 0)
+        mock_install.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -7,6 +7,7 @@ Unit tests for the gaia init command.
 These tests use mocking to avoid actual network calls and installations.
 """
 
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -599,7 +600,11 @@ class TestInstallPipExtras(unittest.TestCase):
         joined = " ".join(warnings)
         self.assertTrue(warnings, "expected a fallback warning")
         self.assertNotIn("pip install pip install", joined)
-        self.assertIn('uv pip install "amd-gaia[rag]"', joined)
+        # #2358: the fallback message must work in a stock venv with no `uv`
+        # on PATH -- not a bare `uv pip install` (the same dead end
+        # install_hints.source_install_command was fixed for).
+        self.assertNotIn("uv pip install", joined)
+        self.assertIn(f'{sys.executable} -m pip install "amd-gaia[rag]"', joined)
 
 
 class TestVersionCompatibility(unittest.TestCase):

--- a/tests/unit/test_registry_installed_import.py
+++ b/tests/unit/test_registry_installed_import.py
@@ -1,0 +1,150 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Crux test for issue #2358: a hub-installed WHEEL agent must be importable
+by a FRESH ``gaia`` process, not just the process that ran the install.
+
+``gaia.hub.installer.install()`` runs ``pip install --target
+<install_root>/<id>/site-packages`` for a Python-agent artifact
+(``_install_python_artifact``, ``installer.py:411``), but
+``AgentRegistry.discover()`` (``src/gaia/agents/registry.py:593``) never
+consults ``installer.list_installed()`` or adds any hub install's
+``site-packages`` to ``sys.path`` before scanning
+``importlib.metadata.entry_points()`` in ``_discover_installed_agents``
+(``registry.py:722``). The only place that currently wires a hub install's
+``site-packages`` onto ``sys.path`` at all is
+``gaia.hub.installer._hot_register`` (``installer.py:704``) -- and only in
+the *calling* process, as an in-memory ``sys.path`` mutation passed via the
+``registry=`` kwarg. A brand-new ``gaia chat`` process (the real-world case
+right after ``gaia init --profile chat`` exits) starts a fresh interpreter
+with none of that state, so the just-installed agent is invisible to it.
+
+This test proves the bug directly:
+
+1. Install a REAL, self-contained fixture wheel (built by
+   ``tests/fixtures/wheel_builder.py`` -- no mocked pip, no mocked
+   ``run_pip``) via ``gaia.hub.installer.install()``, deliberately NOT
+   passing ``registry=`` so no in-process hot-register can mask the gap.
+2. Spawn a SEPARATE Python subprocess (not just a fresh ``AgentRegistry()``
+   in this same process) and ask it to run ``AgentRegistry().discover()``
+   from scratch, with ``$HOME`` redirected to the same temp home the install
+   used.
+
+A subprocess is used instead of an in-process fresh-registry check because
+that is the only way to guarantee zero shared ``sys.path`` /
+``importlib.metadata`` cache state with the install step -- it is what a
+real second ``gaia`` invocation actually experiences, and it sidesteps any
+ambiguity about whether ``pip install --target`` could have left stray
+importable state (e.g. ``.pth`` files) in *this* interpreter.
+
+Both the install step and the discovery step redirect ``$HOME`` to the same
+temp directory via ``monkeypatch``/``env=`` (POSIX ``Path.home()`` honors
+``$HOME``), because ``AgentRegistry.discover()`` step 2
+(``Path.home() / ".gaia" / "agents"``, registry.py:601) and
+``installer.default_install_root()`` (``Path.home() / ".gaia" / "agents"``,
+installer.py:159) both hardcode ``Path.home()`` with no injectable param --
+env-var redirection is the one seam that composes with both the in-process
+install call and the subprocess discovery check.
+
+MUST currently fail: the subprocess prints "NOTFOUND" because nothing
+prepends the install's site-packages before entry-point discovery.
+"""
+
+import os
+import subprocess
+import sys
+
+from gaia.hub import installer as hub_installer
+from tests.fixtures.wheel_builder import (
+    build_chat_shaped_fixture_wheel,
+    build_wheel_fetcher,
+    build_wheel_manifest,
+)
+
+BASE_URL = "https://hub.test"
+FIXTURE_AGENT_ID = "fixturetestagent"
+
+# Runs in a subprocess with $HOME redirected to the same temp home used for
+# the install, and prints exactly "FOUND" or "NOTFOUND" so the parent test
+# can assert on stdout without any other IPC machinery.
+_DISCOVER_SCRIPT = """
+from gaia.agents.registry import AgentRegistry
+
+registry = AgentRegistry()
+registry.discover()
+print("FOUND" if registry.get({agent_id!r}) is not None else "NOTFOUND")
+"""
+
+
+def _real_pip_run_pip(python_exe):
+    """A REAL ``run_pip`` (subprocess pip), not the mock-and-record pattern
+    used elsewhere in this repo's hub-installer tests -- the crux test only
+    proves anything if the wheel is genuinely installed."""
+
+    def run_pip(args):
+        subprocess.run(
+            [python_exe, "-m", "pip", "install", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    return run_pip
+
+
+def test_hub_installed_wheel_agent_importable_in_fresh_process(tmp_path, monkeypatch):
+    """Install for real, then check for the agent from a FRESH interpreter."""
+    tmp_home = tmp_path / "home"
+    tmp_home.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_home))
+
+    wheel_bytes = build_chat_shaped_fixture_wheel(agent_id=FIXTURE_AGENT_ID)
+    manifest, artifact_path = build_wheel_manifest(
+        FIXTURE_AGENT_ID, "0.1.0", wheel_bytes
+    )
+    fetcher = build_wheel_fetcher(
+        BASE_URL, artifact_path, wheel_bytes, FIXTURE_AGENT_ID
+    )
+
+    install_root = tmp_home / ".gaia" / "agents"
+    result = hub_installer.install(
+        FIXTURE_AGENT_ID,
+        manifest=manifest,
+        base_url=BASE_URL,
+        fetcher=fetcher,
+        run_pip=_real_pip_run_pip(sys.executable),
+        install_root=install_root,
+        # Deliberately NOT passing registry= -- this test is about proving
+        # the cross-process gap, not papering over it with the in-process
+        # hot-register path installer.install() also supports.
+    )
+
+    # Sanity: the wheel really did land on disk via a real pip subprocess.
+    site_packages = install_root / FIXTURE_AGENT_ID / "site-packages"
+    assert (site_packages / f"{FIXTURE_AGENT_ID}_pkg" / "agent.py").exists(), (
+        "fixture wheel did not actually install -- test setup is broken, "
+        "not the crux bug"
+    )
+    assert result.hot_registered is False  # no registry= was passed
+
+    env = {**os.environ, "HOME": str(tmp_home)}
+    proc = subprocess.run(
+        [sys.executable, "-c", _DISCOVER_SCRIPT.format(agent_id=FIXTURE_AGENT_ID)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert (
+        proc.returncode == 0
+    ), f"fresh-process discovery subprocess crashed: {proc.stderr}"
+    # discover() logs INFO/WARNING lines to stdout too (see logger config), so
+    # the sentinel is the LAST line, not the whole (polluted) stdout.
+    last_line = proc.stdout.strip().splitlines()[-1] if proc.stdout.strip() else ""
+    assert last_line == "FOUND", (
+        "A fresh `gaia` process could not see the hub-installed wheel agent "
+        "-- this is the #2358 crux bug: gaia.hub.installer.install() only "
+        "mutates sys.path in the calling process (_hot_register), and "
+        "AgentRegistry.discover() never consults installer.list_installed() "
+        f"to wire a hub install's site-packages onto sys.path. "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )

--- a/tests/unit/test_registry_installed_import.py
+++ b/tests/unit/test_registry_installed_import.py
@@ -106,6 +106,12 @@ def test_hub_installed_wheel_agent_importable_in_fresh_process(tmp_path, monkeyp
     )
 
     install_root = tmp_home / ".gaia" / "agents"
+    # This test proves the registry.discover() sys.path-priming mechanism
+    # (#2358 mechanism 1), not the separate active-env `.pth` mechanism
+    # (mechanism 2, covered by test_chat_hub_wheel_journey.py) -- redirect
+    # the `.pth` target to an isolated scratch dir so this test never writes
+    # into the real dev venv's site-packages.
+    fake_active_env = tmp_path / "fake-active-env-site-packages"
     result = hub_installer.install(
         FIXTURE_AGENT_ID,
         manifest=manifest,
@@ -113,6 +119,7 @@ def test_hub_installed_wheel_agent_importable_in_fresh_process(tmp_path, monkeyp
         fetcher=fetcher,
         run_pip=_real_pip_run_pip(sys.executable),
         install_root=install_root,
+        active_env_site_packages=fake_active_env,
         # Deliberately NOT passing registry= -- this test is about proving
         # the cross-process gap, not papering over it with the in-process
         # hot-register path installer.install() also supports.


### PR DESCRIPTION
Closes #2358

## Why this matters

After a plain `pip install amd-gaia`, `gaia chat` — the command `gaia init` recommends next — fails: the chat agent is published through neither channel and `gaia init` never installs it. Fixing that surfaced a deeper bug: a hub-installed **wheel** agent was never importable in a *fresh* `gaia chat` process. The install only mutated the installing process's `sys.path`, and `gaia chat`'s CLI handler imports `gaia_agent_chat` directly (unlike `browse`/`analyze`, which go through the registry). Chat is the first CLI-launched wheel agent, so this path had never actually worked — publishing chat to R2 alone would have been a false green.

This PR makes it work end to end: hub-installed wheel agents become importable in any new process, and `gaia init --profile chat` installs the chat agent from the Hub catalog with honest failure behavior. It also adds the lean workflow that will publish chat to the Hub R2 catalog.

**Merged ≠ shipped.** This PR ships the *code*. The actual live publish (chat → R2) is a separate, manual `agent-publish`-gated action needing AMD's `GAIA_HUB_TOKEN` — now unblocked by #2323 having merged. **#2358 stays open** until the live clean-venv flow (`pip install amd-gaia → gaia init --profile chat → gaia chat`) is verified against the published catalog.

## What's in here (5 threads)

- **Foundational (the crux)** — `AgentRegistry.discover()` primes `sys.path` from installed wheels, and the installer writes/removes a `.pth` in the active environment so a fresh `gaia chat`'s *direct* import resolves (the same mechanism `pip install -e` uses). Generic — fixes every future CLI-launched wheel agent, not just chat.
- **`gaia init` wiring** — installs the profile's chat agent from the catalog when missing; scoped to the chat agent (covers `chat`+`npu`, leaves `email`/`sd`/… untouched). Catalog-not-published → honest hint + exit 0 (no pre-publish regression); published-but-install-fails → fail loud.
- **Installer `uv` fallback** — the Hub installer's wheel-install runner used `uv pip install` only and hard-failed ("install uv…") when `uv` wasn't on PATH. Chat is the first agent routed through init→`installer.install(wheel)`, so on a plain `pip install amd-gaia` box (no `uv`) `gaia init --profile chat` died at the install — the exact dead-end this issue kills. Now falls back `uv` → `python -m uv` → `python -m pip`. **Found by the real-world test below**, which the AC-6 journey masked by injecting its own pip runner (#1655-shaped blind spot); a new unit test exercises the *default* runner with `uv` absent.
- **Honest hints** — the "install from source" hint now resolves in a stock venv (no `uv`-only dead-end); fixed centrally in `install_hints.py`, so `src/gaia/cli.py` is **not touched** (zero overlap with #2323/#2362).
- **Release workflow** — `release_agent_chat.yml`: lean single-wheel build + wheel-smoke (version-burn guard) + `agent-publish`-gated publish, a `dry_run` input, and a tag↔manifest version gate. No per-OS freeze, no npm/OIDC. New chat-specific `stamp_version.py`.

## Test plan

- [x] Crux unit test — a hub-installed wheel is importable by a **fresh** `AgentRegistry().discover()` (red on `main`, green here).
- [x] AC-6 integration journey — real `gaia init --profile chat` → `gaia chat` subprocesses in a throwaway venv; chat reachable, `.pth` verified in the throwaway venv (not the runner's venv).
- [x] `gaia init` catalog-state behavior (not-published → hint+exit 0; install-fail → non-zero); non-chat profiles unaffected.
- [x] New regression test: the **default** installer runner falls back to `python -m pip` when `uv` is absent (the coverage AC-6 lacked).
- [x] `util/lint.py --all` clean (verified on a fresh Linux clone, exit 0); designated unit suite 195 passed (3 failures pre-existing/environmental — verified identical on pure `main`, real Lemonade on :13305 defeats mock-based installer tests).
- [x] **Real-world on an AMD Linux box** — the actual `gaia chat` → `gaia init --profile chat` → `gaia chat` CLI flow against a local Hub catalog serving the real wheel. Before→after transcript in the comment below. **This is what caught the `uv` bug.**
- [ ] **Gated:** live clean-venv `pip install amd-gaia → gaia init --profile chat → gaia chat` from the *published* R2 catalog (needs the manual publish; tracked on #2358).

## Evidence

The crux + AC-6 are real behavior, not prose. Run on this branch rebased onto current `main` (post-#2323):

```
$ pytest tests/unit/test_registry_installed_import.py -q      # the foundational fix
1 passed in 0.99s                                             # (fails on main today)

$ pytest tests/integration/test_chat_hub_wheel_journey.py -q  # AC-6: real gaia init → gaia chat
1 passed in 32.28s
```

<details>
<summary>How AC-6 proves it (clean core-only journey, not a mock)</summary>

Builds a chat wheel, installs it via the real `installer.install()` path into a **disposable throwaway venv** (`pip install -e <repo>` core-only — the "core-wheel-only state a real user is in"), then launches `gaia init --profile chat` and `gaia chat -q` as **real subprocesses** from that venv, asserting the `"chat agent is not installed"` signature is gone and execution reaches real agent logic — and that the `.pth` write landed in the throwaway venv, not the test runner's. This is the exact bug class AC-6 exists to catch (the original shipped because dev/CI always had chat editable-installed).
</details>
