### PR TITLE
docs(testing): bind real-world evidence contract to the changed surface

### DIFF
--- a/.claude/skills/gaia-testing/SKILL.md
+++ b/.claude/skills/gaia-testing/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: "gaia-testing"
-description: "GAIA's multi-tier regression harness — runs unit, integration, and real-world (on-machine) tiers and brings back screenshots, logs, traces, planted-fact retrieval proof, and per-operation timing with anomaly flags, all collected to the local machine (no remote login needed to view). Use this in the GAIA repo in place of the generic `testing` skill — it carries GAIA's exact commands, ports, and `gaia eval agent` baselines. Fires when the user wants real-world / on-hardware proof, screenshots, or end-to-end evidence that a feature, agent, change, fix, or release actually works — not a quick 'is the app running' check (the `verify` skill) or an LLM-behaviour scorecard alone (`gaia eval agent`). Scales: 'run the unit tests' stays unit-only and skips the planning gate; 'test / validate / QA this feature or release' runs all applicable tiers with evidence."
+description: "GAIA's multi-tier regression harness — runs unit, integration, and real-world (on-machine) tiers and brings back screenshots, logs, traces, planted-fact retrieval proof, and per-operation timing with anomaly flags, all collected to the local machine (no remote login needed to view). It carries GAIA's drivers (Agent UI, Agent UI MCP), exact commands, ports, and `gaia eval agent` baselines, and extends (does not replace) the generic `testing` skill. Fires when the user wants real-world / on-hardware proof, screenshots, or end-to-end evidence that a feature, agent, change, fix, or release actually works — not a quick 'is the app running' check (the `verify` skill) or an LLM-behaviour scorecard alone (`gaia eval agent`). Scales: 'run the unit tests' stays unit-only and skips the planning gate; 'test / validate / QA this feature or release' runs all applicable tiers with evidence."
 ---
 
 # GAIA Testing
 
 Test the way that catches regressions `pytest` misses: **unit → integration → real-world**, where the real-world tier drives the *real* interface on *real* hardware and returns screenshots, logs, traces, and timing as evidence. Features ship broken while CI is green — a RAG feature that worked in the backend but was hard-blocked in the UI, a release-note claim about a CLI command the source flatly contradicted. **Runtime observation plus source cross-checking is the point.**
+
+**This is the GAIA specialization of the generic `testing` skill** — the same surface→evidence discipline, wired to GAIA's drivers: the Agent UI via Playwright (`gaia chat --ui`), the Agent UI MCP (`gaia mcp serve`), Lemonade ports, and `gaia eval agent` baselines. It extends that skill; it does not supersede it.
 
 ## Roles — the strongest model plans & judges, a faster model executes
 
@@ -19,7 +21,20 @@ Reach for these rather than hand-rolling — they are how the skill drives and o
 - **Browser-automation MCPs — drive and observe a UI.** Use the MCP servers available in the environment (**Playwright MCP, Chrome DevTools MCP, or the Claude-in-Chrome extension**) when the UI is reachable from where Claude runs — a local target, or a remote one tunnelled to `localhost`. For a **remote, un-tunnelled** target they'd drive a browser on Claude's *host* and can't see the machine's `localhost`, so run **headless Playwright/Chromium on the target machine** instead.
 - **GAIA's Agent UI MCP server — drive the agents without a browser.** `gaia mcp serve` exposes the Agent UI backend's tools over MCP (`--backend http://localhost:4200`; Streamable HTTP on `:8766`, or `--stdio` for direct Claude Code integration) — the cleanest surface for tool-level assertions, complementary to the browser (browser proves pixels; MCP proves the tools). Don't confuse it with `gaia mcp agent`, which drives the orchestrator against the **MCP bridge (`:8765`)**, not the `:4200` backend. `gaia eval agent` is the LLM-behaviour scorecard (Phase 4).
 
-These are availability-aware, not hard dependencies: use whichever the environment actually exposes, and say in the plan which you'll use.
+Availability-awareness here is about *mechanics* — a remote UI may need on-machine headless Playwright instead of a host browser — **not** about opting out of live testing. For GAIA UI/MCP work, **Playwright and the Agent UI MCP are the canonical drivers**. The next section makes the surface→evidence mapping binding.
+
+## The real-world contract — surface → driver → PR evidence
+
+**Default posture: if a change is reachable through the Agent UI, it is tested through the Agent UI, live — and the proof is a screenshot.** Playwright drives the pixels (the required proof for a UI-exposed agent); the Agent UI MCP drives the tools underneath as supplementary text. Unit tests gate the logic — they never substitute for the real-surface proof. Every change carries evidence **matched to the surface it touches, shown on the PR** (an `assets.amd-gaia.ai` R2 link — see *Evidence & artifact conventions* — inline, a follow-up comment, or an evidence branch; the point is that it is *shown*):
+
+| Change touches | Drive it live with | Evidence on the PR |
+|---|---|---|
+| **An agent / behaviour exposed in the Agent UI** (Chat, Email, …) | **Playwright** against `gaia chat --ui` (a real browser) | **Required: Agent UI screenshot(s)** — before→after, at each meaningful step; text from the API/CLI/Agent UI MCP does **not** substitute |
+| **MCP tools / servers** | a live MCP client against the server under test — for the Agent UI's own tools/agents, **GAIA's Agent UI MCP** (`gaia mcp serve`, `:8766`/`--stdio` → `:4200` backend) | The actual tool call and its returned response (text) |
+| **CLI** — a command, flag, or output | the real `gaia <subcommand>` a user runs | The command and its real output, as a code block (text) |
+| **HTTP API / REST** — an endpoint | a real request to the running server | The real request and the response, status + body, as a code block (text) |
+
+**For anything exposed in the Agent UI, the required proof is an Agent UI screenshot** — driving the same agent via the API, CLI, or Agent UI MCP gives useful text evidence but does **not** replace it (use the MCP alongside, as the tool-level complement). Non-UI surfaces (API, CLI, MCP) are proven with the text evidence above. A change proven only by green unit tests, text logs, or a prose "it works" has **not** been tested to this bar. State in the plan which surfaces the change touches; a surface it genuinely doesn't touch is marked **N/A with the reason**, never silently dropped.
 
 ## When this fires — scale to the request
 
@@ -35,6 +50,7 @@ Tiers that are impossible on this machine are decided in Phase 0 and **excluded 
 
 - **Evidence > summaries > source.** Before reporting a pass, the judge reads the screenshot pixels and, for any behaviour/wiring claim, checks the code at the exact ref under test. This is the rule that catches shipped-but-broken features — do not treat the executor's prose as truth.
 - **Proof of a fix or implementation is a visual artifact, never a prose claim.** "It works" is proven by a screenshot or a live browser representation — drive the real UI in a browser (Chrome / Chromium via the browser tooling) and capture it, step by step; for a CLI/API surface, capture the terminal output or the raw response. A change reported as working with no captured artifact has not been proven, and the artifact must be surfaced to the user (and, on a PR, attached to it).
+- **Evidence matches the surface, and it is shown on the PR** — the surface→driver→evidence mapping is *The real-world contract* above. **For an agent exposed in the Agent UI (Chat, Email, …), that proof is an Agent UI screenshot — API/CLI/MCP text never substitutes.** Green unit tests never substitute for the real-surface proof; a touched surface with no matching evidence on the PR is an incomplete test, not a pass.
 - **Verify against the ref under test, not `main`** — a fix on `main` may not be in the branch, and vice versa.
 - **Prove retrieval/behaviour with planted, unguessable facts.** For RAG / search / data flows, inject values a model cannot guess (e.g. mascot `Zephyr`, passphrase `violet-otter-92`, table cell `APAC 8610`, speaker-note `desk 17C`) and require the output to echo them. If the feature has no retrieval/data surface, say so in the plan — planted facts are N/A and the judge verifies by source inspection instead. Never silently skip.
 - **No silent fallbacks / degrade loudly.** An impossible tier is excluded up front; a tier that *fails during execution* stops with an actionable error — it never quietly becomes a partial "pass".
@@ -95,6 +111,13 @@ Exercise cross-component behaviour through the **real CLI a user runs** — neve
 ## Phase 5 — Tier 3: Real-world (on the chosen machine)
 
 1. **Deploy + bring up.** First clear any partial state from a prior failed run on the target (stale processes, half-downloaded model caches, bound ports). Get the build onto the target (clone/checkout the ref, install, build any frontend) and run setup — locally if the target is local (the common case), else via its declared access method. **If the ref is an external fork/PR, honour the untrusted-code Hard rule.** Start services as detached/background processes (or under a terminal multiplexer) so they outlive the executor. (For Lemonade startup gotchas — port conflicts, model loading — see `lemonade-client-patterns.md` and CLAUDE.md rather than re-deriving them here.)
+
+   For a **packaged / hub / sidecar agent** (e.g. the email agent), test the **published-install path from a cold state** — a dev-mode run proves the code, never the install users actually hit (#1655/#2084):
+   - **Install the published artifact fresh** — `gaia agent install <id>` — and confirm the expected version + binary landed.
+   - **Prove it launches and passes its health/version handshake** — `gaia daemon start-agent <id>` (default `--mode user` = the frozen binary users get; `--mode dev` runs from source and proves *only* the code), then `gaia daemon status` / `gaia daemon agents`. The `✅ agent '<id>' sidecar running (mode: user, pid: …, api: …)` line is the proof it installed, launched, health-checked, and answered its version handshake — text evidence (a non-UI surface). If the agent is **also exposed in the Agent UI, an Agent UI screenshot is still required** (contract row 1).
+   - **A self-documenting failure counts as a pass criterion** — run the entry command *before* setup (`gaia <agent> …`) and confirm the error names the exact fix (`gaia agent install …`), not a dead end.
+   - **Headless / remote OAuth gotcha** — a connector's `127.0.0.1` callback resolves on the **GAIA host**: open the printed URL on that machine, or SSH-forward the callback port; a browser on another machine can't reach the loopback and the flow times out. (Same principle as the browser-MCP rule — drive a remote surface *on the box*.)
+   - **Tier it:** install + launch + handshake needs no connector credentials and no Lemonade — that alone is the high-value smoke proof; exercising the agent's real data source (a live inbox, a real Jira project, …) additionally needs a running Lemonade and the tester's own connector credentials.
 2. **Confirm the hardware is actually used — a health 200 is not enough.** Read the backend's own device line from its startup log (e.g. an inference backend reporting `using device <GPU name>` and layers offloaded to GPU). `rocm-smi`/`nvidia-smi` may be **absent** (a Vulkan backend has no ROCm userspace) — fall back to VRAM via sysfs (`/sys/class/drm/card*/device/mem_info_vram_used`) or the backend log. If inference is on CPU, the tier is **"not exercised on GPU"**, not a pass.
 3. **Drive the real surface live, and capture it.** Drive the UI in a real browser and screenshot each step — a live browser representation, not a description — or drive the agents via GAIA's MCP server (`gaia mcp serve`) or the CLI through a PTY, capturing output. Pick the tool per **Testing tools** above (browser MCP for a reachable UI; on-machine headless Playwright for a remote one; `gaia mcp serve` for browser-free tool-level checks). A UI feature still needs a browser screenshot for the proof rule. Exercise the feature end-to-end; for input-type features (RAG document formats, etc.) exercise **every supported type named in the spec/release notes, not just the happy-path one**. Inject the planted facts. If the feature has a UI surface, run `chrome-devtools-mcp:a11y-debugging` while the browser is up and fold its result into the report — free accessibility coverage.
 4. **One GPU + one model slot → run scenarios sequentially** (concurrent heavy runs race-evict each other's models — CLAUDE.md "Run agent evals SERIALLY").
@@ -125,6 +148,15 @@ If the run died mid-deploy, also check for a corrupt/partial model cache before 
 ## Evidence & artifact conventions
 
 - **One per-run directory** on the local host (under the system temp dir, or a project-local `test-runs/`), created **mode 700** so captured secrets/data are not world-readable; with a `shots/` subdir; a fresh dir per run.
+- **Hosting PR/issue-bound artifacts — R2 evidence bucket (preferred).** Upload sanitized screenshots/videos and embed the public URL:
+
+  ```bash
+  rclone copy <run-dir>/shots/NN_step.png gaia:amd-gaia/testing/<pr-or-issue>/<run-id>/ --s3-no-check-bucket
+  # → embed https://assets.amd-gaia.ai/testing/<pr-or-issue>/<run-id>/NN_step.png
+  ```
+
+  Credentials are **machine-local only** — an rclone remote named `gaia` in the user's `rclone.conf` (one-time setup: `scripts/video-demo/R2-SETUP.md`); they are gated by a secret key and must **never** be committed, echoed, or pasted into an issue/PR. No `gaia` remote on this machine → fall back to a throwaway evidence branch and say so in the report. **The bucket is world-readable** (`assets.amd-gaia.ai`), so the sanitize Hard rule is a hard gate before every upload — an artifact you wouldn't post publicly does not go to R2.
+- **Video artifacts** (Agent UI journeys, demos): record with Playwright's built-in video capture or a screen recorder, compress with `scripts/video-demo/compress-video.sh|.ps1`, then upload/link exactly like screenshots (same bucket, same sanitize gate). Prefixes: test-evidence video goes with its run under `testing/<pr-or-issue>/<run-id>/`; demos go under the top-level `demos/<name>/`. A demo that isn't tied to a PR is shared on a GitHub **issue** — demos don't need to live in the repo.
 - **Screenshots** named `NN_description.png`; capture at every meaningful step and on failure. TUIs: capture the rendered text frame (a terminal multiplexer's capture) as the definitive record, plus a PNG.
 - **Logs & traces:** keep raw command output, the agent/tool-call trace, browser console, and server logs; quote raw output in the report rather than paraphrasing.
 - **Surface, don't make them dig:** push the few decisive screenshots to the user via the file-send tool with per-image captions; the rest stay in the dir, referenced by path.

--- a/.claude/skills/gaia-testing/SKILL.md
+++ b/.claude/skills/gaia-testing/SKILL.md
@@ -25,7 +25,7 @@ Availability-awareness here is about *mechanics* — a remote UI may need on-mac
 
 ## The real-world contract — surface → driver → PR evidence
 
-**Default posture: if a change is reachable through the Agent UI, it is tested through the Agent UI, live — and the proof is a screenshot.** Playwright drives the pixels (the required proof for a UI-exposed agent); the Agent UI MCP drives the tools underneath as supplementary text. Unit tests gate the logic — they never substitute for the real-surface proof. Every change carries evidence **matched to the surface it touches, shown on the PR** (an `assets.amd-gaia.ai` R2 link — see *Evidence & artifact conventions* — inline, a follow-up comment, or an evidence branch; the point is that it is *shown*):
+**Default posture: if a change is reachable through the Agent UI, it is tested through the Agent UI, live — and the proof is a screenshot.** Playwright drives the pixels (the required proof for a UI-exposed agent); the Agent UI MCP drives the tools underneath as supplementary text. Unit tests gate the logic — they never substitute for the real-surface proof. Every change carries evidence **matched to the surface it touches, embedded in the PR description** — screenshots as `![caption](https://assets.amd-gaia.ai/…)` markdown images so they **render on the PR itself**, not a bare link and not buried in a follow-up comment (a comment is a fallback only when it keeps a long description clean, and even then the description links to it). A screenshot the reviewer has to hunt for is not shown. See *Evidence & artifact conventions*:
 
 | Change touches | Drive it live with | Evidence on the PR |
 |---|---|---|
@@ -131,7 +131,7 @@ The judge does not rubber-stamp the executor's report.
 2. **Cross-check claims against source** at the tested ref (`gh api .../contents/<path>?ref=<ref>` or the local checkout). For any **CLI or release-note behaviour claim** ("`gaia X` does Y", "command Z exists"), *run the command* and read it in `src/gaia/cli.py` at that ref — never accept it from the notes.
 3. **Verify planted facts in two places:** the screenshot (the UI rendered it) *and* the raw agent/CLI trace (`grep` the captured trace). A fact in the screenshot but absent from the trace can mean a cached/hallucinated response, not live retrieval.
 4. **Check timing** against the thresholds; surface outliers with their hardware context.
-5. **Deliver:** push the decisive screenshots to the user via the file-send tool (each captioned with what it proves), plus a report table (`Tier | Verdict | Evidence`). State plainly any tier that **was not truly exercised** — a warm cache, a skipped login, a CPU fallback. "Not exercised" ≠ "passed". Lead with the finding.
+5. **Deliver:** embed the decisive screenshots **in the PR description** as `![](assets.amd-gaia.ai/…)` images (each captioned with what it proves) and confirm they render on the PR — not a bare link, not comment-only. Also push them to the user via the file-send tool, plus a report table (`Tier | Verdict | Evidence`). State plainly any tier that **was not truly exercised** — a warm cache, a skipped login, a CPU fallback. "Not exercised" ≠ "passed". Lead with the finding.
 
 ## Phase 7 — Cleanup
 
@@ -148,12 +148,15 @@ If the run died mid-deploy, also check for a corrupt/partial model cache before 
 ## Evidence & artifact conventions
 
 - **One per-run directory** on the local host (under the system temp dir, or a project-local `test-runs/`), created **mode 700** so captured secrets/data are not world-readable; with a `shots/` subdir; a fresh dir per run.
-- **Hosting PR/issue-bound artifacts — R2 evidence bucket (preferred).** Upload sanitized screenshots/videos and embed the public URL:
+- **Hosting PR/issue-bound artifacts — R2 evidence bucket (preferred).** Upload the sanitized screenshot/video, then **embed it as a markdown image in the PR description** so it renders on the PR:
 
   ```bash
   rclone copy <run-dir>/shots/NN_step.png gaia:amd-gaia/testing/<pr-or-issue>/<run-id>/ --s3-no-check-bucket
-  # → embed https://assets.amd-gaia.ai/testing/<pr-or-issue>/<run-id>/NN_step.png
+  # then in the PR DESCRIPTION (not just a comment), paste the image so it renders:
+  # ![NN_step — what it proves](https://assets.amd-gaia.ai/testing/<pr-or-issue>/<run-id>/NN_step.png)
   ```
+
+  Verify it renders: open the PR after editing and confirm the image shows, and that the raw URL returns `200 image/png`. A bare link, or an image only in a comment the reviewer must scroll to, does **not** count as shown.
 
   Credentials are **machine-local only** — an rclone remote named `gaia` in the user's `rclone.conf` (one-time setup: `scripts/video-demo/R2-SETUP.md`); they are gated by a secret key and must **never** be committed, echoed, or pasted into an issue/PR. No `gaia` remote on this machine → fall back to a throwaway evidence branch and say so in the report. **The bucket is world-readable** (`assets.amd-gaia.ai`), so the sanitize Hard rule is a hard gate before every upload — an artifact you wouldn't post publicly does not go to R2.
 - **Video artifacts** (Agent UI journeys, demos): record with Playwright's built-in video capture or a screen recorder, compress with `scripts/video-demo/compress-video.sh|.ps1`, then upload/link exactly like screenshots (same bucket, same sanitize gate). Prefixes: test-evidence video goes with its run under `testing/<pr-or-issue>/<run-id>/`; demos go under the top-level `demos/<name>/`. A demo that isn't tied to a PR is shared on a GitHub **issue** — demos don't need to live in the repo.

--- a/.claude/skills/gaia-testing/SKILL.md
+++ b/.claude/skills/gaia-testing/SKILL.md
@@ -25,7 +25,7 @@ Availability-awareness here is about *mechanics* — a remote UI may need on-mac
 
 ## The real-world contract — surface → driver → PR evidence
 
-**Default posture: if a change is reachable through the Agent UI, it is tested through the Agent UI, live — and the proof is a screenshot.** Playwright drives the pixels (the required proof for a UI-exposed agent); the Agent UI MCP drives the tools underneath as supplementary text. Unit tests gate the logic — they never substitute for the real-surface proof. Every change carries evidence **matched to the surface it touches, embedded in the PR description** — screenshots as `![caption](https://assets.amd-gaia.ai/…)` markdown images so they **render on the PR itself**, not a bare link and not buried in a follow-up comment (a comment is a fallback only when it keeps a long description clean, and even then the description links to it). A screenshot the reviewer has to hunt for is not shown. See *Evidence & artifact conventions*:
+**Default posture: if a change is reachable through the Agent UI, it is tested through the Agent UI, live — and the proof is a screenshot.** Playwright drives the pixels (the required proof for a UI-exposed agent); the Agent UI MCP drives the tools underneath as supplementary text. Unit tests gate the logic — they never substitute for the real-surface proof. Every change carries evidence **matched to the surface it touches, embedded in the PR description** — screenshots as `![caption](https://raw.githubusercontent.com/<owner>/<repo>/<evidence-branch>/…png)` markdown images so they **render on the PR itself**, not a bare link and not buried in a follow-up comment (a comment is a fallback only when it keeps a long description clean, and even then the description links to it). **Use a `raw.githubusercontent.com` URL, not an `assets.amd-gaia.ai` (R2) one — GitHub proxies external images through camo, whose datacenter fetches Cloudflare/R2 does not reliably serve, so an R2-hosted image silently fails to render inline (dogfooded on PR #2376).** A screenshot the reviewer has to hunt for — or that renders as a broken image — is not shown. See *Evidence & artifact conventions*:
 
 | Change touches | Drive it live with | Evidence on the PR |
 |---|---|---|
@@ -131,7 +131,7 @@ The judge does not rubber-stamp the executor's report.
 2. **Cross-check claims against source** at the tested ref (`gh api .../contents/<path>?ref=<ref>` or the local checkout). For any **CLI or release-note behaviour claim** ("`gaia X` does Y", "command Z exists"), *run the command* and read it in `src/gaia/cli.py` at that ref — never accept it from the notes.
 3. **Verify planted facts in two places:** the screenshot (the UI rendered it) *and* the raw agent/CLI trace (`grep` the captured trace). A fact in the screenshot but absent from the trace can mean a cached/hallucinated response, not live retrieval.
 4. **Check timing** against the thresholds; surface outliers with their hardware context.
-5. **Deliver:** embed the decisive screenshots **in the PR description** as `![](assets.amd-gaia.ai/…)` images (each captioned with what it proves) and confirm they render on the PR — not a bare link, not comment-only. Also push them to the user via the file-send tool, plus a report table (`Tier | Verdict | Evidence`). State plainly any tier that **was not truly exercised** — a warm cache, a skipped login, a CPU fallback. "Not exercised" ≠ "passed". Lead with the finding.
+5. **Deliver:** embed the decisive screenshots **in the PR description** as `![](raw.githubusercontent.com/…)` images (each captioned with what it proves) and confirm they render on the PR — verify the rendered `<img src>` is `raw.githubusercontent.com` (served directly), not `camo.githubusercontent.com` (proxied, unreliable for R2). Not a bare link, not comment-only. Also push them to the user via the file-send tool, plus a report table (`Tier | Verdict | Evidence`). State plainly any tier that **was not truly exercised** — a warm cache, a skipped login, a CPU fallback. "Not exercised" ≠ "passed". Lead with the finding.
 
 ## Phase 7 — Cleanup
 
@@ -148,17 +148,24 @@ If the run died mid-deploy, also check for a corrupt/partial model cache before 
 ## Evidence & artifact conventions
 
 - **One per-run directory** on the local host (under the system temp dir, or a project-local `test-runs/`), created **mode 700** so captured secrets/data are not world-readable; with a `shots/` subdir; a fresh dir per run.
-- **Hosting PR/issue-bound artifacts — R2 evidence bucket (preferred).** Upload the sanitized screenshot/video, then **embed it as a markdown image in the PR description** so it renders on the PR:
+- **Hosting an inline PR screenshot — `raw.githubusercontent.com` evidence branch (required for images that must render).** GitHub serves `raw.githubusercontent.com` images **directly**; an external URL (like R2's `assets.amd-gaia.ai`) is rewritten to a `camo.githubusercontent.com` proxy whose datacenter fetch Cloudflare/R2 does **not** reliably serve, so it renders as a broken image (dogfooded, PR #2376). Push the sanitized PNG to a throwaway evidence branch and embed its raw URL:
+
+  ```bash
+  git -C <repo> worktree add /tmp/ev -b <branch>-evidence origin/main
+  cp <run-dir>/shots/NN_step.png /tmp/ev/testing/<pr>/ && (cd /tmp/ev && git add -A && git commit -qm evidence && git push -u origin <branch>-evidence)
+  # embed in the PR DESCRIPTION (not just a comment):
+  # ![NN_step — what it proves](https://raw.githubusercontent.com/<owner>/<repo>/<branch>-evidence/testing/<pr>/NN_step.png)
+  ```
+
+  **Verify it renders:** `gh api repos/<owner>/<repo>/issues/<pr> -H "Accept: application/vnd.github.full+json" -q .body_html` and confirm the `<img src>` is `raw.githubusercontent.com` (direct), **not** `camo.githubusercontent.com`. Delete the evidence branch after merge (`/clean_gone`). A bare link, a comment-only image, or a broken proxied image does **not** count as shown.
+- **Durable / user-facing hosting, videos, demos — R2 evidence bucket.** R2 (`assets.amd-gaia.ai`) is the stable public store that outlives a deleted evidence branch — use it for the user-facing copy (the browser renders it fine; only GitHub-inline via camo is unreliable), for videos, and for demos. Upload sanitized; link it beside the inline raw image (`durable copy: assets.amd-gaia.ai/…`).
 
   ```bash
   rclone copy <run-dir>/shots/NN_step.png gaia:amd-gaia/testing/<pr-or-issue>/<run-id>/ --s3-no-check-bucket
-  # then in the PR DESCRIPTION (not just a comment), paste the image so it renders:
-  # ![NN_step — what it proves](https://assets.amd-gaia.ai/testing/<pr-or-issue>/<run-id>/NN_step.png)
+  # → durable link https://assets.amd-gaia.ai/testing/<pr-or-issue>/<run-id>/NN_step.png
   ```
 
-  Verify it renders: open the PR after editing and confirm the image shows, and that the raw URL returns `200 image/png`. A bare link, or an image only in a comment the reviewer must scroll to, does **not** count as shown.
-
-  Credentials are **machine-local only** — an rclone remote named `gaia` in the user's `rclone.conf` (one-time setup: `scripts/video-demo/R2-SETUP.md`); they are gated by a secret key and must **never** be committed, echoed, or pasted into an issue/PR. No `gaia` remote on this machine → fall back to a throwaway evidence branch and say so in the report. **The bucket is world-readable** (`assets.amd-gaia.ai`), so the sanitize Hard rule is a hard gate before every upload — an artifact you wouldn't post publicly does not go to R2.
+  Credentials are **machine-local only** — an rclone remote named `gaia` in the user's `rclone.conf` (one-time setup: `scripts/video-demo/R2-SETUP.md`); they are gated by a secret key and must **never** be committed, echoed, or pasted into an issue/PR. No `gaia` remote on this machine → use the evidence branch alone and say so in the report. **The bucket is world-readable** (`assets.amd-gaia.ai`), so the sanitize Hard rule is a hard gate before every upload — an artifact you wouldn't post publicly does not go to R2.
 - **Video artifacts** (Agent UI journeys, demos): record with Playwright's built-in video capture or a screen recorder, compress with `scripts/video-demo/compress-video.sh|.ps1`, then upload/link exactly like screenshots (same bucket, same sanitize gate). Prefixes: test-evidence video goes with its run under `testing/<pr-or-issue>/<run-id>/`; demos go under the top-level `demos/<name>/`. A demo that isn't tied to a PR is shared on a GitHub **issue** — demos don't need to live in the repo.
 - **Screenshots** named `NN_description.png`; capture at every meaningful step and on failure. TUIs: capture the rendered text frame (a terminal multiplexer's capture) as the definitive record, plus a PNG.
 - **Logs & traces:** keep raw command output, the agent/tool-call trace, browser console, and server logs; quote raw output in the report rather than paraphrasing.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,9 +44,10 @@ Mix automated and manual checks as needed.
 
 <!--
 Real-world proof matched to the surface you changed — GAIA tests on the surface a user
-actually touches. Green unit tests alone are not evidence. Paste inline, or link an
-assets.amd-gaia.ai (R2) URL / follow-up comment / evidence branch. Mark a surface N/A
-(with a reason) if the change doesn't touch it; delete the whole section only for pure
+actually touches. Green unit tests alone are not evidence. **Embed screenshots here in
+the description** as `![caption](https://assets.amd-gaia.ai/testing/<pr>/<run>/shot.png)`
+so they render on the PR — not a bare link, not comment-only. Mark a surface N/A (with a
+reason) if the change doesn't touch it; delete the whole section only for pure
 internal/docs/CI changes.
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,10 +45,11 @@ Mix automated and manual checks as needed.
 <!--
 Real-world proof matched to the surface you changed — GAIA tests on the surface a user
 actually touches. Green unit tests alone are not evidence. **Embed screenshots here in
-the description** as `![caption](https://assets.amd-gaia.ai/testing/<pr>/<run>/shot.png)`
-so they render on the PR — not a bare link, not comment-only. Mark a surface N/A (with a
-reason) if the change doesn't touch it; delete the whole section only for pure
-internal/docs/CI changes.
+the description** as `![caption](https://raw.githubusercontent.com/<owner>/<repo>/<branch>-evidence/…png)`
+so they render on the PR — use a raw.githubusercontent.com URL (an R2/assets.amd-gaia.ai
+image gets camo-proxied and often won't render inline). Not a bare link, not comment-only.
+Mark a surface N/A (with a reason) if the change doesn't touch it; delete the whole section
+only for pure internal/docs/CI changes.
 -->
 
 - [ ] **Agent exposed in the Agent UI** (Chat, Email, …) — live browser (Playwright) **screenshot(s)**, before→after (required; text evidence does not substitute)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,9 +40,25 @@ Mix automated and manual checks as needed.
 
 - [ ]
 
+## Evidence
+
+<!--
+Real-world proof matched to the surface you changed — GAIA tests on the surface a user
+actually touches. Green unit tests alone are not evidence. Paste inline, or link an
+assets.amd-gaia.ai (R2) URL / follow-up comment / evidence branch. Mark a surface N/A
+(with a reason) if the change doesn't touch it; delete the whole section only for pure
+internal/docs/CI changes.
+-->
+
+- [ ] **Agent exposed in the Agent UI** (Chat, Email, …) — live browser (Playwright) **screenshot(s)**, before→after (required; text evidence does not substitute)
+- [ ] **MCP tools / servers** — a live MCP client call + response (Agent UI MCP: `gaia mcp serve`)
+- [ ] **CLI** — the `gaia <subcommand>` you ran and its actual output
+- [ ] **HTTP API / REST** — the real request and the response (status + body)
+
 ## Checklist
 
 - [ ] I have linked a GitHub issue above (`Closes #N` / `Fixes #N` / `Refs #N`).
 - [ ] I have described **why** this change is being made, not just what changed.
 - [ ] I have run linting and tests locally (`python util/lint.py --all`, `pytest tests/unit/`).
+- [ ] I have attached **real-world evidence matched to the surface I changed** (see Evidence above), or marked each surface N/A.
 - [ ] I have updated documentation if user-visible behavior changed (see [CONTRIBUTING.md](../CONTRIBUTING.md)).

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -17,8 +17,10 @@ Spend the attention budget on what can actually break a user or the codebase, in
 
 1. 🔴 **Correctness & safety** — real bugs (wrong logic, crashes, data loss), security
    issues, breaking changes to public API / CLI / REST, and silent-fallback violations.
-2. 🟡 **Missing tests & architecture** — new logic shipped without tests, and GAIA
-   architecture/convention violations (also checked inline by the workflow).
+2. 🟡 **Missing tests & architecture** — new logic shipped without tests, GAIA
+   architecture/convention violations (also checked inline by the workflow), and a
+   user-visible change shipped without **real-world evidence matched to its surface**
+   (see "Real-world evidence" below).
 3. 🟢 **Everything else** — style, naming, micro-optimizations, wording. This is the nit
    tier and is strictly capped (below).
 
@@ -63,6 +65,28 @@ Correctness-first does not mean silent on small wins. A `suggestion` block is we
 genuinely useful, low-risk fix — a clear typo in a docstring, a hardcoded value that should
 be a constant, a noisy log line, an obvious one-line bug fix. These count toward the nit cap
 unless they fix a real bug.
+
+## Real-world evidence
+
+GAIA tests everything on the surface a user actually touches, and the PR must **show** that
+proof. When a diff changes a user-visible surface but the **PR description** shows no matching
+evidence and doesn't point to where it lives (a linked comment or evidence branch), flag it
+**once** as a 🟡 (not per-file) and name the evidence that's missing. Green unit tests are not
+a substitute — they gate the logic, not the surface.
+
+- **An agent exposed in the Agent UI** (Chat, Email, …) → a live **Playwright** run against
+  `gaia chat --ui` with **before→after screenshot(s)** on the PR. This is the one surface where
+  text is **not** enough — API / CLI / Agent UI MCP evidence does not substitute for the screenshot.
+- **MCP tools / servers** → a live MCP client call and its response (the Agent UI MCP,
+  `gaia mcp serve`, for the Agent UI's own tools).
+- **CLI** command/flag/output → the real `gaia <subcommand>` and its output.
+- **HTTP API / REST** → the real request and the response (status + body).
+
+Evidence may live inline, in a follow-up comment, on an evidence branch, or behind an
+`assets.amd-gaia.ai` link (the R2 evidence bucket) — presence is what matters, not location. Do **not** flag when the change touches none of these surfaces
+(internal refactor, docs, tests, CI), when the author marked a surface **N/A with a reason**,
+when the description points to evidence elsewhere, or when the matching evidence is already
+present. This is a nudge for a missing artifact, never a demand to re-run what the PR shows.
 
 ## Length caps
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -82,8 +82,10 @@ a substitute — they gate the logic, not the surface.
 - **CLI** command/flag/output → the real `gaia <subcommand>` and its output.
 - **HTTP API / REST** → the real request and the response (status + body).
 
-Evidence may live inline, in a follow-up comment, on an evidence branch, or behind an
-`assets.amd-gaia.ai` link (the R2 evidence bucket) — presence is what matters, not location. Do **not** flag when the change touches none of these surfaces
+Screenshot evidence should be **embedded in the PR description** as a rendered
+`![](assets.amd-gaia.ai/…)` image (R2 evidence bucket), not a bare link or a comment the
+reviewer must scroll to find. Text evidence (CLI/API/MCP) may sit inline in the description
+or a linked comment. A screenshot that doesn't render on the PR is not shown. Do **not** flag when the change touches none of these surfaces
 (internal refactor, docs, tests, CI), when the author marked a surface **N/A with a reason**,
 when the description points to evidence elsewhere, or when the matching evidence is already
 present. This is a nudge for a missing artifact, never a demand to re-run what the PR shows.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -83,9 +83,10 @@ a substitute — they gate the logic, not the surface.
 - **HTTP API / REST** → the real request and the response (status + body).
 
 Screenshot evidence should be **embedded in the PR description** as a rendered
-`![](assets.amd-gaia.ai/…)` image (R2 evidence bucket), not a bare link or a comment the
-reviewer must scroll to find. Text evidence (CLI/API/MCP) may sit inline in the description
-or a linked comment. A screenshot that doesn't render on the PR is not shown. Do **not** flag when the change touches none of these surfaces
+`![](raw.githubusercontent.com/…)` image (a raw URL renders directly; an R2/assets.amd-gaia.ai
+image gets camo-proxied and often won't render), not a bare link or a comment the reviewer
+must scroll to find. Text evidence (CLI/API/MCP) may sit inline in the description or a
+linked comment. A screenshot that doesn't render on the PR is not shown. Do **not** flag when the change touches none of these surfaces
 (internal refactor, docs, tests, CI), when the author marked a surface **N/A with a reason**,
 when the description points to evidence elsewhere, or when the matching evidence is already
 present. This is a nudge for a missing artifact, never a demand to re-run what the PR shows.


### PR DESCRIPTION
## Summary
Makes GAIA's real-world-testing philosophy **binding**: the gaia-testing skill maps each changed surface to the evidence a PR must show, and REVIEW.md + the PR template enforce it — including that **screenshot evidence is embedded in the PR description** (this PR dogfoods that rule below).

## Why
The discipline existed (two skills, CLAUDE.md) but nothing tied a *changed surface* to *required evidence*, and nothing enforced it at review or PR time — so a UI-visible change could ship on green unit tests alone. Now: an agent exposed in the Agent UI (Chat, Email, …) requires an **Agent UI screenshot** (Playwright), embedded in the description via an `assets.amd-gaia.ai` (R2) link; CLI/API/MCP surfaces are proven with **text evidence**.

## Linked issue
Closes #2375 · Follow-on implementation: #2369–#2372.

## Changes
- **gaia-testing skill** — surface→driver→evidence contract; Playwright + Agent UI MCP as canonical drivers; R2 evidence-hosting; **screenshots embedded in the PR description**; sidecar cold-install-path gate.
- **REVIEW.md** — flags a user-visible change lacking matching evidence; screenshots must render in the description.
- **PR template** — surface-keyed Evidence block that embeds R2 images.

## Evidence (real-world, dogfooded on macOS)

**Agent UI surface — live `gaia chat --ui`, driven by Playwright:**

![GAIA Agent UI — Zoo Agent live turn ending with planted token zebra-quartz-6604](https://raw.githubusercontent.com/amd/gaia/tmi/rwt-evidence/testing/pr-2376/02_agentui-green-turn.png)

Live local inference through the real Agent UI: the Zoo Agent answered with a fun fact ending in the planted token `zebra-quartz-6604` (59.1s · 58.9 tok/s · 521ms TTFT · Gemma-4-E4B @ 32K ctx, Metal GPU). Sidebar deliberately collapsed so personal session titles stay out of the public bucket — the sanitize gate in action. Inline image is served from a throwaway `raw.githubusercontent.com` evidence branch (GitHub's proxy renders it reliably); durable copy on R2: [assets.amd-gaia.ai](https://assets.amd-gaia.ai/testing/pr-2376/2026-07-22-macos/02_agentui-green-turn.png).

**CLI surface — commands match what the skill cites (run against the ref under test):**

```console
$ gaia mcp serve --help
  --port PORT        (default: 8766)
  --backend BACKEND  (default: http://localhost:4200)
  --stdio            stdio transport (for Claude Code / eval runner)

$ python -m gaia.cli daemon --help
  {start,status,stop,restart,agents,start-agent,stop-agent,logs}
```

- [x] **Agent UI** — embedded screenshot above (planted token, live inference)
- [x] **CLI** — command + output above
- [ ] **MCP / HTTP API** — N/A (docs/policy PR; no MCP/API surface changed)

<details>
<summary>Fresh-environment findings surfaced by the run (not caused by this PR)</summary>

- Lemonade served the model at ctx=0; the UI requires 32,768 → a one-time reload fixed it (real pre-flight-banner finding).
- The default chat agent isn't installed locally (`gaia-agent-chat` wheel pending its R2 release), so the turn used an **installed custom agent** — same Agent UI code path, same proof. Its error was self-documenting (the pattern this PR adds to the skill).
</details>
