### PR TITLE
fix(security): harden install trust gate and analyze_data_file sandbox

### DIFF
--- a/.github/workflows/claude-security-audit.yml
+++ b/.github/workflows/claude-security-audit.yml
@@ -114,7 +114,7 @@ jobs:
             grep -rnE "shell=True|os\.system|subprocess\.(run|Popen|call)|\beval\(|\bexec\(" src hub --include=*.py || true
             echo ""
             echo "## PathValidator / allowlist / trust gates (check for asymmetric enforcement)"
-            grep -rnE "is_path_allowed|validate_write|validate_read|allowed_paths|trust_native|ensure_native_trust" src hub --include=*.py || true
+            grep -rnE "is_path_allowed|validate_write|validate_read|allowed_paths|trust_native|ensure_trust_ack|requires_trust_ack" src hub --include=*.py || true
           } > security-worklist.txt
           echo "worklist lines: $(wc -l < security-worklist.txt)"
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -566,7 +566,7 @@ discover/install panel when browsing the Hub, or install headlessly with:
 gaia agent list                            # installed + available hub agents
 gaia agent install <id>                    # latest published version
 gaia agent install <id> --version 0.5.0    # a specific version
-gaia agent install <id> --trust-native     # required for native (C++) agents
+gaia agent install <id> --trust            # required for non-verified agents
 ```
 
 `gaia agent list` shows what the hub offers (with an `[installed]` marker) so

--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -1867,16 +1867,47 @@ class FileSearchToolsMixin:
             try:
                 fp = Path(file_path)
 
-                if not fp.exists():
-                    # Fuzzy fallback: search indexed documents by basename
-                    resolved = None
-                    basename = fp.name.lower()
+                def _resolve_indexed_basename(target: Path):
+                    """Return an already-indexed document Path whose basename
+                    matches *target*, or None. Consults only the in-sandbox index
+                    — never *target*'s on-disk state — so it cannot be used to
+                    probe files outside the sandbox."""
                     if hasattr(self, "rag") and self.rag and self.rag.indexed_files:
+                        wanted = target.name.lower()
                         for indexed_path in self.rag.indexed_files:
-                            if Path(indexed_path).name.lower() == basename:
-                                resolved = Path(indexed_path)
-                                break
-                    if resolved and resolved.exists():
+                            if Path(indexed_path).name.lower() == wanted:
+                                return Path(indexed_path)
+                    return None
+
+                # Enforce the --allowed-paths sandbox FIRST — before any existence
+                # or extension probe — so an out-of-sandbox path yields one
+                # identical refusal whether or not it exists and regardless of its
+                # extension (no file-existence/type oracle). An out-of-sandbox path
+                # proceeds only if its basename matches an indexed document that is
+                # itself inside the sandbox (the fuzzy fallback below).
+                denied = self._read_access_error(str(fp))
+                if denied:
+                    resolved = _resolve_indexed_basename(fp)
+                    if (
+                        resolved is None
+                        or not resolved.exists()
+                        or self._read_access_error(str(resolved))
+                    ):
+                        denied.update(
+                            {"has_errors": True, "operation": "analyze_data_file"}
+                        )
+                        return denied
+                    fp = resolved
+
+                if not fp.exists():
+                    # In-sandbox but missing: fuzzy-resolve to an indexed document
+                    # by basename (re-validated against the sandbox).
+                    resolved = _resolve_indexed_basename(fp)
+                    if (
+                        resolved
+                        and resolved.exists()
+                        and not self._read_access_error(str(resolved))
+                    ):
                         fp = resolved
                     else:
                         return {
@@ -1898,16 +1929,6 @@ class FileSearchToolsMixin:
                         "has_errors": True,
                         "operation": "analyze_data_file",
                     }
-
-                # Enforce the --allowed-paths sandbox on the resolved path
-                # (checked after the indexed-file fallback so legitimately
-                # indexed documents inside the sandbox still resolve).
-                denied = self._read_access_error(str(fp))
-                if denied:
-                    denied.update(
-                        {"has_errors": True, "operation": "analyze_data_file"}
-                    )
-                    return denied
 
                 # Read the file (use resolved fp path in case of fallback)
                 rows, all_columns, read_error = _read_tabular_file(str(fp))

--- a/src/gaia/apps/webui/main.cjs
+++ b/src/gaia/apps/webui/main.cjs
@@ -68,6 +68,7 @@ const {
   parseDeepLink,
   extractDeepLinkFromArgv,
   dispatchDeepLink,
+  buildInstallPrompt,
 } = require("./services/deep-link.cjs");
 
 // ── F7: Ozone hint (issue #782) ─────────────────────────────────────────────
@@ -813,25 +814,46 @@ function handleDeepLink(rawUrl) {
 }
 
 /**
- * Explicit per-agent confirmation for a web-triggered install. This is the
- * security gate: the user must confirm the SPECIFIC agent before any download
- * happens (issue #2196 review). Defaults to the safe (Cancel) option.
+ * Explicit, INFORMED per-agent confirmation for a web-triggered install. This
+ * is the security gate: the user must confirm the SPECIFIC agent — and see
+ * its real trust tier and permissions, not just its bare id — before any
+ * download happens (issue #2196 review; hardened so the shown facts match
+ * the backend's non-verified gate, which now covers every non-verified
+ * agent, not just native ones). Defaults to the safe (Cancel) option.
+ *
+ * Fails closed: if the agent can't be found in the catalog, or the backend
+ * is unreachable, the install is refused with an explanatory error — never
+ * installed blind.
  * @returns {Promise<boolean>}
  */
 async function confirmDeepLinkInstall(command) {
+  let entry;
+  try {
+    entry = await agentProcessManager.fetchCatalogEntry(command.agentId);
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    console.error(
+      `[main] Refusing deep-link install of "${command.agentId}": ${message}`
+    );
+    try {
+      dialog.showErrorBox("Could not verify this agent", message);
+    } catch {
+      /* best-effort */
+    }
+    return false;
+  }
+
+  const prompt = buildInstallPrompt(entry);
   const choice = await dialog.showMessageBox(
     mainWindow && !mainWindow.isDestroyed() ? mainWindow : null,
     {
       type: "question",
-      buttons: ["Install", "Cancel"],
+      buttons: [prompt.requiresTrust ? "Trust & Install" : "Install", "Cancel"],
       defaultId: 1, // Enter selects the safe option
       cancelId: 1,
-      title: "Install agent from the web?",
-      message: `Install the "${command.agentId}" agent?`,
-      detail:
-        `A website asked GAIA to install "${command.agentId}". ` +
-        "Only continue if you trust this source — installing downloads and " +
-        "runs third-party code on your machine.",
+      title: prompt.title,
+      message: prompt.message,
+      detail: prompt.detail,
       noLink: true,
     }
   );
@@ -844,7 +866,7 @@ async function runDeepLink(command) {
   try {
     await dispatchDeepLink(command, {
       confirm: confirmDeepLinkInstall,
-      installAgent: (agentId) => agentProcessManager.installAgent(agentId),
+      installAgent: (agentId, opts) => agentProcessManager.installAgent(agentId, opts),
       focusWindow: () => {
         if (mainWindow && !mainWindow.isDestroyed()) {
           if (mainWindow.isMinimized()) mainWindow.restore();

--- a/src/gaia/apps/webui/services/agent-process-manager.cjs
+++ b/src/gaia/apps/webui/services/agent-process-manager.cjs
@@ -304,6 +304,52 @@ class AgentProcessManager extends EventEmitter {
   }
 
   /**
+   * Fetch a single agent's catalog entry (tier, permissions, verified status)
+   * from the live backend. Used by the gaia:// deep-link install gate
+   * (main.cjs) to build an informed trust prompt — the confirmation must show
+   * the agent's real tier/permissions, not just its bare id.
+   *
+   * Throws with an actionable message when the backend is unreachable or the
+   * agent id isn't in the catalog. Callers MUST treat that as a refusal —
+   * never install without having shown the user what they're installing.
+   *
+   * @param {string} agentId
+   * @returns {Promise<object>} the matching catalog entry
+   */
+  async fetchCatalogEntry(agentId) {
+    if (typeof agentId !== "string" || !agentId.trim()) {
+      throw new Error("fetchCatalogEntry requires a non-empty agent id");
+    }
+    const base = this._backendBaseUrl();
+
+    let resp;
+    try {
+      resp = await fetch(`${base}/api/agents/catalog`, {
+        headers: { ...UI_HEADER },
+      });
+    } catch (err) {
+      throw new Error(
+        `Could not reach the GAIA backend to look up "${agentId}" in the agent catalog: ${err.message}`
+      );
+    }
+
+    if (!resp.ok) {
+      const detail = await this._readErrorDetail(resp);
+      throw new Error(
+        `Agent catalog request failed (HTTP ${resp.status}): ${detail}`
+      );
+    }
+
+    const body = await resp.json();
+    const agents = Array.isArray(body && body.agents) ? body.agents : [];
+    const entry = agents.find((a) => a && a.id === agentId);
+    if (!entry) {
+      throw new Error(`"${agentId}" was not found in the agent catalog.`);
+    }
+    return entry;
+  }
+
+  /**
    * Install a published agent via the backend runtime, streaming progress.
    *
    * @param {string} agentId

--- a/src/gaia/apps/webui/services/deep-link.cjs
+++ b/src/gaia/apps/webui/services/deep-link.cjs
@@ -106,12 +106,19 @@ function extractDeepLinkFromArgv(argv) {
  * untrusted web page, so the install MUST be gated behind an explicit per-agent
  * confirmation — the same trust bar the in-app install enforces (#2201). A bare
  * OS "Open GAIA?" prompt is NOT consent to download and run a specific agent.
- * If `confirm` does not return true, no install is attempted.
+ * If `confirm` does not return true, no install is attempted. `confirm` is
+ * expected to have shown the agent's real catalog tier and permissions first
+ * (see `buildInstallPrompt`), not just its bare id, before resolving true.
+ *
+ * Once confirmed, the install is sent with the trust override set — the
+ * backend's non-verified gate now covers every non-verified agent, not just
+ * native ones, and this out-of-band flow already required its own explicit
+ * per-agent confirmation regardless of tier.
  *
  * @param {{ action: string, agentId: string }} command
  * @param {{
  *   confirm: (command: {action: string, agentId: string}) => Promise<boolean>,
- *   installAgent: (agentId: string) => Promise<any>,
+ *   installAgent: (agentId: string, opts?: { trustNative?: boolean }) => Promise<any>,
  *   focusWindow?: () => void,
  *   logger?: { log?: (...a: any[]) => void, error?: (...a: any[]) => void },
  * }} deps
@@ -142,8 +149,82 @@ async function dispatchDeepLink(command, deps) {
   }
 
   log(`[deep-link] Confirmed — installing "${command.agentId}"`);
-  await installAgent(command.agentId);
+  await installAgent(command.agentId, { trustNative: true });
   return { installed: true };
 }
 
-module.exports = { parseDeepLink, extractDeepLinkFromArgv, dispatchDeepLink };
+// ── Informed trust prompt (security fix: gate ALL non-verified agents) ─────
+//
+// The bare confirm dialog above only ever showed the raw agent id — no tier,
+// no permissions, no AMD-verified indicator. That's per-agent confirmation,
+// but it isn't INFORMED consent. buildInstallPrompt renders the same facts
+// the in-app trust gate (hubLanes.trustGateFor) shows, from a catalog entry,
+// so the caller (main.cjs) can put them in front of the user before they
+// confirm.
+
+const TIER_LABEL = {
+  verified: "AMD Verified",
+  community: "Community",
+  experimental: "Experimental",
+};
+
+/** Normalize a possibly-missing/unknown tier the same way the in-app gate does. */
+function normalizeTier(entry) {
+  const t = entry && entry.security_tier;
+  return t === "verified" || t === "community" ? t : "experimental";
+}
+
+/**
+ * Build the confirmation prompt for a deep-link install from its catalog
+ * entry. Pure — no Electron dependency — so the trust posture is
+ * unit-testable without a running dialog.
+ *
+ * @param {{
+ *   id: string,
+ *   name?: string,
+ *   security_tier?: "verified" | "community" | "experimental",
+ *   permissions?: string[],
+ * } | null | undefined} entry — the agent's catalog entry.
+ * @returns {{ title: string, message: string, detail: string, requiresTrust: boolean }}
+ * @throws {Error} if no entry is given — never build a prompt for an agent
+ *   that couldn't be looked up; the caller must fail closed instead.
+ */
+function buildInstallPrompt(entry) {
+  if (!entry || typeof entry !== "object") {
+    throw new Error(
+      "buildInstallPrompt requires a catalog entry — refuse rather than prompting blind."
+    );
+  }
+
+  const tier = normalizeTier(entry);
+  const requiresTrust = tier !== "verified";
+  const name = entry.name || entry.id;
+  const permissions = Array.isArray(entry.permissions) ? entry.permissions : [];
+
+  const detail = [
+    `Tier: ${TIER_LABEL[tier]}${requiresTrust ? " — NOT AMD-verified" : ""}`,
+    permissions.length
+      ? `Permissions: ${permissions.join(", ")}`
+      : "Permissions: none declared",
+    requiresTrust
+      ? "This agent has not been audited by AMD. Only continue if you trust the " +
+        "publisher — installing downloads and runs third-party code on your machine."
+      : "This agent has been reviewed and verified by AMD.",
+  ].join("\n\n");
+
+  return {
+    title: requiresTrust
+      ? "Install untrusted agent from the web?"
+      : "Install agent from the web?",
+    message: `A website asked GAIA to install "${name}" (${entry.id}).`,
+    detail,
+    requiresTrust,
+  };
+}
+
+module.exports = {
+  parseDeepLink,
+  extractDeepLinkFromArgv,
+  dispatchDeepLink,
+  buildInstallPrompt,
+};

--- a/src/gaia/apps/webui/src/components/InstallConfirmDialog.tsx
+++ b/src/gaia/apps/webui/src/components/InstallConfirmDialog.tsx
@@ -15,8 +15,10 @@ export interface InstallWarning {
  * Build the list of warnings that gate an install. Empty list ⇒ install can
  * proceed without confirmation.
  *
- * - ``native_trust``: a non-verified native (C++) agent runs unsandboxed; the
- *   backend refuses (403) unless the user opts in via ``trust_native``.
+ * - ``native_trust``: this check only raises the warning for a non-verified
+ *   native (C++) agent, but the backend refuses (403) ANY non-verified
+ *   install — not just native ones — unless the caller opts in via
+ *   ``trust_native``.
  * - ``deprecated``: the publisher marked the agent deprecated; it may be
  *   unmaintained or superseded.
  */

--- a/src/gaia/apps/webui/src/components/InstallConfirmDialog.tsx
+++ b/src/gaia/apps/webui/src/components/InstallConfirmDialog.tsx
@@ -15,18 +15,21 @@ export interface InstallWarning {
  * Build the list of warnings that gate an install. Empty list ⇒ install can
  * proceed without confirmation.
  *
- * - ``native_trust``: this check only raises the warning for a non-verified
- *   native (C++) agent, but the backend refuses (403) ANY non-verified
- *   install — not just native ones — unless the caller opts in via
- *   ``trust_native``.
+ * - ``native_trust``: warns that a non-verified *native* (C++) agent ships an
+ *   unsandboxed binary. This is the native-specific warning — deliberately NOT
+ *   keyed off ``requires_trust`` (which is now true for ANY non-verified agent),
+ *   so a non-verified Python agent isn't mislabeled as shipping a native binary.
+ *   The backend's 403 covers every non-verified agent regardless (see
+ *   ``hubLanes.trustGateFor``).
  * - ``deprecated``: the publisher marked the agent deprecated; it may be
  *   unmaintained or superseded.
  */
 export function installWarnings(agent: AgentInfo): InstallWarning[] {
     const warnings: InstallWarning[] = [];
     const nativeUntrusted =
-        agent.requires_trust === true ||
-        (agent.language === 'cpp' && !!agent.security_tier && agent.security_tier !== 'verified');
+        agent.language === 'cpp' &&
+        !!agent.security_tier &&
+        agent.security_tier !== 'verified';
     if (nativeUntrusted) {
         warnings.push({
             type: 'native_trust',

--- a/src/gaia/apps/webui/src/components/__tests__/HubPage.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/HubPage.test.tsx
@@ -158,8 +158,10 @@ describe('HubPage trust gate (issue #1722)', () => {
         await waitFor(() => expect(mockedApi.installAgent).toHaveBeenCalledTimes(1));
         const [id, , trustNative] = mockedApi.installAgent.mock.calls[0];
         expect(id).toBe('rag-kit');
-        // Community (non-native) → gated, but no native-trust flag is sent.
-        expect(trustNative).toBe(false);
+        // Community (non-native, e.g. python) agent still sends trust_native —
+        // the security fix generalizes the wire flag to every non-verified
+        // agent, not just native binaries.
+        expect(trustNative).toBe(true);
     });
 
     it('shows declared permissions in the trust gate', async () => {

--- a/src/gaia/apps/webui/src/types/index.ts
+++ b/src/gaia/apps/webui/src/types/index.ts
@@ -128,9 +128,9 @@ export interface AgentInfo {
      */
     permissions?: string[];
     /**
-     * True when installing this agent needs an explicit native-trust opt-in —
-     * a non-verified native (C++) package that runs unsandboxed. The Hub shows
-     * a "Trust & Install" confirmation before sending ``trust_native``.
+     * True when installing this agent needs an explicit trust opt-in — any
+     * non-verified package (of any language) that runs third-party code. The
+     * Hub shows a "Trust & Install" confirmation before sending ``trust_native``.
      */
     requires_trust?: boolean;
     /** Optional remote avatar image URL from the catalog. */

--- a/src/gaia/apps/webui/src/utils/__tests__/hubLanes.test.ts
+++ b/src/gaia/apps/webui/src/utils/__tests__/hubLanes.test.ts
@@ -83,15 +83,22 @@ describe('trustGateFor — the verified-only refusal (issue #1722)', () => {
         expect(gate.reasons).toHaveLength(0);
     });
 
-    it('requires an override for a community agent (not AMD-verified)', () => {
-        const gate = trustGateFor(agent({ id: 'comm', security_tier: 'community' }));
+    it('sends trust_native for a non-verified PYTHON agent, not just native ones', () => {
+        // The core fix under test: a non-verified agent that ships no native
+        // binary at all must still demand the override and the trust flag.
+        const gate = trustGateFor(
+            agent({ id: 'comm', security_tier: 'community', language: 'python' }),
+        );
         expect(gate.requiresOverride).toBe(true);
+        expect(gate.trustNative).toBe(true);
         expect(gate.reasons.join(' ')).toMatch(/not audited/i);
+        expect(gate.reasons.join(' ')).not.toMatch(/native binary/i);
     });
 
-    it('requires an override for an experimental agent', () => {
+    it('requires an override and trustNative for an experimental agent (also non-native)', () => {
         const gate = trustGateFor(agent({ id: 'exp', security_tier: 'experimental' }));
         expect(gate.requiresOverride).toBe(true);
+        expect(gate.trustNative).toBe(true);
         expect(gate.reasons.join(' ')).toMatch(/experimental/i);
     });
 
@@ -104,12 +111,33 @@ describe('trustGateFor — the verified-only refusal (issue #1722)', () => {
         expect(gate.reasons.join(' ')).toMatch(/without sandboxing/i);
     });
 
+    it('does NOT require an override for a native (cpp) agent that IS verified', () => {
+        const gate = trustGateFor(
+            agent({ id: 'native-verified', language: 'cpp', security_tier: 'verified' }),
+        );
+        expect(gate.requiresOverride).toBe(false);
+        expect(gate.trustNative).toBe(false);
+        expect(gate.reasons).toHaveLength(0);
+    });
+
     it('gates a deprecated agent even when verified', () => {
         const gate = trustGateFor(
             agent({ id: 'old', security_tier: 'verified', deprecated: true }),
         );
         expect(gate.requiresOverride).toBe(true);
         expect(gate.reasons.join(' ')).toMatch(/deprecated/i);
+    });
+
+    it('does NOT mislabel a non-native agent as native even when the backend-generalized requires_trust flag is set', () => {
+        // requires_trust now covers ANY non-verified agent on the backend, so
+        // isNative must stay keyed on language==='cpp' alone — never on
+        // requires_trust — or a non-native agent would wrongly show the
+        // "ships a native binary" reason.
+        const gate = trustGateFor(
+            agent({ id: 'py-comm', security_tier: 'community', requires_trust: true }),
+        );
+        expect(gate.trustNative).toBe(true); // via requiresOverride, not isNative
+        expect(gate.reasons.join(' ')).not.toMatch(/native binary/i);
     });
 
     it('surfaces permissions and platform requirements', () => {

--- a/src/gaia/apps/webui/src/utils/hubLanes.ts
+++ b/src/gaia/apps/webui/src/utils/hubLanes.ts
@@ -82,7 +82,12 @@ export interface TrustGate {
      * (unsandboxed C++) and deprecated agents are always gated too.
      */
     requiresOverride: boolean;
-    /** Whether installing sends ``trust_native`` (non-verified native agent). */
+    /**
+     * Whether installing sends ``trust_native`` to the backend. Mirrors
+     * ``requiresOverride`` — any agent the user had to explicitly override
+     * (non-verified, native, or deprecated) installs with the trust flag set,
+     * not just native packages.
+     */
     trustNative: boolean;
     /** Declared permission scopes, e.g. ``["fs:read", "net:fetch"]``. */
     permissions: string[];
@@ -108,9 +113,11 @@ export function trustTier(agent: AgentInfo): TrustTier {
  */
 export function trustGateFor(agent: AgentInfo): TrustGate {
     const tier = trustTier(agent);
-    const isNative =
-        agent.requires_trust === true ||
-        (agent.language === 'cpp' && tier !== 'verified');
+    // Native = ships an unsandboxed C++ binary. Deliberately NOT keyed off
+    // agent.requires_trust — that field now covers ANY non-verified agent,
+    // not just native ones, so folding it in here would mislabel a
+    // non-verified python agent as "ships a native binary".
+    const isNative = agent.language === 'cpp' && tier !== 'verified';
     const reasons: string[] = [];
 
     if (tier !== 'verified') {
@@ -127,10 +134,14 @@ export function trustGateFor(agent: AgentInfo): TrustGate {
         reasons.push('Deprecated by the publisher — may be unmaintained or superseded.');
     }
 
+    const requiresOverride = tier !== 'verified' || isNative || !!agent.deprecated;
+
     return {
         tier,
-        requiresOverride: tier !== 'verified' || isNative || !!agent.deprecated,
-        trustNative: isNative,
+        requiresOverride,
+        // Send the trust override whenever the user had to acknowledge one —
+        // covers every non-verified agent, not just native packages.
+        trustNative: requiresOverride,
         permissions: agent.permissions ?? [],
         platforms: agent.requirements?.platforms ?? [],
         reasons,

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -3007,12 +3007,12 @@ Examples:
         help="Specific version to install (default: the hub's latest).",
     )
     agent_install_parser.add_argument(
-        "--trust-native",
+        "--trust",
         action="store_true",
-        dest="trust_native",
+        dest="trusted",
         help=(
-            "Explicitly trust a native (C++) agent's unsandboxed binary. Required "
-            "for community/experimental native packages; ignored for Python agents."
+            "Explicitly trust a non-verified agent (it runs third-party code on "
+            "your machine). Required for any community/experimental package."
         ),
     )
 
@@ -7018,16 +7018,16 @@ def handle_agent_install(args):
 
     agent_id = args.agent_id
     version = getattr(args, "version", None)
-    trust_native = getattr(args, "trust_native", False)
+    trusted = getattr(args, "trusted", False)
 
     label = agent_id + (f"@{version}" if version else "")
     print(f"Installing '{label}' from the Agent Hub...")
     try:
-        result = installer.install(agent_id, version=version, trust_native=trust_native)
+        result = installer.install(agent_id, version=version, trusted=trusted)
     except installer.TrustRequiredError as exc:
         print(f"❌ {exc}", file=sys.stderr)
         print(
-            "   Re-run with --trust-native if you trust the publisher.",
+            "   Re-run with --trust if you trust the publisher.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/src/gaia/hub/catalog.py
+++ b/src/gaia/hub/catalog.py
@@ -351,13 +351,13 @@ STATUS_UPDATE_AVAILABLE = "update_available"
 DEFAULT_PACKAGE_TYPE = "agent"
 
 
-def _requires_trust(language: str, security_tier: str) -> bool:
-    """Whether a catalog entry needs an explicit native-trust opt-in to install.
+def _requires_trust(security_tier: str) -> bool:
+    """Whether a catalog entry needs an explicit trust opt-in to install.
 
-    Native (``cpp``) agents outside the ``verified`` tier ship an unsandboxed
-    binary from a non-AMD-audited publisher; the UI prompts before installing.
+    Any agent outside the ``verified`` tier runs third-party code from a
+    non-AMD-verified publisher; the UI prompts before installing.
     """
-    return language == "cpp" and security_tier != "verified"
+    return security_tier != "verified"
 
 
 def merge_with_registry(
@@ -427,7 +427,7 @@ def merge_with_registry(
             "language": language,
             "author": entry.get("author", ""),
             "security_tier": security_tier,
-            "requires_trust": _requires_trust(language, security_tier),
+            "requires_trust": _requires_trust(security_tier),
             # Declared permission scopes (``<domain>:<action>``) shown in the
             # install trust gate. Absent from older entries / local-only agents.
             "permissions": entry.get("permissions", []),
@@ -464,7 +464,7 @@ def merge_with_registry(
             "language": reg.language,
             "author": "",
             "security_tier": reg_tier,
-            "requires_trust": _requires_trust(reg.language, reg_tier),
+            "requires_trust": _requires_trust(reg_tier),
             "permissions": [],
             "download_size_bytes": 0,
             "requirements": {"platforms": []},

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -87,8 +87,9 @@ ARTIFACT_KIND_WHEEL = "wheel"
 ARTIFACT_KIND_BINARY = "binary"
 ARTIFACT_KIND_CPP = "cpp"
 
-# The only security tier whose native agents install without an explicit trust
-# opt-in. ``community`` / ``experimental`` C++ agents require ``trust_native``.
+# The only security tier whose agents install without an explicit trust opt-in.
+# Any non-verified agent (``community`` / ``experimental``, of any language)
+# requires the caller to pass ``trusted=True``.
 VERIFIED_TIER = "verified"
 
 # Least-privileged default when a manifest omits its tier (mirrors the manifest
@@ -126,12 +127,12 @@ class InstallInProgressError(InstallError):
 
 
 class TrustRequiredError(InstallError):
-    """A native (C++) non-verified agent needs explicit trust to install.
+    """A non-verified agent needs an explicit trust opt-in to install.
 
-    Native agents run as unsandboxed binaries on the user's machine, so a
-    ``community``/``experimental`` C++ package is only installed when the caller
-    explicitly opts in (``trust_native=True`` / the UI's *Trust & Install*
-    confirmation). Maps to HTTP 403 at the router boundary.
+    A non-verified agent runs third-party code on the user's machine, so any
+    ``community``/``experimental`` package (of any language) is only installed
+    when the caller explicitly opts in (``trusted=True`` / the UI's
+    *Trust & Install* confirmation). Maps to HTTP 403 at the router boundary.
     """
 
 
@@ -896,35 +897,31 @@ def _hot_register(agent_id: str, install_dir: Path, language: str, registry) -> 
 # ---------------------------------------------------------------------------
 
 
-def requires_native_trust(manifest: Dict[str, Any]) -> bool:
-    """Whether installing *manifest* needs an explicit native-trust opt-in.
+def requires_trust_ack(manifest: Dict[str, Any]) -> bool:
+    """Whether installing *manifest* needs an explicit trust opt-in.
 
-    True for native (``language: cpp``) agents that are not in the ``verified``
-    tier — they ship an unsandboxed binary from a non-AMD-audited publisher.
+    True for any agent not in the ``verified`` tier — a non-AMD-verified package
+    runs third-party code on the user's machine regardless of its language.
     """
-    language = manifest.get("language", "python")
     tier = manifest.get("security_tier", DEFAULT_SECURITY_TIER)
-    return language == "cpp" and tier != VERIFIED_TIER
+    return tier != VERIFIED_TIER
 
 
-def ensure_native_trust(
-    agent_id: str, manifest: Dict[str, Any], *, trust_native: bool
-) -> None:
-    """Raise :class:`TrustRequiredError` if native trust is needed but absent.
+def ensure_trust_ack(agent_id: str, manifest: Dict[str, Any], *, trusted: bool) -> None:
+    """Raise :class:`TrustRequiredError` if trust is needed but not acknowledged.
 
-    No-op for Python agents and ``verified`` native agents. Called both by the
-    router (synchronous 403) and :func:`install` (defense in depth).
+    No-op for ``verified`` agents. Called both by the router (synchronous 403)
+    and :func:`install` (defense in depth).
     """
-    if trust_native or not requires_native_trust(manifest):
+    if trusted or not requires_trust_ack(manifest):
         return
     tier = manifest.get("security_tier", DEFAULT_SECURITY_TIER)
     raise TrustRequiredError(
-        f"'{agent_id}' is a native (C++) agent in the '{tier}' security tier. "
-        f"Native agents run as unsandboxed binaries on your machine, so this one "
-        f"is not installed automatically. Re-install with explicit trust "
-        f"(trust_native=true, or the UI's 'Trust & Install' confirmation) only if "
-        f"you trust its publisher. See "
-        f"https://amd-gaia.ai/docs/spec/agent-hub-restructure."
+        f"'{agent_id}' is a non-verified agent in the '{tier}' security tier. "
+        f"It runs third-party code on your machine, so it is not installed "
+        f"automatically. Re-install with explicit trust (trusted=true, or the "
+        f"UI's 'Trust & Install' confirmation) only if you trust its publisher. "
+        f"See https://amd-gaia.ai/docs/spec/agent-hub-restructure."
     )
 
 
@@ -966,7 +963,7 @@ def install(
     install_root: Optional[Path] = None,
     registry: Any = None,
     skip_compatibility_check: bool = False,
-    trust_native: bool = False,
+    trusted: bool = False,
     platform_key: Optional[str] = None,
     active_env_site_packages: Optional[Path] = None,
 ) -> InstallResult:
@@ -981,8 +978,8 @@ def install(
         install_root: Install root; defaults to ``~/.gaia/agents``.
         registry: Live :class:`AgentRegistry` to hot-register into.
         skip_compatibility_check: Skip the platform/disk gate (tests/forced).
-        trust_native: Explicit opt-in to install a non-verified native (C++)
-            agent. Required for ``community``/``experimental`` C++ packages.
+        trusted: Explicit opt-in to install a non-verified agent. Required for
+            any ``community``/``experimental`` package (of any language).
         platform_key: Artifact-filename platform key (``win32-x64`` etc.) used
             to select among ``versions[v].artifacts[]``; defaults to the real
             host's key (injectable for tests).
@@ -1012,10 +1009,10 @@ def install(
                 )
             language = manifest.get("language", "python")
 
-            # Native-agent trust gate — refuse non-verified C++ packages unless
-            # the caller explicitly opted in (defense in depth; the router also
-            # enforces this synchronously for a clean 403).
-            ensure_native_trust(agent_id, manifest, trust_native=trust_native)
+            # Trust gate — refuse any non-verified package unless the caller
+            # explicitly opted in (defense in depth; the router also enforces
+            # this synchronously for a clean 403).
+            ensure_trust_ack(agent_id, manifest, trusted=trusted)
 
             # Deprecation is non-fatal but must be loud: a deprecated agent may
             # be unmaintained or superseded.

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -2014,7 +2014,11 @@ class InitCommand:
         from gaia.hub import installer as hub_installer
 
         self._print(f"   Installing '{agent_id}' from the Agent Hub...")
-        result = hub_installer.install(agent_id)
+        # Curated first-run profile agent: a hardcoded INIT_PROFILES id, not user
+        # input, so GAIA's own curation is the trust decision. Pass the trust
+        # opt-in explicitly — every non-verified agent now needs it, and the
+        # profile agents are not published in the "verified" tier.
+        result = hub_installer.install(agent_id, trusted=True)
         self._print_success(f"Installed '{agent_id}' from the Agent Hub")
 
         # No AgentRegistry exists in this process to hot-register into (we

--- a/src/gaia/ui/routers/hub.py
+++ b/src/gaia/ui/routers/hub.py
@@ -86,8 +86,9 @@ class InstallRequest(BaseModel):
 
     id: str
     version: Optional[str] = None
-    # Explicit opt-in to install a non-verified native (C++) agent. The UI sets
-    # this after the user accepts the "Trust & Install" confirmation.
+    # Explicit opt-in to install a non-verified agent (any language). The UI sets
+    # this after the user accepts the "Trust & Install" confirmation. The wire
+    # field name is kept as ``trust_native`` for client compatibility.
     trust_native: bool = False
 
 
@@ -145,7 +146,7 @@ def _run_install(
     version: Optional[str],
     registry,
     *,
-    trust_native: bool,
+    trusted: bool,
     manifest: Optional[dict],
 ) -> None:
     """Background install worker. Errors are recorded in install progress."""
@@ -154,7 +155,7 @@ def _run_install(
             agent_id,
             version=version,
             registry=registry,
-            trust_native=trust_native,
+            trusted=trusted,
             manifest=manifest,
         )
     except installer_mod.InstallError as exc:
@@ -190,9 +191,7 @@ async def install_agent(
     except catalog_mod.CatalogError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     try:
-        installer_mod.ensure_native_trust(
-            body.id, manifest, trust_native=body.trust_native
-        )
+        installer_mod.ensure_trust_ack(body.id, manifest, trusted=body.trust_native)
     except installer_mod.TrustRequiredError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
 
@@ -207,7 +206,7 @@ async def install_agent(
         body.id,
         body.version,
         registry,
-        trust_native=body.trust_native,
+        trusted=body.trust_native,
         manifest=manifest,
     )
     return {"id": body.id, "status": "queued"}

--- a/tests/electron/deep-link.test.cjs
+++ b/tests/electron/deep-link.test.cjs
@@ -13,6 +13,7 @@ const {
   parseDeepLink,
   extractDeepLinkFromArgv,
   dispatchDeepLink,
+  buildInstallPrompt,
 } = require("../../src/gaia/apps/webui/services/deep-link.cjs");
 
 describe("parseDeepLink()", () => {
@@ -116,9 +117,13 @@ describe("dispatchDeepLink() — install confirmation gate (security)", () => {
       focusWindow,
     });
 
-    // Confirmation happened before install, and for THIS agent.
+    // Confirmation happened before install, and for THIS agent. Once
+    // confirmed, the trust override is always sent — this out-of-band flow
+    // already required its own explicit per-agent confirmation, and the
+    // backend's non-verified gate now covers every non-verified agent, not
+    // just native ones.
     expect(confirm).toHaveBeenCalledWith(command);
-    expect(installAgent).toHaveBeenCalledWith("summarize");
+    expect(installAgent).toHaveBeenCalledWith("summarize", { trustNative: true });
     expect(confirm.mock.invocationCallOrder[0]).toBeLessThan(
       installAgent.mock.invocationCallOrder[0]
     );
@@ -182,5 +187,86 @@ describe("dispatchDeepLink() — install confirmation gate (security)", () => {
       )
     ).rejects.toThrow(/Unsupported deep-link action/);
     expect(installAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildInstallPrompt() — informed trust prompt (security fix: gate ALL non-verified agents)", () => {
+  test("a non-verified agent's prompt requires trust and says so", () => {
+    const prompt = buildInstallPrompt({
+      id: "sketchy",
+      name: "Sketchy Agent",
+      security_tier: "community",
+      permissions: ["fs:read"],
+    });
+    expect(prompt.requiresTrust).toBe(true);
+    expect(prompt.detail).toMatch(/not amd-verified/i);
+    expect(prompt.detail).toMatch(/fs:read/);
+  });
+
+  test("a verified agent's prompt does not demand extra trust", () => {
+    const prompt = buildInstallPrompt({
+      id: "safe",
+      name: "Safe Agent",
+      security_tier: "verified",
+      permissions: [],
+    });
+    expect(prompt.requiresTrust).toBe(false);
+    expect(prompt.detail).not.toMatch(/not amd-verified/i);
+  });
+
+  test("an unknown/missing tier defaults to the least-trusted posture", () => {
+    const prompt = buildInstallPrompt({ id: "unknown-tier", name: "Mystery" });
+    expect(prompt.requiresTrust).toBe(true);
+  });
+
+  test("refuses to build a prompt (throws) rather than prompting blind when no entry is given", () => {
+    expect(() => buildInstallPrompt(null)).toThrow();
+    expect(() => buildInstallPrompt(undefined)).toThrow();
+  });
+});
+
+describe("dispatchDeepLink() + buildInstallPrompt() — end-to-end trust posture (security fix)", () => {
+  const command = { action: "install", agentId: "summarize" };
+
+  test("(i) a non-verified agent's deep link requires the trust ack and installs with the trust option on consent", async () => {
+    const entry = { id: "summarize", security_tier: "community", permissions: [] };
+    expect(buildInstallPrompt(entry).requiresTrust).toBe(true);
+
+    const installAgent = jest.fn().mockResolvedValue({ status: "completed" });
+    const result = await dispatchDeepLink(command, {
+      confirm: jest.fn().mockResolvedValue(true),
+      installAgent,
+    });
+
+    expect(installAgent).toHaveBeenCalledWith("summarize", { trustNative: true });
+    expect(result).toEqual({ installed: true });
+  });
+
+  test("(ii) declining a non-verified agent's trust ack does not install", async () => {
+    const entry = { id: "summarize", security_tier: "experimental", permissions: [] };
+    expect(buildInstallPrompt(entry).requiresTrust).toBe(true);
+
+    const installAgent = jest.fn();
+    const result = await dispatchDeepLink(command, {
+      confirm: jest.fn().mockResolvedValue(false),
+      installAgent,
+    });
+
+    expect(installAgent).not.toHaveBeenCalled();
+    expect(result).toEqual({ installed: false, reason: "declined" });
+  });
+
+  test("(iii) a verified agent's prompt does not demand extra trust, and still installs with the trust option once confirmed", async () => {
+    const entry = { id: "summarize", security_tier: "verified", permissions: [] };
+    expect(buildInstallPrompt(entry).requiresTrust).toBe(false);
+
+    const installAgent = jest.fn().mockResolvedValue({ status: "completed" });
+    const result = await dispatchDeepLink(command, {
+      confirm: jest.fn().mockResolvedValue(true),
+      installAgent,
+    });
+
+    expect(installAgent).toHaveBeenCalledWith("summarize", { trustNative: true });
+    expect(result).toEqual({ installed: true });
   });
 });

--- a/tests/fixtures/wheel_builder.py
+++ b/tests/fixtures/wheel_builder.py
@@ -164,6 +164,9 @@ def build_wheel_manifest(
     manifest = {
         "id": agent_id,
         "language": "python",
+        # Verified so install-mechanics fixtures aren't blocked by the trust
+        # gate; the gate's behavior is covered in test_hub_security.py.
+        "security_tier": "verified",
         "latest_version": version,
         "requirements": {"platforms": []},
         "versions": {

--- a/tests/unit/test_cli_agent_install.py
+++ b/tests/unit/test_cli_agent_install.py
@@ -31,28 +31,28 @@ class _InstallResult:
         self.hot_registered = False
 
 
-def _args(agent_id="email", version=None, trust_native=False):
+def _args(agent_id="email", version=None, trusted=False):
     return Namespace(
         agent_action="install",
         agent_id=agent_id,
         version=version,
-        trust_native=trust_native,
+        trusted=trusted,
     )
 
 
 def test_install_success_forwards_args_and_prints_next_step(monkeypatch, capsys):
     captured = {}
 
-    def _fake_install(agent_id, *, version=None, trust_native=False):
+    def _fake_install(agent_id, *, version=None, trusted=False):
         captured["agent_id"] = agent_id
         captured["version"] = version
-        captured["trust_native"] = trust_native
+        captured["trusted"] = trusted
         return _InstallResult(agent_id=agent_id, version=version or "0.5.0")
 
     monkeypatch.setattr(installer, "install", _fake_install)
-    cli.handle_agent_install(_args("email", version="0.5.0", trust_native=True))
+    cli.handle_agent_install(_args("email", version="0.5.0", trusted=True))
 
-    assert captured == {"agent_id": "email", "version": "0.5.0", "trust_native": True}
+    assert captured == {"agent_id": "email", "version": "0.5.0", "trusted": True}
     out = capsys.readouterr().out
     assert "✅ Installed 'email' v0.5.0" in out
     # email is a daemon sidecar spec, so the start hint must appear.
@@ -63,7 +63,7 @@ def test_install_non_sidecar_agent_omits_daemon_hint(monkeypatch, capsys):
     monkeypatch.setattr(
         installer,
         "install",
-        lambda agent_id, *, version=None, trust_native=False: _InstallResult(
+        lambda agent_id, *, version=None, trusted=False: _InstallResult(
             agent_id="some-tool", version="1.0.0"
         ),
     )
@@ -74,7 +74,7 @@ def test_install_non_sidecar_agent_omits_daemon_hint(monkeypatch, capsys):
 
 
 def test_install_error_exits_nonzero_and_is_loud(monkeypatch, capsys):
-    def _boom(agent_id, *, version=None, trust_native=False):
+    def _boom(agent_id, *, version=None, trusted=False):
         raise installer.ChecksumError("artifact checksum mismatch for X")
 
     monkeypatch.setattr(installer, "install", _boom)
@@ -89,7 +89,7 @@ def test_install_error_exits_nonzero_and_is_loud(monkeypatch, capsys):
 def test_install_unknown_id_suggests_agent_list(monkeypatch, capsys):
     # A typo'd id 404s on the manifest fetch (a plain requests error, not an
     # InstallError) — the generic branch must point the user at `gaia agent list`.
-    def _boom(agent_id, *, version=None, trust_native=False):
+    def _boom(agent_id, *, version=None, trusted=False):
         raise RuntimeError(
             "404 Client Error: Not Found for url: .../emial/manifest.json"
         )
@@ -104,7 +104,7 @@ def test_install_unknown_id_suggests_agent_list(monkeypatch, capsys):
 
 
 def test_install_trust_required_names_the_flag(monkeypatch, capsys):
-    def _needs_trust(agent_id, *, version=None, trust_native=False):
+    def _needs_trust(agent_id, *, version=None, trusted=False):
         raise installer.TrustRequiredError("'x' is a native agent in 'experimental'")
 
     monkeypatch.setattr(installer, "install", _needs_trust)
@@ -112,7 +112,7 @@ def test_install_trust_required_names_the_flag(monkeypatch, capsys):
         cli.handle_agent_install(_args("x"))
     assert exc.value.code == 1
     err = capsys.readouterr().err
-    assert "--trust-native" in err
+    assert "--trust" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_file_tools.py
+++ b/tests/unit/test_file_tools.py
@@ -933,6 +933,69 @@ class TestReadToolsSandbox:
         assert self._denied(result)
         assert "999999" not in str(result)
 
+    def test_analyze_data_file_denies_before_existence_probe(
+        self, sandboxed_read_tools
+    ):
+        """A nonexistent out-of-sandbox path returns access-denied, not a
+        'File not found' existence oracle."""
+        tools, _, secret_dir = sandboxed_read_tools
+        missing = str(secret_dir / "does_not_exist.csv")
+
+        result = tools["analyze_data_file"](missing)
+
+        assert self._denied(result)
+        assert "not found" not in result.get("error", "").lower()
+
+    def test_analyze_data_file_denies_unsupported_ext_before_sandbox(
+        self, sandboxed_read_tools
+    ):
+        """An out-of-sandbox file with an unsupported extension returns the same
+        access-denied refusal as a supported one — no file-type oracle."""
+        tools, _, secret_dir = sandboxed_read_tools
+        secret = secret_dir / "notes.txt"
+        secret.write_text("nobody should learn this file exists", encoding="utf-8")
+
+        result = tools["analyze_data_file"](str(secret))
+
+        assert self._denied(result)
+        assert "unsupported" not in result.get("error", "").lower()
+
+    def test_analyze_data_file_rag_fallback_resolves_only_in_sandbox(
+        self, tmp_path, monkeypatch
+    ):
+        """The indexed-basename fallback still resolves a document inside the
+        sandbox, but a basename with no in-sandbox index match is denied — so the
+        fallback cannot launder an out-of-sandbox existence probe."""
+        from types import SimpleNamespace
+
+        from gaia import security as _security
+        from gaia.security import PathValidator
+
+        monkeypatch.setattr(_security, "_is_interactive", lambda: False)
+
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        secret_dir = tmp_path / "secret"
+        secret_dir.mkdir()
+        indexed = safe_dir / "report.csv"
+        indexed.write_text("name,amount\nalice,10\n", encoding="utf-8")
+
+        inst = _StubMixin()
+        inst.path_validator = PathValidator(allowed_paths=[str(safe_dir)])
+        inst.rag = SimpleNamespace(indexed_files=[str(indexed)])
+        inst.register_file_search_tools()
+        analyze = _TOOL_REGISTRY["analyze_data_file"]["function"]
+
+        # An out-of-sandbox path whose basename matches an in-sandbox indexed
+        # document resolves to that document (fuzzy fallback preserved).
+        ok = analyze(str(secret_dir / "report.csv"))
+        assert ok.get("status") == "success"
+        assert ok.get("row_count") == 1
+
+        # A basename with no in-sandbox index match is denied uniformly.
+        denied = analyze(str(secret_dir / "other.csv"))
+        assert self._denied(denied)
+
     def test_read_file_no_validator_still_reads(self, read_file_fn, tmp_path):
         """A mixin host with no PathValidator keeps working (backward compat)."""
         f = tmp_path / "plain.txt"

--- a/tests/unit/test_hub_install_sidecar_contract.py
+++ b/tests/unit/test_hub_install_sidecar_contract.py
@@ -74,6 +74,9 @@ def test_installer_output_is_a_sentinel_the_sidecar_fetch_accepts(tmp_path):
         _AGENT_ID,
         version=_VERSION,
         manifest=_manifest(),
+        # Non-verified python agent (models the email sidecar): the install
+        # now requires the explicit trust opt-in every non-verified agent needs.
+        trusted=True,
         base_url=_BASE_URL,
         fetcher=_fetcher,
         run_pip=lambda args: pytest.fail("binary install must never call pip"),
@@ -141,6 +144,7 @@ def test_wheel_kind_install_is_not_accepted_as_a_sidecar_binary(tmp_path):
         _AGENT_ID,
         version=_VERSION,
         manifest=manifest,
+        trusted=True,
         base_url=_BASE_URL,
         fetcher=_wheel_fetcher,
         run_pip=lambda args: None,  # wheel path shells out to pip; stub it

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -39,6 +39,9 @@ def _manifest(agent_id="demo", version="1.0.0", artifact_bytes=b"wheel-bytes", *
     return {
         "id": agent_id,
         "language": "python",
+        # Mechanics tests use a verified manifest so the install trust gate is a
+        # no-op here; the gate itself is covered in test_hub_security.py.
+        "security_tier": "verified",
         "latest_version": version,
         "requirements": {"platforms": [], **reqs},
         "versions": {
@@ -319,7 +322,7 @@ def test_install_cpp_artifact_extracted(tmp_path):
         base_url=BASE,
         fetcher=fetcher,
         install_root=tmp_path,
-        trust_native=True,  # experimental native agent — explicit trust required
+        trusted=True,  # experimental native agent — explicit trust required
     )
     assert result.language == "cpp"
     assert (tmp_path / "native" / "bin" / "demo").exists()
@@ -542,6 +545,7 @@ def _binary_manifest(
     return {
         "id": agent_id,
         "language": "python",
+        "security_tier": "verified",
         "latest_version": version,
         "requirements": {"platforms": []},
         "versions": {
@@ -567,6 +571,7 @@ def _legacy_binary_manifest(
     return {
         "id": agent_id,
         "language": "python",
+        "security_tier": "verified",
         "latest_version": version,
         "requirements": {"platforms": []},
         "versions": {
@@ -819,7 +824,7 @@ def test_install_cpp_with_artifacts_list_uses_singular_zip(tmp_path):
         run_pip=lambda args: pip_calls.append(args),
         install_root=tmp_path,
         platform_key="linux-x64",
-        trust_native=True,
+        trusted=True,
     )
     assert result.language == "cpp"
     assert (tmp_path / "native" / "bin" / "demo").exists()
@@ -867,7 +872,7 @@ def _cpp_install_from_archive(tmp_path, filename, archive_bytes):
         base_url=BASE,
         fetcher=fetcher,
         install_root=tmp_path,
-        trust_native=True,
+        trusted=True,
     )
 
 

--- a/tests/unit/test_hub_lifecycle.py
+++ b/tests/unit/test_hub_lifecycle.py
@@ -377,6 +377,9 @@ def _install_binary_agent(tmp_path, agent_id="email", platform_key="linux-x64"):
         run_pip=refuse_pip,
         install_root=tmp_path,
         platform_key=platform_key,
+        # Non-verified binary agent installed to set up the lifecycle/health
+        # test; the trust gate itself is covered in test_hub_security.py.
+        trusted=True,
     )
     return installer.agent_install_dir(agent_id, tmp_path) / f"{agent_id}-agent"
 

--- a/tests/unit/test_hub_router.py
+++ b/tests/unit/test_hub_router.py
@@ -97,7 +97,7 @@ def test_install_returns_202_and_schedules(client, monkeypatch):
 
     def fake_install(agent_id, **kwargs):
         called["id"] = agent_id
-        called["trust_native"] = kwargs.get("trust_native")
+        called["trusted"] = kwargs.get("trusted")
 
     monkeypatch.setattr(
         catalog_mod,
@@ -112,21 +112,22 @@ def test_install_returns_202_and_schedules(client, monkeypatch):
     assert resp.json()["status"] == "queued"
     # BackgroundTasks run after the response in TestClient.
     assert called.get("id") == "demo"
-    assert called.get("trust_native") is True
+    assert called.get("trusted") is True
 
 
-def test_install_native_non_verified_refused_403(client, monkeypatch):
-    # A community native agent without trust_native is refused synchronously.
+def test_install_non_verified_python_refused_403(client, monkeypatch):
+    # A non-verified PYTHON (community) agent without the trust opt-in is refused
+    # synchronously at the router — the gate is not native-only.
     monkeypatch.setattr(
         catalog_mod,
         "fetch_manifest",
         lambda *a, **k: {
-            "id": "native",
-            "language": "cpp",
+            "id": "demo",
+            "language": "python",
             "security_tier": "community",
         },
     )
-    resp = client.post("/api/agents/install", json={"id": "native"}, headers=UI)
+    resp = client.post("/api/agents/install", json={"id": "demo"}, headers=UI)
     assert resp.status_code == 403
     assert "trust" in resp.json()["detail"].lower()
 
@@ -396,6 +397,7 @@ def test_install_error_surfaces_via_install_status(client, monkeypatch):
     manifest = {
         "id": "email",
         "language": "python",
+        "security_tier": "verified",  # isolate this test from the trust gate
         "latest_version": "0.1.0",
         "requirements": {"platforms": []},
         "versions": {
@@ -439,7 +441,11 @@ def test_email_install_shuts_down_running_sidecar_first(client, monkeypatch):
     monkeypatch.setattr(
         catalog_mod,
         "fetch_manifest",
-        lambda *a, **k: {"id": "email", "language": "python"},
+        lambda *a, **k: {
+            "id": "email",
+            "language": "python",
+            "security_tier": "verified",
+        },
     )
     monkeypatch.setattr(installer_mod, "install", lambda agent_id, **k: None)
     resp = client.post("/api/agents/install", json={"id": "email"}, headers=UI)
@@ -477,7 +483,11 @@ def test_email_install_proceeds_when_stop_sidecar_noops(client, monkeypatch):
     monkeypatch.setattr(
         catalog_mod,
         "fetch_manifest",
-        lambda *a, **k: {"id": "email", "language": "python"},
+        lambda *a, **k: {
+            "id": "email",
+            "language": "python",
+            "security_tier": "verified",
+        },
     )
     called = {}
     monkeypatch.setattr(
@@ -498,7 +508,11 @@ def test_email_install_aborts_when_stop_fails(client, monkeypatch):
     monkeypatch.setattr(
         catalog_mod,
         "fetch_manifest",
-        lambda *a, **k: {"id": "email", "language": "python"},
+        lambda *a, **k: {
+            "id": "email",
+            "language": "python",
+            "security_tier": "verified",
+        },
     )
     called = {}
     monkeypatch.setattr(
@@ -516,7 +530,11 @@ def test_non_email_install_does_not_shutdown_sidecar(client, monkeypatch):
     monkeypatch.setattr(
         catalog_mod,
         "fetch_manifest",
-        lambda *a, **k: {"id": "demo", "language": "python"},
+        lambda *a, **k: {
+            "id": "demo",
+            "language": "python",
+            "security_tier": "verified",
+        },
     )
     monkeypatch.setattr(installer_mod, "install", lambda agent_id, **k: None)
     resp = client.post("/api/agents/install", json={"id": "demo"}, headers=UI)

--- a/tests/unit/test_hub_security.py
+++ b/tests/unit/test_hub_security.py
@@ -19,10 +19,10 @@ from gaia.hub import catalog as catalog_mod
 from gaia.hub import installer
 from gaia.hub.installer import (
     TrustRequiredError,
-    ensure_native_trust,
+    ensure_trust_ack,
     install,
     read_sentinel,
-    requires_native_trust,
+    requires_trust_ack,
 )
 
 BASE = "https://hub.test"
@@ -40,6 +40,10 @@ def _python_manifest(agent_id="demo", version="1.0.0", **extra):
     return {
         "id": agent_id,
         "language": "python",
+        # Default to verified so helpers that don't care about the trust gate
+        # (e.g. the deprecation-warning test) install without an opt-in; callers
+        # that test the gate pass an explicit security_tier via **extra.
+        "security_tier": "verified",
         "latest_version": version,
         "requirements": {"platforms": []},
         "versions": {
@@ -119,7 +123,7 @@ def _clean_state():
 
 
 # ---------------------------------------------------------------------------
-# requires_native_trust / ensure_native_trust
+# requires_trust_ack / ensure_trust_ack
 # ---------------------------------------------------------------------------
 
 
@@ -129,30 +133,31 @@ def _clean_state():
         ("cpp", "experimental", True),
         ("cpp", "community", True),
         ("cpp", "verified", False),
-        ("python", "experimental", False),
-        ("python", "community", False),
+        ("python", "experimental", True),
+        ("python", "community", True),
+        ("python", "verified", False),
     ],
 )
-def test_requires_native_trust_matrix(language, tier, expected):
+def test_requires_trust_ack_matrix(language, tier, expected):
     manifest = {"language": language, "security_tier": tier}
-    assert requires_native_trust(manifest) is expected
+    assert requires_trust_ack(manifest) is expected
 
 
-def test_ensure_native_trust_raises_without_optin():
+def test_ensure_trust_ack_raises_without_optin():
     manifest = {"language": "cpp", "security_tier": "community"}
     with pytest.raises(TrustRequiredError):
-        ensure_native_trust("native", manifest, trust_native=False)
+        ensure_trust_ack("native", manifest, trusted=False)
 
 
-def test_ensure_native_trust_allows_with_optin():
+def test_ensure_trust_ack_allows_with_optin():
     manifest = {"language": "cpp", "security_tier": "community"}
     # Should not raise.
-    ensure_native_trust("native", manifest, trust_native=True)
+    ensure_trust_ack("native", manifest, trusted=True)
 
 
-def test_ensure_native_trust_allows_verified_native_without_optin():
+def test_ensure_trust_ack_allows_verified_native_without_optin():
     manifest = {"language": "cpp", "security_tier": "verified"}
-    ensure_native_trust("native", manifest, trust_native=False)
+    ensure_trust_ack("native", manifest, trusted=False)
 
 
 # ---------------------------------------------------------------------------
@@ -183,7 +188,7 @@ def test_install_native_non_verified_succeeds_with_trust(tmp_path):
         base_url=BASE,
         fetcher=fetcher,
         install_root=tmp_path,
-        trust_native=True,
+        trusted=True,
     )
     assert result.language == "cpp"
     assert (tmp_path / "native" / "bin" / "native").exists()
@@ -199,6 +204,49 @@ def test_install_native_verified_succeeds_without_trust(tmp_path):
         install_root=tmp_path,
     )
     assert result.language == "cpp"
+
+
+def test_install_python_non_verified_refused_without_trust(tmp_path):
+    # A non-verified PYTHON agent also runs third-party code on the user's
+    # machine, so it must require the same explicit trust opt-in as a native one.
+    manifest = _python_manifest(security_tier="experimental")
+    with pytest.raises(TrustRequiredError):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_python_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+    assert read_sentinel("demo", tmp_path) is None
+
+
+def test_install_python_non_verified_succeeds_with_trust(tmp_path):
+    manifest = _python_manifest(security_tier="community")
+    result = install(
+        "demo",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_python_fetcher(manifest),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+        trusted=True,
+    )
+    assert result.language == "python"
+
+
+def test_install_python_verified_succeeds_without_trust(tmp_path):
+    manifest = _python_manifest(security_tier="verified")
+    result = install(
+        "demo",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_python_fetcher(manifest),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+    )
+    assert result.language == "python"
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +292,7 @@ def test_catalog_surfaces_security_tier_and_requires_trust():
     assert by_id["verified-cpp"]["security_tier"] == "verified"
     assert by_id["verified-cpp"]["requires_trust"] is False
     assert by_id["community-cpp"]["requires_trust"] is True
-    assert by_id["experimental-py"]["requires_trust"] is False
+    assert by_id["experimental-py"]["requires_trust"] is True
 
 
 def test_catalog_hides_deprecated_available_by_default():

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -289,6 +289,37 @@ class TestInitCommand(unittest.TestCase):
         cmd._print_step(4, 5, "Installing [rag] dependencies")
         self.assertIn("[rag]", buf.getvalue())
 
+    @patch("gaia.installer.init_command.LemonadeInstaller")
+    def test_hub_agent_bootstrap_installs_with_trust(self, _mock_installer_class):
+        """`gaia init` installs its curated profile agent WITH the trust opt-in.
+
+        Every non-verified agent now needs an explicit trust acknowledgement to
+        install. The curated first-run profile agent is a hardcoded INIT_PROFILES
+        id (trusted by GAIA's own curation), so the bootstrap must pass the flag
+        — otherwise `gaia init` hard-fails for exactly the new users it targets.
+        """
+        from gaia.hub import catalog as hub_catalog
+        from gaia.hub import installer as hub_installer
+        from gaia.installer.init_command import INIT_PROFILES, InitCommand
+
+        agent_id = INIT_PROFILES["chat"]["agent"]
+        cmd = InitCommand(profile="chat", yes=True)
+
+        index = MagicMock()
+        index.agents = [{"id": agent_id}]
+
+        with (
+            patch.object(cmd, "_is_hub_agent_available", return_value=False),
+            patch.object(hub_catalog, "load_index", return_value=index),
+            patch.object(hub_installer, "install") as mock_install,
+        ):
+            mock_install.return_value = MagicMock(path="not-a-real-path")
+            cmd._ensure_hub_agent_installed()
+
+        mock_install.assert_called_once()
+        self.assertEqual(mock_install.call_args.args[0], agent_id)
+        self.assertIs(mock_install.call_args.kwargs.get("trusted"), True)
+
 
 class TestRunInit(unittest.TestCase):
     """Test run_init entry point function."""


### PR DESCRIPTION
Private security follow-up from the v0.23.0 audit — two independent hardening fixes.

- **Hardens the install trust gate to cover all non-verified agents.** Previously only native (C++) non-verified agents required an explicit trust opt-in; now any non-verified agent does, across every install path — the in-app Hub, `POST /api/agents/install`, the CLI (`gaia agent install --trust`), and the `gaia://hub/install/<id>` deep link, which now shows an informed confirmation with the agent's tier / permissions / AMD-verified status (and fails closed if the catalog lookup fails) instead of a bare OS prompt. Curated first-run bootstrap (`gaia init`) passes the opt-in explicitly, so onboarding is unaffected.
- **Fixes an allowed-paths ordering issue in `analyze_data_file`.** The `--allowed-paths` sandbox check now runs before the existence and file-type checks, so any path outside the sandbox returns one identical refusal — matching the other read tools. The indexed-document basename fallback is preserved.

## Test plan

Run locally on this branch — all green except the noted pre-existing failures:

- [x] `pytest tests/unit/test_hub_security.py tests/unit/test_hub_router.py tests/unit/test_hub_installer.py tests/unit/test_cli_agent_install.py tests/unit/test_hub_install_sidecar_contract.py tests/unit/test_file_tools.py -q`
- [x] `pytest tests/unit/test_init_command.py -q` — the new trust-bootstrap test passes; the 3 failures (Lemonade version / PPA / Windows install) are **pre-existing on `main`** (platform-gated) and unrelated to this change
- [x] Frontend (vitest): `npm --prefix src/gaia/apps/webui run test` — hubLanes + HubPage green
- [x] Electron (jest): `npm --prefix tests/electron test -- deep-link` — green
- [x] `python util/lint.py --all` — clean (exit 0)

<details>
<summary>Evidence</summary>

Install gate — exercised against the real router (`POST /api/agents/install` for a non-verified agent):

```
req : {"id":"acme-tool"}                     -> HTTP 403  (trust required)
req : {"id":"acme-tool","trust_native":true} -> HTTP 202  {"status":"queued"}
```

`analyze_data_file` — an out-of-sandbox path returns the same refusal whether or not it exists and regardless of extension:

```
exists, supported ext (.csv)    -> Access denied: '…/secret/exists.csv' is not in allowed paths
exists, unsupported ext (.txt)  -> Access denied: '…/secret/exists.txt' is not in allowed paths
does NOT exist (.csv)           -> Access denied: '…/secret/missing.csv' is not in allowed paths
in-sandbox valid file (.csv)    -> status: success
```

Suites: 247 backend unit tests (hub trust gate, installer, router, CLI, sidecar contract, file tools, init bootstrap) + 20 frontend (vitest) + 139 Electron (jest) green; `util/lint.py --all` clean.
</details>
