### PR TITLE
fix(connectors): register hub-installed sidecar agents so email grant works on fresh install

### DIFF
--- a/src/gaia/agents/registry.py
+++ b/src/gaia/agents/registry.py
@@ -1269,6 +1269,60 @@ class AgentRegistry:
         """
         return self._agents.get(self.canonical_id(agent_id))
 
+    def register_sidecar(
+        self,
+        agent_id: str,
+        display_name: str,
+        required_connections: List[ConnectorRequirement],
+    ) -> None:
+        """Register a daemon-supervised sidecar agent (e.g. email) (#2408).
+
+        A sidecar install (frozen binary + ``.installed`` sentinel under
+        ``~/.gaia/agents/<id>/``) ships no ``agent.py``, so ``discover()``'s
+        directory scan never finds it and the connectors grant flow 404s on
+        its namespaced id forever. This registers a lightweight stand-in with
+        real identity and the connector scopes the daemon spec declares, but
+        a factory that fails loudly rather than importing or instantiating
+        the out-of-process agent — the UI backend never imports the hub
+        wheel (server.py:621-629).
+
+        Idempotent: a no-op if *agent_id* (the BARE id, not the namespaced
+        one) is already registered — protects a real wheel/custom-agent
+        registration, or a repeated call, from being clobbered by this stub.
+        Called by ``gaia.hub.installer.register_installed_sidecars``.
+        """
+        if self.get(agent_id) is not None:
+            return
+
+        def _sidecar_factory(**_kwargs):
+            raise RuntimeError(
+                f"'{agent_id}' runs out-of-process as a daemon sidecar; it "
+                "is not instantiated in-process by the AgentRegistry. It is "
+                "supervised by the gaia daemon and reached over its own "
+                "REST/MCP surface."
+            )
+
+        self._register(
+            AgentRegistration(
+                id=agent_id,
+                name=display_name,
+                description=f"{display_name} agent",
+                source="installed",
+                conversation_starters=[],
+                factory=_sidecar_factory,
+                agent_dir=None,
+                models=[],
+                hidden=False,
+                required_connections=list(required_connections),
+                namespaced_agent_id=f"installed:{agent_id}",
+            )
+        )
+        logger.info(
+            "registry: Registered sidecar agent: %s (namespaced installed:%s)",
+            agent_id,
+            agent_id,
+        )
+
     def list(self) -> List[AgentRegistration]:
         """Return all registered agents."""
         return list(self._agents.values())

--- a/src/gaia/daemon/sidecars/spec.py
+++ b/src/gaia/daemon/sidecars/spec.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, Tuple
 
+from gaia.connectors.providers.base import ConnectorRequirement
+
 
 @dataclass(frozen=True)
 class AgentSidecarSpec:
@@ -44,6 +46,18 @@ class AgentSidecarSpec:
       machine keyring/grants store (the whole point of forward-out: the sidecar
       never holds a long-lived refresh token). MUST equal the hub package's
       ``gaia_agent_email.forwarded_credentials.FORWARDED_MODE_ENV_VAR``.
+
+    Connector-grant registration (#2408) — host/UI-facing only, never consulted
+    by :class:`~gaia.daemon.sidecars.manager.AgentSidecarManager`:
+
+    - ``required_connections`` — the connector scopes this sidecar needs,
+      surfaced into the live ``AgentRegistry`` (via
+      ``gaia.hub.installer.register_installed_sidecars`` ->
+      ``AgentRegistry.register_sidecar``) so the connectors grant flow and
+      ``/api/agents`` can see them without an importable wheel. Transcribed as
+      literals from the hub package's own scope constants (core cannot import
+      the wheel at runtime, #2154) and guarded against drift by
+      ``tests/unit/connectors/test_email_scope_drift.py``.
     """
 
     agent_id: str
@@ -66,6 +80,9 @@ class AgentSidecarSpec:
     grant_agent_id: Optional[str] = None
     forward_providers: Tuple[str, ...] = field(default_factory=tuple)
     forwarded_mode_env_var: Optional[str] = None
+    required_connections: Tuple[ConnectorRequirement, ...] = field(
+        default_factory=tuple
+    )
 
 
 # The email agent's caller-auth token channel (#1706). MUST equal
@@ -89,6 +106,32 @@ _EMAIL_GRANT_AGENT_ID = "installed:email"
 # The email sidecar's forwarded-credentials mode switch (#2154). MUST equal
 # gaia_agent_email.forwarded_credentials.FORWARDED_MODE_ENV_VAR — a literal.
 _EMAIL_FORWARDED_MODE_ENV_VAR = "GAIA_EMAIL_FORWARDED_CREDENTIALS"
+
+# Connector scopes the email sidecar needs (#2408). Transcribed as literals —
+# not imported — so core never depends on the hub wheel (server.py:621-629).
+# MUST equal gaia_agent_email/scopes.py's ALL_SCOPES (GMAIL_SCOPES +
+# CALENDAR_SCOPES) and outlook_scopes.py's OUTLOOK_MAIL_SCOPES +
+# OUTLOOK_CALENDAR_SCOPES. Guarded against drift by
+# tests/unit/connectors/test_email_scope_drift.py.
+_EMAIL_REQUIRED_CONNECTIONS = (
+    ConnectorRequirement(
+        connector_id="google",
+        scopes=(
+            "https://www.googleapis.com/auth/gmail.modify",  # from gaia_agent_email/scopes.py
+            "https://www.googleapis.com/auth/gmail.send",  # from gaia_agent_email/scopes.py
+            "https://www.googleapis.com/auth/calendar.events",  # from gaia_agent_email/scopes.py
+            "https://www.googleapis.com/auth/calendar.readonly",  # from gaia_agent_email/scopes.py
+        ),
+    ),
+    ConnectorRequirement(
+        connector_id="microsoft",
+        scopes=(
+            "https://graph.microsoft.com/Mail.ReadWrite",  # from gaia_agent_email/outlook_scopes.py
+            "https://graph.microsoft.com/Mail.Send",  # from gaia_agent_email/outlook_scopes.py
+            "https://graph.microsoft.com/Calendars.ReadWrite",  # from gaia_agent_email/outlook_scopes.py
+        ),
+    ),
+)
 
 
 def _default_email_src_dir() -> Path:
@@ -114,5 +157,6 @@ def builtin_specs() -> "dict[str, AgentSidecarSpec]":
             grant_agent_id=_EMAIL_GRANT_AGENT_ID,
             forward_providers=("google", "microsoft"),
             forwarded_mode_env_var=_EMAIL_FORWARDED_MODE_ENV_VAR,
+            required_connections=_EMAIL_REQUIRED_CONNECTIONS,
         ),
     }

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -1175,13 +1175,15 @@ def install(
                 percent=90,
                 version=resolved_version,
             )
-            # Binary installs have no site-packages to scan (nothing to
-            # hot-register), regardless of the manifest's declared language.
-            hot = (
-                False
-                if artifact_kind == ARTIFACT_KIND_BINARY
-                else _hot_register(agent_id, install_dir, language, registry)
-            )
+            # Binary installs have no site-packages to scan (nothing for
+            # _hot_register), regardless of the manifest's declared language —
+            # bridge it into the registry directly instead, so a sidecar
+            # agent's connector grants work without a server restart (#2408).
+            if artifact_kind == ARTIFACT_KIND_BINARY:
+                register_installed_sidecars(registry)
+                hot = registry is not None and registry.get(agent_id) is not None
+            else:
+                hot = _hot_register(agent_id, install_dir, language, registry)
 
             # NOTE: the backup snapshot is intentionally retained after a
             # successful update so rollback() can restore the prior version. It

--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -51,6 +51,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from gaia.agents.registry import _RESERVED_BUILTIN_IDS
+from gaia.daemon.sidecars.spec import builtin_specs
 from gaia.hub import catalog as catalog_mod
 from gaia.hub.compatibility import check_compatibility, current_platform_key
 from gaia.logger import get_logger
@@ -889,6 +890,46 @@ def _hot_register(agent_id: str, install_dir: Path, language: str, registry) -> 
         logger.warning("installer: hot-register failed for %s: %s", agent_id, exc)
         return False
     return registry.get(agent_id) is not None
+
+
+def register_installed_sidecars(registry: Any) -> None:
+    """Register every hub-installed daemon-sidecar agent into *registry* (#2408).
+
+    Bridges ``gaia.daemon.sidecars.spec.builtin_specs()`` (what the daemon can
+    supervise, and the connector scopes it declares) with :func:`list_installed`
+    (what is actually on disk) so a binary sidecar agent (e.g. email) is visible
+    to the connectors grant flow and ``/api/agents`` without an importable
+    wheel. A binary install has no site-packages to entry-point-scan, so
+    :func:`_hot_register` never covers it.
+
+    Called once at server startup (right after ``AgentRegistry.discover()``)
+    and again the moment a binary sidecar finishes installing from the Hub
+    panel, so neither trigger point leaves the registry stale until a
+    restart. ``AgentRegistry.register_sidecar`` is itself idempotent against
+    an already-registered bare id, so calling this repeatedly is safe.
+
+    Best-effort at the :func:`list_installed` I/O boundary (mirrors
+    ``AgentRegistry._prime_installed_wheel_agents_path``): a disk read
+    failure logs and registers nothing rather than failing UI boot.
+    """
+    if registry is None:
+        return
+    try:
+        installed = list_installed()
+    except Exception as exc:  # noqa: BLE001 - best-effort discovery step
+        logger.warning(
+            "installer: could not list installed agents for sidecar "
+            "connector registration: %s",
+            exc,
+        )
+        return
+
+    for agent_id, spec in builtin_specs().items():
+        if agent_id not in installed:
+            continue
+        registry.register_sidecar(
+            agent_id, spec.display_name, spec.required_connections
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -112,9 +112,10 @@ def get_agent_registry():
 
 
 # Agent types served by an out-of-process sidecar with a dedicated dispatch
-# branch below. They are never registry-loadable: a binary-only hub install
-# ships no importable wheel, so registry.get() is None even when the agent is
-# installed and healthy.
+# branch below. Since #2408, an installed sidecar IS registry-loadable (the
+# installer bridge registers it for the connectors grant flow), but its
+# factory always raises — chat dispatch must still go through the branch
+# below, never registry.create_agent().
 _SIDECAR_AGENT_TYPES = frozenset({"email"})
 
 

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -232,10 +232,15 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
 
         # ── Agent Registry ──────────────────────────────────────────────
         from gaia.agents.registry import AgentRegistry
+        from gaia.hub.installer import register_installed_sidecars
         from gaia.ui._chat_helpers import set_agent_registry
 
         registry = AgentRegistry()
         registry.discover()
+        # Surface any hub-installed daemon-sidecar agent (e.g. email) that
+        # discover() can't see (no agent.py) so the connectors grant flow and
+        # /api/agents work on a fresh install without a restart (#2408).
+        register_installed_sidecars(registry)
         app.state.agent_registry = registry
         set_agent_registry(registry)
         agent_ids = [r.id for r in registry.list()]

--- a/tests/unit/agents/test_registry.py
+++ b/tests/unit/agents/test_registry.py
@@ -914,3 +914,216 @@ class TestBuilderModelPreferences:
             "builder", available_models=["gemma4-it-e2b-FLM"]
         )
         assert resolved == "gemma4-it-e2b-FLM"
+
+
+# ---------------------------------------------------------------------------
+# Sidecar registration (#2408) — the connector-grant registry gap
+#
+# A daemon-supervised sidecar agent (e.g. email) ships a frozen binary + an
+# ``.installed`` sentinel but no ``agent.py``, so ``discover()``'s directory
+# scan never finds it and the connector-grant flow 404s on its namespaced id
+# forever. ``register_sidecar`` is the core primitive that registers a real
+# (but never-instantiated) stand-in so the grant flow and ``/api/agents`` can
+# see it. Scopes are hardcoded here (not imported from
+# ``gaia.daemon.sidecars.spec``) so this test doesn't just trivially agree
+# with whatever the implementation under test already says.
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterSidecar:
+    _GOOGLE_SCOPES = [
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.readonly",
+    ]
+    _MICROSOFT_SCOPES = [
+        "https://graph.microsoft.com/Mail.ReadWrite",
+        "https://graph.microsoft.com/Mail.Send",
+        "https://graph.microsoft.com/Calendars.ReadWrite",
+    ]
+
+    def _connections(self):
+        from gaia.connectors.providers.base import ConnectorRequirement
+
+        return [
+            ConnectorRequirement(connector_id="google", scopes=self._GOOGLE_SCOPES),
+            ConnectorRequirement(
+                connector_id="microsoft", scopes=self._MICROSOFT_SCOPES
+            ),
+        ]
+
+    def test_bare_id_and_namespaced_id_are_set_separately(self):
+        """The dedup guard and AgentRegistration.id use the BARE id; only
+        namespaced_agent_id (the grant-ledger key) gets the 'installed:'
+        prefix. Getting this backwards silently defeats the dedup guard."""
+        registry = AgentRegistry()
+        registry.register_sidecar("email", "Email", self._connections())
+        reg = registry.get("email")
+        assert reg is not None
+        assert reg.id == "email"
+        assert reg.namespaced_agent_id == "installed:email"
+
+    def test_visible_and_carries_no_model_preference(self):
+        """hidden=False (else it vanishes from /api/agents); models=[] so
+        resolve_model('email', ...) returns None, matching today's
+        unregistered behaviour rather than resolving to some default."""
+        registry = AgentRegistry()
+        registry.register_sidecar("email", "Email", self._connections())
+        reg = registry.get("email")
+        assert reg.hidden is False
+        assert reg.models == []
+
+    def test_carries_both_provider_scope_requirements(self):
+        registry = AgentRegistry()
+        registry.register_sidecar("email", "Email", self._connections())
+        reg = registry.get("email")
+        by_provider = {
+            cr.connector_id: list(cr.scopes) for cr in reg.required_connections
+        }
+        assert by_provider.get("google") == self._GOOGLE_SCOPES
+        assert by_provider.get("microsoft") == self._MICROSOFT_SCOPES
+
+    def test_create_agent_raises_without_constructing_anything(self):
+        """The factory must fail loudly, never import/instantiate the
+        out-of-process sidecar (server.py never imports the hub wheel)."""
+        registry = AgentRegistry()
+        registry.register_sidecar("email", "Email", self._connections())
+        with pytest.raises(RuntimeError, match="out-of-process"):
+            registry.create_agent("email")
+
+    def test_second_call_is_idempotent(self):
+        """Calling register_sidecar twice must not raise or duplicate."""
+        registry = AgentRegistry()
+        registry.register_sidecar("email", "Email", self._connections())
+        registry.register_sidecar("email", "Email", self._connections())
+        ids = [r.id for r in registry.list() if r.id == "email"]
+        assert ids == ["email"]
+
+    def test_does_not_clobber_a_real_pre_existing_registration(self):
+        """A legitimate custom agent (or a prior real registration) claiming
+        the bare id 'email' must survive a register_sidecar call — 'email'
+        is not in _RESERVED_BUILTIN_IDS, so a custom agent CAN legally claim
+        it, and this stub must never silently overwrite it."""
+        registry = AgentRegistry()
+
+        def _real_factory(**_kwargs):
+            return "a real agent instance"
+
+        registry._register(
+            AgentRegistration(
+                id="email",
+                name="Custom Email",
+                description="a user's own custom agent claiming id 'email'",
+                source="custom_python",
+                conversation_starters=[],
+                factory=_real_factory,
+                agent_dir=None,
+                models=[],
+                namespaced_agent_id="custom:deadbeef:email",
+            )
+        )
+
+        registry.register_sidecar("email", "Email", self._connections())
+
+        reg = registry.get("email")
+        assert reg.namespaced_agent_id == "custom:deadbeef:email"
+        assert reg.factory is _real_factory
+
+
+# ---------------------------------------------------------------------------
+# Bridge: gaia.hub.installer.register_installed_sidecars (#2408)
+#
+# The bridge lives in gaia.hub.installer (not core) — it is what makes an
+# on-disk sidecar install visible to a live AgentRegistry. Tested here (not
+# in tests/unit/connectors/) because it needs no email wheel: it only reads
+# gaia.daemon.sidecars.spec.builtin_specs() and a monkeypatched
+# list_installed(), both wheel-free.
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterInstalledSidecarsBridge:
+    @staticmethod
+    def _fake_installed(agent_id: str = "email"):
+        from gaia.hub.installer import ARTIFACT_KIND_BINARY, InstalledAgent
+
+        return {
+            agent_id: InstalledAgent(
+                id=agent_id,
+                version="0.1.0",
+                language="python",
+                installed_at="2026-01-01T00:00:00Z",
+                artifact_kind=ARTIFACT_KIND_BINARY,
+            )
+        }
+
+    def test_installed_sidecar_is_registered_with_required_connections(
+        self, monkeypatch
+    ):
+        from gaia.hub import installer as installer_mod
+
+        monkeypatch.setattr(
+            installer_mod, "list_installed", lambda *a, **kw: self._fake_installed()
+        )
+        registry = AgentRegistry()
+
+        installer_mod.register_installed_sidecars(registry)
+
+        reg = registry.get("email")
+        assert reg is not None
+        assert reg.namespaced_agent_id == "installed:email"
+        assert reg.required_connections  # non-empty
+
+    def test_not_installed_agent_is_not_phantom_registered(self, monkeypatch):
+        from gaia.hub import installer as installer_mod
+
+        monkeypatch.setattr(installer_mod, "list_installed", lambda *a, **kw: {})
+        registry = AgentRegistry()
+
+        installer_mod.register_installed_sidecars(registry)
+
+        assert registry.get("email") is None
+
+    def test_pre_existing_registration_field_survives_the_bridge(self, monkeypatch):
+        """Cardinality alone is insufficient (dict-keyed → count stays 1
+        either way) — assert a DISTINGUISHING field survives, proving the
+        bridge skipped rather than overwrote."""
+        from gaia.hub import installer as installer_mod
+
+        monkeypatch.setattr(
+            installer_mod, "list_installed", lambda *a, **kw: self._fake_installed()
+        )
+        registry = AgentRegistry()
+
+        def _real_factory(**_kwargs):
+            return "a real email agent instance"
+
+        registry._register(
+            AgentRegistration(
+                id="email",
+                name="Custom Email",
+                description="a user's own custom agent claiming id 'email'",
+                source="custom_python",
+                conversation_starters=[],
+                factory=_real_factory,
+                agent_dir=None,
+                models=[],
+                namespaced_agent_id="custom:deadbeef:email",
+            )
+        )
+
+        installer_mod.register_installed_sidecars(registry)
+
+        reg = registry.get("email")
+        assert reg.namespaced_agent_id == "custom:deadbeef:email"
+        assert reg.factory is _real_factory
+
+    def test_registry_none_is_a_safe_no_op(self, monkeypatch):
+        """install() may call this with registry=None (CLI-only installs,
+        e.g. cli.py:7026) — must not raise."""
+        from gaia.hub import installer as installer_mod
+
+        monkeypatch.setattr(
+            installer_mod, "list_installed", lambda *a, **kw: self._fake_installed()
+        )
+        installer_mod.register_installed_sidecars(None)  # must not raise

--- a/tests/unit/chat/ui/test_agents_router.py
+++ b/tests/unit/chat/ui/test_agents_router.py
@@ -15,17 +15,21 @@ from gaia.ui.server import create_app
 def make_mock_registry(*agent_specs):
     """Create a mock AgentRegistry with the given agents.
 
-    Each spec is ``(agent_id, name)`` or ``(agent_id, name, min_memory_gb)``
-    for tests that exercise the memory-requirement field.
+    Each spec is ``(agent_id, name)``, ``(agent_id, name, min_memory_gb)``,
+    or ``(agent_id, name, min_memory_gb, required_connections)`` for tests
+    that exercise the memory-requirement or required-connections fields.
     """
     registry = MagicMock(spec=AgentRegistry)
     registrations = []
     for spec in agent_specs:
-        if len(spec) == 3:
+        min_memory_gb = None
+        required_connections = []
+        if len(spec) == 4:
+            agent_id, name, min_memory_gb, required_connections = spec
+        elif len(spec) == 3:
             agent_id, name, min_memory_gb = spec
         else:
             agent_id, name = spec
-            min_memory_gb = None
         reg = AgentRegistration(
             id=agent_id,
             name=name,
@@ -36,6 +40,7 @@ def make_mock_registry(*agent_specs):
             agent_dir=None,
             models=[],
             min_memory_gb=min_memory_gb,
+            required_connections=required_connections or [],
         )
         registrations.append(reg)
 
@@ -194,9 +199,23 @@ class TestInstalledSidecarAgentsMerge:
         assert data["agents"][0]["name"] == "Email"  # spec.display_name
 
     def test_registry_entry_wins_over_sidecar(self):
-        """A registered (wheel) email is not duplicated by the sidecar merge."""
+        """A registered (wheel) email is not duplicated by the sidecar merge.
+
+        Gives the mock registration a non-empty required_connections (#2408)
+        so this also locks in that a registry-sourced sidecar registration
+        (e.g. from register_installed_sidecars) surfaces its connector
+        requirements through this same union path, not just its name.
+        """
+        from gaia.connectors.providers.base import ConnectorRequirement
+
+        cr = ConnectorRequirement(
+            connector_id="google",
+            scopes=["https://www.googleapis.com/auth/gmail.modify"],
+        )
         app = create_app(db_path=":memory:")
-        app.state.agent_registry = make_mock_registry(("email", "Email (wheel)"))
+        app.state.agent_registry = make_mock_registry(
+            ("email", "Email (wheel)", None, [cr])
+        )
         client = TestClient(app)
         with (
             patch(
@@ -209,6 +228,7 @@ class TestInstalledSidecarAgentsMerge:
         emails = [a for a in data["agents"] if a["id"] == "email"]
         assert len(emails) == 1
         assert emails[0]["name"] == "Email (wheel)"
+        assert emails[0]["required_connections"] != []
 
     def test_uninstalled_sidecar_agent_absent(self):
         """No install sentinel → the agent is NOT phantom-listed."""

--- a/tests/unit/connectors/test_email_scope_drift.py
+++ b/tests/unit/connectors/test_email_scope_drift.py
@@ -1,0 +1,60 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+Drift guard: the email connector scopes transcribed as literals in
+``gaia.daemon.sidecars.spec`` (core cannot import the hub wheel at runtime —
+``server.py`` never imports it, #2154) must stay in lock-step with their
+source of truth in the ``gaia-agent-email`` package (#2408).
+
+Placement is deliberate, not incidental: ``test_email_agent_unit.yml``
+installs the email wheel via ``-e hub/agents/email/python`` AND triggers on
+``tests/unit/connectors/**``, so this test actually RUNS in CI rather than
+being silently skipped by ``pytest.importorskip`` the way it would be under
+``tests/unit/agents/`` or a bare ``tests/unit/test_*`` module (installed
+there with only the ``[api]`` extra). Verify locally with ``pytest -rs``
+that this file shows PASSED, not SKIPPED.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("gaia_agent_email")
+
+
+def test_google_scopes_match_source_of_truth():
+    from gaia_agent_email.scopes import ALL_SCOPES
+
+    from gaia.daemon.sidecars.spec import builtin_specs
+
+    email_spec = builtin_specs()["email"]
+    by_provider = {
+        cr.connector_id: set(cr.scopes) for cr in email_spec.required_connections
+    }
+    assert by_provider.get("google") == set(ALL_SCOPES)
+
+
+def test_microsoft_scopes_match_source_of_truth():
+    from gaia_agent_email.outlook_scopes import (
+        OUTLOOK_CALENDAR_SCOPES,
+        OUTLOOK_MAIL_SCOPES,
+    )
+
+    from gaia.daemon.sidecars.spec import builtin_specs
+
+    email_spec = builtin_specs()["email"]
+    by_provider = {
+        cr.connector_id: set(cr.scopes) for cr in email_spec.required_connections
+    }
+    expected = set(OUTLOOK_MAIL_SCOPES) | set(OUTLOOK_CALENDAR_SCOPES)
+    assert by_provider.get("microsoft") == expected
+
+
+def test_namespaced_id_matches_source_of_truth():
+    from gaia_agent_email.scopes import AGENT_NAMESPACED_ID
+
+    from gaia.daemon.sidecars.spec import builtin_specs
+
+    email_spec = builtin_specs()["email"]
+    assert email_spec.grant_agent_id == AGENT_NAMESPACED_ID

--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -419,6 +419,178 @@ class TestAuthorizeGrantAgents:
 
 
 # ---------------------------------------------------------------------------
+# End-to-end: hub-installed sidecar -> connector-grant flow (#2408)
+#
+# Unlike TestAuthorizeGrantAgents above (which plants a fake registry stand-in
+# to unit-test _resolve_grant_scopes' own logic), these tests run the REAL
+# server lifespan (registry.discover() + the installer bridge) so they
+# reproduce the fresh-install failure at the HTTP boundary. A test that
+# plants `installed:email` directly into app.state.agent_registry passes
+# identically whether or not the sidecar is actually wired into discovery,
+# and proves nothing about this bug.
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarRegistrationEndToEnd:
+    _GOOGLE_ALL_SCOPES = [
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.readonly",
+    ]
+
+    @staticmethod
+    def _fake_installed_email():
+        from gaia.hub.installer import ARTIFACT_KIND_BINARY, InstalledAgent
+
+        return {
+            "email": InstalledAgent(
+                id="email",
+                version="0.1.0",
+                language="python",
+                installed_at="2026-01-01T00:00:00Z",
+                artifact_kind=ARTIFACT_KIND_BINARY,
+            )
+        }
+
+    def test_authorize_succeeds_after_real_lifespan_registers_sidecar(
+        self, monkeypatch
+    ):
+        """A sidecar 'installed' before the server even boots must be
+        resolvable by the grant flow through the real startup path — no
+        fake registry planted."""
+        from starlette.testclient import TestClient
+
+        from gaia.ui.server import create_app
+
+        monkeypatch.setattr(
+            "gaia.hub.installer.list_installed",
+            lambda *a, **kw: self._fake_installed_email(),
+        )
+        mock_start = AsyncMock(
+            return_value={"flow_id": "f1", "authorization_url": "https://auth"}
+        )
+        monkeypatch.setattr("gaia.connectors.start_authorization", mock_start)
+
+        with TestClient(create_app(db_path=":memory:")) as client:
+            resp = client.post(
+                "/api/connectors/google/authorize",
+                json={"scopes": ["openid"], "grant_agents": ["installed:email"]},
+                headers=UI_HEADER,
+            )
+
+        assert resp.status_code == 200, resp.text
+        _, kwargs = mock_start.call_args
+        assert sorted(kwargs["grant_agents"]["installed:email"]) == sorted(
+            self._GOOGLE_ALL_SCOPES
+        )
+
+    def test_authorize_404s_when_the_bridge_is_not_wired(self, monkeypatch):
+        """Sibling with the bridge itself disabled (not just 'not
+        installed') — proves the 200 above comes from server.py's wiring
+        calling the bridge, not incidentally from something else."""
+        from starlette.testclient import TestClient
+
+        from gaia.ui.server import create_app
+
+        monkeypatch.setattr(
+            "gaia.hub.installer.list_installed",
+            lambda *a, **kw: self._fake_installed_email(),
+        )
+        monkeypatch.setattr(
+            "gaia.hub.installer.register_installed_sidecars", lambda registry: None
+        )
+        monkeypatch.setattr("gaia.connectors.start_authorization", AsyncMock())
+
+        with TestClient(create_app(db_path=":memory:")) as client:
+            resp = client.post(
+                "/api/connectors/google/authorize",
+                json={"scopes": ["openid"], "grant_agents": ["installed:email"]},
+                headers=UI_HEADER,
+            )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"]["error"] == "unknown_agent"
+
+
+class TestSidecarInstallNoRestart:
+    """Installing email from the Hub panel while the server is already
+    running must register it into the SAME live registry the connectors
+    router reads — no restart (#2408, the live-install trigger point)."""
+
+    @staticmethod
+    def _binary_manifest(sha256: str, size: int) -> dict:
+        return {
+            "id": "email",
+            "language": "python",
+            "latest_version": "0.1.0",
+            "versions": {
+                "0.1.0": {
+                    "artifact": {
+                        "filename": "email-agent-linux-x64",
+                        "path": "agents/email/0.1.0/email-agent-linux-x64",
+                        "sha256": sha256,
+                        "size_bytes": size,
+                    }
+                }
+            },
+        }
+
+    def test_binary_install_registers_without_restart(self, monkeypatch):
+        import hashlib
+
+        from starlette.testclient import TestClient
+
+        from gaia.hub import installer as installer_mod
+        from gaia.ui.server import create_app
+
+        artifact_bytes = b"fake-email-sidecar-binary"
+        sha256 = hashlib.sha256(artifact_bytes).hexdigest()
+        manifest = self._binary_manifest(sha256, len(artifact_bytes))
+
+        with TestClient(create_app(db_path=":memory:")) as client:
+            registry = client.app.state.agent_registry
+
+            # Baseline: email is not installed yet, so the grant flow 404s.
+            resp = client.post(
+                "/api/connectors/google/authorize",
+                json={"scopes": ["openid"], "grant_agents": ["installed:email"]},
+                headers=UI_HEADER,
+            )
+            assert resp.status_code == 404
+
+            # Drive the exact call the Hub panel's background install task
+            # makes (gaia.ui.routers.hub._run_install -> installer.install),
+            # completing a binary-kind install against the same registry.
+            installer_mod.install(
+                "email",
+                version="0.1.0",
+                manifest=manifest,
+                fetcher=lambda url: artifact_bytes,
+                registry=registry,
+                skip_compatibility_check=True,
+                platform_key="linux-x64",
+            )
+
+            monkeypatch.setattr(
+                "gaia.connectors.start_authorization",
+                AsyncMock(
+                    return_value={
+                        "flow_id": "f1",
+                        "authorization_url": "https://auth",
+                    }
+                ),
+            )
+            resp = client.post(
+                "/api/connectors/google/authorize",
+                json={"scopes": ["openid"], "grant_agents": ["installed:email"]},
+                headers=UI_HEADER,
+            )
+
+        assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
 # POST /api/connectors/{connector_id}/authorize-device — device-code (#1275)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #2408

## Why this matters

On a fresh install, the Email agent could never get mailbox access. Triage failed with *"GAIA is missing required Google permissions… reconnect"*, and the Connectors panel showed **"No agents require access to this connector"** — and wiping `~/.gaia` never fixed it, because the state was structural, not cached.

The Email agent ships as a frozen-binary **sidecar** (its install dir has no `agent.py`), so `AgentRegistry.discover()` skipped it entirely. The connector grant/consent flow reads only that registry, so it never saw the agent's required scopes → no `installed:email` grant could be created → the use-time gate rejected every triage.

**After this change**, the installer registers hub-installed sidecar agents — together with the connectors/scopes they require — into the live registry, at **both** startup and the moment one is installed from the Hub (no restart needed). Connecting Google (or Outlook) now offers and records the grant, and the Connectors panel lists the Email agent under its per-agent grants.

<details>
<summary>How it works</summary>

- `AgentSidecarSpec` gains a `required_connections` field; email's spec declares its google + microsoft `ConnectorRequirement`s (scope literals transcribed from `gaia_agent_email/scopes.py`, guarded against drift by a test).
- `AgentRegistry.register_sidecar()` inserts a sidecar as a registry entry (`id` bare, `namespaced_agent_id="installed:email"`, `hidden=False`, a fail-loud `factory` that never imports the wheel — the agent still runs out-of-process via the daemon).
- `gaia.hub.installer.register_installed_sidecars()` bridges installed sidecar specs into the registry; called from the UI-server lifespan **and** the binary-install path (gated on the install sentinel; skips any id a wheel already registered, so it never clobbers a real registration).
- Single fan-in point: the grant flow, the `/api/agents` panel feed, and the forward-connection path all read the now-populated registry — no other edits.
</details>

## Verified

Unit + lint green, and validated live on real AMD hardware across **both platforms** and the **full connector lifecycle** — the fix fires on a real cold sidecar install, and the Connectors panel now offers the Email agent its grants where it previously said "No agents require access."

**Linux (Strix Halo) — Agent UI, three connection states, all pass:**

![Fresh install: Google offers Email its grant](https://raw.githubusercontent.com/amd/gaia/tmi/2408-evidence/testing/2411/01_fresh_install_google_offers_email.png)

*Brand-new install, Google unconnected — the panel offers "Grant access to these agents when you connect: ☑ Email". Pre-fix this said "No agents require access to this connector."*

![After disconnecting via the UI, Email is still offered](https://raw.githubusercontent.com/amd/gaia/tmi/2408-evidence/testing/2411/02_removed_via_ui_email_still_offered.png)

*After removing the Microsoft connection via the UI — it reverts to "Not configured" but Email is still correctly offered (doesn't vanish, no orphaned grant); authorize still resolves.*

- **Connection present** (Microsoft connected): Email appears under PER-AGENT GRANTS with its 3 scope toggles; granting them writes `installed:email` to the grant ledger; a token request passes **both** authorization gates (no `AGENT_NOT_GRANTED` / `missing_scopes`) — the exact gates the bug blocked. *(Screenshot withheld — it shows a test account address.)*
- **Removed via UI** and **brand-new install**: the two screenshots above.

**Windows (Ryzen AI — the originally-reported platform) — backend, fix fires on a real cold install:**

```
gaia agent install email  →  email-agent.exe (binary) + .installed sentinel   # real Windows artifact; also re-validates #2086
registry: Registered sidecar agent: email (namespaced installed:email)
server: Agent registry initialized with 2 agents: ['builder', 'email']
GET  /api/agents                        → email with google(4) + microsoft(3) scopes
POST /api/connectors/google/authorize   → 500, NOT 404 unknown_agent
```

The authorize call gets *past* `_resolve_grant_scopes` (the check this PR fixes); the 500 is an unrelated Windows-over-SSH keyring limitation (Win32 1312), not the fix.

## Test plan

- [x] `python -m pytest tests/unit/agents/test_registry.py tests/unit/connectors/ tests/unit/chat/ui/test_agents_router.py -q` → **679 passed** (incl. a real-lifespan authorize 404→200 test, a live-install-no-restart test, and a spec↔binary scope drift guard)
- [x] `python util/lint.py --all` → clean
- [x] Real-world, Agent UI on AMD hardware (Linux Strix Halo + Windows Ryzen AI): fix fires on a cold sidecar install; Connectors panel offers Email its grants across connection-present / removed-via-UI / brand-new states