### PR TITLE
test(connectors): fix main red — #2408 install test vs #2410 trust gate

### DIFF
--- a/tests/unit/connectors/test_router_connectors.py
+++ b/tests/unit/connectors/test_router_connectors.py
@@ -562,6 +562,8 @@ class TestSidecarInstallNoRestart:
             # Drive the exact call the Hub panel's background install task
             # makes (gaia.ui.routers.hub._run_install -> installer.install),
             # completing a binary-kind install against the same registry.
+            # trusted=True mirrors the UI's "Trust & Install" confirmation that
+            # a non-verified (experimental) agent like email requires (#2410).
             installer_mod.install(
                 "email",
                 version="0.1.0",
@@ -569,6 +571,7 @@ class TestSidecarInstallNoRestart:
                 fetcher=lambda url: artifact_bytes,
                 registry=registry,
                 skip_compatibility_check=True,
+                trusted=True,
                 platform_key="linux-x64",
             )
 


### PR DESCRIPTION
**Fixes main red.** `Unit Tests` and `Email Agent Unit Tests` are failing on `main` (since 236ba233 / #2411).

## What happened

#2410 (install trust gate, merged just before #2411) now makes `installer.install()` raise `TrustRequiredError` for non-verified **experimental**-tier agents like `email` unless `trusted=True`. #2411's `test_binary_install_registers_without_restart` drives `installer.install("email", …)` directly and didn't pass that flag. Each PR's CI was green against a base *without* the other, so the merge-queue combination was never tested — a clean textual merge that's semantically broken. **Production is unaffected** — real `gaia agent install email` (and the Hub "Trust & Install" flow) already pass `trusted=True`; only the test was stale.

## The fix

One line: the test passes `trusted=True`, mirroring the UI's Trust & Install confirmation (`hub._run_install` → `installer.install`, from `body.trust_native`) that an experimental agent requires. The test still exercises exactly what it's for — that a binary install registers the sidecar into the live registry without a restart.

## Test plan
- [x] `python -m pytest tests/unit/connectors/test_router_connectors.py::TestSidecarInstallNoRestart::test_binary_install_registers_without_restart -q` → passes on latest main (was failing)
- [x] `python -m pytest tests/unit/agents/test_registry.py tests/unit/connectors/ tests/unit/chat/ui/test_agents_router.py -q` → 679 passed
- [x] `black --check` clean