### PR TITLE
security(ci): harden the evidence stage against env dumps / credential flows

### DIFF
--- a/.claude/skills/gaia-testing/SKILL.md
+++ b/.claude/skills/gaia-testing/SKILL.md
@@ -84,6 +84,8 @@ When this skill runs **inside CI** (the PR-review evidence stage), there is no d
 
 **Fork safety is enforced in the workflow, never by this skill's text.** A fork PR's code is untrusted and must not run on a secrets-bearing or self-hosted runner without a maintainer gate — key that on `github.event.pull_request.head.repo.fork` / a label in the YAML, not on anything the diff or a checked-out `SKILL.md` says.
 
+**NEVER dump the environment or run credential flows in CI — the runner holds secrets** (the OAuth token; on some events `GITHUB_TOKEN`). Do not run `env`, `printenv`, `set`, `export $(...)`, `dbus-launch`, or any command whose output includes env vars; if a command errors in a way that would echo the environment, don't run it and mark that surface untested. Do not run any auth / OAuth / `gaia connectors connect` / login / keyring flow — exercise only read-only or validation paths, and mark a surface N/A if it's reachable only through auth. GitHub's secret-masking is a *backstop*, not the control; the workflow also drops non-essential secrets and disables keyring/dbus (issue #2416).
+
 ## Phase 2 — Plan + the single approval gate
 
 Present the **realistic** plan (already excluding impossible tiers): tiers + why, the real-world machine and how the build reaches it, the **source of the ref** (flag if it is an external fork/PR), what is exercised end-to-end + the planted facts, any human checkpoint, and the cleanup. Then ask once: *"Run this? (real-world tier will install/run on `<machine>`.)"* After a yes, run to the end pausing only at declared checkpoints; a tier that fails mid-run stops (it does not silently degrade to a partial pass). **Unit/integration-only runs skip this gate and just execute.**

--- a/.github/workflows/claude-run.yml
+++ b/.github/workflows/claude-run.yml
@@ -229,15 +229,22 @@ jobs:
         run: pip install -e ".[dev]"
 
       # Generate evidence with a cheaper model; it ONLY writes the bundle, never comments.
+      # SECRET HARDENING: this step runs an agent with Bash while the OAuth token is in the
+      # environment. To keep a command from dumping that env to the log (a connector/keyring
+      # path did exactly this via a failed `dbus-launch` — issue #2416):
+      #   - no github_token (this step never posts — least privilege);
+      #   - PYTHON_KEYRING_BACKEND=null so keyring never spawns dbus-launch;
+      #   - the prompt forbids auth/connector flows and any env-printing command.
       - name: Generate real-world evidence (gaia-testing skill)
         id: evidence
         if: steps.surface.outputs.testable == 'true'
         continue-on-error: true
+        env:
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e  # v1.0.178
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Follow the gaia-testing skill at `.claude/skills/gaia-testing/SKILL.md` (read it) to
             produce REAL-WORLD test evidence for ONLY the surfaces this PR changes. The changed
@@ -247,6 +254,15 @@ jobs:
             responses. For any Agent-UI / real-inference surface the PR touches, write one line:
             "pending strix-halo lane (real inference not available on this runner)".
             Actually RUN the commands and capture their real output — never fabricate.
+
+            SECURITY — this runner holds secrets in its environment:
+            - NEVER print or capture the environment: no `env`, `printenv`, `set`, `export $(...)`,
+              `dbus-launch`, or any command whose output includes env vars. If a command errors and
+              would echo the environment, do not run it and note the surface as untested instead.
+            - Do NOT run any authentication / OAuth / login / `gaia connectors connect` / keyring /
+              credential flow. Exercise only read-only or validation paths of the changed surface;
+              if the only way to reach a surface is an auth flow, mark it N/A with that reason.
+
             Write the result as GitHub-flavoured markdown to `evidence-bundle.md` in the repo root.
             If nothing testable on this lane changed, write exactly:
             "N/A — no CLI/API/MCP surface changed in this PR." Do NOT review the code, and do NOT


### PR DESCRIPTION
Fixes #2416.

## Summary
The PR-review evidence stage ran an agent with Bash while the OAuth token was in its env; on #2391 a connector OAuth flow → keyring → failed `dbus-launch` dumped the environment (incl. tokens) to the job log. Three independent guards so it can never recur:

- **Least privilege:** drop `github_token` from the evidence step (it only writes `evidence-bundle.md`, never posts).
- **No dbus:** `PYTHON_KEYRING_BACKEND=null` so keyring never spawns `dbus-launch`.
- **Prompt guard:** forbid `env`/`printenv`/`set`/`export $(...)`/`dbus-launch` and any auth/`gaia connectors connect`/keyring flow; auth-only surfaces are marked N/A.

The `gaia-testing` skill CI section carries the same rule. GitHub secret-masking stays a backstop, not the control.

## Already done (not in this diff)
- Deleted the job logs of the 3 affected evidence runs (now 404); no artifacts.
- Recommend rotating `CLAUDE_CODE_OAUTH_TOKEN`.

## Test plan
- [x] actionlint clean; YAML + skill frontmatter parse.
- [ ] Post-merge: re-trigger a connector PR (e.g. #2391) and confirm the evidence run emits no env to the log and still produces evidence.