### PR TITLE
fix(ci): run evidence stage via direct claude CLI, not the GitHub-coupled action

### DIFF
--- a/.github/workflows/claude-run.yml
+++ b/.github/workflows/claude-run.yml
@@ -229,10 +229,11 @@ jobs:
         run: pip install -e ".[dev]"
 
       # Generate evidence with a cheaper model; it ONLY writes the bundle, never comments.
-      # SECRET HARDENING: this step runs an agent with Bash while the OAuth token is in the
-      # environment. To keep a command from dumping that env to the log (a connector/keyring
-      # path did exactly this via a failed `dbus-launch` — issue #2416):
-      #   - no github_token (this step never posts — least privilege);
+      # Run the Claude CLI DIRECTLY (not claude-code-action): the action always initializes
+      # GitHub auth at startup and, given no token, falls back to OIDC and silently never runs
+      # (the #2417 regression, masked by continue-on-error). This step makes zero GitHub calls,
+      # so it carries NO github token at all — only the model OAuth token, which must exist.
+      # SECRET HARDENING (issue #2416): the agent runs Bash with that token in env, so —
       #   - PYTHON_KEYRING_BACKEND=null so keyring never spawns dbus-launch;
       #   - the prompt forbids auth/connector flows and any env-printing command.
       - name: Generate real-world evidence (gaia-testing skill)
@@ -240,12 +241,10 @@ jobs:
         if: steps.surface.outputs.testable == 'true'
         continue-on-error: true
         env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e  # v1.0.178
-        with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
+          EVIDENCE_PROMPT: |
             Follow the gaia-testing skill at `.claude/skills/gaia-testing/SKILL.md` (read it) to
             produce REAL-WORLD test evidence for ONLY the surfaces this PR changes. The changed
             files are in `pr-files.txt`; the diff is `pr-diff.txt`. This runner is `ubuntu-latest`
@@ -279,10 +278,28 @@ jobs:
             If nothing testable on this lane changed, write exactly:
             "N/A — no CLI/API/MCP surface changed in this PR." Do NOT review the code, and do NOT
             post any PR comment — writing the file is your only output.
-          claude_args: |
-            --max-turns 50
+        run: |
+          # claude-code pinned — bump deliberately. Direct CLI = no GitHub auth / no github token.
+          npm install -g @anthropic-ai/claude-code@2.1.218
+          claude -p "$EVIDENCE_PROMPT" \
+            --allowedTools "Read,Grep,Glob,Bash,Write" \
+            --max-turns 50 \
             --model claude-sonnet-5
-            --allowedTools Read,Grep,Glob,Bash,Write
+
+      # Fail loudly, don't mask: the step above is continue-on-error, so a broken evidence
+      # harness (auth / install / rate-limit) leaves NO bundle — which otherwise reads as
+      # "nothing to test". Write a visible sentinel so the review says the harness broke, not
+      # that the surface was clean. A silent-green evidence stage is exactly how #2417 hid.
+      - name: Flag evidence-harness failure (no silent green)
+        if: steps.surface.outputs.testable == 'true' && steps.evidence.outcome == 'failure'
+        run: |
+          {
+            echo "⚠️ EVIDENCE HARNESS FAILED TO RUN — this is NOT \"nothing to test\"."
+            echo
+            echo "The evidence stage errored before producing evidence (auth / install / rate-limit"
+            echo "— see this run's logs). The changed surface was NOT exercised; the verdict below"
+            echo "rests on static review only."
+          } > evidence-bundle.md
 
       # --- Attempt 1 ---
       # continue-on-error: a rate-limit / expired-token / outage / install-crash must


### PR DESCRIPTION
The PR-review real-world evidence stage has been **silently dead since #2417** — producing no evidence while every run stayed green. Dogfooding #2421 on #2402 surfaced it: the "evidence" verdicts since 16:01 UTC on 2026-07-23 had nothing real behind them.

Fixes #2429.

### Why this matters
- **Before:** #2417 dropped `github_token` from the evidence step for least-privilege, which forced `claude-code-action` onto OIDC. With no `id-token: write`, the action errored *before running the agent* — and `continue-on-error` painted it green. A whole class of PRs got an approve verdict with an empty evidence section.
- **After:** the step runs the Claude CLI **directly** (`claude -p`). It makes zero GitHub calls, so it carries **no GitHub token at all** — only the model OAuth token that must exist regardless. That both fixes the failure *and* advances #2416's goal of shrinking the secret surface, rather than re-adding a token. A **fail-loudly sentinel** now writes a visible "harness failed" bundle on error, so a dead harness can never again masquerade as "nothing to test".

The #2416 hardening that actually closes the leak (env-dump prompt guard + `PYTHON_KEYRING_BACKEND=null`) is unchanged.

<details>
<summary>Root-cause evidence</summary>

| Run | Time (UTC) | vs #2417 (16:01) | OIDC fail | Evidence |
|---|---|---|---|---|
| 30021795048 | 15:42 | before | 0 | ✅ real curl bundle |
| 30023992960 | 16:11 | after | 4 | ❌ agent never ran |
| 30031028923 | 17:49 | after | 4 | ❌ agent never ran |

```
##[error]Action failed with error: Could not fetch an OIDC token.
```
Verified locally that `claude -p --allowedTools "…Bash…"` executes shell headlessly with no token and no `--dangerously-skip-permissions`.
</details>

### Test plan
Can't self-test pre-merge — `pull_request_target` runs the base workflow, and this diff touches no `src/gaia`/`hub` surface, so the evidence gate won't fire on this PR (same constraint as #2414/#2415/#2417/#2421). Validation is post-merge on the exact regression case:

- [ ] Merge, then re-run #2402 and confirm the evidence step now **runs the agent** (no OIDC error) and the bundle carries **route evidence** for `system.py` + a **Spot regression** subsection.
- [ ] Confirm the run is leak-clean (env/token scan) and the step's env contains **no** `GITHUB_TOKEN`.
- [ ] Force a failure path once (or inspect) to confirm the sentinel writes the visible "harness failed" bundle.
- [x] `actionlint .github/workflows/claude-run.yml` — passes locally.