### PR TITLE
fix(agent-email): actionable copy for Lemonade-down /query errors

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -20,6 +20,17 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **`/query` Lemonade-down errors are now actionable, not a raw traceback (#2139).**
+  When the local LLM backend was unreachable, the `/query` SSE stream's terminal
+  `error` event led with the raw `requests`/`urllib3` exception repr, giving the
+  user no next step. The sidecar now classifies connection-shaped failures at the
+  error boundary and emits the standard guidance — Lemonade Server not reachable at
+  `<url>`; start it with `lemonade-server serve` (or `gaia init`); docs link —
+  keeping the original exception appended as `Technical details:` for debugging.
+  Every `/query` client (CLI, `gaia api`, third-party) benefits, not just the Agent
+  UI relay (which mitigated host-side in #2136). Unrelated errors pass through
+  verbatim, never masked behind a Lemonade message.
+
 - **Re-proposal dedup survives headless/scheduled teardown (#2381).**
   `record_proposal` wrote its dedup row through `query()`, which never commits,
   so when the scheduler rebuilt the agent between fires (closing the DB

--- a/hub/agents/email/python/gaia_agent_email/query_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/query_routes.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import asyncio
 import json
 import queue
+import re
 import threading
 import uuid
 from typing import Any, Dict, List, Optional
@@ -226,6 +227,111 @@ def _sse(event: Dict[str, Any]) -> str:
     return f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
 
 
+# ---------------------------------------------------------------------------
+# Terminal-error classification (issue #2139)
+# ---------------------------------------------------------------------------
+
+# Connection/timeout-shaped fragments of the ``requests`` / ``urllib3`` /
+# ``httpx`` error reprs a down or unreachable Lemonade Server produces. Those
+# transport errors are siblings of the builtin ``ConnectionError`` (under
+# ``OSError``, or under ``httpx.HTTPError``), so an ``isinstance`` check alone
+# misses them — the string shape is the reliable signal. Deliberately narrow:
+# a non-match falls through to the raw exception text so unrelated failures are
+# never masked behind a Lemonade message.
+_LEMONADE_DOWN_RE = re.compile(
+    r"connection\s+(?:refused|reset|aborted|error)"
+    r"|connectionerror"
+    r"|connection\s*pool"
+    r"|failed to establish a new connection"
+    r"|max retries exceeded"
+    r"|newconnectionerror"
+    r"|could\s*n[o']t\s+(?:reach|connect|resolve)"
+    r"|no route to host"
+    r"|name or service not known"
+    r"|not reachable"
+    r"|unreachable"
+    r"|(?:read |connect(?:ion)? )?timed?\s*out"
+    r"|timeout",
+    re.IGNORECASE,
+)
+
+#: Where a user looks next — kept as a constant so tests assert on it and the
+#: copy stays stable. Matches the sidecar's other Lemonade-down guidance
+#: (``api_routes._assert_lemonade_reachable``).
+_LEMONADE_DOCS_URL = "https://amd-gaia.ai/docs/guides/email"
+
+
+def _flatten_exception_text(exc: BaseException) -> str:
+    """Join ``str()`` of *exc* and its ``__cause__`` / ``__context__`` chain.
+
+    A transport error is often wrapped (``raise ... from e``), so the
+    connection-shaped detail can live on a cause rather than the outer
+    exception. Cycle-guarded against pathological exception graphs.
+    """
+    parts: List[str] = []
+    cur: Optional[BaseException] = exc
+    seen: set = set()
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        text = str(cur)
+        parts.append(text if text else type(cur).__name__)
+        cur = cur.__cause__ or cur.__context__
+    return "\n".join(parts)
+
+
+def _is_lemonade_unreachable(exc: BaseException) -> bool:
+    """True when *exc* (or its cause chain) is a Lemonade-unreachable failure.
+
+    Two signals: a builtin ``ConnectionError`` anywhere in the cause chain
+    (``ConnectionRefusedError`` / ``ConnectionResetError`` all subclass it),
+    and — for the ``requests`` / ``httpx`` / ``urllib3`` errors that are NOT
+    builtin ``ConnectionError`` subclasses — the connection-shaped repr.
+    """
+    cur: Optional[BaseException] = exc
+    seen: set = set()
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, ConnectionError):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return bool(_LEMONADE_DOWN_RE.search(_flatten_exception_text(exc)))
+
+
+def _terminal_error_detail(exc: BaseException) -> str:
+    """Build the ``agent_error`` content for a failed ``/query`` run.
+
+    A Lemonade-unreachable failure — the most common consumer failure — gets
+    the standard actionable guidance (what failed, what to do, where to look),
+    with the original exception appended (never replacing it) for debugging.
+    Every other exception passes through as ``str(exc)`` so a genuinely
+    unexpected failure is surfaced verbatim, not masked behind a Lemonade
+    message.
+    """
+    if not _is_lemonade_unreachable(exc):
+        return str(exc)
+
+    try:
+        from gaia_agent_email.model_select import _resolve_probe_base
+
+        target = _resolve_probe_base(None)
+    except Exception as resolve_exc:  # noqa: BLE001
+        # Naming the exact URL is cosmetic; never let message-building throw and
+        # lose the original error. Log so the resolution failure isn't silent.
+        logger.debug(
+            "could not resolve Lemonade base URL for error copy: %s", resolve_exc
+        )
+        target = "the local Lemonade Server"
+
+    raw = str(exc) or type(exc).__name__
+    return (
+        f"Local Lemonade Server is not reachable at {target}. The email agent "
+        "runs local inference, so it needs Lemonade Server running. Start it "
+        "with `lemonade-server serve` (or run `gaia init`), then retry. "
+        f"Docs: {_LEMONADE_DOCS_URL}"
+        f"\n\nTechnical details: {raw}"
+    )
+
+
 def _confirmation_refusal(action: str) -> Dict[str, Any]:
     """The terminal ``final`` that ends the stateless-stub confirmation flow (D1)."""
     return {
@@ -345,7 +451,12 @@ async def query(request: QueryRequest) -> StreamingResponse:
                 agent.process_query(user_query)
         except Exception as exc:  # surface loudly as a terminal error event
             logger.exception("email /query run failed for run_id=%s", run.run_id)
-            handler._emit({"type": "agent_error", "content": str(exc)})
+            # Lemonade-down is the most common failure; emit actionable copy
+            # (never the raw urllib3/requests repr) while leaving genuinely
+            # unexpected errors verbatim — see _terminal_error_detail (#2139).
+            handler._emit(
+                {"type": "agent_error", "content": _terminal_error_detail(exc)}
+            )
         finally:
             handler.signal_done()
 

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import json
 import threading
-import time
 import uuid
 
 import pytest
@@ -137,6 +136,57 @@ class _RaisingFakeAgent:
     def process_query(self, query, max_steps=None):
         self.console.print_processing_start(query, 20, "fake-model")
         raise RuntimeError("Lemonade Server is not reachable at http://localhost:13305")
+
+
+class _ConnectionErrorFakeAgent:
+    """Raises a realistic ``requests`` ConnectionError — the raw urllib3 repr a
+    user actually sees when Lemonade is down, NOT a hand-written friendly
+    string (issue #2139 acceptance)."""
+
+    def __init__(self):
+        self.conversation_history = []
+        self.console = None
+        self._cancel_event = None
+
+    def process_query(self, query, max_steps=None):
+        self.console.print_processing_start(query, 20, "fake-model")
+        import requests
+
+        raise requests.exceptions.ConnectionError(
+            "HTTPConnectionPool(host='localhost', port=8000): Max retries "
+            "exceeded with url: /api/v1/chat/completions (Caused by "
+            "NewConnectionError('<urllib3.connection.HTTPConnection object at "
+            "0x10a>: Failed to establish a new connection: [Errno 61] "
+            "Connection refused'))"
+        )
+
+
+class _BuiltinConnRefusedFakeAgent:
+    """Raises a builtin ``ConnectionRefusedError`` (an OS-level transport error,
+    not a friendly string) — classified by type, not string shape."""
+
+    def __init__(self):
+        self.conversation_history = []
+        self.console = None
+        self._cancel_event = None
+
+    def process_query(self, query, max_steps=None):
+        self.console.print_processing_start(query, 20, "fake-model")
+        raise ConnectionRefusedError(61, "Connection refused")
+
+
+class _UnrelatedErrorFakeAgent:
+    """Raises an error that has nothing to do with connectivity — it must pass
+    through verbatim, never masked behind Lemonade copy (issue #2139)."""
+
+    def __init__(self):
+        self.conversation_history = []
+        self.console = None
+        self._cancel_event = None
+
+    def process_query(self, query, max_steps=None):
+        self.console.print_processing_start(query, 20, "fake-model")
+        raise ValueError("triage produced malformed JSON at row 4")
 
 
 # ---------------------------------------------------------------------------
@@ -284,6 +334,94 @@ def test_run_failure_ends_with_terminal_error(app_client, monkeypatch):
     assert events[-1]["type"] == "error"
     assert events[-1]["status"] == 500
     assert "Lemonade" in events[-1]["detail"]
+
+
+def _assert_actionable_lemonade_detail(detail: str) -> None:
+    """The three-part actionable contract (#2139): what failed, what to do,
+    where to look."""
+    lower = detail.lower()
+    assert "lemonade server is not reachable" in lower  # what failed
+    # what to do — start it (either remediation is acceptable copy).
+    assert "lemonade-server serve" in lower or "gaia init" in lower
+    assert "amd-gaia.ai/docs/guides/email" in lower  # where to look
+
+
+def test_lemonade_down_connection_error_gets_actionable_detail(app_client, monkeypatch):
+    """A realistic requests ConnectionError → actionable guidance, with the raw
+    exception appended for debugging (not replacing it)."""
+    fake = _ConnectionErrorFakeAgent()
+    monkeypatch.setattr(query_routes, "build_query_agent", lambda **k: fake)
+    resp = app_client.post("/v1/email/query", json=_req())
+    assert resp.status_code == 200
+
+    events = _parse_sse(resp.text)
+    assert events[-1]["type"] == "error"
+    assert events[-1]["status"] == 500
+    detail = events[-1]["detail"]
+    _assert_actionable_lemonade_detail(detail)
+    # The original exception text is preserved for debugging — appended, never
+    # dropped (the guidance leads, the raw repr trails).
+    assert "Technical details:" in detail
+    assert "Connection refused" in detail
+    assert detail.lower().index("not reachable") < detail.index("Technical details:")
+
+
+def test_lemonade_down_builtin_connection_error_gets_actionable_detail(
+    app_client, monkeypatch
+):
+    """A builtin ConnectionRefusedError is classified by TYPE (its str carries
+    no 'Lemonade' token), proving detection isn't just substring luck."""
+    fake = _BuiltinConnRefusedFakeAgent()
+    monkeypatch.setattr(query_routes, "build_query_agent", lambda **k: fake)
+    resp = app_client.post("/v1/email/query", json=_req())
+    assert resp.status_code == 200
+
+    events = _parse_sse(resp.text)
+    assert events[-1]["type"] == "error"
+    _assert_actionable_lemonade_detail(events[-1]["detail"])
+    assert "Connection refused" in events[-1]["detail"]
+
+
+def test_unrelated_error_passes_through_unmasked(app_client, monkeypatch):
+    """A non-connectivity failure is surfaced verbatim — never rewritten as a
+    Lemonade message (no silent masking of unrelated bugs)."""
+    fake = _UnrelatedErrorFakeAgent()
+    monkeypatch.setattr(query_routes, "build_query_agent", lambda **k: fake)
+    resp = app_client.post("/v1/email/query", json=_req())
+    assert resp.status_code == 200
+
+    events = _parse_sse(resp.text)
+    assert events[-1]["type"] == "error"
+    assert events[-1]["status"] == 500
+    assert events[-1]["detail"] == "triage produced malformed JSON at row 4"
+    assert "Lemonade" not in events[-1]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Classification helper — pure-function coverage (no TestClient)
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_error_detail_classifies_wrapped_connection_cause():
+    """A transport error hidden behind ``raise ... from`` is still classified
+    unreachable — the cause chain is walked, not just ``str(exc)``."""
+    try:
+        raise ConnectionRefusedError(61, "Connection refused")
+    except ConnectionRefusedError as cause:
+        wrapped = RuntimeError("triage tool failed")
+        wrapped.__cause__ = cause
+
+    assert query_routes._is_lemonade_unreachable(wrapped) is True
+    detail = query_routes._terminal_error_detail(wrapped)
+    _assert_actionable_lemonade_detail(detail)
+    # The wrapper's own message is preserved in the appended technical details.
+    assert "triage tool failed" in detail
+
+
+def test_terminal_error_detail_leaves_unrelated_errors_verbatim():
+    exc = ValueError("some unrelated parse failure")
+    assert query_routes._is_lemonade_unreachable(exc) is False
+    assert query_routes._terminal_error_detail(exc) == "some unrelated parse failure"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2139

## Why this matters

When the local LLM backend (Lemonade Server) is down or unreachable — the single most common consumer failure — the email agent's streaming `/query` endpoint ended the run with the **raw `requests`/`urllib3` exception repr** as the terminal `error` detail. Users saw a `HTTPConnectionPool(... Connection refused)` dump with no idea what to do. PR #2136 fixed this **only** for the Agent UI (host-side relay); the CLI, `gaia api`, and any third-party `/query` client still got the raw traceback.

This is the root fix, sidecar-side, so **every** `/query` client gets the standard actionable guidance: *what failed* (Lemonade Server not reachable at `<url>`), *what to do* (start it / `gaia init`), *where to look* (docs) — with the original exception appended as `Technical details:` for debugging. Only connection-shaped failures are rewritten; genuinely-unexpected errors pass through verbatim, so nothing is masked.

## Evidence

**Real `/query` HTTP surface, before → after** (drove the actual route via `TestClient` with a realistic `requests.ConnectionError`):

Before — raw exception verbatim:
```json
{ "type": "error", "status": 500,
  "detail": "HTTPConnectionPool(host='localhost', port=8000): Max retries exceeded with url: /api/v1/chat/completions (Caused by NewConnectionError('...: Failed to establish a new connection: [Errno 61] Connection refused'))" }
```

After — actionable guidance, raw text preserved:
```json
{ "type": "error", "status": 500,
  "detail": "Local Lemonade Server is not reachable at http://localhost:13305/api/v1. The email agent runs local inference, so it needs Lemonade Server running. Start it with `lemonade-server serve` (or run `gaia init`), then retry. Docs: https://amd-gaia.ai/docs/guides/email\n\nTechnical details: HTTPConnectionPool(host='localhost', port=8000): Max retries exceeded ... [Errno 61] Connection refused" }
```

**Unit tests** — `hub/agents/email/python/tests/test_query_route.py` → **16 passed**. New coverage feeds *realistic* connection errors (per the issue's acceptance — not a hand-written friendly string): a `requests.ConnectionError` urllib3 repr, a builtin `ConnectionRefusedError` (classified by **type**, not substring), a wrapped `raise … from ConnectionError` (cause-chain walk), and a `ValueError` that must pass through **unmasked**.

## Test plan

- [x] `python -m pytest hub/agents/email/python/tests/test_query_route.py` → 16 passed
- [x] `black --check` + `isort --check` + `flake8` clean on changed files (also removed a pre-existing unused `import time` in the test file)
- [x] OpenAPI export + translator + capability-matrix suites green (157 passed; the 1 unrelated red is the known worktree editable-install artifact — installed dist metadata `0.1.0` vs source `AGENT_VERSION 0.5.0`, independent of this diff)

## Live-validation TODO (central sweep)

Deferred to the centralized milestone-59 live sweep (shared Lemonade/Agent-UI box is the orchestrator's):

- [ ] **Agent UI:** stop Lemonade Server, issue an email chat `/query`, confirm the error card shows the actionable "start Lemonade Server / `gaia init`" copy (not a raw exception), with `Technical details:` retained.
- [ ] **CLI (`gaia email` / `gaia api`):** with Lemonade stopped, issue a `/query`; confirm the terminal error event carries the actionable copy end-to-end.
- [ ] Sanity: with Lemonade **up**, a normal `/query` still streams a `final` (no false-positive rewrite).
