### PR TITLE
fix(email-agent): applying an existing label fails with 'Invalid label' (T14)

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -20,6 +20,17 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **Applying an existing label by its display name no longer fails with
+  `Invalid label` (#2428).** `label_message` / `move_to_label` (and their batch
+  variants) resolve a label's display name to its provider id via `list_labels`
+  before calling the backend — mirroring the quarantine-label resolver. The model
+  gets display names from `list_labels` and feeds them back into the apply call;
+  Gmail's modify API addresses user labels by id (`Label_###`) and rejected the
+  name, so the very label the agent had just enumerated as valid came back
+  `Invalid label: <name>`. Passing a raw id still works; resolution is memoized
+  per backend so a mixed Gmail+Outlook batch maps each message to its own
+  provider's id; a name matching no existing label now fails with an actionable
+  "here are your labels" error instead of Gmail's cryptic rejection.
 - **Re-proposal dedup survives headless/scheduled teardown (#2381).**
   `record_proposal` wrote its dedup row through `query()`, which never commits,
   so when the scheduler rebuilt the agent between fires (closing the DB

--- a/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
@@ -142,6 +142,54 @@ def remove_star_impl(
         return {"action_id": action_id, "message_id": message_id}
 
 
+def _resolve_label_id(
+    backend, label: str, cache: Optional[Dict[Any, Dict[str, str]]] = None
+) -> str:
+    """Resolve a label display name OR id to a concrete label id for ``backend``.
+
+    Gmail user labels are addressed by id (``Label_###``), not display name; the
+    modify API rejects a bare name with ``Invalid label: <name>``. ``list_labels``
+    returns both id and name, and the model feeds a name back into the apply call
+    (#2428) — so accept either: an exact id match passes through (already an id),
+    an exact display-name match resolves to its id, and a unique case-insensitive
+    match is the last resort (models vary label casing). Anything else fails loud —
+    never silently forwarded to the backend, never auto-created (this agent has no
+    create-label capability; the caller must reference an existing label).
+
+    ``cache`` (optional) memoizes resolutions **keyed by backend** so a batch that
+    reuses one backend hits ``list_labels`` once, not once per message. It MUST be
+    backend-keyed, not label-keyed: a mixed Gmail+Outlook batch resolves the same
+    name to a Gmail ``Label_###`` for one message and to the Outlook category name
+    (id == name) for another — a label-only key would cross-feed the wrong id.
+    """
+    label = label.strip()
+    if cache is not None and backend in cache and label in cache[backend]:
+        return cache[backend][label]
+    labels = backend.list_labels()
+    resolved: Optional[str] = None
+    if label in {lb.get("id") for lb in labels}:  # already a valid id
+        resolved = label
+    else:
+        for lb in labels:  # exact display-name match
+            if lb.get("name") == label:
+                resolved = lb.get("id")
+                break
+    if resolved is None:  # unique case-insensitive match (tolerate model casing)
+        ci = [lb for lb in labels if (lb.get("name") or "").lower() == label.lower()]
+        if len(ci) == 1:
+            resolved = ci[0].get("id")
+    if resolved is None:
+        names = sorted({lb.get("name") for lb in labels if lb.get("name")})
+        raise ValueError(
+            f"Invalid label: {label!r} — no existing label has that id or display "
+            f"name. Existing labels: {names}. Applying requires an existing label; "
+            "call list_labels to see valid names (this agent cannot create labels)."
+        )
+    if cache is not None:
+        cache.setdefault(backend, {})[label] = resolved
+    return resolved
+
+
 def label_message_impl(
     gmail,
     db,
@@ -156,6 +204,9 @@ def label_message_impl(
         {"message_id": message_id, "label_id": label_id},
         debug=debug,
     ) as st:
+        # Resolve a display name (what the model gets from list_labels) to the
+        # id Gmail's modify API requires; record the resolved id for undo (#2428).
+        label_id = _resolve_label_id(gmail, label_id)
         gmail.add_label(message_id, label_id)
         action_id = action_store.record_action(
             db,
@@ -191,6 +242,8 @@ def move_to_label_impl(
         {"message_id": message_id, "label_id": label_id},
         debug=debug,
     ) as st:
+        # Resolve a display name to the id Gmail requires before any call (#2428).
+        label_id = _resolve_label_id(gmail, label_id)
         if prior is None:
             prior = gmail.get_message(message_id)
         prior_labels = list(prior.get("labelIds", []))
@@ -351,6 +404,7 @@ def _run_batch(
     payload: dict | None = None,
     batch_id: str,
     debug: bool = False,
+    arg_resolver=None,
 ) -> dict:
     """Execute a mailbox mutation for each message_id, recording each action.
 
@@ -360,6 +414,12 @@ def _run_batch(
     positional args (e.g. the label id). ``action_mailbox(mid) -> str`` records
     which mailbox the action hit so undo routes correctly.
 
+    ``arg_resolver(backend) -> (op_args, payload)`` (optional) computes the
+    positional args and action payload per backend — used by the label batches to
+    resolve a display name to each provider's label id (#2428). When omitted, the
+    static ``op_args``/``payload`` are used unchanged (the mark/star/archive
+    batches are untouched).
+
     Returns ``{"succeeded": [...], "failed": [...]}``.
     """
     succeeded: list[dict] = []
@@ -367,12 +427,16 @@ def _run_batch(
     for mid in message_ids:
         try:
             backend = resolve_backend(mid)
-            getattr(backend, op_name)(mid, *op_args)
+            if arg_resolver is not None:
+                op_args_eff, payload_eff = arg_resolver(backend)
+            else:
+                op_args_eff, payload_eff = op_args, dict(payload or {})
+            getattr(backend, op_name)(mid, *op_args_eff)
             aid = action_store.record_action(
                 db,
                 action_type=action_type,
                 message_id=mid,
-                payload=dict(payload or {}),
+                payload=dict(payload_eff),
                 batch_id=batch_id,
                 mailbox=action_mailbox(mid) if action_mailbox else None,
             )
@@ -586,9 +650,12 @@ class OrganizeToolsMixin:
 
         @tool
         def label_message(message_id: str, label_id: str, mailbox: str = "") -> str:
-            """Add a label to a message. Pass the label id (e.g. ``Label_1``).
+            """Add a label to a message.
 
-            ``mailbox`` (optional) routes when multiple mailboxes are connected.
+            ``label_id`` may be the label's display name (e.g. ``Newsletters``, as
+            returned by ``list_labels``) or its id (e.g. ``Label_1``); the name is
+            resolved to an id automatically. ``mailbox`` (optional) routes when
+            multiple mailboxes are connected.
             """
             try:
                 if (err := _check_threshold()) is not None:
@@ -615,7 +682,9 @@ class OrganizeToolsMixin:
         def move_to_label(message_id: str, label_id: str, mailbox: str = "") -> str:
             """Move a message out of INBOX into a label.
 
-            ``mailbox`` (optional) routes when multiple mailboxes are connected.
+            ``label_id`` may be the label's display name or its id; the name is
+            resolved to an id automatically. ``mailbox`` (optional) routes when
+            multiple mailboxes are connected.
             """
             try:
                 if (err := _check_threshold()) is not None:
@@ -870,7 +939,12 @@ class OrganizeToolsMixin:
 
         @tool
         def label_message_batch(message_ids: list[str], label_id: str) -> str:
-            """Add a label to multiple messages in one call. Use for 3+ messages."""
+            """Add a label to multiple messages in one call. Use for 3+ messages.
+
+            ``label_id`` may be a label display name (e.g. ``Newsletters``) or an
+            id (e.g. ``Label_1``); the name is resolved to each message's provider
+            id automatically.
+            """
             if not message_ids:
                 return _envelope_ok({"total": 0, "succeeded": [], "failed": []})
             message_ids = _coerce_ids(message_ids)
@@ -879,18 +953,22 @@ class OrganizeToolsMixin:
             try:
                 batch_id = uuid.uuid4().hex
                 label_id_local = label_id  # closure capture
+                label_cache: dict = {}  # backend-keyed memo (see _resolve_label_id)
+
+                def _label_resolver(backend):
+                    resolved = _resolve_label_id(backend, label_id_local, label_cache)
+                    return (resolved,), {"label_id": resolved}
 
                 result = _run_batch(
                     _batch_backend,
                     db,
                     message_ids,
                     op_name="add_label",
-                    op_args=(label_id_local,),
                     action_type="add_label",
                     action_mailbox=_batch_provider,
-                    payload={"label_id": label_id_local},
                     batch_id=batch_id,
                     debug=debug_flag,
+                    arg_resolver=_label_resolver,
                 )
                 for _mid in message_ids:
                     agent._record_organize_op(_mid, "")
@@ -910,7 +988,11 @@ class OrganizeToolsMixin:
 
         @tool
         def move_to_label_batch(message_ids: list[str], label_id: str) -> str:
-            """Move multiple messages out of INBOX into a label in one call. Use for 3+ messages."""
+            """Move multiple messages out of INBOX into a label in one call. Use for 3+ messages.
+
+            ``label_id`` may be a label display name or an id; the name is
+            resolved to each message's provider id automatically.
+            """
             if not message_ids:
                 return _envelope_ok({"total": 0, "succeeded": [], "failed": []})
             message_ids = _coerce_ids(message_ids)
@@ -919,10 +1001,13 @@ class OrganizeToolsMixin:
             try:
                 batch_id = uuid.uuid4().hex
                 label_id_local = label_id
+                label_cache: dict = {}  # backend-keyed memo (see _resolve_label_id)
 
-                def _move_op(backend, mid: str) -> None:
-                    backend.add_label(mid, label_id_local)
+                def _move_op(backend, mid: str) -> str:
+                    resolved = _resolve_label_id(backend, label_id_local, label_cache)
+                    backend.add_label(mid, resolved)
                     backend.archive_message(mid)
+                    return resolved
 
                 def _move_prior_fn(msg: Dict[str, Any]) -> List[str]:
                     return list(msg.get("labelIds", []))
@@ -930,10 +1015,10 @@ class OrganizeToolsMixin:
                 def _move_payload_fn(
                     _msg: Dict[str, Any],
                     prior_labels: List[str],
-                    _op_result: Optional[Dict[str, Any]] = None,
+                    op_result: Optional[str] = None,
                 ) -> Dict[str, Any]:
                     return {
-                        "label_id": label_id_local,
+                        "label_id": op_result or label_id_local,
                         "prior_labels": prior_labels,
                     }
 

--- a/hub/agents/email/python/tests/test_label_resolution_2428.py
+++ b/hub/agents/email/python/tests/test_label_resolution_2428.py
@@ -1,0 +1,278 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Label-apply must resolve a display name to a label id before the backend call (#2428).
+
+Gmail user labels are addressed by id (``Label_###``), not display name; the
+modify API rejects a bare name with ``Invalid label: <name>``. The agent's
+``list_labels`` returns display names, the model feeds one back into the apply
+call, and the backend rejected it — even for the exact label the agent had just
+enumerated as valid.
+
+The fakes below REJECT an unknown label id exactly like the real Gmail modify
+API, so a passing test proves the apply path resolved the name to a valid id
+(not that a lenient stub accepted anything). ``_FakeOutlook`` models the other
+provider (categories: id == name) to guard the mixed-mailbox batch case.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from gaia_agent_email import action_store
+from gaia_agent_email.tools.organize_tools import (
+    OrganizeToolsMixin,
+    label_message_impl,
+    move_to_label_impl,
+)
+from gaia_agent_email.tools.read_tools import list_labels_impl
+
+from gaia.agents.base.tools import _TOOL_REGISTRY, get_tool_metadata
+from gaia.database.mixin import DatabaseMixin
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeGmail:
+    """Gmail-style label-by-id backend that rejects unknown ids like the real
+    ``messages.modify`` API (``Invalid label: <x>``)."""
+
+    def __init__(self):
+        self.messages = {
+            "m1": {"id": "m1", "labelIds": ["INBOX", "UNREAD"], "threadId": "t1"},
+            "m2": {"id": "m2", "labelIds": ["INBOX"], "threadId": "t2"},
+        }
+        self.labels = [
+            {"id": "INBOX", "name": "INBOX", "type": "system"},
+            {"id": "Label_7", "name": "GAIA-FIXTURE", "type": "user"},
+        ]
+        self.list_labels_calls = 0
+
+    def list_labels(self):
+        self.list_labels_calls += 1
+        return [dict(lb) for lb in self.labels]
+
+    def get_message(self, message_id):
+        m = self.messages[message_id]
+        return {
+            "id": message_id,
+            "labelIds": list(m["labelIds"]),
+            "threadId": m["threadId"],
+        }
+
+    def add_label(self, message_id, label_id):
+        if label_id not in {lb["id"] for lb in self.labels}:
+            raise ValueError(f"Invalid label: {label_id}")  # mirror Gmail modify API
+        labels = self.messages[message_id]["labelIds"]
+        if label_id not in labels:
+            labels.append(label_id)
+        return {"id": message_id}
+
+    def archive_message(self, message_id):
+        labels = self.messages[message_id]["labelIds"]
+        if "INBOX" in labels:
+            labels.remove("INBOX")
+        return {"id": message_id}
+
+
+class _FakeOutlook:
+    """Outlook-style category backend: ``list_labels`` returns id == name and
+    ``add_label`` takes the category string as-is (Outlook auto-creates it)."""
+
+    def __init__(self):
+        self.messages = {"m2": {"id": "m2", "labelIds": ["INBOX"], "threadId": "t2"}}
+        self.labels = [{"id": "GAIA-FIXTURE", "name": "GAIA-FIXTURE", "type": "user"}]
+        self.list_labels_calls = 0
+
+    def list_labels(self):
+        self.list_labels_calls += 1
+        return [dict(lb) for lb in self.labels]
+
+    def get_message(self, message_id):
+        m = self.messages[message_id]
+        return {
+            "id": message_id,
+            "labelIds": list(m["labelIds"]),
+            "threadId": m["threadId"],
+        }
+
+    def add_label(self, message_id, label_id):
+        labels = self.messages[message_id]["labelIds"]
+        if label_id not in labels:
+            labels.append(label_id)
+        return {"id": message_id}
+
+    def archive_message(self, message_id):
+        labels = self.messages[message_id]["labelIds"]
+        if "INBOX" in labels:
+            labels.remove("INBOX")
+        return {"id": message_id}
+
+
+class _DB(DatabaseMixin):
+    pass
+
+
+def _make_db():
+    db = _DB()
+    db.init_db(":memory:")
+    action_store.init_schema(db)
+    return db
+
+
+class _FakeAgent(OrganizeToolsMixin, DatabaseMixin):
+    """Minimal host that registers the real organize tool closures so tests can
+    drive them at the tool boundary (the surface the agent loop actually calls)."""
+
+    def __init__(self, backends, providers):
+        self.config = SimpleNamespace(debug=False, undo_window_seconds=30)
+        self._backends = backends
+        self._providers = providers
+        self.init_db(":memory:")
+        action_store.init_schema(self)
+        self._register_organize_tools()
+
+    def _organize_batch_threshold_exceeded(self):
+        return False
+
+    def _provider_for_message(self, message_id, mailbox=None):
+        return self._providers[message_id]
+
+    def _backend_for_message(self, message_id):
+        return self._backends[self._providers[message_id]]
+
+    def _record_organize_op(self, message_id, sender):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _preserve_tool_registry():
+    """Registering closures mutates the module-global tool registry; restore it
+    so this file can't perturb other suites when run together."""
+    snapshot = dict(_TOOL_REGISTRY)
+    yield
+    _TOOL_REGISTRY.clear()
+    _TOOL_REGISTRY.update(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# The fake must reproduce the real failure — otherwise a green test is hollow.
+# ---------------------------------------------------------------------------
+
+
+def test_fake_backend_rejects_display_name_like_real_gmail():
+    gmail = _FakeGmail()
+    with pytest.raises(ValueError, match="Invalid label"):
+        gmail.add_label("m1", "GAIA-FIXTURE")
+
+
+# ---------------------------------------------------------------------------
+# Resolver unit — display name / id / unknown / casing
+# (deferred import: the symbol does not exist at RED time)
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_maps_display_name_to_id():
+    from gaia_agent_email.tools.organize_tools import _resolve_label_id
+
+    assert _resolve_label_id(_FakeGmail(), "GAIA-FIXTURE") == "Label_7"
+
+
+def test_resolver_passes_through_valid_ids():
+    from gaia_agent_email.tools.organize_tools import _resolve_label_id
+
+    gmail = _FakeGmail()
+    assert _resolve_label_id(gmail, "Label_7") == "Label_7"
+    assert _resolve_label_id(gmail, "INBOX") == "INBOX"
+
+
+def test_resolver_unknown_label_fails_loud_and_lists_existing():
+    from gaia_agent_email.tools.organize_tools import _resolve_label_id
+
+    with pytest.raises(ValueError) as ei:
+        _resolve_label_id(_FakeGmail(), "DoesNotExist")
+    msg = str(ei.value)
+    assert "Invalid label" in msg
+    assert "GAIA-FIXTURE" in msg  # names the labels the caller can actually use
+
+
+def test_resolver_tolerates_casing_and_whitespace():
+    from gaia_agent_email.tools.organize_tools import _resolve_label_id
+
+    gmail = _FakeGmail()
+    assert _resolve_label_id(gmail, "gaia-fixture") == "Label_7"
+    assert _resolve_label_id(gmail, "  GAIA-FIXTURE  ") == "Label_7"
+
+
+# ---------------------------------------------------------------------------
+# Impl level — label_message / move_to_label resolve the name themselves
+# ---------------------------------------------------------------------------
+
+
+def test_label_message_impl_resolves_display_name():
+    gmail = _FakeGmail()
+    res = label_message_impl(
+        gmail, _make_db(), message_id="m1", label_id="GAIA-FIXTURE"
+    )
+    assert res["label_id"] == "Label_7"  # resolved id is what gets recorded for undo
+    assert "Label_7" in gmail.messages["m1"]["labelIds"]
+
+
+def test_move_to_label_impl_resolves_display_name():
+    gmail = _FakeGmail()
+    res = move_to_label_impl(
+        gmail, _make_db(), message_id="m1", label_id="GAIA-FIXTURE"
+    )
+    assert res["label_id"] == "Label_7"
+    assert "Label_7" in gmail.messages["m1"]["labelIds"]
+    assert "INBOX" not in gmail.messages["m1"]["labelIds"]  # moved out of inbox
+
+
+# ---------------------------------------------------------------------------
+# Tool boundary — AC-1 / AC-2: enumerate, then apply by display name
+# ---------------------------------------------------------------------------
+
+
+def test_label_message_tool_applies_enumerated_label_by_name():
+    gmail = _FakeGmail()
+    agent = _FakeAgent({"google": gmail}, {"m1": "google"})
+
+    # The agent enumerates labels and sees GAIA-FIXTURE as the custom label...
+    enumerated = list_labels_impl(gmail)
+    assert any(lb["name"] == "GAIA-FIXTURE" for lb in enumerated)
+
+    # ...then applies it BY THAT NAME. AC-1: succeeds. AC-2: never 'Invalid label'.
+    apply = get_tool_metadata("label_message")["function"]
+    out = json.loads(apply("m1", "GAIA-FIXTURE"))
+    assert out["ok"] is True, out
+    assert out["data"]["label_id"] == "Label_7"
+    assert "Label_7" in gmail.messages["m1"]["labelIds"]
+    assert "Invalid label" not in json.dumps(out)
+
+    del agent
+
+
+def test_label_message_batch_resolves_per_backend_without_cross_feed():
+    gmail = _FakeGmail()
+    outlook = _FakeOutlook()
+    agent = _FakeAgent(
+        {"google": gmail, "microsoft": outlook},
+        {"m1": "google", "m2": "microsoft"},
+    )
+
+    apply_batch = get_tool_metadata("label_message_batch")["function"]
+    out = json.loads(apply_batch(["m1", "m2"], "GAIA-FIXTURE"))
+
+    assert out["ok"] is True, out
+    assert len(out["data"]["succeeded"]) == 2
+    assert out["data"]["failed"] == []
+    # Each message gets ITS OWN provider's id — the name is resolved per backend.
+    assert "Label_7" in gmail.messages["m1"]["labelIds"]
+    assert "GAIA-FIXTURE" in outlook.messages["m2"]["labelIds"]
+    assert "Label_7" not in outlook.messages["m2"]["labelIds"]  # no cross-feed
+    # Memoized per backend: exactly one list_labels lookup each.
+    assert gmail.list_labels_calls == 1
+    assert outlook.list_labels_calls == 1
+
+    del agent

--- a/tests/unit/agents/test_email_agent_tools.py
+++ b/tests/unit/agents/test_email_agent_tools.py
@@ -597,9 +597,12 @@ class TestOrderingInvariantParameterized:
                 lambda gmail, db: archive_message_impl(gmail, db, message_id="nope"),
             ),
             (
+                # Use a real label so resolution (#2428) passes and the failure
+                # still lands at the Gmail mutation for the missing message —
+                # the ordering invariant this case exists to prove.
                 "label",
                 lambda gmail, db: label_message_impl(
-                    gmail, db, message_id="nope", label_id="Label_1"
+                    gmail, db, message_id="nope", label_id="STARRED"
                 ),
             ),
             (


### PR DESCRIPTION
Closes #2428

## Why this matters

Asking the email agent to file messages under a label you already have — "label these as `GAIA-FIXTURE`" — failed with `Invalid label: GAIA-FIXTURE`, even though the agent had *just* listed `GAIA-FIXTURE` as your only custom label. Gmail addresses user labels by an internal id (`Label_###`), not their display name, and its modify API rejects a bare name; the model reads a name from `list_labels` and feeds it straight back into the apply call, which the backend then rejected. So a valid, existing label could not be applied by the name the agent itself reported.

Now `label_message` / `move_to_label` (and their batch variants) resolve a display name to the provider's label id via `list_labels` before calling the backend — mirroring the existing quarantine-label resolver. Passing a raw id still works. A name that matches no existing label now fails with an actionable "here are your labels" message instead of Gmail's cryptic rejection. (Create-label remains intentionally absent — the fix only makes applying an *existing* label work.)

Resolution is memoized per backend, so a mixed Gmail+Outlook batch maps each message to its own provider's id (Gmail `Label_###` vs Outlook category name) with no cross-feed.

## Evidence

New unit suite `test_label_resolution_2428.py` — RED first (the fake Gmail backend rejects an unknown label id exactly like the real modify API, so the pre-fix code reproduced `Invalid label: GAIA-FIXTURE` at the tool boundary), GREEN after the fix:

```
test_fake_backend_rejects_display_name_like_real_gmail PASSED   # fake reproduces the bug
test_resolver_maps_display_name_to_id PASSED
test_resolver_passes_through_valid_ids PASSED
test_resolver_unknown_label_fails_loud_and_lists_existing PASSED
test_resolver_tolerates_casing_and_whitespace PASSED
test_label_message_impl_resolves_display_name PASSED
test_move_to_label_impl_resolves_display_name PASSED
test_label_message_tool_applies_enumerated_label_by_name PASSED  # AC-1/AC-2, at the tool boundary
test_label_message_batch_resolves_per_backend_without_cross_feed PASSED  # mixed-mailbox memo
9 passed in 0.95s
```

The key AC test registers the real tool closures on a minimal agent and drives the exact issue flow — enumerate labels (`list_labels` → `GAIA-FIXTURE`), then apply by that name — asserting the tool returns success and never `Invalid label`. Regression check: the four organize/trust/rest-contract/envelope/capability-matrix suites that exercise the shared batch runner and label paths stay green (**202 passed**), confirming the `_run_batch` extension is a no-op for the mark/star/archive batches.

Run locally against the worktree source (email package + gaia core both resolved from this branch):

```
PYTHONPATH=<wt>/src:<wt>/hub/agents/email/python \
  python -m pytest hub/agents/email/python/tests/test_label_resolution_2428.py -v
```

## Test plan

- [x] `test_label_resolution_2428.py` — 9/9 green (resolver, both single impls, both docstring/tool closures, mixed-backend batch)
- [x] No regression: `test_trust.py` + `test_rest_contract.py` + `test_capability_matrix.py` + `test_envelope.py` + new file → 202 passed
- [x] `black --check` + `flake8` clean on changed files
- [ ] Live sweep (deferred — see below)

## Live-validation TODO (central sweep)

Deferred to the centralized milestone-59 live sweep (shared box owned by the orchestrator); not run in this PR:

- **Agent UI:** ask the agent to label messages with an existing custom label by its **display name** (e.g. "label the newsletters as `GAIA-FIXTURE`"); confirm it applies successfully and returns no `Invalid label` for that name.
- **CLI / sidecar:** same request via the agent loop; confirm the label lands in Gmail and the tool result is success.
- Confirm a genuinely non-existent label now returns the actionable "here are your existing labels" error, not the cryptic Gmail rejection.
- Spot-check a **batch** apply ("label these 5 as `<name>`") resolves once and labels all five.

## Note on evals

No `gaia eval agent` run — this is backend/tool name→id **resolution** logic, not a system-prompt, tool-schema, model, or error-classification surface (the only prompt-facing touch is the four tool docstrings' "name or id" wording). No LLM-behavior surface changed.
