### PR TITLE
fix(email-agent): never auto-archive IMPORTANT / security-sender mail (#2426)

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -20,6 +20,14 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **IMPORTANT / account-security mail is never auto-archived unattended (#2426).**
+  At autonomy `full`, one cycle could auto-archive a provider-flagged IMPORTANT
+  message (e.g. a Google security alert) the local model mislabeled as promotional.
+  `TrustPolicy.decide` now applies a one-directional floor: an `archive` candidate
+  that is Gmail-`IMPORTANT` / Outlook high-importance, or from a narrow set of
+  account-security senders, is downgraded to a proposal at every level — a higher
+  level or earned trust can widen what runs silently but can never override it.
+  Ordinary promotional clutter still auto-archives.
 - **Re-proposal dedup survives headless/scheduled teardown (#2381).**
   `record_proposal` wrote its dedup row through `query()`, which never commits,
   so when the scheduler rebuilt the agent between fires (closing the DB

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -1218,6 +1218,7 @@ class EmailTriageAgent(
         without touching ``~/.gaia/goals.db``.
         """
         from gaia_agent_email.tools.read_tools import extract_sender_email
+        from gaia_agent_email.tools.triage_heuristics import LABEL_IMPORTANT
 
         from gaia.agents.base.goal_store import Proposal
 
@@ -1243,6 +1244,9 @@ class EmailTriageAgent(
                 continue
             tool_name, action_type = candidate
             sender = extract_sender_email(row.get("from", ""))
+            # #2426: never auto-archive a provider-IMPORTANT message — the guard
+            # in TrustPolicy.decide downgrades it to a proposal.
+            is_important = LABEL_IMPORTANT in (row.get("label_ids") or [])
             decision = policy.decide(
                 tool=tool_name,
                 action_type=action_type,
@@ -1250,6 +1254,7 @@ class EmailTriageAgent(
                 sender=sender,
                 db=self,
                 preferences=self._session_preferences,
+                is_important=is_important,
             )
             message_id = row.get("id")
             if decision.action == "auto":

--- a/hub/agents/email/python/gaia_agent_email/outlook_backend.py
+++ b/hub/agents/email/python/gaia_agent_email/outlook_backend.py
@@ -84,6 +84,7 @@ _LABEL_INBOX = "INBOX"
 _LABEL_UNREAD = "UNREAD"
 _LABEL_STARRED = "STARRED"
 _LABEL_SENT = "SENT"
+_LABEL_IMPORTANT = "IMPORTANT"
 
 # ``$select`` for ``get_message`` — pull exactly the fields the Gmail-shape
 # translation needs (Graph returns a large default projection otherwise).
@@ -177,6 +178,10 @@ def _derive_label_ids(msg: Dict[str, Any]) -> List[str]:
         labels.append(_LABEL_UNREAD)
     if ((msg.get("flag") or {}).get("flagStatus") or "") == "flagged":
         labels.append(_LABEL_STARRED)
+    # Graph ``importance:high`` is the Outlook equivalent of Gmail's IMPORTANT
+    # label — the auto-archive safety guard (#2426) keys off this string.
+    if (msg.get("importance") or "").strip().lower() == "high":
+        labels.append(_LABEL_IMPORTANT)
     for category in msg.get("categories") or []:
         if category:
             labels.append(category)

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -843,6 +843,10 @@ def triage_inbox_impl(
                 "thread_id": msg.get("threadId"),
                 "subject": payload_headers.get("subject", ""),
                 "from": payload_headers.get("from", ""),
+                # Provider system labels (Gmail labelIds / Outlook-derived) —
+                # the autonomy cycle reads the IMPORTANT flag off this to gate
+                # auto-archive (#2426).
+                "label_ids": list(msg.get("labelIds", [])),
                 "category": heuristic.category,
                 "is_spam": heuristic.is_spam,
                 "is_phishing": heuristic.is_phishing,

--- a/hub/agents/email/python/gaia_agent_email/trust.py
+++ b/hub/agents/email/python/gaia_agent_email/trust.py
@@ -37,6 +37,7 @@ MemoryStore; this ledger is the evidence those grants are earned from.
 
 from __future__ import annotations
 
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Mapping, Optional
@@ -282,6 +283,52 @@ def sender_scope(sender: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Auto-archive safety guard (#2426)
+# ---------------------------------------------------------------------------
+
+# Account-security / account-notification senders. A message from one of these
+# is never auto-archived unattended — even at ``full`` or on a fully-trusted
+# scope — because a mis-categorized security alert silently leaving the inbox
+# is the exact failure this guards against. Matched against the bare, lowercased
+# address. Deliberately conservative and provider-anchored (known account
+# domains + any ``accounts``/``account`` leading domain label + explicit
+# ``security``/``account-security`` local-parts) rather than broad (e.g. "any
+# no-reply@"), which would drown ``full`` mode in proposals. Downgrading to a
+# proposal is the safe failure mode, so bias toward catching a real security
+# sender over avoiding a stray proposal.
+_SECURITY_SENDER_DOMAINS = frozenset(
+    {
+        "id.apple.com",
+        "accountprotection.microsoft.com",
+    }
+)
+_SECURITY_LEADING_LABELS = frozenset({"accounts", "account"})
+_SECURITY_LOCALPART_RE = re.compile(r"^(?:security|account-security)(?:[-.+].*)?$")
+
+
+def is_security_sender(sender: str) -> bool:
+    """True when a sender is an account-security / account-notification address.
+
+    Anchored on a small set of known account domains, on any domain whose
+    leading label is ``accounts``/``account`` (``accounts.google.com``,
+    ``accounts.anybank.com``), and on a ``security``/``account-security``
+    local-part (exactly, or followed by a ``-``/``.``/``+`` separator — so
+    ``security@`` and ``security-alert@`` match but ``securityweekly@`` does
+    not). Case-insensitive; empty / address-less input is False.
+    """
+    addr = (sender or "").strip().lower().rstrip(">")
+    if "@" not in addr:
+        return False
+    local, _, domain = addr.partition("@")
+    domain = domain.strip()
+    if any(domain == d or domain.endswith("." + d) for d in _SECURITY_SENDER_DOMAINS):
+        return True
+    if domain.split(".", 1)[0] in _SECURITY_LEADING_LABELS:
+        return True
+    return bool(_SECURITY_LOCALPART_RE.match(local))
+
+
+# ---------------------------------------------------------------------------
 # TrustLedger — the earned-evidence tally
 # ---------------------------------------------------------------------------
 
@@ -452,11 +499,15 @@ class TrustPolicy:
         sender: str = "",
         db: Any = None,
         preferences: Optional[Mapping[str, Any]] = None,
+        is_important: bool = False,
     ) -> TrustDecision:
         """Return the disposition for one candidate action.
 
         ``tool`` is the tool name (checked against the floor); ``action_type``
-        is the taxonomy key (``archive``, ``draft_reply``, …).
+        is the taxonomy key (``archive``, ``draft_reply``, …). ``is_important``
+        is the provider's importance flag (Gmail ``IMPORTANT`` label / Outlook
+        high-importance): when set, an ``archive`` candidate is downgraded to a
+        proposal rather than auto-executed (#2426), at every autonomy level.
         """
         # 1. Inviolable floor — no level, trust score, or preference lowers it.
         if tool in self.confirm_floor:
@@ -491,6 +542,26 @@ class TrustPolicy:
         if self.level == LEVEL_SUGGEST:
             return TrustDecision(
                 "suggest", reason="autonomy level is suggest-only", confidence=0.0
+            )
+
+        # 5.5 Importance / security-sender guard (#2426): never auto-archive,
+        # unattended, a message the provider marked IMPORTANT or one from an
+        # account-security / notification sender — a mis-categorized security
+        # alert must be PROPOSED, not silently archived. One-directional, like
+        # the send/delete confirm-floor: a higher level or a fully-trusted scope
+        # can never override it. Scoped to ``archive`` (the visibility-removing
+        # action, and the only action the candidate map emits); widen this if
+        # the candidate map grows other visibility-affecting actions.
+        if action_type == "archive" and (is_important or is_security_sender(sender)):
+            why = (
+                "provider-flagged IMPORTANT"
+                if is_important
+                else "account-security / notification sender"
+            )
+            return TrustDecision(
+                "suggest",
+                reason=f"{why} — proposed for your review, not auto-archived",
+                confidence=0.0,
             )
 
         # 6. full level auto-executes every reversible action.

--- a/hub/agents/email/python/tests/test_email_autonomy_cycle.py
+++ b/hub/agents/email/python/tests/test_email_autonomy_cycle.py
@@ -90,6 +90,37 @@ def _urgent_message(message_id: str, sender: str) -> dict:
     }
 
 
+def _security_important_message(
+    message_id: str, sender: str = "no-reply@accounts.google.com"
+) -> dict:
+    """A provider-IMPORTANT message from an account-security sender that triage
+    (mis)classifies PROMOTIONAL — the #2426 auto-archive trap.
+
+    The ``IMPORTANT`` + ``CATEGORY_PROMOTIONS`` label pair makes the heuristic
+    confidently PROMOTIONAL (an archive candidate) with no LLM, while the
+    ``IMPORTANT`` label and the account-security sender are exactly what the
+    guard must refuse to auto-archive. Subject/snippet are deliberately benign
+    (no urgent/commitment/phishing keywords) so the confident-PROMOTIONAL
+    short-circuit is not vetoed.
+    """
+    internal_ms = int(time.time() * 1000)
+    return {
+        "id": message_id,
+        "threadId": f"thread_{message_id}",
+        "labelIds": ["INBOX", "UNREAD", "IMPORTANT", "CATEGORY_PROMOTIONS"],
+        "internalDate": str(internal_ms),
+        "snippet": "Here is a summary of recent activity on your account.",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": f"Google <{sender}>"},
+                {"name": "Subject", "value": "Your Google Account: monthly summary"},
+                {"name": "Message-ID", "value": f"<{message_id}@accounts.google.com>"},
+                {"name": "Date", "value": "Mon, 12 Jun 2026 10:00:00 +0000"},
+            ],
+        },
+    }
+
+
 def _build_agent(tmp_path: Path, messages, *, level: str, **cfg_kw) -> EmailTriageAgent:
     backend = FakeGmailBackend(user_email="me@example.com")
     for msg in messages:
@@ -235,6 +266,63 @@ def test_mixed_inbox_splits_correctly(tmp_path):
     executed_ids = {e["message_id"] for e in report["executed"]}
     assert executed_ids == {"p1"}
     assert report["skipped"] == 1
+
+
+def test_full_cycle_never_auto_archives_important_security_message(tmp_path):
+    """#2426 (AC-1/2/3): at ``full``, a provider-IMPORTANT message from an
+    account-security sender that triage mis-labels PROMOTIONAL must be PROPOSED,
+    not auto-archived — while ordinary promo clutter still auto-archives."""
+    agent = _build_agent(
+        tmp_path,
+        [
+            _promo_message("p1", "deals@shop.com"),
+            _security_important_message("s1"),
+        ],
+        level=LEVEL_FULL,
+    )
+    report = agent._run_email_autonomy_cycle()
+
+    executed_ids = {e["message_id"] for e in report["executed"]}
+    assert executed_ids == {"p1"}, "ordinary promo should still auto-archive"
+    assert "s1" not in executed_ids, "IMPORTANT security mail must NOT auto-archive"
+
+    proposed = " ".join(p.action for p in report["proposals"])
+    assert "s1" in proposed, "the IMPORTANT security message must be proposed"
+
+    # AC-3: it survived in the inbox.
+    assert "INBOX" in agent._gmail.get_message("s1").get("labelIds", [])
+
+
+def test_full_cycle_security_sender_without_important_still_proposed(tmp_path):
+    """#2426 (AC-2 standalone): an account-security sender is never auto-archived
+    unattended even without the provider IMPORTANT label."""
+    msg = _security_important_message("s2")
+    # Drop the IMPORTANT label — the security sender alone must still gate it.
+    msg["labelIds"] = ["INBOX", "UNREAD", "CATEGORY_PROMOTIONS"]
+    agent = _build_agent(tmp_path, [msg], level=LEVEL_FULL)
+    report = agent._run_email_autonomy_cycle()
+
+    assert report["executed"] == []
+    assert len(report["proposals"]) == 1
+    assert "INBOX" in agent._gmail.get_message("s2").get("labelIds", [])
+
+
+def test_triage_row_carries_label_ids(tmp_path):
+    """The autonomy guard reads the provider IMPORTANT flag off ``row['label_ids']``.
+    Lock the plumbing so a future triage edit can't silently drop it and disable
+    the guard."""
+    agent = _build_agent(
+        tmp_path,
+        [_promo_message("p1", "deals@shop.com"), _security_important_message("s1")],
+        level=LEVEL_OFF,
+    )
+    triage = agent._triage_all_backends(max_messages=10)
+    rows = triage["results"]
+    assert rows, "expected triage rows"
+    for row in rows:
+        assert isinstance(row.get("label_ids"), list), row
+    by_id = {r["id"]: r for r in rows}
+    assert "IMPORTANT" in by_id["s1"]["label_ids"]
 
 
 # ---------------------------------------------------------------------------

--- a/hub/agents/email/python/tests/test_outlook_graph_query_shape.py
+++ b/hub/agents/email/python/tests/test_outlook_graph_query_shape.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import httpx
 import pytest
-
-from gaia_agent_email.outlook_backend import LiveOutlookBackend
+from gaia_agent_email.outlook_backend import (
+    LiveOutlookBackend,
+    graph_message_to_gmail,
+)
 
 
 def _backend(handler):
@@ -87,6 +89,32 @@ def test_get_thread_sorts_messages_ascending_client_side():
 
     ids = [m["id"] for m in thread["messages"]]
     assert ids == ["older", "newer"]
+
+
+@pytest.mark.parametrize(
+    "importance, expect_important",
+    [
+        ("high", True),
+        ("High", True),
+        ("normal", False),
+        ("low", False),
+        (None, False),
+    ],
+)
+def test_graph_high_importance_maps_to_important_label(importance, expect_important):
+    """#2426 (AC-1, Outlook equivalent): a Graph high-importance message carries
+    the ``IMPORTANT`` label the auto-archive guard keys off; normal/low/absent
+    importance does not."""
+    msg = {
+        "id": "m1",
+        "conversationId": "c1",
+        "isRead": True,
+        "receivedDateTime": "2026-07-16T12:00:00Z",
+    }
+    if importance is not None:
+        msg["importance"] = importance
+    label_ids = graph_message_to_gmail(msg)["labelIds"]
+    assert ("IMPORTANT" in label_ids) is expect_important
 
 
 if __name__ == "__main__":

--- a/hub/agents/email/python/tests/test_trust.py
+++ b/hub/agents/email/python/tests/test_trust.py
@@ -24,6 +24,7 @@ from gaia_agent_email.trust import (  # noqa: E402
     TrustLedger,
     TrustPolicy,
     category_scope,
+    is_security_sender,
     sender_scope,
 )
 
@@ -299,6 +300,124 @@ def test_earn_trust_negative_evidence_keeps_suggesting(db):
     assert d.confidence == pytest.approx(5 / 8)
 
 
+# ---------------------------------------------------------------------------
+# #2426 — the auto-archive importance / security-sender guard
+# ---------------------------------------------------------------------------
+
+
+def test_full_level_never_auto_archives_important(db):
+    """A provider-IMPORTANT message is proposed, not auto-archived, even at full."""
+    policy = _policy(LEVEL_FULL)
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        sender="deals@shop.com",
+        db=db,
+        is_important=True,
+    )
+    assert d.action == "suggest"
+    assert "IMPORTANT" in d.reason
+
+
+def test_full_level_never_auto_archives_security_sender(db):
+    """An account-security sender is never auto-archived unattended, even at full."""
+    policy = _policy(LEVEL_FULL)
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        sender="no-reply@accounts.google.com",
+        db=db,
+        is_important=False,
+    )
+    assert d.action == "suggest"
+    assert "security" in d.reason.lower()
+
+
+def test_earn_trust_important_beats_ledger_trust(db):
+    """The importance guard overrides an already-earned (ledger-trusted) scope."""
+    policy = _policy(LEVEL_EARN_TRUST, db_min=3, threshold=0.85)
+    scope = sender_scope("deals@shop.com")
+    for _ in range(3):
+        TrustLedger.record_outcome(
+            db, action_type="archive", scope=scope, positive=True
+        )
+    # Without the guard this would be `auto` (trusted). With it: proposed.
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        sender="deals@shop.com",
+        db=db,
+        is_important=True,
+    )
+    assert d.action == "suggest"
+
+
+def test_earn_trust_important_beats_explicit_preference(db):
+    """The importance guard overrides even an explicit low-priority-sender pref."""
+    policy = _policy(LEVEL_EARN_TRUST)
+    prefs = {"low_priority_senders": {"deals@shop.com"}, "category_defaults": {}}
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        sender="deals@shop.com",
+        db=db,
+        preferences=prefs,
+        is_important=True,
+    )
+    assert d.action == "suggest"
+
+
+def test_full_level_still_auto_archives_normal_sender(db):
+    """The guard is narrow: an ordinary, non-important sender still auto-archives."""
+    policy = _policy(LEVEL_FULL)
+    d = policy.decide(
+        tool="archive_message",
+        action_type="archive",
+        sender="deals@shop.com",
+        db=db,
+        is_important=False,
+    )
+    assert d.action == "auto"
+
+
+def test_importance_guard_does_not_lower_send_floor(db):
+    """The importance guard never touches the destructive confirm-floor — a floor
+    tool stays ``confirm`` regardless of the IMPORTANT flag."""
+    policy = _policy(LEVEL_FULL)
+    d = policy.decide(
+        tool="send_now",
+        action_type="send",
+        sender="no-reply@accounts.google.com",
+        db=db,
+        is_important=True,
+    )
+    assert d.action == "confirm"
+
+
+@pytest.mark.parametrize(
+    "sender, expected",
+    [
+        ("no-reply@accounts.google.com", True),
+        ("noreply@accounts.anybank.com", True),
+        ("security@company.com", True),
+        ("account-security@example.org", True),
+        ("security-alert@bank.com", True),
+        ("foo@id.apple.com", True),
+        ("alerts@accountprotection.microsoft.com", True),
+        ("No-Reply@Accounts.Google.Com", True),  # case-insensitive
+        ("deals@shop.com", False),
+        ("boss@company.com", False),
+        ("newsletters@techcrunch.com", False),
+        ("securityweekly@news.com", False),  # not the exact 'security' local-part
+        ("accounts-payable@vendor.com", False),  # billing, not account-security
+        ("", False),
+        ("not-an-email", False),
+    ],
+)
+def test_is_security_sender_matrix(sender, expected):
+    assert is_security_sender(sender) is expected
+
+
 def test_policy_rejects_unknown_level():
     with pytest.raises(ValueError):
         TrustPolicy(level="turbo", ledger=TrustLedger(), confirm_floor=FLOOR)
@@ -339,7 +458,5 @@ def test_record_proposal_commits_across_connection_teardown(tmp_path):
     # Fire 2: fresh agent against the same DB must see the earlier proposal.
     second = _DB()
     second.init_db(db_path)
-    assert trust.has_open_proposal(
-        second, message_id="msg-1", action_type="archive"
-    )
+    assert trust.has_open_proposal(second, message_id="msg-1", action_type="archive")
     second.close_db()


### PR DESCRIPTION
Closes #2426

## Why this matters

At autonomy `full`, one observe→decide→act cycle auto-archived a Gmail-flagged **IMPORTANT** Google security alert (`no-reply@accounts.google.com`) along with newsletters — the local model mislabeled it as promotional clutter, and `full` auto-executes every reversible candidate with no importance check. After this change, a message the provider marks IMPORTANT (Gmail `IMPORTANT` / Outlook high-importance) or one from an account-security / notification sender is **proposed for review, never auto-archived** — at every autonomy level, even on a fully-trusted or explicitly-preferred scope. Ordinary promotional clutter still auto-archives exactly as before.

The guard lives in `TrustPolicy.decide` as a one-directional floor: a higher level or earned trust can widen what runs silently but can never override it — the same shape as the existing send/delete confirm-floor. The provider label is plumbed onto the triage row so the cycle can consult it, and Outlook maps Graph `importance:high` onto the same `IMPORTANT` label the guard keys off. The security-sender matcher is deliberately narrow (known account domains + an `accounts`/`account` leading label + exact `security`/`account-security` local-parts) so `full` mode isn't drowned in proposals.

Deliberately out of scope: the issue's optional *category-confidence floor*. The two hard guards satisfy all three ACs directly; a confidence floor is a broader mitigation of the mis-categorization root cause and is better tracked as a follow-up.

## Acceptance criteria

- [x] **AC-1** — a provider-IMPORTANT message is never auto-archived at any autonomy level; it is proposed.
- [x] **AC-2** — a security / account-notification sender is never auto-archived unattended.
- [x] **AC-3** — a `full` cycle over a mixed inbox with one IMPORTANT message asserts it survives in the inbox (fake backend, no OAuth).

## Evidence (local, hermetic — fake Gmail backend, no LLM/OAuth)

Run in a per-worktree venv with core + email installed editable from this worktree (import paths verified to resolve inside the worktree, not a stale shared `.venv`).

**RED→GREEN:** the three headline cycle tests fail on the unpatched code (the IMPORTANT security message *is* auto-archived) and pass after the fix:

```
3 failed   # before the fix — proves the bug + the tests catch it
3 passed   # after the fix
```

Suite totals:

```
trust + autonomy + outlook suites .......... 107 passed
full hub email suite (regression) .......... 867 passed
```

New tests (all PASSED):

- `test_trust.py` — `test_full_level_never_auto_archives_important`, `…_security_sender`, `test_earn_trust_important_beats_ledger_trust`, `…_explicit_preference`, `test_full_level_still_auto_archives_normal_sender`, `test_importance_guard_does_not_lower_send_floor`, `test_is_security_sender_matrix` (15 cases incl. `security@`✓ vs `securityweekly@`✗, `accounts-payable@`✗).
- `test_email_autonomy_cycle.py` — `test_full_cycle_never_auto_archives_important_security_message` (**AC-1/2/3**), `test_full_cycle_security_sender_without_important_still_proposed` (**AC-2**), `test_triage_row_carries_label_ids` (locks the plumbing).
- `test_outlook_graph_query_shape.py` — `test_graph_high_importance_maps_to_important_label` (5 cases, **AC-1 Outlook**).

Lint: `black`, `isort`, `flake8` (repo flags: `--max-line-length=88 --extend-ignore=E203,W503,E501,…`) clean on all changed files.

No `gaia eval agent` run — this is a guard/logic change, not a prompt or tool-schema surface, so agent-eval behavior is unaffected.

## Live-validation TODO (central sweep)

Deferred to the centralized milestone-59 live sweep (one shared box serves all issues; not run here to avoid parallel-sidecar collisions). This PR stays **draft** until these pass on hardware:

- **Agent UI** — run a `full` autonomy cycle over an inbox containing one Gmail-IMPORTANT security email (e.g. `no-reply@accounts.google.com`); assert it stays in the inbox and appears as a *proposal*, while ordinary newsletters still auto-archive.
- **CLI / REST** — `POST /v1/email/agent/autonomy/run` at level `full`, `max_messages=5`, over the same mixed inbox; assert the IMPORTANT / security message is **not** in the executed-archive list, **is** surfaced as a proposal, and its Gmail `labelIds` still include `INBOX`.
- **Outlook (if a mailbox is available)** — repeat with a high-importance Outlook message to exercise the `importance:high` → `IMPORTANT` mapping.
