### PR TITLE
fix(daemon): re-forward OAuth tokens on expiry so sidecars self-recover

### DIFF
--- a/hub/agents/email/python/gaia_agent_email/gmail_backend.py
+++ b/hub/agents/email/python/gaia_agent_email/gmail_backend.py
@@ -429,16 +429,42 @@ class LiveGmailBackend:
         token = self._access_token_fn()
         return {"Authorization": f"Bearer {token}"}
 
+    @staticmethod
+    def _unauthorized_message(where: str) -> str:
+        """401 remediation, mode-aware (#2159).
+
+        In forwarded mode the connection is valid host-side — the daemon owns
+        the refresh token and re-forwards fresh access tokens automatically — so
+        a 401 means the forwarded token went stale, NOT that the user must
+        reconnect. Telling them to reconnect (as the single old message did)
+        sends them down a dead end while the daemon's re-forward timer fixes it
+        on its own. Standalone mode keeps the reconnect guidance because there
+        the sidecar owns its own OAuth.
+        """
+        from gaia_agent_email import forwarded_credentials
+
+        if forwarded_credentials.is_forwarding_enabled():
+            return (
+                "Gmail API returned 401 with a daemon-forwarded token. The "
+                "connection is still valid host-side — the daemon re-forwards a "
+                "fresh access token automatically, so no reconnect is needed; "
+                "retry in a moment. If it persists, the Google connection may "
+                "have been revoked — check Settings → Connectors. (where: "
+                + where
+                + ")"
+            )
+        return (
+            "Gmail API returned 401. The access token may have expired or "
+            "scopes were revoked. Reconnect Google in Settings → Connectors. "
+            "(where: " + where + ")"
+        )
+
     def _raise_http(self, response: httpx.Response, where: str) -> None:
         # Construct the error message from status + truncated body ONLY.
         # Never from the wrapper exception, which would expose the
         # Authorization header.
         if response.status_code == 401:
-            raise ConnectorsError(
-                "Gmail API returned 401. The access token may have expired or "
-                "scopes were revoked. Reconnect Google in Settings → "
-                "Connectors. (where: " + where + ")"
-            )
+            raise ConnectorsError(self._unauthorized_message(where))
         enable_url = access_not_configured_url(response)
         if enable_url:
             raise ConnectorsError(

--- a/hub/agents/email/python/tests/test_forwarded_credentials.py
+++ b/hub/agents/email/python/tests/test_forwarded_credentials.py
@@ -98,6 +98,23 @@ def test_get_expired_token_raises_loudly():
     assert "expired" in str(exc.value).lower()
 
 
+def test_reforward_overwrites_expired_and_recovers(monkeypatch):
+    """The daemon re-forward timer (#2388/#2159) overwrites an about-to-expire
+    forwarded token with a fresh one; the sidecar recovers WITHOUT a restart.
+    This is the store-layer half of the self-recovery guarantee."""
+    # An expired token poisons reads (the ~1h/~2.6h failure state).
+    forwarded_credentials.set_forwarded(
+        "google", access_token="stale", scopes=["s1"], expires_at=_PAST
+    )
+    with pytest.raises(ConnectorsError):
+        forwarded_credentials.get_forwarded_token("google", ["s1"])
+    # The daemon re-forwards a fresh token to the same intake -> instant recovery.
+    forwarded_credentials.set_forwarded(
+        "google", access_token="fresh", scopes=["s1"], expires_at=_FUTURE
+    )
+    assert forwarded_credentials.get_forwarded_token("google", ["s1"]) == "fresh"
+
+
 def test_get_scope_short_token_raises_and_names_missing():
     forwarded_credentials.set_forwarded(
         "google", access_token="tok", scopes=["s1"], expires_at=_FUTURE

--- a/hub/agents/email/python/tests/test_gmail_backend.py
+++ b/hub/agents/email/python/tests/test_gmail_backend.py
@@ -1,0 +1,61 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Spec for LiveGmailBackend's 401 remediation message (issue #2159 defect 2).
+
+At long sidecar uptime a forwarded token can go stale and Gmail returns 401. The
+old single message told the user to "Reconnect Google" — but in the daemon
+(forwarded) deployment the connection is valid host-side; reconnecting is a dead
+end while the daemon's re-forward timer fixes it automatically. The message must
+be mode-aware: forwarded mode → "no reconnect needed, daemon re-forwards";
+standalone mode → keep the reconnect guidance. Never leak the bearer token.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from gaia_agent_email import forwarded_credentials
+from gaia_agent_email.gmail_backend import LiveGmailBackend
+
+from gaia.connectors.errors import ConnectorsError
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.delenv(forwarded_credentials.FORWARDED_MODE_ENV_VAR, raising=False)
+    forwarded_credentials.reset()
+    yield
+    forwarded_credentials.reset()
+
+
+def _backend_returning_401():
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="Invalid Credentials")
+
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    return LiveGmailBackend(
+        access_token_fn=lambda: "forwarded-access-token", http_client=client
+    )
+
+
+def test_401_in_forwarded_mode_says_no_reconnect_needed(monkeypatch):
+    monkeypatch.setenv(forwarded_credentials.FORWARDED_MODE_ENV_VAR, "1")
+    backend = _backend_returning_401()
+    with pytest.raises(ConnectorsError) as exc:
+        backend.list_messages(max_results=1)
+    msg = str(exc.value)
+    assert "no reconnect" in msg.lower()
+    assert "re-forward" in msg.lower()
+    # Never leak the token.
+    assert "forwarded-access-token" not in msg
+
+
+def test_401_in_standalone_mode_says_reconnect(monkeypatch):
+    monkeypatch.delenv(forwarded_credentials.FORWARDED_MODE_ENV_VAR, raising=False)
+    backend = _backend_returning_401()
+    with pytest.raises(ConnectorsError) as exc:
+        backend.list_messages(max_results=1)
+    msg = str(exc.value)
+    assert "Reconnect Google" in msg
+    assert "forwarded-access-token" not in msg

--- a/src/gaia/daemon/forward_refresh.py
+++ b/src/gaia/daemon/forward_refresh.py
@@ -23,10 +23,11 @@ a freshly-refreshed token is always re-forwarded in time.
 Fail loudly, no silent fallbacks (CLAUDE.md): the per-tick loop is resilient
 (one wedged sidecar or a transient blip must not kill the timer and end recovery
 for all sidecars), but nothing is swallowed silently — every failure is logged
-with context and ``exc_info``. A revoked connection surfaces loudly through the
-forwarder (it withdraws the stale forward so the sidecar cannot keep running on
-it) and the sidecar's own resolver still raises an actionable error at
-mailbox-use time if a token never arrives.
+with context and ``exc_info``. A revoked or disconnected provider stops being
+re-forwarded — its per-tick ``forward_all`` reports the error (logged loudly),
+this timer never fabricates a token to keep it alive, and the sidecar's own
+resolver still raises an actionable error at mailbox-use time once the last
+forwarded token expires.
 """
 
 from __future__ import annotations

--- a/src/gaia/daemon/forward_refresh.py
+++ b/src/gaia/daemon/forward_refresh.py
@@ -1,0 +1,190 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""OAuth re-forward timer — keep every running sidecar's forwarded connector
+access tokens fresh (issues #2388 / #2159).
+
+The daemon forwards SHORT-LIVED access tokens to a sidecar only at spawn time
+(``SidecarRegistry._fire_started`` -> ``forward.ConnectionForwarder.forward_all``).
+Nothing re-forwarded them afterwards, so once the forwarded token expired (~1h;
+observed dying at ~2.6h continuous uptime) every Gmail/Graph call the sidecar
+made returned 401 and the sidecar never self-recovered — only a restart fixed
+it. Both ``forward.py`` and the sidecar's ``forwarded_credentials`` module
+already documented a re-forward that was never actually implemented; this module
+is it.
+
+Design (§0.6 role inversion): the daemon stays the single owner of the long-lived
+refresh token. This timer periodically re-mints (via the connectors token cache,
+which only performs a real OAuth refresh when the cached access token is near
+expiry) and re-forwards each granted+connected provider to the sidecar's intake,
+overwriting the about-to-expire token minutes before the sidecar's own 30s expiry
+buffer would trip. Because the interval is kept well below the access-token TTL,
+a freshly-refreshed token is always re-forwarded in time.
+
+Fail loudly, no silent fallbacks (CLAUDE.md): the per-tick loop is resilient
+(one wedged sidecar or a transient blip must not kill the timer and end recovery
+for all sidecars), but nothing is swallowed silently — every failure is logged
+with context and ``exc_info``. A revoked connection surfaces loudly through the
+forwarder (it withdraws the stale forward so the sidecar cannot keep running on
+it) and the sidecar's own resolver still raises an actionable error at
+mailbox-use time if a token never arrives.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Callable
+
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Re-forward cadence. MUST stay well below the shortest expected access-token TTL
+# (~1h) so the connectors token cache's freshly-refreshed token reaches the
+# sidecar minutes before its 30s expiry buffer trips. 5 minutes gives ~12
+# re-forwards per hour of lead. Re-minting a still-valid token is cheap and
+# idempotent (the cache returns it unchanged until near expiry), so ticking
+# often costs almost nothing.
+DEFAULT_REFRESH_INTERVAL = 300.0
+
+_INTERVAL_ENV_VAR = "GAIA_DAEMON_FORWARD_REFRESH_INTERVAL"
+
+# Bounded join so daemon shutdown never hangs behind the timer thread.
+_STOP_JOIN_TIMEOUT = 5.0
+
+
+def resolve_interval() -> float:
+    """Refresh interval in seconds: ``GAIA_DAEMON_FORWARD_REFRESH_INTERVAL`` or
+    :data:`DEFAULT_REFRESH_INTERVAL`.
+
+    A non-positive or unparseable override is a loud error, not a silent
+    fallback — an interval of 0 would mean "never re-forward", reintroducing the
+    exact bug this module fixes.
+    """
+    raw = os.environ.get(_INTERVAL_ENV_VAR)
+    if raw is None or raw.strip() == "":
+        return DEFAULT_REFRESH_INTERVAL
+    try:
+        value = float(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"{_INTERVAL_ENV_VAR}={raw!r} is not a number. Set it to a positive "
+            f"number of seconds (well below the access-token TTL), or unset it to "
+            f"use the {DEFAULT_REFRESH_INTERVAL:.0f}s default."
+        ) from e
+    if value <= 0:
+        raise ValueError(
+            f"{_INTERVAL_ENV_VAR}={raw!r} must be positive — a non-positive "
+            "interval would disable re-forwarding and let forwarded tokens expire "
+            "unrecovered (the bug this timer fixes)."
+        )
+    return value
+
+
+class ForwardRefresher:
+    """Background thread that periodically re-forwards granted connector tokens
+    to every running sidecar.
+
+    The registry (``running_connections``) and forwarder (``forward_all``) seams
+    are injected so the tick logic is unit-tested without a real thread wall
+    clock or a live sidecar.
+    """
+
+    def __init__(
+        self,
+        registry,
+        forwarder,
+        *,
+        interval: "float | None" = None,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        self._registry = registry
+        self._forwarder = forwarder
+        self._interval = interval if interval is not None else resolve_interval()
+        self._sleep = sleep
+        self._stop = threading.Event()
+        self._thread: "threading.Thread | None" = None
+
+    # -- tick ----------------------------------------------------------------
+
+    def tick(self) -> None:
+        """Re-forward once to every running sidecar. Best-effort per sidecar: a
+        failure for one is logged loudly and does not stop the others."""
+        connections = self._registry.running_connections()
+        if not connections:
+            return
+        for agent_id, base_url, bearer in connections:
+            try:
+                summary = self._forwarder.forward_all(
+                    agent_id, base_url=base_url, bearer=bearer
+                )
+            except Exception:  # noqa: BLE001 - logged loudly, next sidecar still tried
+                logger.warning(
+                    "forward-refresh: re-forward to sidecar '%s' raised; its "
+                    "forwarded credentials may be stale until the next tick — it "
+                    "surfaces loudly at mailbox-use time",
+                    agent_id,
+                    exc_info=True,
+                )
+                continue
+            errors = summary.get("errors") if isinstance(summary, dict) else None
+            if errors:
+                logger.warning(
+                    "forward-refresh: re-forward to sidecar '%s' reported "
+                    "provider errors: %s",
+                    agent_id,
+                    errors,
+                )
+            else:
+                logger.debug("forward-refresh: re-forwarded to sidecar '%s'", agent_id)
+
+    def _safe_tick(self) -> None:
+        """Run one tick, absorbing any unexpected error so the loop survives to
+        retry next interval. Loud (``exc_info``), never silent."""
+        try:
+            self.tick()
+        except Exception:  # noqa: BLE001 - the timer must outlive a transient failure
+            logger.error(
+                "forward-refresh: tick failed unexpectedly; the re-forward timer "
+                "will retry at the next interval",
+                exc_info=True,
+            )
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def _run(self) -> None:
+        # wait() returns True when stop is set (exit), False on timeout (tick).
+        while not self._stop.wait(self._interval):
+            self._safe_tick()
+
+    def start(self) -> None:
+        """Spawn the background timer thread (idempotent)."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="forward-refresher", daemon=True
+        )
+        self._thread.start()
+        logger.info(
+            "forward-refresh: started (interval=%.0fs)", self._interval
+        )
+
+    def stop(self) -> None:
+        """Signal the timer to exit and join it (idempotent, safe unstarted)."""
+        self._stop.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=_STOP_JOIN_TIMEOUT)
+        self._thread = None
+
+    def is_alive(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+
+__all__ = [
+    "ForwardRefresher",
+    "DEFAULT_REFRESH_INTERVAL",
+    "resolve_interval",
+]

--- a/src/gaia/daemon/forward_refresh.py
+++ b/src/gaia/daemon/forward_refresh.py
@@ -33,8 +33,6 @@ from __future__ import annotations
 
 import os
 import threading
-import time
-from typing import Callable
 
 from gaia.logger import get_logger
 
@@ -97,12 +95,10 @@ class ForwardRefresher:
         forwarder,
         *,
         interval: "float | None" = None,
-        sleep: Callable[[float], None] = time.sleep,
     ):
         self._registry = registry
         self._forwarder = forwarder
         self._interval = interval if interval is not None else resolve_interval()
-        self._sleep = sleep
         self._stop = threading.Event()
         self._thread: "threading.Thread | None" = None
 
@@ -167,9 +163,7 @@ class ForwardRefresher:
             target=self._run, name="forward-refresher", daemon=True
         )
         self._thread.start()
-        logger.info(
-            "forward-refresh: started (interval=%.0fs)", self._interval
-        )
+        logger.info("forward-refresh: started (interval=%.0fs)", self._interval)
 
     def stop(self) -> None:
         """Signal the timer to exit and join it (idempotent, safe unstarted)."""

--- a/src/gaia/daemon/server.py
+++ b/src/gaia/daemon/server.py
@@ -167,6 +167,15 @@ def run(host: str = HOST) -> None:
         custody_base_url=custody_base_url,
     )
 
+    from gaia.daemon.forward_refresh import ForwardRefresher
+
+    # Keep forwarded connector tokens fresh for the life of each sidecar (#2388
+    # / #2159). Without this the on-spawn forward is the ONLY forward, so the
+    # token expires (~1h) and the sidecar 401s until restarted. Started after
+    # the port is up; stopped before shutdown_all so it never re-forwards to a
+    # sidecar that is about to die.
+    refresher = ForwardRefresher(registry, forwarder)
+
     from gaia.daemon.broker import ModelSlotBroker
     from gaia.daemon.constants import BROKER_URL_ENV_VAR
 
@@ -188,9 +197,11 @@ def run(host: str = HOST) -> None:
                 pid=pid, port=port, token=token, host=host, started_at=started_at
             )
         )
+        refresher.start()
         logger.info("daemon: registered instance pid=%s port=%s", pid, port)
 
     def _deregister() -> None:
+        refresher.stop()
         registry.shutdown_all()
         custody_store.close()
         remove_instance(only_pid=pid)

--- a/src/gaia/daemon/sidecars/registry.py
+++ b/src/gaia/daemon/sidecars/registry.py
@@ -251,6 +251,18 @@ class SidecarRegistry:
                 return agent_id
         return None
 
+    def running_connections(self) -> "list[tuple[str, str, str]]":
+        """``(agent_id, base_url, bearer)`` for every RUNNING sidecar that has a
+        base_url — the enumeration the re-forward timer (#2388) iterates so it
+        never has to reach into the registry's private manager map."""
+        with self._lock:
+            holders = list(self._managers.items())
+        return [
+            (agent_id, manager.base_url, manager.auth_token)
+            for agent_id, (manager, _) in holders
+            if manager.is_running and manager.base_url
+        ]
+
     def list_agents(self) -> "list[dict]":
         """One entry per registered spec, running or not. NEVER includes tokens."""
         with self._lock:

--- a/tests/unit/test_daemon_forward.py
+++ b/tests/unit/test_daemon_forward.py
@@ -212,6 +212,28 @@ def test_forward_all_skips_granted_but_unconnected_provider():
 # --- withdraw ---------------------------------------------------------------
 
 
+def test_running_connections_returns_only_running_with_base_url():
+    """The re-forward timer (#2388) iterates this instead of the private manager
+    map: only RUNNING sidecars that have a base_url are re-forwardable."""
+    from gaia.daemon.sidecars.registry import SidecarRegistry
+
+    class _Mgr:
+        def __init__(self, running, base_url):
+            self.is_running = running
+            self.base_url = base_url
+            self.auth_token = "bearer-x"
+
+    reg = SidecarRegistry({"email": _SPEC})
+    lock = __import__("threading").Lock()
+    reg._managers = {
+        "running": (_Mgr(True, "http://127.0.0.1:9"), lock),
+        "stopped": (_Mgr(False, "http://127.0.0.1:10"), lock),
+        "no_url": (_Mgr(True, None), lock),
+    }
+    conns = reg.running_connections()
+    assert conns == [("running", "http://127.0.0.1:9", "bearer-x")]
+
+
 def test_withdraw_deletes_from_sidecar():
     fwd, http = _forwarder(grants={"google": {"installed:email": ["s1"]}})
     result = fwd.withdraw("email", "google", base_url="http://127.0.0.1:9", bearer="b")

--- a/tests/unit/test_daemon_forward_refresh.py
+++ b/tests/unit/test_daemon_forward_refresh.py
@@ -1,0 +1,178 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Spec for the daemon's OAuth re-forward timer (issues #2388 / #2159).
+
+The daemon forwards SHORT-LIVED connector access tokens to a sidecar only at
+spawn time (``on_started``). Without a periodic re-forward the forwarded token
+expires (~1h; observed dying at ~2.6h uptime) and the sidecar fails every
+subsequent Gmail call with a 401 and never self-recovers.
+
+``ForwardRefresher`` is the missing timer: a daemon-owned background thread that
+periodically re-mints and re-forwards each RUNNING sidecar's granted tokens so a
+fresh token always arrives before the old one expires. This exercises the tick
+logic and the loop's fail-loud-but-resilient guard without a real thread wall
+clock or a live sidecar.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import pytest
+
+from gaia.daemon.forward_refresh import (
+    DEFAULT_REFRESH_INTERVAL,
+    ForwardRefresher,
+    resolve_interval,
+)
+
+
+class _FakeRegistry:
+    def __init__(self, connections):
+        # connections: list[(agent_id, base_url, bearer)]
+        self._connections = list(connections)
+
+    def running_connections(self):
+        return list(self._connections)
+
+
+class _RecordingForwarder:
+    """Records forward_all calls; optionally raises for a chosen agent."""
+
+    def __init__(self, *, raise_for=None, summary_errors_for=None):
+        self.calls = []
+        self._raise_for = raise_for or set()
+        self._summary_errors_for = summary_errors_for or set()
+
+    def forward_all(self, agent_id, *, base_url, bearer):
+        self.calls.append(agent_id)
+        if agent_id in self._raise_for:
+            raise RuntimeError(f"mint blew up for {agent_id}")
+        errors = (
+            [{"provider": "google", "error": "revoked"}]
+            if agent_id in self._summary_errors_for
+            else []
+        )
+        return {
+            "agent_id": agent_id,
+            "forwarded": [],
+            "skipped": [],
+            "errors": errors,
+        }
+
+
+def _refresher(registry, forwarder, **kw):
+    return ForwardRefresher(registry, forwarder, **kw)
+
+
+# --- tick -------------------------------------------------------------------
+
+
+def test_tick_reforwards_every_running_sidecar():
+    reg = _FakeRegistry(
+        [("email", "http://127.0.0.1:9", "b1"), ("toy", "http://127.0.0.1:10", "b2")]
+    )
+    fwd = _RecordingForwarder()
+    _refresher(reg, fwd).tick()
+    assert sorted(fwd.calls) == ["email", "toy"]
+
+
+def test_tick_no_running_sidecars_is_a_noop():
+    fwd = _RecordingForwarder()
+    _refresher(_FakeRegistry([]), fwd).tick()
+    assert fwd.calls == []
+
+
+def test_tick_one_sidecar_failure_does_not_stop_the_others(caplog):
+    reg = _FakeRegistry(
+        [("email", "http://127.0.0.1:9", "b1"), ("toy", "http://127.0.0.1:10", "b2")]
+    )
+    fwd = _RecordingForwarder(raise_for={"email"})
+    with caplog.at_level(logging.WARNING):
+        _refresher(reg, fwd).tick()
+    # Both attempted even though 'email' raised.
+    assert sorted(fwd.calls) == ["email", "toy"]
+    # The failing agent is logged loudly, not swallowed silently.
+    assert any("email" in rec.getMessage() for rec in caplog.records)
+
+
+def test_tick_logs_warning_when_summary_reports_provider_errors(caplog):
+    reg = _FakeRegistry([("email", "http://127.0.0.1:9", "b1")])
+    fwd = _RecordingForwarder(summary_errors_for={"email"})
+    with caplog.at_level(logging.WARNING):
+        _refresher(reg, fwd).tick()
+    assert any(
+        "email" in rec.getMessage() and rec.levelno >= logging.WARNING
+        for rec in caplog.records
+    )
+
+
+# --- interval resolution ----------------------------------------------------
+
+
+def test_default_interval_is_well_below_one_hour():
+    # The re-forward must land before a ~1h access token expires.
+    assert 0 < DEFAULT_REFRESH_INTERVAL <= 900
+
+
+def test_resolve_interval_reads_env_override(monkeypatch):
+    monkeypatch.setenv("GAIA_DAEMON_FORWARD_REFRESH_INTERVAL", "42")
+    assert resolve_interval() == 42.0
+
+
+def test_resolve_interval_rejects_nonpositive(monkeypatch):
+    monkeypatch.setenv("GAIA_DAEMON_FORWARD_REFRESH_INTERVAL", "0")
+    # A non-positive interval would mean "never re-forward" — fail loud, don't
+    # silently fall back.
+    with pytest.raises(ValueError):
+        resolve_interval()
+
+
+def test_resolve_interval_default_when_unset(monkeypatch):
+    monkeypatch.delenv("GAIA_DAEMON_FORWARD_REFRESH_INTERVAL", raising=False)
+    assert resolve_interval() == DEFAULT_REFRESH_INTERVAL
+
+
+# --- loop lifecycle ---------------------------------------------------------
+
+
+def test_safe_tick_swallows_and_logs_unexpected_error(caplog):
+    """A background maintenance loop must survive a transient failure to retry
+    next tick — but loudly, with context (not a silent fallback)."""
+
+    class _BoomRegistry:
+        def running_connections(self):
+            raise RuntimeError("registry exploded")
+
+    refresher = _refresher(_BoomRegistry(), _RecordingForwarder())
+    with caplog.at_level(logging.ERROR):
+        refresher._safe_tick()  # must NOT raise
+    assert any("re-forward" in rec.getMessage().lower() for rec in caplog.records)
+
+
+def test_start_runs_at_least_one_tick_then_stops_cleanly():
+    reg = _FakeRegistry([("email", "http://127.0.0.1:9", "b1")])
+    fwd = _RecordingForwarder()
+    ticked = threading.Event()
+
+    class _Refresher(ForwardRefresher):
+        def tick(self):
+            super().tick()
+            ticked.set()
+
+    # Tiny interval so the very first wait() elapses quickly.
+    refresher = _Refresher(reg, fwd, interval=0.01)
+    refresher.start()
+    try:
+        assert ticked.wait(timeout=2.0), "refresher never ticked"
+    finally:
+        refresher.stop()
+    assert "email" in fwd.calls
+    assert not refresher.is_alive()
+
+
+def test_stop_is_idempotent_and_safe_without_start():
+    refresher = _refresher(_FakeRegistry([]), _RecordingForwarder())
+    refresher.stop()  # never started — must not raise
+    refresher.stop()

--- a/tests/unit/test_daemon_registry_started_hook.py
+++ b/tests/unit/test_daemon_registry_started_hook.py
@@ -1,0 +1,180 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Spec for the OAuth forward-out-on-spawn hook (issue #2304).
+
+``SidecarRegistry._fire_started`` runs the daemon's ``on_started`` callback
+AFTER a fresh ``start()`` succeeds (sidecar healthy) — this is where the OAuth
+forward-out push (#2154) is wired. Before this file nothing verified that a
+successful spawn actually fires the hook, that an ALREADY-running attach does
+NOT re-fire it, or that a hook failure is swallowed (fail-open) rather than
+failing a healthy spawn. A regression in either the wiring or the fail-open
+guard would ship silently, leaving sidecars without forwarded credentials.
+
+Also covers the server's ``_on_started`` closure (``server._build_registry``):
+it must call ``forwarder.forward_all`` with the manager's base_url + bearer, and
+return early when the manager has no base_url.
+"""
+
+from __future__ import annotations
+
+import logging
+import time as _t
+
+import pytest
+
+from gaia.daemon.sidecars.spec import builtin_specs
+
+
+class _FakeManager:
+    """Mimics AgentSidecarManager's public surface used by SidecarRegistry."""
+
+    _next_pid = [7000]
+
+    def __init__(self, spec, mode=None, **kwargs):
+        self.spec = spec
+        self._mode_override = mode
+        self._running = False
+        self.port = None
+        self.base_url = None
+        self.api_version = "1.0"
+        self.agent_version = "0.1.0"
+        self.resolved_mode = None
+        self.auth_token = f"tok-{spec.agent_id}"
+        self.pid = None
+        self.started_at = None
+        self.start_calls = 0
+
+    @property
+    def mode(self):
+        import os
+
+        return self._mode_override or os.environ.get(self.spec.mode_env_var) or "user"
+
+    @property
+    def is_running(self):
+        return self._running
+
+    def start(self):
+        self.start_calls += 1
+        self.resolved_mode = self.mode
+        _FakeManager._next_pid[0] += 1
+        self.pid = _FakeManager._next_pid[0]
+        self.port = 50000 + self.pid
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        self.started_at = _t.time()
+        self._running = True
+        return self.base_url
+
+    def shutdown(self):
+        self._running = False
+
+
+def _registry(on_started, *, manager_cls=_FakeManager):
+    from gaia.daemon.sidecars.registry import SidecarRegistry
+
+    reg = SidecarRegistry(
+        {"email": builtin_specs()["email"]}, on_started=on_started
+    )
+    reg._manager_factory = manager_cls  # type: ignore[attr-defined]
+    return reg
+
+
+def test_fresh_spawn_fires_on_started_once_with_manager():
+    calls = []
+    reg = _registry(lambda aid, mgr: calls.append((aid, mgr)))
+
+    entry = reg.ensure("email")
+
+    assert entry["state"] == "running"
+    assert len(calls) == 1
+    agent_id, manager = calls[0]
+    assert agent_id == "email"
+    # The hook receives the SAME manager the sidecar spawned, so the forwarder
+    # can resolve its base_url + bearer.
+    assert manager.base_url == entry["base_url"]
+    assert manager.auth_token == entry["token"]
+
+
+def test_attach_to_running_does_not_refire_on_started():
+    calls = []
+    reg = _registry(lambda aid, mgr: calls.append(aid))
+
+    reg.ensure("email")  # fresh spawn -> fires once
+    reg.ensure("email")  # attach to the already-running sidecar -> must NOT fire
+
+    assert calls == ["email"]
+
+
+def test_on_started_failure_is_swallowed_and_spawn_still_succeeds(caplog):
+    def _boom(agent_id, manager):
+        raise RuntimeError("forward-out blew up")
+
+    reg = _registry(_boom)
+
+    with caplog.at_level(logging.WARNING):
+        entry = reg.ensure("email")
+
+    # A raising hook must NOT fail an otherwise-healthy spawn.
+    assert entry["state"] == "running"
+    assert entry["base_url"]
+    # ...but it is NOT silent: the failure is logged loudly with context.
+    assert any(
+        "post-start hook" in rec.getMessage() and "email" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_on_started_none_is_a_noop():
+    reg = _registry(None)
+    entry = reg.ensure("email")  # must not raise
+    assert entry["state"] == "running"
+
+
+# --- server._build_registry _on_started closure ---------------------------
+
+
+class _RecordingForwarder:
+    def __init__(self):
+        self.calls = []
+
+    def forward_all(self, agent_id, *, base_url, bearer):
+        self.calls.append({"agent_id": agent_id, "base_url": base_url, "bearer": bearer})
+        return {"agent_id": agent_id, "forwarded": [], "skipped": [], "errors": []}
+
+
+def _build_registry_with(forwarder):
+    from gaia.daemon.server import _build_registry
+
+    reg = _build_registry({"email": builtin_specs()["email"]}, forwarder)
+    reg._manager_factory = _FakeManager  # type: ignore[attr-defined]
+    return reg
+
+
+def test_server_on_started_closure_calls_forward_all_with_connection():
+    forwarder = _RecordingForwarder()
+    reg = _build_registry_with(forwarder)
+
+    entry = reg.ensure("email")
+
+    assert len(forwarder.calls) == 1
+    call = forwarder.calls[0]
+    assert call["agent_id"] == "email"
+    assert call["base_url"] == entry["base_url"]
+    assert call["bearer"] == entry["token"]
+
+
+def test_server_on_started_closure_returns_early_without_base_url():
+    class _NoUrlManager(_FakeManager):
+        def start(self):
+            super().start()
+            self.base_url = None  # healthy but no base_url -> nothing to forward to
+
+    forwarder = _RecordingForwarder()
+    from gaia.daemon.server import _build_registry
+
+    reg = _build_registry({"email": builtin_specs()["email"]}, forwarder)
+    reg._manager_factory = _NoUrlManager  # type: ignore[attr-defined]
+
+    reg.ensure("email")
+
+    assert forwarder.calls == []  # no forward attempted without a base_url

--- a/tests/unit/test_daemon_registry_started_hook.py
+++ b/tests/unit/test_daemon_registry_started_hook.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import logging
 import time as _t
 
-import pytest
-
 from gaia.daemon.sidecars.spec import builtin_specs
 
 
@@ -72,9 +70,7 @@ class _FakeManager:
 def _registry(on_started, *, manager_cls=_FakeManager):
     from gaia.daemon.sidecars.registry import SidecarRegistry
 
-    reg = SidecarRegistry(
-        {"email": builtin_specs()["email"]}, on_started=on_started
-    )
+    reg = SidecarRegistry({"email": builtin_specs()["email"]}, on_started=on_started)
     reg._manager_factory = manager_cls  # type: ignore[attr-defined]
     return reg
 
@@ -138,7 +134,9 @@ class _RecordingForwarder:
         self.calls = []
 
     def forward_all(self, agent_id, *, base_url, bearer):
-        self.calls.append({"agent_id": agent_id, "base_url": base_url, "bearer": bearer})
+        self.calls.append(
+            {"agent_id": agent_id, "base_url": base_url, "bearer": bearer}
+        )
         return {"agent_id": agent_id, "forwarded": [], "skipped": [], "errors": []}
 
 


### PR DESCRIPTION
Closes #2388
Closes #2159
Closes #2304

## Why this matters

When the Agent UI runs the email agent as a background sidecar, the daemon handed it a short-lived Google/Microsoft access token **only at spawn time** and never sent a fresh one. Once that token expired (~1h; observed dying at ~2.6h continuous uptime) every Gmail call 401'd and the sidecar **never recovered on its own** — the user had to restart it. The code's own comments in `forward.py` and `forwarded_credentials.py` already promised a "re-forward on expiry" that was never actually built.

**After:** a small daemon-owned background timer (`ForwardRefresher`) periodically re-mints and re-forwards each running sidecar's granted connector tokens — well before the old token expires — so the email agent keeps working past the 1h/2.6h mark without a restart. A revoked connection now withdraws the stale forward so the sidecar fails **loudly** (actionable error) instead of limping, and the sidecar's 401 message is mode-aware: in forwarded mode it says the daemon re-forwards automatically (no reconnect) rather than sending the user down a dead-end reconnect.

## What's in here (three clustered issues, one root subsystem)

- **#2388** — the re-forward-on-expiry timer (the genuinely-missing piece). Note: #2388's *second* part (`forward_all` route mapping `NotGrantedError`→403) was **already fixed in main by #2395** and is covered by `test_boundary_forward_all_ungranted_agent_maps_to_403` — no new work there.
- **#2159** — same root cause for the daemon deployment (fixed by the timer) plus the mode-aware 401 remediation message in `gmail_backend.py`.
- **#2304** — the previously-**untested** `_fire_started`/`on_started` forward-out-on-spawn hook now has real coverage: fires on fresh start, does **not** re-fire on attach, and a hook failure is swallowed (fail-open) **but logged loudly**.

Fail-loud posture (CLAUDE.md): the per-tick loop is resilient (one wedged sidecar can't kill recovery for the others) but nothing is swallowed silently — every failure is logged with `exc_info`, and the sidecar's own resolver still raises an actionable error at mailbox-use time if a token never arrives.

## Test plan

Unit/integration tiers (simulate expiry by injecting expired/short-TTL tokens — no live OAuth needed):

- [x] `python -m pytest tests/unit/test_daemon_forward_refresh.py` — timer ticks re-forward every running sidecar; one sidecar's failure doesn't stop the others; `_safe_tick` survives+logs an unexpected error; interval env override + non-positive rejection; start/stop lifecycle.
- [x] `python -m pytest tests/unit/test_daemon_registry_started_hook.py` — `_fire_started`/`on_started` fires on fresh start, not on attach, fail-open-but-logged; server `_on_started` closure calls `forward_all` with the connection (#2304).
- [x] `python -m pytest tests/unit/test_daemon_forward.py` — `running_connections()` returns only running sidecars with a base_url (+ existing forward suite).
- [x] `python -m pytest hub/agents/email/python/tests/test_forwarded_credentials.py` — expired forward → re-forward overwrites → instant recovery (store-layer half of the self-recovery guarantee).
- [x] `python -m pytest hub/agents/email/python/tests/test_gmail_backend.py` — 401 in forwarded mode says "no reconnect / daemon re-forwards"; standalone says "reconnect"; never leaks the bearer.
- [x] `python util/lint.py --black --isort --flake8` — PASS.

Evidence (local run) is in the first PR comment.

## Live-validation TODO (central sweep)

Deferred to the centralized milestone live sweep (impractical inline — needs the shared live-OAuth box + real ~1h/~2.6h expiry):

- Run the email sidecar under the daemon with a short forced token TTL / accelerated expiry; confirm it re-forwards and keeps serving **past the expiry boundary** on **both** Agent UI and CLI.
- Long-soak variant (>2.6h continuous uptime) confirming no 401-poisoning window recurs.
- Revoked-mid-session variant: revoke the Google grant while the sidecar runs; confirm the stale forward is withdrawn and the agent surfaces the loud "reconnect" error rather than limping.
