### PR TITLE
fix(email-agent): resolve draft/reply target from sender or topic (#2403)

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -20,6 +20,17 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **Draft/reply resolves a target from a sender or topic (#2403).**
+  `draft_reply` no longer demands a concrete message id or the exact subject
+  line. Its `message_id` argument now accepts a natural reference — a sender
+  address (`rocm-ci@amd.com`), a topic/incident token (`SIC-4482`), or a subject
+  keyword — and resolves it by searching the connected mailboxes and drafting
+  against the best-matching thread. A concrete id (or one already tagged from
+  triage/scan/read) still passes straight through (no search, no regression).
+  Ambiguity fails LOUD with a candidate list to pick from, and no match fails
+  LOUD with "not found" — never a silent wrong-target and never a bare
+  "give me a message ID / exact subject" wall.
+
 - **Re-proposal dedup survives headless/scheduled teardown (#2381).**
   `record_proposal` wrote its dedup row through `query()`, which never commits,
   so when the scheduler rebuilt the agent between fires (closing the DB

--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -29,7 +29,10 @@ contract version is tracked separately as
   triage/scan/read) still passes straight through (no search, no regression).
   Ambiguity fails LOUD with a candidate list to pick from, and no match fails
   LOUD with "not found" — never a silent wrong-target and never a bare
-  "give me a message ID / exact subject" wall.
+  "give me a message ID / exact subject" wall. The concrete-id probe only treats
+  a genuine 404 (or an in-memory miss) as "not an id here"; a transient backend
+  error (auth expiry, rate-limit, 5xx, network) on a valid id propagates instead
+  of being masked as a misleading "no message found".
 - **`/query` Lemonade-down errors are now actionable, not a raw traceback (#2139).**
   When the local LLM backend was unreachable, the `/query` SSE stream's terminal
   `error` event led with the raw `requests`/`urllib3` exception repr, giving the

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -272,6 +272,17 @@ email"). Map a sender/brand to ``from:``, expected subject words to
 almost certainly mis-formed the query — retry with ``from:``/``subject:``
 operators before telling the user the message can't be found.
 
+REPLYING / DRAFTING:
+To draft a reply you do NOT need the exact subject or a message id. Pass the
+user's own reference straight to ``draft_reply``'s ``message_id`` — a sender
+address ("draft a reply to rocm-ci@amd.com" → ``draft_reply("rocm-ci@amd.com",
+…)``), a topic or incident token ("regarding SIC-4482" → ``draft_reply("SIC-4482",
+…)``), or a subject keyword. The tool resolves it to the right thread by
+searching. NEVER dead-end on "give me a message ID / the exact subject line":
+if the reference is ambiguous the tool returns the candidate list for the user
+to pick from; if nothing matches it says so. Only when the tool reports multiple
+matches do you ask the user which one.
+
 OUTPUT:
 Tool results come back as JSON envelopes ``{"ok": true, "data": ...}``
 or ``{"ok": false, "error": "..."}``. Summarize tool output briefly for
@@ -913,6 +924,31 @@ class EmailTriageAgent(
         raise ValueError(
             f"resolved backend for message {message_id!r} is not in _backends"
         )
+
+    def _resolve_reply_target(
+        self, target: str, explicit_mailbox: Optional[str] = None
+    ) -> tuple[str, str]:
+        """Resolve a reply/draft ``target`` to a concrete ``(message_id, provider)``.
+
+        ``target`` may be a concrete id OR a sender / topic / subject reference
+        (#2403). A concrete id (or one already tagged from triage/scan/read)
+        passes straight through; otherwise the mailbox is searched and the
+        best-matching thread is used. Ambiguous or absent targets fail loud via
+        ``resolve_message_target`` — never a silent wrong-target.
+        """
+        from gaia_agent_email.tools.reply_tools import resolve_message_target
+
+        resolved_id, provider, _msg = resolve_message_target(
+            self._backends,
+            target=target,
+            explicit_mailbox=explicit_mailbox,
+            message_mailbox=self._message_mailbox,
+            debug=bool(getattr(self.config, "debug", False)),
+        )
+        # Remember the resolution so send_draft / undo route back to the same
+        # mailbox for a target the user named by sender/topic.
+        self._remember_message_mailbox(resolved_id, provider)
+        return resolved_id, provider
 
     def _send_backend(self, explicit_mailbox: Optional[str] = None):
         """Resolve a backend for a send-from-scratch (``send_now``).

--- a/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
@@ -203,6 +203,16 @@ def _candidate_line(provider: str, msg: Dict[str, Any]) -> str:
     )
 
 
+def _is_message_not_found(exc: Exception) -> bool:
+    """True when a backend ``get_message`` error means "no message with that id"
+    (HTTP 404), as opposed to auth / rate-limit / 5xx / network failures that
+    must propagate. Both the Gmail and Outlook backends collapse every non-2xx
+    into a ``ConnectorsError`` whose message carries the status, so the 404 is
+    matched on the rendered text (``... returned 404 ...``)."""
+    text = str(exc).lower()
+    return "404" in text or "not found" in text
+
+
 def resolve_message_target(
     backends: Dict[str, Any],
     *,
@@ -260,16 +270,21 @@ def resolve_message_target(
 
     # 1b. Concrete-id probe: a single-token target may itself be a message id.
     # Probe ``get_message`` — a hit means it is a real id (pass through, no
-    # search). Any failure just means "not a valid id here", so fall through to
-    # search; a genuinely missing target still fails loud below.
+    # search). Only a genuine "no such id" (in-memory ``KeyError``, or an HTTP
+    # 404) falls through to search: a transient backend failure (auth expiry,
+    # rate-limit, 5xx, network) on a *valid* id must NOT be swallowed, or the id
+    # would leak into the search query and come back as a misleading
+    # "no message found" (#2403 review; CLAUDE.md no-silent-fallback).
     if not any(c.isspace() for c in target):
         for provider, backend in scoped.items():
-            # Probe only: any failure means "not a valid id here" — fall
-            # through to search, which fails loud if nothing matches.
             try:
                 msg = backend.get_message(target)
-            except Exception:  # noqa: BLE001
-                continue
+            except KeyError:
+                continue  # in-memory backend: not a real id here → search
+            except ConnectorsError as exc:
+                if _is_message_not_found(exc):
+                    continue  # 404: not a real id in this mailbox → search
+                raise  # auth / rate-limit / transient: fail loud, never mask
             if msg:
                 return target, provider, msg
 

--- a/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
@@ -300,7 +300,19 @@ def resolve_message_target(
                 listing = backend.list_messages(query=retried, max_results=max_results)
                 stubs = listing.get("messages", [])
         for stub in stubs:
-            matches.append((provider, backend.get_message(stub["id"])))
+            # A stub can vanish between list_messages and get_message (TOCTOU:
+            # the message was deleted/moved) — skip that candidate rather than
+            # abort the whole resolution. A transient/auth error, though, is a
+            # real failure and must propagate, not be silently dropped
+            # (consistent with the concrete-id probe above; CLAUDE.md fail-loud).
+            try:
+                matches.append((provider, backend.get_message(stub["id"])))
+            except KeyError:
+                continue  # in-memory backend: stub gone → skip
+            except ConnectorsError as exc:
+                if _is_message_not_found(exc):
+                    continue  # 404: message vanished after listing → skip
+                raise
 
     # Collapse to one candidate per thread (latest message wins).
     threads: Dict[Tuple[str, str], Tuple[str, Dict[str, Any]]] = {}

--- a/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/reply_tools.py
@@ -18,11 +18,16 @@ import sqlite3
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
 from gaia_agent_email import action_store
-from gaia_agent_email.tools.read_tools import extract_sender_email
+from gaia_agent_email.tools.envelope import _envelope_err, _envelope_ok
+from gaia_agent_email.tools.read_tools import (
+    extract_sender_email,
+    has_gmail_operator,
+    normalize_gmail_date_operators,
+    operatorize_query,
+)
 from gaia_agent_email.verbose import log_tool_call
 
 from gaia.agents.base.tools import tool
@@ -75,9 +80,7 @@ def _load_attachment_files(paths: str) -> Optional[List[Dict[str, Any]]]:
                 f"extension — rename the file with a standard extension "
                 f"(e.g. .pdf, .png, .csv) and retry"
             )
-        out.append(
-            {"filename": path.name, "mime_type": mime_type, "content": content}
-        )
+        out.append({"filename": path.name, "mime_type": mime_type, "content": content})
     return out
 
 
@@ -156,6 +159,161 @@ def _build_threading_headers(original_msg: Dict[str, Any]) -> Dict[str, str]:
         chain = refs.strip() + (" " if refs else "") + msg_id
         out["References"] = chain
     return out
+
+
+def _internal_ms(msg: Dict[str, Any]) -> int:
+    try:
+        return int(msg.get("internalDate") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _target_search_query(target: str) -> str:
+    """Translate a natural-language reply target into a Gmail query.
+
+    Mirrors the "translate the user's words into operators" rule the agent
+    already applies to search/archive:
+
+    - an operator query the model already formed (``from:`` / ``subject:`` …)
+      passes through untouched;
+    - a bare email address (no spaces, contains ``@``) becomes ``from:<addr>``;
+    - anything else (a topic / incident token / subject phrase) is searched
+      as-is — ``search`` callers add an operator retry when a bare phrase
+      returns nothing.
+    """
+    q = normalize_gmail_date_operators(target)
+    if has_gmail_operator(q):
+        return q
+    if "@" in q and not any(c.isspace() for c in q):
+        return f"from:{q}"
+    return q
+
+
+def _candidate_line(provider: str, msg: Dict[str, Any]) -> str:
+    headers = {
+        (h.get("name") or "").lower(): h.get("value", "")
+        for h in (msg.get("payload") or {}).get("headers", [])
+    }
+    sender = headers.get("from", "(unknown sender)")
+    subject = headers.get("subject", "(no subject)")
+    date = headers.get("date", "")
+    tag = f"[{provider}] " if provider else ""
+    return f'{tag}From: {sender} · Subject: "{subject}"' + (
+        f" · {date}" if date else ""
+    )
+
+
+def resolve_message_target(
+    backends: Dict[str, Any],
+    *,
+    target: str,
+    explicit_mailbox: Optional[str] = None,
+    message_mailbox: Optional[Dict[str, str]] = None,
+    max_results: int = 25,
+    debug: bool = False,
+) -> Tuple[str, str, Optional[Dict[str, Any]]]:
+    """Resolve a reply/draft ``target`` to a concrete ``(message_id, provider, msg)``.
+
+    ``target`` may be a concrete message id OR a natural-language reference —
+    a sender address, brand, or topic/incident token (#2403). Resolution:
+
+    1. A target already known from triage/scan/read (``message_mailbox``) or a
+       concrete id that ``get_message`` accepts passes straight through — no
+       search — so the exact-id path the model uses after ``search_messages``
+       is unchanged (no regression).
+    2. Otherwise the target is translated to a Gmail query (``from:`` for a bare
+       address, the token itself for a topic) and every connected backend is
+       searched. Matches are collapsed by thread (latest message per thread):
+         - **1 thread**  → resolve to its latest message;
+         - **0 threads** → raise an actionable "no message found" error;
+         - **>1 threads** → raise an actionable disambiguation error listing the
+           candidate senders/subjects.
+
+    Never silently drafts against an arbitrary match: ambiguity and absence
+    fail LOUD (``ValueError``), never a silent wrong-target and never a bare
+    "provide an exact subject/message-id" wall.
+    """
+    target = (target or "").strip()
+    if not target:
+        raise ValueError(
+            "No reply target given — name the message by sender, topic, or id "
+            '(e.g. "reply to rocm-ci@amd.com" or a subject keyword).'
+        )
+
+    if explicit_mailbox is not None:
+        if explicit_mailbox not in backends:
+            raise ValueError(
+                f"Mailbox {explicit_mailbox!r} is not connected. Connected: "
+                f"{', '.join(backends) or 'none'}."
+            )
+        scoped = {explicit_mailbox: backends[explicit_mailbox]}
+    else:
+        scoped = dict(backends)
+
+    # 1a. Fast path: a target already tagged from triage/scan/read.
+    if message_mailbox and target in message_mailbox:
+        provider = message_mailbox[target]
+        if (explicit_mailbox is None or provider == explicit_mailbox) and (
+            provider in backends
+        ):
+            return target, provider, None
+
+    # 1b. Concrete-id probe: a single-token target may itself be a message id.
+    # Probe ``get_message`` — a hit means it is a real id (pass through, no
+    # search). Any failure just means "not a valid id here", so fall through to
+    # search; a genuinely missing target still fails loud below.
+    if not any(c.isspace() for c in target):
+        for provider, backend in scoped.items():
+            # Probe only: any failure means "not a valid id here" — fall
+            # through to search, which fails loud if nothing matches.
+            try:
+                msg = backend.get_message(target)
+            except Exception:  # noqa: BLE001
+                continue
+            if msg:
+                return target, provider, msg
+
+    # 2. Search every scoped backend, translating the target to operators.
+    query = _target_search_query(target)
+    matches: List[Tuple[str, Dict[str, Any]]] = []
+    for provider, backend in scoped.items():
+        listing = backend.list_messages(query=query, max_results=max_results)
+        stubs = listing.get("messages", [])
+        if not stubs and not has_gmail_operator(query):
+            retried = operatorize_query(query)
+            if retried != query:
+                listing = backend.list_messages(query=retried, max_results=max_results)
+                stubs = listing.get("messages", [])
+        for stub in stubs:
+            matches.append((provider, backend.get_message(stub["id"])))
+
+    # Collapse to one candidate per thread (latest message wins).
+    threads: Dict[Tuple[str, str], Tuple[str, Dict[str, Any]]] = {}
+    for provider, msg in matches:
+        key = (provider, msg.get("threadId") or msg.get("id"))
+        current = threads.get(key)
+        if current is None or _internal_ms(msg) > _internal_ms(current[1]):
+            threads[key] = (provider, msg)
+
+    groups = sorted(threads.values(), key=lambda pm: _internal_ms(pm[1]), reverse=True)
+
+    if not groups:
+        raise ValueError(
+            f"No message found matching {target!r} in "
+            f"{', '.join(scoped) or 'any connected mailbox'}. Check the sender "
+            "or topic, or run a search/triage first to see what's there."
+        )
+    if len(groups) == 1:
+        provider, msg = groups[0]
+        return msg["id"], provider, msg
+
+    lines = "\n".join(f"  - {_candidate_line(p, m)}" for p, m in groups[:10])
+    more = "" if len(groups) <= 10 else f"\n  … and {len(groups) - 10} more"
+    raise ValueError(
+        f"{len(groups)} messages match {target!r} — which one do you want to "
+        f"reply to? Narrow it by a more specific sender or subject keyword:\n"
+        f"{lines}{more}"
+    )
 
 
 def draft_reply_impl(
@@ -362,13 +520,23 @@ class ReplyToolsMixin:
         ) -> str:
             """Create a reply draft for a message (does NOT send).
 
+            ``message_id`` may be a concrete message id OR a natural reference to
+            the message: a sender address (``rocm-ci@amd.com``), a brand, or a
+            topic / incident token (``SIC-4482``) / subject keyword. When it is
+            not a concrete id, the tool searches your mailboxes and drafts
+            against the best-matching thread — you do NOT need to look up the id
+            or paste the exact subject first. If several messages match it lists
+            them so you can pick; if none match it says so.
+
             ``mailbox`` (optional) names the source mailbox so the draft is
             created in the right account when multiple mailboxes are connected.
             ``attachments`` (optional) is a comma-separated list of full paths
             to local files to attach to the draft.
             """
             try:
-                provider = agent._provider_for_message(message_id, mailbox or None)
+                message_id, provider = agent._resolve_reply_target(
+                    message_id, mailbox or None
+                )
                 backend = agent._backends[provider]
                 result = draft_reply_impl(
                     backend,

--- a/hub/agents/email/python/tests/test_reply_target_resolution_2403.py
+++ b/hub/agents/email/python/tests/test_reply_target_resolution_2403.py
@@ -35,6 +35,7 @@ pytest.importorskip("gaia_agent_email")
 
 from gaia_agent_email.tools.reply_tools import resolve_message_target  # noqa: E402
 
+from gaia.connectors.errors import ConnectorsError  # noqa: E402
 from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -277,3 +278,53 @@ def test_multi_mailbox_same_sender_disambiguates_across_providers():
     text = str(exc.value)
     assert "Gmail freeze SIC-4482" in text
     assert "Outlook freeze SIC-4482" in text
+
+
+# ---------------------------------------------------------------------------
+# Concrete-id probe must not swallow transient errors as "not found" (#2403
+# review; CLAUDE.md no-silent-fallback)
+# ---------------------------------------------------------------------------
+
+
+class _TransientGetBackend(FakeGmailBackend):
+    """``get_message`` hits a transient backend failure (rate-limit / 5xx) —
+    a real error on a possibly-valid id that must propagate, never be masked."""
+
+    def get_message(self, message_id: str) -> dict:
+        raise ConnectorsError(
+            f"Gmail API GET /messages/{message_id} returned 429: rate limited"
+        )
+
+
+class _NotFound404Backend(FakeGmailBackend):
+    """``get_message`` 404s for the probed id (genuinely absent) but works for
+    real stub ids the search returns — the 404 must fall through to search."""
+
+    def get_message(self, message_id: str) -> dict:
+        if message_id == "deadbeefcafe0404":
+            raise ConnectorsError(
+                "Gmail API GET /messages/deadbeefcafe0404 returned 404: Not Found"
+            )
+        return super().get_message(message_id)
+
+
+def test_transient_probe_error_propagates_not_masked_as_not_found():
+    # A valid-looking id whose fetch hits a 429 must raise the backend error,
+    # not fall through and come back as a misleading "no message found".
+    backend = _TransientGetBackend(user_email="user@example.com")
+    backend.add_message(_msg("m1", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"))
+    with pytest.raises(ConnectorsError) as exc:
+        resolve_message_target({"google": backend}, target="deadbeefcafe1234")
+    assert "429" in str(exc.value)
+
+
+def test_probe_404_falls_through_to_search():
+    # A 404 on the probe means "not a real id here" — it must fall through to
+    # search and end in the actionable not-found ValueError, never surface the
+    # raw 404 ConnectorsError.
+    backend = _NotFound404Backend(user_email="user@example.com")
+    backend.add_message(_msg("m1", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"))
+    with pytest.raises(ValueError) as exc:
+        resolve_message_target({"google": backend}, target="deadbeefcafe0404")
+    text = str(exc.value).lower()
+    assert "no message" in text or "not found" in text

--- a/hub/agents/email/python/tests/test_reply_target_resolution_2403.py
+++ b/hub/agents/email/python/tests/test_reply_target_resolution_2403.py
@@ -1,0 +1,279 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Reply/draft target resolution from a sender or topic (#2403).
+
+``draft_reply`` used to require a concrete ``message_id`` (or an exact
+subject the model had already searched for). Asking to "draft a reply to
+rocm-ci@amd.com" or "reply ... regarding SIC-4482" dead-ended on "give me a
+message ID / subject line" even though the sender / incident token uniquely
+identify the message.
+
+``resolve_message_target`` closes that gap: a target given as a sender
+address, brand, or topic token is translated to a search, the best-matching
+thread is picked, and the concrete message id is returned — while a concrete
+id still passes straight through (no regression). Ambiguity and absence fail
+LOUD and actionable, never a silent wrong-target and never a bare
+"provide exact subject/message-id" wall.
+
+All tests are hermetic: FakeGmailBackend only, no Lemonade, no network.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# parents[0] = tests/, [1] = python/, [2] = email/, [3] = agents/,
+# [4] = hub/, [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email.tools.reply_tools import resolve_message_target  # noqa: E402
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _msg(
+    msg_id: str,
+    *,
+    sender: str,
+    subject: str,
+    thread_id: str | None = None,
+    internal_ms: int = 1_700_000_000_000,
+    snippet: str = "",
+) -> dict:
+    """Build a minimal Gmail-API-v1-shape message."""
+    return {
+        "id": msg_id,
+        "threadId": thread_id or msg_id,
+        "internalDate": str(internal_ms),
+        "snippet": snippet,
+        "labelIds": ["INBOX", "UNREAD"],
+        "payload": {
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "Subject", "value": subject},
+                {"name": "Date", "value": "Thu, 23 Jul 2026 09:00:00 +0000"},
+            ]
+        },
+    }
+
+
+def _backend(*messages: dict, user_email: str = "user@example.com") -> FakeGmailBackend:
+    b = FakeGmailBackend(user_email=user_email)
+    for m in messages:
+        b.add_message(m)
+    return b
+
+
+def _list_calls(backend: FakeGmailBackend) -> list:
+    return [c for c in backend.transport.calls if c[0] == "list_messages"]
+
+
+# ---------------------------------------------------------------------------
+# AC (a): a sender / topic target resolves to the right message via search
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_unique_sender_to_message_id():
+    gmail = _backend(
+        _msg(
+            "m1",
+            sender="rocm-ci@amd.com",
+            subject="ACTION REQUIRED: Engineering Freeze SIC-4482",
+        ),
+        _msg("m2", sender="newsletter@othercorp.com", subject="Weekly digest"),
+    )
+    resolved_id, provider, msg = resolve_message_target(
+        {"google": gmail}, target="rocm-ci@amd.com"
+    )
+    assert resolved_id == "m1"
+    assert provider == "google"
+    assert msg is not None
+    # It actually searched (did not demand an id).
+    assert _list_calls(gmail), "expected a search to resolve the sender"
+
+
+def test_resolves_topic_token_via_search():
+    gmail = _backend(
+        _msg(
+            "inc1",
+            sender="rocm-ci@amd.com",
+            subject="ACTION REQUIRED: Engineering Freeze SIC-4482",
+        ),
+        _msg("other", sender="rocm-ci@amd.com", subject="Nightly build passed"),
+    )
+    resolved_id, provider, _ = resolve_message_target(
+        {"google": gmail}, target="SIC-4482"
+    )
+    assert resolved_id == "inc1"
+    assert provider == "google"
+
+
+def test_operator_query_passes_through_to_search():
+    gmail = _backend(
+        _msg("m1", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"),
+    )
+    resolved_id, _, _ = resolve_message_target(
+        {"google": gmail}, target="from:rocm-ci@amd.com"
+    )
+    assert resolved_id == "m1"
+
+
+# ---------------------------------------------------------------------------
+# No regression: a concrete id passes straight through WITHOUT searching
+# ---------------------------------------------------------------------------
+
+
+def test_concrete_id_passes_through_without_search():
+    gmail = _backend(
+        _msg("abc123def456", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"),
+    )
+    resolved_id, provider, _ = resolve_message_target(
+        {"google": gmail}, target="abc123def456"
+    )
+    assert resolved_id == "abc123def456"
+    assert provider == "google"
+    # A concrete id is used as-is — never routed through a search.
+    assert not _list_calls(gmail), "a concrete id must not trigger a search"
+
+
+def test_known_message_mailbox_fast_path_skips_search():
+    gmail = _backend(
+        _msg("known1", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"),
+    )
+    resolved_id, provider, _ = resolve_message_target(
+        {"google": gmail},
+        target="known1",
+        message_mailbox={"known1": "google"},
+    )
+    assert resolved_id == "known1"
+    assert provider == "google"
+    assert not _list_calls(gmail)
+
+
+# ---------------------------------------------------------------------------
+# One thread, several messages → resolve to the latest, NOT ambiguous
+# ---------------------------------------------------------------------------
+
+
+def test_single_thread_multiple_messages_resolves_latest():
+    gmail = _backend(
+        _msg(
+            "t_old",
+            sender="rocm-ci@amd.com",
+            subject="Freeze SIC-4482",
+            thread_id="thread-A",
+            internal_ms=1_700_000_000_000,
+        ),
+        _msg(
+            "t_new",
+            sender="rocm-ci@amd.com",
+            subject="Re: Freeze SIC-4482",
+            thread_id="thread-A",
+            internal_ms=1_700_000_500_000,
+        ),
+    )
+    resolved_id, _, _ = resolve_message_target({"google": gmail}, target="SIC-4482")
+    assert resolved_id == "t_new"
+
+
+# ---------------------------------------------------------------------------
+# AC (b): ambiguous target → actionable disambiguation listing candidates
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguous_multiple_threads_raises_with_candidates():
+    gmail = _backend(
+        _msg(
+            "inv1",
+            sender="alice@corp.com",
+            subject="Invoice 100 overdue",
+            thread_id="thread-1",
+        ),
+        _msg(
+            "inv2",
+            sender="alice@corp.com",
+            subject="Invoice 200 reminder",
+            thread_id="thread-2",
+        ),
+    )
+    with pytest.raises(ValueError) as exc:
+        resolve_message_target({"google": gmail}, target="from:alice@corp.com")
+    text = str(exc.value)
+    # Lists both candidate subjects so the user can pick.
+    assert "Invoice 100 overdue" in text
+    assert "Invoice 200 reminder" in text
+    # It is NOT a bare "give me a message id" dead-end.
+    assert "message id" not in text.lower() or "which" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC (c): no match → actionable "not found", never a message-id wall
+# ---------------------------------------------------------------------------
+
+
+def test_no_match_raises_not_found():
+    gmail = _backend(
+        _msg("m1", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"),
+    )
+    with pytest.raises(ValueError) as exc:
+        resolve_message_target({"google": gmail}, target="nobody@nowhere.example")
+    text = str(exc.value).lower()
+    assert "no message" in text or "not found" in text
+    assert "nobody@nowhere.example" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Explicit mailbox scoping
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_mailbox_restricts_search():
+    google = _backend(
+        _msg("g1", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"),
+    )
+    microsoft = _backend(
+        _msg("o1", sender="rocm-ci@amd.com", subject="Different freeze"),
+    )
+    resolved_id, provider, _ = resolve_message_target(
+        {"google": google, "microsoft": microsoft},
+        target="SIC-4482",
+        explicit_mailbox="google",
+    )
+    assert resolved_id == "g1"
+    assert provider == "google"
+
+
+def test_explicit_mailbox_not_connected_raises():
+    gmail = _backend(_msg("g1", sender="a@b.com", subject="hi"))
+    with pytest.raises(ValueError) as exc:
+        resolve_message_target(
+            {"google": gmail}, target="hi", explicit_mailbox="microsoft"
+        )
+    assert "microsoft" in str(exc.value).lower()
+
+
+def test_multi_mailbox_same_sender_disambiguates_across_providers():
+    google = _backend(
+        _msg("g1", sender="rocm-ci@amd.com", subject="Gmail freeze SIC-4482"),
+    )
+    microsoft = _backend(
+        _msg("o1", sender="rocm-ci@amd.com", subject="Outlook freeze SIC-4482"),
+    )
+    with pytest.raises(ValueError) as exc:
+        resolve_message_target(
+            {"google": google, "microsoft": microsoft}, target="SIC-4482"
+        )
+    text = str(exc.value)
+    assert "Gmail freeze SIC-4482" in text
+    assert "Outlook freeze SIC-4482" in text

--- a/hub/agents/email/python/tests/test_reply_target_resolution_2403.py
+++ b/hub/agents/email/python/tests/test_reply_target_resolution_2403.py
@@ -328,3 +328,69 @@ def test_probe_404_falls_through_to_search():
         resolve_message_target({"google": backend}, target="deadbeefcafe0404")
     text = str(exc.value).lower()
     assert "no message" in text or "not found" in text
+
+
+# ---------------------------------------------------------------------------
+# Search loop must skip a stub that vanished (TOCTOU 404) but propagate a
+# transient error — consistent with the concrete-id probe (#2403 review)
+# ---------------------------------------------------------------------------
+
+
+class _StubVanishedBackend(FakeGmailBackend):
+    """A search stub whose ``get_message`` then 404s — the message was deleted
+    between ``list_messages`` and the fetch. That candidate must be skipped, not
+    abort resolution of the healthy match."""
+
+    _VANISHED = "vanished0404"
+
+    def list_messages(self, *, query=None, max_results=25, page_token=None):
+        base = super().list_messages(
+            query=query, max_results=max_results, page_token=page_token
+        )
+        base["messages"] = [{"id": self._VANISHED, "threadId": "tV"}] + base.get(
+            "messages", []
+        )
+        return base
+
+    def get_message(self, message_id: str) -> dict:
+        if message_id == self._VANISHED:
+            raise ConnectorsError(
+                "Gmail API GET /messages/vanished0404 returned 404: Not Found"
+            )
+        return super().get_message(message_id)
+
+
+class _SearchStubTransientBackend(FakeGmailBackend):
+    """A search stub whose ``get_message`` hits a transient 429 — must propagate,
+    never be silently dropped from the candidate set."""
+
+    def list_messages(self, *, query=None, max_results=25, page_token=None):
+        return {
+            "messages": [{"id": "stub429", "threadId": "t1"}],
+            "nextPageToken": None,
+        }
+
+    def get_message(self, message_id: str) -> dict:
+        if message_id == "stub429":
+            raise ConnectorsError(
+                "Gmail API GET /messages/stub429 returned 429: rate limited"
+            )
+        return super().get_message(message_id)  # probe target → KeyError
+
+
+def test_search_skips_stub_that_vanished_after_listing():
+    backend = _StubVanishedBackend(user_email="user@example.com")
+    backend.add_message(_msg("m1", sender="rocm-ci@amd.com", subject="Freeze SIC-4482"))
+    # Topic target → probe misses (KeyError) → search returns [vanished, m1];
+    # the vanished stub 404s and is skipped, leaving m1 as the sole candidate.
+    resolved_id, provider, _ = resolve_message_target(
+        {"google": backend}, target="SIC-4482"
+    )
+    assert resolved_id == "m1"
+
+
+def test_search_stub_transient_error_propagates():
+    backend = _SearchStubTransientBackend(user_email="user@example.com")
+    with pytest.raises(ConnectorsError) as exc:
+        resolve_message_target({"google": backend}, target="SIC-4482")
+    assert "429" in str(exc.value)


### PR DESCRIPTION
Closes #2403

## Why this matters

Before: asking the email agent to "draft a reply to rocm-ci@amd.com" — or "reply regarding SIC-4482" — dead-ended on *"I need a message ID or subject line to proceed"*, even though the sender address and the incident token each uniquely identify the message and were already on screen from the prior triage. The only form that worked was pasting the **exact full subject line**.

After: `draft_reply`'s `message_id` argument also accepts a natural reference — a sender address, a topic/incident token, or a subject keyword. The tool translates it to a search (`from:` for a bare address, the token itself for a topic), finds the best-matching thread, and drafts against it. A concrete id (or one already tagged from triage/scan/read) still passes straight through with no search, so the exact-id path is unchanged. Ambiguity and absence fail **loud and actionable** — multiple threads list the candidate senders/subjects to pick from; no match says so plainly — never a silent wrong-target and never a bare "give me a message ID" wall.

## Test plan

- [x] `pytest tests/test_reply_target_resolution_2403.py` — 11 tests, all ACs (see Evidence)
- [x] Full email package suite — 848 passed (1 pre-existing env failure, see below)
- [x] `black --check` + `flake8` clean on changed files

## Evidence

New hermetic tests (FakeGmailBackend, no Lemonade/network) cover every acceptance criterion:

```
$ pytest tests/test_reply_target_resolution_2403.py -q
...........                                                              [100%]
11 passed in 0.30s
```

Mapping to ACs:
- **(a) sender / topic resolves without an id** — `test_resolves_unique_sender_to_message_id`, `test_resolves_topic_token_via_search`, `test_operator_query_passes_through_to_search`
- **(b) ambiguous → lists candidates** — `test_ambiguous_multiple_threads_raises_with_candidates`, `test_multi_mailbox_same_sender_disambiguates_across_providers`
- **(c) no match → actionable not-found** — `test_no_match_raises_not_found`
- **(d) exact-id path still works (no regression)** — `test_concrete_id_passes_through_without_search`, `test_known_message_mailbox_fast_path_skips_search`
- thread collapsing + mailbox scoping — `test_single_thread_multiple_messages_resolves_latest`, `test_explicit_mailbox_restricts_search`, `test_explicit_mailbox_not_connected_raises`

Full email suite: **848 passed, 1 failed**. The single failure — `test_rest_contract.py::test_agent_version_matches_package_metadata` (`0.1.0 != 0.5.0`) — is the known worktree editable-install trap (installed dist metadata vs source `AGENT_VERSION`); this change touches no version and does not affect it.

<details>
<summary>Note on the eval-affecting surface</summary>

This edits `draft_reply`'s docstring/tool schema and adds a REPLYING/DRAFTING system-prompt section — LLM-affecting surfaces. A `gaia eval agent` run was **not** performed here (shared Lemonade backend, run serially by the milestone sweep). Flagged for the orchestrator to serial-run if the milestone gate requires it.
</details>

## Live-validation TODO (central sweep)

- Agent UI **and** CLI: "draft a reply to <real sender> saying …" with **no** subject given → confirm it targets the right message and drafts without asking for an id.
- "draft a reply … regarding <topic/incident token>" → resolves via the topic.
- Ambiguous case (a sender with several distinct threads) → agent surfaces the candidate list, does not dead-end.
- No-match case → actionable "not found" copy.
- Regression: the exact-subject / already-searched-id path still drafts in one step.
