### PR TITLE
fix(email-agent): verify archive left inbox + fix same-day search miss

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -20,6 +20,14 @@ contract version is tracked separately as
 
 ### Fixed
 
+- **Archive verifies it took effect, and same-day search finds today's mail (#2406).**
+  Archiving now inspects the provider's post-mutation `INBOX` label and fails
+  loudly instead of reporting a false success when the message is still in the
+  inbox; and `after:today` / relative-day operators normalize to a
+  timezone-robust `newer_than:1d` window so today's mail is reliably found. Both
+  fixes apply on the REST surface (`/v1/email/archive`, `/v1/email/search`) as
+  well as the agent's in-loop tools — a no-op archive returns an actionable 409,
+  not a bare 500.
 - **Re-proposal dedup survives headless/scheduled teardown (#2381).**
   `record_proposal` wrote its dedup row through `query()`, which never commits,
   so when the scheduler rebuilt the agent between fires (closing the DB

--- a/hub/agents/email/python/gaia_agent_email/api_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/api_routes.py
@@ -2415,10 +2415,24 @@ async def confirm_action(
     )
 
 
+_ARCHIVE_VERIFY_409 = {
+    409: {
+        "description": (
+            "The archive did not take effect — the message is still in the inbox "
+            "(the provider's modify call did not remove the INBOX label)."
+        )
+    }
+}
+
+
 @router.post(
     "/archive",
     response_model=EmailArchiveResponse,
-    responses={**_CONNECTOR_ERROR_RESPONSES, **_AMBIGUOUS_PROVIDER_400},
+    responses={
+        **_CONNECTOR_ERROR_RESPONSES,
+        **_AMBIGUOUS_PROVIDER_400,
+        **_ARCHIVE_VERIFY_409,
+    },
 )
 async def archive_email(request: EmailArchiveRequest) -> EmailArchiveResponse:
     """Archive a message — gated on confirmation, reversible for 30s.

--- a/hub/agents/email/python/gaia_agent_email/api_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/api_routes.py
@@ -1292,7 +1292,10 @@ def _search_inbox(
     a list view, not a read. Imported lazily so the OpenAPI export stays
     dependency-light (it never pulls the live-mail machinery).
     """
-    from gaia_agent_email.tools.read_tools import _format_message_for_llm
+    from gaia_agent_email.tools.read_tools import (
+        _format_message_for_llm,
+        normalize_gmail_date_operators,
+    )
 
     # With neither a query nor explicit labels, scope to the INBOX so the
     # empty-search default actually lists the inbox. Without this, live Gmail
@@ -1304,7 +1307,9 @@ def _search_inbox(
         effective_labels = ["INBOX"]
 
     listing = backend.list_messages(
-        query=query,
+        # Normalize same-day/relative date operators (after:today → newer_than:1d)
+        # so REST search matches the agent's in-loop path (#2406).
+        query=normalize_gmail_date_operators(query) if query else query,
         label_ids=effective_labels,
         max_results=max_results,
         page_token=page_token,
@@ -2448,6 +2453,10 @@ async def archive_email(request: EmailArchiveRequest) -> EmailArchiveResponse:
             mailbox=provider,
             batch_id=batch_id,
         )
+    except RuntimeError as e:
+        # Archive did not take effect (message still in inbox) — surface the
+        # actionable message instead of a bare 500 (#2406). Mirrors archive_folder.
+        raise HTTPException(status_code=409, detail=str(e)) from e
     except (AuthRequiredError, ScopeMismatchError, ConnectionRevokedError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
     except ConfigurationError as e:

--- a/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
@@ -28,6 +28,9 @@ from gaia.logger import get_logger
 
 log = get_logger(__name__)
 
+# The Gmail system label whose removal defines "archived / out of the inbox".
+_INBOX_LABEL = "INBOX"
+
 
 # ---------------------------------------------------------------------------
 # Pure impls
@@ -55,6 +58,23 @@ def archive_message_impl(
         prior_labels = list(prior.get("labelIds", []))
         # Gmail call — if this raises, NO db row is written.
         result = gmail.archive_message(message_id)
+        # Verify the archive actually took effect before claiming success.
+        # Gmail's modify response echoes the post-mutation labelIds; if INBOX
+        # is still present the archive silently no-op'd (wrong id resolved or
+        # the provider rejected the change) — fail loudly rather than record a
+        # false success (#2406). Raising here, before record_action, preserves
+        # the no-phantom-undo-row ordering invariant. Folder-based backends
+        # (Outlook) return an id-only result with no labelIds; there the
+        # returned post-archive id is the confirmation, so skip the label check.
+        post_labels = (result or {}).get("labelIds")
+        if post_labels is not None and _INBOX_LABEL in post_labels:
+            raise RuntimeError(
+                f"Archive did not take effect for message {message_id!r}: it is "
+                "still in the inbox (INBOX label present after the archive call). "
+                "This usually means the wrong message id was resolved or the mail "
+                "provider rejected the change. Re-run the search to confirm the "
+                "target message, or archive it manually in your mail client."
+            )
         # Capture the post-archive id: for folder-based backends (Outlook)
         # the move returns a new id; for label-based backends (Gmail) it
         # equals the pre-archive id.
@@ -71,10 +91,15 @@ def archive_message_impl(
             mailbox=mailbox,
         )
         st["result_summary"] = {"action_id": action_id}
+        # Surface the identity of the message actually archived so the success
+        # message can cite it (id/subject/sender), not just the sender name the
+        # user typed (#2406 AC b).
         return {
             "action_id": action_id,
             "message_id": message_id,
             "post_archive_id": post_archive_id,
+            "subject": _extract_subject(prior),
+            "sender": _extract_sender(prior),
         }
 
 
@@ -304,6 +329,14 @@ def _extract_sender(msg: Dict[str, Any]) -> str:
     """Pull the ``From`` header out of a Gmail-API-shape message."""
     for h in (msg.get("payload") or {}).get("headers", []):
         if (h.get("name") or "").lower() == "from":
+            return h.get("value", "")
+    return ""
+
+
+def _extract_subject(msg: Dict[str, Any]) -> str:
+    """Pull the ``Subject`` header out of a Gmail-API-shape message."""
+    for h in (msg.get("payload") or {}).get("headers", []):
+        if (h.get("name") or "").lower() == "subject":
             return h.get("value", "")
     return ""
 

--- a/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/read_tools.py
@@ -591,15 +591,30 @@ def _parse_gmail_date_value(raw: str, *, op: str) -> str:
     return f"{y:04d}/{mo:02d}/{d:02d}"
 
 
+# Relative day-words Gmail cannot parse as absolute dates. For recency
+# operators (after/newer) map them to the timezone-robust ``newer_than:``
+# window instead of a fragile absolute date: Gmail evaluates ``after:DATE``
+# against a Pacific-time day boundary, so a same-day message can fall on the
+# wrong side of it for accounts in other timezones and be missed (#2406).
+# ``newer_than:1d`` is relative to *now* and has no such boundary.
+_RELATIVE_DAY_WINDOWS = {"today": "1d", "yesterday": "2d"}
+
+
 def normalize_gmail_date_operators(query: str) -> str:
     """Rewrite date-operator values in ``query`` to Gmail's ``YYYY/MM/DD``.
 
-    Raises ``ValueError`` on an unparseable value — a loud error beats
-    passing it through as free text and returning a false zero-result.
+    Relative recency words (``after:today`` / ``newer:yesterday``) are rewritten
+    to the timezone-robust ``newer_than:`` window so a present same-day message
+    is reliably matched. Raises ``ValueError`` on an otherwise-unparseable value
+    — a loud error beats passing it through as free text and returning a false
+    zero-result.
     """
 
     def _sub(m: "re.Match[str]") -> str:
         op = m.group("op").lower()
+        bare = m.group("val").strip().strip('"').strip().lower()
+        if op in ("after", "newer") and bare in _RELATIVE_DAY_WINDOWS:
+            return f"newer_than:{_RELATIVE_DAY_WINDOWS[bare]}"
         return f"{op}:{_parse_gmail_date_value(m.group('val'), op=op)}"
 
     return _DATE_OP_RE.sub(_sub, query)

--- a/hub/agents/email/python/openapi.email.json
+++ b/hub/agents/email/python/openapi.email.json
@@ -2913,6 +2913,9 @@
           "403": {
             "description": "Authorization failed — the account's auth is missing, expired, or revoked (reconnect via Settings → Connectors), or a confirmation gate rejected the request (mint a fresh confirmation token)."
           },
+          "409": {
+            "description": "The archive did not take effect — the message is still in the inbox (the provider's modify call did not remove the INBOX label)."
+          },
           "422": {
             "content": {
               "application/json": {

--- a/hub/agents/email/python/tests/test_archive_verify_search_2406.py
+++ b/hub/agents/email/python/tests/test_archive_verify_search_2406.py
@@ -1,0 +1,244 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Regression tests for #2406.
+
+Two defects in one archive flow:
+
+1. **False success** — ``archive_message_impl`` claimed success even when the
+   message never left the inbox. It must verify the INBOX label was actually
+   removed (from the provider's own post-archive response) and fail loudly and
+   actionably otherwise — never a phantom undo row, never a false "archived".
+
+2. **Same-day search miss** — a ``from:X received today`` search returned zero
+   for a message that is present and dated today. The model's ``after:today``
+   phrasing must resolve to the timezone-robust relative window
+   ``newer_than:1d``, and the FakeGmailBackend must model date operators so the
+   fix is covered end-to-end.
+
+All hermetic: FakeGmailBackend + in-memory SQLite, no Lemonade, no network.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# parents[0] = tests/,  [5] = repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email import action_store  # noqa: E402
+from gaia_agent_email.tools.organize_tools import archive_message_impl  # noqa: E402
+from gaia_agent_email.tools.read_tools import (  # noqa: E402
+    normalize_gmail_date_operators,
+    search_messages_impl,
+)
+
+from gaia.database.mixin import DatabaseMixin  # noqa: E402
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DB(DatabaseMixin):
+    pass
+
+
+def _fresh_db() -> _DB:
+    db = _DB()
+    db.init_db(":memory:")
+    action_store.init_schema(db)
+    return db
+
+
+def _msg(
+    *,
+    gid: str,
+    sender: str,
+    subject: str,
+    when_ms: int,
+    labels=("INBOX", "UNREAD"),
+) -> dict:
+    return {
+        "id": gid,
+        "threadId": gid,
+        "labelIds": list(labels),
+        "snippet": subject,
+        "internalDate": str(when_ms),
+        "payload": {
+            "mimeType": "text/plain",
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "Subject", "value": subject},
+            ],
+            "body": {"size": 0},
+        },
+        "sizeEstimate": 100,
+    }
+
+
+def _count_action_rows(db: _DB) -> int:
+    rows = db.query("SELECT COUNT(*) AS n FROM email_actions", {}, one=True)
+    return int(rows["n"])
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — archive must confirm the message left the inbox
+# ---------------------------------------------------------------------------
+
+
+def test_archive_success_when_inbox_removed():
+    gmail = FakeGmailBackend()
+    gmail.add_message(
+        _msg(gid="a1", sender="news@x.com", subject="Hello", when_ms=1_700_000_000_000)
+    )
+    db = _fresh_db()
+
+    result = archive_message_impl(gmail, db, message_id="a1")
+
+    assert result["message_id"] == "a1"
+    assert result["action_id"]
+    # The message really left the inbox.
+    assert "INBOX" not in gmail.get_message("a1")["labelIds"]
+    # Exactly one undo row recorded.
+    assert _count_action_rows(db) == 1
+
+
+def test_archive_surfaces_archived_message_identity():
+    """AC(b): the return payload carries the id/subject/sender actually archived
+    so the success message can cite the concrete message, not just a sender."""
+    gmail = FakeGmailBackend()
+    gmail.add_message(
+        _msg(
+            gid="a2",
+            sender="Claude Team <no-reply@email.claude.com>",
+            subject="Welcome to Claude",
+            when_ms=1_700_000_000_000,
+        )
+    )
+    db = _fresh_db()
+
+    result = archive_message_impl(gmail, db, message_id="a2")
+
+    assert result["message_id"] == "a2"
+    assert result.get("subject") == "Welcome to Claude"
+    assert "no-reply@email.claude.com" in (result.get("sender") or "")
+
+
+class _NoOpArchiveBackend(FakeGmailBackend):
+    """Models a backend whose archive silently fails to remove INBOX (the
+    #2406 false-success case): the modify response still carries INBOX."""
+
+    def archive_message(self, message_id: str):
+        self._transport.record("archive_message", message_id=message_id)
+        # Deliberately DO NOT remove INBOX — return the message unchanged.
+        return self._messages[message_id]
+
+
+def test_archive_false_success_raises_and_records_no_row():
+    gmail = _NoOpArchiveBackend()
+    gmail.add_message(
+        _msg(gid="b1", sender="news@x.com", subject="Stuck", when_ms=1_700_000_000_000)
+    )
+    db = _fresh_db()
+
+    with pytest.raises(RuntimeError, match=r"(?i)inbox"):
+        archive_message_impl(gmail, db, message_id="b1")
+
+    # No phantom undo row on a failed archive (ordering invariant).
+    assert _count_action_rows(db) == 0
+    # And the message is (correctly) still in the inbox — we did not lie.
+    assert "INBOX" in gmail.get_message("b1")["labelIds"]
+
+
+def test_archive_skips_label_check_when_result_has_no_labels():
+    """Folder-based backends (Outlook) return an id-only result with no labelIds;
+    verification is skipped rather than false-failing (provider-correct)."""
+
+    class _FolderBackend(FakeGmailBackend):
+        def archive_message(self, message_id: str):
+            self._transport.record("archive_message", message_id=message_id)
+            # Simulate a folder move: remove from store-view, return new id only.
+            return {"id": "moved_" + message_id}
+
+    gmail = _FolderBackend()
+    gmail.add_message(
+        _msg(gid="c1", sender="news@x.com", subject="Moved", when_ms=1_700_000_000_000)
+    )
+    db = _fresh_db()
+
+    result = archive_message_impl(gmail, db, message_id="c1")
+    assert result["post_archive_id"] == "moved_c1"
+    assert _count_action_rows(db) == 1
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — same-day search must find a present, today-dated message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("from:x@y.com after:today", "from:x@y.com newer_than:1d"),
+        ("after:today", "newer_than:1d"),
+        ("newer:today", "newer_than:1d"),
+        ("from:x@y.com after:yesterday", "from:x@y.com newer_than:2d"),
+        ("after:Today", "newer_than:1d"),
+    ],
+)
+def test_relative_day_words_normalize_to_relative_window(query, expected):
+    assert normalize_gmail_date_operators(query) == expected
+
+
+def test_explicit_dates_still_normalize_to_absolute():
+    # The relative-word path must not disturb concrete dates.
+    assert normalize_gmail_date_operators("after:July 1, 2026") == "after:2026/07/01"
+
+
+def test_fake_backend_honors_newer_than_window():
+    gmail = FakeGmailBackend()
+    now_ms = int(time.time() * 1000)
+    gmail.add_message(
+        _msg(gid="today", sender="news@x.com", subject="Fresh", when_ms=now_ms)
+    )
+    gmail.add_message(
+        _msg(
+            gid="old",
+            sender="news@x.com",
+            subject="Stale",
+            when_ms=now_ms - 10 * 86_400_000,
+        )
+    )
+    listing = gmail.list_messages(query="newer_than:1d")
+    ids = {m["id"] for m in listing["messages"]}
+    assert ids == {"today"}
+
+
+def test_search_finds_same_day_message_from_sender():
+    """AC(d): from:X received today finds a present, same-day inbox message."""
+    gmail = FakeGmailBackend()
+    now_ms = int(time.time() * 1000)
+    gmail.add_message(
+        _msg(
+            gid="fresh",
+            sender="Claude Team <no-reply@email.claude.com>",
+            subject="Welcome to Claude",
+            when_ms=now_ms,
+        )
+    )
+    out = search_messages_impl(
+        gmail, query="from:no-reply@email.claude.com after:today"
+    )
+    assert len(out["messages"]) == 1
+    # The outgoing query used the robust relative window.
+    listed = [c for c in gmail.transport.calls if c[0] == "list_messages"]
+    assert any("newer_than:1d" in (c[1]["query"] or "") for c in listed)

--- a/hub/agents/email/python/tests/test_rest_contract.py
+++ b/hub/agents/email/python/tests/test_rest_contract.py
@@ -1892,3 +1892,85 @@ def test_spec_page_serves_html(client):
     resp = client.get("/v1/email/spec")
     assert resp.status_code == 200
     assert "<html" in resp.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# 8. REST parity for the #2406 fixes — the same-day search normalization and
+#    the archive-verify guard must reach the REST endpoints, not just the
+#    in-loop tool path (both surfaces close #2406).
+# ---------------------------------------------------------------------------
+
+
+def test_search_rest_normalizes_same_day_operator(client):
+    # A raw `after:today` from a REST caller must be normalized to the
+    # timezone-robust `newer_than:1d` window before it reaches the backend —
+    # parity with the agent's in-loop search (#2406).
+    fake = _FakeSearchBackend([])
+    client.app.dependency_overrides[api_routes.get_search_backend] = lambda: fake
+    try:
+        resp = client.post("/v1/email/search", json={"query": "from:alice after:today"})
+    finally:
+        client.app.dependency_overrides.pop(api_routes.get_search_backend, None)
+    assert resp.status_code == 200, resp.text
+    assert fake.calls == [
+        {
+            "query": "from:alice newer_than:1d",
+            "label_ids": None,
+            "max_results": 25,
+            "page_token": None,
+        }
+    ]
+
+
+class _NoOpArchiveMailbox(_FakeMailbox):
+    """Archive is a silent no-op — the modify response still echoes INBOX, the
+    false-success case #2406 guards against (mirrors the label-based backend
+    whose post-mutation labelIds still contain INBOX)."""
+
+    def archive_message(self, message_id):
+        # Return the (unchanged) message so post_labels still carries INBOX,
+        # tripping archive_message_impl's verify guard.
+        return {
+            "id": message_id,
+            "labelIds": list(self.messages[message_id]["labelIds"]),
+        }
+
+
+def test_archive_rest_surfaces_actionable_error_not_500(monkeypatch):
+    # When the provider no-ops the archive (message still in INBOX),
+    # archive_message_impl raises RuntimeError. The REST handler must translate
+    # that to a 4xx carrying the actionable message — not leak a bare 500 with
+    # the guidance stripped (#2406).
+    from gaia_agent_email import action_store
+    from gaia_agent_email import api_routes as email_routes
+
+    from gaia.database.mixin import DatabaseMixin
+
+    class _DB(DatabaseMixin):
+        pass
+
+    db = _DB()
+    db.init_db(":memory:")
+    action_store.init_schema(db)
+
+    mailbox = _NoOpArchiveMailbox()
+    monkeypatch.setattr(email_routes, "resolve_action_db", lambda: db)
+    monkeypatch.setattr(
+        email_routes, "_resolve_mutate_backend", lambda provider: (mailbox, "google")
+    )
+    client = TestClient(export_openapi.build_app())
+
+    tok = client.post(
+        "/v1/email/confirm", json={"action": "archive", "message_id": "m1"}
+    ).json()["confirmation_token"]
+    resp = client.post(
+        "/v1/email/archive", json={"message_id": "m1", "confirmation_token": tok}
+    )
+
+    assert resp.status_code == 409, resp.text  # not 500
+    assert "archive" in resp.json()["detail"].lower()
+    # The message is genuinely still in the inbox — no false "archived".
+    assert "INBOX" in mailbox.messages["m1"]["labelIds"]
+    # No phantom undo row was recorded for a failed archive.
+    rows = db.query("SELECT COUNT(*) AS n FROM email_actions", one=True)
+    assert rows["n"] == 0

--- a/tests/fixtures/email/fake_gmail.py
+++ b/tests/fixtures/email/fake_gmail.py
@@ -643,18 +643,97 @@ class FakeCalendarBackend:
 # ---------------------------------------------------------------------------
 
 
+_RELATIVE_UNIT_SECONDS = {
+    "h": 3600,
+    "d": 86_400,
+    "w": 7 * 86_400,
+    "m": 30 * 86_400,
+    "y": 365 * 86_400,
+}
+
+
+def _relative_window_seconds(value: str) -> Optional[int]:
+    """Parse a Gmail relative window like ``1d`` / ``2w`` / ``3m`` into seconds."""
+    m = re.fullmatch(r"(\d+)\s*([hdwmy])", value.strip().lower())
+    if not m:
+        return None
+    return int(m.group(1)) * _RELATIVE_UNIT_SECONDS[m.group(2)]
+
+
+def _absolute_date_epoch(value: str) -> Optional[float]:
+    """Parse a normalized ``YYYY/MM/DD`` Gmail date into an epoch (UTC midnight)."""
+    m = re.fullmatch(r"(\d{4})/(\d{1,2})/(\d{1,2})", value.strip())
+    if not m:
+        return None
+    try:
+        dt = datetime(
+            int(m.group(1)), int(m.group(2)), int(m.group(3)), tzinfo=timezone.utc
+        )
+    except ValueError:
+        return None
+    return dt.timestamp()
+
+
+def _msg_epoch(msg: Dict[str, Any]) -> float:
+    """Message receipt time in epoch seconds from Gmail's millis ``internalDate``."""
+    try:
+        return int(msg.get("internalDate", "0")) / 1000.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _date_operator_matches(
+    token: str, msg: Dict[str, Any], now: float
+) -> Optional[bool]:
+    """Evaluate a date operator token against ``msg``.
+
+    Returns True/False if ``token`` is a recognized date operator, else None so
+    the caller falls through to its other token handling. Models the operators
+    the email agent emits — ``newer_than``/``older_than`` (relative windows) and
+    the absolute ``after``/``before``/``newer``/``older`` (``YYYY/MM/DD``, the
+    form ``normalize_gmail_date_operators`` produces).
+    """
+    when = _msg_epoch(msg)
+    if token.startswith(("newer_than:", "older_than:")):
+        op, _, val = token.partition(":")
+        window = _relative_window_seconds(val)
+        if window is None:
+            return None
+        if op == "newer_than":
+            return when >= now - window
+        return when <= now - window
+    for op in ("after", "before", "newer", "older"):
+        prefix = op + ":"
+        if token.startswith(prefix):
+            epoch = _absolute_date_epoch(token[len(prefix) :])
+            if epoch is None:
+                return None
+            if op in ("after", "newer"):
+                return when >= epoch
+            return when < epoch
+    return None
+
+
 def _query_matches(query: str, msg: Dict[str, Any]) -> bool:
     """Tiny subset of Gmail's query DSL.
 
-    Only ``is:unread``, ``from:``, ``subject:`` are honored — enough for
-    the eval-harness scenarios we run.
+    ``is:unread``, ``from:``, ``subject:`` and the date operators
+    (``newer_than``/``older_than``/``after``/``before``/``newer``/``older``) are
+    honored — enough for the eval-harness scenarios and the #2406 same-day
+    search coverage.
     """
     headers = {
         (h.get("name") or "").lower(): h.get("value", "")
         for h in (msg.get("payload") or {}).get("headers", [])
     }
     label_ids = set(msg.get("labelIds", []))
+    now = datetime.now(timezone.utc).timestamp()
     for token in query.split():
+        date_verdict = _date_operator_matches(token, msg, now)
+        if date_verdict is not None:
+            if not date_verdict:
+                return False
+            continue
         if token == "is:unread":
             if "UNREAD" not in label_ids:
                 return False


### PR DESCRIPTION
Closes #2406

## Why this matters

Before: the email agent told users a newsletter was "archived and removed from your inbox" when it was still sitting in the inbox — a false success — and a same-day "from:X received today" search came back empty for a message that was present and dated today. Both defects hit the same archive-a-newsletter flow and made T13 (archive undo) untestable.

After: archive only reports success once the message has actually left the inbox (the provider's own post-archive `labelIds` no longer contain `INBOX`); if it didn't, the tool fails loudly with an actionable message instead of lying. Same-day searches reliably find today's mail.

## What changed

- **No false success** (`organize_tools.py` `archive_message_impl`): inspects the archive response's post-mutation `labelIds`; if `INBOX` is still present it raises before `record_action` (no phantom undo row). Folder-based backends (Outlook) return an id-only result with no labels — verification is skipped there (provider-correct, documented). The return payload now also carries the archived message's `subject`/`sender` so the reply can cite the message actually archived, not just the sender the user typed.
- **Same-day search** (`read_tools.py` `normalize_gmail_date_operators`): `after:today` / `newer:yesterday` now normalize to the timezone-robust `newer_than:1d` / `newer_than:2d` window instead of a Pacific-time-fragile absolute date (or a hard raise on the word "today").
- **Test fidelity** (`fake_gmail.py` `_query_matches`): the shared `FakeGmailBackend` now models the date operators (`newer_than`/`older_than`/`after`/`before`) so the same-day search is covered end-to-end against the fake, which models INBOX-label removal.

## Test plan

Hermetic unit tests (FakeGmailBackend + in-memory SQLite, no Lemonade/network):

- [x] archive success when INBOX removed → returns action_id, message leaves inbox, one undo row.
- [x] archive **false-success** (backend leaves INBOX) → raises `RuntimeError`, **no** action row written.
- [x] folder-backend (id-only result) → label check skipped, archives normally.
- [x] `after:today`→`newer_than:1d`, `after:yesterday`→`newer_than:2d`; explicit dates untouched.
- [x] end-to-end `search_messages_impl("from:X after:today")` finds a present same-day message.

```
$ .venv-wt/bin/python -m pytest hub/agents/email/python/tests/test_archive_verify_search_2406.py -q
12 passed

$ .venv-wt/bin/python -m pytest hub/agents/email/python/tests/ -q
850 passed
```
Full run of every repo-root `FakeGmailBackend` consumer: 909 passed (2 unrelated pre-existing failures — memory-tool registration set + `email-validator` accepting a `.example` TLD — both confirmed failing on clean `origin/main` before this change).

## Live-validation TODO (central sweep)

Exercise on a real mailbox, both Agent UI and CLI:
- Archive a real inbox message by sender; confirm in Gmail it actually leaves the inbox, and that the agent only *then* reports success (and cites the actual message's subject).
- Trigger the false-success guard against a message that can't be archived; confirm the agent says what actually happened, no unconditional "removed from your inbox".
- Search "from:X received today" for a message received today and confirm it's found (verify the outgoing query uses `newer_than:1d`).
- Re-verify T13 archive-undo now that archive is trustworthy.

## Eval flag

No tool docstring / JSON schema changed (the fix lives in impl + normalizer + fake backend), so no `gaia eval agent` run is warranted by this change. Not run here (shared Lemonade).
