### PR TITLE
fix(email): bulk-archive undo survives the whole run via a per-turn batch handle

### DIFF
--- a/hub/agents/email/python/gaia_agent_email/action_store.py
+++ b/hub/agents/email/python/gaia_agent_email/action_store.py
@@ -189,21 +189,32 @@ def fetch_batch_undoable(
 ) -> list[Dict[str, Any]]:
     """Return every action row in ``batch_id`` that is still undoable.
 
-    A row is undoable when it has not been undone and is inside the window.
-    Stale or already-undone rows are filtered out — this is the bulk
-    analogue of ``fetch_undoable`` for the batch-undo follow-up (#1270).
-    Returns ``[]`` for an unknown batch.
+    The undo window is measured from batch **completion** (the latest
+    ``created_at`` in the batch), NOT per row (#2163). A multi-item bulk run
+    takes real time; anchoring per row let the earliest items' windows expire
+    mid-run, so the closing "undo within the window" offer was already false for
+    them. Anchoring to completion keeps every item undoable for
+    ``window_seconds`` after the last op — all-or-nothing per batch. The window
+    still genuinely expires (from completion), so undo is not unbounded.
+
+    Already-undone rows are still filtered out per row. Returns ``[]`` for an
+    unknown batch or once the whole-batch window has elapsed.
     """
-    rows = db.query(
-        "SELECT * FROM email_actions WHERE batch_id = :b ORDER BY created_at",
-        {"b": batch_id},
+    rows = list(
+        db.query(
+            "SELECT * FROM email_actions WHERE batch_id = :b ORDER BY created_at",
+            {"b": batch_id},
+        )
+        or ()
     )
-    cutoff = time.time() - window_seconds
+    if not rows:
+        return []
+    completed_at = max(row["created_at"] for row in rows)
+    if time.time() - completed_at > window_seconds:
+        return []
     out: list[Dict[str, Any]] = []
-    for row in rows or ():
+    for row in rows:
         if row["undone_at"] is not None:
-            continue
-        if row["created_at"] < cutoff:
             continue
         payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
         out.append(

--- a/hub/agents/email/python/gaia_agent_email/agent.py
+++ b/hub/agents/email/python/gaia_agent_email/agent.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import os
 import re
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
 
@@ -514,6 +515,12 @@ class EmailTriageAgent(
         # because the agent loop tear-down happens between turns.
         self._organize_op_count = 0
         self._organize_distinct_senders: set[str] = set()
+        # #2163 — per-turn undo batch. A loop of single archive_message calls in
+        # one turn shares this handle, so the set is undoable as ONE batch whose
+        # window is anchored to completion (see action_store.fetch_batch_undoable),
+        # not per-op — otherwise the earliest archives' undo windows expired
+        # mid-run. Re-minted per turn by _reset_organize_counter.
+        self._organize_batch_id = uuid.uuid4().hex
 
         # Session-scoped triage preferences — sender priorities and
         # category defaults that survive across queries within one agent
@@ -1511,6 +1518,9 @@ class EmailTriageAgent(
     def _reset_organize_counter(self) -> None:
         self._organize_op_count = 0
         self._organize_distinct_senders = set()
+        # Fresh per-turn undo batch handle (#2163) — a new turn's archives must
+        # not join the prior turn's (already-completed) undo batch.
+        self._organize_batch_id = uuid.uuid4().hex
 
     def _record_organize_op(self, _message_id: str, sender: str) -> None:
         """Bump the per-turn organize counters. Called by organize-tool

--- a/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
+++ b/hub/agents/email/python/gaia_agent_email/tools/organize_tools.py
@@ -239,9 +239,10 @@ def undo_archive_batch_impl(
         )
         if not rows:
             raise RuntimeError(
-                f"undo window has expired ({window_seconds} s) or batch_id "
-                f"{batch_id!r} has no undoable archive actions. Use your mail "
-                "client to move the messages back to the inbox manually."
+                f"undo window has expired ({window_seconds} s after the batch "
+                f"completed) or batch_id {batch_id!r} has no undoable archive "
+                "actions. Use your mail client to move the messages back to the "
+                "inbox manually."
             )
         restored: List[Dict[str, Any]] = []
         failed: List[Dict[str, Any]] = []
@@ -479,6 +480,11 @@ class OrganizeToolsMixin:
                         message_id=message_id,
                         prior=prior,
                         mailbox=provider,
+                        # #2163 — share the per-turn undo batch so a loop of single
+                        # archives is undoable as ONE batch (undo_archive_batch),
+                        # with a completion-anchored window instead of a per-op
+                        # window that expires mid-run.
+                        batch_id=agent._organize_batch_id,
                         debug=debug_flag,
                     )
                 )

--- a/hub/agents/email/python/tests/test_bulk_archive_gate_2163.py
+++ b/hub/agents/email/python/tests/test_bulk_archive_gate_2163.py
@@ -172,9 +172,9 @@ def test_single_archive_loop_shares_one_undo_batch_surviving_the_run(
             "SELECT DISTINCT batch_id FROM email_actions WHERE action_type='archive'"
         )
         batch_ids = {r["batch_id"] for r in rows}
-        assert batch_ids == {agent._organize_batch_id}, (
-            f"single archives must share the per-turn batch handle, got {batch_ids}"
-        )
+        assert batch_ids == {
+            agent._organize_batch_id
+        }, f"single archives must share the per-turn batch handle, got {batch_ids}"
         batch_id = agent._organize_batch_id
 
         # t = 1040: past the FIRST op's own 30s window (1000+30=1030) but within

--- a/hub/agents/email/python/tests/test_bulk_archive_gate_2163.py
+++ b/hub/agents/email/python/tests/test_bulk_archive_gate_2163.py
@@ -1,21 +1,25 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 """
-Regression tests for #2163 — two defects in bulk archive:
+Regression tests for #2163 — bulk archive left the earliest items unsafe:
 
-1. The bulk-archive confirmation GATE let pre-threshold operations execute
-   UNCONFIRMED. ``archive_message_batch`` checked the per-turn organize counter
-   BEFORE its own ops were counted, so a fresh ``archive_message_batch([6 ids])``
-   saw count == 0, passed the gate, and archived all six with no confirmation.
+The reported repro ("archive all suggested promos") looped the SINGLE
+``archive_message`` tool six times. Each op recorded its own action with its own
+30 s undo window, so during the ~26 s run the earliest items' undo windows had
+already lapsed by the time the agent offered "undo within the window" — the
+offer was false, and there was no single handle to undo the set as a whole.
 
-2. Undo windows EXPIRED MID-RUN. ``fetch_batch_undoable`` measured the window
-   from each row's own ``created_at``; in a multi-item run the earliest items
-   crossed the window before the run finished, so the closing "undo within the
-   window" offer was already false for them.
+The fix follows the issue's remedy (b): a loop of single archives in one turn
+shares ONE per-turn undo batch handle, and ``fetch_batch_undoable`` anchors the
+window to batch COMPLETION (the latest op) rather than per-row. Every item then
+stays undoable for the full window after the run finishes. The sanctioned bulk
+tool ``archive_message_batch`` (issue #1270 — 20+ in one call) is unchanged and
+NOT gated; it was already one undoable batch and now also gets the
+completion-anchored window.
 
-Both are exercised against the real ``FakeGmailBackend`` and a controllable
-clock (the ``action_store`` module's ``time`` is swapped for a settable fake),
-so no wall-clock timing and no live mailbox are involved.
+Exercised against the real ``FakeGmailBackend`` and a controllable clock (the
+``action_store`` module's ``time`` is swapped for a settable fake), so no
+wall-clock timing and no live mailbox are involved.
 """
 
 from __future__ import annotations
@@ -44,7 +48,6 @@ from gaia_agent_email.tools.organize_tools import (  # noqa: E402
 
 from gaia.agents.base.tools import _TOOL_REGISTRY  # noqa: E402
 from gaia.database.mixin import DatabaseMixin  # noqa: E402
-
 from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
 
 EMBEDDING_DIM = 768
@@ -116,7 +119,9 @@ def _build_agent_with_fake_gmail(tmp_path: Path, messages: list[dict]):
             "gaia.agents.base.memory.MemoryMixin._embed_text",
             side_effect=_fake_embed,
         ),
-        patch("gaia.agents.base.memory.MemoryMixin._backfill_embeddings", return_value=0),
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._backfill_embeddings", return_value=0
+        ),
         patch("gaia.agents.base.memory.MemoryMixin._rebuild_faiss_index"),
         patch("gaia.agents.base.memory.MemoryMixin.init_system_context"),
     ):
@@ -132,43 +137,72 @@ def _call_tool(name: str, *args, **kwargs) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Defect 1 — gate blocks pre-threshold bulk archive (AC a)
+# Defects 1+2 on the reported repro path — a loop of SINGLE archive_message
+# calls (N6: "archive all suggested promos") shares ONE per-turn undo batch, so
+# the whole set is undoable as a unit for a window anchored to completion. This
+# is the issue's remedy (b): "mint a single batch-level undo handle whose window
+# starts when the batch completes, not per-op". No pre-threshold op is left with
+# its own clock ticking mid-run.
 # ---------------------------------------------------------------------------
 
 
-def test_bulk_archive_gate_blocks_before_any_op_executes(tmp_path):
-    """archive_message_batch([6 ids]) on a fresh turn must archive NOTHING and
-    return the batch-confirm sentinel — the plan-level gate fires before any op."""
-    msgs = [_inbox_message(f"m{i}", f"s{i}@x.com") for i in range(6)]
+def test_single_archive_loop_shares_one_undo_batch_surviving_the_run(
+    tmp_path, monkeypatch
+):
+    """Five single archive_message calls in one turn share one batch_id, and
+    undo_archive_batch restores ALL of them even after the earliest op's own
+    per-op window would have lapsed — no mid-run expiry."""
+    clock = _Clock(1000.0)
+    monkeypatch.setattr(action_store, "time", clock)
+
+    msgs = [_inbox_message(f"m{i}", "promo@shop.com") for i in range(5)]
     agent, backend = _build_agent_with_fake_gmail(tmp_path, msgs)
     try:
-        agent._reset_organize_counter()  # fresh turn
-        ids = [m["id"] for m in msgs]
-        res = _call_tool("archive_message_batch", ids)
+        agent._reset_organize_counter()  # fresh turn -> fresh batch handle
+        # Loop single archives, advancing the clock so the run spans 20s
+        # (ops at 1000,1005,1010,1015,1020) — like a real multi-item run.
+        for i, m in enumerate(msgs):
+            clock.now = 1000.0 + 5.0 * i
+            res = _call_tool("archive_message", m["id"])
+            assert res["ok"] is True, f"single archive should succeed: {res}"
+            assert "INBOX" not in backend.get_message(m["id"]).get("labelIds", [])
 
-        # Gate tripped: error envelope carrying the batch-confirm sentinel.
-        assert res["ok"] is False, f"expected gate to block, got {res}"
-        assert "Batch threshold exceeded" in res["error"]
+        # All five singles recorded ONE shared batch_id (route b).
+        rows = agent.query(
+            "SELECT DISTINCT batch_id FROM email_actions WHERE action_type='archive'"
+        )
+        batch_ids = {r["batch_id"] for r in rows}
+        assert batch_ids == {agent._organize_batch_id}, (
+            f"single archives must share the per-turn batch handle, got {batch_ids}"
+        )
+        batch_id = agent._organize_batch_id
 
-        # NOTHING archived — every message still in INBOX.
-        for mid in ids:
-            labels = backend.get_message(mid).get("labelIds", [])
-            assert "INBOX" in labels, f"{mid} was archived unconfirmed: {labels}"
+        # t = 1040: past the FIRST op's own 30s window (1000+30=1030) but within
+        # the window measured from completion (1020+30=1050). Undo restores ALL 5.
+        clock.now = 1040.0
+        undo = _call_tool("undo_archive_batch", batch_id)
+        assert undo["ok"] is True, f"undo should succeed within window: {undo}"
+        assert undo["data"]["restored"] == 5
+        for m in msgs:
+            labels = backend.get_message(m["id"]).get("labelIds", [])
+            assert "INBOX" in labels, f"{m['id']} not restored: {labels}"
     finally:
         agent.close_db()
 
 
-def test_below_threshold_batch_still_archives(tmp_path):
-    """A below-threshold batch is NOT gated — no over-gating regression."""
-    msgs = [_inbox_message(f"m{i}", f"s{i}@x.com") for i in range(4)]
+def test_batch_archive_tool_still_archives_bulk_unchanged(tmp_path):
+    """#1270 regression guard: archive_message_batch remains the sanctioned bulk
+    vehicle — a 6-message batch archives all six in one call (no new gate)."""
+    msgs = [_inbox_message(f"m{i}", f"s{i}@x.com") for i in range(6)]
     agent, backend = _build_agent_with_fake_gmail(tmp_path, msgs)
     try:
         agent._reset_organize_counter()
         ids = [m["id"] for m in msgs]
         res = _call_tool("archive_message_batch", ids)
 
-        assert res["ok"] is True, f"below-threshold batch should run: {res}"
-        assert res["data"]["total"] == 4
+        assert res["ok"] is True, f"bulk batch must still archive: {res}"
+        assert res["data"]["total"] == 6
+        assert len(res["data"]["succeeded"]) == 6
         for mid in ids:
             labels = backend.get_message(mid).get("labelIds", [])
             assert "INBOX" not in labels, f"{mid} not archived: {labels}"
@@ -177,7 +211,7 @@ def test_below_threshold_batch_still_archives(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Defect 2 — undo window survives the whole run (AC b)
+# Defect 2 (unit) — the batch undo window is anchored to completion, not per-op
 # ---------------------------------------------------------------------------
 
 
@@ -224,7 +258,9 @@ def test_undo_window_anchored_to_batch_completion(tmp_path, monkeypatch):
     # after completion (1020). Under the old per-row logic rows at 1000 & 1005
     # would be dropped; anchored-to-completion keeps all five undoable.
     clock.now = 1040.0
-    rows = action_store.fetch_batch_undoable(db, batch_id=batch_id, window_seconds=window)
+    rows = action_store.fetch_batch_undoable(
+        db, batch_id=batch_id, window_seconds=window
+    )
     assert len(rows) == 5, f"all 5 must stay undoable at t=1040, got {len(rows)}"
 
     # End-to-end: undo restores every message to the inbox.
@@ -258,7 +294,9 @@ def test_undo_window_still_expires_from_completion(tmp_path, monkeypatch):
     window = 30
     # t = 1051: 31s after completion (1020) — the whole-batch window has elapsed.
     clock.now = 1051.0
-    rows = action_store.fetch_batch_undoable(db, batch_id=batch_id, window_seconds=window)
+    rows = action_store.fetch_batch_undoable(
+        db, batch_id=batch_id, window_seconds=window
+    )
     assert rows == [], "batch must be non-undoable past completion + window"
 
     with pytest.raises(RuntimeError):

--- a/hub/agents/email/python/tests/test_bulk_archive_gate_2163.py
+++ b/hub/agents/email/python/tests/test_bulk_archive_gate_2163.py
@@ -1,0 +1,267 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for #2163 — two defects in bulk archive:
+
+1. The bulk-archive confirmation GATE let pre-threshold operations execute
+   UNCONFIRMED. ``archive_message_batch`` checked the per-turn organize counter
+   BEFORE its own ops were counted, so a fresh ``archive_message_batch([6 ids])``
+   saw count == 0, passed the gate, and archived all six with no confirmation.
+
+2. Undo windows EXPIRED MID-RUN. ``fetch_batch_undoable`` measured the window
+   from each row's own ``created_at``; in a multi-item run the earliest items
+   crossed the window before the run finished, so the closing "undo within the
+   window" offer was already false for them.
+
+Both are exercised against the real ``FakeGmailBackend`` and a controllable
+clock (the ``action_store`` module's ``time`` is swapped for a settable fake),
+so no wall-clock timing and no live mailbox are involved.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# parents[0]=tests/ [1]=python/ [2]=email/ [3]=agents/ [4]=hub/ [5]=repo-root
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("gaia_agent_email")
+
+from gaia_agent_email import action_store  # noqa: E402
+from gaia_agent_email.agent import EmailTriageAgent  # noqa: E402
+from gaia_agent_email.config import EmailAgentConfig  # noqa: E402
+from gaia_agent_email.tools.organize_tools import (  # noqa: E402
+    undo_archive_batch_impl,
+)
+
+from gaia.agents.base.tools import _TOOL_REGISTRY  # noqa: E402
+from gaia.database.mixin import DatabaseMixin  # noqa: E402
+
+from tests.fixtures.email.fake_gmail import FakeGmailBackend  # noqa: E402
+
+EMBEDDING_DIM = 768
+
+
+class _MinimalCalendarBackend:
+    pass
+
+
+class _DB(DatabaseMixin):
+    pass
+
+
+class _Clock:
+    """Controllable clock for the action log. ``now`` is settable per phase."""
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = float(now)
+
+    def time(self) -> float:
+        return self.now
+
+
+def _fake_embed(_text: str) -> np.ndarray:
+    vec = np.ones(EMBEDDING_DIM, dtype=np.float32)
+    vec /= np.linalg.norm(vec)
+    return vec
+
+
+def _inbox_message(message_id: str, sender: str) -> dict:
+    """A Gmail-API-shape INBOX message with a distinct sender."""
+    return {
+        "id": message_id,
+        "threadId": f"thread_{message_id}",
+        "labelIds": ["INBOX", "UNREAD"],
+        "internalDate": "1700000000000",
+        "snippet": "promo",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": f"Deals <{sender}>"},
+                {"name": "Subject", "value": "50% off"},
+                {"name": "Message-ID", "value": f"<{message_id}@x.com>"},
+            ],
+        },
+    }
+
+
+def _build_agent_with_fake_gmail(tmp_path: Path, messages: list[dict]):
+    """EmailTriageAgent backed by a real FakeGmailBackend seeded with messages."""
+    backend = FakeGmailBackend(user_email="me@example.com")
+    for msg in messages:
+        backend.add_message(msg)
+
+    cfg = EmailAgentConfig(
+        gmail_backend=backend,
+        calendar_backend=_MinimalCalendarBackend(),
+        db_path=str(tmp_path / "state.db"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        silent_mode=True,
+        debug=False,
+    )
+    with (
+        patch("gaia.agents.base.agent.AgentSDK") as mock_sdk,
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._get_embedder",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "gaia.agents.base.memory.MemoryMixin._embed_text",
+            side_effect=_fake_embed,
+        ),
+        patch("gaia.agents.base.memory.MemoryMixin._backfill_embeddings", return_value=0),
+        patch("gaia.agents.base.memory.MemoryMixin._rebuild_faiss_index"),
+        patch("gaia.agents.base.memory.MemoryMixin.init_system_context"),
+    ):
+        mock_sdk.return_value = MagicMock()
+        agent = EmailTriageAgent(config=cfg)
+    return agent, backend
+
+
+def _call_tool(name: str, *args, **kwargs) -> dict:
+    entry = _TOOL_REGISTRY.get(name)
+    assert entry is not None, f"tool {name!r} not registered"
+    return json.loads(entry["function"](*args, **kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — gate blocks pre-threshold bulk archive (AC a)
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_archive_gate_blocks_before_any_op_executes(tmp_path):
+    """archive_message_batch([6 ids]) on a fresh turn must archive NOTHING and
+    return the batch-confirm sentinel — the plan-level gate fires before any op."""
+    msgs = [_inbox_message(f"m{i}", f"s{i}@x.com") for i in range(6)]
+    agent, backend = _build_agent_with_fake_gmail(tmp_path, msgs)
+    try:
+        agent._reset_organize_counter()  # fresh turn
+        ids = [m["id"] for m in msgs]
+        res = _call_tool("archive_message_batch", ids)
+
+        # Gate tripped: error envelope carrying the batch-confirm sentinel.
+        assert res["ok"] is False, f"expected gate to block, got {res}"
+        assert "Batch threshold exceeded" in res["error"]
+
+        # NOTHING archived — every message still in INBOX.
+        for mid in ids:
+            labels = backend.get_message(mid).get("labelIds", [])
+            assert "INBOX" in labels, f"{mid} was archived unconfirmed: {labels}"
+    finally:
+        agent.close_db()
+
+
+def test_below_threshold_batch_still_archives(tmp_path):
+    """A below-threshold batch is NOT gated — no over-gating regression."""
+    msgs = [_inbox_message(f"m{i}", f"s{i}@x.com") for i in range(4)]
+    agent, backend = _build_agent_with_fake_gmail(tmp_path, msgs)
+    try:
+        agent._reset_organize_counter()
+        ids = [m["id"] for m in msgs]
+        res = _call_tool("archive_message_batch", ids)
+
+        assert res["ok"] is True, f"below-threshold batch should run: {res}"
+        assert res["data"]["total"] == 4
+        for mid in ids:
+            labels = backend.get_message(mid).get("labelIds", [])
+            assert "INBOX" not in labels, f"{mid} not archived: {labels}"
+    finally:
+        agent.close_db()
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — undo window survives the whole run (AC b)
+# ---------------------------------------------------------------------------
+
+
+def _record_batch_archive(db, backend, clock, batch_id, ids, times):
+    """Archive each id on the backend and record an ``archive`` action at a
+    controlled created_at, all under one batch_id."""
+    for mid, t in zip(ids, times):
+        clock.now = t
+        prior_labels = list(backend.get_message(mid).get("labelIds", []))
+        backend.archive_message(mid)
+        action_store.record_action(
+            db,
+            action_type="archive",
+            message_id=mid,
+            payload={"prior_labels": prior_labels, "post_archive_id": mid},
+            batch_id=batch_id,
+            mailbox="google",
+        )
+
+
+def test_undo_window_anchored_to_batch_completion(tmp_path, monkeypatch):
+    """All items of a bulk run stay undoable for the window AFTER the run
+    completes — the earliest items no longer expire mid-run."""
+    clock = _Clock(1000.0)
+    monkeypatch.setattr(action_store, "time", clock)
+
+    db = _DB()
+    db.init_db(":memory:")
+    action_store.init_schema(db)
+
+    backend = FakeGmailBackend(user_email="me@example.com")
+    ids = [f"m{i}" for i in range(5)]
+    for mid in ids:
+        backend.add_message(_inbox_message(mid, f"s{mid}@x.com"))
+
+    batch_id = "batch2163"
+    # Run spans 20s: ops at 1000,1005,1010,1015,1020 (completion = 1020).
+    times = [1000.0, 1005.0, 1010.0, 1015.0, 1020.0]
+    _record_batch_archive(db, backend, clock, batch_id, ids, times)
+
+    window = 30
+
+    # t = 1040: 40s after the FIRST op (past its own 30s window) but only 20s
+    # after completion (1020). Under the old per-row logic rows at 1000 & 1005
+    # would be dropped; anchored-to-completion keeps all five undoable.
+    clock.now = 1040.0
+    rows = action_store.fetch_batch_undoable(db, batch_id=batch_id, window_seconds=window)
+    assert len(rows) == 5, f"all 5 must stay undoable at t=1040, got {len(rows)}"
+
+    # End-to-end: undo restores every message to the inbox.
+    result = undo_archive_batch_impl(
+        lambda _row: backend, db, batch_id=batch_id, window_seconds=window
+    )
+    assert result["restored"] == 5
+    for mid in ids:
+        assert "INBOX" in backend.get_message(mid).get("labelIds", [])
+
+
+def test_undo_window_still_expires_from_completion(tmp_path, monkeypatch):
+    """The window is anchored to completion but still bounded — past
+    completion + window the batch is no longer undoable (fails loud)."""
+    clock = _Clock(1000.0)
+    monkeypatch.setattr(action_store, "time", clock)
+
+    db = _DB()
+    db.init_db(":memory:")
+    action_store.init_schema(db)
+
+    backend = FakeGmailBackend(user_email="me@example.com")
+    ids = [f"m{i}" for i in range(5)]
+    for mid in ids:
+        backend.add_message(_inbox_message(mid, f"s{mid}@x.com"))
+
+    batch_id = "batch2163b"
+    times = [1000.0, 1005.0, 1010.0, 1015.0, 1020.0]  # completion = 1020
+    _record_batch_archive(db, backend, clock, batch_id, ids, times)
+
+    window = 30
+    # t = 1051: 31s after completion (1020) — the whole-batch window has elapsed.
+    clock.now = 1051.0
+    rows = action_store.fetch_batch_undoable(db, batch_id=batch_id, window_seconds=window)
+    assert rows == [], "batch must be non-undoable past completion + window"
+
+    with pytest.raises(RuntimeError):
+        undo_archive_batch_impl(
+            lambda _row: backend, db, batch_id=batch_id, window_seconds=window
+        )

--- a/tests/unit/agents/email/test_batch_archive.py
+++ b/tests/unit/agents/email/test_batch_archive.py
@@ -226,8 +226,9 @@ class TestBatchArchive20Plus:
 
 
 class TestFetchBatchUndoable:
-    """``action_store.fetch_batch_undoable`` returns the in-window,
-    not-yet-undone rows for a batch and excludes stale / undone ones.
+    """``action_store.fetch_batch_undoable`` returns the not-yet-undone rows for
+    a batch while the batch's window (anchored to COMPLETION — the latest op —
+    since #2163) is still open, and excludes undone ones.
     """
 
     @pytest.fixture
@@ -259,28 +260,34 @@ class TestFetchBatchUndoable:
         rows = action_store.fetch_batch_undoable(db, batch_id="b1", window_seconds=30)
         assert {r["message_id"] for r in rows} == {"m0", "m1", "m2"}
 
-    def test_excludes_stale_and_undone_rows(self, db):
+    def test_undone_excluded_and_window_anchored_to_completion(self, db):
+        # #2163 — the window is anchored to batch COMPLETION (the latest op), not
+        # per row. An individually-older row that shares a batch whose latest op
+        # is fresh stays undoable, so the earliest items of a multi-second run no
+        # longer expire mid-run. Already-undone rows are still excluded per row.
         a_fresh = action_store.record_action(
             db, action_type="archive", message_id="fresh", batch_id="b1"
         )
-        a_stale = action_store.record_action(
-            db, action_type="archive", message_id="stale", batch_id="b1"
+        a_early = action_store.record_action(
+            db, action_type="archive", message_id="early", batch_id="b1"
         )
         a_undone = action_store.record_action(
             db, action_type="archive", message_id="undone", batch_id="b1"
         )
+        # ``early`` is older than the window in isolation, but the batch's latest
+        # op (``fresh``) is well within it — so the whole batch is still undoable.
         db.update(
             "email_actions",
-            {"created_at": time.time() - 3600},
+            {"created_at": time.time() - 20},
             "action_id = :id",
-            {"id": a_stale},
+            {"id": a_early},
         )
         action_store.mark_undone(db, action_id=a_undone)
 
         rows = action_store.fetch_batch_undoable(db, batch_id="b1", window_seconds=30)
         ids = {r["action_id"] for r in rows}
         assert a_fresh in ids
-        assert a_stale not in ids
+        assert a_early in ids  # #2163: kept — window runs from completion
         assert a_undone not in ids
 
     def test_unknown_batch_returns_empty(self, db):


### PR DESCRIPTION
Closes #2163

## Why this matters

When the email agent bulk-archived messages by looping the single `archive_message` tool ("archive all suggested promos"), each archive started its **own** 30-second undo clock. During a ~26-second run the earliest items' undo windows had already lapsed by the time the agent offered "undo within the window" — the offer was false, and there was no single handle to undo the set as a whole. After this change a loop of single archives in one turn is one undoable batch, and the undo window runs from when the batch **finishes**, so every item stays reliably undoable for the full window after the run.

## What changed (two surgical fixes, route (b) from the issue)

- **Per-turn undo batch handle.** Single `archive_message` calls in a turn now share one `batch_id` (minted per turn), so the whole set is undoable together via `undo_archive_batch`.
- **Completion-anchored window.** `fetch_batch_undoable` measures the undo window from the batch's latest op (completion), not per row — killing mid-run expiry while still bounding the window.

The sanctioned bulk tool `archive_message_batch` (issue **#1270** — 20+ archives in one call) is deliberately **not** gated: a count threshold can't tell a deliberate 25-select from a runaway 6, so gating it would break #1270. The issue explicitly offers route (b) — a single batch-level undo handle anchored to completion — which preserves #1270 and fixes the reported repro. `archive_message_batch` was already one undoable batch and now also benefits from the completion-anchored window.

<details>
<summary>Root cause + why not route (a)</summary>

- Defect 2 (mid-run expiry): `action_store.fetch_batch_undoable` dropped any row whose own `created_at` was older than `now - window`; in a multi-item run the earliest rows crossed that before the run finished.
- Defect 1 (pre-threshold ops unconfirmed): the counter-based gate is checked before each op but the counter only reflects prior ops, so early ops slip through. An initial attempt to gate `archive_message_batch` on projected batch size was reverted — it flipped #1270's committed AC (`test_batch_archive.py::test_archives_20_plus_in_one_action`), and no count threshold distinguishes a deliberate bulk select from a runaway. Route (b) makes the whole set atomically reversible instead, which the issue accepts as sufficient.
- The send-floor is untouched — send/forward/permanent-delete remain confirmation-gated.
</details>

## Evidence

Run locally with the worktree source on `PYTHONPATH` and Lemonade pointed at an unreachable URL to mirror CI (no live embedding service):

**New + #1270 window-contract tests — `10 passed`:**
```
test_bulk_archive_gate_2163.py::test_single_archive_loop_shares_one_undo_batch_surviving_the_run PASSED
test_bulk_archive_gate_2163.py::test_batch_archive_tool_still_archives_bulk_unchanged PASSED
test_bulk_archive_gate_2163.py::test_undo_window_anchored_to_batch_completion PASSED
test_bulk_archive_gate_2163.py::test_undo_window_still_expires_from_completion PASSED
tests/unit/agents/email/test_batch_archive.py::TestBatchArchive20Plus::test_archives_20_plus_in_one_action PASSED
tests/unit/agents/email/test_batch_archive.py::TestBatchArchive20Plus::test_batch_archive_reversible_within_undo_window PASSED
tests/unit/agents/email/test_batch_archive.py::TestBatchArchive20Plus::test_batch_archive_undo_fails_after_window PASSED
tests/unit/agents/email/test_batch_archive.py::TestFetchBatchUndoable::test_undone_excluded_and_window_anchored_to_completion PASSED
```
The two acceptance tests use the real `FakeGmailBackend` + a controllable clock (the `action_store` module's `time` is swapped for a settable fake): AC(b) archives 5 messages across a simulated 20s run, advances the clock past the earliest op's own 30s window but within the window-from-completion, and asserts all 5 restore; a companion test asserts the window still expires once past completion+window.

**Full CI-path email suite — `653 passed, 1 skipped, 0 failed`** (`tests/unit/agents/email/`, `test_email_agent*.py`, `test_email_autonomy_cycle.py`, and the new file). **Full `hub/agents/email/python/tests/` — `844 passed`**, the single failure being a pre-existing local editable-install artifact (`test_agent_version_matches_package_metadata`: stale `0.1.0` dist-info vs `0.5.0` source; fails identically with this branch's changes stashed; passes in CI's fresh from-tree install).

Lint clean on changed files (`black`, `isort`, `flake8` with the repo's `--max-line-length=88` config).

## Test plan
- [x] `pytest hub/agents/email/python/tests/test_bulk_archive_gate_2163.py tests/unit/agents/email/test_batch_archive.py` → 10 passed
- [x] `pytest tests/unit/agents/email/ tests/unit/agents/test_email_agent*.py hub/agents/email/python/tests/test_email_autonomy_cycle.py` (Lemonade unreachable) → 653 passed
- [x] `black --check` / `isort --check` / `flake8` on changed files → clean

## No-eval note
No `@tool` docstring or JSON tool schema changed (only an internal-helper docstring + an expired-window error string), so no `gaia eval agent` run is required for this change.

## Live-validation TODO (central sweep)
Deferred to the milestone-59 centralized live sweep (shared box driven by the orchestrator) — reference T13 archive-undo:
- **Agent UI**: "archive all suggested promos" (or any bulk archive of N messages spanning past the old 30s undo window). Confirm the closing "undo" offer holds and every item is still restored by one undo after the run.
- **CLI (`gaia email`)**: same bulk-archive-N flow; verify `undo_archive_batch` restores all items after a multi-second run.
- Verify send/forward/delete remain confirmation-gated (send-floor unaffected).
