### PR TITLE
fix(daemon/email-agent): dev-mode sidecar 'Empty module name' on macOS (bad PYTHON_KEYRING_BACKEND)

### DIFF
--- a/src/gaia/connectors/_keyring.py
+++ b/src/gaia/connectors/_keyring.py
@@ -13,11 +13,64 @@ Importing ``keyring`` through this module turns that into the actionable error
 CLAUDE.md's "fail loudly" rule requires: it names what failed, what to install,
 and where to read more. The re-exported name is the real ``keyring`` module
 (with ``keyring.errors`` pre-imported), so callers use it exactly as before.
+
+Backend-env normalization (#2441): ``PYTHON_KEYRING_BACKEND`` is a keyring
+contract for a *fully-qualified* ``module.Class`` path. keyring resolves it via
+``value.rpartition('.')``, so a **dotless** value (the common dev/test shorthand
+``null``) yields an empty module name and ``__import__('')`` raises
+``ValueError: Empty module name`` — which the email sidecar surfaces as an opaque
+``502``. This shim rewrites the well-known no-op-store shorthands to keyring's
+real null-backend class *before* keyring initializes, so the documented
+"disable the credential store" workflow works instead of crashing.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+
 from gaia.connectors.errors import ConnectorsError
+
+logger = logging.getLogger(__name__)
+
+_KEYRING_BACKEND_ENV_VAR = "PYTHON_KEYRING_BACKEND"
+# keyring's real "store nothing" backend (all reads return None, writes no-op).
+_NULL_KEYRING_BACKEND = "keyring.backends.null.Keyring"
+# Friendly, dotless shorthands a dev/test harness reaches for to disable the OS
+# credential store. Each unambiguously means "no store"; keyring cannot resolve
+# any of them (no dot → empty module name), so mapping them to the real null
+# backend matches intent rather than inventing behavior.
+_NULL_KEYRING_ALIASES = frozenset({"null", "none", "off", "disabled"})
+
+
+def normalize_keyring_backend_env() -> None:
+    """Rewrite a shorthand ``PYTHON_KEYRING_BACKEND`` to keyring's real class path.
+
+    Idempotent and a no-op when the var is unset or already a dotted path. MUST
+    run before the first ``keyring.get_keyring()`` so keyring reads the corrected
+    value (keyring caches the resolved backend on first use). Only the dotless
+    no-op-store shorthands are rewritten; any other value is left untouched for
+    keyring to resolve — a genuine resolution failure is turned into an
+    actionable error by ``store.verify_keyring_backend``, never a silent
+    fallback.
+    """
+    raw = os.environ.get(_KEYRING_BACKEND_ENV_VAR)
+    if raw is None:
+        return
+    if raw.strip().lower() in _NULL_KEYRING_ALIASES:
+        os.environ[_KEYRING_BACKEND_ENV_VAR] = _NULL_KEYRING_BACKEND
+        logger.warning(
+            "%s=%r is a shorthand for the no-op keyring backend; normalizing to "
+            "%r. The OS credential store is DISABLED — OAuth tokens will not "
+            "persist. This is intended for dev/testing only.",
+            _KEYRING_BACKEND_ENV_VAR,
+            raw,
+            _NULL_KEYRING_BACKEND,
+        )
+
+
+# Correct the env before ``import keyring`` resolves any backend downstream.
+normalize_keyring_backend_env()
 
 try:
     import keyring
@@ -30,4 +83,10 @@ except ImportError as e:  # pragma: no cover - exercised via reload in tests
         "See docs/sdk/infrastructure/connections.mdx."
     ) from e
 
-__all__ = ["keyring"]
+__all__ = [
+    "keyring",
+    "normalize_keyring_backend_env",
+    "_KEYRING_BACKEND_ENV_VAR",
+    "_NULL_KEYRING_BACKEND",
+    "_NULL_KEYRING_ALIASES",
+]

--- a/src/gaia/connectors/store.py
+++ b/src/gaia/connectors/store.py
@@ -32,11 +32,18 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 import zlib
 from typing import List, Optional
 
-from gaia.connectors._keyring import keyring  # actionable error if missing (#1621)
+from gaia.connectors._keyring import (  # actionable error if missing (#1621)
+    _KEYRING_BACKEND_ENV_VAR,
+    _NULL_KEYRING_ALIASES,
+    _NULL_KEYRING_BACKEND,
+    keyring,
+    normalize_keyring_backend_env,
+)
 from gaia.connectors.errors import (
     AuthRequiredError,
     ConnectorsError,
@@ -94,8 +101,33 @@ def verify_keyring_backend() -> None:
     Raise ``ConnectorsError`` if the active keyring is one of the refused
     backends. Called eagerly at every save and at every load — cheap, and
     closes the silent-plaintext-fallback path (A4).
+
+    Also the single eager choke point where an unresolvable
+    ``PYTHON_KEYRING_BACKEND`` first surfaces (#2441): keyring resolves the var
+    as a ``module.Class`` path, so a bad value raises deep inside keyring
+    (a dotless value → ``ValueError: Empty module name``). Turn that opaque
+    failure into an actionable error naming the offending value and the correct
+    form — never let it bubble up as an unexplained sidecar 502.
     """
-    backend = keyring.get_keyring()
+    normalize_keyring_backend_env()
+    try:
+        backend = keyring.get_keyring()
+    except Exception as e:  # noqa: BLE001 - re-raised loudly with context below
+        configured = os.environ.get(_KEYRING_BACKEND_ENV_VAR)
+        hint = ""
+        if configured:
+            hint = (
+                f" {_KEYRING_BACKEND_ENV_VAR}={configured!r} is not a valid "
+                "keyring backend identifier: keyring expects a fully-qualified "
+                "'module.Class' path (for example "
+                f"'{_NULL_KEYRING_BACKEND}' to disable the store in "
+                "dev/testing), or one of the GAIA shorthands "
+                f"{sorted(_NULL_KEYRING_ALIASES)}."
+            )
+        raise ConnectorsError(
+            f"Could not initialize the keyring backend: {e}.{hint} "
+            "See docs/security/connections.mdx."
+        ) from e
     cls_name = type(backend).__name__
     if cls_name in _REFUSED_BACKEND_CLASS_NAMES:
         raise ConnectorsError(

--- a/tests/unit/connectors/test_keyring_guard.py
+++ b/tests/unit/connectors/test_keyring_guard.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import builtins
 import importlib
+import os
 import sys
 
 import pytest
@@ -69,3 +70,78 @@ def test_keyring_shim_reexports_real_module() -> None:
     real = importlib.import_module("keyring")
     assert shim.keyring is real
     assert hasattr(shim.keyring, "errors")
+
+
+# ---------------------------------------------------------------------------
+# PYTHON_KEYRING_BACKEND normalization + loud failure (issue #2441)
+#
+# keyring resolves PYTHON_KEYRING_BACKEND as a fully-qualified 'module.Class'
+# path (value.rpartition('.')). A dotless value — the common dev/test shorthand
+# 'null' — yields an empty module name and __import__('') raises
+# ``ValueError: Empty module name`` deep inside keyring, which the email sidecar
+# surfaced as an opaque 502 on macOS dev mode.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("shorthand", ["null", "none", "off", "disabled", "  NULL  "])
+def test_normalize_rewrites_null_shorthand_to_real_backend(
+    shorthand: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dotless no-op-store shorthand is rewritten to keyring's null backend
+    class BEFORE keyring resolves it — so ``keyring.get_keyring()`` no longer
+    raises ``Empty module name``."""
+    from gaia.connectors._keyring import (
+        _NULL_KEYRING_BACKEND,
+        normalize_keyring_backend_env,
+    )
+
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", shorthand)
+    normalize_keyring_backend_env()
+    assert os.environ["PYTHON_KEYRING_BACKEND"] == _NULL_KEYRING_BACKEND
+
+    # The rewritten value is a real, resolvable keyring backend (proves the
+    # Empty-module-name crash is gone for the documented dev/test workflow).
+    import keyring
+
+    monkeypatch.setattr(keyring.core, "_keyring_backend", None, raising=False)
+    backend = keyring.get_keyring()
+    assert type(backend).__module__ == "keyring.backends.null"
+
+
+def test_normalize_is_noop_for_unset_and_dotted_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fully-qualified path (or an unset var) is left untouched — normalization
+    only ever rewrites the dotless shorthands."""
+    from gaia.connectors._keyring import normalize_keyring_backend_env
+
+    monkeypatch.delenv("PYTHON_KEYRING_BACKEND", raising=False)
+    normalize_keyring_backend_env()
+    assert "PYTHON_KEYRING_BACKEND" not in os.environ
+
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "keyring.backends.fail.Keyring")
+    normalize_keyring_backend_env()
+    assert os.environ["PYTHON_KEYRING_BACKEND"] == "keyring.backends.fail.Keyring"
+
+
+def test_verify_keyring_backend_raises_actionable_error_on_bad_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unresolvable (non-shorthand) PYTHON_KEYRING_BACKEND surfaces as an
+    actionable ``ConnectorsError`` naming the offending value and the correct
+    form — never keyring's opaque ``Empty module name`` / import error."""
+    import keyring
+
+    from gaia.connectors.store import verify_keyring_backend
+
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "totally.bogus.Backend")
+    monkeypatch.setattr(keyring.core, "_keyring_backend", None, raising=False)
+
+    with pytest.raises(ConnectorsError) as excinfo:
+        verify_keyring_backend()
+
+    msg = str(excinfo.value)
+    assert "totally.bogus.Backend" in msg  # names the offending value
+    assert "keyring.backends.null.Keyring" in msg  # names the correct form
+    # The opaque keyring message must be wrapped, not surfaced bare.
+    assert "Could not initialize the keyring backend" in msg

--- a/tests/unit/test_agent_sidecar_manager.py
+++ b/tests/unit/test_agent_sidecar_manager.py
@@ -87,6 +87,32 @@ def test_email_spec_dev_src_dir_resolves_under_repo_root():
     assert builtin_specs()["email"].dev_src_dir == expected
 
 
+def test_real_email_spec_dev_spawn_has_nonempty_module_and_existing_app_dir(
+    monkeypatch,
+):
+    """Regression guard for #2441's misdiagnosis: the dev-mode spawn was NEVER
+    the source of the "Empty module name" crash (that was an invalid
+    PYTHON_KEYRING_BACKEND). Prove it here against the REAL builtin email spec —
+    the dev spawn always yields a non-empty import module and an app-dir that
+    exists on disk in a source checkout."""
+    monkeypatch.setenv("GAIA_EMAIL_AGENT_MODE", "dev")
+    spec = builtin_specs()["email"]
+    # Non-empty import module (the value uvicorn __import__s).
+    module = spec.dev_module.split(":", 1)[0]
+    assert module, "dev_module import path must not be empty"
+    assert spec.dev_module == "server:app"
+
+    m = mgr.AgentSidecarManager(spec)
+    argv, kwargs = m.build_spawn_command(port=9127)
+    app_dir = Path(argv[argv.index("--app-dir") + 1])
+    assert app_dir == spec.dev_src_dir / spec.dev_app_dir
+    # In this source checkout the app-dir (and server.py) really exist.
+    assert app_dir.is_dir(), f"dev app-dir does not exist: {app_dir}"
+    assert (app_dir / "server.py").is_file()
+    # The module uvicorn loads is the non-empty top-level `server`, not empty.
+    assert "server:app" in argv and "" not in argv
+
+
 # ---------------------------------------------------------------------------
 # errors.py — relocated hierarchy + backward-compat shim
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

Running the email agent in dev mode on macOS crashed with an opaque `502 "Failed to start the email agent for this query: Empty module name"`, blocking milestone-59 Agent-UI validation on macOS. The culprit was **not** the daemon's dev-mode sidecar spawn (the issue's investigation lead) — the app-dir and `server:app` module resolve correctly and the sidecar starts fine. The real cause: `PYTHON_KEYRING_BACKEND=null` (the documented macOS keychain-hang workaround) is **not** a valid keyring identifier. keyring resolves that env var as a fully-qualified `module.Class` path, so the dotless `null` yields an empty module name and `__import__("")` raises `ValueError: Empty module name` deep inside keyring — surfaced by the sidecar as a 502.

After this change, the well-known no-op-store shorthands (`null`, `none`, `off`, `disabled`) are normalized to keyring's real `keyring.backends.null.Keyring` class before keyring initializes, so the documented dev/test workflow actually runs. Any *other* unresolvable value now fails loud with an actionable error naming the offending value and the correct form — never the opaque "Empty module name".

<details>
<summary>Root cause detail</summary>

The 502 originates in the running sidecar's `/v1/email/query` route (`hub/agents/email/python/gaia_agent_email/query_routes.py:315`) when `build_query_agent` → `build_session_agent` → `config.resolve_mail_backends()` → `connected_mailbox_providers()` → `store.peek_connection()` → `verify_keyring_backend()` calls `keyring.get_keyring()`. Under `PYTHON_KEYRING_BACKEND=null`, keyring's `_load_keyring_class("null")` does `"null".rpartition(".")` → module name `""` → `__import__("")` → `ValueError: Empty module name`. GAIA's own scorecard docs already prescribe the correct fully-qualified form (`keyring.backends.null.Keyring`); the bare `null` shorthand was the footgun.

Fix: `gaia.connectors._keyring.normalize_keyring_backend_env()` rewrites the shorthands before `import keyring` resolves anything; `store.verify_keyring_backend()` also normalizes defensively and wraps `keyring.get_keyring()` so a genuine resolution failure becomes an actionable `ConnectorsError`.
</details>

## Evidence

**Repro (before) — unmodified source, `PYTHON_KEYRING_BACKEND=null GAIA_EMAIL_AGENT_MODE=dev`:**
```
FAILED: ValueError Empty module name
  File ".../keyring/core.py", line 134, in _load_keyring_class
    __import__(module_name)
ValueError: Empty module name
```

**After — same command, with the fix:**
```
WARNING gaia.connectors._keyring | PYTHON_KEYRING_BACKEND='null' is a shorthand for the
  no-op keyring backend; normalizing to 'keyring.backends.null.Keyring'. The OS credential
  store is DISABLED — OAuth tokens will not persist. This is intended for dev/testing only.
OK built agent: EmailTriageAgent
```

**Actionable error for a genuinely-bad (non-shorthand) value:**
```
ConnectorsError: Could not initialize the keyring backend: No module named 'totally'.
  PYTHON_KEYRING_BACKEND='totally.bogus.Backend' is not a valid keyring backend
  identifier: keyring expects a fully-qualified 'module.Class' path (for example
  'keyring.backends.null.Keyring' to disable the store in dev/testing), or one of the
  GAIA shorthands ['disabled', 'none', 'null', 'off']. See docs/security/connections.mdx.
```

**Unit tests** (run against the worktree source):
```
tests/unit/connectors/test_keyring_guard.py ......... (normalization + actionable error)
tests/unit/test_agent_sidecar_manager.py .......... (real email spec dev-spawn: non-empty module + existing app-dir)
52 passed in 2.90s
```

**Lint:** `python util/lint.py --all` → Black / isort / Pylint / Flake8 all PASS ("ALL QUALITY CHECKS PASSED!").

### Test plan
- [ ] `PYTHON_KEYRING_BACKEND=null GAIA_EMAIL_AGENT_MODE=dev gaia daemon stop; gaia email -q "hi"` on macOS from a source checkout launches the email sidecar (no "Empty module name" 502)
- [ ] Agent UI can drive the email agent in dev mode on macOS
- [ ] `python -m pytest tests/unit/connectors/test_keyring_guard.py tests/unit/test_agent_sidecar_manager.py`

Closes #2441
