### PR TITLE
fix(email): don't misclassify timeouts as Lemonade-down (#2139 follow-up)

### DIFF
--- a/hub/agents/email/python/CHANGELOG.md
+++ b/hub/agents/email/python/CHANGELOG.md
@@ -29,7 +29,10 @@ contract version is tracked separately as
   keeping the original exception appended as `Technical details:` for debugging.
   Every `/query` client (CLI, `gaia api`, third-party) benefits, not just the Agent
   UI relay (which mitigated host-side in #2136). Unrelated errors pass through
-  verbatim, never masked behind a Lemonade message.
+  verbatim, never masked behind a Lemonade message — including timeouts, which are
+  deliberately not treated as Lemonade-down (a stopped local server refuses
+  instantly; a timeout means up-but-slow, or a different host such as the Gmail
+  backend, so it must not be relabelled "restart Lemonade").
 
 - **Applying an existing label by its display name no longer fails with
   `Invalid label` (#2428).** `label_message` / `move_to_label` (and their batch

--- a/hub/agents/email/python/gaia_agent_email/query_routes.py
+++ b/hub/agents/email/python/gaia_agent_email/query_routes.py
@@ -231,13 +231,18 @@ def _sse(event: Dict[str, Any]) -> str:
 # Terminal-error classification (issue #2139)
 # ---------------------------------------------------------------------------
 
-# Connection/timeout-shaped fragments of the ``requests`` / ``urllib3`` /
-# ``httpx`` error reprs a down or unreachable Lemonade Server produces. Those
-# transport errors are siblings of the builtin ``ConnectionError`` (under
-# ``OSError``, or under ``httpx.HTTPError``), so an ``isinstance`` check alone
-# misses them — the string shape is the reliable signal. Deliberately narrow:
-# a non-match falls through to the raw exception text so unrelated failures are
-# never masked behind a Lemonade message.
+# Connection-establishment fragments of the ``requests`` / ``urllib3`` /
+# ``httpx`` error reprs a down Lemonade Server produces. Those transport errors
+# are siblings of the builtin ``ConnectionError`` (under ``OSError``, or under
+# ``httpx.HTTPError``), so an ``isinstance`` check alone misses them — the string
+# shape is the reliable signal. Deliberately narrow: a non-match falls through to
+# the raw exception text so unrelated failures are never masked.
+#
+# Timeouts are intentionally NOT matched. A not-running local Lemonade refuses
+# the connection instantly (ECONNREFUSED) — it does not time out; a *timeout*
+# means a server is up-but-slow, or the fault is a different host entirely (the
+# Gmail/Outlook backends use ``httpx`` with their own timeouts, so a Gmail
+# ``ReadTimeout`` must NOT be relabelled "Lemonade unreachable — start it").
 _LEMONADE_DOWN_RE = re.compile(
     r"connection\s+(?:refused|reset|aborted|error)"
     r"|connectionerror"
@@ -248,10 +253,7 @@ _LEMONADE_DOWN_RE = re.compile(
     r"|could\s*n[o']t\s+(?:reach|connect|resolve)"
     r"|no route to host"
     r"|name or service not known"
-    r"|not reachable"
-    r"|unreachable"
-    r"|(?:read |connect(?:ion)? )?timed?\s*out"
-    r"|timeout",
+    r"|not reachable",
     re.IGNORECASE,
 )
 

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -429,6 +429,27 @@ def test_terminal_error_detail_leaves_unrelated_errors_verbatim():
     assert query_routes._terminal_error_detail(exc) == "some unrelated parse failure"
 
 
+def test_timeout_is_not_classified_as_lemonade_down():
+    """A timeout means up-but-slow, or a *different* host (the Gmail/Outlook
+    backends use httpx with their own timeouts) — never a not-running local
+    Lemonade, which refuses instantly. Such errors must pass through verbatim so
+    the user isn't told to restart Lemonade when Gmail is merely slow (#2139)."""
+
+    class _ReadTimeout(Exception):
+        """Stands in for httpx.ReadTimeout — its repr carries 'timeout'."""
+
+    for exc in (
+        _ReadTimeout("The read operation timed out"),
+        _ReadTimeout(""),  # empty str → class-name fallback still says nothing Lemonade
+        TimeoutError("timed out"),
+        RuntimeError("Gmail API call: connect timeout after 15s"),
+        RuntimeError("host is unreachable via the proxy"),
+    ):
+        assert query_routes._is_lemonade_unreachable(exc) is False, exc
+        # And the actionable Lemonade copy is NOT prepended.
+        assert "Lemonade" not in query_routes._terminal_error_detail(exc)
+
+
 # ---------------------------------------------------------------------------
 # Request validation (fail loud, before the stream)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #2432 (which merged) addressing a post-merge review finding on the `/query` Lemonade-down error classifier.

**Before:** the classifier matched a bare `timeout` (and bare `unreachable`) in any exception's text. The Gmail/Outlook backends use `httpx` with their own timeouts, so a Gmail `httpx.ReadTimeout` (Gmail slow, Lemonade fine) got relabelled *"Local Lemonade Server is not reachable — start it with `lemonade-server serve`"* — wrong guidance that sends the user to restart a healthy Lemonade. The raw error under `Technical details:` softened but didn't fix the misdirection.

**After:** timeouts are no longer treated as Lemonade-down. A not-running local Lemonade refuses the connection instantly (ECONNREFUSED) — it doesn't time out; a timeout means up-but-slow or a *different* host. The classifier keeps the connection-establishment signals a stopped server actually produces (refused/reset, failed-to-establish, max-retries, no-route-to-host, name-resolution, "not reachable") and drops the timeout/bare-unreachable alternatives.

Closes the 🟡 finding from the automated review on #2432.

## Test plan
- [x] `pytest hub/agents/email/python/tests/test_query_route.py` — 17 passed, incl. a new regression asserting Gmail `ReadTimeout` / `connect timeout` / bare-unreachable pass through verbatim and are NOT prefixed with the Lemonade copy.
- [x] Connection-refused / `ConnectionRefusedError` / "not reachable" cases still classify as Lemonade-down (existing tests unchanged).
- [x] `black --check` clean.