### PR TITLE
docs: add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report a bug so we can fix it.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this? Numbered steps if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Which version or commit hash are you on?
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, runtime version, anything else that might be relevant.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output. This is automatically rendered as code.
+      render: shell


### PR DESCRIPTION
Adds a structured bug-report template using GitHub's issue-form syntax. New bug reports will get consistent fields (what-happened, reproduce, expected, version, environment, logs) which makes triage faster.

Uses the YAML form format â€” renders as an actual form on issue creation.