### PR TITLE
ci(review): allow fork-PR checkout under pull_request_target (checkout@v7)

### DIFF
--- a/.github/workflows/claude-run.yml
+++ b/.github/workflows/claude-run.yml
@@ -71,6 +71,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          # checkout@v7 refuses fork-PR checkout under pull_request_target by default (pwn-request
+          # guard). Safe to opt in HERE because the fork tree is only diffed and READ as review
+          # input — never executed. The ONLY step that runs PR code (the evidence stage below) is
+          # gated to head.repo.fork == false. INVARIANT: any future step that builds/installs/runs
+          # the checked-out tree MUST carry that same fork gate, or this opt-in becomes an RCE.
+          allow-unsafe-pr-checkout: true
 
       - name: Generate PR diff
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review_comment'


### PR DESCRIPTION
## Why this matters
Every fork (external-contributor) PR currently gets **no automated review** — `actions/checkout@v7` refuses to check out fork PR head code under `pull_request_target` (its default `allow-unsafe-pr-checkout: false` pwn-request guard), so the review job dies at checkout in ~5s before Claude runs. Live case: #2459 (`sven-25`). Our YAML didn't change; v7 tightened the default.

This opts in on the `Checkout PR head` step. It's safe because the fork tree is only **diffed and read** as review input, never executed — the one step that runs PR code (the evidence stage) is already gated to `head.repo.fork == false`. A loud comment records that invariant so a future edit can't silently turn it into an RCE.

Fixes #2460.

## Test plan
- [ ] Fork PR targeting this branch (base = `tmi/fix-2460-fork-checkout`) reaches the Claude review step and posts a review — no 'Refusing to check out fork…' failure. (pull_request_target uses the base branch's workflow, so a fork PR to this branch exercises the fix pre-merge.)
- [ ] Post-merge: re-trigger #2459 on `main` and confirm the review runs.
- [ ] Evidence stage still skipped on fork PRs (`head.repo.fork == false` gate intact — no fork code executed with secrets).