### PR TITLE
[DO NOT MERGE] dummy fork PR — validate #2461 fork checkout fix (#2460)

### DIFF
--- a/src/gaia/_dummy_fork_test_2460.py
+++ b/src/gaia/_dummy_fork_test_2460.py
@@ -1,0 +1,5 @@
+# Throwaway file for the fork-PR checkout test in #2460 / PR #2461.
+# This PR is a dummy and will be closed, never merged. It exists only to
+# confirm actions/checkout@v7 checks out fork PR code under pull_request_target
+# with allow-unsafe-pr-checkout: true, and that the evidence stage stays skipped
+# on fork PRs (head.repo.fork == false gate).


### PR DESCRIPTION
**Throwaway PR — will be closed, never merged.**

Validates PR #2461. Base is the fix branch `tmi/fix-2460-fork-checkout`, and `pull_request_target` uses the **base branch's** workflow, so this fork PR exercises the fixed `claude-run.yml` pre-merge.

Expected:
- `pr-review / run` passes the `Checkout PR head` step (no 'Refusing to check out fork…' error) and posts a review.
- The evidence stage stays **skipped** (this is a fork; `head.repo.fork == false` gate) even though it touches `src/gaia/` — proving no fork code runs with secrets.

Part of #2460.