### PR TITLE
[DO NOT MERGE] dummy fork PR — validate #2461 fork checkout fix on main (#2460)

### DIFF
--- a/src/gaia/_dummy_fork_test_2460.py
+++ b/src/gaia/_dummy_fork_test_2460.py
@@ -1,0 +1,5 @@
+# Throwaway file for the fork-PR checkout test in #2460 / PR #2461.
+# This PR is a dummy and will be closed, never merged. It exists only to
+# confirm actions/checkout@v7 checks out fork PR code under pull_request_target
+# with allow-unsafe-pr-checkout: true, and that the evidence stage stays skipped
+# on fork PRs (head.repo.fork == false gate).


### PR DESCRIPTION
**Throwaway PR — will be closed, never merged.** Replaces #2462 (its base, the fix branch, was deleted on merge).

Validates that #2461 (now on main) fixes fork-PR review. `pull_request_target` runs main's workflow, which now sets `allow-unsafe-pr-checkout: true`.

Expected:
- `pr-review / run` passes the `Checkout PR head` step (no 'Refusing to check out fork…') and posts a review.
- Evidence stage stays **skipped** (fork; `head.repo.fork == false` gate) despite touching `src/gaia/`.

Part of #2460.